### PR TITLE
Add helper for dispatching notify events

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -6,6 +6,7 @@ import type { SlDialog } from "@shoelace-style/shoelace";
 import "tailwindcss/tailwind.css";
 
 import type { ArchiveTab } from "./pages/archive";
+import type { NotifyEvent } from "./utils/LiteElement";
 import LiteElement, { html } from "./utils/LiteElement";
 import APIRouter from "./utils/APIRouter";
 import AuthService from "./utils/AuthService";
@@ -478,16 +479,7 @@ export class App extends LiteElement {
     };
   }
 
-  onNotify(
-    event: CustomEvent<{
-      title?: string;
-      /** Can contain HTML */
-      message?: string;
-      type?: "success" | "warning" | "danger" | "primary";
-      icon?: string;
-      duration?: number;
-    }>
-  ) {
+  onNotify(event: NotifyEvent) {
     event.stopPropagation();
 
     const {

--- a/frontend/src/pages/accept-invite.ts
+++ b/frontend/src/pages/accept-invite.ts
@@ -48,16 +48,12 @@ export class AcceptInvite extends LiteElement {
     if (this.isLoggedIn) {
       this.getInviteInfo();
     } else {
-      this.dispatchEvent(
-        new CustomEvent("notify", {
-          detail: {
-            message: msg("Log in to continue."),
-            type: "success",
-            icon: "check2-circle",
-            duration: 10000,
-          },
-        })
-      );
+      this.notify({
+        message: msg("Log in to continue."),
+        type: "success",
+        icon: "check2-circle",
+        duration: 10000,
+      });
 
       this.navTo(
         `/log-in?redirectUrl=${encodeURIComponent(
@@ -160,15 +156,11 @@ export class AcceptInvite extends LiteElement {
         }
       );
 
-      this.dispatchEvent(
-        new CustomEvent("notify", {
-          detail: {
-            message: msg(str`You've joined ${this.inviteInfo.archiveName}.`),
-            type: "success",
-            icon: "check2-circle",
-          },
-        })
-      );
+      this.notify({
+        message: msg(str`You've joined ${this.inviteInfo.archiveName}.`),
+        type: "success",
+        icon: "check2-circle",
+      });
 
       this.navTo(DASHBOARD_ROUTE);
     } catch (err: any) {
@@ -181,17 +173,13 @@ export class AcceptInvite extends LiteElement {
   }
 
   private onDecline() {
-    this.dispatchEvent(
-      new CustomEvent("notify", {
-        detail: {
-          message: msg(
-            str`You've declined to join ${this.inviteInfo.archiveName}.`
-          ),
-          type: "info",
-          icon: "info-circle",
-        },
-      })
-    );
+    this.notify({
+      message: msg(
+        str`You've declined to join ${this.inviteInfo.archiveName}.`
+      ),
+      type: "info",
+      icon: "info-circle",
+    });
 
     this.navTo(DASHBOARD_ROUTE);
   }

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -501,21 +501,16 @@ export class CrawlTemplatesNew extends LiteElement {
         }
       );
 
-      this.dispatchEvent(
-        new CustomEvent("notify", {
-          bubbles: true,
-          detail: {
-            message: data.run_now_job
-              ? msg(
-                  str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
-                )
-              : msg("Crawl template created."),
-            type: "success",
-            icon: "check2-circle",
-            duration: 10000,
-          },
-        })
-      );
+      this.notify({
+        message: data.run_now_job
+          ? msg(
+              str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
+            )
+          : msg("Crawl template created."),
+        type: "success",
+        icon: "check2-circle",
+        duration: 10000,
+      });
 
       this.navTo(`/archives/${this.archiveId}/crawl-templates`);
     } catch (e: any) {

--- a/frontend/src/pages/verify.ts
+++ b/frontend/src/pages/verify.ts
@@ -65,18 +65,13 @@ export class Verify extends LiteElement {
     const isLoggedIn = Boolean(this.authState);
     const shouldLogOut = isLoggedIn && this.authState?.username !== data.email;
 
-    this.dispatchEvent(
-      new CustomEvent("notify", {
-        detail: {
-          title: msg("Email address verified"),
-          message:
-            isLoggedIn && !shouldLogOut ? "" : msg("Log in to continue."),
-          type: "success",
-          icon: "check2-circle",
-          duration: 10000,
-        },
-      })
-    );
+    this.notify({
+      title: msg("Email address verified"),
+      message: isLoggedIn && !shouldLogOut ? "" : msg("Log in to continue."),
+      type: "success",
+      icon: "check2-circle",
+      duration: 10000,
+    });
 
     if (shouldLogOut) {
       this.dispatchEvent(new CustomEvent("log-out"));

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -6,13 +6,16 @@ import { APIError } from "./api";
 export interface NotifyEvent extends CustomEvent {
   detail: {
     /**
-     * Can contain HTML
+     * Notification message body.
+     * Can contain HTML.
      * HTML is rendered as-is without sanitation
-     * */
+     **/
     message: string;
+    /** Notification title */
     title?: string;
-    type?: "success" | "warning" | "danger" | "primary" | "info";
+    /** Shoelace icon name */
     icon?: string;
+    type?: "success" | "warning" | "danger" | "primary" | "info";
     duration?: number;
   };
 }

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -3,6 +3,15 @@ import { LitElement, html } from "lit";
 import type { Auth } from "../utils/AuthService";
 import { APIError } from "./api";
 
+export interface NotifyEvent extends CustomEvent {
+  detail: {
+    message: string;
+    type: string;
+    icon: string;
+    duration: number;
+  };
+}
+
 export { html };
 
 export default class LiteElement extends LitElement {
@@ -23,6 +32,18 @@ export default class LiteElement extends LitElement {
         detail: (event.currentTarget as HTMLAnchorElement).href,
         bubbles: true,
         composed: true,
+      })
+    );
+  }
+
+  /**
+   * Emit global notification
+   */
+  notify(detail: NotifyEvent["detail"]) {
+    this.dispatchEvent(
+      new CustomEvent("notify", {
+        bubbles: true,
+        detail,
       })
     );
   }

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -5,10 +5,15 @@ import { APIError } from "./api";
 
 export interface NotifyEvent extends CustomEvent {
   detail: {
+    /**
+     * Can contain HTML
+     * HTML is rendered as-is without sanitation
+     * */
     message: string;
-    type: string;
-    icon: string;
-    duration: number;
+    title?: string;
+    type?: "success" | "warning" | "danger" | "primary" | "info";
+    icon?: string;
+    duration?: number;
   };
 }
 


### PR DESCRIPTION
Refactors `notify` events dispatches to use `this.notify` helper.

No behavioral changes--manually tested with notifications on new crawl config creation.