### PR TITLE
Crawls API improvements

### DIFF
--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -47,8 +47,6 @@ class RawCrawlConfig(BaseModel):
 
     seeds: List[Union[str, Seed]]
 
-    # collection: Optional[str] = "my-web-archive"
-
     scopeType: Optional[ScopeType] = ScopeType.PREFIX
     scope: Union[str, List[str], None] = ""
     exclude: Union[str, List[str], None] = ""
@@ -96,6 +94,8 @@ class CrawlConfig(BaseMongoModel):
     config: RawCrawlConfig
 
     name: Optional[str]
+
+    created: Optional[datetime]
 
     colls: Optional[List[str]] = []
 
@@ -168,6 +168,8 @@ class CrawlOps:
             )
 
         result = await self.crawl_configs.insert_one(data)
+
+        data["created"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
 
         crawlconfig = CrawlConfig.from_dict(data)
 

--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -248,8 +248,6 @@ class CrawlOps:
         if config:
             out["configName"] = config.name
 
-        config = await self.users
-
         return out
 
     # pylint: disable=too-many-arguments


### PR DESCRIPTION
Fixes most issues in #110:

- Add new `/crawls:id` endpoint.
- Return crawl template name in `/crawls` and `/crawls/:id` response data to show in UI
- Add `created` field to crawlconfig
- Return created at date in `/crawlconfigs` and `/crawlconfigs/:id`
- For crawl list, return `fileSize` and `fileCount` for each crawl instead 
- Add `configName` field to crawls
- Remove `schedule` from crawl (view via crawl config)
- For crawl list, drop `files` array and `aid` from crawl response.
- Flatten crawls list to single `crawls` list instead of `running` and `finished`