### PR TITLE
Allow for "custom" scopeType

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -29,6 +29,7 @@ class ScopeType(str, Enum):
     HOST = "host"
     DOMAIN = "domain"
     ANY = "any"
+    CUSTOM = "custom"
 
 
 # ============================================================================


### PR DESCRIPTION
At the moment picking "custom" yields a UI error:

```
scopeType: value is not a valid enumeration member; permitted: 'page', 'page-spa', 'prefix', 'host', 'domain', 'any'
```
