### PR TITLE
Show last crawl state in UI

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -792,23 +792,39 @@ export class CrawlTemplatesDetail extends LiteElement {
             class="flex items-center justify-between border border-zinc-100 rounded p-1 mt-1"
           >
             ${this.crawlTemplate?.lastCrawlId
-              ? html`<a
+              ? html`
+                  <span>
+                    <sl-icon
+                      class="inline-block align-middle mr-1"
+                      name=${this.crawlTemplate.lastCrawlState === "complete"
+                        ? "check-circle-fill"
+                        : this.crawlTemplate.lastCrawlState === "failed"
+                        ? "x-circle-fill"
+                        : "exclamation-circle-fill"}
+                    ></sl-icon>
+                    <span class="inline-block align-middle capitalize">
+                      ${this.crawlTemplate.lastCrawlState.replace(/_/g, " ")}
+                    </span>
+                    <sl-format-date
+                      class="inline-block align-middle text-sm text-neutral-500"
+                      date=${
+                        `${this.crawlTemplate.lastCrawlTime}Z` /** Z for UTC */
+                      }
+                      month="2-digit"
+                      day="2-digit"
+                      year="2-digit"
+                      hour="numeric"
+                      minute="numeric"
+                      time-zone-name="short"
+                    ></sl-format-date>
+                  </span>
+                  <a
                     class="text-primary font-medium hover:underline text-sm p-1"
                     href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlTemplate.lastCrawlId}#watch`}
                     @click=${this.navLink}
                     >${msg("View crawl")}</a
                   >
-                  <sl-format-date
-                    date=${
-                      `${this.crawlTemplate.lastCrawlTime}Z` /** Z for UTC */
-                    }
-                    month="2-digit"
-                    day="2-digit"
-                    year="2-digit"
-                    hour="numeric"
-                    minute="numeric"
-                    time-zone-name="short"
-                  ></sl-format-date>`
+                `
               : html`<span class="text-0-400 text-sm p-1"
                   >${msg("None")}</span
                 >`}

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -147,7 +147,15 @@ export class CrawlTemplatesList extends LiteElement {
                   </div>
                   <div>
                     ${t.crawlCount
-                      ? html`<sl-tooltip content=${msg("Last complete crawl")}>
+                      ? html`<sl-tooltip>
+                          <span slot="content" class="capitalize">
+                            ${msg(
+                              str`Last Crawl: ${t.lastCrawlState.replace(
+                                /_/g,
+                                " "
+                              )}`
+                            )}
+                          </span>
                           <a
                             class="font-medium hover:underline"
                             href=${`/archives/${this.archiveId}/crawls/crawl/${t.lastCrawlId}`}
@@ -157,11 +165,18 @@ export class CrawlTemplatesList extends LiteElement {
                             }}
                           >
                             <sl-icon
-                              class="inline-block align-middle mr-1 text-purple-400"
-                              name="check-circle-fill"
+                              class="inline-block align-middle mr-1 ${t.lastCrawlState ===
+                              "failed"
+                                ? "text-neutral-400"
+                                : "text-purple-400"}"
+                              name=${t.lastCrawlState === "complete"
+                                ? "check-circle-fill"
+                                : t.lastCrawlState === "failed"
+                                ? "x-circle-fill"
+                                : "exclamation-circle-fill"}
                             ></sl-icon
                             ><sl-format-date
-                              class="inline-block align-middle text-0-600"
+                              class="inline-block align-middle text-neutral-600"
                               date=${`${t.lastCrawlTime}Z` /** Z for UTC */}
                               month="2-digit"
                               day="2-digit"

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -1,3 +1,10 @@
+type CrawlState =
+  | "running"
+  | "complete"
+  | "failed"
+  | "partial_complete"
+  | "timed_out";
+
 export type Crawl = {
   id: string;
   userid: string;
@@ -8,7 +15,7 @@ export type Crawl = {
   manual: boolean;
   started: string; // UTC ISO date
   finished?: string; // UTC ISO date
-  state: string; // "running" | "complete" | "failed" | "partial_complete"
+  state: CrawlState;
   scale: number;
   stats: { done: string; found: string } | null;
   resources?: { name: string; path: string; hash: string; size: number }[];
@@ -38,6 +45,7 @@ export type CrawlTemplate = {
   crawlCount: number;
   lastCrawlId: string;
   lastCrawlTime: string;
+  lastCrawlState: CrawlState;
   currCrawlId: string;
   newId: string | null;
   oldId: string | null;


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/98) Shows user the last crawl state in crawl template views

### Manual testing
1. Run app and go to crawl template list page. Verify that icon next to the last crawl time is a checkmark for completed crawls, X for failed crawls and ! otherwise. Verify tooltip for icon shows crawl state
2. Verify the same in "Latest Crawl" section of crawl template detail page

### Screenshots
Crawl list:
<img width="344" alt="Screen Shot 2022-03-08 at 11 20 46 AM" src="https://user-images.githubusercontent.com/4672952/157310863-a64f7331-7833-4b0a-9238-b94ee7c8610c.png">

<img width="348" alt="Screen Shot 2022-03-08 at 11 20 50 AM" src="https://user-images.githubusercontent.com/4672952/157310886-abdd6317-f0ba-4757-90db-295cf4ac33a2.png">

<img width="341" alt="Screen Shot 2022-03-08 at 11 21 52 AM" src="https://user-images.githubusercontent.com/4672952/157310905-0c64ca7a-fb4f-4cae-8cd6-f83c335e3aae.png">

Crawl template detail:
<img width="716" alt="Screen Shot 2022-03-08 at 11 25 32 AM" src="https://user-images.githubusercontent.com/4672952/157310922-c6c8b821-b460-419e-9e54-3ee38618201a.png">

<img width="710" alt="Screen Shot 2022-03-08 at 11 25 57 AM" src="https://user-images.githubusercontent.com/4672952/157310940-80ee2796-b12f-42ed-8827-d7ded24bdb85.png">

