### PR TITLE
Configure crawls with JSON

### DIFF
--- a/frontend/src/components/copy-button.ts
+++ b/frontend/src/components/copy-button.ts
@@ -7,8 +7,10 @@ import { msg, localized } from "@lit/localize";
  *
  * Usage example:
  * ```ts
- * <btrix-copy-button .value=${value}></btrix-copy-button>
+ * <btrix-copy-button .value=${value} @on-copied=${console.log}></btrix-copy-button>
  * ```
+ *
+ * @event on-copied
  */
 @localized()
 export class CopyButton extends LitElement {
@@ -36,6 +38,8 @@ export class CopyButton extends LitElement {
     navigator.clipboard.writeText(this.value!);
 
     this.isCopied = true;
+
+    this.dispatchEvent(new CustomEvent("on-copied", { detail: this.value }));
 
     this.timeoutId = window.setTimeout(() => {
       this.isCopied = false;

--- a/frontend/src/components/copy-button.ts
+++ b/frontend/src/components/copy-button.ts
@@ -1,0 +1,44 @@
+import { LitElement, html } from "lit";
+import { property, state } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
+/**
+ * Copy text to clipboard on click
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-copy-button .value=${value}></btrix-copy-button>
+ * ```
+ */
+@localized()
+export class CopyButton extends LitElement {
+  @property({ type: String })
+  value?: string;
+
+  @state()
+  private isCopied: boolean = false;
+
+  timeoutId?: number;
+
+  disconnectedCallback() {
+    window.clearTimeout(this.timeoutId);
+  }
+
+  render() {
+    return html`
+      <sl-button size="small" @click=${this.onClick} ?disabled=${!this.value}
+        >${this.isCopied ? msg("Copied") : msg("Copy")}</sl-button
+      >
+    `;
+  }
+
+  private onClick() {
+    navigator.clipboard.writeText(this.value!);
+
+    this.isCopied = true;
+
+    this.timeoutId = window.setTimeout(() => {
+      this.isCopied = false;
+    }, 3000);
+  }
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -9,6 +9,9 @@ import("./account-settings").then(({ AccountSettings }) => {
 import("./archive-invite-form").then(({ ArchiveInviteForm }) => {
   customElements.define("btrix-archive-invite-form", ArchiveInviteForm);
 });
+import("./copy-button").then(({ CopyButton }) => {
+  customElements.define("btrix-copy-button", CopyButton);
+});
 import("./invite-form").then(({ InviteForm }) => {
   customElements.define("btrix-invite-form", InviteForm);
 });

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -224,6 +224,18 @@ export class CrawlTemplates extends LiteElement {
       class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-sm"
       contenteditable="true"
       spellcheck="false"
+      @keydown=${(e: any) => {
+        // Add indentation when pressing tab key instead of moving focus
+        if (e.keyCode === /* tab: */ 9) {
+          e.preventDefault();
+
+          const range = window.getSelection()!.getRangeAt(0);
+          const tabNode = document.createTextNode("  ");
+          range.insertNode(tabNode);
+          range.setStartAfter(tabNode);
+          range.setEndAfter(tabNode);
+        }
+      }}
     ><code class="language-json">${code}</code></pre>`;
   }
 

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -209,7 +209,22 @@ export class CrawlTemplates extends LiteElement {
   }
 
   private renderAdvancedSettings() {
-    return html`TODO`;
+    return html`
+      <h4>${msg("JSON configuration")}</h4>
+      <p>${msg("Edit or paste in an existing JSON crawl template.")}</p>
+
+      ${this.renderJSON()}
+    `;
+  }
+
+  private renderJSON() {
+    const code = JSON.stringify({ a: "b" }, null, 2);
+
+    return html`<pre
+      class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-sm"
+      contenteditable="true"
+      spellcheck="false"
+    ><code class="language-json">${code}</code></pre>`;
   }
 
   private async onSubmit(event: { detail: { formData: FormData } }) {

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -111,6 +111,29 @@ export class CrawlTemplates extends LiteElement {
     return this.renderList();
   }
 
+  private toggleAdvancedSettingsView(isVisible: boolean) {
+    if (!isVisible && !this.invalidJsonTemplateMessage) {
+      try {
+        const hasChanges =
+          JSON.stringify(JSON.parse(this.jsonTemplate), null, 2) !==
+          initialJsonTemplate;
+
+        if (hasChanges) {
+          if (
+            window.confirm(
+              msg("Are you sure? Your JSON configuration will be overwritten.")
+            )
+          ) {
+            this.isAdvancedSettingsView = isVisible;
+            this.jsonTemplate = initialJsonTemplate;
+          }
+        }
+      } catch {}
+    } else {
+      this.isAdvancedSettingsView = isVisible;
+    }
+  }
+
   private renderNew() {
     return html`
       <h2 class="text-xl font-bold">${msg("New Crawl Template")}</h2>
@@ -125,7 +148,7 @@ export class CrawlTemplates extends LiteElement {
           <sl-switch
             ?checked=${this.isAdvancedSettingsView}
             @sl-change=${(e: any) =>
-              (this.isAdvancedSettingsView = e.target.checked)}
+              this.toggleAdvancedSettingsView(e.target.checked)}
           >
             <span class="text-sm">${msg("Advanced custom settings")}</span>
           </sl-switch>

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -244,7 +244,9 @@ export class CrawlTemplates extends LiteElement {
             ${this.renderJSON()}
 
             <div class="absolute top-2 right-2">
-              <sl-button size="small">${msg("Copy")}</sl-button>
+              <btrix-copy-button
+                .value=${JSON.stringify(this.jsonTemplate, null, 2)}
+              ></btrix-copy-button>
             </div>
           </div>
 

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -15,6 +15,13 @@ const initialValues = {
   scopeType: "prefix",
   // limit: 0,
 };
+const initialJsonTemplate = JSON.stringify(
+  {
+    config: {},
+  },
+  null,
+  2
+);
 
 @localized()
 export class CrawlTemplates extends LiteElement {
@@ -34,13 +41,7 @@ export class CrawlTemplates extends LiteElement {
   isRunNow: boolean = initialValues.runNow;
 
   @state()
-  private jsonTemplate: string = JSON.stringify(
-    {
-      config: {},
-    },
-    null,
-    2
-  );
+  private jsonTemplate: string = initialJsonTemplate;
 
   @state()
   private invalidJsonTemplateMessage: string = "";
@@ -230,6 +231,11 @@ export class CrawlTemplates extends LiteElement {
                 >${msg("Invalid JSON")}</sl-tag
               >`
             : ""}
+          ${this.jsonTemplate !== initialJsonTemplate
+            ? html`<sl-tag type="success" size="small" class="ml-1"
+                >${msg("Settings changed")}</sl-tag
+              >`
+            : ""}
         </label>
 
         <div class="grid gap-4">
@@ -338,9 +344,14 @@ export class CrawlTemplates extends LiteElement {
     let params = this.parseTemplate(event.detail.formData);
 
     if (!this.invalidJsonTemplateMessage) {
+      const { config, ...other } = JSON.parse(this.jsonTemplate);
       params = {
         ...params,
-        ...JSON.parse(this.jsonTemplate),
+        ...other,
+        config: {
+          ...params.config,
+          ...config,
+        },
       };
     }
 

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -315,11 +315,15 @@ export class CrawlTemplates extends LiteElement {
   private renderPagesSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="text-lg font-medium">${msg("Pages")}</h3>
+        <h3 class="text-lg font-medium">${msg("Crawl configuration")}</h3>
       </div>
       <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
         <div class="flex justify-between">
-          <h4 class="font-medium">${msg("Configure Seeds")}</h4>
+          <h4 class="font-medium">
+            ${this.isSeedsJsonView
+              ? msg("Custom Config")
+              : msg("Configure Seeds")}
+          </h4>
           <sl-switch
             ?checked=${this.isSeedsJsonView}
             @sl-change=${(e: any) => (this.isSeedsJsonView = e.target.checked)}

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -159,6 +159,16 @@ export class CrawlTemplates extends LiteElement {
               </div>
             </section>
 
+            <div
+              id="advanced-settings"
+              class="col-span-1 p-4 md:p-8 md:border-b"
+            >
+              <h3 class="text-md font-medium">${msg("Advanced settings")}</h3>
+            </div>
+            <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
+              ${this.renderAdvancedSettings()}
+            </section>
+
             <div class="col-span-4 p-4 md:p-8 text-center">
               ${this.isRunNow
                 ? html`
@@ -196,6 +206,10 @@ export class CrawlTemplates extends LiteElement {
         )}
       </div>
     `;
+  }
+
+  private renderAdvancedSettings() {
+    return html`TODO`;
   }
 
   private async onSubmit(event: { detail: { formData: FormData } }) {

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -145,7 +145,11 @@ export class CrawlTemplates extends LiteElement {
                 : ""}
 
               <div>
-                <sl-button type="primary" submit
+                <sl-button
+                  type="primary"
+                  submit
+                  ?loading=${this.isSubmitting}
+                  ?disabled=${this.isSubmitting}
                   >${msg("Save Crawl Template")}</sl-button
                 >
               </div>

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -9,6 +9,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button/button"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/details/details"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/dialog/dialog"
 );
 import(

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -55,8 +55,11 @@ export default class LiteElement extends LitElement {
         if (typeof detail === "string") {
           errorMessage = detail;
         } else {
-          // TODO client error details
-          errorMessage = "Unknown API error";
+          // TODO return client error details
+          const fieldDetail = detail[0];
+          const { loc, msg } = fieldDetail;
+
+          errorMessage = `${loc[loc.length - 1]} ${msg}`;
         }
       } catch {
         errorMessage = "Unknown API error";


### PR DESCRIPTION
WIP https://github.com/webrecorder/browsertrix-cloud/issues/74

MVP configure crawl with JSON. Properties in the JSON config will override form settings. There is no syncing in between the form and JSON at the moment for simplicity.

### Manual testing
1. Run app and go to Archives > archive > Crawl Templates > new
2. Go to "Pages" section and click "Use JSON editor" toggle. Verify JSON editor shows
3. Interact with JSON editor. Verify JSON is formatted or shows correct error when clicking out of text area.
4. Save config. Verify that invalid JSON is not submitted and valid JSON is formatted into the payload as expected.

### Screenshots
**Toggled off**
<img width="1019" alt="Screen Shot 2022-01-18 at 7 37 27 PM" src="https://user-images.githubusercontent.com/4672952/150059594-134cd299-9d40-4554-a9a3-43f46d252037.png">

**Toggled on**
<img width="723" alt="Screen Shot 2022-01-18 at 7 37 33 PM" src="https://user-images.githubusercontent.com/4672952/150059617-3a5618ff-d585-46f8-a935-8e9bde578011.png">

**Feedback on invalid JSON**
<img width="716" alt="Screen Shot 2022-01-18 at 7 40 16 PM" src="https://user-images.githubusercontent.com/4672952/150059725-501d6cea-f79a-4c9e-b87b-ef5e891a1993.png">

