### PR TITLE
Show crawl replay for running crawls

### DIFF
--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -488,7 +488,7 @@ export class CrawlDetail extends LiteElement {
               replayBase="/replay/"
               noSandbox="true"
             ></replay-web-page>`
-          : ``}
+          : this.renderNoFilesMessage()}
       </div>
     `;
   }
@@ -645,11 +645,13 @@ export class CrawlDetail extends LiteElement {
               )}
             </ul>
           `
-        : html`
-            <p class="text-sm text-neutral-400">
-              ${msg("No files to download yet.")}
-            </p>
-          `}
+        : this.renderNoFilesMessage()}
+    `;
+  }
+
+  private renderNoFilesMessage() {
+    return html`
+      <p class="text-sm text-neutral-400">${msg("No files yet.")}</p>
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -93,11 +93,19 @@ export class CrawlDetail extends LiteElement {
     switch (this.sectionName) {
       case "watch": {
         if (this.crawl) {
-          if (this.isRunning) {
-            sectionContent = this.renderWatch();
-          } else {
-            sectionContent = this.renderReplay();
-          }
+          sectionContent = html`
+            ${this.isRunning
+              ? html`
+                  <section class="border rounded p-3 pl-5 mb-3">
+                    ${this.renderWatch()}
+                  </section>
+                `
+              : ""}
+
+            <section class="border rounded p-3 pl-5">
+              ${this.renderReplay()}
+            </section>
+          `;
         } else {
           // TODO loading indicator?
           return "";
@@ -400,7 +408,7 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderWatch() {
-    if (!this.authState) return "";
+    if (!this.authState || !this.crawl) return "";
 
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
@@ -418,22 +426,18 @@ export class CrawlDetail extends LiteElement {
           : ""}
       </header>
 
-      ${this.crawl
-        ? html` <div id="screencast-crawl">
-            <btrix-screencast
-              authToken=${authToken}
-              archiveId=${this.crawl.aid}
-              crawlId=${this.crawlId!}
-              .watchIPs=${this.crawl.watchIPs || []}
-            ></btrix-screencast>
-          </div>`
-        : ""}
+      <div id="screencast-crawl">
+        <btrix-screencast
+          authToken=${authToken}
+          archiveId=${this.crawl.aid}
+          crawlId=${this.crawlId!}
+          .watchIPs=${this.crawl.watchIPs || []}
+        ></btrix-screencast>
+      </div>
     `;
   }
 
   private renderReplay() {
-    const isRunning = this.isRunning;
-
     const bearer = this.authState?.headers?.Authorization?.split(" ", 2)[1];
 
     // for now, just use the first file until multi-wacz support is fully implemented
@@ -456,7 +460,7 @@ export class CrawlDetail extends LiteElement {
 
       <div
         id="replay-crawl"
-        class="aspect-4/3 rounded border ${isRunning
+        class="aspect-4/3 rounded border ${this.isRunning
           ? "border-purple-200"
           : "border-slate-100"}"
       >

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -65,6 +65,13 @@ export class CrawlDetail extends LiteElement {
     return this.crawl.state === "running" || this.crawl.state === "starting";
   }
 
+  private get hasFiles(): boolean | null {
+    if (!this.crawl) return null;
+    if (!this.crawl.resources) return false;
+
+    return this.crawl.resources.length > 0;
+  }
+
   async firstUpdated() {
     if (!this.crawlsBaseUrl) {
       throw new Error("Crawls base URL not defined");
@@ -474,7 +481,7 @@ export class CrawlDetail extends LiteElement {
 
       <div id="replay-crawl" class="aspect-4/3 rounded border overflow-hidden">
         <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
-        ${replaySource
+        ${replaySource && this.hasFiles
           ? html`<replay-web-page
               source="${replaySource}"
               coll="${ifDefined(this.crawl?.id)}"
@@ -613,38 +620,36 @@ export class CrawlDetail extends LiteElement {
     return html`
       <h3 class="text-lg font-medium my-2">${msg("Download Files")}</h3>
 
-      ${this.crawl
-        ? this.crawl.resources && this.crawl.resources.length
-          ? html`
-              <ul class="border rounded text-sm">
-                ${this.crawl.resources.map(
-                  (file) => html`
-                    <li
-                      class="flex justify-between p-3 border-t first:border-t-0"
-                    >
-                      <div class="whitespace-nowrap truncate">
-                        <a
-                          class="text-primary hover:underline"
-                          href=${file.path}
-                          download
-                          title=${file.name}
-                          >${file.name.slice(file.name.lastIndexOf("/") + 1)}
-                        </a>
-                      </div>
-                      <div class="whitespace-nowrap">
-                        <sl-format-bytes value=${file.size}></sl-format-bytes>
-                      </div>
-                    </li>
-                  `
-                )}
-              </ul>
-            `
-          : html`
-              <p class="text-sm text-neutral-400">
-                ${msg("No files to download yet.")}
-              </p>
-            `
-        : ""}
+      ${this.hasFiles
+        ? html`
+            <ul class="border rounded text-sm">
+              ${this.crawl!.resources!.map(
+                (file) => html`
+                  <li
+                    class="flex justify-between p-3 border-t first:border-t-0"
+                  >
+                    <div class="whitespace-nowrap truncate">
+                      <a
+                        class="text-primary hover:underline"
+                        href=${file.path}
+                        download
+                        title=${file.name}
+                        >${file.name.slice(file.name.lastIndexOf("/") + 1)}
+                      </a>
+                    </div>
+                    <div class="whitespace-nowrap">
+                      <sl-format-bytes value=${file.size}></sl-format-bytes>
+                    </div>
+                  </li>
+                `
+              )}
+            </ul>
+          `
+        : html`
+            <p class="text-sm text-neutral-400">
+              ${msg("No files to download yet.")}
+            </p>
+          `}
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -788,7 +788,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                         class="text-primary font-medium hover:underline text-sm p-1"
                         href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlTemplate.currCrawlId}#watch`}
                         @click=${this.navLink}
-                        >${msg("View crawl")}</a
+                        >${msg("Watch crawl")}</a
                       >`
                     : this.crawlTemplate.inactive
                     ? ""
@@ -842,7 +842,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                     class="text-primary font-medium hover:underline text-sm p-1"
                     href=${`/archives/${this.archiveId}/crawls/crawl/${this.crawlTemplate.lastCrawlId}#watch`}
                     @click=${this.navLink}
-                    >${msg("View crawl")}</a
+                    >${msg("Watch crawl")}</a
                   >
                 `
               : html`<span class="text-0-400 text-sm p-1"
@@ -1206,7 +1206,7 @@ export class CrawlTemplatesDetail extends LiteElement {
               href="/archives/${this
                 .archiveId}/crawls/crawl/${data.started}#watch"
               @click=${this.navLink.bind(this)}
-              >View crawl</a
+              >Watch crawl</a
             >`
         ),
         type: "success",

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -537,7 +537,7 @@ export class CrawlTemplatesList extends LiteElement {
           }}
         >
           <span class="whitespace-nowrap">
-            ${this.runningCrawlsMap[t.id] ? msg("View crawl") : msg("Run now")}
+            ${this.runningCrawlsMap[t.id] ? msg("Watch crawl") : msg("Run now")}
           </span>
         </button>
       </div>
@@ -680,7 +680,7 @@ export class CrawlTemplatesList extends LiteElement {
               href="/archives/${this
                 .archiveId}/crawls/crawl/${data.started}#watch"
               @click=${this.navLink.bind(this)}
-              >View crawl</a
+              >Watch crawl</a
             >`
         ),
         type: "success",


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/227) Show both crawl replay and watch for running crawls.

### Manual testing
1. Run app and start a crawl
2. Go to crawl detail page. Verify side navigation shows "Watch Crawl" tab
3. Click "Watch Crawl". Verify watch view shows
4. Click "Replay" and "Files". Verify view updates as expected

### Screenshots
Tab navigation:
<img width="185" alt="Screen Shot 2022-05-30 at 4 47 22 PM" src="https://user-images.githubusercontent.com/4672952/171068979-bf525e7a-01d1-4237-9851-3406ed8c9419.png">

Watch view when crawl is not running:
<img width="858" alt="Screen Shot 2022-05-30 at 4 49 33 PM" src="https://user-images.githubusercontent.com/4672952/171068980-40f38b65-194f-4eb9-b214-b1ed7cdeeaf1.png">

