### PR TITLE
Fix "View crawl" links

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -417,7 +417,7 @@ export class CrawlTemplatesDetail extends LiteElement {
             this.crawlTemplate!.name
           }</strong>. <br /><a class="underline hover:no-underline" href="/archives/${
             this.archiveId
-          }/crawls/crawl/${data.run_now_job}">View crawl</a>`
+          }/crawls/crawl/${data.started}">View crawl</a>`
         ),
         type: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -415,7 +415,7 @@ export class CrawlTemplatesList extends LiteElement {
 
       this.notify({
         message: msg(
-          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.run_now_job}">View crawl</a>`
+          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.started}">View crawl</a>`
         ),
         type: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -541,7 +541,7 @@ export class CrawlTemplatesNew extends LiteElement {
       );
 
       this.notify({
-        message: data.started
+        message: data.run_now_job
           ? msg(
               str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.started}">View crawl</a>`
             )

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -541,9 +541,9 @@ export class CrawlTemplatesNew extends LiteElement {
       );
 
       this.notify({
-        message: data.run_now_job
+        message: data.started
           ? msg(
-              str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.run_now_job}">View crawl</a>`
+              str`Crawl running with new template. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.started}">View crawl</a>`
             )
           : msg("Crawl template created."),
         type: "success",

--- a/frontend/src/pages/archive/crawl-templates.ts
+++ b/frontend/src/pages/archive/crawl-templates.ts
@@ -155,7 +155,7 @@ export class CrawlTemplatesList extends LiteElement {
 
       this.notify({
         message: msg(
-          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.run_now_job}">View crawl</a>`
+          str`Started crawl from <strong>${template.name}</strong>. <br /><a class="underline hover:no-underline" href="/archives/${this.archiveId}/crawls/crawl/${data.started}">View crawl</a>`
         ),
         type: "success",
         icon: "check2-circle",


### PR DESCRIPTION
Fixes "View crawl" links by using correct ID in `/run` response

### Manual testing
- Click "Run now" from crawl template list, click "View crawl" link in notification. Verify you're redirected to the crawl.
- Create a new config and keep "Run immediately" checked, click "View crawl" link in notification and verify.