### PR TITLE
Duplicate crawl config from list

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -378,6 +378,7 @@ export class App extends LiteElement {
           @notify="${this.onNotify}"
           .authState=${this.authService.authState}
           .userInfo=${this.userInfo}
+          .viewStateData=${this.viewState.data}
           archiveId=${this.viewState.params.id}
           archiveTab=${this.viewState.params.tab as ArchiveTab}
           ?isAddingMember=${this.viewState.route === "archiveAddMember"}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -6,12 +6,12 @@ import type { SlDialog } from "@shoelace-style/shoelace";
 import "tailwindcss/tailwind.css";
 
 import type { ArchiveTab } from "./pages/archive";
-import type { NotifyEvent } from "./utils/LiteElement";
+import type { NotifyEvent, NavigateEvent } from "./utils/LiteElement";
 import LiteElement, { html } from "./utils/LiteElement";
 import APIRouter from "./utils/APIRouter";
 import AuthService from "./utils/AuthService";
 import type { LoggedInEvent } from "./utils/AuthService";
-import type { ViewState, NavigateEvent } from "./utils/APIRouter";
+import type { ViewState } from "./utils/APIRouter";
 import type { CurrentUser } from "./types/user";
 import type { AuthState } from "./utils/AuthService";
 import theme from "./theme";
@@ -145,7 +145,7 @@ export class App extends LiteElement {
     }
   }
 
-  navigate(newViewPath: string) {
+  navigate(newViewPath: string, state?: object) {
     if (newViewPath.startsWith("http")) {
       const url = new URL(newViewPath);
       newViewPath = `${url.pathname}${url.search}`;
@@ -157,6 +157,8 @@ export class App extends LiteElement {
     } else {
       this.viewState = this.router.match(newViewPath);
     }
+
+    this.viewState.data = state;
 
     window.history.pushState(this.viewState, "", this.viewState.pathname);
   }
@@ -468,7 +470,7 @@ export class App extends LiteElement {
   onNavigateTo(event: NavigateEvent) {
     event.stopPropagation();
 
-    this.navigate(event.detail);
+    this.navigate(event.detail.url, event.detail.state);
   }
 
   onUserInfoChange(event: CustomEvent<Partial<CurrentUser>>) {

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -109,24 +109,24 @@ export class CrawlTemplatesDetail extends LiteElement {
                           ? " border-t"
                           : ""}"
                         role="row"
-                        title=${seed.url}
+                        title=${typeof seed === "string" ? seed : seed.url}
                       >
                         <div
                           class="col-span-3 break-all leading-tight"
                           role="cell"
                         >
-                          ${seed.url}
+                          ${typeof seed === "string" ? seed : seed.url}
                         </div>
                         <span
                           class="col-span-1 uppercase text-0-500 text-xs"
                           role="cell"
-                          >${seed.scopeType ||
+                          >${(typeof seed !== "string" && seed.scopeType) ||
                           this.crawlTemplate?.config.scopeType}</span
                         >
                         <span
                           class="col-span-1 uppercase text-0-500 text-xs font-mono"
                           role="cell"
-                          >${seed.limit ||
+                          >${(typeof seed !== "string" && seed.limit) ||
                           this.crawlTemplate?.config.limit}</span
                         >
                       </li>`
@@ -290,22 +290,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       this.authState!
     );
 
-    const { config, ...template } = data;
-
-    return {
-      ...template,
-      config: {
-        ...config,
-        // Normalize seed format
-        seeds: config.seeds.map((seed) =>
-          typeof seed === "string"
-            ? {
-                url: seed,
-              }
-            : seed
-        ),
-      },
-    };
+    return data;
   }
 
   private async runNow(): Promise<void> {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -124,14 +124,14 @@ export class CrawlTemplatesList extends LiteElement {
                     <li
                       class="p-2 hover:bg-zinc-100 cursor-pointer"
                       role="menuitem"
-                      @click=${() => this.duplicate(t)}
+                      @click=${() => this.duplicateConfig(t)}
                     >
                       <sl-icon
                         class="inline-block align-middle px-1"
                         name="files"
                       ></sl-icon>
                       <span class="inline-block align-middle pr-2"
-                        >${msg("Duplicate")}</span
+                        >${msg("Duplicate crawl config")}</span
                       >
                     </li>
                     <li
@@ -280,11 +280,22 @@ export class CrawlTemplatesList extends LiteElement {
   /**
    * Create a new template using existing template data
    */
-  private async duplicate(template: CrawlTemplate) {
-    this.navTo(
-      `/archives/${this.archiveId}/crawl-templates/${template.id}`,
-      template
-    );
+  private async duplicateConfig(template: CrawlTemplate) {
+    const crawlConfig: CrawlTemplate["config"] = {
+      seeds: template.config.seeds,
+      scopeType: template.config.scopeType,
+      limit: template.config.limit,
+    };
+
+    this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {
+      crawlConfig,
+    });
+
+    this.notify({
+      message: msg(str`Copied crawl configuration to new template.`),
+      type: "success",
+      icon: "check2-circle",
+    });
   }
 
   private async deleteTemplate(template: CrawlTemplate): Promise<void> {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -120,9 +120,24 @@ export class CrawlTemplatesList extends LiteElement {
                     style="font-size: 1rem"
                   ></sl-icon-button>
 
-                  <ul role="menu">
+                  <ul class="text-sm whitespace-nowrap" role="menu">
                     <li
-                      class="px-4 py-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+                      class="p-2 hover:bg-zinc-100 cursor-pointer"
+                      role="menuitem"
+                      @click=${(e: any) => {
+                        this.duplicate(t);
+                      }}
+                    >
+                      <sl-icon
+                        class="inline-block align-middle px-1"
+                        name="files"
+                      ></sl-icon>
+                      <span class="inline-block align-middle pr-2"
+                        >${msg("Duplicate")}</span
+                      >
+                    </li>
+                    <li
+                      class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
                       role="menuitem"
                       @click=${(e: any) => {
                         // Close dropdown before deleting template
@@ -131,7 +146,13 @@ export class CrawlTemplatesList extends LiteElement {
                         this.deleteTemplate(t);
                       }}
                     >
-                      ${msg("Delete")}
+                      <sl-icon
+                        class="inline-block align-middle px-1"
+                        name="file-earmark-x"
+                      ></sl-icon>
+                      <span class="inline-block align-middle pr-2"
+                        >${msg("Delete")}</span
+                      >
                     </li>
                   </ul>
                 </sl-dropdown>
@@ -256,6 +277,10 @@ export class CrawlTemplatesList extends LiteElement {
     this.runningCrawlsMap = runningCrawlsMap;
 
     return crawlConfigs;
+  }
+
+  private async duplicate(template: CrawlTemplate) {
+    console.log(template);
   }
 
   private async deleteTemplate(template: CrawlTemplate): Promise<void> {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -124,9 +124,7 @@ export class CrawlTemplatesList extends LiteElement {
                     <li
                       class="p-2 hover:bg-zinc-100 cursor-pointer"
                       role="menuitem"
-                      @click=${(e: any) => {
-                        this.duplicate(t);
-                      }}
+                      @click=${() => this.duplicate(t)}
                     >
                       <sl-icon
                         class="inline-block align-middle px-1"
@@ -279,8 +277,14 @@ export class CrawlTemplatesList extends LiteElement {
     return crawlConfigs;
   }
 
+  /**
+   * Create a new template using existing template data
+   */
   private async duplicate(template: CrawlTemplate) {
-    console.log(template);
+    this.navTo(
+      `/archives/${this.archiveId}/crawl-templates/${template.id}`,
+      template
+    );
   }
 
   private async deleteTemplate(template: CrawlTemplate): Promise<void> {

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -1,6 +1,7 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 
+import type { ViewState } from "../../utils/APIRouter";
 import type { AuthState } from "../../utils/AuthService";
 import type { CurrentUser } from "../../types/user";
 import type { ArchiveData } from "../../utils/archives";
@@ -22,6 +23,9 @@ export class Archive extends LiteElement {
 
   @property({ type: Object })
   userInfo?: CurrentUser;
+
+  @property({ type: Object })
+  viewStateData?: ViewState["data"];
 
   @property({ type: String })
   archiveId?: string;
@@ -138,6 +142,8 @@ export class Archive extends LiteElement {
   }
 
   private renderCrawlTemplates() {
+    const crawlConfig = this.viewStateData?.crawlConfig;
+
     if (this.isNewResourceTab) {
       return html`
         <div class="md:grid grid-cols-6 gap-5">
@@ -156,6 +162,7 @@ export class Archive extends LiteElement {
             class="col-span-5 mt-6"
             .authState=${this.authState!}
             .archiveId=${this.archiveId!}
+            .initialCrawlConfig=${crawlConfig}
           ></btrix-crawl-templates-new>
         </div>
       `;

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -4,7 +4,7 @@ type SeedConfig = {
 };
 
 export type CrawlConfig = {
-  seeds: ({ url: string } & SeedConfig)[];
+  seeds: (string | ({ url: string } & SeedConfig))[];
 } & SeedConfig;
 
 export type CrawlTemplate = {

--- a/frontend/src/utils/APIRouter.ts
+++ b/frontend/src/utils/APIRouter.ts
@@ -14,8 +14,9 @@ export type ViewState = {
   // e.g. "/users/:id"
   // e.g. "/redirect?url"
   params: { [key: string]: string };
+  // arbitrary data to pass between routes
+  data?: object;
 };
-export interface NavigateEvent extends CustomEvent {}
 
 export default class APIRouter {
   routes: Routes;

--- a/frontend/src/utils/APIRouter.ts
+++ b/frontend/src/utils/APIRouter.ts
@@ -15,7 +15,7 @@ export type ViewState = {
   // e.g. "/redirect?url"
   params: { [key: string]: string };
   // arbitrary data to pass between routes
-  data?: object;
+  data?: { [key: string]: any };
 };
 
 export default class APIRouter {

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -3,6 +3,13 @@ import { LitElement, html } from "lit";
 import type { Auth } from "../utils/AuthService";
 import { APIError } from "./api";
 
+export interface NavigateEvent extends CustomEvent {
+  detail: {
+    url: string;
+    state?: object;
+  };
+}
+
 export interface NotifyEvent extends CustomEvent {
   detail: {
     /**
@@ -27,21 +34,31 @@ export default class LiteElement extends LitElement {
     return this;
   }
 
-  navTo(url: string) {
-    this.dispatchEvent(
-      new CustomEvent("navigate", { detail: url, bubbles: true })
-    );
+  navTo(url: string, state?: object): void {
+    const evt: NavigateEvent = new CustomEvent("navigate", {
+      detail: { url, state },
+      bubbles: true,
+    });
+    this.dispatchEvent(evt);
   }
 
-  navLink(event: Event) {
+  /**
+   * Bind to anchor tag to prevent full page navigation
+   * @example
+   * ```ts
+   * <a href="/" @click=${this.navLink}>go</a>
+   * ```
+   * @param event Click event
+   */
+  navLink(event: Event): void {
     event.preventDefault();
-    this.dispatchEvent(
-      new CustomEvent("navigate", {
-        detail: (event.currentTarget as HTMLAnchorElement).href,
-        bubbles: true,
-        composed: true,
-      })
-    );
+
+    const evt: NavigateEvent = new CustomEvent("navigate", {
+      detail: { url: (event.currentTarget as HTMLAnchorElement).href },
+      bubbles: true,
+      composed: true,
+    });
+    this.dispatchEvent(evt);
   }
 
   /**


### PR DESCRIPTION
WIP https://github.com/webrecorder/browsertrix-cloud/pull/99

Copies `seeds`, `scopeType` and `limit` config from an existing crawl template to the new template form.

### Manual testing
1. Run app and go to crawl templates view
2. Click "more" icon (`...`) in a template with a simple seeds configuration (i.e. not JSON config) and choose "Duplicate crawl config". Verify it takes you to the new template creation page with the "Crawl configurations" form filled out.
3. Go back to templates view, and repeat for template with complex per-seed configuration. Verify new template page is filled out with JSON as expected

### Screenshots
**New menu item highlighted:**
<img width="517" alt="Screen Shot 2022-01-24 at 9 54 14 PM" src="https://user-images.githubusercontent.com/4672952/150919612-9d355e11-2c9f-48f8-85e3-c2ca41398bf8.png">

**Notification on duplication:**
<img width="436" alt="Screen Shot 2022-01-24 at 9 55 42 PM" src="https://user-images.githubusercontent.com/4672952/150919642-d7a3e59b-907e-405e-9847-69ddef134f36.png">

