### PR TITLE
Refactor backend data model to support UUID (fixes #118)

### DIFF
--- a/backend/archives.py
+++ b/backend/archives.py
@@ -96,7 +96,7 @@ class Archive(BaseMongoModel):
             user_list = await user_manager.get_user_names_by_ids(keys)
 
             for archive_user in user_list:
-                id_ = str(archive_user["id"])
+                id_ = archive_user["id"]
                 role = result["users"].get(id_)
                 if not role:
                     continue
@@ -136,9 +136,9 @@ class ArchiveOps:
         # pylint: disable=too-many-arguments
         """Create new archive with default storage for new user"""
 
-        id_ = str(uuid.uuid4())
+        id_ = uuid.uuid4()
 
-        storage_path = id_ + "/"
+        storage_path = str(id_) + "/"
 
         archive = Archive(
             id=id_,
@@ -161,11 +161,11 @@ class ArchiveOps:
         self, aid: str, user: User, role: UserRole = UserRole.VIEWER
     ):
         """Get an archive for user by unique id"""
-        query = {f"users.{user.id}": {"$gte": role.value}, "_id": aid}
+        query = {f"users.{user.id}": {"$gte": role.value}, "_id": uuid.UUID(aid)}
         res = await self.archives.find_one(query)
         return Archive.from_dict(res)
 
-    async def get_archive_by_id(self, aid: str):
+    async def get_archive_by_id(self, aid: uuid.UUID):
         """Get an archive by id"""
         res = await self.archives.find_one({"_id": aid})
         return Archive.from_dict(res)
@@ -206,7 +206,7 @@ class ArchiveOps:
         await self.update(archive)
         return True
 
-    async def inc_usage(self, aid, amount):
+    async def inc_usage(self, aid: uuid.UUID, amount: int):
         """ Increment usage counter by month for this archive """
         yymm = datetime.utcnow().strftime("%Y-%m")
         res = await self.archives.find_one_and_update(

--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -186,7 +186,7 @@ class CrawlOps:
 
         return result, new_name
 
-    async def update_crawl_schedule(self, cid: uuid.UUID, update: UpdateSchedule):
+    async def update_crawl_schedule(self, cid: str, update: UpdateSchedule):
         """ Update schedule for existing crawl config"""
 
         if not await self.crawl_configs.find_one_and_update(
@@ -215,7 +215,7 @@ class CrawlOps:
                 {
                     "$lookup": {
                         "from": "users",
-                        "localField": "user",
+                        "localField": "userid",
                         "foreignField": "id",
                         "as": "userName",
                     },
@@ -257,13 +257,13 @@ class CrawlOps:
 
     async def delete_crawl_config(self, cid: uuid.UUID, archive: Archive):
         """Delete config"""
-        await self.crawl_manager.delete_crawl_config_by_id(cid)
+        await self.crawl_manager.delete_crawl_config_by_id(str(cid))
 
         return await self.crawl_configs.delete_one({"_id": cid, "aid": archive.id})
 
     async def delete_crawl_configs(self, archive: Archive):
         """Delete all crawl configs for user"""
-        await self.crawl_manager.delete_crawl_configs_for_archive(archive.id)
+        await self.crawl_manager.delete_crawl_configs_for_archive(str(archive.id))
 
         return await self.crawl_configs.delete_many({"aid": archive.id})
 
@@ -312,7 +312,7 @@ def init_crawl_config_api(mdb, user_dep, archive_ops, crawl_manager):
 
         success = False
         try:
-            success = await ops.update_crawl_schedule(uuid.UUID(cid), update)
+            success = await ops.update_crawl_schedule(cid, update)
 
         except Exception as e:
             # pylint: disable=raise-missing-from
@@ -342,7 +342,7 @@ def init_crawl_config_api(mdb, user_dep, archive_ops, crawl_manager):
 
         crawl_id = None
         try:
-            crawl_id = await crawl_manager.run_crawl_config(cid, user.id)
+            crawl_id = await crawl_manager.run_crawl_config(cid, str(user.id))
         except Exception as e:
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=500, detail=f"Error starting crawl: {e}")

--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -255,17 +255,17 @@ class CrawlOps:
         res = await self.crawl_configs.find_one({"_id": cid, "aid": archive.id})
         return CrawlConfig.from_dict(res)
 
-    async def delete_crawl_config(self, cid: uuid.UUID, archive: Archive):
+    async def delete_crawl_config(self, cid: str, archive: Archive):
         """Delete config"""
-        await self.crawl_manager.delete_crawl_config_by_id(str(cid))
+        await self.crawl_manager.delete_crawl_config_by_id(cid)
 
         return await self.crawl_configs.delete_one({"_id": cid, "aid": archive.id})
 
-    async def delete_crawl_configs(self, archive: Archive):
-        """Delete all crawl configs for user"""
-        await self.crawl_manager.delete_crawl_configs_for_archive(str(archive.id))
+    # async def delete_crawl_configs(self, archive: Archive):
+    #    """Delete all crawl configs for user"""
+    #    await self.crawl_manager.delete_crawl_configs_for_archive(archive.id_str)
 
-        return await self.crawl_configs.delete_many({"aid": archive.id})
+    #    return await self.crawl_configs.delete_many({"aid": archive.id})
 
 
 # ============================================================================
@@ -358,7 +358,7 @@ def init_crawl_config_api(mdb, user_dep, archive_ops, crawl_manager):
     async def delete_crawl_config(
         cid: str, archive: Archive = Depends(archive_crawl_dep)
     ):
-        result = await ops.delete_crawl_config(uuid.UUID(cid), archive)
+        result = await ops.delete_crawl_config(cid, archive)
         if not result or not result.deleted_count:
             raise HTTPException(
                 status_code=404, detail=f"Crawl Config '{cid}' Not Found"

--- a/backend/db.py
+++ b/backend/db.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import motor.motor_asyncio
 
-from pydantic import BaseModel
+from pydantic import BaseModel, UUID4
 
 
 DATABASE_URL = (
@@ -31,14 +31,14 @@ def init_db():
 class BaseMongoModel(BaseModel):
     """Base pydantic model that is also a mongo doc"""
 
-    id: Optional[str]
+    id: Optional[UUID4]
 
     @classmethod
     def from_dict(cls, data):
         """convert dict from mongo to an Archive"""
         if not data:
             return None
-        data["id"] = str(data.pop("_id"))
+        data["id"] = data.pop("_id")
         return cls(**data)
 
     def serialize(self, **opts):

--- a/backend/db.py
+++ b/backend/db.py
@@ -33,7 +33,6 @@ class BaseMongoModel(BaseModel):
 
     id: Optional[UUID4]
 
-
     @property
     def id_str(self):
         """ Return id as str """

--- a/backend/db.py
+++ b/backend/db.py
@@ -33,6 +33,12 @@ class BaseMongoModel(BaseModel):
 
     id: Optional[UUID4]
 
+
+    @property
+    def id_str(self):
+        """ Return id as str """
+        return str(self.id)
+
     @classmethod
     def from_dict(cls, data):
         """convert dict from mongo to an Archive"""

--- a/backend/dockerman.py
+++ b/backend/dockerman.py
@@ -160,14 +160,14 @@ class DockerManager:
         # if default, ensure name is in default storages list
         return self.storages[storage_name]
 
-    async def update_archive_storage(self, aid, uid, storage):
+    async def update_archive_storage(self, aid, userid, storage):
         """ No storage kept for docker manager """
 
     async def add_crawl_config(self, crawlconfig, storage, run_now):
         """ Add new crawl config """
         cid = str(crawlconfig.id)
-        userid = str(crawlconfig.user)
-        aid = str(crawlconfig.archive)
+        userid = str(crawlconfig.userid)
+        aid = str(crawlconfig.aid)
 
         labels = {
             "btrix.user": userid,
@@ -267,7 +267,7 @@ class DockerManager:
 
         return result
 
-    async def run_crawl_config(self, cid, manual=True, schedule="", uid=None):
+    async def run_crawl_config(self, cid, manual=True, schedule="", userid=None):
         """ Run crawl job for cron job based on specified crawlconfig id (cid) """
 
         if not manual:
@@ -284,8 +284,8 @@ class DockerManager:
         volume_data = await volume_obj.show()
 
         labels = volume_data["Labels"]
-        if uid:
-            labels["btrix.user"] = uid
+        if userid:
+            labels["btrix.user"] = userid
 
         archive = None
         storage = None
@@ -389,7 +389,7 @@ class DockerManager:
         await self.client.volumes.create({"Name": name, "Labels": labels})
 
         await self._add_config_to_volume(
-            name, "crawl-config.json", crawlconfig.config.dict()
+            name, "crawl-config.json", crawlconfig.get_raw_config()
         )
 
         return name

--- a/backend/dockerman.py
+++ b/backend/dockerman.py
@@ -538,7 +538,7 @@ class DockerManager:
         return crawl_cls(
             id=container["Id"],
             state=state,
-            user=labels["btrix.user"],
+            userid=labels["btrix.user"],
             aid=labels["btrix.archive"],
             cid=labels["btrix.crawlconfig"],
             schedule=labels["btrix.run.schedule"],

--- a/backend/invites.py
+++ b/backend/invites.py
@@ -78,7 +78,7 @@ class InviteOps:
             headers,
         )
 
-    async def get_valid_invite(self, invite_token: str, email):
+    async def get_valid_invite(self, invite_token: uuid.UUID, email):
         """ Retrieve a valid invite data from db, or throw if invalid"""
         invite_data = await self.invites.find_one({"_id": invite_token})
         if not invite_data:

--- a/backend/invites.py
+++ b/backend/invites.py
@@ -5,7 +5,7 @@ from enum import IntEnum
 from typing import Optional
 import uuid
 
-from pydantic import BaseModel
+from pydantic import BaseModel, UUID4
 from fastapi import HTTPException
 
 
@@ -27,7 +27,7 @@ class InvitePending(BaseMongoModel):
 
     created: datetime
     inviterEmail: str
-    aid: Optional[str]
+    aid: Optional[UUID4]
     role: Optional[UserRole] = UserRole.VIEWER
     email: Optional[str]
 

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -424,7 +424,7 @@ class K8SManager:
 
             result = self._make_crawl_for_job(job, "canceled", True)
         else:
-            result = True
+            result = self._make_crawl_for_job(job, "stopping", False)
 
         await self._delete_job(job_name)
 
@@ -493,7 +493,7 @@ class K8SManager:
             id=job.metadata.name,
             state=state,
             scale=job.spec.parallelism or 1,
-            user=job.metadata.labels["btrix.user"],
+            userid=job.metadata.labels["btrix.user"],
             aid=job.metadata.labels["btrix.archive"],
             cid=job.metadata.labels["btrix.crawlconfig"],
             # schedule=job.metadata.annotations.get("btrix.run.schedule", ""),

--- a/backend/main.py
+++ b/backend/main.py
@@ -74,6 +74,7 @@ def main():
         app,
         mdb,
         os.environ.get("REDIS_URL"),
+        user_manager,
         crawl_manager,
         crawl_config_ops,
         archive_ops,

--- a/backend/users.py
+++ b/backend/users.py
@@ -48,7 +48,7 @@ class UserCreateIn(models.CreateUpdateDictModel):
 
     name: Optional[str] = ""
 
-    inviteToken: Optional[str]
+    inviteToken: Optional[UUID4]
 
     newArchive: bool
     newArchiveName: Optional[str] = ""
@@ -62,7 +62,7 @@ class UserCreate(models.BaseUserCreate):
 
     name: Optional[str] = ""
 
-    inviteToken: Optional[str]
+    inviteToken: Optional[UUID4]
 
     newArchive: bool
     newArchiveName: Optional[str] = ""
@@ -324,7 +324,7 @@ def init_users_api(app, user_manager):
 
     @users_router.get("/invite/{token}", tags=["invites"])
     async def get_invite_info(token: str, email: str):
-        invite = await user_manager.invites.get_valid_invite(token, email)
+        invite = await user_manager.invites.get_valid_invite(uuid.UUID(token), email)
         return await user_manager.format_invite(invite)
 
     @users_router.get("/me/invite/{token}", tags=["invites"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build: ./frontend
     image: registry.digitalocean.com/btrix/webrecorder/browsertrix-frontend
     ports:
-      - 9870:80
+      - 9871:80
 
     depends_on:
       - backend


### PR DESCRIPTION
- update all mongo models to use UUID type as main '_id' (users continue to use 'id' as defined by fastapi-users)
- update all foreign doc references to use UUID instead of string
- api handlers convert str->uuid as needed
api fix:
- fix single crawl api, add CrawlOut response model
- fix collections api
- fix standalone-docker apis
- for manual job, set user to current user, overriding the setting from crawlconfig
- consistent naming: use userid for user uuid, aid for archive uuid
- support `stopping` state when waiting for crawl to stop, check stopped crawls first before checking running crawls