### PR TITLE
Run and delete crawl templates from list view

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -1,5 +1,6 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
+import cronParser from "cron-parser";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -33,10 +34,13 @@ export class CrawlTemplatesList extends LiteElement {
   @state()
   crawlTemplates?: CrawlTemplate[];
 
+  private get timeZone() {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
   async firstUpdated() {
     try {
       this.crawlTemplates = await this.getCrawlTemplates();
-
       if (!this.crawlTemplates.length) {
         this.navTo(`/archives/${this.archiveId}/crawl-templates/new`);
       }
@@ -51,54 +55,96 @@ export class CrawlTemplatesList extends LiteElement {
   }
 
   render() {
+    if (!this.crawlTemplates) {
+      return html`<div
+        class="w-full flex items-center justify-center my-24 text-4xl"
+      >
+        <sl-spinner></sl-spinner>
+      </div>`;
+    }
+
     return html`
       <div class="text-center"></div>
 
-      <div class="grid grid-cols-3 gap-4 mb-4">
+      <div
+        class=${this.crawlTemplates.length
+          ? "grid sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4"
+          : "flex justify-center"}
+      >
         <div
-          class="col-span-1 border rounded p-4"
+          class="col-span-1 bg-slate-50 border border-dotted border-primary text-primary rounded px-6 py-4 flex items-center justify-center"
           @click=${() =>
             this.navTo(`/archives/${this.archiveId}/crawl-templates/new`)}
           role="button"
         >
-          <sl-icon name="plus-square-dotted"></sl-icon> ${msg(
-            "Create new crawl template"
-          )}
+          <sl-icon class="mr-2" name="plus-square-dotted"></sl-icon>
+          <span
+            class="mr-2 ${this.crawlTemplates.length
+              ? "text-sm"
+              : "font-medium"}"
+            >${msg("Create New Crawl Template")}</span
+          >
         </div>
       </div>
 
-      <div class="grid grid-cols-3 gap-4">
-        ${this.crawlTemplates?.map(
+      <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+        ${this.crawlTemplates.map(
           (t) =>
             html`<div
-              class="col-span-1 border rounded shadow hover:shadow-sm p-4"
+              class="col-span-1 border border-purple-100 hover:border-purple-300 rounded shadow hover:shadow-sm shadow-purple-200 transition-all p-4 text-sm"
               role="button"
               aria-label=${t.name}
             >
               <div
-                class="font-medium overflow-hidden whitespace-nowrap truncate mb-1"
+                class="font-medium whitespace-nowrap truncate mb-1"
                 title=${t.name}
               >
                 ${t.name || "?"}
               </div>
-              <div class="grid gap-1 text-sm">
-                <div>
-                  ${t.config.seeds.length === 1
-                    ? msg(str`${t.config.seeds.length} seed URL`)
-                    : msg(str`${t.config.seeds.length} seed URLs`)}
-                </div>
-                <div>
-                  ${t.crawlCount === 1
-                    ? msg(str`${t.crawlCount} crawl`)
-                    : msg(str`${t.crawlCount || 0} crawls`)}
-                </div>
-                <div class="flex justify-between">
-                  <span
-                    >${t.schedule
-                      ? msg("Scheduled crawls")
-                      : msg("No schedule")}</span
+              <div class="flex justify-between items-end">
+                <div class="grid gap-1 text-xs">
+                  <div
+                    class="font-mono whitespace-nowrap truncate text-gray-500"
+                    title=${t.config.seeds.join(", ")}
                   >
-                  <sl-button size="small">${msg("Run now")}</sl-button>
+                    ${t.config.seeds.join(", ")}
+                  </div>
+                  <div class="font-mono text-purple-500">
+                    ${t.crawlCount === 1
+                      ? msg(str`${t.crawlCount} crawl`)
+                      : msg(
+                          str`${(t.crawlCount || 0).toLocaleString()} crawls`
+                        )}
+                  </div>
+                  <div class="text-gray-500">
+                    ${t.schedule
+                      ? msg(html`Next run:
+                          <span
+                            ><sl-format-date
+                              date="${cronParser
+                                .parseExpression(t.schedule, {
+                                  utc: true,
+                                })
+                                .next()
+                                .toString()}"
+                              month="2-digit"
+                              day="2-digit"
+                              year="2-digit"
+                              hour="numeric"
+                              time-zone=${this.timeZone}
+                            ></sl-format-date
+                          ></span>`)
+                      : html`<span class="text-gray-400"
+                          >${msg("No schedule")}</span
+                        >`}
+                  </div>
+                </div>
+                <div>
+                  <button
+                    class="text-xs border rounded-sm px-2 py-1 border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"
+                  >
+                    ${msg("Run now")}
+                  </button>
                 </div>
               </div>
             </div>`

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -228,7 +228,7 @@ export class CrawlTemplatesList extends LiteElement {
       };
     };
 
-    const data: { crawl_configs: CrawlConfig[] } = await this.apiFetch(
+    const data: { crawlConfigs: CrawlConfig[] } = await this.apiFetch(
       `/archives/${this.archiveId}/crawlconfigs`,
       this.authState!
     );
@@ -236,7 +236,7 @@ export class CrawlTemplatesList extends LiteElement {
     const crawlConfigs: CrawlTemplate[] = [];
     const runningCrawlsMap: RunningCrawlsMap = {};
 
-    data.crawl_configs.forEach(({ config, ...configMeta }) => {
+    data.crawlConfigs.forEach(({ config, ...configMeta }) => {
       crawlConfigs.push({
         ...configMeta,
         config: {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -38,16 +38,8 @@ export class CrawlTemplatesList extends LiteElement {
   @state()
   runningCrawlsMap: { [configId: string]: string } = {};
 
-  private runCrawlButtonTimerIds: number[] = [];
-
   private get timeZone() {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  }
-
-  disconnectedCallback() {
-    this.runCrawlButtonTimerIds.forEach((id) => {
-      window.clearTimeout(id);
-    });
   }
 
   async firstUpdated() {
@@ -103,9 +95,7 @@ export class CrawlTemplatesList extends LiteElement {
         ${this.crawlTemplates.map(
           (t) =>
             html`<div
-              class="${this.runningCrawlsMap[t.id]
-                ? "motion-safe:animate-pulse "
-                : ""}col-span-1 p-1 border hover:border-indigo-200 rounded text-sm transition-colors"
+              class="col-span-1 p-1 border hover:border-indigo-200 rounded text-sm transition-colors"
               aria-label=${t.name}
             >
               <header class="flex">
@@ -196,16 +186,19 @@ export class CrawlTemplatesList extends LiteElement {
                 </div>
                 <div>
                   <button
-                    class="text-xs border rounded-sm px-2 h-7 ${this
-                      .runningCrawlsMap[t.id]
-                      ? "border-purple-50"
-                      : "border-purple-200 hover:border-purple-500"} text-purple-600 transition-colors"
-                    @click=${() => this.runNow(t)}
-                    ?disabled=${Boolean(this.runningCrawlsMap[t.id])}
+                    class="text-xs border rounded-sm px-2 h-7 border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"
+                    @click=${() =>
+                      this.runningCrawlsMap[t.id]
+                        ? this.navTo(
+                            `/archives/${this.archiveId}/crawls/${
+                              this.runningCrawlsMap[t.id]
+                            }`
+                          )
+                        : this.runNow(t)}
                   >
                     <span>
                       ${this.runningCrawlsMap[t.id]
-                        ? msg("Running...")
+                        ? msg("View crawl")
                         : msg("Run now")}
                     </span>
                   </button>
@@ -279,16 +272,6 @@ export class CrawlTemplatesList extends LiteElement {
         icon: "check2-circle",
         duration: 10000,
       });
-
-      // TODO handle crawl done instead of on timeout
-      this.runCrawlButtonTimerIds.push(
-        window.setTimeout(() => {
-          const { [template.id]: _discard, ...runningCrawlsMap } =
-            this.runningCrawlsMap;
-
-          this.runningCrawlsMap = runningCrawlsMap;
-        }, 8000)
-      );
     } catch {
       this.notify({
         message: msg("Sorry, couldn't run crawl at this time."),

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -3,7 +3,18 @@ import { msg, localized, str } from "@lit/localize";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-import type { CrawlTemplate } from "./types";
+import type { CrawlConfig } from "./types";
+
+type CrawlTemplate = {
+  id: string;
+  name: string;
+  schedule: string;
+  user: string;
+  crawlCount: number;
+  lastCrawlId: string;
+  lastCrawlTime: string;
+  config: CrawlConfig;
+};
 
 /**
  * Usage:
@@ -21,9 +32,6 @@ export class CrawlTemplatesList extends LiteElement {
 
   @state()
   crawlTemplates?: CrawlTemplate[];
-
-  @state()
-  private serverError?: string;
 
   async firstUpdated() {
     try {
@@ -44,19 +52,56 @@ export class CrawlTemplatesList extends LiteElement {
 
   render() {
     return html`
-      <div class="text-center">
-        <sl-button
+      <div class="text-center"></div>
+
+      <div class="grid grid-cols-3 gap-4 mb-4">
+        <div
+          class="col-span-1 border rounded p-4"
           @click=${() =>
             this.navTo(`/archives/${this.archiveId}/crawl-templates/new`)}
+          role="button"
         >
-          <sl-icon slot="prefix" name="plus-square-dotted"></sl-icon>
-          ${msg("Create new crawl template")}
-        </sl-button>
+          <sl-icon name="plus-square-dotted"></sl-icon> ${msg(
+            "Create new crawl template"
+          )}
+        </div>
       </div>
 
-      <div>
+      <div class="grid grid-cols-3 gap-4">
         ${this.crawlTemplates?.map(
-          (template) => html`<div>${template.id}</div>`
+          (t) =>
+            html`<div
+              class="col-span-1 border rounded shadow hover:shadow-sm p-4"
+              role="button"
+              aria-label=${t.name}
+            >
+              <div
+                class="font-medium overflow-hidden whitespace-nowrap truncate mb-1"
+                title=${t.name}
+              >
+                ${t.name || "?"}
+              </div>
+              <div class="grid gap-1 text-sm">
+                <div>
+                  ${t.config.seeds.length === 1
+                    ? msg(str`${t.config.seeds.length} seed URL`)
+                    : msg(str`${t.config.seeds.length} seed URLs`)}
+                </div>
+                <div>
+                  ${t.crawlCount === 1
+                    ? msg(str`${t.crawlCount} crawl`)
+                    : msg(str`${t.crawlCount || 0} crawls`)}
+                </div>
+                <div class="flex justify-between">
+                  <span
+                    >${t.schedule
+                      ? msg("Scheduled crawls")
+                      : msg("No schedule")}</span
+                  >
+                  <sl-button size="small">${msg("Run now")}</sl-button>
+                </div>
+              </div>
+            </div>`
         )}
       </div>
     `;

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -190,7 +190,10 @@ export class CrawlTemplatesList extends LiteElement {
                 </div>
                 <div>
                   <button
-                    class="text-xs border rounded-sm px-2 h-7 border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"
+                    class="text-xs border rounded-sm px-2 h-7 ${this
+                      .runningCrawlsMap[t.id]
+                      ? "bg-purple-50"
+                      : "bg-white"} border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"
                     @click=${() =>
                       this.runningCrawlsMap[t.id]
                         ? this.navTo(

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -19,11 +19,28 @@ export class CrawlTemplatesList extends LiteElement {
   @property({ type: String })
   archiveId!: string;
 
-  @property({ type: Array })
+  @state()
   crawlTemplates?: CrawlTemplate[];
 
   @state()
   private serverError?: string;
+
+  async firstUpdated() {
+    try {
+      this.crawlTemplates = await this.getCrawlTemplates();
+
+      if (!this.crawlTemplates.length) {
+        this.navTo(`/archives/${this.archiveId}/crawl-templates/new`);
+      }
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't retrieve crawl templates at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+        duration: 10000,
+      });
+    }
+  }
 
   render() {
     return html`
@@ -43,6 +60,15 @@ export class CrawlTemplatesList extends LiteElement {
         )}
       </div>
     `;
+  }
+
+  private async getCrawlTemplates(): Promise<CrawlTemplate[]> {
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/crawlconfigs`,
+      this.authState!
+    );
+
+    return data.crawl_configs;
   }
 }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -5,7 +5,16 @@ import cronParser from "cron-parser";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { getLocaleTimeZone } from "../../utils/localization";
-import type { CrawlTemplate } from "./types";
+import type { CrawlConfig } from "./types";
+
+export type NewCrawlTemplate = {
+  id?: string;
+  name: string;
+  schedule: string;
+  runNow: boolean;
+  crawlTimeout?: number;
+  config: CrawlConfig;
+};
 
 const initialValues = {
   name: "",
@@ -448,7 +457,7 @@ export class CrawlTemplatesNew extends LiteElement {
     const crawlTimeoutMinutes = formData.get("crawlTimeoutMinutes");
     const pageLimit = formData.get("limit");
     const seedUrlsStr = formData.get("seedUrls");
-    const template: Partial<CrawlTemplate> = {
+    const template: Partial<NewCrawlTemplate> = {
       name: formData.get("name") as string,
       schedule: this.getUTCSchedule(),
       runNow: this.isRunNow,

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -7,7 +7,6 @@ import type { ArchiveData } from "../../utils/archives";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { needLogin } from "../../utils/auth";
 import { isOwner } from "../../utils/archives";
-import type { CrawlTemplate } from "./types";
 import "./crawl-templates-list";
 import "./crawl-templates-new";
 

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -41,9 +41,6 @@ export class Archive extends LiteElement {
   private archive?: ArchiveData;
 
   @state()
-  private crawlTemplates?: CrawlTemplate[];
-
-  @state()
   private successfullyInvitedEmail?: string;
 
   async firstUpdated() {
@@ -61,17 +58,7 @@ export class Archive extends LiteElement {
   }
 
   async updated(changedProperties: any) {
-    if (
-      changedProperties.has("archiveTab") &&
-      this.archiveTab === "crawl-templates" &&
-      !this.isNewResourceTab
-    ) {
-      this.crawlTemplates = await this.getCrawlTemplates();
-
-      if (!this.crawlTemplates.length) {
-        this.navTo(`/archives/${this.archiveId}/crawl-templates/new`);
-      }
-    } else if (changedProperties.has("isAddingMember") && this.isAddingMember) {
+    if (changedProperties.has("isAddingMember") && this.isAddingMember) {
       this.successfullyInvitedEmail = undefined;
     }
   }
@@ -178,7 +165,6 @@ export class Archive extends LiteElement {
     return html`<btrix-crawl-templates-list
       .authState=${this.authState!}
       .archiveId=${this.archiveId!}
-      .crawlTemplates=${this.crawlTemplates}
     ></btrix-crawl-templates-list>`;
   }
 
@@ -265,15 +251,6 @@ export class Archive extends LiteElement {
     const data = await this.apiFetch(`/archives/${archiveId}`, this.authState!);
 
     return data;
-  }
-
-  async getCrawlTemplates(): Promise<CrawlTemplate[]> {
-    const data = await this.apiFetch(
-      `/archives/${this.archiveId}/crawlconfigs`,
-      this.authState!
-    );
-
-    return data.crawl_configs;
   }
 
   onInviteSuccess(

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,12 +1,5 @@
-export type CrawlTemplate = {
-  id?: string;
-  name: string;
-  schedule: string;
-  runNow: boolean;
-  crawlTimeout?: number;
-  config: {
-    seeds: string[];
-    scopeType?: string;
-    limit?: number;
-  };
+export type CrawlConfig = {
+  seeds: string[];
+  scopeType?: string;
+  limit?: number;
 };

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -40,14 +40,13 @@ function makeTheme() {
       lg: `var(--sl-border-radius-large)`,
       xl: `var(--sl-border-radius-x-large)`,
     },
-    // FIXME enabling this custom theme disabled colorful box shadows
-    // boxShadow: {
-    //   sm: `var(--sl-shadow-small)`,
-    //   DEFAULT: `var(--sl-shadow-medium)`,
-    //   md: `var(--sl-shadow-medium)`,
-    //   lg: `var(--sl-shadow-large)`,
-    //   xl: `var(--sl-shadow-x-large)`,
-    // },
+    boxShadow: {
+      sm: `var(--sl-shadow-small)`,
+      DEFAULT: `var(--sl-shadow-medium)`,
+      md: `var(--sl-shadow-medium)`,
+      lg: `var(--sl-shadow-large)`,
+      xl: `var(--sl-shadow-x-large)`,
+    },
   };
 }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -40,13 +40,14 @@ function makeTheme() {
       lg: `var(--sl-border-radius-large)`,
       xl: `var(--sl-border-radius-x-large)`,
     },
-    boxShadow: {
-      sm: `var(--sl-shadow-small)`,
-      DEFAULT: `var(--sl-shadow-medium)`,
-      md: `var(--sl-shadow-medium)`,
-      lg: `var(--sl-shadow-large)`,
-      xl: `var(--sl-shadow-x-large)`,
-    },
+    // FIXME enabling this custom theme disabled colorful box shadows
+    // boxShadow: {
+    //   sm: `var(--sl-shadow-small)`,
+    //   DEFAULT: `var(--sl-shadow-medium)`,
+    //   md: `var(--sl-shadow-medium)`,
+    //   lg: `var(--sl-shadow-large)`,
+    //   xl: `var(--sl-shadow-x-large)`,
+    // },
   };
 }
 


### PR DESCRIPTION
(WIP https://github.com/webrecorder/browsertrix-cloud/issues/89)

Run and delete crawl templates from the list view, + some layout and styling improvements.

### Manual testing
1. Run app and go to an archive's Crawl Templates page
2. Click "Run now". Verify that UI shows feedback and link to last crawl
3. Click three dots "more" icon and click "Delete". Verify that crawl config is deleted

### Screenshots
**List view**
<img width="1033" alt="Screen Shot 2022-01-20 at 10 37 53 PM" src="https://user-images.githubusercontent.com/4672952/150479397-a341cf66-17f7-4289-ac70-788fee4df0b6.png">

**Alert on run now**
<img width="482" alt="Screen Shot 2022-01-20 at 10 38 42 PM" src="https://user-images.githubusercontent.com/4672952/150479457-8bd6ab5b-dc65-45a1-bf59-df36cdd033c1.png">

**Delete
<img width="386" alt="Screen Shot 2022-01-20 at 10 39 08 PM" src="https://user-images.githubusercontent.com/4672952/150479493-7f87bd79-56ee-47b6-ab49-fda49b3875bb.png">
 in menu**


### Opinions
I chose to put these in a grid to visually differentiate from crawls—the grid items resemble documents a bit, which works to visualize “template”. That said, UX/UI/styles can definitely be updated and improved down the line--I upgraded to the latest Tailwind version if you want to play around with the styles.