### PR TITLE
helm chart: support cloud-based persistent volumes if values 'volume_…

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: browsertrix-cloud
 description: A chart for running the Webrecorder Browsertrix System
 type: application
+icon: https://webrecorder.net/assets/icon.png
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.

--- a/chart/templates/minio.yaml
+++ b/chart/templates/minio.yaml
@@ -1,6 +1,42 @@
 {{- if .Values.minio_local }}
 
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: minio-storage-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+
+  resources:
+    requests:
+      storage: 5Gi
+
+  {{- if .Values.volume_storage_class }}
+  storageClassName: {{ .Values.volume_storage_class }}
+  {{- end }}
+
+
+{{- if not .Values.volume_storage_class }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "local-minio-store-pv"
+spec:
+  capacity:
+    storage: 5Gi
+
+  accessModes:
+    - "ReadWriteOnce"
+
+  hostPath:
+    path: /tmp/btrix-minio-data
+{{- end }}
+
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,9 +56,8 @@ spec:
     spec:
       volumes:
         - name: data-storage
-          hostPath:
-            path: /tmp/browsertrix-minio-data
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: minio-storage-pvc
 
       containers:
         - name: minio
@@ -36,6 +71,7 @@ spec:
           volumeMounts:
             - name: data-storage
               mountPath: /data
+              subPath: minio
 
 ---
 apiVersion: v1

--- a/chart/templates/mongo.yaml
+++ b/chart/templates/mongo.yaml
@@ -14,6 +14,41 @@ stringData:
 
 
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mongo-storage-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+
+  resources:
+    requests:
+      storage: 2Gi
+
+  {{- if .Values.volume_storage_class }}
+  storageClassName: {{ .Values.volume_storage_class }}
+  {{- end }}
+
+
+{{- if not .Values.volume_storage_class }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "local-mongo-store-pv"
+spec:
+  capacity:
+    storage: 2Gi
+
+  accessModes:
+    - "ReadWriteOnce"
+
+  hostPath:
+    path: /tmp/btrix-mongo-data
+{{- end }}
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,9 +67,8 @@ spec:
     spec:
       volumes:
         - name: data-db
-          hostPath:
-            path: /tmp/browsertrix-mongo-data
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: mongo-storage-pvc
 
       containers:
         - name: mongo
@@ -47,6 +81,7 @@ spec:
           volumeMounts:
             - name: data-db
               mountPath: /data/db
+              subPath: mongo
 
 ---
 apiVersion: v1

--- a/chart/templates/redis.yaml
+++ b/chart/templates/redis.yaml
@@ -1,6 +1,42 @@
 {{- if .Values.redis_local }}
 
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: redis-storage-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+
+  resources:
+    requests:
+      storage: 1Gi
+
+  {{- if .Values.volume_storage_class }}
+  storageClassName: {{ .Values.volume_storage_class }}
+  {{- end }}
+
+
+{{- if not .Values.volume_storage_class }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "local-redis-store-pv"
+spec:
+  capacity:
+    storage: 1Gi
+
+  accessModes:
+    - "ReadWriteOnce"
+
+  hostPath:
+    path: /tmp/btrix-redis-data
+{{- end }}
+
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,9 +56,8 @@ spec:
     spec:
       volumes:
         - name: data-storage
-          hostPath:
-            path: /tmp/browsertrix-redis-data
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: redis-storage-pvc
 
       containers:
         - name: redis
@@ -33,6 +68,7 @@ spec:
           volumeMounts:
             - name: data-storage
               mountPath: /data
+              subPath: redis
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,11 @@
 # =========================================
 name: browsertrix-cloud
 
+# when running in the cloud, set this value to cloud-specific block storage
+# keep empty to use hostPath (eg. on minikube)
+volume_storage_class:
+
+
 registration_enabled: 1
 jwt_token_lifetime_minutes: 60
 


### PR DESCRIPTION
…storage_class' is specified.

use PersistentVolumeClaim to create a persistent volume for each local service (mongo, minio, redis) when running in a cloud setup
if cloud-specified volume storage class not specified, create default hostPath volume (eg. for minikube)
lint: add default icon for chart