### PR TITLE
Create crawl template with browser profile

### DIFF
--- a/frontend/src/pages/archive/browser-profiles-list.ts
+++ b/frontend/src/pages/archive/browser-profiles-list.ts
@@ -3,7 +3,7 @@ import { msg, localized, str } from "@lit/localize";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-import { Profile } from "./types";
+import type { Profile } from "./types";
 
 /**
  * Usage:

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -587,6 +587,29 @@ export class CrawlTemplatesDetail extends LiteElement {
         ${this.crawlTemplate?.config.extraHops ? msg("Yes") : msg("No")}
       </div>
 
+      <div class="mb-5">
+        <div class="text-sm text-0-600">${msg("Browser Profile")}</div>
+        ${this.crawlTemplate
+          ? html`
+              ${this.crawlTemplate.profileid
+                ? html`<a
+                    class="font-medium text-neutral-700 hover:text-neutral-900"
+                    href=${`/archives/${this.archiveId}/browser-profiles/profile/${this.crawlTemplate.profileid}`}
+                    @click=${this.navLink}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="link-45deg"
+                    ></sl-icon>
+                    <span class="inline-block align-middle"
+                      >${this.crawlTemplate.profileName}</span
+                    >
+                  </a>`
+                : html`<span class="text-0-400">${msg("None")}</span>`}
+            `
+          : ""}
+      </div>
+
       <sl-details style="--sl-spacing-medium: var(--sl-spacing-small)">
         <span slot="summary" class="text-sm">
           <span class="font-medium">${msg("Advanced Configuration")}</span>

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -18,6 +18,7 @@ export type NewCrawlTemplate = {
   crawlTimeout?: number;
   scale: number;
   config: CrawlConfig;
+  profileid: string;
 };
 
 const initialValues = {
@@ -241,7 +242,7 @@ export class CrawlTemplatesNew extends LiteElement {
           required
         ></sl-input>
 
-        <sl-select name="profileid" label=${msg("Browser Profile")} clearable>
+        <sl-select name="profileId" label=${msg("Browser Profile")} clearable>
           ${this.browserProfiles?.map(
             (profile) => html`
               <sl-menu-item value=${profile.id}> ${profile.name} </sl-menu-item>
@@ -499,6 +500,7 @@ export class CrawlTemplatesNew extends LiteElement {
       runNow: this.isRunNow,
       crawlTimeout: crawlTimeoutMinutes ? +crawlTimeoutMinutes * 60 : 0,
       scale: +scale,
+      profileid: formData.get("profileId") as string,
     };
 
     if (this.isConfigCodeView) {

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -90,6 +90,9 @@ export class CrawlTemplatesNew extends LiteElement {
   @state()
   browserProfiles?: Profile[];
 
+  @state()
+  selectedProfile?: Profile;
+
   private get timeZone() {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
@@ -242,31 +245,64 @@ export class CrawlTemplatesNew extends LiteElement {
           required
         ></sl-input>
 
-        <sl-select
-          name="profileId"
-          label=${msg("Browser Profile")}
-          clearable
-          ?disabled=${!this.browserProfiles?.length}
-        >
-          ${this.browserProfiles?.map(
-            (profile) => html`
-              <sl-menu-item value=${profile.id}>
-                ${profile.name}
-                <div slot="suffix">
-                  <div class="text-xs">
-                    <sl-format-date
-                      date=${`${profile.created}Z` /** Z for UTC */}
-                      month="2-digit"
-                      day="2-digit"
-                      year="2-digit"
-                      hour="numeric"
-                      minute="numeric"
-                    ></sl-format-date>
-                  </div></div
-              ></sl-menu-item>
-            `
-          )}
-        </sl-select>
+        <div>
+          <sl-select
+            label=${msg("Browser Profile")}
+            clearable
+            value=${this.selectedProfile?.id || ""}
+            ?disabled=${!this.browserProfiles?.length}
+            @sl-change=${(e: any) =>
+              (this.selectedProfile = this.browserProfiles?.find(
+                ({ id }) => id === e.target.value
+              ))}
+          >
+            ${this.browserProfiles?.map(
+              (profile) => html`
+                <sl-menu-item value=${profile.id}>
+                  ${profile.name}
+                  <div slot="suffix">
+                    <div class="text-xs">
+                      <sl-format-date
+                        date=${`${profile.created}Z` /** Z for UTC */}
+                        month="2-digit"
+                        day="2-digit"
+                        year="2-digit"
+                        hour="numeric"
+                        minute="numeric"
+                      ></sl-format-date>
+                    </div></div
+                ></sl-menu-item>
+              `
+            )}
+          </sl-select>
+
+          ${this.selectedProfile
+            ? html`
+                <div
+                  class="mt-2 border bg-slate-50 border-slate-100 rounded p-2 text-sm flex justify-between"
+                >
+                  ${this.selectedProfile.description
+                    ? html`<em class="text-slate-500"
+                        >${this.selectedProfile.description}</em
+                      >`
+                    : ""}
+                  <a
+                    href=${`/archives/${this.archiveId}/browser-profiles/profile/${this.selectedProfile.id}`}
+                    class="font-medium text-primary hover:text-indigo-500"
+                    target="_blank"
+                  >
+                    <span class="inline-block align-middle mr-1"
+                      >${msg("View profile")}</span
+                    >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="box-arrow-up-right"
+                    ></sl-icon>
+                  </a>
+                </div>
+              `
+            : ""}
+        </div>
       </section>
     `;
   }
@@ -359,7 +395,7 @@ export class CrawlTemplatesNew extends LiteElement {
               </sl-button-group>
             </div>
           </fieldset>
-          <div class="text-sm text-gray-500 mt-2">
+          <div class="text-sm text-neutral-500 mt-2">
             ${this.formattededNextCrawlDate
               ? msg(
                   html`Next scheduled crawl: ${this.formattededNextCrawlDate}`

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -242,7 +242,12 @@ export class CrawlTemplatesNew extends LiteElement {
           required
         ></sl-input>
 
-        <sl-select name="profileId" label=${msg("Browser Profile")} clearable>
+        <sl-select
+          name="profileId"
+          label=${msg("Browser Profile")}
+          clearable
+          ?disabled=${!this.browserProfiles?.length}
+        >
           ${this.browserProfiles?.map(
             (profile) => html`
               <sl-menu-item value=${profile.id}> ${profile.name} </sl-menu-item>

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -3,6 +3,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import cronParser from "cron-parser";
 import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
+import orderBy from "lodash/fp/orderBy";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -274,8 +275,6 @@ export class CrawlTemplatesNew extends LiteElement {
                         month="2-digit"
                         day="2-digit"
                         year="2-digit"
-                        hour="numeric"
-                        minute="numeric"
                       ></sl-format-date>
                     </div></div
                 ></sl-menu-item>
@@ -670,7 +669,7 @@ export class CrawlTemplatesNew extends LiteElement {
     try {
       const data = await this.getProfiles();
 
-      this.browserProfiles = data;
+      this.browserProfiles = orderBy("created")("desc")(data) as Profile[];
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't retrieve browser profiles at this time."),

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -256,6 +256,9 @@ export class CrawlTemplatesNew extends LiteElement {
                 ({ id }) => id === e.target.value
               ))}
           >
+            ${this.browserProfiles
+              ? ""
+              : html` <sl-spinner slot="prefix"></sl-spinner> `}
             ${this.browserProfiles?.map(
               (profile) => html`
                 <sl-menu-item value=${profile.id}>

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -250,7 +250,20 @@ export class CrawlTemplatesNew extends LiteElement {
         >
           ${this.browserProfiles?.map(
             (profile) => html`
-              <sl-menu-item value=${profile.id}> ${profile.name} </sl-menu-item>
+              <sl-menu-item value=${profile.id}>
+                ${profile.name}
+                <div slot="suffix">
+                  <div class="text-xs">
+                    <sl-format-date
+                      date=${`${profile.created}Z` /** Z for UTC */}
+                      month="2-digit"
+                      day="2-digit"
+                      year="2-digit"
+                      hour="numeric"
+                      minute="numeric"
+                    ></sl-format-date>
+                  </div></div
+              ></sl-menu-item>
             `
           )}
         </sl-select>

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -255,6 +255,10 @@ export class CrawlTemplatesNew extends LiteElement {
               (this.selectedProfile = this.browserProfiles?.find(
                 ({ id }) => id === e.target.value
               ))}
+            @sl-focus=${() => {
+              // Refetch to keep list up to date
+              this.fetchBrowserProfiles();
+            }}
           >
             ${this.browserProfiles
               ? ""
@@ -279,6 +283,27 @@ export class CrawlTemplatesNew extends LiteElement {
             )}
           </sl-select>
 
+          ${this.browserProfiles && !this.browserProfiles.length
+            ? html`
+                <div class="mt-2 text-sm text-neutral-500">
+                  <span class="inline-block align-middle"
+                    >${msg("No browser profiles found.")}</span
+                  >
+                  <a
+                    href=${`/archives/${this.archiveId}/browser-profiles/new`}
+                    class="font-medium text-primary hover:text-indigo-500"
+                    target="_blank"
+                    ><span class="inline-block align-middle"
+                      >${msg("Create a browser profile")}</span
+                    >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="box-arrow-up-right"
+                    ></sl-icon
+                  ></a>
+                </div>
+              `
+            : ""}
           ${this.selectedProfile
             ? html`
                 <div

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -669,7 +669,9 @@ export class CrawlTemplatesNew extends LiteElement {
     try {
       const data = await this.getProfiles();
 
-      this.browserProfiles = orderBy("created")("desc")(data) as Profile[];
+      this.browserProfiles = orderBy(["name", "created"])(["asc", "desc"])(
+        data
+      ) as Profile[];
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't retrieve browser profiles at this time."),

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -54,6 +54,8 @@ export type CrawlTemplate = {
   inactive: boolean;
   config: CrawlConfig;
   scale: number;
+  profileid: string | null;
+  profileName: string | null;
 };
 
 export type Profile = {


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/199) Allows users to choose a browser profile when creating a crawl template.

### Manual testing
Prerequisite: Create a browser profile if you don't already have one
1. Run app and go to New Crawl Template page
2. Choose browser profile from dropdown and save
3. Go to crawl template detail page. Verify that browser profile selection is saved

### Screenshots
**New field in create form:**
<img width="1014" alt="Screen Shot 2022-04-16 at 6 19 06 PM" src="https://user-images.githubusercontent.com/4672952/163696363-caba6c41-54be-49d0-8abc-b0694a9399f3.png">

**New field in detail:**
<img width="1016" alt="Screen Shot 2022-04-16 at 6 18 48 PM" src="https://user-images.githubusercontent.com/4672952/163696368-4bcba6d9-9e7a-4961-ad08-febd4b18e810.png">

