### PR TITLE
Change scale of running crawls

### DIFF
--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -251,6 +251,8 @@ export class CrawlDetail extends LiteElement {
                       ${this.numberFormatter.format(+this.crawl.stats.found)}
                     </span>
                   `
+                : this.crawl
+                ? html` <span class="text-0-400">${msg("Unknown")}</span> `
                 : html`<sl-skeleton class="h-6"></sl-skeleton>`}
             </dd>
           </div>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -91,7 +91,7 @@ export class CrawlDetail extends LiteElement {
     }
 
     return html`
-      <div class="mb-5">
+      <div class="mb-7">
         <a
           class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
           href=${`/archives/${this.archiveId}/crawls`}
@@ -107,14 +107,21 @@ export class CrawlDetail extends LiteElement {
         </a>
       </div>
 
-      <div class="mb-5">${this.renderHeader()}</div>
+      <div class="mb-2">${this.renderHeader()}</div>
 
-      <div class="grid grid-cols-6 gap-4">
-        <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
-        <div class="col-span-6 md:col-span-5 md:py-2">
-          <main>${sectionContent}</main>
-        </div>
-      </div>
+      <main>
+        <section class="grid grid-cols-6 gap-4 mb-4">
+          <div class="col-span-6 md:col-span-1">
+            <h3 class="font-medium p-2">${msg("Summary")}</h3>
+          </div>
+          <div class="col-span-6 md:col-span-5">${this.renderSummary()}</div>
+        </section>
+
+        <section class="grid grid-cols-6 gap-4">
+          <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
+          <div class="col-span-6 md:col-span-5">${sectionContent}</div>
+        </section>
+      </main>
     `;
   }
 
@@ -133,16 +140,9 @@ export class CrawlDetail extends LiteElement {
           role="menuitem"
           aria-selected=${isActive ? "true" : "false"}
         >
-          <div
-            class="hidden md:block absolute left-0 top-2 h-6 border-l-2 rounded-full transition-colors ${section ===
-            this.sectionName
-              ? "border-l-primary"
-              : "border-l-transparent"}"
-            role="presentation"
-          ></div>
           <a
-            class="block ml-2 p-2 font-medium rounded hover:bg-neutral-50 ${isActive
-              ? "text-primary"
+            class="block px-2 py-1 my-1 font-medium rounded hover:bg-neutral-50 ${isActive
+              ? "text-primary bg-slate-50"
               : "text-neutral-500 hover:text-neutral-900"}"
             href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlId}#${section}`}
             @click=${() => (this.sectionName = section)}
@@ -168,123 +168,128 @@ export class CrawlDetail extends LiteElement {
     const isRunning = this.crawl?.state === "running";
 
     return html`
-      <header>
-        <div class="flex justify-between mb-2">
-          <h2 class="text-2xl font-medium mb-3 md:h-8">
-            ${msg(
-              html`<span class="font-normal">Crawl of</span> ${this.crawl
-                  ? this.crawl.configName
-                  : html`<sl-skeleton
-                      class="inline-block"
-                      style="width: 15em"
-                    ></sl-skeleton>`}`
-            )}
-          </h2>
-          <div>
-            ${isRunning
-              ? html`
-                  <sl-button class="mr-2" size="small" @click=${this.stop}>
-                    ${msg("Stop Crawl")}
-                  </sl-button>
-                  <sl-button size="small" type="danger" @click=${this.cancel}>
-                    ${msg("Cancel Crawl")}
-                  </sl-button>
-                `
-              : this.crawl
-              ? html`
-                  <sl-button
-                    href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
-                    size="small"
-                    @click=${this.navLink}
-                  >
-                    ${msg("View Config")}
-                  </sl-button>
-                `
-              : ""}
-          </div>
+      <header class="flex justify-between">
+        <h2 class="text-2xl font-medium mb-3 md:h-8">
+          ${msg(
+            html`<span class="font-normal">Crawl of</span> ${this.crawl
+                ? this.crawl.configName
+                : html`<sl-skeleton
+                    class="inline-block"
+                    style="width: 15em"
+                  ></sl-skeleton>`}`
+          )}
+        </h2>
+        <div>
+          ${isRunning
+            ? html`
+                <sl-button class="mr-2" size="small" @click=${this.stop}>
+                  ${msg("Stop Crawl")}
+                </sl-button>
+                <sl-button size="small" type="danger" @click=${this.cancel}>
+                  ${msg("Cancel Crawl")}
+                </sl-button>
+              `
+            : this.crawl
+            ? html`
+                <sl-button
+                  href=${`/archives/${this.archiveId}/crawl-templates/config/${this.crawl.cid}`}
+                  size="small"
+                  @click=${this.navLink}
+                >
+                  ${msg("View Config")}
+                </sl-button>
+              `
+            : ""}
         </div>
-        <dl class="grid grid-cols-4 gap-5 rounded border py-3 px-4">
-          <div class="col-span-1">
-            <dt class="text-xs text-0-600">${msg("Status")}</dt>
-            <dd>
-              ${this.crawl
-                ? html`
-                    <div class="flex items-baseline justify-between">
-                      <div
-                        class="whitespace-nowrap capitalize${isRunning
-                          ? " motion-safe:animate-pulse"
-                          : ""}"
-                      >
-                        <span
-                          class="inline-block ${this.crawl.state === "failed"
-                            ? "text-red-500"
-                            : this.crawl.state === "complete"
-                            ? "text-emerald-500"
-                            : isRunning
-                            ? "text-purple-500"
-                            : "text-zinc-300"}"
-                          style="font-size: 10px; vertical-align: 2px"
-                        >
-                          &#9679;
-                        </span>
-                        ${this.crawl.state.replace(/_/g, " ")}
-                      </div>
-                    </div>
-                  `
-                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-            </dd>
-          </div>
-          <div class="col-span-1">
-            <dt class="text-xs text-0-600">${msg("Pages Crawled")}</dt>
-            <dd>
-              ${this.crawl?.stats
-                ? html`
-                    <span
-                      class="font-mono tracking-tighter${isRunning
-                        ? " text-purple-600"
+      </header>
+    `;
+  }
+
+  private renderSummary() {
+    const isRunning = this.crawl?.state === "running";
+
+    return html`
+      <dl class="grid grid-cols-4 gap-5 rounded-lg border py-3 px-5 text-sm">
+        <div class="col-span-1">
+          <dt class="text-xs text-0-600">${msg("Status")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  <div class="flex items-baseline justify-between">
+                    <div
+                      class="whitespace-nowrap capitalize${isRunning
+                        ? " motion-safe:animate-pulse"
                         : ""}"
                     >
-                      ${this.numberFormatter.format(+this.crawl.stats.done)}
-                      <span class="text-0-400">/</span>
-                      ${this.numberFormatter.format(+this.crawl.stats.found)}
-                    </span>
-                  `
-                : this.crawl
-                ? html` <span class="text-0-400">${msg("Unknown")}</span> `
-                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-            </dd>
-          </div>
-          <div class="col-span-1">
-            <dt class="text-xs text-0-600">${msg("Run Duration")}</dt>
-            <dd>
-              ${this.crawl
-                ? html`
-                    ${this.crawl.finished
-                      ? html`${RelativeDuration.humanize(
-                          new Date(`${this.crawl.finished}Z`).valueOf() -
-                            new Date(`${this.crawl.started}Z`).valueOf()
-                        )}`
-                      : html`
-                          <span class="text-purple-600">
-                            <btrix-relative-duration
-                              value=${`${this.crawl.started}Z`}
-                            ></btrix-relative-duration>
-                          </span>
-                        `}
-                  `
-                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-            </dd>
-          </div>
-          <div class="col-span-1">
-            <dt class="text-xs text-0-600">${msg("Crawl Scale")}</dt>
-            <dd>
-              ${this.crawl
-                ? html`<span class="font-mono">${this.crawl.scale}</span>`
-                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-            </dd>
-          </div>
-        </dl>
-      </header>
+                      <span
+                        class="inline-block ${this.crawl.state === "failed"
+                          ? "text-red-500"
+                          : this.crawl.state === "complete"
+                          ? "text-emerald-500"
+                          : isRunning
+                          ? "text-purple-500"
+                          : "text-zinc-300"}"
+                        style="font-size: 10px; vertical-align: 2px"
+                      >
+                        &#9679;
+                      </span>
+                      ${this.crawl.state.replace(/_/g, " ")}
+                    </div>
+                  </div>
+                `
+              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div class="col-span-1">
+          <dt class="text-xs text-0-600">${msg("Pages Crawled")}</dt>
+          <dd>
+            ${this.crawl?.stats
+              ? html`
+                  <span
+                    class="font-mono tracking-tighter${isRunning
+                      ? " text-purple-600"
+                      : ""}"
+                  >
+                    ${this.numberFormatter.format(+this.crawl.stats.done)}
+                    <span class="text-0-400">/</span>
+                    ${this.numberFormatter.format(+this.crawl.stats.found)}
+                  </span>
+                `
+              : this.crawl
+              ? html` <span class="text-0-400">${msg("Unknown")}</span> `
+              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div class="col-span-1">
+          <dt class="text-xs text-0-600">${msg("Run Duration")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`
+                  ${this.crawl.finished
+                    ? html`${RelativeDuration.humanize(
+                        new Date(`${this.crawl.finished}Z`).valueOf() -
+                          new Date(`${this.crawl.started}Z`).valueOf()
+                      )}`
+                    : html`
+                        <span class="text-purple-600">
+                          <btrix-relative-duration
+                            value=${`${this.crawl.started}Z`}
+                          ></btrix-relative-duration>
+                        </span>
+                      `}
+                `
+              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+          </dd>
+        </div>
+        <div class="col-span-1">
+          <dt class="text-xs text-0-600">${msg("Crawl Scale")}</dt>
+          <dd>
+            ${this.crawl
+              ? html`<span class="font-mono">${this.crawl.scale}</span>`
+              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+          </dd>
+        </div>
+      </dl>
     `;
   }
 
@@ -298,7 +303,7 @@ export class CrawlDetail extends LiteElement {
     const replaySource = this.crawl?.resources?.[0]?.path;
 
     return html`
-      <h3 class="text-lg font-medium mb-2">${msg("Watch or Replay Crawl")}</h3>
+      <h3 class="text-lg font-medium my-2">${msg("Watch or Replay Crawl")}</h3>
 
       <div
         class="aspect-video rounded border ${isRunning
@@ -352,7 +357,7 @@ export class CrawlDetail extends LiteElement {
 
   private renderOverview() {
     return html`
-      <dl class="grid grid-cols-2 gap-5">
+      <dl class="grid grid-cols-2 gap-5 rounded-lg border p-5">
         <div class="col-span-1">
           <dt class="text-sm text-0-600">${msg("Started")}</dt>
           <dd>
@@ -449,7 +454,7 @@ export class CrawlDetail extends LiteElement {
 
   private renderFiles() {
     return html`
-      <h3 class="text-lg font-medium mb-2">${msg("Download Files")}</h3>
+      <h3 class="text-lg font-medium my-2">${msg("Download Files")}</h3>
       <ul class="border rounded text-sm">
         ${this.crawl?.resources?.map(
           (file) => html`

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -91,25 +91,23 @@ export class CrawlDetail extends LiteElement {
     }
 
     return html`
-      <div class="grid grid-cols-6 gap-4 items-start pb-3 mb-2 border-b">
-        <div class="col-span-6 md:col-span-1">
-          <a
-            class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
-            href=${`/archives/${this.archiveId}/crawls`}
-            @click=${this.navLink}
+      <div class="mb-5">
+        <a
+          class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
+          href=${`/archives/${this.archiveId}/crawls`}
+          @click=${this.navLink}
+        >
+          <sl-icon
+            name="arrow-left"
+            class="inline-block align-middle"
+          ></sl-icon>
+          <span class="inline-block align-middle"
+            >${msg("Back to Crawls")}</span
           >
-            <sl-icon
-              name="arrow-left"
-              class="inline-block align-middle"
-            ></sl-icon>
-            <span class="inline-block align-middle"
-              >${msg("Back to Crawls")}</span
-            >
-          </a>
-        </div>
-
-        <div class="col-span-6 md:col-span-5">${this.renderHeader()}</div>
+        </a>
       </div>
+
+      <div class="mb-5">${this.renderHeader()}</div>
 
       <div class="grid grid-cols-6 gap-4">
         <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
@@ -136,7 +134,7 @@ export class CrawlDetail extends LiteElement {
           aria-selected=${isActive ? "true" : "false"}
         >
           <div
-            class="absolute left-0 top-2 h-6 border-l-2 rounded-full transition-colors ${section ===
+            class="hidden md:block absolute left-0 top-2 h-6 border-l-2 rounded-full transition-colors ${section ===
             this.sectionName
               ? "border-l-primary"
               : "border-l-transparent"}"
@@ -171,8 +169,8 @@ export class CrawlDetail extends LiteElement {
 
     return html`
       <header>
-        <div class="flex justify-between">
-          <h2 class="text-lg font-medium mb-3 md:h-6">
+        <div class="flex justify-between mb-2">
+          <h2 class="text-2xl font-medium mb-3 md:h-8">
             ${msg(
               html`<span class="font-normal">Crawl of</span> ${this.crawl
                   ? this.crawl.configName
@@ -205,9 +203,9 @@ export class CrawlDetail extends LiteElement {
               : ""}
           </div>
         </div>
-        <dl class="grid grid-cols-4 gap-5">
+        <dl class="grid grid-cols-4 gap-5 rounded border py-3 px-4">
           <div class="col-span-1">
-            <dt class="text-sm text-0-600">${msg("Status")}</dt>
+            <dt class="text-xs text-0-600">${msg("Status")}</dt>
             <dd>
               ${this.crawl
                 ? html`
@@ -237,7 +235,7 @@ export class CrawlDetail extends LiteElement {
             </dd>
           </div>
           <div class="col-span-1">
-            <dt class="text-sm text-0-600">${msg("Pages Crawled")}</dt>
+            <dt class="text-xs text-0-600">${msg("Pages Crawled")}</dt>
             <dd>
               ${this.crawl?.stats
                 ? html`
@@ -257,7 +255,7 @@ export class CrawlDetail extends LiteElement {
             </dd>
           </div>
           <div class="col-span-1">
-            <dt class="text-sm text-0-600">${msg("Run Duration")}</dt>
+            <dt class="text-xs text-0-600">${msg("Run Duration")}</dt>
             <dd>
               ${this.crawl
                 ? html`

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -275,6 +275,14 @@ export class CrawlDetail extends LiteElement {
                 : html`<sl-skeleton class="h-6"></sl-skeleton>`}
             </dd>
           </div>
+          <div class="col-span-1">
+            <dt class="text-xs text-0-600">${msg("Crawl Scale")}</dt>
+            <dd>
+              ${this.crawl
+                ? html`<span class="font-mono">${this.crawl.scale}</span>`
+                : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+            </dd>
+          </div>
         </dl>
       </header>
     `;

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -140,7 +140,7 @@ export class CrawlDetail extends LiteElement {
       </main>
 
       <sl-dialog
-        label=${msg(str`Scale Crawl`)}
+        label=${msg(str`Change Crawl Scale`)}
         ?open=${this.openDialogName === "scale"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
         @sl-show=${() => (this.isDialogVisible = true)}
@@ -207,10 +207,6 @@ export class CrawlDetail extends LiteElement {
           ${this.isRunning
             ? html`
                 <sl-button-group>
-                  <sl-button size="small" @click=${this.stop}>
-                    <sl-icon name="slash-circle" slot="prefix"></sl-icon>
-                    <span> ${msg("Stop")} </span>
-                  </sl-button>
                   <sl-button
                     size="small"
                     @click=${() => {
@@ -221,9 +217,13 @@ export class CrawlDetail extends LiteElement {
                     <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
                     <span> ${msg("Scale")} </span>
                   </sl-button>
+                  <sl-button size="small" @click=${this.stop}>
+                    <sl-icon name="slash-circle" slot="prefix"></sl-icon>
+                    <span> ${msg("Stop")} </span>
+                  </sl-button>
                   <sl-button size="small" @click=${this.cancel}>
                     <sl-icon
-                      class="text-danger hover:text-white"
+                      class="text-danger"
                       name="trash"
                       slot="prefix"
                     ></sl-icon>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -455,24 +455,37 @@ export class CrawlDetail extends LiteElement {
   private renderFiles() {
     return html`
       <h3 class="text-lg font-medium my-2">${msg("Download Files")}</h3>
-      <ul class="border rounded text-sm">
-        ${this.crawl?.resources?.map(
-          (file) => html`
-            <li class="flex justify-between p-3 border-t first:border-t-0">
-              <div>
-                <a
-                  class="text-primary hover:underline"
-                  href=${file.path}
-                  download
-                  title=${file.name}
-                  >${file.name.slice(file.name.lastIndexOf("/") + 1)}
-                </a>
-              </div>
-              <div><sl-format-bytes value=${file.size}></sl-format-bytes></div>
-            </li>
-          `
-        )}
-      </ul>
+
+      ${this.crawl
+        ? this.crawl.resources && this.crawl.resources.length
+          ? html`
+              <ul class="border rounded text-sm">
+                ${this.crawl.resources.map(
+                  (file) => html`
+                    <li
+                      class="flex justify-between p-3 border-t first:border-t-0"
+                    >
+                      <div>
+                        <a
+                          class="text-primary hover:underline"
+                          href=${file.path}
+                          download
+                          title=${file.name}
+                          >${file.name.slice(file.name.lastIndexOf("/") + 1)}
+                        </a>
+                      </div>
+                      <div>
+                        <sl-format-bytes value=${file.size}></sl-format-bytes>
+                      </div>
+                    </li>
+                  `
+                )}
+              </ul>
+            `
+          : html`
+              <p class="text-neutral-400">${msg("No files to download.")}</p>
+            `
+        : ""}
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -811,7 +811,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     `;
   }
 
-  renderEditScale() {
+  private renderEditScale() {
     if (!this.crawlTemplate) return;
 
     return html`

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -378,16 +378,6 @@ export class CrawlsList extends LiteElement {
             ${isRunning(crawl)
               ? html`
                   <li
-                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
-                    role="menuitem"
-                    @click=${(e: any) => {
-                      this.cancel(crawl.id);
-                      e.target.closest("sl-dropdown").hide();
-                    }}
-                  >
-                    ${msg("Cancel immediately")}
-                  </li>
-                  <li
                     class="p-2 hover:bg-zinc-100 cursor-pointer"
                     role="menuitem"
                     @click=${(e: any) => {
@@ -395,8 +385,31 @@ export class CrawlsList extends LiteElement {
                       e.target.closest("sl-dropdown").hide();
                     }}
                   >
-                    ${msg("Stop gracefully")}
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="slash-circle"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${msg("Stop gracefully")}
+                    </span>
                   </li>
+                  <li
+                    class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+                    role="menuitem"
+                    @click=${(e: any) => {
+                      this.cancel(crawl.id);
+                      e.target.closest("sl-dropdown").hide();
+                    }}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="trash"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${msg("Cancel immediately")}
+                    </span>
+                  </li>
+                  <hr />
                 `
               : ""}
             <li

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -9,6 +9,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button/button"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/button-group/button-group"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/checkbox/checkbox"
 );
 import(


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/143) Allows user to change crawl scale from crawl detail page, + some layout adjustments to make room for more fields and action buttons.

### Manual testing
1. Run app and start a crawl
2. Go to crawl detail page. Verify you see "Scale" option next to other action buttons
3. Click "Scale". Verify dialog opens with current scale selected
4. Choose a different scale. Verify scale updates

### Screenshots
<img width="1033" alt="Screen Shot 2022-02-25 at 12 05 34 PM" src="https://user-images.githubusercontent.com/4672952/155790999-24fdf274-1f7d-4cba-99b5-f645ef318841.png">
<img width="525" alt="Screen Shot 2022-02-25 at 12 05 37 PM" src="https://user-images.githubusercontent.com/4672952/155791025-a008523b-3498-4e7b-8d26-f8cd8d24e54b.png">
<img width="1033" alt="Screen Shot 2022-02-25 at 12 05 49 PM" src="https://user-images.githubusercontent.com/4672952/155791037-6b5c4d50-9a61-4312-a1fa-c142327a1f80.png">
