### PR TITLE
Compute crawl config name from seed URLs

### DIFF
--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -51,6 +51,7 @@ const STEPS = [
   "crawlSetup",
   "browserSettings",
   "crawlScheduling",
+  "crawlInformation",
   "confirmSettings",
 ] as const;
 type StepName = typeof STEPS[number];
@@ -94,7 +95,7 @@ type FormState = {
 
 const getDefaultProgressState = (hasConfigId = false): ProgressState => {
   let activeTab: StepName = "crawlSetup";
-  if (window.location.hash) {
+  if (hasConfigId && window.location.hash) {
     const hashValue = window.location.hash.slice(1);
 
     if (STEPS.includes(hashValue as any)) {
@@ -113,6 +114,11 @@ const getDefaultProgressState = (hasConfigId = false): ProgressState => {
         completed: hasConfigId,
       },
       crawlScheduling: {
+        enabled: hasConfigId,
+        error: false,
+        completed: hasConfigId,
+      },
+      crawlInformation: {
         enabled: hasConfigId,
         error: false,
         completed: hasConfigId,
@@ -263,23 +269,13 @@ export class CrawlConfigEditor extends LiteElement {
     ) {
       this.initializeEditor();
     }
-    if (changedProperties.get("formState") && this.formState) {
-      const hasRequiredFields = this.hasRequiredFields();
-      if (hasRequiredFields && !this.progressState.tabs.crawlSetup.error) {
-        this.updateProgressState({
-          tabs: {
-            crawlSetup: { completed: true },
-          },
-        });
-      }
-    }
     if (changedProperties.get("progressState") && this.progressState) {
-      if (
-        (changedProperties.get("progressState") as ProgressState)
-          .currentStep !== this.progressState.currentStep
-      ) {
-        this.formElem?.scrollIntoView({ behavior: "smooth" });
-      }
+      this.handleProgressStateChange(
+        changedProperties.get("progressState") as ProgressState
+      );
+    }
+    if (changedProperties.get("formState") && this.formState) {
+      this.handleFormStateChange();
     }
   }
 
@@ -366,6 +362,7 @@ export class CrawlConfigEditor extends LiteElement {
       crawlSetup: msg("Crawl Setup"),
       browserSettings: msg("Browser Settings"),
       crawlScheduling: msg("Crawl Scheduling"),
+      crawlInformation: msg("Crawl Information"),
       confirmSettings: msg("Confirm Settings"),
     };
 
@@ -402,9 +399,6 @@ export class CrawlConfigEditor extends LiteElement {
           <btrix-tab-panel name="newJobConfig-crawlSetup">
             ${this.renderPanelContent(
               html`
-                ${this.renderSectionHeading(msg("Crawl Information"))}
-                ${this.renderJobInformation()}
-                ${this.renderSectionHeading(msg("Crawler Settings"))}
                 ${when(this.jobType === "url-list", this.renderUrlListSetup)}
                 ${when(
                   this.jobType === "seed-crawl",
@@ -422,6 +416,9 @@ export class CrawlConfigEditor extends LiteElement {
           </btrix-tab-panel>
           <btrix-tab-panel name="newJobConfig-crawlScheduling">
             ${this.renderPanelContent(this.renderJobScheduling())}
+          </btrix-tab-panel>
+          <btrix-tab-panel name="newJobConfig-crawlInformation">
+            ${this.renderPanelContent(this.renderJobInformation())}
           </btrix-tab-panel>
           <btrix-tab-panel name="newJobConfig-confirmSettings">
             ${this.renderPanelContent(this.renderConfirmSettings(), {
@@ -1262,6 +1259,53 @@ https://example.net`}
       return Boolean(this.formState.jobName && this.formState.primarySeedUrl);
     }
     return Boolean(this.formState.jobName && this.formState.urlList);
+  }
+
+  private handleFormStateChange() {
+    if (!this.formState.jobName) {
+      this.setDefaultJobName();
+    }
+    const hasRequiredFields = this.hasRequiredFields();
+    if (hasRequiredFields && !this.progressState.tabs.crawlSetup.error) {
+      this.updateProgressState({
+        tabs: {
+          crawlSetup: { completed: true },
+        },
+      });
+    }
+  }
+
+  private handleProgressStateChange(oldState: ProgressState) {
+    const { currentStep } = this.progressState;
+    if (oldState.currentStep !== currentStep) {
+      this.formElem?.scrollIntoView({ behavior: "smooth" });
+    }
+  }
+
+  private setDefaultJobName() {
+    // Set default crawl name based on seed URLs
+    if (!this.formState.primarySeedUrl && !this.formState.urlList) {
+      return;
+    }
+    let jobName = "";
+    if (this.jobType === "seed-crawl") {
+      jobName = this.formState.primarySeedUrl;
+    } else {
+      const urlList = urlListToArray(this.formState.urlList);
+
+      const firstUrl = urlList[0].trim();
+      if (urlList.length > 1) {
+        const remainder = urlList.length - 1;
+        if (remainder === 1) {
+          jobName = msg(str`${firstUrl} + ${remainder} more URL`);
+        } else {
+          jobName = msg(str`${firstUrl} + ${remainder} more URLs`);
+        }
+      } else {
+        jobName = firstUrl;
+      }
+    }
+    this.updateFormState({ jobName });
   }
 
   private async handleRemoveRegex(e: ExclusionRemoveEvent) {

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -50,7 +50,7 @@ type NewCrawlConfigParams = CrawlConfigParams & {
 const STEPS = [
   "crawlSetup",
   "browserSettings",
-  "jobScheduling",
+  "crawlScheduling",
   "confirmSettings",
 ] as const;
 type StepName = typeof STEPS[number];
@@ -112,7 +112,7 @@ const getDefaultProgressState = (hasConfigId = false): ProgressState => {
         error: false,
         completed: hasConfigId,
       },
-      jobScheduling: {
+      crawlScheduling: {
         enabled: hasConfigId,
         error: false,
         completed: hasConfigId,
@@ -365,7 +365,7 @@ export class CrawlConfigEditor extends LiteElement {
     const tabLabels: Record<StepName, string> = {
       crawlSetup: msg("Crawl Setup"),
       browserSettings: msg("Browser Settings"),
-      jobScheduling: msg("Crawl Scheduling"),
+      crawlScheduling: msg("Crawl Scheduling"),
       confirmSettings: msg("Confirm Settings"),
     };
 
@@ -420,7 +420,7 @@ export class CrawlConfigEditor extends LiteElement {
           <btrix-tab-panel name="newJobConfig-browserSettings">
             ${this.renderPanelContent(this.renderCrawlBehaviors())}
           </btrix-tab-panel>
-          <btrix-tab-panel name="newJobConfig-jobScheduling">
+          <btrix-tab-panel name="newJobConfig-crawlScheduling">
             ${this.renderPanelContent(this.renderJobScheduling())}
           </btrix-tab-panel>
           <btrix-tab-panel name="newJobConfig-confirmSettings">


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/431.

### Manual testing
1. Run app `yarn start`
2. Go to new crawl config page. Click "URL List".
3. Enter URLs and go through flow by clicking "Next" and then save. Verify that default name saves as expected.
4. Start new URL List crawl config flow again. Enter URLs and click "Confirm & Save" without clicking "Next" and then save. Verify default name saves as expected.
5. Go to crawl config edit view. Verify name shows in "Crawl Information" section as expected.

### Screenshots
**"Crawl Information" tab for new URL List config**:
<img width="1121" alt="Screen Shot 2023-01-02 at 11 51 03 AM" src="https://user-images.githubusercontent.com/4672952/210273390-f3abe08b-39b9-48b4-822f-e862901378b1.png">
