### PR TITLE
Update app layout

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -218,6 +218,13 @@ export class App extends LiteElement {
                   >
                     ${msg("Your account")}
                   </sl-menu-item>
+                  ${this.userInfo?.isAdmin
+                    ? html` <sl-menu-item
+                        @click=${() => this.navigate(ROUTES.usersInvite)}
+                      >
+                        ${msg("Invite Users")}
+                      </sl-menu-item>`
+                    : ""}
                   <sl-menu-item @click="${this.onLogOut}"
                     >${msg("Log Out")}</sl-menu-item
                   >
@@ -265,21 +272,6 @@ export class App extends LiteElement {
               label: msg("Archives"),
             })}
           </ul>
-          ${this.userInfo?.isAdmin
-            ? html` <span class="uppercase text-sm font-medium"
-                  >${msg("Admin", {
-                    desc: "Heading for links to administrative pages",
-                  })}</span
-                >
-                <ul class="flex md:flex-col">
-                  ${navLink({
-                    // activeRoutes: ["users", "usersInvite"],
-                    activeRoutes: ["usersInvite"],
-                    href: ROUTES.usersInvite,
-                    label: msg("Invite Users"),
-                  })}
-                </ul>`
-            : ""}
         </nav>
         <div class="p-4 md:p-8 flex-1">${template}</div>
       </div>

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -195,49 +195,54 @@ export class App extends LiteElement {
 
   renderNavBar() {
     return html`
-      <nav
-        class="flex items-center justify-between p-2 bg-gray-900 text-gray-50"
-      >
-        <div>
-          <a href="/" @click="${this.navLink}"
-            ><h1 class="text-base px-2">${msg("Browsertrix Cloud")}</h1></a
-          >
-        </div>
-        <div class="grid grid-flow-col gap-5 items-center">
-          ${this.authService.authState
-            ? html` <sl-dropdown>
-                <div class="p-2" role="button" slot="trigger">
-                  ${this.userInfo?.name || this.userInfo?.email}
-                  <span class="text-xs"
-                    ><sl-icon name="chevron-down"></sl-icon
-                  ></span>
-                </div>
-                <sl-menu>
-                  <sl-menu-item
-                    @click=${() => this.navigate(ROUTES.accountSettings)}
+      <div class="bg-gray-900 text-gray-50">
+        <nav
+          class="max-w-screen-xl mx-auto p-2 box-border flex items-center justify-between"
+        >
+          <div>
+            <a href="/archives" @click="${this.navLink}"
+              ><h1 class="text-base">${msg("Browsertrix Cloud")}</h1></a
+            >
+          </div>
+          <div class="grid grid-flow-col gap-5 items-center">
+            ${this.authService.authState
+              ? html` <sl-dropdown>
+                  <div class="p-2" role="button" slot="trigger">
+                    ${this.userInfo?.name || this.userInfo?.email}
+                    <span class="text-xs"
+                      ><sl-icon name="chevron-down"></sl-icon
+                    ></span>
+                  </div>
+                  <sl-menu>
+                    <sl-menu-item
+                      @click=${() => this.navigate(ROUTES.accountSettings)}
+                    >
+                      ${msg("Your account")}
+                    </sl-menu-item>
+                    ${this.userInfo?.isAdmin
+                      ? html` <sl-menu-item
+                          @click=${() => this.navigate(ROUTES.usersInvite)}
+                        >
+                          ${msg("Invite Users")}
+                        </sl-menu-item>`
+                      : ""}
+                    <sl-menu-item @click="${this.onLogOut}"
+                      >${msg("Log Out")}</sl-menu-item
+                    >
+                  </sl-menu>
+                </sl-dropdown>`
+              : html`
+                  <a href="/log-in"> ${msg("Log In")} </a>
+                  <sl-button
+                    outline
+                    @click="${() => this.navigate("/sign-up")}"
                   >
-                    ${msg("Your account")}
-                  </sl-menu-item>
-                  ${this.userInfo?.isAdmin
-                    ? html` <sl-menu-item
-                        @click=${() => this.navigate(ROUTES.usersInvite)}
-                      >
-                        ${msg("Invite Users")}
-                      </sl-menu-item>`
-                    : ""}
-                  <sl-menu-item @click="${this.onLogOut}"
-                    >${msg("Log Out")}</sl-menu-item
-                  >
-                </sl-menu>
-              </sl-dropdown>`
-            : html`
-                <a href="/log-in"> ${msg("Log In")} </a>
-                <sl-button outline @click="${() => this.navigate("/sign-up")}">
-                  <span class="text-white">${msg("Sign up")}</span>
-                </sl-button>
-              `}
-        </div>
-      </nav>
+                    <span class="text-white">${msg("Sign up")}</span>
+                  </sl-button>
+                `}
+          </div>
+        </nav>
+      </div>
     `;
   }
 
@@ -263,17 +268,8 @@ export class App extends LiteElement {
       </li>
     `;
     const appLayout = (template: TemplateResult) => html`
-      <div class="w-full flex flex-col md:flex-row">
-        <nav class="md:w-80 md:p-4 md:border-r">
-          <ul class="flex md:flex-col">
-            ${navLink({
-              activeRoutes: ["archives", "archive"],
-              href: DASHBOARD_ROUTE,
-              label: msg("Archives"),
-            })}
-          </ul>
-        </nav>
-        <div class="p-4 md:p-8 flex-1">${template}</div>
+      <div class="w-full max-w-screen-xl mx-auto p-2 md:py-8 box-border">
+        ${template}
       </div>
     `;
 

--- a/frontend/src/pages/archive.ts
+++ b/frontend/src/pages/archive.ts
@@ -68,9 +68,16 @@ export class Archive extends LiteElement {
     const showMembers = Boolean(this.archive.users);
 
     return html`<article class="grid gap-4">
-      <header>
-        <h1 class="text-2xl font-bold">${this.archive.name}</h1>
-      </header>
+      <nav class="font-medium text-sm text-gray-500">
+        <a
+          class="text-primary hover:underline"
+          href="/archives"
+          @click="${this.navLink}"
+          >${msg("Archives")}</a
+        >
+        <span class="font-mono">/</span>
+        <span>${this.archive.name}</span>
+      </nav>
 
       <main>
         <sl-tab-group @sl-tab-show=${this.updateUrl}>


### PR DESCRIPTION
(https://github.com/ikreymer/browsertrix-cloud/issues/75) Update app layout to remove side bar that wasn't doing much and link "Browsertrix Cloud" to archives page instead.

### Manual testing
1. Run app and click app name in http://localhost:9870/. Verify it send you to the login page if logged out, and `/archives` if logged in
2. Click on an archive. Verify you see a breadcrumb eg `Archives / you@email.com's Archive`
3. Log in as an admin. Click on your email in the navbar. Verify you see the "Invite users" link

### Screenshots
Archive page:
<img width="816" alt="Screen Shot 2022-01-11 at 1 28 13 PM" src="https://user-images.githubusercontent.com/4672952/149026931-74cf1793-90da-43dc-926e-701826c38760.png">

Admin dropdown:
<img width="275" alt="Screen Shot 2022-01-11 at 1 28 35 PM" src="https://user-images.githubusercontent.com/4672952/149026940-5be64190-3c15-46b0-b9e3-8f0592765579.png">

