### PR TITLE
Add single crawl info api at /crawls/{crawl_id}

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -665,8 +665,6 @@ def init_crawls_api(
 
         return crawls[0]
 
-
-
     @app.post(
         "/archives/{aid}/crawls/{crawl_id}/scale",
         tags=["crawls"],

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -81,7 +81,7 @@ def test_wait_for_complete():
 
     while True:
         r = requests.get(
-            f"{api_prefix}/archives/{archive_id}/crawls/{crawl_id}.json",
+            f"{api_prefix}/archives/{archive_id}/crawls/{crawl_id}/replay.json",
             headers=headers,
         )
         data = r.json()
@@ -105,6 +105,13 @@ def test_wait_for_complete():
     wacz_size = data["resources"][0]["size"]
     wacz_hash = data["resources"][0]["hash"]
 
+def test_crawl_info():
+    r = requests.get(
+        f"{api_prefix}/archives/{archive_id}/crawls/{crawl_id}",
+        headers=headers,
+    )
+    data = r.json()
+    assert data["fileSize"] == wacz_size
 
 def test_download_wacz():
     r = requests.get(host_prefix + wacz_path)

--- a/frontend/src/pages/archive/crawl-detail.ts
+++ b/frontend/src/pages/archive/crawl-detail.ts
@@ -560,7 +560,7 @@ export class CrawlDetail extends LiteElement {
     const bearer = this.authState?.headers?.Authorization?.split(" ", 2)[1];
 
     // for now, just use the first file until multi-wacz support is fully implemented
-    const replaySource = `/api/archives/${this.crawl?.aid}/crawls/${this.crawlId}.json?auth_bearer=${bearer}`;
+    const replaySource = `/api/archives/${this.crawl?.aid}/crawls/${this.crawlId}/replay.json?auth_bearer=${bearer}`;
     //const replaySource = this.crawl?.resources?.[0]?.path;
 
     const canReplay = replaySource && this.hasFiles;
@@ -881,7 +881,7 @@ export class CrawlDetail extends LiteElement {
 
   private async getCrawl(): Promise<Crawl> {
     const data: Crawl = await this.apiFetch(
-      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}.json`,
+      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}/replay.json`,
       this.authState!
     );
 


### PR DESCRIPTION
backend: crawl info apis:
- add /crawls/{crawl_id} api endpoint which just lists the crawl info, without resolving the individual files
- move /crawls/{crawl_id}.json -> /crawls/{crawl_id}/replay.json for clarity that it's used for replay (BREAKING CHANGE)