### PR TITLE
Fix password autocomplete and suggestions

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,4 +1,5 @@
 import { Alert } from "./alert";
+import { Input } from "./input/input";
 import("./locale-picker").then(({ LocalePicker }) => {
   customElements.define("btrix-locale-picker", LocalePicker);
 });
@@ -19,3 +20,4 @@ import("./not-found").then(({ NotFound }) => {
 });
 
 customElements.define("btrix-alert", Alert);
+customElements.define("btrix-input", Input);

--- a/frontend/src/components/input/input.css
+++ b/frontend/src/components/input/input.css
@@ -1,12 +1,19 @@
 .sl-input {
-  color: var(--sl-input-color);
-  transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border,
+  transition: var(--sl-transition-fast) border,
     var(--sl-transition-fast) box-shadow,
     var(--sl-transition-fast) background-color;
+}
+
+.sl-input:hover {
+  border-color: var(--sl-input-border-color-hover);
 }
 
 .sl-input:focus {
   border-color: var(--sl-input-border-color-focus);
   box-shadow: var(--sl-focus-ring);
+}
+
+.sl-input input {
+  color: var(--sl-input-color);
   outline: 0;
 }

--- a/frontend/src/components/input/input.css
+++ b/frontend/src/components/input/input.css
@@ -1,0 +1,12 @@
+.sl-input {
+  color: var(--sl-input-color);
+  transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border,
+    var(--sl-transition-fast) box-shadow,
+    var(--sl-transition-fast) background-color;
+}
+
+.sl-input:focus {
+  border-color: var(--sl-input-border-color-focus);
+  box-shadow: var(--sl-focus-ring);
+  outline: 0;
+}

--- a/frontend/src/components/input/input.css
+++ b/frontend/src/components/input/input.css
@@ -3,14 +3,29 @@
   margin-bottom: var(--sl-spacing-3x-small);
 }
 
+.sl-input-wrapper {
+  position: relative;
+  font-size: var(--sl-input-font-size-medium);
+  height: var(--sl-input-height-medium);
+}
+
 .sl-input {
-  display: flex;
-  align-items: center;
+  width: 100%;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  min-width: 0;
+  height: calc(
+    var(--sl-input-height-medium) - var(--sl-input-border-width) * 2
+  );
+  color: var(--sl-input-color);
   background-color: var(--sl-input-background-color);
   border: solid var(--sl-input-border-width) var(--sl-input-border-color);
   border-radius: var(--sl-input-border-radius-medium);
-  font-size: var(--sl-input-font-size-medium);
-  height: var(--sl-input-height-medium);
+  box-shadow: none;
+  padding: var(--sl-input-spacing-medium);
+  cursor: inherit;
+  -webkit-appearance: none;
   transition: var(--sl-transition-fast) border,
     var(--sl-transition-fast) box-shadow,
     var(--sl-transition-fast) background-color;
@@ -20,42 +35,18 @@
   border-color: var(--sl-input-border-color-hover);
 }
 
-.sl-input:focus-within {
+.sl-input:focus {
   border-color: var(--sl-input-border-color-focus);
   box-shadow: var(--sl-focus-ring);
 }
 
-.sl-input-control {
-  flex: 1;
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  min-width: 0;
-  height: calc(
-    var(--sl-input-height-medium) - var(--sl-input-border-width) * 2
-  );
-  color: var(--sl-input-color);
-  border: none;
-  background: none;
-  box-shadow: none;
-  padding: 0;
-  cursor: inherit;
-  -webkit-appearance: none;
-}
-
-.sl-input-control:focus {
-  outline: none;
-  box-shadow: none;
-}
-
-.sl-input-control:only-child {
-  margin: 0 var(--sl-input-spacing-medium);
-}
-
-.sl-input-control:not(:only-child) {
-  margin: 0 0 0 var(--sl-input-spacing-medium);
+.sl-input:not(:only-child) {
+  padding-right: calc(var(--sl-spacing-x-small) * 2 + 2em);
 }
 
 .sl-input-icon-button {
+  position: absolute;
+  top: calc(var(--sl-input-border-width) + var(--sl-spacing-3x-small));
+  right: 0;
   margin-right: var(--sl-spacing-x-small);
 }

--- a/frontend/src/components/input/input.css
+++ b/frontend/src/components/input/input.css
@@ -1,4 +1,16 @@
+.sl-label {
+  font-size: var(--sl-input-label-font-size-medium);
+  margin-bottom: var(--sl-spacing-3x-small);
+}
+
 .sl-input {
+  display: flex;
+  align-items: center;
+  background-color: var(--sl-input-background-color);
+  border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  border-radius: var(--sl-input-border-radius-medium);
+  font-size: var(--sl-input-font-size-medium);
+  height: var(--sl-input-height-medium);
   transition: var(--sl-transition-fast) border,
     var(--sl-transition-fast) box-shadow,
     var(--sl-transition-fast) background-color;
@@ -8,12 +20,42 @@
   border-color: var(--sl-input-border-color-hover);
 }
 
-.sl-input:focus {
+.sl-input:focus-within {
   border-color: var(--sl-input-border-color-focus);
   box-shadow: var(--sl-focus-ring);
 }
 
-.sl-input input {
+.sl-input-control {
+  flex: 1;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  min-width: 0;
+  height: calc(
+    var(--sl-input-height-medium) - var(--sl-input-border-width) * 2
+  );
   color: var(--sl-input-color);
-  outline: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
+  padding: 0;
+  cursor: inherit;
+  -webkit-appearance: none;
+}
+
+.sl-input-control:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.sl-input-control:only-child {
+  margin: 0 var(--sl-input-spacing-medium);
+}
+
+.sl-input-control:not(:only-child) {
+  margin: 0 0 0 var(--sl-input-spacing-medium);
+}
+
+.sl-input-icon-button {
+  margin-right: var(--sl-spacing-x-small);
 }

--- a/frontend/src/components/input/input.ts
+++ b/frontend/src/components/input/input.ts
@@ -45,14 +45,12 @@ export class Input extends LiteElement {
 
   render() {
     return html`
-      <div class="mb-1">
-        <label for=${this.id} class="text-sm">${this.label}</label>
+      <div class="sl-label">
+        <label for=${this.id}>${this.label}</label>
       </div>
-      <div
-        class="sl-input flex items-center border border-gray-300 rounded-md h-10"
-      >
+      <div class="sl-input">
         <input
-          class="flex-1 ${this.togglePassword ? "ml-4" : "mx-4"}"
+          class="sl-input-control"
           id=${this.id}
           name=${ifDefined(this.name)}
           type=${this.type === "password" && this.isPasswordVisible
@@ -64,12 +62,11 @@ export class Input extends LiteElement {
         />
         ${this.togglePassword
           ? html`
-              <div class="mr-2">
-                <sl-icon-button
-                  name=${this.isPasswordVisible ? "eye-slash" : "eye"}
-                  @click=${this.onTogglePassword}
-                ></sl-icon-button>
-              </div>
+              <sl-icon-button
+                class="sl-input-icon-button"
+                name=${this.isPasswordVisible ? "eye-slash" : "eye"}
+                @click=${this.onTogglePassword}
+              ></sl-icon-button>
             `
           : ""}
       </div>

--- a/frontend/src/components/input/input.ts
+++ b/frontend/src/components/input/input.ts
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 import LiteElement from "../../utils/LiteElement";
@@ -28,23 +28,55 @@ export class Input extends LiteElement {
   @property({ type: String })
   type?: string;
 
+  @property({ type: String })
+  placeholder?: string;
+
   @property()
   autocomplete?: any;
 
   @property()
   required?: any;
 
+  @property({ type: Boolean })
+  togglePassword?: boolean;
+
+  @state()
+  isPasswordVisible: boolean = false;
+
   render() {
     return html`
-      <label class="block mb-1 text-sm" for="password">${this.label}</label>
-      <input
-        class="sl-input block border border-gray-300 rounded-md px-4 w-full h-10"
-        id=${this.id}
-        name=${ifDefined(this.name)}
-        type=${ifDefined(this.type as any)}
-        autocomplete=${ifDefined(this.autocomplete)}
-        ?required=${Boolean(this.required)}
-      />
+      <div class="mb-1">
+        <label for=${this.id} class="text-sm">${this.label}</label>
+      </div>
+      <div
+        class="sl-input flex items-center border border-gray-300 rounded-md h-10"
+      >
+        <input
+          class="flex-1 ${this.togglePassword ? "ml-4" : "mx-4"}"
+          id=${this.id}
+          name=${ifDefined(this.name)}
+          type=${this.type === "password" && this.isPasswordVisible
+            ? "text"
+            : ifDefined(this.type as any)}
+          autocomplete=${ifDefined(this.autocomplete)}
+          placeholder=${ifDefined(this.placeholder)}
+          ?required=${Boolean(this.required)}
+        />
+        ${this.togglePassword
+          ? html`
+              <div class="mr-2">
+                <sl-icon-button
+                  name=${this.isPasswordVisible ? "eye-slash" : "eye"}
+                  @click=${this.onTogglePassword}
+                ></sl-icon-button>
+              </div>
+            `
+          : ""}
+      </div>
     `;
+  }
+
+  private onTogglePassword() {
+    this.isPasswordVisible = !this.isPasswordVisible;
   }
 }

--- a/frontend/src/components/input/input.ts
+++ b/frontend/src/components/input/input.ts
@@ -8,7 +8,9 @@ import "./input.css";
 /**
  * Styled input element in the light DOM.
  * Use instead of `sl-input` when disabling shadow DOM is necessary
+ * (e.g. for password manager autocomplete)
  * See https://github.com/ikreymer/browsertrix-cloud/issues/72
+ * and https://github.com/shoelace-style/shoelace/issues/413
  *
  * Usage example:
  * ```ts
@@ -48,9 +50,9 @@ export class Input extends LiteElement {
       <div class="sl-label">
         <label for=${this.id}>${this.label}</label>
       </div>
-      <div class="sl-input">
+      <div class="sl-input-wrapper">
         <input
-          class="sl-input-control"
+          class="sl-input"
           id=${this.id}
           name=${ifDefined(this.name)}
           type=${this.type === "password" && this.isPasswordVisible

--- a/frontend/src/components/input/input.ts
+++ b/frontend/src/components/input/input.ts
@@ -1,0 +1,50 @@
+import { html } from "lit";
+import { property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import LiteElement from "../../utils/LiteElement";
+import "./input.css";
+
+/**
+ * Styled input element in the light DOM.
+ * Use instead of `sl-input` when disabling shadow DOM is necessary
+ * See https://github.com/ikreymer/browsertrix-cloud/issues/72
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-input label="Email" name="email"></btrix-input>
+ * ```
+ */
+export class Input extends LiteElement {
+  @property()
+  label?: string;
+
+  @property({ type: String })
+  id: string = "";
+
+  @property({ type: String })
+  name?: string;
+
+  @property({ type: String })
+  type?: string;
+
+  @property()
+  autocomplete?: any;
+
+  @property()
+  required?: any;
+
+  render() {
+    return html`
+      <label class="block mb-1 text-sm" for="password">${this.label}</label>
+      <input
+        class="sl-input block border border-gray-300 rounded-md px-4 w-full h-10"
+        id=${this.id}
+        name=${ifDefined(this.name)}
+        type=${ifDefined(this.type as any)}
+        autocomplete=${ifDefined(this.autocomplete)}
+        ?required=${Boolean(this.required)}
+      />
+    `;
+  }
+}

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -62,7 +62,7 @@ export class SignUpForm extends LiteElement {
                 />
               `
             : html`
-                <sl-input
+                <btrix-input
                   id="email"
                   name="email"
                   type="email"
@@ -71,23 +71,23 @@ export class SignUpForm extends LiteElement {
                   autocomplete="email"
                   required
                 >
-                </sl-input>
+                </btrix-input>
               `}
         </div>
         <div class="mb-5">
-          <sl-input
+          <btrix-input
             id="password"
             name="password"
             type="password"
             label=${msg("Create a password")}
             autocomplete="new-password"
-            toggle-password
+            togglePassword
             required
           >
-          </sl-input>
+          </btrix-input>
         </div>
         <div class="mb-5">
-          <sl-input
+          <btrix-input
             id="name"
             name="name"
             label=${msg("Your name")}
@@ -96,7 +96,7 @@ export class SignUpForm extends LiteElement {
             })}
             autocomplete="nickname"
           >
-          </sl-input>
+          </btrix-input>
           <p class="mt-2 text-sm text-gray-500">
             <span class="text-gray-400">${msg("(optional)")}</span> ${msg(
               "Your name will be visible to archive collaborators."

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -224,28 +224,45 @@ export class LogInPage extends LiteElement {
     }
 
     return html`
+      <style>
+        input {
+          transition: var(--sl-transition-fast) color,
+            var(--sl-transition-fast) border,
+            var(--sl-transition-fast) box-shadow,
+            var(--sl-transition-fast) background-color;
+        }
+
+        input:focus {
+          border-color: var(--sl-input-border-color-focus);
+          box-shadow: var(--sl-focus-ring);
+          outline: 0;
+        }
+      </style>
       <sl-form @sl-submit="${this.onSubmitLogIn}" aria-describedby="formError">
         <div class="mb-5">
-          <sl-input
+          <label class="block mb-1 text-sm" for="email">${msg("Email")}</label>
+          <input
+            class="block border border-gray-300 rounded-md px-4 w-full h-10"
             id="email"
             name="username"
             type="email"
-            label="${msg("Email")}"
             autocomplete="username"
+            style="color: var(--sl-input-color);"
             required
-          >
-          </sl-input>
+          />
         </div>
         <div class="mb-5">
-          <sl-input
+          <label class="block mb-1 text-sm" for="password"
+            >${msg("Password")}</label
+          >
+          <input
+            class="block border border-gray-300 rounded-md px-4 w-full h-10"
             id="password"
             name="password"
             type="password"
-            label="${msg("Password")}"
             autocomplete="current-password"
             required
-          >
-          </sl-input>
+          />
         </div>
 
         ${formError}

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -240,10 +240,10 @@ export class LogInPage extends LiteElement {
       </style>
       <sl-form @sl-submit="${this.onSubmitLogIn}" aria-describedby="formError">
         <div class="mb-5">
-          <label class="block mb-1 text-sm" for="email">${msg("Email")}</label>
           <btrix-input
             id="email"
             name="username"
+            label=${msg("Email")}
             type="email"
             autocomplete="username"
             required
@@ -251,14 +251,13 @@ export class LogInPage extends LiteElement {
           </btrix-input>
         </div>
         <div class="mb-5">
-          <label class="block mb-1 text-sm" for="password"
-            >${msg("Password")}</label
-          >
           <btrix-input
             id="password"
             name="password"
+            label=${msg("Password")}
             type="password"
             autocomplete="current-password"
+            togglePassword
             required
           >
           </btrix-input>

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -241,28 +241,27 @@ export class LogInPage extends LiteElement {
       <sl-form @sl-submit="${this.onSubmitLogIn}" aria-describedby="formError">
         <div class="mb-5">
           <label class="block mb-1 text-sm" for="email">${msg("Email")}</label>
-          <input
-            class="block border border-gray-300 rounded-md px-4 w-full h-10"
+          <btrix-input
             id="email"
             name="username"
             type="email"
             autocomplete="username"
-            style="color: var(--sl-input-color);"
             required
-          />
+          >
+          </btrix-input>
         </div>
         <div class="mb-5">
           <label class="block mb-1 text-sm" for="password"
             >${msg("Password")}</label
           >
-          <input
-            class="block border border-gray-300 rounded-md px-4 w-full h-10"
+          <btrix-input
             id="password"
             name="password"
             type="password"
             autocomplete="current-password"
             required
-          />
+          >
+          </btrix-input>
         </div>
 
         ${formError}

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -295,14 +295,15 @@ export class LogInPage extends LiteElement {
         aria-describedby="formError"
       >
         <div class="mb-5">
-          <sl-input
+          <btrix-input
             id="email"
             name="email"
             type="email"
             label="${msg("Your email address")}"
+            autocomplete="username"
             required
           >
-          </sl-input>
+          </btrix-input>
         </div>
 
         ${formError}

--- a/frontend/src/pages/reset-password.ts
+++ b/frontend/src/pages/reset-password.ts
@@ -33,16 +33,16 @@ export class ResetPassword extends LiteElement {
         <div class="md:bg-white md:shadow-xl md:rounded-lg md:px-12 md:py-12">
           <sl-form @sl-submit="${this.onSubmit}" aria-describedby="formError">
             <div class="mb-5">
-              <sl-input
+              <btrix-input
                 id="password"
                 name="password"
                 type="password"
                 label="${msg("New password")}"
                 autocomplete="new-password"
-                toggle-password
+                togglePassword
                 required
               >
-              </sl-input>
+              </btrix-input>
             </div>
 
             ${formError}


### PR DESCRIPTION
(https://github.com/ikreymer/browsertrix-cloud/issues/72) Per advice from the Shoelace discord channel, recreate `sl-input` using Shoelace design tokens for inputs where autocomplete (and other password manager features) should be enabled.

May be superseded by https://github.com/shoelace-style/shoelace/issues/413 

### Manual testing
I'm testing using 1Password. Run locally and test:
- [x] Log in http://localhost:9870/log-in
- [x] Forgot password http://localhost:9870/log-in/forgot-password
- [x] Reset password
- [x] Sign up http://localhost:9870/sign-up

### Screenshots

https://user-images.githubusercontent.com/4672952/148631279-3e17ea0a-98b2-46e5-98a3-3fdaf611e966.mov

<img width="418" alt="Screen Shot 2022-01-07 at 8 27 27 PM" src="https://user-images.githubusercontent.com/4672952/148631343-40dbf087-611d-43aa-b2bc-b650f5df1225.png">

