### PR TITLE
Deactivate crawl templates in UI

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -80,7 +80,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       ${this.renderCurrentlyRunningNotice()}
 
       <section class="px-4 py-3 border-t border-b mb-4 text-sm">
-        <dl class="grid grid-cols-2">
+        <dl class="grid grid-cols-3">
           <div>
             <dt class="text-xs text-0-600">${msg("Created at")}</dt>
             <dd class="h-5">
@@ -228,39 +228,43 @@ export class CrawlTemplatesDetail extends LiteElement {
                   : this.renderReadOnlySchedule()}
               </div>
 
-              <div class="ml-2">
-                ${this.crawlTemplate
-                  ? html`
-                      <sl-button
-                        size="small"
-                        href=${`/archives/${
-                          this.archiveId
-                        }/crawl-templates/config/${this.crawlTemplate.id}${
-                          this.isEditing ? "" : "?edit=true"
-                        }`}
-                        @click=${(e: any) => {
-                          const hasChanges =
-                            this.isEditing && this.editedSchedule;
-                          if (
-                            !hasChanges ||
-                            window.confirm(
-                              msg(
-                                "You have unsaved schedule changes. Are you sure?"
-                              )
-                            )
-                          ) {
-                            this.navLink(e);
-                            this.editedSchedule = "";
-                          } else {
-                            e.preventDefault();
-                          }
-                        }}
-                      >
-                        ${this.isEditing ? msg("Cancel") : msg("Edit")}
-                      </sl-button>
-                    `
-                  : html`<sl-skeleton></sl-skeleton>`}
-              </div>
+              ${this.crawlTemplate?.inactive
+                ? ""
+                : html`
+                    <div class="ml-2">
+                      ${this.crawlTemplate
+                        ? html`
+                            <sl-button
+                              size="small"
+                              href=${`/archives/${
+                                this.archiveId
+                              }/crawl-templates/config/${
+                                this.crawlTemplate.id
+                              }${this.isEditing ? "" : "?edit=true"}`}
+                              @click=${(e: any) => {
+                                const hasChanges =
+                                  this.isEditing && this.editedSchedule;
+                                if (
+                                  !hasChanges ||
+                                  window.confirm(
+                                    msg(
+                                      "You have unsaved schedule changes. Are you sure?"
+                                    )
+                                  )
+                                ) {
+                                  this.navLink(e);
+                                  this.editedSchedule = "";
+                                } else {
+                                  e.preventDefault();
+                                }
+                              }}
+                            >
+                              ${this.isEditing ? msg("Cancel") : msg("Edit")}
+                            </sl-button>
+                          `
+                        : html`<sl-skeleton></sl-skeleton>`}
+                    </div>
+                  `}
             </div>
           </div>
         </section>
@@ -293,6 +297,8 @@ export class CrawlTemplatesDetail extends LiteElement {
                               @click=${this.navLink}
                               >${msg("View crawl")}</a
                             >`
+                          : this.crawlTemplate.inactive
+                          ? ""
                           : html`<span class="text-0-400 text-sm p-1"
                                 >${msg("None")}</span
                               ><button

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -4,7 +4,6 @@ import cronstrue from "cronstrue"; // TODO localize
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-import { getLocaleTimeZone } from "../../utils/localization";
 import type { CrawlTemplate } from "./types";
 import { getUTCSchedule } from "./utils";
 import "../../components/crawl-scheduler";
@@ -72,6 +71,8 @@ export class CrawlTemplatesDetail extends LiteElement {
         </a>
       </nav>
 
+      ${this.renderInactiveNotice()}
+
       <h2 class="text-xl font-bold mb-4 h-7">
         ${this.crawlTemplate?.name ||
         html`<sl-skeleton class="h-7" style="width: 20em"></sl-skeleton>`}
@@ -80,7 +81,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       ${this.renderCurrentlyRunningNotice()}
 
       <section class="px-4 py-3 border-t border-b mb-4 text-sm">
-        <dl class="grid grid-cols-3">
+        <dl class="grid grid-cols-2">
           <div>
             <dt class="text-xs text-0-600">${msg("Created at")}</dt>
             <dd class="h-5">
@@ -346,6 +347,26 @@ export class CrawlTemplatesDetail extends LiteElement {
         </section>
       </main>
     `;
+  }
+
+  private renderInactiveNotice() {
+    if (this.crawlTemplate?.inactive) {
+      return html`
+        <div class="mb-5">
+          <btrix-alert type="warning">
+            <sl-icon
+              name="exclamation-octagon"
+              class="inline-block align-middle mr-2"
+            ></sl-icon>
+            <span class="inline-block align-middle">
+              ${msg("This crawl template is inactive.")}
+            </span>
+          </btrix-alert>
+        </div>
+      `;
+    }
+
+    return "";
   }
 
   private renderCurrentlyRunningNotice() {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -1,3 +1,4 @@
+import type { HTMLTemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import cronParser from "cron-parser";
@@ -111,66 +112,7 @@ export class CrawlTemplatesList extends LiteElement {
                   ${t.name || "?"}
                 </a>
 
-                <sl-dropdown @click=${(e: any) => e.stopPropagation()}>
-                  <sl-icon-button
-                    slot="trigger"
-                    name="three-dots-vertical"
-                    label="More"
-                    style="font-size: 1rem"
-                  ></sl-icon-button>
-
-                  <ul class="text-sm text-0-800 whitespace-nowrap" role="menu">
-                    <li
-                      class="p-2 hover:bg-zinc-100 cursor-pointer"
-                      role="menuitem"
-                      @click=${(e: any) => {
-                        e.target.closest("sl-dropdown").hide();
-                        this.showEditDialog = true;
-                        this.selectedTemplateForEdit = t;
-                      }}
-                    >
-                      <sl-icon
-                        class="inline-block align-middle px-1"
-                        name="pencil-square"
-                      ></sl-icon>
-                      <span class="inline-block align-middle pr-2"
-                        >${msg("Edit crawl schedule")}</span
-                      >
-                    </li>
-
-                    <li
-                      class="p-2 hover:bg-zinc-100 cursor-pointer"
-                      role="menuitem"
-                      @click=${() => this.duplicateConfig(t)}
-                    >
-                      <sl-icon
-                        class="inline-block align-middle px-1"
-                        name="files"
-                      ></sl-icon>
-                      <span class="inline-block align-middle pr-2"
-                        >${msg("Duplicate crawl config")}</span
-                      >
-                    </li>
-                    <li
-                      class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
-                      role="menuitem"
-                      @click=${(e: any) => {
-                        // Close dropdown before deleting template
-                        e.target.closest("sl-dropdown").hide();
-
-                        this.deleteTemplate(t);
-                      }}
-                    >
-                      <sl-icon
-                        class="inline-block align-middle px-1"
-                        name="file-earmark-x"
-                      ></sl-icon>
-                      <span class="inline-block align-middle pr-2"
-                        >${msg("Delete")}</span
-                      >
-                    </li>
-                  </ul>
-                </sl-dropdown>
+                ${this.renderCardMenu(t)}
               </header>
 
               <div class="px-3 pb-3 flex justify-between items-end text-0-800">
@@ -276,30 +218,7 @@ export class CrawlTemplatesList extends LiteElement {
                           >`}
                   </div>
                 </div>
-                <div>
-                  <button
-                    class="text-xs border rounded px-2 h-7 ${this
-                      .runningCrawlsMap[t.id]
-                      ? "bg-purple-50"
-                      : "bg-white"} border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"
-                    @click=${(e: any) => {
-                      e.stopPropagation();
-                      this.runningCrawlsMap[t.id]
-                        ? this.navTo(
-                            `/archives/${this.archiveId}/crawls/crawl/${
-                              this.runningCrawlsMap[t.id]
-                            }`
-                          )
-                        : this.runNow(t);
-                    }}
-                  >
-                    <span class="whitespace-nowrap">
-                      ${this.runningCrawlsMap[t.id]
-                        ? msg("View crawl")
-                        : msg("Run now")}
-                    </span>
-                  </button>
-                </div>
+                ${this.renderCardFooter(t)}
               </div>
             </div>`
         )}
@@ -324,6 +243,137 @@ export class CrawlTemplatesList extends LiteElement {
             `
           : ""}
       </sl-dialog>
+    `;
+  }
+
+  renderCardMenu(t: CrawlTemplate) {
+    const menuItems: HTMLTemplateResult[] = [
+      html`
+        <li
+          class="p-2 hover:bg-zinc-100 cursor-pointer"
+          role="menuitem"
+          @click=${() => this.duplicateConfig(t)}
+        >
+          <sl-icon
+            class="inline-block align-middle px-1"
+            name="files"
+          ></sl-icon>
+          <span class="inline-block align-middle pr-2"
+            >${msg("Duplicate crawl config")}</span
+          >
+        </li>
+      `,
+    ];
+
+    if (!t.inactive) {
+      menuItems.unshift(html`
+        <li
+          class="p-2 hover:bg-zinc-100 cursor-pointer"
+          role="menuitem"
+          @click=${(e: any) => {
+            e.target.closest("sl-dropdown").hide();
+            this.showEditDialog = true;
+            this.selectedTemplateForEdit = t;
+          }}
+        >
+          <sl-icon
+            class="inline-block align-middle px-1"
+            name="pencil-square"
+          ></sl-icon>
+          <span class="inline-block align-middle pr-2"
+            >${msg("Edit crawl schedule")}</span
+          >
+        </li>
+      `);
+    }
+
+    if (t.crawlCount && !t.inactive) {
+      menuItems.push(html`
+        <li
+          class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+          role="menuitem"
+          @click=${(e: any) => {
+            // Close dropdown before deleting template
+            e.target.closest("sl-dropdown").hide();
+
+            this.deleteTemplate(t);
+          }}
+        >
+          <sl-icon
+            class="inline-block align-middle px-1"
+            name="file-earmark-minus"
+          ></sl-icon>
+          <span class="inline-block align-middle pr-2"
+            >${msg("Deactivate")}</span
+          >
+        </li>
+      `);
+    }
+
+    if (!t.crawlCount) {
+      menuItems.push(html`
+        <li
+          class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+          role="menuitem"
+          @click=${(e: any) => {
+            // Close dropdown before deleting template
+            e.target.closest("sl-dropdown").hide();
+
+            this.deleteTemplate(t);
+          }}
+        >
+          <sl-icon
+            class="inline-block align-middle px-1"
+            name="file-earmark-x"
+          ></sl-icon>
+          <span class="inline-block align-middle pr-2">${msg("Delete")}</span>
+        </li>
+      `);
+    }
+
+    return html`
+      <sl-dropdown @click=${(e: any) => e.stopPropagation()}>
+        <sl-icon-button
+          slot="trigger"
+          name="three-dots-vertical"
+          label="More"
+          style="font-size: 1rem"
+        ></sl-icon-button>
+
+        <ul class="text-sm text-0-800 whitespace-nowrap" role="menu">
+          ${menuItems.map((item: HTMLTemplateResult) => item)}
+        </ul>
+      </sl-dropdown>
+    `;
+  }
+
+  renderCardFooter(t: CrawlTemplate) {
+    if (t.inactive) {
+      return "";
+    }
+
+    return html`
+      <div>
+        <button
+          class="text-xs border rounded px-2 h-7 ${this.runningCrawlsMap[t.id]
+            ? "bg-purple-50"
+            : "bg-white"} border-purple-200 hover:border-purple-500 text-purple-600 transition-colors"
+          @click=${(e: any) => {
+            e.stopPropagation();
+            this.runningCrawlsMap[t.id]
+              ? this.navTo(
+                  `/archives/${this.archiveId}/crawls/crawl/${
+                    this.runningCrawlsMap[t.id]
+                  }`
+                )
+              : this.runNow(t);
+          }}
+        >
+          <span class="whitespace-nowrap">
+            ${this.runningCrawlsMap[t.id] ? msg("View crawl") : msg("Run now")}
+          </span>
+        </button>
+      </div>
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -246,7 +246,7 @@ export class CrawlTemplatesList extends LiteElement {
     `;
   }
 
-  renderCardMenu(t: CrawlTemplate) {
+  private renderCardMenu(t: CrawlTemplate) {
     const menuItems: HTMLTemplateResult[] = [
       html`
         <li
@@ -347,7 +347,7 @@ export class CrawlTemplatesList extends LiteElement {
     `;
   }
 
-  renderCardFooter(t: CrawlTemplate) {
+  private renderCardFooter(t: CrawlTemplate) {
     if (t.inactive) {
       return "";
     }

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -296,7 +296,7 @@ export class CrawlTemplatesList extends LiteElement {
             // Close dropdown before deleting template
             e.target.closest("sl-dropdown").hide();
 
-            this.deleteTemplate(t);
+            this.deactivateTemplate(t);
           }}
         >
           <sl-icon
@@ -336,7 +336,7 @@ export class CrawlTemplatesList extends LiteElement {
         <sl-icon-button
           slot="trigger"
           name="three-dots-vertical"
-          label="More"
+          label=${msg("More")}
           style="font-size: 1rem"
         ></sl-icon-button>
 
@@ -422,6 +422,34 @@ export class CrawlTemplatesList extends LiteElement {
       type: "success",
       icon: "check2-circle",
     });
+  }
+
+  private async deactivateTemplate(template: CrawlTemplate): Promise<void> {
+    try {
+      await this.apiFetch(
+        `/archives/${this.archiveId}/crawlconfigs/${template.id}`,
+        this.authState!,
+        {
+          method: "DELETE",
+        }
+      );
+
+      this.notify({
+        message: msg(html`Deactivated <strong>${template.name}</strong>.`),
+        type: "success",
+        icon: "check2-circle",
+      });
+
+      this.crawlTemplates = this.crawlTemplates!.filter(
+        (t) => t.id !== template.id
+      );
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't deactivate crawl template at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
   }
 
   private async deleteTemplate(template: CrawlTemplate): Promise<void> {

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -370,7 +370,7 @@ export class CrawlsList extends LiteElement {
           <sl-icon-button
             slot="trigger"
             name="three-dots"
-            label="More"
+            label=${msg("More")}
             style="font-size: 1rem"
           ></sl-icon-button>
 

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -11,7 +11,7 @@ export type Crawl = {
   state: string; // "running" | "complete" | "failed" | "partial_complete"
   scale: number;
   stats: { done: string; found: string } | null;
-  resources?: { name: string; path: string, hash: string; size: number }[];
+  resources?: { name: string; path: string; hash: string; size: number }[];
   fileCount?: number;
   fileSize?: number;
   completions?: number;
@@ -32,11 +32,14 @@ export type CrawlTemplate = {
   name: string;
   schedule: string;
   userid: string;
-  userName?: string;
+  userName: string | null;
   created: string;
   crawlCount: number;
   lastCrawlId: string;
   lastCrawlTime: string;
   currCrawlId: string;
+  newId: string | null;
+  oldId: string | null;
+  inactive: boolean;
   config: CrawlConfig;
 };


### PR DESCRIPTION
WIP https://github.com/webrecorder/browsertrix-cloud/issues/144

- Differentiate between "deactivate" and "delete"
- Show "Inactive" banner for inactive crawl templates

### Manual testing
1. Run app and go to crawl templates -> new
2. Create a crawl template with "run now" disabled
3. Click "..." more icon in crawl template detail view. Verify that menu item reads "Delete"
4. Delete template. Verify you're redirected to list view, and clicking back will show an error.
4. Go back to crawl templates list and view details for a template with crawls
5. Click "..." more icon in crawl template detail view. Verify that menu item reads "Deactivate"
6. Deactivate template. Verify you're redirected to list view
7. Go back. Verify that you see a "This crawl template is inactive" banner
8. Click "..." more icon in crawl template detail view. Verify that you can still duplicate the inactive crawl template

### Screenshots
<img width="523" alt="Screen Shot 2022-02-18 at 6 16 44 PM" src="https://user-images.githubusercontent.com/4672952/154783361-7b436fd9-8773-4359-929e-b721fd05cb73.png">

<img width="519" alt="Screen Shot 2022-02-18 at 6 16 47 PM" src="https://user-images.githubusercontent.com/4672952/154783364-d10451ee-9918-4747-9b2b-6d43fad005a9.png">

<img width="1035" alt="Screen Shot 2022-02-19 at 5 57 13 PM" src="https://user-images.githubusercontent.com/4672952/154825420-c457dba6-2378-4c6e-93b1-8e2efa535107.png">

