### PR TITLE
Use archive_viewer_dep permissions to GET crawls

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -85,7 +85,7 @@ jobs:
  
       - 
         name: Run Tests
-        run: py.test -vv ./backend/test/*.py
+        run: pytest -vv ./backend/test/*.py
 
       -
         name: Print Backend Logs

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -66,7 +66,7 @@ jobs:
  
       - 
         name: Run Tests
-        run: py.test -vv ./backend/test/*.py
+        run: pytest -vv ./backend/test/*.py
 
       -
         name: Print Backend Logs

--- a/backend/btrixcloud/archives.py
+++ b/backend/btrixcloud/archives.py
@@ -230,6 +230,11 @@ def init_archives_api(app, mdb, user_manager, invites, user_dep: User):
         archive = await ops.get_archive_for_user_by_id(uuid.UUID(aid), user)
         if not archive:
             raise HTTPException(status_code=404, detail=f"Archive '{aid}' not found")
+        if not archive.is_viewer(user):
+            raise HTTPException(
+                status_code=403,
+                detail="User does not have permission to view this archive",
+            )
 
         return archive
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -569,6 +569,7 @@ def init_crawls_api(
 
     ops = CrawlOps(mdb, users, crawl_manager, crawl_config_ops, archives)
 
+    archive_viewer_dep = archives.archive_viewer_dep
     archive_crawl_dep = archives.archive_crawl_dep
 
     @app.get("/archives/all/crawls", tags=["crawls"], response_model=ListCrawls)
@@ -579,7 +580,7 @@ def init_crawls_api(
         return ListCrawls(crawls=await ops.list_crawls(None, running_only=True))
 
     @app.get("/archives/{aid}/crawls", tags=["crawls"], response_model=ListCrawls)
-    async def list_crawls(archive: Archive = Depends(archive_crawl_dep)):
+    async def list_crawls(archive: Archive = Depends(archive_viewer_dep)):
         return ListCrawls(crawls=await ops.list_crawls(archive))
 
     @app.post(
@@ -632,7 +633,7 @@ def init_crawls_api(
         tags=["crawls"],
         response_model=CrawlOut,
     )
-    async def get_crawl(crawl_id, archive: Archive = Depends(archive_crawl_dep)):
+    async def get_crawl(crawl_id, archive: Archive = Depends(archive_viewer_dep)):
         return await ops.get_crawl(crawl_id, archive)
 
     @app.get(
@@ -657,7 +658,7 @@ def init_crawls_api(
         response_model=ListCrawlOut,
     )
     async def list_single_crawl(
-        crawl_id, archive: Archive = Depends(archive_crawl_dep)
+        crawl_id, archive: Archive = Depends(archive_viewer_dep)
     ):
         crawls = await ops.list_crawls(archive, crawl_id=crawl_id)
         if len(crawls) < 1:

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -47,6 +47,15 @@ class InviteToArchiveRequest(InviteRequest):
 
 
 # ============================================================================
+class AddToArchiveRequest(InviteRequest):
+    """Request to add a new user to an archive directly"""
+
+    role: UserRole
+    password: str
+    name: str
+
+
+# ============================================================================
 class InviteOps:
     """invite users (optionally to an archive), send emails and delete invites"""
 

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -180,6 +180,33 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
         except (DuplicateKeyError, UserAlreadyExists):
             print(f"User {email} already exists", flush=True)
 
+    async def create_non_super_user(
+        self, email: str, password: str, name: str = "New user"
+    ):
+        if not email:
+            print("No user defined", flush=True)
+            return
+
+        if not password:
+            password = passlib.pwd.genword()
+
+        try:
+            user_create = UserCreate(
+                name=name,
+                email=email,
+                password=password,
+                is_superuser=False,
+                newArchive=True,
+                is_verified=True,
+            )
+            created_user = await super().create(user_create, safe=False, request=None)
+            await self.on_after_register_custom(created_user, user_create, request=None)
+            return created_user
+
+        except (DuplicateKeyError, UserAlreadyExists):
+            print(f"User {email} already exists", flush=True)
+
+
     async def on_after_register_custom(
         self, user: UserDB, user_create: UserCreate, request: Optional[Request]
     ):

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -36,7 +36,7 @@ def admin_crawl_id(admin_auth_headers, admin_aid):
     # Start crawl.
     crawl_data = {
         "runNow": True,
-        "name": "Test Crawl",
+        "name": "Admin Test Crawl",
         "config": {"seeds": ["https://example.com/"]},
     }
     r = requests.post(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -1,0 +1,83 @@
+import pytest
+import requests
+import time
+
+
+API_PREFIX = "http://127.0.0.1:30870/api"
+
+ADMIN_USERNAME = "admin@example.com"
+ADMIN_PW = "PASSW0RD!"
+
+VIEWER_USERNAME = "viewer@example.com"
+VIEWER_PW = "viewerPASSW0RD!"
+
+@pytest.fixture(scope="session")
+def admin_auth_headers():
+    r = requests.post(
+        f"{API_PREFIX}/auth/jwt/login",
+        data={
+            "username": ADMIN_USERNAME,
+            "password": ADMIN_PW,
+            "grant_type": "password",
+        },
+    )
+    data = r.json()
+    access_token = data.get("access_token")
+    return {"Authorization": f"Bearer {access_token}"}
+
+@pytest.fixture(scope="session")
+def admin_aid(admin_auth_headers):
+    r = requests.get(f"{API_PREFIX}/archives", headers=admin_auth_headers)
+    data = r.json()
+    return data["archives"][0]["id"]
+
+@pytest.fixture(scope="session")
+def admin_crawl_id(admin_auth_headers, admin_aid):
+    # Start crawl.
+    crawl_data = {
+        "runNow": True,
+        "name": "Test Crawl",
+        "config": {"seeds": ["https://example.com/"]},
+    }
+    r = requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
+        headers=admin_auth_headers,
+        json=crawl_data,
+    )
+    data = r.json()
+    crawl_id = data["run_now_job"]
+    # Wait for it to complete and then return crawl ID
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/archives/{admin_aid}/crawls/{crawl_id}/replay.json",
+            headers=admin_auth_headers,
+        )
+        data = r.json()
+        if data["state"] == "complete":
+            return crawl_id
+        time.sleep(5)
+
+@pytest.fixture(scope="session")
+def viewer_auth_headers(admin_auth_headers, admin_aid):
+    requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/add-user",
+        json={
+            "email": VIEWER_USERNAME,
+            "password": VIEWER_PW,
+            "name": "newviewer",
+            "role": 10,
+        },
+        headers=admin_auth_headers,
+    )
+    r = requests.post(
+        f"{API_PREFIX}/auth/jwt/login",
+        data={
+            "username": VIEWER_USERNAME,
+            "password": VIEWER_PW,
+            "grant_type": "password",
+        },
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    access_token = data.get("access_token")
+    return {"Authorization": f"Bearer {access_token}"}

--- a/backend/test/test_login.py
+++ b/backend/test/test_login.py
@@ -1,14 +1,13 @@
 import requests
 
-api_prefix = "http://127.0.0.1:30870/api"
+from .conftest import API_PREFIX, ADMIN_USERNAME, ADMIN_PW
 
 
 def test_login_invalid():
-    username = "admin@example.com"
     password = "invalid"
     r = requests.post(
-        f"{api_prefix}/auth/jwt/login",
-        data={"username": username, "password": password, "grant_type": "password"},
+        f"{API_PREFIX}/auth/jwt/login",
+        data={"username": ADMIN_USERNAME, "password": password, "grant_type": "password"},
     )
     data = r.json()
 
@@ -17,11 +16,9 @@ def test_login_invalid():
 
 
 def test_login():
-    username = "admin@example.com"
-    password = "PASSW0RD!"
     r = requests.post(
-        f"{api_prefix}/auth/jwt/login",
-        data={"username": username, "password": password, "grant_type": "password"},
+        f"{API_PREFIX}/auth/jwt/login",
+        data={"username": ADMIN_USERNAME, "password": ADMIN_PW, "grant_type": "password"},
     )
     data = r.json()
 

--- a/backend/test/test_permissions.py
+++ b/backend/test/test_permissions.py
@@ -2,6 +2,7 @@ import requests
 
 from .conftest import API_PREFIX
 
+
 def test_admin_get_archive_crawls(admin_auth_headers, admin_aid, admin_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawls",
@@ -12,15 +13,20 @@ def test_admin_get_archive_crawls(admin_auth_headers, admin_aid, admin_crawl_id)
     assert data["crawls"][0]["id"] == admin_crawl_id
     assert data["crawls"][0]["aid"] == admin_aid
 
+
 def test_viewer_get_archive_crawls(viewer_auth_headers, admin_aid, admin_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawls",
         headers=viewer_auth_headers
     )
     data = r.json()
-    assert len(data["crawls"]) > 0
-    assert data["crawls"][0]["id"] == admin_crawl_id
-    assert data["crawls"][0]["aid"] == admin_aid
+    crawls = data["crawls"]
+    crawl_ids = []
+    for crawl in crawls:
+        crawl_ids.append(crawl["id"])
+    assert len(crawls) > 0
+    assert admin_crawl_id in crawl_ids
+
 
 def test_viewer_get_crawl(viewer_auth_headers, admin_aid, admin_crawl_id):
     r = requests.get(
@@ -30,6 +36,7 @@ def test_viewer_get_crawl(viewer_auth_headers, admin_aid, admin_crawl_id):
     data = r.json()
     assert data["id"] == admin_crawl_id
     assert data["aid"] == admin_aid
+
 
 def test_viewer_get_crawl_replay(viewer_auth_headers, admin_aid, admin_crawl_id):
     r = requests.get(

--- a/backend/test/test_permissions.py
+++ b/backend/test/test_permissions.py
@@ -1,0 +1,42 @@
+import requests
+
+from .conftest import API_PREFIX
+
+def test_admin_get_archive_crawls(admin_auth_headers, admin_aid, admin_crawl_id):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls",
+        headers=admin_auth_headers
+    )
+    data = r.json()
+    assert len(data["crawls"]) > 0
+    assert data["crawls"][0]["id"] == admin_crawl_id
+    assert data["crawls"][0]["aid"] == admin_aid
+
+def test_viewer_get_archive_crawls(viewer_auth_headers, admin_aid, admin_crawl_id):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls",
+        headers=viewer_auth_headers
+    )
+    data = r.json()
+    assert len(data["crawls"]) > 0
+    assert data["crawls"][0]["id"] == admin_crawl_id
+    assert data["crawls"][0]["aid"] == admin_aid
+
+def test_viewer_get_crawl(viewer_auth_headers, admin_aid, admin_crawl_id):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls/{admin_crawl_id}",
+        headers=viewer_auth_headers
+    )
+    data = r.json()
+    assert data["id"] == admin_crawl_id
+    assert data["aid"] == admin_aid
+
+def test_viewer_get_crawl_replay(viewer_auth_headers, admin_aid, admin_crawl_id):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls/{admin_crawl_id}/replay.json",
+        headers=viewer_auth_headers
+    )
+    data = r.json()
+    assert data["id"] == admin_crawl_id
+    assert data["aid"] == admin_aid
+    assert data["resources"]

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -1,0 +1,18 @@
+import requests
+
+from .conftest import API_PREFIX
+
+
+def test_create_super_user(admin_auth_headers):
+    assert admin_auth_headers
+    auth = admin_auth_headers["Authorization"]
+    token = auth.replace("Bearer ", "")
+    assert token != "None"
+    assert len(token) > 4
+
+def test_create_non_super_user(viewer_auth_headers):
+    assert viewer_auth_headers
+    auth = viewer_auth_headers["Authorization"]
+    token = auth.replace("Bearer ", "")
+    assert token != "None"
+    assert len(token) > 4


### PR DESCRIPTION
Connected to https://github.com/webrecorder/browsertrix-cloud/issues/208

This PR modifies a few of the endpoints that `GET` crawls within an archive to use the `archive_dep` (Viewer, Crawl, or Admin) permissions role rather than `archive_crawl_dep`, and ensures that the user has at least `is_viewer()` permissions. This resolves an issue where a user with Viewer permissions could not `GET` details about crawls or lists of crawls from the API that they should have permissions to. Endpoints to start, modify, or delete crawls are unchanged.

This PR also adds:
- A new endpoint to directly create a user and add them to an existing archive, skipping the invitation workflow, which is necessary for...
- Some tests to cover the changes as well as pytest fixtures which may prove useful across the test modules. Existing tests have been refactored a bit to use these fixtures and limit duplication.