### PR TITLE
View and edit browser profile

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -21,6 +21,9 @@ import("./copy-button").then(({ CopyButton }) => {
 import("./invite-form").then(({ InviteForm }) => {
   customElements.define("btrix-invite-form", InviteForm);
 });
+import("./profile-browser").then(({ ProfileBrowser }) => {
+  customElements.define("btrix-profile-browser", ProfileBrowser);
+});
 import("./relative-duration").then(({ RelativeDuration }) => {
   customElements.define("btrix-relative-duration", RelativeDuration);
 });

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -1,7 +1,7 @@
 // import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
-import { msg, localized } from "@lit/localize";
+import { msg, localized, str } from "@lit/localize";
 
 import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
@@ -188,6 +188,7 @@ export class ProfileBrowser extends LiteElement {
                 ? " hover:bg-slate-50 hover:text-primary"
                 : ""}"
               role=${this.iframeSrc ? "button" : "listitem"}
+              title=${msg(str`Go to ${url}`)}
               @click=${() =>
                 this.iframeSrc ? this.navigateBrowser({ url }) : {}}
             >

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -1,0 +1,79 @@
+// import { LitElement, html } from "lit";
+import { property, state } from "lit/decorators.js";
+import { ref } from "lit/directives/ref.js";
+import { msg, localized } from "@lit/localize";
+
+import LiteElement, { html } from "../utils/LiteElement";
+
+// TODO remove sidebar constaint once devtools panel
+// is hidden on the backend
+const SIDE_BAR_WIDTH = 288;
+
+/**
+ * View embedded profile browser
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-profile-browser
+ *   browserSrc=${browserSrc}
+ *   isFullscreen=${isFullscreen}
+ * ></btrix-profile-browser>
+ * ```
+ */
+@localized()
+export class ProfileBrowser extends LiteElement {
+  /** Iframe browserUrl */
+  @property({ type: String })
+  browserSrc?: string;
+
+  @property({ type: Boolean })
+  isFullscreen = false;
+
+  @property({ type: Boolean })
+  isLoading = false;
+
+  render() {
+    if (this.isLoading)
+      return html`
+        <div
+          class="aspect-video bg-slate-50 flex items-center justify-center text-4xl"
+          style="padding-right: ${SIDE_BAR_WIDTH}px"
+        >
+          <sl-spinner></sl-spinner>
+        </div>
+      `;
+
+    return html`
+      <div
+        class="bg-slate-50 w-full ${this.isFullscreen
+          ? "h-screen"
+          : "aspect-video"}"
+      >
+        ${this.browserSrc
+          ? html`<iframe
+              class="w-full h-full"
+              title=${msg("Interactive browser for creating browser profile")}
+              src=${this.browserSrc}
+              ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
+            ></iframe>`
+          : ""}
+      </div>
+    `;
+  }
+
+  private onIframeRef(el: HTMLIFrameElement) {
+    if (!el) return;
+
+    el.addEventListener("load", () => {
+      // TODO see if we can make this work locally without CORs errors
+      try {
+        //el.style.width = "132%";
+        el.contentWindow?.localStorage.setItem("uiTheme", '"default"');
+        el.contentWindow?.localStorage.setItem(
+          "InspectorView.screencastSplitViewState",
+          `{"vertical":{"size":${SIDE_BAR_WIDTH}}}`
+        );
+      } catch (e) {}
+    });
+  }
+}

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -3,7 +3,10 @@ import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
 import { msg, localized } from "@lit/localize";
 
+import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
+
+const POLL_INTERVAL_SECONDS = 3;
 
 /**
  * View embedded profile browser
@@ -11,7 +14,11 @@ import LiteElement, { html } from "../utils/LiteElement";
  * Usage example:
  * ```ts
  * <btrix-profile-browser
- *   browserSrc=${browserSrc}
+ *   authState=${authState}
+ *   archiveId=${archiveId}
+ *   browserId=${browserId}
+ *   initialNavigateUrl=${initialNavigateUrl}
+ *   origins=${origins}
  * ></btrix-profile-browser>
  * ```
  */
@@ -21,22 +28,328 @@ export class ProfileBrowser extends LiteElement {
   // is hidden on the backend
   static SIDE_BAR_WIDTH = 288;
 
-  /** Iframe browserUrl */
+  /** Profile creation only works in Chromium-based browsers */
+  static isBrowserCompatible = Boolean((window as any).chrome);
+
+  @property({ type: Object })
+  authState!: AuthState;
+
   @property({ type: String })
-  browserSrc?: string;
+  archiveId!: string;
+
+  @property({ type: String })
+  browserId?: string;
+
+  @property({ type: String })
+  initialNavigateUrl?: string;
+
+  @property({ type: Array })
+  origins?: string[];
+
+  @state()
+  private iframeSrc?: string;
+
+  @state()
+  private hasFetchError = false;
+
+  @state()
+  private isFullscreen = false;
+
+  @state()
+  private newOrigins: string[] = [];
+
+  private pollTimerId?: number;
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    document.addEventListener("fullscreenchange", this.onFullscreenChange);
+  }
+
+  disconnectedCallback() {
+    window.clearTimeout(this.pollTimerId);
+    document.removeEventListener("fullscreenchange", this.onFullscreenChange);
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    if (changedProperties.has("browserId") && this.browserId) {
+      this.fetchBrowser();
+    }
+  }
 
   render() {
     return html`
-      ${this.browserSrc
-        ? html`<iframe
-            class="w-full h-full"
-            title=${msg("Interactive browser for creating browser profile")}
-            src=${this.browserSrc}
-            ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
-          ></iframe>`
-        : ""}
+      <div id="interactive-browser" class="lg:flex relative">
+        <div class="grow lg:rounded-lg border overflow-hidden bg-slate-50">
+          <div
+            class="w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
+            aria-live="polite"
+          >
+            ${this.renderBrowser()}
+          </div>
+          <div
+            class="rounded-b lg:rounded-b-none lg:rounded-r border w-72  bg-white absolute h-full top-0 right-0"
+          >
+            ${this.renderFullscreenButton()} ${this.renderOrigins()}
+            ${this.renderNewOrigins()}
+          </div>
+        </div>
+      </div>
     `;
   }
+
+  private renderBrowser() {
+    if (!ProfileBrowser.isBrowserCompatible) {
+      return html`
+        <btrix-alert type="warning" class="text-sm">
+          ${msg(
+            "Browser profile creation is only supported in Chromium-based browsers (such as Chrome) at this time. Please re-open this page in a compatible browser to proceed."
+          )}
+        </btrix-alert>
+      `;
+    }
+
+    if (this.hasFetchError) {
+      return html`
+        <btrix-alert type="danger">
+          ${msg(`The interactive browser is not available.`)}
+        </btrix-alert>
+      `;
+    }
+
+    if (this.iframeSrc) {
+      return html`<iframe
+        class="w-full h-full"
+        title=${msg("Interactive browser for creating browser profile")}
+        src=${this.iframeSrc}
+        ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
+      ></iframe>`;
+    }
+
+    if (this.browserId && !this.iframeSrc) {
+      return html`
+        <div
+          class="w-full h-full flex items-center justify-center text-4xl"
+          style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
+        >
+          <sl-spinner></sl-spinner>
+        </div>
+      `;
+    }
+
+    return "";
+  }
+
+  private renderFullscreenButton() {
+    return html`${document.fullscreenEnabled
+      ? html`
+          <div class="p-2 text-right">
+            <sl-button
+              size="small"
+              @click=${() =>
+                this.isFullscreen
+                  ? document.exitFullscreen()
+                  : this.enterFullscreen("interactive-browser")}
+            >
+              ${this.isFullscreen
+                ? html`
+                    <sl-icon
+                      slot="prefix"
+                      name="fullscreen-exit"
+                      label=${msg("Exit fullscreen")}
+                    ></sl-icon>
+                    ${msg("Exit")}
+                  `
+                : html`
+                    <sl-icon
+                      slot="prefix"
+                      name="arrows-fullscreen"
+                      label=${msg("Enter fullscreen")}
+                    ></sl-icon>
+                    ${msg("Fullscreen")}
+                  `}
+            </sl-button>
+          </div>
+        `
+      : ""}`;
+  }
+
+  private renderOrigins() {
+    return html`
+      <h4 class="text-xs text-neutral-500 leading-tight p-2 border-b">
+        ${msg("Visited URLs")}
+      </h4>
+      <ul>
+        ${this.origins?.map(
+          (url) => html`
+            <li
+              class="p-2 flex items-center justify-between border-t first:border-t-0 border-t-neutral-100${this
+                .iframeSrc
+                ? " hover:bg-slate-50 hover:text-primary"
+                : ""}"
+              role=${this.iframeSrc ? "button" : "listitem"}
+              @click=${() =>
+                this.iframeSrc ? this.navigateBrowser({ url }) : {}}
+            >
+              <div class="text-sm truncate w-full">${url}</div>
+              ${this.iframeSrc
+                ? html`<sl-icon name="play-btn" class="text-xl"></sl-icon>`
+                : ""}
+            </li>
+          `
+        )}
+      </ul>
+    `;
+  }
+
+  private renderNewOrigins() {
+    if (!this.newOrigins.length) return;
+
+    return html`
+      <h4 class="text-xs text-neutral-500 leading-tight p-2 border-b">
+        <span class="inline-block align-middle"
+          >${msg("Newly Visited URLs")}</span
+        >
+        <sl-tooltip
+          content=${msg(
+            "Newly visited URLs are not included in the browser profile."
+          )}
+          ><sl-icon
+            class="inline-block align-middle"
+            name="info-circle"
+          ></sl-icon
+        ></sl-tooltip>
+      </h4>
+      <ul>
+        ${this.newOrigins.map(
+          (url) => html`
+            <li
+              class="p-2 flex items-center justify-between border-t first:border-t-0 border-t-neutral-100"
+            >
+              <div class="text-sm truncate w-full">${url}</div>
+            </li>
+          `
+        )}
+      </ul>
+    `;
+  }
+
+  /**
+   * Fetch browser profiles and update internal state
+   */
+  private async fetchBrowser(): Promise<void> {
+    try {
+      await this.checkBrowserStatus();
+    } catch (e) {
+      this.hasFetchError = true;
+
+      this.notify({
+        message: msg("Sorry, couldn't create browser profile at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  /**
+   * Check whether temporary browser is up
+   **/
+  private async checkBrowserStatus() {
+    const result = await this.getBrowser();
+
+    if (result.detail === "waiting_for_browser") {
+      this.pollTimerId = window.setTimeout(
+        () => this.checkBrowserStatus(),
+        POLL_INTERVAL_SECONDS * 1000
+      );
+
+      return;
+    } else if (result.url) {
+      if (this.initialNavigateUrl) {
+        await this.navigateBrowser({ url: this.initialNavigateUrl });
+      }
+
+      this.iframeSrc = result.url;
+
+      this.pingBrowser();
+    } else {
+      console.debug("Unknown checkBrowserStatus state");
+    }
+  }
+
+  private async getBrowser(): Promise<{
+    detail?: string;
+    url?: string;
+  }> {
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/profiles/browser/${this.browserId}`,
+      this.authState!
+    );
+
+    return data;
+  }
+
+  /**
+   * Navigate to URL in temporary browser
+   **/
+  private async navigateBrowser({ url }: { url: string }) {
+    const data = this.apiFetch(
+      `/archives/${this.archiveId}/profiles/browser/${this.browserId}/navigate`,
+      this.authState!,
+      {
+        method: "POST",
+        body: JSON.stringify({ url }),
+      }
+    );
+
+    return data;
+  }
+
+  /**
+   * Ping temporary browser every minute to keep it alive
+   **/
+  private async pingBrowser() {
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/profiles/browser/${this.browserId}/ping`,
+      this.authState!,
+      {
+        method: "POST",
+      }
+    );
+
+    if (!this.origins) {
+      this.origins = data.origins;
+    } else {
+      this.newOrigins = data.origins.filter(
+        (url: string) => !this.origins?.includes(url)
+      );
+    }
+
+    this.pollTimerId = window.setTimeout(() => this.pingBrowser(), 60 * 1000);
+  }
+
+  /**
+   * Enter fullscreen mode
+   * @param id ID of element to fullscreen
+   */
+  private async enterFullscreen(id: string) {
+    try {
+      document.getElementById(id)!.requestFullscreen({
+        // Show browser navigation controls
+        navigationUI: "show",
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  private onFullscreenChange = () => {
+    if (document.fullscreenElement) {
+      this.isFullscreen = true;
+    } else {
+      this.isFullscreen = false;
+    }
+  };
 
   private onIframeRef(el: HTMLIFrameElement) {
     if (!el) return;

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -207,12 +207,10 @@ export class ProfileBrowser extends LiteElement {
 
     return html`
       <h4 class="text-xs text-neutral-500 leading-tight p-2 border-b">
-        <span class="inline-block align-middle"
-          >${msg("Newly Visited URLs")}</span
-        >
+        <span class="inline-block align-middle">${msg("Newly Visited")}</span>
         <sl-tooltip
           content=${msg(
-            "Newly visited URLs are not included in the browser profile."
+            "Newly visited URLs have not been saved to the browser profile yet."
           )}
           ><sl-icon
             class="inline-block align-middle"

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -72,8 +72,12 @@ export class ProfileBrowser extends LiteElement {
   }
 
   updated(changedProperties: Map<string, any>) {
-    if (changedProperties.has("browserId") && this.browserId) {
-      this.fetchBrowser();
+    if (changedProperties.has("browserId")) {
+      if (this.browserId) {
+        this.fetchBrowser();
+      } else if (changedProperties.get("browserId")) {
+        this.iframeSrc = undefined;
+      }
     }
   }
 

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -180,25 +180,7 @@ export class ProfileBrowser extends LiteElement {
         ${msg("Visited URLs")}
       </h4>
       <ul>
-        ${this.origins?.map(
-          (url) => html`
-            <li
-              class="p-2 flex items-center justify-between border-t first:border-t-0 border-t-neutral-100${this
-                .iframeSrc
-                ? " hover:bg-slate-50 hover:text-primary"
-                : ""}"
-              role=${this.iframeSrc ? "button" : "listitem"}
-              title=${msg(str`Go to ${url}`)}
-              @click=${() =>
-                this.iframeSrc ? this.navigateBrowser({ url }) : {}}
-            >
-              <div class="text-sm truncate w-full">${url}</div>
-              ${this.iframeSrc
-                ? html`<sl-icon name="play-btn" class="text-xl"></sl-icon>`
-                : ""}
-            </li>
-          `
-        )}
+        ${this.origins?.map((url) => this.renderOriginItem(url))}
       </ul>
     `;
   }
@@ -220,17 +202,26 @@ export class ProfileBrowser extends LiteElement {
         ></sl-tooltip>
       </h4>
       <ul>
-        ${this.newOrigins.map(
-          (url) => html`
-            <li
-              class="p-2 flex items-center justify-between border-t first:border-t-0 border-t-neutral-100"
-            >
-              <div class="text-sm truncate w-full">${url}</div>
-            </li>
-          `
-        )}
+        ${this.newOrigins.map((url) => this.renderOriginItem(url))}
       </ul>
     `;
+  }
+
+  private renderOriginItem(url: string) {
+    return html`<li
+      class="p-2 flex items-center justify-between border-t first:border-t-0 border-t-neutral-100${this
+        .iframeSrc
+        ? " hover:bg-slate-50 hover:text-primary"
+        : ""}"
+      role=${this.iframeSrc ? "button" : "listitem"}
+      title=${msg(str`Go to ${url}`)}
+      @click=${() => (this.iframeSrc ? this.navigateBrowser({ url }) : {})}
+    >
+      <div class="text-sm truncate w-full">${url}</div>
+      ${this.iframeSrc
+        ? html`<sl-icon name="play-btn" class="text-xl"></sl-icon>`
+        : ""}
+    </li>`;
   }
 
   /**

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -5,10 +5,6 @@ import { msg, localized } from "@lit/localize";
 
 import LiteElement, { html } from "../utils/LiteElement";
 
-// TODO remove sidebar constaint once devtools panel
-// is hidden on the backend
-const SIDE_BAR_WIDTH = 288;
-
 /**
  * View embedded profile browser
  *
@@ -16,46 +12,29 @@ const SIDE_BAR_WIDTH = 288;
  * ```ts
  * <btrix-profile-browser
  *   browserSrc=${browserSrc}
- *   isFullscreen=${isFullscreen}
  * ></btrix-profile-browser>
  * ```
  */
 @localized()
 export class ProfileBrowser extends LiteElement {
+  // TODO remove sidebar constaint once devtools panel
+  // is hidden on the backend
+  static SIDE_BAR_WIDTH = 288;
+
   /** Iframe browserUrl */
   @property({ type: String })
   browserSrc?: string;
 
-  @property({ type: Boolean })
-  isFullscreen = false;
-
-  @property({ type: Boolean })
-  isLoading = false;
-
   render() {
-    if (this.isLoading)
-      return html`
-        <div
-          class="h-96 bg-slate-50 flex items-center justify-center text-4xl"
-          style="padding-right: ${SIDE_BAR_WIDTH}px"
-        >
-          <sl-spinner></sl-spinner>
-        </div>
-      `;
-
     return html`
-      <div
-        class="bg-slate-50 w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
-      >
-        ${this.browserSrc
-          ? html`<iframe
-              class="w-full h-full"
-              title=${msg("Interactive browser for creating browser profile")}
-              src=${this.browserSrc}
-              ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
-            ></iframe>`
-          : ""}
-      </div>
+      ${this.browserSrc
+        ? html`<iframe
+            class="w-full h-full"
+            title=${msg("Interactive browser for creating browser profile")}
+            src=${this.browserSrc}
+            ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
+          ></iframe>`
+        : ""}
     `;
   }
 
@@ -69,7 +48,7 @@ export class ProfileBrowser extends LiteElement {
         el.contentWindow?.localStorage.setItem("uiTheme", '"default"');
         el.contentWindow?.localStorage.setItem(
           "InspectorView.screencastSplitViewState",
-          `{"vertical":{"size":${SIDE_BAR_WIDTH}}}`
+          `{"vertical":{"size":${ProfileBrowser.SIDE_BAR_WIDTH}}}`
         );
       } catch (e) {}
     });

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -107,19 +107,26 @@ export class ProfileBrowser extends LiteElement {
   private renderBrowser() {
     if (!ProfileBrowser.isBrowserCompatible) {
       return html`
-        <btrix-alert type="warning" class="text-sm">
-          ${msg(
-            "Browser profile creation is only supported in Chromium-based browsers (such as Chrome) at this time. Please re-open this page in a compatible browser to proceed."
-          )}
-        </btrix-alert>
+        <div style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;">
+          <btrix-alert type="warning" class="text-sm">
+            ${msg(
+              "Browser profile creation is only supported in Chromium-based browsers (such as Chrome) at this time. Please re-open this page in a compatible browser to proceed."
+            )}
+          </btrix-alert>
+        </div>
       `;
     }
 
     if (this.hasFetchError) {
       return html`
-        <btrix-alert type="danger">
-          ${msg(`The interactive browser is not available.`)}
-        </btrix-alert>
+        <div style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;">
+          <btrix-alert
+            type="danger"
+            style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
+          >
+            ${msg(`The interactive browser is not available.`)}
+          </btrix-alert>
+        </div>
       `;
     }
 

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -6,7 +6,7 @@ import { msg, localized, str } from "@lit/localize";
 import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
 
-const POLL_INTERVAL_SECONDS = 3;
+const POLL_INTERVAL_SECONDS = 2;
 
 /**
  * View embedded profile browser
@@ -315,7 +315,10 @@ export class ProfileBrowser extends LiteElement {
       );
     }
 
-    this.pollTimerId = window.setTimeout(() => this.pingBrowser(), 60 * 1000);
+    this.pollTimerId = window.setTimeout(
+      () => this.pingBrowser(),
+      POLL_INTERVAL_SECONDS * 1000
+    );
   }
 
   /**

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -181,7 +181,13 @@ export class ProfileBrowser extends LiteElement {
   private renderOrigins() {
     return html`
       <h4 class="text-xs text-neutral-500 leading-tight p-2 border-b">
-        ${msg("Visited URLs")}
+        <span class="inline-block align-middle">${msg("Visited Sites")}</span>
+        <sl-tooltip content=${msg("Websites in the browser profile")}
+          ><sl-icon
+            class="inline-block align-middle"
+            name="info-circle"
+          ></sl-icon
+        ></sl-tooltip>
       </h4>
       <ul>
         ${this.origins?.map((url) => this.renderOriginItem(url))}
@@ -194,10 +200,10 @@ export class ProfileBrowser extends LiteElement {
 
     return html`
       <h4 class="text-xs text-neutral-500 leading-tight p-2 border-b">
-        <span class="inline-block align-middle">${msg("Newly Visited")}</span>
+        <span class="inline-block align-middle">${msg("New Sites")}</span>
         <sl-tooltip
           content=${msg(
-            "Newly visited URLs have not been saved to the browser profile yet."
+            "Websites that are not in the browser profile yet. Finish editing and save to add these websites to the profile."
           )}
           ><sl-icon
             class="inline-block align-middle"

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -36,7 +36,7 @@ export class ProfileBrowser extends LiteElement {
     if (this.isLoading)
       return html`
         <div
-          class="aspect-video bg-slate-50 flex items-center justify-center text-4xl"
+          class="h-96 bg-slate-50 flex items-center justify-center text-4xl"
           style="padding-right: ${SIDE_BAR_WIDTH}px"
         >
           <sl-spinner></sl-spinner>
@@ -45,9 +45,7 @@ export class ProfileBrowser extends LiteElement {
 
     return html`
       <div
-        class="bg-slate-50 w-full ${this.isFullscreen
-          ? "h-screen"
-          : "aspect-video"}"
+        class="bg-slate-50 w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
       >
         ${this.browserSrc
           ? html`<iframe

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -77,6 +77,8 @@ export class ProfileBrowser extends LiteElement {
         this.fetchBrowser();
       } else if (changedProperties.get("browserId")) {
         this.iframeSrc = undefined;
+
+        window.clearTimeout(this.pollTimerId);
       }
     }
   }
@@ -293,6 +295,8 @@ export class ProfileBrowser extends LiteElement {
    * Navigate to URL in temporary browser
    **/
   private async navigateBrowser({ url }: { url: string }) {
+    if (!this.iframeSrc) return;
+
     const data = this.apiFetch(
       `/archives/${this.archiveId}/profiles/browser/${this.browserId}/navigate`,
       this.authState!,
@@ -309,6 +313,8 @@ export class ProfileBrowser extends LiteElement {
    * Ping temporary browser every minute to keep it alive
    **/
   private async pingBrowser() {
+    if (!this.iframeSrc) return;
+
     const data = await this.apiFetch(
       `/archives/${this.archiveId}/profiles/browser/${this.browserId}/ping`,
       this.authState!,

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -180,7 +180,8 @@ export class BrowserProfilesDetail extends LiteElement {
                   <sl-button
                     type="primary"
                     outline
-                    ?disabled=${this.isLoading}
+                    ?disabled=${this.isLoading ||
+                    !ProfileBrowser.isBrowserCompatible}
                     ?loading=${this.isLoading}
                     @click=${this.startBrowserPreview}
                     ><sl-icon

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -102,8 +102,8 @@ export class BrowserProfilesDetail extends LiteElement {
       </header>
 
       <section class="rounded border p-4 mb-5">
-        <dl class="grid grid-cols-2 gap-5">
-          <div class="col-span-2 md:col-span-1">
+        <dl class="grid grid-cols-3 gap-5">
+          <div class="col-span-3 md:col-span-1">
             <dt class="text-sm text-0-600">${msg("Description")}</dt>
             <dd>
               ${this.profile
@@ -112,7 +112,7 @@ export class BrowserProfilesDetail extends LiteElement {
                 : ""}
             </dd>
           </div>
-          <div class="col-span-2 md:col-span-1">
+          <div class="col-span-3 md:col-span-1">
             <dt class="text-sm text-0-600">
               <span class="inline-block align-middle"
                 >${msg("Created at")}</span
@@ -132,6 +132,38 @@ export class BrowserProfilesDetail extends LiteElement {
                     ></sl-format-date>
                   `
                 : ""}
+            </dd>
+          </div>
+          <div class="col-span-3 md:col-span-1">
+            <dt class="text-sm text-0-600">
+              <span class="inline-block align-middle"
+                >${msg("Crawl Templates")}</span
+              >
+              <sl-tooltip content=${msg("Crawl Templates using this profile")}>
+                <sl-icon
+                  class="inline-block align-middle"
+                  name="info-circle"
+                ></sl-icon>
+              </sl-tooltip>
+            </dt>
+            <dd>
+              <ul class="text-sm font-medium">
+                ${this.profile?.crawlconfigs.map(
+                  ({ id, name }) =>
+                    html`
+                      <li>
+                        <a
+                          class="text-neutral-600 hover:underline"
+                          href=${`/archives/${
+                            this.profile!.aid
+                          }/crawl-templates/config/${id}`}
+                        >
+                          ${name}
+                        </a>
+                      </li>
+                    `
+                )}
+              </ul>
             </dd>
           </div>
         </dl>

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -172,7 +172,7 @@ export class BrowserProfilesDetail extends LiteElement {
                 >
                   <p class="mb-4 text-neutral-600 max-w-prose">
                     ${msg(
-                      "Load browser profile to view or edit web pages in the profile."
+                      "Load browser profile to view or edit websites in the profile."
                     )}
                   </p>
                   <sl-button

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -8,7 +8,11 @@ import { Profile } from "./types";
 /**
  * Usage:
  * ```ts
- * <btrix-browser-profiles-detail></btrix-browser-profiles-detail>
+ * <btrix-browser-profiles-detail
+ *  authState=${authState}
+ *  archiveId=${archiveId}
+ *  profileId=${profileId}
+ * ></btrix-browser-profiles-detail>
  * ```
  */
 @localized()

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -142,9 +142,11 @@ export class BrowserProfilesDetail extends LiteElement {
 
           ${this.browserId && !this.isLoading
             ? html`
+                <!-- Hide browser area with overlay -->
+                <!-- TODO remove when browser no longer shows dev tools -->
                 ${this.isSubmitting
                   ? html`<div
-                      class="absolute top-0 left-0 h-full flex items-center justify-center text-4xl bg-slate-50 lg:rounded-lg border"
+                      class="absolute top-0 left-0 h-full flex items-center justify-center text-4xl bg-slate-50 lg:rounded-l-lg border border-r-0"
                       style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
                     >
                       <sl-spinner></sl-spinner>
@@ -320,6 +322,7 @@ export class BrowserProfilesDetail extends LiteElement {
     }
 
     this.isSubmitting = true;
+    this.showSaveButton = false;
 
     const params = {
       name: this.profile!.name,
@@ -349,6 +352,8 @@ export class BrowserProfilesDetail extends LiteElement {
         type: "danger",
         icon: "exclamation-octagon",
       });
+
+      this.showSaveButton = true;
     }
 
     this.isSubmitting = false;

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -186,7 +186,7 @@ export class BrowserProfilesDetail extends LiteElement {
                 >
                   <p class="mb-4 text-neutral-600 max-w-prose">
                     ${msg(
-                      "Load browser profile to view or edit websites in the profile."
+                      "Load browser to view or edit websites in the profile."
                     )}
                   </p>
                   <sl-button
@@ -200,7 +200,7 @@ export class BrowserProfilesDetail extends LiteElement {
                       slot="prefix"
                       name="collection-play-fill"
                     ></sl-icon>
-                    ${msg("Load Browser Profile")}</sl-button
+                    ${msg("Load Browser")}</sl-button
                   >
                 </div>
               `}

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -116,7 +116,7 @@ export class BrowserProfilesDetail extends LiteElement {
       <section>
         <header>
           <h3 class="text-lg font-medium mb-2">
-            ${msg("Browser Profile Viewer")}
+            ${msg("Browser Profile Editor")}
           </h3>
         </header>
 
@@ -150,7 +150,7 @@ export class BrowserProfilesDetail extends LiteElement {
                 >
                   <p class="mb-4 text-neutral-600 max-w-prose">
                     ${msg(
-                      "Start the viewer to visit or edit web pages in the profile."
+                      "Load browser profile to view or edit web pages in the profile."
                     )}
                   </p>
                   <sl-button
@@ -163,7 +163,7 @@ export class BrowserProfilesDetail extends LiteElement {
                       slot="prefix"
                       name="collection-play-fill"
                     ></sl-icon>
-                    ${msg("Start Viewer")}</sl-button
+                    ${msg("Load Browser Profile")}</sl-button
                   >
                 </div>
               `}

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -38,7 +38,16 @@ export class BrowserProfilesDetail extends LiteElement {
   private isSubmitting = false;
 
   @state()
+  private showSaveButton = false;
+
+  @state()
   private browserId?: string;
+
+  private showSaveButtonTimerId?: number;
+
+  disconnectedCallback() {
+    window.clearTimeout(this.showSaveButtonTimerId);
+  }
 
   firstUpdated() {
     this.fetchProfile();
@@ -140,20 +149,21 @@ export class BrowserProfilesDetail extends LiteElement {
                     >
                       <sl-spinner></sl-spinner>
                     </div>`
-                  : html`
-                      <div
-                        class="absolute top-0 p-2"
-                        style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
+                  : ""}
+                ${this.showSaveButton
+                  ? html`<div
+                      class="absolute top-0 p-2"
+                      style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
+                    >
+                      <sl-button
+                        class="shadow"
+                        type="primary"
+                        size="small"
+                        @click=${this.saveProfile}
+                        >${msg("Done Editing")}</sl-button
                       >
-                        <sl-button
-                          class="shadow"
-                          type="primary"
-                          size="small"
-                          @click=${this.saveProfile}
-                          >${msg("Done Editing")}</sl-button
-                        >
-                      </div>
-                    `}
+                    </div>`
+                  : ""}
               `
             : html`
                 <div
@@ -200,6 +210,11 @@ export class BrowserProfilesDetail extends LiteElement {
       });
 
       this.browserId = data.browserid;
+
+      // Slightly delay showing the save button while browser loads
+      this.showSaveButtonTimerId = window.setTimeout(() => {
+        this.showSaveButton = true;
+      }, 3 * 1000);
     } catch (e) {
       this.isLoading = false;
 
@@ -293,6 +308,16 @@ export class BrowserProfilesDetail extends LiteElement {
 
   private async saveProfile() {
     if (!this.browserId) return;
+
+    if (
+      !window.confirm(
+        msg(
+          "Save browser changes to profile? You will need to reload the editor to make additional changes."
+        )
+      )
+    ) {
+      return;
+    }
 
     this.isSubmitting = true;
 

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -3,6 +3,7 @@ import { msg, localized, str } from "@lit/localize";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
+import { ProfileBrowser } from "../../components/profile-browser";
 import { Profile } from "./types";
 
 /**
@@ -40,6 +41,9 @@ export class BrowserProfilesDetail extends LiteElement {
 
   @state()
   private isFullscreen = false;
+
+  @state()
+  private browserUrl?: string;
 
   /** Profile creation only works in Chromium-based browsers */
   private isBrowserCompatible = Boolean((window as any).chrome);
@@ -167,9 +171,36 @@ export class BrowserProfilesDetail extends LiteElement {
             class="grow lg:rounded-lg border overflow-hidden"
             aria-live="polite"
           >
-            <btrix-profile-browser
-              ?isFullscreen=${this.isFullscreen}
-            ></btrix-profile-browser>
+            ${this.browserUrl
+              ? html`
+                  <div
+                    class="w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
+                  >
+                    <btrix-profile-browser
+                      browserSrc=${this.browserUrl}
+                    ></btrix-profile-browser>
+                  </div>
+                `
+              : html`
+                  <div
+                    class="w-full h-96 bg-slate-50 flex items-center justify-center text-4xl"
+                    style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px"
+                  >
+                    ${this.profile
+                      ? html`<sl-button
+                          type="primary"
+                          @click=${() => this.previewBrowser()}
+                          ><sl-icon
+                            slot="prefix"
+                            name="collection-play-fill"
+                          ></sl-icon>
+                          ${msg("Start Preview")}</sl-button
+                        >`
+                      : html`<sl-skeleton
+                          style="width: 6em; height: 2em;"
+                        ></sl-skeleton>`}
+                  </div>
+                `}
           </div>
           <div
             class="rounded-b lg:rounded-b-none lg:rounded-r border w-72 bg-white absolute h-full right-0"
@@ -277,7 +308,7 @@ export class BrowserProfilesDetail extends LiteElement {
                     name="play-btn"
                     class="text-xl"
                     ?disabled=${!this.isBrowserCompatible || this.isSubmitting}
-                    @click=${() => this.launchBrowser(url)}
+                    @click=${() => this.previewBrowser(url)}
                   ></sl-icon-button>
                 </div>
               </div>
@@ -297,7 +328,7 @@ export class BrowserProfilesDetail extends LiteElement {
    *                         different than starting URL, which will
    *                         override the profile start url
    */
-  private async launchBrowser(navigateStartUrl?: string) {
+  private async previewBrowser(navigateStartUrl?: string) {
     if (!this.profile) return;
 
     this.isSubmitting = true;

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -330,7 +330,7 @@ export class BrowserProfilesDetail extends LiteElement {
     };
 
     try {
-      await this.apiFetch(
+      const data = await this.apiFetch(
         `/archives/${this.archiveId}/profiles/${this.profileId}`,
         this.authState!,
         {
@@ -345,6 +345,7 @@ export class BrowserProfilesDetail extends LiteElement {
         icon: "check2-circle",
       });
 
+      this.profile = data;
       this.browserId = undefined;
     } catch (e) {
       this.notify({

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -114,8 +114,10 @@ export class BrowserProfilesDetail extends LiteElement {
       </section>
 
       <section>
-        <header class="flex justify-between">
-          <h3 class="text-lg font-medium mb-2">${msg("Preview Profile")}</h3>
+        <header>
+          <h3 class="text-lg font-medium mb-2">
+            ${msg("Browser Profile Viewer")}
+          </h3>
         </header>
 
         <main class="relative">
@@ -127,12 +129,30 @@ export class BrowserProfilesDetail extends LiteElement {
           ></btrix-profile-browser>
 
           ${this.browserId
-            ? ""
+            ? html` <div
+                class="absolute top-0 p-2"
+                style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
+              >
+                <sl-button
+                  class="shadow"
+                  type="primary"
+                  size="small"
+                  ?disabled=${this.isSubmitting}
+                  ?loading=${this.isSubmitting}
+                  @click=${this.saveProfile}
+                  >${msg("Save Changes")}</sl-button
+                >
+              </div>`
             : html`
                 <div
-                  class="absolute top-0 left-0 h-full flex items-center justify-center"
+                  class="absolute top-0 left-0 h-full flex flex-col items-center justify-center"
                   style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
                 >
+                  <p class="mb-4 text-neutral-600 max-w-prose">
+                    ${msg(
+                      "Start the viewer to visit or edit web pages in the profile."
+                    )}
+                  </p>
                   <sl-button
                     type="primary"
                     outline
@@ -143,7 +163,7 @@ export class BrowserProfilesDetail extends LiteElement {
                       slot="prefix"
                       name="collection-play-fill"
                     ></sl-icon>
-                    ${msg("Start Preview")}</sl-button
+                    ${msg("Start Viewer")}</sl-button
                   >
                 </div>
               `}
@@ -162,7 +182,7 @@ export class BrowserProfilesDetail extends LiteElement {
       const data = await this.createBrowser({ url });
 
       this.notify({
-        message: msg("Starting up browser."),
+        message: msg("Starting up browser..."),
         type: "success",
         icon: "check2-circle",
       });
@@ -192,7 +212,7 @@ export class BrowserProfilesDetail extends LiteElement {
       const data = await this.createBrowser({ url });
 
       this.notify({
-        message: msg("Starting up browser."),
+        message: msg("Starting up browser with current profile..."),
         type: "success",
         icon: "check2-circle",
       });
@@ -257,6 +277,42 @@ export class BrowserProfilesDetail extends LiteElement {
     );
 
     return data;
+  }
+
+  private async saveProfile() {
+    if (!this.browserId) return;
+
+    this.isSubmitting = true;
+
+    const params = {
+      name: this.profile!.name,
+      browserid: this.browserId,
+    };
+
+    try {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/profiles/${this.profileId}`,
+        this.authState!,
+        {
+          method: "PATCH",
+          body: JSON.stringify(params),
+        }
+      );
+
+      this.notify({
+        message: msg("Successfully saved browser profile."),
+        type: "success",
+        icon: "check2-circle",
+      });
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't save browser profile at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+
+    this.isSubmitting = false;
   }
 
   /**

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -210,7 +210,9 @@ export class BrowserProfilesDetail extends LiteElement {
           this.profile.description || ""
         )}&profileId=${window.encodeURIComponent(
           this.profile.id
-        )}&navigateUrl=${window.encodeURIComponent(navigateStartUrl || "")}`
+        )}&navigateUrl=${window.encodeURIComponent(
+          navigateStartUrl && navigateStartUrl !== url ? navigateStartUrl : ""
+        )}`
       );
     } catch (e) {
       this.isSubmitting = false;

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -32,12 +32,6 @@ export class BrowserProfilesDetail extends LiteElement {
   private profile?: Profile;
 
   @state()
-  showCreateDialog = false;
-
-  @state()
-  private isCreateFormVisible = false;
-
-  @state()
   private isSubmitting = false;
 
   @state()
@@ -73,9 +67,9 @@ export class BrowserProfilesDetail extends LiteElement {
           ${this.profile
             ? html` <sl-button
                 size="small"
-                @click=${() => (this.showCreateDialog = true)}
+                @click=${() => this.duplicateProfile()}
               >
-                ${msg("Edit Browser Profile")}</sl-button
+                ${msg("Duplicate Profile")}</sl-button
               >`
             : html`<sl-skeleton
                 style="width: 6em; height: 2em;"
@@ -154,57 +148,7 @@ export class BrowserProfilesDetail extends LiteElement {
                 </div>
               `}
         </main>
-      </section>
-
-      <sl-dialog
-        label=${msg(str`Edit Browser Profile`)}
-        ?open=${this.showCreateDialog}
-        @sl-request-close=${this.hideDialog}
-        @sl-show=${() => (this.isCreateFormVisible = true)}
-        @sl-after-hide=${() => (this.isCreateFormVisible = false)}
-      >
-        ${this.isCreateFormVisible ? this.renderCreateForm() : ""}
-      </sl-dialog> `;
-  }
-
-  private renderCreateForm() {
-    return html`<sl-form @sl-submit=${this.onSubmit}>
-      <div class="grid gap-5">
-        <sl-select
-          name="url"
-          label=${msg("Starting URL")}
-          value=${this.profile?.origins[0] || ""}
-          required
-          hoist
-          ?disabled=${!ProfileBrowser.isBrowserCompatible}
-          @sl-hide=${this.stopProp}
-          @sl-after-hide=${this.stopProp}
-        >
-          ${this.profile?.origins.map(
-            (origin) => html`
-              <sl-menu-item value=${origin}>${origin}</sl-menu-item>
-            `
-          )}
-        </sl-select>
-
-        <div class="text-right">
-          <sl-button @click=${this.hideDialog}>${msg("Cancel")}</sl-button>
-          <sl-button
-            type="primary"
-            submit
-            ?disabled=${!ProfileBrowser.isBrowserCompatible ||
-            this.isSubmitting}
-            ?loading=${this.isSubmitting}
-          >
-            ${msg("Start Editing")}
-          </sl-button>
-        </div>
-      </div>
-    </sl-form>`;
-  }
-
-  private hideDialog() {
-    this.showCreateDialog = false;
+      </section>`;
   }
 
   private async startBrowserPreview() {
@@ -237,13 +181,12 @@ export class BrowserProfilesDetail extends LiteElement {
     this.isSubmitting = false;
   }
 
-  async onSubmit(event: { detail: { formData: FormData } }) {
+  private async duplicateProfile() {
     if (!this.profile) return;
 
     this.isSubmitting = true;
 
-    const { formData } = event.detail;
-    const url = formData.get("url") as string;
+    const url = this.profile.origins[0];
 
     try {
       const data = await this.createBrowser({ url });

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -35,13 +35,22 @@ export class BrowserProfilesDetail extends LiteElement {
   private isLoading = false;
 
   @state()
-  private isSubmitting = false;
+  private isSubmittingBrowserChange = false;
+
+  @state()
+  private isSubmittingProfileChange = false;
 
   @state()
   private showSaveButton = false;
 
   @state()
   private browserId?: string;
+
+  @state()
+  private isEditDialogOpen = false;
+
+  @state()
+  private isEditDialogContentVisible = false;
 
   private showSaveButtonTimerId?: number;
 
@@ -72,17 +81,20 @@ export class BrowserProfilesDetail extends LiteElement {
 
       <header class="md:flex items-center justify-between mb-3">
         <h2 class="text-xl md:text-3xl font-bold md:h-9 mb-1">
-          ${this.profile?.name ||
-          html`<sl-skeleton class="md:h-9 w-80"></sl-skeleton>`}
+          ${this.profile?.name
+            ? html`${this.profile?.name}
+                <sl-button
+                  size="small"
+                  type="text"
+                  @click=${() => (this.isEditDialogOpen = true)}
+                >
+                  ${msg("Edit")}
+                </sl-button>`
+            : html`<sl-skeleton class="md:h-9 w-80"></sl-skeleton>`}
         </h2>
         <div>
           ${this.profile
-            ? html` <sl-button
-                size="small"
-                @click=${() => this.duplicateProfile()}
-              >
-                ${msg("Duplicate Profile")}</sl-button
-              >`
+            ? this.renderMenu()
             : html`<sl-skeleton
                 style="width: 6em; height: 2em;"
               ></sl-skeleton>`}
@@ -144,7 +156,7 @@ export class BrowserProfilesDetail extends LiteElement {
             ? html`
                 <!-- Hide browser area with overlay -->
                 <!-- TODO remove when browser no longer shows dev tools -->
-                ${this.isSubmitting
+                ${this.isSubmittingBrowserChange
                   ? html`<div
                       class="absolute top-0 left-0 h-full flex items-center justify-center text-4xl bg-slate-50 lg:rounded-l-lg border border-r-0"
                       style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
@@ -161,7 +173,7 @@ export class BrowserProfilesDetail extends LiteElement {
                         class="shadow"
                         type="primary"
                         size="small"
-                        @click=${this.saveProfile}
+                        @click=${this.saveBrowser}
                         >${msg("Done Editing")}</sl-button
                       >
                     </div>`
@@ -193,7 +205,100 @@ export class BrowserProfilesDetail extends LiteElement {
                 </div>
               `}
         </main>
-      </section>`;
+      </section>
+
+      <sl-dialog
+        label=${msg(str`Edit Profile`)}
+        ?open=${this.isEditDialogOpen}
+        @sl-request-close=${() => (this.isEditDialogOpen = false)}
+        @sl-show=${() => (this.isEditDialogContentVisible = true)}
+        @sl-after-hide=${() => (this.isEditDialogContentVisible = false)}
+      >
+        ${this.isEditDialogContentVisible ? this.renderEditProfile() : ""}
+      </sl-dialog> `;
+  }
+
+  private renderMenu() {
+    return html`
+      <sl-dropdown placement="bottom-end" distance="4">
+        <sl-button slot="trigger" type="primary" size="small" caret
+          >${msg("Actions")}</sl-button
+        >
+
+        <ul class="text-left text-sm text-0-800 whitespace-nowrap" role="menu">
+          <li
+            class="p-2 hover:bg-zinc-100 cursor-pointer"
+            role="menuitem"
+            @click=${(e: any) => {
+              e.target.closest("sl-dropdown").hide();
+              this.isEditDialogOpen = true;
+            }}
+          >
+            <sl-icon
+              class="inline-block align-middle px-1"
+              name="pencil-square"
+            ></sl-icon>
+            <span class="inline-block align-middle pr-2"
+              >${msg("Edit name & description")}</span
+            >
+          </li>
+          <li
+            class="p-2 hover:bg-zinc-100 cursor-pointer"
+            role="menuitem"
+            @click=${() => this.duplicateProfile()}
+          >
+            <sl-icon
+              class="inline-block align-middle px-1"
+              name="files"
+            ></sl-icon>
+            <span class="inline-block align-middle pr-2"
+              >${msg("Duplicate profile")}</span
+            >
+          </li>
+        </ul>
+      </sl-dropdown>
+    `;
+  }
+
+  private renderEditProfile() {
+    if (!this.profile) return;
+
+    return html`
+      <sl-form @sl-submit=${this.onSubmitEdit}>
+        <div class="mb-5">
+          <sl-input
+            name="name"
+            label=${msg("Name")}
+            autocomplete="off"
+            value=${this.profile.name}
+            required
+          ></sl-input>
+        </div>
+
+        <div class="mb-5">
+          <sl-textarea
+            name="description"
+            label=${msg("Description")}
+            rows="2"
+            autocomplete="off"
+            value=${this.profile.description || ""}
+          ></sl-textarea>
+        </div>
+
+        <div class="text-right">
+          <sl-button type="text" @click=${() => (this.isEditDialogOpen = false)}
+            >${msg("Cancel")}</sl-button
+          >
+          <sl-button
+            type="primary"
+            submit
+            ?disabled=${this.isSubmittingProfileChange}
+            ?loading=${this.isSubmittingProfileChange}
+            >${msg("Save Changes")}</sl-button
+          >
+        </div>
+      </sl-form>
+    `;
   }
 
   private async startBrowserPreview() {
@@ -309,7 +414,7 @@ export class BrowserProfilesDetail extends LiteElement {
     return data;
   }
 
-  private async saveProfile() {
+  private async saveBrowser() {
     if (!this.browserId) return;
 
     if (
@@ -322,7 +427,7 @@ export class BrowserProfilesDetail extends LiteElement {
       return;
     }
 
-    this.isSubmitting = true;
+    this.isSubmittingBrowserChange = true;
     this.showSaveButton = false;
 
     const params = {
@@ -340,14 +445,17 @@ export class BrowserProfilesDetail extends LiteElement {
         }
       );
 
-      this.notify({
-        message: msg("Successfully saved browser profile."),
-        type: "success",
-        icon: "check2-circle",
-      });
+      if (data.success === true) {
+        this.notify({
+          message: msg("Successfully saved browser profile."),
+          type: "success",
+          icon: "check2-circle",
+        });
 
-      this.profile = data;
-      this.browserId = undefined;
+        this.browserId = undefined;
+      } else {
+        throw data;
+      }
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't save browser profile at this time."),
@@ -358,7 +466,55 @@ export class BrowserProfilesDetail extends LiteElement {
       this.showSaveButton = true;
     }
 
-    this.isSubmitting = false;
+    this.isSubmittingBrowserChange = false;
+  }
+
+  private async onSubmitEdit(e: { detail: { formData: FormData } }) {
+    this.isSubmittingProfileChange = true;
+
+    const { formData } = e.detail;
+    const name = formData.get("name") as string;
+    const description = formData.get("description") as string;
+
+    const params = {
+      name,
+      description,
+    };
+
+    try {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/profiles/${this.profileId}`,
+        this.authState!,
+        {
+          method: "PATCH",
+          body: JSON.stringify(params),
+        }
+      );
+
+      if (data.success === true) {
+        this.notify({
+          message: msg("Successfully saved browser profile."),
+          type: "success",
+          icon: "check2-circle",
+        });
+
+        this.profile = {
+          ...this.profile,
+          ...params,
+        } as Profile;
+        this.isEditDialogOpen = false;
+      } else {
+        throw data;
+      }
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't save browser profile at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+
+    this.isSubmittingProfileChange = false;
   }
 
   /**

--- a/frontend/src/pages/archive/browser-profiles-list.ts
+++ b/frontend/src/pages/archive/browser-profiles-list.ts
@@ -186,32 +186,6 @@ export class BrowserProfilesList extends LiteElement {
           </div>
         </div>
 
-        <details>
-          <summary class="text-sm text-neutral-500 font-medium cursor-pointer">
-            ${msg("More options")}
-          </summary>
-
-          <div class="p-3">
-            <sl-select
-              name="profileId"
-              label=${msg("Extend Profile")}
-              help-text=${msg("Extend an existing browser profile.")}
-              clearable
-              ?disabled=${!this.isBrowserCompatible}
-              @sl-hide=${this.stopProp}
-              @sl-after-hide=${this.stopProp}
-            >
-              ${this.browserProfiles?.map(
-                (profile) => html`
-                  <sl-menu-item value=${profile.id}
-                    >${profile.name}</sl-menu-item
-                  >
-                `
-              )}
-            </sl-select>
-          </div>
-        </details>
-
         <div class="text-right">
           <sl-button @click=${this.hideDialog}>${msg("Cancel")}</sl-button>
           <sl-button
@@ -220,7 +194,7 @@ export class BrowserProfilesList extends LiteElement {
             ?disabled=${!this.isBrowserCompatible || this.isSubmitting}
             ?loading=${this.isSubmitting}
           >
-            ${msg("Start Browser")}
+            ${msg("Start Profile Creator")}
           </sl-button>
         </div>
       </div>
@@ -236,17 +210,12 @@ export class BrowserProfilesList extends LiteElement {
 
     const { formData } = event.detail;
     const url = formData.get("url") as string;
-    const profileId = formData.get("profileId") as string;
+
     const params: {
       url: string;
-      profileId?: string;
     } = {
       url: `${formData.get("urlPrefix")}${url.substring(url.indexOf(",") + 1)}`,
     };
-
-    if (profileId) {
-      params.profileId = profileId;
-    }
 
     try {
       const data = await this.apiFetch(

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -74,10 +74,20 @@ export class BrowserProfilesNew extends LiteElement {
         </a>
       </div>
 
-      <div
-        class="flex items-center justify-between mb-3 p-2 border bg-slate-50"
-      >
-        <p class="text-sm text-slate-600 mr-3 p-2">
+      ${this.params.profileId
+        ? html`
+            <div class="mb-2">
+              <btrix-alert class="text-sm" type="info"
+                >${msg(
+                  html`Extending <strong>${this.params.name}</strong>`
+                )}</btrix-alert
+              >
+            </div>
+          `
+        : ""}
+
+      <div class="flex items-center justify-between mb-3 p-2 bg-slate-50">
+        <p class="text-sm text-slate-600 mr-3 p-1">
           ${msg(
             "Interact with the browser to record your browser profile. You will complete and save your profile in the next step."
           )}
@@ -100,17 +110,6 @@ export class BrowserProfilesNew extends LiteElement {
         ?open=${this.isDialogVisible}
         @sl-request-close=${() => (this.isDialogVisible = false)}
       >
-        ${this.params.profileId
-          ? html`
-              <div class="mb-2">
-                <btrix-alert class="text-sm" type="info"
-                  >${msg(
-                    html`Extending <strong>${this.params.name}</strong>`
-                  )}</btrix-alert
-                >
-              </div>
-            `
-          : ""}
         ${this.renderForm()}
       </sl-dialog>
     `;
@@ -126,7 +125,7 @@ export class BrowserProfilesNew extends LiteElement {
             desc: "Example browser profile name",
           })}
           autocomplete="off"
-          value=${this.params.name || ""}
+          value=${this.params.name ? msg(str`${this.params.name} Copy`) : ""}
           required
         ></sl-input>
 

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -30,6 +30,9 @@ export class BrowserProfilesNew extends LiteElement {
   private browserUrl?: string;
 
   @state()
+  private browserOrigins: string[] = [];
+
+  @state()
   private isSubmitting = false;
 
   @state()
@@ -288,7 +291,7 @@ export class BrowserProfilesNew extends LiteElement {
 
       this.browserUrl = result.url;
 
-      // this.pingBrowser();
+      this.pingBrowser();
     } else {
       console.debug("Unknown checkBrowserStatus state");
     }
@@ -326,7 +329,7 @@ export class BrowserProfilesNew extends LiteElement {
    * Ping temporary browser every minute to keep it alive
    **/
   private async pingBrowser() {
-    await this.apiFetch(
+    const data = await this.apiFetch(
       `/archives/${this.archiveId}/profiles/browser/${this.browserId}/ping`,
       this.authState!,
       {
@@ -334,6 +337,9 @@ export class BrowserProfilesNew extends LiteElement {
       }
     );
 
+    console.log(data);
+
+    this.browserOrigins = data.origins;
     this.pollTimerId = window.setTimeout(() => this.pingBrowser(), 60 * 1000);
   }
 

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -89,7 +89,7 @@ export class BrowserProfilesNew extends LiteElement {
       <div class="flex items-center justify-between mb-3 p-2 bg-slate-50">
         <p class="text-sm text-slate-600 mr-3 p-1">
           ${msg(
-            "Interact with the browser to record your browser profile. You will complete and save your profile in the next step."
+            "Interact with the browsing tool to record your browser profile. You will complete and save your profile in the next step."
           )}
         </p>
 

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -29,6 +29,9 @@ export class BrowserProfilesNew extends LiteElement {
   @state()
   private isSubmitting = false;
 
+  @state()
+  private isDialogVisible = false;
+
   // URL params can be used to pass name and description
   // base ID determines whether this is an edit/extension
   @state()
@@ -71,12 +74,18 @@ export class BrowserProfilesNew extends LiteElement {
         </a>
       </div>
 
-      <div class="mb-5">
-        <p class="text-sm text-neutral-500">
+      <div
+        class="flex items-center justify-between mb-3 p-2 border bg-slate-50"
+      >
+        <p class="text-sm text-slate-600 mr-3 p-2">
           ${msg(
-            "Interact with the browser to record your browser profile. When you’re finished interacting, name and save the profile."
+            "Interact with the browser to record your browser profile. You will complete and save your profile in the next step."
           )}
         </p>
+
+        <sl-button type="primary" @click=${() => (this.isDialogVisible = true)}>
+          ${msg("Next")}
+        </sl-button>
       </div>
 
       <btrix-profile-browser
@@ -86,20 +95,24 @@ export class BrowserProfilesNew extends LiteElement {
         initialNavigateUrl=${ifDefined(this.params.navigateUrl)}
       ></btrix-profile-browser>
 
-      <div>
+      <sl-dialog
+        label=${msg(str`Save Browser Profile`)}
+        ?open=${this.isDialogVisible}
+        @sl-request-close=${() => (this.isDialogVisible = false)}
+      >
         ${this.params.profileId
           ? html`
               <div class="mb-2">
                 <btrix-alert class="text-sm" type="info"
                   >${msg(
-                    html`Viewing <strong>${this.params.name}</strong>`
+                    html`Extending <strong>${this.params.name}</strong>`
                   )}</btrix-alert
                 >
               </div>
             `
           : ""}
         ${this.renderForm()}
-      </div>
+      </sl-dialog>
     `;
   }
 
@@ -130,14 +143,8 @@ export class BrowserProfilesNew extends LiteElement {
         ></sl-textarea>
 
         <div class="text-right">
-          <sl-button
-            type="text"
-            href=${this.params.profileId
-              ? `/archives/${this.archiveId}/browser-profiles/profile/${this.params.profileId}`
-              : `/archives/${this.archiveId}/browser-profiles`}
-            @click=${this.navLink}
-          >
-            ${msg("Cancel")}
+          <sl-button type="text" @click=${() => (this.isDialogVisible = false)}>
+            ${msg("Back")}
           </sl-button>
 
           <sl-button
@@ -146,7 +153,7 @@ export class BrowserProfilesNew extends LiteElement {
             ?disabled=${this.isSubmitting}
             ?loading=${this.isSubmitting}
           >
-            ${msg("Save Profile")}
+            ${msg("Create Profile")}
           </sl-button>
         </div>
       </div>

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -170,29 +170,14 @@ export class BrowserProfilesNew extends LiteElement {
     };
 
     try {
-      let data: {
-        id: string;
-      };
-
-      if (this.params.profileId) {
-        data = await this.apiFetch(
-          `/archives/${this.archiveId}/profiles/${this.params.profileId}`,
-          this.authState!,
-          {
-            method: "PATCH",
-            body: JSON.stringify(params),
-          }
-        );
-      } else {
-        data = await this.apiFetch(
-          `/archives/${this.archiveId}/profiles`,
-          this.authState!,
-          {
-            method: "POST",
-            body: JSON.stringify(params),
-          }
-        );
-      }
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/profiles`,
+        this.authState!,
+        {
+          method: "POST",
+          body: JSON.stringify(params),
+        }
+      );
 
       this.notify({
         message: msg("Successfully created browser profile."),

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -44,14 +44,10 @@ export class BrowserProfilesNew extends LiteElement {
 
   firstUpdated() {
     const params = new URLSearchParams(window.location.search);
-    const name = params.get("name");
     const profileId = params.get("profileId");
 
     this.params = {
-      name:
-        profileId && name
-          ? msg(str`${this.params.name} Copy`)
-          : name || msg("My Profile"),
+      name: params.get("name") || "",
       description: params.get("description") || "",
       navigateUrl: params.get("navigateUrl") || "",
       profileId: profileId || null,
@@ -131,7 +127,9 @@ export class BrowserProfilesNew extends LiteElement {
             desc: "Example browser profile name",
           })}
           autocomplete="off"
-          value=${this.params.name || ""}
+          value=${this.params.profileId && this.params.name
+            ? msg(str`${this.params.name} Copy`)
+            : this.params.name || msg("My Profile")}
           required
         ></sl-input>
 

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -4,7 +4,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-import { ProfileBrowser } from "../../components/profile-browser";
 
 /**
  * Usage:
@@ -28,16 +27,7 @@ export class BrowserProfilesNew extends LiteElement {
   browserId!: string;
 
   @state()
-  private browserUrl?: string;
-
-  @state()
   private isSubmitting = false;
-
-  @state()
-  private hasFetchError = false;
-
-  @state()
-  private isFullscreen = false;
 
   // URL params can be used to pass name and description
   // base ID determines whether this is an edit/extension
@@ -45,33 +35,18 @@ export class BrowserProfilesNew extends LiteElement {
   private params: Partial<{
     name: string;
     description: string;
+    navigateUrl: string;
     profileId: string | null;
-    navigateUrl: string | null;
   }> = {};
-
-  private pollTimerId?: number;
-
-  connectedCallback() {
-    super.connectedCallback();
-
-    document.addEventListener("fullscreenchange", this.onFullscreenChange);
-  }
-
-  disconnectedCallback() {
-    window.clearTimeout(this.pollTimerId);
-    document.removeEventListener("fullscreenchange", this.onFullscreenChange);
-  }
 
   firstUpdated() {
     const params = new URLSearchParams(window.location.search);
     this.params = {
       name: params.get("name") || msg("My Profile"),
       description: params.get("description") || "",
+      navigateUrl: params.get("navigateUrl") || "",
       profileId: params.get("profileId") || null,
-      navigateUrl: params.get("navigateUrl") || null,
     };
-
-    this.fetchBrowser();
   }
 
   render() {
@@ -104,100 +79,26 @@ export class BrowserProfilesNew extends LiteElement {
         </p>
       </div>
 
-      <div id="interactive-browser" aria-live="polite">
-        ${this.hasFetchError
-          ? html`
-              <btrix-alert type="danger">
-                ${msg(
-                  html`The interactive browser is not available. Try creating a
-                    new browser profile.
-                    <a
-                      class="font-medium underline"
-                      href=${`/archives/${this.archiveId}/browser-profiles/new`}
-                      @click=${this.navLink}
-                      >Create New</a
-                    >`
-                )}
-              </btrix-alert>
-            `
-          : html`
-              <div class="lg:flex bg-white relative">
-                <div class="grow lg:rounded-lg overflow-hidden">
-                  ${this.browserUrl
-                    ? html`
-                        <div
-                          class="w-full ${this.isFullscreen
-                            ? "h-screen"
-                            : "h-96"}"
-                        >
-                          <btrix-profile-browser
-                            browserSrc=${this.browserUrl}
-                          ></btrix-profile-browser>
-                        </div>
-                      `
-                    : html`
-                        <div
-                          class="w-full h-96 bg-slate-50 flex items-center justify-center text-4xl"
-                          style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px"
-                        >
-                          <sl-spinner></sl-spinner>
-                        </div>
-                      `}
-                </div>
-                <div
-                  class="rounded-b lg:rounded-b-none lg:rounded-r border w-72 p-2 shadow-inner bg-white absolute h-full right-0"
-                >
-                  ${document.fullscreenEnabled
-                    ? html`
-                        <div class="mb-4 text-right">
-                          <sl-button
-                            type="neutral"
-                            size="small"
-                            @click=${() =>
-                              this.isFullscreen
-                                ? document.exitFullscreen()
-                                : this.enterFullscreen("interactive-browser")}
-                          >
-                            ${this.isFullscreen
-                              ? html`
-                                  <sl-icon
-                                    slot="prefix"
-                                    name="fullscreen-exit"
-                                    label=${msg("Exit fullscreen")}
-                                  ></sl-icon>
-                                  ${msg("Exit")}
-                                `
-                              : html`
-                                  <sl-icon
-                                    slot="prefix"
-                                    name="arrows-fullscreen"
-                                    label=${msg("Fullscreen")}
-                                  ></sl-icon>
-                                  ${msg("Go Fullscreen")}
-                                `}
-                          </sl-button>
-                        </div>
-                      `
-                    : ""}
+      <btrix-profile-browser
+        .authState=${this.authState}
+        archiveId=${this.archiveId}
+        browserId=${this.browserId}
+        initialNavigateUrl=${ifDefined(this.params.navigateUrl)}
+      ></btrix-profile-browser>
 
-                  <div class="p-2">
-                    ${this.params.profileId
-                      ? html`
-                          <div class="mb-2">
-                            <btrix-alert class="text-sm" type="info"
-                              >${msg(
-                                html`Viewing
-                                  <strong>${this.params.name}</strong>`
-                              )}</btrix-alert
-                            >
-                          </div>
-                        `
-                      : ""}
-                    ${this.renderForm()}
-                  </div>
-                </div>
+      <div>
+        ${this.params.profileId
+          ? html`
+              <div class="mb-2">
+                <btrix-alert class="text-sm" type="info"
+                  >${msg(
+                    html`Viewing <strong>${this.params.name}</strong>`
+                  )}</btrix-alert
+                >
               </div>
-            `}
+            `
+          : ""}
+        ${this.renderForm()}
       </div>
     `;
   }
@@ -213,7 +114,6 @@ export class BrowserProfilesNew extends LiteElement {
           })}
           autocomplete="off"
           value=${this.params.name || ""}
-          ?disabled=${!this.browserUrl}
           required
         ></sl-input>
 
@@ -227,7 +127,6 @@ export class BrowserProfilesNew extends LiteElement {
           rows="2"
           autocomplete="off"
           value=${this.params.description || ""}
-          ?disabled=${!this.browserUrl}
         ></sl-textarea>
 
         <div class="text-right">
@@ -244,7 +143,7 @@ export class BrowserProfilesNew extends LiteElement {
           <sl-button
             type="primary"
             submit
-            ?disabled=${!this.browserUrl || this.isSubmitting}
+            ?disabled=${this.isSubmitting}
             ?loading=${this.isSubmitting}
           >
             ${msg("Save Profile")}
@@ -254,96 +153,8 @@ export class BrowserProfilesNew extends LiteElement {
     </sl-form>`;
   }
 
-  /**
-   * Fetch browser profiles and update internal state
-   */
-  private async fetchBrowser(): Promise<void> {
-    try {
-      await this.checkBrowserStatus();
-    } catch (e) {
-      this.hasFetchError = true;
-
-      this.notify({
-        message: msg("Sorry, couldn't create browser profile at this time."),
-        type: "danger",
-        icon: "exclamation-octagon",
-      });
-    }
-  }
-
-  /**
-   * Check whether temporary browser is up
-   **/
-  private async checkBrowserStatus() {
-    const result = await this.getBrowser();
-
-    if (result.detail === "waiting_for_browser") {
-      this.pollTimerId = window.setTimeout(
-        () => this.checkBrowserStatus(),
-        5 * 1000
-      );
-    } else if (result.url) {
-      if (this.params.navigateUrl) {
-        await this.navigateBrowser({ url: this.params.navigateUrl });
-      }
-
-      this.browserUrl = result.url;
-
-      this.pingBrowser();
-    } else {
-      console.debug("Unknown checkBrowserStatus state");
-    }
-  }
-
-  private async getBrowser(): Promise<{
-    detail?: string;
-    url?: string;
-  }> {
-    const data = await this.apiFetch(
-      `/archives/${this.archiveId}/profiles/browser/${this.browserId}`,
-      this.authState!
-    );
-
-    return data;
-  }
-
-  /**
-   * Navigate to URL in temporary browser
-   **/
-  private async navigateBrowser({ url }: { url: string }) {
-    const data = this.apiFetch(
-      `/archives/${this.archiveId}/profiles/browser/${this.browserId}/navigate`,
-      this.authState!,
-      {
-        method: "POST",
-        body: JSON.stringify({ url }),
-      }
-    );
-
-    return data;
-  }
-
-  /**
-   * Ping temporary browser every minute to keep it alive
-   **/
-  private async pingBrowser() {
-    const data = await this.apiFetch(
-      `/archives/${this.archiveId}/profiles/browser/${this.browserId}/ping`,
-      this.authState!,
-      {
-        method: "POST",
-      }
-    );
-
-    this.pollTimerId = window.setTimeout(() => this.pingBrowser(), 60 * 1000);
-  }
-
   private async onSubmit(event: { detail: { formData: FormData } }) {
     this.isSubmitting = true;
-
-    if (this.isFullscreen) {
-      await document.exitFullscreen();
-    }
 
     const { formData } = event.detail;
     const params = {
@@ -396,29 +207,6 @@ export class BrowserProfilesNew extends LiteElement {
       });
     }
   }
-
-  /**
-   * Enter fullscreen mode
-   * @param id ID of element to fullscreen
-   */
-  private async enterFullscreen(id: string) {
-    try {
-      document.getElementById(id)!.requestFullscreen({
-        // Show browser navigation controls
-        navigationUI: "show",
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  private onFullscreenChange = () => {
-    if (document.fullscreenElement) {
-      this.isFullscreen = true;
-    } else {
-      this.isFullscreen = false;
-    }
-  };
 }
 
 customElements.define("btrix-browser-profiles-new", BrowserProfilesNew);

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -1,6 +1,6 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
-import { ref } from "lit/directives/ref.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -28,9 +28,6 @@ export class BrowserProfilesNew extends LiteElement {
 
   @state()
   private browserUrl?: string;
-
-  @state()
-  private browserOrigins: string[] = [];
 
   @state()
   private isSubmitting = false;
@@ -125,15 +122,11 @@ export class BrowserProfilesNew extends LiteElement {
           : html`
               <div class="lg:flex bg-white relative">
                 <div class="grow lg:rounded-lg overflow-hidden">
-                  ${this.browserUrl
-                    ? this.renderBrowser()
-                    : html`
-                        <div
-                          class="aspect-video bg-slate-50 flex items-center justify-center text-4xl pr-72"
-                        >
-                          <sl-spinner></sl-spinner>
-                        </div>
-                      `}
+                  <btrix-profile-browser
+                    browserSrc=${ifDefined(this.browserUrl)}
+                    ?isFullscreen=${this.isFullscreen}
+                    ?isLoading=${!this.browserUrl}
+                  ></btrix-profile-browser>
                 </div>
                 <div
                   class="rounded-b lg:rounded-b-none lg:rounded-r border w-72 p-2 shadow-inner bg-white absolute h-full right-0"
@@ -245,17 +238,6 @@ export class BrowserProfilesNew extends LiteElement {
     </sl-form>`;
   }
 
-  private renderBrowser() {
-    return html`
-      <iframe
-        class="w-full ${this.isFullscreen ? "h-screen" : "aspect-video"}"
-        title=${msg("Interactive browser for creating browser profile")}
-        src=${this.browserUrl!}
-        ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
-      ></iframe>
-    `;
-  }
-
   /**
    * Fetch browser profiles and update internal state
    */
@@ -337,9 +319,6 @@ export class BrowserProfilesNew extends LiteElement {
       }
     );
 
-    console.log(data);
-
-    this.browserOrigins = data.origins;
     this.pollTimerId = window.setTimeout(() => this.pingBrowser(), 60 * 1000);
   }
 
@@ -400,23 +379,6 @@ export class BrowserProfilesNew extends LiteElement {
         icon: "exclamation-octagon",
       });
     }
-  }
-
-  private onIframeRef(el: HTMLIFrameElement) {
-    if (!el) return;
-
-    el.addEventListener("load", () => {
-      // TODO see if we can make this work locally without CORs errors
-      const sidebarWidth = 288;
-      try {
-        //el.style.width = "132%";
-        el.contentWindow?.localStorage.setItem("uiTheme", '"default"');
-        el.contentWindow?.localStorage.setItem(
-          "InspectorView.screencastSplitViewState",
-          `{"vertical":{"size":${sidebarWidth}}}`
-        );
-      } catch (e) {}
-    });
   }
 
   /**

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -44,11 +44,17 @@ export class BrowserProfilesNew extends LiteElement {
 
   firstUpdated() {
     const params = new URLSearchParams(window.location.search);
+    const name = params.get("name");
+    const profileId = params.get("profileId");
+
     this.params = {
-      name: params.get("name") || msg("My Profile"),
+      name:
+        profileId && name
+          ? msg(str`${this.params.name} Copy`)
+          : name || msg("My Profile"),
       description: params.get("description") || "",
       navigateUrl: params.get("navigateUrl") || "",
-      profileId: params.get("profileId") || null,
+      profileId: profileId || null,
     };
   }
 
@@ -125,7 +131,7 @@ export class BrowserProfilesNew extends LiteElement {
             desc: "Example browser profile name",
           })}
           autocomplete="off"
-          value=${this.params.name ? msg(str`${this.params.name} Copy`) : ""}
+          value=${this.params.name || ""}
           required
         ></sl-input>
 

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -4,6 +4,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
+import { ProfileBrowser } from "../../components/profile-browser";
 
 /**
  * Usage:
@@ -122,11 +123,26 @@ export class BrowserProfilesNew extends LiteElement {
           : html`
               <div class="lg:flex bg-white relative">
                 <div class="grow lg:rounded-lg overflow-hidden">
-                  <btrix-profile-browser
-                    browserSrc=${ifDefined(this.browserUrl)}
-                    ?isFullscreen=${this.isFullscreen}
-                    ?isLoading=${!this.browserUrl}
-                  ></btrix-profile-browser>
+                  ${this.browserUrl
+                    ? html`
+                        <div
+                          class="w-full ${this.isFullscreen
+                            ? "h-screen"
+                            : "h-96"}"
+                        >
+                          <btrix-profile-browser
+                            browserSrc=${this.browserUrl}
+                          ></btrix-profile-browser>
+                        </div>
+                      `
+                    : html`
+                        <div
+                          class="w-full h-96 bg-slate-50 flex items-center justify-center text-4xl"
+                          style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px"
+                        >
+                          <sl-spinner></sl-spinner>
+                        </div>
+                      `}
                 </div>
                 <div
                   class="rounded-b lg:rounded-b-none lg:rounded-r border w-72 p-2 shadow-inner bg-white absolute h-full right-0"

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -45,6 +45,7 @@ export class BrowserProfilesNew extends LiteElement {
     name: string;
     description: string;
     profileId: string | null;
+    navigateUrl: string | null;
   }> = {};
 
   private pollTimerId?: number;
@@ -66,6 +67,7 @@ export class BrowserProfilesNew extends LiteElement {
       name: params.get("name") || msg("My Profile"),
       description: params.get("description") || "",
       profileId: params.get("profileId") || null,
+      navigateUrl: params.get("navigateUrl") || null,
     };
 
     this.fetchBrowser();
@@ -280,9 +282,13 @@ export class BrowserProfilesNew extends LiteElement {
         5 * 1000
       );
     } else if (result.url) {
+      if (this.params.navigateUrl) {
+        await this.navigateBrowser({ url: this.params.navigateUrl });
+      }
+
       this.browserUrl = result.url;
 
-      this.pingBrowser();
+      // this.pingBrowser();
     } else {
       console.debug("Unknown checkBrowserStatus state");
     }
@@ -295,6 +301,22 @@ export class BrowserProfilesNew extends LiteElement {
     const data = await this.apiFetch(
       `/archives/${this.archiveId}/profiles/browser/${this.browserId}`,
       this.authState!
+    );
+
+    return data;
+  }
+
+  /**
+   * Navigate to URL in temporary browser
+   **/
+  private async navigateBrowser({ url }: { url: string }) {
+    const data = this.apiFetch(
+      `/archives/${this.archiveId}/profiles/browser/${this.browserId}/navigate`,
+      this.authState!,
+      {
+        method: "POST",
+        body: JSON.stringify({ url }),
+      }
     );
 
     return data;

--- a/frontend/src/pages/archive/browser-profiles-new.ts
+++ b/frontend/src/pages/archive/browser-profiles-new.ts
@@ -339,7 +339,7 @@ export class BrowserProfilesNew extends LiteElement {
           `/archives/${this.archiveId}/profiles/${this.params.profileId}`,
           this.authState!,
           {
-            method: "PUT",
+            method: "PATCH",
             body: JSON.stringify(params),
           }
         );

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -67,9 +67,5 @@ export type Profile = {
   profileId: string;
   baseProfileName: string;
   aid: string;
-  resource: {
-    filename: string;
-    hash: string;
-    size: number;
-  };
+  crawlconfigs: { id: string; name: string }[];
 };

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
   archiveCrawl: "/archives/:id/:tab/crawl/:crawlId",
   browserProfile: "/archives/:id/:tab/profile/:browserProfileId",
   browser:
-    "/archives/:id/:tab/profile/browser/:browserId?name&description&profileId",
+    "/archives/:id/:tab/profile/browser/:browserId?name&description&profileId&navigateUrl",
   crawlTemplate: "/archives/:id/:tab/config/:crawlConfigId",
   crawlTemplateEdit: "/archives/:id/:tab/config/:crawlConfigId?edit",
   users: "/users",


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/199#issuecomment-1102919825) List visited URLs in side bar and refactor profile creation flow.

### Manual testing

### Screenshots
Prerequisite: Chromium-based browser
1. Go to Browser Profiles and start creating a new profile with "New Browser Profile"
2. Interact with browser, visiting different URLs. Verify that URLs besides starting URL shows under "Newly Visited"
3. Click "Next" and save. Verify new profile is created as expected
4. Click "Start Viewer". Verify profile loads as expected
5. Click different origins under "Visited URLs" in sidebar. Verify browser loads URL (may take a few seconds)
6. Navigate to new URLs and click "Save Changes". Refresh to verify changes are saved
7. Click "Duplicate Browser Profile" and complete workflow. Verify profile is created as expected

### Screenshots
**Browser profile detail view:**
<img width="1023" alt="Screen Shot 2022-04-19 at 5 07 50 PM" src="https://user-images.githubusercontent.com/4672952/164121005-ac69f138-d74d-4fd0-8e47-b6b937dcd64e.png">

**Detail view with profile loaded:**
<img width="1018" alt="Screen Shot 2022-04-19 at 5 09 08 PM" src="https://user-images.githubusercontent.com/4672952/164121194-e2ad6969-2359-4093-aa7a-67401781cdad.png">

**New browser profile view:**
<img width="1017" alt="Screen Shot 2022-04-19 at 5 03 32 PM" src="https://user-images.githubusercontent.com/4672952/164120983-4ae275d5-4956-4153-b35c-ded7b02fab50.png">

**Duplicating browser profile:**
<img width="1027" alt="Screen Shot 2022-04-19 at 5 10 46 PM" src="https://user-images.githubusercontent.com/4672952/164121227-5ea883ee-95d7-434f-9b54-2183108dda60.png">



