### PR TITLE
Fix seed URLs reset on JSON view toggle

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -643,9 +643,12 @@ export class CrawlTemplatesDetail extends LiteElement {
             </sl-switch>
           </div>
 
-          ${this.isSeedsJsonView
-            ? this.renderSeedsJson()
-            : this.renderSeedsForm()}
+          <div class="${this.isSeedsJsonView ? "" : "hidden"}">
+            ${this.renderSeedsJson()}
+          </div>
+          <div class="grid gap-5${this.isSeedsJsonView ? " hidden" : ""}">
+            ${this.renderSeedsForm()}
+          </div>
 
           <div class="text-right">
             <sl-button

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -374,9 +374,12 @@ export class CrawlTemplatesNew extends LiteElement {
           </sl-switch>
         </div>
 
-        ${this.isSeedsJsonView
-          ? this.renderSeedsJson()
-          : this.renderSeedsForm()}
+        <div class="${this.isSeedsJsonView ? "" : "hidden"}">
+          ${this.renderSeedsJson()}
+        </div>
+        <div class="grid gap-5${this.isSeedsJsonView ? "hidden" : ""}">
+          ${this.renderSeedsForm()}
+        </div>
       </section>
     `;
   }


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/160

### Manual testing
1. Run app and go to crawl templates > new. Enter in seed URLs and toggle "Use JSON editor" on and off. Verify seed URLs are still intact
2. Choose an crawl template and edit the configuration. Verify that seed URL and toggle works as expected