### PR TITLE
build: increase network timeout for yarn for frontend build for arm64 build

### DIFF
--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - 
-        uses: balchua/microk8s-actions@v0.3.0
+        uses: balchua/microk8s-actions@v0.3.1
         with:
           channel: '1.25/stable'
           addons: '["dns", "helm3", "hostpath-storage", "registry", "metrics-server"]'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
 
 WORKDIR /app
 COPY yarn.lock package.json ./
-RUN yarn --frozen-lockfile
+RUN yarn --frozen-lockfile --network-timeout 1000000
 
 COPY lit-localize.json \
     postcss.config.js \


### PR DESCRIPTION
Per nodejs/docker-node#1335 and associated solution, it seems like increasing the yarn timeout is the main solution at the moment.