### PR TITLE
Screencast UX enhancements

### DIFF
--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -57,6 +57,12 @@ export class Screencast extends LitElement {
       margin-bottom: var(--sl-spacing-x-small);
     }
 
+    .screen-count span,
+    .screen-count sl-icon {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
     .screen {
       border: 1px solid var(--sl-color-neutral-100);
       border-radius: var(--sl-border-radius-medium);
@@ -195,11 +201,19 @@ export class Screencast extends LitElement {
             </div> `
           : html`
               <div class="screen-count">
-                ${msg(
-                  str`Running in ${
-                    this.browsersCount * this.scale
-                  } browser windows`
-                )}
+                <span
+                  >${msg(
+                    str`Running in ${
+                      this.browsersCount * this.scale
+                    } browser windows`
+                  )}</span
+                >
+                <sl-tooltip
+                  content=${msg(
+                    str`${this.browsersCount} browsers × ${this.scale} crawlers. Number of crawlers corresponds to scale.`
+                  )}
+                  ><sl-icon name="info-circle"></sl-icon
+                ></sl-tooltip>
               </div>
             `}
 

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -344,9 +344,9 @@ export class Screencast extends LitElement {
         if (order === undefined) {
           // Find and fill first empty slot
           const emptySlots = Array.from(this.dataMap.keys()).filter(
-            (k) => !this.dataMap.get(k)
+            (k) => this.dataMap.get(k) === null
           );
-          this.pageOrder[id] = Math.min(...emptySlots);
+          this.pageOrder[id] = emptySlots.length ? Math.min(...emptySlots) : 0;
 
           order = this.pageOrder[id];
         }

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -109,7 +109,11 @@ export class Screencast extends LitElement {
       max-width: 40em;
     }
 
-    img {
+    .frame {
+      overflow: hidden;
+    }
+
+    .frame > img {
       display: block;
       width: 100%;
       height: auto;
@@ -233,13 +237,18 @@ export class Screencast extends LitElement {
                   @click=${() => (this.focusedScreenData = pageData)}
                 >
                   <figcaption>${pageData.url}</figcaption>
-                  <img
-                    src="data:image/png;base64,${pageData.data}"
-                    style="aspect-ratio: ${this.screenWidth} / ${this
-                      .screenHeight}"
-                  />
+                  <div
+                    class="frame"
+                    style="aspect-ratio: ${this.screenWidth /
+                    this.screenHeight}"
+                  >
+                    <img src="data:image/png;base64,${pageData.data}" />
+                  </div>
                 </figure>`
-              : html`<div class="placeholder"></div>`
+              : html`<div
+                  class="placeholder"
+                  style="aspect-ratio: ${this.screenWidth / this.screenHeight}"
+                ></div>`
           )}
         </div>
       </div>
@@ -336,7 +345,6 @@ export class Screencast extends LitElement {
       this.browsersCount = message.browsers;
       this.screenWidth = message.width;
       this.screenHeight = message.height;
-      console.log(message);
     } else {
       const { id } = message;
 

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -175,7 +175,6 @@ export class Screencast extends LitElement {
 
   render() {
     const browserCount = this.dataList.length;
-    const cols = browserCount > 1 ? 2 : 1;
 
     return html`
       <div class="wrapper">
@@ -186,9 +185,7 @@ export class Screencast extends LitElement {
           : ""}
         <div
           class="container"
-          style="grid-template-columns: repeat(${cols}, minmax(0, 1fr)); grid-template-rows: repeat(${Math.ceil(
-            browserCount / cols
-          )}, auto);"
+          style="grid-template-columns: repeat(${browserCount}, minmax(0, 1fr))"
         >
           ${this.dataList.map((pageData) =>
             pageData

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -52,8 +52,9 @@ export class Screencast extends LitElement {
     }
 
     .screen-count {
-      color: var(--sl-color-neutral-500);
+      color: var(--sl-color-neutral-400);
       font-size: var(--sl-font-size-small);
+      margin-bottom: var(--sl-spacing-x-small);
     }
 
     .screen {
@@ -192,17 +193,21 @@ export class Screencast extends LitElement {
           ? html`<div class="spinner">
               <sl-spinner></sl-spinner>
             </div> `
-          : ""}
-        <div class="screen-count">
-          ${msg(
-            str`${this.browsersCount * this.scale} browser windows available`
-          )}
-        </div>
+          : html`
+              <div class="screen-count">
+                ${msg(
+                  str`Running in ${
+                    this.browsersCount * this.scale
+                  } browser windows`
+                )}
+              </div>
+            `}
+
         <div
           class="container"
           style="grid-template-columns: repeat(${this
             .browsersCount}, minmax(0, 1fr)); grid-template-rows: repeat(${this
-            .scale}, auto)"
+            .scale}, minmax(2rem, auto))"
         >
           ${this.dataList.map((pageData) =>
             pageData

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -362,16 +362,6 @@ export class Screencast extends LitElement {
 
         this.dataMap[idx] = message;
         this.updateDataList();
-      } else if (message.msg === "close") {
-        const idx = this.pageOrderMap.get(id);
-
-        if (idx !== undefined) {
-          // TODO uncomment after investigating backend sending
-          // "close" event while still screencasting
-          // this.dataMap[idx] = null;
-          // this.updateDataList();
-          // this.pageOrderMap.set(id, -1);
-        }
       }
     }
   }

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -168,6 +168,8 @@ export class Screencast extends LitElement {
   }
 
   render() {
+    const cols = this.screenCount > 1 ? 2 : 1;
+
     return html`
       <div class="wrapper">
         ${this.isConnecting
@@ -177,8 +179,9 @@ export class Screencast extends LitElement {
           : ""}
         <div
           class="container"
-          style="grid-template-columns: repeat(${this
-            .screenCount}, minmax(0, 1fr))"
+          style="grid-template-columns: repeat(${cols}, minmax(0, 1fr)); grid-template-rows: repeat(${Math.ceil(
+            this.screenCount / cols
+          )}, auto);"
         >
           ${this.dataList.map(
             (pageData) => html` <figure

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -365,12 +365,10 @@ export class Screencast extends LitElement {
       } else if (message.msg === "close") {
         const idx = this.pageOrderMap.get(id);
 
-        if (idx !== undefined) {
-          // TODO uncomment after investigating backend sending
-          // "close" event while still screencasting
-          // this.dataMap[idx] = null;
-          // this.updateDataList();
-          // this.pageOrderMap.set(id, -1);
+        if (idx !== undefined && idx !== null) {
+          this.dataMap[idx] = null;
+          this.updateDataList();
+          this.pageOrderMap.set(id, -1);
         }
       }
     }

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -366,10 +366,11 @@ export class Screencast extends LitElement {
         const idx = this.pageOrderMap.get(id);
 
         if (idx !== undefined) {
-          this.dataMap[idx] = null;
-          this.updateDataList();
-
-          this.pageOrderMap.set(id, -1);
+          // TODO uncomment after investigating backend sending
+          // "close" event while still screencasting
+          // this.dataMap[idx] = null;
+          // this.updateDataList();
+          // this.pageOrderMap.set(id, -1);
         }
       }
     }

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -362,6 +362,16 @@ export class Screencast extends LitElement {
 
         this.dataMap[idx] = message;
         this.updateDataList();
+      } else if (message.msg === "close") {
+        const idx = this.pageOrderMap.get(id);
+
+        if (idx !== undefined) {
+          // TODO uncomment after investigating backend sending
+          // "close" event while still screencasting
+          // this.dataMap[idx] = null;
+          // this.updateDataList();
+          // this.pageOrderMap.set(id, -1);
+        }
       }
     }
   }

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -64,6 +64,7 @@ export class Screencast extends LitElement {
 
     .placeholder {
       background-color: var(--sl-color-neutral-50);
+      border-radius: var(--sl-border-radius-medium);
     }
 
     figure {

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -64,40 +64,36 @@ export class Screencast extends LitElement {
     }
 
     .screen {
-      border: 1px solid var(--sl-color-neutral-100);
+      border: 1px solid var(--sl-panel-border-color);
       border-radius: var(--sl-border-radius-medium);
-      cursor: pointer;
-      transition: opacity 0.1s border-color 0.1s;
       overflow: hidden;
     }
 
-    .screen:hover {
-      opacity: 0.8;
-      border-color: var(--sl-color-neutral-300);
+    .screen[role="button"] {
+      cursor: pointer;
+      transition: opacity 0.1s border-color 0.1s;
     }
 
-    .placeholder {
-      background-color: var(--sl-color-neutral-50);
-      border-radius: var(--sl-border-radius-medium);
+    .screen[role="button"]:hover {
+      opacity: 0.8;
+      border-color: var(--sl-color-neutral-300);
     }
 
     figure {
       margin: 0;
     }
 
-    figcaption {
-      flex: 1;
-      border-bottom-width: 1px;
-      border-bottom-color: var(--sl-panel-border-color);
-      color: var(--sl-color-neutral-600);
-      font-size: var(--sl-font-size-small);
+    .caption {
       padding: var(--sl-spacing-x-small);
+      flex: 1;
+      border-bottom: 1px solid var(--sl-panel-border-color);
+      color: var(--sl-color-neutral-600);
     }
 
-    figcaption,
+    .caption,
     .dialog-label {
       display: block;
-      font-size: var(--sl-font-size-small);
+      font-size: var(--sl-font-size-x-small);
       line-height: 1;
       /* Truncate: */
       overflow: hidden;
@@ -110,6 +106,7 @@ export class Screencast extends LitElement {
     }
 
     .frame {
+      background-color: var(--sl-color-neutral-50);
       overflow: hidden;
     }
 
@@ -228,27 +225,28 @@ export class Screencast extends LitElement {
             .browsersCount}, minmax(0, 1fr)); grid-template-rows: repeat(${this
             .scale}, minmax(2rem, auto))"
         >
-          ${this.dataList.map((pageData) =>
-            pageData
-              ? html` <figure
-                  class="screen"
-                  title="${pageData.url}"
-                  role="button"
-                  @click=${() => (this.focusedScreenData = pageData)}
-                >
-                  <figcaption>${pageData.url}</figcaption>
-                  <div
-                    class="frame"
-                    style="aspect-ratio: ${this.screenWidth /
-                    this.screenHeight}"
-                  >
-                    <img src="data:image/png;base64,${pageData.data}" />
-                  </div>
-                </figure>`
-              : html`<div
-                  class="placeholder"
+          ${this.dataList.map(
+            (pageData) =>
+              html` <figure
+                class="screen"
+                title=${pageData?.url || ""}
+                role=${pageData ? "button" : "presentation"}
+                @click=${pageData
+                  ? () => (this.focusedScreenData = pageData)
+                  : () => {}}
+              >
+                <figcaption class="caption">
+                  ${pageData?.url || html`&nbsp;`}
+                </figcaption>
+                <div
+                  class="frame"
                   style="aspect-ratio: ${this.screenWidth / this.screenHeight}"
-                ></div>`
+                >
+                  ${pageData
+                    ? html`<img src="data:image/png;base64,${pageData.data}" />`
+                    : ""}
+                </div>
+              </figure>`
           )}
         </div>
       </div>

--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -154,6 +154,7 @@ export class Screencast extends LitElement {
   // Multiply by scale to get available browser window count
   private browsersCount = 0;
   private screenWidth = 640;
+  private screenHeight = 480;
 
   shouldUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.size === 1 && changedProperties.has("watchIPs")) {
@@ -232,7 +233,11 @@ export class Screencast extends LitElement {
                   @click=${() => (this.focusedScreenData = pageData)}
                 >
                   <figcaption>${pageData.url}</figcaption>
-                  <img src="data:image/png;base64,${pageData.data}" />
+                  <img
+                    src="data:image/png;base64,${pageData.data}"
+                    style="aspect-ratio: ${this.screenWidth} / ${this
+                      .screenHeight}"
+                  />
                 </figure>`
               : html`<div class="placeholder"></div>`
           )}
@@ -330,6 +335,8 @@ export class Screencast extends LitElement {
       );
       this.browsersCount = message.browsers;
       this.screenWidth = message.width;
+      this.screenHeight = message.height;
+      console.log(message);
     } else {
       const { id } = message;
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -445,7 +445,7 @@ export class CrawlDetail extends LiteElement {
       ${isStarting
         ? html`<div class="rounded border p-3">
             <p class="text-sm text-neutral-600 motion-safe:animate-pulse">
-              ${msg("Crawl is starting...")}
+              ${msg("Crawl starting...")}
             </p>
           </div>`
         : isRunning

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -433,7 +433,7 @@ export class CrawlDetail extends LiteElement {
 
       ${isStarting
         ? html`<div class="rounded border p-3">
-            <p class="text-sm text-neutral-600">
+            <p class="text-sm text-neutral-600 motion-safe:animate-pulse">
               ${msg("Crawl is starting...")}
             </p>
           </div>`

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -455,6 +455,7 @@ export class CrawlDetail extends LiteElement {
                 authToken=${authToken}
                 archiveId=${this.crawl.aid}
                 crawlId=${this.crawlId!}
+                scale=${this.crawl.scale}
                 .watchIPs=${this.crawl.watchIPs || []}
               ></btrix-screencast>
             </div>

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -8,6 +8,7 @@ import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { CopyButton } from "../../components/copy-button";
 import type { Crawl } from "./types";
+import { times } from "lodash";
 
 type SectionName = "overview" | "watch" | "replay" | "files" | "logs";
 
@@ -78,6 +79,16 @@ export class CrawlDetail extends LiteElement {
     }
 
     this.fetchCrawl();
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    const prevCrawl = changedProperties.get("crawl");
+
+    if (prevCrawl && this.crawl) {
+      if (prevCrawl.state === "running" && this.crawl.state !== "running") {
+        this.crawlDone();
+      }
+    }
   }
 
   connectedCallback(): void {
@@ -834,6 +845,24 @@ export class CrawlDetail extends LiteElement {
 
   private stopPollTimer() {
     window.clearTimeout(this.timerId);
+  }
+
+  /** Callback when crawl is no longer running */
+  private crawlDone() {
+    if (!this.crawl) return;
+
+    this.notify({
+      message: msg(
+        html`Done crawling <strong>${this.crawl.configName}</strong>.`
+      ),
+      type: "success",
+      icon: "check2-circle",
+    });
+
+    if (this.sectionName === "watch") {
+      // Show replay tab
+      this.sectionName = "replay";
+    }
   }
 
   /**


### PR DESCRIPTION
Addresses https://github.com/webrecorder/browsertrix-cloud/issues/233

- Show placeholder for inactive browser screens
- Show number of available browser windows
- Redirect to 'replay' on crawl finished if user is on watch view

### Screenshots
**With "Running in N browser windows" text:**
<img width="864" alt="Screen Shot 2022-06-07 at 2 45 27 PM" src="https://user-images.githubusercontent.com/4672952/172488371-0a702e2b-daf2-4bda-a19e-ed4271193d57.png">

### Demo
**Empty slot filled (last column:)**
https://user-images.githubusercontent.com/4672952/172478747-7ffb90ba-1425-486d-8640-c6790f58bb71.mov

**Screens replaced with placeholder after close:**
https://user-images.githubusercontent.com/4672952/172478842-6f3f8301-eff0-4bce-84ce-c0d1c46db2db.mov


