### PR TITLE
Update home page routing

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -214,7 +214,7 @@ export class App extends LiteElement {
           class="max-w-screen-lg mx-auto px-3 box-border h-12 flex items-center justify-between"
         >
           <div>
-            <a href="/archives" @click="${this.navLink}"
+            <a href="/" @click="${this.navLink}"
               ><h1 class="text-sm font-medium">
                 ${msg("Browsertrix Cloud")}
               </h1></a
@@ -384,15 +384,11 @@ export class App extends LiteElement {
         ></btrix-reset-password>`;
 
       case "home":
-        return html`<div class="w-full flex items-center justify-center">
-          <sl-button
-            type="primary"
-            size="large"
-            @click="${() => this.navigate("/log-in")}"
-          >
-            ${msg("Log In")}
-          </sl-button>
-        </div>`;
+        return html`<btrix-home
+          class="w-full"
+          .authState=${this.authService.authState}
+          .isAdmin=${this.userInfo ? this.userInfo.isAdmin : null}
+        ></btrix-home>`;
 
       case "archives":
         return html`<btrix-archives

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -464,9 +464,10 @@ export class App extends LiteElement {
 
     this.authService.logout();
     this.authService = new AuthService();
+    this.userInfo = undefined;
 
     if (redirect) {
-      this.navigate("/");
+      this.navigate("/log-in");
     }
   }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -386,6 +386,8 @@ export class App extends LiteElement {
       case "home":
         return html`<btrix-home
           class="w-full"
+          @navigate=${this.onNavigateTo}
+          @logged-in=${this.onLoggedIn}
           .authState=${this.authService.authState}
           .isAdmin=${this.userInfo ? this.userInfo.isAdmin : null}
         ></btrix-home>`;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -385,11 +385,11 @@ export class App extends LiteElement {
 
       case "home":
         return html`<btrix-home
-          class="w-full"
+          class="w-full md:bg-neutral-50"
           @navigate=${this.onNavigateTo}
           @logged-in=${this.onLoggedIn}
           .authState=${this.authService.authState}
-          .isAdmin=${this.userInfo ? this.userInfo.isAdmin : null}
+          .userInfo="${this.userInfo}"
         ></btrix-home>`;
 
       case "archives":

--- a/frontend/src/pages/archives.ts
+++ b/frontend/src/pages/archives.ts
@@ -25,14 +25,6 @@ export class Archives extends LiteElement {
   }
 
   render() {
-    if (!this.archiveList || !this.userInfo) {
-      return html`
-        <div class="flex items-center justify-center my-24 text-4xl">
-          <sl-spinner></sl-spinner>
-        </div>
-      `;
-    }
-
     return html`
       <div class="bg-white">
         <header
@@ -43,7 +35,13 @@ export class Archives extends LiteElement {
         <hr />
       </div>
       <main class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border">
-        ${this.renderArchives()}
+        ${this.archiveList
+          ? this.renderArchives()
+          : html`
+              <div class="flex items-center justify-center my-24 text-4xl">
+                <sl-spinner></sl-spinner>
+              </div>
+            `}
       </main>
     `;
   }

--- a/frontend/src/pages/archives.ts
+++ b/frontend/src/pages/archives.ts
@@ -20,9 +20,6 @@ export class Archives extends LiteElement {
   @state()
   private archiveList?: ArchiveData[];
 
-  @state()
-  private isInviteComplete?: boolean;
-
   async firstUpdated() {
     this.archiveList = await this.getArchives();
   }
@@ -33,25 +30,6 @@ export class Archives extends LiteElement {
         <div class="flex items-center justify-center my-24 text-4xl">
           <sl-spinner></sl-spinner>
         </div>
-      `;
-    }
-
-    if (this.userInfo.isAdmin && !this.archiveList.length) {
-      return html`
-        <div class="bg-white">
-          <header
-            class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border md:py-8"
-          >
-            <h1 class="text-2xl font-medium">${msg("Archives")}</h1>
-            <p class="mt-4 text-neutral-600">
-              ${msg("Invite users to start archiving.")}
-            </p>
-          </header>
-          <hr />
-        </div>
-        <main class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border">
-          ${this.renderAdminOnboarding()}
-        </main>
       `;
     }
 
@@ -103,32 +81,6 @@ export class Archives extends LiteElement {
             `
         )}
       </ul>
-    `;
-  }
-
-  private renderAdminOnboarding() {
-    if (this.isInviteComplete) {
-      return html`
-        <div class="border rounded-lg bg-white p-4 md:p-8">
-          <h2 class="text-2xl font-medium mb-4">${msg("Invite a User")}</h2>
-          <sl-button @click=${() => (this.isInviteComplete = false)}
-            >${msg("Send another invite")}</sl-button
-          >
-        </div>
-      `;
-    }
-    return html`
-      <div class="border rounded-lg bg-white p-4 md:p-8">
-        <h2 class="text-2xl font-medium mb-4">${msg("Invite a User")}</h2>
-        <p class="mb-4 text-neutral-600 text-sm">
-          ${msg("Each user will manage their own archive.")}
-        </p>
-
-        <btrix-invite-form
-          .authState=${this.authState}
-          @success=${() => (this.isInviteComplete = true)}
-        ></btrix-invite-form>
-      </div>
     `;
   }
 

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -32,9 +32,11 @@ export class Home extends LiteElement {
       return this.renderLoggedInNonAdmin();
     }
 
-    return html`<div class="flex items-center justify-center my-24 text-4xl">
-      <sl-spinner></sl-spinner>
-    </div>`;
+    return "";
+
+    // return html`<div class="flex items-center justify-center my-24 text-4xl">
+    //   <sl-spinner></sl-spinner>
+    // </div>`;
   }
 
   private renderLoggedInAdmin() {

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -52,24 +52,26 @@ export class Home extends LiteElement {
         <hr />
       </div>
       <main class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border">
-        <h2 class="text-2xl font-medium mb-4">${msg("Invite a User")}</h2>
+        <div class="border rounded-lg bg-white p-4 md:p-8">
+          <h2 class="text-2xl font-medium mb-4">${msg("Invite a User")}</h2>
 
-        ${this.isInviteComplete
-          ? html`
-              <sl-button @click=${() => (this.isInviteComplete = false)}
-                >${msg("Send another invite")}</sl-button
-              >
-            `
-          : html`
-              <p class="mb-4 text-neutral-600 text-sm">
-                ${msg("Each user will manage their own archive.")}
-              </p>
+          ${this.isInviteComplete
+            ? html`
+                <sl-button @click=${() => (this.isInviteComplete = false)}
+                  >${msg("Send another invite")}</sl-button
+                >
+              `
+            : html`
+                <p class="mb-4 text-neutral-600 text-sm">
+                  ${msg("Each user will manage their own archive.")}
+                </p>
 
-              <btrix-invite-form
-                .authState=${this.authState}
-                @success=${() => (this.isInviteComplete = true)}
-              ></btrix-invite-form>
-            `}
+                <btrix-invite-form
+                  .authState=${this.authState}
+                  @success=${() => (this.isInviteComplete = true)}
+                ></btrix-invite-form>
+              `}
+        </div>
       </main>
     `;
   }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -1,7 +1,8 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized } from "@lit/localize";
 
-import { AuthState } from "../utils/AuthService";
+import type { AuthState } from "../utils/AuthService";
+import type { CurrentUser } from "../types/user";
 import LiteElement, { html } from "../utils/LiteElement";
 
 @localized()
@@ -9,8 +10,8 @@ export class Home extends LiteElement {
   @property({ type: Object })
   authState?: AuthState;
 
-  @property({ type: Boolean })
-  isAdmin: boolean | null = null;
+  @property({ type: Object })
+  userInfo?: CurrentUser;
 
   @state()
   private isInviteComplete?: boolean;
@@ -24,24 +25,22 @@ export class Home extends LiteElement {
   }
 
   render() {
-    if (this.isAdmin === true) {
-      return this.renderLoggedInAdmin();
-    }
+    if (this.userInfo) {
+      if (this.userInfo.isAdmin === true) {
+        return this.renderLoggedInAdmin();
+      }
 
-    if (this.isAdmin === false) {
-      return this.renderLoggedInNonAdmin();
+      if (this.userInfo.isAdmin === false) {
+        return this.renderLoggedInNonAdmin();
+      }
     }
 
     return "";
-
-    // return html`<div class="flex items-center justify-center my-24 text-4xl">
-    //   <sl-spinner></sl-spinner>
-    // </div>`;
   }
 
   private renderLoggedInAdmin() {
     return html`
-      <div>
+      <div class="bg-white">
         <header
           class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border md:py-8"
         >
@@ -76,6 +75,12 @@ export class Home extends LiteElement {
   }
 
   private renderLoggedInNonAdmin() {
-    return html`renderLoggedInNonAdmin`;
+    return html`
+      <btrix-archives
+        class="w-full md:bg-neutral-50"
+        .authState="${this.authState}"
+        .userInfo="${this.userInfo}"
+      ></btrix-archives>
+    `;
   }
 }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -15,11 +15,15 @@ export class Home extends LiteElement {
   @state()
   private isInviteComplete?: boolean;
 
-  render() {
-    if (!this.authState) {
-      return this.renderLoggedOut();
+  connectedCallback() {
+    if (this.authState) {
+      super.connectedCallback();
+    } else {
+      this.navTo("/log-in");
     }
+  }
 
+  render() {
     if (this.isAdmin === true) {
       return this.renderLoggedInAdmin();
     }
@@ -71,9 +75,5 @@ export class Home extends LiteElement {
 
   private renderLoggedInNonAdmin() {
     return html`renderLoggedInNonAdmin`;
-  }
-
-  private renderLoggedOut() {
-    return html`renderLoggedOut`;
   }
 }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -35,7 +35,16 @@ export class Home extends LiteElement {
       }
     }
 
-    return "";
+    return html`
+      <div class="bg-white" role="presentation">
+        <header
+          class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border md:py-8"
+        >
+          <h1 class="text-2xl font-medium h-8"></h1>
+        </header>
+        <hr />
+      </div>
+    `;
   }
 
   private renderLoggedInAdmin() {
@@ -45,15 +54,12 @@ export class Home extends LiteElement {
           class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border md:py-8"
         >
           <h1 class="text-2xl font-medium">${msg("Welcome")}</h1>
-          <p class="mt-4 text-neutral-600">
-            ${msg("Invite users to start archiving.")}
-          </p>
         </header>
         <hr />
       </div>
       <main class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border">
         <div class="border rounded-lg bg-white p-4 md:p-8">
-          <h2 class="text-2xl font-medium mb-4">${msg("Invite a User")}</h2>
+          <h2 class="text-xl font-medium mb-4">${msg("Invite a User")}</h2>
 
           ${this.isInviteComplete
             ? html`
@@ -62,6 +68,9 @@ export class Home extends LiteElement {
                 >
               `
             : html`
+                <p class="mb-2 text-neutral-600 text-sm">
+                  ${msg("Invite users to start archiving.")}
+                </p>
                 <p class="mb-4 text-neutral-600 text-sm">
                   ${msg("Each user will manage their own archive.")}
                 </p>
@@ -79,7 +88,6 @@ export class Home extends LiteElement {
   private renderLoggedInNonAdmin() {
     return html`
       <btrix-archives
-        class="w-full md:bg-neutral-50"
         .authState="${this.authState}"
         .userInfo="${this.userInfo}"
       ></btrix-archives>

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -1,0 +1,42 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
+import { AuthState } from "../utils/AuthService";
+import LiteElement, { html } from "../utils/LiteElement";
+
+@localized()
+export class Home extends LiteElement {
+  @property({ type: Object })
+  authState?: AuthState;
+
+  @property({ type: Boolean })
+  isAdmin: boolean | null = null;
+
+  render() {
+    if (!this.authState) {
+      return this.renderLoggedOut();
+    }
+
+    if (this.isAdmin === true) {
+      return this.renderLoggedInAdmin();
+    }
+
+    if (this.isAdmin === false) {
+      return this.renderLoggedInNonAdmin();
+    }
+
+    return html`spinner`;
+  }
+
+  private renderLoggedInAdmin() {
+    return html`renderLoggedInAdmin`;
+  }
+
+  private renderLoggedInNonAdmin() {
+    return html`renderLoggedInNonAdmin`;
+  }
+
+  private renderLoggedOut() {
+    return html`renderLoggedOut`;
+  }
+}

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -12,6 +12,9 @@ export class Home extends LiteElement {
   @property({ type: Boolean })
   isAdmin: boolean | null = null;
 
+  @state()
+  private isInviteComplete?: boolean;
+
   render() {
     if (!this.authState) {
       return this.renderLoggedOut();
@@ -25,11 +28,45 @@ export class Home extends LiteElement {
       return this.renderLoggedInNonAdmin();
     }
 
-    return html`spinner`;
+    return html`<div class="flex items-center justify-center my-24 text-4xl">
+      <sl-spinner></sl-spinner>
+    </div>`;
   }
 
   private renderLoggedInAdmin() {
-    return html`renderLoggedInAdmin`;
+    return html`
+      <div>
+        <header
+          class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border md:py-8"
+        >
+          <h1 class="text-2xl font-medium">${msg("Welcome")}</h1>
+          <p class="mt-4 text-neutral-600">
+            ${msg("Invite users to start archiving.")}
+          </p>
+        </header>
+        <hr />
+      </div>
+      <main class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border">
+        <h2 class="text-2xl font-medium mb-4">${msg("Invite a User")}</h2>
+
+        ${this.isInviteComplete
+          ? html`
+              <sl-button @click=${() => (this.isInviteComplete = false)}
+                >${msg("Send another invite")}</sl-button
+              >
+            `
+          : html`
+              <p class="mb-4 text-neutral-600 text-sm">
+                ${msg("Each user will manage their own archive.")}
+              </p>
+
+              <btrix-invite-form
+                .authState=${this.authState}
+                @success=${() => (this.isInviteComplete = true)}
+              ></btrix-invite-form>
+            `}
+      </main>
+    `;
   }
 
   private renderLoggedInNonAdmin() {

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,3 +1,6 @@
+import { Home } from "./home";
+customElements.define("btrix-home", Home);
+
 import(/* webpackChunkName: "sign-up" */ "./sign-up").then(({ SignUp }) => {
   customElements.define("btrix-sign-up", SignUp);
 });

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -21,4 +21,4 @@ export const ROUTES = {
   usersInvite: "/users/invite",
 } as const;
 
-export const DASHBOARD_ROUTE = ROUTES.archives;
+export const DASHBOARD_ROUTE = ROUTES.home;


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/183) Refactors home view (root "/" path) and routing with following logic:
- If logged out, redirect to `/log-in` when visiting `/`
- If logged in and is a super admin, show user invite view
- If logged in and is not super admin, show archives view