### PR TITLE
Ensure generated config file has correct extension.

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,7 +33,7 @@ ENV RWP_BASE_URL=${RWP_BASE_URL}
 COPY --from=build /app/dist /usr/share/nginx/html
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY ./frontend.template /etc/nginx/templates/
+COPY ./frontend.template /etc/nginx/templates/frontend.conf.template
 
 RUN rm /etc/nginx/conf.d/*
 


### PR DESCRIPTION
The Docker setup wasn't working for me, because the system was generating a config file called `frontend` whereas the NGINX config was only reading files of the form `*.conf`. This PR ensures the config file is called `frontend.conf`.