### PR TITLE
K8s: update chart for local minio + mongo default

### DIFF
--- a/chart/templates/minio.yaml
+++ b/chart/templates/minio.yaml
@@ -50,17 +50,11 @@ spec:
 
       initContainers:
         - name: init-bucket
-          image: {{ .Values.minio_mc_image }}
+          image: {{ .Values.minio_image }}
           imagePullPolicy: {{ .Values.minio_pull_policy }}
-          env:
-            - name: MC_HOST_local
-              valueFrom:
-                secretKeyRef:
-                  name: auth-secrets
-                  key: MC_HOST
 
           command: ['/bin/sh']
-          args: ['-c', 'mc mb --ignore-existing local/{{ .Values.minio_local_bucket_name }}' ]
+          args: ["-c", "mkdir", "-p", "/data/{{ .Values.minio_local_bucket_name }}" ]
 
       containers:
         - name: minio

--- a/chart/templates/minio.yaml
+++ b/chart/templates/minio.yaml
@@ -54,7 +54,12 @@ spec:
           imagePullPolicy: {{ .Values.minio_pull_policy }}
 
           command: ['/bin/sh']
-          args: ["-c", "mkdir", "-p", "/data/{{ .Values.minio_local_bucket_name }}" ]
+          args: ["mkdir", "-p", "/data/{{ .Values.minio_local_bucket_name }}" ]
+
+          volumeMounts:
+            - name: data-minio
+              mountPath: /data
+              subPath: minio
 
       containers:
         - name: minio

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,7 +66,7 @@ mongo_local: true
 
 mongo_host: "local-mongo.default"
 
-mongo_image: "mongo"
+mongo_image: "docker.io/library/mongo:5.0.11"
 mongo_pull_policy: "IfNotPresent"
 
 mongo_requests_cpu: "12m"
@@ -140,7 +140,7 @@ minio_image: minio/minio
 minio_mc_image: minio/mc
 minio_pull_policy: "IfNotPresent"
 
-minio_local_bucket_name: &local_bucket_name "test-bucket"
+minio_local_bucket_name: &local_bucket_name "btrix-data"
 
 
 # Storage


### PR DESCRIPTION
- Update `values.yaml` and charts to work with local minio + mongo deploy
- minio: create dir for local bucket directly, use `btrix-data` as default bucket name.
- mongo: use 5.0 image for now
