### PR TITLE
Create crawl config UX enhancements

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -372,6 +372,7 @@ export class App extends LiteElement {
           class="w-full"
           @navigate=${this.onNavigateTo}
           @need-login=${this.onNeedLogin}
+          @notify="${this.onNotify}"
           .authState=${this.authService.authState}
           .userInfo=${this.userInfo}
           archiveId=${this.viewState.params.id}
@@ -480,12 +481,15 @@ export class App extends LiteElement {
   onNotify(
     event: CustomEvent<{
       title?: string;
+      /** Can contain HTML */
       message?: string;
       type?: "success" | "warning" | "danger" | "primary";
       icon?: string;
       duration?: number;
     }>
   ) {
+    event.stopPropagation();
+
     const {
       title,
       message,
@@ -493,12 +497,6 @@ export class App extends LiteElement {
       icon = "info-circle",
       duration = 5000,
     } = event.detail;
-
-    const escapeHtml = (html: any) => {
-      const div = document.createElement("div");
-      div.textContent = html;
-      return div.innerHTML;
-    };
 
     const alert = Object.assign(document.createElement("sl-alert"), {
       type: type,
@@ -513,8 +511,8 @@ export class App extends LiteElement {
       innerHTML: `
         <sl-icon name="${icon}" slot="icon"></sl-icon>
         <span>
-          ${title ? `<strong>${escapeHtml(title)}</strong>` : ""}
-          ${message ? `<div>${escapeHtml(message)}</div>` : ""}
+          ${title ? `<strong>${title}</strong>` : ""}
+          ${message ? `<div>${message}</div>` : ""}
         </span>
 
       `,

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -532,13 +532,29 @@ export class CrawlTemplates extends LiteElement {
     this.isSubmitting = true;
 
     try {
-      await this.apiFetch(
+      const data = await this.apiFetch(
         `/archives/${this.archiveId}/crawlconfigs/`,
         this.authState,
         {
           method: "POST",
           body: JSON.stringify(params),
         }
+      );
+
+      this.dispatchEvent(
+        new CustomEvent("notify", {
+          bubbles: true,
+          detail: {
+            message: data.run_now_job
+              ? msg(
+                  str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
+                )
+              : msg("Crawl template created."),
+            type: "success",
+            icon: "check2-circle",
+            duration: 10000,
+          },
+        })
       );
 
       this.navTo(`/archives/${this.archiveId}/crawl-templates`);

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -63,9 +63,9 @@ export class CrawlTemplates extends LiteElement {
   @state()
   private scheduleTime: { hour: number; minute: number; period: "AM" | "PM" } =
     {
-      hour: 12,
+      hour: new Date().getHours() % 12 || 12,
       minute: 0,
-      period: "AM",
+      period: new Date().getHours() > 11 ? "PM" : "AM",
     };
 
   @state()
@@ -285,7 +285,7 @@ export class CrawlTemplates extends LiteElement {
                 )}
               </sl-select>
               <sl-select
-                value="AM"
+                value=${this.scheduleTime.period}
                 class="w-24"
                 ?disabled=${!this.scheduleInterval}
                 @sl-select=${(e: any) =>
@@ -572,10 +572,8 @@ export class CrawlTemplates extends LiteElement {
       if (period === "AM") {
         periodOffset = -12;
       }
-    } else if (hour === 1) {
-      if (period === "PM") {
-        periodOffset = 12;
-      }
+    } else if (period === "PM") {
+      periodOffset = 12;
     }
 
     localDate.setHours(+hour + periodOffset);

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -136,7 +136,8 @@ export class CrawlTemplates extends LiteElement {
         <div class="border rounded-lg">
           <sl-form @sl-submit=${this.onSubmit} aria-describedby="formError">
             <div class="md:grid grid-cols-4">
-              ${this.renderBasicSettings()} ${this.renderPagesSettings()}
+              ${this.renderBasicSettings()} ${this.renderCrawlConfigSettings()}
+              ${this.renderScheduleSettings()}
             </div>
 
             <div class="p-4 md:p-8 text-center grid gap-5">
@@ -198,124 +199,128 @@ export class CrawlTemplates extends LiteElement {
   private renderBasicSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="text-lg font-medium">${msg("Basic settings")}</h3>
+        <h3 class="font-medium">${msg("Basic settings")}</h3>
       </div>
       <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
-        <div>
-          <sl-input
-            name="name"
-            label=${msg("Name")}
-            placeholder=${msg("Example (example.com) Weekly Crawl", {
-              desc: "Example crawl template name",
-            })}
-            autocomplete="off"
-            value=${initialValues.name}
-            required
-          ></sl-input>
-        </div>
-        <div>
-          <div class="flex items-end">
-            <div class="pr-2 flex-1">
-              <sl-select
-                name="schedule"
-                label=${msg("Schedule")}
-                value=${this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleInterval = e.target.value)}
-              >
-                <sl-menu-item value="">${msg("None")}</sl-menu-item>
-                <sl-menu-item value="daily">${msg("Daily")}</sl-menu-item>
-                <sl-menu-item value="weekly">${msg("Weekly")}</sl-menu-item>
-                <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
-              </sl-select>
-            </div>
-            <div class="grid grid-flow-col gap-2 items-center">
-              <span class="px-1">${msg("at")}</span>
-              <sl-select
-                name="scheduleHour"
-                value=${this.scheduleTime.hour}
-                class="w-24"
-                ?disabled=${!this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleTime = {
-                    ...this.scheduleTime,
-                    hour: +e.target.value,
-                  })}
-              >
-                ${hours.map(
-                  ({ value, label }) =>
-                    html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-                )}
-              </sl-select>
-              <span>:</span>
-              <sl-select
-                name="scheduleMinute"
-                value=${this.scheduleTime.minute}
-                class="w-24"
-                ?disabled=${!this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleTime = {
-                    ...this.scheduleTime,
-                    minute: +e.target.value,
-                  })}
-              >
-                ${minutes.map(
-                  ({ value, label }) =>
-                    html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-                )}
-              </sl-select>
-              <sl-select
-                value="AM"
-                class="w-24"
-                ?disabled=${!this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleTime = {
-                    ...this.scheduleTime,
-                    period: e.target.value,
-                  })}
-              >
-                <sl-menu-item value="AM"
-                  >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
-                >
-                <sl-menu-item value="PM"
-                  >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
-                >
-              </sl-select>
-              <span class="px-1">${this.timeZoneShortName}</span>
-            </div>
-          </div>
-          <div class="text-sm text-gray-500 mt-1">
-            ${this.nextScheduledCrawlMessage || msg("No crawls scheduled")}
-          </div>
-        </div>
-
-        <div>
-          <sl-switch
-            name="runNow"
-            ?checked=${initialValues.runNow}
-            @sl-change=${(e: any) => (this.isRunNow = e.target.checked)}
-            >${msg("Run immediately on save")}</sl-switch
-          >
-        </div>
-
-        <div>
-          <sl-input
-            name="crawlTimeoutMinutes"
-            label=${msg("Time limit")}
-            placeholder=${msg("unlimited")}
-            type="number"
-          >
-            <span slot="suffix">${msg("minutes")}</span>
-          </sl-input>
-        </div>
+        <sl-input
+          name="name"
+          label=${msg("Name")}
+          help-text=${msg(
+            "Required. Name your template to easily identify it later."
+          )}
+          placeholder=${msg("Example (example.com) Weekly Crawl", {
+            desc: "Example crawl template name",
+          })}
+          autocomplete="off"
+          value=${initialValues.name}
+          required
+        ></sl-input>
       </section>
     `;
   }
 
-  private renderPagesSettings() {
+  private renderScheduleSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="text-lg font-medium">${msg("Crawl configuration")}</h3>
+        <h3 class="font-medium">${msg("Schedule")}</h3>
+      </div>
+      <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
+        <div class="flex items-end">
+          <div class="pr-2 flex-1">
+            <sl-select
+              name="schedule"
+              label=${msg("Schedule")}
+              value=${this.scheduleInterval}
+              @sl-select=${(e: any) => (this.scheduleInterval = e.target.value)}
+            >
+              <sl-menu-item value="">${msg("None")}</sl-menu-item>
+              <sl-menu-item value="daily">${msg("Daily")}</sl-menu-item>
+              <sl-menu-item value="weekly">${msg("Weekly")}</sl-menu-item>
+              <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
+            </sl-select>
+          </div>
+          <div class="grid grid-flow-col gap-2 items-center">
+            <span class="px-1">${msg("at")}</span>
+            <sl-select
+              name="scheduleHour"
+              value=${this.scheduleTime.hour}
+              class="w-24"
+              ?disabled=${!this.scheduleInterval}
+              @sl-select=${(e: any) =>
+                (this.scheduleTime = {
+                  ...this.scheduleTime,
+                  hour: +e.target.value,
+                })}
+            >
+              ${hours.map(
+                ({ value, label }) =>
+                  html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+              )}
+            </sl-select>
+            <span>:</span>
+            <sl-select
+              name="scheduleMinute"
+              value=${this.scheduleTime.minute}
+              class="w-24"
+              ?disabled=${!this.scheduleInterval}
+              @sl-select=${(e: any) =>
+                (this.scheduleTime = {
+                  ...this.scheduleTime,
+                  minute: +e.target.value,
+                })}
+            >
+              ${minutes.map(
+                ({ value, label }) =>
+                  html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+              )}
+            </sl-select>
+            <sl-select
+              value="AM"
+              class="w-24"
+              ?disabled=${!this.scheduleInterval}
+              @sl-select=${(e: any) =>
+                (this.scheduleTime = {
+                  ...this.scheduleTime,
+                  period: e.target.value,
+                })}
+            >
+              <sl-menu-item value="AM"
+                >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
+              >
+              <sl-menu-item value="PM"
+                >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
+              >
+            </sl-select>
+            <span class="px-1">${this.timeZoneShortName}</span>
+          </div>
+        </div>
+        <div class="text-sm text-gray-500 mt-1">
+          ${this.nextScheduledCrawlMessage || msg("No crawls scheduled")}
+        </div>
+
+        <sl-switch
+          name="runNow"
+          ?checked=${initialValues.runNow}
+          @sl-change=${(e: any) => (this.isRunNow = e.target.checked)}
+          >${msg("Run immediately on save")}</sl-switch
+        >
+
+        <sl-input
+          name="crawlTimeoutMinutes"
+          label=${msg("Time limit")}
+          placeholder=${msg("unlimited")}
+          type="number"
+        >
+          <span slot="suffix">${msg("minutes")}</span>
+        </sl-input>
+      </section>
+    `;
+  }
+
+  private renderCrawlConfigSettings() {
+    return html`
+      <div class="col-span-1 p-4 md:p-8 md:border-b">
+        <h3 class="font-medium">${msg("Crawl configuration")}</h3>
       </div>
       <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
         <div class="flex justify-between">
@@ -344,11 +349,12 @@ export class CrawlTemplates extends LiteElement {
       <sl-textarea
         name="seedUrls"
         label=${msg("Seed URLs")}
-        helpText=${msg("Separated by a new line, space or comma")}
         placeholder=${msg(`https://webrecorder.net\nhttps://example.com`, {
           desc: "Example seed URLs",
         })}
-        help-text=${msg("Separate URLs with a new line, space or comma.")}
+        help-text=${msg(
+          "Required. Separate URLs with a new line, space or comma."
+        )}
         rows="3"
         required
       ></sl-textarea>

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -91,27 +91,26 @@ export class CrawlTemplates extends LiteElement {
     return getLocaleTimeZone();
   }
 
-  private get nextScheduledCrawlMessage() {
+  private get formattededNextCrawlDate() {
     const utcSchedule = this.getUTCSchedule();
 
     return this.scheduleInterval
-      ? msg(html`Next scheduled crawl:
-          <sl-format-date
-            date="${cronParser
-              .parseExpression(utcSchedule, {
-                utc: true,
-              })
-              .next()
-              .toString()}"
-            weekday="long"
-            month="long"
-            day="numeric"
-            year="numeric"
-            hour="numeric"
-            minute="numeric"
-            time-zone-name="short"
-            time-zone=${this.timeZone}
-          ></sl-format-date>`)
+      ? html`<sl-format-date
+          date="${cronParser
+            .parseExpression(utcSchedule, {
+              utc: true,
+            })
+            .next()
+            .toString()}"
+          weekday="long"
+          month="long"
+          day="numeric"
+          year="numeric"
+          hour="numeric"
+          minute="numeric"
+          time-zone-name="short"
+          time-zone=${this.timeZone}
+        ></sl-format-date>`
       : undefined;
   }
 
@@ -166,7 +165,16 @@ export class CrawlTemplates extends LiteElement {
                           </p>
                         `
                       : ""}
-                    ${this.nextScheduledCrawlMessage}
+                    ${this.scheduleInterval
+                      ? html`
+                          <p class="mb-2">
+                            ${msg(
+                              html`Scheduled crawl will run
+                              ${this.formattededNextCrawlDate}.`
+                            )}
+                          </p>
+                        `
+                      : ""}
                   </div>`
                 : ""}
             </div>
@@ -222,80 +230,87 @@ export class CrawlTemplates extends LiteElement {
   private renderScheduleSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="font-medium">${msg("Schedule")}</h3>
+        <h3 class="font-medium">${msg("Crawl schedule")}</h3>
       </div>
       <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
-        <div class="flex items-end">
-          <div class="pr-2 flex-1">
-            <sl-select
-              name="schedule"
-              label=${msg("Schedule")}
-              value=${this.scheduleInterval}
-              @sl-select=${(e: any) => (this.scheduleInterval = e.target.value)}
-            >
-              <sl-menu-item value="">${msg("None")}</sl-menu-item>
-              <sl-menu-item value="daily">${msg("Daily")}</sl-menu-item>
-              <sl-menu-item value="weekly">${msg("Weekly")}</sl-menu-item>
-              <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
-            </sl-select>
-          </div>
-          <div class="grid grid-flow-col gap-2 items-center">
-            <span class="px-1">${msg("at")}</span>
-            <sl-select
-              name="scheduleHour"
-              value=${this.scheduleTime.hour}
-              class="w-24"
-              ?disabled=${!this.scheduleInterval}
-              @sl-select=${(e: any) =>
-                (this.scheduleTime = {
-                  ...this.scheduleTime,
-                  hour: +e.target.value,
-                })}
-            >
-              ${hours.map(
-                ({ value, label }) =>
-                  html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-              )}
-            </sl-select>
-            <span>:</span>
-            <sl-select
-              name="scheduleMinute"
-              value=${this.scheduleTime.minute}
-              class="w-24"
-              ?disabled=${!this.scheduleInterval}
-              @sl-select=${(e: any) =>
-                (this.scheduleTime = {
-                  ...this.scheduleTime,
-                  minute: +e.target.value,
-                })}
-            >
-              ${minutes.map(
-                ({ value, label }) =>
-                  html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-              )}
-            </sl-select>
-            <sl-select
-              value="AM"
-              class="w-24"
-              ?disabled=${!this.scheduleInterval}
-              @sl-select=${(e: any) =>
-                (this.scheduleTime = {
-                  ...this.scheduleTime,
-                  period: e.target.value,
-                })}
-            >
-              <sl-menu-item value="AM"
-                >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
+        <div>
+          <div class="flex items-end">
+            <div class="pr-2 flex-1">
+              <sl-select
+                name="schedule"
+                label=${msg("Recurring crawls")}
+                value=${this.scheduleInterval}
+                @sl-select=${(e: any) =>
+                  (this.scheduleInterval = e.target.value)}
               >
-              <sl-menu-item value="PM"
-                >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
+                <sl-menu-item value="">${msg("None")}</sl-menu-item>
+                <sl-menu-item value="daily">${msg("Daily")}</sl-menu-item>
+                <sl-menu-item value="weekly">${msg("Weekly")}</sl-menu-item>
+                <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
+              </sl-select>
+            </div>
+            <div class="grid grid-flow-col gap-2 items-center">
+              <span class="px-1">${msg("at")}</span>
+              <sl-select
+                name="scheduleHour"
+                value=${this.scheduleTime.hour}
+                class="w-24"
+                ?disabled=${!this.scheduleInterval}
+                @sl-select=${(e: any) =>
+                  (this.scheduleTime = {
+                    ...this.scheduleTime,
+                    hour: +e.target.value,
+                  })}
               >
-            </sl-select>
-            <span class="px-1">${this.timeZoneShortName}</span>
+                ${hours.map(
+                  ({ value, label }) =>
+                    html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+                )}
+              </sl-select>
+              <span>:</span>
+              <sl-select
+                name="scheduleMinute"
+                value=${this.scheduleTime.minute}
+                class="w-24"
+                ?disabled=${!this.scheduleInterval}
+                @sl-select=${(e: any) =>
+                  (this.scheduleTime = {
+                    ...this.scheduleTime,
+                    minute: +e.target.value,
+                  })}
+              >
+                ${minutes.map(
+                  ({ value, label }) =>
+                    html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+                )}
+              </sl-select>
+              <sl-select
+                value="AM"
+                class="w-24"
+                ?disabled=${!this.scheduleInterval}
+                @sl-select=${(e: any) =>
+                  (this.scheduleTime = {
+                    ...this.scheduleTime,
+                    period: e.target.value,
+                  })}
+              >
+                <sl-menu-item value="AM"
+                  >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
+                >
+                <sl-menu-item value="PM"
+                  >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
+                >
+              </sl-select>
+              <span class="px-1">${this.timeZoneShortName}</span>
+            </div>
           </div>
-        </div>
-        <div class="text-sm text-gray-500 mt-1">
-          ${this.nextScheduledCrawlMessage || msg("No crawls scheduled")}
+          <div class="text-sm text-gray-500 mt-1">
+            ${this.formattededNextCrawlDate
+              ? msg(
+                  html`Next scheduled crawl: ${this.formattededNextCrawlDate}`
+                )
+              : msg("No crawls scheduled")}
+          </div>
         </div>
 
         <sl-switch


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/87)

UX enhancements to the new crawl config page:
- Update section to 1. Basic, 2. Crawl config, 3. Crawl schedule
- Default time to current hour instead of midnight
- Show toast linking to new crawl if running immediately

### Manual testing
1. Run app and go to Archives > archive > Crawl Templates > new. Verify new section order
2. Interact with time scheduler. Verify "next scheduled crawl" formatted datetime updates as expected
3. Save template with "run now" enabled. Verify you see a toast alert linking to the new crawl
4. Click "View crawl". Verify you're taken to the correct URL (page itself will return "Not found")

### Screenshots
**Toast alert on create with "run now" enabled**
<img width="465" alt="Screen Shot 2022-01-18 at 9 00 19 PM" src="https://user-images.githubusercontent.com/4672952/150067451-bc00be0a-1a0d-4498-8517-e35a0d45cfcc.png">

