### PR TITLE
backend: initial tags api support (addresses #365):

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -573,6 +573,12 @@ class CrawlConfigOps:
 
         return result.inserted_id
 
+    def get_crawl_config_tags(self, archive):
+        cursor = await self.crawl_configs.distinct("tags", {"aid": archive.id})
+        results = await cursor.to_list(length=1000)
+        print(results)
+        return results
+
 
 # ============================================================================
 # pylint: disable=redefined-builtin,invalid-name,too-many-locals,too-many-arguments
@@ -652,6 +658,10 @@ def init_crawl_config_api(
             )
 
         return await ops.do_make_inactive(crawlconfig)
+
+    @router.get("/tags")
+    async def get_crawl_config_tags(archive: Archive = Depends(archive_crawl_dep)):
+        return await ops.get_crawl_config_tags(archive)
 
     archive_ops.router.include_router(router)
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -365,7 +365,7 @@ class CrawlConfigOps:
 
         return {"success": True}
 
-    async def get_crawl_configs(self, archive: Archive, tags: List[str] = None):
+    async def get_crawl_configs(self, archive: Archive, tags: Optional[List[str]] = None):
         """Get all crawl configs for an archive is a member of"""
         match_query = {"aid": archive.id, "inactive": {"$ne": True}}
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -365,7 +365,9 @@ class CrawlConfigOps:
 
         return {"success": True}
 
-    async def get_crawl_configs(self, archive: Archive, tags: Optional[List[str]] = None):
+    async def get_crawl_configs(
+        self, archive: Archive, tags: Optional[List[str]] = None
+    ):
         """Get all crawl configs for an archive is a member of"""
         match_query = {"aid": archive.id, "inactive": {"$ne": True}}
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -225,7 +225,7 @@ class CrawlConfigOps:
         )
 
         await self.crawl_configs.create_index(
-            [("aid": pymongo.HASHED), ("tags": pymongo.ASCENDING)]
+            [("aid", pymongo.HASHED), ("tags", pymongo.ASCENDING)]
         )
 
     def set_coll_ops(self, coll_ops):
@@ -576,10 +576,8 @@ class CrawlConfigOps:
         return result.inserted_id
 
     async def get_crawl_config_tags(self, archive):
-        results = await self.crawl_configs.distinct("tags", {"aid": archive.id})
-        #results = await cursor.to_list(length=1000)
-        print(results)
-        return results
+        """get distinct tags from all crawl configs for this archive"""
+        return await self.crawl_configs.distinct("tags", {"aid": archive.id})
 
 
 # ============================================================================

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -573,7 +573,7 @@ class CrawlConfigOps:
 
         return result.inserted_id
 
-    def get_crawl_config_tags(self, archive):
+    async def get_crawl_config_tags(self, archive):
         cursor = await self.crawl_configs.distinct("tags", {"aid": archive.id})
         results = await cursor.to_list(length=1000)
         print(results)

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -225,7 +225,7 @@ class CrawlConfigOps:
         )
 
         await self.crawl_configs.create_index(
-            [("aid", pymongo.HASHED), ("tags", pymongo.ASCENDING)]
+            [("aid", pymongo.ASCENDING), ("tags", pymongo.ASCENDING)]
         )
 
     def set_coll_ops(self, coll_ops):

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -3,7 +3,8 @@ import requests
 import time
 
 
-API_PREFIX = "http://127.0.0.1:30870/api"
+HOST_PREFIX = "http://127.0.0.1:30870"
+API_PREFIX = HOST_PREFIX + "/api"
 
 ADMIN_USERNAME = "admin@example.com"
 ADMIN_PW = "PASSW0RD!"
@@ -14,24 +15,33 @@ VIEWER_PW = "viewerPASSW0RD!"
 
 @pytest.fixture(scope="session")
 def admin_auth_headers():
-    r = requests.post(
-        f"{API_PREFIX}/auth/jwt/login",
-        data={
-            "username": ADMIN_USERNAME,
-            "password": ADMIN_PW,
-            "grant_type": "password",
-        },
-    )
-    data = r.json()
-    access_token = data.get("access_token")
-    return {"Authorization": f"Bearer {access_token}"}
+    while True:
+        r = requests.post(
+            f"{API_PREFIX}/auth/jwt/login",
+            data={
+                "username": ADMIN_USERNAME,
+                "password": ADMIN_PW,
+                "grant_type": "password",
+            },
+        )
+        data = r.json()
+        try:
+            return {"Authorization": f"Bearer {data['access_token']}"}
+        except:
+            print("Waiting for admin_auth_headers")
+            time.sleep(5)
 
 
 @pytest.fixture(scope="session")
 def admin_aid(admin_auth_headers):
-    r = requests.get(f"{API_PREFIX}/archives", headers=admin_auth_headers)
-    data = r.json()
-    return data["archives"][0]["id"]
+    while True:
+        r = requests.get(f"{API_PREFIX}/archives", headers=admin_auth_headers)
+        data = r.json()
+        try:
+            return data["archives"][0]["id"]
+        except:
+            print("Waiting for admin_aid")
+            time.sleep(5)
 
 
 @pytest.fixture(scope="session")

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -40,7 +40,7 @@ def admin_crawl_id(admin_auth_headers, admin_aid):
     crawl_data = {
         "runNow": True,
         "name": "Admin Test Crawl",
-        "config": {"seeds": ["https://example.com/"]},
+        "config": {"seeds": ["https://webrecorder.net/"], "limit": 1},
     }
     r = requests.post(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -1,0 +1,80 @@
+import requests
+import hashlib
+import time
+import io
+import zipfile
+
+from .conftest import API_PREFIX, ADMIN_USERNAME, ADMIN_PW
+
+new_cid_1 = None
+new_cid_2 = None
+
+def get_sample_crawl_data(tags):
+    return {
+        "runNow": False,
+        "name": "Test Crawl",
+        "config": {"seeds": ["https://example.com/"]},
+        "tags": tags,
+    }
+
+def test_create_new_config_1(admin_auth_headers, admin_aid):
+    r = requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
+        headers=admin_auth_headers,
+        json=get_sample_crawl_data(["tag-1", "tag-2"])
+    )
+
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["added"]
+    assert data["run_now_job"] == None
+
+    global new_cid_1
+    new_cid_1 = data["added"]
+
+def test_get_config_1(admin_auth_headers, admin_aid):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/{new_cid_1}",
+        headers=admin_auth_headers,
+    )
+    assert r.json()["tags"] == ["tag-1", "tag-2"]
+
+def test_get_config_by_tag_1(admin_auth_headers, admin_aid):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/tags",
+        headers=admin_auth_headers,
+    )
+    assert r.json() == ["tag-1", "tag-2"]
+
+def test_create_new_config_2(admin_auth_headers, admin_aid):
+    r = requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
+        headers=admin_auth_headers,
+        json=get_sample_crawl_data(["tag-3", "tag-0"])
+    )
+
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["added"]
+    assert data["run_now_job"] == None
+
+    global new_cid_2
+    new_cid_2 = data["added"]
+
+def test_get_config_by_tag_2(admin_auth_headers, admin_aid):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/tags",
+        headers=admin_auth_headers,
+    )
+    assert r.json() == ["tag-0", "tag-1", "tag-2", "tag-3"]
+
+def test_get_config_2(admin_auth_headers, admin_aid):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/{new_cid_2}",
+        headers=admin_auth_headers,
+    )
+    assert r.json()["tags"] == ["tag-3", "tag-0"]
+
+

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -1,10 +1,6 @@
 import requests
-import hashlib
-import time
-import io
-import zipfile
 
-from .conftest import API_PREFIX, ADMIN_USERNAME, ADMIN_PW
+from .conftest import API_PREFIX
 
 new_cid_1 = None
 new_cid_2 = None

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -4,9 +4,7 @@ import time
 import io
 import zipfile
 
-from .conftest import API_PREFIX, ADMIN_USERNAME, ADMIN_PW
-
-host_prefix = "http://127.0.0.1:30870"
+from .conftest import API_PREFIX, HOST_PREFIX
 
 wacz_path = None
 wacz_size = None

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -35,7 +35,7 @@ def test_create_new_config(admin_auth_headers, admin_aid):
     crawl_data = {
         "runNow": True,
         "name": "Test Crawl",
-        "config": {"seeds": ["https://example.com/"]},
+        "config": {"seeds": ["https://webrecorder.net/"]},
     }
     r = requests.post(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
@@ -110,4 +110,4 @@ def test_verify_wacz():
     assert "pages/pages.jsonl" in z.namelist()
 
     pages = z.open("pages/pages.jsonl").read().decode("utf-8")
-    assert '"https://example.com/"' in pages
+    assert '"https://webrecorder.net/"' in pages

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -89,7 +89,7 @@ def test_crawl_info(admin_auth_headers, admin_aid, admin_crawl_id):
 
 
 def test_download_wacz():
-    r = requests.get(host_prefix + wacz_path)
+    r = requests.get(HOST_PREFIX + wacz_path)
     assert r.status_code == 200
     assert len(r.content) == wacz_size
 


### PR DESCRIPTION
- add 'tags' field to crawlconfig (array of strings)
- allow querying crawlconfigs to specify multiple 'tag' query args, eg. tag=A&tag=B
- tags list accessible via `/archives/{aid}/crawlconfigs/tags`
- tests: add tests for tag creation and filtering, also fix potential errors with test fixtures by adding retry