### PR TITLE
Filter and sort crawl templates

### DIFF
--- a/frontend/src/pages/archive/browser-profiles-list.ts
+++ b/frontend/src/pages/archive/browser-profiles-list.ts
@@ -49,7 +49,7 @@ export class BrowserProfilesList extends LiteElement {
     return html`<header class="mb-3 text-right">
         <a
           href=${`/archives/${this.archiveId}/browser-profiles/new`}
-          class="inline-block bg-primary hover:bg-indigo-400 text-white text-center font-medium leading-none rounded px-3 py-2 transition-colors"
+          class="inline-block bg-indigo-500 hover:bg-indigo-400 text-white text-center font-medium leading-none rounded px-3 py-2 transition-colors"
           role="button"
           @click=${this.navLink}
         >

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -100,58 +100,7 @@ export class CrawlTemplatesList extends LiteElement {
     }
 
     return html`
-      <header class="flex items-center justify-between mb-3">
-        <div class="text-sm">
-          <button
-            class="inline-block font-medium border-b-2 ${this
-              .filterByScheduled === null
-              ? "border-b-current text-primary"
-              : "border-b-transparent text-neutral-500"} mr-3"
-            aria-selected=${this.filterByScheduled === null}
-            @click=${() => (this.filterByScheduled = null)}
-          >
-            ${msg("All")}
-          </button>
-          <button
-            class="inline-block font-medium border-b-2 ${this
-              .filterByScheduled === true
-              ? "border-b-current text-primary"
-              : "border-b-transparent text-neutral-500"} mr-3"
-            aria-selected=${this.filterByScheduled === true}
-            @click=${() => (this.filterByScheduled = true)}
-          >
-            ${msg("Scheduled")}
-          </button>
-          <button
-            class="inline-block font-medium border-b-2 ${this
-              .filterByScheduled === false
-              ? "border-b-current text-primary"
-              : "border-b-transparent text-neutral-500"} mr-3"
-            aria-selected=${this.filterByScheduled === false}
-            @click=${() => (this.filterByScheduled = false)}
-          >
-            ${msg("No schedule")}
-          </button>
-        </div>
-        <div>
-          <a
-            href=${`/archives/${this.archiveId}/crawl-templates/new`}
-            class="block bg-indigo-500 hover:bg-indigo-400 text-white text-center font-medium leading-none rounded px-3 py-2 transition-colors"
-            role="button"
-            @click=${this.navLink}
-          >
-            <sl-icon
-              class="inline-block align-middle mr-2"
-              name="plus-lg"
-            ></sl-icon
-            ><span class="inline-block align-middle mr-2 text-sm"
-              >${msg("New Crawl Template")}</span
-            >
-          </a>
-        </div>
-      </header>
-
-      <div class="mb-3">${this.renderControls()}</div>
+      <div class="mb-4">${this.renderControls()}</div>
 
       ${this.renderTemplateList()}
 
@@ -179,13 +128,13 @@ export class CrawlTemplatesList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-2 gap-3 items-center">
-        <div class="col-span-2 md:col-span-1">
+      <div class="flex flex-wrap items-center">
+        <div class="grow mr-4 mb-4">
           <sl-input
             class="w-full"
             slot="trigger"
             placeholder=${msg("Search by name")}
-            pill
+            style="--sl-input-height-medium: 2.25rem;"
             clearable
             ?disabled=${!this.crawlTemplates?.length}
             @sl-input=${this.onSearchInput}
@@ -193,7 +142,59 @@ export class CrawlTemplatesList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="col-span-2 md:col-span-1 flex items-center justify-end">
+
+        <div class="grow-0 mb-4">
+          <a
+            href=${`/archives/${this.archiveId}/crawl-templates/new`}
+            class="block bg-indigo-500 hover:bg-indigo-400 text-white text-center font-medium leading-none rounded px-3 py-2 transition-colors"
+            role="button"
+            @click=${this.navLink}
+          >
+            <sl-icon
+              class="inline-block align-middle mr-2"
+              name="plus-lg"
+            ></sl-icon
+            ><span class="inline-block align-middle mr-2 text-sm"
+              >${msg("New Crawl Template")}</span
+            >
+          </a>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-between">
+        <div class="text-sm">
+          <button
+            class="inline-block font-medium border-2 border-transparent ${this
+              .filterByScheduled === null
+              ? "border-b-current text-primary"
+              : "text-neutral-500"} mr-3"
+            aria-selected=${this.filterByScheduled === null}
+            @click=${() => (this.filterByScheduled = null)}
+          >
+            ${msg("All")}
+          </button>
+          <button
+            class="inline-block font-medium border-2 border-transparent ${this
+              .filterByScheduled === true
+              ? "border-b-current text-primary"
+              : "text-neutral-500"} mr-3"
+            aria-selected=${this.filterByScheduled === true}
+            @click=${() => (this.filterByScheduled = true)}
+          >
+            ${msg("Scheduled")}
+          </button>
+          <button
+            class="inline-block font-medium border-2 border-transparent ${this
+              .filterByScheduled === false
+              ? "border-b-current text-primary"
+              : "text-neutral-500"} mr-3"
+            aria-selected=${this.filterByScheduled === false}
+            @click=${() => (this.filterByScheduled = false)}
+          >
+            ${msg("No schedule")}
+          </button>
+        </div>
+        <div class="flex items-center justify-end">
           <div class="whitespace-nowrap text-sm text-0-500 mr-2">
             ${msg("Sort By")}
           </div>
@@ -210,6 +211,7 @@ export class CrawlTemplatesList extends LiteElement {
           >
             <sl-button
               slot="trigger"
+              size="small"
               pill
               caret
               ?disabled=${!this.crawlTemplates?.length}

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -63,7 +63,10 @@ export class CrawlTemplatesList extends LiteElement {
   };
 
   @state()
-  private filterBy: string = "";
+  private searchBy: string = "";
+
+  @state()
+  private filterByScheduled: boolean | null = null;
 
   // For fuzzy search:
   private fuse = new Fuse([], {
@@ -96,28 +99,23 @@ export class CrawlTemplatesList extends LiteElement {
     }
 
     return html`
-      <div
-        class=${this.crawlTemplates.length
-          ? "grid sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4"
-          : "flex justify-center"}
-      >
-        <a
-          href=${`/archives/${this.archiveId}/crawl-templates/new`}
-          class="col-span-1 bg-slate-50 border border-indigo-200 hover:border-primary text-primary text-center font-medium rounded px-6 py-4 transition-colors"
-          @click=${this.navLink}
-          role="button"
-        >
-          <sl-icon
-            class="inline-block align-middle mr-2"
-            name="plus-square"
-          ></sl-icon
-          ><span
-            class="inline-block align-middle mr-2 ${this.crawlTemplates.length
-              ? "text-sm"
-              : "font-medium"}"
-            >${msg("New Crawl Template")}</span
+      <div class="flex justify-end mb-3">
+        <div>
+          <a
+            href=${`/archives/${this.archiveId}/crawl-templates/new`}
+            class="block bg-indigo-500 hover:bg-indigo-400 text-white text-center font-medium leading-none rounded px-3 py-2 transition-colors"
+            role="button"
+            @click=${this.navLink}
           >
-        </a>
+            <sl-icon
+              class="inline-block align-middle mr-2"
+              name="plus-lg"
+            ></sl-icon
+            ><span class="inline-block align-middle mr-2 text-sm"
+              >${msg("New Crawl Template")}</span
+            >
+          </a>
+        </div>
       </div>
 
       <div class="mb-4">${this.renderControls()}</div>
@@ -162,7 +160,7 @@ export class CrawlTemplatesList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="col-span-12 md:col-span-1 flex items-center justify-end">
+        <div class="col-span-2 md:col-span-1 flex items-center justify-end">
           <div class="whitespace-nowrap text-sm text-0-500 mr-2">
             ${msg("Sort By")}
           </div>
@@ -221,7 +219,7 @@ export class CrawlTemplatesList extends LiteElement {
       map(this.renderTemplateItem.bind(this)),
     ];
 
-    if (this.filterBy.length >= MIN_SEARCH_LENGTH) {
+    if (this.searchBy.length >= MIN_SEARCH_LENGTH) {
       flowFns.unshift(this.filterResults);
     }
 
@@ -494,11 +492,11 @@ export class CrawlTemplatesList extends LiteElement {
   }
 
   private onSearchInput = debounce(200)((e: any) => {
-    this.filterBy = e.target.value;
+    this.searchBy = e.target.value;
   }) as any;
 
   private filterResults = () => {
-    const results = this.fuse.search(this.filterBy);
+    const results = this.fuse.search(this.searchBy);
 
     return results.map(({ item }) => item);
   };

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -6,6 +6,7 @@ import debounce from "lodash/fp/debounce";
 import flow from "lodash/fp/flow";
 import map from "lodash/fp/map";
 import orderBy from "lodash/fp/orderBy";
+import filter from "lodash/fp/filter";
 import Fuse from "fuse.js";
 
 import type { AuthState } from "../../utils/AuthService";
@@ -99,7 +100,39 @@ export class CrawlTemplatesList extends LiteElement {
     }
 
     return html`
-      <div class="flex justify-end mb-3">
+      <header class="flex items-center justify-between mb-3">
+        <div class="text-sm">
+          <button
+            class="inline-block font-medium border-b-2 ${this
+              .filterByScheduled === null
+              ? "border-b-current text-primary"
+              : "border-b-transparent text-neutral-500"} mr-3"
+            aria-selected=${this.filterByScheduled === null}
+            @click=${() => (this.filterByScheduled = null)}
+          >
+            ${msg("All")}
+          </button>
+          <button
+            class="inline-block font-medium border-b-2 ${this
+              .filterByScheduled === true
+              ? "border-b-current text-primary"
+              : "border-b-transparent text-neutral-500"} mr-3"
+            aria-selected=${this.filterByScheduled === true}
+            @click=${() => (this.filterByScheduled = true)}
+          >
+            ${msg("Scheduled")}
+          </button>
+          <button
+            class="inline-block font-medium border-b-2 ${this
+              .filterByScheduled === false
+              ? "border-b-current text-primary"
+              : "border-b-transparent text-neutral-500"} mr-3"
+            aria-selected=${this.filterByScheduled === false}
+            @click=${() => (this.filterByScheduled = false)}
+          >
+            ${msg("No schedule")}
+          </button>
+        </div>
         <div>
           <a
             href=${`/archives/${this.archiveId}/crawl-templates/new`}
@@ -116,9 +149,9 @@ export class CrawlTemplatesList extends LiteElement {
             >
           </a>
         </div>
-      </div>
+      </header>
 
-      <div class="mb-4">${this.renderControls()}</div>
+      <div class="mb-3">${this.renderControls()}</div>
 
       ${this.renderTemplateList()}
 
@@ -218,6 +251,12 @@ export class CrawlTemplatesList extends LiteElement {
       orderBy(this.orderBy.field, this.orderBy.direction),
       map(this.renderTemplateItem.bind(this)),
     ];
+
+    if (this.filterByScheduled === true) {
+      flowFns.unshift(filter(({ schedule }: any) => Boolean(schedule)));
+    } else if (this.filterByScheduled === false) {
+      flowFns.unshift(filter(({ schedule }: any) => !schedule));
+    }
 
     if (this.searchBy.length >= MIN_SEARCH_LENGTH) {
       flowFns.unshift(this.filterResults);

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -73,6 +73,7 @@ export class CrawlTemplatesList extends LiteElement {
   private fuse = new Fuse([], {
     keys: ["name"],
     shouldSort: false,
+    threshold: 0.4, // stricter; default is 0.6
   });
 
   async firstUpdated() {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -91,18 +91,24 @@ export class CrawlTemplatesList extends LiteElement {
   }
 
   render() {
-    if (!this.crawlTemplates) {
-      return html`<div
-        class="w-full flex items-center justify-center my-24 text-4xl"
-      >
-        <sl-spinner></sl-spinner>
-      </div>`;
-    }
-
     return html`
       <div class="mb-4">${this.renderControls()}</div>
 
-      ${this.renderTemplateList()}
+      ${this.crawlTemplates
+        ? this.crawlTemplates.length
+          ? this.renderTemplateList()
+          : html`
+              <div class="border-t border-b py-5">
+                <p class="text-center text-0-500">
+                  ${msg("No crawl templates yet.")}
+                </p>
+              </div>
+            `
+        : html`<div
+            class="w-full flex items-center justify-center my-24 text-4xl"
+          >
+            <sl-spinner></sl-spinner>
+          </div>`}
 
       <sl-dialog
         label=${msg(str`Edit Crawl Schedule`)}
@@ -161,90 +167,93 @@ export class CrawlTemplatesList extends LiteElement {
         </div>
       </div>
 
-      <div class="flex flex-wrap items-center justify-between">
-        <div class="text-sm">
-          <button
-            class="inline-block font-medium border-2 border-transparent ${this
-              .filterByScheduled === null
-              ? "border-b-current text-primary"
-              : "text-neutral-500"} mr-3"
-            aria-selected=${this.filterByScheduled === null}
-            @click=${() => (this.filterByScheduled = null)}
-          >
-            ${msg("All")}
-          </button>
-          <button
-            class="inline-block font-medium border-2 border-transparent ${this
-              .filterByScheduled === true
-              ? "border-b-current text-primary"
-              : "text-neutral-500"} mr-3"
-            aria-selected=${this.filterByScheduled === true}
-            @click=${() => (this.filterByScheduled = true)}
-          >
-            ${msg("Scheduled")}
-          </button>
-          <button
-            class="inline-block font-medium border-2 border-transparent ${this
-              .filterByScheduled === false
-              ? "border-b-current text-primary"
-              : "text-neutral-500"} mr-3"
-            aria-selected=${this.filterByScheduled === false}
-            @click=${() => (this.filterByScheduled = false)}
-          >
-            ${msg("No schedule")}
-          </button>
-        </div>
-        <div class="flex items-center justify-end">
-          <div class="whitespace-nowrap text-sm text-0-500 mr-2">
-            ${msg("Sort By")}
-          </div>
-          <sl-dropdown
-            placement="bottom-end"
-            distance="4"
-            @sl-select=${(e: any) => {
-              const [field, direction] = e.detail.item.value.split("_");
-              this.orderBy = {
-                field: field,
-                direction: direction,
-              };
-            }}
-          >
-            <sl-button
-              slot="trigger"
-              size="small"
-              pill
-              caret
-              ?disabled=${!this.crawlTemplates?.length}
-              >${(sortableFieldLabels as any)[this.orderBy.field] ||
-              sortableFieldLabels[
-                `${this.orderBy.field}_${this.orderBy.direction}`
-              ]}</sl-button
-            >
-            <sl-menu>
-              ${Object.entries(sortableFieldLabels).map(
-                ([value, label]) => html`
-                  <sl-menu-item
-                    value=${value}
-                    ?checked=${value ===
-                    `${this.orderBy.field}_${this.orderBy.direction}`}
-                    >${label}</sl-menu-item
-                  >
-                `
-              )}
-            </sl-menu>
-          </sl-dropdown>
-          <sl-icon-button
-            name="arrow-down-up"
-            label=${msg("Reverse sort")}
-            @click=${() => {
-              this.orderBy = {
-                ...this.orderBy,
-                direction: this.orderBy.direction === "asc" ? "desc" : "asc",
-              };
-            }}
-          ></sl-icon-button>
-        </div>
-      </div>
+      ${this.crawlTemplates && this.crawlTemplates.length
+        ? html`<div class="flex flex-wrap items-center justify-between">
+            <div class="text-sm">
+              <button
+                class="inline-block font-medium border-2 border-transparent ${this
+                  .filterByScheduled === null
+                  ? "border-b-current text-primary"
+                  : "text-neutral-500"} mr-3"
+                aria-selected=${this.filterByScheduled === null}
+                @click=${() => (this.filterByScheduled = null)}
+              >
+                ${msg("All")}
+              </button>
+              <button
+                class="inline-block font-medium border-2 border-transparent ${this
+                  .filterByScheduled === true
+                  ? "border-b-current text-primary"
+                  : "text-neutral-500"} mr-3"
+                aria-selected=${this.filterByScheduled === true}
+                @click=${() => (this.filterByScheduled = true)}
+              >
+                ${msg("Scheduled")}
+              </button>
+              <button
+                class="inline-block font-medium border-2 border-transparent ${this
+                  .filterByScheduled === false
+                  ? "border-b-current text-primary"
+                  : "text-neutral-500"} mr-3"
+                aria-selected=${this.filterByScheduled === false}
+                @click=${() => (this.filterByScheduled = false)}
+              >
+                ${msg("No schedule")}
+              </button>
+            </div>
+            <div class="flex items-center justify-end">
+              <div class="whitespace-nowrap text-sm text-0-500 mr-2">
+                ${msg("Sort By")}
+              </div>
+              <sl-dropdown
+                placement="bottom-end"
+                distance="4"
+                @sl-select=${(e: any) => {
+                  const [field, direction] = e.detail.item.value.split("_");
+                  this.orderBy = {
+                    field: field,
+                    direction: direction,
+                  };
+                }}
+              >
+                <sl-button
+                  slot="trigger"
+                  size="small"
+                  pill
+                  caret
+                  ?disabled=${!this.crawlTemplates?.length}
+                  >${(sortableFieldLabels as any)[this.orderBy.field] ||
+                  sortableFieldLabels[
+                    `${this.orderBy.field}_${this.orderBy.direction}`
+                  ]}</sl-button
+                >
+                <sl-menu>
+                  ${Object.entries(sortableFieldLabels).map(
+                    ([value, label]) => html`
+                      <sl-menu-item
+                        value=${value}
+                        ?checked=${value ===
+                        `${this.orderBy.field}_${this.orderBy.direction}`}
+                        >${label}</sl-menu-item
+                      >
+                    `
+                  )}
+                </sl-menu>
+              </sl-dropdown>
+              <sl-icon-button
+                name="arrow-down-up"
+                label=${msg("Reverse sort")}
+                @click=${() => {
+                  this.orderBy = {
+                    ...this.orderBy,
+                    direction:
+                      this.orderBy.direction === "asc" ? "desc" : "asc",
+                  };
+                }}
+              ></sl-icon-button>
+            </div>
+          </div>`
+        : ""}
     `;
   }
 

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -177,7 +177,7 @@ export class CrawlsList extends LiteElement {
         </div>
         <div class="col-span-12 md:col-span-1 flex items-center justify-end">
           <div class="whitespace-nowrap text-sm text-0-500 mr-2">
-            ${msg("Sort by")}
+            ${msg("Sort By")}
           </div>
           <sl-dropdown
             placement="bottom-end"

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -129,7 +129,7 @@ export class CrawlsList extends LiteElement {
 
     return html`
       <main>
-        <header class="pb-4">${this.renderControls()}</header>
+        <header class="mb-4">${this.renderControls()}</header>
         <section>
           ${this.crawls.length
             ? this.renderCrawlList()
@@ -164,10 +164,10 @@ export class CrawlsList extends LiteElement {
       <div class="grid grid-cols-2 gap-3 items-center">
         <div class="col-span-2 md:col-span-1">
           <sl-input
+            size="small"
             class="w-full"
             slot="trigger"
             placeholder=${msg("Search by Crawl Template name or ID")}
-            pill
             clearable
             ?disabled=${!this.crawls?.length}
             @sl-input=${this.onSearchInput}
@@ -192,6 +192,7 @@ export class CrawlsList extends LiteElement {
           >
             <sl-button
               slot="trigger"
+              size="small"
               pill
               caret
               ?disabled=${!this.crawls?.length}


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/153) Filters, sorts and enables searching crawl templates by name. Crawls list and browser profiles list tweaked for UI consistency.

### Manual testing
Go to Crawl Templates and test that the following works as expected:
- "Search by name" input
- Filter by "Scheduled" or "No schedule", or show all with "All"
- Sort by newest/oldest crawl template and newest/oldest crawl

### Screenshots
**New control bar:**
<img width="1027" alt="Screen Shot 2022-04-18 at 4 33 12 PM" src="https://user-images.githubusercontent.com/4672952/163893734-3340cea3-0517-4216-b7f3-ffda33c7347f.png">

**Sort options:**
<img width="213" alt="Screen Shot 2022-04-18 at 4 33 21 PM" src="https://user-images.githubusercontent.com/4672952/163893765-6ee6ed0d-4306-4c66-b39c-feafe71d9bd7.png">

**Filter by name:**
<img width="1032" alt="Screen Shot 2022-04-18 at 4 41 14 PM" src="https://user-images.githubusercontent.com/4672952/163893776-cb978256-d7a2-4e9b-ad24-a02268ce4515.png">

