### PR TITLE
Add global settings endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from db import init_db
 
 from emailsender import EmailSender
-from users import init_users_api, init_user_manager
+from users import init_users_api, init_user_manager, JWT_TOKEN_LIFETIME
 from archives import init_archives_api
 
 from storages import init_storages_api
@@ -29,6 +29,11 @@ def main():
     crawl_manager = None
 
     mdb = init_db()
+
+    settings = {
+        "registrationEnabled": os.environ.get("REGISTRATION_ENABLED") == "1",
+        "jwtTokenLifetime": JWT_TOKEN_LIFETIME
+    }
 
     user_manager = init_user_manager(mdb, email)
 
@@ -73,6 +78,10 @@ def main():
     crawl_config_ops.set_coll_ops(coll_ops)
 
     app.include_router(archive_ops.router)
+
+    @app.get("/api/settings")
+    async def get_settings():
+        return settings
 
     @app.get("/healthz")
     async def healthz():

--- a/backend/users.py
+++ b/backend/users.py
@@ -23,7 +23,7 @@ from fastapi_users.db import MongoDBUserDatabase
 # ============================================================================
 PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", uuid.uuid4().hex)
 
-JWT_LIFETIME = int(os.environ.get("JWT_LIFETIME", 3600))
+JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME", 60)) * 60
 
 
 # ============================================================================
@@ -185,7 +185,7 @@ def init_users_api(app, user_manager):
     """ init fastapi_users """
     jwt_authentication = JWTAuthentication(
         secret=PASSWORD_SECRET,
-        lifetime_seconds=JWT_LIFETIME,
+        lifetime_seconds=JWT_TOKEN_LIFETIME,
         tokenUrl="/auth/jwt/login",
     )
 

--- a/backend/users.py
+++ b/backend/users.py
@@ -23,7 +23,7 @@ from fastapi_users.db import MongoDBUserDatabase
 # ============================================================================
 PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", uuid.uuid4().hex)
 
-JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME", 60)) * 60
+JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME_MINUTES", 60)) * 60
 
 
 # ============================================================================

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -23,6 +23,11 @@ data:
 
   NO_DELETE_JOBS: "{{ .Values.no_delete_jobs | default '0' }}"
 
+  REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default '0' }}"
+
+  JWT_TOKEN_LIFETIME: "{{ .Values.jwt_token_lifetime | default '60' }}"
+
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
 
   REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default '0' }}"
 
-  JWT_TOKEN_LIFETIME: "{{ .Values.jwt_token_lifetime | default '60' }}"
+  JWT_TOKEN_LIFETIME_MINUTES: "{{ .Values.jwt_token_lifetime_minutes | default '60' }}"
 
 
 ---

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,10 @@
+# Settings
+# =========================================
 name: browsertrix-cloud
+
+registration_enabled: 1
+jwt_token_lifetime_minutes: 60
+
 
 # API Image
 # =========================================

--- a/configs/config.sample.env
+++ b/configs/config.sample.env
@@ -31,6 +31,6 @@ CRAWL_ARGS="--timeout 90 --logging stats,behaviors,debug --generateWACZ --screen
 
 REGISTRATION_ENABLED=1
 
-JWT_TOKEN_LIFETIME=60
+JWT_TOKEN_LIFETIME_MINUTES=60
 
 

--- a/configs/config.sample.env
+++ b/configs/config.sample.env
@@ -29,3 +29,8 @@ CRAWLER_IMAGE=webrecorder/browsertrix-crawler
 
 CRAWL_ARGS="--timeout 90 --logging stats,behaviors,debug --generateWACZ --screencastPort 9037"
 
+REGISTRATION_ENABLED=1
+
+JWT_TOKEN_LIFETIME=60
+
+


### PR DESCRIPTION
add /api/settings endpoint for misc system-wide settings
setting 'registrationEnabled' if open registration should be enabled, to support #51 
setting 'jwtTokenLifetime' returns the jwt token expiry in seconds, to support #48 