### PR TITLE
Copy extra hops value when duplicating crawl config

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -580,11 +580,15 @@ export class CrawlTemplatesDetail extends LiteElement {
           : ""}
       </div>
 
+      <div class="mb-5">
+        <div class="text-sm text-0-600">${msg("Include External Links")}</div>
+        ${this.crawlTemplate?.config.extraHops ? msg("Yes") : msg("No")}
+      </div>
+
       <sl-details style="--sl-spacing-medium: var(--sl-spacing-small)">
         <span slot="summary" class="text-sm">
-          <span class="font-medium">${msg("Advanced configuration")}</span>
-          <sl-tag size="small" type="neutral">${msg("JSON")}</sl-tag></span
-        >
+          <span class="font-medium">${msg("JSON Configuration")}</span>
+        </span>
         <div class="relative">
           <pre
             class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-xs"

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1072,9 +1072,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     if (!this.crawlTemplate) return;
 
     const config: CrawlTemplate["config"] = {
-      seeds: this.crawlTemplate.config.seeds,
-      scopeType: this.crawlTemplate.config.scopeType,
-      limit: this.crawlTemplate.config.limit,
+      ...this.crawlTemplate.config,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -405,9 +405,7 @@ export class CrawlTemplatesList extends LiteElement {
    */
   private async duplicateConfig(template: CrawlTemplate) {
     const config: CrawlTemplate["config"] = {
-      seeds: template.config.seeds,
-      scopeType: template.config.scopeType,
-      limit: template.config.limit,
+      ...template.config,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -411,7 +411,9 @@ export class CrawlTemplatesNew extends LiteElement {
         <sl-menu-item value="any">Any</sl-menu-item>
       </sl-select>
 
-      <sl-checkbox name="extraHopsOne"
+      <sl-checkbox
+        name="extraHopsOne"
+        ?checked=${this.initialCrawlTemplate!.config.extraHops === 1}
         >${msg("Include External Links (“one hop out”)")}
       </sl-checkbox>
       <sl-input


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/158, shows extra hop value on detail page.

### Manual testing
1. Run app and go to crawl templates
2. Duplicate config from list view. Verify "include external links" value copies over as expected.
3. Repeat and verify for crawl template detail view

### Screenshots
**New field in detail view:**
<img width="1018" alt="Screen Shot 2022-03-03 at 4 34 08 PM" src="https://user-images.githubusercontent.com/4672952/156676539-ad2c781e-dcbc-420f-b80b-45253c297632.png">

