### PR TITLE
Update crawl template copy

### DIFF
--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -375,22 +375,6 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderSummary() {
-    let crawlScaleLabel = `${this.crawl?.scale}`;
-
-    switch (this.crawl?.scale) {
-      case 1:
-        crawlScaleLabel = msg("Standard", { desc: "Crawl scale label" });
-        break;
-      case 2:
-        crawlScaleLabel = msg("Big (2x)", { desc: "Crawl scale label" });
-        break;
-      case 3:
-        crawlScaleLabel = msg("Bigger (3x)", { desc: "Crawl scale label" });
-        break;
-      default:
-        break;
-    }
-
     return html`
       <dl class="grid grid-cols-4 gap-5 rounded-lg border py-3 px-5 text-sm">
         <div class="col-span-2 md:col-span-1">
@@ -465,10 +449,10 @@ export class CrawlDetail extends LiteElement {
           </dd>
         </div>
         <div class="col-span-2 md:col-span-1">
-          <dt class="text-xs text-0-600">${msg("Crawl Scale")}</dt>
+          <dt class="text-xs text-0-600">${msg("Crawler Instances")}</dt>
           <dd>
             ${this.crawl
-              ? crawlScaleLabel
+              ? this.crawl?.scale
               : html`<sl-skeleton class="h-5"></sl-skeleton>`}
           </dd>
         </div>
@@ -774,15 +758,15 @@ export class CrawlDetail extends LiteElement {
     const scaleOptions = [
       {
         value: 1,
-        label: msg("Standard"),
+        label: "1",
       },
       {
         value: 2,
-        label: msg("Big (2x)"),
+        label: "2",
       },
       {
         value: 3,
-        label: msg("Bigger (3x)"),
+        label: "3",
       },
     ];
 

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -877,7 +877,7 @@ export class CrawlTemplatesDetail extends LiteElement {
             ></sl-tooltip>
           </label>
 
-          <sl-menu-item value="1">${msg("1 (Standard)")}</sl-menu-item>
+          <sl-menu-item value="1">${msg("1")}</sl-menu-item>
           <sl-menu-item value="2">${msg("2")}</sl-menu-item>
           <sl-menu-item value="3">${msg("3")}</sl-menu-item>
         </sl-select>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -752,7 +752,9 @@ export class CrawlTemplatesDetail extends LiteElement {
         </div>
         <div class="col-span-1">
           <dt class="text-sm text-0-600">
-            <span class="inline-block align-middle">${msg("Crawl Scale")}</span>
+            <span class="inline-block align-middle"
+              >${msg("Crawler Instances")}</span
+            >
           </dt>
           <dd>
             <span class="inline-block font-mono mr-2"
@@ -855,15 +857,29 @@ export class CrawlTemplatesDetail extends LiteElement {
       <sl-form @sl-submit=${this.handleSubmitEditScale}>
         <sl-select
           name="scale"
-          label=${msg("Crawl Scale")}
           value=${this.crawlTemplate.scale}
           hoist
           @sl-hide=${this.stopProp}
           @sl-after-hide=${this.stopProp}
         >
-          <sl-menu-item value="1">${msg("Standard")}</sl-menu-item>
-          <sl-menu-item value="2">${msg("Big (2x)")}</sl-menu-item>
-          <sl-menu-item value="3">${msg("Bigger (3x)")}</sl-menu-item>
+          <label slot="label">
+            <span class="inline-block align-middle">
+              ${msg("Crawler Instances")}
+            </span>
+            <sl-tooltip
+              content=${msg(
+                "The number of crawler instances that will run in parallel for this crawl job."
+              )}
+              ><sl-icon
+                class="inline-block align-middle ml-1 text-neutral-500"
+                name="info-circle"
+              ></sl-icon
+            ></sl-tooltip>
+          </label>
+
+          <sl-menu-item value="1">${msg("1 (Standard)")}</sl-menu-item>
+          <sl-menu-item value="2">${msg("2")}</sl-menu-item>
+          <sl-menu-item value="3">${msg("3")}</sl-menu-item>
         </sl-select>
 
         <div class="mt-5 text-right">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -357,14 +357,24 @@ export class CrawlTemplatesNew extends LiteElement {
         class="col-span-3 md:col-span-2 pb-6 md:p-8 border-b grid grid-cols-1 gap-5"
       >
         <div class="col-span-1">
-          <sl-select
-            name="scale"
-            label=${msg("Crawl Scale")}
-            value=${initialValues.scale}
-          >
-            <sl-menu-item value="1">${msg("Standard")}</sl-menu-item>
-            <sl-menu-item value="2">${msg("Big (2x)")}</sl-menu-item>
-            <sl-menu-item value="3">${msg("Bigger (3x)")}</sl-menu-item>
+          <sl-select name="scale" value=${initialValues.scale}>
+            <label slot="label">
+              <span class="inline-block align-middle">
+                ${msg("Crawler Instances")}
+              </span>
+              <sl-tooltip
+                content=${msg(
+                  "The number of crawler instances that will run in parallel for this crawl job."
+                )}
+                ><sl-icon
+                  class="inline-block align-middle ml-1 text-neutral-500"
+                  name="info-circle"
+                ></sl-icon
+              ></sl-tooltip>
+            </label>
+            <sl-menu-item value="1">${msg("1")}</sl-menu-item>
+            <sl-menu-item value="2">${msg("2")}</sl-menu-item>
+            <sl-menu-item value="3">${msg("3")}</sl-menu-item>
           </sl-select>
         </div>
         <div class="col-span-1 flex justify-between">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -155,6 +155,15 @@ export class CrawlTemplatesNew extends LiteElement {
             </div>
 
             <div class="p-4 md:p-8 text-center grid gap-5">
+              <div>
+                <sl-checkbox
+                  name="runNow"
+                  ?checked=${initialValues.runNow}
+                  @sl-change=${(e: any) => (this.isRunNow = e.target.checked)}
+                  >${msg("Run immediately on save")}
+                </sl-checkbox>
+              </div>
+
               ${this.serverError
                 ? html`<btrix-alert id="formError" type="danger"
                     >${this.serverError}</btrix-alert
@@ -167,31 +176,11 @@ export class CrawlTemplatesNew extends LiteElement {
                   submit
                   ?loading=${this.isSubmitting}
                   ?disabled=${this.isSubmitting}
-                  >${msg("Save Crawl Template")}</sl-button
+                  >${this.isRunNow
+                    ? msg("Save & Run Template")
+                    : msg("Save Template")}</sl-button
                 >
               </div>
-
-              ${this.isRunNow || this.scheduleInterval
-                ? html`<div class="text-sm text-gray-500">
-                    ${this.isRunNow
-                      ? html`
-                          <p class="mb-2">
-                            ${msg("A crawl will start immediately on save.")}
-                          </p>
-                        `
-                      : ""}
-                    ${this.scheduleInterval
-                      ? html`
-                          <p class="mb-2">
-                            ${msg(
-                              html`Scheduled crawl will run
-                              ${this.formattededNextCrawlDate}.`
-                            )}
-                          </p>
-                        `
-                      : ""}
-                  </div>`
-                : ""}
             </div>
           </sl-form>
         </div>
@@ -328,13 +317,6 @@ export class CrawlTemplatesNew extends LiteElement {
               : msg("No crawls scheduled")}
           </div>
         </div>
-
-        <sl-checkbox
-          name="runNow"
-          ?checked=${initialValues.runNow}
-          @sl-change=${(e: any) => (this.isRunNow = e.target.checked)}
-          >${msg("Run immediately on save")}
-        </sl-checkbox>
 
         <sl-input
           name="crawlTimeoutMinutes"


### PR DESCRIPTION
Resolves #294

### Screenshots
**New crawl template form: Tooltip on hover & options open:**
<img width="655" alt="Screen Shot 2022-09-26 at 6 00 03 PM" src="https://user-images.githubusercontent.com/4672952/192407735-5a254fdd-954a-4ee5-bc37-124e0190c705.png">


**New crawl template "Run immediately" checked:**
<img width="1026" alt="Screen Shot 2022-09-26 at 6 04 56 PM" src="https://user-images.githubusercontent.com/4672952/192407748-9e60556a-78d4-4707-8e2c-86beb6ca904f.png">

**Unchecked:**
<img width="1027" alt="Screen Shot 2022-09-26 at 6 05 02 PM" src="https://user-images.githubusercontent.com/4672952/192407751-5788ae13-574d-49a9-b0d0-3d3a6614cc66.png">

**Crawl detail label:**
<img width="864" alt="Screen Shot 2022-09-26 at 6 01 09 PM" src="https://user-images.githubusercontent.com/4672952/192407747-56cf23a2-6d29-4b5a-b851-9de173a22c91.png">

**Crawl template edit dialog:**
<img width="602" alt="Screen Shot 2022-09-26 at 6 00 53 PM" src="https://user-images.githubusercontent.com/4672952/192407740-8a624bde-45a0-4503-9103-aba1fe257954.png">