### PR TITLE
Improve format of crawl template config error from server

### DIFF
--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -574,7 +574,7 @@ export class CrawlTemplatesNew extends LiteElement {
       ${msg(
         "Couldn't save crawl template. Please fix the following crawl configuration issues:"
       )}
-      <ul class="list-disc">
+      <ul class="list-disc w-fit mx-auto">
         ${detailsWithoutDictError.map(renderDetail)}
       </ul>
     `;

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -8,6 +8,7 @@ import LiteElement, { html } from "../../utils/LiteElement";
 import { ScheduleInterval, humanizeNextDate } from "../../utils/cron";
 import type { CrawlConfig, Profile } from "./types";
 import { getUTCSchedule } from "../../utils/cron";
+import { TemplateResult } from "lit";
 
 type NewCrawlTemplate = {
   id?: string;
@@ -89,7 +90,7 @@ export class CrawlTemplatesNew extends LiteElement {
   private browserProfileId?: string | null;
 
   @state()
-  private serverError?: string;
+  private serverError?: TemplateResult | string;
 
   private get formattededNextCrawlDate() {
     const utcSchedule = this.getUTCSchedule();
@@ -536,13 +537,47 @@ export class CrawlTemplatesNew extends LiteElement {
       }
     } catch (e: any) {
       if (e?.isApiError) {
-        this.serverError = e?.message;
+        const isConfigError = ({ loc }: any) =>
+          loc.some((v: string) => v === "config");
+        if (e.details && e.details.some(isConfigError)) {
+          this.serverError = this.formatConfigServerError(e.details);
+        } else {
+          this.serverError = e.message;
+        }
       } else {
         this.serverError = msg("Something unexpected went wrong");
       }
     }
 
     this.isSubmitting = false;
+  }
+
+  /**
+   * Format `config` related API error returned from server
+   */
+  private formatConfigServerError(details: any): TemplateResult {
+    const detailsWithoutDictError = details.filter(
+      ({ type }: any) => type !== "type_error.dict"
+    );
+
+    const renderDetail = ({ loc, msg: detailMsg }: any) => html`
+      <li>
+        ${loc.some((v: string) => v === "seeds") &&
+        typeof loc[loc.length - 1] === "number"
+          ? msg(str`Seed URL ${loc[loc.length - 1] + 1}: `)
+          : `${loc[loc.length - 1]}: `}
+        ${detailMsg}
+      </li>
+    `;
+
+    return html`
+      ${msg(
+        "Couldn't save crawl template. Please fix the following crawl configuration issues:"
+      )}
+      <ul class="list-disc">
+        ${detailsWithoutDictError.map(renderDetail)}
+      </ul>
+    `;
   }
 
   private getUTCSchedule(): string {

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -121,10 +121,11 @@ export default class LiteElement extends LitElement {
         this.dispatchEvent(new CustomEvent("need-login"));
       }
 
+      let detail;
       let errorMessage: string;
 
       try {
-        const detail = (await resp.json()).detail;
+        detail = (await resp.json()).detail;
 
         if (typeof detail === "string") {
           errorMessage = detail;
@@ -139,10 +140,10 @@ export default class LiteElement extends LitElement {
         errorMessage = "Unknown API error";
       }
 
-      // TODO client error details
       throw new APIError({
         message: errorMessage,
         status: resp.status,
+        details: detail,
       });
     }
 

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import type { TemplateResult } from "lit";
+import { msg } from "@lit/localize";
 
 import type { Auth } from "../utils/AuthService";
 import { APIError } from "./api";
@@ -122,23 +123,23 @@ export default class LiteElement extends LitElement {
       }
 
       let detail;
-      let errorMessage: string;
+      let errorMessage: string = msg("Unknown API error");
 
       try {
         detail = (await resp.json()).detail;
 
         if (typeof detail === "string") {
           errorMessage = detail;
-        } else {
-          // TODO return client error details
-          const fieldDetail = detail[detail.length - 1];
+        } else if (Array.isArray(detail) && detail.length) {
+          const fieldDetail = detail[0];
           const { loc, msg } = fieldDetail;
 
-          errorMessage = `${loc[loc.length - 1]} ${msg}`;
+          const fieldName = loc
+            .filter((v: any) => v !== "body" && typeof v === "string")
+            .join(" ");
+          errorMessage = `${fieldName} ${msg}`;
         }
-      } catch {
-        errorMessage = "Unknown API error";
-      }
+      } catch {}
 
       throw new APIError({
         message: errorMessage,

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,13 +1,29 @@
+type StatusCode = number;
+type Detail = {
+  loc: any[];
+  msg: string;
+};
+
 export class APIError extends Error {
-  statusCode: number;
+  statusCode: StatusCode;
+  details: Detail[] | null;
 
   get isApiError() {
     return true;
   }
 
-  constructor({ message, status }: { message: string; status: number }) {
+  constructor({
+    message,
+    status,
+    details,
+  }: {
+    message: string;
+    status: StatusCode;
+    details?: Detail[];
+  }) {
     super(message);
 
     this.statusCode = status;
+    this.details = details || null;
   }
 }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -2,6 +2,7 @@ type StatusCode = number;
 type Detail = {
   loc: any[];
   msg: string;
+  type: string;
 };
 
 export class APIError extends Error {


### PR DESCRIPTION
Shows user a more customized error for invalid seed config.

Partially addresses https://github.com/webrecorder/browsertrix-cloud/issues/280

### Screenshots
**Error for invalid seed URL from list in basic edit view:**
<img width="964" alt="Screen Shot 2022-06-29 at 4 04 19 PM" src="https://user-images.githubusercontent.com/4672952/176560671-e94f0e5a-b961-4c1d-9db2-058ea4f47e89.png">

**Error for missing `seeds` in advanced edit view:**
<img width="952" alt="Screen Shot 2022-06-29 at 4 04 29 PM" src="https://user-images.githubusercontent.com/4672952/176560761-e375d10d-4463-456f-8896-9c799ed080c3.png">

