### PR TITLE
Allow users to change password

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@formatjs/intl-getcanonicallocales": "^1.8.0",
     "@lit/localize": "^0.11.1",
     "@shoelace-style/shoelace": "^2.0.0-beta.61",
+    "@xstate/fsm": "^1.6.2",
     "axios": "^0.22.0",
     "color": "^4.0.1",
     "lit": "^2.0.0",

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -1,0 +1,89 @@
+import { state } from "lit/decorators.js";
+import type { AuthState } from "../types/auth";
+import LiteElement, { html } from "../utils/LiteElement";
+import { needLogin } from "../utils/auth";
+
+@needLogin
+export class AccountSettings extends LiteElement {
+  authState?: AuthState;
+
+  @state()
+  isChangingPassword: boolean = false;
+
+  @state()
+  isSubmitting: boolean = false;
+
+  @state()
+  submitError?: string;
+
+  render() {
+    return html`<div class="grid gap-4">
+      <h1 class="text-xl font-bold">Account settings</h1>
+
+      <section class="p-4 md:p-8 border rounded-lg grid gap-6">
+        <div>
+          <div class="mb-1 text-gray-500">Email</div>
+          <div>${this.authState!.username}</div>
+        </div>
+
+        ${this.isChangingPassword
+          ? this.renderChangePasswordForm()
+          : html`
+              <div>
+                <sl-button
+                  type="primary"
+                  outline
+                  @click=${() => (this.isChangingPassword = true)}
+                  >Change password</sl-button
+                >
+              </div>
+            `}
+      </section>
+    </div>`;
+  }
+
+  renderChangePasswordForm() {
+    return html` <div class="max-w-sm">
+      <h3 class="font-bold mb-3">Change password</h3>
+      <sl-form @sl-submit="${this.onSubmit}">
+        <div class="mb-5">
+          <sl-input
+            name="password"
+            type="password"
+            label="Current password"
+            required
+          >
+          </sl-input>
+        </div>
+        <div class="mb-5">
+          <sl-input
+            name="newPassword"
+            type="password"
+            label="New password"
+            required
+          >
+          </sl-input>
+        </div>
+        <div class="mb-5">
+          <sl-input
+            name="confirmNewPassword"
+            type="password"
+            label="Confirm new password"
+            required
+          >
+          </sl-input>
+        </div>
+        <sl-button type="primary" ?loading=${this.isSubmitting} submit
+          >Update</sl-button
+        >
+      </sl-form>
+
+      <div id="login-error" class="text-red-600">${this.submitError}</div>
+    </div>`;
+  }
+
+  async onSubmit(event: { detail: { formData: FormData } }) {
+    const { formData } = event.detail;
+    console.log(formData);
+  }
+}

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -1,9 +1,12 @@
 import { state, query } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
 import type { AuthState } from "../types/auth";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
 
 @needLogin
+@localized()
 export class AccountSettings extends LiteElement {
   authState?: AuthState;
 
@@ -32,13 +35,15 @@ export class AccountSettings extends LiteElement {
     if (newPassword === confirmNewPassword) {
       this.confirmNewPasswordInput!.setCustomValidity("");
     } else {
-      this.confirmNewPasswordInput!.setCustomValidity(`Passwords don't match`);
+      this.confirmNewPasswordInput!.setCustomValidity(
+        msg("Passwords don't match")
+      );
     }
   }
 
   render() {
     return html`<div class="grid gap-4">
-      <h1 class="text-xl font-bold">Account settings</h1>
+      <h1 class="text-xl font-bold">${msg("Account settings")}</h1>
 
       <section class="p-4 md:p-8 border rounded-lg grid gap-6">
         <div>
@@ -54,7 +59,7 @@ export class AccountSettings extends LiteElement {
                   type="primary"
                   outline
                   @click=${() => (this.isChangingPassword = true)}
-                  >Change password</sl-button
+                  >${msg("Change password")}</sl-button
                 >
               </div>
             `}
@@ -76,7 +81,7 @@ export class AccountSettings extends LiteElement {
     }
 
     return html` <div class="max-w-sm">
-      <h3 class="font-bold mb-3">Change password</h3>
+      <h3 class="font-bold mb-3">${msg("Change password")}</h3>
       <sl-form @sl-submit="${this.onSubmit}" aria-describedby="formError">
         <div class="mb-5">
           <sl-input
@@ -84,7 +89,7 @@ export class AccountSettings extends LiteElement {
             class="${this.submitErrors.password ? "text-danger" : ""}"
             name="password"
             type="password"
-            label="Current password"
+            label="${msg("Current password")}"
             aria-describedby="passwordError"
             required
           >
@@ -100,7 +105,7 @@ export class AccountSettings extends LiteElement {
             id="newPassword"
             name="newPassword"
             type="password"
-            label="New password"
+            label="${msg("New password")}"
             required
             @sl-blur=${this.checkPasswordMatch}
           >
@@ -111,7 +116,7 @@ export class AccountSettings extends LiteElement {
             id="confirmNewPassword"
             name="confirmNewPassword"
             type="password"
-            label="Confirm new password"
+            label="${msg("Confirm new password")}"
             required
             @sl-blur=${this.checkPasswordMatch}
           >
@@ -121,7 +126,7 @@ export class AccountSettings extends LiteElement {
         ${formError}
 
         <sl-button type="primary" ?loading=${this.isSubmitting} submit
-          >Update</sl-button
+          >${msg("Update password")}</sl-button
         >
       </sl-form>
     </div>`;
@@ -173,8 +178,7 @@ export class AccountSettings extends LiteElement {
     }
 
     if (!nextAuthState) {
-      // TODO localize
-      this.submitErrors.password = "Wrong password";
+      this.submitErrors.password = msg("Wrong password");
       this.isSubmitting = false;
       return;
     }
@@ -191,7 +195,7 @@ export class AccountSettings extends LiteElement {
     } catch (e) {
       console.error(e);
 
-      this.submitErrors._server = "Something went wrong changing password";
+      this.submitErrors._server = msg("Something went wrong changing password");
     }
 
     this.isSubmitting = false;

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -6,7 +6,28 @@ import type { AuthState } from "../types/auth";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
 
-const machine = createMachine({
+type FormEvent =
+  | { type: "EDIT" }
+  | { type: "CANCEL" }
+  | { type: "SUBMIT" }
+  | { type: "SUCCESS" }
+  | { type: "ERROR" };
+
+type FormTypestate =
+  | {
+      value: "readOnly";
+      context: any;
+    }
+  | {
+      value: "editingForm";
+      context: any;
+    }
+  | {
+      value: "submittingForm";
+      context: any;
+    };
+
+const machine = createMachine<any, FormEvent, FormTypestate>({
   id: "changePasswordForm",
   initial: "readOnly",
   states: {

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -63,6 +63,18 @@ export class AccountSettings extends LiteElement {
   }
 
   renderChangePasswordForm() {
+    let formError;
+
+    if (this.submitErrors._server) {
+      formError = html`
+        <div class="mb-5">
+          <bt-alert id="formError" type="danger"
+            >${this.submitErrors._server}</bt-alert
+          >
+        </div>
+      `;
+    }
+
     return html` <div class="max-w-sm">
       <h3 class="font-bold mb-3">Change password</h3>
       <sl-form @sl-submit="${this.onSubmit}" aria-describedby="formError">
@@ -105,13 +117,8 @@ export class AccountSettings extends LiteElement {
           >
           </sl-input>
         </div>
-        ${this.submitErrors._server
-          ? html`<div class="mb-5">
-              <btrix-alert id="formError" type="danger">
-                ${this.submitErrors._server}
-              </btrix-alert>
-            </div>`
-          : ""}
+
+        ${formError}
 
         <sl-button type="primary" ?loading=${this.isSubmitting} submit
           >Update</sl-button

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -105,17 +105,18 @@ export class AccountSettings extends LiteElement {
           >
           </sl-input>
         </div>
+        ${this.submitErrors._server
+          ? html`<div class="mb-5">
+              <btrix-alert id="formError" type="danger">
+                ${this.submitErrors._server}
+              </btrix-alert>
+            </div>`
+          : ""}
+
         <sl-button type="primary" ?loading=${this.isSubmitting} submit
           >Update</sl-button
         >
       </sl-form>
-
-      <!-- TODO style -->
-      ${this.submitErrors._server
-        ? html`<div id="formError" class="text-danger" role="alert">
-            ${this.submitErrors._server}
-          </div>`
-        : ""}
     </div>`;
   }
 

--- a/frontend/src/components/alert.ts
+++ b/frontend/src/components/alert.ts
@@ -1,0 +1,52 @@
+import { LitElement, html, css } from "lit";
+import { property } from "lit/decorators.js";
+
+/**
+ * Alert used inline, e.g. for form server errors
+ *
+ * Usage example:
+ * ```ts
+ * <input aria-describedby="error_message" />
+ * <btrix-alert id="error_message>${errorMessage}</btrix-alert>
+ * ```
+ */
+export class Alert extends LitElement {
+  @property({ type: String })
+  type: "success" | "warning" | "danger" | "info" = "info";
+
+  static styles = css`
+    :host > div {
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
+      border-radius: var(--sl-border-radius-medium);
+    }
+
+    .success {
+      background-color: var(--sl-color-success-50);
+      color: var(--success);
+    }
+
+    .warning {
+      background-color: var(--sl-color-warning-50);
+      color: var(--warning);
+    }
+
+    .danger {
+      background-color: var(--sl-color-danger-50);
+      color: var(--danger);
+    }
+
+    .info {
+      background-color: var(--sl-color-sky-50);
+      color: var(--sl-color-sky-600);
+    }
+  `;
+
+  render() {
+    console.log("id:", this.id);
+    return html`
+      <div class="${this.type}" role="alert">
+        <slot></slot>
+      </div>
+    `;
+  }
+}

--- a/frontend/src/components/alert.ts
+++ b/frontend/src/components/alert.ts
@@ -7,7 +7,7 @@ import { property } from "lit/decorators.js";
  * Usage example:
  * ```ts
  * <input aria-describedby="error_message" />
- * <btrix-alert id="error_message>${errorMessage}</btrix-alert>
+ * <bt-alert id="error_message>${errorMessage}</bt-alert>
  * ```
  */
 export class Alert extends LitElement {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -120,9 +120,10 @@ export class App extends LiteElement {
                   ></span>
                 </div>
                 <sl-menu>
-                  <sl-menu-item>
-                    <!-- TODO check tabindex -->
-                    <a href="${ROUTES.accountSettings}">Your account</a>
+                  <sl-menu-item
+                    @click=${() => this.navigate(ROUTES.accountSettings)}
+                  >
+                    ${msg("Your account")}
                   </sl-menu-item>
                   <sl-menu-item @click="${this.onLogOut}"
                     >${msg("Log Out")}</sl-menu-item

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -99,7 +99,7 @@ export class App extends LiteElement {
         ${this.renderNavBar()}
         <main class="relative flex-auto flex">${this.renderPage()}</main>
         <footer class="flex justify-center p-4 border-t">
-          <locale-picker></locale-picker>
+          <bt-locale-picker></bt-locale-picker>
         </footer>
       </div>
     `;
@@ -256,8 +256,8 @@ export class App extends LiteElement {
   }
 }
 
-customElements.define("btrix-alert", Alert);
-customElements.define("locale-picker", LocalePicker);
+customElements.define("bt-alert", Alert);
+customElements.define("bt-locale-picker", LocalePicker);
 customElements.define("browsertrix-app", App);
 customElements.define("log-in", LogInPage);
 customElements.define("my-account", MyAccountPage);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -4,6 +4,7 @@ import { msg, updateWhenLocaleChanges } from "@lit/localize";
 
 import "./shoelace";
 import { LocalePicker } from "./components/locale-picker";
+import { AccountSettings } from "./components/account-settings";
 import { LogInPage } from "./pages/log-in";
 import { MyAccountPage } from "./pages/my-account";
 import { ArchivePage } from "./pages/archive-info";
@@ -18,6 +19,7 @@ const ROUTES = {
   home: "/",
   login: "/log-in",
   myAccount: "/my-account",
+  accountSettings: "/account/settings",
   "archive-info": "/archive/:aid",
   "archive-info-tab": "/archive/:aid/:tab",
 } as const;
@@ -122,7 +124,10 @@ export class App extends LiteElement {
                   ></span>
                 </div>
                 <sl-menu>
-                  <sl-menu-item>Your account</sl-menu-item>
+                  <sl-menu-item>
+                    <!-- TODO check tabindex -->
+                    <a href="${ROUTES.accountSettings}">Your account</a>
+                  </sl-menu-item>
                   <sl-menu-item @click="${this.onLogOut}"
                     >${msg("Log Out")}</sl-menu-item
                   >
@@ -155,7 +160,7 @@ export class App extends LiteElement {
             ${navLink({ href: "/users", label: "Users" })}
           </ul>
         </nav>
-        ${template}
+        <div class="p-4 md:p-8 flex-1">${template}</div>
       </div>
     `;
 
@@ -186,6 +191,14 @@ export class App extends LiteElement {
           @need-login="${this.onNeedLogin}"
           .authState="${this.authState}"
         ></my-account>`);
+
+      case "accountSettings":
+        return appLayout(html`<btrix-account-settings
+          class="w-full"
+          @navigate="${this.onNavigateTo}"
+          @need-login="${this.onNeedLogin}"
+          .authState="${this.authState}"
+        ></btrix-account-settings>`);
 
       case "archive-info":
       case "archive-info-tab":
@@ -242,3 +255,4 @@ customElements.define("log-in", LogInPage);
 customElements.define("my-account", MyAccountPage);
 customElements.define("btrix-archive", ArchivePage);
 customElements.define("btrix-archive-configs", ArchiveConfigsPage);
+customElements.define("btrix-account-settings", AccountSettings);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,6 +1,6 @@
 import type { TemplateResult } from "lit";
 import { state } from "lit/decorators.js";
-import { msg, updateWhenLocaleChanges } from "@lit/localize";
+import { msg, localized } from "@lit/localize";
 
 import "./shoelace";
 import { LocalePicker } from "./components/locale-picker";
@@ -25,7 +25,7 @@ const ROUTES = {
   "archive-info-tab": "/archive/:aid/:tab",
 } as const;
 
-// ===========================================================================
+@localized()
 export class App extends LiteElement {
   router: APIRouter;
 
@@ -41,11 +41,6 @@ export class App extends LiteElement {
 
   constructor() {
     super();
-
-    // Note we use updateWhenLocaleChanges here so that we're always up to date with
-    // the active locale (the result of getLocale()) when the locale changes via a
-    // history navigation.
-    updateWhenLocaleChanges(this);
 
     const authState = window.localStorage.getItem("authState");
     if (authState) {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -4,6 +4,7 @@ import { msg, updateWhenLocaleChanges } from "@lit/localize";
 
 import "./shoelace";
 import { LocalePicker } from "./components/locale-picker";
+import { Alert } from "./components/alert";
 import { AccountSettings } from "./components/account-settings";
 import { LogInPage } from "./pages/log-in";
 import { MyAccountPage } from "./pages/my-account";
@@ -255,6 +256,7 @@ export class App extends LiteElement {
   }
 }
 
+customElements.define("btrix-alert", Alert);
 customElements.define("locale-picker", LocalePicker);
 customElements.define("browsertrix-app", App);
 customElements.define("log-in", LogInPage);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -221,13 +221,19 @@ export class App extends LiteElement {
     this.navigate("/");
   }
 
-  onLoggedIn(event: CustomEvent<{ auth: string; username: string }>) {
+  onLoggedIn(
+    event: CustomEvent<{ api?: boolean; auth: string; username: string }>
+  ) {
+    const { detail } = event;
     this.authState = {
-      username: event.detail.username,
-      headers: { Authorization: event.detail.auth },
+      username: detail.username,
+      headers: { Authorization: detail.auth },
     };
     window.localStorage.setItem("authState", JSON.stringify(this.authState));
-    this.navigate(ROUTES.myAccount);
+
+    if (!detail.api) {
+      this.navigate(ROUTES.myAccount);
+    }
   }
 
   onNeedLogin(event?: CustomEvent<{ api: boolean }>) {

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -10,10 +10,20 @@ export class LogInPage extends LiteElement {
   loginError?: string;
 
   render() {
+    let formError;
+
+    if (this.loginError) {
+      formError = html`
+        <div class="mb-5">
+          <bt-alert id="formError" type="danger">${this.loginError}</bt-alert>
+        </div>
+      `;
+    }
+
     return html`
       <div class="md:bg-white md:shadow-2xl md:rounded-lg md:px-12 md:py-12">
         <div class="max-w-md">
-          <sl-form @sl-submit="${this.onSubmit}">
+          <sl-form @sl-submit="${this.onSubmit}" aria-describedby="formError">
             <div class="mb-5">
               <sl-input
                 id="username"
@@ -35,6 +45,9 @@ export class LogInPage extends LiteElement {
               >
               </sl-input>
             </div>
+
+            ${formError}
+
             <sl-button
               class="w-full"
               type="primary"
@@ -43,8 +56,6 @@ export class LogInPage extends LiteElement {
               >Log in</sl-button
             >
           </sl-form>
-
-          <div id="login-error" class="text-danger">${this.loginError}</div>
         </div>
       </div>
     `;

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -44,7 +44,7 @@ export class LogInPage extends LiteElement {
             >
           </sl-form>
 
-          <div id="login-error" class="text-red-600">${this.loginError}</div>
+          <div id="login-error" class="text-danger">${this.loginError}</div>
         </div>
       </div>
     `;

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -1,7 +1,10 @@
 import { state, property } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
 import LiteElement, { html } from "../utils/LiteElement";
 import type { Auth } from "../types/auth";
 
+@localized()
 export class LogInPage extends LiteElement {
   @state()
   isLoggingIn: boolean = false;
@@ -28,8 +31,7 @@ export class LogInPage extends LiteElement {
               <sl-input
                 id="username"
                 name="username"
-                label="Username"
-                placeholder="Username"
+                label="${msg("Username")}"
                 required
               >
               </sl-input>
@@ -39,8 +41,7 @@ export class LogInPage extends LiteElement {
                 id="password"
                 name="password"
                 type="password"
-                label="Password"
-                placeholder="Password"
+                label="${msg("Password")}"
                 required
               >
               </sl-input>
@@ -53,7 +54,7 @@ export class LogInPage extends LiteElement {
               type="primary"
               ?loading=${this.isLoggingIn}
               submit
-              >Log in</sl-button
+              >${msg("Log in")}</sl-button
             >
           </sl-form>
         </div>
@@ -83,7 +84,7 @@ export class LogInPage extends LiteElement {
     });
     if (resp.status !== 200) {
       this.isLoggingIn = false;
-      this.loginError = "Sorry, invalid credentials";
+      this.loginError = msg("Sorry, invalid username or password");
       return;
     }
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -14,7 +14,11 @@ const primaryColor = Color(PRIMARY_COLOR);
 
 const theme = css`
   :root {
+    /* contextual variables */
     --primary: ${unsafeCSS(PRIMARY_COLOR)};
+    --success: var(--sl-color-success-600);
+    --warning: var(--sl-color-warning-600);
+    --danger: var(--sl-color-danger-600);
 
     /*
      * Theme Tokens

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -25,8 +25,20 @@ export default class LiteElement extends LitElement {
     );
   }
 
-  async apiFetch(path: string, auth: Auth) {
-    const resp = await fetch("/api" + path, { headers: auth.headers });
+  async apiFetch(
+    path: string,
+    auth: Auth,
+    options?: { method?: string; headers?: any; body?: any }
+  ) {
+    const { headers, ...opts } = options || {};
+    const resp = await fetch("/api" + path, {
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+        ...auth.headers,
+      },
+      ...opts,
+    });
 
     if (resp.status !== 200) {
       if (resp.status === 401) {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -24,6 +24,7 @@ function makeTheme() {
     colors: {
       ...colors.map(makeColorPalette),
       primary: `var(--primary)`,
+      danger: `var(--sl-color-danger-600)`,
     },
     fontFamily: {
       sans: `var(--sl-font-sans)`,

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -24,7 +24,9 @@ function makeTheme() {
     colors: {
       ...colors.map(makeColorPalette),
       primary: `var(--primary)`,
-      danger: `var(--sl-color-danger-600)`,
+      success: `var(--success)`,
+      warning: `var(--warning)`,
+      danger: `var(--danger)`,
     },
     fontFamily: {
       sans: `var(--sl-font-sans)`,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1041,6 +1041,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
   integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
 
+"@xstate/fsm@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.2.tgz#177a6920ba0d7d8522585641adc42ba59ecd9e36"
+  integrity sha512-vOfiFVQu9mQceA8oJ3PcA4vwhtyo/j/mbVDVIlHDOh3iuiTqMnp805zZ3QsouRdO2Ie3B7n3jMw8BntI74fZxg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
(https://github.com/ikreymer/browsertrix-cloud/issues/21) Users can change their own password from their account settings page.

### Testing
Pre-req: run `yarn` to install new dependencies
1. Start server with `yarn start-dev`
2. Log in
3. Go to http://localhost:9870/account/settings
4. Click "Change password" and try to change your password. Verify that new password/confirmation works, and that an incorrect password will show an error

### Screenshots

Account settings page:
<img width="913" alt="Screen Shot 2021-11-23 at 1 24 45 PM" src="https://user-images.githubusercontent.com/4672952/143131755-0905d672-5fc1-4e3b-a820-95ef5d042d63.png">

Form:
<img width="413" alt="Screen Shot 2021-11-23 at 1 25 37 PM" src="https://user-images.githubusercontent.com/4672952/143131773-0148732b-5b5a-4fc9-845d-b5ebdc2b0da7.png">

On password confirmation mismatch:
<img width="416" alt="Screen Shot 2021-11-23 at 1 25 03 PM" src="https://user-images.githubusercontent.com/4672952/143131809-a7c22950-0406-4db2-a109-61100ac410cd.png">

On wrong password:
<img width="413" alt="Screen Shot 2021-11-23 at 1 27 03 PM" src="https://user-images.githubusercontent.com/4672952/143131909-5d41b00d-f981-40d4-b1ce-194df7f27eaf.png">

On success:
<img width="929" alt="Screen Shot 2021-11-23 at 1 25 33 PM" src="https://user-images.githubusercontent.com/4672952/143131935-4c495cd0-72c5-4d56-879b-56101c626e68.png">

### Opinions

Uses an [xstate finite state machine](https://github.com/statelyai/xstate/tree/main/packages/xstate-fsm) for predictive handling of form states.