### PR TITLE
Archive and crawl navigation improvements

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -44,11 +44,7 @@ export class App extends LiteElement {
   userInfo?: CurrentUser;
 
   @state()
-  private viewState!: ViewState & {
-    aid?: string;
-    // TODO common tab type
-    tab?: "running" | "finished" | "configs";
-  };
+  private viewState!: ViewState;
 
   @state()
   private globalDialogContent: DialogContent = {};
@@ -203,7 +199,7 @@ export class App extends LiteElement {
 
   renderNavBar() {
     return html`
-      <div class="bg-gray-900 text-gray-50">
+      <div class="border-b">
         <nav
           class="max-w-screen-lg mx-auto p-2 box-border flex items-center justify-between"
         >
@@ -214,7 +210,7 @@ export class App extends LiteElement {
           </div>
           <div class="grid grid-flow-col gap-5 items-center">
             ${this.authService.authState
-              ? html` <sl-dropdown>
+              ? html` <sl-dropdown placement="bottom-end">
                   <div class="p-2" role="button" slot="trigger">
                     ${this.userInfo?.name || this.userInfo?.email}
                     <span class="text-xs"
@@ -255,32 +251,6 @@ export class App extends LiteElement {
   }
 
   renderPage() {
-    const navLink = ({
-      activeRoutes,
-      href,
-      label,
-    }: {
-      activeRoutes: string[];
-      href: string;
-      label: string;
-    }) => html`
-      <li>
-        <a
-          class="block p-2 ${activeRoutes.includes(this.viewState.route!)
-            ? "text-primary"
-            : ""}"
-          href="${href}"
-          @click="${this.navLink}"
-          >${label}</a
-        >
-      </li>
-    `;
-    const appLayout = (template: TemplateResult) => html`
-      <div class="w-full max-w-screen-lg mx-auto p-2 md:py-8 box-border">
-        ${template}
-      </div>
-    `;
-
     switch (this.viewState.route) {
       case "signUp": {
         if (!this.isAppSettingsLoaded) {
@@ -365,13 +335,13 @@ export class App extends LiteElement {
         </div>`;
 
       case "archives":
-        return appLayout(html`<btrix-archives
-          class="w-full"
+        return html`<btrix-archives
+          class="w-full max-w-screen-lg mx-auto p-2 md:py-8 box-border"
           @navigate="${this.onNavigateTo}"
           @need-login="${this.onNeedLogin}"
           .authState="${this.authService.authState}"
           .userInfo="${this.userInfo}"
-        ></btrix-archives>`);
+        ></btrix-archives>`;
 
       case "archive":
       case "archiveAddMember":
@@ -379,7 +349,7 @@ export class App extends LiteElement {
       case "crawl":
       case "crawlTemplate":
       case "crawlTemplateEdit":
-        return appLayout(html`<btrix-archive
+        return html`<btrix-archive
           class="w-full"
           @navigate=${this.onNavigateTo}
           @need-login=${this.onNeedLogin}
@@ -394,37 +364,26 @@ export class App extends LiteElement {
           ?isAddingMember=${this.viewState.route === "archiveAddMember"}
           ?isNewResourceTab=${this.viewState.route === "archiveNewResourceTab"}
           ?isEditing=${Boolean(this.viewState.params.edit)}
-        ></btrix-archive>`);
+        ></btrix-archive>`;
 
       case "accountSettings":
-        return appLayout(html`<btrix-account-settings
-          class="w-full"
+        return html`<btrix-account-settings
+          class="w-full max-w-screen-lg mx-auto p-2 md:py-8 box-border"
           @navigate="${this.onNavigateTo}"
           @need-login="${this.onNeedLogin}"
           .authState="${this.authService.authState}"
           .userInfo="${this.userInfo}"
-        ></btrix-account-settings>`);
-
-      case "archive-info":
-      case "archive-info-tab":
-        return appLayout(html`<btrix-archive
-          class="w-full"
-          @navigate="${this.onNavigateTo}"
-          .authState="${this.authService.authState}"
-          .viewState="${this.viewState}"
-          aid="${this.viewState.params.aid}"
-          tab="${this.viewState.tab || "running"}"
-        ></btrix-archive>`);
+        ></btrix-account-settings>`;
 
       case "usersInvite": {
         if (this.userInfo?.isAdmin) {
-          return appLayout(html`<btrix-users-invite
-            class="w-full"
+          return html`<btrix-users-invite
+            class="w-full max-w-screen-lg mx-auto p-2 md:py-8 box-border"
             @navigate="${this.onNavigateTo}"
             @need-login="${this.onNeedLogin}"
             .authState="${this.authService.authState}"
             .userInfo="${this.userInfo}"
-          ></btrix-users-invite>`);
+          ></btrix-users-invite>`;
         } else {
           return this.renderNotFoundPage();
         }
@@ -554,20 +513,24 @@ export class App extends LiteElement {
       noHeader: true,
       body: html`
         <div class="grid gap-4 text-center">
-          <p class="mt-8 text-2xl font-medium">Welcome to Browsertrix Cloud!</p>
+          <p class="mt-8 text-2xl font-medium">
+            ${msg("Welcome to Browsertrix Cloud!")}
+          </p>
 
           <p>
-            A confirmation email was sent to: <br />
-            <strong>${email}</strong>.
+            ${msg(html`A confirmation email was sent to: <br />
+              <strong>${email}</strong>.`)}
           </p>
           <p class="max-w-xs mx-auto">
-            Click the link in your email to confirm your email address.
+            ${msg(
+              "Click the link in your email to confirm your email address."
+            )}
           </p>
         </div>
 
         <div class="mb-4 mt-8 text-center">
           <sl-button type="primary" @click=${() => this.closeDialog()}
-            >Got it, go to dashboard</sl-button
+            >${msg("Got it, go to dashboard")}</sl-button
           >
         </div>
       `,

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -201,7 +201,7 @@ export class App extends LiteElement {
     return html`
       <div class="border-b">
         <nav
-          class="max-w-screen-lg mx-auto box-border h-12 flex items-center justify-between"
+          class="max-w-screen-lg mx-auto px-3 box-border h-12 flex items-center justify-between"
         >
           <div>
             <a href="/archives" @click="${this.navLink}"

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -201,7 +201,7 @@ export class App extends LiteElement {
     return html`
       <div class="border-b">
         <nav
-          class="max-w-screen-lg mx-auto p-2 box-border flex items-center justify-between"
+          class="max-w-screen-lg mx-auto box-border h-12 flex items-center justify-between"
         >
           <div>
             <a href="/archives" @click="${this.navLink}"
@@ -237,12 +237,16 @@ export class App extends LiteElement {
                 </sl-dropdown>`
               : html`
                   <a href="/log-in"> ${msg("Log In")} </a>
-                  <sl-button
-                    outline
-                    @click="${() => this.navigate("/sign-up")}"
-                  >
-                    <span class="text-white">${msg("Sign up")}</span>
-                  </sl-button>
+                  ${this.isRegistrationEnabled
+                    ? html`
+                        <sl-button
+                          type="text"
+                          @click="${() => this.navigate("/sign-up")}"
+                        >
+                          ${msg("Sign up")}
+                        </sl-button>
+                      `
+                    : html``}
                 `}
           </div>
         </nav>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -171,9 +171,9 @@ export class CrawlDetail extends LiteElement {
 
     return html`
       <header>
-        <h2 class="text-xl font-medium mb-3 md:h-7">
+        <h2 class="text-lg font-medium mb-3 md:h-6">
           ${msg(
-            html`<span class="text-neutral-500">Crawl of</span> ${this.crawl
+            html`<span class="font-normal">Crawl of</span> ${this.crawl
                 ? this.crawl.configName
                 : html`<sl-skeleton
                     class="inline-block"
@@ -371,7 +371,7 @@ export class CrawlDetail extends LiteElement {
             ${this.crawl
               ? html`
                   <a
-                    class="font-medium text-neutral-600 hover:text-neutral-900"
+                    class="font-medium text-neutral-700 hover:text-neutral-900"
                     href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
                     @click=${this.navLink}
                   >

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -136,15 +136,15 @@ export class CrawlDetail extends LiteElement {
           aria-selected=${isActive ? "true" : "false"}
         >
           <div
-            class="absolute left-0 top-4 h-2 w-2 rounded-full transition-colors ${section ===
+            class="absolute left-0 top-2 h-6 border-l-2 rounded-full transition-colors ${section ===
             this.sectionName
-              ? "bg-primary"
-              : "bg-transparent"}"
+              ? "border-l-primary"
+              : "border-l-transparent"}"
             role="presentation"
           ></div>
           <a
-            class="block ml-2 p-2 font-medium ${isActive
-              ? "text-neutral-900"
+            class="block ml-2 p-2 font-medium rounded hover:bg-neutral-50 ${isActive
+              ? "text-primary"
               : "text-neutral-500 hover:text-neutral-900"}"
             href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlId}#${section}`}
             @click=${() => (this.sectionName = section)}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -171,107 +171,28 @@ export class CrawlDetail extends LiteElement {
 
     return html`
       <header>
-        <h2 class="text-lg font-medium mb-3 md:h-6">
-          ${msg(
-            html`<span class="font-normal">Crawl of</span> ${this.crawl
-                ? this.crawl.configName
-                : html`<sl-skeleton
-                    class="inline-block"
-                    style="width: 15em"
-                  ></sl-skeleton>`}`
-          )}
-        </h2>
-        <div class="grid grid-cols-4 gap-3">
-          <dl class="col-span-4 md:col-span-3 grid grid-cols-3 gap-5">
-            <div class="col-span-1">
-              <dt class="text-sm text-0-600">${msg("Status")}</dt>
-              <dd>
-                ${this.crawl
-                  ? html`
-                      <div class="flex items-baseline justify-between">
-                        <div
-                          class="whitespace-nowrap capitalize${isRunning
-                            ? " motion-safe:animate-pulse"
-                            : ""}"
-                        >
-                          ${this.crawl.state.replace(/_/g, " ")}
-                        </div>
-                      </div>
-                    `
-                  : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-                ${isRunning
-                  ? html`
-                      <sl-details
-                        class="mt-2"
-                        style="--sl-spacing-medium: var(--sl-spacing-x-small)"
-                      >
-                        <span slot="summary" class="text-sm text-0-700">
-                          ${msg("Manage")}
-                        </span>
-
-                        <div class="mb-3 text-center text-sm leading-none">
-                          <sl-button
-                            class="mr-2"
-                            size="small"
-                            @click=${this.stop}
-                          >
-                            ${msg("Stop Crawl")}
-                          </sl-button>
-                          <sl-button
-                            size="small"
-                            type="danger"
-                            @click=${this.cancel}
-                          >
-                            ${msg("Cancel Crawl")}
-                          </sl-button>
-                        </div>
-                      </sl-details>
-                    `
-                  : ""}
-              </dd>
-            </div>
-            <div class="col-span-1">
-              <dt class="text-sm text-0-600">${msg("Pages Crawled")}</dt>
-              <dd>
-                ${this.crawl?.stats
-                  ? html`
-                      <span
-                        class="font-mono tracking-tighter${isRunning
-                          ? " text-purple-600"
-                          : ""}"
-                      >
-                        ${this.numberFormatter.format(+this.crawl.stats.done)}
-                        <span class="text-0-400">/</span>
-                        ${this.numberFormatter.format(+this.crawl.stats.found)}
-                      </span>
-                    `
-                  : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-              </dd>
-            </div>
-            <div class="col-span-1">
-              <dt class="text-sm text-0-600">${msg("Run Duration")}</dt>
-              <dd>
-                ${this.crawl
-                  ? html`
-                      ${this.crawl.finished
-                        ? html`${RelativeDuration.humanize(
-                            new Date(`${this.crawl.finished}Z`).valueOf() -
-                              new Date(`${this.crawl.started}Z`).valueOf()
-                          )}`
-                        : html`
-                            <span class="text-purple-600">
-                              <btrix-relative-duration
-                                value=${`${this.crawl.started}Z`}
-                              ></btrix-relative-duration>
-                            </span>
-                          `}
-                    `
-                  : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-              </dd>
-            </div>
-          </dl>
-          <div class="col-span-1">
-            ${this.crawl
+        <div class="flex justify-between">
+          <h2 class="text-lg font-medium mb-3 md:h-6">
+            ${msg(
+              html`<span class="font-normal">Crawl of</span> ${this.crawl
+                  ? this.crawl.configName
+                  : html`<sl-skeleton
+                      class="inline-block"
+                      style="width: 15em"
+                    ></sl-skeleton>`}`
+            )}
+          </h2>
+          <div>
+            ${isRunning
+              ? html`
+                  <sl-button class="mr-2" size="small" @click=${this.stop}>
+                    ${msg("Stop Crawl")}
+                  </sl-button>
+                  <sl-button size="small" type="danger" @click=${this.cancel}>
+                    ${msg("Cancel Crawl")}
+                  </sl-button>
+                `
+              : this.crawl
               ? html`
                   <sl-button
                     href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
@@ -281,9 +202,68 @@ export class CrawlDetail extends LiteElement {
                     ${msg("View Config")}
                   </sl-button>
                 `
-              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+              : ""}
           </div>
         </div>
+        <dl class="grid grid-cols-4 gap-5">
+          <div class="col-span-1">
+            <dt class="text-sm text-0-600">${msg("Status")}</dt>
+            <dd>
+              ${this.crawl
+                ? html`
+                    <div class="flex items-baseline justify-between">
+                      <div
+                        class="whitespace-nowrap capitalize${isRunning
+                          ? " motion-safe:animate-pulse"
+                          : ""}"
+                      >
+                        ${this.crawl.state.replace(/_/g, " ")}
+                      </div>
+                    </div>
+                  `
+                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+            </dd>
+          </div>
+          <div class="col-span-1">
+            <dt class="text-sm text-0-600">${msg("Pages Crawled")}</dt>
+            <dd>
+              ${this.crawl?.stats
+                ? html`
+                    <span
+                      class="font-mono tracking-tighter${isRunning
+                        ? " text-purple-600"
+                        : ""}"
+                    >
+                      ${this.numberFormatter.format(+this.crawl.stats.done)}
+                      <span class="text-0-400">/</span>
+                      ${this.numberFormatter.format(+this.crawl.stats.found)}
+                    </span>
+                  `
+                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+            </dd>
+          </div>
+          <div class="col-span-1">
+            <dt class="text-sm text-0-600">${msg("Run Duration")}</dt>
+            <dd>
+              ${this.crawl
+                ? html`
+                    ${this.crawl.finished
+                      ? html`${RelativeDuration.humanize(
+                          new Date(`${this.crawl.finished}Z`).valueOf() -
+                            new Date(`${this.crawl.started}Z`).valueOf()
+                        )}`
+                      : html`
+                          <span class="text-purple-600">
+                            <btrix-relative-duration
+                              value=${`${this.crawl.started}Z`}
+                            ></btrix-relative-duration>
+                          </span>
+                        `}
+                  `
+                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+            </dd>
+          </div>
+        </dl>
       </header>
     `;
   }
@@ -354,28 +334,6 @@ export class CrawlDetail extends LiteElement {
     return html`
       <dl class="grid grid-cols-2 gap-5">
         <div class="col-span-1">
-          <dt class="text-sm text-0-600">${msg("Crawl Template")}</dt>
-          <dd>
-            ${this.crawl
-              ? html`
-                  <a
-                    class="font-medium text-neutral-700 hover:text-neutral-900"
-                    href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
-                    @click=${this.navLink}
-                  >
-                    <sl-icon
-                      class="inline-block align-middle"
-                      name="link-45deg"
-                    ></sl-icon>
-                    <span class="inline-block align-middle">
-                      ${this.crawl.configName}
-                    </span>
-                  </a>
-                `
-              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-          </dd>
-        </div>
-        <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Started")}</dt>
           <dd>
             ${this.crawl
@@ -389,6 +347,26 @@ export class CrawlDetail extends LiteElement {
                     minute="numeric"
                     time-zone-name="short"
                   ></sl-format-date>
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div class="col-span-1">
+          <dt class="text-sm text-0-600">${msg("Finished")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  ${this.crawl.finished
+                    ? html`<sl-format-date
+                        date=${`${this.crawl.finished}Z` /** Z for UTC */}
+                        month="2-digit"
+                        day="2-digit"
+                        year="2-digit"
+                        hour="numeric"
+                        minute="numeric"
+                        time-zone-name="short"
+                      ></sl-format-date>`
+                    : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
@@ -411,22 +389,37 @@ export class CrawlDetail extends LiteElement {
           </dd>
         </div>
         <div class="col-span-1">
-          <dt class="text-sm text-0-600">${msg("Finished")}</dt>
+          <dt class="text-sm text-0-600">${msg("Crawl Template")}</dt>
           <dd>
             ${this.crawl
               ? html`
-                  ${this.crawl.finished
-                    ? html`<sl-format-date
-                        date=${`${this.crawl.finished}Z` /** Z for UTC */}
-                        month="2-digit"
-                        day="2-digit"
-                        year="2-digit"
-                        hour="numeric"
-                        minute="numeric"
-                        time-zone-name="short"
-                      ></sl-format-date>`
-                    : html`<span class="text-0-400">${msg("Pending")}</span>`}
+                  <a
+                    class="font-medium text-neutral-700 hover:text-neutral-900"
+                    href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
+                    @click=${this.navLink}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="link-45deg"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${this.crawl.configName}
+                    </span>
+                  </a>
                 `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div class="col-span-1">
+          <dt class="text-sm text-0-600">${msg("Crawl ID")}</dt>
+          <dd class="truncate">
+            ${this.crawl
+              ? html`<btrix-copy-button
+                    value=${this.crawl.id}
+                  ></btrix-copy-button>
+                  <code class="text-xs" title=${this.crawl.id}
+                    >${this.crawl.id}</code
+                  > `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
         </div>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -217,6 +217,18 @@ export class CrawlDetail extends LiteElement {
                           ? " motion-safe:animate-pulse"
                           : ""}"
                       >
+                        <span
+                          class="inline-block ${this.crawl.state === "failed"
+                            ? "text-red-500"
+                            : this.crawl.state === "complete"
+                            ? "text-emerald-500"
+                            : isRunning
+                            ? "text-purple-500"
+                            : "text-zinc-300"}"
+                          style="font-size: 10px; vertical-align: 2px"
+                        >
+                          &#9679;
+                        </span>
                         ${this.crawl.state.replace(/_/g, " ")}
                       </div>
                     </div>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -194,18 +194,6 @@ export class CrawlDetail extends LiteElement {
                             ? " motion-safe:animate-pulse"
                             : ""}"
                         >
-                          <span
-                            class="inline-block ${this.crawl.state === "failed"
-                              ? "text-red-500"
-                              : this.crawl.state === "complete"
-                              ? "text-emerald-500"
-                              : isRunning
-                              ? "text-purple-500"
-                              : "text-zinc-300"}"
-                            style="font-size: 10px; vertical-align: 2px"
-                          >
-                            &#9679;
-                          </span>
                           ${this.crawl.state.replace(/_/g, " ")}
                         </div>
                       </div>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -8,7 +8,7 @@ import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { Crawl } from "./types";
 
-type SectionName = "overview" | "preview" | "download" | "logs";
+type SectionName = "overview" | "recording" | "download" | "logs";
 
 const POLL_INTERVAL_SECONDS = 10;
 
@@ -61,7 +61,7 @@ export class CrawlDetail extends LiteElement {
   connectedCallback(): void {
     // Set initial active section based on URL #hash value
     const hash = window.location.hash.slice(1);
-    if (["overview", "preview", "download", "logs"].includes(hash)) {
+    if (["overview", "recording", "download", "logs"].includes(hash)) {
       this.sectionName = hash as SectionName;
     }
     super.connectedCallback();
@@ -76,7 +76,7 @@ export class CrawlDetail extends LiteElement {
     let sectionContent: string | TemplateResult = "";
 
     switch (this.sectionName) {
-      case "preview":
+      case "recording":
         sectionContent = this.renderWatch();
         break;
       case "download":
@@ -137,7 +137,7 @@ export class CrawlDetail extends LiteElement {
 
       <div class="grid grid-cols-5 gap-5">
         <div class="col-span-5 md:col-span-1">${this.renderNav()}</div>
-        <div class="col-span-5 md:col-span-4 md:py-5">
+        <div class="col-span-5 md:col-span-4 md:py-2">
           <main>${sectionContent}</main>
         </div>
       </div>
@@ -168,7 +168,7 @@ export class CrawlDetail extends LiteElement {
       <nav class="border-b md:border-b-0">
         <ul class="flex flex-row md:flex-col">
           ${renderNavItem({ section: "overview", label: msg("Overview") })}
-          ${renderNavItem({ section: "preview", label: msg("Preview") })}
+          ${renderNavItem({ section: "recording", label: msg("Recording") })}
           ${renderNavItem({ section: "download", label: msg("Download") })}
           ${renderNavItem({ section: "logs", label: msg("Logs") })}
         </ul>
@@ -242,8 +242,8 @@ export class CrawlDetail extends LiteElement {
     const isRunning = this.crawl?.state === "running";
 
     return html`
-      <dl class="grid grid-cols-4 gap-5">
-        <div class="col-span-2">
+      <dl class="grid grid-cols-3 gap-5">
+        <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Status")}</dt>
           <dd>
             ${this.crawl
@@ -337,7 +337,7 @@ export class CrawlDetail extends LiteElement {
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
         </div>
-        <div class="col-span-2">
+        <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Started")}</dt>
           <dd>
             ${this.crawl
@@ -355,7 +355,7 @@ export class CrawlDetail extends LiteElement {
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
         </div>
-        <div class="col-span-2">
+        <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Finished")}</dt>
           <dd>
             ${this.crawl
@@ -375,7 +375,7 @@ export class CrawlDetail extends LiteElement {
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
         </div>
-        <div class="col-span-2">
+        <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Reason")}</dt>
           <dd>
             ${this.crawl

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -8,7 +8,7 @@ import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { Crawl } from "./types";
 
-type SectionName = "overview" | "recording" | "download" | "logs";
+type SectionName = "overview" | "watch" | "download" | "logs";
 
 const POLL_INTERVAL_SECONDS = 10;
 
@@ -61,7 +61,7 @@ export class CrawlDetail extends LiteElement {
   connectedCallback(): void {
     // Set initial active section based on URL #hash value
     const hash = window.location.hash.slice(1);
-    if (["overview", "recording", "download", "logs"].includes(hash)) {
+    if (["overview", "watch", "download", "logs"].includes(hash)) {
       this.sectionName = hash as SectionName;
     }
     super.connectedCallback();
@@ -76,7 +76,7 @@ export class CrawlDetail extends LiteElement {
     let sectionContent: string | TemplateResult = "";
 
     switch (this.sectionName) {
-      case "recording":
+      case "watch":
         sectionContent = this.renderWatch();
         break;
       case "download":
@@ -158,7 +158,7 @@ export class CrawlDetail extends LiteElement {
       <nav class="border-b md:border-b-0">
         <ul class="flex flex-row md:flex-col" role="menu">
           ${renderNavItem({ section: "overview", label: msg("Overview") })}
-          ${renderNavItem({ section: "recording", label: msg("Recording") })}
+          ${renderNavItem({ section: "watch", label: msg("View Crawl") })}
           ${renderNavItem({ section: "download", label: msg("Download") })}
           ${renderNavItem({ section: "logs", label: msg("Logs") })}
         </ul>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -151,22 +151,36 @@ export class CrawlDetail extends LiteElement {
     }: {
       section: SectionName;
       label: any;
-    }) => html`
-      <li>
-        <a
-          class="block p-2 font-medium ${section === this.sectionName
-            ? "text-neutral-900"
-            : "text-neutral-500 hover:text-neutral-900"}"
-          href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlId}#${section}`}
-          @click=${() => (this.sectionName = section)}
+    }) => {
+      const isActive = section === this.sectionName;
+      return html`
+        <li
+          class="relative"
+          role="menuitem"
+          aria-selected=${isActive ? "true" : "false"}
         >
-          ${label}
-        </a>
-      </li>
-    `;
+          <div
+            class="absolute left-0 top-4 h-2 w-2 rounded-full transition-colors ${section ===
+            this.sectionName
+              ? "bg-primary"
+              : "bg-transparent"}"
+            role="presentation"
+          ></div>
+          <a
+            class="block ml-2 p-2 font-medium ${isActive
+              ? "text-neutral-900"
+              : "text-neutral-500 hover:text-neutral-900"}"
+            href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlId}#${section}`}
+            @click=${() => (this.sectionName = section)}
+          >
+            ${label}
+          </a>
+        </li>
+      `;
+    };
     return html`
       <nav class="border-b md:border-b-0">
-        <ul class="flex flex-row md:flex-col">
+        <ul class="flex flex-row md:flex-col" role="menu">
           ${renderNavItem({ section: "overview", label: msg("Overview") })}
           ${renderNavItem({ section: "recording", label: msg("Recording") })}
           ${renderNavItem({ section: "download", label: msg("Download") })}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -91,8 +91,8 @@ export class CrawlDetail extends LiteElement {
     }
 
     return html`
-      <div class="grid grid-cols-5 gap-5 pb-3 border-b mb-2 items-start">
-        <div class="col-span-5 md:col-span-1">
+      <div class="grid grid-cols-6 gap-4 items-start pb-3 mb-2 border-b">
+        <div class="col-span-6 md:col-span-1">
           <a
             class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
             href=${`/archives/${this.archiveId}/crawls`}
@@ -107,37 +107,13 @@ export class CrawlDetail extends LiteElement {
             >
           </a>
         </div>
-        <header class="col-span-5 md:col-span-4 flex justify-between">
-          <h2 class="text-xl font-medium mb-1 md:h-7">
-            ${msg(
-              html`<span class="text-neutral-500">Crawl of</span> ${this.crawl
-                  ? this.crawl.configName
-                  : html`<sl-skeleton
-                      class="inline-block"
-                      style="width: 15em"
-                    ></sl-skeleton>`}`
-            )}
-          </h2>
 
-          <div>
-            ${this.crawl
-              ? html`
-                  <sl-button
-                    href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
-                    size="small"
-                    @click=${this.navLink}
-                  >
-                    View crawl template
-                  </sl-button>
-                `
-              : ""}
-          </div>
-        </header>
+        <div class="col-span-6 md:col-span-5">${this.renderHeader()}</div>
       </div>
 
-      <div class="grid grid-cols-5 gap-5">
-        <div class="col-span-5 md:col-span-1">${this.renderNav()}</div>
-        <div class="col-span-5 md:col-span-4 md:py-2">
+      <div class="grid grid-cols-6 gap-4">
+        <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
+        <div class="col-span-6 md:col-span-5 md:py-2">
           <main>${sectionContent}</main>
         </div>
       </div>
@@ -187,6 +163,140 @@ export class CrawlDetail extends LiteElement {
           ${renderNavItem({ section: "logs", label: msg("Logs") })}
         </ul>
       </nav>
+    `;
+  }
+
+  private renderHeader() {
+    const isRunning = this.crawl?.state === "running";
+
+    return html`
+      <header>
+        <h2 class="text-xl font-medium mb-3 md:h-7">
+          ${msg(
+            html`<span class="text-neutral-500">Crawl of</span> ${this.crawl
+                ? this.crawl.configName
+                : html`<sl-skeleton
+                    class="inline-block"
+                    style="width: 15em"
+                  ></sl-skeleton>`}`
+          )}
+        </h2>
+        <div class="grid grid-cols-4 gap-3">
+          <dl class="col-span-4 md:col-span-3 grid grid-cols-3 gap-5">
+            <div class="col-span-1">
+              <dt class="text-sm text-0-600">${msg("Status")}</dt>
+              <dd>
+                ${this.crawl
+                  ? html`
+                      <div class="flex items-baseline justify-between">
+                        <div
+                          class="whitespace-nowrap capitalize${isRunning
+                            ? " motion-safe:animate-pulse"
+                            : ""}"
+                        >
+                          <span
+                            class="inline-block ${this.crawl.state === "failed"
+                              ? "text-red-500"
+                              : this.crawl.state === "complete"
+                              ? "text-emerald-500"
+                              : isRunning
+                              ? "text-purple-500"
+                              : "text-zinc-300"}"
+                            style="font-size: 10px; vertical-align: 2px"
+                          >
+                            &#9679;
+                          </span>
+                          ${this.crawl.state.replace(/_/g, " ")}
+                        </div>
+                      </div>
+                    `
+                  : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+                ${isRunning
+                  ? html`
+                      <sl-details
+                        class="mt-2"
+                        style="--sl-spacing-medium: var(--sl-spacing-x-small)"
+                      >
+                        <span slot="summary" class="text-sm text-0-700">
+                          ${msg("Manage")}
+                        </span>
+
+                        <div class="mb-3 text-center text-sm leading-none">
+                          <sl-button
+                            class="mr-2"
+                            size="small"
+                            @click=${this.stop}
+                          >
+                            ${msg("Stop Crawl")}
+                          </sl-button>
+                          <sl-button
+                            size="small"
+                            type="danger"
+                            @click=${this.cancel}
+                          >
+                            ${msg("Cancel Crawl")}
+                          </sl-button>
+                        </div>
+                      </sl-details>
+                    `
+                  : ""}
+              </dd>
+            </div>
+            <div class="col-span-1">
+              <dt class="text-sm text-0-600">${msg("Pages Crawled")}</dt>
+              <dd>
+                ${this.crawl?.stats
+                  ? html`
+                      <span
+                        class="font-mono tracking-tighter${isRunning
+                          ? " text-purple-600"
+                          : ""}"
+                      >
+                        ${this.numberFormatter.format(+this.crawl.stats.done)}
+                        <span class="text-0-400">/</span>
+                        ${this.numberFormatter.format(+this.crawl.stats.found)}
+                      </span>
+                    `
+                  : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+              </dd>
+            </div>
+            <div class="col-span-1">
+              <dt class="text-sm text-0-600">${msg("Run Duration")}</dt>
+              <dd>
+                ${this.crawl
+                  ? html`
+                      ${this.crawl.finished
+                        ? html`${RelativeDuration.humanize(
+                            new Date(`${this.crawl.finished}Z`).valueOf() -
+                              new Date(`${this.crawl.started}Z`).valueOf()
+                          )}`
+                        : html`
+                            <span class="text-purple-600">
+                              <btrix-relative-duration
+                                value=${`${this.crawl.started}Z`}
+                              ></btrix-relative-duration>
+                            </span>
+                          `}
+                    `
+                  : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+              </dd>
+            </div>
+          </dl>
+          <div class="col-span-1">
+            ${this.crawl
+              ? html`
+                  <sl-button
+                    href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
+                    size="small"
+                    @click=${this.navLink}
+                  >
+                    ${msg("View Config")}
+                  </sl-button>
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </div>
+        </div>
+      </header>
     `;
   }
 
@@ -253,100 +363,26 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderOverview() {
-    const isRunning = this.crawl?.state === "running";
-
     return html`
-      <dl class="grid grid-cols-3 gap-5">
+      <dl class="grid grid-cols-2 gap-5">
         <div class="col-span-1">
-          <dt class="text-sm text-0-600">${msg("Status")}</dt>
+          <dt class="text-sm text-0-600">${msg("Crawl Template")}</dt>
           <dd>
             ${this.crawl
               ? html`
-                  <div class="flex items-baseline justify-between">
-                    <div
-                      class="whitespace-nowrap capitalize${isRunning
-                        ? " motion-safe:animate-pulse"
-                        : ""}"
-                    >
-                      <span
-                        class="inline-block ${this.crawl.state === "failed"
-                          ? "text-red-500"
-                          : this.crawl.state === "complete"
-                          ? "text-emerald-500"
-                          : isRunning
-                          ? "text-purple-500"
-                          : "text-zinc-300"}"
-                        style="font-size: 10px; vertical-align: 2px"
-                      >
-                        &#9679;
-                      </span>
-                      ${this.crawl.state.replace(/_/g, " ")}
-                    </div>
-                  </div>
-                `
-              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-            ${isRunning
-              ? html`
-                  <sl-details
-                    class="mt-2"
-                    style="--sl-spacing-medium: var(--sl-spacing-x-small)"
+                  <a
+                    class="font-medium text-neutral-600 hover:text-neutral-900"
+                    href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
+                    @click=${this.navLink}
                   >
-                    <span slot="summary" class="text-sm text-0-700">
-                      ${msg("Manage")}
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="link-45deg"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${this.crawl.configName}
                     </span>
-
-                    <div class="mb-3 text-center text-sm leading-none">
-                      <sl-button class="mr-2" size="small" @click=${this.stop}>
-                        ${msg("Stop Crawl")}
-                      </sl-button>
-                      <sl-button
-                        size="small"
-                        type="danger"
-                        @click=${this.cancel}
-                      >
-                        ${msg("Cancel Crawl")}
-                      </sl-button>
-                    </div>
-                  </sl-details>
-                `
-              : ""}
-          </dd>
-        </div>
-        <div class="col-span-1">
-          <dt class="text-sm text-0-600">${msg("Pages Crawled")}</dt>
-          <dd>
-            ${this.crawl?.stats
-              ? html`
-                  <span
-                    class="font-mono tracking-tighter${isRunning
-                      ? " text-purple-600"
-                      : ""}"
-                  >
-                    ${this.numberFormatter.format(+this.crawl.stats.done)}
-                    <span class="text-0-400">/</span>
-                    ${this.numberFormatter.format(+this.crawl.stats.found)}
-                  </span>
-                `
-              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-          </dd>
-        </div>
-        <div class="col-span-1">
-          <dt class="text-sm text-0-600">${msg("Run Duration")}</dt>
-          <dd>
-            ${this.crawl
-              ? html`
-                  ${this.crawl.finished
-                    ? html`${RelativeDuration.humanize(
-                        new Date(`${this.crawl.finished}Z`).valueOf() -
-                          new Date(`${this.crawl.started}Z`).valueOf()
-                      )}`
-                    : html`
-                        <span class="text-purple-600">
-                          <btrix-relative-duration
-                            value=${`${this.crawl.started}Z`}
-                          ></btrix-relative-duration>
-                        </span>
-                      `}
+                  </a>
                 `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>
@@ -370,6 +406,23 @@ export class CrawlDetail extends LiteElement {
           </dd>
         </div>
         <div class="col-span-1">
+          <dt class="text-sm text-0-600">${msg("Reason")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  ${this.crawl.manual
+                    ? msg(
+                        html`Manual start by
+                          <span
+                            >${this.crawl?.userName || this.crawl?.userid}</span
+                          >`
+                      )
+                    : msg(html`Scheduled run`)}
+                `
+              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Finished")}</dt>
           <dd>
             ${this.crawl
@@ -385,23 +438,6 @@ export class CrawlDetail extends LiteElement {
                         time-zone-name="short"
                       ></sl-format-date>`
                     : html`<span class="text-0-400">${msg("Pending")}</span>`}
-                `
-              : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-          </dd>
-        </div>
-        <div class="col-span-1">
-          <dt class="text-sm text-0-600">${msg("Reason")}</dt>
-          <dd>
-            ${this.crawl
-              ? html`
-                  ${this.crawl.manual
-                    ? msg(
-                        html`Manual start by
-                          <span
-                            >${this.crawl?.userName || this.crawl?.userid}</span
-                          >`
-                      )
-                    : msg(html`Scheduled run`)}
                 `
               : html`<sl-skeleton class="h-6"></sl-skeleton>`}
           </dd>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -109,12 +109,14 @@ export class CrawlDetail extends LiteElement {
         </div>
         <header class="col-span-5 md:col-span-4 flex justify-between">
           <h2 class="text-xl font-medium mb-1 md:h-7">
-            ${this.crawl
-              ? msg(
-                  html`<span class="text-neutral-500">Crawl of</span> ${this
-                      .crawl.configName}`
-                )
-              : html`<sl-skeleton style="width: 30em"></sl-skeleton>`}
+            ${msg(
+              html`<span class="text-neutral-500">Crawl of</span> ${this.crawl
+                  ? this.crawl.configName
+                  : html`<sl-skeleton
+                      class="inline-block"
+                      style="width: 15em"
+                    ></sl-skeleton>`}`
+            )}
           </h2>
 
           <div>
@@ -163,8 +165,8 @@ export class CrawlDetail extends LiteElement {
       </li>
     `;
     return html`
-      <nav>
-        <ul>
+      <nav class="border-b md:border-b-0">
+        <ul class="flex flex-row md:flex-col">
           ${renderNavItem({ section: "overview", label: msg("Overview") })}
           ${renderNavItem({ section: "preview", label: msg("Preview") })}
           ${renderNavItem({ section: "download", label: msg("Download") })}

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -118,7 +118,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                           <sl-button
                             size="small"
                             type="text"
-                            @click=${() => (this.openDialogName = "config")}
+                            @click=${() => (this.openDialogName = "name")}
                           >
                             ${msg("Edit")}
                           </sl-button>

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -116,7 +116,7 @@ export class Archive extends LiteElement {
     }
 
     return html`<article>
-      <header class="w-full max-w-screen-lg mx-auto box-border py-4">
+      <header class="w-full max-w-screen-lg mx-auto px-3 box-border py-4">
         <nav class="text-sm text-neutral-400">
           <a
             class="font-medium hover:underline"
@@ -129,7 +129,7 @@ export class Archive extends LiteElement {
         </nav>
       </header>
 
-      <div class="w-full max-w-screen-lg mx-auto">
+      <div class="w-full max-w-screen-lg mx-auto px-3 box-border">
         <nav class="-ml-3 flex items-end overflow-x-auto">
           ${this.renderNavTab({ tabName: "crawls", label: msg("Crawls") })}
           ${this.renderNavTab({
@@ -146,7 +146,7 @@ export class Archive extends LiteElement {
 
       <main>
         <div
-          class="w-full max-w-screen-lg mx-auto box-border py-5"
+          class="w-full max-w-screen-lg mx-auto px-3 box-border py-5"
           aria-labelledby="${this.archiveTab}-tab"
         >
           ${tabPanelContent}

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -175,7 +175,7 @@ export class Archive extends LiteElement {
         <div
           class="text-sm font-medium py-3 border-b-2 transition-colors ${isActive
             ? "border-primary text-primary"
-            : "border-transparent text-neutral-500 hover:border-neutral-100"}"
+            : "border-transparent text-neutral-500 hover:border-neutral-100 hover:text-neutral-900"}"
         >
           ${label}
         </div>

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -112,20 +112,22 @@ export class Archive extends LiteElement {
         break;
     }
 
-    return html`<article class="grid gap-4">
-      <nav class="font-medium text-sm text-gray-500">
-        <a
-          class="text-primary hover:underline"
-          href="/archives"
-          @click="${this.navLink}"
-          >${msg("Archives")}</a
-        >
-        <span class="font-mono">/</span>
-        <span>${this.archive.name}</span>
-      </nav>
+    return html`<article>
+      <header class="w-full max-w-screen-lg mx-auto box-border py-4">
+        <nav class="text-sm text-neutral-400">
+          <a
+            class="font-medium hover:underline"
+            href="/archives"
+            @click="${this.navLink}"
+            >${msg("Archives")}</a
+          >
+          <span class="font-mono">/</span>
+          <span>${this.archive.name}</span>
+        </nav>
+      </header>
 
-      <main>
-        <nav class="flex items-end overflow-x-auto">
+      <div class="w-full max-w-screen-lg mx-auto">
+        <nav class="mx-auto flex items-end overflow-x-auto">
           ${this.renderNavTab({ tabName: "crawls", label: msg("Crawls") })}
           ${this.renderNavTab({
             tabName: "crawl-templates",
@@ -134,10 +136,16 @@ export class Archive extends LiteElement {
           ${showMembersTab
             ? this.renderNavTab({ tabName: "members", label: msg("Members") })
             : ""}
-          <hr class="flex-1 border-t-2" />
         </nav>
+      </div>
 
-        <div class="my-4" aria-labelledby="${this.archiveTab}-tab">
+      <hr />
+
+      <main>
+        <div
+          class="w-full max-w-screen-lg mx-auto box-border py-5"
+          aria-labelledby="${this.archiveTab}-tab"
+        >
           ${tabPanelContent}
         </div>
       </main>
@@ -156,14 +164,18 @@ export class Archive extends LiteElement {
     return html`
       <a
         id="${tabName}-tab"
-        class="block flex-shrink-0 text-sm font-medium p-3 md:px-5 border-b-2 transition-colors ${isActive
-          ? "border-primary text-primary"
-          : "text-0-600"}"
+        class="block flex-shrink-0 px-3 hover:bg-neutral-50 rounded-t transition-colors"
         href=${`/archives/${this.archiveId}/${tabName}`}
         aria-selected=${isActive}
         @click=${this.navLink}
       >
-        ${label}
+        <div
+          class="text-sm font-medium py-3 border-b-2 transition-colors ${isActive
+            ? "border-primary text-primary"
+            : "border-transparent text-neutral-500 hover:border-neutral-100"}"
+        >
+          ${label}
+        </div>
       </a>
     `;
   }

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -80,11 +80,14 @@ export class Archive extends LiteElement {
 
   render() {
     if (!this.archive) {
-      return html`<div
-        class="w-full flex items-center justify-center my-24 text-4xl"
-      >
-        <sl-spinner></sl-spinner>
-      </div>`;
+      return html`
+        <div
+          class="absolute top-1/2 left-1/2 -mt-4 -ml-4"
+          style="font-size: 2rem"
+        >
+          <sl-spinner></sl-spinner>
+        </div>
+      `;
     }
 
     const showMembersTab = Boolean(this.archive.users);
@@ -127,7 +130,7 @@ export class Archive extends LiteElement {
       </header>
 
       <div class="w-full max-w-screen-lg mx-auto">
-        <nav class="mx-auto flex items-end overflow-x-auto">
+        <nav class="-ml-3 flex items-end overflow-x-auto">
           ${this.renderNavTab({ tabName: "crawls", label: msg("Crawls") })}
           ${this.renderNavTab({
             tabName: "crawl-templates",


### PR DESCRIPTION
- Visual alignment improvements to global navigation and archive tabs (i.e. crawls, crawl templates, members)
- Fix spinner/loading indicator alignment on archive view
- Separate crawl detail page into navigable sections in preparation for https://github.com/webrecorder/browsertrix-cloud/issues/134 and https://github.com/webrecorder/browsertrix-cloud/issues/142

A UX nice-to-have sometime down the road is having the home page be the user's default archive.

### Manual testing
1. Run app and go to an archive. Verify tabs still work as expected
2. Click into a crawl. Verify navigation on side works as expected

### Screenshots

**Overview (default):**
<img width="1033" alt="Screen Shot 2022-02-22 at 11 45 59 AM" src="https://user-images.githubusercontent.com/4672952/155207608-88a2361c-d67a-4db9-ae37-a1df859a4a8d.png">

**Recording:**
<img width="1018" alt="Screen Shot 2022-02-22 at 11 46 03 AM" src="https://user-images.githubusercontent.com/4672952/155207648-61e56c97-17b2-4ab0-b6f6-e9fc458392ae.png">

**Download:**
<img width="1020" alt="Screen Shot 2022-02-22 at 11 46 08 AM" src="https://user-images.githubusercontent.com/4672952/155207683-5a52551a-85ea-4657-acf3-4b1b7a32132d.png">

### Opinions
I called the watch/replay tab "Recording" to try and find a short tab name without adding a conditional "watch" or "replay". Another option I thought of is "View capture", unless @ikreymer you think "Watch or Replay" is the best?