### PR TITLE
Crawl config detail views

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "axios": "^0.22.0",
     "color": "^4.0.1",
     "cron-parser": "^4.2.1",
+    "cronstrue": "^1.123.0",
     "lit": "^2.0.0",
     "path-parser": "^6.1.0",
     "tailwindcss": "^3.0.15"

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -369,6 +369,7 @@ export class App extends LiteElement {
       case "archive":
       case "archiveAddMember":
       case "archiveNewResourceTab":
+      case "crawlTemplate":
         return appLayout(html`<btrix-archive
           class="w-full"
           @navigate=${this.onNavigateTo}
@@ -377,7 +378,10 @@ export class App extends LiteElement {
           .authState=${this.authService.authState}
           .userInfo=${this.userInfo}
           archiveId=${this.viewState.params.id}
-          archiveTab=${this.viewState.params.tab as ArchiveTab}
+          archiveTab=${this.viewState.params.crawlConfigId
+            ? "crawl-templates"
+            : (this.viewState.params.tab as ArchiveTab)}
+          crawlConfigId=${this.viewState.params.crawlConfigId}
           ?isAddingMember=${this.viewState.route === "archiveAddMember"}
           ?isNewResourceTab=${this.viewState.route === "archiveNewResourceTab"}
         ></btrix-archive>`);

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -73,6 +73,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         <dl class="grid grid-cols-2">
           <div>
             <dt class="text-xs text-0-600">${msg("Created by")}</dt>
+            <!-- TODO show name -->
             <dd>${this.crawlTemplate.user}</dd>
           </div>
         </dl>
@@ -102,9 +103,11 @@ export class CrawlTemplatesDetail extends LiteElement {
                 ${this.crawlTemplate.config.seeds
                   .slice(0, this.showAllSeedURLs ? undefined : SEED_URLS_MAX)
                   .map(
-                    (seed) =>
+                    (seed, i) =>
                       html`<li
-                        class="grid grid-cols-5 gap-4 items-baseline py-1 border-b border-zinc-100 "
+                        class="grid grid-cols-5 gap-4 items-baseline py-1 border-zinc-100${i
+                          ? " border-t"
+                          : ""}"
                         role="row"
                         title=${seed.url}
                       >

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -53,12 +53,12 @@ export class CrawlTemplatesDetail extends LiteElement {
     }
 
     return html`
-      <h2 class="text-xl font-bold mb-3">${this.crawlTemplate.name}</h2>
+      <h2 class="text-xl font-bold mb-4">${this.crawlTemplate.name}</h2>
 
       ${this.crawlTemplate.currCrawlId
         ? html`
             <a
-              class="flex items-center justify-between my-5 px-3 py-2 border rounded-lg bg-purple-50 border-purple-200 hover:border-purple-500 shadow shadow-purple-200 text-purple-800 transition-colors"
+              class="flex items-center justify-between mb-4 px-3 py-2 border rounded-lg bg-purple-50 border-purple-200 hover:border-purple-500 shadow shadow-purple-200 text-purple-800 transition-colors"
               href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
               @click=${this.navLink}
             >
@@ -68,18 +68,18 @@ export class CrawlTemplatesDetail extends LiteElement {
           `
         : ""}
 
+      <section class="px-4 py-3 border-t border-b mb-4 text-sm">
+        <dl class="grid grid-cols-2">
+          <div>
+            <dt class="text-xs text-0-600">${msg("Created by")}</dt>
+            <dd>${this.crawlTemplate.user}</dd>
+          </div>
+        </dl>
+
+        <!-- TODO created at? -->
+      </section>
+
       <main class="border rounded-lg">
-        <section class="p-4  border-b text-sm">
-          <dl class="grid grid-cols-2">
-            <div>
-              <dt class="text-xs text-0-600">${msg("Created by")}</dt>
-              <dd>${this.crawlTemplate.user}</dd>
-            </div>
-          </dl>
-
-          <!-- TODO created at? -->
-        </section>
-
         <section class="md:grid grid-cols-4">
           <div class="col-span-1 p-4 md:p-8 md:border-b">
             <h3 class="font-medium">${msg("Configuration")}</h3>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -139,6 +139,22 @@ export class CrawlTemplatesDetail extends LiteElement {
                   </sl-button>`
                 : ""}
             </div>
+
+            <sl-details style="--sl-spacing-medium: var(--sl-spacing-small)">
+              <span slot="summary" class="text-sm"
+                >${msg("Advanced configuration")}
+                <sl-tag size="small" type="neutral"
+                  >${msg("JSON")}</sl-tag
+                ></span
+              >
+              <pre
+                class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-xs"
+              ><code>${JSON.stringify(
+                this.crawlTemplate.config,
+                null,
+                2
+              )}</code></pre>
+            </sl-details>
           </div>
         </section>
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -231,15 +231,22 @@ export class CrawlTemplatesDetail extends LiteElement {
                   class="flex items-center justify-between border border-zinc-100 rounded p-1 mt-1"
                 >
                   ${this.crawlTemplate.currCrawlId
-                    ? html`<a
+                    ? html` <a
                         class="text-primary font-medium hover:underline text-sm p-1"
                         href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
                         @click=${this.navLink}
                         >${msg("View crawl")}</a
                       >`
                     : html`<span class="text-0-400 text-sm p-1"
-                        >${msg("None")}</span
-                      >`}
+                          >${msg("None")}</span
+                        ><button
+                          class="text-xs border rounded px-2 h-7 bg-purple-500 hover:bg-purple-400 text-white transition-colors"
+                          @click=${() => this.runNow()}
+                        >
+                          <span class="whitespace-nowrap">
+                            ${msg("Run now")}
+                          </span>
+                        </button>`}
                 </dd>
               </div>
               <div>
@@ -299,6 +306,46 @@ export class CrawlTemplatesDetail extends LiteElement {
         ),
       },
     };
+  }
+
+  private async runNow(): Promise<void> {
+    try {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawlconfigs/${
+          this.crawlTemplate!.id
+        }/run`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      const crawlId = data.started;
+
+      this.crawlTemplate = {
+        ...this.crawlTemplate,
+        currCrawlId: crawlId,
+      } as CrawlTemplate;
+
+      this.notify({
+        message: msg(
+          str`Started crawl from <strong>${
+            this.crawlTemplate!.name
+          }</strong>. <br /><a class="underline hover:no-underline" href="/archives/${
+            this.archiveId
+          }/crawls/${data.run_now_job}">View crawl</a>`
+        ),
+        type: "success",
+        icon: "check2-circle",
+        duration: 10000,
+      });
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't run crawl at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
   }
 }
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -56,11 +56,22 @@ export class CrawlTemplatesDetail extends LiteElement {
       <h2 class="text-xl font-bold mb-3">${this.crawlTemplate.name}</h2>
 
       <main class="border rounded-lg">
-        <section class="md:grid grid-cols-3">
+        <section class="p-4  border-b text-sm">
+          <dl class="grid grid-cols-2">
+            <div>
+              <dt class="text-xs text-0-600">${msg("Created by")}</dt>
+              <dd>${this.crawlTemplate.user}</dd>
+            </div>
+          </dl>
+
+          <!-- TODO created at? -->
+        </section>
+
+        <section class="md:grid grid-cols-4">
           <div class="col-span-1 p-4 md:p-8 md:border-b">
             <h3 class="font-medium">${msg("Configuration")}</h3>
           </div>
-          <div class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+          <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-600">${msg("Seed URLs")}</dt>
@@ -91,22 +102,22 @@ export class CrawlTemplatesDetail extends LiteElement {
                 </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">${msg("Scope type")}</dt>
+                <dt class="text-sm text-0-600">${msg("Scope Type")}</dt>
                 <dd>${this.crawlTemplate.config.scopeType}</dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">${msg("Page limit")}</dt>
+                <dt class="text-sm text-0-600">${msg("Page Limit")}</dt>
                 <dd>${this.crawlTemplate.config.limit}</dd>
               </div>
             </dl>
           </div>
         </section>
 
-        <section class="md:grid grid-cols-3">
+        <section class="md:grid grid-cols-4">
           <div class="col-span-1 p-4 md:p-8 md:border-b">
             <h3 class="font-medium">${msg("Schedule")}</h3>
           </div>
-          <div class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+          <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-600">${msg("Schedule")}</dt>
@@ -116,31 +127,65 @@ export class CrawlTemplatesDetail extends LiteElement {
           </div>
         </section>
 
-        <section class="md:grid grid-cols-3">
-          <div class="col-span-1 p-4 md:p-8 md:border-b">
+        <section class="md:grid grid-cols-4">
+          <div class="col-span-1 p-4 md:p-8">
             <h3 class="font-medium">${msg("Crawls")}</h3>
           </div>
-          <div class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+          <div class="col-span-3 p-4 md:p-8 grid gap-5">
             <dl class="grid gap-5">
               <div>
-                <dt class="text-sm text-0-600">${msg("Last Crawl Time")}</dt>
-                <dd>${this.crawlTemplate.lastCrawlTime}</dd>
+                <dt class="text-sm text-0-600">${msg("# of Crawls")}</dt>
+                <dd>
+                  ${(this.crawlTemplate.crawlCount || 0).toLocaleString()}
+                </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">${msg("Last Crawl ID")}</dt>
-                <dd>${this.crawlTemplate.lastCrawlId}</dd>
+                <dt class="text-sm text-0-600">
+                  ${msg("Currently Running Crawl")}
+                </dt>
+                <dd
+                  class="flex items-center justify-between border rounded p-1 mt-1"
+                >
+                  ${this.crawlTemplate.currCrawlId
+                    ? html`<a
+                        class="text-primary font-medium hover:underline text-sm p-1"
+                        href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
+                        @click=${this.navLink}
+                        >${msg("View running crawl")}</a
+                      >`
+                    : html` <span class="text-0-400 text-sm p-1"
+                        >${msg("None")}</span
+                      >`}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">
+                  ${msg("Latest Finished Crawl")}
+                </dt>
+                <dd
+                  class="flex items-center justify-between border rounded p-1 mt-1"
+                >
+                  <a
+                    class="text-primary font-medium hover:underline text-sm p-1"
+                    href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.lastCrawlId}`}
+                    @click=${this.navLink}
+                    >${msg("View crawl")}</a
+                  >
+                  <sl-format-date
+                    date=${
+                      `${this.crawlTemplate.lastCrawlTime}Z` /** Z for UTC */
+                    }
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="numeric"
+                    minute="numeric"
+                    time-zone-name="short"
+                  ></sl-format-date>
+                </dd>
               </div>
             </dl>
           </div>
-        </section>
-
-        <section class="p-4 md:p-8 border-b">
-          <dl class="grid grid-cols-2">
-            <div>
-              <dt class="text-sm text-0-600">${msg("Created by")}</dt>
-              <dd>${this.crawlTemplate.user}</dd>
-            </div>
-          </dl>
         </section>
       </main>
     `;

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -55,6 +55,19 @@ export class CrawlTemplatesDetail extends LiteElement {
     return html`
       <h2 class="text-xl font-bold mb-3">${this.crawlTemplate.name}</h2>
 
+      ${this.crawlTemplate.currCrawlId
+        ? html`
+            <a
+              class="flex items-center justify-between my-5 px-3 py-2 border rounded-lg bg-purple-50 border-purple-200 hover:border-purple-500 text-purple-800 transition-colors"
+              href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
+              @click=${this.navLink}
+            >
+              <span>${msg("View currently running crawl")}</span>
+              <sl-icon name="arrow-right"></sl-icon>
+            </a>
+          `
+        : ""}
+
       <main class="border rounded-lg">
         <section class="p-4  border-b text-sm">
           <dl class="grid grid-cols-2">
@@ -153,35 +166,37 @@ export class CrawlTemplatesDetail extends LiteElement {
                         @click=${this.navLink}
                         >${msg("View running crawl")}</a
                       >`
-                    : html` <span class="text-0-400 text-sm p-1"
+                    : html`<span class="text-0-400 text-sm p-1"
                         >${msg("None")}</span
                       >`}
                 </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">
-                  ${msg("Latest Finished Crawl")}
-                </dt>
+                <dt class="text-sm text-0-600">${msg("Latest Crawl")}</dt>
                 <dd
                   class="flex items-center justify-between border rounded p-1 mt-1"
                 >
-                  <a
-                    class="text-primary font-medium hover:underline text-sm p-1"
-                    href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.lastCrawlId}`}
-                    @click=${this.navLink}
-                    >${msg("View crawl")}</a
-                  >
-                  <sl-format-date
-                    date=${
-                      `${this.crawlTemplate.lastCrawlTime}Z` /** Z for UTC */
-                    }
-                    month="2-digit"
-                    day="2-digit"
-                    year="2-digit"
-                    hour="numeric"
-                    minute="numeric"
-                    time-zone-name="short"
-                  ></sl-format-date>
+                  ${this.crawlTemplate.lastCrawlId
+                    ? html`<a
+                          class="text-primary font-medium hover:underline text-sm p-1"
+                          href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.lastCrawlId}`}
+                          @click=${this.navLink}
+                          >${msg("View crawl")}</a
+                        >
+                        <sl-format-date
+                          date=${
+                            `${this.crawlTemplate.lastCrawlTime}Z` /** Z for UTC */
+                          }
+                          month="2-digit"
+                          day="2-digit"
+                          year="2-digit"
+                          hour="numeric"
+                          minute="numeric"
+                          time-zone-name="short"
+                        ></sl-format-date>`
+                    : html`<span class="text-0-400 text-sm p-1"
+                        >${msg("None")}</span
+                      >`}
                 </dd>
               </div>
             </dl>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -214,7 +214,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                   ${msg("Currently Running Crawl")}
                 </dt>
                 <dd
-                  class="flex items-center justify-between border rounded p-1 mt-1"
+                  class="flex items-center justify-between border border-zinc-100 rounded p-1 mt-1"
                 >
                   ${this.crawlTemplate.currCrawlId
                     ? html`<a
@@ -231,7 +231,7 @@ export class CrawlTemplatesDetail extends LiteElement {
               <div>
                 <dt class="text-sm text-0-600">${msg("Latest Crawl")}</dt>
                 <dd
-                  class="flex items-center justify-between border rounded p-1 mt-1"
+                  class="flex items-center justify-between border border-zinc-100 rounded p-1 mt-1"
                 >
                   ${this.crawlTemplate.lastCrawlId
                     ? html`<a

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -58,7 +58,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       ${this.crawlTemplate.currCrawlId
         ? html`
             <a
-              class="flex items-center justify-between my-5 px-3 py-2 border rounded-lg bg-purple-50 border-purple-200 hover:border-purple-500 text-purple-800 transition-colors"
+              class="flex items-center justify-between my-5 px-3 py-2 border rounded-lg bg-purple-50 border-purple-200 hover:border-purple-500 shadow shadow-purple-200 text-purple-800 transition-colors"
               href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
               @click=${this.navLink}
             >
@@ -85,55 +85,60 @@ export class CrawlTemplatesDetail extends LiteElement {
             <h3 class="font-medium">${msg("Configuration")}</h3>
           </div>
           <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
-            <dl class="grid gap-5">
-              <div>
-                <dt class="text-sm text-0-600">${msg("Seed URLs")}</dt>
-                <dd>
-                  <ul>
-                    ${this.crawlTemplate.config.seeds
-                      .slice(
-                        0,
-                        this.showAllSeedURLs ? undefined : SEED_URLS_MAX
-                      )
-                      .map(
-                        (seed) =>
-                          html`<li class="grid grid-cols-3">
-                            <span>${seed.url}</span>
-                            <span class="uppercase text-0-500 text-xs"
-                              >${seed.scopeType}</span
-                            >
-                            <span class="uppercase text-0-500 text-xs"
-                              >${seed.limit}</span
-                            >
-                          </li>`
-                      )}
-                  </ul>
-
-                  ${this.crawlTemplate.config.seeds.length > SEED_URLS_MAX
-                    ? html`<div
-                        class="inline-block font-medium text-primary text-sm mt-1"
-                        role="button"
-                        @click=${() =>
-                          (this.showAllSeedURLs = !this.showAllSeedURLs)}
+            <div role="table">
+              <div class="grid grid-cols-3" role="row">
+                <span class="text-sm text-0-600" role="columnheader"
+                  >${msg("Seed URL")}</span
+                >
+                <span class="text-sm text-0-600" role="columnheader"
+                  >${msg("Scope Type")}</span
+                >
+                <span class="text-sm text-0-600" role="columnheader"
+                  >${msg("Page Limit")}</span
+                >
+              </div>
+              <ul role="rowgroup">
+                ${this.crawlTemplate.config.seeds
+                  .slice(0, this.showAllSeedURLs ? undefined : SEED_URLS_MAX)
+                  .map(
+                    (seed) =>
+                      html`<li
+                        class="grid grid-cols-3 items-baseline"
+                        role="row"
                       >
-                        ${this.showAllSeedURLs
-                          ? msg("Show less")
-                          : msg(str`Show
+                        <span role="cell">${seed.url}</span>
+                        <span class="uppercase text-0-500 text-xs" role="cell"
+                          >${seed.scopeType ||
+                          this.crawlTemplate?.config.scopeType}</span
+                        >
+                        <span
+                          class="uppercase text-0-500 text-xs font-mono"
+                          role="cell"
+                          >${seed.limit ||
+                          this.crawlTemplate?.config.limit}</span
+                        >
+                      </li>`
+                  )}
+              </ul>
+
+              ${this.crawlTemplate.config.seeds.length > SEED_URLS_MAX
+                ? html`<sl-button
+                    class="mt-2"
+                    type="neutral"
+                    size="small"
+                    @click=${() =>
+                      (this.showAllSeedURLs = !this.showAllSeedURLs)}
+                  >
+                    <span class="text-sm">
+                      ${this.showAllSeedURLs
+                        ? msg("Show less")
+                        : msg(str`Show
                     ${this.crawlTemplate.config.seeds.length - SEED_URLS_MAX}
                     more`)}
-                      </div>`
-                    : ""}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-sm text-0-600">${msg("Scope Type")}</dt>
-                <dd>${this.crawlTemplate.config.scopeType}</dd>
-              </div>
-              <div>
-                <dt class="text-sm text-0-600">${msg("Page Limit")}</dt>
-                <dd class="font-mono">${this.crawlTemplate.config.limit}</dd>
-              </div>
-            </dl>
+                    </span>
+                  </sl-button>`
+                : ""}
+            </div>
           </div>
         </section>
 
@@ -178,7 +183,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                         class="text-primary font-medium hover:underline text-sm p-1"
                         href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
                         @click=${this.navLink}
-                        >${msg("View running crawl")}</a
+                        >${msg("View crawl")}</a
                       >`
                     : html`<span class="text-0-400 text-sm p-1"
                         >${msg("None")}</span

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -86,14 +86,14 @@ export class CrawlTemplatesDetail extends LiteElement {
           </div>
           <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
             <div role="table">
-              <div class="grid grid-cols-3" role="row">
-                <span class="text-sm text-0-600" role="columnheader"
+              <div class="grid grid-cols-5 gap-4" role="row">
+                <span class="col-span-3 text-sm text-0-600" role="columnheader"
                   >${msg("Seed URL")}</span
                 >
-                <span class="text-sm text-0-600" role="columnheader"
+                <span class="col-span-1 text-sm text-0-600" role="columnheader"
                   >${msg("Scope Type")}</span
                 >
-                <span class="text-sm text-0-600" role="columnheader"
+                <span class="col-span-1 text-sm text-0-600" role="columnheader"
                   >${msg("Page Limit")}</span
                 >
               </div>
@@ -103,16 +103,24 @@ export class CrawlTemplatesDetail extends LiteElement {
                   .map(
                     (seed) =>
                       html`<li
-                        class="grid grid-cols-3 items-baseline"
+                        class="grid grid-cols-5 gap-4 items-baseline py-1 border-b border-zinc-100 "
                         role="row"
+                        title=${seed.url}
                       >
-                        <span role="cell">${seed.url}</span>
-                        <span class="uppercase text-0-500 text-xs" role="cell"
+                        <div
+                          class="col-span-3 break-all leading-tight"
+                          role="cell"
+                        >
+                          ${seed.url}
+                        </div>
+                        <span
+                          class="col-span-1 uppercase text-0-500 text-xs"
+                          role="cell"
                           >${seed.scopeType ||
                           this.crawlTemplate?.config.scopeType}</span
                         >
                         <span
-                          class="uppercase text-0-500 text-xs font-mono"
+                          class="col-span-1 uppercase text-0-500 text-xs font-mono"
                           role="cell"
                           >${seed.limit ||
                           this.crawlTemplate?.config.limit}</span
@@ -141,19 +149,33 @@ export class CrawlTemplatesDetail extends LiteElement {
             </div>
 
             <sl-details style="--sl-spacing-medium: var(--sl-spacing-small)">
-              <span slot="summary" class="text-sm"
-                >${msg("Advanced configuration")}
+              <span slot="summary" class="text-sm">
+                <span class="font-medium"
+                  >${msg("Advanced configuration")}</span
+                >
                 <sl-tag size="small" type="neutral"
                   >${msg("JSON")}</sl-tag
                 ></span
               >
-              <pre
-                class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-xs"
-              ><code>${JSON.stringify(
-                this.crawlTemplate.config,
-                null,
-                2
-              )}</code></pre>
+              <div class="relative">
+                <pre
+                  class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-xs"
+                ><code>${JSON.stringify(
+                  this.crawlTemplate.config,
+                  null,
+                  2
+                )}</code></pre>
+
+                <div class="absolute top-2 right-2">
+                  <btrix-copy-button
+                    .value="${JSON.stringify(
+                      this.crawlTemplate.config,
+                      null,
+                      2
+                    )}"
+                  ></btrix-copy-button>
+                </div>
+              </div>
             </sl-details>
           </div>
         </section>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -5,6 +5,8 @@ import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { CrawlTemplate } from "./types";
 
+const SEED_URLS_MAX = 3;
+
 /**
  * Usage:
  * ```ts
@@ -23,7 +25,10 @@ export class CrawlTemplatesDetail extends LiteElement {
   crawlConfigId!: string;
 
   @state()
-  crawlTemplate?: CrawlTemplate;
+  private crawlTemplate?: CrawlTemplate;
+
+  @state()
+  private showAllSeedURLs: boolean = false;
 
   async firstUpdated() {
     try {
@@ -51,27 +56,92 @@ export class CrawlTemplatesDetail extends LiteElement {
       <h2 class="text-xl font-bold mb-3">${this.crawlTemplate.name}</h2>
 
       <main class="border rounded-lg">
-        <section class="p-4 md:p-8 border-b">
-          <dl>
-            <div>
-              <dt class="text-sm text-0-500">${msg("Seed URLs")}</dt>
-              <dd>${this.crawlTemplate.config.seeds}</dd>
-            </div>
-            <div>
-              <dt class="text-sm text-0-500">${msg("Schedule")}</dt>
-              <dd>${this.crawlTemplate.schedule}</dd>
-            </div>
-          </dl>
+        <section class="md:grid grid-cols-3">
+          <div class="col-span-1 p-4 md:p-8 md:border-b">
+            <h3 class="font-medium">${msg("Configuration")}</h3>
+          </div>
+          <div class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+            <dl class="grid gap-5">
+              <div>
+                <dt class="text-sm text-0-600">${msg("Seed URLs")}</dt>
+                <dd>
+                  <ul>
+                    ${this.crawlTemplate.config.seeds
+                      .slice(
+                        0,
+                        this.showAllSeedURLs ? undefined : SEED_URLS_MAX
+                      )
+                      .map((seed) => html`<li>${seed}</li>`)}
+                  </ul>
+
+                  ${this.crawlTemplate.config.seeds.length > SEED_URLS_MAX
+                    ? html`<div
+                        class="inline-block font-medium text-primary text-sm mt-1"
+                        role="button"
+                        @click=${() =>
+                          (this.showAllSeedURLs = !this.showAllSeedURLs)}
+                      >
+                        ${this.showAllSeedURLs
+                          ? msg("Show less")
+                          : msg(str`Show
+                    ${this.crawlTemplate.config.seeds.length - SEED_URLS_MAX}
+                    more`)}
+                      </div>`
+                    : ""}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">${msg("Scope type")}</dt>
+                <dd>${this.crawlTemplate.config.scopeType}</dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">${msg("Page limit")}</dt>
+                <dd>${this.crawlTemplate.config.limit}</dd>
+              </div>
+            </dl>
+          </div>
         </section>
 
-        <div class="md:grid grid-cols-4">
+        <section class="md:grid grid-cols-3">
+          <div class="col-span-1 p-4 md:p-8 md:border-b">
+            <h3 class="font-medium">${msg("Schedule")}</h3>
+          </div>
+          <div class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+            <dl class="grid gap-5">
+              <div>
+                <dt class="text-sm text-0-600">${msg("Schedule")}</dt>
+                <dd>${this.crawlTemplate.schedule}</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+
+        <section class="md:grid grid-cols-3">
           <div class="col-span-1 p-4 md:p-8 md:border-b">
             <h3 class="font-medium">${msg("Crawls")}</h3>
           </div>
-          <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
-            TODO list
-          </section>
-        </div>
+          <div class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+            <dl class="grid gap-5">
+              <div>
+                <dt class="text-sm text-0-600">${msg("Last Crawl Time")}</dt>
+                <dd>${this.crawlTemplate.lastCrawlTime}</dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">${msg("Last Crawl ID")}</dt>
+                <dd>${this.crawlTemplate.lastCrawlId}</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+
+        <section class="p-4 md:p-8 border-b">
+          <dl class="grid grid-cols-2">
+            <div>
+              <dt class="text-sm text-0-600">${msg("Created by")}</dt>
+              <dd>${this.crawlTemplate.user}</dd>
+            </div>
+          </dl>
+        </section>
       </main>
     `;
   }
@@ -82,22 +152,8 @@ export class CrawlTemplatesDetail extends LiteElement {
       this.authState!
     );
 
-    // TODO replace mock data
-    return {
-      id: this.crawlConfigId,
-      name: "PLACEHOLDER",
-      schedule: "PLACEHOLDER",
-      user: "PLACEHOLDER",
-      crawlCount: 1,
-      lastCrawlId: "PLACEHOLDER",
-      lastCrawlTime: "PLACEHOLDER",
-      currCrawlId: "PLACEHOLDER",
-      config: {
-        seeds: ["https://example.com"],
-      },
-    };
-
-    // return data
+    console.log(data);
+    return data;
   }
 }
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1,0 +1,104 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+
+import type { AuthState } from "../../utils/AuthService";
+import LiteElement, { html } from "../../utils/LiteElement";
+import type { CrawlTemplate } from "./types";
+
+/**
+ * Usage:
+ * ```ts
+ * <btrix-crawl-templates-detail></btrix-crawl-templates-detail>
+ * ```
+ */
+@localized()
+export class CrawlTemplatesDetail extends LiteElement {
+  @property({ type: Object })
+  authState!: AuthState;
+
+  @property({ type: String })
+  archiveId!: string;
+
+  @property({ type: String })
+  crawlConfigId!: string;
+
+  @state()
+  crawlTemplate?: CrawlTemplate;
+
+  async firstUpdated() {
+    try {
+      this.crawlTemplate = await this.getCrawlTemplate();
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't retrieve crawl template at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+        duration: 10000,
+      });
+    }
+  }
+
+  render() {
+    if (!this.crawlTemplate) {
+      return html`<div
+        class="w-full flex items-center justify-center my-24 text-4xl"
+      >
+        <sl-spinner></sl-spinner>
+      </div>`;
+    }
+
+    return html`
+      <h2 class="text-xl font-bold mb-3">${this.crawlTemplate.name}</h2>
+
+      <main class="border rounded-lg">
+        <section class="p-4 md:p-8 border-b">
+          <dl>
+            <div>
+              <dt class="text-sm text-0-500">${msg("Seed URLs")}</dt>
+              <dd>${this.crawlTemplate.config.seeds}</dd>
+            </div>
+            <div>
+              <dt class="text-sm text-0-500">${msg("Schedule")}</dt>
+              <dd>${this.crawlTemplate.schedule}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <div class="md:grid grid-cols-4">
+          <div class="col-span-1 p-4 md:p-8 md:border-b">
+            <h3 class="font-medium">${msg("Crawls")}</h3>
+          </div>
+          <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
+            TODO list
+          </section>
+        </div>
+      </main>
+    `;
+  }
+
+  async getCrawlTemplate(): Promise<CrawlTemplate> {
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/crawlconfigs/${this.crawlConfigId}`,
+      this.authState!
+    );
+
+    // TODO replace mock data
+    return {
+      id: this.crawlConfigId,
+      name: "PLACEHOLDER",
+      schedule: "PLACEHOLDER",
+      user: "PLACEHOLDER",
+      crawlCount: 1,
+      lastCrawlId: "PLACEHOLDER",
+      lastCrawlTime: "PLACEHOLDER",
+      currCrawlId: "PLACEHOLDER",
+      config: {
+        seeds: ["https://example.com"],
+      },
+    };
+
+    // return data
+  }
+}
+
+customElements.define("btrix-crawl-templates-detail", CrawlTemplatesDetail);

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1,5 +1,6 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
+import cronstrue from "cronstrue"; // TODO localize
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -187,10 +188,20 @@ export class CrawlTemplatesDetail extends LiteElement {
           <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
             <dl class="grid gap-5">
               <div>
-                <dt class="text-sm text-0-600">${msg("Schedule")}</dt>
+                <dt class="text-sm text-0-600">${msg("Recurring crawls")}</dt>
                 <dd>
-                  ${this.crawlTemplate.schedule ||
-                  html`<span class="text-0-400">${msg("None")}</span>`}
+                  ${this.crawlTemplate.schedule
+                    ? // TODO localize
+                      // NOTE human-readable string is in UTC, limitation of library
+                      // currently being used.
+                      // https://github.com/bradymholt/cRonstrue/issues/94
+                      html`<span
+                        >${cronstrue.toString(this.crawlTemplate.schedule, {
+                          verbose: true,
+                        })}
+                        (in UTC time zone)</span
+                      >`
+                    : html`<span class="text-0-400">${msg("None")}</span>`}
                 </dd>
               </div>
             </dl>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -95,7 +95,18 @@ export class CrawlTemplatesDetail extends LiteElement {
                         0,
                         this.showAllSeedURLs ? undefined : SEED_URLS_MAX
                       )
-                      .map((seed) => html`<li>${seed}</li>`)}
+                      .map(
+                        (seed) =>
+                          html`<li class="grid grid-cols-3">
+                            <span>${seed.url}</span>
+                            <span class="uppercase text-0-500 text-xs"
+                              >${seed.scopeType}</span
+                            >
+                            <span class="uppercase text-0-500 text-xs"
+                              >${seed.limit}</span
+                            >
+                          </li>`
+                      )}
                   </ul>
 
                   ${this.crawlTemplate.config.seeds.length > SEED_URLS_MAX
@@ -120,7 +131,7 @@ export class CrawlTemplatesDetail extends LiteElement {
               </div>
               <div>
                 <dt class="text-sm text-0-600">${msg("Page Limit")}</dt>
-                <dd>${this.crawlTemplate.config.limit}</dd>
+                <dd class="font-mono">${this.crawlTemplate.config.limit}</dd>
               </div>
             </dl>
           </div>
@@ -134,7 +145,10 @@ export class CrawlTemplatesDetail extends LiteElement {
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-600">${msg("Schedule")}</dt>
-                <dd>${this.crawlTemplate.schedule}</dd>
+                <dd>
+                  ${this.crawlTemplate.schedule ||
+                  html`<span class="text-0-400">${msg("None")}</span>`}
+                </dd>
               </div>
             </dl>
           </div>
@@ -148,7 +162,7 @@ export class CrawlTemplatesDetail extends LiteElement {
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-600">${msg("# of Crawls")}</dt>
-                <dd>
+                <dd class="font-mono">
                   ${(this.crawlTemplate.crawlCount || 0).toLocaleString()}
                 </dd>
               </div>
@@ -207,13 +221,27 @@ export class CrawlTemplatesDetail extends LiteElement {
   }
 
   async getCrawlTemplate(): Promise<CrawlTemplate> {
-    const data = await this.apiFetch(
+    const data: CrawlTemplate = await this.apiFetch(
       `/archives/${this.archiveId}/crawlconfigs/${this.crawlConfigId}`,
       this.authState!
     );
 
-    console.log(data);
-    return data;
+    const { config, ...template } = data;
+
+    return {
+      ...template,
+      config: {
+        ...config,
+        // Normalize seed format
+        seeds: config.seeds.map((seed) =>
+          typeof seed === "string"
+            ? {
+                url: seed,
+              }
+            : seed
+        ),
+      },
+    };
   }
 }
 

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -4,19 +4,8 @@ import cronParser from "cron-parser";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-import type { CrawlConfig } from "./types";
+import type { CrawlTemplate } from "./types";
 
-type CrawlTemplate = {
-  id: string;
-  name: string;
-  schedule: string;
-  user: string;
-  crawlCount: number;
-  lastCrawlId: string;
-  lastCrawlTime: string;
-  currCrawlId: string;
-  config: CrawlConfig;
-};
 type RunningCrawlsMap = {
   /** Map of configId: crawlId */
   [configId: string]: string;
@@ -72,27 +61,28 @@ export class CrawlTemplatesList extends LiteElement {
     }
 
     return html`
-      <div class="text-center"></div>
-
       <div
         class=${this.crawlTemplates.length
           ? "grid sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4"
           : "flex justify-center"}
       >
-        <div
-          class="col-span-1 bg-slate-50 border border-indigo-200 text-primary rounded px-6 py-4 flex items-center justify-center"
-          @click=${() =>
-            this.navTo(`/archives/${this.archiveId}/crawl-templates/new`)}
+        <a
+          href=${`/archives/${this.archiveId}/crawl-templates/new`}
+          class="col-span-1 bg-slate-50 border border-indigo-200 hover:border-indigo-400 text-primary text-center font-medium rounded px-6 py-4 transition-colors"
+          @click=${this.navLink}
           role="button"
         >
-          <sl-icon class="mr-2" name="plus-square"></sl-icon>
-          <span
-            class="mr-2 ${this.crawlTemplates.length
+          <sl-icon
+            class="inline-block align-middle mr-2"
+            name="plus-square"
+          ></sl-icon
+          ><span
+            class="inline-block align-middle mr-2 ${this.crawlTemplates.length
               ? "text-sm"
               : "font-medium"}"
             >${msg("Create New Crawl Template")}</span
           >
-        </div>
+        </a>
       </div>
 
       <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -130,12 +130,16 @@ export class CrawlTemplatesList extends LiteElement {
               <div class="px-3 pb-3 flex justify-between items-end">
                 <div class="grid gap-2 text-xs leading-none">
                   <div class="overflow-hidden">
-                    <sl-tooltip content=${t.config.seeds.join(", ")}>
+                    <sl-tooltip
+                      content=${t.config.seeds.map(({ url }) => url).join(", ")}
+                    >
                       <div
                         class="font-mono whitespace-nowrap truncate text-0-500"
                       >
                         <span class="underline decoration-dashed"
-                          >${t.config.seeds.join(", ")}</span
+                          >${t.config.seeds
+                            .map(({ url }) => url)
+                            .join(", ")}</span
                         >
                       </div>
                     </sl-tooltip>
@@ -267,9 +271,13 @@ export class CrawlTemplatesList extends LiteElement {
         ...configMeta,
         config: {
           ...config,
-          // Flatten seeds into array of URL strings
+          // Normalize seed format
           seeds: config.seeds.map((seed) =>
-            typeof seed === "string" ? seed : seed.url
+            typeof seed === "string"
+              ? {
+                  url: seed,
+                }
+              : seed
           ),
         },
       });

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -152,35 +152,34 @@ export class CrawlTemplatesList extends LiteElement {
                         )}
                   </div>
                   <div>
-                    <sl-tooltip content=${msg("Last crawl time")}>
-                      <span>
-                        ${t.crawlCount
-                          ? html`<sl-icon
-                                class="inline-block align-middle mr-1 text-purple-400"
-                                name="check-circle-fill"
-                              ></sl-icon
-                              ><sl-format-date
-                                class="inline-block align-middle text-0-600"
-                                date=${`${t.lastCrawlTime}Z` /** Z for UTC */}
-                                month="2-digit"
-                                day="2-digit"
-                                year="2-digit"
-                                hour="numeric"
-                                minute="numeric"
-                                time-zone=${this.timeZone}
-                              ></sl-format-date>`
-                          : html`
-                              <sl-icon
-                                class="inline-block align-middle mr-1 text-0-400"
-                                name="slash-circle"
-                              ></sl-icon
-                              ><span
-                                class="inline-block align-middle text-0-400"
-                                >${msg("No crawls")}</span
-                              >
-                            `}
-                      </span>
-                    </sl-tooltip>
+                    ${t.crawlCount
+                      ? html`<sl-tooltip content=${msg("Last crawl time")}>
+                          <span>
+                            <sl-icon
+                              class="inline-block align-middle mr-1 text-purple-400"
+                              name="check-circle-fill"
+                            ></sl-icon
+                            ><sl-format-date
+                              class="inline-block align-middle text-0-600"
+                              date=${`${t.lastCrawlTime}Z` /** Z for UTC */}
+                              month="2-digit"
+                              day="2-digit"
+                              year="2-digit"
+                              hour="numeric"
+                              minute="numeric"
+                              time-zone=${this.timeZone}
+                            ></sl-format-date>
+                          </span>
+                        </sl-tooltip>`
+                      : html`
+                          <sl-icon
+                            class="inline-block align-middle mr-1 text-0-400"
+                            name="slash-circle"
+                          ></sl-icon
+                          ><span class="inline-block align-middle text-0-400"
+                            >${msg("No crawls")}</span
+                          >
+                        `}
                   </div>
                   <div>
                     ${t.schedule

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -157,7 +157,7 @@ export class CrawlTemplatesList extends LiteElement {
                               ></sl-icon
                               ><sl-format-date
                                 class="inline-block align-middle text-0-600"
-                                date=${t.lastCrawlTime}
+                                date=${`${t.lastCrawlTime}Z` /** Z for UTC */}
                                 month="2-digit"
                                 day="2-digit"
                                 year="2-digit"

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -219,7 +219,7 @@ export class CrawlTemplatesList extends LiteElement {
                 </div>
                 <div>
                   <button
-                    class="text-xs border rounded-sm px-2 h-7 ${this
+                    class="text-xs border rounded px-2 h-7 ${this
                       .runningCrawlsMap[t.id]
                       ? "bg-purple-50"
                       : "bg-white"} border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -129,11 +129,15 @@ export class CrawlTemplatesList extends LiteElement {
 
               <div class="px-3 pb-3 flex justify-between items-end">
                 <div class="grid gap-2 text-xs leading-none">
-                  <div class="font-mono whitespace-nowrap truncate text-0-500">
+                  <div class="overflow-hidden">
                     <sl-tooltip content=${t.config.seeds.join(", ")}>
-                      <span class="underline decoration-dashed"
-                        >${t.config.seeds.join(", ")}</span
+                      <div
+                        class="font-mono whitespace-nowrap truncate text-0-500"
                       >
+                        <span class="underline decoration-dashed"
+                          >${t.config.seeds.join(", ")}</span
+                        >
+                      </div>
                     </sl-tooltip>
                   </div>
                   <div class="font-mono text-purple-500">
@@ -146,20 +150,31 @@ export class CrawlTemplatesList extends LiteElement {
                   <div>
                     <sl-tooltip content=${msg("Last crawl time")}>
                       <span>
-                        <sl-icon
-                          class="inline-block align-middle mr-1 text-purple-400"
-                          name="check-circle-fill"
-                        ></sl-icon
-                        ><sl-format-date
-                          class="inline-block align-middle text-0-600"
-                          date=${t.lastCrawlTime}
-                          month="2-digit"
-                          day="2-digit"
-                          year="2-digit"
-                          hour="numeric"
-                          minute="numeric"
-                          time-zone=${this.timeZone}
-                        ></sl-format-date>
+                        ${t.crawlCount
+                          ? html`<sl-icon
+                                class="inline-block align-middle mr-1 text-purple-400"
+                                name="check-circle-fill"
+                              ></sl-icon
+                              ><sl-format-date
+                                class="inline-block align-middle text-0-600"
+                                date=${t.lastCrawlTime}
+                                month="2-digit"
+                                day="2-digit"
+                                year="2-digit"
+                                hour="numeric"
+                                minute="numeric"
+                                time-zone=${this.timeZone}
+                              ></sl-format-date>`
+                          : html`
+                              <sl-icon
+                                class="inline-block align-middle mr-1 text-0-400"
+                                name="slash-circle"
+                              ></sl-icon
+                              ><span
+                                class="inline-block align-middle text-0-400"
+                                >${msg("No crawls")}</span
+                              >
+                            `}
                       </span>
                     </sl-tooltip>
                   </div>
@@ -214,7 +229,7 @@ export class CrawlTemplatesList extends LiteElement {
                           )
                         : this.runNow(t)}
                   >
-                    <span>
+                    <span class="whitespace-nowrap">
                       ${this.runningCrawlsMap[t.id]
                         ? msg("View crawl")
                         : msg("Run now")}

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -139,11 +139,12 @@ export class CrawlTemplatesList extends LiteElement {
 
               <div class="px-3 pb-3 flex justify-between items-end">
                 <div class="grid gap-2 text-xs leading-none">
-                  <div
-                    class="font-mono whitespace-nowrap truncate text-0-500"
-                    title=${t.config.seeds.join(", ")}
-                  >
-                    ${t.config.seeds.join(", ")}
+                  <div class="font-mono whitespace-nowrap truncate text-0-500">
+                    <sl-tooltip content=${t.config.seeds.join(", ")}>
+                      <span class="underline decoration-dashed"
+                        >${t.config.seeds.join(", ")}</span
+                      >
+                    </sl-tooltip>
                   </div>
                   <div class="font-mono text-purple-500">
                     ${t.crawlCount === 1

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -80,12 +80,12 @@ export class CrawlTemplatesList extends LiteElement {
           : "flex justify-center"}
       >
         <div
-          class="col-span-1 bg-slate-50 border border-dotted border-primary text-primary rounded px-6 py-4 flex items-center justify-center"
+          class="col-span-1 bg-slate-50 border border-indigo-200 text-primary rounded px-6 py-4 flex items-center justify-center"
           @click=${() =>
             this.navTo(`/archives/${this.archiveId}/crawl-templates/new`)}
           role="button"
         >
-          <sl-icon class="mr-2" name="plus-square-dotted"></sl-icon>
+          <sl-icon class="mr-2" name="plus-square"></sl-icon>
           <span
             class="mr-2 ${this.crawlTemplates.length
               ? "text-sm"
@@ -138,9 +138,9 @@ export class CrawlTemplatesList extends LiteElement {
               </header>
 
               <div class="px-3 pb-3 flex justify-between items-end">
-                <div class="grid gap-1 text-xs">
+                <div class="grid gap-2 text-xs leading-none">
                   <div
-                    class="font-mono whitespace-nowrap truncate text-gray-500"
+                    class="font-mono whitespace-nowrap truncate text-0-500"
                     title=${t.config.seeds.join(", ")}
                   >
                     ${t.config.seeds.join(", ")}
@@ -152,10 +152,15 @@ export class CrawlTemplatesList extends LiteElement {
                           str`${(t.crawlCount || 0).toLocaleString()} crawls`
                         )}
                   </div>
-                  <div class="text-gray-500">
-                    ${msg(html`Last:
-                      <span
+                  <div>
+                    <sl-tooltip content=${msg("Last crawl time")}>
+                      <span>
+                        <sl-icon
+                          class="inline-block align-middle mr-1 text-purple-400"
+                          name="check-circle-fill"
+                        ></sl-icon
                         ><sl-format-date
+                          class="inline-block align-middle text-0-600"
                           date=${t.lastCrawlTime}
                           month="2-digit"
                           day="2-digit"
@@ -163,29 +168,44 @@ export class CrawlTemplatesList extends LiteElement {
                           hour="numeric"
                           minute="numeric"
                           time-zone=${this.timeZone}
-                        ></sl-format-date
-                      ></span>`)}
+                        ></sl-format-date>
+                      </span>
+                    </sl-tooltip>
                   </div>
-                  <div class="text-gray-500">
+                  <div>
                     ${t.schedule
-                      ? msg(html`Next:
-                          <sl-format-date
-                            date="${cronParser
-                              .parseExpression(t.schedule, {
-                                utc: true,
-                              })
-                              .next()
-                              .toString()}"
-                            month="2-digit"
-                            day="2-digit"
-                            year="2-digit"
-                            hour="numeric"
-                            minute="numeric"
-                            time-zone=${this.timeZone}
-                          ></sl-format-date>`)
-                      : html`<span class="text-gray-400"
-                          >${msg("No schedule")}</span
-                        >`}
+                      ? html`
+                          <sl-tooltip content=${msg("Next scheduled crawl")}>
+                            <span>
+                              <sl-icon
+                                class="inline-block align-middle mr-1"
+                                name="clock-history"
+                              ></sl-icon
+                              ><sl-format-date
+                                class="inline-block align-middle text-0-600"
+                                date="${cronParser
+                                  .parseExpression(t.schedule, {
+                                    utc: true,
+                                  })
+                                  .next()
+                                  .toString()}"
+                                month="2-digit"
+                                day="2-digit"
+                                year="2-digit"
+                                hour="numeric"
+                                minute="numeric"
+                                time-zone=${this.timeZone}
+                              ></sl-format-date>
+                            </span>
+                          </sl-tooltip>
+                        `
+                      : html`<sl-icon
+                            class="inline-block align-middle mr-1 text-0-400"
+                            name="slash-circle"
+                          ></sl-icon
+                          ><span class="inline-block align-middle text-0-400"
+                            >${msg("No schedule")}</span
+                          >`}
                   </div>
                 </div>
                 <div>

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -468,7 +468,11 @@ export class CrawlTemplatesNew extends LiteElement {
       template.config = JSON.parse(this.seedsJson);
     } else {
       template.config = {
-        seeds: (seedUrlsStr as string).trim().replace(/,/g, " ").split(/\s+/g),
+        seeds: (seedUrlsStr as string)
+          .trim()
+          .replace(/,/g, " ")
+          .split(/\s+/g)
+          .map((url) => ({ url })),
         scopeType: formData.get("scopeType") as string,
         limit: pageLimit ? +pageLimit : 0,
       };

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -123,7 +123,7 @@ export class CrawlTemplatesNew extends LiteElement {
       <main class="mt-6">
         <div class="border rounded-lg">
           <sl-form @sl-submit=${this.onSubmit} aria-describedby="formError">
-            <div class="md:grid grid-cols-4">
+            <div class="md:grid grid-cols-3">
               ${this.renderBasicSettings()} ${this.renderCrawlConfigSettings()}
               ${this.renderScheduleSettings()}
             </div>
@@ -176,9 +176,9 @@ export class CrawlTemplatesNew extends LiteElement {
   private renderBasicSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="font-medium">${msg("Basic settings")}</h3>
+        <h3 class="font-medium">${msg("Basic Settings")}</h3>
       </div>
-      <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
+      <section class="col-span-2 p-4 md:p-8 border-b grid gap-5">
         <sl-input
           name="name"
           label=${msg("Name")}
@@ -199,9 +199,9 @@ export class CrawlTemplatesNew extends LiteElement {
   private renderScheduleSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="font-medium">${msg("Crawl schedule")}</h3>
+        <h3 class="font-medium">${msg("Crawl Schedule")}</h3>
       </div>
-      <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
+      <section class="col-span-2 p-4 md:p-8 border-b grid gap-5">
         <div>
           <div class="flex items-end">
             <div class="pr-2 flex-1">
@@ -218,62 +218,62 @@ export class CrawlTemplatesNew extends LiteElement {
                 <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
               </sl-select>
             </div>
-            <div class="grid grid-flow-col gap-2 items-center">
-              <span class="px-1">${msg("at")}</span>
-              <sl-select
-                name="scheduleHour"
-                value=${this.scheduleTime.hour}
-                class="w-24"
-                ?disabled=${!this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleTime = {
-                    ...this.scheduleTime,
-                    hour: +e.target.value,
-                  })}
-              >
-                ${hours.map(
-                  ({ value, label }) =>
-                    html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-                )}
-              </sl-select>
-              <span>:</span>
-              <sl-select
-                name="scheduleMinute"
-                value=${this.scheduleTime.minute}
-                class="w-24"
-                ?disabled=${!this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleTime = {
-                    ...this.scheduleTime,
-                    minute: +e.target.value,
-                  })}
-              >
-                ${minutes.map(
-                  ({ value, label }) =>
-                    html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-                )}
-              </sl-select>
-              <sl-select
-                value=${this.scheduleTime.period}
-                class="w-24"
-                ?disabled=${!this.scheduleInterval}
-                @sl-select=${(e: any) =>
-                  (this.scheduleTime = {
-                    ...this.scheduleTime,
-                    period: e.target.value,
-                  })}
-              >
-                <sl-menu-item value="AM"
-                  >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
-                >
-                <sl-menu-item value="PM"
-                  >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
-                >
-              </sl-select>
-              <span class="px-1">${this.timeZoneShortName}</span>
-            </div>
           </div>
-          <div class="text-sm text-gray-500 mt-1">
+          <div class="grid grid-flow-col gap-2 items-center mt-2">
+            <span class="px-1">${msg("At")}</span>
+            <sl-select
+              name="scheduleHour"
+              value=${this.scheduleTime.hour}
+              class="w-24"
+              ?disabled=${!this.scheduleInterval}
+              @sl-select=${(e: any) =>
+                (this.scheduleTime = {
+                  ...this.scheduleTime,
+                  hour: +e.target.value,
+                })}
+            >
+              ${hours.map(
+                ({ value, label }) =>
+                  html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+              )}
+            </sl-select>
+            <span>:</span>
+            <sl-select
+              name="scheduleMinute"
+              value=${this.scheduleTime.minute}
+              class="w-24"
+              ?disabled=${!this.scheduleInterval}
+              @sl-select=${(e: any) =>
+                (this.scheduleTime = {
+                  ...this.scheduleTime,
+                  minute: +e.target.value,
+                })}
+            >
+              ${minutes.map(
+                ({ value, label }) =>
+                  html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+              )}
+            </sl-select>
+            <sl-select
+              value=${this.scheduleTime.period}
+              class="w-24"
+              ?disabled=${!this.scheduleInterval}
+              @sl-select=${(e: any) =>
+                (this.scheduleTime = {
+                  ...this.scheduleTime,
+                  period: e.target.value,
+                })}
+            >
+              <sl-menu-item value="AM"
+                >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
+              >
+              <sl-menu-item value="PM"
+                >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
+              >
+            </sl-select>
+            <span class="px-1">${this.timeZoneShortName}</span>
+          </div>
+          <div class="text-sm text-gray-500 mt-2">
             ${this.formattededNextCrawlDate
               ? msg(
                   html`Next scheduled crawl: ${this.formattededNextCrawlDate}`
@@ -304,9 +304,9 @@ export class CrawlTemplatesNew extends LiteElement {
   private renderCrawlConfigSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="font-medium">${msg("Crawl configuration")}</h3>
+        <h3 class="font-medium">${msg("Crawl Configuration")}</h3>
       </div>
-      <section class="col-span-3 p-4 md:p-8 border-b grid gap-5">
+      <section class="col-span-2 p-4 md:p-8 border-b grid gap-5">
         <div class="flex justify-between">
           <h4 class="font-medium">
             ${this.isSeedsJsonView

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -7,6 +7,7 @@ import type { ArchiveData } from "../../utils/archives";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { needLogin } from "../../utils/auth";
 import { isOwner } from "../../utils/archives";
+import "./crawl-templates-detail";
 import "./crawl-templates-list";
 import "./crawl-templates-new";
 
@@ -66,8 +67,6 @@ export class Archive extends LiteElement {
   }
 
   render() {
-    console.log("this.crawlConfigId:", this.crawlConfigId);
-    console.log("this.archiveTab:", this.archiveTab);
     if (!this.archive) {
       return html`<div
         class="w-full flex items-center justify-center my-24 text-4xl"
@@ -96,8 +95,10 @@ export class Archive extends LiteElement {
             slot="nav"
             panel="crawl-templates"
             ?active=${this.archiveTab === "crawl-templates"}
-            >${msg("Crawl Templates")}</sl-tab
-          >
+            @click=${() =>
+              this.navTo(`/archives/${this.archiveId}/crawl-templates`)}
+            >${msg("Crawl Templates")}
+          </sl-tab>
           <sl-tab
             slot="nav"
             panel="settings"
@@ -143,29 +144,34 @@ export class Archive extends LiteElement {
   }
 
   private renderCrawlTemplates() {
-    if (this.crawlConfigId) {
-      return html`TODO`;
-    }
-
-    if (this.isNewResourceTab) {
+    if (this.isNewResourceTab || this.crawlConfigId) {
       return html`
-        <div class="md:grid grid-cols-6 gap-5">
+        <div class="md:grid grid-cols-6 gap-6">
           <nav class="col-span-1 mb-6">
             <a
               class="font-medium text-sm text-primary hover:opacity-80 flex items-center"
               href=${`/archives/${this.archiveId}/crawl-templates`}
               @click=${this.navLink}
               ><sl-icon class="mr-1" name="arrow-left"></sl-icon> ${msg(
-                "Back to list"
+                "Back to templates"
               )}</a
             >
           </nav>
 
-          <btrix-crawl-templates-new
-            class="col-span-5 mt-6"
-            .authState=${this.authState!}
-            .archiveId=${this.archiveId!}
-          ></btrix-crawl-templates-new>
+          ${this.crawlConfigId
+            ? html`
+                <btrix-crawl-templates-detail
+                  class="col-span-5 mt-6"
+                  .authState=${this.authState!}
+                  .archiveId=${this.archiveId!}
+                  .crawlConfigId=${this.crawlConfigId}
+                ></btrix-crawl-templates-detail>
+              `
+            : html` <btrix-crawl-templates-new
+                class="col-span-5 mt-6"
+                .authState=${this.authState!}
+                .archiveId=${this.archiveId!}
+              ></btrix-crawl-templates-new>`}
         </div>
       `;
     }

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -29,6 +29,9 @@ export class Archive extends LiteElement {
   @property({ type: String })
   archiveTab: ArchiveTab = defaultTab;
 
+  @property({ type: String })
+  crawlConfigId?: string;
+
   @property({ type: Boolean })
   isAddingMember: boolean = false;
 
@@ -63,6 +66,8 @@ export class Archive extends LiteElement {
   }
 
   render() {
+    console.log("this.crawlConfigId:", this.crawlConfigId);
+    console.log("this.archiveTab:", this.archiveTab);
     if (!this.archive) {
       return html`<div
         class="w-full flex items-center justify-center my-24 text-4xl"
@@ -138,6 +143,10 @@ export class Archive extends LiteElement {
   }
 
   private renderCrawlTemplates() {
+    if (this.crawlConfigId) {
+      return html`TODO`;
+    }
+
     if (this.isNewResourceTab) {
       return html`
         <div class="md:grid grid-cols-6 gap-5">

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -3,3 +3,15 @@ export type CrawlConfig = {
   scopeType?: string;
   limit?: number;
 };
+
+export type CrawlTemplate = {
+  id: string;
+  name: string;
+  schedule: string;
+  user: string;
+  crawlCount: number;
+  lastCrawlId: string;
+  lastCrawlTime: string;
+  currCrawlId: string;
+  config: CrawlConfig;
+};

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,8 +1,11 @@
-export type CrawlConfig = {
-  seeds: string[];
+type SeedConfig = {
   scopeType?: string;
   limit?: number;
 };
+
+export type CrawlConfig = {
+  seeds: (string | ({ url: string } & SeedConfig))[];
+} & SeedConfig;
 
 export type CrawlTemplate = {
   id: string;

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -4,7 +4,7 @@ type SeedConfig = {
 };
 
 export type CrawlConfig = {
-  seeds: (string | ({ url: string } & SeedConfig))[];
+  seeds: ({ url: string } & SeedConfig)[];
 } & SeedConfig;
 
 export type CrawlTemplate = {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -14,6 +14,7 @@ export const ROUTES = {
   archive: "/archives/:id/:tab",
   archiveNewResourceTab: "/archives/:id/:tab/new",
   archiveAddMember: "/archives/:id/:tab/add-member",
+  crawlTemplate: "/archives/:id/crawl-templates/:crawlConfigId",
   users: "/users",
   usersInvite: "/users/invite",
 } as const;

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -59,5 +59,8 @@ import(
 import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/textarea/textarea"
 );
+import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/tooltip/tooltip"
+);
 
 setBasePath("/shoelace");

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -85,7 +85,7 @@ export default class LiteElement extends LitElement {
           errorMessage = detail;
         } else {
           // TODO return client error details
-          const fieldDetail = detail[0];
+          const fieldDetail = detail[detail.length - 1];
           const { loc, msg } = fieldDetail;
 
           errorMessage = `${loc[loc.length - 1]} ${msg}`;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1776,6 +1776,11 @@ cron-parser@^4.2.1:
   dependencies:
     luxon "^1.28.0"
 
+cronstrue@^1.123.0:
+  version "1.123.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-1.123.0.tgz#de622dd8ea07981790f488d3f89a25e6e728ac8b"
+  integrity sha512-hVu9yNYRYr+jj5KET1p7FaBxFwtCHM1ByffP9lZ6yJ6p53u4VEmzH8117v9PUydxWNzc8Eq+sCZEzsKcB3ckiA==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"


### PR DESCRIPTION
WIP https://github.com/webrecorder/browsertrix-cloud/issues/89

- Adjust details in list view for improved readability
- New detail view page with configuration, schedule and crawl details

TODOs recorded here https://github.com/webrecorder/browsertrix-cloud/issues/100

### Manual testing
1. Run app and go to crawl template list page. Click on a crawl template name, verify it takes you to the detail page
2. Choose or create a template with more than 3 seed URLs. Verify the detail view has a "show more" button that displays all the URLs
3. Click "Advanced Configuration". It should show the entire JSON `config` object
3. Scroll to "Crawls" section and click "Run now". Verify crawl starts

### Screenshots
**Enhancements to last/next crawl detail in list view*
<img width="673" alt="Screen Shot 2022-01-24 at 6 52 43 PM" src="https://user-images.githubusercontent.com/4672952/150903908-273002d4-c074-4958-b0a1-3e5fbd58775f.png">

**New detail view**
<img width="856" alt="Screen Shot 2022-01-24 at 6 53 08 PM" src="https://user-images.githubusercontent.com/4672952/150903966-b0f01a8e-3e4d-44a5-b874-bdc6d9bf4a55.png">

**Expanded seeds**
<img width="582" alt="Screen Shot 2022-01-24 at 6 53 44 PM" src="https://user-images.githubusercontent.com/4672952/150903997-bfcdf89b-782a-4b1b-887e-a8c5d4a4e9b6.png">

**Expanded "Advanced Configuration"**
<img width="579" alt="Screen Shot 2022-01-24 at 6 54 04 PM" src="https://user-images.githubusercontent.com/4672952/150904023-666f7e25-1b63-47ed-b593-8810fa2d54e7.png">

**Formatted schedule**
<img width="846" alt="Screen Shot 2022-01-24 at 6 54 49 PM" src="https://user-images.githubusercontent.com/4672952/150904065-0d0cbd46-ebf6-4e4a-a911-10b8627c1695.png">

**Banner in detail view when crawl is running**
<img width="870" alt="Screen Shot 2022-01-24 at 6 54 21 PM" src="https://user-images.githubusercontent.com/4672952/150904043-061abac7-03ba-470b-9a21-79fcf609c6d6.png">

**Crawls section when no crawl is currently running**
<img width="840" alt="Screen Shot 2022-01-24 at 7 07 54 PM" src="https://user-images.githubusercontent.com/4672952/150904116-228630a1-ef8a-4b38-8b91-af42006568a5.png">

