### PR TITLE
Fix unable to save edits to simple view

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1112,8 +1112,8 @@ export class CrawlTemplatesDetail extends LiteElement {
     const configValue = formData.get("config") as string;
     let config: CrawlConfig;
 
-    if (configValue) {
-      if (this.invalidSeedsJsonMessage) return;
+    if (this.isSeedsJsonView) {
+      if (!configValue || this.invalidSeedsJsonMessage) return;
 
       config = JSON.parse(configValue) as CrawlConfig;
     } else {


### PR DESCRIPTION
Fixes bug introduced by https://github.com/webrecorder/browsertrix-cloud/pull/172 where changes to simple view config is not saved.

### Manual testing
1. Run app and go to a crawl template detail page
2. Edit the crawl configuration with JSON view turned off. Verify crawl config saves as expected