### PR TITLE
Remove exclusion from running crawl

### DIFF
--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -77,7 +77,7 @@ export class CrawlQueue extends LiteElement {
 
   render() {
     return html`
-      <btrix-details open disabled>
+      <btrix-details open>
         <span slot="title"> ${msg("Crawl Queue")} ${this.renderBadge()} </span>
         <div slot="summary-description">
           ${this.queue?.total && this.queue.total > this.pageSize
@@ -139,8 +139,12 @@ export class CrawlQueue extends LiteElement {
       <footer class="text-center">
         <span class="text-xs text-neutral-400" aria-live="polite">
           ${msg(
-            str`${((this.page - 1) * this.pageSize + 1).toLocaleString()}⁠–⁠${(
-              this.page * this.pageSize
+            str`${(
+              (this.page - 1) * this.pageSize +
+              1
+            ).toLocaleString()}⁠–⁠${Math.min(
+              this.page * this.pageSize,
+              this.queue.total
             ).toLocaleString()} of ${this.queue.total.toLocaleString()} URLs`
           )}
         </span>

--- a/frontend/src/components/details.ts
+++ b/frontend/src/components/details.ts
@@ -30,9 +30,8 @@ export class Details extends LitElement {
     }
 
     summary {
-      border-bottom: 1px solid var(--sl-panel-border-color);
       color: var(--sl-color-neutral-500);
-      margin-bottom: var(--sl-spacing-x-small);
+      margin-bottom: var(--sl-spacing-2x-small);
       line-height: 1;
       display: flex;
       align-items: center;
@@ -40,6 +39,8 @@ export class Details extends LitElement {
     }
 
     details[aria-disabled="false"] summary {
+      border-bottom: 1px solid var(--sl-panel-border-color);
+      margin-bottom: var(--sl-spacing-x-small);
       cursor: pointer;
       user-select: none;
     }

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -89,6 +89,7 @@ export class ExclusionEditor extends LiteElement {
     return html`
       ${this.config
         ? html`<btrix-queue-exclusion-table
+            ?isActiveCrawl=${this.isActiveCrawl}
             .config=${this.config}
             @on-remove=${this.deleteExclusion}
           >

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -88,7 +88,10 @@ export class ExclusionEditor extends LiteElement {
   private renderTable() {
     return html`
       ${this.config
-        ? html`<btrix-queue-exclusion-table .config=${this.config}>
+        ? html`<btrix-queue-exclusion-table
+            .config=${this.config}
+            @on-remove=${this.handleRemoveExclusion}
+          >
           </btrix-queue-exclusion-table>`
         : html`
             <div class="flex items-center justify-center my-9 text-xl">
@@ -134,6 +137,42 @@ export class ExclusionEditor extends LiteElement {
       this.regex = value;
     } else {
       this.regex = "";
+    }
+  }
+
+  private async handleRemoveExclusion(e: CustomEvent) {
+    const { value } = e.detail;
+
+    try {
+      const data = await this.apiFetch(
+        `/archives/${this.archiveId}/crawls/${this.crawlId}/exclusions?regex=${value}`,
+        this.authState!,
+        {
+          method: "DELETE",
+        }
+      );
+
+      if (data.new_cid) {
+        this.notify({
+          message: msg(html`Removed exclusion: <code>${value}</code>`),
+          type: "success",
+          icon: "check2-circle",
+        });
+
+        this.dispatchEvent(
+          new CustomEvent("on-success", {
+            detail: { cid: data.new_cid },
+          })
+        );
+      } else {
+        throw data;
+      }
+    } catch (e: any) {
+      this.notify({
+        message: msg("Sorry, couldn't remove exclusion at this time."),
+        type: "danger",
+        icon: "exclamation-octagon",
+      });
     }
   }
 

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -90,7 +90,7 @@ export class ExclusionEditor extends LiteElement {
       ${this.config
         ? html`<btrix-queue-exclusion-table
             .config=${this.config}
-            @on-remove=${this.handleRemoveExclusion}
+            @on-remove=${this.deleteExclusion}
           >
           </btrix-queue-exclusion-table>`
         : html`
@@ -140,7 +140,7 @@ export class ExclusionEditor extends LiteElement {
     }
   }
 
-  private async handleRemoveExclusion(e: CustomEvent) {
+  private async deleteExclusion(e: CustomEvent) {
     const { value } = e.detail;
 
     try {
@@ -169,7 +169,10 @@ export class ExclusionEditor extends LiteElement {
       }
     } catch (e: any) {
       this.notify({
-        message: msg("Sorry, couldn't remove exclusion at this time."),
+        message:
+          e.message === "crawl_running_cant_deactivate"
+            ? msg("Cannot remove exclusion when crawl is no longer running.")
+            : msg("Sorry, couldn't remove exclusion at this time."),
         type: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/components/icon-button.ts
+++ b/frontend/src/components/icon-button.ts
@@ -20,9 +20,20 @@ export class IconButton extends LitElement {
   @property({ type: String })
   variant: "primary" | "danger" | "neutral" = "neutral";
 
+  @property({ type: Boolean })
+  disabled: boolean = false;
+
+  @property({ type: Boolean })
+  loading: boolean = false;
+
   static styles = css`
+    :host {
+      display: inline-block;
+    }
+
     button {
       all: unset;
+      display: block;
       width: 1.5rem;
       height: 1.5rem;
       padding: 0.25rem;
@@ -35,6 +46,12 @@ export class IconButton extends LitElement {
         transform 0.15s;
     }
 
+    button[disabled] {
+      cursor: not-allowed;
+      background-color: var(--sl-color-neutral-100) !important;
+      color: var(--sl-color-neutral-300) !important;
+    }
+
     sl-icon {
       display: block;
       font-size: 1rem;
@@ -45,19 +62,19 @@ export class IconButton extends LitElement {
       box-shadow: var(--sl-shadow-x-small);
     }
 
-    .primary:hover,
-    .danger:hover {
+    .primary:not([disabled]):hover,
+    .dangery:not([disabled]):hover {
       box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.1);
       transform: translateY(1px);
     }
 
     .primary {
-      background-color: var(--sl-color-primary-50);
-      color: var(--sl-color-primary-600);
+      background-color: var(--sl-color-blue-50);
+      color: var(--sl-color-blue-600);
     }
 
     .primary:hover {
-      background-color: var(--sl-color-primary-100);
+      background-color: var(--sl-color-blue-100);
     }
 
     .danger {
@@ -70,19 +87,23 @@ export class IconButton extends LitElement {
     }
 
     .neutral {
-      background-color: var(--sl-color-neutral-0);
       color: var(--sl-color-neutral-500);
     }
 
     .neutral:hover {
-      background-color: var(--sl-color-neutral-50);
-      color: var(--sl-color-neutral-700);
+      color: var(--sl-color-blue-500);
     }
   `;
 
   render() {
-    return html`<button type=${this.type} class=${this.variant}>
-      <sl-icon name=${this.name}></sl-icon>
+    return html`<button
+      type=${this.type}
+      class=${this.variant}
+      ?disabled=${this.disabled}
+    >
+      ${this.loading
+        ? html`<sl-spinner></sl-spinner>`
+        : html`<sl-icon name=${this.name}></sl-icon>`}
     </button>`;
   }
 }

--- a/frontend/src/components/icon-button.ts
+++ b/frontend/src/components/icon-button.ts
@@ -1,0 +1,88 @@
+import { LitElement, html, css } from "lit";
+import { property } from "lit/decorators.js";
+
+/**
+ * Button with single icon.
+ * Icons names from https://shoelace.style/components/icon
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-icon-button name="plus-lg"></btrix-icon-button>
+ * ```
+ */
+export class IconButton extends LitElement {
+  @property({ type: String })
+  name: string = "square";
+
+  @property({ type: String })
+  type: "submit" | "button" = "button";
+
+  @property({ type: String })
+  variant: "primary" | "danger" | "neutral" = "neutral";
+
+  static styles = css`
+    button {
+      all: unset;
+      width: 1.5rem;
+      height: 1.5rem;
+      padding: 0.25rem;
+      border-radius: var(--sl-border-radius-small);
+      box-sizing: border-box;
+      text-align: center;
+      cursor: pointer;
+      transform: translateY(0px);
+      transition: background-color 0.15s, box-shadow 0.15s, color 0.15s,
+        transform 0.15s;
+    }
+
+    sl-icon {
+      display: block;
+      font-size: 1rem;
+    }
+
+    .primary,
+    .danger {
+      box-shadow: var(--sl-shadow-x-small);
+    }
+
+    .primary:hover,
+    .danger:hover {
+      box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.1);
+      transform: translateY(1px);
+    }
+
+    .primary {
+      background-color: var(--sl-color-primary-50);
+      color: var(--sl-color-primary-600);
+    }
+
+    .primary:hover {
+      background-color: var(--sl-color-primary-100);
+    }
+
+    .danger {
+      background-color: var(--sl-color-danger-50);
+      color: var(--sl-color-danger-600);
+    }
+
+    .danger:hover {
+      background-color: var(--sl-color-danger-100);
+    }
+
+    .neutral {
+      background-color: var(--sl-color-neutral-0);
+      color: var(--sl-color-neutral-500);
+    }
+
+    .neutral:hover {
+      background-color: var(--sl-color-neutral-50);
+      color: var(--sl-color-neutral-700);
+    }
+  `;
+
+  render() {
+    return html`<button type=${this.type} class=${this.variant}>
+      <sl-icon name=${this.name}></sl-icon>
+    </button>`;
+  }
+}

--- a/frontend/src/components/icon-button.ts
+++ b/frontend/src/components/icon-button.ts
@@ -97,13 +97,35 @@ export class IconButton extends LitElement {
 
   render() {
     return html`<button
-      type=${this.type}
+      type="submit"
       class=${this.variant}
       ?disabled=${this.disabled}
+      @click=${this.handleClick}
     >
       ${this.loading
         ? html`<sl-spinner></sl-spinner>`
         : html`<sl-icon name=${this.name}></sl-icon>`}
     </button>`;
+  }
+
+  private handleClick(e: MouseEvent) {
+    if (this.disabled || this.loading) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    if (this.type === "submit") {
+      this.submit();
+    }
+  }
+
+  private submit() {
+    const form = (this.closest("form") ||
+      this.closest("sl-form")) as HTMLFormElement;
+
+    if (form) {
+      form.submit();
+    }
   }
 }

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -69,6 +69,9 @@ import("./crawl-pending-exclusions").then(({ CrawlPendingExclusions }) => {
 import("./badge").then(({ Badge }) => {
   customElements.define("btrix-badge", Badge);
 });
+import("./icon-button").then(({ IconButton }) => {
+  customElements.define("btrix-icon-button", IconButton);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/pagination.ts
+++ b/frontend/src/components/pagination.ts
@@ -87,6 +87,9 @@ export class Pagination extends LitElement {
   `;
 
   @property({ type: Number })
+  page: number = 1;
+
+  @property({ type: Number })
   totalCount: number = 0;
 
   @property({ type: Number })
@@ -94,9 +97,6 @@ export class Pagination extends LitElement {
 
   @state()
   private inputValue = "";
-
-  @state()
-  private page: number = 1;
 
   @state()
   private pages = 0;

--- a/frontend/src/components/queue-exclusion-form.ts
+++ b/frontend/src/components/queue-exclusion-form.ts
@@ -73,8 +73,8 @@ export class QueueExclusionForm extends LiteElement {
               <sl-menu-item value="regex">${msg("Regex")}</sl-menu-item>
             </sl-select>
           </div>
-          <div class="pl-1 flex-1 md:flex">
-            <div class="flex-1 mb-2 md:mb-0 md:mr-2">
+          <div class="pl-1 flex-1 flex">
+            <div class="flex-1 mr-1 mb-2 md:mb-0">
               <sl-input
                 class=${this.fieldErrorMessage ? "invalid" : ""}
                 name="excludeValue"
@@ -122,15 +122,15 @@ export class QueueExclusionForm extends LiteElement {
                   : ""}
               </sl-input>
             </div>
-            <div class="flex-0">
-              <sl-button
-                type="primary"
-                size="small"
-                submit
+            <div class="flex-0 w-9 pt-1 text-center">
+              <btrix-icon-button
+                type="submit"
+                variant="primary"
+                name="plus-lg"
                 ?disabled=${this.isRegexInvalid || this.isSubmitting}
                 ?loading=${this.isSubmitting}
-                >${msg("Add Exclusion")}</sl-button
               >
+              </btrix-icon-button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/queue-exclusion-form.ts
+++ b/frontend/src/components/queue-exclusion-form.ts
@@ -59,7 +59,7 @@ export class QueueExclusionForm extends LiteElement {
     return html`
       <sl-form @sl-submit=${this.onSubmit}>
         <div class="flex">
-          <div class="pr-1 flex-0 w-40">
+          <div class="px-1 flex-0 w-40">
             <sl-select
               name="excludeType"
               placeholder=${msg("Select Type")}
@@ -122,7 +122,7 @@ export class QueueExclusionForm extends LiteElement {
                   : ""}
               </sl-input>
             </div>
-            <div class="flex-0 w-9 pt-1 text-center">
+            <div class="flex-0 w-10 pt-1 text-center">
               <btrix-icon-button
                 type="submit"
                 variant="primary"

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -60,6 +60,9 @@ export class QueueExclusionTable extends LiteElement {
   }
 
   render() {
+    const [typeColClass, valueColClass, actionColClass] =
+      this.getColumnClassNames(0, this.results.length);
+
     return html`<btrix-details open disabled>
       <h4 slot="title">${msg("Exclusion Table")}</h4>
       <div slot="summary-description">
@@ -81,20 +84,17 @@ export class QueueExclusionTable extends LiteElement {
         <thead class="text-xs font-mono text-neutral-600 uppercase">
           <tr class="h-8 text-left">
             <th
-              class="font-normal px-2 w-40 bg-slate-50 rounded-tl border-t border-x${this
-                .results.length === 0
-                ? " border-b rounded-bl"
-                : ""}"
+              class="font-normal px-2 w-40 bg-slate-50 rounded-tl ${typeColClass}"
             >
               ${msg("Exclusion Type")}
             </th>
-            <th
-              class="font-normal px-2 bg-slate-50 rounded-tr border-t border-r${this
-                .results.length === 0
-                ? " border-b rounded-br"
-                : ""}"
-            >
+            <th class="font-normal px-2 bg-slate-50 ${valueColClass}">
               ${msg("Exclusion Value")}
+            </th>
+            <th
+              class="font-normal px-2 w-0 bg-slate-50 rounded-tr ${actionColClass}"
+            >
+              <span class="sr-only">Row actions</span>
             </th>
           </tr>
         </thead>
@@ -110,13 +110,8 @@ export class QueueExclusionTable extends LiteElement {
     index: number,
     arr: Exclusion[]
   ) => {
-    let typeColClass = "";
-    let valueColClass = "";
-
-    if (index === arr.length - 1) {
-      typeColClass = " border-b rounded-bl";
-      valueColClass = " border-b rounded-br";
-    }
+    const [typeColClass, valueColClass, actionColClass] =
+      this.getColumnClassNames(index, arr.length - 1);
 
     let typeLabel: string = exclusion.type;
     let value: any = exclusion.value;
@@ -137,13 +132,26 @@ export class QueueExclusionTable extends LiteElement {
 
     return html`
       <tr class="h-8">
-        <td class="border-t border-x p-2 whitespace-nowrap${typeColClass}">
-          ${typeLabel}
-        </td>
-        <td class="border-t border-r p-2 font-mono${valueColClass}">
-          ${value}
+        <td class="p-2 whitespace-nowrap ${typeColClass}">${typeLabel}</td>
+        <td class="p-2 font-mono ${valueColClass}">${value}</td>
+        <td class="text-lg ${actionColClass}">
+          <sl-icon-button name="trash3"></sl-icon-button>
         </td>
       </tr>
     `;
   };
+
+  getColumnClassNames(index: number, count: number) {
+    let typeColClass = "border-t border-x";
+    let valueColClass = "border-t border-r";
+    let actionColClass = "border-t border-r";
+
+    if (index === count) {
+      typeColClass += " border-b rounded-bl";
+      valueColClass += " border-b";
+      actionColClass += " border-b rounded-br";
+    }
+
+    return [typeColClass, valueColClass, actionColClass];
+  }
 }

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -18,6 +18,8 @@ import type { Exclusion } from "./queue-exclusion-form";
  * >
  * </btrix-queue-exclusion-table>
  * ```
+ *
+ * @event on-remove { value: string; }
  */
 @localized()
 export class QueueExclusionTable extends LiteElement {
@@ -137,18 +139,16 @@ export class QueueExclusionTable extends LiteElement {
         </td>
         <td class="p-2 font-mono ${valueColClass}">${value}</td>
         <td class="text-[1rem] text-center ${actionColClass}">
-          <sl-tooltip content=${msg("Remove exclusion")}>
-            <btrix-icon-button
-              name="trash"
-              @click=${console.log}
-            ></btrix-icon-button>
-          </sl-tooltip>
+          <btrix-icon-button
+            name="trash"
+            @click=${() => this.removeExclusion(exclusion)}
+          ></btrix-icon-button>
         </td>
       </tr>
     `;
   };
 
-  getColumnClassNames(index: number, count: number) {
+  private getColumnClassNames(index: number, count: number) {
     let typeColClass = "border-t border-x";
     let valueColClass = "border-t border-r";
     let actionColClass = "border-t border-r";
@@ -160,5 +160,13 @@ export class QueueExclusionTable extends LiteElement {
     }
 
     return [typeColClass, valueColClass, actionColClass];
+  }
+
+  private removeExclusion(exclusion: Exclusion) {
+    this.dispatchEvent(
+      new CustomEvent("on-remove", {
+        detail: exclusion,
+      })
+    );
   }
 }

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -78,10 +78,24 @@ export class QueueExclusionTable extends LiteElement {
         class="w-full leading-none border-separate"
         style="border-spacing: 0;"
       >
-        <thead class="text-xs text-neutral-700">
-          <tr class="text-left">
-            <th class="font-normal px-2 pb-1 w-40">${msg("Exclusion Type")}</th>
-            <th class="font-normal px-2 pb-1">${msg("Exclusion Value")}</th>
+        <thead class="text-xs font-mono text-neutral-600 uppercase">
+          <tr class="h-8 text-left">
+            <th
+              class="font-normal px-2 w-40 bg-slate-50 rounded-tl border-t border-x${this
+                .results.length === 0
+                ? " border-b rounded-bl"
+                : ""}"
+            >
+              ${msg("Exclusion Type")}
+            </th>
+            <th
+              class="font-normal px-2 bg-slate-50 rounded-tr border-t border-r${this
+                .results.length === 0
+                ? " border-b rounded-br"
+                : ""}"
+            >
+              ${msg("Exclusion Value")}
+            </th>
           </tr>
         </thead>
         <tbody class="text-neutral-600">
@@ -99,10 +113,6 @@ export class QueueExclusionTable extends LiteElement {
     let typeColClass = "";
     let valueColClass = "";
 
-    if (index === 0) {
-      typeColClass = " rounded-tl";
-      valueColClass = " rounded-tr";
-    }
     if (index === arr.length - 1) {
       typeColClass = " border-b rounded-bl";
       valueColClass = " border-b rounded-br";
@@ -126,7 +136,7 @@ export class QueueExclusionTable extends LiteElement {
     }
 
     return html`
-      <tr class="even:bg-neutral-50 h-8">
+      <tr class="h-8">
         <td class="border-t border-x p-2 whitespace-nowrap${typeColClass}">
           ${typeLabel}
         </td>

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -134,8 +134,8 @@ export class QueueExclusionTable extends LiteElement {
       <tr class="h-8">
         <td class="p-2 whitespace-nowrap ${typeColClass}">${typeLabel}</td>
         <td class="p-2 font-mono ${valueColClass}">${value}</td>
-        <td class="text-lg ${actionColClass}">
-          <sl-icon-button name="trash3"></sl-icon-button>
+        <td class="text-[1rem] ${actionColClass}">
+          <sl-icon-button name="trash"></sl-icon-button>
         </td>
       </tr>
     `;

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -82,7 +82,7 @@ export class QueueExclusionTable extends LiteElement {
         style="border-spacing: 0;"
       >
         <thead class="text-xs font-mono text-neutral-600 uppercase">
-          <tr class="h-8 text-left">
+          <tr class="h-10 text-left">
             <th
               class="font-normal px-2 w-40 bg-slate-50 rounded-tl ${typeColClass}"
             >
@@ -92,7 +92,7 @@ export class QueueExclusionTable extends LiteElement {
               ${msg("Exclusion Value")}
             </th>
             <th
-              class="font-normal px-2 w-9 bg-slate-50 rounded-tr ${actionColClass}"
+              class="font-normal px-2 w-10 bg-slate-50 rounded-tr ${actionColClass}"
             >
               <span class="sr-only">Row actions</span>
             </th>
@@ -131,11 +131,18 @@ export class QueueExclusionTable extends LiteElement {
     }
 
     return html`
-      <tr class="h-8">
-        <td class="p-2 whitespace-nowrap ${typeColClass}">${typeLabel}</td>
+      <tr class="h-10">
+        <td class="py-2 px-3 whitespace-nowrap ${typeColClass}">
+          ${typeLabel}
+        </td>
         <td class="p-2 font-mono ${valueColClass}">${value}</td>
         <td class="text-[1rem] text-center ${actionColClass}">
-          <btrix-icon-button name="trash"></btrix-icon-button>
+          <sl-tooltip content=${msg("Remove exclusion")}>
+            <btrix-icon-button
+              name="trash"
+              @click=${console.log}
+            ></btrix-icon-button>
+          </sl-tooltip>
         </td>
       </tr>
     `;

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -92,7 +92,7 @@ export class QueueExclusionTable extends LiteElement {
               ${msg("Exclusion Value")}
             </th>
             <th
-              class="font-normal px-2 w-0 bg-slate-50 rounded-tr ${actionColClass}"
+              class="font-normal px-2 w-9 bg-slate-50 rounded-tr ${actionColClass}"
             >
               <span class="sr-only">Row actions</span>
             </th>
@@ -134,8 +134,8 @@ export class QueueExclusionTable extends LiteElement {
       <tr class="h-8">
         <td class="p-2 whitespace-nowrap ${typeColClass}">${typeLabel}</td>
         <td class="p-2 font-mono ${valueColClass}">${value}</td>
-        <td class="text-[1rem] ${actionColClass}">
-          <sl-icon-button name="trash"></sl-icon-button>
+        <td class="text-[1rem] text-center ${actionColClass}">
+          <btrix-icon-button name="trash"></btrix-icon-button>
         </td>
       </tr>
     `;

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -26,6 +26,9 @@ export class QueueExclusionTable extends LiteElement {
   @property({ type: Array })
   config?: CrawlConfig;
 
+  @property({ type: Boolean })
+  isActiveCrawl = false;
+
   @state()
   private results: Exclusion[] = [];
 
@@ -102,17 +105,13 @@ export class QueueExclusionTable extends LiteElement {
       >
         <thead class="text-xs font-mono text-neutral-600 uppercase">
           <tr class="h-10 text-left">
-            <th
-              class="font-normal px-2 w-40 bg-slate-50 rounded-tl ${typeColClass}"
-            >
+            <th class="font-normal px-2 w-40 bg-slate-50 ${typeColClass}">
               ${msg("Exclusion Type")}
             </th>
             <th class="font-normal px-2 bg-slate-50 ${valueColClass}">
               ${msg("Exclusion Value")}
             </th>
-            <th
-              class="font-normal px-2 w-10 bg-slate-50 rounded-tr ${actionColClass}"
-            >
+            <th class="font-normal px-2 w-10 bg-slate-50 ${actionColClass}">
               <span class="sr-only">Row actions</span>
             </th>
           </tr>
@@ -130,7 +129,7 @@ export class QueueExclusionTable extends LiteElement {
     arr: Exclusion[]
   ) => {
     const [typeColClass, valueColClass, actionColClass] =
-      this.getColumnClassNames(index, arr.length - 1);
+      this.getColumnClassNames(index + 1, arr.length);
 
     let typeLabel: string = exclusion.type;
     let value: any = exclusion.value;
@@ -174,10 +173,29 @@ export class QueueExclusionTable extends LiteElement {
     let valueColClass = "border-t border-r";
     let actionColClass = "border-t border-r";
 
+    if (index === 0) {
+      typeColClass += " rounded-tl";
+
+      if (this.isActiveCrawl) {
+        actionColClass += " rounded-tr";
+      } else {
+        valueColClass += " rounded-tr";
+      }
+    }
+
     if (index === count) {
       typeColClass += " border-b rounded-bl";
-      valueColClass += " border-b";
-      actionColClass += " border-b rounded-br";
+
+      if (this.isActiveCrawl) {
+        valueColClass += " border-b";
+        actionColClass += " border-b rounded-br";
+      } else {
+        valueColClass += " border-b rounded-br";
+      }
+    }
+
+    if (!this.isActiveCrawl) {
+      actionColClass += " hidden";
     }
 
     return [typeColClass, valueColClass, actionColClass];


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/351

### Manual testing
1. Run with `yarn start`
2. Start crawl and go to "Crawl Queue & Exclusions" tab
3. Click trash icon in row of exclusion table. Verify exclusion is removed as expected.

### Screenshots
<img width="791" alt="Screen Shot 2022-11-08 at 3 57 01 PM" src="https://user-images.githubusercontent.com/4672952/200684946-05aff8b7-b1b4-4e1f-88e7-328cd691204d.png">

### Follow-ups
@Shrinks99 The trash icon in the mockups is not included in our current shoelace version (introduced in v2.0.0-beta.79). I used the older icon version for now, and will upgrade when completing this task: https://github.com/webrecorder/browsertrix-cloud/issues/79