### PR TITLE
replay route: (prepare for replay, #124)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ supports docker and kubernetes based deployments of multiple browsertrix-crawler
 
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 
 from db import init_db
 
@@ -93,6 +93,13 @@ def main():
     @app.get("/healthz")
     async def healthz():
         return {}
+
+    @app.get("/replay/sw.js")
+    async def replay_sw():
+        return Response(
+            content='importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.5.7/sw.js");',
+            media_type="application/javascript",
+        )
 
 
 # ============================================================================

--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -50,7 +50,7 @@ spec:
 
           env:
             - name: BACKEND_HOST
-              value: {{ .Values.name }}-frontend
+              value: {{ .Values.name }}-backend
 
             - name: BROWSER_SCREENCAST_URL
               value: http://$2.crawlers.svc.cluster.local:9037

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -53,6 +53,12 @@ server {
       index  index.html index.htm;
     }
 
+    location /replay/ {
+      proxy_pass http://${BACKEND_HOST}:8000;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # used by docker only: k8s deployment handles /api directly via ingress
     location /api/ {
       proxy_pass http://${BACKEND_HOST}:8000/;


### PR DESCRIPTION
- add support for /replay/sw.js
- ensure route works in both k8s and docker (routed via main nginx)