### PR TITLE
Add signing server via authsign (k8s only)

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
@@ -55,6 +56,20 @@ spec:
             name: browsertrix-cloud-frontend
             port:
               number: 80
+
+{{ if .Values.signer.host }}
+  - host: {{ .Values.signer.host }}
+    http:
+      paths:
+      - path: /(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: auth-signer
+            port:
+              number: 80
+
+{{ end }}
 
 {{ if .Values.ingress.tls }}
 ---

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -53,4 +53,9 @@ stringData:
   STORE_ACCESS_ENDPOINT_URL: "{{ $storage.endpoint_url }}"
   {{- end }}
 
+  {{- if $.Values.signer.auth_token }}
+  WACZ_SIGN_TOKEN: "{{ $.Values.signer.auth_token }}"
+  WACZ_SIGN_URL: "http://auth-signer.default:5053/sign"
+  {{- end }}
+
 {{- end }}

--- a/chart/templates/signer.yaml
+++ b/chart/templates/signer.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.signer.enabled }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-signer-config
+  namespace: {{ .Release.Namespace }}
+
+type: Opaque
+stringData:
+  config.yaml: |
+    signing:
+      domain: {{ .Values.signer.host }}  # domain to retrieve a cert for (passed to ACME servers, required)
+      email: {{ .Values.signer.cert_email }}  # email for acme auth (passed to ACME servers, required)
+      port: 80  # local port for acme domain check (should be 80, change if running behind a proxy)
+
+      output: /data  # dir to store the keys and certs (for internal use)
+
+      staging: False  # generate staging certs
+
+      # optional: set a 'cross-singing' CA and private key
+      # this will be used along with ACME (Lets Encrypt) to sign the same CSR
+      # csca_cert: <ca-cert.pem>
+      # csca_private_key: <ca-private-key.pem>
+
+      # rfc3161 timestamp authority cert chain + timestamp urls
+      # at least one required, if multiple, one is selected at random
+      timestamping:
+        # time server cert chain (cert + ca cert)
+        # pkg:// url to load from python package data
+        - certfile: pkg://authsign.trusted/ts-chain.pem
+          url: http://freetsa.org/tsr  # timeserver URL
+
+
+# default trusted roots stored in authsign.trusted package
+# uncomment to override
+# trusted_roots: pkg://authsign.trusted/roots.yaml
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-signer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: auth-signer
+  replicas: {{ .Values.api_num_replicas }}
+  template:
+    metadata:
+      labels:
+        app: auth-signer
+
+      annotations:
+        # force helm to update the deployment each time
+        {{- if not .Values.frontend_only }}
+        "helm.update": {{ randAlphaNum 5 | quote }}
+        {{- end }}
+
+    spec:
+      volumes:
+        - name: signer-config
+          secret:
+            secretName: auth-signer-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+
+      containers:
+        - name: signer
+          image: {{ .Values.signer.image }}
+          imagePullPolicy: {{ .Values.signer.image_pull_policy }}
+          command: ["uvicorn", "authsign.main:app", "--port", "5053", "--host", "0.0.0.0", "--log-config", "/app/log.json"]
+          env:
+            - name: CONFIG
+              value: "/app-data/config.yaml"
+
+            - name: AUTH_TOKEN
+              value: "{{ .Values.signer.auth_token }}"
+
+          volumeMounts:
+            - name: signer-config
+              mountPath: /app-data
+              readOnly: true
+
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: auth-signer
+  labels:
+    app: auth-signer
+
+spec:
+  selector:
+    app: auth-signer
+
+{{- if .Values.service }}
+  {{- if .Values.service.type }}
+  type: {{ .Values.service.type | quote }}
+  {{- end }}
+{{- end }}
+
+  ports:
+    - protocol: TCP
+      port: 80
+      name: signer-cert
+
+    - protocol: TCP
+      port: 5053
+      name: signer-api
+
+
+{{- end }}

--- a/chart/templates/signer.yaml
+++ b/chart/templates/signer.yaml
@@ -37,6 +37,40 @@ stringData:
 # uncomment to override
 # trusted_roots: pkg://authsign.trusted/roots.yaml
 
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: signer-storage-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+
+  resources:
+    requests:
+      storage: 1Gi
+
+  {{- if .Values.volume_storage_class }}
+  storageClassName: {{ .Values.volume_storage_class }}
+  {{- end }}
+
+
+{{- if not .Values.volume_storage_class }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "signer-store-pv"
+spec:
+  capacity:
+    storage: 1Gi
+
+  accessModes:
+    - "ReadWriteOnce"
+
+  hostPath:
+    path: /tmp/btrix-signer-data
+{{- end }}
 
 ---
 apiVersion: apps/v1
@@ -55,8 +89,8 @@ spec:
         app: auth-signer
 
       annotations:
-        # force helm to update the deployment each time
-        {{- if not .Values.frontend_only }}
+        # force update if signer_update is set
+        {{- if .Values.signer_update }}
         "helm.update": {{ randAlphaNum 5 | quote }}
         {{- end }}
 
@@ -69,6 +103,10 @@ spec:
               - key: config.yaml
                 path: config.yaml
 
+        - name: signer-storage
+          persistentVolumeClaim:
+            claimName: signer-storage-pvc
+
       containers:
         - name: signer
           image: {{ .Values.signer.image }}
@@ -76,15 +114,19 @@ spec:
           command: ["uvicorn", "authsign.main:app", "--port", "5053", "--host", "0.0.0.0", "--log-config", "/app/log.json"]
           env:
             - name: CONFIG
-              value: "/app-data/config.yaml"
+              value: "/app-config/config.yaml"
 
             - name: AUTH_TOKEN
               value: "{{ .Values.signer.auth_token }}"
 
           volumeMounts:
             - name: signer-config
-              mountPath: /app-data
+              mountPath: /app-config
               readOnly: true
+
+            - name: signer-storage
+              mountPath: /data
+              subPath: signer
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -137,6 +137,16 @@ ingress:
   tls: false
 
 
+# Signing Options
+# =========================================
+# optionally enable signer
+signer:
+  enabled: false
+  # host: <set to signer domain>
+  # cert_email: "test@example.com
+  # image: webrecorder/authsign:0.3.1
+  # image_pull_policy: "IfNotPresent"
+  # auth_token: <set to custom value>
 
 
 # Optional: configure load balancing


### PR DESCRIPTION
k8s only (thus far) support for signing serve:
- add k8s deployment of signing server, if 'signer.enabled' chart value if set
- update ingress to provide access for signing server to verify domain, run signing server itself on different port (also turn off ssl redirects to support signing server)
- set WACZ_SIGN_URL and WACZ_SIGN_TOKEN (supported in browesertrix-crawler 0.5.0)
- authsign deployment uses a volume to store current certs