### PR TITLE
Frontend Node version support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,5 +98,8 @@
       "no-unused-vars": "warn"
     }
   },
-  "prettier": {}
+  "prettier": {},
+  "engines": {
+    "node": ">=16 <20"
+  }
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -58,8 +58,8 @@ const version = (() => {
   }
 
   try {
-    return fs.readFileSync("../version.txt", {encoding: "utf-8"}).trim();
-  } catch(e) {}
+    return fs.readFileSync("../version.txt", { encoding: "utf-8" }).trim();
+  } catch (e) {}
 
   return packageJSON.version;
 })();
@@ -70,6 +70,9 @@ module.exports = {
     path: path.resolve(__dirname, "dist"),
     filename: `js/[name]${isDevServer ? "" : ".[contenthash]"}.js`,
     publicPath: "/",
+    // Fix node >v16 compatibility issues
+    // https://stackoverflow.com/a/73465262
+    hashFunction: "xxhash64",
   },
 
   devtool: "inline-source-map",


### PR DESCRIPTION
Fix compatibility issues between Node.js 16 and >16 when building Webpack bundle.

See: https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported/73465262#73465262

Manually tested using nvm:
1. `nvm use v19`
2. `rm -rf node_modules && yarn`
3. `yarn build`
4. Repeated for v16