### PR TITLE
Update superadmin invite URL

### DIFF
--- a/frontend/src/components/invite-form.ts
+++ b/frontend/src/components/invite-form.ts
@@ -69,24 +69,19 @@ export class InviteForm extends LiteElement {
   async onSubmit(event: { detail: { formData: FormData } }) {
     if (!this.authState) return;
 
+    this.serverError = undefined;
     this.isSubmitting = true;
 
     const { formData } = event.detail;
     const inviteEmail = formData.get("inviteEmail") as string;
 
     try {
-      const data = await this.apiFetch(
-        // TODO actual path
-        `/invite`,
-        this.authState,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            email: inviteEmail,
-            role: Number(formData.get("role")),
-          }),
-        }
-      );
+      const data = await this.apiFetch(`/users/invite`, this.authState, {
+        method: "POST",
+        body: JSON.stringify({
+          email: inviteEmail,
+        }),
+      });
 
       this.dispatchEvent(
         new CustomEvent("success", {

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -23,6 +23,7 @@ export class SignUpForm extends LiteElement {
 
   @property({ type: Boolean })
   // TODO replace with archive info
+  // https://github.com/ikreymer/browsertrix-cloud/issues/35
   isArchiveInvite?: boolean;
 
   @state()

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -21,6 +21,10 @@ export class SignUpForm extends LiteElement {
   @property({ type: String })
   inviteToken?: string;
 
+  @property({ type: Boolean })
+  // TODO replace with archive info
+  isArchiveInvite?: boolean;
+
   @state()
   private serverError?: string;
 
@@ -133,7 +137,7 @@ export class SignUpForm extends LiteElement {
       newArchive: true,
     };
 
-    if (this.inviteToken) {
+    if (this.inviteToken && this.isArchiveInvite) {
       registerParams.inviteToken = this.inviteToken;
       registerParams.newArchive = false;
     }


### PR DESCRIPTION
Update with actual admin user invite API endpoint

### Manual testing
1. Run `yarn start` and log in as `dev@webrecorder.net `
2. Invite another user. Log out
3. Go email and copy invite link, replacing host with `http://localhost:9870`
4. Sign up, do not "accept invite" on next page (see https://github.com/ikreymer/browsertrix-cloud/pull/61) and go to  http://localhost:9870/archives. Verify you see your own archive