### PR TITLE
API filters by user + crawl collection ids

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -366,13 +366,19 @@ class CrawlConfigOps:
         return {"success": True}
 
     async def get_crawl_configs(
-        self, archive: Archive, tags: Optional[List[str]] = None
+        self,
+        archive: Archive,
+        userid: Optional[UUID4] = None,
+        tags: Optional[List[str]] = None,
     ):
         """Get all crawl configs for an archive is a member of"""
         match_query = {"aid": archive.id, "inactive": {"$ne": True}}
 
         if tags:
             match_query["tags"] = {"$all": tags}
+
+        if userid:
+            match_query["userid"] = userid
 
         # pylint: disable=duplicate-code
         cursor = self.crawl_configs.aggregate(
@@ -599,9 +605,10 @@ def init_crawl_config_api(
     @router.get("", response_model=CrawlConfigsResponse)
     async def get_crawl_configs(
         archive: Archive = Depends(archive_crawl_dep),
+        userid: Optional[UUID4] = None,
         tag: Union[List[str], None] = Query(default=None),
     ):
-        return await ops.get_crawl_configs(archive, tag)
+        return await ops.get_crawl_configs(archive, userid=userid, tags=tag)
 
     @router.get("/tags")
     async def get_crawl_config_tags(archive: Archive = Depends(archive_crawl_dep)):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -173,6 +173,7 @@ class CrawlOps:
         archive: Optional[Archive] = None,
         cid: uuid.UUID = None,
         collid: uuid.UUID = None,
+        userid: uuid.UUID = None,
         crawl_id: str = None,
         exclude_files=True,
         running_only=False,
@@ -190,6 +191,9 @@ class CrawlOps:
 
         if collid:
             query["colls"] = collid
+
+        if userid:
+            query["userid"] = userid
 
         if running_only:
             query["state"] = {"$in": ["running", "starting", "stopping"]}
@@ -580,8 +584,10 @@ def init_crawls_api(
         return ListCrawls(crawls=await ops.list_crawls(None, running_only=True))
 
     @app.get("/archives/{aid}/crawls", tags=["crawls"], response_model=ListCrawls)
-    async def list_crawls(archive: Archive = Depends(archive_viewer_dep)):
-        return ListCrawls(crawls=await ops.list_crawls(archive))
+    async def list_crawls(
+        archive: Archive = Depends(archive_viewer_dep), userid: Optional[UUID4] = None
+    ):
+        return ListCrawls(crawls=await ops.list_crawls(archive, userid=userid))
 
     @app.post(
         "/archives/{aid}/crawls/{crawl_id}/cancel",

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -577,12 +577,12 @@ def init_crawls_api(
     archive_crawl_dep = archives.archive_crawl_dep
 
     @app.get("/archives/all/crawls", tags=["crawls"], response_model=ListCrawls)
-    async def list_crawls_admin(user: User = Depends(user_dep), cid: uuid.UUID = None):
+    async def list_crawls_admin(user: User = Depends(user_dep), userid: Optional[UUID4] = None, cid: Optional[UUID4] = None):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         return ListCrawls(
-            crawls=await ops.list_crawls(None, running_only=True, cid=cid)
+            crawls=await ops.list_crawls(None, userid=userid, cid=cid, running_only=True)
         )
 
     @app.get("/archives/{aid}/crawls", tags=["crawls"], response_model=ListCrawls)
@@ -654,7 +654,6 @@ def init_crawls_api(
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         crawls = await ops.list_crawls(crawl_id=crawl_id)
-        print("crawls", crawls)
         if len(crawls) < 1:
             raise HTTPException(status_code=404, detail="crawl_not_found")
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -577,19 +577,31 @@ def init_crawls_api(
     archive_crawl_dep = archives.archive_crawl_dep
 
     @app.get("/archives/all/crawls", tags=["crawls"], response_model=ListCrawls)
-    async def list_crawls_admin(user: User = Depends(user_dep), userid: Optional[UUID4] = None, cid: Optional[UUID4] = None):
+    async def list_crawls_admin(
+        user: User = Depends(user_dep),
+        userid: Optional[UUID4] = None,
+        cid: Optional[UUID4] = None,
+    ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         return ListCrawls(
-            crawls=await ops.list_crawls(None, userid=userid, cid=cid, running_only=True)
+            crawls=await ops.list_crawls(
+                None, userid=userid, cid=cid, running_only=True
+            )
         )
 
     @app.get("/archives/{aid}/crawls", tags=["crawls"], response_model=ListCrawls)
     async def list_crawls(
-        archive: Archive = Depends(archive_viewer_dep), userid: Optional[UUID4] = None, cid: Optional[UUID4] = None
+        archive: Archive = Depends(archive_viewer_dep),
+        userid: Optional[UUID4] = None,
+        cid: Optional[UUID4] = None,
     ):
-        return ListCrawls(crawls=await ops.list_crawls(archive, userid=userid, cid=cid, running_only=False))
+        return ListCrawls(
+            crawls=await ops.list_crawls(
+                archive, userid=userid, cid=cid, running_only=False
+            )
+        )
 
     @app.post(
         "/archives/{aid}/crawls/{crawl_id}/cancel",

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -577,17 +577,19 @@ def init_crawls_api(
     archive_crawl_dep = archives.archive_crawl_dep
 
     @app.get("/archives/all/crawls", tags=["crawls"], response_model=ListCrawls)
-    async def list_crawls_admin(user: User = Depends(user_dep)):
+    async def list_crawls_admin(user: User = Depends(user_dep), cid: uuid.UUID = None):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
-        return ListCrawls(crawls=await ops.list_crawls(None, running_only=True))
+        return ListCrawls(
+            crawls=await ops.list_crawls(None, running_only=True, cid=cid)
+        )
 
     @app.get("/archives/{aid}/crawls", tags=["crawls"], response_model=ListCrawls)
     async def list_crawls(
-        archive: Archive = Depends(archive_viewer_dep), userid: Optional[UUID4] = None
+        archive: Archive = Depends(archive_viewer_dep), userid: Optional[UUID4] = None, cid: Optional[UUID4] = None
     ):
-        return ListCrawls(crawls=await ops.list_crawls(archive, userid=userid))
+        return ListCrawls(crawls=await ops.list_crawls(archive, userid=userid, cid=cid, running_only=False))
 
     @app.post(
         "/archives/{aid}/crawls/{crawl_id}/cancel",

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -253,9 +253,13 @@ class ProfileOps:
 
         return {"success": True}
 
-    async def list_profiles(self, archive: Archive):
+    async def list_profiles(self, archive: Archive, userid: Optional[UUID4] = None):
         """list all profiles"""
-        cursor = self.profiles.find({"aid": archive.id})
+        query = {"aid": archive.id}
+        if userid:
+            query["userid"] = userid
+
+        cursor = self.profiles.find(query)
         results = await cursor.to_list(length=1000)
         return [Profile.from_dict(res) for res in results]
 
@@ -395,8 +399,9 @@ def init_profiles_api(mdb, crawl_manager, archive_ops, user_dep):
     @router.get("", response_model=List[Profile])
     async def list_profiles(
         archive: Archive = Depends(archive_crawl_dep),
+        userid: Optional[UUID4] = None,
     ):
-        return await ops.list_profiles(archive)
+        return await ops.list_profiles(archive, userid)
 
     @router.post("", response_model=Profile)
     async def commit_browser_to_new(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -85,6 +85,7 @@ def admin_crawl_id(admin_auth_headers, admin_aid):
 def admin_config_id(admin_crawl_id):
     return _admin_config_id
 
+
 @pytest.fixture(scope="session")
 def viewer_auth_headers(admin_auth_headers, admin_aid):
     requests.post(
@@ -108,6 +109,7 @@ def viewer_auth_headers(admin_auth_headers, admin_aid):
     data = r.json()
     access_token = data.get("access_token")
     return {"Authorization": f"Bearer {access_token}"}
+
 
 @pytest.fixture(scope="session")
 def crawler_auth_headers(admin_auth_headers, admin_aid):
@@ -133,10 +135,12 @@ def crawler_auth_headers(admin_auth_headers, admin_aid):
     access_token = data.get("access_token")
     return {"Authorization": f"Bearer {access_token}"}
 
+
 @pytest.fixture(scope="session")
 def crawler_userid(crawler_auth_headers):
     r = requests.get(f"{API_PREFIX}/users/me", headers=crawler_auth_headers)
     return r.json()["id"]
+
 
 @pytest.fixture(scope="session")
 def crawler_crawl_id(crawler_auth_headers, admin_aid):
@@ -167,6 +171,7 @@ def crawler_crawl_id(crawler_auth_headers, admin_aid):
         if data["state"] == "complete":
             return crawl_id
         time.sleep(5)
+
 
 @pytest.fixture(scope="session")
 def crawler_config_id(crawler_crawl_id):

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -12,6 +12,9 @@ ADMIN_PW = "PASSW0RD!"
 VIEWER_USERNAME = "viewer@example.com"
 VIEWER_PW = "viewerPASSW0RD!"
 
+CRAWLER_USERNAME = "crawler@example.com"
+CRAWLER_PW = "crawlerPASSWORD!"
+
 
 @pytest.fixture(scope="session")
 def admin_auth_headers():
@@ -90,8 +93,36 @@ def viewer_auth_headers(admin_auth_headers, admin_aid):
             "password": VIEWER_PW,
             "grant_type": "password",
         },
-        headers=admin_auth_headers,
     )
     data = r.json()
     access_token = data.get("access_token")
     return {"Authorization": f"Bearer {access_token}"}
+
+@pytest.fixture(scope="session")
+def crawler_auth_headers(admin_auth_headers, admin_aid):
+    requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/add-user",
+        json={
+            "email": CRAWLER_USERNAME,
+            "password": CRAWLER_PW,
+            "name": "new-crawler",
+            "role": 20,
+        },
+        headers=admin_auth_headers,
+    )
+    r = requests.post(
+        f"{API_PREFIX}/auth/jwt/login",
+        data={
+            "username": CRAWLER_USERNAME,
+            "password": CRAWLER_PW,
+            "grant_type": "password",
+        },
+    )
+    data = r.json()
+    access_token = data.get("access_token")
+    return {"Authorization": f"Bearer {access_token}"}
+
+@pytest.fixture(scope="session")
+def crawler_userid(crawler_auth_headers):
+    r = requests.get(f"{API_PREFIX}/users/me", headers=crawler_auth_headers)
+    return r.json()["id"]

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -5,6 +5,7 @@ from .conftest import API_PREFIX
 new_cid_1 = None
 new_cid_2 = None
 
+
 def get_sample_crawl_data(tags):
     return {
         "runNow": False,
@@ -13,11 +14,12 @@ def get_sample_crawl_data(tags):
         "tags": tags,
     }
 
+
 def test_create_new_config_1(admin_auth_headers, admin_aid):
     r = requests.post(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
         headers=admin_auth_headers,
-        json=get_sample_crawl_data(["tag-1", "tag-2"])
+        json=get_sample_crawl_data(["tag-1", "tag-2"]),
     )
 
     assert r.status_code == 200
@@ -29,12 +31,14 @@ def test_create_new_config_1(admin_auth_headers, admin_aid):
     global new_cid_1
     new_cid_1 = data["added"]
 
+
 def test_get_config_1(admin_auth_headers, admin_aid):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/{new_cid_1}",
         headers=admin_auth_headers,
     )
     assert r.json()["tags"] == ["tag-1", "tag-2"]
+
 
 def test_get_config_by_tag_1(admin_auth_headers, admin_aid):
     r = requests.get(
@@ -43,11 +47,12 @@ def test_get_config_by_tag_1(admin_auth_headers, admin_aid):
     )
     assert r.json() == ["tag-1", "tag-2"]
 
+
 def test_create_new_config_2(admin_auth_headers, admin_aid):
     r = requests.post(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
         headers=admin_auth_headers,
-        json=get_sample_crawl_data(["tag-3", "tag-0"])
+        json=get_sample_crawl_data(["tag-3", "tag-0"]),
     )
 
     assert r.status_code == 200
@@ -59,6 +64,7 @@ def test_create_new_config_2(admin_auth_headers, admin_aid):
     global new_cid_2
     new_cid_2 = data["added"]
 
+
 def test_get_config_by_tag_2(admin_auth_headers, admin_aid):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/tags",
@@ -66,11 +72,10 @@ def test_get_config_by_tag_2(admin_auth_headers, admin_aid):
     )
     assert r.json() == ["tag-0", "tag-1", "tag-2", "tag-3"]
 
+
 def test_get_config_2(admin_auth_headers, admin_aid):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/{new_cid_2}",
         headers=admin_auth_headers,
     )
     assert r.json()["tags"] == ["tag-3", "tag-0"]
-
-

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -33,7 +33,9 @@ def test_get_config_by_user(crawler_auth_headers, admin_aid, crawler_userid):
     assert len(r.json()["crawlConfigs"]) == 1
 
 
-def test_ensure_crawl_and_admin_user_crawls(admin_aid, crawler_crawl_id, admin_crawl_id):
+def test_ensure_crawl_and_admin_user_crawls(
+    admin_aid, crawler_auth_headers, crawler_crawl_id, admin_crawl_id
+):
     assert crawler_crawl_id
     assert admin_crawl_id
     r = requests.get(

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -9,7 +9,7 @@ def get_sample_crawl_data():
         "config": {"seeds": ["https://example.com/"]},
     }
 
-def test_create_new_config_2_diff_user(crawler_auth_headers, admin_aid):
+def test_create_new_config_crawler_user(crawler_auth_headers, admin_aid):
     r = requests.post(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
         headers=crawler_auth_headers,
@@ -29,11 +29,34 @@ def test_get_config_by_user(crawler_auth_headers, admin_aid, crawler_userid):
     )
     assert len(r.json()["crawlConfigs"]) == 1
 
-def test_get_crawl_job_by_user(crawler_auth_headers, admin_aid, crawler_userid, admin_crawl_id):
+def test_ensure_crawl_and_admin_user_crawls(admin_id, crawler_crawl_id, admin_crawl_id):
+    assert crawler_crawl_id
+    assert admin_crawl_id
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls",
+        headers=crawler_auth_headers,
+    )
+    assert len(r.json()["crawls"]) == 2
+
+def test_get_crawl_job_by_user(crawler_auth_headers, admin_aid, crawler_userid, crawler_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawls?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["crawls"]) == 0
+    assert len(r.json()["crawls"]) == 1
+
+def test_get_crawl_job_by_config(crawler_auth_headers, admin_aid, admin_config_id, crawler_config_id):
+
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls?cid={admin_config_id}",
+        headers=crawler_auth_headers,
+    )
+    assert len(r.json()["crawls"]) == 1
+
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls?cid={crawler_config_id}",
+        headers=crawler_auth_headers,
+    )
+    assert len(r.json()["crawls"]) == 1
 
 

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -2,6 +2,7 @@ import requests
 
 from .conftest import API_PREFIX
 
+
 def get_sample_crawl_data():
     return {
         "runNow": False,
@@ -9,11 +10,12 @@ def get_sample_crawl_data():
         "config": {"seeds": ["https://example.com/"]},
     }
 
+
 def test_create_new_config_crawler_user(crawler_auth_headers, admin_aid):
     r = requests.post(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
         headers=crawler_auth_headers,
-        json=get_sample_crawl_data()
+        json=get_sample_crawl_data(),
     )
 
     assert r.status_code == 200
@@ -22,12 +24,14 @@ def test_create_new_config_crawler_user(crawler_auth_headers, admin_aid):
     assert data["added"]
     assert data["run_now_job"] == None
 
+
 def test_get_config_by_user(crawler_auth_headers, admin_aid, crawler_userid):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
     assert len(r.json()["crawlConfigs"]) == 1
+
 
 def test_ensure_crawl_and_admin_user_crawls(admin_id, crawler_crawl_id, admin_crawl_id):
     assert crawler_crawl_id
@@ -38,14 +42,20 @@ def test_ensure_crawl_and_admin_user_crawls(admin_id, crawler_crawl_id, admin_cr
     )
     assert len(r.json()["crawls"]) == 2
 
-def test_get_crawl_job_by_user(crawler_auth_headers, admin_aid, crawler_userid, crawler_crawl_id):
+
+def test_get_crawl_job_by_user(
+    crawler_auth_headers, admin_aid, crawler_userid, crawler_crawl_id
+):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawls?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
     assert len(r.json()["crawls"]) == 1
 
-def test_get_crawl_job_by_config(crawler_auth_headers, admin_aid, admin_config_id, crawler_config_id):
+
+def test_get_crawl_job_by_config(
+    crawler_auth_headers, admin_aid, admin_config_id, crawler_config_id
+):
 
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawls?cid={admin_config_id}",
@@ -58,5 +68,3 @@ def test_get_crawl_job_by_config(crawler_auth_headers, admin_aid, admin_config_i
         headers=crawler_auth_headers,
     )
     assert len(r.json()["crawls"]) == 1
-
-

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -33,7 +33,7 @@ def test_get_config_by_user(crawler_auth_headers, admin_aid, crawler_userid):
     assert len(r.json()["crawlConfigs"]) == 1
 
 
-def test_ensure_crawl_and_admin_user_crawls(admin_id, crawler_crawl_id, admin_crawl_id):
+def test_ensure_crawl_and_admin_user_crawls(admin_aid, crawler_crawl_id, admin_crawl_id):
     assert crawler_crawl_id
     assert admin_crawl_id
     r = requests.get(

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -1,0 +1,39 @@
+import requests
+
+from .conftest import API_PREFIX
+
+def get_sample_crawl_data():
+    return {
+        "runNow": False,
+        "name": "Test Crawl",
+        "config": {"seeds": ["https://example.com/"]},
+    }
+
+def test_create_new_config_2_diff_user(crawler_auth_headers, admin_aid):
+    r = requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs/",
+        headers=crawler_auth_headers,
+        json=get_sample_crawl_data()
+    )
+
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["added"]
+    assert data["run_now_job"] == None
+
+def test_get_config_by_user(crawler_auth_headers, admin_aid, crawler_userid):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawlconfigs?userid={crawler_userid}",
+        headers=crawler_auth_headers,
+    )
+    assert len(r.json()["crawlConfigs"]) == 1
+
+def test_get_crawl_job_by_user(crawler_auth_headers, admin_aid, crawler_userid, admin_crawl_id):
+    r = requests.get(
+        f"{API_PREFIX}/archives/{admin_aid}/crawls?userid={crawler_userid}",
+        headers=crawler_auth_headers,
+    )
+    assert len(r.json()["crawls"]) == 0
+
+

--- a/backend/test/test_permissions.py
+++ b/backend/test/test_permissions.py
@@ -16,6 +16,7 @@ def test_admin_get_archive_crawls(admin_auth_headers, admin_aid, admin_crawl_id)
         crawl_ids.append(crawl["id"])
     assert admin_crawl_id in crawl_ids
 
+
 def test_viewer_get_archive_crawls(viewer_auth_headers, admin_aid, admin_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/archives/{admin_aid}/crawls", headers=viewer_auth_headers

--- a/backend/test/test_permissions.py
+++ b/backend/test/test_permissions.py
@@ -8,10 +8,13 @@ def test_admin_get_archive_crawls(admin_auth_headers, admin_aid, admin_crawl_id)
         f"{API_PREFIX}/archives/{admin_aid}/crawls", headers=admin_auth_headers
     )
     data = r.json()
-    assert len(data["crawls"]) > 0
-    assert data["crawls"][0]["id"] == admin_crawl_id
-    assert data["crawls"][0]["aid"] == admin_aid
-
+    crawls = data["crawls"]
+    crawl_ids = []
+    assert len(crawls) > 0
+    for crawl in crawls:
+        assert crawl["aid"] == admin_aid
+        crawl_ids.append(crawl["id"])
+    assert admin_crawl_id in crawl_ids
 
 def test_viewer_get_archive_crawls(viewer_auth_headers, admin_aid, admin_crawl_id):
     r = requests.get(
@@ -20,9 +23,10 @@ def test_viewer_get_archive_crawls(viewer_auth_headers, admin_aid, admin_crawl_i
     data = r.json()
     crawls = data["crawls"]
     crawl_ids = []
-    for crawl in crawls:
-        crawl_ids.append(crawl["id"])
     assert len(crawls) > 0
+    for crawl in crawls:
+        assert crawl["aid"] == admin_aid
+        crawl_ids.append(crawl["id"])
     assert admin_crawl_id in crawl_ids
 
 


### PR DESCRIPTION
- Adds filter of crawls, crawlconfigs and profiles by `userid=` query arg (fixes #460)
- Adds filter of crawls by crawlconfig `cid=` query arg (fixes #400)
- Test improvements: test creation of multiple crawls, including with crawler permissions user.