### PR TITLE
docker image fix

### DIFF
--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker buildx build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg RWP_BASE_URL="https://replayweb.page/" --platform linux/amd64 --push -t registry.digitalocean.com/btrix/webrecorder/browsertrix-frontend ./frontend/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,13 @@ COPY yarn.lock .
 RUN yarn --frozen-lockfile
 COPY *.* ./
 COPY src ./src/
+
+ARG GIT_COMMIT_HASH
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
+
+ARG GIT_BRANCH_NAME
+ENV GIT_BRANCH_NAME=${GIT_BRANCH_NAME}
+
 RUN yarn build
 
 FROM nginx

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -17,11 +17,11 @@ const dotEnvPath = path.resolve(
 );
 // Get git info to use as Glitchtip release version
 
-const gitBranch = childProcess
+const gitBranch = process.env.GIT_BRANCH_NAME || childProcess
   .execSync("git rev-parse --abbrev-ref HEAD")
   .toString()
   .trim();
-const commitHash = childProcess
+const commitHash = process.env.GIT_COMMIT_HASH || childProcess
   .execSync("git rev-parse --short HEAD")
   .toString()
   .trim();

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -25,6 +25,8 @@ const execCommand = (cmd, defValue) => {
   }
 }
 
+// Local dev only
+// Git branch and commit hash is used to add build info to error reporter when running locally
 const gitBranch = process.env.GIT_BRANCH_NAME ||
   execCommand("git rev-parse --abbrev-ref HEAD", "unknown");
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -17,14 +17,19 @@ const dotEnvPath = path.resolve(
 );
 // Get git info to use as Glitchtip release version
 
-const gitBranch = process.env.GIT_BRANCH_NAME || childProcess
-  .execSync("git rev-parse --abbrev-ref HEAD")
-  .toString()
-  .trim();
-const commitHash = process.env.GIT_COMMIT_HASH || childProcess
-  .execSync("git rev-parse --short HEAD")
-  .toString()
-  .trim();
+const execCommand = (cmd, defValue) => {
+  try {
+    return childProcess.execSync(cmd).toString().trim();
+  } catch (e) {
+    return defValue;
+  }
+}
+
+const gitBranch = process.env.GIT_BRANCH_NAME ||
+  execCommand("git rev-parse --abbrev-ref HEAD", "unknown");
+
+const commitHash = process.env.GIT_COMMIT_HASH ||
+  execCommand("git rev-parse --short HEAD", "unknown");
 
 require("dotenv").config({
   path: dotEnvPath,


### PR DESCRIPTION
frontend docker build: pass GIT_COMMIT_HASH and GIT_BRANCH_NAME as env vars (for glitchtip id) to remove dependency on git in webpack.config.js when building docker image.
fixes #150

also add `./build-frontend.sh` to simplify building frontend image.