### PR TITLE
Fix language configuration UI

### DIFF
--- a/frontend/src/components/language-select.ts
+++ b/frontend/src/components/language-select.ts
@@ -47,7 +47,7 @@ export class LanguageSelect extends LitElement {
     return html`
       <sl-select
         clearable
-        placeholder=${msg("Default")}
+        placeholder=${msg("Browser Default")}
         value=${ifDefined(this.value)}
         ?hoist=${this.hoist}
       >

--- a/frontend/src/components/language-select.ts
+++ b/frontend/src/components/language-select.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from "lit";
 import { state, property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { localized, msg } from "@lit/localize";
 import sortBy from "lodash/fp/sortBy";
 import ISO6391 from "iso-639-1";
@@ -35,12 +36,20 @@ export class LanguageSelect extends LitElement {
     }
   `;
 
+  @property({ type: String })
+  value?: LanguageCode;
+
   @property({ type: Boolean })
   hoist = false;
 
   render() {
     return html`
-      <sl-select clearable placeholder=${msg("Default")} ?hoist=${this.hoist}>
+      <sl-select
+        clearable
+        placeholder=${msg("Default")}
+        value=${ifDefined(this.value)}
+        ?hoist=${this.hoist}
+      >
         <div slot="label"><slot name="label"></slot></div>
         ${languages.map(
           ({ code, name, nativeName }) => html`

--- a/frontend/src/components/language-select.ts
+++ b/frontend/src/components/language-select.ts
@@ -43,28 +43,12 @@ export class LanguageSelect extends LitElement {
   @property({ type: Boolean })
   hoist = false;
 
-  private browserLanguage?: string;
-
-  connectedCallback() {
-    const browserLanguage = navigator.languages?.length
-      ? navigator.languages[0]
-      : navigator.language;
-    if (browserLanguage) {
-      this.browserLanguage = browserLanguage.slice(
-        0,
-        browserLanguage.indexOf("-")
-      );
-    }
-
-    super.connectedCallback();
-  }
-
   render() {
     return html`
       <sl-select
         clearable
         placeholder=${msg("Default")}
-        value=${ifDefined(this.value || this.browserLanguage)}
+        value=${ifDefined(this.value)}
         ?hoist=${this.hoist}
       >
         <div slot="label"><slot name="label">${msg("Language")}</slot></div>

--- a/frontend/src/components/language-select.ts
+++ b/frontend/src/components/language-select.ts
@@ -15,11 +15,12 @@ const languages = sortBy("name")(
 }>;
 
 /**
- * Choose language from dropdown
+ * Choose language from dropdown.
+ * Uses ISO 639-1 codes (2 letters representing macrolanguages.)
  *
  * Usage:
  * ```ts
- * <btrix-language-select @sl-select=${console.debug}>
+ * <btrix-language-select value=${defaultValue} @sl-select=${console.debug}>
  *   <span slot="label">Label</span>
  * </btrix-language-select>
  * ```
@@ -42,15 +43,31 @@ export class LanguageSelect extends LitElement {
   @property({ type: Boolean })
   hoist = false;
 
+  private browserLanguage?: string;
+
+  connectedCallback() {
+    const browserLanguage = navigator.languages?.length
+      ? navigator.languages[0]
+      : navigator.language;
+    if (browserLanguage) {
+      this.browserLanguage = browserLanguage.slice(
+        0,
+        browserLanguage.indexOf("-")
+      );
+    }
+
+    super.connectedCallback();
+  }
+
   render() {
     return html`
       <sl-select
         clearable
         placeholder=${msg("Default")}
-        value=${ifDefined(this.value)}
+        value=${ifDefined(this.value || this.browserLanguage)}
         ?hoist=${this.hoist}
       >
-        <div slot="label"><slot name="label"></slot></div>
+        <div slot="label"><slot name="label">${msg("Language")}</slot></div>
         ${languages.map(
           ({ code, name, nativeName }) => html`
             <sl-menu-item value=${code}>

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -104,6 +104,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         this.isConfigCodeView = true;
       }
       this.configCode = jsonToYaml(this.crawlTemplate.config);
+      this.browserLanguage = this.crawlTemplate.config.lang;
       if (this.crawlTemplate.config.exclude?.length) {
         this.exclusions = this.crawlTemplate.config.exclude;
       }
@@ -725,6 +726,7 @@ export class CrawlTemplatesDetail extends LiteElement {
           </div>
           <div>
             <btrix-language-select
+              .value=${this.browserLanguage}
               @sl-select=${(e: CustomEvent) =>
                 (this.browserLanguage = e.detail.item.value)}
               @sl-clear=${() => (this.browserLanguage = null)}

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -27,7 +27,6 @@ type NewCrawlTemplate = {
   scale: number;
   config: CrawlConfig;
   profileid: string | null;
-  lang: string | null;
 };
 
 export type InitialCrawlTemplate = Pick<
@@ -553,7 +552,6 @@ export class CrawlTemplatesNew extends LiteElement {
       crawlTimeout: crawlTimeoutMinutes ? +crawlTimeoutMinutes * 60 : 0,
       scale: +scale,
       profileid: this.browserProfileId,
-      lang: this.browserLanguage || null,
     };
 
     if (this.isConfigCodeView) {
@@ -565,6 +563,7 @@ export class CrawlTemplatesNew extends LiteElement {
         limit: pageLimit ? +pageLimit : 0,
         extraHops: formData.get("extraHopsOne") ? 1 : 0,
         exclude: trimExclusions(this.exclusions),
+        lang: this.browserLanguage || null,
       };
     }
 

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -141,9 +141,7 @@ export class CrawlTemplatesNew extends LiteElement {
     }
     this.browserProfileId = this.initialCrawlTemplate.profileid;
     // Default to current user browser language
-    const browserLanguage = navigator.languages?.length
-      ? navigator.languages[0]
-      : navigator.language;
+    const browserLanguage = window.navigator.language;
     if (browserLanguage) {
       this.browserLanguage = browserLanguage.slice(
         0,

--- a/frontend/src/pages/archive/crawl-templates-new.ts
+++ b/frontend/src/pages/archive/crawl-templates-new.ts
@@ -140,6 +140,17 @@ export class CrawlTemplatesNew extends LiteElement {
       this.exclusions = this.initialCrawlTemplate.config.exclude;
     }
     this.browserProfileId = this.initialCrawlTemplate.profileid;
+    // Default to current user browser language
+    const browserLanguage = navigator.languages?.length
+      ? navigator.languages[0]
+      : navigator.language;
+    if (browserLanguage) {
+      this.browserLanguage = browserLanguage.slice(
+        0,
+        browserLanguage.indexOf("-")
+      );
+    }
+
     super.connectedCallback();
   }
 
@@ -394,6 +405,7 @@ export class CrawlTemplatesNew extends LiteElement {
         </div>
         <div class="col-span-1">
           <btrix-language-select
+            .value=${this.browserLanguage}
             @sl-select=${(e: CustomEvent) =>
               (this.browserLanguage = e.detail.item.value)}
             @sl-clear=${() => (this.browserLanguage = null)}


### PR DESCRIPTION
Fixes #386.

### Manual testing
1. Run app `yarn start`
2. Go to New Crawl Template page. Verify that "Language" dropdown shows your current browser language.
3. Save template. Verify language is saved as expected.
4. Click "Edit" in "Configuration" section. Verify language is shown in dropdown and can be saved as expected.