### PR TITLE
Add "crawler" role to members

### DIFF
--- a/frontend/src/components/archive-invite-form.ts
+++ b/frontend/src/components/archive-invite-form.ts
@@ -56,8 +56,12 @@ export class ArchiveInviteForm extends LiteElement {
             <sl-radio name="role" value=${AccessCode.owner}>
               ${msg("Admin")}
               <span class="text-gray-500">
-                - ${msg("Can start & configure crawls and invite others")}</span
+                - ${msg("Can manage crawls and invite others")}</span
               >
+            </sl-radio>
+            <sl-radio name="role" value=${AccessCode.crawler}>
+              ${msg("Crawler")}
+              <span class="text-gray-500"> - ${msg("Can manage crawls")}</span>
             </sl-radio>
             <sl-radio name="role" value=${AccessCode.viewer} checked>
               ${msg("Viewer")}

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -291,16 +291,23 @@ export class Archive extends LiteElement {
 
   private renderAddMember() {
     return html`
-      <sl-button
-        type="text"
-        href=${`/archives/${this.archiveId}/members`}
-        @click=${this.navLink}
-        ><sl-icon name="arrow-left"></sl-icon> ${msg(
-          "Back to members list"
-        )}</sl-button
-      >
+      <div class="mb-5">
+        <a
+          class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
+          href=${`/archives/${this.archiveId}/members`}
+          @click=${this.navLink}
+        >
+          <sl-icon
+            name="arrow-left"
+            class="inline-block align-middle"
+          ></sl-icon>
+          <span class="inline-block align-middle"
+            >${msg("Back to Members")}</span
+          >
+        </a>
+      </div>
 
-      <div class="mt-3 border rounded-lg p-4 md:p-8 md:pt-6">
+      <div class="border rounded-lg p-4 md:p-8 md:pt-6">
         <h2 class="text-lg font-medium mb-4">${msg("Add New Member")}</h2>
         <btrix-archive-invite-form
           @success=${this.onInviteSuccess}

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -7,7 +7,7 @@ import type { CurrentUser } from "../../types/user";
 import type { ArchiveData } from "../../utils/archives";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { needLogin } from "../../utils/auth";
-import { isOwner } from "../../utils/archives";
+import { isOwner, AccessCode } from "../../utils/archives";
 import "./crawl-templates-detail";
 import "./crawl-templates-list";
 import "./crawl-templates-new";
@@ -276,7 +276,11 @@ export class Archive extends LiteElement {
                   html`<span class="text-gray-400">${msg("Member")}</span>`}
                 </div>
                 <div class="p-3" role="cell">
-                  ${isOwner(role) ? msg("Admin") : msg("Viewer")}
+                  ${isOwner(role)
+                    ? msg("Admin")
+                    : role === AccessCode.crawler
+                    ? msg("Crawler")
+                    : msg("Viewer")}
                 </div>
               </div>
             `

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -263,7 +263,7 @@ export class Archive extends LiteElement {
               ${msg("Name", { desc: "Team member's name" })}
             </div>
             <div class="px-3 py-2" role="columnheader" aria-sort="none">
-              ${msg("Roles", { desc: "Team member's roles" })}
+              ${msg("Role", { desc: "Team member's role" })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/139) Shows "crawler" role as option to users, + minor improvement to "back" link on new member view.

### Manual testing
1. Run app and go to archive > members > "Add member". Verify new "Crawler" option shows
2. Invite user as crawler and finish signing up as that user. Verify that user now shows as "Crawler" on the archive > members tab.

### Screenshots
**Add member form:**
<img width="1043" alt="Screen Shot 2022-03-01 at 11 31 00 AM" src="https://user-images.githubusercontent.com/4672952/156236357-2b700151-c995-4b72-b2f7-06e580279d5b.png">

**Members list:**
<img width="1042" alt="Screen Shot 2022-03-01 at 11 27 28 AM" src="https://user-images.githubusercontent.com/4672952/156236398-87a4f24f-9e6e-4742-b3be-cf3ee3deffab.png">

