### PR TITLE
Initial crawl detail page

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -15,6 +15,9 @@ import("./copy-button").then(({ CopyButton }) => {
 import("./invite-form").then(({ InviteForm }) => {
   customElements.define("btrix-invite-form", InviteForm);
 });
+import("./relative-duration").then(({ RelativeDuration }) => {
+  customElements.define("btrix-relative-duration", RelativeDuration);
+});
 import("./sign-up-form").then(({ SignUpForm }) => {
   customElements.define("btrix-sign-up-form", SignUpForm);
 });

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -16,11 +16,17 @@ export class RelativeDuration extends LitElement {
   @property({ type: String })
   value?: string; // `new Date` compatible date format
 
+  static humanize(duration: number) {
+    return humanizeDuration(duration, {
+      secondsDecimalDigits: 0,
+    });
+  }
+
   render() {
     if (!this.value) return "";
 
-    return humanizeDuration(Date.now() - new Date(this.value).valueOf(), {
-      secondsDecimalDigits: 0,
-    });
+    return RelativeDuration.humanize(
+      Date.now() - new Date(this.value).valueOf()
+    );
   }
 }

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -1,0 +1,26 @@
+import { LitElement } from "lit";
+import { property, state } from "lit/decorators.js";
+import humanizeDuration from "pretty-ms";
+
+/**
+ * Show time passed from date in human-friendly format
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-relative-duration value=${value}></btrix-relative-duration>
+ * ```
+ *
+ * @event on-copied
+ */
+export class RelativeDuration extends LitElement {
+  @property({ type: String })
+  value?: string; // `new Date` compatible date format
+
+  render() {
+    if (!this.value) return "";
+
+    return humanizeDuration(Date.now() - new Date(this.value).valueOf(), {
+      secondsDecimalDigits: 0,
+    });
+  }
+}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -371,6 +371,7 @@ export class App extends LiteElement {
       case "archive":
       case "archiveAddMember":
       case "archiveNewResourceTab":
+      case "crawl":
       case "crawlTemplate":
       case "crawlTemplateEdit":
         return appLayout(html`<btrix-archive
@@ -386,6 +387,7 @@ export class App extends LiteElement {
             ? "crawl-templates"
             : (this.viewState.params.tab as ArchiveTab)}
           crawlConfigId=${this.viewState.params.crawlConfigId}
+          crawlId=${this.viewState.params.crawlId}
           ?isAddingMember=${this.viewState.route === "archiveAddMember"}
           ?isNewResourceTab=${this.viewState.route === "archiveNewResourceTab"}
           ?isEditing=${Boolean(this.viewState.params.edit)}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -324,9 +324,7 @@ export class CrawlDetail extends LiteElement {
               <div>
                 <a
                   class="text-primary hover:underline"
-                  href=${file.filename.startsWith("http")
-                    ? file.filename
-                    : `${window.location.protocol}//${window.location.host}/${file.filename}`}
+                  href=${file.filename}
                   download
                   title=${file.filename.slice(
                     file.filename.lastIndexOf("/") + 1

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -135,7 +135,7 @@ export class CrawlDetail extends LiteElement {
               ? html`
                   <a
                     class="font-medium  hover:underline"
-                    href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
+                    href=${`/archives/${this.archiveId}/crawl-templates/${this.crawl.cid}`}
                     @click=${this.navLink}
                     >${this.crawl.configName}</a
                   >

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -33,16 +33,7 @@ export class CrawlDetail extends LiteElement {
   private isWatchExpanded: boolean = false;
 
   async firstUpdated() {
-    try {
-      this.crawl = await this.getCrawl();
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't retrieve crawl at this time."),
-        type: "danger",
-        icon: "exclamation-octagon",
-        duration: 10000,
-      });
-    }
+    this.fetchCrawl();
 
     try {
       this.watchUrl = await this.watchCrawl();
@@ -166,11 +157,11 @@ export class CrawlDetail extends LiteElement {
                     <span
                       class="inline-block ${this.crawl.state === "failed"
                         ? "text-red-500"
-                        : this.crawl.state === "partial_complete"
-                        ? "text-emerald-200"
+                        : this.crawl.state === "complete"
+                        ? "text-emerald-500"
                         : isRunning
                         ? "text-purple-500"
-                        : "text-emerald-500"}"
+                        : "text-zinc-300"}"
                       style="font-size: 10px; vertical-align: 2px"
                     >
                       &#9679;
@@ -275,6 +266,21 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
+  /**
+   * Fetch crawl and update internal state
+   */
+  private async fetchCrawl(): Promise<void> {
+    try {
+      this.crawl = await this.getCrawl();
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't retrieve crawl at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
   async getCrawl(): Promise<Crawl> {
     // Mock to use in dev:
     // return import("../../__mocks__/api/archives/[id]/crawls").then(
@@ -313,9 +319,13 @@ export class CrawlDetail extends LiteElement {
       );
 
       if (data.canceled === true) {
-        // TODO
+        this.fetchCrawl();
       } else {
-        // TODO
+        this.notify({
+          message: msg("Sorry, couldn't cancel crawl at this time."),
+          type: "danger",
+          icon: "exclamation-octagon",
+        });
       }
     }
   }
@@ -331,9 +341,13 @@ export class CrawlDetail extends LiteElement {
       );
 
       if (data.stopped_gracefully === true) {
-        // TODO
+        this.fetchCrawl();
       } else {
-        // TODO
+        this.notify({
+          message: msg("Sorry, couldn't stop crawl at this time."),
+          type: "danger",
+          icon: "exclamation-octagon",
+        });
       }
     }
   }

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -54,14 +54,14 @@ export class CrawlDetail extends LiteElement {
       <header class="px-4 py-3 border-t border-b mb-4 text-sm">
         <dl class="grid grid-cols-2 gap-10">
           <div>
-            <dt class="text-xs text-0-600">${msg("Crawl ID")}</dt>
-            <dd>
+            <dt class="text-xs text-0-500">${msg("Crawl ID")}</dt>
+            <dd class="text-0-700">
               <div class="text-sm font-mono truncate">${this.crawl.id}</div>
             </dd>
           </div>
           <div>
-            <dt class="text-xs text-0-600">${msg("Crawl Template")}</dt>
-            <dd>
+            <dt class="text-xs text-0-500">${msg("Crawl Template")}</dt>
+            <dd class="text-0-700">
               <div class="text-sm font-mono truncate">
                 <a
                   class="hover:underline"
@@ -77,14 +77,26 @@ export class CrawlDetail extends LiteElement {
 
       <main class="grid gap-4">
         <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
-          <div class="col-span-8 md:col-span-5">
-            <div class="aspect-video bg-slate-50 rounded">[watch/replay]</div>
+          <div class="col-span-8 md:col-span-5 relative">
+            <div
+              class="aspect-video bg-slate-50 rounded border ${isRunning
+                ? "border-purple-200"
+                : "border-slate-100"}"
+            >
+              [watch/replay]
+            </div>
+            <div class="absolute top-2 right-2 bg-white/90 rounded-full">
+              <sl-icon-button
+                name="arrows-fullscreen"
+                label=${msg("Fullscreen")}
+              ></sl-icon-button>
+            </div>
           </div>
 
           <div class="col-span-8 md:col-span-3 border rounded p-4 md:p-8">
             <dl class="grid gap-5">
               <div>
-                <dt class="text-sm text-0-600">${msg("Status")}</dt>
+                <dt class="text-sm text-0-500">${msg("Status")}</dt>
                 <dd>
                   <div
                     class="whitespace-nowrap capitalize${isRunning
@@ -127,7 +139,7 @@ export class CrawlDetail extends LiteElement {
                 </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">
+                <dt class="text-sm text-0-500">
                   ${this.crawl.finished ? msg("Finished") : msg("Run duration")}
                 </dt>
                 <dd>
@@ -148,7 +160,7 @@ export class CrawlDetail extends LiteElement {
                 </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">${msg("Started")}</dt>
+                <dt class="text-sm text-0-500">${msg("Started")}</dt>
                 <dd>
                   <sl-format-date
                     date=${`${this.crawl.started}Z` /** Z for UTC */}
@@ -162,7 +174,7 @@ export class CrawlDetail extends LiteElement {
                 </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">${msg("Reason")}</dt>
+                <dt class="text-sm text-0-500">${msg("Reason")}</dt>
                 <dd>
                   ${this.crawl.manual
                     ? msg(html`Manual start by <span>${this.crawl.user}</span>`)

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -53,36 +53,6 @@ export class CrawlDetail extends LiteElement {
     const isRunning = this.crawl?.state === "running";
 
     return html`
-      <header class="px-4 py-3 border-t border-b mb-4 text-sm">
-        <dl class="grid grid-cols-2 gap-10">
-          <div>
-            <dt class="text-xs text-0-500">${msg("Crawl ID")}</dt>
-            <dd class="text-0-700">
-              <div class="text-sm font-mono truncate">
-                ${this.crawl?.id || html`<sl-skeleton></sl-skeleton>`}
-              </div>
-            </dd>
-          </div>
-          <div>
-            <dt class="text-xs text-0-500">${msg("Crawl Template")}</dt>
-            <dd class="text-0-700">
-              <div class="text-sm font-mono truncate">
-                ${this.crawl
-                  ? html`
-                      <a
-                        class="hover:underline"
-                        href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
-                        @click=${this.navLink}
-                        >${this.crawl.cid}</a
-                      >
-                    `
-                  : html`<sl-skeleton></sl-skeleton>`}
-              </div>
-            </dd>
-          </div>
-        </dl>
-      </header>
-
       <main class="grid gap-4">
         <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
           <div class="col-span-8 md:col-span-5 relative">
@@ -104,6 +74,22 @@ export class CrawlDetail extends LiteElement {
 
           <div class="col-span-8 md:col-span-3 border rounded p-4 md:p-8">
             <dl class="grid gap-5">
+              <div>
+                <dt class="text-sm text-0-500">${msg("Crawl Template")}</dt>
+                <dd>
+                  ${this.crawl
+                    ? html`
+                        <a
+                          class="font-medium  hover:underline"
+                          href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
+                          @click=${this.navLink}
+                          >${this.crawl.configName}</a
+                        >
+                      `
+                    : html`<sl-skeleton></sl-skeleton>`}
+                </dd>
+              </div>
+
               <div>
                 <dt class="text-sm text-0-500">${msg("Status")}</dt>
                 <dd>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -29,6 +29,9 @@ export class CrawlDetail extends LiteElement {
   @state()
   private watchUrl?: string;
 
+  @state()
+  private isWatchExpanded: boolean = false;
+
   async firstUpdated() {
     try {
       this.crawl = await this.getCrawl();
@@ -55,7 +58,11 @@ export class CrawlDetail extends LiteElement {
     return html`
       <main class="grid gap-4">
         <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
-          <div class="col-span-8 md:col-span-5 relative">
+          <div
+            class="col-span-8 ${this.isWatchExpanded
+              ? "md:col-span-8"
+              : "md:col-span-5"} relative"
+          >
             <div
               class="aspect-video bg-slate-50 rounded border ${isRunning
                 ? "border-purple-200"
@@ -64,19 +71,49 @@ export class CrawlDetail extends LiteElement {
               <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
               [watch/replay]
             </div>
-            <div class="absolute top-2 right-2 bg-white/90 rounded-full">
-              <sl-icon-button
-                name="arrows-fullscreen"
-                label=${msg("Fullscreen")}
-              ></sl-icon-button>
+            <div
+              class="absolute top-2 right-2 flex bg-white/90 hover:bg-white rounded-full"
+            >
+              ${this.isWatchExpanded
+                ? html`
+                    <sl-icon-button
+                      class="px-1"
+                      name="arrows-angle-contract"
+                      label=${msg("Contract crawl video")}
+                      @click=${() => (this.isWatchExpanded = false)}
+                    ></sl-icon-button>
+                  `
+                : html`
+                    <sl-icon-button
+                      class="px-1"
+                      name="arrows-angle-expand"
+                      label=${msg("Expand crawl video")}
+                      @click=${() => (this.isWatchExpanded = true)}
+                    ></sl-icon-button>
+                  `}
+              ${this.watchUrl
+                ? html`
+                    <sl-icon-button
+                      class="border-l px-1"
+                      href=${this.watchUrl}
+                      name="box-arrow-up-right"
+                      label=${msg("Open in new window")}
+                      target="_blank"
+                    ></sl-icon-button>
+                  `
+                : ""}
             </div>
           </div>
 
-          <div class="col-span-8 md:col-span-3 border rounded p-4 md:p-8">
+          <div
+            class="col-span-8 ${this.isWatchExpanded
+              ? "md:col-span-8"
+              : "md:col-span-3"} border rounded p-4 md:p-8"
+          >
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-500">${msg("Crawl Template")}</dt>
-                <dd class="h-6">
+                <dd>
                   ${this.crawl
                     ? html`
                         <a
@@ -86,7 +123,7 @@ export class CrawlDetail extends LiteElement {
                           >${this.crawl.configName}</a
                         >
                       `
-                    : html`<sl-skeleton></sl-skeleton>`}
+                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
                 </dd>
               </div>
 
@@ -142,7 +179,7 @@ export class CrawlDetail extends LiteElement {
                     ? msg("Finished")
                     : msg("Run duration")}
                 </dt>
-                <dd class="h-6">
+                <dd>
                   ${this.crawl
                     ? html`
                         ${this.crawl.finished
@@ -159,12 +196,12 @@ export class CrawlDetail extends LiteElement {
                               value=${`${this.crawl.started}Z`}
                             ></btrix-relative-duration>`}
                       `
-                    : html`<sl-skeleton></sl-skeleton>`}
+                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
                 </dd>
               </div>
               <div>
                 <dt class="text-sm text-0-500">${msg("Started")}</dt>
-                <dd class="h-6">
+                <dd>
                   ${this.crawl
                     ? html`
                         <sl-format-date
@@ -177,12 +214,12 @@ export class CrawlDetail extends LiteElement {
                           time-zone-name="short"
                         ></sl-format-date>
                       `
-                    : html`<sl-skeleton></sl-skeleton>`}
+                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
                 </dd>
               </div>
               <div>
                 <dt class="text-sm text-0-500">${msg("Reason")}</dt>
-                <dd class="h-6">
+                <dd>
                   ${this.crawl
                     ? html`
                         ${this.crawl.manual
@@ -192,7 +229,7 @@ export class CrawlDetail extends LiteElement {
                             )
                           : msg(html`Scheduled run`)}
                       `
-                    : html`<sl-skeleton></sl-skeleton>`}
+                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
                 </dd>
               </div>
             </dl>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -155,10 +155,9 @@ export class CrawlDetail extends LiteElement {
                               minute="numeric"
                               time-zone-name="short"
                             ></sl-format-date>`
-                          : humanizeDuration(
-                              Date.now() -
-                                new Date(`${this.crawl.started}Z`).valueOf()
-                            )}
+                          : html`<btrix-relative-duration
+                              value=${`${this.crawl.started}Z`}
+                            ></btrix-relative-duration>`}
                       `
                     : html`<sl-skeleton></sl-skeleton>`}
                 </dd>
@@ -265,6 +264,8 @@ export class CrawlDetail extends LiteElement {
       }
     }
   }
+
+  private updateDuration() {}
 }
 
 customElements.define("btrix-crawl-detail", CrawlDetail);

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -65,7 +65,7 @@ export class CrawlDetail extends LiteElement {
         </h2>
       </header>
 
-      <main class="grid gap-4">
+      <main class="grid gap-5">
         <section
           class="grid grid-cols-2 md:grid-cols-8 gap-3 rounded-lg md:p-4 md:bg-zinc-100"
         >
@@ -86,7 +86,10 @@ export class CrawlDetail extends LiteElement {
           </div>
         </section>
 
-        <section>${this.renderFiles()}</section>
+        <section>
+          <h3 class="text-lg font-medium mb-2">${msg("Files")}</h3>
+          ${this.renderFiles()}
+        </section>
       </main>
     `;
   }
@@ -314,16 +317,17 @@ export class CrawlDetail extends LiteElement {
 
   private renderFiles() {
     return html`
-      <h3 class="text-lg font-medium mb-2">${msg("Files")}</h3>
-      <ul class="border rounded">
-        <li class="flex justify-between p-3 border-t first:border-t-0">
-          <div>[File name]</div>
-          <div>[Download link]</div>
-        </li>
-        <li class="flex justify-between p-3 border-t first:border-t-0">
-          <div>[File name]</div>
-          <div>[Download link]</div>
-        </li>
+      <ul class="border rounded text-sm">
+        ${this.crawl?.files?.map(
+          (file) => html`
+            <li class="flex justify-between p-3 border-t first:border-t-0">
+              <div>
+                ${file.filename.slice(file.filename.lastIndexOf("/") + 1)}
+              </div>
+              <div><sl-format-bytes value=${file.size}></sl-format-bytes></div>
+            </li>
+          `
+        )}
       </ul>
     `;
   }

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -52,7 +52,7 @@ export class CrawlDetail extends LiteElement {
 
     return html`
       <header class="px-4 py-3 border-t border-b mb-4 text-sm">
-        <dl class="grid grid-cols-2 gap-5">
+        <dl class="grid grid-cols-2 gap-10">
           <div>
             <dt class="text-xs text-0-600">${msg("Crawl ID")}</dt>
             <dd>
@@ -75,30 +75,6 @@ export class CrawlDetail extends LiteElement {
         </dl>
       </header>
 
-      ${isRunning
-        ? html`
-            <div
-              class="flex items-center justify-between border rounded-lg bg-purple-50 border-purple-300 text-purple-800 p-4 mb-4"
-            >
-              <p class="font-medium">${msg("Crawl is currently running.")}</p>
-              <div class="text-sm leading-none">
-                <button
-                  class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
-                  @click=${this.cancel}
-                >
-                  ${msg("Cancel Crawl")}
-                </button>
-                <button
-                  class="px-3 py-2 bg-purple-600 hover:bg-purple-500 border border-purple-500 text-white rounded-sm font-medium transition-colors"
-                  @click=${this.stop}
-                >
-                  ${msg("Stop Crawl")}
-                </button>
-              </div>
-            </div>
-          `
-        : ""}
-
       <main class="grid gap-4">
         <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
           <div class="col-span-8 md:col-span-5">
@@ -109,8 +85,45 @@ export class CrawlDetail extends LiteElement {
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-600">${msg("Status")}</dt>
-                <dd class="capitalize">
-                  ${this.crawl.state.replace(/_/g, " ")}
+                <dd>
+                  <div
+                    class="whitespace-nowrap capitalize${isRunning
+                      ? " motion-safe:animate-pulse"
+                      : ""}"
+                  >
+                    <span
+                      class="inline-block ${this.crawl.state === "failed"
+                        ? "text-red-500"
+                        : this.crawl.state === "partial_complete"
+                        ? "text-emerald-200"
+                        : isRunning
+                        ? "text-purple-500"
+                        : "text-emerald-500"}"
+                      style="font-size: 10px; vertical-align: 2px"
+                    >
+                      &#9679;
+                    </span>
+                    ${this.crawl.state.replace(/_/g, " ")}
+                  </div>
+
+                  ${isRunning
+                    ? html`
+                        <div class="mt-2 text-sm leading-none">
+                          <button
+                            class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
+                            @click=${this.cancel}
+                          >
+                            ${msg("Cancel Crawl")}
+                          </button>
+                          <button
+                            class="px-3 py-2 bg-purple-600 hover:bg-purple-500 border border-purple-500 text-white rounded-sm font-medium transition-colors"
+                            @click=${this.stop}
+                          >
+                            ${msg("Stop Crawl")}
+                          </button>
+                        </div>
+                      `
+                    : ""}
                 </dd>
               </div>
               <div>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -43,12 +43,12 @@ export class CrawlDetail extends LiteElement {
   async firstUpdated() {
     this.fetchCrawl();
 
-    try {
-      this.watchUrl = await this.watchCrawl();
-      console.log(this.watchUrl);
-    } catch (e) {
-      console.error(e);
-    }
+    // try {
+    //   this.watchUrl = await this.watchCrawl();
+    //   console.log(this.watchUrl);
+    // } catch (e) {
+    //   console.error(e);
+    // }
   }
 
   disconnectedCallback(): void {
@@ -59,14 +59,16 @@ export class CrawlDetail extends LiteElement {
   render() {
     return html`
       <header class="my-3">
-        <h2 class="font-mono text-sm text-0-400 h-5">
+        <h2 class="font-mono text-xs text-0-400 h-4">
           ${this.crawl?.id ||
           html`<sl-skeleton style="width: 37em"></sl-skeleton>`}
         </h2>
       </header>
 
       <main class="grid gap-4">
-        <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
+        <section
+          class="grid grid-cols-2 md:grid-cols-8 gap-3 rounded-lg md:p-4 md:bg-zinc-100"
+        >
           <div
             class="col-span-8 ${this.isWatchExpanded
               ? "md:col-span-8"
@@ -78,7 +80,7 @@ export class CrawlDetail extends LiteElement {
           <div
             class="col-span-8 ${this.isWatchExpanded
               ? "md:col-span-8"
-              : "md:col-span-3"} border rounded-lg p-4 md:p-8"
+              : "md:col-span-3"} border rounded-lg bg-white p-4 md:p-8"
           >
             ${this.renderDetails()}
           </div>
@@ -94,7 +96,7 @@ export class CrawlDetail extends LiteElement {
 
     return html`
       <div
-        class="aspect-video bg-slate-50 rounded border ${isRunning
+        class="aspect-video rounded border ${isRunning
           ? "border-purple-200"
           : "border-slate-100"}"
       >
@@ -219,19 +221,15 @@ export class CrawlDetail extends LiteElement {
           <dd>
             ${this.crawl?.stats
               ? html`
-                  ${isRunning
-                    ? html`
-                        <span
-                          class="text-purple-600 font-mono tracking-tighter"
-                        >
-                          ${this.numberFormatter.format(+this.crawl.stats.done)}
-                          <span class="text-0-400">/</span>
-                          ${this.numberFormatter.format(
-                            +this.crawl.stats.found
-                          )}
-                        </span>
-                      `
-                    : html``}
+                  <span
+                    class="font-mono tracking-tighter${isRunning
+                      ? " text-purple-600"
+                      : ""}"
+                  >
+                    ${this.numberFormatter.format(+this.crawl.stats.done)}
+                    <span class="text-0-400">/</span>
+                    ${this.numberFormatter.format(+this.crawl.stats.found)}
+                  </span>
                 `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -76,7 +76,7 @@ export class CrawlDetail extends LiteElement {
             <dl class="grid gap-5">
               <div>
                 <dt class="text-sm text-0-500">${msg("Crawl Template")}</dt>
-                <dd>
+                <dd class="h-6">
                   ${this.crawl
                     ? html`
                         <a
@@ -115,7 +115,7 @@ export class CrawlDetail extends LiteElement {
                           ${this.crawl.state.replace(/_/g, " ")}
                         </div>
                       `
-                    : html`<sl-skeleton></sl-skeleton>`}
+                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
                   ${isRunning
                     ? html`
                         <div class="mt-2 text-sm leading-none">
@@ -142,7 +142,7 @@ export class CrawlDetail extends LiteElement {
                     ? msg("Finished")
                     : msg("Run duration")}
                 </dt>
-                <dd>
+                <dd class="h-6">
                   ${this.crawl
                     ? html`
                         ${this.crawl.finished
@@ -165,7 +165,7 @@ export class CrawlDetail extends LiteElement {
               </div>
               <div>
                 <dt class="text-sm text-0-500">${msg("Started")}</dt>
-                <dd>
+                <dd class="h-6">
                   ${this.crawl
                     ? html`
                         <sl-format-date
@@ -183,7 +183,7 @@ export class CrawlDetail extends LiteElement {
               </div>
               <div>
                 <dt class="text-sm text-0-500">${msg("Reason")}</dt>
-                <dd>
+                <dd class="h-6">
                   ${this.crawl
                     ? html`
                         ${this.crawl.manual

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -322,7 +322,21 @@ export class CrawlDetail extends LiteElement {
           (file) => html`
             <li class="flex justify-between p-3 border-t first:border-t-0">
               <div>
-                ${file.filename.slice(file.filename.lastIndexOf("/") + 1)}
+                <a
+                  class="text-primary hover:underline"
+                  href=${file.filename.startsWith("http")
+                    ? file.filename
+                    : `${window.location.protocol}//${window.location.host}/${file.filename}`}
+                  download
+                  title=${file.filename.slice(
+                    file.filename.lastIndexOf("/") + 1
+                  )}
+                  >${msg(
+                    str`Download ${file.filename.slice(
+                      file.filename.lastIndexOf(".")
+                    )}`
+                  )}</a
+                >
               </div>
               <div><sl-format-bytes value=${file.size}></sl-format-bytes></div>
             </li>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -28,7 +28,7 @@ export class CrawlDetail extends LiteElement {
 
   async firstUpdated() {
     try {
-      this.crawl = await this.getCrawlTemplate();
+      this.crawl = await this.getCrawl();
     } catch {
       this.notify({
         message: msg("Sorry, couldn't retrieve crawl at this time."),
@@ -81,13 +81,19 @@ export class CrawlDetail extends LiteElement {
               class="flex items-center justify-between border rounded-lg bg-purple-50 border-purple-300 text-purple-800 p-4 mb-4"
             >
               <p class="font-medium">${msg("Crawl is currently running.")}</p>
-              <div>
-                <sl-button size="small" class="mr-2"
-                  >${msg("Cancel Crawl")}</sl-button
+              <div class="text-sm leading-none">
+                <button
+                  class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
+                  @click=${this.cancel}
                 >
-                <sl-button size="small" type="danger"
-                  >${msg("Stop Crawl")}</sl-button
+                  ${msg("Cancel Crawl")}
+                </button>
+                <button
+                  class="px-3 py-2 bg-purple-600 hover:bg-purple-500 border border-purple-500 text-white rounded-sm font-medium transition-colors"
+                  @click=${this.stop}
                 >
+                  ${msg("Stop Crawl")}
+                </button>
               </div>
             </div>
           `
@@ -129,14 +135,6 @@ export class CrawlDetail extends LiteElement {
                 </dd>
               </div>
               <div>
-                <dt class="text-sm text-0-600">${msg("Reason")}</dt>
-                <dd>
-                  ${this.crawl.manual
-                    ? msg(html`Manual start by <span>${this.crawl.user}</span>`)
-                    : msg(html`Scheduled run`)}
-                </dd>
-              </div>
-              <div>
                 <dt class="text-sm text-0-600">${msg("Started")}</dt>
                 <dd>
                   <sl-format-date
@@ -150,6 +148,14 @@ export class CrawlDetail extends LiteElement {
                   ></sl-format-date>
                 </dd>
               </div>
+              <div>
+                <dt class="text-sm text-0-600">${msg("Reason")}</dt>
+                <dd>
+                  ${this.crawl.manual
+                    ? msg(html`Manual start by <span>${this.crawl.user}</span>`)
+                    : msg(html`Scheduled run`)}
+                </dd>
+              </div>
             </dl>
           </div>
         </section>
@@ -157,11 +163,11 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
-  async getCrawlTemplate(): Promise<Crawl> {
+  async getCrawl(): Promise<Crawl> {
     // Mock to use in dev:
     return import("../../__mocks__/api/archives/[id]/crawls").then(
-      // (module) => module.default.running[0]
-      (module) => module.default.finished[0]
+      (module) => module.default.running[0]
+      // (module) => module.default.finished[0]
     );
 
     // const data: Crawl = await this.apiFetch(
@@ -170,6 +176,42 @@ export class CrawlDetail extends LiteElement {
     // );
 
     // return data;
+  }
+
+  async cancel() {
+    if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawls/${this.crawlId}/cancel`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      if (data.canceled === true) {
+        // TODO
+      } else {
+        // TODO
+      }
+    }
+  }
+
+  async stop() {
+    if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawls/${this.crawlId}/stop`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      if (data.stopped_gracefully === true) {
+        // TODO
+      } else {
+        // TODO
+      }
+    }
   }
 }
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -198,18 +198,16 @@ export class CrawlDetail extends LiteElement {
                     </span>
 
                     <div class="mb-3 text-center text-sm leading-none">
-                      <button
-                        class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
+                      <sl-button class="mr-2" size="small" @click=${this.stop}>
+                        ${msg("Stop Crawl")}
+                      </sl-button>
+                      <sl-button
+                        size="small"
+                        type="danger"
                         @click=${this.cancel}
                       >
                         ${msg("Cancel Crawl")}
-                      </button>
-                      <button
-                        class="px-3 py-2 bg-purple-600 hover:bg-purple-500 border border-purple-500 text-white rounded-sm font-medium transition-colors"
-                        @click=${this.stop}
-                      >
-                        ${msg("Stop Crawl")}
-                      </button>
+                      </sl-button>
                     </div>
                   </sl-details>
                 `

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -48,6 +48,8 @@ export class CrawlDetail extends LiteElement {
       </div>`;
     }
 
+    const isRunning = this.crawl.state === "running";
+
     return html`
       <header class="px-4 py-3 border-t border-b mb-4 text-sm">
         <dl class="grid grid-cols-2 gap-5">
@@ -73,61 +75,84 @@ export class CrawlDetail extends LiteElement {
         </dl>
       </header>
 
-      <main class="grid gap-4">
-        <div class="border rounded p-4 md:p-8">
-          <div class="aspect-video bg-slate-50 rounded"></div>
-        </div>
+      ${isRunning
+        ? html`
+            <div
+              class="flex items-center justify-between border rounded-lg bg-purple-50 border-purple-300 text-purple-800 p-4 mb-4"
+            >
+              <p class="font-medium">${msg("Crawl is currently running.")}</p>
+              <div>
+                <sl-button size="small" class="mr-2"
+                  >${msg("Cancel Crawl")}</sl-button
+                >
+                <sl-button size="small" type="danger"
+                  >${msg("Stop Crawl")}</sl-button
+                >
+              </div>
+            </div>
+          `
+        : ""}
 
-        <div class="border rounded p-4 md:p-8">
-          <dl class="grid grid-cols-2 gap-5">
-            <div>
-              <dt class="text-sm text-0-600">${msg("Status")}</dt>
-              <dd class="capitalize">${this.crawl.state.replace(/_/g, " ")}</dd>
-            </div>
-            <div>
-              <dt class="text-sm text-0-600">
-                ${this.crawl.finished ? msg("Finished") : msg("Run duration")}
-              </dt>
-              <dd>
-                ${this.crawl.finished
-                  ? html`<sl-format-date
-                      date=${`${this.crawl.finished}Z` /** Z for UTC */}
-                      month="2-digit"
-                      day="2-digit"
-                      year="2-digit"
-                      hour="numeric"
-                      minute="numeric"
-                      time-zone-name="short"
-                    ></sl-format-date>`
-                  : humanizeDuration(
-                      Date.now() - new Date(`${this.crawl.started}Z`).valueOf()
-                    )}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-sm text-0-600">${msg("Reason")}</dt>
-              <dd class="truncate">
-                ${this.crawl.manual
-                  ? msg(html`Manual start by <span>${this.crawl.user}</span>`)
-                  : msg(html`Scheduled run`)}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-sm text-0-600">${msg("Started")}</dt>
-              <dd>
-                <sl-format-date
-                  date=${`${this.crawl.started}Z` /** Z for UTC */}
-                  month="2-digit"
-                  day="2-digit"
-                  year="2-digit"
-                  hour="numeric"
-                  minute="numeric"
-                  time-zone-name="short"
-                ></sl-format-date>
-              </dd>
-            </div>
-          </dl>
-        </div>
+      <main class="grid gap-4">
+        <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
+          <div class="col-span-8 md:col-span-5">
+            <div class="aspect-video bg-slate-50 rounded">[watch/replay]</div>
+          </div>
+
+          <div class="col-span-8 md:col-span-3 border rounded p-4 md:p-8">
+            <dl class="grid gap-5">
+              <div>
+                <dt class="text-sm text-0-600">${msg("Status")}</dt>
+                <dd class="capitalize">
+                  ${this.crawl.state.replace(/_/g, " ")}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">
+                  ${this.crawl.finished ? msg("Finished") : msg("Run duration")}
+                </dt>
+                <dd>
+                  ${this.crawl.finished
+                    ? html`<sl-format-date
+                        date=${`${this.crawl.finished}Z` /** Z for UTC */}
+                        month="2-digit"
+                        day="2-digit"
+                        year="2-digit"
+                        hour="numeric"
+                        minute="numeric"
+                        time-zone-name="short"
+                      ></sl-format-date>`
+                    : humanizeDuration(
+                        Date.now() -
+                          new Date(`${this.crawl.started}Z`).valueOf()
+                      )}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">${msg("Reason")}</dt>
+                <dd>
+                  ${this.crawl.manual
+                    ? msg(html`Manual start by <span>${this.crawl.user}</span>`)
+                    : msg(html`Scheduled run`)}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-sm text-0-600">${msg("Started")}</dt>
+                <dd>
+                  <sl-format-date
+                    date=${`${this.crawl.started}Z` /** Z for UTC */}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="numeric"
+                    minute="numeric"
+                    time-zone-name="short"
+                  ></sl-format-date>
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </section>
       </main>
     `;
   }
@@ -135,6 +160,7 @@ export class CrawlDetail extends LiteElement {
   async getCrawlTemplate(): Promise<Crawl> {
     // Mock to use in dev:
     return import("../../__mocks__/api/archives/[id]/crawls").then(
+      // (module) => module.default.running[0]
       (module) => module.default.finished[0]
     );
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -142,7 +142,7 @@ export class CrawlDetail extends LiteElement {
     return html`
       <dl class="grid grid-cols-2 gap-5">
         <div class="col-span-2">
-          <dt class="text-sm text-0-500">${msg("Crawl Template")}</dt>
+          <dt class="text-sm text-0-600">${msg("Crawl Template")}</dt>
           <dd>
             ${this.crawl
               ? html`
@@ -158,7 +158,7 @@ export class CrawlDetail extends LiteElement {
         </div>
 
         <div class="col-span-2">
-          <dt class="text-sm text-0-500">${msg("Status")}</dt>
+          <dt class="text-sm text-0-600">${msg("Status")}</dt>
           <dd>
             ${this.crawl
               ? html`
@@ -195,7 +195,7 @@ export class CrawlDetail extends LiteElement {
                       ${msg("Manage")}
                     </span>
 
-                    <div class="text-center text-sm leading-none">
+                    <div class="mb-3 text-center text-sm leading-none">
                       <button
                         class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
                         @click=${this.cancel}
@@ -215,7 +215,7 @@ export class CrawlDetail extends LiteElement {
           </dd>
         </div>
         <div class="col-span-1">
-          <dt class="text-sm text-0-500">${msg("Pages")}</dt>
+          <dt class="text-sm text-0-600">${msg("Pages Crawled")}</dt>
           <dd>
             ${this.crawl?.stats
               ? html`
@@ -237,7 +237,7 @@ export class CrawlDetail extends LiteElement {
           </dd>
         </div>
         <div class="col-span-1">
-          <dt class="text-sm text-0-500">${msg("Run duration")}</dt>
+          <dt class="text-sm text-0-600">${msg("Run Duration")}</dt>
           <dd>
             ${this.crawl
               ? html`
@@ -246,15 +246,19 @@ export class CrawlDetail extends LiteElement {
                         new Date(`${this.crawl.finished}Z`).valueOf() -
                           new Date(`${this.crawl.started}Z`).valueOf()
                       )}`
-                    : html`<btrix-relative-duration
-                        value=${`${this.crawl.started}Z`}
-                      ></btrix-relative-duration>`}
+                    : html`
+                        <span class="text-purple-600">
+                          <btrix-relative-duration
+                            value=${`${this.crawl.started}Z`}
+                          ></btrix-relative-duration>
+                        </span>
+                      `}
                 `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
         </div>
         <div class="col-span-2">
-          <dt class="text-sm text-0-500">${msg("Started")}</dt>
+          <dt class="text-sm text-0-600">${msg("Started")}</dt>
           <dd>
             ${this.crawl
               ? html`
@@ -272,7 +276,7 @@ export class CrawlDetail extends LiteElement {
           </dd>
         </div>
         <div class="col-span-2">
-          <dt class="text-sm text-0-500">${msg("Finished")}</dt>
+          <dt class="text-sm text-0-600">${msg("Finished")}</dt>
           <dd>
             ${this.crawl
               ? html`
@@ -286,19 +290,22 @@ export class CrawlDetail extends LiteElement {
                         minute="numeric"
                         time-zone-name="short"
                       ></sl-format-date>`
-                    : html`<span class="text-0-500">${msg("Pending")}</span>`}
+                    : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
         </div>
         <div class="col-span-2">
-          <dt class="text-sm text-0-500">${msg("Reason")}</dt>
+          <dt class="text-sm text-0-600">${msg("Reason")}</dt>
           <dd>
             ${this.crawl
               ? html`
                   ${this.crawl.manual
                     ? msg(
-                        html`Manual start by <span>${this.crawl?.userid}</span>`
+                        html`Manual start by
+                          <span
+                            >${this.crawl?.userName || this.crawl?.userid}</span
+                          >`
                       )
                     : msg(html`Scheduled run`)}
                 `

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -1,0 +1,150 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import humanizeDuration from "pretty-ms";
+
+import type { AuthState } from "../../utils/AuthService";
+import LiteElement, { html } from "../../utils/LiteElement";
+import type { Crawl } from "./types";
+
+/**
+ * Usage:
+ * ```ts
+ * <btrix-crawl-detail></btrix-crawl-detail>
+ * ```
+ */
+@localized()
+export class CrawlDetail extends LiteElement {
+  @property({ type: Object })
+  authState?: AuthState;
+
+  @property({ type: String })
+  archiveId?: string;
+
+  @property({ type: String })
+  crawlId?: string;
+
+  @state()
+  private crawl?: Crawl;
+
+  async firstUpdated() {
+    try {
+      this.crawl = await this.getCrawlTemplate();
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't retrieve crawl at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+        duration: 10000,
+      });
+    }
+  }
+
+  render() {
+    if (!this.crawl) {
+      return html`<div
+        class="w-full flex items-center justify-center my-24 text-4xl"
+      >
+        <sl-spinner></sl-spinner>
+      </div>`;
+    }
+
+    return html`
+      <header class="px-4 py-3 border-t border-b mb-4 text-sm">
+        <dl class="grid grid-cols-2 gap-5">
+          <div>
+            <dt class="text-xs text-0-600">${msg("Crawl ID")}</dt>
+            <dd>
+              <div class="text-sm font-mono truncate">${this.crawl.id}</div>
+            </dd>
+          </div>
+          <div>
+            <dt class="text-xs text-0-600">${msg("Crawl Template")}</dt>
+            <dd>
+              <div class="text-sm font-mono truncate">
+                <a
+                  class="hover:underline"
+                  href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
+                  @click=${this.navLink}
+                  >${this.crawl.cid}</a
+                >
+              </div>
+            </dd>
+          </div>
+        </dl>
+      </header>
+
+      <main class="grid gap-4">
+        <div class="border rounded p-4 md:p-8">
+          <div class="aspect-video bg-slate-50 rounded"></div>
+        </div>
+
+        <div class="border rounded p-4 md:p-8">
+          <dl class="grid grid-cols-2 gap-5">
+            <div>
+              <dt class="text-sm text-0-600">${msg("Status")}</dt>
+              <dd class="capitalize">${this.crawl.state.replace(/_/g, " ")}</dd>
+            </div>
+            <div>
+              <dt class="text-sm text-0-600">
+                ${this.crawl.finished ? msg("Finished") : msg("Run duration")}
+              </dt>
+              <dd>
+                ${this.crawl.finished
+                  ? html`<sl-format-date
+                      date=${`${this.crawl.finished}Z` /** Z for UTC */}
+                      month="2-digit"
+                      day="2-digit"
+                      year="2-digit"
+                      hour="numeric"
+                      minute="numeric"
+                      time-zone-name="short"
+                    ></sl-format-date>`
+                  : humanizeDuration(
+                      Date.now() - new Date(`${this.crawl.started}Z`).valueOf()
+                    )}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-sm text-0-600">${msg("Reason")}</dt>
+              <dd class="truncate">
+                ${this.crawl.manual
+                  ? msg(html`Manual start by <span>${this.crawl.user}</span>`)
+                  : msg(html`Scheduled run`)}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-sm text-0-600">${msg("Started")}</dt>
+              <dd>
+                <sl-format-date
+                  date=${`${this.crawl.started}Z` /** Z for UTC */}
+                  month="2-digit"
+                  day="2-digit"
+                  year="2-digit"
+                  hour="numeric"
+                  minute="numeric"
+                  time-zone-name="short"
+                ></sl-format-date>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </main>
+    `;
+  }
+
+  async getCrawlTemplate(): Promise<Crawl> {
+    // Mock to use in dev:
+    return import("../../__mocks__/api/archives/[id]/crawls").then(
+      (module) => module.default.finished[0]
+    );
+
+    // const data: Crawl = await this.apiFetch(
+    //   `/archives/${this.archiveId}/crawls/${this.crawlId}`,
+    //   this.authState!
+    // );
+
+    // return data;
+  }
+}
+
+customElements.define("btrix-crawl-detail", CrawlDetail);

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -40,15 +40,15 @@ export class CrawlDetail extends LiteElement {
   }
 
   render() {
-    if (!this.crawl) {
-      return html`<div
-        class="w-full flex items-center justify-center my-24 text-4xl"
-      >
-        <sl-spinner></sl-spinner>
-      </div>`;
-    }
+    // if (!this.crawl) {
+    //   return html`<div
+    //     class="w-full flex items-center justify-center my-24 text-4xl"
+    //   >
+    //     <sl-spinner></sl-spinner>
+    //   </div>`;
+    // }
 
-    const isRunning = this.crawl.state === "running";
+    const isRunning = this.crawl?.state === "running";
 
     return html`
       <header class="px-4 py-3 border-t border-b mb-4 text-sm">
@@ -56,19 +56,25 @@ export class CrawlDetail extends LiteElement {
           <div>
             <dt class="text-xs text-0-500">${msg("Crawl ID")}</dt>
             <dd class="text-0-700">
-              <div class="text-sm font-mono truncate">${this.crawl.id}</div>
+              <div class="text-sm font-mono truncate">
+                ${this.crawl?.id || html`<sl-skeleton></sl-skeleton>`}
+              </div>
             </dd>
           </div>
           <div>
             <dt class="text-xs text-0-500">${msg("Crawl Template")}</dt>
             <dd class="text-0-700">
               <div class="text-sm font-mono truncate">
-                <a
-                  class="hover:underline"
-                  href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
-                  @click=${this.navLink}
-                  >${this.crawl.cid}</a
-                >
+                ${this.crawl
+                  ? html`
+                      <a
+                        class="hover:underline"
+                        href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
+                        @click=${this.navLink}
+                        >${this.crawl.cid}</a
+                      >
+                    `
+                  : html`<sl-skeleton></sl-skeleton>`}
               </div>
             </dd>
           </div>
@@ -98,26 +104,29 @@ export class CrawlDetail extends LiteElement {
               <div>
                 <dt class="text-sm text-0-500">${msg("Status")}</dt>
                 <dd>
-                  <div
-                    class="whitespace-nowrap capitalize${isRunning
-                      ? " motion-safe:animate-pulse"
-                      : ""}"
-                  >
-                    <span
-                      class="inline-block ${this.crawl.state === "failed"
-                        ? "text-red-500"
-                        : this.crawl.state === "partial_complete"
-                        ? "text-emerald-200"
-                        : isRunning
-                        ? "text-purple-500"
-                        : "text-emerald-500"}"
-                      style="font-size: 10px; vertical-align: 2px"
-                    >
-                      &#9679;
-                    </span>
-                    ${this.crawl.state.replace(/_/g, " ")}
-                  </div>
-
+                  ${this.crawl
+                    ? html`
+                        <div
+                          class="whitespace-nowrap capitalize${isRunning
+                            ? " motion-safe:animate-pulse"
+                            : ""}"
+                        >
+                          <span
+                            class="inline-block ${this.crawl.state === "failed"
+                              ? "text-red-500"
+                              : this.crawl.state === "partial_complete"
+                              ? "text-emerald-200"
+                              : isRunning
+                              ? "text-purple-500"
+                              : "text-emerald-500"}"
+                            style="font-size: 10px; vertical-align: 2px"
+                          >
+                            &#9679;
+                          </span>
+                          ${this.crawl.state.replace(/_/g, " ")}
+                        </div>
+                      `
+                    : html`<sl-skeleton></sl-skeleton>`}
                   ${isRunning
                     ? html`
                         <div class="mt-2 text-sm leading-none">
@@ -140,45 +149,62 @@ export class CrawlDetail extends LiteElement {
               </div>
               <div>
                 <dt class="text-sm text-0-500">
-                  ${this.crawl.finished ? msg("Finished") : msg("Run duration")}
+                  ${this.crawl?.finished
+                    ? msg("Finished")
+                    : msg("Run duration")}
                 </dt>
                 <dd>
-                  ${this.crawl.finished
-                    ? html`<sl-format-date
-                        date=${`${this.crawl.finished}Z` /** Z for UTC */}
-                        month="2-digit"
-                        day="2-digit"
-                        year="2-digit"
-                        hour="numeric"
-                        minute="numeric"
-                        time-zone-name="short"
-                      ></sl-format-date>`
-                    : humanizeDuration(
-                        Date.now() -
-                          new Date(`${this.crawl.started}Z`).valueOf()
-                      )}
+                  ${this.crawl
+                    ? html`
+                        ${this.crawl.finished
+                          ? html`<sl-format-date
+                              date=${`${this.crawl.finished}Z` /** Z for UTC */}
+                              month="2-digit"
+                              day="2-digit"
+                              year="2-digit"
+                              hour="numeric"
+                              minute="numeric"
+                              time-zone-name="short"
+                            ></sl-format-date>`
+                          : humanizeDuration(
+                              Date.now() -
+                                new Date(`${this.crawl.started}Z`).valueOf()
+                            )}
+                      `
+                    : html`<sl-skeleton></sl-skeleton>`}
                 </dd>
               </div>
               <div>
                 <dt class="text-sm text-0-500">${msg("Started")}</dt>
                 <dd>
-                  <sl-format-date
-                    date=${`${this.crawl.started}Z` /** Z for UTC */}
-                    month="2-digit"
-                    day="2-digit"
-                    year="2-digit"
-                    hour="numeric"
-                    minute="numeric"
-                    time-zone-name="short"
-                  ></sl-format-date>
+                  ${this.crawl
+                    ? html`
+                        <sl-format-date
+                          date=${`${this.crawl.started}Z` /** Z for UTC */}
+                          month="2-digit"
+                          day="2-digit"
+                          year="2-digit"
+                          hour="numeric"
+                          minute="numeric"
+                          time-zone-name="short"
+                        ></sl-format-date>
+                      `
+                    : html`<sl-skeleton></sl-skeleton>`}
                 </dd>
               </div>
               <div>
                 <dt class="text-sm text-0-500">${msg("Reason")}</dt>
                 <dd>
-                  ${this.crawl.manual
-                    ? msg(html`Manual start by <span>${this.crawl.user}</span>`)
-                    : msg(html`Scheduled run`)}
+                  ${this.crawl
+                    ? html`
+                        ${this.crawl.manual
+                          ? msg(
+                              html`Manual start by
+                                <span>${this.crawl?.user}</span>`
+                            )
+                          : msg(html`Scheduled run`)}
+                      `
+                    : html`<sl-skeleton></sl-skeleton>`}
                 </dd>
               </div>
             </dl>
@@ -190,17 +216,17 @@ export class CrawlDetail extends LiteElement {
 
   async getCrawl(): Promise<Crawl> {
     // Mock to use in dev:
-    return import("../../__mocks__/api/archives/[id]/crawls").then(
-      (module) => module.default.running[0]
-      // (module) => module.default.finished[0]
-    );
-
-    // const data: Crawl = await this.apiFetch(
-    //   `/archives/${this.archiveId}/crawls/${this.crawlId}`,
-    //   this.authState!
+    // return import("../../__mocks__/api/archives/[id]/crawls").then(
+    //   (module) => module.default.running[0]
+    //   // (module) => module.default.finished[0]
     // );
 
-    // return data;
+    const data: Crawl = await this.apiFetch(
+      `/archives/${this.archiveId}/crawls/${this.crawlId}`,
+      this.authState!
+    );
+
+    return data;
   }
 
   async cancel() {

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -26,6 +26,9 @@ export class CrawlDetail extends LiteElement {
   @state()
   private crawl?: Crawl;
 
+  @state()
+  private watchUrl?: string;
+
   async firstUpdated() {
     try {
       this.crawl = await this.getCrawl();
@@ -37,17 +40,16 @@ export class CrawlDetail extends LiteElement {
         duration: 10000,
       });
     }
+
+    try {
+      this.watchUrl = await this.watchCrawl();
+      console.log(this.watchUrl);
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   render() {
-    // if (!this.crawl) {
-    //   return html`<div
-    //     class="w-full flex items-center justify-center my-24 text-4xl"
-    //   >
-    //     <sl-spinner></sl-spinner>
-    //   </div>`;
-    // }
-
     const isRunning = this.crawl?.state === "running";
 
     return html`
@@ -89,6 +91,7 @@ export class CrawlDetail extends LiteElement {
                 ? "border-purple-200"
                 : "border-slate-100"}"
             >
+              <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
               [watch/replay]
             </div>
             <div class="absolute top-2 right-2 bg-white/90 rounded-full">
@@ -229,7 +232,19 @@ export class CrawlDetail extends LiteElement {
     return data;
   }
 
-  async cancel() {
+  private async watchCrawl(): Promise<string> {
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/crawls/${this.crawlId}/watch`,
+      this.authState!,
+      {
+        method: "POST",
+      }
+    );
+
+    return data.watch_url;
+  }
+
+  private async cancel() {
     if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
       const data = await this.apiFetch(
         `/archives/${this.archiveId}/crawls/${this.crawlId}/cancel`,
@@ -247,7 +262,7 @@ export class CrawlDetail extends LiteElement {
     }
   }
 
-  async stop() {
+  private async stop() {
     if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
       const data = await this.apiFetch(
         `/archives/${this.archiveId}/crawls/${this.crawlId}/stop`,

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -298,7 +298,7 @@ export class CrawlDetail extends LiteElement {
               ? html`
                   ${this.crawl.manual
                     ? msg(
-                        html`Manual start by <span>${this.crawl?.user}</span>`
+                        html`Manual start by <span>${this.crawl?.userid}</span>`
                       )
                     : msg(html`Scheduled run`)}
                 `

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -53,9 +53,14 @@ export class CrawlDetail extends LiteElement {
   }
 
   render() {
-    const isRunning = this.crawl?.state === "running";
-
     return html`
+      <header class="my-3">
+        <h2 class="font-mono text-sm text-0-400 h-5">
+          ${this.crawl?.id ||
+          html`<sl-skeleton style="width: 37em"></sl-skeleton>`}
+        </h2>
+      </header>
+
       <main class="grid gap-4">
         <section class="grid grid-cols-2 md:grid-cols-8 gap-5">
           <div
@@ -63,179 +68,210 @@ export class CrawlDetail extends LiteElement {
               ? "md:col-span-8"
               : "md:col-span-5"} relative"
           >
-            <div
-              class="aspect-video bg-slate-50 rounded border ${isRunning
-                ? "border-purple-200"
-                : "border-slate-100"}"
-            >
-              <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
-              [watch/replay]
-            </div>
-            <div
-              class="absolute top-2 right-2 flex bg-white/90 hover:bg-white rounded-full"
-            >
-              ${this.isWatchExpanded
-                ? html`
-                    <sl-icon-button
-                      class="px-1"
-                      name="arrows-angle-contract"
-                      label=${msg("Contract crawl video")}
-                      @click=${() => (this.isWatchExpanded = false)}
-                    ></sl-icon-button>
-                  `
-                : html`
-                    <sl-icon-button
-                      class="px-1"
-                      name="arrows-angle-expand"
-                      label=${msg("Expand crawl video")}
-                      @click=${() => (this.isWatchExpanded = true)}
-                    ></sl-icon-button>
-                  `}
-              ${this.watchUrl
-                ? html`
-                    <sl-icon-button
-                      class="border-l px-1"
-                      href=${this.watchUrl}
-                      name="box-arrow-up-right"
-                      label=${msg("Open in new window")}
-                      target="_blank"
-                    ></sl-icon-button>
-                  `
-                : ""}
-            </div>
+            ${this.renderWatch()}
           </div>
 
           <div
             class="col-span-8 ${this.isWatchExpanded
               ? "md:col-span-8"
-              : "md:col-span-3"} border rounded p-4 md:p-8"
+              : "md:col-span-3"} border rounded-lg p-4 md:p-8"
           >
-            <dl class="grid gap-5">
-              <div>
-                <dt class="text-sm text-0-500">${msg("Crawl Template")}</dt>
-                <dd>
-                  ${this.crawl
-                    ? html`
-                        <a
-                          class="font-medium  hover:underline"
-                          href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
-                          @click=${this.navLink}
-                          >${this.crawl.configName}</a
-                        >
-                      `
-                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-                </dd>
-              </div>
-
-              <div>
-                <dt class="text-sm text-0-500">${msg("Status")}</dt>
-                <dd>
-                  ${this.crawl
-                    ? html`
-                        <div
-                          class="whitespace-nowrap capitalize${isRunning
-                            ? " motion-safe:animate-pulse"
-                            : ""}"
-                        >
-                          <span
-                            class="inline-block ${this.crawl.state === "failed"
-                              ? "text-red-500"
-                              : this.crawl.state === "partial_complete"
-                              ? "text-emerald-200"
-                              : isRunning
-                              ? "text-purple-500"
-                              : "text-emerald-500"}"
-                            style="font-size: 10px; vertical-align: 2px"
-                          >
-                            &#9679;
-                          </span>
-                          ${this.crawl.state.replace(/_/g, " ")}
-                        </div>
-                      `
-                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-                  ${isRunning
-                    ? html`
-                        <div class="mt-2 text-sm leading-none">
-                          <button
-                            class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
-                            @click=${this.cancel}
-                          >
-                            ${msg("Cancel Crawl")}
-                          </button>
-                          <button
-                            class="px-3 py-2 bg-purple-600 hover:bg-purple-500 border border-purple-500 text-white rounded-sm font-medium transition-colors"
-                            @click=${this.stop}
-                          >
-                            ${msg("Stop Crawl")}
-                          </button>
-                        </div>
-                      `
-                    : ""}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-sm text-0-500">
-                  ${this.crawl?.finished
-                    ? msg("Finished")
-                    : msg("Run duration")}
-                </dt>
-                <dd>
-                  ${this.crawl
-                    ? html`
-                        ${this.crawl.finished
-                          ? html`<sl-format-date
-                              date=${`${this.crawl.finished}Z` /** Z for UTC */}
-                              month="2-digit"
-                              day="2-digit"
-                              year="2-digit"
-                              hour="numeric"
-                              minute="numeric"
-                              time-zone-name="short"
-                            ></sl-format-date>`
-                          : html`<btrix-relative-duration
-                              value=${`${this.crawl.started}Z`}
-                            ></btrix-relative-duration>`}
-                      `
-                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-sm text-0-500">${msg("Started")}</dt>
-                <dd>
-                  ${this.crawl
-                    ? html`
-                        <sl-format-date
-                          date=${`${this.crawl.started}Z` /** Z for UTC */}
-                          month="2-digit"
-                          day="2-digit"
-                          year="2-digit"
-                          hour="numeric"
-                          minute="numeric"
-                          time-zone-name="short"
-                        ></sl-format-date>
-                      `
-                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-sm text-0-500">${msg("Reason")}</dt>
-                <dd>
-                  ${this.crawl
-                    ? html`
-                        ${this.crawl.manual
-                          ? msg(
-                              html`Manual start by
-                                <span>${this.crawl?.user}</span>`
-                            )
-                          : msg(html`Scheduled run`)}
-                      `
-                    : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-                </dd>
-              </div>
-            </dl>
+            ${this.renderDetails()}
           </div>
         </section>
+
+        <section>${this.renderFiles()}</section>
       </main>
+    `;
+  }
+
+  private renderWatch() {
+    const isRunning = this.crawl?.state === "running";
+
+    return html`
+      <div
+        class="aspect-video bg-slate-50 rounded border ${isRunning
+          ? "border-purple-200"
+          : "border-slate-100"}"
+      >
+        <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
+        [watch/replay]
+      </div>
+      <div
+        class="absolute top-2 right-2 flex bg-white/90 hover:bg-white rounded-full"
+      >
+        ${this.isWatchExpanded
+          ? html`
+              <sl-icon-button
+                class="px-1"
+                name="arrows-angle-contract"
+                label=${msg("Contract crawl video")}
+                @click=${() => (this.isWatchExpanded = false)}
+              ></sl-icon-button>
+            `
+          : html`
+              <sl-icon-button
+                class="px-1"
+                name="arrows-angle-expand"
+                label=${msg("Expand crawl video")}
+                @click=${() => (this.isWatchExpanded = true)}
+              ></sl-icon-button>
+            `}
+        ${this.watchUrl
+          ? html`
+              <sl-icon-button
+                class="border-l px-1"
+                href=${this.watchUrl}
+                name="box-arrow-up-right"
+                label=${msg("Open in new window")}
+                target="_blank"
+              ></sl-icon-button>
+            `
+          : ""}
+      </div>
+    `;
+  }
+
+  private renderDetails() {
+    const isRunning = this.crawl?.state === "running";
+
+    return html`
+      <dl class="grid gap-5">
+        <div>
+          <dt class="text-sm text-0-500">${msg("Crawl Template")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  <a
+                    class="font-medium  hover:underline"
+                    href=${`/archives/${this.crawl.aid}/crawl-templates/${this.crawl.cid}`}
+                    @click=${this.navLink}
+                    >${this.crawl.configName}</a
+                  >
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+
+        <div>
+          <dt class="text-sm text-0-500">${msg("Status")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  <div
+                    class="whitespace-nowrap capitalize${isRunning
+                      ? " motion-safe:animate-pulse"
+                      : ""}"
+                  >
+                    <span
+                      class="inline-block ${this.crawl.state === "failed"
+                        ? "text-red-500"
+                        : this.crawl.state === "partial_complete"
+                        ? "text-emerald-200"
+                        : isRunning
+                        ? "text-purple-500"
+                        : "text-emerald-500"}"
+                      style="font-size: 10px; vertical-align: 2px"
+                    >
+                      &#9679;
+                    </span>
+                    ${this.crawl.state.replace(/_/g, " ")}
+                  </div>
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+            ${isRunning
+              ? html`
+                  <div class="mt-2 text-sm leading-none">
+                    <button
+                      class="px-3 py-2 bg-white border border-purple-400 hover:border-purple-600 text-purple-600 hover:text-purple-500 rounded-sm font-medium mr-2 transition-colors"
+                      @click=${this.cancel}
+                    >
+                      ${msg("Cancel Crawl")}
+                    </button>
+                    <button
+                      class="px-3 py-2 bg-purple-600 hover:bg-purple-500 border border-purple-500 text-white rounded-sm font-medium transition-colors"
+                      @click=${this.stop}
+                    >
+                      ${msg("Stop Crawl")}
+                    </button>
+                  </div>
+                `
+              : ""}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-sm text-0-500">
+            ${this.crawl?.finished ? msg("Finished") : msg("Run duration")}
+          </dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  ${this.crawl.finished
+                    ? html`<sl-format-date
+                        date=${`${this.crawl.finished}Z` /** Z for UTC */}
+                        month="2-digit"
+                        day="2-digit"
+                        year="2-digit"
+                        hour="numeric"
+                        minute="numeric"
+                        time-zone-name="short"
+                      ></sl-format-date>`
+                    : html`<btrix-relative-duration
+                        value=${`${this.crawl.started}Z`}
+                      ></btrix-relative-duration>`}
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-sm text-0-500">${msg("Started")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  <sl-format-date
+                    date=${`${this.crawl.started}Z` /** Z for UTC */}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="numeric"
+                    minute="numeric"
+                    time-zone-name="short"
+                  ></sl-format-date>
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-sm text-0-500">${msg("Reason")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  ${this.crawl.manual
+                    ? msg(
+                        html`Manual start by <span>${this.crawl?.user}</span>`
+                      )
+                    : msg(html`Scheduled run`)}
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+      </dl>
+    `;
+  }
+
+  private renderFiles() {
+    return html`
+      <h3 class="text-lg font-medium mb-2">${msg("Files")}</h3>
+      <ul class="border rounded">
+        <li class="flex justify-between p-3 border-t first:border-t-0">
+          <div>[File name]</div>
+          <div>[Download link]</div>
+        </li>
+        <li class="flex justify-between p-3 border-t first:border-t-0">
+          <div>[File name]</div>
+          <div>[Download link]</div>
+        </li>
+      </ul>
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -272,7 +272,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                         ${this.crawlTemplate.currCrawlId
                           ? html` <a
                               class="text-primary font-medium hover:underline text-sm p-1"
-                              href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
+                              href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlTemplate.currCrawlId}`}
                               @click=${this.navLink}
                               >${msg("View crawl")}</a
                             >`
@@ -298,7 +298,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                   ${this.crawlTemplate?.lastCrawlId
                     ? html`<a
                           class="text-primary font-medium hover:underline text-sm p-1"
-                          href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.lastCrawlId}`}
+                          href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlTemplate.lastCrawlId}`}
                           @click=${this.navLink}
                           >${msg("View crawl")}</a
                         >
@@ -330,7 +330,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       return html`
         <a
           class="flex items-center justify-between mb-4 px-3 py-2 border rounded-lg bg-purple-50 border-purple-200 hover:border-purple-500 shadow shadow-purple-200 text-purple-800 transition-colors"
-          href=${`/archives/${this.archiveId}/crawls/${this.crawlTemplate.currCrawlId}`}
+          href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlTemplate.currCrawlId}`}
           @click=${this.navLink}
         >
           <span>${msg("View currently running crawl")}</span>
@@ -417,7 +417,7 @@ export class CrawlTemplatesDetail extends LiteElement {
             this.crawlTemplate!.name
           }</strong>. <br /><a class="underline hover:no-underline" href="/archives/${
             this.archiveId
-          }/crawls/${data.run_now_job}">View crawl</a>`
+          }/crawls/crawl/${data.run_now_job}">View crawl</a>`
         ),
         type: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -280,7 +280,7 @@ export class CrawlTemplatesList extends LiteElement {
                       e.stopPropagation();
                       this.runningCrawlsMap[t.id]
                         ? this.navTo(
-                            `/archives/${this.archiveId}/crawls/${
+                            `/archives/${this.archiveId}/crawls/crawl/${
                               this.runningCrawlsMap[t.id]
                             }`
                           )
@@ -415,7 +415,7 @@ export class CrawlTemplatesList extends LiteElement {
 
       this.notify({
         message: msg(
-          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
+          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.run_now_job}">View crawl</a>`
         ),
         type: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -543,7 +543,7 @@ export class CrawlTemplatesNew extends LiteElement {
       this.notify({
         message: data.run_now_job
           ? msg(
-              str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
+              str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.run_now_job}">View crawl</a>`
             )
           : msg("Crawl template created."),
         type: "success",

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -155,7 +155,7 @@ export class CrawlTemplatesList extends LiteElement {
 
       this.notify({
         message: msg(
-          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/${data.run_now_job}">View crawl</a>`
+          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.run_now_job}">View crawl</a>`
         ),
         type: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -321,9 +321,9 @@ export class CrawlsList extends LiteElement {
               <div
                 class="whitespace-nowrap truncate text-sm text-purple-600 font-mono tracking-tighter"
               >
-                ${this.numberFormatter.format(crawl.stats.done)}
+                ${this.numberFormatter.format(+crawl.stats.done)}
                 <span class="text-0-400">/</span>
-                ${this.numberFormatter.format(crawl.stats.found)}
+                ${this.numberFormatter.format(+crawl.stats.found)}
               </div>
               <div class="text-0-500 text-sm whitespace-nowrap truncate">
                 ${msg("pages crawled")}

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -237,8 +237,8 @@ export class CrawlsList extends LiteElement {
       class="grid grid-cols-12 gap-4 p-4 leading-none hover:bg-zinc-50 hover:text-primary border-t first:border-t-0 transition-colors"
       role="button"
       @click=${() =>
-        this.navTo(`/archives/${crawl.aid}/crawls/crawl/${crawl.id}`)}
-      title=${`/archives/${crawl.aid}/crawls/crawl/${crawl.id}`}
+        this.navTo(`/archives/${this.archiveId}/crawls/crawl/${crawl.id}`)}
+      title=${`/archives/${this.archiveId}/crawls/crawl/${crawl.id}`}
     >
       <div class="col-span-12 md:col-span-5">
         <div class="font-medium mb-1">

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -7,6 +7,7 @@ import orderBy from "lodash/fp/orderBy";
 import Fuse from "fuse.js";
 
 import { CopyButton } from "../../components/copy-button";
+import { RelativeDuration } from "../../components/relative-duration";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { Crawl } from "./types";
@@ -329,12 +330,9 @@ export class CrawlsList extends LiteElement {
               </div>
               <div class="text-0-500 text-sm whitespace-nowrap truncate">
                 ${msg(
-                  str`in ${humanizeDuration(
+                  str`in ${RelativeDuration.humanize(
                     new Date(`${crawl.finished}Z`).valueOf() -
-                      new Date(`${crawl.started}Z`).valueOf(),
-                    {
-                      secondsDecimalDigits: 0,
-                    }
+                      new Date(`${crawl.started}Z`).valueOf()
                   )}`
                 )}
               </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -235,24 +235,14 @@ export class CrawlsList extends LiteElement {
 
   private renderCrawlItem = ({ item: crawl }: CrawlSearchResult) => {
     return html`<li
-      class="grid grid-cols-12 gap-4 p-4 leading-none hover:bg-zinc-50 hover:text-primary border-t first:border-t-0 transition-colors"
+      class="grid grid-cols-12 gap-2 p-4 leading-none hover:bg-zinc-50 hover:text-primary border-t first:border-t-0 transition-colors"
       role="button"
       @click=${() =>
         this.navTo(`/archives/${this.archiveId}/crawls/crawl/${crawl.id}`)}
-      title=${`/archives/${this.archiveId}/crawls/crawl/${crawl.id}`}
+      title=${crawl.configName || crawl.cid}
     >
       <div class="col-span-12 md:col-span-5">
-        <div class="font-medium mb-1">
-          <a
-            class="hover:text-0-600 transition-colors"
-            href=${`/archives/${this.archiveId}/crawl-templates/${crawl.cid}`}
-            @click=${(e: any) => {
-              e.stopPropagation();
-              this.navLink(e);
-            }}
-            >${crawl.configName || crawl.cid}</a
-          >
-        </div>
+        <div class="font-medium mb-1">${crawl.configName || crawl.cid}</div>
         <div class="text-0-700 text-sm whitespace-nowrap truncate">
           <sl-format-date
             date=${`${crawl.started}Z` /** Z for UTC */}
@@ -262,20 +252,9 @@ export class CrawlsList extends LiteElement {
             hour="numeric"
             minute="numeric"
           ></sl-format-date>
-          ${crawl.manual
-            ? html` <span
-                class="bg-fuchsia-50 text-fuchsia-700 text-xs rounded px-1 leading-4"
-                >${msg("Manual Start")}</span
-              >`
-            : html`
-                <span
-                  class="bg-teal-50 text-teal-700 text-xs rounded px-1 leading-4"
-                  >${msg("Scheduled Run")}</span
-                >
-              `}
         </div>
       </div>
-      <div class="col-span-6 md:col-span-2 flex items-start">
+      <div class="col-span-4 md:col-span-2 flex items-start">
         <div class="mr-2">
           <!-- TODO switch case in lit template? needed for tailwindcss purging -->
           <span
@@ -312,7 +291,7 @@ export class CrawlsList extends LiteElement {
           </div>
         </div>
       </div>
-      <div class="col-span-6 md:col-span-2">
+      <div class="col-span-4 md:col-span-2">
         ${crawl.finished
           ? html`
               <div class="whitespace-nowrap truncate text-sm">
@@ -352,17 +331,27 @@ export class CrawlsList extends LiteElement {
             `
           : ""}
       </div>
-      <div class="col-span-6 md:col-span-2">
+      <div class="col-span-4 md:col-span-2">
         ${crawl.manual
           ? html`
-              <div class="text-0-500 text-sm whitespace-nowrap truncate">
-                ${msg("Started by")}
+              <div class="whitespace-nowrap truncate">
+                <span
+                  class="bg-fuchsia-50 text-fuchsia-700 text-sm rounded px-1 leading-4"
+                  >${msg("Manual Start")}</span
+                >
               </div>
-              <div class="text-0-500 text-sm whitespace-nowrap truncate">
-                ${crawl.username || crawl.user}
+              <div class="ml-1 text-0-500 text-sm whitespace-nowrap truncate">
+                ${msg(str`by ${crawl.username || crawl.user}`)}
               </div>
             `
-          : ""}
+          : html`
+              <div class="whitespace-nowrap truncate">
+                <span
+                  class="bg-teal-50 text-teal-700 text-sm rounded px-1 leading-4"
+                  >${msg("Scheduled Run")}</span
+                >
+              </div>
+            `}
       </div>
       <div class="col-span-12 md:col-span-1 flex justify-end">
         <sl-dropdown @click=${(e: any) => e.stopPropagation()}>
@@ -398,6 +387,16 @@ export class CrawlsList extends LiteElement {
                   </li>
                 `
               : ""}
+            <li
+              class="p-2 hover:bg-zinc-100 cursor-pointer"
+              role="menuitem"
+              @click=${(e: any) => {
+                CopyButton.copyToClipboard(crawl.id);
+                e.target.closest("sl-dropdown").hide();
+              }}
+            >
+              ${msg("Copy Crawl ID")}
+            </li>
             <li
               class="p-2 hover:bg-zinc-100 cursor-pointer"
               role="menuitem"

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -366,7 +366,7 @@ export class CrawlsList extends LiteElement {
             ${isRunning(crawl)
               ? html`
                   <li
-                    class="p-2 hover:bg-zinc-100 cursor-pointer"
+                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
                       this.cancel(crawl.id);
@@ -376,7 +376,7 @@ export class CrawlsList extends LiteElement {
                     ${msg("Cancel immediately")}
                   </li>
                   <li
-                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+                    class="p-2 hover:bg-zinc-100 cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
                       this.stop(crawl.id);

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -10,26 +10,7 @@ import Fuse from "fuse.js";
 import { CopyButton } from "../../components/copy-button";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-
-type Crawl = {
-  id: string;
-  user: string;
-  username?: string;
-  aid: string;
-  cid: string;
-  configName?: string;
-  schedule: string;
-  manual: boolean;
-  started: string; // UTC ISO date
-  finished?: string; // UTC ISO date
-  state: string; // "running" | "complete" | "failed" | "partial_complete"
-  scale: number;
-  stats: { done: number; found: number } | null;
-  files?: { filename: string; hash: string; size: number }[];
-  fileCount?: number;
-  fileSize?: number;
-  completions?: number;
-};
+import type { Crawl } from "./types";
 
 type CrawlSearchResult = {
   item: Crawl;
@@ -255,13 +236,19 @@ export class CrawlsList extends LiteElement {
   private renderCrawlItem = ({ item: crawl }: CrawlSearchResult) => {
     return html`<li
       class="grid grid-cols-12 gap-2 items-center md:gap-6 p-4 leading-none border-t first:border-t-0"
+      role="button"
+      @click=${() =>
+        this.navTo(`/archives/${crawl.aid}/crawls/crawl/${crawl.id}`)}
     >
       <div class="col-span-12 md:col-span-5">
         <div class="font-medium mb-1">
           <a
             class="hover:text-0-600 transition-colors"
             href=${`/archives/${this.archiveId}/crawl-templates/${crawl.cid}`}
-            @click=${this.navLink}
+            @click=${(e: any) => {
+              e.stopPropagation();
+              this.navLink(e);
+            }}
             >${crawl.configName || crawl.cid}</a
           >
         </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -100,8 +100,8 @@ export class CrawlsList extends LiteElement {
   }
 
   disconnectedCallback(): void {
-    super.disconnectedCallback();
     this.stopPollTimer();
+    super.disconnectedCallback();
   }
 
   render() {

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -235,10 +235,11 @@ export class CrawlsList extends LiteElement {
 
   private renderCrawlItem = ({ item: crawl }: CrawlSearchResult) => {
     return html`<li
-      class="grid grid-cols-12 gap-2 items-center md:gap-6 p-4 leading-none border-t first:border-t-0"
+      class="grid grid-cols-12 gap-2 items-center md:gap-6 p-4 leading-none border-t first:border-t-0 hover:bg-zinc-50 transition-colors"
       role="button"
       @click=${() =>
         this.navTo(`/archives/${crawl.aid}/crawls/crawl/${crawl.id}`)}
+      title=${`/archives/${crawl.aid}/crawls/crawl/${crawl.id}`}
     >
       <div class="col-span-12 md:col-span-5">
         <div class="font-medium mb-1">

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -235,7 +235,7 @@ export class CrawlsList extends LiteElement {
 
   private renderCrawlItem = ({ item: crawl }: CrawlSearchResult) => {
     return html`<li
-      class="grid grid-cols-12 gap-2 items-center md:gap-6 p-4 leading-none border-t first:border-t-0 hover:bg-zinc-50 transition-colors"
+      class="grid grid-cols-12 gap-4 p-4 leading-none hover:bg-zinc-50 hover:text-primary border-t first:border-t-0 transition-colors"
       role="button"
       @click=${() =>
         this.navTo(`/archives/${crawl.aid}/crawls/crawl/${crawl.id}`)}

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -365,7 +365,7 @@ export class CrawlsList extends LiteElement {
           : ""}
       </div>
       <div class="col-span-12 md:col-span-1 flex justify-end">
-        <sl-dropdown>
+        <sl-dropdown @click=${(e: any) => e.stopPropagation()}>
           <sl-icon-button
             slot="trigger"
             name="three-dots"
@@ -373,14 +373,13 @@ export class CrawlsList extends LiteElement {
             style="font-size: 1rem"
           ></sl-icon-button>
 
-          <ul class="text-sm whitespace-nowrap" role="menu">
+          <ul class="text-sm text-0-800 whitespace-nowrap" role="menu">
             ${isRunning(crawl)
               ? html`
                   <li
                     class="p-2 hover:bg-zinc-100 cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
-                      e.stopPropagation();
                       this.cancel(crawl.id);
                       e.target.closest("sl-dropdown").hide();
                     }}
@@ -391,7 +390,6 @@ export class CrawlsList extends LiteElement {
                     class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
-                      e.stopPropagation();
                       this.stop(crawl.id);
                       e.target.closest("sl-dropdown").hide();
                     }}
@@ -404,7 +402,6 @@ export class CrawlsList extends LiteElement {
               class="p-2 hover:bg-zinc-100 cursor-pointer"
               role="menuitem"
               @click=${(e: any) => {
-                e.stopPropagation();
                 CopyButton.copyToClipboard(crawl.cid);
                 e.target.closest("sl-dropdown").hide();
               }}
@@ -415,7 +412,6 @@ export class CrawlsList extends LiteElement {
               class="p-2 hover:bg-zinc-100 cursor-pointer"
               role="menuitem"
               @click=${(e: any) => {
-                e.stopPropagation();
                 this.navTo(
                   `/archives/${this.archiveId}/crawl-templates/${crawl.cid}`
                 );

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -334,14 +334,14 @@ export class CrawlsList extends LiteElement {
       <div class="col-span-4 md:col-span-2">
         ${crawl.manual
           ? html`
-              <div class="whitespace-nowrap truncate">
+              <div class="whitespace-nowrap truncate mb-1">
                 <span
                   class="bg-fuchsia-50 text-fuchsia-700 text-sm rounded px-1 leading-4"
                   >${msg("Manual Start")}</span
                 >
               </div>
               <div class="ml-1 text-0-500 text-sm whitespace-nowrap truncate">
-                ${msg(str`by ${crawl.username || crawl.user}`)}
+                ${msg(str`by ${crawl.userName || crawl.userid}`)}
               </div>
             `
           : html`

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -1,6 +1,5 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
-import humanizeDuration from "pretty-ms";
 import debounce from "lodash/fp/debounce";
 import flow from "lodash/fp/flow";
 import map from "lodash/fp/map";
@@ -306,12 +305,9 @@ export class CrawlsList extends LiteElement {
                     date=${`${crawl.finished}Z` /** Z for UTC */}
                   ></sl-relative-time>
                 `
-              : humanizeDuration(
-                  Date.now() - new Date(`${crawl.started}Z`).valueOf(),
-                  {
-                    secondsDecimalDigits: 0,
-                  }
-                )}
+              : html`<btrix-relative-duration
+                  value=${`${crawl.started}Z`}
+                ></btrix-relative-duration>`}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -11,6 +11,7 @@ import { isOwner } from "../../utils/archives";
 import "./crawl-templates-detail";
 import "./crawl-templates-list";
 import "./crawl-templates-new";
+import "./crawl-detail";
 import "./crawls-list";
 
 export type ArchiveTab = "crawls" | "crawl-templates" | "members";
@@ -34,6 +35,9 @@ export class Archive extends LiteElement {
 
   @property({ type: String })
   archiveTab: ArchiveTab = defaultTab;
+
+  @property({ type: String })
+  crawlId?: string;
 
   @property({ type: String })
   crawlConfigId?: string;
@@ -151,6 +155,14 @@ export class Archive extends LiteElement {
   }
 
   private renderCrawls() {
+    if (this.crawlId) {
+      return html`<btrix-crawl-detail
+        .authState=${this.authState!}
+        .archiveId=${this.archiveId!}
+        crawlId=${this.crawlId}
+      ></btrix-crawl-detail>`;
+    }
+
     return html`<btrix-crawls-list
       .authState=${this.authState!}
       .archiveId=${this.archiveId!}

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,10 +1,10 @@
 export type Crawl = {
   id: string;
   user: string;
-  username?: string;
+  username: string;
   aid: string;
   cid: string;
-  configName?: string;
+  configName: string;
   schedule: string;
   manual: boolean;
   started: string; // UTC ISO date

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -10,7 +10,7 @@ export type Crawl = {
   finished?: string; // UTC ISO date
   state: string; // "running" | "complete" | "failed" | "partial_complete"
   scale: number;
-  stats: { done: number; found: number } | null;
+  stats: { done: string; found: string } | null;
   files?: { filename: string; hash: string; size: number }[];
   fileCount?: number;
   fileSize?: number;

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,3 +1,23 @@
+export type Crawl = {
+  id: string;
+  user: string;
+  username?: string;
+  aid: string;
+  cid: string;
+  configName?: string;
+  schedule: string;
+  manual: boolean;
+  started: string; // UTC ISO date
+  finished?: string; // UTC ISO date
+  state: string; // "running" | "complete" | "failed" | "partial_complete"
+  scale: number;
+  stats: { done: number; found: number } | null;
+  files?: { filename: string; hash: string; size: number }[];
+  fileCount?: number;
+  fileSize?: number;
+  completions?: number;
+};
+
 type SeedConfig = {
   scopeType?: string;
   limit?: number;

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -2,7 +2,6 @@ export type Crawl = {
   id: string;
   user: string;
   username: string;
-  aid: string;
   cid: string;
   configName: string;
   schedule: string;

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,7 +1,7 @@
 export type Crawl = {
   id: string;
-  user: string;
-  username: string;
+  userid: string;
+  userName: string;
   cid: string;
   configName: string;
   schedule: string;

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -14,6 +14,7 @@ export const ROUTES = {
   archive: "/archives/:id/:tab",
   archiveNewResourceTab: "/archives/:id/:tab/new",
   archiveAddMember: "/archives/:id/:tab/add-member",
+  crawl: "/archives/:id/:tab/crawl/:crawlId",
   crawlTemplate: "/archives/:id/crawl-templates/:crawlConfigId",
   crawlTemplateEdit: "/archives/:id/crawl-templates/:crawlConfigId?edit",
   users: "/users",


### PR DESCRIPTION
WIP https://github.com/webrecorder/browsertrix-cloud/issues/106

Adds new crawl detail page.

TODO in follow-up (all need backend changes):
- File count for completed crawls
- Watch/replay inline or link out

### Manual testing
1. Run app and go to Archives > archive
2. Click a completed crawl. Verify crawl shows with expected data
3. Run and then click running crawl. Verify crawl shows in running state (see screenshot)
4. Cancel and stop crawls. Verify crawl stops as expected

### Screenshots
<img width="1019" alt="Screen Shot 2022-01-29 at 5 17 01 PM" src="https://user-images.githubusercontent.com/4672952/151683177-67206c56-030a-407e-9130-9f34a91dcc1d.png">

<img width="1025" alt="Screen Shot 2022-01-29 at 5 17 10 PM" src="https://user-images.githubusercontent.com/4672952/151683180-f1b86fa4-c61c-49a4-bf73-2569efdca8d6.png">

<img width="328" alt="Screen Shot 2022-01-29 at 5 56 00 PM" src="https://user-images.githubusercontent.com/4672952/151683751-a8509988-5c20-4f1f-a074-cf32000c27dd.png">

<img width="1040" alt="Screen Shot 2022-01-30 at 6 18 01 PM" src="https://user-images.githubusercontent.com/4672952/151730325-43500518-5268-48be-ac71-8f11d198a923.png">

