### PR TITLE
Backend Invite System Refactor

### DIFF
--- a/backend/emailsender.py
+++ b/backend/emailsender.py
@@ -47,13 +47,27 @@ The verification token is: {token}"""
         """Send email to invite new user"""
 
         message = f"""
-You are invited by {sender} to join their archive, {archive_name} on Browsertrix Cloud!
+You are invited by {sender} to join their archive, "{archive_name}" on Browsertrix Cloud!
 
 You can join by clicking here: {self.host}/join/{token}?email={receiver_email}
 
 The invite token is: {token}"""
 
         self._send_encrypted(receiver_email, message)
+
+    def send_existing_user_invite(self, receiver_email, sender, archive_name, token):
+        """Send email to invite new user"""
+
+        message = f"""
+You are invited by {sender} to join their archive, "{archive_name}" on Browsertrix Cloud!
+
+You can join by clicking here: {self.host}/invite/accept/{token}?email={receiver_email}
+
+The invite token is: {token}"""
+
+        self._send_encrypted(receiver_email, message)
+
+
 
     def send_user_forgot_password(self, receiver_email, token):
         """Send password reset email with token"""

--- a/backend/invites.py
+++ b/backend/invites.py
@@ -159,8 +159,8 @@ class InviteOps:
 
         await user_manager.user_db.update(other_user)
 
-        self.email.send_new_user_invite(
-            other_user.email, user.name, archive_name, invite_code
+        self.email.send_existing_user_invite(
+            other_user.email, user.name, archive_name,invite_code
         )
 
         return False

--- a/backend/invites.py
+++ b/backend/invites.py
@@ -1,0 +1,171 @@
+""" Invite system management """
+
+from datetime import datetime
+from enum import IntEnum
+from typing import Optional
+import uuid
+
+from pydantic import BaseModel
+from fastapi import HTTPException
+
+
+from db import BaseMongoModel
+
+
+# ============================================================================
+class UserRole(IntEnum):
+    """User role"""
+
+    VIEWER = 10
+    CRAWLER = 20
+    OWNER = 40
+
+
+# ============================================================================
+class InvitePending(BaseModel):
+    """Pending Request to join"""
+
+    created: datetime
+    aid: Optional[str]
+    role: Optional[UserRole] = UserRole.VIEWER
+
+
+# ============================================================================
+class InviteRequest(BaseModel):
+    """Request to invite another user"""
+
+    email: str
+
+
+# ============================================================================
+class InviteToArchiveRequest(InviteRequest):
+    """Request to invite another user to an archive"""
+
+    role: UserRole
+
+
+# ============================================================================
+class NewUserInvite(InvitePending, BaseMongoModel):
+    """An invite for a new user, with an email and invite token as id"""
+
+    email: str
+
+
+# ============================================================================
+class InviteOps:
+    """ invite users (optionally to an archive), send emails and delete invites """
+
+    def __init__(self, db, email):
+        self.invites = db["invites"]
+        self.email = email
+
+    async def add_new_user_invite(
+        self,
+        new_user_invite: NewUserInvite,
+        inviter_email: str,
+        archive_name: Optional[str],
+    ):
+        """Add invite for new user"""
+
+        res = await self.invites.find_one({"email": new_user_invite.email})
+        if res:
+            raise HTTPException(
+                status_code=403, detail="This user has already been invited"
+            )
+
+        await self.invites.insert_one(new_user_invite.to_dict())
+
+        self.email.send_new_user_invite(
+            new_user_invite.email, inviter_email, archive_name, new_user_invite.id
+        )
+
+    async def get_valid_invite(self, invite_token: str, user):
+        """ Retrieve a valid invite data from db, or throw if invalid"""
+        invite_data = await self.invites.find_one({"_id": invite_token})
+        if not invite_data:
+            print("NO DATA", flush=True)
+            raise HTTPException(status_code=400, detail="Invalid Invite Code")
+
+        new_user_invite = NewUserInvite.from_dict(invite_data)
+        print(new_user_invite, flush=True)
+
+        if user.email != new_user_invite.email:
+            raise HTTPException(status_code=400, detail="Invalid Invite Code")
+
+        return new_user_invite
+
+    async def remove_invite(self, invite_token: str):
+        """ remove invite from invite list """
+        await self.invites.delete_one({"_id": invite_token})
+
+    # pylint: disable=no-self-use
+    def accept_user_invite(self, user, invite_token: str):
+        """ remove invite from user, if valid token, throw if not """
+        invite = user.invites.pop(invite_token, "")
+        if not invite:
+            raise HTTPException(status_code=400, detail="Invalid Invite Code")
+
+        return invite
+
+    # pylint: disable=too-many-arguments
+    async def invite_user(
+        self,
+        invite: InviteRequest,
+        user,
+        user_manager,
+        archive=None,
+        allow_existing=False,
+    ):
+        """create new invite for user to join, optionally an archive.
+        if allow_existing is false, don't allow invites to existing users"""
+        invite_code = uuid.uuid4().hex
+
+        aid = None
+        archive_name = None
+        if archive:
+            aid = archive.id
+            archive_name = archive.name
+
+        invite_pending = InvitePending(
+            aid=aid,
+            created=datetime.utcnow(),
+            role=invite.role if hasattr(invite, "role") else None,
+        )
+
+        other_user = await user_manager.user_db.get_by_email(invite.email)
+
+        if not other_user:
+            await self.add_new_user_invite(
+                NewUserInvite(
+                    id=invite_code, email=invite.email, **invite_pending.dict()
+                ),
+                user.email,
+                archive_name,
+            )
+            return True
+
+        if not allow_existing:
+            raise HTTPException(status_code=400, detail="User already registered")
+
+        if other_user.email == user.email:
+            raise HTTPException(status_code=400, detail="Can't invite ourselves!")
+
+        if archive.users.get(str(other_user.id)):
+            raise HTTPException(
+                status_code=400, detail="User already a member of this archive."
+            )
+
+        other_user.invites[invite_code] = invite_pending
+
+        await user_manager.user_db.update(other_user)
+
+        self.email.send_new_user_invite(
+            other_user.email, user.name, archive_name, invite_code
+        )
+
+        return False
+
+
+def init_invites(mdb, email):
+    """ init InviteOps"""
+    return InviteOps(mdb, email)

--- a/backend/users.py
+++ b/backend/users.py
@@ -152,7 +152,11 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
             except HTTPException as exc:
                 print(exc)
 
-        asyncio.create_task(self.request_verify(user, request))
+            # if user has been invited, mark as verified immediately
+            await self._update(user, {"is_verified": True})
+
+        else:
+            asyncio.create_task(self.request_verify(user, request))
 
     async def on_after_forgot_password(
         self, user: UserDB, token: str, request: Optional[Request] = None
@@ -189,7 +193,7 @@ def init_users_api(app, user_manager):
     jwt_authentication = JWTAuthentication(
         secret=PASSWORD_SECRET,
         lifetime_seconds=JWT_TOKEN_LIFETIME,
-        tokenUrl="/auth/jwt/login",
+        tokenUrl="auth/jwt/login",
     )
 
     fastapi_users = FastAPIUsers(

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
 
   REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default '0' }}"
 
-  JWT_TOKEN_LIFETIME_MINUTES: "{{ .Values.jwt_token_lifetime_minutes | default '60' }}"
+  JWT_TOKEN_LIFETIME_MINUTES: "{{ .Values.jwt_token_lifetime_minutes | default 60 }}"
 
 
 ---


### PR DESCRIPTION
- refactor invite system, move to separate InviteOps object, used by archives and user
- supporting three invite use cases:
1) superuser invites any user not registered, not added to any archive
2) archive admin invites any user not registered, add to one of their archives
3) archive admin invites existing registered user, add to one of their archives

- support superadmin invite via /users/invite (part of #37)
- superadmin invite has no archive set and does not add user to archive
- redundant email verification email not sent if accepting from an invite #50 
- openapi.json: fixes tokenUrl path to be relative
- use different email template / accept url for existing user, `/invite/accept/`