### PR TITLE
Configure API base URL in frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,12 @@
 
 ## Quickstart
 
+Copy environment variables from the sample file:
+
+```sh
+cp sample.env.local .env.local
+```
+
 Install dependencies:
 
 ```sh
@@ -15,6 +21,9 @@ yarn start-dev
 ```
 
 This will open `localhost:9870` in a new tab in your default browser.
+
+To develop against a local instance of the backend API,
+follow instructions for deploying to a local Docker instance. Update `API_BASE_URL` and then restart the dev server.
 
 ## Scripts
 
@@ -32,11 +41,13 @@ This will open `localhost:9870` in a new tab in your default browser.
 Tests assertions are written in [Chai](https://www.chaijs.com/api/bdd/).
 
 To watch for file changes while running tests:
+
 ```sh
 yarn test --watch
 ```
 
 To run tests in multiple browsers:
+
 ```sh
 yarn test --browsers chromium firefox webkit
 ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@web/test-runner-playwright": "^0.8.8",
     "autoprefixer": "^10.3.6",
     "css-loader": "^6.3.0",
+    "dotenv": "^10.0.0",
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-lit": "^1.6.1",

--- a/frontend/sample.env.local
+++ b/frontend/sample.env.local
@@ -1,0 +1,1 @@
+API_BASE_URL='http://btrix.cloud'

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,7 +2,13 @@
 const path = require("path");
 const ESLintPlugin = require("eslint-webpack-plugin");
 
-const backendUrl = new URL("http://btrix.cloud/");
+const isDevServer = process.env.WEBPACK_SERVE;
+
+require("dotenv").config({
+  path: path.resolve(process.cwd(), `.env${isDevServer ? `.local` : ""}`),
+});
+
+const backendUrl = new URL(process.env.API_BASE_URL || "http://btrix.cloud/");
 
 module.exports = {
   entry: "./src/index.js",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1585,6 +1585,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
### Testing

1. Copy `sample.env.local` to `.env.local`
2. Replace `API_BASE_URL` in `.env.local` with https://btrix-dev.webrecorder.net or http://localhost:8000
3. Start dev server with `yarn start-dev` and go to http://localhost:9870/log-in. Open network tab and attempt to log in. There should be an API request to http://localhost:9870/api/auth/jwt/login with the expected API response