### PR TITLE
Refresh access token

### DIFF
--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -6,7 +6,7 @@ import { createMachine, interpret, assign } from "@xstate/fsm";
 import type { CurrentUser } from "../types/user";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
-import type { AuthState } from "../utils/AuthService";
+import type { AuthState, Auth } from "../utils/AuthService";
 import AuthService from "../utils/AuthService";
 
 @localized()
@@ -333,7 +333,7 @@ export class AccountSettings extends LiteElement {
     this.formStateService.send("SUBMIT");
 
     const { formData } = event.detail;
-    let nextAuthState: AuthState = null;
+    let nextAuthState: Auth | null = null;
 
     try {
       nextAuthState = await AuthService.login({

--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -25,23 +25,23 @@ describe("browsertrix-app", () => {
     expect(el).instanceOf(App);
   });
 
-  // it("sets auth state from local storage", async () => {
-  //   stub(window.localStorage, "getItem").callsFake((key) => {
-  //     if (key === "btrix.auth")
-  //       return JSON.stringify({
-  //         username: "test-auth@example.com",
-  //       });
-  //     return null;
-  //   });
-  //   const el = (await fixture("<browsertrix-app></browsertrix-app>")) as App;
+  it("sets auth state from session storage", async () => {
+    stub(window.sessionStorage, "getItem").callsFake((key) => {
+      if (key === "btrix.auth")
+        return JSON.stringify({
+          username: "test-auth@example.com",
+        });
+      return null;
+    });
+    const el = (await fixture("<browsertrix-app></browsertrix-app>")) as App;
 
-  //   expect(el.authService.authState).to.eql({
-  //     username: "test-auth@example.com",
-  //   });
-  // });
+    expect(el.authService.authState).to.eql({
+      username: "test-auth@example.com",
+    });
+  });
 
   it("sets user info", async () => {
-    stub(window.localStorage, "getItem").callsFake((key) => {
+    stub(window.sessionStorage, "getItem").callsFake((key) => {
       if (key === "btrix.auth")
         return JSON.stringify({
           username: "test-auth@example.com",

--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -26,7 +26,7 @@ describe("browsertrix-app", () => {
   });
 
   it("sets auth state from session storage", async () => {
-    stub(window.sessionStorage, "getItem").callsFake((key) => {
+    stub(window.localStorage, "getItem").callsFake((key) => {
       if (key === "btrix.auth")
         return JSON.stringify({
           username: "test-auth@example.com",
@@ -41,7 +41,7 @@ describe("browsertrix-app", () => {
   });
 
   it("sets user info", async () => {
-    stub(window.sessionStorage, "getItem").callsFake((key) => {
+    stub(window.localStorage, "getItem").callsFake((key) => {
       if (key === "btrix.auth")
         return JSON.stringify({
           username: "test-auth@example.com",

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -59,7 +59,7 @@ type DialogContent = {
 @localized()
 export class App extends LiteElement {
   private router: APIRouter = new APIRouter(ROUTES);
-  private authService: AuthService = new AuthService();
+  authService: AuthService = new AuthService();
 
   @state()
   userInfo?: CurrentUser;
@@ -384,7 +384,6 @@ export class App extends LiteElement {
     this.authService.persist({
       username: detail.username,
       headers: detail.headers,
-      sessionExpiresAt: detail.sessionExpiresAt,
       tokenExpiresAt: detail.tokenExpiresAt,
     });
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -132,7 +132,7 @@ export class App extends LiteElement {
       };
     } catch (err: any) {
       if (err?.message === "Unauthorized") {
-        this.authService.revoke();
+        this.authService.logout();
         this.navigate(ROUTES.login);
       }
     }
@@ -371,7 +371,8 @@ export class App extends LiteElement {
     const detail = event.detail || {};
     const redirect = detail.redirect !== false;
 
-    this.authService.revoke();
+    this.authService.logout();
+    this.authService = new AuthService();
 
     if (redirect) {
       this.navigate("/");
@@ -381,7 +382,7 @@ export class App extends LiteElement {
   onLoggedIn(event: LoggedInEvent) {
     const { detail } = event;
 
-    this.authService.persist({
+    this.authService.startPersist({
       username: detail.username,
       headers: detail.headers,
       tokenExpiresAt: detail.tokenExpiresAt,
@@ -399,7 +400,7 @@ export class App extends LiteElement {
   }
 
   onNeedLogin(event?: CustomEvent<{ api: boolean }>) {
-    this.authService.revoke();
+    this.authService.logout();
 
     if (event?.detail?.api) {
       // TODO refresh instead of redirect

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -384,7 +384,8 @@ export class App extends LiteElement {
     this.authService.persist({
       username: detail.username,
       headers: detail.headers,
-      expiresAtTs: detail.expiresAtTs,
+      sessionExpiresAt: detail.sessionExpiresAt,
+      tokenExpiresAt: detail.tokenExpiresAt,
     });
 
     if (!detail.api) {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -399,12 +399,9 @@ export class App extends LiteElement {
     this.updateUserInfo();
   }
 
-  onNeedLogin(event?: CustomEvent<{ api: boolean }>) {
+  onNeedLogin() {
     this.authService.logout();
 
-    if (event?.detail?.api) {
-      // TODO refresh instead of redirect
-    }
     this.navigate(ROUTES.login);
   }
 

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -142,22 +142,15 @@ export default class AuthService {
     window.clearTimeout(this.timerId);
 
     if (!this._authState) return;
-
-    console.log(this._authState);
-
     const paddedNow = Date.now() + FRESHNESS_TIMER_INTERVAL;
 
     if (this._authState.sessionExpiresAt > paddedNow) {
       if (this._authState.tokenExpiresAt > paddedNow) {
-        console.log("not expired");
-
         // Restart timer
         this.timerId = window.setTimeout(() => {
           this.checkFreshness();
         }, FRESHNESS_TIMER_INTERVAL);
       } else {
-        console.log("expires before next check");
-
         try {
           const auth = await this.refresh();
           this._authState.headers = auth.headers;

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -162,12 +162,10 @@ export default class AuthService {
           }, FRESHNESS_TIMER_INTERVAL);
         } catch (e) {
           console.debug(e);
-
-          // TODO handle
         }
       }
     } else {
-      // TODO notify expired
+      this.logout();
     }
   }
 

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -94,7 +94,7 @@ export default class AuthService {
   }
 
   retrieve(): AuthState {
-    const authState = window.localStorage.getItem(AuthService.storageKey);
+    const authState = window.sessionStorage.getItem(AuthService.storageKey);
 
     if (authState) {
       this._authState = JSON.parse(authState);
@@ -107,7 +107,7 @@ export default class AuthService {
   persist(authState: AuthState) {
     if (authState) {
       this._authState = authState;
-      window.localStorage.setItem(
+      window.sessionStorage.setItem(
         AuthService.storageKey,
         JSON.stringify(this.authState)
       );
@@ -119,7 +119,7 @@ export default class AuthService {
 
   revoke() {
     this._authState = null;
-    window.localStorage.setItem(AuthService.storageKey, "");
+    window.sessionStorage.setItem(AuthService.storageKey, "");
   }
 
   private async checkFreshness() {

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -98,7 +98,7 @@ export default class AuthService {
   }
 
   retrieve(): AuthState {
-    const auth = window.sessionStorage.getItem(AuthService.storageKey);
+    const auth = window.localStorage.getItem(AuthService.storageKey);
 
     if (auth) {
       this._authState = JSON.parse(auth);
@@ -108,28 +108,34 @@ export default class AuthService {
     return this._authState;
   }
 
-  persist(auth: Auth) {
+  startPersist(auth: Auth) {
     if (auth) {
-      this._authState = {
-        username: auth.username,
-        headers: auth.headers,
-        tokenExpiresAt: auth.tokenExpiresAt,
-        sessionExpiresAt: Date.now() + SESSION_LIFETIME,
-      };
-
-      window.sessionStorage.setItem(
-        AuthService.storageKey,
-        JSON.stringify(auth)
-      );
+      this.persist(auth);
       this.checkFreshness();
     } else {
       console.warn("No authState to persist");
     }
   }
 
-  revoke() {
+  logout() {
+    window.clearTimeout(this.timerId);
+    this.revoke();
+  }
+
+  private revoke() {
     this._authState = null;
-    window.sessionStorage.removeItem(AuthService.storageKey);
+    window.localStorage.removeItem(AuthService.storageKey);
+  }
+
+  private persist(auth: Auth) {
+    this._authState = {
+      username: auth.username,
+      headers: auth.headers,
+      tokenExpiresAt: auth.tokenExpiresAt,
+      sessionExpiresAt: Date.now() + SESSION_LIFETIME,
+    };
+
+    window.localStorage.setItem(AuthService.storageKey, JSON.stringify(auth));
   }
 
   private async checkFreshness() {

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -43,11 +43,7 @@ export default class LiteElement extends LitElement {
 
     if (resp.status !== 200) {
       if (resp.status === 401) {
-        this.dispatchEvent(
-          new CustomEvent("need-login", {
-            detail: { api: true },
-          })
-        );
+        this.dispatchEvent(new CustomEvent("need-login"));
       }
 
       let errorMessage: string;


### PR DESCRIPTION
(https://github.com/ikreymer/browsertrix-cloud/issues/22) Checks access token freshness every 5 minutes and automatically refreshes it up to the hardcoded session length.

### Manual testing
This needs unit tests, because manual testing is a bit clunky... I shortened the hardcoded token expiration and freshness check timers to 5 min and 1 min respectively, and left the tab open.

### Opinions
- Session length is set to 24 hours. The frontend no longer automatically refreshes the token at the end of the session. A similar mechanism could be enforced on the backend for extra security.
- This does bring up a security issue where an attacker could refresh an access token forever. We might want to look at separate refresh tokens before going to production. Could possibly follow: https://indominusbyte.github.io/fastapi-jwt-auth/usage/freshness/
- There are some security concerns with storing the access token in localStorage. Again, before going to prod, we'd want to check that correct security headers are set: https://security.stackexchange.com/a/179507 and maybe reassess storing in cookies: https://indominusbyte.github.io/fastapi-jwt-auth/usage/jwt-in-cookies/ 

### TODO
Possibly read token expiry from `/api/settings`