### PR TITLE
Make crawl list interactive

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "color": "^4.0.1",
     "cron-parser": "^4.2.1",
     "cronstrue": "^1.123.0",
+    "fuse.js": "^6.5.3",
     "lit": "^2.0.0",
     "lodash": "^4.17.21",
     "path-parser": "^6.1.0",

--- a/frontend/src/components/copy-button.ts
+++ b/frontend/src/components/copy-button.ts
@@ -22,6 +22,10 @@ export class CopyButton extends LitElement {
 
   timeoutId?: number;
 
+  static copyToClipboard(value: string) {
+    navigator.clipboard.writeText(value);
+  }
+
   disconnectedCallback() {
     window.clearTimeout(this.timeoutId);
   }
@@ -35,7 +39,7 @@ export class CopyButton extends LitElement {
   }
 
   private onClick() {
-    navigator.clipboard.writeText(this.value!);
+    CopyButton.copyToClipboard(this.value!);
 
     this.isCopied = true;
 

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -139,6 +139,7 @@ export class CrawlsList extends LiteElement {
             slot="trigger"
             placeholder=${msg("Search by Crawl Template ID")}
             pill
+            clearable
             @sl-input=${this.onSearchInput}
           >
             <sl-icon name="search" slot="prefix"></sl-icon>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -22,6 +22,12 @@ type Crawl = {
   completions?: number;
 };
 
+const sortableFieldLabels = {
+  started: msg("Start Time"),
+  state: msg("End State"),
+  cid: msg("Crawl Template"),
+};
+
 function isRunning(crawl: Crawl) {
   return crawl.state === "running";
 }
@@ -104,7 +110,29 @@ export class CrawlsList extends LiteElement {
                 ></sl-format-date>`
               : ""}
           </div>
-          <div>[Sort by]</div>
+          <div>
+            <span class="inline-block align-middle mr-1 text-sm"
+              >${msg("Sort by")}</span
+            >
+            <sl-dropdown
+              placement="bottom-end"
+              distance="4"
+              @sl-select=${(e: any) => {
+                console.log(e.detail.item.value);
+              }}
+            >
+              <sl-button slot="trigger" size="small" caret
+                >${sortableFieldLabels[this.orderBy.field]}</sl-button
+              >
+              <sl-menu>
+                ${Object.entries(sortableFieldLabels).map(
+                  ([value, label]) => html`
+                    <sl-menu-item value=${value}>${label}</sl-menu-item>
+                  `
+                )}
+              </sl-menu>
+            </sl-dropdown>
+          </div>
         </header>
 
         <section class="col-span-5 lg:col-span-1">[Filters]</section>
@@ -253,19 +281,19 @@ export class CrawlsList extends LiteElement {
   }
 
   private async getCrawls(): Promise<{ running: Crawl[]; finished: Crawl[] }> {
-    // // Mock to use in dev:
-    // return import("../../__mocks__/api/archives/[id]/crawls").then(
-    //   (module) => module.default
-    // );
-
-    const data = await this.apiFetch(
-      `/archives/${this.archiveId}/crawls`,
-      this.authState!
+    // Mock to use in dev:
+    return import("../../__mocks__/api/archives/[id]/crawls").then(
+      (module) => module.default
     );
 
-    this.lastFetched = Date.now();
+    // const data = await this.apiFetch(
+    //   `/archives/${this.archiveId}/crawls`,
+    //   this.authState!
+    // );
 
-    return data;
+    // this.lastFetched = Date.now();
+
+    // return data;
   }
 
   private async cancel(id: string) {

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -57,10 +57,7 @@ export class CrawlsList extends LiteElement {
   private lastFetched?: number;
 
   @state()
-  private runningCrawls?: Crawl[];
-
-  @state()
-  private finishedCrawls?: Crawl[];
+  private crawls?: Crawl[];
 
   @state()
   private orderBy: {
@@ -84,7 +81,7 @@ export class CrawlsList extends LiteElement {
   }
 
   render() {
-    if (!this.runningCrawls || !this.finishedCrawls) {
+    if (!this.crawls) {
       return html`<div
         class="w-full flex items-center justify-center my-24 text-4xl"
       >
@@ -118,7 +115,10 @@ export class CrawlsList extends LiteElement {
               placement="bottom-end"
               distance="4"
               @sl-select=${(e: any) => {
-                console.log(e.detail.item.value);
+                this.orderBy = {
+                  ...this.orderBy,
+                  field: e.detail.item.value,
+                };
               }}
             >
               <sl-button slot="trigger" size="small" caret
@@ -138,8 +138,7 @@ export class CrawlsList extends LiteElement {
         <section class="col-span-5 lg:col-span-1">[Filters]</section>
         <section class="col-span-5 lg:col-span-4 border rounded">
           <ul>
-            ${this.runningCrawls.map(this.renderCrawlItem)}
-            ${this.finishedCrawls.map(this.renderCrawlItem)}
+            ${this.sortCrawls(this.crawls).map(this.renderCrawlItem)}
           </ul>
         </section>
       </main>
@@ -269,8 +268,7 @@ export class CrawlsList extends LiteElement {
     try {
       const { running, finished } = await this.getCrawls();
 
-      this.runningCrawls = this.sortCrawls(running);
-      this.finishedCrawls = this.sortCrawls(finished);
+      this.crawls = [...running, ...finished];
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't retrieve crawls at this time."),

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -22,6 +22,10 @@ type Crawl = {
   completions?: number;
 };
 
+function isRunning(crawl: Crawl) {
+  return crawl.state === "running";
+}
+
 /**
  * Usage:
  * ```ts
@@ -137,7 +141,7 @@ export class CrawlsList extends LiteElement {
               ? "text-red-500"
               : crawl.state === "partial_complete"
               ? "text-emerald-200"
-              : crawl.state === "running"
+              : isRunning(crawl)
               ? "text-purple-500"
               : "text-emerald-500"}"
             style="font-size: 10px; vertical-align: 2px"
@@ -190,7 +194,7 @@ export class CrawlsList extends LiteElement {
           ></sl-format-date>
         </div>
       </div>
-      <div class="col-span-12 md:col-span-1 text-right">
+      <div class="col-span-12 md:col-span-1 flex justify-end">
         <sl-dropdown>
           <sl-icon-button
             slot="trigger"
@@ -200,9 +204,30 @@ export class CrawlsList extends LiteElement {
           ></sl-icon-button>
 
           <ul class="text-sm whitespace-nowrap" role="menu">
-            <li class="p-2 hover:bg-zinc-100 cursor-pointer" role="menuitem">
-              [item]
-            </li>
+            ${isRunning(crawl)
+              ? html`
+                  <li
+                    class="p-2 hover:bg-zinc-100 cursor-pointer"
+                    role="menuitem"
+                    @click=${(e: any) => {
+                      e.stopPropagation();
+                      this.cancel(crawl.id);
+                    }}
+                  >
+                    ${msg("Cancel immediately")}
+                  </li>
+                  <li
+                    class="p-2 hover:bg-zinc-100 cursor-pointer"
+                    role="menuitem"
+                    @click=${(e: any) => {
+                      e.stopPropagation();
+                      this.stop(crawl.id);
+                    }}
+                  >
+                    ${msg("Stop gracefully")}
+                  </li>
+                `
+              : ""}
           </ul>
         </sl-dropdown>
       </div>
@@ -223,6 +248,42 @@ export class CrawlsList extends LiteElement {
     this.lastFetched = Date.now();
 
     return data;
+  }
+
+  async cancel(id: string) {
+    if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawls/${id}/cancel`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      if (data.canceled === true) {
+        // TODO
+      } else {
+        // TODO
+      }
+    }
+  }
+
+  async stop(id: string) {
+    if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawls/${id}/stop`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      if (data.stopped_gracefully === true) {
+        // TODO
+      } else {
+        // TODO
+      }
+    }
   }
 }
 

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -112,20 +112,21 @@ export class CrawlsList extends LiteElement {
       <main>
         <header class="pb-4">${this.renderControls()}</header>
         <section>${this.renderCrawlList()}</section>
-        <footer>
-          [Updated]
-          ${this.lastFetched
-            ? html`<sl-format-date
-                class="inline-block align-middle text-0-600"
-                date=${new Date(this.lastFetched).toString()}
-                month="2-digit"
-                day="2-digit"
-                year="2-digit"
-                hour="numeric"
-                minute="numeric"
-                second="numeric"
-              ></sl-format-date>`
-            : ""}
+        <footer class="mt-3">
+          <span class="text-0-400 text-sm">
+            ${this.lastFetched
+              ? msg(html`Last updated:
+                  <sl-format-date
+                    date=${new Date(this.lastFetched).toString()}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="numeric"
+                    minute="numeric"
+                    second="numeric"
+                  ></sl-format-date>`)
+              : ""}
+          </span>
         </footer>
       </main>
     `;
@@ -351,18 +352,18 @@ export class CrawlsList extends LiteElement {
 
   private async getCrawls(): Promise<{ running: Crawl[]; finished: Crawl[] }> {
     // Mock to use in dev:
-    return import("../../__mocks__/api/archives/[id]/crawls").then(
-      (module) => module.default
-    );
-
-    // const data = await this.apiFetch(
-    //   `/archives/${this.archiveId}/crawls`,
-    //   this.authState!
+    // return import("../../__mocks__/api/archives/[id]/crawls").then(
+    //   (module) => module.default
     // );
 
-    // this.lastFetched = Date.now();
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/crawls`,
+      this.authState!
+    );
 
-    // return data;
+    this.lastFetched = Date.now();
+
+    return data;
   }
 
   private async cancel(id: string) {

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -153,8 +153,7 @@ export class CrawlsList extends LiteElement {
         </div>
         <div>
           <div
-            class="whitespace-nowrap truncate mb-1 capitalize${crawl.state ===
-            "running"
+            class="whitespace-nowrap mb-1 capitalize${crawl.state === "running"
               ? " motion-safe:animate-pulse"
               : ""}"
           >

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -23,9 +23,12 @@ type Crawl = {
 };
 
 const sortableFieldLabels = {
-  started: msg("Start Time"),
-  state: msg("End State"),
-  cid: msg("Crawl Template"),
+  started_asc: msg("Oldest"),
+  started_desc: msg("Newest"),
+  state_asc: msg("Status"),
+  state_desc: msg("Status (Reverse)"),
+  cid_asc: msg("Crawl Template ID"),
+  cid_desc: msg("Crawl Template ID (Reverse)"),
 };
 
 function isRunning(crawl: Crawl) {
@@ -107,29 +110,36 @@ export class CrawlsList extends LiteElement {
                 ></sl-format-date>`
               : ""}
           </div>
-          <div>
-            <span class="inline-block align-middle mr-1 text-sm"
-              >${msg("Sort by")}</span
-            >
+          <div class="flex items-center">
+            <div class="mr-1 text-sm">${msg("Sort by")}</div>
             <sl-dropdown
               placement="bottom-end"
               distance="4"
               @sl-select=${(e: any) => {
+                const [field, direction] = e.detail.item.value.split("_");
                 this.orderBy = {
-                  ...this.orderBy,
-                  field: e.detail.item.value,
+                  field: field,
+                  direction: direction,
                 };
               }}
             >
               <sl-button slot="trigger" size="small" caret
-                >${sortableFieldLabels[this.orderBy.field]}</sl-button
+                >${sortableFieldLabels[
+                  `${this.orderBy.field}_${this.orderBy.direction}`
+                ]}</sl-button
               >
               <sl-menu>
-                ${Object.entries(sortableFieldLabels).map(
-                  ([value, label]) => html`
-                    <sl-menu-item value=${value}>${label}</sl-menu-item>
-                  `
-                )}
+                ${Object.entries(sortableFieldLabels)
+                  .filter(
+                    ([value]) =>
+                      value !==
+                      `${this.orderBy.field}_${this.orderBy.direction}`
+                  )
+                  .map(
+                    ([value, label]) => html`
+                      <sl-menu-item value=${value}>${label}</sl-menu-item>
+                    `
+                  )}
               </sl-menu>
             </sl-dropdown>
           </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -139,11 +139,11 @@ export class CrawlsList extends LiteElement {
           <span
             class="inline-block ${crawl.state === "failed"
               ? "text-red-500"
-              : crawl.state === "partial_complete"
-              ? "text-emerald-200"
+              : crawl.state === "complete"
+              ? "text-emerald-500"
               : isRunning(crawl)
               ? "text-purple-500"
-              : "text-emerald-500"}"
+              : "text-zinc-300"}"
             style="font-size: 10px; vertical-align: 2px"
           >
             &#9679;

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -35,10 +35,8 @@ const MIN_SEARCH_LENGTH = 2;
 const sortableFieldLabels = {
   started_desc: msg("Newest"),
   started_asc: msg("Oldest"),
-  state_asc: msg("Status"),
-  state_desc: msg("Status (Reverse)"),
-  cid_asc: msg("Crawl Template ID"),
-  cid_desc: msg("Crawl Template ID (Reverse)"),
+  state: msg("Status"),
+  cid: msg("Crawl Template ID"),
 };
 
 function isRunning(crawl: Crawl) {
@@ -162,7 +160,8 @@ export class CrawlsList extends LiteElement {
             }}
           >
             <sl-button slot="trigger" pill caret
-              >${sortableFieldLabels[
+              >${(sortableFieldLabels as any)[this.orderBy.field] ||
+              sortableFieldLabels[
                 `${this.orderBy.field}_${this.orderBy.direction}`
               ]}</sl-button
             >
@@ -179,6 +178,16 @@ export class CrawlsList extends LiteElement {
               )}
             </sl-menu>
           </sl-dropdown>
+          <sl-icon-button
+            name="arrow-down-up"
+            label=${msg("Reverse sort")}
+            @click=${() => {
+              this.orderBy = {
+                ...this.orderBy,
+                direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+              };
+            }}
+          ></sl-icon-button>
         </div>
       </div>
     `;

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -352,9 +352,9 @@ export class CrawlsList extends LiteElement {
    */
   private async fetchCrawls(): Promise<void> {
     try {
-      const { running, finished } = await this.getCrawls();
+      const { crawls } = await this.getCrawls();
 
-      this.crawls = [...running, ...finished];
+      this.crawls = crawls;
       // Update search/filter collection
       this.fuse.setCollection(this.crawls as any);
     } catch (e) {
@@ -366,7 +366,7 @@ export class CrawlsList extends LiteElement {
     }
   }
 
-  private async getCrawls(): Promise<{ running: Crawl[]; finished: Crawl[] }> {
+  private async getCrawls(): Promise<{ crawls: Crawl[] }> {
     // Mock to use in dev:
     // return import("../../__mocks__/api/archives/[id]/crawls").then(
     //   (module) => module.default

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -224,7 +224,7 @@ export class CrawlsList extends LiteElement {
         <div class="text-0-500 text-sm whitespace-nowrap truncate">
           <a
             class="hover:underline"
-            href=${`/archives/${crawl.aid}/crawl-templates/${crawl.cid}`}
+            href=${`/archives/${this.archiveId}/crawl-templates/${crawl.cid}`}
             @click=${this.navLink}
             >${crawl.cid}</a
           >

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -33,8 +33,8 @@ type CrawlSearchResult = {
 
 const MIN_SEARCH_LENGTH = 2;
 const sortableFieldLabels = {
-  started_asc: msg("Oldest"),
   started_desc: msg("Newest"),
+  started_asc: msg("Oldest"),
   state_asc: msg("Status"),
   state_desc: msg("Status (Reverse)"),
   cid_asc: msg("Crawl Template ID"),
@@ -88,9 +88,9 @@ export class CrawlsList extends LiteElement {
   private fuse = new Fuse([], { keys: ["cid"], shouldSort: false });
 
   private sortCrawls(crawls: CrawlSearchResult[]): CrawlSearchResult[] {
-    return orderBy(`item.${this.orderBy.field}`)(this.orderBy.direction)(
-      crawls
-    ) as CrawlSearchResult[];
+    return orderBy(({ item }) => item[this.orderBy.field])(
+      this.orderBy.direction
+    )(crawls) as CrawlSearchResult[];
   }
 
   protected updated(changedProperties: Map<string, any>) {
@@ -134,8 +134,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-6 gap-3 items-center">
-        <div class="col-span-6 md:col-span-3">
+      <div class="grid grid-cols-2 gap-3 items-center">
+        <div class="col-span-2 md:col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"
@@ -146,15 +146,10 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="col-span-6 md:col-span-1">
-          <span class="text-xs text-0-400"
-            >${this.filterBy.length >= MIN_SEARCH_LENGTH
-              ? msg(str`Viewing filtered results`)
-              : ""}</span
-          >
-        </div>
-        <div class="col-span-6 md:col-span-2 flex items-center justify-end">
-          <div class="mr-2 text-sm text-0-600">${msg("Sort by")}</div>
+        <div class="col-span-2 md:col-span-1 flex items-center justify-end">
+          <div class="whitespace-nowrap text-sm text-0-600 mr-2">
+            ${msg("Sort by")}
+          </div>
           <sl-dropdown
             placement="bottom-end"
             distance="4"
@@ -200,8 +195,8 @@ export class CrawlsList extends LiteElement {
     return html`
       <ul class="border rounded">
         ${flow(
-          this.sortCrawls.bind(this),
           filterResults,
+          this.sortCrawls.bind(this),
           map(this.renderCrawlItem)
         )(this.crawls as any)}
       </ul>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -220,7 +220,7 @@ export class CrawlsList extends LiteElement {
                     ${msg("Cancel immediately")}
                   </li>
                   <li
-                    class="p-2 hover:bg-zinc-100 cursor-pointer"
+                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
                       e.stopPropagation();

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -1,4 +1,3 @@
-import type { TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import humanizeDuration from "pretty-ms";
@@ -8,6 +7,7 @@ import map from "lodash/fp/map";
 import orderBy from "lodash/fp/orderBy";
 import Fuse from "fuse.js";
 
+import { CopyButton } from "../../components/copy-button";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 
@@ -112,7 +112,7 @@ export class CrawlsList extends LiteElement {
       <main>
         <header class="pb-4">${this.renderControls()}</header>
         <section>${this.renderCrawlList()}</section>
-        <footer class="mt-3">
+        <footer class="mt-2">
           <span class="text-0-400 text-sm">
             ${this.lastFetched
               ? msg(html`Last updated:
@@ -316,6 +316,17 @@ export class CrawlsList extends LiteElement {
                   </li>
                 `
               : ""}
+            <li
+              class="p-2 hover:bg-zinc-100 cursor-pointer"
+              role="menuitem"
+              @click=${(e: any) => {
+                e.stopPropagation();
+                CopyButton.copyToClipboard(crawl.cid);
+                e.target.closest("sl-dropdown").hide();
+              }}
+            >
+              ${msg("Copy Crawl Template ID")}
+            </li>
           </ul>
         </sl-dropdown>
       </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2646,6 +2646,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+fuse.js@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.5.3.tgz#7446c0acbc4ab0ab36fa602e97499bdb69452b93"
+  integrity sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg==
+
 get-intrinsic@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"


### PR DESCRIPTION
(WIP https://github.com/webrecorder/browsertrix-cloud/issues/106)

- Cancel and stop crawl
- Sorts crawls by start time, status and crawl template ID
- Filters crawls by crawl template ID
- Adds shortcut to copy template ID

### Manual testing
Testing filtering/sorting:
1. Run app and go to Archives > archive > Crawls
2. Interact with search bar and sort dropdown. Verify the following:
  - Typing in more than 1 character in the search bar will begin fuzzy search (searching anywhere within CID)
  - Search bar is clearable by clicking "X"
  - Each sort option works as expected
  - Clicking "reverse" button next to sort dropdown works
  - Combining search + sort
3. Click "..." more icon on crawl and click "Copy Crawl Template ID". Paste into search bar to verify it works

Testing cancel/stop:
1. Run app and go to Archives > archive > Crawls Templates
2. Click "Run now" to start a crawl
3. Click "Crawls" tab
4. Click "..." more icon on running crawl and choose "Cancel immediately". Verify crawl stops and shows as "canceled".
5. Repeat steps 1-4 but choose "Stop gracefully". Verify crawl stops. (as discussed, the crawl doesn't show up in the crawl list any more--maybe an intermediary `stopping` state could be added?)

### Screeshots
**Filter and sort controls:**
<img width="1034" alt="Screen Shot 2022-01-28 at 1 35 42 PM" src="https://user-images.githubusercontent.com/4672952/151625501-f93611fb-70c7-4bfd-a9ff-ec38485d61a8.png">

**Sort dropdown:**
<img width="252" alt="Screen Shot 2022-01-28 at 1 35 47 PM" src="https://user-images.githubusercontent.com/4672952/151625505-d26c74dd-61ad-467e-bd6a-24b4ee5de5ae.png">

**Filtered view:**
<img width="1029" alt="Screen Shot 2022-01-28 at 1 36 42 PM" src="https://user-images.githubusercontent.com/4672952/151625511-b89de77a-1c81-4c05-bbcb-4d36f9b2c0d8.png">

**New menu items:**
<img width="228" alt="Screen Shot 2022-01-28 at 5 21 01 PM" src="https://user-images.githubusercontent.com/4672952/151641712-7a096998-e65b-4ed0-bb68-7ec3f1a37578.png">

