### PR TITLE
Fix auth not persisting on reload

### DIFF
--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -32,7 +32,8 @@ export interface LoggedInEvent<T = LoggedInEventDetail> extends CustomEvent {
 }
 
 // Check for token freshness every 5 minutes
-const FRESHNESS_TIMER_INTERVAL = 60 * 1000 * 5;
+// const FRESHNESS_TIMER_INTERVAL = 60 * 1000 * 5;
+const FRESHNESS_TIMER_INTERVAL = 10 * 1000;
 // Hardcode 24h expiry for now
 const SESSION_LIFETIME = 1000 * 60 * 60 * 24;
 
@@ -180,6 +181,7 @@ export default class AuthService {
           const auth = await this.refresh();
           this._authState.headers = auth.headers;
           this._authState.tokenExpiresAt = auth.tokenExpiresAt;
+          this.persist(this._authState);
 
           console.debug(
             "refreshed. restart timer tokenExpiresAt:",

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -160,18 +160,18 @@ export default class AuthService {
   private async checkFreshness() {
     window.clearTimeout(this.timerId);
 
-    console.debug("checkFreshness authState:", this._authState);
+    // console.debug("checkFreshness authState:", this._authState);
 
     if (!this._authState) return;
     const paddedNow = Date.now() + FRESHNESS_TIMER_INTERVAL - 500; // tweak padding to account for API fetch time
 
     if (this._authState.sessionExpiresAt > paddedNow) {
       if (this._authState.tokenExpiresAt > paddedNow) {
-        console.debug(
-          "fresh! restart timer tokenExpiresAt:",
-          new Date(this._authState.tokenExpiresAt)
-        );
-        console.debug("fresh! restart timer paddedNow:", new Date(paddedNow));
+        // console.debug(
+        //   "fresh! restart timer tokenExpiresAt:",
+        //   new Date(this._authState.tokenExpiresAt)
+        // );
+        // console.debug("fresh! restart timer paddedNow:", new Date(paddedNow));
         // Restart timer
         this.timerId = window.setTimeout(() => {
           this.checkFreshness();
@@ -183,14 +183,14 @@ export default class AuthService {
           this._authState.tokenExpiresAt = auth.tokenExpiresAt;
           this.persist(this._authState);
 
-          console.debug(
-            "refreshed. restart timer tokenExpiresAt:",
-            new Date(this._authState.tokenExpiresAt)
-          );
-          console.debug(
-            "refreshed. restart timer paddedNow:",
-            new Date(paddedNow)
-          );
+          // console.debug(
+          //   "refreshed. restart timer tokenExpiresAt:",
+          //   new Date(this._authState.tokenExpiresAt)
+          // );
+          // console.debug(
+          //   "refreshed. restart timer paddedNow:",
+          //   new Date(paddedNow)
+          // );
 
           // Restart timer
           this.timerId = window.setTimeout(() => {

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -32,8 +32,7 @@ export interface LoggedInEvent<T = LoggedInEventDetail> extends CustomEvent {
 }
 
 // Check for token freshness every 5 minutes
-// const FRESHNESS_TIMER_INTERVAL = 60 * 1000 * 5;
-const FRESHNESS_TIMER_INTERVAL = 10 * 1000;
+const FRESHNESS_TIMER_INTERVAL = 60 * 1000 * 5;
 // Hardcode 24h expiry for now
 const SESSION_LIFETIME = 1000 * 60 * 60 * 24;
 

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -163,7 +163,7 @@ export default class AuthService {
     console.debug("checkFreshness authState:", this._authState);
 
     if (!this._authState) return;
-    const paddedNow = Date.now() + FRESHNESS_TIMER_INTERVAL;
+    const paddedNow = Date.now() + FRESHNESS_TIMER_INTERVAL - 500; // tweak padding to account for API fetch time
 
     if (this._authState.sessionExpiresAt > paddedNow) {
       if (this._authState.tokenExpiresAt > paddedNow) {


### PR DESCRIPTION
Persist refresh token to local storage to fix stale token being used after browser reload. Fixes #101. Also removed unnecessary `console.debug`s.

### Manual testing
Run app and keep open for 5 minutes (`dev` tokens currently expire at 5 minutes.) Reload browser and interact with app in a way that makes API calls, e.g. going to crawls page. Verify you're not logged out.

### Follow-ups
More general authentication UX improvement tracked here: https://github.com/webrecorder/browsertrix-cloud/issues/361