### PR TITLE
Editable exclusion table cells

### DIFF
--- a/frontend/src/components/details.ts
+++ b/frontend/src/components/details.ts
@@ -95,7 +95,7 @@ export class Details extends LitElement {
         @toggle=${this.onToggle}
         aria-disabled=${this.disabled ? "true" : "false"}
       >
-        <summary>
+        <summary tabindex=${this.disabled ? "-1" : "0"}>
           <div class="summary-content">
             <div class="title">
               <slot name="title"></slot>

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -92,7 +92,7 @@ export class ExclusionEditor extends LiteElement {
     return html`
       ${this.config
         ? html`<btrix-queue-exclusion-table
-            ?editable=${this.isActiveCrawl}
+            ?removable=${this.isActiveCrawl}
             .exclusions=${this.config.exclude || []}
             @on-remove=${this.deleteExclusion}
           >

--- a/frontend/src/components/exclusion-editor.ts
+++ b/frontend/src/components/exclusion-editor.ts
@@ -1,6 +1,7 @@
 import { property, state } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 
+import type { ExclusionRemoveEvent } from "./queue-exclusion-table";
 import type {
   ExclusionAddEvent,
   ExclusionChangeEvent,
@@ -144,12 +145,12 @@ export class ExclusionEditor extends LiteElement {
     }
   }
 
-  private async deleteExclusion(e: CustomEvent) {
-    const { value } = e.detail;
+  private async deleteExclusion(e: ExclusionRemoveEvent) {
+    const { regex } = e.detail;
 
     try {
       const data = await this.apiFetch(
-        `/archives/${this.archiveId}/crawls/${this.crawlId}/exclusions?regex=${value}`,
+        `/archives/${this.archiveId}/crawls/${this.crawlId}/exclusions?regex=${regex}`,
         this.authState!,
         {
           method: "DELETE",
@@ -158,7 +159,7 @@ export class ExclusionEditor extends LiteElement {
 
       if (data.new_cid) {
         this.notify({
-          message: msg(html`Removed exclusion: <code>${value}</code>`),
+          message: msg(html`Removed exclusion: <code>${regex}</code>`),
           variant: "success",
           icon: "check2-circle",
         });

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -97,43 +97,76 @@ export class QueueExclusionTable extends LiteElement {
     const [typeColClass, valueColClass, actionColClass] =
       this.getColumnClassNames(0, this.results.length, true);
 
-    return html`<btrix-details open disabled>
-      <h4 slot="title">${msg("Exclusions")}</h4>
-      <div slot="summary-description">
-        ${this.total && this.total > this.pageSize
-          ? html`<btrix-pagination
-              page=${this.page}
-              size=${this.pageSize}
-              totalCount=${this.total}
-              @page-change=${(e: CustomEvent) => {
-                this.page = e.detail.page;
-              }}
-            >
-            </btrix-pagination>`
-          : ""}
-      </div>
-      <table
-        class="w-full leading-none border-separate"
-        style="border-spacing: 0;"
-      >
-        <thead class="text-xs font-mono text-neutral-600 uppercase">
-          <tr class="h-10 text-left">
-            <th class="font-normal px-2 w-40 bg-slate-50 ${typeColClass}">
-              ${msg("Exclusion Type")}
-            </th>
-            <th class="font-normal px-2 bg-slate-50 ${valueColClass}">
-              ${msg("Exclusion Value")}
-            </th>
-            <th class="font-normal px-2 w-10 bg-slate-50 ${actionColClass}">
-              <span class="sr-only">Row actions</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          ${this.results.map(this.renderItem)}
-        </tbody>
-      </table>
-    </btrix-details> `;
+    return html`
+      <style>
+        ::-moz-placeholder {
+          opacity: 0.5 !important;
+        }
+
+        .inputCell::placeholder {
+          color: var(--sl-input-placeholder-color) !important;
+          font-weight: inherit;
+        }
+
+        .inputCell {
+          outline: 0;
+          transition: var(--sl-transition-fast) color,
+            var(--sl-transition-fast) border,
+            var(--sl-transition-fast) box-shadow,
+            var(--sl-transition-fast) background-color;
+        }
+
+        .inputCell:hover {
+          background-color: var(--sl-input-background-color-hover);
+          border-color: var(--sl-input-border-color-hover);
+        }
+
+        .inputCell:focus {
+          background-color: var(--sl-input-background-color-focus);
+          border-color: var(--sl-input-border-color-focus);
+          box-shadow: 0 0 0 var(--sl-focus-ring-width)
+            var(--sl-input-focus-ring-color);
+        }
+      </style>
+
+      <btrix-details open disabled>
+        <h4 slot="title">${msg("Exclusions")}</h4>
+        <div slot="summary-description">
+          ${this.total && this.total > this.pageSize
+            ? html`<btrix-pagination
+                page=${this.page}
+                size=${this.pageSize}
+                totalCount=${this.total}
+                @page-change=${(e: CustomEvent) => {
+                  this.page = e.detail.page;
+                }}
+              >
+              </btrix-pagination>`
+            : ""}
+        </div>
+        <table
+          class="w-full leading-none border-separate"
+          style="border-spacing: 0;"
+        >
+          <thead class="text-xs font-mono text-neutral-600 uppercase">
+            <tr class="h-10 text-left">
+              <th class="font-normal px-2 w-40 bg-slate-50 ${typeColClass}">
+                ${msg("Exclusion Type")}
+              </th>
+              <th class="font-normal px-2 bg-slate-50 ${valueColClass}">
+                ${msg("Exclusion Value")}
+              </th>
+              <th class="font-normal px-2 w-10 bg-slate-50 ${actionColClass}">
+                <span class="sr-only">Row actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            ${this.results.map(this.renderItem)}
+          </tbody>
+        </table>
+      </btrix-details>
+    `;
   }
 
   private renderItem = (
@@ -217,7 +250,7 @@ export class QueueExclusionTable extends LiteElement {
       return html`
         <input
           placeholder=${msg("Enter value")}
-          class="styledInput block w-full h-9 px-2"
+          class="inputCell block w-full h-9 px-2"
           value=${exclusion.value}
           @change=${(e: InputEvent) => {
             const inputElem = e.target as HTMLInputElement;

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -243,7 +243,6 @@ export class QueueExclusionTable extends LiteElement {
           autocomplete="off"
           autocorrect="off"
           minlength=${MIN_LENGTH}
-          clearable
           @sl-clear=${() => {
             this.updateExclusion({
               type: exclusion.type,

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -33,6 +33,9 @@ export class QueueExclusionTable extends LiteElement {
   @property({ type: Boolean })
   editable = false;
 
+  @property({ type: Boolean })
+  removable = false;
+
   @state()
   private results: Exclusion[] = [];
 
@@ -180,7 +183,7 @@ export class QueueExclusionTable extends LiteElement {
     if (index === 0) {
       typeColClass += " rounded-tl";
 
-      if (this.editable) {
+      if (this.removable) {
         actionColClass += " rounded-tr";
       } else {
         valueColClass += " rounded-tr";
@@ -190,7 +193,7 @@ export class QueueExclusionTable extends LiteElement {
     if (index === count) {
       typeColClass += " border-b rounded-bl";
 
-      if (this.editable) {
+      if (this.removable) {
         valueColClass += " border-b";
         actionColClass += " border-b rounded-br";
       } else {
@@ -198,7 +201,7 @@ export class QueueExclusionTable extends LiteElement {
       }
     }
 
-    if (!this.editable) {
+    if (!this.removable) {
       actionColClass += " hidden";
     }
 

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -14,6 +14,7 @@ export type ExclusionChangeEvent = CustomEvent<{
 }>;
 
 export type ExclusionRemoveEvent = CustomEvent<{
+  index: number;
   regex: string;
 }>;
 
@@ -178,7 +179,7 @@ export class QueueExclusionTable extends LiteElement {
         <td class="text-[1rem] text-center ${actionColClass}">
           <btrix-icon-button
             name="trash3"
-            @click=${() => this.removeExclusion(exclusion)}
+            @click=${() => this.removeExclusion(exclusion, index)}
           ></btrix-icon-button>
         </td>
       </tr>
@@ -381,14 +382,14 @@ export class QueueExclusionTable extends LiteElement {
     }
   }
 
-  private removeExclusion({ value, type }: Exclusion) {
+  private removeExclusion({ value, type }: Exclusion, index: number) {
     this.exclusionToRemove = value;
-    console.log(value);
 
     this.dispatchEvent(
       new CustomEvent("on-remove", {
         detail: {
           regex: formatValue(type, value),
+          index,
         },
       }) as ExclusionRemoveEvent
     );

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -99,36 +99,13 @@ export class QueueExclusionTable extends LiteElement {
 
     return html`
       <style>
-        ::-moz-placeholder {
-          opacity: 0.5 !important;
-        }
-
-        .inputCell::placeholder {
-          color: var(--sl-input-placeholder-color) !important;
-          font-weight: inherit;
-        }
-
-        .inputCell {
-          outline: 0;
-          transition: var(--sl-transition-fast) color,
-            var(--sl-transition-fast) border,
-            var(--sl-transition-fast) box-shadow,
-            var(--sl-transition-fast) background-color;
-        }
-
-        .inputCell:hover {
-          background-color: var(--sl-input-background-color-hover);
-          border-color: var(--sl-input-border-color-hover);
-        }
-
-        .inputCell:focus {
-          background-color: var(--sl-input-background-color-focus);
-          border-color: var(--sl-input-border-color-focus);
-          box-shadow: 0 0 0 var(--sl-focus-ring-width)
-            var(--sl-input-focus-ring-color);
+        btrix-queue-exclusion-table sl-input {
+          --sl-input-border-width: 0;
+          --sl-input-border-radius-medium: 0;
+          --sl-input-font-family: var(--sl-font-mono);
+          --sl-input-spacing-medium: var(--sl-spacing-small);
         }
       </style>
-
       <btrix-details open disabled>
         <h4 slot="title">${msg("Exclusions")}</h4>
         <div slot="summary-description">
@@ -248,10 +225,11 @@ export class QueueExclusionTable extends LiteElement {
 
     if (this.editable) {
       return html`
-        <input
+        <sl-input
           placeholder=${msg("Enter value")}
-          class="inputCell block w-full h-9 px-2"
+          class="m-0"
           value=${exclusion.value}
+          clearable
           @change=${(e: InputEvent) => {
             const inputElem = e.target as HTMLInputElement;
             // Get latest exclusion type value from select
@@ -266,7 +244,7 @@ export class QueueExclusionTable extends LiteElement {
               index,
             });
           }}
-        />
+        ></sl-input>
       `;
     }
 

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -186,11 +186,10 @@ export class QueueExclusionTable extends LiteElement {
           .value=${exclusion.type}
           @sl-hide=${this.stopProp}
           @sl-after-hide=${this.stopProp}
-          @sl-select=${(e: any) => {
-            exclusion.type = e.target.value;
+          @sl-select=${(e: Event) => {
             this.updateExclusion({
-              type: exclusion.type,
-              value: e.target.value,
+              type: (e.target as HTMLSelectElement).value as Exclusion["type"],
+              value: exclusion.value,
               index,
             });
           }}
@@ -219,6 +218,20 @@ export class QueueExclusionTable extends LiteElement {
         <input
           placeholder=${msg("Enter value")}
           class="styledInput block w-full h-9 px-2"
+          @change=${(e: InputEvent) => {
+            const inputElem = e.target as HTMLInputElement;
+            // Get latest exclusion type value from select
+            const typeSelectElem = inputElem
+              .closest("tr")
+              ?.querySelector("sl-select");
+            const exclusionType = typeSelectElem?.value || exclusion.type;
+
+            this.updateExclusion({
+              type: exclusionType as Exclusion["type"],
+              value: inputElem.value,
+              index,
+            });
+          }}
         />
       `;
     }

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -36,6 +36,9 @@ export class QueueExclusionTable extends LiteElement {
   @property({ type: Array })
   exclusions?: CrawlConfig["exclude"];
 
+  @property({ type: Number })
+  pageSize: number = 5;
+
   @property({ type: Boolean })
   editable = false;
 
@@ -47,9 +50,6 @@ export class QueueExclusionTable extends LiteElement {
 
   @state()
   private page: number = 1;
-
-  @state()
-  private pageSize: number = 5;
 
   @state()
   private exclusionToRemove?: string;

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -54,7 +54,7 @@ export class QueueExclusionTable extends LiteElement {
 
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("exclusions") && this.exclusions) {
-      this.exclusionToRemove = "";
+      this.exclusionToRemove = undefined;
 
       const prevVal = changedProperties.get("exclusions");
       if (prevVal) {
@@ -138,33 +138,18 @@ export class QueueExclusionTable extends LiteElement {
     const [typeColClass, valueColClass, actionColClass] =
       this.getColumnClassNames(index + 1, arr.length);
 
-    let typeLabel: string = exclusion.type;
-    let value: any = exclusion.value;
-
-    switch (exclusion.type) {
-      case "regex":
-        typeLabel = msg("Regex");
-        value = staticHtml`<span class="regex">${unsafeStatic(
-          new RegexColorize().colorizeText(exclusion.value)
-        )}</span>`;
-        break;
-      case "text":
-        typeLabel = msg("Matches Text");
-        break;
-      default:
-        break;
-    }
-
     return html`
       <tr
-        class="h-10 ${this.exclusionToRemove === value
+        class="h-10 ${this.exclusionToRemove === exclusion.value
           ? "text-neutral-200"
           : "text-neutral-600"}"
       >
         <td class="py-2 px-3 whitespace-nowrap ${typeColClass}">
-          ${typeLabel}
+          ${this.renderType(exclusion)}
         </td>
-        <td class="p-2 font-mono ${valueColClass}">${value}</td>
+        <td class="p-2 font-mono ${valueColClass}">
+          ${this.renderValue(exclusion)}
+        </td>
         <td class="text-[1rem] text-center ${actionColClass}">
           <btrix-icon-button
             name="trash3"
@@ -174,6 +159,35 @@ export class QueueExclusionTable extends LiteElement {
       </tr>
     `;
   };
+
+  private renderType(exclusion: Exclusion) {
+    let typeLabel: string = exclusion.type;
+
+    if (exclusion.type === "regex") typeLabel = msg("Regex");
+    if (exclusion.type === "text") typeLabel = msg("Matches Text");
+
+    if (this.editable) {
+      return html`TODO`;
+    }
+
+    return typeLabel;
+  }
+
+  private renderValue(exclusion: Exclusion) {
+    let value: any = exclusion.value;
+
+    if (this.editable) {
+      return html`TODO`;
+    }
+
+    if (exclusion.type === "regex") {
+      value = staticHtml`<span class="regex">${unsafeStatic(
+        new RegexColorize().colorizeText(exclusion.value)
+      )}</span>`;
+    }
+
+    return value;
+  }
 
   private getColumnClassNames(index: number, count: number) {
     let typeColClass = "border-t border-x";

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -218,6 +218,7 @@ export class QueueExclusionTable extends LiteElement {
         <input
           placeholder=${msg("Enter value")}
           class="styledInput block w-full h-9 px-2"
+          value=${exclusion.value}
           @change=${(e: InputEvent) => {
             const inputElem = e.target as HTMLInputElement;
             // Get latest exclusion type value from select

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -383,6 +383,7 @@ export class QueueExclusionTable extends LiteElement {
 
   private removeExclusion({ value, type }: Exclusion) {
     this.exclusionToRemove = value;
+    console.log(value);
 
     this.dispatchEvent(
       new CustomEvent("on-remove", {

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1213,7 +1213,13 @@ export class CrawlTemplatesDetail extends LiteElement {
 
   private async handleSubmitEditConfiguration(e: SubmitEvent) {
     e.preventDefault();
-    const formData = new FormData(e.target as HTMLFormElement);
+    const form = e.target as HTMLFormElement;
+
+    if (form.querySelector("[invalid]")) {
+      return;
+    }
+
+    const formData = new FormData(form);
     const profileId = (formData.get("browserProfile") as string) || null;
 
     let config: CrawlConfig;

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1111,7 +1111,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     return html`
       <btrix-queue-exclusion-table
         .exclusions=${this.exclusions}
-        editable
+        removable
         @on-remove=${(e: ExclusionRemoveEvent) => {
           if (!this.exclusions) return;
           const { regex: value } = e.detail;

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -1125,6 +1125,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         .exclusions=${this.exclusions}
         pageSize="50"
         editable
+        removable
         @on-remove=${this.handleRemoveRegex}
         @on-change=${this.handleChangeRegex}
       ></btrix-queue-exclusion-table>
@@ -1171,9 +1172,15 @@ export class CrawlTemplatesDetail extends LiteElement {
   }
 
   private handleRemoveRegex(e: ExclusionRemoveEvent) {
-    const { regex } = e.detail;
-    if (!this.exclusions || !regex) return;
-    this.exclusions = this.exclusions.filter((v) => v !== regex);
+    const { index } = e.detail;
+    if (!this.exclusions) {
+      this.exclusions = defaultExclusions;
+    } else {
+      this.exclusions = [
+        ...this.exclusions.slice(0, index),
+        ...this.exclusions.slice(index + 1),
+      ];
+    }
   }
 
   private handleChangeRegex(e: ExclusionChangeEvent) {

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -5,6 +5,8 @@ import { msg, localized, str } from "@lit/localize";
 import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 import compact from "lodash/fp/compact";
 import merge from "lodash/fp/merge";
+import flow from "lodash/fp/flow";
+import uniq from "lodash/fp/uniq";
 import ISO6391 from "iso-639-1";
 
 import type { AuthState } from "../../utils/AuthService";
@@ -22,6 +24,8 @@ const SEED_URLS_MAX = 3;
 
 // Show default empty editable rows
 const defaultExclusions = [""];
+
+const trimExclusions = flow(uniq, compact);
 
 /**
  * Usage:
@@ -75,7 +79,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         if (this.isConfigCodeView) {
           this.configCode = jsonToYaml(
             merge(this.crawlTemplate.config, {
-              exclude: compact(this.exclusions),
+              exclude: trimExclusions(this.exclusions),
             })
           );
         } else if (this.isConfigCodeView === false) {
@@ -1220,7 +1224,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         scopeType: formData.get("scopeType") as string,
         limit: pageLimit ? +pageLimit : 0,
         extraHops: formData.get("extraHopsOne") ? 1 : 0,
-        exclude: compact(this.exclusions),
+        exclude: trimExclusions(this.exclusions),
         lang: this.browserLanguage,
       };
     }

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -497,6 +497,7 @@ export class CrawlTemplatesNew extends LiteElement {
         .exclusions=${this.exclusions}
         pageSize="50"
         editable
+        removable
         @on-remove=${this.handleRemoveRegex}
         @on-change=${this.handleChangeRegex}
       ></btrix-queue-exclusion-table>
@@ -571,9 +572,15 @@ export class CrawlTemplatesNew extends LiteElement {
   }
 
   private handleRemoveRegex(e: ExclusionRemoveEvent) {
-    const { regex } = e.detail;
-    if (!this.exclusions || !regex) return;
-    this.exclusions = this.exclusions.filter((v) => v !== regex);
+    const { index } = e.detail;
+    if (!this.exclusions) {
+      this.exclusions = defaultValue.config.exclude;
+    } else {
+      this.exclusions = [
+        ...this.exclusions.slice(0, index),
+        ...this.exclusions.slice(index + 1),
+      ];
+    }
   }
 
   private handleChangeRegex(e: ExclusionChangeEvent) {

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -587,6 +587,11 @@ export class CrawlTemplatesNew extends LiteElement {
   private async onSubmit(event: SubmitEvent) {
     event.preventDefault();
     if (!this.authState) return;
+    const form = event.target as HTMLFormElement;
+
+    if (form.querySelector("[invalid]")) {
+      return;
+    }
 
     const formData = new FormData(event.target as HTMLFormElement);
     const params = this.parseTemplate(formData);

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -501,7 +501,7 @@ export class CrawlTemplatesNew extends LiteElement {
         @click=${() => (this.exclusions = [...(this.exclusions || []), ""])}
       >
         <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-        <span class="text-neutral-600">${msg("Add Row")}</span>
+        <span class="text-neutral-600">${msg("Add More")}</span>
       </sl-button>
     `;
   }

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -39,12 +39,8 @@ const defaultValue = {
   config: {
     seeds: [],
     scopeType: "prefix",
-    exclude: [
-      // Show default empty editable rows
-      "",
-      "",
-      "",
-    ],
+    // Show default empty editable rows
+    exclude: Array.from({ length: 3 }).map(() => ""),
   },
 } as InitialCrawlTemplate;
 const hours = Array.from({ length: 12 }).map((x, i) => ({
@@ -495,10 +491,18 @@ export class CrawlTemplatesNew extends LiteElement {
     return html`
       <btrix-queue-exclusion-table
         .exclusions=${this.exclusions}
+        pageSize="50"
         editable
         @on-remove=${this.handleRemoveRegex}
         @on-change=${this.handleChangeRegex}
       ></btrix-queue-exclusion-table>
+      <sl-button
+        class="w-full mt-1"
+        @click=${() => (this.exclusions = [...(this.exclusions || []), ""])}
+      >
+        <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+        <span class="text-neutral-600">${msg("Add Row")}</span>
+      </sl-button>
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -4,6 +4,8 @@ import { msg, localized, str } from "@lit/localize";
 import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 import compact from "lodash/fp/compact";
 import merge from "lodash/fp/merge";
+import flow from "lodash/fp/flow";
+import uniq from "lodash/fp/uniq";
 
 import type {
   ExclusionRemoveEvent,
@@ -51,6 +53,8 @@ const minutes = Array.from({ length: 60 }).map((x, i) => ({
   value: i,
   label: `${i}`.padStart(2, "0"),
 }));
+
+const trimExclusions = flow(uniq, compact);
 
 /**
  * Usage:
@@ -145,7 +149,7 @@ export class CrawlTemplatesNew extends LiteElement {
       if (this.isConfigCodeView) {
         this.configCode = jsonToYaml(
           merge(this.initialCrawlTemplate.config, {
-            exclude: compact(this.exclusions),
+            exclude: trimExclusions(this.exclusions),
           })
         );
       } else if (this.isConfigCodeView === false) {
@@ -559,7 +563,7 @@ export class CrawlTemplatesNew extends LiteElement {
         scopeType: formData.get("scopeType") as string,
         limit: pageLimit ? +pageLimit : 0,
         extraHops: formData.get("extraHopsOne") ? 1 : 0,
-        exclude: compact(this.exclusions),
+        exclude: trimExclusions(this.exclusions),
       };
     }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -5,8 +5,10 @@ import { parse as yamlToJson, stringify as jsonToYaml } from "yaml";
 import compact from "lodash/fp/compact";
 import merge from "lodash/fp/merge";
 
-import type { ExclusionAddEvent } from "../../components/queue-exclusion-form";
-import type { ExclusionRemoveEvent } from "../../components/queue-exclusion-table";
+import type {
+  ExclusionRemoveEvent,
+  ExclusionChangeEvent,
+} from "../../components/queue-exclusion-table";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { ScheduleInterval, humanizeNextDate } from "../../utils/cron";
@@ -495,14 +497,8 @@ export class CrawlTemplatesNew extends LiteElement {
         .exclusions=${this.exclusions}
         editable
         @on-remove=${this.handleRemoveRegex}
+        @on-change=${this.handleChangeRegex}
       ></btrix-queue-exclusion-table>
-      <div class="mt-2">
-        <btrix-queue-exclusion-form
-          fieldErrorMessage=${this.exclusionFieldErrorMessage || ""}
-          @on-add=${this.handleAddRegex}
-        >
-        </btrix-queue-exclusion-form>
-      </div>
     `;
   }
 
@@ -572,16 +568,12 @@ export class CrawlTemplatesNew extends LiteElement {
     this.exclusions = this.exclusions.filter((v) => v !== regex);
   }
 
-  private handleAddRegex(e: ExclusionAddEvent) {
-    this.exclusionFieldErrorMessage = "";
-    const { regex, onSuccess } = e.detail;
-    if (this.exclusions && compact(this.exclusions).indexOf(regex) > -1) {
-      this.exclusionFieldErrorMessage = msg("Exclusion already exists");
-      return;
-    }
+  private handleChangeRegex(e: ExclusionChangeEvent) {
+    const { regex, index } = e.detail;
 
-    this.exclusions = [...(this.exclusions || []), regex];
-    onSuccess();
+    const nextExclusions = [...this.exclusions!];
+    nextExclusions[index] = regex;
+    this.exclusions = nextExclusions;
   }
 
   private async onSubmit(event: SubmitEvent) {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -103,35 +103,6 @@ const theme = css`
   sl-input.invalid:focus-within::part(base) {
     box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-color-danger-100);
   }
-
-  /* Harmonize with native HTML */
-  ::-moz-placeholder {
-    opacity: 0.5 !important;
-  }
-
-  .styledInput::placeholder {
-    color: var(--sl-input-placeholder-color) !important;
-    font-weight: inherit;
-  }
-
-  .styledInput {
-    outline: 0;
-    transition: var(--sl-transition-fast) color,
-      var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow,
-      var(--sl-transition-fast) background-color;
-  }
-
-  .styledInput:hover {
-    background-color: var(--sl-input-background-color-hover);
-    border-color: var(--sl-input-border-color-hover);
-  }
-
-  .styledInput:focus {
-    background-color: var(--sl-input-background-color-focus);
-    border-color: var(--sl-input-border-color-focus);
-    box-shadow: 0 0 0 var(--sl-focus-ring-width)
-      var(--sl-input-focus-ring-color);
-  }
 `;
 
 export default theme;

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -103,6 +103,35 @@ const theme = css`
   sl-input.invalid:focus-within::part(base) {
     box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-color-danger-100);
   }
+
+  /* Harmonize with native HTML */
+  ::-moz-placeholder {
+    opacity: 0.5 !important;
+  }
+
+  .styledInput::placeholder {
+    color: var(--sl-input-placeholder-color) !important;
+    font-weight: inherit;
+  }
+
+  .styledInput {
+    outline: 0;
+    transition: var(--sl-transition-fast) color,
+      var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+  }
+
+  .styledInput:hover {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+
+  .styledInput:focus {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width)
+      var(--sl-input-focus-ring-color);
+  }
 `;
 
 export default theme;


### PR DESCRIPTION
Enables users to edit exclusion table cells directly when creating and editing crawl templates. Resolves #376.

### Manual testing
1. Run `yarn start`
2. Create a new crawl template, interacting with "Exclusions" table in "Crawl Settings" section. Verify table cells are editable, new row can be added/removed, and errors show on submit attempt.
3. Save new crawl template. Verify exclusions are saved as expected on crawl detail view.
4. Click "Edit" in "Configuration" section. Update exclusions, verify exclusions are saved as expected.

### Screenshots
**New Crawl Template view:**
<img width="637" alt="Screen Shot 2022-11-21 at 2 54 59 PM" src="https://user-images.githubusercontent.com/4672952/203185183-1ea02ad1-6e4e-4a50-8bc2-1855cbffff51.png">

**Error states:**
<img width="629" alt="Screen Shot 2022-11-21 at 4 25 59 PM" src="https://user-images.githubusercontent.com/4672952/203185204-3134cc58-7829-4db2-bb45-a1a0475a25f8.png">
<img width="635" alt="Screen Shot 2022-11-21 at 4 26 05 PM" src="https://user-images.githubusercontent.com/4672952/203185210-9b03f29d-5325-4dec-9450-4495877837f4.png">
<img width="637" alt="Screen Shot 2022-11-21 at 4 26 15 PM" src="https://user-images.githubusercontent.com/4672952/203185212-3069ae6c-f6bd-4507-b1ef-d493087b3069.png">

