### PR TITLE
Re-run crawl from detail view + handle inactive crawl template

### DIFF
--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -932,12 +932,20 @@ export class CrawlDetail extends LiteElement {
         icon: "check2-circle",
         duration: 8000,
       });
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't run crawl at this time."),
-        type: "danger",
-        icon: "exclamation-octagon",
-      });
+    } catch (e: any) {
+      if (e.isApiError && e.statusCode === 404) {
+        this.notify({
+          message: e.message,
+          type: "danger",
+          icon: "exclamation-octagon",
+        });
+      } else {
+        this.notify({
+          message: msg("Sorry, couldn't run crawl at this time."),
+          type: "danger",
+          icon: "exclamation-octagon",
+        });
+      }
     }
   }
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -768,7 +768,8 @@ export class CrawlDetail extends LiteElement {
       this.crawl = await this.getCrawl();
 
       if (this.isActive) {
-        // Start timer for next poll
+        // Restart timer for next poll
+        this.stopPollTimer();
         this.timerId = window.setTimeout(() => {
           this.fetchCrawl();
         }, 1000 * POLL_INTERVAL_SECONDS);
@@ -785,12 +786,6 @@ export class CrawlDetail extends LiteElement {
   }
 
   async getCrawl(): Promise<Crawl> {
-    // Mock to use in dev:
-    // return import("../../__mocks__/api/archives/[id]/crawls").then(
-    //   (module) => module.default.running[0]
-    //   // (module) => module.default.finished[0]
-    // );
-
     const data: Crawl = await this.apiFetch(
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}.json`,
       this.authState!

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -969,20 +969,12 @@ export class CrawlDetail extends LiteElement {
         icon: "check2-circle",
         duration: 8000,
       });
-    } catch (e: any) {
-      if (e.isApiError && e.statusCode === 404) {
-        this.notify({
-          message: e.message,
-          type: "danger",
-          icon: "exclamation-octagon",
-        });
-      } else {
-        this.notify({
-          message: msg("Sorry, couldn't run crawl at this time."),
-          type: "danger",
-          icon: "exclamation-octagon",
-        });
-      }
+    } catch {
+      this.notify({
+        message: msg("Sorry, couldn't run crawl at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
     }
   }
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -81,11 +81,19 @@ export class CrawlDetail extends LiteElement {
   }
 
   updated(changedProperties: Map<string, any>) {
-    const prevCrawl = changedProperties.get("crawl");
+    const prevId = changedProperties.get("crawlId");
 
-    if (prevCrawl && this.crawl) {
-      if (prevCrawl.state === "running" && this.crawl.state !== "running") {
-        this.crawlDone();
+    if (prevId && prevId !== this.crawlId) {
+      // Handle update on URL change, e.g. from re-run
+      this.stopPollTimer();
+      this.fetchCrawl();
+    } else {
+      const prevCrawl = changedProperties.get("crawl");
+
+      if (prevCrawl && this.crawl) {
+        if (prevCrawl.state === "running" && this.crawl.state !== "running") {
+          this.crawlDone();
+        }
       }
     }
   }
@@ -913,20 +921,12 @@ export class CrawlDetail extends LiteElement {
       );
 
       if (data.started) {
-        this.fetchCrawl();
+        this.navTo(`/archives/${this.crawl.aid}/crawls/crawl/${data.started}`);
       }
 
       this.notify({
         message: msg(
-          html`Started crawl from <strong>${this.crawl.configName}</strong>.
-            <br />
-            <a
-              class="underline hover:no-underline"
-              href="/archives/${this.crawl
-                .aid}/crawls/crawl/${data.started}#watch"
-              @click=${this.navLink.bind(this)}
-              >Watch crawl</a
-            >`
+          html`Started crawl from <strong>${this.crawl.configName}</strong>.`
         ),
         type: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1135,6 +1135,11 @@ export class CrawlTemplatesDetail extends LiteElement {
         }
       );
 
+      this.crawlTemplate = {
+        ...this.crawlTemplate,
+        inactive: true,
+      };
+
       this.notify({
         message: msg(
           html`Deactivated <strong>${this.crawlTemplate.name}</strong>.`

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -45,9 +45,6 @@ export class CrawlsList extends LiteElement {
   @property({ type: Object })
   authState!: AuthState;
 
-  @property({ type: String })
-  archiveId?: string;
-
   // e.g. `/archive/${this.archiveId}/crawls`
   @property({ type: String })
   crawlsBaseUrl!: string;
@@ -579,8 +576,7 @@ export class CrawlsList extends LiteElement {
               <br />
               <a
                 class="underline hover:no-underline"
-                href="/archives/${this
-                  .archiveId}/crawls/crawl/${crawlTemplate.currCrawlId}"
+                href="/archives/${crawl.aid}/crawls/crawl/${crawlTemplate.currCrawlId}"
                 @click=${this.navLink.bind(this)}
                 >View crawl</a
               >`
@@ -610,8 +606,7 @@ export class CrawlsList extends LiteElement {
             <br />
             <a
               class="underline hover:no-underline"
-              href="/archives/${this
-                .archiveId}/crawls/crawl/${data.started}#watch"
+              href="/archives/${crawl.aid}/crawls/crawl/${data.started}#watch"
               @click=${this.navLink.bind(this)}
               >Watch crawl</a
             >`

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -615,12 +615,20 @@ export class CrawlsList extends LiteElement {
         icon: "check2-circle",
         duration: 8000,
       });
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't run crawl at this time."),
-        type: "danger",
-        icon: "exclamation-octagon",
-      });
+    } catch (e: any) {
+      if (e.isApiError && e.statusCode === 404) {
+        this.notify({
+          message: e.message,
+          type: "danger",
+          icon: "exclamation-octagon",
+        });
+      } else {
+        this.notify({
+          message: msg("Sorry, couldn't run crawl at this time."),
+          type: "danger",
+          icon: "exclamation-octagon",
+        });
+      }
     }
   }
 


### PR DESCRIPTION
https://github.com/webrecorder/browsertrix-cloud/issues/253#issuecomment-1159376594 Adds re-run to crawl detail view and improves inactive crawl template UX:
- Crawl detail view: Show re-run button only if crawl template is active
- Crawl detail view: Show "Inactive" tag next to crawl template name in overview tab
- Crawl detail & list view: Show server error message on 404
- Crawl template detail view: Show "Inactive" banner immediately after deactivating crawl template

### Manual testing
1. Run app and go to detail view of crawl with active crawl template. Verify "Re-run crawl" option is seen in "Action" dropdown menu
2. Re-run crawl. Verify view updates to show newly running crawl
3. Go to crawl templates and deactivate one. Verify inactive message banner shows at top.
4. Scroll down to last run crawl and open crawl detail view. Verify "Re-run crawl" option is not available under "Action" menu.
5. Go to crawl list view and attempt to re-run crawl using deactivated template. Verify notification with error shows.

### Screenshots
**Error on re-running deactivated crawl template:**
<img width="447" alt="Screen Shot 2022-06-21 at 5 14 33 PM" src="https://user-images.githubusercontent.com/4672952/174908472-afa3d089-15d2-4430-a86b-b47a5c0734d4.png">

**"Inactive" tag next to crawl template name:**
<img width="847" alt="Screen Shot 2022-06-21 at 5 22 57 PM" src="https://user-images.githubusercontent.com/4672952/174908524-87b22781-40fa-4526-86d4-0c6998342a2c.png">

