### PR TITLE
Re-run crawl from crawls list view

### DIFF
--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -315,7 +315,25 @@ export class CrawlsList extends LiteElement {
                     </li>
                     <hr />
                   `
-                : ""}
+                : html`
+                    <li
+                      class="p-2 text-purple-500 hover:bg-purple-500 hover:text-white cursor-pointer"
+                      role="menuitem"
+                      @click=${(e: any) => {
+                        this.runNow(crawl);
+                        e.target.closest("sl-dropdown").hide();
+                      }}
+                    >
+                      <sl-icon
+                        class="inline-block align-middle"
+                        name="arrow-clockwise"
+                      ></sl-icon>
+                      <span class="inline-block align-middle">
+                        ${msg("Re-run crawl")}
+                      </span>
+                    </li>
+                    <hr />
+                  `}
               <li
                 class="p-2 hover:bg-zinc-100 cursor-pointer"
                 role="menuitem"
@@ -544,6 +562,45 @@ export class CrawlsList extends LiteElement {
           icon: "exclamation-octagon",
         });
       }
+    }
+  }
+
+  private async runNow(crawl: Crawl) {
+    try {
+      const data = await this.apiFetch(
+        `/archives/${crawl.aid}/crawlconfigs/${crawl.cid}/run`,
+        this.authState!,
+        {
+          method: "POST",
+        }
+      );
+
+      if (data.started) {
+        this.fetchCrawls();
+      }
+
+      this.notify({
+        message: msg(
+          html`Started crawl from <strong>${crawl.configName}</strong>.
+            <br />
+            <a
+              class="underline hover:no-underline"
+              href="/archives/${this
+                .archiveId}/crawls/crawl/${data.started}#watch"
+              @click=${this.navLink.bind(this)}
+              >Watch crawl</a
+            >`
+        ),
+        type: "success",
+        icon: "check2-circle",
+        duration: 8000,
+      });
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't run crawl at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
     }
   }
 }

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -488,7 +488,8 @@ export class CrawlsList extends LiteElement {
       // Update search/filter collection
       this.fuse.setCollection(this.crawls as any);
 
-      // Start timer for next poll
+      // Restart timer for next poll
+      this.stopPollTimer();
       this.timerId = window.setTimeout(() => {
         this.fetchCrawls();
       }, 1000 * POLL_INTERVAL_SECONDS);


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/253) Allow users to re-run crawl from list action menu.

### Manual testing
1. Run app and go to crawls list view
2. Click "..." action menu for a completed crawl
3. Click "Re-run crawl". Verify new crawl starts
4. Find completed crawl with same crawl config and repeat. Verify new crawl is prevented

### Screenshots
**Menu item:**
<img width="200" alt="Screen Shot 2022-06-15 at 4 14 44 PM" src="https://user-images.githubusercontent.com/4672952/173958070-e7e49b20-bc6d-48b3-b700-5a502be92e1b.png">

**Notices:**
<img width="430" alt="Screen Shot 2022-06-15 at 4 14 57 PM" src="https://user-images.githubusercontent.com/4672952/173958096-94a4c978-cf96-48a5-bf8e-190651a6a336.png">

