### PR TITLE
Show exclusion editor when creating & editing crawl templates

### DIFF
--- a/frontend/src/components/details.ts
+++ b/frontend/src/components/details.ts
@@ -30,7 +30,7 @@ export class Details extends LitElement {
     }
 
     summary {
-      color: var(--sl-color-neutral-500);
+      color: var(--sl-input-label-color);
       margin-bottom: var(--sl-spacing-2x-small);
       line-height: 1;
       display: flex;

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -92,7 +92,7 @@ export class ExclusionEditor extends LiteElement {
     return html`
       ${this.config
         ? html`<btrix-queue-exclusion-table
-            ?isActiveCrawl=${this.isActiveCrawl}
+            ?editable=${this.isActiveCrawl}
             .exclusions=${this.config.exclude || []}
             @on-remove=${this.deleteExclusion}
           >

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -1,10 +1,13 @@
 import { property, state } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 
+import type {
+  ExclusionAddEvent,
+  ExclusionChangeEvent,
+} from "./queue-exclusion-form";
 import type { CrawlConfig } from "../pages/archive/types";
 import LiteElement, { html } from "../utils/LiteElement";
 import type { AuthState } from "../utils/AuthService";
-import { regexEscape } from "../utils/string";
 
 type URLs = string[];
 type ResponseData = {
@@ -104,8 +107,8 @@ export class ExclusionEditor extends LiteElement {
             <btrix-queue-exclusion-form
               ?isSubmitting=${this.isSubmitting}
               fieldErrorMessage=${this.exclusionFieldErrorMessage}
-              @on-regex=${this.handleRegex}
-              @submit=${this.onSubmit}
+              @on-change=${this.handleRegexChange}
+              @on-add=${this.handleAddRegex}
             >
             </btrix-queue-exclusion-form>
           </div>`
@@ -131,7 +134,7 @@ export class ExclusionEditor extends LiteElement {
     ></btrix-crawl-queue>`;
   }
 
-  private handleRegex(e: CustomEvent) {
+  private handleRegexChange(e: ExclusionChangeEvent) {
     const { value, valid } = e.detail;
 
     if (valid) {
@@ -211,17 +214,10 @@ export class ExclusionEditor extends LiteElement {
     return data;
   }
 
-  private async onSubmit(e: CustomEvent) {
+  private async handleAddRegex(e: ExclusionAddEvent) {
     this.isSubmitting = true;
 
-    const { formData, onSuccess } = e.detail;
-    const excludeType = formData.get("excludeType");
-    const excludeValue = formData.get("excludeValue");
-    let regex = excludeValue;
-
-    if (excludeType === "text") {
-      regex = regexEscape(excludeValue);
-    }
+    const { regex, onSuccess } = e.detail;
 
     try {
       const data = await this.apiFetch(

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -93,7 +93,7 @@ export class ExclusionEditor extends LiteElement {
       ${this.config
         ? html`<btrix-queue-exclusion-table
             ?isActiveCrawl=${this.isActiveCrawl}
-            .config=${this.config}
+            .exclusions=${this.config.exclude || []}
             @on-remove=${this.deleteExclusion}
           >
           </btrix-queue-exclusion-table>`

--- a/frontend/src/components/queue-exclusion-form.ts
+++ b/frontend/src/components/queue-exclusion-form.ts
@@ -67,6 +67,11 @@ export class QueueExclusionForm extends LiteElement {
     }
   }
 
+  disconnectedCallback(): void {
+    this.onInput.cancel();
+    super.disconnectedCallback();
+  }
+
   render() {
     return html`
       <fieldset>
@@ -197,7 +202,9 @@ export class QueueExclusionForm extends LiteElement {
     );
   }
 
-  private handleAdd() {
+  private async handleAdd() {
+    this.onInput.flush();
+    await this.updateComplete;
     if (!this.inputValue) return;
 
     let regex = this.inputValue;

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -89,7 +89,7 @@ export class QueueExclusionTable extends LiteElement {
       this.getColumnClassNames(0, this.results.length);
 
     return html`<btrix-details open disabled>
-      <h4 slot="title">${msg("Exclusion Table")}</h4>
+      <h4 slot="title">${msg("Exclusions")}</h4>
       <div slot="summary-description">
         ${this.total && this.total > this.pageSize
           ? html`<btrix-pagination

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -27,7 +27,7 @@ export class QueueExclusionTable extends LiteElement {
   exclusions?: CrawlConfig["exclude"];
 
   @property({ type: Boolean })
-  isActiveCrawl = false;
+  editable = false;
 
   @state()
   private results: Exclusion[] = [];
@@ -176,7 +176,7 @@ export class QueueExclusionTable extends LiteElement {
     if (index === 0) {
       typeColClass += " rounded-tl";
 
-      if (this.isActiveCrawl) {
+      if (this.editable) {
         actionColClass += " rounded-tr";
       } else {
         valueColClass += " rounded-tr";
@@ -186,7 +186,7 @@ export class QueueExclusionTable extends LiteElement {
     if (index === count) {
       typeColClass += " border-b rounded-bl";
 
-      if (this.isActiveCrawl) {
+      if (this.editable) {
         valueColClass += " border-b";
         actionColClass += " border-b rounded-br";
       } else {
@@ -194,7 +194,7 @@ export class QueueExclusionTable extends LiteElement {
       }
     }
 
-    if (!this.isActiveCrawl) {
+    if (!this.editable) {
       actionColClass += " hidden";
     }
 

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -14,7 +14,7 @@ import type { Exclusion } from "./queue-exclusion-form";
  * Usage example:
  * ```ts
  * <btrix-queue-exclusion-table
- *   .config=${this.crawlTemplate.config}
+ *   .exclusions=${this.crawlTemplate.config.exclude}
  * >
  * </btrix-queue-exclusion-table>
  * ```
@@ -24,7 +24,7 @@ import type { Exclusion } from "./queue-exclusion-form";
 @localized()
 export class QueueExclusionTable extends LiteElement {
   @property({ type: Array })
-  config?: CrawlConfig;
+  exclusions?: CrawlConfig["exclude"];
 
   @property({ type: Boolean })
   isActiveCrawl = false;
@@ -42,16 +42,16 @@ export class QueueExclusionTable extends LiteElement {
   private exclusionToRemove?: string;
 
   private get total() {
-    return this.config?.exclude?.length;
+    return this.exclusions?.length;
   }
 
   willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("config") && this.config?.exclude) {
+    if (changedProperties.has("exclusions") && this.exclusions) {
       this.exclusionToRemove = "";
 
-      const prevConfig = changedProperties.get("config");
-      if (prevConfig) {
-        const prevTotal = prevConfig.exclude?.length;
+      const prevVal = changedProperties.get("exclusions");
+      if (prevVal) {
+        const prevTotal = prevVal.length;
         const lastPage = Math.ceil(this.total! / this.pageSize);
         if (this.total! < prevTotal) {
           this.page = Math.min(this.page, lastPage);
@@ -67,9 +67,9 @@ export class QueueExclusionTable extends LiteElement {
   }
 
   private updatePageResults() {
-    if (!this.config?.exclude) return;
+    if (!this.exclusions) return;
 
-    this.results = this.config.exclude
+    this.results = this.exclusions
       .slice((this.page - 1) * this.pageSize, this.page * this.pageSize)
       .map((str: any) => {
         const unescaped = str.replace(/\\/g, "");

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -8,6 +8,10 @@ import LiteElement, { html } from "../utils/LiteElement";
 import { regexEscape } from "../utils/string";
 import type { Exclusion } from "./queue-exclusion-form";
 
+export type ExclusionRemoveEvent = CustomEvent<{
+  value: string;
+}>;
+
 /**
  * Crawl queue exclusion table
  *
@@ -19,7 +23,7 @@ import type { Exclusion } from "./queue-exclusion-form";
  * </btrix-queue-exclusion-table>
  * ```
  *
- * @event on-remove { value: string; }
+ * @event on-remove ExclusionRemoveEvent
  */
 @localized()
 export class QueueExclusionTable extends LiteElement {
@@ -207,7 +211,7 @@ export class QueueExclusionTable extends LiteElement {
     this.dispatchEvent(
       new CustomEvent("on-remove", {
         detail: exclusion,
-      })
+      }) as ExclusionRemoveEvent
     );
   }
 }

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -538,6 +538,29 @@ export class CrawlTemplatesDetail extends LiteElement {
     const configCodeYaml = jsonToYaml(this.crawlTemplate?.config || {});
 
     return html`
+      <div class="mb-5">
+        <div class="text-sm text-0-600">${msg("Browser Profile")}</div>
+        ${this.crawlTemplate
+          ? html`
+              ${this.crawlTemplate.profileid
+                ? html`<a
+                    class="font-medium text-neutral-700 hover:text-neutral-900"
+                    href=${`/archives/${this.archiveId}/browser-profiles/profile/${this.crawlTemplate.profileid}`}
+                    @click=${this.navLink}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="link-45deg"
+                    ></sl-icon>
+                    <span class="inline-block align-middle"
+                      >${this.crawlTemplate.profileName}</span
+                    >
+                  </a>`
+                : html`<span class="text-0-400">${msg("None")}</span>`}
+            `
+          : ""}
+      </div>
+
       <div class="mb-5" role="table">
         <div
           class="hidden md:grid grid-cols-5 gap-4 items-end text-xs md:text-sm text-0-600"
@@ -606,28 +629,6 @@ export class CrawlTemplatesDetail extends LiteElement {
       </div>
 
       <div class="mb-5">
-        <div class="text-sm text-0-600">${msg("Browser Profile")}</div>
-        ${this.crawlTemplate
-          ? html`
-              ${this.crawlTemplate.profileid
-                ? html`<a
-                    class="font-medium text-neutral-700 hover:text-neutral-900"
-                    href=${`/archives/${this.archiveId}/browser-profiles/profile/${this.crawlTemplate.profileid}`}
-                    @click=${this.navLink}
-                  >
-                    <sl-icon
-                      class="inline-block align-middle"
-                      name="link-45deg"
-                    ></sl-icon>
-                    <span class="inline-block align-middle"
-                      >${this.crawlTemplate.profileName}</span
-                    >
-                  </a>`
-                : html`<span class="text-0-400">${msg("None")}</span>`}
-            `
-          : ""}
-      </div>
-      <div class="mb-5">
         ${this.crawlTemplate?.config.exclude?.length
           ? html`
               <btrix-queue-exclusion-table
@@ -676,6 +677,13 @@ export class CrawlTemplatesDetail extends LiteElement {
               `
             : ""}
 
+          <div>
+            <btrix-select-browser-profile
+              archiveId=${this.archiveId}
+              .profileId=${this.crawlTemplate.profileid || null}
+              .authState=${this.authState}
+            ></btrix-select-browser-profile>
+          </div>
           <div class="flex flex-wrap justify-between">
             <h4 class="font-medium">
               ${this.isConfigCodeView
@@ -697,16 +705,9 @@ export class CrawlTemplatesDetail extends LiteElement {
           <div class="grid gap-5${this.isConfigCodeView ? " hidden" : ""}">
             ${this.renderSeedsForm()}
           </div>
-
-          <div>
-            <btrix-select-browser-profile
-              archiveId=${this.archiveId}
-              .profileId=${this.crawlTemplate.profileid || null}
-              .authState=${this.authState}
-            ></btrix-select-browser-profile>
+          <div class="${this.isConfigCodeView ? " hidden" : ""}">
+            ${this.renderExclusionEditor()}
           </div>
-
-          <div>${this.renderExclusionEditor()}</div>
 
           <div class="text-right">
             <sl-button

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -607,6 +607,17 @@ export class CrawlTemplatesDetail extends LiteElement {
             `
           : ""}
       </div>
+      <div class="mb-5">
+        ${this.crawlTemplate?.config.exclude?.length
+          ? html`
+              <btrix-queue-exclusion-table
+                .exclusions=${this.crawlTemplate.config.exclude}
+              >
+              </btrix-queue-exclusion-table>
+            `
+          : html` <div class="text-sm text-0-600">${msg("Exclusions")}</div>
+              ${msg("None")}`}
+      </div>
 
       <sl-details style="--sl-spacing-medium: var(--sl-spacing-small)">
         <span slot="summary" class="text-sm">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -131,6 +131,21 @@ export class CrawlTemplatesNew extends LiteElement {
     super.connectedCallback();
   }
 
+  willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.get("isConfigCodeView") !== undefined) {
+      if (this.isConfigCodeView) {
+        this.configCode = jsonToYaml(
+          merge(this.initialCrawlTemplate.config, {
+            exclude: this.exclusions,
+          })
+        );
+      } else if (this.isConfigCodeView === false) {
+        this.exclusions =
+          (yamlToJson(this.configCode) as CrawlConfig).exclude || [];
+      }
+    }
+  }
+
   render() {
     return html`
       <nav class="mb-5">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -33,6 +33,7 @@ const initialValues = {
   config: {
     seeds: [],
     scopeType: "prefix",
+    exclude: [],
   },
 };
 const hours = Array.from({ length: 12 }).map((x, i) => ({
@@ -380,6 +381,7 @@ export class CrawlTemplatesNew extends LiteElement {
           class="col-span-1 grid gap-5${this.isConfigCodeView ? " hidden" : ""}"
         >
           ${this.renderSeedsForm()}
+          <div>${this.renderExclusionEditor()}</div>
         </div>
       </section>
     `;
@@ -427,6 +429,26 @@ export class CrawlTemplatesNew extends LiteElement {
       >
         <span slot="suffix">${msg("pages")}</span>
       </sl-input>
+    `;
+  }
+
+  private renderExclusionEditor() {
+    if (!this.initialCrawlTemplate?.config) {
+      return;
+    }
+
+    return html`
+      <btrix-queue-exclusion-table
+        .config=${this.initialCrawlTemplate.config}
+        @on-remove=${console.debug}
+      ></btrix-queue-exclusion-table>
+      <div class="mt-2">
+        <btrix-queue-exclusion-form
+          @on-regex=${console.debug}
+          @submit=${console.debug}
+        >
+        </btrix-queue-exclusion-form>
+      </div>
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -3,6 +3,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 
+import type { ExclusionAddEvent } from "../../components/queue-exclusion-form";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { ScheduleInterval, humanizeNextDate } from "../../utils/cron";
@@ -443,10 +444,7 @@ export class CrawlTemplatesNew extends LiteElement {
         @on-remove=${console.debug}
       ></btrix-queue-exclusion-table>
       <div class="mt-2">
-        <btrix-queue-exclusion-form
-          @on-regex=${console.debug}
-          @submit=${console.debug}
-        >
+        <btrix-queue-exclusion-form @on-add=${this.handleAddRegex}>
         </btrix-queue-exclusion-form>
       </div>
     `;
@@ -508,6 +506,11 @@ export class CrawlTemplatesNew extends LiteElement {
     }
 
     return template;
+  }
+
+  private handleAddRegex(e: ExclusionAddEvent) {
+    const { regex } = e.detail;
+    console.log(regex);
   }
 
   private async onSubmit(event: {

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -445,6 +445,7 @@ export class CrawlTemplatesNew extends LiteElement {
     return html`
       <btrix-queue-exclusion-table
         .exclusions=${this.exclusions}
+        editable
         @on-remove=${console.debug}
       ></btrix-queue-exclusion-table>
       <div class="mt-2">

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -2,6 +2,7 @@ import { state, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
+import merge from "lodash/fp/merge";
 
 import type { ExclusionAddEvent } from "../../components/queue-exclusion-form";
 import type { AuthState } from "../../utils/AuthService";
@@ -27,16 +28,15 @@ export type InitialCrawlTemplate = Pick<
   "name" | "config" | "profileid"
 >;
 
-const initialValues = {
+const defaultValue = {
   name: "",
-  runNow: true,
-  scale: "1",
+  profileid: null,
   config: {
     seeds: [],
     scopeType: "prefix",
     exclude: [],
   },
-};
+} as InitialCrawlTemplate;
 const hours = Array.from({ length: 12 }).map((x, i) => ({
   value: i + 1,
   label: `${i + 1}`,
@@ -60,11 +60,19 @@ export class CrawlTemplatesNew extends LiteElement {
   @property({ type: String })
   archiveId!: string;
 
+  // Use custom property accessor to prevent
+  // overriding default crawl template values
   @property({ type: Object })
-  initialCrawlTemplate?: InitialCrawlTemplate;
+  get initialCrawlTemplate() {
+    return this._initialCrawlTemplate;
+  }
+  private _initialCrawlTemplate: InitialCrawlTemplate = defaultValue;
+  set initialCrawlTemplate(val: any) {
+    this._initialCrawlTemplate = merge(this._initialCrawlTemplate, val);
+  }
 
   @state()
-  private isRunNow: boolean = initialValues.runNow;
+  private isRunNow: boolean = true;
 
   @state()
   private scheduleInterval: ScheduleInterval | "" = "";
@@ -104,20 +112,12 @@ export class CrawlTemplatesNew extends LiteElement {
     // Show JSON editor view if complex initial config is specified
     // (e.g. cloning a template) since form UI doesn't support
     // all available fields in the config
-    const isComplexConfig = this.initialCrawlTemplate?.config.seeds.some(
+    const isComplexConfig = this.initialCrawlTemplate.config.seeds.some(
       (seed: any) => typeof seed !== "string"
     );
     if (isComplexConfig) {
       this.isConfigCodeView = true;
     }
-    this.initialCrawlTemplate = {
-      name: this.initialCrawlTemplate?.name || initialValues.name,
-      profileid: this.initialCrawlTemplate?.profileid || null,
-      config: {
-        ...initialValues.config,
-        ...this.initialCrawlTemplate?.config,
-      },
-    };
     this.configCode = jsonToYaml(this.initialCrawlTemplate.config);
     this.browserProfileId = this.initialCrawlTemplate.profileid;
     super.connectedCallback();
@@ -160,7 +160,7 @@ export class CrawlTemplatesNew extends LiteElement {
               <div>
                 <sl-checkbox
                   name="runNow"
-                  ?checked=${initialValues.runNow}
+                  ?checked=${this.isRunNow}
                   @sl-change=${(e: any) => (this.isRunNow = e.target.checked)}
                   >${msg("Run immediately on save")}
                 </sl-checkbox>
@@ -204,14 +204,14 @@ export class CrawlTemplatesNew extends LiteElement {
             desc: "Example crawl template name",
           })}
           autocomplete="off"
-          value=${this.initialCrawlTemplate!.name}
+          value=${this.initialCrawlTemplate.name}
           required
         ></sl-input>
 
         <div>
           <btrix-select-browser-profile
             archiveId=${this.archiveId}
-            .profileId=${this.initialCrawlTemplate?.profileid || null}
+            .profileId=${this.initialCrawlTemplate.profileid}
             .authState=${this.authState}
             @on-change=${(e: any) =>
               (this.browserProfileId = e.detail.value
@@ -341,7 +341,7 @@ export class CrawlTemplatesNew extends LiteElement {
         class="col-span-3 md:col-span-2 pb-6 md:p-8 border-b grid grid-cols-1 gap-5"
       >
         <div class="col-span-1">
-          <sl-select name="scale" value=${initialValues.scale}>
+          <sl-select name="scale" value="1">
             <label slot="label">
               <span class="inline-block align-middle">
                 ${msg("Crawler Instances")}
@@ -400,13 +400,13 @@ export class CrawlTemplatesNew extends LiteElement {
           "Required. Separate URLs with a new line, space or comma."
         )}
         rows="3"
-        value=${this.initialCrawlTemplate!.config.seeds.join("\n")}
+        value=${this.initialCrawlTemplate.config.seeds.join("\n")}
         ?required=${!this.isConfigCodeView}
       ></sl-textarea>
       <sl-select
         name="scopeType"
         label=${msg("Scope Type")}
-        value=${this.initialCrawlTemplate!.config.scopeType!}
+        value=${this.initialCrawlTemplate.config.scopeType!}
       >
         <sl-menu-item value="page">Page</sl-menu-item>
         <sl-menu-item value="page-spa">Page SPA</sl-menu-item>
@@ -418,14 +418,14 @@ export class CrawlTemplatesNew extends LiteElement {
 
       <sl-checkbox
         name="extraHopsOne"
-        ?checked=${this.initialCrawlTemplate!.config.extraHops === 1}
+        ?checked=${this.initialCrawlTemplate.config.extraHops === 1}
         >${msg("Include External Links (“one hop out”)")}
       </sl-checkbox>
       <sl-input
         name="limit"
         label=${msg("Page Limit")}
         type="number"
-        value=${ifDefined(this.initialCrawlTemplate!.config.limit)}
+        value=${ifDefined(this.initialCrawlTemplate.config.limit)}
         placeholder=${msg("unlimited")}
       >
         <span slot="suffix">${msg("pages")}</span>
@@ -434,7 +434,7 @@ export class CrawlTemplatesNew extends LiteElement {
   }
 
   private renderExclusionEditor() {
-    if (!this.initialCrawlTemplate?.config) {
+    if (!this.initialCrawlTemplate.config) {
       return;
     }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -94,6 +94,9 @@ export class CrawlTemplatesNew extends LiteElement {
   private configCode: string = "";
 
   @state()
+  private exclusions: CrawlConfig["exclude"] = defaultValue.config.exclude;
+
+  @state()
   private isSubmitting: boolean = false;
 
   @state()
@@ -119,6 +122,7 @@ export class CrawlTemplatesNew extends LiteElement {
       this.isConfigCodeView = true;
     }
     this.configCode = jsonToYaml(this.initialCrawlTemplate.config);
+    this.exclusions = this.initialCrawlTemplate.config.exclude;
     this.browserProfileId = this.initialCrawlTemplate.profileid;
     super.connectedCallback();
   }
@@ -440,7 +444,7 @@ export class CrawlTemplatesNew extends LiteElement {
 
     return html`
       <btrix-queue-exclusion-table
-        .config=${this.initialCrawlTemplate.config}
+        .exclusions=${this.exclusions}
         @on-remove=${console.debug}
       ></btrix-queue-exclusion-table>
       <div class="mt-2">

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -75,6 +75,7 @@ const theme = css`
     --sl-input-label-font-size-small: var(--sl-font-size-x-small);
     --sl-input-label-font-size-medium: var(--sl-font-size-small);
     --sl-input-label-font-size-large: var(--sl-font-size-medium);
+    --sl-input-label-color: var(--sl-color-neutral-800);
   }
 
   .sl-toast-stack {


### PR DESCRIPTION
Resolves #320

### Manual testing
1. Run app with `yarn start`
2. Go to new crawl template view
3. Enter and remove exclusions from table in "Crawl Settings"
4. Save crawl template. Verify exclusions are saved as expected in crawl detail view
5. Click "Edit" button in "Configuration" section
6. Enter and remove exclusions from table
7. Save crawl template. Verify exclusions are saved as expected in crawl detail view
8. Click "Actions" -> "Duplicate crawl config". Verify exclusions are copied as expected

### Screenshots
**New Crawl Template view:**
<img width="967" alt="Screen Shot 2022-11-14 at 1 58 41 PM" src="https://user-images.githubusercontent.com/4672952/201777754-e59d38fb-838b-48ab-83fc-dc0eb6ce1df7.png">

**Crawl Template detail view:**
<img width="989" alt="Screen Shot 2022-11-14 at 2 28 05 PM" src="https://user-images.githubusercontent.com/4672952/201781694-c001b010-ef27-437b-9280-e64cb11bcf93.png">

**Crawl Template detail edit dialog:**
<img width="568" alt="Screen Shot 2022-11-14 at 2 29 42 PM" src="https://user-images.githubusercontent.com/4672952/201781734-0ec55120-0411-48cc-ba90-3e87beb76e3d.png">

### Opinions
This is an intermediary update before the crawl template creation/edit UI changes (https://github.com/webrecorder/browsertrix-cloud/issues/348) so I opted for putting the table under other config fields. It could be easily moved around within the section if that makes more sense (cc @Shrinks99 )