### PR TITLE
Fix app not loading on older Safari

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@shoelace-style/shoelace": "2.0.0-beta.85",
     "@xstate/fsm": "^1.6.2",
     "axios": "^0.22.0",
+    "broadcastchannel-polyfill": "^1.0.1",
     "color": "^4.0.1",
     "fuse.js": "^6.5.3",
     "immutable": "^4.1.0",

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -4,6 +4,7 @@ import { property, state, query } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized } from "@lit/localize";
 import type { SlDialog } from "@shoelace-style/shoelace";
+import "broadcastchannel-polyfill";
 import "tailwindcss/tailwind.css";
 
 import type { ArchiveTab } from "./pages/archive";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1443,6 +1443,11 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+broadcastchannel-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/broadcastchannel-polyfill/-/broadcastchannel-polyfill-1.0.1.tgz#7596b3d78526b3919e76562aff00cd1278a205ea"
+  integrity sha512-iooPAN913j4xfrIu5o+mDaks9UUDOBfgjn8SsuzysfXr/X+f8m9y5t8c5rAbW6P0LdUXBJx33zwN4Cs6b9BGRw==
+
 browserslist@^4.14.5:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.2.tgz#aa15dbd2fab399a399fe4df601bb09363c5458a6"


### PR DESCRIPTION
Fixes app not loading on Safari versions older than 15.4. Tested with version 15.2. Resolves https://github.com/webrecorder/browsertrix-cloud/issues/425

### Manual testing
Run app `yarn start` and load in Safari version 15.3 or older. Verify app loads and functions as expected.