### PR TITLE
Define websocket host in common webpack config

### DIFF
--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -233,7 +233,7 @@ export class Screencast extends LitElement {
     }
 
     const baseURL = `${window.location.protocol === "https:" ? "wss" : "ws"}:${
-      window.location.host
+      process.env.WEBSOCKET_HOST || window.location.host
     }/watch/${this.archiveId}/${this.crawlId}`;
 
     this.watchIPs.forEach((ip: string) => {

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const webpack = require("webpack");
 const { merge } = require("webpack-merge");
 
 const common = require("./webpack.config.js");
@@ -8,7 +7,9 @@ const common = require("./webpack.config.js");
 const RWP_BASE_URL = process.env.RWP_BASE_URL || "https://replayweb.page/";
 
 if (!process.env.API_BASE_URL) {
-  throw new Error("To run a dev frontend server, please set the API_BASE_URL pointing to your backend api server in '.env.local'")
+  throw new Error(
+    "To run a dev frontend server, please set the API_BASE_URL pointing to your backend api server in '.env.local'"
+  );
 }
 
 const devBackendUrl = new URL(process.env.API_BASE_URL);
@@ -55,10 +56,4 @@ module.exports = merge(common, {
     },
     port: 9870,
   },
-
-  plugins: [
-    new webpack.DefinePlugin({
-      "process.env.WEBSOCKET_HOST": JSON.stringify(devBackendUrl.host),
-    }),
-  ],
 });


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/193 by defining the `WEBSOCKET_HOST` variable in the common webpack config.

Verified fix with `yarn start`, `yarn build` and building the frontend dockerfile.