### PR TITLE
Crawl Config Editing Support

### DIFF
--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -87,7 +87,7 @@ class CrawlConfigIn(BaseModel):
     crawlTimeout: Optional[int] = 0
     parallel: Optional[int] = 1
 
-    oldId: Optional[str] = ""
+    oldId: Optional[UUID4]
 
 
 # ============================================================================
@@ -199,7 +199,7 @@ class CrawlConfigOps:
         old_id = data.get("oldId")
 
         if old_id:
-            old_config = await self.get_crawl_config(uuid.UUID(old_id), archive)
+            old_config = await self.get_crawl_config(old_id, archive)
             async with await self.dbclient.start_session() as sesh:
                 async with sesh.start_transaction():
                     await self.make_inactive(old_config, data["_id"])

--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -228,7 +228,9 @@ class CrawlOps:
 
         await self.archives.inc_usage(crawl.aid, dura)
 
-        await self.crawl_configs.inc_crawls(crawl.cid, crawl.id, crawl.finished)
+        await self.crawl_configs.inc_crawls(
+            crawl.cid, crawl.id, crawl.finished, crawl.state
+        )
 
         return True
 

--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -340,7 +340,9 @@ class CrawlOps:
         self, crawl: Union[CrawlOut, ListCrawlOut], archive: Archive
     ):
         """ Resolve running crawl data """
-        config = await self.crawl_configs.get_crawl_config(crawl.cid, archive)
+        config = await self.crawl_configs.get_crawl_config(
+            crawl.cid, archive, active_only=False
+        )
 
         if config:
             crawl.configName = config.name

--- a/backend/db.py
+++ b/backend/db.py
@@ -24,7 +24,7 @@ def init_db():
 
     mdb = client["browsertrixcloud"]
 
-    return mdb
+    return client, mdb
 
 
 # ============================================================================

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,7 +30,7 @@ def main():
     email = EmailSender()
     crawl_manager = None
 
-    mdb = init_db()
+    dbclient, mdb = init_db()
 
     settings = {
         "registrationEnabled": os.environ.get("REGISTRATION_ENABLED") == "1",
@@ -64,6 +64,7 @@ def main():
     init_storages_api(archive_ops, crawl_manager, current_active_user)
 
     crawl_config_ops = init_crawl_config_api(
+        dbclient,
         mdb,
         current_active_user,
         user_manager,


### PR DESCRIPTION
Backend support for #137:
- Crawl Configs are only deleted if no crawls have been run, otherwise they are marked as 'inactive'
- Crawl Configs that have a running crawl can not be deleted or marked as inactive.
- Add `inactive`, `oldId` and `newId` fields to crawl configs data model.
- When creating a new config, can pass in an `oldId`, which causes the old config to be marked as inactive, and linked to the new config (via its `newId` field). The new config should replace the old config (though it can have a different name).
- Add a PATCH crawl config endpoint, which allows updating the `schedule` as well as the `name` (to replace the old schedule update only endpoint)
- Support for #98 - the crawl config also stores a `lastCrawlState` which indicates status of last crawl, eg. `completed`, `failed`, etc...