### PR TITLE
Frontend verification UX fixes

### DIFF
--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -40,7 +40,9 @@ class RequestVerify extends LitElement {
         ?disabled=${this.isRequesting}
         @click=${this.requestVerification}
       >
-        ${msg("Resend verification email")}
+        ${this.isRequesting
+          ? msg("Sending...")
+          : msg("Resend verification email")}
       </span>
     `;
   }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -231,6 +231,8 @@ export class App extends LiteElement {
           class="w-full flex items-center justify-center"
           token="${this.viewState.params.token}"
           @navigate="${this.onNavigateTo}"
+          @log-out="${this.onLogOut}"
+          .authState="${this.authState}"
         ></btrix-verify>`;
 
       case "login":

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -32,6 +32,13 @@ const ROUTES = {
   "archive-info-tab": "/archive/:aid/:tab",
 } as const;
 
+/**
+ * @event navigate
+ * @event need-login
+ * @event logged-in
+ * @event log-out
+ * @event user-info-change
+ */
 @localized()
 export class App extends LiteElement {
   private router: APIRouter = new APIRouter(ROUTES);
@@ -232,6 +239,7 @@ export class App extends LiteElement {
           token="${this.viewState.params.token}"
           @navigate="${this.onNavigateTo}"
           @log-out="${this.onLogOut}"
+          @user-info-change="${this.onUserInfoChange}"
           .authState="${this.authState}"
         ></btrix-verify>`;
 
@@ -335,6 +343,14 @@ export class App extends LiteElement {
 
   onNavigateTo(event: NavigateEvent) {
     this.navigate(event.detail);
+  }
+
+  onUserInfoChange(event: CustomEvent<Partial<CurrentUser>>) {
+    // @ts-ignore
+    this.userInfo = {
+      ...this.userInfo,
+      ...event.detail,
+    };
   }
 
   clearAuthState() {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -358,7 +358,7 @@ export class App extends LiteElement {
   onNotify(
     event: CustomEvent<{
       message: TemplateResult | string;
-      type?: string;
+      type?: "success" | "warning" | "danger" | "primary";
       icon?: string;
       duration?: number;
     }>
@@ -380,6 +380,12 @@ export class App extends LiteElement {
       type: type,
       closable: true,
       duration: duration,
+      style: [
+        "--sl-panel-background-color: var(--sl-color-neutral-1000)",
+        "--sl-color-neutral-700: var(--sl-color-neutral-0)",
+        // "--sl-panel-border-width: 0px",
+        "--sl-spacing-large: var(--sl-spacing-medium)",
+      ].join(";"),
       innerHTML: `
         <sl-icon name="${icon}" slot="icon"></sl-icon>
         ${escapeHtml(message)}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -34,6 +34,7 @@ const ROUTES = {
 
 /**
  * @event navigate
+ * @event notify
  * @event need-login
  * @event logged-in
  * @event log-out
@@ -238,6 +239,7 @@ export class App extends LiteElement {
           class="w-full flex items-center justify-center"
           token="${this.viewState.params.token}"
           @navigate="${this.onNavigateTo}"
+          @notify="${this.onNotify}"
           @log-out="${this.onLogOut}"
           @user-info-change="${this.onUserInfoChange}"
           .authState="${this.authState}"
@@ -351,6 +353,41 @@ export class App extends LiteElement {
       ...this.userInfo,
       ...event.detail,
     };
+  }
+
+  onNotify(
+    event: CustomEvent<{
+      message: TemplateResult | string;
+      type?: string;
+      icon?: string;
+      duration?: number;
+    }>
+  ) {
+    const {
+      message,
+      type = "primary",
+      icon = "info-circle",
+      duration = 4000,
+    } = event.detail;
+
+    const escapeHtml = (html: any) => {
+      const div = document.createElement("div");
+      div.textContent = html;
+      return div.innerHTML;
+    };
+
+    const alert = Object.assign(document.createElement("sl-alert"), {
+      type: type,
+      closable: true,
+      duration: duration,
+      innerHTML: `
+        <sl-icon name="${icon}" slot="icon"></sl-icon>
+        ${escapeHtml(message)}
+      `,
+    });
+
+    document.body.append(alert);
+    alert.toast();
   }
 
   clearAuthState() {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -230,6 +230,7 @@ export class App extends LiteElement {
         return html`<btrix-verify
           class="w-full flex items-center justify-center"
           token="${this.viewState.params.token}"
+          @navigate="${this.onNavigateTo}"
         ></btrix-verify>`;
 
       case "login":

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -357,17 +357,19 @@ export class App extends LiteElement {
 
   onNotify(
     event: CustomEvent<{
-      message: TemplateResult | string;
+      title?: string;
+      message?: string;
       type?: "success" | "warning" | "danger" | "primary";
       icon?: string;
       duration?: number;
     }>
   ) {
     const {
+      title,
       message,
       type = "primary",
       icon = "info-circle",
-      duration = 4000,
+      duration = 5000,
     } = event.detail;
 
     const escapeHtml = (html: any) => {
@@ -388,7 +390,11 @@ export class App extends LiteElement {
       ].join(";"),
       innerHTML: `
         <sl-icon name="${icon}" slot="icon"></sl-icon>
-        ${escapeHtml(message)}
+        <span>
+          ${title ? `<strong>${escapeHtml(title)}</strong>` : ""}
+          ${message ? `<div>${escapeHtml(message)}</div>` : ""}
+        </span>
+
       `,
     });
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -308,8 +308,8 @@ export class App extends LiteElement {
     }
   }
 
-  onLogOut(event: CustomEvent<{ redirect?: boolean }>) {
-    const { detail } = event;
+  onLogOut(event: CustomEvent<{ redirect?: boolean } | null>) {
+    const detail = event.detail || {};
     const redirect = detail.redirect !== false;
 
     this.clearAuthState();

--- a/frontend/src/pages/verify.ts
+++ b/frontend/src/pages/verify.ts
@@ -58,10 +58,20 @@ export class Verify extends LiteElement {
     }
   }
 
-  private onVerificationComplete(data: { email: string }) {
+  private onVerificationComplete(data: {
+    email: string;
+    is_verified: boolean;
+  }) {
     if (this.authState && this.authState.username !== data.email) {
       this.dispatchEvent(new CustomEvent("log-out"));
     } else {
+      this.dispatchEvent(
+        new CustomEvent("user-info-change", {
+          detail: {
+            isVerified: data.is_verified,
+          },
+        })
+      );
       this.navTo("/log-in");
     }
   }

--- a/frontend/src/pages/verify.ts
+++ b/frontend/src/pages/verify.ts
@@ -62,6 +62,16 @@ export class Verify extends LiteElement {
     email: string;
     is_verified: boolean;
   }) {
+    this.dispatchEvent(
+      new CustomEvent("notify", {
+        detail: {
+          message: msg("Email address verified"),
+          type: "success",
+          icon: "check2-circle",
+        },
+      })
+    );
+
     if (this.authState && this.authState.username !== data.email) {
       this.dispatchEvent(new CustomEvent("log-out"));
     } else {

--- a/frontend/src/pages/verify.ts
+++ b/frontend/src/pages/verify.ts
@@ -43,6 +43,11 @@ export class Verify extends LiteElement {
           this.serverError = msg("This verification email is not valid.");
           break;
         }
+
+        if (detail === "VERIFY_USER_ALREADY_VERIFIED") {
+          this.navTo("/log-in");
+          break;
+        }
       default:
         this.serverError = msg("Something unexpected went wrong");
         break;

--- a/frontend/src/pages/verify.ts
+++ b/frontend/src/pages/verify.ts
@@ -62,17 +62,21 @@ export class Verify extends LiteElement {
     email: string;
     is_verified: boolean;
   }) {
+    const isLoggedIn = this.authState && this.authState.username !== data.email;
+
     this.dispatchEvent(
       new CustomEvent("notify", {
         detail: {
-          message: msg("Email address verified"),
+          title: msg("Email address verified"),
+          message: isLoggedIn ? "" : msg("Log in to continue."),
           type: "success",
           icon: "check2-circle",
+          duration: 10000,
         },
       })
     );
 
-    if (this.authState && this.authState.username !== data.email) {
+    if (isLoggedIn) {
       this.dispatchEvent(new CustomEvent("log-out"));
     } else {
       this.dispatchEvent(

--- a/frontend/src/pages/verify.ts
+++ b/frontend/src/pages/verify.ts
@@ -62,13 +62,15 @@ export class Verify extends LiteElement {
     email: string;
     is_verified: boolean;
   }) {
-    const isLoggedIn = this.authState && this.authState.username !== data.email;
+    const isLoggedIn = Boolean(this.authState);
+    const shouldLogOut = isLoggedIn && this.authState?.username !== data.email;
 
     this.dispatchEvent(
       new CustomEvent("notify", {
         detail: {
           title: msg("Email address verified"),
-          message: isLoggedIn ? "" : msg("Log in to continue."),
+          message:
+            isLoggedIn && !shouldLogOut ? "" : msg("Log in to continue."),
           type: "success",
           icon: "check2-circle",
           duration: 10000,
@@ -76,16 +78,19 @@ export class Verify extends LiteElement {
       })
     );
 
-    if (isLoggedIn) {
+    if (shouldLogOut) {
       this.dispatchEvent(new CustomEvent("log-out"));
     } else {
-      this.dispatchEvent(
-        new CustomEvent("user-info-change", {
-          detail: {
-            isVerified: data.is_verified,
-          },
-        })
-      );
+      if (isLoggedIn) {
+        this.dispatchEvent(
+          new CustomEvent("user-info-change", {
+            detail: {
+              isVerified: data.is_verified,
+            },
+          })
+        );
+      }
+
       this.navTo("/log-in");
     }
   }

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -4,6 +4,7 @@
  */
 import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
 import "@shoelace-style/shoelace/dist/themes/light.css";
+import "@shoelace-style/shoelace/dist/components/alert/alert";
 import "@shoelace-style/shoelace/dist/components/button/button";
 import "@shoelace-style/shoelace/dist/components/form/form";
 import "@shoelace-style/shoelace/dist/components/icon/icon";

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -50,6 +50,11 @@ const theme = css`
     --sl-input-label-font-size-medium: var(--sl-font-size-small);
     --sl-input-label-font-size-large: var(--sl-font-size-medium);
   }
+
+  .sl-toast-stack {
+    bottom: 0;
+    top: auto;
+  }
 `;
 
 export default theme;


### PR DESCRIPTION
Changes:
- Show toast alert when user is verified
- Redirect to correct page on verified (fixes spinner forever spinnin': https://github.com/ikreymer/browsertrix-cloud/issues/39)
- Update already-logged in user info on verify
- Adds new toast component. Usage:
```ts
new CustomEvent("notify", {
  detail: {
    title: "notification title",
    message: "notification body",
    type: "success",
    icon: "check2-circle",
    duration: 10000,
  },
})
```

### Manual testing
To test with a brand new user, run app with `yarn start-dev` and then:
1. Log out if already logged in, go to http://localhost:9870/sign-up
2. Sign up with email address where you have inbox access
3. Copy token from verification email and go to `http://localhost:9870/verify?token=your_token`. Verify that you're redirected to the login page and that toast notification shows

To test with logged in user:
1. Log in as a user that is signed up but not verified yet
2. Go to http://localhost:9870/account/settings
3. Click "Resend verification email". Verify that text changes to "sent"
4. Copy token from verification email and go to `http://localhost:9870/verify?token=your_token`. Verify that you're redirected to the dashboard home page and that toast notification shows

### Screenshots

Toast notification for logged in user:
<img width="447" alt="Screen Shot 2021-12-01 at 10 40 50 AM" src="https://user-images.githubusercontent.com/4672952/144295266-dfa11de7-5106-48ee-8f65-306c286762ea.png">

Toast notification for new/logged out user:
<img width="907" alt="Screen Shot 2021-12-01 at 10 40 44 AM" src="https://user-images.githubusercontent.com/4672952/144295305-5e7bd980-47db-4421-b212-c2ed30c52ff8.png">