### PR TITLE
Watch Stream Directly from Browsertrix Crawler

### DIFF
--- a/backend/crawls.py
+++ b/backend/crawls.py
@@ -548,9 +548,10 @@ def init_crawls_api(
         tags=["crawls"],
     )
 
-    #pylint: disable=unused-argument
-    async def ip_access_check(crawl_id, crawler_ip, archive: Archive = Depends(archive_crawl_dep)):
+    # pylint: disable=unused-argument
+    async def ip_access_check(
+        crawl_id, crawler_ip, archive: Archive = Depends(archive_crawl_dep)
+    ):
         return await ops.ip_access_check(crawl_id, crawler_ip)
-
 
     return ops

--- a/backend/dockerman.py
+++ b/backend/dockerman.py
@@ -361,6 +361,7 @@ class DockerManager:
 
     async def get_running_crawl(self, crawl_id, aid=None):
         """ Return a single running crawl as CrawlOut """
+        # pylint: disable=broad-except,bare-except
         try:
             container = await self.client.containers.get(crawl_id)
 
@@ -374,10 +375,17 @@ class DockerManager:
             if stop_type == "canceled":
                 return None
 
-            return self._make_crawl_for_container(
+            crawl = self._make_crawl_for_container(
                 container, "stopping" if stop_type else "running", False, CrawlOut
             )
-        # pylint: disable=broad-except
+
+            try:
+                crawl.watchIPs = [container.attrs["NetworkSettings"]["IPAddress"]]
+            except:
+                crawl.watchIPs = []
+
+            return crawl
+
         except Exception as exc:
             print(exc, flush=True)
             return None

--- a/backend/dockerman.py
+++ b/backend/dockerman.py
@@ -15,7 +15,8 @@ from tempfile import NamedTemporaryFile
 
 import aiodocker
 import aioprocessing
-import aioredis
+from redis import asyncio as aioredis
+
 
 from scheduler import run_scheduler
 

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -5,7 +5,8 @@ import datetime
 import json
 import asyncio
 import base64
-import aioredis
+from redis import asyncio as aioredis
+
 
 from kubernetes_asyncio import client, config, watch
 from kubernetes_asyncio.stream import WsApiClient

--- a/backend/k8sman.py
+++ b/backend/k8sman.py
@@ -389,7 +389,17 @@ class K8SManager:
             if not status:
                 return None
 
-            return self._make_crawl_for_job(job, status, False, CrawlOut)
+            crawl = self._make_crawl_for_job(job, status, False, CrawlOut)
+
+            pods = await self.core_api.list_namespaced_pod(
+                namespace=self.namespace,
+                label_selector=f"job-name={name},btrix.archive={aid}",
+            )
+
+            crawl.watchIPs = [
+                pod.status.pod_ip for pod in pods.items if pod.status.pod_ip
+            ]
+            return crawl
 
         # pylint: disable=broad-except
         except Exception:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,3 @@ apscheduler
 aioprocessing
 aiobotocore
 redis>=4.2.0rc1
-websockets

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,5 +8,5 @@ aiodocker
 apscheduler
 aioprocessing
 aiobotocore
-aioredis
+redis>=4.2.0rc1
 websockets

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -64,18 +64,16 @@ spec:
             httpGet:
               path: /healthz
               port: 8000
-            failureThreshold: 12
+            initialDelaySeconds: 20
             periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 5
+            failureThreshold: 30
 
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8000
-            initialDelaySeconds: 5
+            initialDelaySeconds: 15
             periodSeconds: 30
-            timeoutSeconds: 3
             failureThreshold: 5
 
           livenessProbe:
@@ -84,7 +82,6 @@ spec:
               port: 8000
             initialDelaySeconds: 15
             periodSeconds: 30
-            timeoutSeconds: 3
             failureThreshold: 5
 
 

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -36,5 +36,27 @@ server {
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    location ~* /watch/([^/]+)/([^/]+)/([^/]+)/ws {
+      set $archive $1;
+      set $crawl $2;
+      set $crawlerip $3;
+      #auth_request  /authcheck;
+
+      proxy_pass http://$crawlerip:9037/ws;
+      proxy_set_header Host "localhost";
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $http_connection;
+    }
+
+    location = /authcheck {
+      internal;
+      proxy_pass http://${BACKEND_HOST}:8000/archives/$archive/crawls/$crawl/$crawlerip?$args;
+      proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
+    }
+
 }
 

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -41,7 +41,8 @@ server {
       set $archive $1;
       set $crawl $2;
       set $crawlerip $3;
-      #auth_request  /authcheck;
+      set $auth_bearer $arg_auth_bearer;
+      auth_request  /ipaccess;
 
       proxy_pass http://$crawlerip:9037/ws;
       proxy_set_header Host "localhost";
@@ -51,9 +52,9 @@ server {
       proxy_set_header Connection $http_connection;
     }
 
-    location = /authcheck {
+    location = /ipaccess {
       internal;
-      proxy_pass http://${BACKEND_HOST}:8000/archives/$archive/crawls/$crawl/$crawlerip?$args;
+      proxy_pass http://${BACKEND_HOST}:8000/archives/$archive/crawls/$crawl/ipaccess/$crawlerip?auth_bearer=$auth_bearer;
       proxy_pass_request_body off;
       proxy_set_header Content-Length "";
     }


### PR DESCRIPTION
Update watch backend to stream directly from the crawler.
Return a list of `watchIPs` in crawler info
Proxy connection via `/watch/{aid}/{crawlId}/{watchIP}/ws?auth_token={bearer token}` as per https://github.com/webrecorder/browsertrix-cloud/issues/134#issuecomment-1055844059
Add an nginx `auth_request` to ensure client has access to specified IPs
Additional fix for #134