### PR TITLE
Edit browser profile name and description

### DIFF
--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -445,14 +445,17 @@ export class BrowserProfilesDetail extends LiteElement {
         }
       );
 
-      this.notify({
-        message: msg("Successfully saved browser profile."),
-        type: "success",
-        icon: "check2-circle",
-      });
+      if (data.success === true) {
+        this.notify({
+          message: msg("Successfully saved browser profile."),
+          type: "success",
+          icon: "check2-circle",
+        });
 
-      this.profile = data;
-      this.browserId = undefined;
+        this.browserId = undefined;
+      } else {
+        throw data;
+      }
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't save browser profile at this time."),
@@ -488,14 +491,21 @@ export class BrowserProfilesDetail extends LiteElement {
         }
       );
 
-      this.notify({
-        message: msg("Successfully saved browser profile."),
-        type: "success",
-        icon: "check2-circle",
-      });
+      if (data.success === true) {
+        this.notify({
+          message: msg("Successfully saved browser profile."),
+          type: "success",
+          icon: "check2-circle",
+        });
 
-      this.profile = data;
-      this.isEditDialogOpen = false;
+        this.profile = {
+          ...this.profile,
+          ...params,
+        } as Profile;
+        this.isEditDialogOpen = false;
+      } else {
+        throw data;
+      }
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't save browser profile at this time."),

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -77,12 +77,7 @@ export class BrowserProfilesDetail extends LiteElement {
         </h2>
         <div>
           ${this.profile
-            ? html` <sl-button
-                size="small"
-                @click=${() => this.duplicateProfile()}
-              >
-                ${msg("Duplicate Profile")}</sl-button
-              >`
+            ? this.renderMenu()
             : html`<sl-skeleton
                 style="width: 6em; height: 2em;"
               ></sl-skeleton>`}
@@ -194,6 +189,32 @@ export class BrowserProfilesDetail extends LiteElement {
               `}
         </main>
       </section>`;
+  }
+
+  private renderMenu() {
+    return html`
+      <sl-dropdown placement="bottom-end" distance="4">
+        <sl-button slot="trigger" type="primary" size="small" caret
+          >${msg("Actions")}</sl-button
+        >
+
+        <ul class="text-left text-sm text-0-800 whitespace-nowrap" role="menu">
+          <li
+            class="p-2 hover:bg-zinc-100 cursor-pointer"
+            role="menuitem"
+            @click=${() => this.duplicateProfile()}
+          >
+            <sl-icon
+              class="inline-block align-middle px-1"
+              name="files"
+            ></sl-icon>
+            <span class="inline-block align-middle pr-2"
+              >${msg("Duplicate profile")}</span
+            >
+          </li>
+        </ul>
+      </sl-dropdown>
+    `;
   }
 
   private async startBrowserPreview() {


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/199) Allow users to edit profile name and description

### Manual testing
1. Go to Browser Profiles and choose a profile
2. Click "Edit" next to the name. Verify edit dialog shows, and changes save as expected
3. Click "Actions" -> "Edit name & description" and repeat test

### Screenshots
**Edit button and action menu item**
<img width="1022" alt="Screen Shot 2022-04-20 at 7 44 06 PM" src="https://user-images.githubusercontent.com/4672952/164366686-018a14de-b632-4c11-a317-801e6b76c319.png">

**Edit dialog**
<img width="508" alt="Screen Shot 2022-04-20 at 7 44 16 PM" src="https://user-images.githubusercontent.com/4672952/164366692-f190357c-a570-44c5-8b1b-00aa9bc30927.png">