### PR TITLE
crawl config new template: add support for 'extraHops' config option

### DIFF
--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -55,6 +55,7 @@ class RawCrawlConfig(BaseModel):
 
     depth: Optional[int] = -1
     limit: Optional[int] = 0
+    extraHops: Optional[int] = 0
 
     behaviorTimeout: Optional[int] = 90
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -227,7 +227,7 @@ export class CrawlTemplatesNew extends LiteElement {
             <div class="pr-2 flex-1">
               <sl-select
                 name="schedule"
-                label=${msg("Recurring crawls")}
+                label=${msg("Recurring Crawls")}
                 value=${this.scheduleInterval}
                 @sl-select=${(e: any) =>
                   (this.scheduleInterval = e.target.value)}
@@ -311,7 +311,7 @@ export class CrawlTemplatesNew extends LiteElement {
 
         <sl-input
           name="crawlTimeoutMinutes"
-          label=${msg("Time limit")}
+          label=${msg("Time Limit")}
           placeholder=${msg("unlimited")}
           type="number"
         >
@@ -365,7 +365,7 @@ export class CrawlTemplatesNew extends LiteElement {
       ></sl-textarea>
       <sl-select
         name="scopeType"
-        label=${msg("Scope type")}
+        label=${msg("Crawl Scope")}
         value=${this.initialCrawlConfig!.scopeType!}
       >
         <sl-menu-item value="page">Page</sl-menu-item>
@@ -374,9 +374,13 @@ export class CrawlTemplatesNew extends LiteElement {
         <sl-menu-item value="host">Host</sl-menu-item>
         <sl-menu-item value="any">Any</sl-menu-item>
       </sl-select>
+      <sl-checkbox
+        name="extraHopsOne"
+      >${msg("Include External Links ('one hop out')")}
+      </sl-checkbox>
       <sl-input
         name="limit"
-        label=${msg("Page limit")}
+        label=${msg("Page Limit")}
         type="number"
         value=${ifDefined(this.initialCrawlConfig!.limit)}
         placeholder=${msg("unlimited")}
@@ -497,6 +501,7 @@ export class CrawlTemplatesNew extends LiteElement {
           .map((url) => ({ url })),
         scopeType: formData.get("scopeType") as string,
         limit: pageLimit ? +pageLimit : 0,
+        extraHops: formData.get("extraHopsOne") ? 1 : 0,
       };
     }
 

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,6 +1,7 @@
 type SeedConfig = {
   scopeType?: string;
   limit?: number;
+  extraHops?: number;
 };
 
 export type CrawlConfig = {

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -9,6 +9,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button/button"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/checkbox/checkbox"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/details/details"
 );
 import(


### PR DESCRIPTION
Adds support via a new checkbox, which sets `extraHops` to 1.

### Testing

1) Create New Crawl Config
2) New checkbox should be present:
<img width="885" alt="Screen Shot 2022-01-26 at 6 37 51 PM" src="https://user-images.githubusercontent.com/1015759/151282727-6e1c02aa-9450-4ca6-8516-8b12f407bf9d.png">
4) Create crawl with checkbox checked.

3) Crawl config details includes the `extraHops` value set to 1
<img width="652" alt="Screen Shot 2022-01-26 at 6 46 31 PM" src="https://user-images.githubusercontent.com/1015759/151282946-6cb9cc54-4ee1-49d5-bab9-a4f87b5e9b4d.png">

(Updated backend deployed for testing).
