### PR TITLE
Improve crawl elapsed time UX

### DIFF
--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -57,24 +57,20 @@ export class RelativeDuration extends LitElement {
   }
 
   protected updated(changedProperties: Map<string | number | symbol, unknown>) {
-    const durationChanged =
-      changedProperties.has("value") || changedProperties.has("endTime");
-
-    if (changedProperties.has("tickSeconds") || durationChanged) {
+    if (changedProperties.has("tickSeconds")) {
       window.clearTimeout(this.timerId);
     }
-    if (this.tickSeconds && durationChanged) {
+
+    if (changedProperties.has("endTime") && this.tickSeconds) {
       this.tick(this.tickSeconds * 1000);
     }
   }
 
   private tick(timeoutMs: number) {
+    window.clearTimeout(this.timerId);
+
     this.timerId = window.setTimeout(() => {
       this.endTime = Date.now();
-
-      if (this.tickSeconds) {
-        this.tick(this.tickSeconds * 1000);
-      }
     }, timeoutMs);
   }
 

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -17,6 +17,12 @@ export class RelativeDuration extends LitElement {
   @property({ type: String })
   value?: string; // `new Date` compatible date format
 
+  @property({ type: Boolean })
+  compact = false;
+
+  @property({ type: Boolean })
+  verbose = false;
+
   @state()
   private now = Date.now();
 
@@ -27,7 +33,9 @@ export class RelativeDuration extends LitElement {
     const minMs = 60 * 1000;
 
     if (duration < minMs) {
-      return msg(str`< 1 minute`);
+      return msg(str`< 1 minute`, {
+        desc: "Less than one minute",
+      });
     }
 
     return humanizeDuration(duration, {
@@ -50,7 +58,13 @@ export class RelativeDuration extends LitElement {
   render() {
     if (!this.value) return "";
 
-    return RelativeDuration.humanize(this.now - new Date(this.value).valueOf());
+    return RelativeDuration.humanize(
+      this.now - new Date(this.value).valueOf(),
+      {
+        compact: this.compact,
+        verbose: this.verbose,
+      }
+    );
   }
 
   private updateValue() {

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -42,8 +42,12 @@ export class RelativeDuration extends LitElement {
     }
 
     if (!options.verbose && options.unitCount === undefined) {
-      // Show seconds up to 2 minutes
-      options.unitCount = duration < 120 * 1000 ? 2 : 1;
+      // Show second unit if less than 2 min or greater than 1 hr
+      if (duration >= 60 * 2 * 1000 || duration >= 60 * 60 * 1000) {
+        options.unitCount = 2;
+      } else {
+        options.unitCount = 1;
+      }
     }
 
     return humanizeDuration(duration, {

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -3,7 +3,7 @@ import { property, state } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import humanizeDuration from "pretty-ms";
 
-type HumanizeOptions = {
+export type HumanizeOptions = {
   compact?: boolean;
   verbose?: boolean;
   unitCount?: number;
@@ -41,15 +41,6 @@ export class RelativeDuration extends LitElement {
   private timerId?: number;
 
   static humanize(duration: number, options: HumanizeOptions = {}) {
-    if (!options.verbose && options.unitCount === undefined) {
-      // Show second unit if less than 2 min or greater than 1 hr
-      if (duration < 60 * 2 * 1000 || duration > 60 * 60 * 1000) {
-        options.unitCount = 2;
-      } else {
-        options.unitCount = 1;
-      }
-    }
-
     return humanizeDuration(duration, {
       secondsDecimalDigits: 0,
       ...options,

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -23,16 +23,22 @@ export class RelativeDuration extends LitElement {
   value?: string; // `new Date` compatible date format
 
   @property({ type: Number })
-  endTime?: number; // Optional value to compare to
+  tickSeconds?: number; // Enables ticks every specified seconds
+
+  @property({ type: Number })
+  endTime?: number = Date.now();
 
   @property({ type: Boolean })
-  compact = false;
+  compact? = false;
 
   @property({ type: Boolean })
-  verbose = false;
+  verbose? = false;
 
   @property({ type: Number })
   unitCount?: number;
+
+  @state()
+  private timerId?: number;
 
   static humanize(duration: number, options: HumanizeOptions = {}) {
     if (!options.verbose && duration < 10 * 1000) {
@@ -61,7 +67,30 @@ export class RelativeDuration extends LitElement {
   }
 
   disconnectedCallback(): void {
+    window.clearTimeout(this.timerId);
     super.disconnectedCallback();
+  }
+
+  protected updated(changedProperties: Map<string | number | symbol, unknown>) {
+    const durationChanged =
+      changedProperties.has("value") || changedProperties.has("endTime");
+
+    if (changedProperties.has("tickSeconds") || durationChanged) {
+      window.clearTimeout(this.timerId);
+    }
+    if (this.tickSeconds && durationChanged) {
+      this.tick(this.tickSeconds * 1000);
+    }
+  }
+
+  private tick(timeoutMs: number) {
+    this.timerId = window.setTimeout(() => {
+      this.endTime = Date.now();
+
+      if (this.tickSeconds) {
+        this.tick(this.tickSeconds * 1000);
+      }
+    }, timeoutMs);
   }
 
   render() {

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -5,7 +5,6 @@ import humanizeDuration from "pretty-ms";
 
 /**
  * Show time passed from date in human-friendly format
- * Updates every 10 seconds
  *
  * Usage example:
  * ```ts
@@ -17,17 +16,14 @@ export class RelativeDuration extends LitElement {
   @property({ type: String })
   value?: string; // `new Date` compatible date format
 
+  @property({ type: Number })
+  endTime?: number; // Optional value to compare to
+
   @property({ type: Boolean })
   compact = false;
 
   @property({ type: Boolean })
   verbose = false;
-
-  @state()
-  private now = Date.now();
-
-  // For long polling:
-  private timerId?: number;
 
   static humanize(duration: number, options: any = {}) {
     const minMs = 60 * 1000;
@@ -46,12 +42,9 @@ export class RelativeDuration extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-
-    this.timerId = window.setInterval(() => this.updateValue(), 1000 * 10);
   }
 
   disconnectedCallback(): void {
-    window.clearInterval(this.timerId);
     super.disconnectedCallback();
   }
 
@@ -59,15 +52,11 @@ export class RelativeDuration extends LitElement {
     if (!this.value) return "";
 
     return RelativeDuration.humanize(
-      this.now - new Date(this.value).valueOf(),
+      (this.endTime || Date.now()) - new Date(this.value).valueOf(),
       {
         compact: this.compact,
         verbose: this.verbose,
       }
     );
-  }
-
-  private updateValue() {
-    this.now = Date.now();
   }
 }

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -43,7 +43,7 @@ export class RelativeDuration extends LitElement {
 
     if (!options.verbose && options.unitCount === undefined) {
       // Show second unit if less than 2 min or greater than 1 hr
-      if (duration >= 60 * 2 * 1000 || duration >= 60 * 60 * 1000) {
+      if (duration < 60 * 2 * 1000 || duration > 60 * 60 * 1000) {
         options.unitCount = 2;
       } else {
         options.unitCount = 1;

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -3,6 +3,12 @@ import { property, state } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import humanizeDuration from "pretty-ms";
 
+type HumanizeOptions = {
+  compact?: boolean;
+  verbose?: boolean;
+  unitCount?: number;
+};
+
 /**
  * Show time passed from date in human-friendly format
  *
@@ -25,13 +31,19 @@ export class RelativeDuration extends LitElement {
   @property({ type: Boolean })
   verbose = false;
 
-  static humanize(duration: number, options: any = {}) {
-    const minMs = 60 * 1000;
+  @property({ type: Number })
+  unitCount?: number;
 
-    if (duration < minMs) {
-      return msg(str`< 1 minute`, {
-        desc: "Less than one minute",
+  static humanize(duration: number, options: HumanizeOptions = {}) {
+    if (!options.verbose && duration < 10 * 1000) {
+      return msg(str`< 10 seconds`, {
+        desc: "Less than ten seconds",
       });
+    }
+
+    if (!options.verbose && options.unitCount === undefined) {
+      // Show seconds up to 2 minutes
+      options.unitCount = duration < 120 * 1000 ? 2 : 1;
     }
 
     return humanizeDuration(duration, {
@@ -56,6 +68,7 @@ export class RelativeDuration extends LitElement {
       {
         compact: this.compact,
         verbose: this.verbose,
+        unitCount: this.unitCount,
       }
     );
   }

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -41,12 +41,6 @@ export class RelativeDuration extends LitElement {
   private timerId?: number;
 
   static humanize(duration: number, options: HumanizeOptions = {}) {
-    if (!options.verbose && duration < 10 * 1000) {
-      return msg(str`< 10 seconds`, {
-        desc: "Less than ten seconds",
-      });
-    }
-
     if (!options.verbose && options.unitCount === undefined) {
       // Show second unit if less than 2 min or greater than 1 hr
       if (duration < 60 * 2 * 1000 || duration > 60 * 60 * 1000) {

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -5,7 +5,7 @@ import humanizeDuration from "pretty-ms";
 
 /**
  * Show time passed from date in human-friendly format
- * Updates every 5 seconds
+ * Updates every 10 seconds
  *
  * Usage example:
  * ```ts
@@ -47,7 +47,7 @@ export class RelativeDuration extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
 
-    this.timerId = window.setInterval(() => this.updateValue(), 1000 * 5);
+    this.timerId = window.setInterval(() => this.updateValue(), 1000 * 10);
   }
 
   disconnectedCallback(): void {

--- a/frontend/src/components/relative-duration.ts
+++ b/frontend/src/components/relative-duration.ts
@@ -1,5 +1,6 @@
 import { LitElement } from "lit";
 import { property, state } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
 import humanizeDuration from "pretty-ms";
 
 /**
@@ -11,6 +12,7 @@ import humanizeDuration from "pretty-ms";
  * <btrix-relative-duration value=${value}></btrix-relative-duration>
  * ```
  */
+@localized()
 export class RelativeDuration extends LitElement {
   @property({ type: String })
   value?: string; // `new Date` compatible date format
@@ -21,9 +23,16 @@ export class RelativeDuration extends LitElement {
   // For long polling:
   private timerId?: number;
 
-  static humanize(duration: number) {
+  static humanize(duration: number, options: any = {}) {
+    const minMs = 60 * 1000;
+
+    if (duration < minMs) {
+      return msg(str`< 1 minute`);
+    }
+
     return humanizeDuration(duration, {
       secondsDecimalDigits: 0,
+      ...options,
     });
   }
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -39,9 +39,6 @@ export class CrawlDetail extends LiteElement {
   crawlId?: string;
 
   @state()
-  private lastFetched?: number;
-
-  @state()
   private crawl?: Crawl;
 
   @state()
@@ -836,8 +833,6 @@ export class CrawlDetail extends LiteElement {
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}.json`,
       this.authState!
     );
-
-    this.lastFetched = Date.now();
 
     return data;
   }

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -445,6 +445,7 @@ export class CrawlDetail extends LiteElement {
                           <btrix-relative-duration
                             value=${`${this.crawl.started}Z`}
                             endTime=${this.lastFetched || Date.now()}
+                            verbose
                           ></btrix-relative-duration>
                         </span>
                       `}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -444,8 +444,8 @@ export class CrawlDetail extends LiteElement {
                         <span class="text-purple-600">
                           <btrix-relative-duration
                             value=${`${this.crawl.started}Z`}
-                            endTime=${this.lastFetched || Date.now()}
-                            unitCount="2"
+                            unitCount="3"
+                            tickSeconds="1"
                           ></btrix-relative-duration>
                         </span>
                       `}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -39,6 +39,9 @@ export class CrawlDetail extends LiteElement {
   crawlId?: string;
 
   @state()
+  private lastFetched?: number;
+
+  @state()
   private crawl?: Crawl;
 
   @state()
@@ -441,6 +444,7 @@ export class CrawlDetail extends LiteElement {
                         <span class="text-purple-600">
                           <btrix-relative-duration
                             value=${`${this.crawl.started}Z`}
+                            endTime=${this.lastFetched || Date.now()}
                           ></btrix-relative-duration>
                         </span>
                       `}
@@ -831,6 +835,8 @@ export class CrawlDetail extends LiteElement {
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}.json`,
       this.authState!
     );
+
+    this.lastFetched = Date.now();
 
     return data;
   }

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -445,7 +445,7 @@ export class CrawlDetail extends LiteElement {
                           <btrix-relative-duration
                             value=${`${this.crawl.started}Z`}
                             endTime=${this.lastFetched || Date.now()}
-                            verbose
+                            unitCount="2"
                           ></btrix-relative-duration>
                         </span>
                       `}

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -405,7 +405,7 @@ export class CrawlsList extends LiteElement {
               ${!crawl.finished
                 ? html`
                     ${crawl.state === "canceled" ? msg("Unknown") : ""}
-                    ${crawl.state === "running"
+                    ${isActive(crawl)
                       ? html`
                           <btrix-relative-duration
                             class="text-purple-500"

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -398,6 +398,8 @@ export class CrawlsList extends LiteElement {
                       date=${`${crawl.finished}Z` /** Z for UTC */}
                     ></sl-relative-time>
                   `
+                : crawl.state === "canceled"
+                ? msg("Unknown")
                 : html`<btrix-relative-duration
                     value=${`${crawl.started}Z`}
                   ></btrix-relative-duration>`}

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -256,7 +256,6 @@ export class CrawlsList extends LiteElement {
       <a
         href=${`${this.crawlsBaseUrl}/crawl/${crawl.id}`}
         class="grid grid-cols-12 gap-4 p-4 leading-none hover:bg-zinc-50 hover:text-primary transition-colors"
-        title=${crawl.configName}
         @click=${this.navLink}
       >
         <div class="col-span-11 md:col-span-5">
@@ -405,20 +404,27 @@ export class CrawlsList extends LiteElement {
                 : html`
                     ${crawl.state === "canceled"
                       ? msg("Unknown")
-                      : html`<btrix-relative-duration
-                          class="text-purple-500"
-                          value=${`${crawl.started}Z`}
-                          endTime=${this.lastFetched || Date.now()}
-                          title=${msg(
-                            str`Running for ${RelativeDuration.humanize(
-                              Date.now() -
-                                new Date(`${crawl.started}Z`).valueOf(),
-                              { verbose: true }
-                            )}`
-                          )}
-                          compact
-                          verbose
-                        ></btrix-relative-duration>`}
+                      : html`
+                          <sl-tooltip placement="bottom">
+                            <span slot="content">
+                              ${msg(
+                                str`Running for ${RelativeDuration.humanize(
+                                  Date.now() -
+                                    new Date(`${crawl.started}Z`).valueOf(),
+                                  { verbose: true }
+                                )}`
+                              )}
+                            </span>
+
+                            <btrix-relative-duration
+                              class="text-purple-500"
+                              value=${`${crawl.started}Z`}
+                              endTime=${this.lastFetched || Date.now()}
+                              compact
+                              verbose
+                            ></btrix-relative-duration>
+                          </sl-tooltip>
+                        `}
                   `}
             </div>
           </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -137,7 +137,9 @@ export class CrawlsList extends LiteElement {
             ? this.renderCrawlList()
             : html`
                 <div class="border-t border-b py-5">
-                  <p class="text-center text-0-500">${msg("No crawls yet.")}</p>
+                  <p class="text-center text-neutral-500">
+                    ${msg("No crawls yet.")}
+                  </p>
                 </div>
               `}
         </section>
@@ -177,7 +179,9 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
         <div class="col-span-12 md:col-span-1 flex items-center justify-end">
-          <div class="whitespace-nowrap text-0-500 mr-2">${msg("Sort By")}</div>
+          <div class="whitespace-nowrap text-neutral-500 mr-2">
+            ${msg("Sort By")}
+          </div>
           <sl-dropdown
             placement="bottom-end"
             distance="4"
@@ -376,7 +380,7 @@ export class CrawlsList extends LiteElement {
                 : crawl.state === "complete"
                 ? "text-emerald-500"
                 : isActive(crawl)
-                ? "text-purple-500"
+                ? "text-purple-500 motion-safe:animate-pulse"
                 : "text-zinc-300"}"
               style="font-size: 10px; vertical-align: 2px"
             >
@@ -391,20 +395,31 @@ export class CrawlsList extends LiteElement {
             >
               ${crawl.state.replace(/_/g, " ")}
             </div>
-            <div class="text-0-500 text-sm whitespace-nowrap truncate">
+            <div class="text-neutral-500 text-sm whitespace-nowrap truncate">
               ${crawl.finished
                 ? html`
                     <sl-relative-time
                       date=${`${crawl.finished}Z` /** Z for UTC */}
                     ></sl-relative-time>
                   `
-                : crawl.state === "canceled"
-                ? msg("Unknown")
-                : html`<btrix-relative-duration
-                    value=${`${crawl.started}Z`}
-                    compact
-                    verbose
-                  ></btrix-relative-duration>`}
+                : html`
+                    ${crawl.state === "canceled"
+                      ? msg("Unknown")
+                      : html`<btrix-relative-duration
+                          class="text-purple-500"
+                          value=${`${crawl.started}Z`}
+                          endTime=${this.lastFetched || Date.now()}
+                          title=${msg(
+                            str`Running for ${RelativeDuration.humanize(
+                              Date.now() -
+                                new Date(`${crawl.started}Z`).valueOf(),
+                              { verbose: true }
+                            )}`
+                          )}
+                          compact
+                          verbose
+                        ></btrix-relative-duration>`}
+                  `}
             </div>
           </div>
         </div>
@@ -418,13 +433,15 @@ export class CrawlsList extends LiteElement {
                       lang=${/* TODO localize: */ "en"}
                     ></sl-format-bytes>
                   </span>
-                  <span class="text-0-500">
+                  <span class="text-neutral-500">
                     (${crawl.fileCount === 1
                       ? msg(str`${crawl.fileCount} file`)
                       : msg(str`${crawl.fileCount} files`)})
                   </span>
                 </div>
-                <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                <div
+                  class="text-neutral-500 text-sm whitespace-nowrap truncate"
+                >
                   ${msg(
                     str`in ${RelativeDuration.humanize(
                       new Date(`${crawl.finished}Z`).valueOf() -
@@ -443,7 +460,9 @@ export class CrawlsList extends LiteElement {
                   <span class="text-0-400">/</span>
                   ${this.numberFormatter.format(+crawl.stats.found)}
                 </div>
-                <div class="text-0-500 text-sm whitespace-nowrap truncate">
+                <div
+                  class="text-neutral-500 text-sm whitespace-nowrap truncate"
+                >
                   ${msg("pages crawled")}
                 </div>
               `
@@ -458,7 +477,9 @@ export class CrawlsList extends LiteElement {
                     >${msg("Manual Start")}</span
                   >
                 </div>
-                <div class="ml-1 text-0-500 text-sm whitespace-nowrap truncate">
+                <div
+                  class="ml-1 text-neutral-500 text-sm whitespace-nowrap truncate"
+                >
                   ${msg(str`by ${crawl.userName || crawl.userid}`)}
                 </div>
               `

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -426,7 +426,8 @@ export class CrawlsList extends LiteElement {
                   ${msg(
                     str`in ${RelativeDuration.humanize(
                       new Date(`${crawl.finished}Z`).valueOf() -
-                        new Date(`${crawl.started}Z`).valueOf()
+                        new Date(`${crawl.started}Z`).valueOf(),
+                      { compact: true }
                     )}`
                   )}
                 </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -401,10 +401,12 @@ export class CrawlsList extends LiteElement {
                       date=${`${crawl.finished}Z` /** Z for UTC */}
                     ></sl-relative-time>
                   `
-                : html`
-                    ${crawl.state === "canceled"
-                      ? msg("Unknown")
-                      : html`
+                : ""}
+              ${!crawl.finished
+                ? html`
+                    ${crawl.state === "canceled" ? msg("Unknown") : ""}
+                    ${crawl.state === "running"
+                      ? html`
                           <sl-tooltip placement="bottom">
                             <span slot="content">
                               ${msg(
@@ -420,12 +422,12 @@ export class CrawlsList extends LiteElement {
                               class="text-purple-500"
                               value=${`${crawl.started}Z`}
                               endTime=${this.lastFetched || Date.now()}
-                              compact
-                              verbose
                             ></btrix-relative-duration>
                           </sl-tooltip>
-                        `}
-                  `}
+                        `
+                      : ""}
+                  `
+                : ""}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -407,23 +407,11 @@ export class CrawlsList extends LiteElement {
                     ${crawl.state === "canceled" ? msg("Unknown") : ""}
                     ${crawl.state === "running"
                       ? html`
-                          <sl-tooltip placement="bottom">
-                            <span slot="content">
-                              ${msg(
-                                str`Running for ${RelativeDuration.humanize(
-                                  Date.now() -
-                                    new Date(`${crawl.started}Z`).valueOf(),
-                                  { verbose: true }
-                                )}`
-                              )}
-                            </span>
-
-                            <btrix-relative-duration
-                              class="text-purple-500"
-                              value=${`${crawl.started}Z`}
-                              endTime=${this.lastFetched || Date.now()}
-                            ></btrix-relative-duration>
-                          </sl-tooltip>
+                          <btrix-relative-duration
+                            class="text-purple-500"
+                            value=${`${crawl.started}Z`}
+                            endTime=${this.lastFetched || Date.now()}
+                          ></btrix-relative-duration>
                         `
                       : ""}
                   `

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -13,7 +13,6 @@ import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { Crawl, CrawlTemplate } from "./types";
 import type { InitialCrawlTemplate } from "./crawl-templates-new";
-import { triggerFocusFor } from "@open-wc/testing";
 
 type CrawlSearchResult = {
   item: Crawl;

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -402,6 +402,8 @@ export class CrawlsList extends LiteElement {
                 ? msg("Unknown")
                 : html`<btrix-relative-duration
                     value=${`${crawl.started}Z`}
+                    compact
+                    verbose
                   ></btrix-relative-duration>`}
             </div>
           </div>

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -5,7 +5,8 @@ type CrawlState =
   | "failed"
   | "partial_complete"
   | "timed_out"
-  | "stopping";
+  | "stopping"
+  | "canceled";
 
 export type Crawl = {
   id: string;


### PR DESCRIPTION
The crawl duration in the list view currently feels like "broken real-time" since the updated numbers seem arbitrary. Rounding to a whole minute or hour instead feels easier to get a general sense of how much time has elapsed. Users can still hover over the duration or click into crawl details to view more exact elapsed time.

Additionally, this change removes the timer from the `<btrix-relative-duration>` component for a performance boost, since the crawl list and detail view is updating every 10 seconds anyway.

Resolves #295

### Manual testing
1. Run app and go to crawls list
2. Start new crawl. Verify crawl elapsed time updates by the second until 2 minutes, then updates by the minute
3. Go to crawl detail page. Verify time updates by the second regardless of duration

### Screenshots
**Crawl detail:**

https://user-images.githubusercontent.com/4672952/193669611-d3363870-934e-48d2-a1ce-385f8929e753.mov

**Crawl list:**

https://user-images.githubusercontent.com/4672952/193669608-afb6f11d-2bf8-4185-a735-f90915a0e86a.mov

