### PR TITLE
Delete browser profile

### DIFF
--- a/backend/profiles.py
+++ b/backend/profiles.py
@@ -361,7 +361,7 @@ class ProfileOps:
         # delete profile.pathname
 
         res = await self.profiles.delete_one(query)
-        if not res or res.get("deleteCount") != 1:
+        if not res or res.deleted_count != 1:
             raise HTTPException(status_code=404, detail="profile_not_found")
 
         return {"success": True}

--- a/frontend/src/pages/archive/browser-profiles-list.ts
+++ b/frontend/src/pages/archive/browser-profiles-list.ts
@@ -324,7 +324,7 @@ export class BrowserProfilesList extends LiteElement {
 
   private async deleteProfile(profile: Profile) {
     try {
-      await this.apiFetch(
+      const data = await this.apiFetch(
         `/archives/${this.archiveId}/profiles/${profile.id}`,
         this.authState!,
         {
@@ -332,15 +332,31 @@ export class BrowserProfilesList extends LiteElement {
         }
       );
 
-      this.notify({
-        message: msg(html`Deleted <strong>${profile.name}</strong>.`),
-        type: "success",
-        icon: "check2-circle",
-      });
+      if (data.error && data.crawlconfigs) {
+        this.notify({
+          message: msg(
+            html`Could not delete <strong>${profile.name}</strong>, in use by
+              <strong
+                >${data.crawlconfigs
+                  .map(({ name }: any) => name)
+                  .join(", ")}</strong
+              >. Please remove browser profile from crawl template to continue.`
+          ),
+          type: "warning",
+          icon: "exclamation-triangle",
+          duration: 15000,
+        });
+      } else {
+        this.notify({
+          message: msg(html`Deleted <strong>${profile.name}</strong>.`),
+          type: "success",
+          icon: "check2-circle",
+        });
 
-      this.browserProfiles = this.browserProfiles!.filter(
-        (p) => p.id !== profile.id
-      );
+        this.browserProfiles = this.browserProfiles!.filter(
+          (p) => p.id !== profile.id
+        );
+      }
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't delete browser profile at this time."),

--- a/frontend/src/pages/archive/browser-profiles-list.ts
+++ b/frontend/src/pages/archive/browser-profiles-list.ts
@@ -324,7 +324,7 @@ export class BrowserProfilesList extends LiteElement {
 
   private async deleteProfile(profile: Profile) {
     try {
-      const data = await this.apiFetch(
+      await this.apiFetch(
         `/archives/${this.archiveId}/profiles/${profile.id}`,
         this.authState!,
         {
@@ -337,6 +337,10 @@ export class BrowserProfilesList extends LiteElement {
         type: "success",
         icon: "check2-circle",
       });
+
+      this.browserProfiles = this.browserProfiles!.filter(
+        (p) => p.id !== profile.id
+      );
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't delete browser profile at this time."),

--- a/frontend/src/pages/archive/browser-profiles-list.ts
+++ b/frontend/src/pages/archive/browser-profiles-list.ts
@@ -170,7 +170,29 @@ export class BrowserProfilesList extends LiteElement {
               e.target.closest("sl-dropdown").hide();
             }}
           >
-            ${msg("Duplicate browser profile")}
+            <sl-icon
+              class="inline-block align-middle px-1"
+              name="files"
+            ></sl-icon>
+            <span class="inline-block align-middle pr-2"
+              >${msg("Duplicate profile")}</span
+            >
+          </li>
+          <li
+            class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
+            role="menuitem"
+            @click=${(e: any) => {
+              // Close dropdown before deleting template
+              e.target.closest("sl-dropdown").hide();
+
+              this.deleteProfile(data);
+            }}
+          >
+            <sl-icon
+              class="inline-block align-middle px-1"
+              name="file-earmark-x"
+            ></sl-icon>
+            <span class="inline-block align-middle pr-2">${msg("Delete")}</span>
           </li>
         </ul>
       </sl-dropdown>
@@ -294,6 +316,30 @@ export class BrowserProfilesList extends LiteElement {
     } catch (e) {
       this.notify({
         message: msg("Sorry, couldn't create browser profile at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async deleteProfile(profile: Profile) {
+    try {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/profiles/${profile.id}`,
+        this.authState!,
+        {
+          method: "DELETE",
+        }
+      );
+
+      this.notify({
+        message: msg(html`Deleted <strong>${profile.name}</strong>.`),
+        type: "success",
+        icon: "check2-circle",
+      });
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't delete browser profile at this time."),
         type: "danger",
         icon: "exclamation-octagon",
       });


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/222) Enables deleting browser profile from list and detail view.

### Manual testing
1. Run app, go to browser profiles list view
2. Click "..." icon in browser profile row to see more actions, click "Delete". Verify browser profile is deleted or shows a message if it's used by a crawl template
3. Repeat from actions menu in browser profile detail view

### Screenshots
**New menu item:**
<img width="205" alt="Screen Shot 2022-06-01 at 3 15 27 PM" src="https://user-images.githubusercontent.com/4672952/171511048-0a8423b0-f0d7-43ad-bb45-a38b449a0900.png">

**Message when in use by crawl template:**
<img width="438" alt="Screen Shot 2022-06-01 at 3 15 33 PM" src="https://user-images.githubusercontent.com/4672952/171511051-77925241-e8aa-42f0-8e81-4860f22f6361.png">

