### PR TITLE
Fix shoelace alert not available on page load

### DIFF
--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -4,9 +4,7 @@
  */
 import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
 import "@shoelace-style/shoelace/dist/themes/light.css";
-import(
-  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/alert/alert"
-);
+import "@shoelace-style/shoelace/dist/components/alert/alert";
 import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button/button"
 );


### PR DESCRIPTION
Creating an alert on page load will result in an error, since the alert component is loaded dynamically.

### Bug reproduction
1. Generate an archive invite, log out, and refresh the page
2. Visit the invite accept link. The toast alert "Log in to continue" won't show since the alert component is not available immediately on page load