### PR TITLE
Frontend forgot/reset password flow

### DIFF
--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -186,6 +186,7 @@ export class AccountSettings extends LiteElement {
             label="${msg("Current password")}"
             aria-describedby="passwordError"
             autocomplete="current-password"
+            toggle-password
             required
           >
           </sl-input>

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -100,7 +100,7 @@ const machine = createMachine<FormContext, FormEvent, FormTypestate>(
 export class AccountSettings extends LiteElement {
   authState?: AuthState;
 
-  private _stateService = interpret(machine);
+  private formStateService = interpret(machine);
 
   @state()
   private formState = machine.initialState;
@@ -112,15 +112,15 @@ export class AccountSettings extends LiteElement {
   private confirmNewPasswordInput?: HTMLInputElement;
 
   firstUpdated() {
-    this._stateService.subscribe((state) => {
+    this.formStateService.subscribe((state) => {
       this.formState = state;
     });
 
-    this._stateService.start();
+    this.formStateService.start();
   }
 
   disconnectedCallback() {
-    this._stateService.stop();
+    this.formStateService.stop();
   }
 
   checkPasswordMatch() {
@@ -170,7 +170,7 @@ export class AccountSettings extends LiteElement {
                 <sl-button
                   type="primary"
                   outline
-                  @click=${() => this._stateService.send("EDIT")}
+                  @click=${() => this.formStateService.send("EDIT")}
                   >${msg("Change password")}</sl-button
                 >
               </div>
@@ -247,7 +247,7 @@ export class AccountSettings extends LiteElement {
           >
           <sl-button
             type="text"
-            @click=${() => this._stateService.send("CANCEL")}
+            @click=${() => this.formStateService.send("CANCEL")}
             >${msg("Cancel")}</sl-button
           >
         </div>
@@ -258,7 +258,7 @@ export class AccountSettings extends LiteElement {
   async onSubmit(event: { detail: { formData: FormData } }) {
     if (!this.authState) return;
 
-    this._stateService.send("SUBMIT");
+    this.formStateService.send("SUBMIT");
 
     const { formData } = event.detail;
     let nextAuthState: AuthState = null;
@@ -300,7 +300,7 @@ export class AccountSettings extends LiteElement {
     }
 
     if (!nextAuthState) {
-      this._stateService.send({
+      this.formStateService.send({
         type: "ERROR",
         detail: {
           fieldErrors: {
@@ -321,7 +321,7 @@ export class AccountSettings extends LiteElement {
         body: JSON.stringify(params),
       });
 
-      this._stateService.send({
+      this.formStateService.send({
         type: "SUCCESS",
         detail: {
           successMessage: "Successfully updated password",
@@ -330,7 +330,7 @@ export class AccountSettings extends LiteElement {
     } catch (e) {
       console.error(e);
 
-      this._stateService.send({
+      this.formStateService.send({
         type: "ERROR",
         detail: {
           serverError: msg("Something went wrong changing password"),

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -105,12 +105,6 @@ export class AccountSettings extends LiteElement {
   @state()
   private formState = machine.initialState;
 
-  @query("#newPassword")
-  private newPasswordInput?: HTMLInputElement;
-
-  @query("#confirmNewPassword")
-  private confirmNewPasswordInput?: HTMLInputElement;
-
   firstUpdated() {
     this.formStateService.subscribe((state) => {
       this.formState = state;
@@ -121,19 +115,6 @@ export class AccountSettings extends LiteElement {
 
   disconnectedCallback() {
     this.formStateService.stop();
-  }
-
-  checkPasswordMatch() {
-    const newPassword = this.newPasswordInput!.value;
-    const confirmNewPassword = this.confirmNewPasswordInput!.value;
-
-    if (newPassword === confirmNewPassword) {
-      this.confirmNewPasswordInput!.setCustomValidity("");
-    } else {
-      this.confirmNewPasswordInput!.setCustomValidity(
-        msg("Passwords don't match")
-      );
-    }
   }
 
   render() {
@@ -204,6 +185,7 @@ export class AccountSettings extends LiteElement {
             type="password"
             label="${msg("Current password")}"
             aria-describedby="passwordError"
+            autocomplete="current-password"
             required
           >
           </sl-input>
@@ -219,19 +201,9 @@ export class AccountSettings extends LiteElement {
             name="newPassword"
             type="password"
             label="${msg("New password")}"
+            autocomplete="new-password"
+            toggle-password
             required
-            @sl-blur=${this.checkPasswordMatch}
-          >
-          </sl-input>
-        </div>
-        <div class="mb-5">
-          <sl-input
-            id="confirmNewPassword"
-            name="confirmNewPassword"
-            type="password"
-            label="${msg("Confirm new password")}"
-            required
-            @sl-blur=${this.checkPasswordMatch}
           >
           </sl-input>
         </div>

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -7,6 +7,7 @@ import { LocalePicker } from "./components/locale-picker";
 import { Alert } from "./components/alert";
 import { AccountSettings } from "./components/account-settings";
 import { LogInPage } from "./pages/log-in";
+import { ResetPassword } from "./pages/reset-password";
 import { MyAccountPage } from "./pages/my-account";
 import { ArchivePage } from "./pages/archive-info";
 import { ArchiveConfigsPage } from "./pages/archive-info-tab";
@@ -20,6 +21,7 @@ const ROUTES = {
   home: "/",
   login: "/log-in",
   forgotPassword: "/log-in/forgot-password",
+  resetPassword: "/reset-password?token",
   myAccount: "/my-account",
   accountSettings: "/account/settings",
   "archive-info": "/archive/:aid",
@@ -175,6 +177,14 @@ export class App extends LiteElement {
           .viewState=${this.viewState}
         ></log-in>`;
 
+      case "resetPassword":
+        return html`<btrix-reset-password
+          class="w-full md:bg-gray-100 flex items-center justify-center"
+          @navigate=${this.onNavigateTo}
+          @logged-in=${this.onLoggedIn}
+          .authState=${this.authState}
+        ></btrix-reset-password>`;
+
       case "home":
         return html`<div class="w-full flex items-center justify-center">
           <sl-button
@@ -265,3 +275,4 @@ customElements.define("my-account", MyAccountPage);
 customElements.define("btrix-archive", ArchivePage);
 customElements.define("btrix-archive-configs", ArchiveConfigsPage);
 customElements.define("btrix-account-settings", AccountSettings);
+customElements.define("btrix-reset-password", ResetPassword);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -19,6 +19,7 @@ import theme from "./theme";
 const ROUTES = {
   home: "/",
   login: "/log-in",
+  forgotPassword: "/log-in/forgot-password",
   myAccount: "/my-account",
   accountSettings: "/account/settings",
   "archive-info": "/archive/:aid",
@@ -165,11 +166,13 @@ export class App extends LiteElement {
 
     switch (this.viewState.route) {
       case "login":
+      case "forgotPassword":
         return html`<log-in
           class="w-full md:bg-gray-100 flex items-center justify-center"
-          @navigate="${this.onNavigateTo}"
-          @logged-in="${this.onLoggedIn}"
-          .authState="${this.authState}"
+          @navigate=${this.onNavigateTo}
+          @logged-in=${this.onLoggedIn}
+          .authState=${this.authState}
+          .viewState=${this.viewState}
         ></log-in>`;
 
       case "home":

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -30,7 +30,7 @@ const ROUTES = {
 
 @localized()
 export class App extends LiteElement {
-  private router: APIRouter;
+  private router: APIRouter = new APIRouter(ROUTES);
 
   @state()
   authState: AuthState | null = null;
@@ -48,9 +48,21 @@ export class App extends LiteElement {
     const authState = window.localStorage.getItem("authState");
     if (authState) {
       this.authState = JSON.parse(authState);
+
+      if (
+        window.location.pathname === "/log-in" ||
+        window.location.pathname === "/reset-password"
+      ) {
+        // Redirect to logged in home page
+        this.viewState = this.router.match(ROUTES.myAccount);
+        window.history.replaceState(
+          this.viewState,
+          "",
+          this.viewState.pathname
+        );
+      }
     }
 
-    this.router = new APIRouter(ROUTES);
     this.syncViewState();
   }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -30,7 +30,7 @@ const ROUTES = {
 
 @localized()
 export class App extends LiteElement {
-  router: APIRouter;
+  private router: APIRouter;
 
   @state()
   authState: AuthState | null = null;
@@ -183,6 +183,7 @@ export class App extends LiteElement {
           @navigate=${this.onNavigateTo}
           @logged-in=${this.onLoggedIn}
           .authState=${this.authState}
+          .viewState=${this.viewState}
         ></btrix-reset-password>`;
 
       case "home":

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -144,7 +144,7 @@ export class LogInPage extends LiteElement {
 
   updated(changedProperties: any) {
     if (changedProperties.has("viewState")) {
-      const route = this.viewState._route;
+      const route = this.viewState.route;
 
       if (route === "login") {
         this.formStateService.send("SHOW_SIGN_IN_WITH_PASSWORD");

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -221,9 +221,10 @@ export class LogInPage extends LiteElement {
       <sl-form @sl-submit="${this.onSubmitLogIn}" aria-describedby="formError">
         <div class="mb-5">
           <sl-input
-            id="username"
+            id="email"
             name="username"
-            label="${msg("Username")}"
+            type="email"
+            label="${msg("Email")}"
             required
           >
           </sl-input>

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -225,6 +225,7 @@ export class LogInPage extends LiteElement {
             name="username"
             type="email"
             label="${msg("Email")}"
+            autocomplete="username"
             required
           >
           </sl-input>
@@ -235,6 +236,7 @@ export class LogInPage extends LiteElement {
             name="password"
             type="password"
             label="${msg("Password")}"
+            autocomplete="current-password"
             required
           >
           </sl-input>

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -329,9 +329,11 @@ export class LogInPage extends LiteElement {
       if (data.token_type === "bearer" && data.access_token) {
         const auth = "Bearer " + data.access_token;
         const detail = { auth, username };
+
         this.dispatchEvent(new CustomEvent("logged-in", { detail }));
 
-        this.formStateService.send("SUCCESS");
+        // no state update here, since "logged-in" event
+        // will result in a route change
       } else {
         throw new Error("Unknown auth type");
       }

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -2,8 +2,8 @@ import { state, property } from "lit/decorators.js";
 import { msg, localized } from "@lit/localize";
 import { createMachine, interpret, assign } from "@xstate/fsm";
 
+import type { ViewState } from "../utils/APIRouter";
 import LiteElement, { html } from "../utils/LiteElement";
-import type { Auth } from "../types/auth";
 
 type FormContext = {
   successMessage?: string;
@@ -22,8 +22,8 @@ type FormErrorEvent = {
   };
 };
 type FormEvent =
-  | { type: "CLICK_FORGOT_PASSWORD" }
-  | { type: "CANCEL" }
+  | { type: "SHOW_SIGN_IN_WITH_PASSWORD" }
+  | { type: "SHOW_FORGOT_PASSWORD" }
   | { type: "SUBMIT" }
   | FormSuccessEvent
   | FormErrorEvent;
@@ -60,11 +60,14 @@ const machine = createMachine<FormContext, FormEvent, FormTypestate>(
     states: {
       ["signIn"]: {
         on: {
-          CLICK_FORGOT_PASSWORD: {
+          SHOW_FORGOT_PASSWORD: {
             target: "forgotPassword",
             actions: "reset",
           },
-          SUBMIT: "signingIn",
+          SUBMIT: {
+            target: "signingIn",
+            actions: "reset",
+          },
         },
       },
       ["signingIn"]: {
@@ -77,7 +80,16 @@ const machine = createMachine<FormContext, FormEvent, FormTypestate>(
         },
       },
       ["forgotPassword"]: {
-        on: { CANCEL: "signIn", SUBMIT: "submittingForgotPassword" },
+        on: {
+          SHOW_SIGN_IN_WITH_PASSWORD: {
+            target: "signIn",
+            actions: "reset",
+          },
+          SUBMIT: {
+            target: "submittingForgotPassword",
+            actions: "reset",
+          },
+        },
       },
       ["submittingForgotPassword"]: {
         on: {
@@ -110,6 +122,9 @@ const machine = createMachine<FormContext, FormEvent, FormTypestate>(
 
 @localized()
 export class LogInPage extends LiteElement {
+  @property({ type: Object })
+  viewState!: ViewState;
+
   private formStateService = interpret(machine);
 
   @state()
@@ -127,7 +142,69 @@ export class LogInPage extends LiteElement {
     this.formStateService.stop();
   }
 
+  updated(changedProperties: any) {
+    if (changedProperties.has("viewState")) {
+      const route = this.viewState._route;
+
+      if (route === "login") {
+        this.formStateService.send("SHOW_SIGN_IN_WITH_PASSWORD");
+      } else if (route === "forgotPassword") {
+        this.formStateService.send("SHOW_FORGOT_PASSWORD");
+      }
+    }
+  }
+
   render() {
+    let form, link, successMessage;
+
+    if (
+      this.formState.value === "forgotPassword" ||
+      this.formState.value === "submittingForgotPassword"
+    ) {
+      form = this.renderForgotPasswordForm();
+      link = html`
+        <a
+          class="text-sm text-gray-400 hover:text-gray-500"
+          href="/log-in"
+          @click=${this.navLink}
+          >${msg("Sign in with password")}</a
+        >
+      `;
+    } else {
+      form = this.renderLoginForm();
+      link = html`
+        <a
+          class="text-sm text-gray-400 hover:text-gray-500"
+          href="/log-in/forgot-password"
+          @click=${this.navLink}
+          >${msg("Forgot your password?")}</a
+        >
+      `;
+    }
+
+    if (this.formState.context.successMessage) {
+      successMessage = html`
+        <div>
+          <bt-alert type="success"
+            >${this.formState.context.successMessage}</bt-alert
+          >
+        </div>
+      `;
+    }
+
+    return html`
+      <article class="w-full max-w-sm grid gap-5">
+        ${successMessage}
+
+        <main class="md:bg-white md:shadow-xl md:rounded-lg md:px-12 md:py-12">
+          <div>${form}</div>
+        </main>
+        <footer class="text-center">${link}</footer>
+      </article>
+    `;
+  }
+
+  private renderLoginForm() {
     let formError;
 
     if (this.formState.context.serverError) {
@@ -141,49 +218,86 @@ export class LogInPage extends LiteElement {
     }
 
     return html`
-      <div class="md:bg-white md:shadow-2xl md:rounded-lg md:px-12 md:py-12">
-        <div class="max-w-md">
-          <sl-form @sl-submit="${this.onSubmit}" aria-describedby="formError">
-            <div class="mb-5">
-              <sl-input
-                id="username"
-                name="username"
-                label="${msg("Username")}"
-                required
-              >
-              </sl-input>
-            </div>
-            <div class="mb-5">
-              <sl-input
-                id="password"
-                name="password"
-                type="password"
-                label="${msg("Password")}"
-                required
-              >
-              </sl-input>
-            </div>
-
-            ${formError}
-
-            <sl-button
-              class="w-full"
-              type="primary"
-              ?loading=${this.formState.value === "signingIn"}
-              submit
-              >${msg("Log in")}</sl-button
-            >
-          </sl-form>
+      <sl-form @sl-submit="${this.onSubmitLogIn}" aria-describedby="formError">
+        <div class="mb-5">
+          <sl-input
+            id="username"
+            name="username"
+            label="${msg("Username")}"
+            required
+          >
+          </sl-input>
         </div>
-      </div>
+        <div class="mb-5">
+          <sl-input
+            id="password"
+            name="password"
+            type="password"
+            label="${msg("Password")}"
+            required
+          >
+          </sl-input>
+        </div>
+
+        ${formError}
+
+        <sl-button
+          class="w-full"
+          type="primary"
+          ?loading=${this.formState.value === "signingIn"}
+          submit
+          >${msg("Log in")}</sl-button
+        >
+      </sl-form>
     `;
   }
 
-  async onSubmit(event: { detail: { formData: FormData } }) {
+  private renderForgotPasswordForm() {
+    let formError;
+
+    if (this.formState.context.serverError) {
+      formError = html`
+        <div class="mb-5">
+          <bt-alert id="formError" type="danger"
+            >${this.formState.context.serverError}</bt-alert
+          >
+        </div>
+      `;
+    }
+
+    return html`
+      <sl-form
+        @sl-submit="${this.onSubmitResetPassword}"
+        aria-describedby="formError"
+      >
+        <div class="mb-5">
+          <sl-input
+            id="email"
+            name="email"
+            type="email"
+            label="${msg("Your email address")}"
+            required
+          >
+          </sl-input>
+        </div>
+
+        ${formError}
+
+        <sl-button
+          class="w-full"
+          type="primary"
+          ?loading=${this.formState.value === "submittingForgotPassword"}
+          submit
+          >${msg("Request password reset")}</sl-button
+        >
+      </sl-form>
+    `;
+  }
+
+  async onSubmitLogIn(event: { detail: { formData: FormData } }) {
     this.formStateService.send("SUBMIT");
 
     const { formData } = event.detail;
-
     const username = formData.get("username") as string;
     const password = formData.get("password") as string;
 
@@ -227,6 +341,46 @@ export class LogInPage extends LiteElement {
         type: "ERROR",
         detail: {
           serverError: msg("Something went wrong, couldn't sign you in"),
+        },
+      });
+    }
+  }
+
+  async onSubmitResetPassword(event: { detail: { formData: FormData } }) {
+    this.formStateService.send("SUBMIT");
+
+    const { formData } = event.detail;
+    const email = formData.get("email") as string;
+
+    const resp = await fetch("/api/auth/forgot-password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email }),
+    });
+
+    if (resp.status === 202) {
+      this.formStateService.send({
+        type: "SUCCESS",
+        detail: {
+          successMessage: msg(
+            "Successfully received your request. You will receive an email to reset your password if your email is found in our system."
+          ),
+        },
+      });
+    } else if (resp.status === 422) {
+      this.formStateService.send({
+        type: "ERROR",
+        detail: {
+          serverError: msg("That email is not a valid email address"),
+        },
+      });
+    } else {
+      this.formStateService.send({
+        type: "ERROR",
+        detail: {
+          serverError: msg("Something unexpected went wrong"),
         },
       });
     }

--- a/frontend/src/pages/reset-password.ts
+++ b/frontend/src/pages/reset-password.ts
@@ -36,6 +36,8 @@ export class ResetPassword extends LiteElement {
                 name="password"
                 type="password"
                 label="${msg("New password")}"
+                autocomplete="new-password"
+                toggle-password
                 required
               >
               </sl-input>

--- a/frontend/src/pages/reset-password.ts
+++ b/frontend/src/pages/reset-password.ts
@@ -1,0 +1,80 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
+import LiteElement, { html } from "../utils/LiteElement";
+
+@localized()
+export class ResetPassword extends LiteElement {
+  @state()
+  private serverError?: string;
+
+  @state()
+  private isSubmitting: boolean = false;
+
+  render() {
+    let formError;
+
+    if (this.serverError) {
+      formError = html`
+        <div class="mb-5">
+          <bt-alert id="formError" type="danger">${this.serverError}</bt-alert>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="w-full max-w-sm grid gap-5">
+        <div class="md:bg-white md:shadow-xl md:rounded-lg md:px-12 md:py-12">
+          <sl-form @sl-submit="${this.onSubmit}" aria-describedby="formError">
+            <div class="mb-5">
+              <sl-input
+                id="password"
+                name="password"
+                type="password"
+                label="${msg("New password")}"
+                required
+              >
+              </sl-input>
+            </div>
+
+            ${formError}
+
+            <sl-button
+              class="w-full"
+              type="primary"
+              ?loading=${this.isSubmitting}
+              submit
+              >${msg("Change password")}</sl-button
+            >
+          </sl-form>
+        </div>
+      </div>
+    `;
+  }
+
+  async onSubmit(event: { detail: { formData: FormData } }) {
+    this.isSubmitting = true;
+
+    const { formData } = event.detail;
+    const password = formData.get("password") as string;
+
+    const resp = await fetch("/api/auth/reset-password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ token: "TODO", password }),
+    });
+
+    if (resp.status === 200) {
+      // TODO redirect
+    } else if (resp.status === 422) {
+      // TODO password validation details
+      this.serverError = msg("Invalid password");
+    } else {
+      this.serverError = msg("Something unexpected went wrong");
+    }
+
+    this.isSubmitting = false;
+  }
+}


### PR DESCRIPTION
Allows users to request a password reset email. Will need to redo manual testing once backend is updated to send emails. The URL to direct users right now is `/reset-password?token={reset token}` but that can be easily changed @ikreymer 

(note: https://github.com/ikreymer/browsertrix-cloud/pull/29 needs to merged in before this branch)

### Manual testing

1. Run with `yarn start-dev`
2. Log out if already logged in, go to http://localhost:9870/log-in/forgot-password
3. Enter in email to reset password. Verify success message shows on submit
4. Go to http://localhost:9870/reset-password?token=something and enter anything into the password field. Verify that server error is returned, since the token is not valid

### Screenshots

Login page updated with "forgot password" link
<img width="890" alt="Screen Shot 2021-11-23 at 8 20 12 PM" src="https://user-images.githubusercontent.com/4672952/143174802-00383f51-64d2-4a3d-8dff-09157dd51134.png">

Forgot password form
<img width="419" alt="Screen Shot 2021-11-24 at 10 23 28 AM" src="https://user-images.githubusercontent.com/4672952/143294106-ca5d06bf-17a6-4f2d-b8d9-1f1c5a5a2e15.png">

Success message on form submission
<img width="890" alt="Screen Shot 2021-11-23 at 8 20 36 PM" src="https://user-images.githubusercontent.com/4672952/143174874-ac9c71b0-8d15-4772-ba24-e898088b4c8d.png">

Change password form
<img width="890" alt="Screen Shot 2021-11-23 at 8 20 50 PM" src="https://user-images.githubusercontent.com/4672952/143174900-7f627860-889e-4458-8917-41060bc9e2cd.png">

Change password error
<img width="890" alt="Screen Shot 2021-11-23 at 8 20 57 PM" src="https://user-images.githubusercontent.com/4672952/143174927-ac14e30c-bbc7-4fdf-9682-4f3a0103a4b3.png">
