### PR TITLE
Persist currently selected team/archive

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -811,10 +811,7 @@ export class App extends LiteElement {
   private clearUser() {
     this.authService.logout();
     this.authService = new AuthService();
-    if (this.userInfo) {
-      this.unpersistUserSettings(this.userInfo.id);
-      this.userInfo = undefined;
-    }
+    this.userInfo = undefined;
     this.selectedTeamId = undefined;
   }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -83,11 +83,14 @@ export class App extends LiteElement {
 
   async connectedCallback() {
     const authState = await AuthService.initSessionStorage();
+    this.syncViewState();
     if (authState) {
       this.authService.saveLogin(authState);
+      if (this.viewState.route === "archive") {
+        this.selectedTeamId = this.viewState.params.id;
+      }
       this.updateUserInfo();
     }
-    this.syncViewState();
     super.connectedCallback();
 
     window.addEventListener("popstate", () => {
@@ -99,9 +102,6 @@ export class App extends LiteElement {
   }
 
   willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("userInfo") && this.userInfo) {
-      this.selectedTeamId = this.userInfo.defaultTeamId;
-    }
     if (
       changedProperties.get("viewState") &&
       this.viewState.route === "archive"
@@ -145,7 +145,6 @@ export class App extends LiteElement {
       ]);
 
       const userInfoSuccess = userInfoResp.status === "fulfilled";
-      let defaultTeamId: CurrentUser["defaultTeamId"];
 
       if (archivesResp.status === "fulfilled") {
         const { archives } = archivesResp.value;
@@ -153,7 +152,7 @@ export class App extends LiteElement {
         if (userInfoSuccess) {
           const userInfo = userInfoResp.value;
           if (archives.length && !userInfo?.is_superuser) {
-            defaultTeamId = archives[0].id;
+            this.selectedTeamId = this.selectedTeamId || archives[0].id;
           }
         }
       } else {
@@ -168,7 +167,6 @@ export class App extends LiteElement {
           name: value.name,
           isVerified: value.is_verified,
           isAdmin: value.is_superuser,
-          defaultTeamId,
         };
       } else {
         throw userInfoResp.reason;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -49,6 +49,8 @@ type APIUser = {
  */
 @localized()
 export class App extends LiteElement {
+  static storageKey = "btrix.app";
+
   @property({ type: String })
   version?: string;
 
@@ -368,6 +370,7 @@ export class App extends LiteElement {
           @sl-select=${(e: CustomEvent) => {
             const { value } = e.detail.item;
             this.navigate(`/archives/${value}${value ? "/crawls" : ""}`);
+            this.persistSelectedTeam(value);
           }}
         >
           ${when(
@@ -861,6 +864,18 @@ export class App extends LiteElement {
         }
       }
     );
+  }
+
+  private getPersistedSelectedTeam() {
+    return window.localStorage.getItem(`${App.storageKey}.teamId`);
+  }
+
+  private persistSelectedTeam(id: string) {
+    window.localStorage.setItem(`${App.storageKey}.teamId`, id);
+  }
+
+  private unpersistSelectedTeam() {
+    window.localStorage.removeItem(`${App.storageKey}.teamId`);
   }
 }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -716,6 +716,9 @@ export class App extends LiteElement {
     const detail = event.detail || {};
     const redirect = detail.redirect !== false;
 
+    if (this.userInfo) {
+      this.unpersistUserSettings(this.userInfo.id);
+    }
     this.clearUser();
 
     if (redirect) {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -88,9 +88,7 @@ export class App extends LiteElement {
     this.syncViewState();
     if (authState) {
       this.authService.saveLogin(authState);
-      if (this.viewState.route === "archive") {
-        this.selectedTeamId = this.viewState.params.id;
-      }
+      this.setInitialSelectedTeam();
       this.updateUserInfo();
     }
     super.connectedCallback();
@@ -109,6 +107,16 @@ export class App extends LiteElement {
       this.viewState.route === "archive"
     ) {
       this.selectedTeamId = this.viewState.params.id;
+    }
+  }
+  private setInitialSelectedTeam() {
+    if (this.viewState.route === "archive") {
+      this.selectedTeamId = this.viewState.params.id;
+    } else {
+      const storedId = this.getPersistedSelectedTeam();
+      if (storedId) {
+        this.selectedTeamId = storedId;
+      }
     }
   }
 
@@ -801,6 +809,7 @@ export class App extends LiteElement {
     this.authService = new AuthService();
     this.userInfo = undefined;
     this.selectedTeamId = undefined;
+    this.unpersistSelectedTeam();
   }
 
   private getArchives(): Promise<{ archives: ArchiveData[] }> {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -4,5 +4,4 @@ export type CurrentUser = {
   name: string;
   isVerified: boolean;
   isAdmin: boolean;
-  defaultTeamId?: string;
 };


### PR DESCRIPTION
Persists user selection of team to local storage. User selection will only be reset when the user explicitly logs out or changes browsers/devices.

- Resolves https://github.com/webrecorder/browsertrix-cloud/issues/440
- Closes https://github.com/webrecorder/browsertrix-cloud/issues/417

### Manual testing
1. Run app `yarn start`
2. Log in as normal user in multiple teams. Verify you're redirected to your default team crawls page
3. Select the team from the nav bar
4. Open a new tab. Verify that the selected team is still selected in the new tab