### PR TITLE
Fix login page update side effect

### DIFF
--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -149,14 +149,8 @@ export class LogInPage extends LiteElement {
   }
 
   updated(changedProperties: any) {
-    if (changedProperties.has("viewState")) {
-      const route = this.viewState.route;
-
-      if (route === "login") {
-        this.formStateService.send("SHOW_SIGN_IN_WITH_PASSWORD");
-      } else if (route === "forgotPassword") {
-        this.formStateService.send("SHOW_FORGOT_PASSWORD");
-      }
+    if (changedProperties.get("viewState")) {
+      this.syncFormStateView();
     }
   }
 
@@ -208,6 +202,18 @@ export class LogInPage extends LiteElement {
         <footer class="text-center">${link}</footer>
       </article>
     `;
+  }
+
+  private async syncFormStateView() {
+    await this.updateComplete;
+
+    const route = this.viewState.route;
+
+    if (route === "login") {
+      this.formStateService.send("SHOW_SIGN_IN_WITH_PASSWORD");
+    } else if (route === "forgotPassword") {
+      this.formStateService.send("SHOW_FORGOT_PASSWORD");
+    }
   }
 
   private renderLoginForm() {

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -148,8 +148,10 @@ export class LogInPage extends LiteElement {
     this.formStateService.stop();
   }
 
-  updated(changedProperties: any) {
+  async updated(changedProperties: any) {
     if (changedProperties.get("viewState")) {
+      await this.updateComplete;
+
       this.syncFormStateView();
     }
   }
@@ -204,9 +206,7 @@ export class LogInPage extends LiteElement {
     `;
   }
 
-  private async syncFormStateView() {
-    await this.updateComplete;
-
+  private syncFormStateView() {
     const route = this.viewState.route;
 
     if (route === "login") {


### PR DESCRIPTION
(https://github.com/ikreymer/browsertrix-cloud/issues/76) Uses `await this.updateComplete` to wait for `viewState` to finish rendering to DOM before updating form state.

### Manual testing
1. Run app with browser dev tools open
2. Visit http://localhost:9870/log-in. Verify that page renders correctly and there is no `Element btrix-log-in scheduled an update` warning in logs
3. Click "Forgot your password" and then "Sign in with password". Verify that view renders correctly without any warnings