### PR TITLE
Continue to watch crawl while stopping

### DIFF
--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -481,6 +481,7 @@ export class CrawlDetail extends LiteElement {
 
     const isStarting = this.crawl.state === "starting";
     const isRunning = this.crawl.state === "running";
+    const isStopping = this.crawl.state === "stopping";
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`
@@ -505,7 +506,20 @@ export class CrawlDetail extends LiteElement {
           </div>`
         : this.isActive
         ? html`
-            <div id="screencast-crawl">
+            ${isStopping
+              ? html`
+                  <div class="mb-4">
+                    <btrix-alert type="warning" class="text-sm">
+                      ${msg("Crawl stopping...")}
+                    </btrix-alert>
+                  </div>
+                `
+              : ""}
+
+            <div
+              id="screencast-crawl"
+              class="${isStopping ? "opacity-40" : ""} transition-opacity"
+            >
               <btrix-screencast
                 authToken=${authToken}
                 archiveId=${this.crawl.aid}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -98,7 +98,10 @@ export class CrawlDetail extends LiteElement {
       const prevCrawl = changedProperties.get("crawl");
 
       if (prevCrawl && this.crawl) {
-        if (prevCrawl.state === "running" && this.crawl.state !== "running") {
+        if (
+          (prevCrawl.state === "running" || prevCrawl.state === "stopping") &&
+          !this.isActive
+        ) {
           this.crawlDone();
         }
       }

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -500,7 +500,7 @@ export class CrawlDetail extends LiteElement {
               ${msg("Crawl starting...")}
             </p>
           </div>`
-        : isRunning
+        : this.isActive
         ? html`
             <div id="screencast-crawl">
               <btrix-screencast


### PR DESCRIPTION
(Reopened https://github.com/webrecorder/browsertrix-cloud/issues/262) Keep watch tab enabled while crawl is active but stopping, with a status alert, and redirect to "Replay" only once complete.

### Screenshots
**Status banner when crawl is stopping in tab:**
<img width="862" alt="Screen Shot 2022-09-21 at 12 01 25 PM" src="https://user-images.githubusercontent.com/4672952/191589037-3252ef12-6ba9-47b0-84ad-bdb99d85cc76.png">
