### PR TITLE
Support proxying /data dir for easier testing of remote instances

### DIFF
--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -43,8 +43,14 @@ module.exports = merge(common, {
         headers: {
           Host: devBackendUrl.host,
         },
-        pathRewrite: { "^/api": "" },
         ws: true,
+      },
+
+      "/data": {
+        target: devBackendUrl.href,
+        headers: {
+          Host: devBackendUrl.host,
+        },
       },
     },
     // Serve replay service worker file


### PR DESCRIPTION
The default local deployment now serves WACZ files from `/data` endpoint. However, when deployed remotely (not using k8s), the replay is not usable unless the user has configured HTTPs since the replayweb.page service worker can not run over HTTP.

Since we already have a dev server proxying the /api endpoint, this simply adds the proxying of the /data endpoint as well, which will allow downloading the WACZ files and also replaying them locally via localhost.

The `.env.local` entries will need to be updated from `API_BASE_URL=http://remote.example.com:9871/api/` to 
`API_BASE_URL=http://remote.example.com:9871/`