### PR TITLE
View crawl in fullscreen

### DIFF
--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -772,7 +772,8 @@ export class CrawlDetail extends LiteElement {
    */
   private async enterFullscreen(id: string) {
     try {
-      document.getElementById(id)?.requestFullscreen({
+      document.getElementById(id)!.requestFullscreen({
+        // Show browser navigation controls
         navigationUI: "show",
       });
     } catch (err) {

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -394,13 +394,26 @@ export class CrawlDetail extends LiteElement {
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`
-      <h3 class="text-lg font-medium mb-2">${msg("Watch Crawl")}</h3>
+      <header class="flex justify-between">
+        <h3 class="text-lg font-medium mb-2">${msg("Watch Crawl")}</h3>
+        ${document.fullscreenEnabled
+          ? html`
+              <sl-icon-button
+                name="arrows-fullscreen"
+                label=${msg("Fullscreen")}
+                @click=${() => this.enterFullscreen("screencast-crawl")}
+              ></sl-icon-button>
+            `
+          : ""}
+      </header>
 
-      <btrix-screencast
-        authToken=${authToken}
-        archiveId=${this.archiveId!}
-        crawlId=${this.crawlId!}
-      ></btrix-screencast>
+      <div id="screencast-crawl">
+        <btrix-screencast
+          authToken=${authToken}
+          archiveId=${this.archiveId!}
+          crawlId=${this.crawlId!}
+        ></btrix-screencast>
+      </div>
     `;
   }
 
@@ -414,9 +427,21 @@ export class CrawlDetail extends LiteElement {
     const replaySource = this.crawl?.resources?.[0]?.path;
 
     return html`
-      <h3 class="text-lg font-medium mb-2">${msg("Replay Crawl")}</h3>
+      <header class="flex justify-between">
+        <h3 class="text-lg font-medium mb-2">${msg("Replay Crawl")}</h3>
+        ${document.fullscreenEnabled
+          ? html`
+              <sl-icon-button
+                name="arrows-fullscreen"
+                label=${msg("Fullscreen")}
+                @click=${() => this.enterFullscreen("replay-crawl")}
+              ></sl-icon-button>
+            `
+          : ""}
+      </header>
 
       <div
+        id="replay-crawl"
         class="aspect-4/3 rounded border ${isRunning
           ? "border-purple-200"
           : "border-slate-100"}"
@@ -430,38 +455,6 @@ export class CrawlDetail extends LiteElement {
               noSandbox="true"
             ></replay-web-page>`
           : ``}
-      </div>
-      <div
-        class="absolute top-2 right-2 flex bg-white/90 hover:bg-white rounded-full"
-      >
-        ${this.isWatchExpanded
-          ? html`
-              <sl-icon-button
-                class="px-1"
-                name="arrows-angle-contract"
-                label=${msg("Contract crawl video")}
-                @click=${() => (this.isWatchExpanded = false)}
-              ></sl-icon-button>
-            `
-          : html`
-              <sl-icon-button
-                class="px-1"
-                name="arrows-angle-expand"
-                label=${msg("Expand crawl video")}
-                @click=${() => (this.isWatchExpanded = true)}
-              ></sl-icon-button>
-            `}
-        ${this.watchUrl
-          ? html`
-              <sl-icon-button
-                class="border-l px-1"
-                href=${this.watchUrl}
-                name="box-arrow-up-right"
-                label=${msg("Open in new window")}
-                target="_blank"
-              ></sl-icon-button>
-            `
-          : ""}
       </div>
     `;
   }
@@ -771,6 +764,20 @@ export class CrawlDetail extends LiteElement {
 
   private stopPollTimer() {
     window.clearTimeout(this.timerId);
+  }
+
+  /**
+   * Enter fullscreen mode
+   * @param id ID of element to fullscreen
+   */
+  private async enterFullscreen(id: string) {
+    try {
+      document.getElementById(id)?.requestFullscreen({
+        navigationUI: "show",
+      });
+    } catch (err) {
+      console.error(err);
+    }
   }
 }
 


### PR DESCRIPTION
Watch or replay crawl in browser fullscreen mode.

Fixes https://github.com/webrecorder/browsertrix-cloud/issues/164

### Manual testing
1. Run app and go to completed crawl detail > "View Crawl". Click fullscreen icon on right side of "Replay Crawl". Verify that replay takes full screen
2. Repeat with a running crawl. Verify that screencast enters full screen

### Screenshots
**Replay header with icon:**
<img width="873" alt="Screen Shot 2022-02-28 at 5 35 26 PM" src="https://user-images.githubusercontent.com/4672952/156088372-72951dc0-66cc-4e88-a6ae-5ee0bfa856fe.png">

**Watch crawl in fullscreen mode:**
<img width="1512" alt="Screen Shot 2022-02-28 at 5 35 58 PM" src="https://user-images.githubusercontent.com/4672952/156088435-e371987c-98ed-4035-99aa-5477f0e87a4b.png">

