### PR TITLE
Email config options

### DIFF
--- a/backend/emailsender.py
+++ b/backend/emailsender.py
@@ -11,8 +11,10 @@ class EmailSender:
 
     def __init__(self):
         self.sender = os.environ.get("EMAIL_SENDER")
-        self.password = os.environ.get("EMAIL_PASSWORD")
+        self.password = os.environ.get("EMAIL_PASSWORD", None)
         self.smtp_server = os.environ.get("EMAIL_SMTP_HOST")
+        self.smtp_port = os.environ.get("EMAIL_SMTP_PORT", 587)
+        self.smtp_starttls = os.environ.get("EMAIL_SMTP_STARTTLS", "true")
 
         self.default_origin = os.environ.get("APP_ORIGIN")
 
@@ -25,11 +27,13 @@ class EmailSender:
             return
 
         context = ssl.create_default_context()
-        with smtplib.SMTP(self.smtp_server, 587) as server:
+        with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
             server.ehlo()  # Can be omitted
-            server.starttls(context=context)
+            if self.smtp_starttls.lower() == "true":
+                server.starttls(context=context)
             server.ehlo()  # Can be omitted
-            server.login(self.sender, self.password)
+            if self.password != None:
+                server.login(self.sender, self.password)
             server.sendmail(self.sender, receiver, message)
 
     def get_origin(self, headers):

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,7 +33,7 @@ ENV RWP_BASE_URL=${RWP_BASE_URL}
 COPY --from=build /app/dist /usr/share/nginx/html
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY ./frontend.template /etc/nginx/templates/
+COPY ./frontend.template /etc/nginx/templates/frontend.conf.template
 
 RUN rm /etc/nginx/conf.d/*
 


### PR DESCRIPTION
Roughly inspired by how Airflow does things: https://airflow.apache.org/docs/apache-airflow/stable/howto/email-config.html#using-default-smtp

This PR adds some more options to allow TLS to be switched off, allow connection to SMTP without logging in, and to make use of the specified port number.

Creating as a draft because:

- this PR includes the other PR content! #228 oops.
- this PR does not support all the options that Airflow uses, and maybe that needs fixing.
- this PR does not include any documentation.