### PR TITLE
Make it clearer that browser profile is optional

### DIFF
--- a/frontend/src/components/select-browser-profile.ts
+++ b/frontend/src/components/select-browser-profile.ts
@@ -50,9 +50,8 @@ export class SelectBrowserProfile extends LiteElement {
         clearable
         value=${this.selectedProfile?.id || ""}
         placeholder=${this.browserProfiles
-          ? msg("Select Profile")
+          ? msg("Default Profile")
           : msg("Loading")}
-        ?disabled=${!this.browserProfiles?.length}
         hoist
         @sl-change=${this.onChange}
         @sl-focus=${() => {
@@ -81,11 +80,14 @@ export class SelectBrowserProfile extends LiteElement {
             ></sl-menu-item>
           `
         )}
+        ${this.browserProfiles && !this.browserProfiles.length
+          ? this.renderNoProfiles()
+          : ""}
       </sl-select>
 
-      ${this.browserProfiles && !this.browserProfiles.length
-        ? this.renderNoProfiles()
-        : this.renderSelectedProfileInfo()}
+      ${this.browserProfiles && this.browserProfiles.length
+        ? this.renderSelectedProfileInfo()
+        : ""}
     `;
   }
 
@@ -120,14 +122,21 @@ export class SelectBrowserProfile extends LiteElement {
 
   private renderNoProfiles() {
     return html`
-      <div class="mt-2 text-sm text-neutral-500">
+      <div class="mx-2 text-sm text-neutral-500">
         <span class="inline-block align-middle"
-          >${msg("No browser profiles found.")}</span
+          >${msg("No additional browser profiles found.")}</span
         >
         <a
           href=${`/archives/${this.archiveId}/browser-profiles/new`}
           class="font-medium text-primary hover:text-indigo-500"
           target="_blank"
+          @click=${(e: any) => {
+            const select = e.target.closest("sl-select");
+            if (select) {
+              select.blur();
+              select.dropdown?.hide();
+            }
+          }}
           ><span class="inline-block align-middle"
             >${msg("Create a browser profile")}</span
           >


### PR DESCRIPTION
(https://github.com/webrecorder/browsertrix-cloud/issues/274) Tweak crawl template creation/edit UX to make it clearer that browser profiles are optional when there are no browser profiles.

### Manual testing
Prerequisite: Delete browser profiles or use an account without browser profiles.
1. Go to crawl template creation view. Verify that browser profile select shows "Default Profile"
2. Open select. Verify dropdown shows link to create a new browser profile.
3. Click link and finish creating browser profile. Go back to tab with new crawl template workflow and open browser profile select. Verify dropdown shows new browser profile.
4. Repeat test for edit crawl template workflow.

### Screenshots
**Field in new Crawl Template view**
<img width="636" alt="Screen Shot 2022-08-09 at 2 28 51 PM" src="https://user-images.githubusercontent.com/4672952/183767246-464f7a34-6567-4bab-8257-e90c9e7855c7.png">

**Dropdown open**
<img width="632" alt="Screen Shot 2022-08-09 at 2 28 55 PM" src="https://user-images.githubusercontent.com/4672952/183767249-4bce51cd-a952-4437-846a-bd1999558369.png">

