### PR TITLE
Schedule time of day when creating config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@xstate/fsm": "^1.6.2",
     "axios": "^0.22.0",
     "color": "^4.0.1",
+    "cron-parser": "^4.2.1",
     "lit": "^2.0.0",
     "path-parser": "^6.1.0",
     "tailwindcss": "^2.2.16"

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -9,7 +9,7 @@ type CrawlTemplate = any; // TODO
 const initialValues = {
   name: `Example crawl ${Date.now()}`, // TODO remove placeholder
   runNow: true,
-  schedule: "@weekly",
+  schedule: "0 0 * * 0",
   timeHour: "00",
   timeMinute: "00",
   // crawlTimeoutMinutes: 0,
@@ -85,10 +85,20 @@ export class CrawlTemplates extends LiteElement {
                     label=${msg("Schedule")}
                     value=${initialValues.schedule}
                   >
-                    <sl-menu-item value="">None</sl-menu-item>
-                    <sl-menu-item value="@daily">Daily</sl-menu-item>
-                    <sl-menu-item value="@weekly">Weekly</sl-menu-item>
-                    <sl-menu-item value="@monthly">Monthly</sl-menu-item>
+                    <!-- https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax -->
+                    <sl-menu-item value="">${msg("None")}</sl-menu-item>
+                    <sl-menu-item value="0 * * * *"
+                      >${msg("Hourly")}</sl-menu-item
+                    >
+                    <sl-menu-item value="0 0 * * *"
+                      >${msg("Daily")}</sl-menu-item
+                    >
+                    <sl-menu-item value="0 0 * * ${new Date().getDay()}"
+                      >${msg("Weekly")}</sl-menu-item
+                    >
+                    <sl-menu-item value="0 0 ${new Date().getDate()} * *"
+                      >${msg("Monthly")}</sl-menu-item
+                    >
                   </sl-select>
                 </div>
                 <div class="grid grid-flow-col gap-2 items-center">

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -137,7 +137,7 @@ export class CrawlTemplates extends LiteElement {
                       <sl-format-date
                         date="${cronParser
                           .parseExpression(this.cronSchedule, {
-                            // utc: true,
+                            utc: true,
                           })
                           .next()
                           .toString()}"
@@ -147,6 +147,7 @@ export class CrawlTemplates extends LiteElement {
                         hour="numeric"
                         minute="numeric"
                         time-zone-name="short"
+                        time-zone="utc"
                       ></sl-format-date>`
                   )}
                 </div>

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -111,6 +111,7 @@ export class CrawlTemplates extends LiteElement {
                       name="scheduleHour"
                       value="0"
                       class="w-24"
+                      ?disabled=${!this.cronSchedule}
                       @sl-select=${(e: any) =>
                         this.setCronTime({ hour: e.target.value })}
                     >
@@ -126,6 +127,7 @@ export class CrawlTemplates extends LiteElement {
                       name="scheduleMinute"
                       value="0"
                       class="w-24"
+                      ?disabled=${!this.cronSchedule}
                       @sl-select=${(e: any) =>
                         this.setCronTime({ minute: e.target.value })}
                     >
@@ -167,7 +169,7 @@ export class CrawlTemplates extends LiteElement {
                   name="runNow"
                   ?checked=${initialValues.runNow}
                   @sl-change=${(e: any) => (this.isRunNow = e.target.checked)}
-                  >${msg("Run immediately")}</sl-switch
+                  >${msg("Run immediately on save")}</sl-switch
                 >
               </div>
 

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -311,7 +311,7 @@ export class CrawlTemplates extends LiteElement {
     const seedUrlsStr = formData.get("seedUrls");
     const params = {
       name: formData.get("name"),
-      schedule: formData.get("schedule"),
+      schedule: this.cronSchedule,
       runNow: this.isRunNow,
       crawlTimeout: crawlTimeoutMinutes ? +crawlTimeoutMinutes * 60 : 0,
       config: {
@@ -323,22 +323,22 @@ export class CrawlTemplates extends LiteElement {
 
     console.log(params);
 
-    // try {
-    //   await this.apiFetch(
-    //     `/archives/${this.archiveId}/crawlconfigs/`,
-    //     this.authState,
-    //     {
-    //       method: "POST",
-    //       body: JSON.stringify(params),
-    //     }
-    //   );
+    try {
+      await this.apiFetch(
+        `/archives/${this.archiveId}/crawlconfigs/`,
+        this.authState,
+        {
+          method: "POST",
+          body: JSON.stringify(params),
+        }
+      );
 
-    //   console.debug("success");
+      console.debug("success");
 
-    //   this.navTo(`/archives/${this.archiveId}/crawl-templates`);
-    // } catch (e) {
-    //   console.error(e);
-    // }
+      this.navTo(`/archives/${this.archiveId}/crawl-templates`);
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   /** Set day, month or day of week in cron schedule */

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -4,6 +4,7 @@ import cronParser from "cron-parser";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
+import { getLocaleTimeZone } from "../../utils/localization";
 
 type CrawlTemplate = any; // TODO
 
@@ -46,6 +47,10 @@ export class CrawlTemplates extends LiteElement {
 
   @state()
   private cronSchedule: string = initialValues.schedule;
+
+  private get timeZoneName() {
+    return getLocaleTimeZone();
+  }
 
   render() {
     if (this.isNew) {
@@ -139,7 +144,7 @@ export class CrawlTemplates extends LiteElement {
                           >`
                       )}
                     </sl-select>
-                    <span class="px-1">${msg("UTC")}</span>
+                    <span class="px-1">${this.timeZoneName}</span>
                   </div>
                 </div>
                 <div class="text-sm text-gray-500 mt-1">
@@ -148,9 +153,7 @@ export class CrawlTemplates extends LiteElement {
                         html`Next scheduled crawl:
                           <sl-format-date
                             date="${cronParser
-                              .parseExpression(this.cronSchedule, {
-                                utc: true,
-                              })
+                              .parseExpression(this.cronSchedule)
                               .next()
                               .toString()}"
                             weekday="long"
@@ -160,7 +163,6 @@ export class CrawlTemplates extends LiteElement {
                             hour="numeric"
                             minute="numeric"
                             time-zone-name="short"
-                            time-zone="utc"
                           ></sl-format-date>`
                       )
                     : msg("No crawls scheduled")}

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -41,10 +41,10 @@ export class CrawlTemplates extends LiteElement {
   crawlTemplates?: CrawlTemplate[];
 
   @state()
-  isRunNow: boolean = initialValues.runNow;
+  private isRunNow: boolean = initialValues.runNow;
 
   @state()
-  cronSchedule: string = initialValues.schedule;
+  private cronSchedule: string = initialValues.schedule;
 
   render() {
     if (this.isNew) {

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -11,8 +11,6 @@ type CrawlTemplate = any; // TODO
 const initialValues = {
   name: `Example crawl ${Date.now()}`, // TODO remove placeholder
   runNow: true,
-  timeHour: "00",
-  timeMinute: "00",
   // crawlTimeoutMinutes: 0,
   seedUrls: "",
   scopeType: "prefix",

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -367,6 +367,8 @@ export class CrawlTemplates extends LiteElement {
 
     const { minute, hour, period } = this.scheduleTime;
     const localDate = new Date();
+
+    // Convert 12-hr to 24-hr time
     let periodOffset = 0;
 
     if (hour === 12) {
@@ -381,7 +383,6 @@ export class CrawlTemplates extends LiteElement {
 
     localDate.setHours(+hour + periodOffset);
     localDate.setMinutes(+minute);
-    // let dayOfMonth = '*', month = '*', dayOfWeek = '*'
     const dayOfMonth =
       this.scheduleInterval === "monthly" ? localDate.getUTCDate() : "*";
     const dayOfWeek =

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -10,6 +10,7 @@ type CrawlTemplate = any; // TODO
 const initialValues = {
   name: `Example crawl ${Date.now()}`, // TODO remove placeholder
   runNow: true,
+  // https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
   schedule: `0 0 * * ${new Date().getDay()}`,
   timeHour: "00",
   timeMinute: "00",

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -90,7 +90,7 @@ export class CrawlTemplates extends LiteElement {
                       label=${msg("Schedule")}
                       value=${initialValues.schedule}
                       @sl-select=${(e: any) =>
-                        this.setCronSchedule(e.target.value)}
+                        this.setCronInterval(e.target.value)}
                     >
                       <!-- https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax -->
                       <sl-menu-item value="">${msg("None")}</sl-menu-item>
@@ -141,6 +141,7 @@ export class CrawlTemplates extends LiteElement {
                           })
                           .next()
                           .toString()}"
+                        weekday="long"
                         month="long"
                         day="numeric"
                         year="numeric"
@@ -301,9 +302,17 @@ export class CrawlTemplates extends LiteElement {
     // }
   }
 
-  private setCronSchedule(expression: string) {
-    console.log(expression);
+  private setCronInterval(expression: string) {
+    if (!expression) {
+      this.cronSchedule = "";
+      return;
+    }
 
-    this.cronSchedule = expression;
+    const [minute = "0", hour = "0"] = this.cronSchedule.split(" ");
+    const [, newHour, dayOfMonth, month, dayOfWeek] = expression.split(" ");
+
+    this.cronSchedule = `${minute} ${
+      newHour === "*" ? newHour : hour
+    } ${dayOfMonth} ${month} ${dayOfWeek}`;
   }
 }

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -10,11 +10,20 @@ const initialValues = {
   name: `Example crawl ${Date.now()}`, // TODO remove placeholder
   runNow: true,
   schedule: "@weekly",
+  timeHour: "00",
+  timeMinute: "00",
   // crawlTimeoutMinutes: 0,
   seedUrls: "",
   scopeType: "prefix",
   // limit: 0,
 };
+const makeTimeOptions = (length: number) =>
+  Array.from({ length }).map((x, i) => ({
+    value: i,
+    label: `${i}`.padStart(2, "0"),
+  }));
+const hours = makeTimeOptions(24);
+const minutes = makeTimeOptions(60);
 
 @localized()
 export class CrawlTemplates extends LiteElement {
@@ -70,8 +79,7 @@ export class CrawlTemplates extends LiteElement {
                 ></sl-input>
               </div>
               <div class="flex items-end">
-                <!-- TODO schedule time -->
-                <div>
+                <div class="pr-2 flex-1">
                   <sl-select
                     name="schedule"
                     label=${msg("Schedule")}
@@ -83,12 +91,27 @@ export class CrawlTemplates extends LiteElement {
                     <sl-menu-item value="@monthly">Monthly</sl-menu-item>
                   </sl-select>
                 </div>
-                <!-- <div>
-                  <btrix-input
-                    name="scheduleTime"
-                    type="time"
-                  ></btrix-input>
-                </div> -->
+                <div class="grid grid-flow-col gap-2 items-center">
+                  <span class="px-1">${msg("at")}</span>
+                  <sl-select name="scheduleHour" value="0" class="w-24">
+                    ${hours.map(
+                      ({ value, label }) =>
+                        html`<sl-menu-item value=${value}
+                          >${label}</sl-menu-item
+                        >`
+                    )}
+                  </sl-select>
+                  <span>:</span>
+                  <sl-select name="scheduleMinute" value="0" class="w-24">
+                    ${minutes.map(
+                      ({ value, label }) =>
+                        html`<sl-menu-item value=${value}
+                          >${label}</sl-menu-item
+                        >`
+                    )}
+                  </sl-select>
+                  <span class="px-1">${msg("UTC")}</span>
+                </div>
               </div>
               <div>
                 <sl-switch
@@ -220,21 +243,21 @@ export class CrawlTemplates extends LiteElement {
 
     console.log(params);
 
-    try {
-      await this.apiFetch(
-        `/archives/${this.archiveId}/crawlconfigs/`,
-        this.authState,
-        {
-          method: "POST",
-          body: JSON.stringify(params),
-        }
-      );
+    // try {
+    //   await this.apiFetch(
+    //     `/archives/${this.archiveId}/crawlconfigs/`,
+    //     this.authState,
+    //     {
+    //       method: "POST",
+    //       body: JSON.stringify(params),
+    //     }
+    //   );
 
-      console.debug("success");
+    //   console.debug("success");
 
-      this.navTo(`/archives/${this.archiveId}/crawl-templates`);
-    } catch (e) {
-      console.error(e);
-    }
+    //   this.navTo(`/archives/${this.archiveId}/crawl-templates`);
+    // } catch (e) {
+    //   console.error(e);
+    // }
   }
 }

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -142,25 +142,27 @@ export class CrawlTemplates extends LiteElement {
                   </div>
                 </div>
                 <div class="text-sm text-gray-500 mt-1">
-                  ${msg(
-                    html`Next scheduled crawl:
-                      <sl-format-date
-                        date="${cronParser
-                          .parseExpression(this.cronSchedule, {
-                            utc: true,
-                          })
-                          .next()
-                          .toString()}"
-                        weekday="long"
-                        month="long"
-                        day="numeric"
-                        year="numeric"
-                        hour="numeric"
-                        minute="numeric"
-                        time-zone-name="short"
-                        time-zone="utc"
-                      ></sl-format-date>`
-                  )}
+                  ${this.cronSchedule
+                    ? msg(
+                        html`Next scheduled crawl:
+                          <sl-format-date
+                            date="${cronParser
+                              .parseExpression(this.cronSchedule, {
+                                utc: true,
+                              })
+                              .next()
+                              .toString()}"
+                            weekday="long"
+                            month="long"
+                            day="numeric"
+                            year="numeric"
+                            hour="numeric"
+                            minute="numeric"
+                            time-zone-name="short"
+                            time-zone="utc"
+                          ></sl-format-date>`
+                      )
+                    : msg("No crawls scheduled")}
                 </div>
               </div>
 
@@ -238,37 +240,40 @@ export class CrawlTemplates extends LiteElement {
                 >${msg("Save Crawl Template")}</sl-button
               >
 
-              <div class="text-sm text-gray-500 mt-6">
-                ${this.isRunNow
-                  ? html`
-                      <p class="mb-2">
-                        ${msg("A crawl will start immediately on save.")}
-                      </p>
-                    `
-                  : ""}
-
-                <p>
-                  ${msg(
-                    html`Next scheduled crawl:
-                      <sl-format-date
-                        date="${cronParser
-                          .parseExpression(this.cronSchedule, {
-                            utc: true,
-                          })
-                          .next()
-                          .toString()}"
-                        weekday="long"
-                        month="long"
-                        day="numeric"
-                        year="numeric"
-                        hour="numeric"
-                        minute="numeric"
-                        time-zone-name="short"
-                        time-zone="utc"
-                      ></sl-format-date>`
-                  )}
-                </p>
-              </div>
+              ${this.isRunNow || this.cronSchedule
+                ? html`<div class="text-sm text-gray-500 mt-6">
+                    ${this.isRunNow
+                      ? html`
+                          <p class="mb-2">
+                            ${msg("A crawl will start immediately on save.")}
+                          </p>
+                        `
+                      : ""}
+                    ${this.cronSchedule
+                      ? html` <p>
+                          ${msg(
+                            html`Next scheduled crawl:
+                              <sl-format-date
+                                date="${cronParser
+                                  .parseExpression(this.cronSchedule, {
+                                    utc: true,
+                                  })
+                                  .next()
+                                  .toString()}"
+                                weekday="long"
+                                month="long"
+                                day="numeric"
+                                year="numeric"
+                                hour="numeric"
+                                minute="numeric"
+                                time-zone-name="short"
+                                time-zone="utc"
+                              ></sl-format-date>`
+                          )}
+                        </p>`
+                      : ""}
+                  </div>`
+                : ""}
             </div>
           </div>
         </sl-form>

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -15,6 +15,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/form/form"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/format-date/format-date"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/icon/icon"
 );
 import(

--- a/frontend/src/utils/localization.ts
+++ b/frontend/src/utils/localization.ts
@@ -14,3 +14,19 @@ export const setLocaleFromUrl = async () => {
   const locale = url.searchParams.get("locale") || sourceLocale;
   await setLocale(locale);
 };
+
+/**
+ * Get time zone short name from locales
+ * @param locales List of locale codes. Omit for browser default
+ **/
+export const getLocaleTimeZone = (locales?: string[]) => {
+  const date = new Date();
+
+  return date
+    .toLocaleTimeString(locales || [], {
+      timeZoneName: "short",
+      hour: "2-digit",
+    })
+    .replace(date.toLocaleTimeString([], { hour: "2-digit" }), "")
+    .trim();
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1758,6 +1758,13 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cron-parser@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-4.2.1.tgz#b43205d05ccd5c93b097dae64f3bd811f5993af3"
+  integrity sha512-5sJBwDYyCp+0vU5b7POl8zLWfgV5fOHxlc45FWoWdHecGC7MQHCjx0CHivCMRnGFovghKhhyYM+Zm9DcY5qcHg==
+  dependencies:
+    luxon "^1.28.0"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -3559,6 +3566,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"
+  integrity sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==
 
 make-dir@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
WIP https://github.com/webrecorder/browsertrix-cloud/issues/74

Formats schedule in UTC with hour and minute selections.

### Assumptions
- kube-controller-manager is in UTC
- the next weekly or monthly interval will run a week/month from template creation, not on the first day of the week or first day of the month. We could make this configurable down the road.

### Manual testing
1. Run app and go to Archives > archive > Crawl Templates > new
2. Update schedule interval and time dropdowns. Verify that "Next scheduled crawl" date updates as expected
3. Open browser dev tools network tab and save template. Verify that `schedule` in payload is formatted as expected

### Screenshots
**Default schedule field**
<img width="727" alt="Screen Shot 2022-01-17 at 6 29 58 PM" src="https://user-images.githubusercontent.com/4672952/149860647-905cfe1a-3675-44aa-a996-88e4b5e3c1db.png">

**Schedule disabled**
<img width="715" alt="Screen Shot 2022-01-17 at 6 30 08 PM" src="https://user-images.githubusercontent.com/4672952/149860664-c001bf89-c06c-4a09-b2fa-db1054ae2230.png">

**Example text near button**
<img width="477" alt="Screen Shot 2022-01-17 at 6 30 28 PM" src="https://user-images.githubusercontent.com/4672952/149860681-84e082ae-2fa5-454e-8c00-35b3df23b890.png">

