### PR TITLE
Set scale when creating or editing crawl template

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -616,7 +616,7 @@ export class CrawlTemplatesDetail extends LiteElement {
             <h4 class="font-medium">
               ${this.isSeedsJsonView
                 ? msg("Custom Config")
-                : msg("Configure Seeds")}
+                : msg("Crawl Configuration")}
             </h4>
             <sl-switch
               ?checked=${this.isSeedsJsonView}
@@ -695,8 +695,8 @@ export class CrawlTemplatesDetail extends LiteElement {
 
   private renderCrawls() {
     return html`
-      <dl class="grid gap-5">
-        <div>
+      <dl class="grid grid-cols-2 gap-5">
+        <div class="col-span-1">
           <dt class="text-sm text-0-600">
             <span class="inline-block align-middle">${msg("# of Crawls")}</span>
             <sl-tooltip
@@ -713,7 +713,13 @@ export class CrawlTemplatesDetail extends LiteElement {
             ${(this.crawlTemplate?.crawlCount || 0).toLocaleString()}
           </dd>
         </div>
-        <div>
+        <div class="col-span-1">
+          <dt class="text-sm text-0-600">
+            <span class="inline-block align-middle">${msg("Crawl Scale")}</span>
+          </dt>
+          <dd class="font-mono">${this.crawlTemplate?.scale}</dd>
+        </div>
+        <div class="col-span-2">
           <dt class="text-sm text-0-600">${msg("Currently Running Crawl")}</dt>
           <dd
             class="flex items-center justify-between border border-zinc-100 rounded p-1 mt-1"
@@ -743,7 +749,7 @@ export class CrawlTemplatesDetail extends LiteElement {
               : html` <sl-skeleton style="width: 6em"></sl-skeleton> `}
           </dd>
         </div>
-        <div>
+        <div class="col-span-2">
           <dt class="text-sm text-0-600">${msg("Latest Crawl")}</dt>
           <dd
             class="flex items-center justify-between border border-zinc-100 rounded p-1 mt-1"
@@ -847,7 +853,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       ></sl-textarea>
       <sl-select
         name="scopeType"
-        label=${msg("Crawl Scope")}
+        label=${msg("Scope Type")}
         value=${this.crawlTemplate!.config.scopeType!}
         @sl-hide=${this.stopProp}
         @sl-after-hide=${this.stopProp}
@@ -861,7 +867,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       <sl-checkbox
         name="extraHopsOne"
         ?checked=${Boolean(this.crawlTemplate!.config.extraHops)}
-        >${msg("Include External Links ('one hop out')")}
+        >${msg("Include External Links (“one hop out”)")}
       </sl-checkbox>
       <sl-input
         name="limit"

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -811,7 +811,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     `;
   }
 
-  renderEditScale() {
+  private renderEditScale() {
     if (!this.crawlTemplate) return;
 
     return html`

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -320,6 +320,22 @@ export class CrawlTemplatesDetail extends LiteElement {
             >${msg("Change schedule")}</span
           >
         </li>
+        <li
+          class="p-2 hover:bg-zinc-100 cursor-pointer"
+          role="menuitem"
+          @click=${(e: any) => {
+            closeDropdown(e);
+            this.openDialogName = "scale";
+          }}
+        >
+          <sl-icon
+            class="inline-block align-middle px-1"
+            name="plus-slash-minus"
+          ></sl-icon>
+          <span class="inline-block align-middle pr-2"
+            >${msg("Change scale")}</span
+          >
+        </li>
         <hr />
       `);
     }

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -826,7 +826,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         >
           <sl-menu-item value="1">${msg("Standard")}</sl-menu-item>
           <sl-menu-item value="2">${msg("Big (2x)")}</sl-menu-item>
-          <sl-menu-item value="3">${msg("Bigger (4x)")}</sl-menu-item>
+          <sl-menu-item value="3">${msg("Bigger (3x)")}</sl-menu-item>
         </sl-select>
 
         <div class="mt-5 text-right">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -355,9 +355,9 @@ export class CrawlTemplatesNew extends LiteElement {
             label=${msg("Crawl Scale")}
             value=${initialValues.scale}
           >
-            <sl-menu-item value="1">Standard</sl-menu-item>
-            <sl-menu-item value="2">Big (2x)</sl-menu-item>
-            <sl-menu-item value="4">Bigger (4x)</sl-menu-item>
+            <sl-menu-item value="1">${msg("Standard")}</sl-menu-item>
+            <sl-menu-item value="2">${msg("Big (2x)")}</sl-menu-item>
+            <sl-menu-item value="3">${msg("Bigger (4x)")}</sl-menu-item>
           </sl-select>
         </div>
         <div class="flex justify-between">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -516,11 +516,13 @@ export class CrawlTemplatesNew extends LiteElement {
     const crawlTimeoutMinutes = formData.get("crawlTimeoutMinutes");
     const pageLimit = formData.get("limit");
     const seedUrlsStr = formData.get("seedUrls");
+    const scale = formData.get("scale") as string;
     const template: Partial<NewCrawlTemplate> = {
       name: formData.get("name") as string,
       schedule: this.getUTCSchedule(),
       runNow: this.isRunNow,
       crawlTimeout: crawlTimeoutMinutes ? +crawlTimeoutMinutes * 60 : 0,
+      scale: +scale,
     };
 
     if (this.isSeedsJsonView) {

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -357,7 +357,7 @@ export class CrawlTemplatesNew extends LiteElement {
           >
             <sl-menu-item value="1">${msg("Standard")}</sl-menu-item>
             <sl-menu-item value="2">${msg("Big (2x)")}</sl-menu-item>
-            <sl-menu-item value="3">${msg("Bigger (4x)")}</sl-menu-item>
+            <sl-menu-item value="3">${msg("Bigger (3x)")}</sl-menu-item>
           </sl-select>
         </div>
         <div class="flex justify-between">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -15,12 +15,14 @@ export type NewCrawlTemplate = {
   schedule: string;
   runNow: boolean;
   crawlTimeout?: number;
+  scale: number;
   config: CrawlConfig;
 };
 
 const initialValues = {
   name: "",
   runNow: true,
+  scale: "1",
   config: {
     seeds: [],
     scopeType: "prefix",
@@ -344,14 +346,25 @@ export class CrawlTemplatesNew extends LiteElement {
   private renderCrawlConfigSettings() {
     return html`
       <div class="col-span-1 p-4 md:p-8 md:border-b">
-        <h3 class="font-medium">${msg("Crawl Configuration")}</h3>
+        <h3 class="font-medium">${msg("Crawl Settings")}</h3>
       </div>
       <section class="col-span-2 p-4 md:p-8 border-b grid gap-5">
+        <div>
+          <sl-select
+            name="scale"
+            label=${msg("Crawl Scale")}
+            value=${initialValues.scale}
+          >
+            <sl-menu-item value="1">Standard</sl-menu-item>
+            <sl-menu-item value="2">Big (2x)</sl-menu-item>
+            <sl-menu-item value="4">Bigger (4x)</sl-menu-item>
+          </sl-select>
+        </div>
         <div class="flex justify-between">
           <h4 class="font-medium">
             ${this.isSeedsJsonView
               ? msg("Custom Config")
-              : msg("Configure Seeds")}
+              : msg("Crawl Configuration")}
           </h4>
           <sl-switch
             ?checked=${this.isSeedsJsonView}
@@ -385,7 +398,7 @@ export class CrawlTemplatesNew extends LiteElement {
       ></sl-textarea>
       <sl-select
         name="scopeType"
-        label=${msg("Crawl Scope")}
+        label=${msg("Scope Type")}
         value=${this.initialCrawlTemplate!.config.scopeType!}
       >
         <sl-menu-item value="page">Page</sl-menu-item>
@@ -394,8 +407,9 @@ export class CrawlTemplatesNew extends LiteElement {
         <sl-menu-item value="host">Host</sl-menu-item>
         <sl-menu-item value="any">Any</sl-menu-item>
       </sl-select>
+
       <sl-checkbox name="extraHopsOne"
-        >${msg("Include External Links ('one hop out')")}
+        >${msg("Include External Links (“one hop out”)")}
       </sl-checkbox>
       <sl-input
         name="limit"

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -378,16 +378,6 @@ export class CrawlsList extends LiteElement {
             ${isRunning(crawl)
               ? html`
                   <li
-                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
-                    role="menuitem"
-                    @click=${(e: any) => {
-                      this.cancel(crawl.id);
-                      e.target.closest("sl-dropdown").hide();
-                    }}
-                  >
-                    ${msg("Cancel immediately")}
-                  </li>
-                  <li
                     class="p-2 hover:bg-zinc-100 cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
@@ -395,8 +385,31 @@ export class CrawlsList extends LiteElement {
                       e.target.closest("sl-dropdown").hide();
                     }}
                   >
-                    ${msg("Stop gracefully")}
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="slash-circle"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${msg("Stop gracefully")}
+                    </span>
                   </li>
+                  <li
+                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+                    role="menuitem"
+                    @click=${(e: any) => {
+                      this.cancel(crawl.id);
+                      e.target.closest("sl-dropdown").hide();
+                    }}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="trash"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${msg("Cancel immediately")}
+                    </span>
+                  </li>
+                  <hr />
                 `
               : ""}
             <li

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -42,4 +42,5 @@ export type CrawlTemplate = {
   oldId: string | null;
   inactive: boolean;
   config: CrawlConfig;
+  scale: number;
 };

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -9,6 +9,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button/button"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button-group/button-group"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/checkbox/checkbox"
 );
 import(


### PR DESCRIPTION
(WIP https://github.com/webrecorder/browsertrix-cloud/issues/143) Allow user to specify scale when creating a new crawl template or editing an existing crawl template from the detail page.

TODO in follow-up:
- Edit from running crawl (@ikreymer if a user edits the crawl scale from the template while a crawl is already running, should it apply to the running crawl, too? Or maybe there can be a checkbox option like "[x] Apply to running crawl"?)
- Edit from crawl template list (should be addressed via https://github.com/webrecorder/browsertrix-cloud/issues/153)

### Manual testing
1. Run app and go to crawl template > new
2. Create a new crawl template and choose "Crawl Scale" option. Verify template saves as expected
3. Edit "Crawl Scale" value from template detail page action menu or "Edit" button in "Crawls" section. Verify template saves as expected

### Screenshots
**New field when creating crawl template:**
<img width="1025" alt="Screen Shot 2022-02-24 at 6 33 33 PM" src="https://user-images.githubusercontent.com/4672952/155642845-f728a7a4-ee13-4200-8837-a0d7a8222247.png">

**New field in crawl template detail view:**
<img width="1024" alt="Screen Shot 2022-02-24 at 6 33 55 PM" src="https://user-images.githubusercontent.com/4672952/155642881-5863d3ff-76ed-4d2f-87b0-7edeec6dd344.png">

**Edit modal in crawl template detail view:**
<img width="606" alt="Screen Shot 2022-02-24 at 6 34 02 PM" src="https://user-images.githubusercontent.com/4672952/155642909-14324272-1f1d-403d-aa8a-554d312359b3.png">

