### PR TITLE
Frontend archives -> teams migration

### DIFF
--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -233,11 +233,18 @@ export class AccountSettings extends LiteElement {
     }
 
     return html`<div class="grid gap-4">
-      <h1 class="text-xl font-semibold">${msg("Account settings")}</h1>
+      <h1 class="text-xl font-semibold">${msg("Account Settings")}</h1>
 
       ${successMessage}
 
       <section class="p-4 md:p-8 border rounded-lg grid gap-6">
+        <div>
+          <div class="mb-1 text-gray-500">${msg("Name")}</div>
+          <div class="inline-flex items-center">
+            <span class="mr-3">${this.userInfo?.name}</span>
+          </div>
+        </div>
+
         <div>
           <div class="mb-1 text-gray-500">${msg("Email")}</div>
           <div class="inline-flex items-center">

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -311,7 +311,7 @@ export class App extends LiteElement {
                         @click=${() => this.navigate(ROUTES.accountSettings)}
                       >
                         <sl-icon slot="prefix" name="gear"></sl-icon>
-                        ${msg("Your Account")}
+                        ${msg("Account Settings")}
                       </sl-menu-item>
                       ${this.userInfo?.isAdmin
                         ? html` <sl-menu-item

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -264,12 +264,6 @@ export class App extends LiteElement {
                 >
                   <a
                     class="text-neutral-500 hover:text-neutral-400 font-medium"
-                    href="/archives"
-                    @click=${this.navLink}
-                    >${msg("All Teams")}</a
-                  >
-                  <a
-                    class="text-neutral-500 hover:text-neutral-400 font-medium"
                     href="/crawls"
                     @click=${this.navLink}
                     >${msg("Running Crawls")}</a

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -230,7 +230,7 @@ export class App extends LiteElement {
                     class="text-neutral-500 hover:text-neutral-400 font-medium"
                     href="/archives"
                     @click=${this.navLink}
-                    >${msg("All Archives")}</a
+                    >${msg("All Teams")}</a
                   >
                   <a
                     class="text-neutral-500 hover:text-neutral-400 font-medium"

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -350,6 +350,20 @@ export class App extends LiteElement {
 
   private renderTeamDropdown() {
     if (!this.teams) return;
+
+    if (this.teams.length === 1) {
+      const team = this.teams[0];
+      return html`
+        <sl-button
+          href=${`/archives/${team.id}/crawls`}
+          variant="text"
+          size="small"
+          @click=${this.navLink}
+          >${team.name}</sl-button
+        >
+      `;
+    }
+
     const selectedId =
       this.viewState.route === "archives"
         ? this.viewState.params.id

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -364,10 +364,17 @@ export class App extends LiteElement {
       `;
     }
 
-    const selectedId =
-      this.viewState.route === "archives"
-        ? this.viewState.params.id
-        : this.defaultTeamId;
+    let selectedId = this.defaultTeamId;
+    switch (this.viewState.route) {
+      case "archive":
+        selectedId = this.viewState.params.id;
+        break;
+      case "archives":
+        selectedId = "";
+        break;
+      default:
+        break;
+    }
 
     const selectedOption = selectedId
       ? this.teams.find(({ id }) => id === selectedId)

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -349,29 +349,46 @@ export class App extends LiteElement {
   }
 
   private renderTeamDropdown() {
+    if (!this.teams) return;
     const selectedId =
       this.viewState.route === "archives"
         ? this.viewState.params.id
         : this.defaultTeamId;
+
+    const selectedOption = selectedId
+      ? this.teams.find(({ id }) => id === selectedId)
+      : { id: "", name: msg("All Teams") };
+    if (!selectedOption) {
+      console.debug(`Could't find team with ID ${selectedId}`, this.teams);
+      return;
+    }
+
     return html`
-      <sl-select
-        class="w-40 min-w-min"
-        value=${selectedId || ""}
-        size="small"
-        pill
-        @sl-select=${(e: CustomEvent) => {
-          const { value } = e.detail.item;
-          this.navigate(`/archives/${value}${value ? "/crawls" : ""}`);
-        }}
-      >
-        ${this.teams?.map(
-          (team) => html`
-            <sl-menu-item value=${team.id}>${team.name}</sl-menu-item>
-          `
-        )}
-        <sl-divider></sl-divider>
-        <sl-menu-item value="">${msg("All Teams")}</sl-menu-item>
-      </sl-select>
+      <sl-dropdown placement="bottom-end">
+        <sl-button slot="trigger" variant="text" size="small" caret
+          >${selectedOption.name}</sl-button
+        >
+        <sl-menu
+          @sl-select=${(e: CustomEvent) => {
+            const { value } = e.detail.item;
+            this.navigate(`/archives/${value}${value ? "/crawls" : ""}`);
+          }}
+        >
+          ${this.teams.map(
+            (team) => html`
+              <sl-menu-item
+                value=${team.id}
+                ?checked=${team.id === selectedOption.id}
+                >${team.name}</sl-menu-item
+              >
+            `
+          )}
+          <sl-divider></sl-divider>
+          <sl-menu-item value="" ?checked=${!selectedOption.id}
+            >${msg("All Teams")}</sl-menu-item
+          >
+        </sl-menu>
+      </sl-dropdown>
     `;
   }
 

--- a/frontend/src/pages/archive/crawls-list.ts
+++ b/frontend/src/pages/archive/crawls-list.ts
@@ -101,8 +101,12 @@ export class CrawlsList extends LiteElement {
     )(crawls) as CrawlSearchResult[];
   }
 
-  protected updated(changedProperties: Map<string, any>) {
-    if (changedProperties.has("shouldFetch")) {
+  protected willUpdate(changedProperties: Map<string, any>) {
+    if (
+      changedProperties.has("shouldFetch") ||
+      changedProperties.get("crawlsBaseUrl") ||
+      changedProperties.get("crawlsAPIBaseUrl")
+    ) {
       if (this.shouldFetch) {
         if (!this.crawlsBaseUrl) {
           throw new Error("Crawls base URL not defined");

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -145,19 +145,6 @@ export class Archive extends LiteElement {
     }
 
     return html`<article>
-      <header class="w-full max-w-screen-lg mx-auto px-3 box-border py-4">
-        <nav class="text-sm text-neutral-400">
-          <a
-            class="font-medium hover:underline"
-            href="/archives"
-            @click="${this.navLink}"
-            >${msg("Teams")}</a
-          >
-          <span class="font-mono">/</span>
-          <span>${this.archive.name}</span>
-        </nav>
-      </header>
-
       <div class="w-full max-w-screen-lg mx-auto px-3 box-border">
         <nav class="-ml-3 flex items-end overflow-x-auto">
           ${this.renderNavTab({ tabName: "crawls", label: msg("Crawls") })}

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -71,29 +71,26 @@ export class Archive extends LiteElement {
   @state()
   private successfullyInvitedEmail?: string;
 
-  async firstUpdated() {
-    if (!this.archiveId) return;
+  async willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("archiveId") && this.archiveId) {
+      try {
+        const archive = await this.getArchive(this.archiveId);
 
-    try {
-      const archive = await this.getArchive(this.archiveId);
+        if (!archive) {
+          this.navTo("/archives");
+        } else {
+          this.archive = archive;
+        }
+      } catch {
+        this.archive = null;
 
-      if (!archive) {
-        this.navTo("/archives");
-      } else {
-        this.archive = archive;
+        this.notify({
+          message: msg("Sorry, couldn't retrieve archive at this time."),
+          variant: "danger",
+          icon: "exclamation-octagon",
+        });
       }
-    } catch {
-      this.archive = null;
-
-      this.notify({
-        message: msg("Sorry, couldn't retrieve archive at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
     }
-  }
-
-  async updated(changedProperties: any) {
     if (changedProperties.has("isAddingMember") && this.isAddingMember) {
       this.successfullyInvitedEmail = undefined;
     }
@@ -216,7 +213,6 @@ export class Archive extends LiteElement {
 
     return html`<btrix-crawls-list
       .authState=${this.authState!}
-      archiveId=${this.archiveId!}
       crawlsBaseUrl=${crawlsBaseUrl}
       ?shouldFetch=${this.archiveTab === "crawls"}
     ></btrix-crawls-list>`;

--- a/frontend/src/pages/archive/index.ts
+++ b/frontend/src/pages/archive/index.ts
@@ -151,7 +151,7 @@ export class Archive extends LiteElement {
             class="font-medium hover:underline"
             href="/archives"
             @click="${this.navLink}"
-            >${msg("Archives")}</a
+            >${msg("Teams")}</a
           >
           <span class="font-mono">/</span>
           <span>${this.archive.name}</span>

--- a/frontend/src/pages/archives.ts
+++ b/frontend/src/pages/archives.ts
@@ -29,7 +29,7 @@ export class Archives extends LiteElement {
         <header
           class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border md:py-8"
         >
-          <h1 class="text-xl font-medium">${msg("Archives")}</h1>
+          <h1 class="text-xl font-medium">${msg("Teams")}</h1>
         </header>
         <hr />
       </div>

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -23,18 +23,21 @@ export class Home extends LiteElement {
   connectedCallback() {
     if (this.authState) {
       super.connectedCallback();
+      if (this.userInfo && !this.userInfo.defaultTeamId) {
+        this.fetchArchives();
+      }
     } else {
       this.navTo("/log-in");
     }
   }
 
-  async willUpdate(changedProperties: Map<string, any>) {
+  willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("userInfo") && this.userInfo) {
       if (this.userInfo.defaultTeamId) {
         this.navTo(`/archives/${this.userInfo.defaultTeamId}/crawls`);
       }
     } else if (changedProperties.has("authState") && this.authState) {
-      this.archiveList = await this.getArchives();
+      this.fetchArchives();
     }
   }
 
@@ -173,6 +176,10 @@ export class Home extends LiteElement {
         @success=${() => (this.isInviteComplete = true)}
       ></btrix-invite-form>
     `;
+  }
+
+  private async fetchArchives() {
+    this.archiveList = await this.getArchives();
   }
 
   private async getArchives(): Promise<ArchiveData[]> {

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -14,9 +14,6 @@ export class Home extends LiteElement {
   @property({ type: Object })
   userInfo?: CurrentUser;
 
-  @property({ type: String })
-  defaultTeamId?: ArchiveData["id"];
-
   @state()
   private isInviteComplete?: boolean;
 
@@ -32,8 +29,10 @@ export class Home extends LiteElement {
   }
 
   async willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("defaultTeamId") && this.defaultTeamId) {
-      this.navTo(`/archives/${this.defaultTeamId}/crawls`);
+    if (changedProperties.has("userInfo") && this.userInfo) {
+      if (this.userInfo.defaultTeamId) {
+        this.navTo(`/archives/${this.userInfo.defaultTeamId}/crawls`);
+      }
     } else if (changedProperties.has("authState") && this.authState) {
       this.archiveList = await this.getArchives();
     }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -50,7 +50,7 @@ export class Home extends LiteElement {
     }
 
     if (this.userInfo.isAdmin === false) {
-      title = msg("Archives");
+      title = msg("Teams");
       content = this.renderLoggedInNonAdmin();
     }
 
@@ -106,9 +106,7 @@ export class Home extends LiteElement {
         <div class="grid grid-cols-3 gap-8">
           <div class="col-span-3 md:col-span-2">
             <section>
-              <h2 class="text-lg font-medium mb-3 mt-2">
-                ${msg("All Archives")}
-              </h2>
+              <h2 class="text-lg font-medium mb-3 mt-2">${msg("All Teams")}</h2>
               <btrix-archives-list
                 .userInfo=${this.userInfo}
                 .archiveList=${this.archiveList}

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -14,6 +14,9 @@ export class Home extends LiteElement {
   @property({ type: Object })
   userInfo?: CurrentUser;
 
+  @property({ type: String })
+  teamId?: string;
+
   @state()
   private isInviteComplete?: boolean;
 
@@ -23,7 +26,7 @@ export class Home extends LiteElement {
   connectedCallback() {
     if (this.authState) {
       super.connectedCallback();
-      if (this.userInfo && !this.userInfo.defaultTeamId) {
+      if (this.userInfo && !this.teamId) {
         this.fetchArchives();
       }
     } else {
@@ -32,10 +35,8 @@ export class Home extends LiteElement {
   }
 
   willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("userInfo") && this.userInfo) {
-      if (this.userInfo.defaultTeamId) {
-        this.navTo(`/archives/${this.userInfo.defaultTeamId}/crawls`);
-      }
+    if (changedProperties.has("teamId") && this.teamId) {
+      this.navTo(`/archives/${this.teamId}/crawls`);
     } else if (changedProperties.has("authState") && this.authState) {
       this.fetchArchives();
     }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -14,21 +14,28 @@ export class Home extends LiteElement {
   @property({ type: Object })
   userInfo?: CurrentUser;
 
+  @property({ type: String })
+  defaultTeamId?: ArchiveData["id"];
+
   @state()
   private isInviteComplete?: boolean;
 
   @state()
   private archiveList?: ArchiveData[];
 
-  async firstUpdated() {
-    this.archiveList = await this.getArchives();
-  }
-
   connectedCallback() {
     if (this.authState) {
       super.connectedCallback();
     } else {
       this.navTo("/log-in");
+    }
+  }
+
+  async willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("defaultTeamId") && this.defaultTeamId) {
+      this.navTo(`/archives/${this.defaultTeamId}/crawls`);
+    } else if (changedProperties.has("authState") && this.authState) {
+      this.archiveList = await this.getArchives();
     }
   }
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -114,6 +114,15 @@ const theme = css`
     box-shadow: var(--sl-shadow-small);
   }
 
+  /* Prevent horizontal scrollbar */
+  sl-select::part(menu) {
+    overflow-x: hidden;
+  }
+
+  sl-dropdown sl-menu::part(base) {
+    z-index: 9999;
+  }
+
   /* Decrease control spacing on small select */
   sl-select[size="small"]::part(control) {
     --sl-input-spacing-small: var(--sl-spacing-x-small);

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -119,10 +119,6 @@ const theme = css`
     overflow-x: hidden;
   }
 
-  sl-dropdown sl-menu::part(base) {
-    z-index: 9999;
-  }
-
   /* Decrease control spacing on small select */
   sl-select[size="small"]::part(control) {
     --sl-input-spacing-small: var(--sl-spacing-x-small);

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -4,4 +4,5 @@ export type CurrentUser = {
   name: string;
   isVerified: boolean;
   isAdmin: boolean;
+  defaultTeamId?: string;
 };


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/423.
- Renames all user-facing "Archives" to "Teams"
- Allows users to choose team from dropdown, if they are a part of more than one
- Non-superadmin users are automatically redirected to their "default" team (first archive they've created or have been added to)

### Manual testing
1. Run app `yarn start`
2. Log in as normal user. Verify you're redirected to your default team crawls page
3. If your user is a part of more than one team, verify that you can select the team from the nav bar. If you only have one team, verify you see the name of the team in the nav bar.
4. Log out and log in as super admin. Verify you're not redirected to a default team page. Verify you can select a team or view all teams from the nav bar.
5. Click on "Browsertrix Cloud" on home page. Verify you're taken to the admin dashboard if superadmin, or your team crawls for regular users.

### Screenshots
**Nav bar menu for non-superadmin user in single team:**
<img width="261" alt="Screen Shot 2022-12-21 at 12 11 36 PM" src="https://user-images.githubusercontent.com/4672952/208999617-7ff7bb75-bf51-4abf-beb3-151ce93411e0.png">

**Nav bar for non-superadmin user in multiple teams:**
<img width="1146" alt="Screen Shot 2022-12-21 at 12 18 57 PM" src="https://user-images.githubusercontent.com/4672952/208999428-81ab3ae5-b4fc-4261-84f3-6285ebe7ec0a.png">

**Dropdown open:**
<img width="260" alt="Screen Shot 2022-12-21 at 12 13 51 PM" src="https://user-images.githubusercontent.com/4672952/208999495-8d053bc3-175f-498b-ae75-87be6c04ae8b.png">

**Nav bar for super admin:**
<img width="1121" alt="Screen Shot 2022-12-21 at 12 18 39 PM" src="https://user-images.githubusercontent.com/4672952/208999317-bf844800-2227-4eb9-a24f-46f7485cfb78.png">


### Potential improvements
Right now the frontend is determining the default team by retrieving archives and selecting the first created archive/team. It'd be nicer experience to return the archive/team ID from the [`GET /api/users/{id}`](https://dev.browsertrix.cloud/api/docs#/users/users_user_api_users__id__get) endpoint, to eliminate the need to wait for `GET /api/archives` to resolve before redirecting the user. This would also set the groundwork for letting users pick their own default team from user settings in the future.