### PR TITLE
Enable frontend exception tracking

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
 API_BASE_URL=https://btrix.webrecorder.net/api
+GLITCHTIP_DSN=

--- a/frontend/sample.env.local
+++ b/frontend/sample.env.local
@@ -1,1 +1,2 @@
 API_BASE_URL=https://btrix-dev.webrecorder.net/api
+GLITCHTIP_DSN=

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -25,7 +25,8 @@
           dsn: dsn,
           release: "<%= commit_hash %>",
           environment: "<%= environment %>",
-          autoSessionTracking: false
+          debug: "<%= environment %>" === "development",
+          autoSessionTracking: false, // Turn off unsupported page/session tracking
         });
       }
     </script>

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -9,8 +9,24 @@
     <title>Browsertrix Cloud</title>
     <base href="/" />
     <script defer src="<%= rwp_base_url %>ui.js"></script>
+    <script
+      src="https://unpkg.com/@sentry/browser@latest/build/bundle.min.js"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <browsertrix-app></browsertrix-app>
+
+    <script>
+      const dsn = "<%= glitchtip_dsn %>"
+
+      if (dsn) {
+        Sentry.init({
+          dsn: dsn,
+          release: "<%= commit_hash %>",
+          environment: "<%= environment %>"
+        });
+      }
+    </script>
   </body>
 </html>

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -24,7 +24,8 @@
         Sentry.init({
           dsn: dsn,
           release: "<%= commit_hash %>",
-          environment: "<%= environment %>"
+          environment: "<%= environment %>",
+          autoSessionTracking: false
         });
       }
     </script>

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -4,6 +4,7 @@ const ESLintPlugin = require("eslint-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const Dotenv = require("dotenv-webpack");
+const childProcess = require("child_process");
 
 const isDevServer = process.env.WEBPACK_SERVE;
 
@@ -14,6 +15,16 @@ const dotEnvPath = path.resolve(
   process.cwd(),
   `.env${isDevServer ? `.local` : ""}`
 );
+// Get git info to use as Glitchtip release version
+
+const gitBranch = childProcess
+  .execSync("git rev-parse --abbrev-ref HEAD")
+  .toString()
+  .trim();
+const commitHash = childProcess
+  .execSync("git rev-parse --short HEAD")
+  .toString()
+  .trim();
 
 require("dotenv").config({
   path: dotEnvPath,
@@ -107,6 +118,9 @@ module.exports = {
       template: "src/index.ejs",
       templateParameters: {
         rwp_base_url: RWP_BASE_URL,
+        glitchtip_dsn: process.env.GLITCHTIP_DSN || "",
+        environment: isDevServer ? "development" : "production",
+        commit_hash: `${gitBranch} (${commitHash})`,
       },
       // Need to block during local development for HMR:
       inject: isDevServer ? "head" : true,


### PR DESCRIPTION
Adds exception tracking to debug issues like https://github.com/webrecorder/browsertrix-cloud/issues/101

### Setup
1. Copy DSN from https://app.glitchtip.com/webrecorder/settings/projects/browsertrix-cloud
2. Add as `GLITCHTIP_DSN` to `.env.local` and run app
3. Try manually throwing an exception in the code. You should see it reported in https://app.glitchtip.com/webrecorder/issues

### Screenshots

Example error as reported in GlitchTip UI:

<img width="933" alt="Screen Shot 2022-02-15 at 12 59 05 PM" src="https://user-images.githubusercontent.com/4672952/154148195-d725d7b9-518c-4f18-97a4-b993bf4bd220.png">


### Opinions

Trying out [GlitchTip](https://glitchtip.com/), which is an open-source fork of [Sentry](https://sentry.io/welcome/). @ikreymer I sent you an invite to join the project on GlitchTip as an admin.

You may need to disable adblockers when running the frontend in order for the errors to report.