### PR TITLE
Fix skipping to confirm when duplicating crawl config

### DIFF
--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -519,8 +519,6 @@ export class CrawlConfigEditor extends LiteElement {
   }
 
   private renderFooter({ isFirst = false, isLast = false }) {
-    const isConfirmSettingsEnabled =
-      this.progressState.tabs.crawlSetup.completed;
     return html`
       <div class="px-6 py-4 border-t flex justify-between">
         ${isFirst
@@ -588,13 +586,14 @@ export class CrawlConfigEditor extends LiteElement {
                     <sl-button
                       size="small"
                       @click=${() => {
-                        if (!isConfirmSettingsEnabled) {
-                          this.nextStep();
-                        } else {
+                        if (this.hasRequiredFields()) {
                           this.updateProgressState({
                             activeTab: "confirmSettings",
                             currentStep: "confirmSettings",
+                            tabs: { crawlSetup: { completed: true } },
                           });
+                        } else {
+                          this.nextStep();
                         }
                       }}
                     >


### PR DESCRIPTION
Fixes jumping to the confirmation view when creating a new crawl config by duplicating an existing config. (Didn't create an issue for this one)

### Manual testing
1. Go to crawl config list view. Click vertical "..." icon > "Duplicate crawl config"
2. Enter in required fields and click "Confirm & Save". Verify you're taken to the confirmation step