### PR TITLE
Backend API prefix

### DIFF
--- a/Deployment.md
+++ b/Deployment.md
@@ -16,7 +16,7 @@ Then, run `docker-compose build; docker-compose up -d` to launch.
 
 To update/relaunch, use `./docker-restart.sh`.
 
-The API should be available at: `http://localhost:8000/docs`
+The API documentation should be available at: `http://localhost:9871/api/docs`.
 
 To allow downloading of WACZ files via the UI from a remote host, set the `STORE_ACCESS_ENDPOINT_URL` to use the domain of the host.
 Otherwise, the files are accesible only through the default Minio service running on port 9000.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,5 @@ RUN pip install -r requirements.txt
 
 ADD . /app
 
-CMD uvicorn main:app --host 0.0.0.0 --root-path /api --access-log --log-level info
+CMD uvicorn main:app_main --host 0.0.0.0 --access-log --log-level info
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,5 @@ RUN pip install -r requirements.txt
 
 ADD . /app
 
-CMD uvicorn main:app_main --host 0.0.0.0 --access-log --log-level info
+CMD uvicorn main:app_root --host 0.0.0.0 --access-log --log-level info
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,8 @@ supports docker and kubernetes based deployments of multiple browsertrix-crawler
 import os
 
 from fastapi import FastAPI
+from fastapi.routing import APIRouter
+from fastapi.responses import JSONResponse
 
 from db import init_db
 
@@ -22,8 +24,14 @@ from colls import init_collections_api
 from crawls import init_crawls_api
 
 
-app = FastAPI()
+API_PREFIX = "/api"
+app_root = FastAPI(
+    docs_url=API_PREFIX + "/docs",
+    redoc_url=API_PREFIX + "/redoc",
+    openapi_url=API_PREFIX + "/openapi.json",
+)
 
+app = APIRouter()
 
 # ============================================================================
 # pylint: disable=too-many-locals
@@ -107,9 +115,15 @@ def main():
     async def healthz():
         return {}
 
+    @app.get("/openapi.json")
+    async def openapi() -> JSONResponse:
+        return JSONResponse(app_root.openapi())
+
+    app_root.include_router(app, prefix=API_PREFIX)
+
 
 # ============================================================================
-@app.on_event("startup")
+@app_root.on_event("startup")
 async def startup():
     """init on startup"""
     main()

--- a/backend/main.py
+++ b/backend/main.py
@@ -115,7 +115,7 @@ def main():
     async def healthz():
         return {}
 
-    @app.get("/openapi.json")
+    @app.get("/openapi.json", include_in_schema=False)
     async def openapi() -> JSONResponse:
         return JSONResponse(app_root.openapi())
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -111,13 +111,15 @@ def main():
     async def get_settings():
         return settings
 
-    @app.get("/healthz")
-    async def healthz():
-        return {}
+    # internal routes
 
     @app.get("/openapi.json", include_in_schema=False)
     async def openapi() -> JSONResponse:
         return JSONResponse(app_root.openapi())
+
+    @app_root.get("/healthz", include_in_schema=False)
+    async def healthz():
+        return {}
 
     app_root.include_router(app, prefix=API_PREFIX)
 

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
               number: 9000
 {{- end }}
 
-      - path: /api/(.*)
+      - path: /(api/.*)
         pathType: Prefix
         backend:
           service:

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -55,7 +55,7 @@ stringData:
   STORE_ACCESS_ENDPOINT_URL: "{{ $storage.endpoint_url }}"
   {{- end }}
 
-  STORE_REGION: {{ $storage.region | default "" }}
+  STORE_REGION: "{{ $storage.region }}"
 
   {{- if $.Values.signer.auth_token }}
   WACZ_SIGN_TOKEN: "{{ $.Values.signer.auth_token }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,9 @@ services:
       - mongo
       - volume_placeholder_image
 
-    ports:
-      - 8000:8000
+# enable to expose backend api container directly
+#    ports:
+#      - 8000:8000
 
   frontend:
     build: ./frontend
@@ -33,9 +34,6 @@ services:
   redis:
     image: redis
     command: redis-server --appendonly yes
-
-    #ports:
-    #  - 6379:6379
 
     volumes:
       - btrix-redis-data:/data

--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -32,7 +32,7 @@ server {
 
     # used by docker only: k8s deployment handles /api directly via ingress
     location /api/ {
-      proxy_pass http://${BACKEND_HOST}:8000/;
+      proxy_pass http://${BACKEND_HOST}:8000;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
     }


### PR DESCRIPTION
- Routing: Fix API routing such that `/api/docs` works on backend container directly, as well as when accessed via frontend.
- Docs: Update docs to use 9871 for local api access, comment out 8000 access, though can be enabled if needed.
- Fixes #236 