### PR TITLE
Misc backend fixes for cloud deployment

### DIFF
--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -66,7 +66,7 @@ class RawCrawlConfig(BaseModel):
     combineWARC: Optional[bool] = False
 
     logging: Optional[str] = ""
-    behaviors: Optional[str] = "autoscroll"
+    behaviors: Optional[str] = "autoscroll,autoplay,autofetch,siteSpecific"
 
 
 # ============================================================================

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -37,8 +37,8 @@ class K8SManager:
         self.namespace = namespace
         self._default_storage_endpoints = {}
 
-        self.crawler_image = os.environ.get("CRAWLER_IMAGE")
-        self.crawler_image_pull_policy = "IfNotPresent"
+        self.crawler_image = os.environ["CRAWLER_IMAGE"]
+        self.crawler_image_pull_policy = os.environ["CRAWLER_PULL_POLICY"]
 
         self.crawl_retries = int(os.environ.get("CRAWL_RETRIES", "3"))
 
@@ -643,7 +643,7 @@ class K8SManager:
                             {
                                 "name": "crawler",
                                 "image": self.crawler_image,
-                                "imagePullPolicy": "Never",
+                                "imagePullPolicy": self.crawler_image_pull_policy,
                                 "command": [
                                     "crawl",
                                     "--config",

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -19,6 +19,8 @@ data:
 
   REDIS_CRAWLS_DONE_KEY: "crawls-done"
 
+  NO_DELETE_JOBS: "{{ .Values.no_delete_jobs | default '0' }}"
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
 
   CRAWLER_NAMESPACE: {{ .Values.crawler_namespace }}
   CRAWLER_IMAGE: {{ .Values.crawler_image }}
+  CRAWLER_PULL_POLICY: {{ .Values.crawler_pull_policy }}
 
   CRAWL_TIMEOUT: "{{ .Values.crawl_timeout }}"
   CRAWL_RETRIES: "{{ .Values.crawl_retries }}"

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -29,8 +29,8 @@ spec:
   rules:
   - host: {{ .Values.ingress.host }}
     http:
-{{- if .Values.minio_local }}
       paths:
+{{- if .Values.minio_local }}
       - path: /data/(.*)
         pathType: Prefix
         backend:
@@ -51,7 +51,7 @@ spec:
 {{ if .Values.ingress.tls }}
 ---
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: cert-main

--- a/chart/templates/main.yaml
+++ b/chart/templates/main.yaml
@@ -31,8 +31,8 @@ spec:
         - name: nginx-resolver
           emptyDir: {}
 
-{{- if .Values.minio_local }}
       initContainers:
+{{- if .Values.minio_local }}
         - name: init-bucket
           image: {{ .Values.minio_mc_image }}
           imagePullPolicy: {{ .Values.minio_pull_policy }}
@@ -44,7 +44,7 @@ spec:
                   key: MC_HOST
 
           command: ['/bin/sh']
-          args: ['-c', 'mc mb local/test-bucket; mc policy set public local/test-bucket' ]
+          args: ['-c', 'mc mb --ignore-existing local/{{ .Values.minio_local_bucket_name }}' ]
 {{- end }}
 
         - name: init-nginx

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -31,7 +31,13 @@ type: Opaque
 stringData:
   STORE_ACCESS_KEY: "{{ $storage.access_key }}"
   STORE_SECRET_KEY: "{{ $storage.secret_key }}"
-  STORE_ENDPOINT_URL: "{{ $storage.endpoint_url }}{{ $storage.bucket_name }}/"
+
+  {{- if $storage.bucket_name }}
+  STORE_ENDPOINT_URL: "{{ $storage.endpoint_url }}{{ $storage.bucket_name }}"
+  {{- else }}
+  STORE_ENDPOINT_URL: "{{ $storage.endpoint_url }}"
+  {{- end }}
+
   {{- if and $.Values.ingress.host $.Values.minio_local }}
   STORE_ACCESS_ENDPOINT_URL: {{ $.Values.ingress.scheme | default "https" }}://{{ $.Values.ingress.host }}/data/{{ $storage.bucket_name }}/
   {{- end }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -38,8 +38,12 @@ stringData:
   STORE_ENDPOINT_URL: "{{ $storage.endpoint_url }}"
   {{- end }}
 
-  {{- if and $.Values.ingress.host $.Values.minio_local }}
+  {{- if $storage.access_endpoint_url }}
+  STORE_ACCESS_ENDPOINT_URL: "{{ $storage.access_endpoint_url }}"
+  {{- else if and $.Values.ingress.host $.Values.minio_local }}
   STORE_ACCESS_ENDPOINT_URL: {{ $.Values.ingress.scheme | default "https" }}://{{ $.Values.ingress.host }}/data/{{ $storage.bucket_name }}/
+  {{- else }}
+  STORE_ACCESS_ENDPOINT_URL: "{{ $storage.endpoint_url }}"
   {{- end }}
 
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -57,7 +57,7 @@ redis_url: "redis://local-redis.default:6379/1"
 # =========================================
 
 crawler_image: "webrecorder/browsertrix-crawler:latest"
-crawler_pull_policy: "Never"
+crawler_pull_policy: "IfNotPresent"
 
 crawler_namespace: "crawlers"
 
@@ -66,19 +66,6 @@ crawl_retries: 1
 
 # browsertrix-crawler args:
 crawler_args: "--timeout 90 --logging stats,behaviors,debug --generateWACZ --screencastPort 9037"
-
-
-
-# Storage
-# =========================================
-
-storages:
-  - name: "default"
-    access_key: "ADMIN"
-    secret_key: "PASSW0RD"
-    bucket_name: "test-bucket"
-
-    endpoint_url: "http://local-minio.default:9000/"
 
 
 # Local Minio Pod (optional)
@@ -92,6 +79,21 @@ minio_host: "local-minio.default:9000"
 minio_image: minio/minio
 minio_mc_image: minio/mc
 minio_pull_policy: "IfNotPresent"
+
+minio_local_bucket_name: &local_bucket_name "test-bucket"
+
+
+# Storage
+# =========================================
+# should include the local minio bucket, if enabled, and any other available buckets for default storage
+
+storages:
+  - name: "default"
+    access_key: "ADMIN"
+    secret_key: "PASSW0RD"
+    bucket_name: *local_bucket_name
+
+    endpoint_url: "http://local-minio.default:9000/"
 
 
 # Deployment options

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   backend:
     build: ./backend
-    image: webrecorder/browsertrix-api
+    image: registry.digitalocean.com/btrix/webrecorder/browsertrix-api
     ports:
       - 8000:8000
 


### PR DESCRIPTION
- k8s crawler image pull policy: use crawler_image_pull_policy setting from values (via env var)
- crawl config: run all behaviors by default
- debugging: add a 'no_delete_jobs' option to avoid deleting failed manual jobs, to allow for debugging
- support custom storage access endpoint for k8s
- minio: fix running without local minio
- minio: don't error if bucket already exists
- fix running certmanager for ingress (todo: need to add to chart)