### PR TITLE
backend fixes: fix graceful stop + stats

### DIFF
--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -184,6 +184,8 @@ class CrawlOps:
         """Add finished crawl to db, increment archive usage.
         If crawl file provided, update and add file"""
         if crawl_file:
+            await self.get_redis_stats([crawl])
+
             crawl_update = {
                 "$set": crawl.to_dict(exclude={"files", "completions"}),
                 "$push": {"files": crawl_file.dict()},
@@ -204,10 +206,6 @@ class CrawlOps:
             except pymongo.errors.DuplicateKeyError:
                 # print(f"Crawl Already Added: {crawl.id} - {crawl.state}")
                 return False
-
-            if crawl.state == "stopping":
-                print("Stopping Crawl...", flush=True)
-                return True
 
         dura = int((crawl.finished - crawl.started).total_seconds())
 
@@ -334,18 +332,26 @@ class CrawlOps:
 
         def pairwise(iterable):
             val = iter(iterable)
-            return zip(val, val)
+            return zip(val, val, val)
 
         async with self.redis.pipeline(transaction=True) as pipe:
             for crawl in crawl_list:
                 key = crawl.id
                 pipe.llen(f"{key}:d")
                 pipe.scard(f"{key}:s")
+                pipe.get(f"{key}:stop")
 
             results = await pipe.execute()
 
-        for crawl, (done, total) in zip(crawl_list, pairwise(results)):
+        for crawl, (done, total, stopping) in zip(crawl_list, pairwise(results)):
+            if stopping:
+                crawl.state = "stopping"
+
             crawl.stats = {"done": done, "found": total}
+
+    async def mark_stopping(self, crawl_id):
+        """ Mark crawl as in process of stopping in redis """
+        await self.redis.setex(f"{crawl_id}:stop", 600, 1)
 
     async def delete_crawls(self, aid: uuid.UUID, delete_list: DeleteCrawlList):
         """ Delete a list of crawls by id for given archive """
@@ -401,9 +407,9 @@ def init_crawls_api(
     async def crawl_graceful_stop(
         crawl_id, archive: Archive = Depends(archive_crawl_dep)
     ):
-        crawl = None
+        stopping = False
         try:
-            crawl = await crawl_manager.stop_crawl(
+            stopping = await crawl_manager.stop_crawl(
                 crawl_id, archive.id_str, graceful=True
             )
 
@@ -411,12 +417,12 @@ def init_crawls_api(
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=400, detail=f"Error Stopping Crawl: {exc}")
 
-        if not crawl:
+        if not stopping:
             raise HTTPException(status_code=404, detail=f"Crawl not found: {crawl_id}")
 
-        await ops.store_crawl(crawl)
+        await ops.mark_stopping(crawl_id)
 
-        return {"stopped_gracefully": True}
+        return {"stopping_gracefully": True}
 
     @app.post("/archives/{aid}/crawls/delete", tags=["crawls"])
     async def delete_crawls(

--- a/backend/dockerman.py
+++ b/backend/dockerman.py
@@ -234,7 +234,7 @@ class DockerManager:
         running = []
 
         for container in containers:
-            crawl = await self.get_running_crawl(container["Id"], aid)
+            crawl = await self.get_running_crawl(container["Id"][:12], aid)
             if crawl:
                 running.append(crawl)
 
@@ -502,7 +502,7 @@ class DockerManager:
         }
 
         container = await self.client.containers.run(run_config)
-        return container["id"]
+        return container["id"][:12]
 
     async def _list_running_containers(self, labels):
         results = await self.client.containers.list(
@@ -536,7 +536,7 @@ class DockerManager:
         labels = container["Config"]["Labels"]
 
         return crawl_cls(
-            id=container["Id"],
+            id=container["Id"][:12],
             state=state,
             userid=labels["btrix.user"],
             aid=labels["btrix.archive"],

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -424,7 +424,7 @@ class K8SManager:
 
             result = self._make_crawl_for_job(job, "canceled", True)
         else:
-            result = self._make_crawl_for_job(job, "stopping", False)
+            result = True
 
         await self._delete_job(job_name)
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -21,9 +21,9 @@ data:
 
   REDIS_CRAWLS_DONE_KEY: "crawls-done"
 
-  NO_DELETE_JOBS: "{{ .Values.no_delete_jobs | default '0' }}"
+  NO_DELETE_JOBS: "{{ .Values.no_delete_jobs | default 0 }}"
 
-  REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default '0' }}"
+  REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default 0 }}"
 
   JWT_TOKEN_LIFETIME_MINUTES: "{{ .Values.jwt_token_lifetime_minutes | default 60 }}"
 


### PR DESCRIPTION
- use redis to track stopping state, to be overwritten when finished
- also include stats in completed crawls
- docker: use short container id for crawl id
- graceful stop returns 'stopping_gracefully' instead of 'stopped_gracefully'