### PR TITLE
Enable duplicating and editing browser profile

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -36,6 +36,9 @@ import("./not-found").then(({ NotFound }) => {
 import("./screencast").then(({ Screencast: Screencast }) => {
   customElements.define("btrix-screencast", Screencast);
 });
+import("./select-browser-profile").then(({ SelectBrowserProfile }) => {
+  customElements.define("btrix-select-browser-profile", SelectBrowserProfile);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/select-browser-profile.ts
+++ b/frontend/src/components/select-browser-profile.ts
@@ -1,0 +1,175 @@
+import { html } from "lit";
+import { property, state } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+import orderBy from "lodash/fp/orderBy";
+
+import type { AuthState } from "../utils/AuthService";
+import LiteElement from "../utils/LiteElement";
+import type { Profile } from "../pages/archive/types";
+
+/**
+ * Browser profile select dropdown
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-select-browser-profile
+ *   authState=${authState}
+ *   archiveId=${archiveId}
+ *   .selectedProfile=${selectedProfile}
+ * ></btrix-select-browser-profile>
+ * ```
+ *
+ * @event
+ */
+@localized()
+export class SelectBrowserProfile extends LiteElement {
+  @property({ type: Object })
+  authState!: AuthState;
+
+  @property({ type: String })
+  archiveId!: string;
+
+  @property({ type: String })
+  initialProfileId?: string;
+
+  @property({ type: Object })
+  selectedProfile?: Profile;
+
+  @state()
+  private browserProfiles?: Profile[];
+
+  protected firstUpdated() {
+    this.fetchBrowserProfiles();
+  }
+
+  render() {
+    return html`
+      <sl-select
+        label=${msg("Browser Profile")}
+        clearable
+        value=${this.selectedProfile?.id || ""}
+        placeholder=${this.browserProfiles
+          ? msg("Select Profile")
+          : msg("Loading")}
+        ?disabled=${!this.browserProfiles?.length}
+        @sl-change=${(e: any) =>
+          (this.selectedProfile = this.browserProfiles?.find(
+            ({ id }) => id === e.target.value
+          ))}
+        @sl-focus=${() => {
+          // Refetch to keep list up to date
+          this.fetchBrowserProfiles();
+        }}
+      >
+        ${this.browserProfiles
+          ? ""
+          : html` <sl-spinner slot="prefix"></sl-spinner> `}
+        ${this.browserProfiles?.map(
+          (profile) => html`
+            <sl-menu-item value=${profile.id}>
+              ${profile.name}
+              <div slot="suffix">
+                <div class="text-xs">
+                  <sl-format-date
+                    date=${`${profile.created}Z` /** Z for UTC */}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                  ></sl-format-date>
+                </div></div
+            ></sl-menu-item>
+          `
+        )}
+      </sl-select>
+
+      ${this.browserProfiles && !this.browserProfiles.length
+        ? this.renderNoProfiles()
+        : this.renderSelectedProfileInfo()}
+    `;
+  }
+
+  private renderSelectedProfileInfo() {
+    if (!this.selectedProfile) return;
+
+    return html`
+      <div
+        class="mt-2 border bg-neutral-50 rounded p-2 text-sm flex justify-between"
+      >
+        ${this.selectedProfile.description
+          ? html`<em class="text-slate-500"
+              >${this.selectedProfile.description}</em
+            >`
+          : ""}
+        <a
+          href=${`/archives/${this.archiveId}/browser-profiles/profile/${this.selectedProfile.id}`}
+          class="font-medium text-primary hover:text-indigo-500"
+          target="_blank"
+        >
+          <span class="inline-block align-middle mr-1"
+            >${msg("View profile")}</span
+          >
+          <sl-icon
+            class="inline-block align-middle"
+            name="box-arrow-up-right"
+          ></sl-icon>
+        </a>
+      </div>
+    `;
+  }
+
+  private renderNoProfiles() {
+    return html`
+      <div class="mt-2 text-sm text-neutral-500">
+        <span class="inline-block align-middle"
+          >${msg("No browser profiles found.")}</span
+        >
+        <a
+          href=${`/archives/${this.archiveId}/browser-profiles/new`}
+          class="font-medium text-primary hover:text-indigo-500"
+          target="_blank"
+          ><span class="inline-block align-middle"
+            >${msg("Create a browser profile")}</span
+          >
+          <sl-icon
+            class="inline-block align-middle"
+            name="box-arrow-up-right"
+          ></sl-icon
+        ></a>
+      </div>
+    `;
+  }
+
+  /**
+   * Fetch browser profiles and update internal state
+   */
+  private async fetchBrowserProfiles(): Promise<void> {
+    try {
+      const data = await this.getProfiles();
+
+      this.browserProfiles = orderBy(["name", "created"])(["asc", "desc"])(
+        data
+      ) as Profile[];
+
+      if (this.initialProfileId && !this.selectedProfile) {
+        this.selectedProfile = this.browserProfiles.find(
+          ({ id }) => id === this.initialProfileId
+        );
+      }
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't retrieve browser profiles at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async getProfiles(): Promise<Profile[]> {
+    const data = await this.apiFetch(
+      `/archives/${this.archiveId}/profiles`,
+      this.authState!
+    );
+
+    return data;
+  }
+}

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1077,7 +1077,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     detail: { formData: FormData };
   }) {
     const { formData } = e.detail;
-    const profileId = formData.get("browserProfile") as string;
+    const profileId = (formData.get("browserProfile") as string) || null;
 
     let config: CrawlConfig;
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -654,14 +654,6 @@ export class CrawlTemplatesDetail extends LiteElement {
               `
             : ""}
 
-          <div>
-            <btrix-select-browser-profile
-              archiveId=${this.archiveId}
-              profileId=${this.crawlTemplate.profileid || ""}
-              .authState=${this.authState}
-            ></btrix-select-browser-profile>
-          </div>
-
           <div class="flex flex-wrap justify-between">
             <h4 class="font-medium">
               ${this.isConfigCodeView
@@ -682,6 +674,14 @@ export class CrawlTemplatesDetail extends LiteElement {
           </div>
           <div class="grid gap-5${this.isConfigCodeView ? " hidden" : ""}">
             ${this.renderSeedsForm()}
+          </div>
+
+          <div>
+            <btrix-select-browser-profile
+              archiveId=${this.archiveId}
+              profileId=${this.crawlTemplate.profileid || ""}
+              .authState=${this.authState}
+            ></btrix-select-browser-profile>
           </div>
 
           <div class="text-right">
@@ -930,7 +930,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       </sl-dialog>
 
       <sl-dialog
-        label=${msg(str`Edit Crawl Settings`)}
+        label=${msg(str`Edit Crawl Configuration`)}
         style="--width: ${dialogWidth}"
         ?open=${this.openDialogName === "config"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
@@ -1252,8 +1252,6 @@ export class CrawlTemplatesDetail extends LiteElement {
       name: this.crawlTemplate!.name,
       schedule: this.crawlTemplate!.schedule,
       profileid: profileId || this.crawlTemplate!.profileid,
-      // runNow: this.crawlTemplate!.runNow,
-      // crawlTimeout: this.crawlTemplate!.crawlTimeout,
       config,
     };
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1041,7 +1041,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     const crawlTemplate: InitialCrawlTemplate = {
       name: msg(str`${this.crawlTemplate.name} Copy`),
       config: this.crawlTemplate.config,
-      profileid: this.crawlTemplate.profileid || "",
+      profileid: this.crawlTemplate.profileid || null,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1251,7 +1251,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       oldId: this.crawlTemplate!.id,
       name: this.crawlTemplate!.name,
       schedule: this.crawlTemplate!.schedule,
-      profileid: profileId || this.crawlTemplate!.profileid,
+      profileid: profileId,
       config,
     };
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -7,6 +7,7 @@ import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
+import type { InitialCrawlTemplate } from "./crawl-templates-new";
 import type { CrawlTemplate, CrawlConfig } from "./types";
 import { getUTCSchedule } from "./utils";
 import "../../components/crawl-scheduler";
@@ -1029,15 +1030,13 @@ export class CrawlTemplatesDetail extends LiteElement {
   private async duplicateConfig() {
     if (!this.crawlTemplate) return;
 
-    const config: CrawlTemplate["config"] = {
-      ...this.crawlTemplate.config,
+    const crawlTemplate: InitialCrawlTemplate = {
+      name: msg(str`${this.crawlTemplate.name} Copy`),
+      config: this.crawlTemplate.config,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {
-      crawlTemplate: {
-        name: msg(str`${this.crawlTemplate.name} Copy`),
-        config,
-      },
+      crawlTemplate,
     });
 
     this.notify({

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -679,7 +679,7 @@ export class CrawlTemplatesDetail extends LiteElement {
           <div>
             <btrix-select-browser-profile
               archiveId=${this.archiveId}
-              profileId=${this.crawlTemplate.profileid || ""}
+              .profileId=${this.crawlTemplate.profileid || null}
               .authState=${this.authState}
             ></btrix-select-browser-profile>
           </div>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1033,6 +1033,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     const crawlTemplate: InitialCrawlTemplate = {
       name: msg(str`${this.crawlTemplate.name} Copy`),
       config: this.crawlTemplate.config,
+      profileid: this.crawlTemplate.profileid || "",
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -11,6 +11,7 @@ import Fuse from "fuse.js";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
+import type { InitialCrawlTemplate } from "./crawl-templates-new";
 import type { CrawlTemplate } from "./types";
 import { getUTCSchedule } from "./utils";
 import "../../components/crawl-scheduler";
@@ -581,15 +582,13 @@ export class CrawlTemplatesList extends LiteElement {
    * Create a new template using existing template data
    */
   private async duplicateConfig(template: CrawlTemplate) {
-    const config: CrawlTemplate["config"] = {
-      ...template.config,
+    const crawlTemplate: InitialCrawlTemplate = {
+      name: msg(str`${template.name} Copy`),
+      config: template.config,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {
-      crawlTemplate: {
-        name: msg(str`${template.name} Copy`),
-        config,
-      },
+      crawlTemplate,
     });
 
     this.notify({

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -585,6 +585,7 @@ export class CrawlTemplatesList extends LiteElement {
     const crawlTemplate: InitialCrawlTemplate = {
       name: msg(str`${template.name} Copy`),
       config: template.config,
+      profileid: template.profileid || "",
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -585,7 +585,7 @@ export class CrawlTemplatesList extends LiteElement {
     const crawlTemplate: InitialCrawlTemplate = {
       name: msg(str`${template.name} Copy`),
       config: template.config,
-      profileid: template.profileid || "",
+      profileid: template.profileid || null,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -248,7 +248,9 @@ export class CrawlTemplatesNew extends LiteElement {
             .profileId=${this.initialCrawlTemplate?.profileid || null}
             .authState=${this.authState}
             @on-change=${(e: any) =>
-              (this.browserProfileId = e.detail.value.id)}
+              (this.browserProfileId = e.detail.value
+                ? e.detail.value.id
+                : null)}
           ></btrix-select-browser-profile>
         </div>
       </section>
@@ -504,8 +506,6 @@ export class CrawlTemplatesNew extends LiteElement {
       scale: +scale,
       profileid: this.browserProfileId,
     };
-
-    console.log('this.browserProfileId"', this.browserProfileId);
 
     if (this.isConfigCodeView) {
       template.config = yamlToJson(this.configCode) as CrawlConfig;

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -87,10 +87,10 @@ export class CrawlTemplatesNew extends LiteElement {
   private isSubmitting: boolean = false;
 
   @state()
-  private serverError?: string;
+  private browserProfileId?: string;
 
   @state()
-  private selectedProfile?: Profile;
+  private serverError?: string;
 
   private get timeZone() {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -142,6 +142,7 @@ export class CrawlTemplatesNew extends LiteElement {
       },
     };
     this.configCode = jsonToYaml(this.initialCrawlTemplate.config);
+    this.browserProfileId = this.initialCrawlTemplate.profileid;
     super.connectedCallback();
   }
 
@@ -244,9 +245,10 @@ export class CrawlTemplatesNew extends LiteElement {
         <div>
           <btrix-select-browser-profile
             archiveId=${this.archiveId}
-            initialProfileId=${this.initialCrawlTemplate?.profileid || ""}
+            profileId=${this.initialCrawlTemplate?.profileid || ""}
             .authState=${this.authState}
-            .selectedProfile=${this.selectedProfile}
+            @on-change=${(e: any) =>
+              (this.browserProfileId = e.detail.value.id)}
           ></btrix-select-browser-profile>
         </div>
       </section>
@@ -500,8 +502,10 @@ export class CrawlTemplatesNew extends LiteElement {
       runNow: this.isRunNow,
       crawlTimeout: crawlTimeoutMinutes ? +crawlTimeoutMinutes * 60 : 0,
       scale: +scale,
-      profileid: this.selectedProfile?.id,
+      profileid: this.browserProfileId,
     };
+
+    console.log('this.browserProfileId"', this.browserProfileId);
 
     if (this.isConfigCodeView) {
       template.config = yamlToJson(this.configCode) as CrawlConfig;

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -11,7 +11,7 @@ import { getLocaleTimeZone } from "../../utils/localization";
 import type { CrawlConfig, Profile } from "./types";
 import { getUTCSchedule } from "./utils";
 
-export type NewCrawlTemplate = {
+type NewCrawlTemplate = {
   id?: string;
   name: string;
   schedule: string;
@@ -21,6 +21,8 @@ export type NewCrawlTemplate = {
   config: CrawlConfig;
   profileid: string;
 };
+
+export type InitialCrawlTemplate = Pick<NewCrawlTemplate, "name" | "config">;
 
 const initialValues = {
   name: "",
@@ -55,10 +57,7 @@ export class CrawlTemplatesNew extends LiteElement {
   archiveId!: string;
 
   @property({ type: Object })
-  initialCrawlTemplate?: {
-    name: string;
-    config: CrawlConfig;
-  };
+  initialCrawlTemplate?: InitialCrawlTemplate;
 
   @state()
   private isRunNow: boolean = initialValues.runNow;

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -18,7 +18,7 @@ type NewCrawlTemplate = {
   crawlTimeout?: number;
   scale: number;
   config: CrawlConfig;
-  profileid: string;
+  profileid: string | null;
 };
 
 export type InitialCrawlTemplate = Pick<

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -22,7 +22,10 @@ type NewCrawlTemplate = {
   profileid: string;
 };
 
-export type InitialCrawlTemplate = Pick<NewCrawlTemplate, "name" | "config">;
+export type InitialCrawlTemplate = Pick<
+  NewCrawlTemplate,
+  "name" | "config" | "profileid"
+>;
 
 const initialValues = {
   name: "",
@@ -136,6 +139,7 @@ export class CrawlTemplatesNew extends LiteElement {
     }
     this.initialCrawlTemplate = {
       name: this.initialCrawlTemplate?.name || initialValues.name,
+      profileid: this.initialCrawlTemplate?.profileid || "",
       config: {
         ...initialValues.config,
         ...this.initialCrawlTemplate?.config,
@@ -250,6 +254,9 @@ export class CrawlTemplatesNew extends LiteElement {
             label=${msg("Browser Profile")}
             clearable
             value=${this.selectedProfile?.id || ""}
+            placeholder=${this.browserProfiles
+              ? msg("Select Profile")
+              : msg("Loading")}
             ?disabled=${!this.browserProfiles?.length}
             @sl-change=${(e: any) =>
               (this.selectedProfile = this.browserProfiles?.find(
@@ -671,6 +678,12 @@ export class CrawlTemplatesNew extends LiteElement {
       this.browserProfiles = orderBy(["name", "created"])(["asc", "desc"])(
         data
       ) as Profile[];
+
+      if (this.initialCrawlTemplate?.profileid && !this.selectedProfile) {
+        this.selectedProfile = this.browserProfiles.find(
+          ({ id }) => id === this.initialCrawlTemplate?.profileid
+        );
+      }
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't retrieve browser profiles at this time."),

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -135,7 +135,7 @@ export class CrawlTemplatesNew extends LiteElement {
     }
     this.initialCrawlTemplate = {
       name: this.initialCrawlTemplate?.name || initialValues.name,
-      profileid: this.initialCrawlTemplate?.profileid || "",
+      profileid: this.initialCrawlTemplate?.profileid || null,
       config: {
         ...initialValues.config,
         ...this.initialCrawlTemplate?.config,
@@ -245,7 +245,7 @@ export class CrawlTemplatesNew extends LiteElement {
         <div>
           <btrix-select-browser-profile
             archiveId=${this.archiveId}
-            profileId=${this.initialCrawlTemplate?.profileid || ""}
+            .profileId=${this.initialCrawlTemplate?.profileid || null}
             .authState=${this.authState}
             @on-change=${(e: any) =>
               (this.browserProfileId = e.detail.value.id)}

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -87,7 +87,7 @@ export class CrawlTemplatesNew extends LiteElement {
   private isSubmitting: boolean = false;
 
   @state()
-  private browserProfileId?: string;
+  private browserProfileId?: string | null;
 
   @state()
   private serverError?: string;


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/230) Enables duplicating & editing browser profile on crawl template, fixes browser profile removed on edit.

### Manual testing
1. Run app and go to a new crawl templates page
2. Create a new crawl template with a browser profile. Verify browser profile saves as expected.
3. Test edit configuration:
    - Updating configuration without browser profile should no longer remove profile
    - Browser profile can be added, changed and deleted
4. Duplicate crawl template from detail page. Verify browser profile is copied
5. Repeat from crawl template list view

### Screenshots
New field in "Edit Crawl Configuration" dialog:
<img width="594" alt="Screen Shot 2022-05-30 at 6 11 06 PM" src="https://user-images.githubusercontent.com/4672952/171074523-bf94877e-72ba-4dfa-8a70-56f46f85bb80.png">

