### PR TITLE
Show sign up confirmation message

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,6 +1,7 @@
 import type { TemplateResult } from "lit";
-import { state } from "lit/decorators.js";
+import { state, query } from "lit/decorators.js";
 import { msg, localized } from "@lit/localize";
+import type { SlDialog } from "@shoelace-style/shoelace";
 
 import "./shoelace";
 import { LocalePicker } from "./components/locale-picker";
@@ -51,11 +52,17 @@ export class App extends LiteElement {
   userInfo?: CurrentUser;
 
   @state()
-  viewState!: ViewState & {
+  private viewState!: ViewState & {
     aid?: string;
     // TODO common tab type
     tab?: "running" | "finished" | "configs";
   };
+
+  @state()
+  private globalDialogContent?: TemplateResult;
+
+  @query("#globalDialog")
+  private globalDialog!: SlDialog;
 
   constructor() {
     super();
@@ -93,6 +100,15 @@ export class App extends LiteElement {
     window.addEventListener("popstate", (event) => {
       this.syncViewState();
     });
+  }
+
+  private showDialog(content: TemplateResult) {
+    this.globalDialogContent = content;
+    this.globalDialog.show();
+  }
+
+  private hideDialog() {
+    this.globalDialog.hide();
   }
 
   async updated(changedProperties: any) {
@@ -155,6 +171,12 @@ export class App extends LiteElement {
           <bt-locale-picker></bt-locale-picker>
         </footer>
       </div>
+
+      <sl-dialog
+        id="globalDialog"
+        @sl-after-hide=${() => (this.globalDialogContent = undefined)}
+        >${this.globalDialogContent}</sl-dialog
+      >
     `;
   }
 
@@ -320,7 +342,12 @@ export class App extends LiteElement {
   }
 
   onLoggedIn(
-    event: CustomEvent<{ api?: boolean; auth: string; username: string }>
+    event: CustomEvent<{
+      api?: boolean;
+      firstLogin?: boolean;
+      auth: string;
+      username: string;
+    }>
   ) {
     const { detail } = event;
     this.authState = {

--- a/frontend/src/pages/sign-up.ts
+++ b/frontend/src/pages/sign-up.ts
@@ -183,7 +183,7 @@ export class SignUp extends LiteElement {
     const data = await resp.json();
     if (data.token_type === "bearer" && data.access_token) {
       const auth = "Bearer " + data.access_token;
-      const detail = { auth, username: email };
+      const detail = { auth, username: email, firstLogin: true };
       this.dispatchEvent(new CustomEvent("logged-in", { detail }));
     } else {
       throw new Error("Unknown authorization type");

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -6,6 +6,7 @@ import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.j
 import "@shoelace-style/shoelace/dist/themes/light.css";
 import "@shoelace-style/shoelace/dist/components/alert/alert";
 import "@shoelace-style/shoelace/dist/components/button/button";
+import "@shoelace-style/shoelace/dist/components/dialog/dialog";
 import "@shoelace-style/shoelace/dist/components/form/form";
 import "@shoelace-style/shoelace/dist/components/icon/icon";
 import "@shoelace-style/shoelace/dist/components/input/input";


### PR DESCRIPTION
(https://github.com/ikreymer/browsertrix-cloud/issues/41) Show confirmation message on sign up.

This is an initial pass, and can be expanded upon into an onboarding flow with with https://github.com/ikreymer/browsertrix-cloud/projects/1#card-74019331

### Manual testing
1. Run `yarn start-dev`, log out if signed in, and go to http://localhost:9870/sign-up
2. Sign up for a new account. Verify that you see a "Welcome" message on successful sign up

### Screenshots
<img width="1274" alt="Screen Shot 2021-12-01 at 12 45 38 PM" src="https://user-images.githubusercontent.com/4672952/144311968-ef818d88-f809-433b-b84f-dae8e9817043.png">
