### PR TITLE
Crawl config tag editor UI

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -52,6 +52,14 @@ export class ConfigDetails extends LiteElement {
         >
         <btrix-desc-list>
           ${this.renderSetting(msg("Name"), crawlConfig?.name)}
+          ${this.renderSetting(
+            msg("Tags"),
+            crawlConfig?.tags?.length
+              ? crawlConfig.tags.map(
+                  (tag) => html`<btrix-tag class="mt-1 mr-2">${tag}</btrix-tag>`
+                )
+              : undefined
+          )}
         </btrix-desc-list>
       </section>
       <section id="crawler-settings" class="mb-8">

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -95,6 +95,9 @@ import("./section-heading").then(({ SectionHeading }) => {
 import("./config-details").then(({ ConfigDetails }) => {
   customElements.define("btrix-config-details", ConfigDetails);
 });
+import("./tag-input").then(({ TagInput }) => {
+  customElements.define("btrix-tag-input", TagInput);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -98,6 +98,9 @@ import("./config-details").then(({ ConfigDetails }) => {
 import("./tag-input").then(({ TagInput }) => {
   customElements.define("btrix-tag-input", TagInput);
 });
+import("./tag").then(({ Tag }) => {
+  customElements.define("btrix-tag", Tag);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -3,6 +3,7 @@ import { state, property, query } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import type { SlInput } from "@shoelace-style/shoelace";
 import inputCss from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
+import union from "lodash/fp/union";
 
 export type TimeInputChangeEvent = CustomEvent<{
   hour: number;
@@ -28,6 +29,7 @@ export class TagInput extends LitElement {
   static styles = css`
     :host {
       --sl-input-spacing-medium: var(--sl-spacing-x-small);
+      --tag-height: 1.5rem;
     }
 
     ${inputCss}
@@ -35,40 +37,108 @@ export class TagInput extends LitElement {
     .input {
       flex-wrap: wrap;
       height: auto;
-      /* min-height: calc(var(--sl-input-height-medium) + 0.5rem); */
+      overflow: visible;
+      min-height: calc(var(--tag-height) + 1rem);
     }
 
     .input__control {
       --sl-input-spacing-medium: var(--sl-spacing-small);
       align-self: center;
       background: yellow;
+      width: 100%;
+    }
+
+    .dropdownWrapper {
+      flex: 1 0 10rem;
     }
 
     sl-tag {
       margin-left: var(--sl-spacing-2x-small);
-      /* margin-top: 0.4rem; */
+      margin-top: calc(0.5rem - 1px);
     }
 
     sl-tag::part(base) {
-      height: 1.5rem;
+      height: var(--tag-height);
       background-color: var(--sl-color-blue-100);
       border-color: var(--sl-color-blue-500);
       color: var(--sl-color-blue-600);
+    }
+
+    sl-tag::part(remove-button) {
+      color: var(--sl-color-blue-600);
+      border-radius: 100%;
+      transition: background-color 0.1s;
+    }
+
+    sl-tag::part(remove-button):hover {
+      background-color: var(--sl-color-blue-600);
+      color: #fff;
+    }
+
+    .dropdown {
+      position: absolute;
+      z-index: 9999;
+      margin-top: -0.25rem;
+      margin-left: 0.25rem;
+      transform-origin: top left;
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    .animateShow {
+      animation: dropdownShow 100ms ease forwards;
+    }
+
+    .animateHide {
+      animation: dropdownHide 100ms ease forwards;
+    }
+
+    @keyframes dropdownShow {
+      from {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+
+      to {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes dropdownHide {
+      from {
+        opacity: 1;
+        transform: scale(1);
+      }
+
+      to {
+        opacity: 0;
+        transform: scale(0.9);
+        display: none;
+      }
     }
   `;
 
   @property({ type: Boolean })
   disabled = false;
 
-  //   TODO validate required
+  // TODO validate required
   @property({ type: Boolean })
   required = false;
 
   @state()
-  tags: string[] = ["test"];
+  private tags: string[] = ["test"];
+
+  @state()
+  private inputValue = "";
+
+  @state()
+  private dropdownIsOpen?: boolean;
 
   @query("#input")
-  input!: HTMLInputElement;
+  private input!: HTMLInputElement;
 
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("tags") && this.required) {
@@ -99,14 +169,37 @@ export class TagInput extends LitElement {
           @click=${this.onInputWrapperClick}
         >
           ${this.renderTags()}
-          <input
-            id="input"
-            class="input__control"
-            @focus=${this.onFocus}
-            @blur=${this.onBlur}
-            @keydown=${this.onKeydown}
-            ?required=${this.required && !this.tags.length}
-          />
+
+          <div class="dropdownWrapper">
+            <input
+              slot="trigger"
+              id="input"
+              class="input__control"
+              @focus=${this.onFocus}
+              @blur=${this.onBlur}
+              @keydown=${this.onKeydown}
+              @keyup=${this.onKeyup}
+              ?required=${this.required && !this.tags.length}
+              role="combobox"
+              aria-controls="dropdown"
+              aria-expanded="${this.dropdownIsOpen === true}"
+            />
+            <div
+              id="dropdown"
+              class="dropdown ${this.dropdownIsOpen === true
+                ? "animateShow"
+                : this.dropdownIsOpen === false
+                ? "animateHide"
+                : "hidden"}"
+            >
+              <sl-menu role="listbox" @sl-select=${this.onSelect}>
+                <!-- TODO tag options from API -->
+                <sl-menu-item role="option" value=${this.inputValue}
+                  >${msg(str`Add “${this.inputValue}”`)}</sl-menu-item
+                >
+              </sl-menu>
+            </div>
+          </div>
         </div>
       </div>
     `;
@@ -127,6 +220,12 @@ export class TagInput extends LitElement {
     `;
   };
 
+  private onSelect(e: CustomEvent) {
+    this.tags = union([e.detail.item.value], this.tags);
+    this.input.value = "";
+    this.dropdownIsOpen = false;
+  }
+
   private onFocus(e: FocusEvent) {
     const el = e.target as HTMLInputElement;
     (el.parentElement as HTMLElement).classList.add("input--focused");
@@ -135,33 +234,29 @@ export class TagInput extends LitElement {
   private async onBlur(e: FocusEvent) {
     const el = e.target as HTMLInputElement;
     (el.parentElement as HTMLElement).classList.remove("input--focused");
+    this.dropdownIsOpen = false;
+  }
 
-    if (el.value) {
+  private async onKeydown(e: KeyboardEvent) {
+    if (e.key === "," || e.key === "Enter") {
+      e.preventDefault();
+
+      const el = e.target as HTMLInputElement;
+      const value = el.value.trim();
+      if (!value) return;
+
       await this.updateComplete;
-      this.tags = [
-        ...this.tags,
-        ...el.value
-          .trim()
-          .replace(/,/g, " ")
-          .split(/\s+/g)
-          .filter((v) => v && !this.tags.includes(v)),
-      ];
-
+      this.tags = union([value], this.tags);
+      this.dropdownIsOpen = false;
       el.value = "";
     }
   }
 
-  private async onKeydown(e: KeyboardEvent) {
-    if (e.key === "," || e.key === " " || e.key === "Enter") {
-      e.preventDefault();
-      const el = e.target as HTMLInputElement;
-      const value = el.value.trim().replace(/,/g, " ");
-      if (!value) return;
-
-      await this.updateComplete;
-      this.tags = [...this.tags.filter((v) => v !== value), value];
-
-      el.value = "";
+  private async onKeyup(e: KeyboardEvent) {
+    const el = e.target as HTMLInputElement;
+    this.inputValue = el.value;
+    if (el.value.length) {
+      this.dropdownIsOpen = true;
     }
   }
 

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -1,0 +1,114 @@
+import { LitElement, html, css } from "lit";
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import type { SlInput } from "@shoelace-style/shoelace";
+import inputCss from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
+
+export type TimeInputChangeEvent = CustomEvent<{
+  hour: number;
+  minute: number;
+  period: "AM" | "PM";
+}>;
+
+/**
+ * Usage:
+ * ```ts
+ * <btrix-time-input
+ *   hour="1"
+ *   minute="1"
+ *   period="AM"
+ *   @time-change=${console.log}
+ * ></btrix-time-input>
+ * ```
+ *
+ * @events
+ */
+@localized()
+export class TagInput extends LitElement {
+  static styles = css`
+    ${inputCss}
+
+    .input__control {
+      outline: 1px solid red;
+    }
+
+    sl-tag {
+      margin-top: 0.4rem;
+    }
+  `;
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  @state()
+  tags: string[] = ["foo"];
+
+  render() {
+    return html`
+      <div class="form-control">
+        <label class="form-control__label" for="input">
+          <slot name="label">${msg("Tags")}</slot>
+        </label>
+        <div class="input input--medium input--standard">
+          ${this.renderTags()}
+          <input
+            id="input"
+            class="input__control"
+            @focus=${this.onFocus}
+            @blur=${this.onBlur}
+            @keydown=${this.onKeydown}
+          />
+        </div>
+      </div>
+    `;
+  }
+
+  private renderTags() {
+    return this.tags.map(this.renderTag);
+  }
+
+  private renderTag = (content: string) => {
+    return html`
+      <sl-tag size="small" variant="primary" pill removable>${content}</sl-tag>
+    `;
+  };
+
+  private onFocus(e: FocusEvent) {
+    console.log("onFocus");
+    const el = e.target as HTMLInputElement;
+    (el.parentElement as HTMLElement).classList.add("input--focused");
+  }
+
+  private async onBlur(e: FocusEvent) {
+    console.log("onBlur");
+    const el = e.target as HTMLInputElement;
+    (el.parentElement as HTMLElement).classList.remove("input--focused");
+    console.log(el.value);
+
+    await this.updateComplete;
+    this.tags = [
+      ...this.tags,
+      ...el.value
+        .trim()
+        .replace(/,/g, " ")
+        .split(/\s+/g)
+        .filter((v) => v && !this.tags.includes(v)),
+    ];
+
+    el.value = "";
+  }
+
+  private async onKeydown(e: KeyboardEvent) {
+    if (e.key === "," || e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      const el = e.target as HTMLInputElement;
+      const value = el.value.trim().replace(/,/g, " ");
+      if (!value) return;
+
+      await this.updateComplete;
+      this.tags = [...this.tags.filter((v) => v !== value), value];
+
+      el.value = "";
+    }
+  }
+}

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -262,7 +262,7 @@ export class TagInput extends LitElement {
   }
 
   private onBlur(e: FocusEvent) {
-    if (e.relatedTarget === this.menu?.querySelector("sl-menu-item")) {
+    if (this.menu?.contains(e.relatedTarget as HTMLElement)) {
       // Keep focus on form control if moving to menu selection
       return;
     }

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -35,17 +35,25 @@ export class TagInput extends LitElement {
     .input {
       flex-wrap: wrap;
       height: auto;
-      min-height: calc(var(--sl-input-height-medium) + 0.5rem);
+      /* min-height: calc(var(--sl-input-height-medium) + 0.5rem); */
     }
 
     .input__control {
       --sl-input-spacing-medium: var(--sl-spacing-small);
       align-self: center;
+      background: yellow;
     }
 
     sl-tag {
       margin-left: var(--sl-spacing-2x-small);
-      margin-top: 0.4rem;
+      /* margin-top: 0.4rem; */
+    }
+
+    sl-tag::part(base) {
+      height: 1.5rem;
+      background-color: var(--sl-color-blue-100);
+      border-color: var(--sl-color-blue-500);
+      color: var(--sl-color-blue-600);
     }
   `;
 
@@ -57,7 +65,7 @@ export class TagInput extends LitElement {
   required = false;
 
   @state()
-  tags: string[] = [];
+  tags: string[] = ["test"];
 
   @query("#input")
   input!: HTMLInputElement;
@@ -79,7 +87,11 @@ export class TagInput extends LitElement {
   render() {
     return html`
       <div class="form-control form-control--has-label">
-        <label class="form-control__label" for="input">
+        <label
+          class="form-control__label"
+          part="form-control-label"
+          for="input"
+        >
           <slot name="label">${msg("Tags")}</slot>
         </label>
         <div

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -49,7 +49,8 @@ export class TagInput extends LitElement {
     }
 
     .dropdownWrapper {
-      flex: 1 0 10rem;
+      flex-grow: 1;
+      flex-shrink: 0;
     }
 
     sl-tag {
@@ -158,6 +159,7 @@ export class TagInput extends LitElement {
   }
 
   render() {
+    const placeholder = msg("Tags separated by comma");
     return html`
       <div class="form-control form-control--has-label">
         <label
@@ -173,7 +175,10 @@ export class TagInput extends LitElement {
         >
           ${this.renderTags()}
 
-          <div class="dropdownWrapper">
+          <div
+            class="dropdownWrapper"
+            style="min-width: ${placeholder.length}ch"
+          >
             <input
               slot="trigger"
               id="input"
@@ -184,7 +189,7 @@ export class TagInput extends LitElement {
               @keyup=${this.onKeyup}
               @paste=${this.onPaste}
               ?required=${this.required && !this.tags.length}
-              placeholder=${msg("Tags separated by comma")}
+              placeholder=${placeholder}
               role="combobox"
               aria-controls="dropdown"
               aria-expanded="${this.dropdownIsOpen === true}"
@@ -294,12 +299,7 @@ export class TagInput extends LitElement {
   private onPaste(e: ClipboardEvent) {
     const text = e.clipboardData?.getData("text");
     if (text) {
-      this.addTags(
-        text
-          .split(",")
-          .map((v) => v.trim())
-          .filter((v) => v)
-      );
+      this.addTags(text.split(","));
     }
   }
 
@@ -311,7 +311,10 @@ export class TagInput extends LitElement {
 
   private async addTags(tags: string[]) {
     await this.updateComplete;
-    this.tags = union(tags, this.tags);
+    this.tags = union(
+      tags.map((v) => v.trim()).filter((v) => v),
+      this.tags
+    );
     this.dropdownIsOpen = false;
     this.input!.value = "";
   }

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from "lit";
-import { state, property } from "lit/decorators.js";
+import { state, property, query } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import type { SlInput } from "@shoelace-style/shoelace";
 import inputCss from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
@@ -46,12 +46,33 @@ export class TagInput extends LitElement {
   @property({ type: Boolean })
   disabled = false;
 
+  //   TODO validate required
+  @property({ type: Boolean })
+  required = false;
+
   @state()
-  tags: string[] = ["foo"];
+  tags: string[] = [];
+
+  @query("#input")
+  input!: HTMLInputElement;
+
+  willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("tags") && this.required) {
+      if (this.tags.length) {
+        this.removeAttribute("data-invalid");
+      } else {
+        this.setAttribute("data-invalid", "");
+      }
+    }
+  }
+
+  reportValidity() {
+    this.input.reportValidity();
+  }
 
   render() {
     return html`
-      <div class="form-control">
+      <div class="form-control form-control--has-label">
         <label class="form-control__label" for="input">
           <slot name="label">${msg("Tags")}</slot>
         </label>
@@ -63,6 +84,7 @@ export class TagInput extends LitElement {
             @focus=${this.onFocus}
             @blur=${this.onBlur}
             @keydown=${this.onKeydown}
+            ?required=${this.required && !this.tags.length}
           />
         </div>
       </div>

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -56,6 +56,9 @@ export class TagInput extends LitElement {
     btrix-tag {
       margin-left: var(--sl-spacing-x-small);
       margin-top: calc(0.5rem - 1px);
+      max-width: calc(
+        100% - var(--sl-spacing-x-small) - var(--sl-spacing-x-small)
+      );
     }
 
     .dropdown {
@@ -243,7 +246,11 @@ export class TagInput extends LitElement {
       this.dispatchChange();
     };
     return html`
-      <btrix-tag variant="primary" removable @sl-remove=${removeTag}
+      <btrix-tag
+        variant="primary"
+        removable
+        @sl-remove=${removeTag}
+        title=${content}
         >${content}</btrix-tag
       >
     `;

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -226,7 +226,7 @@ export class TagInput extends LitElement {
                 ${this.tagOptions.length ? html`<sl-divider></sl-divider>` : ""}
 
                 <sl-menu-item role="option" value=${this.inputValue}>
-                  ${msg(str`Add “${this.inputValue}”`)}
+                  ${msg(str`Add “${this.inputValue.toLocaleLowerCase()}”`)}
                 </sl-menu-item>
               </sl-menu>
             </div>
@@ -330,7 +330,7 @@ export class TagInput extends LitElement {
   private async addTags(tags: Tags) {
     await this.updateComplete;
     this.tags = union(
-      tags.map((v) => v.trim()).filter((v) => v),
+      tags.map((v) => v.trim().toLocaleLowerCase()).filter((v) => v),
       this.tags
     );
     this.dispatchChange();

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -32,8 +32,13 @@ export class TagInput extends LitElement {
 
     ${inputCss}
 
+    .input {
+      flex-wrap: wrap;
+      height: auto;
+      min-height: var(--sl-input-height-medium);
+    }
+
     .input__control {
-      outline: 1px solid red;
       --sl-input-spacing-medium: var(--sl-spacing-small);
     }
 
@@ -76,7 +81,10 @@ export class TagInput extends LitElement {
         <label class="form-control__label" for="input">
           <slot name="label">${msg("Tags")}</slot>
         </label>
-        <div class="input input--medium input--standard">
+        <div
+          class="input input--medium input--standard"
+          @click=${this.onInputWrapperClick}
+        >
           ${this.renderTags()}
           <input
             id="input"
@@ -146,6 +154,12 @@ export class TagInput extends LitElement {
       this.tags = [...this.tags.filter((v) => v !== value), value];
 
       el.value = "";
+    }
+  }
+
+  private onInputWrapperClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) {
+      this.input.focus();
     }
   }
 }

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -342,12 +342,7 @@ export class TagInput extends LitElement {
 
   private async getOptions() {
     // TODO actual API call
-    await new Promise((resolve) => {
-      window.setTimeout(() => {
-        resolve(null);
-      }, 1000);
-    });
-
-    return ["temp1", "temp2"];
+    // https://github.com/webrecorder/browsertrix-cloud/issues/453
+    return [];
   }
 }

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -35,11 +35,12 @@ export class TagInput extends LitElement {
     .input {
       flex-wrap: wrap;
       height: auto;
-      min-height: var(--sl-input-height-medium);
+      min-height: calc(var(--sl-input-height-medium) + 0.5rem);
     }
 
     .input__control {
       --sl-input-spacing-medium: var(--sl-spacing-small);
+      align-self: center;
     }
 
     sl-tag {
@@ -108,12 +109,7 @@ export class TagInput extends LitElement {
       this.tags = this.tags.filter((v) => v !== content);
     };
     return html`
-      <sl-tag
-        size="small"
-        variant="primary"
-        pill
-        removable
-        @sl-remove=${removeTag}
+      <sl-tag variant="primary" pill removable @sl-remove=${removeTag}
         >${content}</sl-tag
       >
     `;

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -26,13 +26,19 @@ export type TimeInputChangeEvent = CustomEvent<{
 @localized()
 export class TagInput extends LitElement {
   static styles = css`
+    :host {
+      --sl-input-spacing-medium: var(--sl-spacing-x-small);
+    }
+
     ${inputCss}
 
     .input__control {
       outline: 1px solid red;
+      --sl-input-spacing-medium: var(--sl-spacing-small);
     }
 
     sl-tag {
+      margin-left: var(--sl-spacing-2x-small);
       margin-top: 0.4rem;
     }
   `;
@@ -68,34 +74,43 @@ export class TagInput extends LitElement {
   }
 
   private renderTag = (content: string) => {
+    const removeTag = () => {
+      this.tags = this.tags.filter((v) => v !== content);
+    };
     return html`
-      <sl-tag size="small" variant="primary" pill removable>${content}</sl-tag>
+      <sl-tag
+        size="small"
+        variant="primary"
+        pill
+        removable
+        @sl-remove=${removeTag}
+        >${content}</sl-tag
+      >
     `;
   };
 
   private onFocus(e: FocusEvent) {
-    console.log("onFocus");
     const el = e.target as HTMLInputElement;
     (el.parentElement as HTMLElement).classList.add("input--focused");
   }
 
   private async onBlur(e: FocusEvent) {
-    console.log("onBlur");
     const el = e.target as HTMLInputElement;
     (el.parentElement as HTMLElement).classList.remove("input--focused");
-    console.log(el.value);
 
-    await this.updateComplete;
-    this.tags = [
-      ...this.tags,
-      ...el.value
-        .trim()
-        .replace(/,/g, " ")
-        .split(/\s+/g)
-        .filter((v) => v && !this.tags.includes(v)),
-    ];
+    if (el.value) {
+      await this.updateComplete;
+      this.tags = [
+        ...this.tags,
+        ...el.value
+          .trim()
+          .replace(/,/g, " ")
+          .split(/\s+/g)
+          .filter((v) => v && !this.tags.includes(v)),
+      ];
 
-    el.value = "";
+      el.value = "";
+    }
   }
 
   private async onKeydown(e: KeyboardEvent) {

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -19,8 +19,7 @@ export class Tag extends SLTag {
       background-color: var(--sl-color-blue-100);
       border-color: var(--sl-color-blue-500);
       color: var(--sl-color-blue-600);
-      font-family: var(--font-monostyle-family);
-      font-variation-settings: var(--font-monostyle-variation);
+      font-family: var(--sl-font-sans);
     }
 
     .tag__remove {

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -1,0 +1,39 @@
+import { css } from "lit";
+import SLTag from "@shoelace-style/shoelace/dist/components/tag/tag.js";
+import tagStyles from "@shoelace-style/shoelace/dist/components/tag/tag.styles.js";
+
+/**
+ * Customized <sl-tag>
+ *
+ * Usage:
+ * ```ts
+ * <btrix-tag>Content</btrix-tag>
+ * ```
+ */
+export class Tag extends SLTag {
+  static styles = css`
+    ${tagStyles}
+
+    .tag {
+      height: var(--tag-height, 1.5rem);
+      background-color: var(--sl-color-blue-100);
+      border-color: var(--sl-color-blue-500);
+      color: var(--sl-color-blue-600);
+      font-family: var(--font-monostyle-family);
+      font-variation-settings: var(--font-monostyle-variation);
+    }
+
+    .tag__remove {
+      color: var(--sl-color-blue-600);
+      border-radius: 100%;
+      transition: background-color 0.1s;
+    }
+
+    .tag__remove:hover {
+      background-color: var(--sl-color-blue-600);
+      color: #fff;
+    }
+  `;
+
+  pill = true;
+}

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -22,6 +22,13 @@ export class Tag extends SLTag {
       font-family: var(--sl-font-sans);
     }
 
+    .tag__content {
+      max-width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .tag__remove {
       color: var(--sl-color-blue-600);
       border-radius: 100%;

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -1244,6 +1244,11 @@ https://example.net`}
       ${this.renderHelpTextCol(
         html`Try to create a unique name to help keep things organized!`
       )}
+      ${this.renderFormCol(html` <btrix-tag-input></btrix-tag-input> `)}
+      ${this.renderHelpTextCol(
+        html`Create or assign this crawl (and its outputs) to one or more tags
+        to help organize your archived data.`
+      )}
     `;
   }
 

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -313,46 +313,47 @@ export class CrawlConfigEditor extends LiteElement {
 
   private getInitialFormState(): Partial<FormState> {
     if (!this.initialCrawlConfig) return {};
-    const seedState: Partial<FormState> = {};
+    const formState: Partial<FormState> = {};
     const { seeds, scopeType } = this.initialCrawlConfig.config;
     if (this.initialCrawlConfig.jobType === "seed-crawl") {
-      seedState.primarySeedUrl =
+      formState.primarySeedUrl =
         typeof seeds[0] === "string" ? seeds[0] : seeds[0].url;
     } else {
       // Treat "custom" like URL list
-      seedState.urlList = seeds
+      formState.urlList = seeds
         .map((seed) => (typeof seed === "string" ? seed : seed.url))
         .join("\n");
 
       if (this.initialCrawlConfig.jobType === "custom") {
-        seedState.scopeType = scopeType || "page";
+        formState.scopeType = scopeType || "page";
       }
     }
 
-    const scheduleState: Partial<FormState> = {};
     if (this.initialCrawlConfig.schedule) {
-      scheduleState.scheduleType = "cron";
-      scheduleState.scheduleFrequency = getScheduleInterval(
+      formState.scheduleType = "cron";
+      formState.scheduleFrequency = getScheduleInterval(
         this.initialCrawlConfig.schedule
       );
       const nextDate = getNextDate(this.initialCrawlConfig.schedule)!;
-      scheduleState.scheduleDayOfMonth = nextDate.getDate();
-      scheduleState.scheduleDayOfWeek = nextDate.getDay();
+      formState.scheduleDayOfMonth = nextDate.getDate();
+      formState.scheduleDayOfWeek = nextDate.getDay();
       const hours = nextDate.getHours();
-      scheduleState.scheduleTime = {
+      formState.scheduleTime = {
         hour: hours % 12 || 12,
         minute: nextDate.getMinutes(),
         period: hours > 11 ? "PM" : "AM",
       };
     } else {
       if (this.configId) {
-        scheduleState.scheduleType = "none";
+        formState.scheduleType = "none";
       } else {
-        scheduleState.scheduleType = "now";
+        formState.scheduleType = "now";
       }
     }
 
-    // TODO tags
+    if (this.initialCrawlConfig.tags?.length) {
+      formState.tags = this.initialCrawlConfig.tags;
+    }
 
     return {
       jobName: this.initialCrawlConfig.name,
@@ -363,8 +364,7 @@ export class CrawlConfigEditor extends LiteElement {
         .scopeType as FormState["scopeType"],
       exclusions: this.initialCrawlConfig.config.exclude,
       includeLinkedPages: Boolean(this.initialCrawlConfig.config.extraHops),
-      ...seedState,
-      ...scheduleState,
+      ...formState,
     };
   }
 

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -35,6 +35,7 @@ import type {
   ExclusionChangeEvent,
 } from "../../components/queue-exclusion-table";
 import type { TimeInputChangeEvent } from "../../components/time-input";
+import type { Tags, TagsChangeEvent } from "../../components/tag-input";
 import type {
   CrawlConfigParams,
   Profile,
@@ -91,6 +92,7 @@ type FormState = {
   runNow: boolean;
   jobName: CrawlConfigParams["name"];
   browserProfile: Profile | null;
+  tags: Tags;
 };
 
 const getDefaultProgressState = (hasConfigId = false): ProgressState => {
@@ -156,6 +158,7 @@ const getDefaultFormState = (): FormState => ({
   runNow: false,
   jobName: "",
   browserProfile: null,
+  tags: [],
 });
 const defaultProgressState = getDefaultProgressState();
 const orderedTabNames = STEPS.filter(
@@ -348,6 +351,8 @@ export class CrawlConfigEditor extends LiteElement {
         scheduleState.scheduleType = "now";
       }
     }
+
+    // TODO tags
 
     return {
       jobName: this.initialCrawlConfig.name,
@@ -1244,7 +1249,20 @@ https://example.net`}
       ${this.renderHelpTextCol(
         html`Try to create a unique name to help keep things organized!`
       )}
-      ${this.renderFormCol(html` <btrix-tag-input></btrix-tag-input> `)}
+      ${this.renderFormCol(
+        html`
+          <btrix-tag-input
+            .initialTags=${this.formState.tags}
+            @tags-change=${(e: TagsChangeEvent) =>
+              this.updateFormState(
+                {
+                  tags: e.detail.tags,
+                },
+                true
+              )}
+          ></btrix-tag-input>
+        `
+      )}
       ${this.renderHelpTextCol(
         html`Create or assign this crawl (and its outputs) to one or more tags
         to help organize your archived data.`
@@ -1267,6 +1285,7 @@ https://example.net`}
         <btrix-config-details .crawlConfig=${crawlConfig}>
         </btrix-config-details>
       </div>
+
       ${when(this.formHasError, () =>
         this.renderErrorAlert(
           msg(
@@ -1633,6 +1652,7 @@ https://example.net`}
       crawlTimeout: this.formState.crawlTimeoutMinutes
         ? this.formState.crawlTimeoutMinutes * 60
         : 0,
+      tags: this.formState.tags,
       config: {
         ...(this.jobType === "seed-crawl"
           ? this.parseSeededConfig()

--- a/frontend/src/pages/archive/crawl-templates-detail.ts
+++ b/frontend/src/pages/archive/crawl-templates-detail.ts
@@ -460,6 +460,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       profileid: this.crawlConfig.profileid || null,
       jobType: this.crawlConfig.jobType,
       schedule: this.crawlConfig.schedule,
+      tags: this.crawlConfig.tags,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawl-templates-list.ts
+++ b/frontend/src/pages/archive/crawl-templates-list.ts
@@ -581,6 +581,7 @@ export class CrawlTemplatesList extends LiteElement {
       profileid: template.profileid || null,
       jobType: template.jobType,
       schedule: template.schedule,
+      tags: template.tags,
     };
 
     this.navTo(`/archives/${this.archiveId}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -710,6 +710,7 @@ export class CrawlsList extends LiteElement {
       profileid: template.profileid || null,
       jobType: template.jobType,
       schedule: template.schedule,
+      tags: template.tags,
     };
 
     this.navTo(`/archives/${crawl.aid}/crawl-templates/new`, {

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -61,6 +61,7 @@ export type CrawlConfigParams = {
   profileid: string | null;
   config: SeedConfig;
   crawlTimeout: number | null;
+  tags?: string[]; // TODO tags type
 };
 
 export type InitialCrawlConfig = Pick<

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -61,12 +61,12 @@ export type CrawlConfigParams = {
   profileid: string | null;
   config: SeedConfig;
   crawlTimeout: number | null;
-  tags?: string[]; // TODO tags type
+  tags?: string[];
 };
 
 export type InitialCrawlConfig = Pick<
   CrawlConfigParams,
-  "name" | "profileid" | "schedule"
+  "name" | "profileid" | "schedule" | "tags"
 > & {
   jobType?: JobType;
   config: Pick<

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -99,12 +99,14 @@ const theme = css`
   }
 
   /* Add more spacing between label, input and help text */
+  btrix-tag-input::part(form-control-label),
   sl-input::part(form-control-label),
   sl-textarea::part(form-control-label),
   sl-select::part(form-control-label) {
     line-height: 1.4;
     margin-bottom: 0.375rem;
   }
+  btrix-tag-input::part(form-control-help-text),
   sl-input::part(form-control-help-text),
   sl-textarea::part(form-control-help-text),
   sl-select::part(form-control-help-text) {


### PR DESCRIPTION
Allow users to set tags on a crawl config. Resolves #362

### Manual testing
1. Run app with `yarn start`
2. Go to New Crawl Config page. Complete flow up to Crawl Information
   - Verify Tags field is shown
   - Verify you can add multiple tags and remove tags
   - Verify tags can be added to field by clicking "Add" button, hitting enter, or clicking away from the input area.
3. Save new crawl config. Verify tags are shown on the crawl config detail view.
4. Edit crawl config. Verify tags can be added and removed as expected.
5. Duplicate crawl config. Verify tags are duplicated

### Screenshots
**New Crawl Config - Crawl Information step:**
<img width="922" alt="Screen Shot 2023-01-10 at 8 23 07 PM" src="https://user-images.githubusercontent.com/4672952/211717607-9f85b61e-4946-41ef-9789-df2ca66f236d.png">

**On user input, hovered on "Add" button:**
<img width="165" alt="Screen Shot 2023-01-10 at 8 23 13 PM" src="https://user-images.githubusercontent.com/4672952/211717639-d6962026-d251-46a5-84c7-d9e45158ce0b.png">

**Entered tags:**
<img width="520" alt="Screen Shot 2023-01-10 at 8 23 19 PM" src="https://user-images.githubusercontent.com/4672952/211717669-39baf7de-447a-4e4f-8e5c-ca7a9b957fa9.png">

**On crawl config details (on crawls and crawl config view):**
<img width="904" alt="Screen Shot 2023-01-10 at 8 23 37 PM" src="https://user-images.githubusercontent.com/4672952/211717709-c2e93e29-c1a6-415b-9d5c-cb539027d890.png">

### Follow-ups
Autocomplete is ready to implement but still needs some back end changes. Tracked in separate issue here: https://github.com/webrecorder/browsertrix-cloud/issues/453