### PR TITLE
New WS Endpoint for Watching Crawl

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,5 @@ RUN pip install -r requirements.txt
 
 ADD . /app
 
-CMD uvicorn main:app --host 0.0.0.0 --root-path /api --reload --access-log --log-level debug
+CMD uvicorn main:app --host 0.0.0.0 --root-path /api --reload --access-log --log-level info
 

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -301,31 +301,6 @@ class K8SManager:
 
         return crawls
 
-    async def init_crawl_screencast(self, crawl_id, aid):
-        """ Init service for this job/crawl_id to support screencasting """
-        labels = {"btrix.archive": aid}
-
-        service = client.V1Service(
-            kind="Service",
-            api_version="v1",
-            metadata={
-                "name": crawl_id,
-                "labels": labels,
-            },
-            spec={
-                "selector": {"job-name": crawl_id},
-                "ports": [{"protocol": "TCP", "port": 9037, "name": "screencast"}],
-            },
-        )
-
-        try:
-            await self.core_api.create_namespaced_service(
-                body=service, namespace=self.namespace
-            )
-        except client.exceptions.ApiException as api_exc:
-            if api_exc.status != 409:
-                raise api_exc
-
     async def process_crawl_complete(self, crawlcomplete):
         """Ensure the crawlcomplete data is valid (job exists and user matches)
         Fill in additional details about the crawl"""
@@ -548,17 +523,6 @@ class K8SManager:
             grace_period_seconds=60,
             propagation_policy="Foreground",
         )
-
-        try:
-            await self.core_api.delete_namespaced_service(
-                name=name,
-                namespace=self.namespace,
-                grace_period_seconds=60,
-                propagation_policy="Foreground",
-            )
-        # pylint: disable=bare-except
-        except:
-            pass
 
     def _create_config_map(self, crawlconfig, labels):
         """ Create Config Map based on CrawlConfig + labels """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ apscheduler
 aioprocessing
 aiobotocore
 aioredis
+websockets

--- a/backend/users.py
+++ b/backend/users.py
@@ -266,18 +266,16 @@ class OA2BearerOrQuery(OAuth2PasswordBearer):
     ) -> Optional[str]:
         param = None
         exc = None
-        if request:
-            try:
-                param = await super().__call__(request)
-                if param:
-                    return param
+        # use websocket as request if no request
+        request = request or websocket
+        try:
+            param = await super().__call__(request)
+            if param:
+                return param
 
-            # pylint: disable=broad-except
-            except Exception as super_exc:
-                exc = super_exc
-        else:
-            # use websocket as query param
-            request = websocket
+        # pylint: disable=broad-except
+        except Exception as super_exc:
+            exc = super_exc
 
         param = request.query_params.get("auth_bearer")
 

--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -52,9 +52,6 @@ spec:
             - name: BACKEND_HOST
               value: {{ .Values.name }}-backend
 
-            - name: BROWSER_SCREENCAST_URL
-              value: http://$2.crawlers.svc.cluster.local:9037
-
           resources:
             limits:
               cpu: {{ .Values.nginx_limits_cpu }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,7 +96,7 @@ crawler_namespace: "crawlers"
 crawl_retries: 3
 
 # browsertrix-crawler args:
-crawler_args: "--timeout 90 --logging stats,behaviors,debug --generateWACZ --screencastPort 9037 --text --workers 2"
+crawler_args: "--timeout 90 --logging stats,behaviors,debug --generateWACZ --text --workers 2 --screencastRedis"
 
 crawler_requests_cpu: "800m"
 crawler_limits_cpu: "1200m"

--- a/configs/config.sample.env
+++ b/configs/config.sample.env
@@ -32,7 +32,7 @@ REDIS_URL=redis://redis/0
 # Browsertrix Crawler image to use
 CRAWLER_IMAGE=webrecorder/browsertrix-crawler
 
-CRAWL_ARGS="--timeout 90 --logging stats,behaviors,debug --generateWACZ --screencastPort 9037"
+CRAWL_ARGS="--timeout 90 --logging stats,behaviors,debug --generateWACZ --screencastRedis"
 
 REGISTRATION_ENABLED=1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
 
     environment:
       - BACKEND_HOST=backend
-      - BROWSER_SCREENCAST_URL=http://$$2:9037
 
   redis:
     image: redis

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -10,7 +10,7 @@ server {
     index index.html index.htm;
 
     error_page 500 501 502 503 504 /50x.html;
-    
+
     merge_slashes off;
     location = /50x.html {
         root /usr/share/nginx/html;
@@ -19,35 +19,6 @@ server {
     # fallback to index for any page
     error_page 404 /index.html;
   
-    location ~* /watch/([^/]+)/([^/]+)/ws {
-      set $archive $1;
-      set $crawl $2;
-      #auth_request  /authcheck;
-
-      proxy_pass ${BROWSER_SCREENCAST_URL}/ws;
-      proxy_set_header Host "localhost";
-
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $http_connection;
-    }
-
-    location ~* /watch/([^/]+)/([^/]+)/ {
-      set $archive $1;
-      set $crawl $2;
-      #auth_request  /authcheck;
-
-      proxy_pass ${BROWSER_SCREENCAST_URL}/;
-      proxy_set_header Host "localhost";
-    }
-
-    location = /authcheck {
-      internal;
-      proxy_pass http://localhost:8000/archives/$archive/crawls/$crawl;
-      proxy_pass_request_body off;
-      proxy_set_header Content-Length "";
-    }
-
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;


### PR DESCRIPTION
The watch endpoint is now handled via the backend itself, rather than proxying to a single running crawler image.
This should allow watching multiple browsers (workers) in a single image, as well as crawls scaled across multiple instances.
Using redis pubsub channels to communicate between crawler image and websocket connected to backend.
One channel is used to start/stop screencasting (messages sent from backend->crawler), and another is used to receive screencast data (crawler->backend)
Remove old screencasting logic and setup in nginx and backend.

The screencasting endpoint is at `/archives/{aid}/crawls/{crawl_id}/watch/ws`