### PR TITLE
Frontend browser profile editor enhancements

### DIFF
--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -79,6 +79,7 @@ export class ProfileBrowser extends LiteElement {
   updated(changedProperties: Map<string, any>) {
     if (changedProperties.has("browserId")) {
       if (this.browserId) {
+        window.clearTimeout(this.pollTimerId);
         this.fetchBrowser();
       } else if (changedProperties.get("browserId")) {
         this.iframeSrc = undefined;
@@ -251,9 +252,14 @@ export class ProfileBrowser extends LiteElement {
   }
 
   /**
-   * Fetch browser profiles and update internal state
+   * Fetch browser profile and update internal state
    */
   private async fetchBrowser(): Promise<void> {
+    await this.updateComplete;
+
+    this.iframeSrc = undefined;
+    this.isIframeLoaded = false;
+
     try {
       await this.checkBrowserStatus();
     } catch (e) {
@@ -342,7 +348,7 @@ export class ProfileBrowser extends LiteElement {
     if (!this.origins) {
       this.origins = data.origins;
     } else {
-      this.newOrigins = data.origins.filter(
+      this.newOrigins = data.origins?.filter(
         (url: string) => !this.origins?.includes(url)
       );
     }

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -293,6 +293,8 @@ export class ProfileBrowser extends LiteElement {
 
       this.iframeSrc = result.url;
 
+      await this.updateComplete;
+
       this.dispatchEvent(new CustomEvent("load", { detail: result.url }));
 
       this.pingBrowser();

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -96,8 +96,8 @@ export class ProfileBrowser extends LiteElement {
           <div
             class="rounded-b lg:rounded-b-none lg:rounded-r border w-72  bg-white absolute h-full top-0 right-0"
           >
-            ${this.renderFullscreenButton()} ${this.renderOrigins()}
-            ${this.renderNewOrigins()}
+            ${document.fullscreenEnabled ? this.renderFullscreenButton() : ""}
+            ${this.renderOrigins()} ${this.renderNewOrigins()}
           </div>
         </div>
       </div>
@@ -154,37 +154,37 @@ export class ProfileBrowser extends LiteElement {
   }
 
   private renderFullscreenButton() {
-    return html`${document.fullscreenEnabled
-      ? html`
-          <div class="p-2 text-right">
-            <sl-button
-              size="small"
-              @click=${() =>
-                this.isFullscreen
-                  ? document.exitFullscreen()
-                  : this.enterFullscreen("interactive-browser")}
-            >
-              ${this.isFullscreen
-                ? html`
-                    <sl-icon
-                      slot="prefix"
-                      name="fullscreen-exit"
-                      label=${msg("Exit fullscreen")}
-                    ></sl-icon>
-                    ${msg("Exit")}
-                  `
-                : html`
-                    <sl-icon
-                      slot="prefix"
-                      name="arrows-fullscreen"
-                      label=${msg("Enter fullscreen")}
-                    ></sl-icon>
-                    ${msg("Fullscreen")}
-                  `}
-            </sl-button>
-          </div>
-        `
-      : ""}`;
+    if (!this.browserId) return;
+
+    return html`
+      <div class="p-2 text-right">
+        <sl-button
+          size="small"
+          @click=${() =>
+            this.isFullscreen
+              ? document.exitFullscreen()
+              : this.enterFullscreen("interactive-browser")}
+        >
+          ${this.isFullscreen
+            ? html`
+                <sl-icon
+                  slot="prefix"
+                  name="fullscreen-exit"
+                  label=${msg("Exit fullscreen")}
+                ></sl-icon>
+                ${msg("Exit")}
+              `
+            : html`
+                <sl-icon
+                  slot="prefix"
+                  name="arrows-fullscreen"
+                  label=${msg("Enter fullscreen")}
+                ></sl-icon>
+                ${msg("Fullscreen")}
+              `}
+        </sl-button>
+      </div>
+    `;
   }
 
   private renderOrigins() {

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -230,7 +230,7 @@ export class BrowserProfilesDetail extends LiteElement {
               @load=${() => (this.isBrowserLoaded = true)}
             ></btrix-profile-browser>
 
-            ${this.browserId
+            ${this.browserId || this.isBrowserLoading
               ? ""
               : html`
                   <div
@@ -244,7 +244,6 @@ export class BrowserProfilesDetail extends LiteElement {
                       type="primary"
                       outline
                       ?disabled=${!ProfileBrowser.isBrowserCompatible}
-                      ?loading=${this.isBrowserLoading}
                       @click=${this.startBrowserPreview}
                       ><sl-icon
                         slot="prefix"
@@ -390,41 +389,38 @@ export class BrowserProfilesDetail extends LiteElement {
   }
 
   private async startEditBrowser() {
-    if (!this.profile) return;
+    const prevBrowserId = this.browserId;
 
-    if (this.browserId) {
-      const browserId = this.browserId;
-      this.browserId = undefined;
+    this.isEditingBrowser = true;
+
+    this.startBrowserPreview();
+
+    if (prevBrowserId) {
       try {
-        await this.deleteBrowser(browserId);
+        await this.deleteBrowser(prevBrowserId);
       } catch (e) {
         // TODO Investigate DELETE is returning 404
         console.debug(e);
       }
     }
-
-    this.isEditingBrowser = true;
-    this.startBrowserPreview();
   }
 
   private async cancelEditBrowser() {
+    const prevBrowserId = this.browserId;
+
     this.isEditingBrowser = false;
+    this.isBrowserLoaded = false;
 
-    if (this.browserId) {
-      const browserId = this.browserId;
-      this.browserId = undefined;
-      this.isBrowserLoading = false;
-      this.isBrowserLoaded = false;
+    this.startBrowserPreview();
 
+    if (prevBrowserId) {
       try {
-        await this.deleteBrowser(browserId);
+        await this.deleteBrowser(prevBrowserId);
       } catch (e) {
         // TODO Investigate DELETE is returning 404
         console.debug(e);
       }
     }
-
-    this.startBrowserPreview();
   }
 
   private async duplicateProfile() {

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -538,7 +538,7 @@ export class BrowserProfilesDetail extends LiteElement {
     if (
       !window.confirm(
         msg(
-          "Save browser changes to profile? You will need to reload the editor to make additional changes."
+          "Save browser changes to profile? You will need to re-load the editor to make additional changes."
         )
       )
     ) {
@@ -569,6 +569,7 @@ export class BrowserProfilesDetail extends LiteElement {
           icon: "check2-circle",
         });
 
+        this.isEditingBrowser = false;
         this.browserId = undefined;
       } else {
         throw data;

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -172,16 +172,19 @@ export class BrowserProfilesDetail extends LiteElement {
       </section>
 
       <section>
-        <header class="flex justify-between mb-2">
+        <header>
           <h3 class="text-lg font-medium">${msg("Browser Profile")}</h3>
-          <div>
+        </header>
+
+        <div class="rounded p-2 bg-slate-50">
+          <div class="mb-2 text-right">
             ${this.isEditingBrowser && !this.isBrowserLoading
               ? html`
                   <sl-button size="small" @click=${this.cancelEditBrowser}
                     >${msg("Cancel")}</sl-button
                   >
                   <sl-button
-                    type="primary"
+                    type="neutral"
                     size="small"
                     ?loading=${this.isSubmittingBrowserChange}
                     ?disabled=${this.isSubmittingBrowserChange ||
@@ -198,42 +201,42 @@ export class BrowserProfilesDetail extends LiteElement {
                   >${msg("Edit Browser Profile")}</sl-button
                 >`}
           </div>
-        </header>
 
-        <main class="relative">
-          <btrix-profile-browser
-            .authState=${this.authState}
-            archiveId=${this.archiveId}
-            browserId=${ifDefined(this.browserId)}
-            .origins=${this.profile?.origins}
-            @load=${() => (this.isBrowserLoaded = true)}
-          ></btrix-profile-browser>
+          <main class="relative">
+            <btrix-profile-browser
+              .authState=${this.authState}
+              archiveId=${this.archiveId}
+              browserId=${ifDefined(this.browserId)}
+              .origins=${this.profile?.origins}
+              @load=${() => (this.isBrowserLoaded = true)}
+            ></btrix-profile-browser>
 
-          ${this.browserId
-            ? ""
-            : html`
-                <div
-                  class="absolute top-0 left-0 h-full flex flex-col items-center justify-center"
-                  style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
-                >
-                  <p class="mb-4 text-neutral-600 max-w-prose">
-                    ${msg("Load browser to view websites in the profile.")}
-                  </p>
-                  <sl-button
-                    type="primary"
-                    outline
-                    ?disabled=${!ProfileBrowser.isBrowserCompatible}
-                    ?loading=${this.isBrowserLoading}
-                    @click=${this.startBrowserPreview}
-                    ><sl-icon
-                      slot="prefix"
-                      name="collection-play-fill"
-                    ></sl-icon>
-                    ${msg("Load Browser")}</sl-button
+            ${this.browserId
+              ? ""
+              : html`
+                  <div
+                    class="absolute top-0 left-0 h-full flex flex-col items-center justify-center"
+                    style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
                   >
-                </div>
-              `}
-        </main>
+                    <p class="mb-4 text-neutral-600 max-w-prose">
+                      ${msg("Load browser to view websites in the profile.")}
+                    </p>
+                    <sl-button
+                      type="primary"
+                      outline
+                      ?disabled=${!ProfileBrowser.isBrowserCompatible}
+                      ?loading=${this.isBrowserLoading}
+                      @click=${this.startBrowserPreview}
+                      ><sl-icon
+                        slot="prefix"
+                        name="collection-play-fill"
+                      ></sl-icon>
+                      ${msg("Load Browser")}</sl-button
+                    >
+                  </div>
+                `}
+          </main>
+        </div>
       </section>
 
       <sl-dialog

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -57,6 +57,7 @@ export class BrowserProfilesDetail extends LiteElement {
 
   disconnectedCallback() {
     window.clearTimeout(this.showSaveButtonTimerId);
+    this.deleteBrowser();
   }
 
   firstUpdated() {
@@ -475,6 +476,18 @@ export class BrowserProfilesDetail extends LiteElement {
       {
         method: "POST",
         body: JSON.stringify(params),
+      }
+    );
+  }
+
+  private deleteBrowser() {
+    if (!this.browserId) return;
+
+    return this.apiFetch(
+      `/archives/${this.archiveId}/profiles/browser/${this.browserId}`,
+      this.authState!,
+      {
+        method: "DELETE",
       }
     );
   }

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -53,9 +53,6 @@ export class BrowserProfilesDetail extends LiteElement {
   @state()
   private isEditDialogContentVisible = false;
 
-  @state()
-  private isEditingBrowser = false;
-
   disconnectedCallback() {
     if (this.browserId) {
       this.deleteBrowser(this.browserId);
@@ -181,7 +178,7 @@ export class BrowserProfilesDetail extends LiteElement {
         <div class="rounded p-2 bg-slate-50">
           <div class="mb-2 flex justify-between items-center">
             <div class="text-sm text-neutral-500 mx-1">
-              ${this.browserId && this.isEditingBrowser
+              ${this.browserId
                 ? html`
                     ${msg(
                       "Interact with the browsing tool to make changes to your browser profile."
@@ -191,7 +188,7 @@ export class BrowserProfilesDetail extends LiteElement {
             </div>
 
             <div>
-              ${this.isEditingBrowser && !this.isBrowserLoading
+              ${this.browserId && !this.isBrowserLoading
                 ? html`
                     <sl-button size="small" @click=${this.cancelEditBrowser}
                       >${msg("Cancel")}</sl-button
@@ -206,7 +203,7 @@ export class BrowserProfilesDetail extends LiteElement {
                       ?disabled=${this.isSubmittingBrowserChange ||
                       !this.isBrowserLoaded}
                       @click=${this.saveBrowser}
-                      >${msg("Save Changes")}</sl-button
+                      >${msg("Save")}</sl-button
                     >
                   `
                 : html`
@@ -238,7 +235,9 @@ export class BrowserProfilesDetail extends LiteElement {
                     style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
                   >
                     <p class="mb-4 text-neutral-600 max-w-prose">
-                      ${msg("Load browser to view websites in the profile.")}
+                      ${msg(
+                        "Load browser to view or edit websites in the profile."
+                      )}
                     </p>
                     <sl-button
                       type="primary"
@@ -391,9 +390,7 @@ export class BrowserProfilesDetail extends LiteElement {
   private async startEditBrowser() {
     const prevBrowserId = this.browserId;
 
-    this.isEditingBrowser = true;
-
-    this.startBrowserPreview();
+    await this.startBrowserPreview();
 
     if (prevBrowserId) {
       try {
@@ -408,10 +405,8 @@ export class BrowserProfilesDetail extends LiteElement {
   private async cancelEditBrowser() {
     const prevBrowserId = this.browserId;
 
-    this.isEditingBrowser = false;
     this.isBrowserLoaded = false;
-
-    this.startBrowserPreview();
+    this.browserId = undefined;
 
     if (prevBrowserId) {
       try {
@@ -592,7 +587,6 @@ export class BrowserProfilesDetail extends LiteElement {
           icon: "check2-circle",
         });
 
-        this.isEditingBrowser = false;
         this.browserId = undefined;
       } else {
         throw data;

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -429,7 +429,7 @@ export class BrowserProfilesDetail extends LiteElement {
         )
       ) {
         this.browserId = undefined;
-        this.deleteBrowser(); // TODO DELETE is returning 404
+        await this.deleteBrowser(); // TODO DELETE is returning 404
       } else {
         return;
       }

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -202,6 +202,9 @@ export class BrowserProfilesDetail extends LiteElement {
                     <sl-button size="small" @click=${this.cancelEditBrowser}
                       >${msg("Cancel")}</sl-button
                     >
+                    <sl-button size="small" @click=${this.startBrowserPreview}
+                      >${msg("Reset")}</sl-button
+                    >
                     <sl-button
                       type="primary"
                       size="small"
@@ -212,7 +215,15 @@ export class BrowserProfilesDetail extends LiteElement {
                       >${msg("Save Changes")}</sl-button
                     >
                   `
-                : this.renderEditButton()}
+                : html`
+                    <sl-button
+                      size="small"
+                      ?loading=${this.isBrowserLoading}
+                      ?disabled=${this.isBrowserLoading}
+                      @click=${this.startEditBrowser}
+                      >${msg("Edit Browser Profile")}</sl-button
+                    >
+                  `}
             </div>
           </div>
 
@@ -317,38 +328,6 @@ export class BrowserProfilesDetail extends LiteElement {
           </li>
         </ul>
       </sl-dropdown>
-    `;
-  }
-
-  private renderEditButton() {
-    if (this.browserId) {
-      return html`
-        <sl-button
-          size="small"
-          ?loading=${this.isBrowserLoading}
-          ?disabled=${this.isBrowserLoading}
-          @click=${this.startEditBrowser}
-          >${msg("Switch to Edit Mode")}</sl-button
-        >
-        <sl-button
-          size="small"
-          type="neutral"
-          ?loading=${!this.isBrowserLoaded}
-          ?disabled=${!this.isBrowserLoaded}
-          @click=${() => (this.isEditingBrowser = true)}
-          >${msg("Enable Save")}</sl-button
-        >
-      `;
-    }
-
-    return html`
-      <sl-button
-        size="small"
-        ?loading=${this.isBrowserLoading}
-        ?disabled=${this.isBrowserLoading}
-        @click=${this.startEditBrowser}
-        >${msg("Edit Websites")}</sl-button
-      >
     `;
   }
 

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -56,9 +56,6 @@ export class BrowserProfilesDetail extends LiteElement {
   @state()
   private isEditingBrowser = false;
 
-  @state()
-  private browserCreatedAt?: Date;
-
   disconnectedCallback() {
     if (this.browserId) {
       this.deleteBrowser(this.browserId);
@@ -373,7 +370,6 @@ export class BrowserProfilesDetail extends LiteElement {
     if (!this.profile) return;
 
     this.isBrowserLoading = true;
-    this.browserCreatedAt = new Date();
 
     const url = this.profile.origins[0];
 
@@ -408,8 +404,7 @@ export class BrowserProfilesDetail extends LiteElement {
     }
 
     this.isEditingBrowser = true;
-
-    await this.startBrowserPreview();
+    this.startBrowserPreview();
   }
 
   private async cancelEditBrowser() {
@@ -428,6 +423,8 @@ export class BrowserProfilesDetail extends LiteElement {
         console.debug(e);
       }
     }
+
+    this.startBrowserPreview();
   }
 
   private async duplicateProfile() {

--- a/frontend/src/pages/archive/browser-profiles-detail.ts
+++ b/frontend/src/pages/archive/browser-profiles-detail.ts
@@ -193,9 +193,6 @@ export class BrowserProfilesDetail extends LiteElement {
                     <sl-button size="small" @click=${this.cancelEditBrowser}
                       >${msg("Cancel")}</sl-button
                     >
-                    <sl-button size="small" @click=${this.startEditBrowser}
-                      >${msg("Reset")}</sl-button
-                    >
                     <sl-button
                       type="primary"
                       size="small"
@@ -211,8 +208,8 @@ export class BrowserProfilesDetail extends LiteElement {
                       size="small"
                       ?loading=${this.isBrowserLoading}
                       ?disabled=${this.isBrowserLoading}
-                      @click=${this.startEditBrowser}
-                      >${msg("Edit Browser Profile")}</sl-button
+                      @click=${this.duplicateProfile}
+                      >${msg("Duplicate")}</sl-button
                     >
                   `}
             </div>
@@ -384,21 +381,6 @@ export class BrowserProfilesDetail extends LiteElement {
         type: "danger",
         icon: "exclamation-octagon",
       });
-    }
-  }
-
-  private async startEditBrowser() {
-    const prevBrowserId = this.browserId;
-
-    await this.startBrowserPreview();
-
-    if (prevBrowserId) {
-      try {
-        await this.deleteBrowser(prevBrowserId);
-      } catch (e) {
-        // TODO Investigate DELETE is returning 404
-        console.debug(e);
-      }
     }
   }
 


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/274) Enable canceling and resetting browser profile during edit.

### Screenshots
**Separate edit button:**
<img width="1015" alt="Screen Shot 2022-07-26 at 9 16 32 PM" src="https://user-images.githubusercontent.com/4672952/181164031-e2624ad5-9c75-47aa-b1c7-ca6d3bc80071.png">

**Cancel and reset buttons:**
<img width="1010" alt="Screen Shot 2022-07-26 at 9 21 40 PM" src="https://user-images.githubusercontent.com/4672952/181164051-13e1a7b6-bcaf-4a5e-9509-38cd86e858ef.png">

