### PR TITLE
Poll crawls list & add additional details

### DIFF
--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -87,7 +87,10 @@ export class CrawlsList extends LiteElement {
   private filterBy: string = "";
 
   // For fuzzy search:
-  private fuse = new Fuse([], { keys: ["cid"], shouldSort: false });
+  private fuse = new Fuse([], {
+    keys: ["cid", "configName"],
+    shouldSort: false,
+  });
 
   // For long polling:
   private timerId?: number;
@@ -156,7 +159,7 @@ export class CrawlsList extends LiteElement {
           <sl-input
             class="w-full"
             slot="trigger"
-            placeholder=${msg("Search by Crawl Template ID")}
+            placeholder=${msg("Search by Crawl Template name or ID")}
             pill
             clearable
             @sl-input=${this.onSearchInput}

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -165,7 +165,7 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
         <div class="col-span-2 md:col-span-1 flex items-center justify-end">
-          <div class="whitespace-nowrap text-sm text-0-600 mr-2">
+          <div class="whitespace-nowrap text-sm text-0-500 mr-2">
             ${msg("Sort by")}
           </div>
           <sl-dropdown
@@ -238,15 +238,23 @@ export class CrawlsList extends LiteElement {
     >
       <div class="col-span-12 md:col-span-4">
         <div class="font-medium whitespace-nowrap truncate mb-1">
-          ${crawl.id}
-        </div>
-        <div class="text-0-500 text-sm whitespace-nowrap truncate">
           <a
-            class="hover:underline"
+            class="hover:text-0-600 transition-colors"
             href=${`/archives/${this.archiveId}/crawl-templates/${crawl.cid}`}
             @click=${this.navLink}
             >${crawl.configName || crawl.cid}</a
           >
+        </div>
+        <div class="text-0-500 text-sm whitespace-nowrap truncate">
+          <sl-format-date
+            class="inline-block align-middle text-0-500"
+            date=${`${crawl.started}Z` /** Z for UTC */}
+            month="2-digit"
+            day="2-digit"
+            year="2-digit"
+            hour="numeric"
+            minute="numeric"
+          ></sl-format-date>
         </div>
       </div>
       <div class="col-span-6 md:col-span-2 flex items-start">
@@ -278,7 +286,6 @@ export class CrawlsList extends LiteElement {
               ? html`
                   <sl-relative-time
                     date=${`${crawl.finished}Z` /** Z for UTC */}
-                    sync
                   ></sl-relative-time>
                 `
               : humanizeDuration(
@@ -298,15 +305,9 @@ export class CrawlsList extends LiteElement {
         </div>
 
         <div class="text-0-500 text-sm whitespace-nowrap truncate">
-          <sl-format-date
-            class="inline-block align-middle text-0-600"
+          <sl-relative-time
             date=${`${crawl.started}Z` /** Z for UTC */}
-            month="2-digit"
-            day="2-digit"
-            year="2-digit"
-            hour="numeric"
-            minute="numeric"
-          ></sl-format-date>
+          ></sl-relative-time>
         </div>
       </div>
       <div class="col-span-6 md:col-span-2">

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -14,6 +14,7 @@ import LiteElement, { html } from "../../utils/LiteElement";
 type Crawl = {
   id: string;
   user: string;
+  username?: string;
   aid: string;
   cid: string;
   configName?: string;
@@ -313,7 +314,7 @@ export class CrawlsList extends LiteElement {
               </div>
               <div class="text-0-500 text-sm whitespace-nowrap truncate">
                 <!-- TODO show user name -->
-                ${crawl.user}
+                ${crawl.username || crawl.user}
               </div>
             `
           : html`

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -89,6 +89,9 @@ export class CrawlsList extends LiteElement {
   // For long polling:
   private timerId?: number;
 
+  // TODO localize
+  private numberFormatter = new Intl.NumberFormat();
+
   private sortCrawls(crawls: CrawlSearchResult[]): CrawlSearchResult[] {
     return orderBy(({ item }) => item[this.orderBy.field])(
       this.orderBy.direction
@@ -284,7 +287,7 @@ export class CrawlsList extends LiteElement {
           </div>
         </div>
       </div>
-      <div class="col-span-6 md:col-span-4">
+      <div class="col-span-6 md:col-span-3">
         <div class="whitespace-nowrap truncate mb-1">
           ${crawl.manual
             ? msg(html`Manual start by <span>${crawl.user}</span>`)
@@ -303,19 +306,45 @@ export class CrawlsList extends LiteElement {
           ></sl-format-date>
         </div>
       </div>
-      <div class="col-span-6 md:col-span-1">
+      <div class="col-span-6 md:col-span-2">
         ${crawl.files
           ? html`
-              <div class="whitespace-nowrap truncate mb-1 text-sm font-mono">
-                <sl-format-bytes
-                  value=${crawl.files.reduce((v, { size }) => v + size, 0)}
-                  lang=${/* TODO localize: */ "en"}
-                ></sl-format-bytes>
+              <div class="whitespace-nowrap truncate text-sm">
+                <span class="font-mono text-0-800 tracking-tighter">
+                  <sl-format-bytes
+                    value=${crawl.files.reduce((v, { size }) => v + size, 0)}
+                    lang=${/* TODO localize: */ "en"}
+                  ></sl-format-bytes>
+                </span>
+                <span class="text-0-500">
+                  (${crawl.files.length === 1
+                    ? msg(str`${crawl.files.length} file`)
+                    : msg(str`${crawl.files.length} files`)})
+                </span>
               </div>
               <div class="text-0-500 text-sm whitespace-nowrap truncate">
-                ${crawl.files.length === 1
-                  ? msg(str`${crawl.files.length} file`)
-                  : msg(str`${crawl.files.length} files`)}
+                ${msg(
+                  str`in ${humanizeDuration(
+                    new Date(`${crawl.finished}Z`).valueOf() -
+                      new Date(`${crawl.started}Z`).valueOf(),
+                    {
+                      secondsDecimalDigits: 0,
+                    }
+                  )}`
+                )}
+              </div>
+            `
+          : crawl.stats
+          ? html`
+              <div
+                class="whitespace-nowrap truncate text-sm text-purple-600 font-mono tracking-tighter"
+              >
+                ${this.numberFormatter.format(crawl.stats.done)}
+                <span class="text-0-400">/</span>
+                ${this.numberFormatter.format(crawl.stats.found)}
+              </div>
+              <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                ${msg("pages crawled")}
               </div>
             `
           : ""}

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -251,9 +251,8 @@ export class CrawlsList extends LiteElement {
             >${crawl.configName || crawl.cid}</a
           >
         </div>
-        <div class="text-0-500 text-sm whitespace-nowrap truncate">
+        <div class="text-0-800 text-sm whitespace-nowrap truncate">
           <sl-format-date
-            class="inline-block align-middle text-0-500"
             date=${`${crawl.started}Z` /** Z for UTC */}
             month="2-digit"
             day="2-digit"
@@ -304,17 +303,36 @@ export class CrawlsList extends LiteElement {
         </div>
       </div>
       <div class="col-span-6 md:col-span-3">
-        <div class="whitespace-nowrap truncate mb-1">
-          ${crawl.manual
-            ? msg(html`Manual start by <span>${crawl.user}</span>`)
-            : msg(html`Scheduled run`)}
-        </div>
+        ${crawl.manual
+          ? html`
+              <div class="whitespace-nowrap truncate mb-1">
+                <span
+                  class="bg-fuchsia-50 text-fuchsia-800 text-xs rounded px-1 leading-4"
+                  >${msg("Manual Start")}</span
+                >
+              </div>
+              <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                <!-- TODO show user name -->
+                ${crawl.user}
+              </div>
+            `
+          : html`
+              <div class="whitespace-nowrap truncate mb-1">
+                <span
+                  class="bg-teal-50 text-teal-800 text-xs rounded px-1 leading-4"
+                  >${msg("Scheduled Run")}</span
+                >
+              </div>
 
-        <div class="text-0-500 text-sm whitespace-nowrap truncate">
-          <sl-relative-time
-            date=${`${crawl.started}Z` /** Z for UTC */}
-          ></sl-relative-time>
-        </div>
+              <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                <sl-format-date
+                  date=${`${crawl.started}Z` /** Z for UTC */}
+                  weekday="long"
+                  month="short"
+                  day="numeric"
+                ></sl-format-date>
+              </div>
+            `}
       </div>
       <div class="col-span-6 md:col-span-2">
         ${crawl.finished

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -40,7 +40,10 @@ const sortableFieldLabels = {
   started_desc: msg("Newest"),
   started_asc: msg("Oldest"),
   state: msg("Status"),
+  configName: msg("Crawl Template Name"),
   cid: msg("Crawl Template ID"),
+  fileSize_asc: msg("Smallest Files"),
+  fileSize_desc: msg("Largest Files"),
 };
 
 function isRunning(crawl: Crawl) {

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -400,6 +400,18 @@ export class CrawlsList extends LiteElement {
             >
               ${msg("Copy Crawl Template ID")}
             </li>
+            <li
+              class="p-2 hover:bg-zinc-100 cursor-pointer"
+              role="menuitem"
+              @click=${(e: any) => {
+                e.stopPropagation();
+                this.navTo(
+                  `/archives/${this.archiveId}/crawl-templates/${crawl.cid}`
+                );
+              }}
+            >
+              ${msg("View Crawl Template")}
+            </li>
           </ul>
         </sl-dropdown>
       </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -16,6 +16,7 @@ type Crawl = {
   user: string;
   aid: string;
   cid: string;
+  configName?: string;
   schedule: string;
   manual: boolean;
   started: string; // UTC ISO date
@@ -24,6 +25,8 @@ type Crawl = {
   scale: number;
   stats: { done: number; found: number } | null;
   files?: { filename: string; hash: string; size: number }[];
+  fileCount?: number;
+  fileSize?: number;
   completions?: number;
 };
 
@@ -242,7 +245,7 @@ export class CrawlsList extends LiteElement {
             class="hover:underline"
             href=${`/archives/${this.archiveId}/crawl-templates/${crawl.cid}`}
             @click=${this.navLink}
-            >${crawl.cid}</a
+            >${crawl.configName || crawl.cid}</a
           >
         </div>
       </div>
@@ -307,19 +310,19 @@ export class CrawlsList extends LiteElement {
         </div>
       </div>
       <div class="col-span-6 md:col-span-2">
-        ${crawl.files
+        ${typeof crawl.fileCount !== "undefined"
           ? html`
               <div class="whitespace-nowrap truncate text-sm">
                 <span class="font-mono text-0-800 tracking-tighter">
                   <sl-format-bytes
-                    value=${crawl.files.reduce((v, { size }) => v + size, 0)}
+                    value=${crawl.fileSize || 0}
                     lang=${/* TODO localize: */ "en"}
                   ></sl-format-bytes>
                 </span>
                 <span class="text-0-500">
-                  (${crawl.files.length === 1
-                    ? msg(str`${crawl.files.length} file`)
-                    : msg(str`${crawl.files.length} files`)})
+                  (${crawl.fileCount === 1
+                    ? msg(str`${crawl.fileCount} file`)
+                    : msg(str`${crawl.fileCount} files`)})
                 </span>
               </div>
               <div class="text-0-500 text-sm whitespace-nowrap truncate">

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -243,7 +243,7 @@ export class CrawlsList extends LiteElement {
           >
         </div>
       </div>
-      <div class="col-span-6 md:col-span-3 flex items-start">
+      <div class="col-span-6 md:col-span-2 flex items-start">
         <div class="mr-2">
           <!-- TODO switch case in lit template? needed for tailwindcss purging -->
           <span
@@ -302,6 +302,23 @@ export class CrawlsList extends LiteElement {
             minute="numeric"
           ></sl-format-date>
         </div>
+      </div>
+      <div class="col-span-6 md:col-span-1">
+        ${crawl.files
+          ? html`
+              <div class="whitespace-nowrap truncate mb-1 text-sm font-mono">
+                <sl-format-bytes
+                  value=${crawl.files.reduce((v, { size }) => v + size, 0)}
+                  lang=${/* TODO localize: */ "en"}
+                ></sl-format-bytes>
+              </div>
+              <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                ${crawl.files.length === 1
+                  ? msg(str`${crawl.files.length} file`)
+                  : msg(str`${crawl.files.length} files`)}
+              </div>
+            `
+          : ""}
       </div>
       <div class="col-span-12 md:col-span-1 flex justify-end">
         <sl-dropdown>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -317,7 +317,7 @@ export class CrawlsList extends LiteElement {
         </div>
       </div>
       <div class="col-span-6 md:col-span-2">
-        ${typeof crawl.fileCount !== "undefined"
+        ${crawl.finished
           ? html`
               <div class="whitespace-nowrap truncate text-sm">
                 <span class="font-mono text-0-800 tracking-tighter">

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -241,10 +241,10 @@ export class CrawlsList extends LiteElement {
 
   private renderCrawlItem = ({ item: crawl }: CrawlSearchResult) => {
     return html`<li
-      class="grid grid-cols-12 gap-4 md:gap-6 p-4 leading-none border-t first:border-t-0"
+      class="grid grid-cols-12 gap-2 items-center md:gap-6 p-4 leading-none border-t first:border-t-0"
     >
-      <div class="col-span-12 md:col-span-4">
-        <div class="font-medium whitespace-nowrap truncate mb-1">
+      <div class="col-span-12 md:col-span-5">
+        <div class="font-medium mb-1">
           <a
             class="hover:text-0-600 transition-colors"
             href=${`/archives/${this.archiveId}/crawl-templates/${crawl.cid}`}
@@ -252,7 +252,7 @@ export class CrawlsList extends LiteElement {
             >${crawl.configName || crawl.cid}</a
           >
         </div>
-        <div class="text-0-800 text-sm whitespace-nowrap truncate">
+        <div class="text-0-700 text-sm whitespace-nowrap truncate">
           <sl-format-date
             date=${`${crawl.started}Z` /** Z for UTC */}
             month="2-digit"
@@ -261,6 +261,17 @@ export class CrawlsList extends LiteElement {
             hour="numeric"
             minute="numeric"
           ></sl-format-date>
+          ${crawl.manual
+            ? html` <span
+                class="bg-fuchsia-50 text-fuchsia-700 text-xs rounded px-1 leading-4"
+                >${msg("Manual Start")}</span
+              >`
+            : html`
+                <span
+                  class="bg-teal-50 text-teal-700 text-xs rounded px-1 leading-4"
+                  >${msg("Scheduled Run")}</span
+                >
+              `}
         </div>
       </div>
       <div class="col-span-6 md:col-span-2 flex items-start">
@@ -303,38 +314,6 @@ export class CrawlsList extends LiteElement {
           </div>
         </div>
       </div>
-      <div class="col-span-6 md:col-span-3">
-        ${crawl.manual
-          ? html`
-              <div class="whitespace-nowrap truncate mb-1">
-                <span
-                  class="bg-fuchsia-50 text-fuchsia-800 text-xs rounded px-1 leading-4"
-                  >${msg("Manual Start")}</span
-                >
-              </div>
-              <div class="text-0-500 text-sm whitespace-nowrap truncate">
-                <!-- TODO show user name -->
-                ${crawl.username || crawl.user}
-              </div>
-            `
-          : html`
-              <div class="whitespace-nowrap truncate mb-1">
-                <span
-                  class="bg-teal-50 text-teal-800 text-xs rounded px-1 leading-4"
-                  >${msg("Scheduled Run")}</span
-                >
-              </div>
-
-              <div class="text-0-500 text-sm whitespace-nowrap truncate">
-                <sl-format-date
-                  date=${`${crawl.started}Z` /** Z for UTC */}
-                  weekday="long"
-                  month="short"
-                  day="numeric"
-                ></sl-format-date>
-              </div>
-            `}
-      </div>
       <div class="col-span-6 md:col-span-2">
         ${crawl.finished
           ? html`
@@ -374,6 +353,18 @@ export class CrawlsList extends LiteElement {
               </div>
               <div class="text-0-500 text-sm whitespace-nowrap truncate">
                 ${msg("pages crawled")}
+              </div>
+            `
+          : ""}
+      </div>
+      <div class="col-span-6 md:col-span-2">
+        ${crawl.manual
+          ? html`
+              <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                ${msg("Started by")}
+              </div>
+              <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                ${crawl.username || crawl.user}
               </div>
             `
           : ""}

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -21,6 +21,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/form/form"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/format-bytes/format-bytes"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/format-date/format-date"
 );
 import(


### PR DESCRIPTION
(WIP https://github.com/webrecorder/browsertrix-cloud/issues/106)

- Polls crawls list every 10 seconds to get latest updates
- Shows config name, number of files & stats

### Manual testing
1. Run app and go to Archives > archive > Crawls. Verify that crawl template name and file data shows as expected
2. Run a crawl from the crawl templates page and go back to crawls. Verify that running crawls shows page stats and the run duration is updated every 10 seconds

### Screenshots
**Running crawl:**
<img width="1014" alt="Screen Shot 2022-01-29 at 1 47 06 PM" src="https://user-images.githubusercontent.com/4672952/151678575-1c76f5e9-b991-4c12-acc8-0e23010c9145.png">

**Completed crawl (didn't have config name when run):**
<img width="1021" alt="Screen Shot 2022-01-29 at 1 47 24 PM" src="https://user-images.githubusercontent.com/4672952/151678576-bd1d0db3-a69b-4946-8242-1e89d096ccc5.png">

