### PR TITLE
Edit crawl config as YAML

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "lodash": "^4.17.21",
     "path-parser": "^6.1.0",
     "pretty-ms": "^7.0.1",
-    "tailwindcss": "^3.0.15"
+    "tailwindcss": "^3.0.15",
+    "yaml": "^2.0.0-11"
   },
   "scripts": {
     "test": "web-test-runner \"src/**/*.test.{ts,js}\" --node-resolve --playwright --browsers chromium",

--- a/frontend/src/components/config-editor.ts
+++ b/frontend/src/components/config-editor.ts
@@ -29,18 +29,18 @@ export class ConfigEditor extends LiteElement {
   language: "json" | "yaml" = "json";
 
   @state()
-  lineCount = 1;
+  stagedValue = "";
 
   @state()
   errorMessage = "";
 
   firstUpdated() {
-    this.lineCount = this.value.split("\n").length;
+    this.stagedValue = this.value;
   }
 
   updated(changedProperties: Map<string, any>) {
     if (changedProperties.get("value")) {
-      this.lineCount = this.value.split("\n").length;
+      this.stagedValue = this.value;
     }
   }
 
@@ -60,7 +60,7 @@ export class ConfigEditor extends LiteElement {
             <sl-menu-item value="yaml">${msg("YAML")}</sl-menu-item>
           </sl-select>
 
-          <btrix-copy-button .value=${this.value}></btrix-copy-button>
+          <btrix-copy-button .value=${this.stagedValue}></btrix-copy-button>
         </header>
 
         ${this.renderTextArea()}
@@ -77,12 +77,12 @@ export class ConfigEditor extends LiteElement {
   }
 
   private renderTextArea() {
+    const lineCount = this.stagedValue.split("\n").length;
+
     return html`
       <div class="flex font-mono text-sm leading-relaxed py-2">
         <div class="shrink-0 w-12 px-2 text-right text-neutral-300">
-          ${[...new Array(this.lineCount)].map(
-            (line, i) => html`${i + 1}<br />`
-          )}
+          ${[...new Array(lineCount)].map((line, i) => html`${i + 1}<br />`)}
         </div>
         <div class="flex-1 px-2 overflow-x-auto text-slate-700">
           <textarea
@@ -92,7 +92,7 @@ export class ConfigEditor extends LiteElement {
             autocapitalize="off"
             spellcheck="false"
             wrap="off"
-            rows=${this.lineCount}
+            rows=${lineCount}
             .value=${this.value}
             @keydown=${(e: any) => {
               const textarea = e.target;
@@ -107,9 +107,9 @@ export class ConfigEditor extends LiteElement {
                   textarea.selectionStart,
                   "end"
                 );
-              } else if (e.keyCode === /* enter: */ 13) {
-                this.lineCount = this.lineCount + 1;
               }
+
+              this.stagedValue = e.target.value;
             }}
             @change=${(e: any) => {
               e.stopPropagation();
@@ -119,10 +119,6 @@ export class ConfigEditor extends LiteElement {
               // Use timeout to get value after paste
               window.setTimeout(() => {
                 const { value } = e.target;
-
-                // Update line count pre-emptively in case there's an
-                // error with the pasted values
-                this.lineCount = value.split("\n").length;
 
                 this.onChange(value);
               });

--- a/frontend/src/components/config-editor.ts
+++ b/frontend/src/components/config-editor.ts
@@ -47,7 +47,7 @@ export class ConfigEditor extends LiteElement {
   render() {
     return html`
       <article class="border rounded">
-        <header class="flex bg-neutral-50 border-b p-1">
+        <header class="flex justify-between bg-neutral-50 border-b p-1">
           <sl-select
             value=${this.language}
             size="small"
@@ -59,7 +59,10 @@ export class ConfigEditor extends LiteElement {
             <sl-menu-item value="json">${msg("JSON")}</sl-menu-item>
             <sl-menu-item value="yaml">${msg("YAML")}</sl-menu-item>
           </sl-select>
+
+          <btrix-copy-button .value=${this.value}></btrix-copy-button>
         </header>
+
         ${this.renderTextArea()}
 
         <div class="text-sm">
@@ -76,15 +79,15 @@ export class ConfigEditor extends LiteElement {
   private renderTextArea() {
     return html`
       <div class="flex font-mono text-sm leading-relaxed py-2">
-        <div class="shrink-0 w-12 px-2 text-right text-neutral-400">
+        <div class="shrink-0 w-12 px-2 text-right text-neutral-300">
           ${[...new Array(this.lineCount)].map(
             (line, i) => html`${i + 1}<br />`
           )}
         </div>
-        <div class="flex-1 px-2 overflow-auto text-slate-700">
+        <div class="flex-1 px-2 overflow-x-auto text-slate-700">
           <textarea
             class="language-${this
-              .language} block w-full h-full outline-none resize-none"
+              .language} block w-full h-full overflow-y-hidden outline-none resize-none"
             autocomplete="off"
             autocapitalize="off"
             spellcheck="false"
@@ -115,7 +118,13 @@ export class ConfigEditor extends LiteElement {
             @paste=${(e: any) => {
               // Use timeout to get value after paste
               window.setTimeout(() => {
-                this.onChange(e.target.value);
+                const { value } = e.target;
+
+                // Update line count pre-emptively in case there's an
+                // error with the pasted values
+                this.lineCount = value.split("\n").length;
+
+                this.onChange(value);
               });
             }}
           ></textarea>
@@ -176,6 +185,9 @@ export class ConfigEditor extends LiteElement {
   private onChange(nextValue: string) {
     try {
       this.checkValidity(nextValue);
+
+      this.errorMessage = "";
+
       this.dispatchEvent(
         new CustomEvent("on-change", {
           detail: {

--- a/frontend/src/components/config-editor.ts
+++ b/frontend/src/components/config-editor.ts
@@ -41,7 +41,7 @@ export class ConfigEditor extends LiteElement {
             ${this.errorMessage
               ? html`
                   <sl-icon
-                    class="text-danger inline-block align-middle"
+                    class="text-danger inline-block align-middle mr-1"
                     name="x-octagon"
                   ></sl-icon>
                   <span
@@ -51,7 +51,7 @@ export class ConfigEditor extends LiteElement {
                 `
               : html`
                   <sl-icon
-                    class="text-success inline-block align-middle"
+                    class="text-success inline-block align-middle mr-1"
                     name="check2"
                   ></sl-icon>
                   <span
@@ -87,7 +87,7 @@ export class ConfigEditor extends LiteElement {
         <div class="shrink-0 w-12 px-2 text-right text-neutral-300">
           ${[...new Array(lineCount)].map((line, i) => html`${i + 1}<br />`)}
         </div>
-        <div class="flex-1 px-2 overflow-x-auto text-slate-700">
+        <div class="flex-1 px-2 overflow-x-auto text-slate-600">
           <textarea
             name="config"
             id="config-editor-textarea"

--- a/frontend/src/components/config-editor.ts
+++ b/frontend/src/components/config-editor.ts
@@ -68,7 +68,7 @@ export class ConfigEditor extends LiteElement {
         <div class="text-sm">
           ${this.errorMessage
             ? html`<btrix-alert type="danger">
-                ${this.errorMessage}
+                <div class="whitespace-pre-wrap">${this.errorMessage}</div>
               </btrix-alert> `
             : html` <btrix-alert> ${msg("Valid configuration")} </btrix-alert>`}
         </div>
@@ -178,7 +178,7 @@ export class ConfigEditor extends LiteElement {
     if (this.language === "json") {
       JSON.parse(value);
     } else if (this.language === "yaml") {
-      yamlToJson(this.value);
+      yamlToJson(value);
     }
   }
 

--- a/frontend/src/components/config-editor.ts
+++ b/frontend/src/components/config-editor.ts
@@ -1,0 +1,120 @@
+import { property, state } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+import { parse as jsonToYaml, stringify as yamlToJson } from "yaml";
+import parseJson from "parse-json";
+
+import LiteElement, { html } from "../utils/LiteElement";
+
+/**
+ * Usage example:
+ * ```ts
+ * <btrix-config-editor
+ *   value=${value}
+ *   @on-change=${handleChange}
+ * >
+ * </btrix-config-editor>
+ * ```
+ *
+ * @event on-change
+ */
+@localized()
+export class ConfigEditor extends LiteElement {
+  @property({ type: String })
+  value = "";
+
+  @state()
+  language: "json" | "yaml" = "json";
+
+  render() {
+    return html`
+      <article class="border rounded">
+        <header class="flex bg-neutral-50 border-b p-1">
+          <sl-select
+            value=${this.language}
+            size="small"
+            hoist
+            @sl-hide=${this.stopProp}
+            @sl-after-hide=${this.stopProp}
+            @sl-select=${this.handleLanguageChange}
+          >
+            <sl-menu-item value="json">${msg("JSON")}</sl-menu-item>
+            <sl-menu-item value="yaml">${msg("YAML")}</sl-menu-item>
+          </sl-select>
+        </header>
+        <textarea
+          class="language-${this
+            .language} block w-full text-slate-700 p-4 font-mono text-sm"
+          autocomplete="off"
+          rows="10"
+          spellcheck="false"
+          .value=${this.value}
+          @keydown=${(e: any) => {
+            // Add indentation when pressing tab key instead of moving focus
+            if (e.keyCode === /* tab: */ 9) {
+              e.preventDefault();
+
+              const textarea = e.target;
+
+              textarea.setRangeText(
+                "  ",
+                textarea.selectionStart,
+                textarea.selectionStart,
+                "end"
+              );
+            }
+          }}
+          @change=${(e: any) => {
+            e.stopPropagation();
+            this.onChange(e.target.value);
+          }}
+        ></textarea>
+      </article>
+    `;
+  }
+
+  private handleLanguageChange(e: any) {
+    this.language = e.target.value;
+
+    let value = this.value;
+
+    try {
+      switch (this.language) {
+        case "json":
+          const yaml = jsonToYaml(this.value);
+          value = JSON.stringify(yaml, null, 2);
+          break;
+        case "yaml":
+          const json = JSON.parse(this.value);
+          value = yamlToJson(json);
+          break;
+        default:
+          break;
+      }
+
+      this.onChange(value);
+    } catch (e) {
+      console.debug(e);
+
+      // TODO handle parse error
+    }
+  }
+
+  private onChange(nextValue: string) {
+    this.dispatchEvent(
+      new CustomEvent("on-change", {
+        detail: {
+          value: nextValue,
+        },
+      })
+    );
+  }
+
+  /**
+   * Stop propgation of sl-select events.
+   * Prevents bug where sl-dialog closes when dropdown closes
+   * https://github.com/shoelace-style/shoelace/issues/170
+   */
+  private stopProp(e: CustomEvent) {
+    e.stopPropagation();
+  }
+}

--- a/frontend/src/components/config-editor.ts
+++ b/frontend/src/components/config-editor.ts
@@ -41,33 +41,7 @@ export class ConfigEditor extends LiteElement {
             <sl-menu-item value="yaml">${msg("YAML")}</sl-menu-item>
           </sl-select>
         </header>
-        <textarea
-          class="language-${this
-            .language} block w-full text-slate-700 p-4 font-mono text-sm"
-          autocomplete="off"
-          rows="10"
-          spellcheck="false"
-          .value=${this.value}
-          @keydown=${(e: any) => {
-            // Add indentation when pressing tab key instead of moving focus
-            if (e.keyCode === /* tab: */ 9) {
-              e.preventDefault();
-
-              const textarea = e.target;
-
-              textarea.setRangeText(
-                "  ",
-                textarea.selectionStart,
-                textarea.selectionStart,
-                "end"
-              );
-            }
-          }}
-          @change=${(e: any) => {
-            e.stopPropagation();
-            this.onChange(e.target.value);
-          }}
-        ></textarea>
+        ${this.renderTextArea()}
       </article>
     `;
   }
@@ -97,6 +71,63 @@ export class ConfigEditor extends LiteElement {
 
       // TODO handle parse error
     }
+  }
+
+  private renderTextArea() {
+    const lines = this.value.split("\n");
+    const rowCount = lines.length + 1;
+
+    return html`
+      <div>
+        <div class="flex font-mono text-sm leading-relaxed">
+          <div class="shrink-0 w-12 px-2 text-right text-neutral-400">
+            ${[...new Array(rowCount)].map((line, i) => html`${i + 1}<br />`)}
+          </div>
+          <div class="flex-1 px-2 overflow-auto text-slate-700">
+            <textarea
+              class="language-${this
+                .language} block w-full h-full outline-none resize-none"
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck="false"
+              wrap="off"
+              rows=${rowCount}
+              .value=${this.value}
+              @keydown=${(e: any) => {
+                // Add indentation when pressing tab key instead of moving focus
+                if (e.keyCode === /* tab: */ 9) {
+                  e.preventDefault();
+
+                  const textarea = e.target;
+
+                  textarea.setRangeText(
+                    "  ",
+                    textarea.selectionStart,
+                    textarea.selectionStart,
+                    "end"
+                  );
+                }
+              }}
+              @keyup=${(e: any) => {
+                if (e.keyCode === /* enter: */ 13) {
+                  this.onChange(e.target.value);
+                }
+              }}
+              @change=${(e: any) => {
+                e.stopPropagation();
+                this.onChange(e.target.value);
+              }}
+              @paste=${(e: any) => {
+                // Use timeout to get value after paste
+                window.setTimeout(() => {
+                  this.onChange(e.target.value);
+                });
+              }}
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    `;
   }
 
   private onChange(nextValue: string) {

--- a/frontend/src/components/copy-button.ts
+++ b/frontend/src/components/copy-button.ts
@@ -7,7 +7,11 @@ import { msg, localized } from "@lit/localize";
  *
  * Usage example:
  * ```ts
- * <btrix-copy-button .value=${value} @on-copied=${console.log}></btrix-copy-button>
+ * <btrix-copy-button .value=${value}></btrix-copy-button>
+ * ```
+ * Or:
+ * ```ts
+ * <btrix-copy-button .getValue=${() => value}></btrix-copy-button>
  * ```
  *
  * @event on-copied
@@ -16,6 +20,9 @@ import { msg, localized } from "@lit/localize";
 export class CopyButton extends LitElement {
   @property({ type: String })
   value?: string;
+
+  @property({ type: Function })
+  getValue?: () => string;
 
   @state()
   private isCopied: boolean = false;
@@ -33,18 +40,22 @@ export class CopyButton extends LitElement {
 
   render() {
     return html`
-      <sl-button size="small" @click=${this.onClick} ?disabled=${!this.value}
+      <sl-button
+        size="small"
+        @click=${this.onClick}
+        ?disabled=${!this.value && !this.getValue}
         >${this.isCopied ? msg("Copied") : msg("Copy")}</sl-button
       >
     `;
   }
 
   private onClick() {
-    CopyButton.copyToClipboard(this.value!);
+    const value = (this.getValue ? this.getValue() : this.value) || "";
+    CopyButton.copyToClipboard(value);
 
     this.isCopied = true;
 
-    this.dispatchEvent(new CustomEvent("on-copied", { detail: this.value }));
+    this.dispatchEvent(new CustomEvent("on-copied", { detail: value }));
 
     this.timeoutId = window.setTimeout(() => {
       this.isCopied = false;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -9,6 +9,9 @@ import("./account-settings").then(({ AccountSettings }) => {
 import("./archive-invite-form").then(({ ArchiveInviteForm }) => {
   customElements.define("btrix-archive-invite-form", ArchiveInviteForm);
 });
+import("./config-editor").then(({ ConfigEditor }) => {
+  customElements.define("btrix-config-editor", ConfigEditor);
+});
 import("./copy-button").then(({ CopyButton }) => {
   customElements.define("btrix-copy-button", CopyButton);
 });

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -3,7 +3,7 @@ import { state, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import cronstrue from "cronstrue"; // TODO localize
-import { parse as yamlToJson } from "yaml";
+import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -71,7 +71,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       if (isComplexConfig) {
         this.isConfigCodeView = true;
       }
-      this.configCode = JSON.stringify(this.crawlTemplate.config, null, 2);
+      this.configCode = jsonToYaml(this.crawlTemplate.config);
     } catch (e: any) {
       this.notify({
         message:

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -589,16 +589,12 @@ export class CrawlTemplatesDetail extends LiteElement {
 
       <sl-details style="--sl-spacing-medium: var(--sl-spacing-small)">
         <span slot="summary" class="text-sm">
-          <span class="font-medium">${msg("JSON Configuration")}</span>
+          <span class="font-medium">${msg("Advanced Configuration")}</span>
         </span>
         <div class="relative">
           <pre
-            class="language-json bg-gray-800 text-gray-50 p-4 rounded font-mono text-xs overflow-auto"
-          ><code>${JSON.stringify(
-            this.crawlTemplate?.config || {},
-            null,
-            2
-          )}</code></pre>
+            class="language-yaml text-neutral-600 p-4 rounded font-mono leading-relaxed text-xs overflow-auto"
+          ><code>${jsonToYaml(this.crawlTemplate?.config || {})}</code></pre>
 
           <div class="absolute top-2 right-2">
             <btrix-copy-button

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1056,12 +1056,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     if (this.isConfigCodeView) {
       if (!this.configCode) return;
 
-      // Assume JSON if code starts with bracket, YAML otherwise
-      config = (
-        this.configCode.startsWith("{")
-          ? JSON.parse(this.configCode)
-          : yamlToJson(this.configCode)
-      ) as CrawlConfig;
+      config = yamlToJson(this.configCode) as CrawlConfig;
     } else {
       const pageLimit = formData.get("limit") as string;
       const seedUrlsStr = formData.get("seedUrls") as string;

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -645,7 +645,7 @@ export class CrawlTemplatesDetail extends LiteElement {
               @sl-change=${(e: any) =>
                 (this.isConfigCodeView = e.target.checked)}
             >
-              <span class="text-sm">${msg("Use JSON/YAML")}</span>
+              <span class="text-sm">${msg("Advanced Editor")}</span>
             </sl-switch>
           </div>
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -3,6 +3,7 @@ import { state, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import cronstrue from "cronstrue"; // TODO localize
+import { parse as yamlToJson } from "yaml";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -36,13 +37,11 @@ export class CrawlTemplatesDetail extends LiteElement {
   private showAllSeedURLs: boolean = false;
 
   @state()
-  private isSeedsJsonView: boolean = false;
+  private isConfigCodeView: boolean = false;
 
+  /** YAML or stringified JSON config */
   @state()
-  private seedsJson: string = "";
-
-  @state()
-  private invalidSeedsJsonMessage: string = "";
+  private configCode: string = "";
 
   @state()
   private isSubmittingUpdate: boolean = false;
@@ -70,9 +69,9 @@ export class CrawlTemplatesDetail extends LiteElement {
         (seed: any) => typeof seed !== "string"
       );
       if (isComplexConfig) {
-        this.isSeedsJsonView = true;
+        this.isConfigCodeView = true;
       }
-      this.seedsJson = JSON.stringify(this.crawlTemplate.config, null, 2);
+      this.configCode = JSON.stringify(this.crawlTemplate.config, null, 2);
     } catch (e: any) {
       this.notify({
         message:
@@ -385,7 +384,7 @@ export class CrawlTemplatesDetail extends LiteElement {
           >${msg("Actions")}</sl-button
         >
 
-        <ul class="text-sm text-0-800 whitespace-nowrap" role="menu">
+        <ul class="text-left text-sm text-0-800 whitespace-nowrap" role="menu">
           ${menuItems.map((item: HTMLTemplateResult) => item)}
         </ul>
       </sl-dropdown>
@@ -637,23 +636,23 @@ export class CrawlTemplatesDetail extends LiteElement {
 
           <div class="flex flex-wrap justify-between">
             <h4 class="font-medium">
-              ${this.isSeedsJsonView
+              ${this.isConfigCodeView
                 ? msg("Custom Config")
                 : msg("Crawl Configuration")}
             </h4>
             <sl-switch
-              ?checked=${this.isSeedsJsonView}
+              ?checked=${this.isConfigCodeView}
               @sl-change=${(e: any) =>
-                (this.isSeedsJsonView = e.target.checked)}
+                (this.isConfigCodeView = e.target.checked)}
             >
-              <span class="text-sm">${msg("Use JSON Editor")}</span>
+              <span class="text-sm">${msg("Use JSON/YAML")}</span>
             </sl-switch>
           </div>
 
-          <div class="${this.isSeedsJsonView ? "" : "hidden"}">
-            ${this.renderSeedsJson()}
+          <div class="${this.isConfigCodeView ? "" : "hidden"}">
+            ${this.renderSeedsCodeEditor()}
           </div>
-          <div class="grid gap-5${this.isSeedsJsonView ? " hidden" : ""}">
+          <div class="grid gap-5${this.isConfigCodeView ? " hidden" : ""}">
             ${this.renderSeedsForm()}
           </div>
 
@@ -666,8 +665,7 @@ export class CrawlTemplatesDetail extends LiteElement {
             <sl-button
               type="primary"
               submit
-              ?disabled=${Boolean(this.invalidSeedsJsonMessage) ||
-              this.isSubmittingUpdate}
+              ?disabled=${this.isSubmittingUpdate}
               ?loading=${this.isSubmittingUpdate}
               >${msg("Save Changes")}</sl-button
             >
@@ -952,7 +950,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         )}
         rows="3"
         value=${this.crawlTemplate!.config.seeds.join("\n")}
-        required
+        ?required=${!this.isConfigCodeView}
       ></sl-textarea>
       <sl-select
         name="scopeType"
@@ -986,94 +984,15 @@ export class CrawlTemplatesDetail extends LiteElement {
     `;
   }
 
-  private renderSeedsJson() {
+  private renderSeedsCodeEditor() {
     return html`
-      <div class="grid gap-4">
-        <div>
-          <p class="mb-2">
-            ${msg(
-              html`See
-                <a
-                  href="https://github.com/webrecorder/browsertrix-crawler#crawling-configuration-options"
-                  class="text-primary hover:underline"
-                  target="_blank"
-                  >Browsertrix Crawler docs
-                  <sl-icon name="box-arrow-up-right"></sl-icon
-                ></a>
-                for all configuration options.`
-            )}
-          </p>
-        </div>
-
-        <div class="grid grid-cols-3 gap-4">
-          <div class="relative col-span-3 md:col-span-2">
-            ${this.renderSeedsJsonInput()}
-
-            <div class="absolute top-2 right-2">
-              <btrix-copy-button .value=${this.seedsJson}></btrix-copy-button>
-            </div>
-          </div>
-
-          <div class="col-span-3 md:col-span-1">
-            ${this.invalidSeedsJsonMessage
-              ? html`<btrix-alert type="danger">
-                  ${this.invalidSeedsJsonMessage}
-                </btrix-alert> `
-              : html` <btrix-alert> ${msg("Valid JSON")} </btrix-alert>`}
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderSeedsJsonInput() {
-    return html`
-      <textarea
-        id="json-editor"
-        name="config"
-        class="language-json block w-full bg-gray-800 text-gray-50 p-4 rounded font-mono text-sm"
-        autocomplete="off"
-        rows="10"
-        spellcheck="false"
-        .value=${this.seedsJson}
-        @keydown=${(e: any) => {
-          // Add indentation when pressing tab key instead of moving focus
-          if (e.keyCode === /* tab: */ 9) {
-            e.preventDefault();
-
-            const textarea = e.target;
-
-            textarea.setRangeText(
-              "  ",
-              textarea.selectionStart,
-              textarea.selectionStart,
-              "end"
-            );
-          }
+      <btrix-config-editor
+        value=${this.configCode}
+        @on-change=${(e: any) => {
+          this.configCode = e.detail.value;
         }}
-        @change=${(e: any) => (this.seedsJson = e.target.value)}
-        @blur=${this.updateSeedsJson}
-      ></textarea>
+      ></btrix-config-editor>
     `;
-  }
-
-  private updateSeedsJson(e: any) {
-    const textarea = e.target;
-    const text = textarea.value;
-
-    try {
-      const json = JSON.parse(text);
-
-      this.seedsJson = JSON.stringify(json, null, 2);
-      this.invalidSeedsJsonMessage = "";
-
-      textarea.setCustomValidity("");
-      textarea.reportValidity();
-    } catch (e: any) {
-      this.invalidSeedsJsonMessage = e.message
-        ? msg(str`JSON is invalid: ${e.message.replace("JSON.parse: ", "")}`)
-        : msg("JSON is invalid.");
-    }
   }
 
   async getCrawlTemplate(): Promise<CrawlTemplate> {
@@ -1131,13 +1050,18 @@ export class CrawlTemplatesDetail extends LiteElement {
     detail: { formData: FormData };
   }) {
     const { formData } = e.detail;
-    const configValue = formData.get("config") as string;
+
     let config: CrawlConfig;
 
-    if (this.isSeedsJsonView) {
-      if (!configValue || this.invalidSeedsJsonMessage) return;
+    if (this.isConfigCodeView) {
+      if (!this.configCode) return;
 
-      config = JSON.parse(configValue) as CrawlConfig;
+      // Assume JSON if code starts with bracket, YAML otherwise
+      config = (
+        this.configCode.startsWith("{")
+          ? JSON.parse(this.configCode)
+          : yamlToJson(this.configCode)
+      ) as CrawlConfig;
     } else {
       const pageLimit = formData.get("limit") as string;
       const seedUrlsStr = formData.get("seedUrls") as string;

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -73,7 +73,7 @@ export class CrawlTemplatesNew extends LiteElement {
     };
 
   @state()
-  private isConfigCodeView: boolean = true;
+  private isConfigCodeView: boolean = false;
 
   @state()
   private configCode: string = "";

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -384,7 +384,7 @@ export class CrawlTemplatesNew extends LiteElement {
             ?checked=${this.isConfigCodeView}
             @sl-change=${(e: any) => (this.isConfigCodeView = e.target.checked)}
           >
-            <span class="text-sm">${msg("Use JSON/YAML")}</span>
+            <span class="text-sm">${msg("Advanced Editor")}</span>
           </sl-switch>
         </div>
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -2,7 +2,7 @@ import { state, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import cronParser from "cron-parser";
-import { parse as yamlToJson } from "yaml";
+import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -134,7 +134,7 @@ export class CrawlTemplatesNew extends LiteElement {
         ...this.initialCrawlTemplate?.config,
       },
     };
-    this.configCode = JSON.stringify(this.initialCrawlTemplate.config, null, 2);
+    this.configCode = jsonToYaml(this.initialCrawlTemplate.config);
     super.connectedCallback();
   }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -489,12 +489,7 @@ export class CrawlTemplatesNew extends LiteElement {
     };
 
     if (this.isConfigCodeView) {
-      // Assume JSON if code starts with bracket, YAML otherwise
-      template.config = (
-        this.configCode.startsWith("{")
-          ? JSON.parse(this.configCode)
-          : yamlToJson(this.configCode)
-      ) as CrawlConfig;
+      template.config = yamlToJson(this.configCode) as CrawlConfig;
     } else {
       template.config = {
         seeds: (seedUrlsStr as string).trim().replace(/,/g, " ").split(/\s+/g),

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -73,13 +73,10 @@ export class CrawlTemplatesNew extends LiteElement {
     };
 
   @state()
-  private isSeedsJsonView: boolean = false;
+  private isConfigCodeView: boolean = true;
 
   @state()
-  private seedsJson: string = "";
-
-  @state()
-  private invalidSeedsJsonMessage: string = "";
+  private configCode: string = "";
 
   @state()
   private isSubmitting: boolean = false;
@@ -126,7 +123,7 @@ export class CrawlTemplatesNew extends LiteElement {
       (seed: any) => typeof seed !== "string"
     );
     if (isComplexConfig) {
-      this.isSeedsJsonView = true;
+      this.isConfigCodeView = true;
     }
     this.initialCrawlTemplate = {
       name: this.initialCrawlTemplate?.name || initialValues.name,
@@ -135,7 +132,7 @@ export class CrawlTemplatesNew extends LiteElement {
         ...this.initialCrawlTemplate?.config,
       },
     };
-    this.seedsJson = JSON.stringify(this.initialCrawlTemplate.config, null, 2);
+    this.configCode = JSON.stringify(this.initialCrawlTemplate.config, null, 2);
     super.connectedCallback();
   }
 
@@ -167,7 +164,7 @@ export class CrawlTemplatesNew extends LiteElement {
       <main class="mt-6">
         <div class="md:border md:rounded-lg">
           <sl-form @sl-submit=${this.onSubmit} aria-describedby="formError">
-            <div class="md:grid grid-cols-3">
+            <div class="grid grid-cols-3">
               ${this.renderBasicSettings()} ${this.renderCrawlConfigSettings()}
               ${this.renderScheduleSettings()}
             </div>
@@ -219,10 +216,10 @@ export class CrawlTemplatesNew extends LiteElement {
 
   private renderBasicSettings() {
     return html`
-      <div class="col-span-1 py-2 md:p-8 md:border-b">
+      <div class="col-span-3 md:col-span-1 py-2 md:p-8 md:border-b">
         <h3 class="font-medium">${msg("Basic Settings")}</h3>
       </div>
-      <section class="col-span-2 pb-6 md:p-8 border-b grid gap-5">
+      <section class="col-span-3 md:col-span-2 pb-6 md:p-8 border-b grid gap-5">
         <sl-input
           name="name"
           label=${msg("Name")}
@@ -242,10 +239,10 @@ export class CrawlTemplatesNew extends LiteElement {
 
   private renderScheduleSettings() {
     return html`
-      <div class="col-span-1 py-2 md:p-8 md:border-b">
+      <div class="col-span-3 md:col-span-1 py-2 md:p-8 md:border-b">
         <h3 class="font-medium">${msg("Crawl Schedule")}</h3>
       </div>
-      <section class="col-span-2 pb-6 md:p-8 border-b grid gap-5">
+      <section class="col-span-3 md:col-span-2 pb-6 md:p-8 border-b grid gap-5">
         <div>
           <div class="flex items-end">
             <div class="pr-2 flex-1">
@@ -358,11 +355,13 @@ export class CrawlTemplatesNew extends LiteElement {
 
   private renderCrawlConfigSettings() {
     return html`
-      <div class="col-span-1 py-2 md:p-8 md:border-b">
+      <div class="col-span-3 md:col-span-1 py-2 md:p-8 md:border-b">
         <h3 class="font-medium">${msg("Crawl Settings")}</h3>
       </div>
-      <section class="col-span-2 pb-6 md:p-8 border-b grid gap-5">
-        <div>
+      <section
+        class="col-span-3 md:col-span-2 pb-6 md:p-8 border-b grid grid-cols-1 gap-5"
+      >
+        <div class="col-span-1">
           <sl-select
             name="scale"
             label=${msg("Crawl Scale")}
@@ -373,24 +372,26 @@ export class CrawlTemplatesNew extends LiteElement {
             <sl-menu-item value="3">${msg("Bigger (3x)")}</sl-menu-item>
           </sl-select>
         </div>
-        <div class="flex justify-between">
+        <div class="col-span-1 flex justify-between">
           <h4 class="font-medium">
-            ${this.isSeedsJsonView
+            ${this.isConfigCodeView
               ? msg("Custom Config")
               : msg("Crawl Configuration")}
           </h4>
           <sl-switch
-            ?checked=${this.isSeedsJsonView}
-            @sl-change=${(e: any) => (this.isSeedsJsonView = e.target.checked)}
+            ?checked=${this.isConfigCodeView}
+            @sl-change=${(e: any) => (this.isConfigCodeView = e.target.checked)}
           >
-            <span class="text-sm">${msg("Use JSON Editor")}</span>
+            <span class="text-sm">${msg("Use YAML/JSON")}</span>
           </sl-switch>
         </div>
 
-        <div class="${this.isSeedsJsonView ? "" : "hidden"}">
-          ${this.renderSeedsJson()}
+        <div class="col-span-1${this.isConfigCodeView ? "" : " hidden"}">
+          ${this.renderSeedsCodeEditor()}
         </div>
-        <div class="grid gap-5${this.isSeedsJsonView ? "hidden" : ""}">
+        <div
+          class="col-span-1 grid gap-5${this.isConfigCodeView ? " hidden" : ""}"
+        >
           ${this.renderSeedsForm()}
         </div>
       </section>
@@ -442,7 +443,7 @@ export class CrawlTemplatesNew extends LiteElement {
     `;
   }
 
-  private renderSeedsJson() {
+  private renderSeedsCodeEditor() {
     return html`
       <div class="grid gap-4">
         <div>
@@ -461,74 +462,14 @@ export class CrawlTemplatesNew extends LiteElement {
           </p>
         </div>
 
-        <div class="grid grid-cols-3 gap-4">
-          <div class="relative col-span-2">
-            ${this.renderSeedsJsonInput()}
-
-            <div class="absolute top-2 right-2">
-              <btrix-copy-button .value=${this.seedsJson}></btrix-copy-button>
-            </div>
-          </div>
-
-          <div class="col-span-1">
-            ${this.invalidSeedsJsonMessage
-              ? html`<btrix-alert type="danger">
-                  ${this.invalidSeedsJsonMessage}
-                </btrix-alert> `
-              : html` <btrix-alert> ${msg("Valid JSON")} </btrix-alert>`}
-          </div>
-        </div>
+        <btrix-config-editor
+          value=${this.configCode}
+          @on-change=${(e: any) => {
+            this.configCode = e.detail.value;
+          }}
+        ></btrix-config-editor>
       </div>
     `;
-  }
-
-  private renderSeedsJsonInput() {
-    return html`
-      <textarea
-        id="json-editor"
-        class="language-json block w-full bg-gray-800 text-gray-50 p-4 rounded font-mono text-sm"
-        autocomplete="off"
-        rows="10"
-        spellcheck="false"
-        .value=${this.seedsJson}
-        @keydown=${(e: any) => {
-          // Add indentation when pressing tab key instead of moving focus
-          if (e.keyCode === /* tab: */ 9) {
-            e.preventDefault();
-
-            const textarea = e.target;
-
-            textarea.setRangeText(
-              "  ",
-              textarea.selectionStart,
-              textarea.selectionStart,
-              "end"
-            );
-          }
-        }}
-        @change=${(e: any) => (this.seedsJson = e.target.value)}
-        @blur=${this.updateSeedsJson}
-      ></textarea>
-    `;
-  }
-
-  private updateSeedsJson(e: any) {
-    const textarea = e.target;
-    const text = textarea.value;
-
-    try {
-      const json = JSON.parse(text);
-
-      this.seedsJson = JSON.stringify(json, null, 2);
-      this.invalidSeedsJsonMessage = "";
-
-      textarea.setCustomValidity("");
-      textarea.reportValidity();
-    } catch (e: any) {
-      this.invalidSeedsJsonMessage = e.message
-        ? msg(str`JSON is invalid: ${e.message.replace("JSON.parse: ", "")}`)
-        : msg("JSON is invalid.");
-    }
   }
 
   private parseTemplate(formData: FormData) {
@@ -544,8 +485,8 @@ export class CrawlTemplatesNew extends LiteElement {
       scale: +scale,
     };
 
-    if (this.isSeedsJsonView) {
-      template.config = JSON.parse(this.seedsJson);
+    if (this.isConfigCodeView) {
+      template.config = JSON.parse(this.configCode);
     } else {
       template.config = {
         seeds: (seedUrlsStr as string).trim().replace(/,/g, " ").split(/\s+/g),
@@ -564,19 +505,7 @@ export class CrawlTemplatesNew extends LiteElement {
   }) {
     if (!this.authState) return;
 
-    if (this.isSeedsJsonView && this.invalidSeedsJsonMessage) {
-      // Check JSON validity
-      const jsonEditor = event.target.querySelector("#json-editor");
-
-      jsonEditor.setCustomValidity(msg("Please correct JSON errors."));
-      jsonEditor.reportValidity();
-
-      return;
-    }
-
     const params = this.parseTemplate(event.detail.formData);
-
-    console.log(params);
 
     this.serverError = undefined;
     this.isSubmitting = true;

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -2,6 +2,7 @@ import { state, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import cronParser from "cron-parser";
+import { parse as yamlToJson } from "yaml";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -383,7 +384,7 @@ export class CrawlTemplatesNew extends LiteElement {
             ?checked=${this.isConfigCodeView}
             @sl-change=${(e: any) => (this.isConfigCodeView = e.target.checked)}
           >
-            <span class="text-sm">${msg("Use YAML/JSON")}</span>
+            <span class="text-sm">${msg("Use JSON/YAML")}</span>
           </sl-switch>
         </div>
 
@@ -488,7 +489,12 @@ export class CrawlTemplatesNew extends LiteElement {
     };
 
     if (this.isConfigCodeView) {
-      template.config = JSON.parse(this.configCode);
+      // Assume JSON if code starts with bracket, YAML otherwise
+      template.config = (
+        this.configCode.startsWith("{")
+          ? JSON.parse(this.configCode)
+          : yamlToJson(this.configCode)
+      ) as CrawlConfig;
     } else {
       template.config = {
         seeds: (seedUrlsStr as string).trim().replace(/,/g, " ").split(/\s+/g),

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -75,6 +75,7 @@ export class CrawlTemplatesNew extends LiteElement {
   @state()
   private isConfigCodeView: boolean = false;
 
+  /** YAML or stringified JSON config */
   @state()
   private configCode: string = "";
 
@@ -411,7 +412,7 @@ export class CrawlTemplatesNew extends LiteElement {
         )}
         rows="3"
         value=${this.initialCrawlTemplate!.config.seeds.join("\n")}
-        required
+        ?required=${!this.isConfigCodeView}
       ></sl-textarea>
       <sl-select
         name="scopeType"
@@ -445,8 +446,8 @@ export class CrawlTemplatesNew extends LiteElement {
 
   private renderSeedsCodeEditor() {
     return html`
-      <div class="grid gap-4">
-        <div>
+      <div class="grid grid-cols-1 gap-4">
+        <div class="col-span-1">
           <p class="mb-2">
             ${msg(
               html`See
@@ -463,6 +464,7 @@ export class CrawlTemplatesNew extends LiteElement {
         </div>
 
         <btrix-config-editor
+          class="col-span-1"
           value=${this.configCode}
           @on-change=${(e: any) => {
             this.configCode = e.detail.value;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5604,6 +5604,11 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.0.0-11:
+  version "2.0.0-11"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-11.tgz#269af42637a41ec1ebf2abb546a28949545f0cbb"
+  integrity sha512-5kGSQrzDyjCk0BLuFfjkoUE9vYcoyrwZIZ+GnpOSM9vhkvPjItYiWJ1jpRSo0aU4QmsoNrFwDT4O7XS2UGcBQg==
+
 yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/203) Support editing crawl config as YAML.

### Manual testing
1. Run app and go to new crawl template page
2. Toggle "Advanced Editor". Verify code editor is shown
3. Type and paste in config as plain JSON or YAML. Verify code editor works as expected
4. Enter in invalid YAML. Verify error is shown and you're prevented from creating the crawl template
5. Fix invalid YAML. Verify crawl template is created with expected crawl config
6. Repeat test for editing config

### Screenshots
**YAML:**
<img width="640" alt="Screen Shot 2022-04-05 at 2 56 33 PM" src="https://user-images.githubusercontent.com/4672952/161856463-5d281411-defc-413a-9cc9-77c5d728b4e6.png">

**YAML error handling:**
<img width="629" alt="Screen Shot 2022-04-05 at 2 56 54 PM" src="https://user-images.githubusercontent.com/4672952/161856485-48610db6-e9fd-49c7-bd79-200cc2aab242.png">

**Crawl template detail view:**
<img width="640" alt="Screen Shot 2022-04-05 at 3 05 37 PM" src="https://user-images.githubusercontent.com/4672952/161857644-6142f542-5eb1-4d96-940d-55b45dc2b2eb.png">


### Ideas
The yaml parse errors are pretty nice. Could implement friendly JSON parse errors.