### PR TITLE
Fixed issue with missing variables affecting deployments on Podman

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -95,10 +95,12 @@ class BaseCrawlManager(ABC):
         # Create Config Map
         await self._create_config_map(
             crawlconfig,
-            USER_ID=str(crawlconfig.userid),
             STORE_PATH=storage_path,
             STORE_FILENAME=out_filename,
             STORAGE_NAME=storage_name,
+            USER_ID=str(crawlconfig.userid),
+            ARCHIVE_ID=str(crawlconfig.aid),
+            CRAWL_CONFIG_ID=str(crawlconfig.id),
             PROFILE_FILENAME=profile_filename,
         )
 


### PR DESCRIPTION
Added missing variables that were removed in [this commit](https://github.com/webrecorder/browsertrix-cloud/commit/3859be009aa0ca82c1868363552f9c6936063175). Without these variables, Podman deployments no longer work.

Note: fix only tested on Podman.