### PR TITLE
Support for setting scale in crawlconfig

### DIFF
--- a/backend/archives.py
+++ b/backend/archives.py
@@ -16,6 +16,10 @@ from users import User
 from invites import InvitePending, InviteToArchiveRequest, UserRole
 
 
+# crawl scale for constraint
+MAX_CRAWL_SCALE = 3
+
+
 # ============================================================================
 class UpdateRole(InviteToArchiveRequest):
     """Update existing role for user"""

--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -13,13 +13,10 @@ from pydantic import BaseModel, UUID4, conint
 from fastapi import APIRouter, Depends, HTTPException
 
 from users import User
-from archives import Archive
+from archives import Archive, MAX_CRAWL_SCALE
 
 from db import BaseMongoModel
 
-
-# max crawl scale schema constraint
-MAX_SCALE = 3
 
 # ============================================================================
 class ScopeType(str, Enum):
@@ -88,7 +85,7 @@ class CrawlConfigIn(BaseModel):
     colls: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
-    scale: Optional[conint(ge=1, le=MAX_SCALE)]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
 
     oldId: Optional[UUID4]
 
@@ -108,7 +105,7 @@ class CrawlConfig(BaseMongoModel):
     colls: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
-    scale: Optional[conint(ge=1, le=MAX_SCALE)]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
 
     aid: UUID4
 
@@ -150,7 +147,7 @@ class UpdateCrawlConfig(BaseModel):
 
     name: Optional[str]
     schedule: Optional[str]
-    scale: Optional[conint(ge=1, le=MAX_SCALE)]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
 
 
 # ============================================================================

--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -85,7 +85,7 @@ class CrawlConfigIn(BaseModel):
     colls: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
-    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
 
     oldId: Optional[UUID4]
 
@@ -105,7 +105,7 @@ class CrawlConfig(BaseMongoModel):
     colls: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
-    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
 
     aid: UUID4
 

--- a/backend/crawlconfigs.py
+++ b/backend/crawlconfigs.py
@@ -9,7 +9,7 @@ import asyncio
 from datetime import datetime
 
 import pymongo
-from pydantic import BaseModel, UUID4
+from pydantic import BaseModel, UUID4, conint
 from fastapi import APIRouter, Depends, HTTPException
 
 from users import User
@@ -17,6 +17,9 @@ from archives import Archive
 
 from db import BaseMongoModel
 
+
+# max crawl scale schema constraint
+MAX_SCALE = 3
 
 # ============================================================================
 class ScopeType(str, Enum):
@@ -85,7 +88,7 @@ class CrawlConfigIn(BaseModel):
     colls: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
-    scale: Optional[int] = 1
+    scale: Optional[conint(ge=1, le=MAX_SCALE)]
 
     oldId: Optional[UUID4]
 
@@ -105,7 +108,7 @@ class CrawlConfig(BaseMongoModel):
     colls: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
-    scale: Optional[int] = 1
+    scale: Optional[conint(ge=1, le=MAX_SCALE)]
 
     aid: UUID4
 
@@ -147,7 +150,7 @@ class UpdateCrawlConfig(BaseModel):
 
     name: Optional[str]
     schedule: Optional[str]
-    scale: Optional[int]
+    scale: Optional[conint(ge=1, le=MAX_SCALE)]
 
 
 # ============================================================================
@@ -221,7 +224,7 @@ class CrawlConfigOps:
         """ Update name, scale and/or schedule for an existing crawl config """
 
         # set update query
-        query = update.dict(exclude_unset=True, exclude_default=True, exclude_none=True)
+        query = update.dict(exclude_unset=True, exclude_defaults=True, exclude_none=True)
 
         if len(query) == 0:
             raise HTTPException(status_code=400, detail="no_update_data")

--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -9,12 +9,12 @@ from typing import Optional, List, Dict, Union
 from datetime import datetime
 
 from fastapi import Depends, Request, HTTPException
-from pydantic import BaseModel, UUID4
+from pydantic import BaseModel, UUID4, conint
 import pymongo
 import aioredis
 
 from db import BaseMongoModel
-from archives import Archive
+from archives import Archive, MAX_CRAWL_SCALE
 from storages import get_presigned_url
 
 
@@ -29,7 +29,7 @@ class DeleteCrawlList(BaseModel):
 class CrawlScale(BaseModel):
     """ scale the crawl to N parallel containers """
 
-    scale: int = 1
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
 
 
 # ============================================================================
@@ -70,7 +70,7 @@ class Crawl(BaseMongoModel):
 
     state: str
 
-    scale: int = 1
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
     completions: Optional[int] = 0
 
     stats: Optional[Dict[str, str]]

--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -29,7 +29,7 @@ class DeleteCrawlList(BaseModel):
 class CrawlScale(BaseModel):
     """ scale the crawl to N parallel containers """
 
-    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
+    scale: conint(ge=1, le=MAX_CRAWL_SCALE) = 1
 
 
 # ============================================================================
@@ -70,7 +70,7 @@ class Crawl(BaseMongoModel):
 
     state: str
 
-    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
+    scale: conint(ge=1, le=MAX_CRAWL_SCALE) = 1
     completions: Optional[int] = 0
 
     stats: Optional[Dict[str, str]]

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -468,9 +468,6 @@ class K8SManager:
         if not job or job.metadata.labels["btrix.archive"] != aid:
             return "Invalid Crawled"
 
-        if parallelism < 1 or parallelism > 10:
-            return "Invalid Scale: Must be between 1 and 10"
-
         job.spec.parallelism = parallelism
 
         await self.batch_api.patch_namespaced_job(

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -201,7 +201,7 @@ class K8SManager:
             labels,
             annotations,
             crawlconfig.crawlTimeout,
-            crawlconfig.parallel,
+            crawlconfig.scale,
         )
 
         spec = client.V1beta1CronJobSpec(


### PR DESCRIPTION
The `scale` field can now be set in the crawl config, and also updated via `PATCH`. Value is currently constrained to 1-3.
Also add constraint to running crawl scaling.