### PR TITLE
backend prod settings:

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,5 @@ RUN pip install -r requirements.txt
 
 ADD . /app
 
-CMD uvicorn main:app --host 0.0.0.0 --root-path /api --reload --access-log --log-level info
+CMD uvicorn main:app --host 0.0.0.0 --root-path /api --access-log --log-level info
 

--- a/build-backend.sh
+++ b/build-backend.sh
@@ -1,1 +1,2 @@
-docker buildx build --platform linux/amd64 --push -t registry.digitalocean.com/btrix/webrecorder/browsertrix-api ./backend/
+docker buildx build --platform linux/amd64 --push -t webrecorder/browsertrix-backend ./backend/
+

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker buildx build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg RWP_BASE_URL="https://replayweb.page/" --platform linux/amd64 --push -t registry.digitalocean.com/btrix/webrecorder/browsertrix-frontend ./frontend/
+docker buildx build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg RWP_BASE_URL="https://replayweb.page/" --platform linux/amd64 --push -t webrecorder/browsertrix-frontend ./frontend/

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -64,8 +64,10 @@ spec:
             httpGet:
               path: /healthz
               port: 8000
-            failureThreshold: 30
+            failureThreshold: 12
             periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 5
 
           readinessProbe:
             httpGet:
@@ -73,6 +75,8 @@ spec:
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 5
 
           livenessProbe:
             httpGet:
@@ -80,6 +84,9 @@ spec:
               port: 8000
             initialDelaySeconds: 15
             periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 5
+
 
 ---
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -35,6 +35,8 @@ data:
 
   JWT_TOKEN_LIFETIME_MINUTES: "{{ .Values.jwt_token_lifetime_minutes | default 60 }}"
 
+  WEB_CONCURRENCY: "{{ .Values.backend_workers | default 4 }}"
+
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,6 +10,12 @@ volume_storage_class:
 registration_enabled: 1
 jwt_token_lifetime_minutes: 60
 
+# number of workers for backend api
+backend_workers: 4
+
+# base url for replayweb.page
+rwp_base_url: "https://replayweb.page/"
+
 superuser:
   # set this to enable a superuser admin
   email: admin@example.com

--- a/configs/config.sample.env
+++ b/configs/config.sample.env
@@ -36,6 +36,9 @@ CRAWL_ARGS="--timeout 90 --logging stats,behaviors,debug --generateWACZ --screen
 
 REGISTRATION_ENABLED=1
 
+# number of workers to run for backend
+WEB_CONCURRENCY=4
+
 JWT_TOKEN_LIFETIME_MINUTES=60
 
 # auth sign -- uncomment to enable signing


### PR DESCRIPTION
- set WEB_CONCURRENCY env var to configure number of backend api workers for both docker and k8s
- set via 'backend_workers' in values.yaml
- also add 'rwp_base_url' to values.yaml
- update containers to use public webrecorder/browsertrix-backend and webrecorder/browsertrix-frontend containers
- make liveness, readiness and startup health checks more tolerant