### PR TITLE
Display exclusions & list of URLs in crawl queue

### DIFF
--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -46,7 +46,7 @@ export class CrawlQueue extends LiteElement {
   private page: number = 1;
 
   @state()
-  private pageSize: number = 10;
+  private pageSize: number = 30;
 
   @state()
   private total?: number;

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -85,42 +85,45 @@ export class CrawlQueue extends LiteElement {
     }
 
     return html`
-      <header class="flex justify-end">
-        <btrix-pagination
-          size=${this.pageSize}
-          totalCount=${this.total}
-          @page-change=${(e: CustomEvent) => {
-            this.page = e.detail.page;
-          }}
-        >
-        </btrix-pagination>
-      </header>
+      <btrix-details open disabled>
+        <span slot="title">${msg("Queued URLs")}</span>
+        <div slot="summary-description">
+          <btrix-pagination
+            size=${this.pageSize}
+            totalCount=${this.total}
+            @page-change=${(e: CustomEvent) => {
+              this.page = e.detail.page;
+            }}
+          >
+          </btrix-pagination>
+        </div>
 
-      <btrix-numbered-list
-        class="text-xs break-all transition-opacity${this.isLoading
-          ? " opacity-60"
-          : ""}"
-        .items=${this.results.map((url, idx) => ({
-          order: idx + 1 + (this.page - 1) * this.pageSize,
-          content: html`<a
-            href=${url}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            >${url}</a
-          >`,
-        }))}
-        aria-live="polite"
-      ></btrix-numbered-list>
+        <btrix-numbered-list
+          class="text-xs break-all transition-opacity${this.isLoading
+            ? " opacity-60"
+            : ""}"
+          .items=${this.results.map((url, idx) => ({
+            order: idx + 1 + (this.page - 1) * this.pageSize,
+            content: html`<a
+              href=${url}
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+              >${url}</a
+            >`,
+          }))}
+          aria-live="polite"
+        ></btrix-numbered-list>
 
-      <footer class="text-center">
-        <span class="text-xs text-neutral-400" aria-live="polite">
-          ${msg(
-            str`${((this.page - 1) * this.pageSize + 1).toLocaleString()}-${(
-              this.page * this.pageSize
-            ).toLocaleString()} of ${this.total.toLocaleString()} URLs`
-          )}
-        </span>
-      </footer>
+        <footer class="text-center">
+          <span class="text-xs text-neutral-400" aria-live="polite">
+            ${msg(
+              str`${((this.page - 1) * this.pageSize + 1).toLocaleString()}-${(
+                this.page * this.pageSize
+              ).toLocaleString()} of ${this.total.toLocaleString()} URLs`
+            )}
+          </span>
+        </footer>
+      </btrix-details>
     `;
   }
 

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -97,7 +97,8 @@ export class CrawlQueue extends LiteElement {
 
       <btrix-numbered-list
         class="text-xs transition-opacity${this.isLoading ? " opacity-60" : ""}"
-        .items=${this.results.map((url) => ({
+        .items=${this.results.map((url, idx) => ({
+          order: idx + 1 + (this.page - 1) * this.pageSize,
           content: html`<a
             href=${url}
             target="_blank"
@@ -131,7 +132,9 @@ export class CrawlQueue extends LiteElement {
 
   private async getQueue(): Promise<ResponseData> {
     const data: ResponseData = await this.apiFetch(
-      `/archives/${this.archiveId}/crawls/${this.crawlId}/queue?offset=${this.page}&count=${this.pageSize}`,
+      `/archives/${this.archiveId}/crawls/${this.crawlId}/queue?offset=${
+        (this.page - 1) * this.pageSize
+      }&count=${this.page * this.pageSize - 1}`,
       this.authState!
     );
 

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -85,10 +85,7 @@ export class CrawlQueue extends LiteElement {
     }
 
     return html`
-      <header class="flex items-center justify-end">
-        <span class="text-neutral-500" aria-live="polite">
-          ${msg(str`${this.total.toLocaleString()} URLs in queue`)}
-        </span>
+      <header class="flex justify-end">
         <btrix-pagination
           size=${this.pageSize}
           totalCount=${this.total}
@@ -114,6 +111,16 @@ export class CrawlQueue extends LiteElement {
         }))}
         aria-live="polite"
       ></btrix-numbered-list>
+
+      <footer class="text-center">
+        <span class="text-xs text-neutral-400" aria-live="polite">
+          ${msg(
+            str`${((this.page - 1) * this.pageSize + 1).toLocaleString()}-${(
+              this.page * this.pageSize
+            ).toLocaleString()} of ${this.total.toLocaleString()} URLs`
+          )}
+        </span>
+      </footer>
     `;
   }
 

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -1,0 +1,129 @@
+import { property, state } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
+import LiteElement, { html } from "../utils/LiteElement";
+import type { AuthState } from "../utils/AuthService";
+
+type Pages = string[];
+type ResponseData = {
+  total: number;
+  results: Pages;
+  matched: Pages;
+};
+
+/**
+ * Show real-time crawl queue results
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-crawl-queue
+ *   archiveId=${this.crawl.aid}
+ *   crawlId=${this.crawl.id}
+ *   .authState=${this.authState}
+ * ></btrix-crawl-queue>
+ * ```
+ */
+@localized()
+export class CrawlQueue extends LiteElement {
+  @property({ type: Object })
+  authState?: AuthState;
+
+  @property({ type: String })
+  archiveId?: string;
+
+  @property({ type: String })
+  crawlId?: string;
+
+  @state()
+  private results: Pages = [];
+
+  @state()
+  private isLoading = false;
+
+  @state()
+  private page: number = 1;
+
+  @state()
+  private pageSize: number = 10;
+
+  @state()
+  private total?: number;
+
+  private timerId?: number;
+
+  disconnectedCallback() {
+    window.clearInterval(this.timerId);
+    super.disconnectedCallback();
+  }
+
+  async firstUpdated() {
+    await this.performUpdate;
+    this.fetchQueue();
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    if (changedProperties.has("page")) {
+      this.fetchQueue();
+    }
+  }
+
+  render() {
+    if (!this.total) {
+      return html`
+        <p class="text-sm text-neutral-400">${msg("No pages queued.")}</p>
+      `;
+    }
+
+    return html`
+      <btrix-pagination
+        size=${this.pageSize}
+        totalCount=${this.total}
+        @page-change=${(e: CustomEvent) => {
+          this.page = e.detail.page;
+        }}
+      >
+      </btrix-pagination>
+
+      <btrix-numbered-list
+        class="text-xs"
+        .items=${this.results.map((url) => ({
+          content: html`<a
+            href=${url}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            >${url}</a
+          >`,
+        }))}
+        aria-live="polite"
+      ></btrix-numbered-list>
+    `;
+  }
+
+  private async fetchQueue() {
+    this.isLoading = true;
+
+    try {
+      const { total, results } = await this.getQueue();
+
+      this.total = total;
+      this.results = results;
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't fetch crawl queue at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+
+    this.isLoading = false;
+  }
+
+  private async getQueue(): Promise<ResponseData> {
+    const data: ResponseData = await this.apiFetch(
+      `/archives/${this.archiveId}/crawls/${this.crawlId}/queue?offset=${this.page}&count=${this.pageSize}`,
+      this.authState!
+    );
+
+    return data;
+  }
+}

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -61,31 +61,42 @@ export class CrawlQueue extends LiteElement {
     this.fetchQueue();
   }
 
-  updated(changedProperties: Map<string, any>) {
+  async updated(changedProperties: Map<string, any>) {
     if (changedProperties.has("page")) {
+      await this.performUpdate;
       this.fetchQueue();
     }
   }
 
   render() {
     if (!this.total) {
+      if (this.isLoading) {
+        return html`
+          <div class="flex items-center justify-center text-3xl">
+            <sl-spinner></sl-spinner>
+          </div>
+        `;
+      }
+
       return html`
         <p class="text-sm text-neutral-400">${msg("No pages queued.")}</p>
       `;
     }
 
     return html`
-      <btrix-pagination
-        size=${this.pageSize}
-        totalCount=${this.total}
-        @page-change=${(e: CustomEvent) => {
-          this.page = e.detail.page;
-        }}
-      >
-      </btrix-pagination>
+      <header class="flex justify-end">
+        <btrix-pagination
+          size=${this.pageSize}
+          totalCount=${this.total}
+          @page-change=${(e: CustomEvent) => {
+            this.page = e.detail.page;
+          }}
+        >
+        </btrix-pagination>
+      </header>
 
       <btrix-numbered-list
-        class="text-xs"
+        class="text-xs transition-opacity${this.isLoading ? " opacity-60" : ""}"
         .items=${this.results.map((url) => ({
           content: html`<a
             href=${url}

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -87,7 +87,7 @@ export class CrawlQueue extends LiteElement {
     return html`
       <header class="flex items-center justify-end">
         <span class="text-neutral-500" aria-live="polite">
-          ${msg(str`${this.total} URLs in queue`)}
+          ${msg(str`${this.total.toLocaleString()} URLs in queue`)}
         </span>
         <btrix-pagination
           size=${this.pageSize}

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -1,5 +1,5 @@
 import { property, state } from "lit/decorators.js";
-import { msg, localized } from "@lit/localize";
+import { msg, localized, str } from "@lit/localize";
 
 import LiteElement, { html } from "../utils/LiteElement";
 import type { AuthState } from "../utils/AuthService";
@@ -85,7 +85,10 @@ export class CrawlQueue extends LiteElement {
     }
 
     return html`
-      <header class="flex justify-end">
+      <header class="flex items-center justify-end">
+        <span class="text-neutral-500" aria-live="polite">
+          ${msg(str`${this.total} URLs in queue`)}
+        </span>
         <btrix-pagination
           size=${this.pageSize}
           totalCount=${this.total}

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -117,7 +117,7 @@ export class CrawlQueue extends LiteElement {
         <footer class="text-center">
           <span class="text-xs text-neutral-400" aria-live="polite">
             ${msg(
-              str`${((this.page - 1) * this.pageSize + 1).toLocaleString()}-${(
+              str`${((this.page - 1) * this.pageSize + 1).toLocaleString()}–${(
                 this.page * this.pageSize
               ).toLocaleString()} of ${this.total.toLocaleString()} URLs`
             )}

--- a/frontend/src/components/details.ts
+++ b/frontend/src/components/details.ts
@@ -21,6 +21,9 @@ export class Details extends LitElement {
   @property({ type: Boolean })
   open? = false;
 
+  @property({ type: Boolean })
+  disabled? = false;
+
   static styles = css`
     :host {
       display: block;
@@ -39,7 +42,7 @@ export class Details extends LitElement {
       user-select: none;
     }
 
-    summary::before {
+    summary:not([aria-disabled="true"])::before {
       display: block;
       width: 1rem;
       height: 1rem;
@@ -47,11 +50,11 @@ export class Details extends LitElement {
       flex: 0;
     }
 
-    details[open] summary::before {
+    details:not([aria-disabled="true"])[open] summary::before {
       content: url(${unsafeCSS(caretDownFillSvg)});
     }
 
-    details:not([open]) summary::before {
+    details:not([aria-disabled="true"]):not([open]) summary::before {
       content: url(${unsafeCSS(caretRightFillSvg)});
     }
 
@@ -81,7 +84,11 @@ export class Details extends LitElement {
 
   render() {
     return html`
-      <details ?open=${this.open} @toggle=${this.onToggle}>
+      <details
+        ?open=${this.open}
+        @toggle=${this.onToggle}
+        aria-disabled=${this.disabled ? "true" : "false"}
+      >
         <summary>
           <div class="summary-content">
             <div class="title">

--- a/frontend/src/components/details.ts
+++ b/frontend/src/components/details.ts
@@ -35,14 +35,17 @@ export class Details extends LitElement {
 
       margin-bottom: var(--sl-spacing-x-small);
       line-height: 1;
-      cursor: pointer;
       display: flex;
       align-items: center;
       list-style: none;
+    }
+
+    details[aria-disabled="false"] summary {
+      cursor: pointer;
       user-select: none;
     }
 
-    summary:not([aria-disabled="true"])::before {
+    details[aria-disabled="false"] summary::before {
       display: block;
       width: 1rem;
       height: 1rem;
@@ -50,11 +53,11 @@ export class Details extends LitElement {
       flex: 0;
     }
 
-    details:not([aria-disabled="true"])[open] summary::before {
+    details[aria-disabled="false"][open] summary::before {
       content: url(${unsafeCSS(caretDownFillSvg)});
     }
 
-    details:not([aria-disabled="true"]):not([open]) summary::before {
+    details[aria-disabled="false"]:not([open]) summary::before {
       content: url(${unsafeCSS(caretRightFillSvg)});
     }
 
@@ -86,6 +89,7 @@ export class Details extends LitElement {
     return html`
       <details
         ?open=${this.open}
+        @click=${this.onClick}
         @toggle=${this.onToggle}
         aria-disabled=${this.disabled ? "true" : "false"}
       >
@@ -100,6 +104,13 @@ export class Details extends LitElement {
         <slot></slot>
       </details>
     `;
+  }
+
+  private onClick(e: Event) {
+    if (this.disabled) {
+      e.preventDefault();
+      return;
+    }
   }
 
   private onToggle(e: Event) {

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -51,6 +51,9 @@ import("./numbered-list").then(({ NumberedList }) => {
 import("./pagination").then(({ Pagination }) => {
   customElements.define("btrix-pagination", Pagination);
 });
+import("./crawl-queue").then(({ CrawlQueue }) => {
+  customElements.define("btrix-crawl-queue", CrawlQueue);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -42,6 +42,9 @@ import("./screencast").then(({ Screencast: Screencast }) => {
 import("./select-browser-profile").then(({ SelectBrowserProfile }) => {
   customElements.define("btrix-select-browser-profile", SelectBrowserProfile);
 });
+import("./queue-exclusion-form").then(({ QueueExclusionForm }) => {
+  customElements.define("btrix-queue-exclusion-form", QueueExclusionForm);
+});
 import("./queue-exclusion-table").then(({ QueueExclusionTable }) => {
   customElements.define("btrix-queue-exclusion-table", QueueExclusionTable);
 });

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css } from "lit";
 import { property } from "lit/decorators.js";
 
 type ListItem = {
+  order?: number;
   content: any; // any lit template content
 };
 
@@ -57,6 +58,7 @@ export class NumberedList extends LitElement {
     }
 
     li::marker {
+      content: attr(data-marker);
       color: var(--sl-color-neutral-400);
       font-size: var(--sl-font-size-medium);
       font-weight: var(--sl-font-weight-normal);
@@ -75,7 +77,12 @@ export class NumberedList extends LitElement {
   render() {
     return html`
       <ol>
-        ${this.items.map((item) => html` <li>${item.content}</li> `)}
+        ${this.items.map(
+          (item, idx) =>
+            html`
+              <li data-marker="${item.order || idx + 1}. ">${item.content}</li>
+            `
+        )}
       </ol>
 
       ${this.innerStyle}

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -26,42 +26,55 @@ export class NumberedList extends LitElement {
       display: block;
     }
 
-    ol {
+    .list {
+      display: grid;
+      grid-template-columns: minmax(6ch, max-content) 1fr;
+      align-items: center;
       font-family: var(--sl-font-mono);
-      line-height: 1.1;
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
     }
 
-    li {
+    .list li {
+      display: contents;
+    }
+
+    .item-content {
       border-left: var(--sl-panel-border-width) solid
         var(--sl-panel-border-color);
       border-right: var(--sl-panel-border-width) solid
         var(--sl-panel-border-color);
       padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
+      line-height: 1.25;
     }
 
-    li:first-child {
+    li:first-child .item-content {
       border-top: var(--sl-panel-border-width) solid
         var(--sl-panel-border-color);
       border-top-left-radius: var(--sl-border-radius-medium);
       border-top-right-radius: var(--sl-border-radius-medium);
     }
 
-    li:last-child {
+    li:last-child .item-content {
       border-bottom: var(--sl-panel-border-width) solid
         var(--sl-panel-border-color);
       border-bottom-left-radius: var(--sl-border-radius-medium);
       border-bottom-right-radius: var(--sl-border-radius-medium);
     }
 
-    li:nth-child(even) {
+    li:nth-child(even) .item-content {
       background-color: var(--sl-color-neutral-50);
     }
 
-    li::marker {
-      content: attr(data-marker);
+    .item-marker {
       color: var(--sl-color-neutral-400);
+      line-height: 1;
       font-size: var(--sl-font-size-medium);
       font-weight: var(--sl-font-weight-normal);
+      text-align: right;
+      margin-right: var(--sl-spacing-x-small);
+      white-space: nowrap;
     }
 
     a {
@@ -76,11 +89,14 @@ export class NumberedList extends LitElement {
 
   render() {
     return html`
-      <ol>
+      <ol class="list">
         ${this.items.map(
           (item, idx) =>
             html`
-              <li data-marker="${item.order || idx + 1}. ">${item.content}</li>
+              <li>
+                <div class="item-marker">${item.order || idx + 1}.</div>
+                <div class="item-content">${item.content}</div>
+              </li>
             `
         )}
       </ol>

--- a/frontend/src/components/pagination.ts
+++ b/frontend/src/components/pagination.ts
@@ -65,9 +65,10 @@ export class Pagination extends LitElement {
     }
 
     /* Use width of text to determine input width */
-    .inputValue {
+    .totalPages {
       padding: 0 1ch;
       height: var(--sl-input-height-small);
+      min-width: 1ch;
       visibility: hidden;
     }
 
@@ -164,7 +165,7 @@ export class Pagination extends LitElement {
   private renderInput() {
     return html`
       <div class="pageInput">
-        <div class="inputValue" role="none">${this.inputValue}</div>
+        <div class="totalPages" role="none">${this.pages}</div>
         <sl-input
           class="input"
           type="number"

--- a/frontend/src/components/pagination.ts
+++ b/frontend/src/components/pagination.ts
@@ -10,11 +10,11 @@ import chevronRight from "../assets/images/chevron-right.svg";
  *
  * Usage example:
  * ```ts
- * <btrix-pagination page='2' totalCount='10'>
+ * <btrix-pagination totalCount="11" @page-change=${this.console.log}>
  * </btrix-pagination>
  * ```
  *
- * @event page-change
+ * @event page-change { page: number; pages: number; }
  */
 @localized()
 export class Pagination extends LitElement {
@@ -35,6 +35,8 @@ export class Pagination extends LitElement {
 
     button {
       all: unset;
+      display: flex;
+      align-items: center;
     }
 
     sl-input::part(input) {
@@ -116,6 +118,8 @@ export class Pagination extends LitElement {
     }
 
     if (changedProperties.get("page") && this.page) {
+      await this.performUpdate;
+      this.inputValue = `${this.page}`;
       this.onPageChange();
     }
   }

--- a/frontend/src/components/pagination.ts
+++ b/frontend/src/components/pagination.ts
@@ -37,6 +37,7 @@ export class Pagination extends LitElement {
       all: unset;
       display: flex;
       align-items: center;
+      cursor: pointer;
     }
 
     sl-input::part(input) {

--- a/frontend/src/components/pagination.ts
+++ b/frontend/src/components/pagination.ts
@@ -41,15 +41,8 @@ export class Pagination extends LitElement {
     }
 
     sl-input::part(input) {
-      -moz-appearance: textfield;
       margin: 0 0.5ch;
       text-align: center;
-    }
-
-    sl-input::part(input)::-webkit-outer-spin-button,
-    sl-input::part(input)::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
     }
 
     .currentPage {
@@ -168,7 +161,6 @@ export class Pagination extends LitElement {
         <div class="totalPages" role="none">${this.pages}</div>
         <sl-input
           class="input"
-          type="number"
           inputmode="numeric"
           size="small"
           value=${this.inputValue}
@@ -184,7 +176,15 @@ export class Pagination extends LitElement {
             }
           }}
           @keyup=${(e: any) => {
-            this.inputValue = e.target.value;
+            const { key } = e;
+
+            if (key === "ArrowUp" || key === "ArrowRight") {
+              this.inputValue = `${Math.min(+this.inputValue + 1, this.pages)}`;
+            } else if (key === "ArrowDown" || key === "ArrowLeft") {
+              this.inputValue = `${Math.max(+this.inputValue - 1, 1)}`;
+            } else {
+              this.inputValue = e.target.value;
+            }
           }}
           @sl-change=${(e: any) => {
             const page = +e.target.value;

--- a/frontend/src/components/queue-exclusion-form.ts
+++ b/frontend/src/components/queue-exclusion-form.ts
@@ -1,0 +1,64 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+
+import type { CrawlConfig } from "../pages/archive/types";
+import LiteElement, { html } from "../utils/LiteElement";
+
+const MIN_LENGTH = 2;
+
+/**
+ * Crawl queue exclusion form
+ */
+@localized()
+export class QueueExclusionForm extends LiteElement {
+  @state()
+  private selectValue = "text";
+
+  @state()
+  private inputValue = "";
+
+  render() {
+    return html`
+      <sl-form class="flex">
+        <div class="pt-3 pr-1 flex-0 w-40">
+          <sl-select
+            name="type"
+            placeholder=${msg("Select Type")}
+            size="small"
+            .value=${this.selectValue}
+            @sl-select=${(e: any) => (this.selectValue = e.target.value)}
+          >
+            <sl-menu-item value="text">${msg("Matches Text")}</sl-menu-item>
+            <sl-menu-item value="regex">${msg("Regex")}</sl-menu-item>
+          </sl-select>
+        </div>
+        <div class="pt-3 pl-1 flex-1 md:flex">
+          <div class="flex-1 mb-2 md:mb-0 md:mr-2">
+            <sl-input
+              name="value"
+              size="small"
+              autocomplete="off"
+              minlength=${MIN_LENGTH}
+              placeholder=${this.selectValue === "text"
+                ? "/skip-this-page"
+                : "example.com/skip.*"}
+              .value=${this.inputValue}
+              @sl-input=${(e: any) => (this.inputValue = e.target.value)}
+            >
+            </sl-input>
+          </div>
+          <div class="flex-0">
+            <sl-button
+              type="primary"
+              size="small"
+              submit
+              ?disabled=${!this.inputValue ||
+              this.inputValue.length < MIN_LENGTH}
+              >${msg("Add Exclusion")}</sl-button
+            >
+          </div>
+        </div>
+      </sl-form>
+    `;
+  }
+}

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -1,6 +1,7 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized } from "@lit/localize";
 
+import type { CrawlConfig } from "../pages/archive/types";
 import LiteElement, { html } from "../utils/LiteElement";
 
 type Exclusion = {
@@ -16,13 +17,24 @@ const MIN_LENGTH = 2;
 @localized()
 export class QueueExclusionTable extends LiteElement {
   @property({ type: Array })
-  exclusions: Exclusion[] = [];
+  exclude?: CrawlConfig["exclude"];
 
   @state()
   private selectValue = "text";
 
   @state()
   private inputValue = "";
+
+  private exclusions: Exclusion[] = [];
+
+  willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("exclude") && this.exclude) {
+      this.exclusions = this.exclude.map((str) => ({
+        type: "regex",
+        value: str,
+      }));
+    }
+  }
 
   render() {
     return html`

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -11,6 +11,14 @@ type Exclusion = {
 
 /**
  * Crawl queue exclusion table
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-queue-exclusion-table
+ *   .exclude=${this.crawlTemplate?.config?.exclude}
+ * >
+ * </btrix-queue-exclusion-table>
+ * ```
  */
 @localized()
 export class QueueExclusionTable extends LiteElement {
@@ -82,9 +90,7 @@ export class QueueExclusionTable extends LiteElement {
 
     return html`
       <tr class="even:bg-neutral-50">
-        <td
-          class="border-t border-x p-2 whitespace-nowrap bg-neutral-0${typeColClass}"
-        >
+        <td class="border-t border-x p-2 whitespace-nowrap${typeColClass}">
           ${typeLabel}
         </td>
         <td class="border-t border-r p-2 font-mono${valueColClass}">

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -3,6 +3,7 @@ import { msg, localized } from "@lit/localize";
 
 import type { CrawlConfig } from "../pages/archive/types";
 import LiteElement, { html } from "../utils/LiteElement";
+import { regexEscape } from "../utils/string";
 
 type Exclusion = {
   type: "text" | "regex";
@@ -22,14 +23,6 @@ type Exclusion = {
  */
 @localized()
 export class QueueExclusionTable extends LiteElement {
-  /**
-   * Escape string to use as regex
-   * From https://github.com/tc39/proposal-regex-escaping/blob/main/polyfill.js#L3
-   */
-  static escape(s: any) {
-    return String(s).replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
-  }
-
   @property({ type: Array })
   exclude?: CrawlConfig["exclude"];
 
@@ -38,7 +31,7 @@ export class QueueExclusionTable extends LiteElement {
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("exclude") && this.exclude) {
       this.exclusions = this.exclude.map((str: any) => ({
-        type: QueueExclusionTable.escape(str) === str ? "text" : "regex",
+        type: regexEscape(str) === str ? "text" : "regex",
         value: str,
       }));
     }

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -9,28 +9,28 @@ type Exclusion = {
   value: string;
 };
 
-const MIN_LENGTH = 2;
-
 /**
  * Crawl queue exclusion table
  */
 @localized()
 export class QueueExclusionTable extends LiteElement {
+  /**
+   * Escape string to use as regex
+   * From https://github.com/tc39/proposal-regex-escaping/blob/main/polyfill.js#L3
+   */
+  static escape(s: any) {
+    return String(s).replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
+  }
+
   @property({ type: Array })
   exclude?: CrawlConfig["exclude"];
-
-  @state()
-  private selectValue = "text";
-
-  @state()
-  private inputValue = "";
 
   private exclusions: Exclusion[] = [];
 
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("exclude") && this.exclude) {
-      this.exclusions = this.exclude.map((str) => ({
-        type: "regex",
+      this.exclusions = this.exclude.map((str: any) => ({
+        type: QueueExclusionTable.escape(str) === str ? "text" : "regex",
         value: str,
       }));
     }
@@ -51,48 +51,6 @@ export class QueueExclusionTable extends LiteElement {
         <tbody class="text-neutral-500">
           ${this.exclusions.map(this.renderItem)}
         </tbody>
-        <tfoot>
-          <tr>
-            <td class="pt-3 pr-1 align-top">
-              <sl-select
-                name="type"
-                placeholder=${msg("Select Type")}
-                size="small"
-                .value=${this.selectValue}
-                @sl-select=${(e: any) => (this.selectValue = e.target.value)}
-              >
-                <sl-menu-item value="text">${msg("Matches Text")}</sl-menu-item>
-                <sl-menu-item value="regex">${msg("Regex")}</sl-menu-item>
-              </sl-select>
-            </td>
-            <td class="pt-3 pl-1 align-top md:flex">
-              <div class="flex-1 mb-2 md:mb-0 md:mr-2">
-                <sl-input
-                  name="value"
-                  size="small"
-                  autocomplete="off"
-                  minlength=${MIN_LENGTH}
-                  placeholder=${this.selectValue === "text"
-                    ? "/skip-this-page"
-                    : "example.com/skip.*"}
-                  .value=${this.inputValue}
-                  @sl-input=${(e: any) => (this.inputValue = e.target.value)}
-                >
-                </sl-input>
-              </div>
-              <div class="flex-0">
-                <sl-button
-                  type="primary"
-                  size="small"
-                  submit
-                  ?disabled=${!this.inputValue ||
-                  this.inputValue.length < MIN_LENGTH}
-                  >${msg("Add Exclusion")}</sl-button
-                >
-              </div>
-            </td>
-          </tr>
-        </tfoot>
       </table>
     `;
   }

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -30,10 +30,13 @@ export class QueueExclusionTable extends LiteElement {
 
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("exclude") && this.exclude) {
-      this.exclusions = this.exclude.map((str: any) => ({
-        type: regexEscape(str) === str ? "text" : "regex",
-        value: str,
-      }));
+      this.exclusions = this.exclude.map((str: any) => {
+        const unescaped = str.replace(/\\/g, "");
+        return {
+          type: regexEscape(unescaped) === str ? "text" : "regex",
+          value: unescaped,
+        };
+      });
     }
   }
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -523,11 +523,13 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderQueue() {
-    return html`<h3 class="text-lg font-medium leading-none mb-4">
+    return html`<h3 class="text-lg font-medium leading-none">
         ${msg("Crawl Queue")}
       </h3>
 
-      ${this.isActive
+      ${!this.crawl
+        ? ""
+        : this.isActive
         ? html`
             <btrix-crawl-queue
               archiveId=${this.crawl!.aid}

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -535,22 +535,25 @@ export class CrawlDetail extends LiteElement {
         ${msg("Queue Exclusions")}
       </h3>
 
-      <btrix-queue-exclusion-table
-        .exclude=${this.crawlTemplate?.config?.exclude}
-      >
-      </btrix-queue-exclusion-table>
+      <btrix-details open disabled>
+        <h4 slot="title">${msg("Exclusion Table")}</h4>
+        <btrix-queue-exclusion-table
+          .exclude=${this.crawlTemplate?.config?.exclude}
+        >
+        </btrix-queue-exclusion-table>
+      </btrix-details>
 
-      ${!this.crawl
-        ? ""
-        : this.isActive
+      ${this.crawl && this.isActive
         ? html`
-            <btrix-crawl-queue
-              archiveId=${this.crawl!.aid}
-              crawlId=${this.crawl!.id}
-              .authState=${this.authState}
-            ></btrix-crawl-queue>
+            <div class="mt-5">
+              <btrix-crawl-queue
+                archiveId=${this.crawl!.aid}
+                crawlId=${this.crawl!.id}
+                .authState=${this.authState}
+              ></btrix-crawl-queue>
+            </div>
           `
-        : this.renderInactiveCrawlMessage()} `;
+        : ""} `;
   }
 
   private renderReplay() {

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -535,6 +535,11 @@ export class CrawlDetail extends LiteElement {
         ${msg("Queue Exclusions")}
       </h3>
 
+      <btrix-queue-exclusion-table
+        .exclude=${this.crawlTemplate?.config?.exclude}
+      >
+      </btrix-queue-exclusion-table>
+
       ${!this.crawl
         ? ""
         : this.isActive

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -523,7 +523,7 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderQueue() {
-    return html`<h3 class="text-lg font-medium leading-none">
+    return html`<h3 class="text-lg font-medium leading-none mb-4">
         ${msg("Crawl Queue")}
       </h3>
 

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -9,7 +9,13 @@ import LiteElement, { html } from "../../utils/LiteElement";
 import { CopyButton } from "../../components/copy-button";
 import type { Crawl, CrawlTemplate } from "./types";
 
-type SectionName = "overview" | "watch" | "replay" | "files" | "logs" | "queue";
+type SectionName =
+  | "overview"
+  | "watch"
+  | "replay"
+  | "files"
+  | "logs"
+  | "exclusions";
 
 const POLL_INTERVAL_SECONDS = 10;
 
@@ -111,7 +117,9 @@ export class CrawlDetail extends LiteElement {
     // Set initial active section based on URL #hash value
     const hash = window.location.hash.slice(1);
     if (
-      ["overview", "watch", "replay", "files", "logs", "queue"].includes(hash)
+      ["overview", "watch", "replay", "files", "logs", "exclusions"].includes(
+        hash
+      )
     ) {
       this.sectionName = hash as SectionName;
     }
@@ -146,7 +154,7 @@ export class CrawlDetail extends LiteElement {
       case "logs":
         sectionContent = this.renderLogs();
         break;
-      case "queue":
+      case "exclusions":
         sectionContent = this.renderQueue();
         break;
       default:
@@ -229,7 +237,7 @@ export class CrawlDetail extends LiteElement {
       <nav class="border-b md:border-b-0">
         <ul class="flex flex-row md:flex-col" role="menu">
           ${renderNavItem({ section: "overview", label: msg("Overview") })}
-          ${renderNavItem({ section: "queue", label: msg("Queue") })}
+          ${renderNavItem({ section: "exclusions", label: msg("Exclusions") })}
           ${this.isActive
             ? renderNavItem({
                 section: "watch",
@@ -524,7 +532,7 @@ export class CrawlDetail extends LiteElement {
 
   private renderQueue() {
     return html`<h3 class="text-lg font-medium leading-none mb-4">
-        ${msg("Crawl Queue")}
+        ${msg("Queue Exclusions")}
       </h3>
 
       ${!this.crawl

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -89,7 +89,6 @@ export class CrawlsList extends LiteElement {
     shouldSort: false,
   });
 
-  // For long polling:
   private timerId?: number;
 
   // TODO localize

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -35,6 +35,7 @@ type SeedConfig = {
 
 export type CrawlConfig = {
   seeds: (string | ({ url: string } & SeedConfig))[];
+  exclude?: string[];
 } & SeedConfig;
 
 export type CrawlTemplate = {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -91,6 +91,7 @@ const theme = css`
   /* Decrease control spacing on small select */
   sl-select[size="small"]::part(control) {
     --sl-input-spacing-small: var(--sl-spacing-x-small);
+    line-height: 1.5;
   }
 `;
 

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape string to use as regex
+ * From https://github.com/tc39/proposal-regex-escaping/blob/main/polyfill.js#L3
+ */
+export function regexEscape(s: any) {
+  return String(s).replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
+}


### PR DESCRIPTION
Add new crawl queue section to crawl detail view with exclusions table and queue list that updates every ~5 seconds.

Resolves https://github.com/webrecorder/browsertrix-cloud/issues/318.

### Manual testing
1. Update API base URL in `.env.local`: `API_BASE_URL=https://stanford.browsertrix.cloud`
2. Run app with `yarn start`
3. Create crawl template with exclusions using the Advanced config editor. Example:
```
exclude:
  - likes$
  - media$
  - with_replies$
  - followers$
  - following$
  - photos$
  - twitter.com/settings.*
  - skip-this-string
  - twitter\.com/match/this/text/
  ```
4. Start crawl and go to crawl detail page. Click "Exclusions" on side navigation. Verify exclusions & crawl queue is displayed as expected
5. Interact with pagination controls. Verify pages update as expected
6. Click on a URL. Verify page opens in new tab
7. Wait for crawl to finish or cancel/stop crawl. Verify "Crawl is not running." message is shown

### Screenshots
**New tab in crawl detail view:**
<img width="1015" alt="Screen Shot 2022-10-10 at 2 30 15 PM" src="https://user-images.githubusercontent.com/4672952/194955302-470bd5fc-df58-43ca-8df8-b799eb38eb47.png">

**Page in queue list:**
<img width="801" alt="Screen Shot 2022-10-10 at 2 30 23 PM" src="https://user-images.githubusercontent.com/4672952/194955326-378051f8-077c-49bf-844f-e4df19fe61a3.png">

**Tab when crawl is not running:**
<img width="1021" alt="Screen Shot 2022-10-10 at 2 35 14 PM" src="https://user-images.githubusercontent.com/4672952/194955987-0c89ddb0-5fbf-4d57-81b8-35fff4b1f1d7.png">


### TODO Follow-ups
- Tab name and headings will change when the exclusion editor is built
- Paginate exclusion table
- Typography & spacing pass to match mockups