### PR TITLE
Stop/Cancel Crawl Fixes and Improvements

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -133,14 +133,11 @@ class BaseCrawlManager(ABC):
 
         return True
 
-    async def stop_crawl(self, crawl_id, aid, graceful=True):
-        """Attempt to stop crawl, either gracefully by issuing a SIGTERM which
-        will attempt to finish current pages
-
-        OR, abruptly by first issueing a SIGABRT, followed by SIGTERM, which
-        will terminate immediately"""
+    async def shutdown_crawl(self, crawl_id, aid, graceful=True):
+        """Request a crawl cancelation or stop by calling an API
+        on the job pod/container, returning the result"""
         return await self._post_to_job(
-            crawl_id, aid, "/cancel" if not graceful else "/stop"
+            crawl_id, aid, "/stop" if graceful else "/cancel"
         )
 
     async def scale_crawl(self, crawl_id, aid, scale=1):

--- a/backend/btrixcloud/k8s/crawl_job.py
+++ b/backend/btrixcloud/k8s/crawl_job.py
@@ -57,17 +57,17 @@ class K8SCrawlJob(K8SJobMixin, CrawlJob):
         except:
             return None
 
-    async def _send_shutdown_signal(self, graceful=True):
+    async def _send_shutdown_signal(self):
         pods = await self.core_api.list_namespaced_pod(
             namespace=self.namespace,
             label_selector=f"crawl={self.job_id},role=crawler",
         )
 
-        await send_signal_to_pods(
+        return await send_signal_to_pods(
             self.core_api_ws,
             self.namespace,
             pods.items,
-            "SIGABRT" if not graceful else "SIGINT",
+            "SIGINT",
         )
 
     # pylint: disable=line-too-long

--- a/backend/btrixcloud/k8s/utils.py
+++ b/backend/btrixcloud/k8s/utils.py
@@ -27,7 +27,7 @@ async def create_from_yaml(k8s_client, doc, namespace):
 async def send_signal_to_pods(core_api_ws, namespace, pods, signame, func=None):
     """ send signal to all pods """
     command = ["kill", "-s", signame, "1"]
-    interrupted = False
+    signaled = False
 
     try:
         for pod in pods:
@@ -40,10 +40,10 @@ async def send_signal_to_pods(core_api_ws, namespace, pods, signame, func=None):
                 command=command,
                 stdout=True,
             )
-            interrupted = True
+            signaled = True
 
     # pylint: disable=broad-except
     except Exception as exc:
-        print(f"Exec Error: {exc}", flush=True)
+        print(f"Send Signal Error: {exc}", flush=True)
 
-    return interrupted
+    return signaled

--- a/backend/btrixcloud/swarm/swarmmanager.py
+++ b/backend/btrixcloud/swarm/swarmmanager.py
@@ -184,7 +184,11 @@ class SwarmManager(BaseCrawlManager):
             async with session.request(
                 "POST", f"http://job-{crawl_id}_job:8000{path}", json=data
             ) as resp:
-                await resp.json()
+                try:
+                    return await resp.json()
+                # pylint: disable=bare-except
+                except:
+                    return {"error": "post_failed"}
 
     async def _delete_crawl_configs(self, label):
         """ delete crawl configs by specified label """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ fastapi==0.71.0
 fastapi-users[mongodb]==9.2.2
 loguru
 aiofiles
-kubernetes-asyncio>=22.6.4
+kubernetes-asyncio==22.6.5
 aiobotocore
 redis>=4.2.0rc1
 pyyaml

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -792,7 +792,7 @@ export class CrawlDetail extends LiteElement {
         }
       );
 
-      if (data.canceled === true) {
+      if (data.success === true) {
         this.fetchCrawl();
       } else {
         this.notify({
@@ -814,7 +814,7 @@ export class CrawlDetail extends LiteElement {
         }
       );
 
-      if (data.stopping_gracefully === true) {
+      if (data.success === true) {
         this.fetchCrawl();
       } else {
         this.notify({

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -536,7 +536,7 @@ export class CrawlsList extends LiteElement {
         }
       );
 
-      if (data.canceled === true) {
+      if (data.success === true) {
         this.fetchCrawls();
       } else {
         this.notify({
@@ -558,7 +558,7 @@ export class CrawlsList extends LiteElement {
         }
       );
 
-      if (data.stopped_gracefully === true) {
+      if (data.success === true) {
         this.fetchCrawls();
       } else {
         this.notify({


### PR DESCRIPTION
- only send signal if stopping, no need for canceling as pods/containers will be removed
- refactor stop/cancel handling to be unified in manager, separate in job
- when stopping / graceful shutdown, return false if sending signal fails
- return `success=true` in json response if and only if stop/cancel actually succeeds, return 'error' message in error, should fix #270
- allow canceling after stopping / if stopping fails
- ensure finished time is set in case of cancelation before crawl starts, should fix #273