### PR TITLE
Edit crawl schedule

### DIFF
--- a/frontend/src/components/crawl-scheduler.ts
+++ b/frontend/src/components/crawl-scheduler.ts
@@ -1,0 +1,220 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import cronstrue from "cronstrue"; // TODO localize
+
+import LiteElement, { html } from "../utils/LiteElement";
+import { getLocaleTimeZone } from "../utils/localization";
+import type { CrawlTemplate } from "../pages/archive/types";
+
+/**
+ * Usage:
+ * ```ts
+ * <btrix-crawl-templates-scheduler></btrix-crawl-templates-scheduler>
+ * ```
+ */
+@localized()
+export class CrawlTemplatesScheduler extends LiteElement {
+  @state()
+  private schedule?: CrawlTemplate["schedule"];
+
+  @state()
+  private editedSchedule?: string;
+
+  @state()
+  private isScheduleDisabled?: boolean;
+
+  private get timeZoneShortName() {
+    return getLocaleTimeZone();
+  }
+
+  render() {
+    // TODO consolidate with new
+    const hours = Array.from({ length: 12 }).map((x, i) => ({
+      value: i + 1,
+      label: `${i + 1}`,
+    }));
+    const minutes = Array.from({ length: 60 }).map((x, i) => ({
+      value: i,
+      label: `${i}`.padStart(2, "0"),
+    }));
+
+    const getInitialScheduleInterval = (schedule: string) => {
+      const [minute, hour, dayofMonth, month, dayOfWeek] = schedule.split(" ");
+      if (dayofMonth === "*") {
+        if (dayOfWeek === "*") {
+          return "daily";
+        }
+        return "weekly";
+      }
+      return "monthly";
+    };
+
+    const nowHour = new Date().getHours();
+    const initialHours = nowHour % 12 || 12;
+    const initialPeriod = nowHour > 11 ? "PM" : "AM";
+    const scheduleIntervalsMap = {
+      daily: `0 ${nowHour} * * *`,
+      weekly: `0 ${nowHour} * * ${new Date().getDay()}`,
+      monthly: `0 ${nowHour} ${new Date().getDate()} * *`,
+    };
+    const initialInterval = this.schedule
+      ? getInitialScheduleInterval(this.schedule)
+      : "weekly";
+    const nextSchedule =
+      this.editedSchedule || scheduleIntervalsMap[initialInterval];
+
+    return html`
+      <sl-form @sl-submit=${this.onSubmit}>
+        <div class="flex items-end">
+          <div class="pr-2 flex-1">
+            <sl-select
+              name="scheduleInterval"
+              label=${msg("Recurring crawls")}
+              value=${initialInterval}
+              @sl-select=${(e: any) => {
+                if (e.target.value) {
+                  this.isScheduleDisabled = false;
+                  this.editedSchedule = `${nextSchedule
+                    .split(" ")
+                    .slice(0, 2)
+                    .join(" ")} ${(scheduleIntervalsMap as any)[e.target.value]
+                    .split(" ")
+                    .slice(2)
+                    .join(" ")}`;
+                } else {
+                  this.isScheduleDisabled = true;
+                }
+              }}
+            >
+              <sl-menu-item value="">${msg("None")}</sl-menu-item>
+              <sl-menu-item value="daily">${msg("Daily")}</sl-menu-item>
+              <sl-menu-item value="weekly">${msg("Weekly")}</sl-menu-item>
+              <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
+            </sl-select>
+          </div>
+        </div>
+        <div class="grid grid-flow-col gap-2 items-center mt-2">
+          <span class="px-1">${msg("At")}</span>
+          <sl-select
+            name="scheduleHour"
+            class="w-24"
+            value=${initialHours}
+            ?disabled=${this.isScheduleDisabled}
+            @sl-select=${(e: any) => {
+              const hour = +e.target.value;
+              const period = e.target
+                .closest("sl-form")
+                .querySelector('sl-select[name="schedulePeriod"]').value;
+
+              this.setScheduleHour({ hour, period, schedule: nextSchedule });
+            }}
+          >
+            ${hours.map(
+              ({ value, label }) =>
+                html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+            )}
+          </sl-select>
+          <span>:</span>
+          <sl-select
+            name="scheduleMinute"
+            class="w-24"
+            value="0"
+            ?disabled=${this.isScheduleDisabled}
+            @sl-select=${(e: any) =>
+              (this.editedSchedule = `${e.target.value} ${nextSchedule
+                .split(" ")
+                .slice(1)
+                .join(" ")}`)}
+          >
+            ${minutes.map(
+              ({ value, label }) =>
+                html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
+            )}
+          </sl-select>
+          <sl-select
+            name="schedulePeriod"
+            class="w-24"
+            value=${initialPeriod}
+            ?disabled=${this.isScheduleDisabled}
+            @sl-select=${(e: any) => {
+              const hour = +e.target
+                .closest("sl-form")
+                .querySelector('sl-select[name="scheduleHour"]').value;
+              const period = e.target.value;
+
+              this.setScheduleHour({ hour, period, schedule: nextSchedule });
+            }}
+          >
+            <sl-menu-item value="AM"
+              >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
+            >
+            <sl-menu-item value="PM"
+              >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
+            >
+          </sl-select>
+          <span class="px-1">${this.timeZoneShortName}</span>
+        </div>
+
+        <div class="mt-5">
+          ${this.isScheduleDisabled
+            ? msg(html`<span class="font-medium"
+                >Crawls will not repeat.</span
+              >`)
+            : msg(
+                html`<span class="font-medium">New schedule will be:</span
+                  ><br />
+                  <span class="text-0-600"
+                    >${cronstrue.toString(nextSchedule, {
+                      verbose: true,
+                    })}
+                    (in ${this.timeZoneShortName} time zone)</span
+                  >`
+              )}
+        </div>
+
+        <div class="mt-5">
+          <sl-button type="primary" submit
+            >${msg("Save Crawl Schedule")}</sl-button
+          >
+        </div>
+      </sl-form>
+    `;
+  }
+
+  private onSubmit(event: any) {
+    this.dispatchEvent(new CustomEvent("submit", event));
+  }
+
+  /**
+   * Set correct local hour in schedule in 24-hr format
+   **/
+  private setScheduleHour({
+    hour,
+    period,
+    schedule,
+  }: {
+    hour: number;
+    period: "AM" | "PM";
+    schedule: string;
+  }) {
+    // Convert 12-hr to 24-hr time
+    let periodOffset = 0;
+
+    if (hour === 12) {
+      if (period === "AM") {
+        periodOffset = -12;
+      }
+    } else if (period === "PM") {
+      periodOffset = 12;
+    }
+
+    this.editedSchedule = `${schedule.split(" ")[0]} ${
+      hour + periodOffset
+    } ${schedule.split(" ").slice(2).join(" ")}`;
+  }
+}
+
+customElements.define(
+  "btrix-crawl-templates-scheduler",
+  CrawlTemplatesScheduler
+);

--- a/frontend/src/components/crawl-scheduler.ts
+++ b/frontend/src/components/crawl-scheduler.ts
@@ -9,12 +9,17 @@ import type { CrawlTemplate } from "../pages/archive/types";
 /**
  * Usage:
  * ```ts
- * <btrix-crawl-templates-scheduler></btrix-crawl-templates-scheduler>
+ * <btrix-crawl-templates-scheduler
+ *   schedule="0 0 * * *"
+ *   @submit=${this.handleSubmit}
+ * ></btrix-crawl-templates-scheduler>
  * ```
+ *
+ * @event submit
  */
 @localized()
 export class CrawlTemplatesScheduler extends LiteElement {
-  @state()
+  @property({ type: String })
   private schedule?: CrawlTemplate["schedule"];
 
   @state()

--- a/frontend/src/components/crawl-scheduler.ts
+++ b/frontend/src/components/crawl-scheduler.ts
@@ -72,6 +72,8 @@ export class CrawlTemplatesScheduler extends LiteElement {
               label=${msg("Recurring crawls")}
               value=${initialInterval}
               hoist
+              @sl-hide=${this.stopProp}
+              @sl-after-hide=${this.stopProp}
               @sl-select=${(e: any) => {
                 if (e.target.value) {
                   this.isScheduleDisabled = false;
@@ -102,6 +104,8 @@ export class CrawlTemplatesScheduler extends LiteElement {
             value=${initialHours}
             ?disabled=${this.isScheduleDisabled}
             hoist
+            @sl-hide=${this.stopProp}
+            @sl-after-hide=${this.stopProp}
             @sl-select=${(e: any) => {
               const hour = +e.target.value;
               const period = e.target
@@ -123,6 +127,8 @@ export class CrawlTemplatesScheduler extends LiteElement {
             value="0"
             ?disabled=${this.isScheduleDisabled}
             hoist
+            @sl-hide=${this.stopProp}
+            @sl-after-hide=${this.stopProp}
             @sl-select=${(e: any) =>
               (this.editedSchedule = `${e.target.value} ${nextSchedule
                 .split(" ")
@@ -140,6 +146,8 @@ export class CrawlTemplatesScheduler extends LiteElement {
             value=${initialPeriod}
             ?disabled=${this.isScheduleDisabled}
             hoist
+            @sl-hide=${this.stopProp}
+            @sl-after-hide=${this.stopProp}
             @sl-select=${(e: any) => {
               const hour = +e.target
                 .closest("sl-form")
@@ -215,6 +223,15 @@ export class CrawlTemplatesScheduler extends LiteElement {
     this.editedSchedule = `${schedule.split(" ")[0]} ${
       hour + periodOffset
     } ${schedule.split(" ").slice(2).join(" ")}`;
+  }
+
+  /**
+   * Stop propgation of sl-select events.
+   * Prevents bug where sl-dialog closes when dropdown closes
+   * https://github.com/shoelace-style/shoelace/issues/170
+   */
+  private stopProp(e: CustomEvent) {
+    e.stopPropagation();
   }
 }
 

--- a/frontend/src/components/crawl-scheduler.ts
+++ b/frontend/src/components/crawl-scheduler.ts
@@ -71,6 +71,7 @@ export class CrawlTemplatesScheduler extends LiteElement {
               name="scheduleInterval"
               label=${msg("Recurring crawls")}
               value=${initialInterval}
+              hoist
               @sl-select=${(e: any) => {
                 if (e.target.value) {
                   this.isScheduleDisabled = false;
@@ -100,6 +101,7 @@ export class CrawlTemplatesScheduler extends LiteElement {
             class="w-24"
             value=${initialHours}
             ?disabled=${this.isScheduleDisabled}
+            hoist
             @sl-select=${(e: any) => {
               const hour = +e.target.value;
               const period = e.target
@@ -120,6 +122,7 @@ export class CrawlTemplatesScheduler extends LiteElement {
             class="w-24"
             value="0"
             ?disabled=${this.isScheduleDisabled}
+            hoist
             @sl-select=${(e: any) =>
               (this.editedSchedule = `${e.target.value} ${nextSchedule
                 .split(" ")
@@ -136,6 +139,7 @@ export class CrawlTemplatesScheduler extends LiteElement {
             class="w-24"
             value=${initialPeriod}
             ?disabled=${this.isScheduleDisabled}
+            hoist
             @sl-select=${(e: any) => {
               const hour = +e.target
                 .closest("sl-form")

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -372,6 +372,7 @@ export class App extends LiteElement {
       case "archiveAddMember":
       case "archiveNewResourceTab":
       case "crawlTemplate":
+      case "crawlTemplateEdit":
         return appLayout(html`<btrix-archive
           class="w-full"
           @navigate=${this.onNavigateTo}
@@ -387,6 +388,7 @@ export class App extends LiteElement {
           crawlConfigId=${this.viewState.params.crawlConfigId}
           ?isAddingMember=${this.viewState.route === "archiveAddMember"}
           ?isNewResourceTab=${this.viewState.route === "archiveNewResourceTab"}
+          ?isEditing=${Boolean(this.viewState.params.edit)}
         ></btrix-archive>`);
 
       case "accountSettings":

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -404,12 +404,17 @@ export class CrawlTemplatesDetail extends LiteElement {
     target: any;
   }): Promise<void> {
     const { formData } = event.detail;
-    const utcSchedule = getUTCSchedule({
-      interval: formData.get("scheduleInterval") as any,
-      hour: formData.get("scheduleHour") as any,
-      minute: formData.get("scheduleMinute") as any,
-      period: formData.get("schedulePeriod") as any,
-    });
+    const interval = formData.get("scheduleInterval");
+    let schedule = "";
+
+    if (interval) {
+      schedule = getUTCSchedule({
+        interval: formData.get("scheduleInterval") as any,
+        hour: formData.get("scheduleHour") as any,
+        minute: formData.get("scheduleMinute") as any,
+        period: formData.get("schedulePeriod") as any,
+      });
+    }
 
     try {
       await this.apiFetch(
@@ -419,13 +424,11 @@ export class CrawlTemplatesDetail extends LiteElement {
         this.authState!,
         {
           method: "PATCH",
-          body: JSON.stringify({
-            schedule: utcSchedule,
-          }),
+          body: JSON.stringify({ schedule }),
         }
       );
 
-      this.crawlTemplate!.schedule = utcSchedule;
+      this.crawlTemplate!.schedule = schedule;
 
       this.notify({
         message: msg("Successfully saved new schedule."),

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -7,6 +7,7 @@ import LiteElement, { html } from "../../utils/LiteElement";
 import { getLocaleTimeZone } from "../../utils/localization";
 import type { CrawlTemplate } from "./types";
 import { getUTCSchedule } from "./utils";
+import "../../components/crawl-scheduler";
 
 const SEED_URLS_MAX = 3;
 
@@ -341,156 +342,11 @@ export class CrawlTemplatesDetail extends LiteElement {
   }
 
   private renderEditSchedule() {
-    // TODO consolidate with new
-    const hours = Array.from({ length: 12 }).map((x, i) => ({
-      value: i + 1,
-      label: `${i + 1}`,
-    }));
-    const minutes = Array.from({ length: 60 }).map((x, i) => ({
-      value: i,
-      label: `${i}`.padStart(2, "0"),
-    }));
-
-    const getInitialScheduleInterval = (schedule: string) => {
-      const [minute, hour, dayofMonth, month, dayOfWeek] = schedule.split(" ");
-      if (dayofMonth === "*") {
-        if (dayOfWeek === "*") {
-          return "daily";
-        }
-        return "weekly";
-      }
-      return "monthly";
-    };
-
-    const nowHour = new Date().getHours();
-    const initialHours = nowHour % 12 || 12;
-    const initialPeriod = nowHour > 11 ? "PM" : "AM";
-    const scheduleIntervalsMap = {
-      daily: `0 ${nowHour} * * *`,
-      weekly: `0 ${nowHour} * * ${new Date().getDay()}`,
-      monthly: `0 ${nowHour} ${new Date().getDate()} * *`,
-    };
-    const initialInterval = this.crawlTemplate!.schedule
-      ? getInitialScheduleInterval(this.crawlTemplate!.schedule)
-      : "weekly";
-    const nextSchedule =
-      this.editedSchedule || scheduleIntervalsMap[initialInterval];
-
     return html`
-      <sl-form @sl-submit=${this.onSubmitSchedule}>
-        <div class="flex items-end">
-          <div class="pr-2 flex-1">
-            <sl-select
-              name="scheduleInterval"
-              label=${msg("Recurring crawls")}
-              value=${initialInterval}
-              @sl-select=${(e: any) => {
-                if (e.target.value) {
-                  this.isScheduleDisabled = false;
-                  this.editedSchedule = `${nextSchedule
-                    .split(" ")
-                    .slice(0, 2)
-                    .join(" ")} ${(scheduleIntervalsMap as any)[e.target.value]
-                    .split(" ")
-                    .slice(2)
-                    .join(" ")}`;
-                } else {
-                  this.isScheduleDisabled = true;
-                }
-              }}
-            >
-              <sl-menu-item value="">${msg("None")}</sl-menu-item>
-              <sl-menu-item value="daily">${msg("Daily")}</sl-menu-item>
-              <sl-menu-item value="weekly">${msg("Weekly")}</sl-menu-item>
-              <sl-menu-item value="monthly">${msg("Monthly")}</sl-menu-item>
-            </sl-select>
-          </div>
-        </div>
-        <div class="grid grid-flow-col gap-2 items-center mt-2">
-          <span class="px-1">${msg("At")}</span>
-          <sl-select
-            name="scheduleHour"
-            class="w-24"
-            value=${initialHours}
-            ?disabled=${this.isScheduleDisabled}
-            @sl-select=${(e: any) => {
-              const hour = +e.target.value;
-              const period = e.target
-                .closest("sl-form")
-                .querySelector('sl-select[name="schedulePeriod"]').value;
-
-              this.setScheduleHour({ hour, period, schedule: nextSchedule });
-            }}
-          >
-            ${hours.map(
-              ({ value, label }) =>
-                html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-            )}
-          </sl-select>
-          <span>:</span>
-          <sl-select
-            name="scheduleMinute"
-            class="w-24"
-            value="0"
-            ?disabled=${this.isScheduleDisabled}
-            @sl-select=${(e: any) =>
-              (this.editedSchedule = `${e.target.value} ${nextSchedule
-                .split(" ")
-                .slice(1)
-                .join(" ")}`)}
-          >
-            ${minutes.map(
-              ({ value, label }) =>
-                html`<sl-menu-item value=${value}>${label}</sl-menu-item>`
-            )}
-          </sl-select>
-          <sl-select
-            name="schedulePeriod"
-            class="w-24"
-            value=${initialPeriod}
-            ?disabled=${this.isScheduleDisabled}
-            @sl-select=${(e: any) => {
-              const hour = +e.target
-                .closest("sl-form")
-                .querySelector('sl-select[name="scheduleHour"]').value;
-              const period = e.target.value;
-
-              this.setScheduleHour({ hour, period, schedule: nextSchedule });
-            }}
-          >
-            <sl-menu-item value="AM"
-              >${msg("AM", { desc: "Time AM/PM" })}</sl-menu-item
-            >
-            <sl-menu-item value="PM"
-              >${msg("PM", { desc: "Time AM/PM" })}</sl-menu-item
-            >
-          </sl-select>
-          <span class="px-1">${this.timeZoneShortName}</span>
-        </div>
-
-        <div class="mt-5">
-          ${this.isScheduleDisabled
-            ? msg(html`<span class="font-medium"
-                >Crawls will not repeat.</span
-              >`)
-            : msg(
-                html`<span class="font-medium">New schedule will be:</span
-                  ><br />
-                  <span class="text-0-600"
-                    >${cronstrue.toString(nextSchedule, {
-                      verbose: true,
-                    })}
-                    (in ${this.timeZoneShortName} time zone)</span
-                  >`
-              )}
-        </div>
-
-        <div class="mt-5">
-          <sl-button type="primary" submit
-            >${msg("Save Crawl Schedule")}</sl-button
-          >
-        </div>
-      </sl-form>
+      <btrix-crawl-templates-scheduler
+        schedule=${this.crawlTemplate!.schedule}
+        @submit=${this.onSubmitSchedule}
+      ></btrix-crawl-templates-scheduler>
     `;
   }
 
@@ -568,6 +424,8 @@ export class CrawlTemplatesDetail extends LiteElement {
           }),
         }
       );
+
+      this.crawlTemplate!.schedule = utcSchedule;
 
       this.notify({
         message: msg("Successfully saved new schedule."),

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -486,7 +486,9 @@ export class CrawlTemplatesDetail extends LiteElement {
         </div>
 
         <div class="mt-5">
-          <sl-button type="primary" submit>${msg("Save schedule")}</sl-button>
+          <sl-button type="primary" submit
+            >${msg("Save Crawl Schedule")}</sl-button
+          >
         </div>
       </sl-form>
     `;

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -222,8 +222,18 @@ export class CrawlTemplatesDetail extends LiteElement {
                     this.crawlTemplate!.id
                   }${this.isEditing ? "" : "?edit=true"}`}
                   @click=${(e: any) => {
-                    this.navLink(e);
-                    this.editedSchedule = "";
+                    const hasChanges = this.isEditing && this.editedSchedule;
+                    if (
+                      !hasChanges ||
+                      window.confirm(
+                        msg("You have unsaved schedule changes. Are you sure?")
+                      )
+                    ) {
+                      this.navLink(e);
+                      this.editedSchedule = "";
+                    } else {
+                      e.preventDefault();
+                    }
                   }}
                 >
                   ${this.isEditing ? msg("Cancel") : msg("Edit")}
@@ -544,7 +554,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     });
 
     try {
-      const data = await this.apiFetch(
+      await this.apiFetch(
         `/archives/${this.archiveId}/crawlconfigs/${
           this.crawlTemplate!.id
         }/schedule`,
@@ -563,7 +573,9 @@ export class CrawlTemplatesDetail extends LiteElement {
         icon: "check2-circle",
       });
 
-      this.navTo(`/archives/${this.archiveId}/crawl-templates`);
+      this.navTo(
+        `/archives/${this.archiveId}/crawl-templates/${this.crawlTemplate!.id}`
+      );
     } catch (e: any) {
       console.error(e);
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -543,8 +543,6 @@ export class CrawlTemplatesDetail extends LiteElement {
       period: formData.get("schedulePeriod") as any,
     });
 
-    console.log(utcSchedule);
-
     try {
       const data = await this.apiFetch(
         `/archives/${this.archiveId}/crawlconfigs/${
@@ -558,8 +556,6 @@ export class CrawlTemplatesDetail extends LiteElement {
           }),
         }
       );
-
-      console.log("data;", data);
 
       this.notify({
         message: msg("Successfully saved new schedule."),

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -31,6 +31,9 @@ export class CrawlTemplatesDetail extends LiteElement {
   @state()
   private showAllSeedURLs: boolean = false;
 
+  @state()
+  private isEditingSchedule: boolean = false;
+
   async firstUpdated() {
     try {
       this.crawlTemplate = await this.getCrawlTemplate();
@@ -86,8 +89,8 @@ export class CrawlTemplatesDetail extends LiteElement {
           <div class="col-span-1 p-4 md:p-8 md:border-b">
             <h3 class="font-medium">${msg("Configuration")}</h3>
           </div>
-          <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
-            <div role="table">
+          <div class="col-span-3 p-4 md:p-8 border-b">
+            <div class="mb-5" role="table">
               <div class="grid grid-cols-5 gap-4" role="row">
                 <span class="col-span-3 text-sm text-0-600" role="columnheader"
                   >${msg("Seed URL")}</span
@@ -188,26 +191,37 @@ export class CrawlTemplatesDetail extends LiteElement {
           <div class="col-span-1 p-4 md:p-8 md:border-b">
             <h3 class="font-medium">${msg("Schedule")}</h3>
           </div>
-          <div class="col-span-3 p-4 md:p-8 border-b grid gap-5">
-            <dl class="grid gap-5">
-              <div>
-                <dt class="text-sm text-0-600">${msg("Recurring crawls")}</dt>
-                <dd>
-                  ${this.crawlTemplate.schedule
-                    ? // TODO localize
-                      // NOTE human-readable string is in UTC, limitation of library
-                      // currently being used.
-                      // https://github.com/bradymholt/cRonstrue/issues/94
-                      html`<span
-                        >${cronstrue.toString(this.crawlTemplate.schedule, {
-                          verbose: true,
-                        })}
-                        (in UTC time zone)</span
-                      >`
-                    : html`<span class="text-0-400">${msg("None")}</span>`}
-                </dd>
+          <div class="col-span-3 p-4 border-b">
+            <div class="flex justify-between">
+              <dl class="md:p-4 grid gap-5">
+                <div>
+                  <dt class="text-sm text-0-600">${msg("Recurring crawls")}</dt>
+                  <dd>
+                    ${this.crawlTemplate.schedule
+                      ? // TODO localize
+                        // NOTE human-readable string is in UTC, limitation of library
+                        // currently being used.
+                        // https://github.com/bradymholt/cRonstrue/issues/94
+                        html`<span
+                          >${cronstrue.toString(this.crawlTemplate.schedule, {
+                            verbose: true,
+                          })}
+                          (in UTC time zone)</span
+                        >`
+                      : html`<span class="text-0-400">${msg("None")}</span>`}
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="ml-2">
+                <sl-button
+                  size="small"
+                  @click=${() => (this.isEditingSchedule = true)}
+                >
+                  ${msg("Edit")}
+                </sl-button>
               </div>
-            </dl>
+            </div>
           </div>
         </section>
 
@@ -215,7 +229,7 @@ export class CrawlTemplatesDetail extends LiteElement {
           <div class="col-span-1 p-4 md:p-8">
             <h3 class="font-medium">${msg("Crawls")}</h3>
           </div>
-          <div class="col-span-3 p-4 md:p-8 grid gap-5">
+          <div class="col-span-3 p-4 md:p-8">
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-600">${msg("# of Crawls")}</dt>

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -5,6 +5,7 @@ import cronParser from "cron-parser";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { CrawlTemplate } from "./types";
+import "../../components/crawl-scheduler";
 
 type RunningCrawlsMap = {
   /** Map of configId: crawlId */
@@ -30,6 +31,9 @@ export class CrawlTemplatesList extends LiteElement {
 
   @state()
   runningCrawlsMap: RunningCrawlsMap = {};
+
+  @state()
+  selectedTemplateForEdit?: CrawlTemplate;
 
   private get timeZone() {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -114,10 +118,10 @@ export class CrawlTemplatesList extends LiteElement {
                     <li
                       class="p-2 hover:bg-zinc-100 cursor-pointer"
                       role="menuitem"
-                      @click=${() =>
-                        this.navTo(
-                          `/archives/${this.archiveId}/crawl-templates/${t.id}?edit=true`
-                        )}
+                      @click=${(e: any) => {
+                        e.target.closest("sl-dropdown").hide();
+                        this.selectedTemplateForEdit = t;
+                      }}
                     >
                       <sl-icon
                         class="inline-block align-middle px-1"
@@ -285,6 +289,13 @@ export class CrawlTemplatesList extends LiteElement {
             </div>`
         )}
       </div>
+
+      <sl-dialog
+        label=${msg(str`${this.selectedTemplateForEdit?.name} Crawl Schedule`)}
+        ?open=${Boolean(this.selectedTemplateForEdit)}
+      >
+        <btrix-crawl-templates-scheduler></btrix-crawl-templates-scheduler>
+      </sl-dialog>
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -426,12 +426,17 @@ export class CrawlTemplatesList extends LiteElement {
     if (!this.selectedTemplateForEdit) return;
 
     const { formData } = event.detail;
-    const utcSchedule = getUTCSchedule({
-      interval: formData.get("scheduleInterval") as any,
-      hour: formData.get("scheduleHour") as any,
-      minute: formData.get("scheduleMinute") as any,
-      period: formData.get("schedulePeriod") as any,
-    });
+    const interval = formData.get("scheduleInterval");
+    let schedule = "";
+
+    if (interval) {
+      schedule = getUTCSchedule({
+        interval: formData.get("scheduleInterval") as any,
+        hour: formData.get("scheduleHour") as any,
+        minute: formData.get("scheduleMinute") as any,
+        period: formData.get("schedulePeriod") as any,
+      });
+    }
     const editedTemplateId = this.selectedTemplateForEdit.id;
 
     try {
@@ -440,9 +445,7 @@ export class CrawlTemplatesList extends LiteElement {
         this.authState!,
         {
           method: "PATCH",
-          body: JSON.stringify({
-            schedule: utcSchedule,
-          }),
+          body: JSON.stringify({ schedule }),
         }
       );
 
@@ -450,7 +453,7 @@ export class CrawlTemplatesList extends LiteElement {
         t.id === editedTemplateId
           ? {
               ...t,
-              schedule: utcSchedule,
+              schedule,
             }
           : t
       );

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -114,6 +114,23 @@ export class CrawlTemplatesList extends LiteElement {
                     <li
                       class="p-2 hover:bg-zinc-100 cursor-pointer"
                       role="menuitem"
+                      @click=${() =>
+                        this.navTo(
+                          `/archives/${this.archiveId}/crawl-templates/${t.id}?edit=true`
+                        )}
+                    >
+                      <sl-icon
+                        class="inline-block align-middle px-1"
+                        name="pencil-square"
+                      ></sl-icon>
+                      <span class="inline-block align-middle pr-2"
+                        >${msg("Edit crawl schedule")}</span
+                      >
+                    </li>
+
+                    <li
+                      class="p-2 hover:bg-zinc-100 cursor-pointer"
+                      role="menuitem"
                       @click=${() => this.duplicateConfig(t)}
                     >
                       <sl-icon

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -39,10 +39,6 @@ export class CrawlTemplatesList extends LiteElement {
   @state()
   selectedTemplateForEdit?: CrawlTemplate;
 
-  private get timeZone() {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  }
-
   async firstUpdated() {
     try {
       this.crawlTemplates = await this.getCrawlTemplates();
@@ -218,7 +214,7 @@ export class CrawlTemplatesList extends LiteElement {
                               year="2-digit"
                               hour="numeric"
                               minute="numeric"
-                              time-zone=${this.timeZone}
+                              time-zone-name="short"
                             ></sl-format-date>
                           </span>
                         </sl-tooltip>`
@@ -254,7 +250,7 @@ export class CrawlTemplatesList extends LiteElement {
                                 year="2-digit"
                                 hour="numeric"
                                 minute="numeric"
-                                time-zone=${this.timeZone}
+                                time-zone-name="short"
                               ></sl-format-date>
                             </span>
                           </sl-tooltip>

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -20,7 +20,6 @@ export type NewCrawlTemplate = {
 const initialValues = {
   name: "",
   runNow: true,
-  schedule: "@weekly",
   config: {
     seeds: [],
     scopeType: "prefix",

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -7,6 +7,7 @@ import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { getLocaleTimeZone } from "../../utils/localization";
 import type { CrawlConfig } from "./types";
+import { getUTCSchedule } from "./utils";
 
 export type NewCrawlTemplate = {
   id?: string;
@@ -558,40 +559,18 @@ export class CrawlTemplatesNew extends LiteElement {
     this.isSubmitting = false;
   }
 
-  /**
-   * Get schedule as UTC cron job expression
-   * https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
-   **/
   private getUTCSchedule(): string {
     if (!this.scheduleInterval) {
       return "";
     }
-
     const { minute, hour, period } = this.scheduleTime;
-    const localDate = new Date();
 
-    // Convert 12-hr to 24-hr time
-    let periodOffset = 0;
-
-    if (hour === 12) {
-      if (period === "AM") {
-        periodOffset = -12;
-      }
-    } else if (period === "PM") {
-      periodOffset = 12;
-    }
-
-    localDate.setHours(+hour + periodOffset);
-    localDate.setMinutes(+minute);
-    const dayOfMonth =
-      this.scheduleInterval === "monthly" ? localDate.getUTCDate() : "*";
-    const dayOfWeek =
-      this.scheduleInterval === "weekly" ? localDate.getUTCDay() : "*";
-    const month = "*";
-
-    const schedule = `${localDate.getUTCMinutes()} ${localDate.getUTCHours()} ${dayOfMonth} ${month} ${dayOfWeek}`;
-
-    return schedule;
+    return getUTCSchedule({
+      interval: this.scheduleInterval,
+      hour,
+      minute,
+      period,
+    });
   }
 }
 

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -1,0 +1,174 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import cronParser from "cron-parser";
+
+import type { AuthState } from "../../utils/AuthService";
+import LiteElement, { html } from "../../utils/LiteElement";
+import type { CrawlTemplate } from "./types";
+
+type RunningCrawlsMap = {
+  /** Map of configId: crawlId */
+  [configId: string]: string;
+};
+
+/**
+ * Usage:
+ * ```ts
+ * <btrix-crawl-templates-list></btrix-crawl-templates-list>
+ * ```
+ */
+@localized()
+export class CrawlTemplatesList extends LiteElement {
+  @property({ type: Object })
+  authState!: AuthState;
+
+  @property({ type: String })
+  archiveId!: string;
+
+  @state()
+  crawlTemplates?: CrawlTemplate[];
+
+  @state()
+  runningCrawlsMap: RunningCrawlsMap = {};
+
+  private get timeZone() {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
+  async firstUpdated() {
+    try {
+      this.crawlTemplates = await this.getCrawlTemplates();
+      if (!this.crawlTemplates.length) {
+        this.navTo(`/archives/${this.archiveId}/crawl-templates/new`);
+      }
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't retrieve crawl templates at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+        duration: 10000,
+      });
+    }
+  }
+
+  render() {
+    if (!this.crawlTemplates) {
+      return html`<div
+        class="w-full flex items-center justify-center my-24 text-4xl"
+      >
+        <sl-spinner></sl-spinner>
+      </div>`;
+    }
+
+    return html``;
+  }
+
+  /**
+   * Fetch crawl templates and record running crawls
+   * associated with the crawl templates
+   **/
+  private async getCrawlTemplates(): Promise<CrawlTemplate[]> {
+    type CrawlConfig = Omit<CrawlTemplate, "config"> & {
+      config: Omit<CrawlTemplate["config"], "seeds"> & {
+        seeds: (string | { url: string })[];
+      };
+    };
+
+    const data: { crawlConfigs: CrawlConfig[] } = await this.apiFetch(
+      `/archives/${this.archiveId}/crawlconfigs`,
+      this.authState!
+    );
+
+    const crawlConfigs: CrawlTemplate[] = [];
+    const runningCrawlsMap: RunningCrawlsMap = {};
+
+    data.crawlConfigs.forEach(({ config, ...configMeta }) => {
+      crawlConfigs.push({
+        ...configMeta,
+        config: {
+          ...config,
+          // Normalize seed format
+          seeds: config.seeds.map((seed) =>
+            typeof seed === "string"
+              ? {
+                  url: seed,
+                }
+              : seed
+          ),
+        },
+      });
+
+      if (configMeta.currCrawlId) {
+        runningCrawlsMap[configMeta.id] = configMeta.currCrawlId;
+      }
+    });
+
+    this.runningCrawlsMap = runningCrawlsMap;
+
+    return crawlConfigs;
+  }
+
+  private async deleteTemplate(template: CrawlTemplate): Promise<void> {
+    try {
+      await this.apiFetch(
+        `/archives/${this.archiveId}/crawlconfigs/${template.id}`,
+        this.authState!,
+        {
+          method: "DELETE",
+        }
+      );
+
+      this.notify({
+        message: msg(str`Deleted <strong>${template.name}</strong>.`),
+        type: "success",
+        icon: "check2-circle",
+      });
+
+      this.crawlTemplates = this.crawlTemplates!.filter(
+        (t) => t.id !== template.id
+      );
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't delete crawl template at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async runNow(template: CrawlTemplate): Promise<void> {
+    try {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawlconfigs/${template.id}/run`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      const crawlId = data.started;
+
+      this.runningCrawlsMap = {
+        ...this.runningCrawlsMap,
+        [template.id]: crawlId,
+      };
+
+      this.notify({
+        message: msg(
+          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
+        ),
+        type: "success",
+        icon: "check2-circle",
+        duration: 10000,
+      });
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't run crawl at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+}
+
+customElements.define("btrix-crawl-templates-list", CrawlTemplatesList);

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -40,6 +40,9 @@ export class Archive extends LiteElement {
   @property({ type: Boolean })
   isAddingMember: boolean = false;
 
+  @property({ type: Boolean })
+  isEditing: boolean = false;
+
   /** Whether new resource is being added in tab */
   @property({ type: Boolean })
   isNewResourceTab: boolean = false;
@@ -171,6 +174,7 @@ export class Archive extends LiteElement {
                   .authState=${this.authState!}
                   .archiveId=${this.archiveId!}
                   .crawlConfigId=${this.crawlConfigId}
+                  .isEditing=${this.isEditing}
                 ></btrix-crawl-templates-detail>
               `
             : html` <btrix-crawl-templates-new

--- a/frontend/src/pages/archive/utils.ts
+++ b/frontend/src/pages/archive/utils.ts
@@ -26,7 +26,7 @@ export function getUTCSchedule({
     periodOffset = 12;
   }
 
-  localDate.setHours(+hour + periodOffset);
+  localDate.setHours(hour + periodOffset);
   localDate.setMinutes(+minute);
   const dayOfMonth = interval === "monthly" ? localDate.getUTCDate() : "*";
   const dayOfWeek = interval === "weekly" ? localDate.getUTCDay() : "*";

--- a/frontend/src/pages/archive/utils.ts
+++ b/frontend/src/pages/archive/utils.ts
@@ -9,8 +9,8 @@ export function getUTCSchedule({
   period,
 }: {
   interval: "daily" | "weekly" | "monthly";
-  minute: number;
-  hour: number;
+  minute: number | string;
+  hour: number | string;
   period: "AM" | "PM";
 }): string {
   const localDate = new Date();
@@ -26,7 +26,7 @@ export function getUTCSchedule({
     periodOffset = 12;
   }
 
-  localDate.setHours(hour + periodOffset);
+  localDate.setHours(+hour + periodOffset);
   localDate.setMinutes(+minute);
   const dayOfMonth = interval === "monthly" ? localDate.getUTCDate() : "*";
   const dayOfWeek = interval === "weekly" ? localDate.getUTCDay() : "*";

--- a/frontend/src/pages/archive/utils.ts
+++ b/frontend/src/pages/archive/utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Get schedule as UTC cron job expression
+ * https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
+ **/
+export function getUTCSchedule({
+  interval,
+  minute,
+  hour,
+  period,
+}: {
+  interval: "daily" | "weekly" | "monthly";
+  minute: number;
+  hour: number;
+  period: "AM" | "PM";
+}): string {
+  const localDate = new Date();
+
+  // Convert 12-hr to 24-hr time
+  let periodOffset = 0;
+
+  if (hour === 12) {
+    if (period === "AM") {
+      periodOffset = -12;
+    }
+  } else if (period === "PM") {
+    periodOffset = 12;
+  }
+
+  localDate.setHours(+hour + periodOffset);
+  localDate.setMinutes(+minute);
+  const dayOfMonth = interval === "monthly" ? localDate.getUTCDate() : "*";
+  const dayOfWeek = interval === "weekly" ? localDate.getUTCDay() : "*";
+  const month = "*";
+
+  const schedule = `${localDate.getUTCMinutes()} ${localDate.getUTCHours()} ${dayOfMonth} ${month} ${dayOfWeek}`;
+
+  return schedule;
+}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   archiveNewResourceTab: "/archives/:id/:tab/new",
   archiveAddMember: "/archives/:id/:tab/add-member",
   crawlTemplate: "/archives/:id/crawl-templates/:crawlConfigId",
+  crawlTemplateEdit: "/archives/:id/crawl-templates/:crawlConfigId?edit",
   users: "/users",
   usersInvite: "/users/invite",
 } as const;


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/89) Allow user to edit crawl schedule from crawl template list or detail view.

### Manual testing
1. Run app and go to crawl templates page.
2. Click "..." more icon, choose "Edit crawl schedule"
3. Update schedule. Verify changes save as expected
4. Click on a template and scroll down to schedule. Click "Edit"
5. Update schedule. Verify changes save as expected

### Screenshots
**New menu item:**
<img width="518" alt="Screen Shot 2022-01-25 at 6 15 55 PM" src="https://user-images.githubusercontent.com/4672952/151095033-a686b382-8894-4faf-badc-d6c892116b47.png">

**Modal:**
<img width="1056" alt="Screen Shot 2022-01-25 at 6 16 03 PM" src="https://user-images.githubusercontent.com/4672952/151095053-39d0cd00-cab3-48e1-96ee-8183eed580db.png">

**Edit button in detail page:**
<img width="856" alt="Screen Shot 2022-01-25 at 6 16 12 PM" src="https://user-images.githubusercontent.com/4672952/151095089-6703cb39-52a3-45f6-8533-ede5b32e1330.png">

**Form in detail page:**
<img width="849" alt="Screen Shot 2022-01-25 at 6 16 17 PM" src="https://user-images.githubusercontent.com/4672952/151095110-702020b6-d21f-43d8-b19a-826e97b5726d.png">

