### PR TITLE
crawl templates: check that lastCrawlState is not null

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -141,7 +141,7 @@ export class CrawlTemplatesList extends LiteElement {
                       ? html`<sl-tooltip>
                           <span slot="content" class="capitalize">
                             ${msg(
-                              str`Last Crawl: ${t.lastCrawlState.replace(
+                              str`Last Crawl: ${t.lastCrawlState && t.lastCrawlState.replace(
                                 /_/g,
                                 " "
                               )}`


### PR DESCRIPTION
Fixed an issue that I encountered on testing server where `lastCrawlState` was not set.