### PR TITLE
Add default organization

### DIFF
--- a/backend/btrixcloud/archives.py
+++ b/backend/btrixcloud/archives.py
@@ -1,6 +1,7 @@
 """
 Archive API handling
 """
+import os
 import uuid
 
 from typing import Dict, Union, Literal, Optional
@@ -147,6 +148,12 @@ class ArchiveOps:
     ):
         # pylint: disable=too-many-arguments
         """Create new archive with default storage for new user"""
+        default_org = await self.get_default_org()
+        if default_org and default_org.name == archive_name:
+            print(
+                f'\'Name "{archive_name}" reserved by default organization - skipping'
+            )
+            return
 
         id_ = uuid.uuid4()
 
@@ -187,6 +194,13 @@ class ArchiveOps:
         """Get an archive by id"""
         res = await self.archives.find_one({"_id": aid})
         return Archive.from_dict(res)
+
+    async def get_default_org(self):
+        """Get default organization"""
+        default_org = os.environ.get("DEFAULT_ORG", "My Organization")
+        res = await self.archives.find_one({"name": default_org})
+        if res:
+            return Archive.from_dict(res)
 
     async def update(self, archive: Archive):
         """Update existing archive"""

--- a/backend/btrixcloud/archives.py
+++ b/backend/btrixcloud/archives.py
@@ -228,9 +228,14 @@ class ArchiveOps:
         """Create default organization if doesn't exist."""
         await self.init_index()
 
-        existing_default = await self.get_default_org()
-        if existing_default:
-            print("Default organization already exists - skipping", flush=True)
+        default_org = await self.get_default_org()
+        if default_org:
+            if default_org.name == DEFAULT_ORG:
+                print("Default organization already exists - skipping", flush=True)
+            else:
+                default_org.name = DEFAULT_ORG
+                await self.update(default_org)
+                print(f'Default organization renamed to "{DEFAULT_ORG}"', flush=True)
             return
 
         id_ = uuid.uuid4()

--- a/backend/btrixcloud/archives.py
+++ b/backend/btrixcloud/archives.py
@@ -341,6 +341,26 @@ def init_archives_api(app, mdb, user_manager, invites, user_dep: User):
             ]
         }
 
+    @app.post("/archives/create", tags=["archives"])
+    async def create_archive(
+        new_archive: RenameArchive,
+        user: User = Depends(user_dep),
+    ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
+        id_ = uuid.uuid4()
+        storage_path = str(id_) + "/"
+        archive = Archive(
+            id=id_,
+            name=new_archive.name,
+            users={},
+            storage=DefaultStorage(name="default", path=storage_path),
+        )
+        await ops.add_archive(archive)
+
+        return {"added": True}
+
     @router.get("", tags=["archives"])
     async def get_archive(
         archive: Archive = Depends(archive_dep), user: User = Depends(user_dep)

--- a/backend/btrixcloud/archives.py
+++ b/backend/btrixcloud/archives.py
@@ -156,6 +156,10 @@ class ArchiveOps:
             try:
                 return await self.archives.create_index("name", unique=True)
             except AutoReconnect:
+                print(
+                    "Database connection unavailable to create index. Will try again in 5 scconds",
+                    flush=True,
+                )
                 time.sleep(5)
 
     async def add_archive(self, archive: Archive):

--- a/backend/btrixcloud/archives.py
+++ b/backend/btrixcloud/archives.py
@@ -155,7 +155,7 @@ class ArchiveOps:
 
     async def init_index(self):
         """init lookup index"""
-        self.archives.create_index("name", unique=True)
+        await self.archives.create_index("name", unique=True)
 
     async def add_archive(self, archive: Archive):
         """Add new archive"""

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -77,6 +77,11 @@ class InviteOps:
                 status_code=403, detail="This user has already been invited"
             )
 
+        if not archive_name or not new_user_invite.aid:
+            default_org = await self.archives.find_one({"default": True})
+            new_user_invite.aid = default_org["_id"]
+            archive_name = default_org["name"]
+
         await self.invites.insert_one(new_user_invite.to_dict())
 
         self.email.send_new_user_invite(
@@ -126,8 +131,6 @@ class InviteOps:
         if allow_existing is false, don't allow invites to existing users"""
         invite_code = uuid.uuid4().hex
 
-        aid = None
-        archive_name = None
         if archive:
             aid = archive.id
             archive_name = archive.name

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -77,8 +77,10 @@ class InviteOps:
                 status_code=403, detail="This user has already been invited"
             )
 
+        # Invitations to a specific org via API must invite role, so if it's
+        # absent assume this is a general invitation from superadmin.
         if not new_user_invite.role:
-            new_user_invite.role = UserRole.CRAWLER
+            new_user_invite.role = UserRole.OWNER
 
         await self.invites.insert_one(new_user_invite.to_dict())
 

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -77,10 +77,8 @@ class InviteOps:
                 status_code=403, detail="This user has already been invited"
             )
 
-        if not archive_name or not new_user_invite.aid:
-            default_org = await self.archives.find_one({"default": True})
-            new_user_invite.aid = default_org["_id"]
-            archive_name = default_org["name"]
+        if not new_user_invite.role:
+            new_user_invite.role = UserRole.CRAWLER
 
         await self.invites.insert_one(new_user_invite.to_dict())
 

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -8,7 +8,6 @@ import uuid
 from pydantic import BaseModel, UUID4
 from fastapi import HTTPException
 
-
 from .db import BaseMongoModel
 
 
@@ -61,6 +60,7 @@ class InviteOps:
 
     def __init__(self, mdb, email):
         self.invites = mdb["invites"]
+        self.archives = mdb["archives"]
         self.email = email
 
     async def add_new_user_invite(
@@ -131,6 +131,10 @@ class InviteOps:
         if archive:
             aid = archive.id
             archive_name = archive.name
+        else:
+            default_org = await self.archives.find_one({"default": True})
+            aid = default_org["_id"]
+            archive_name = default_org["name"]
 
         invite_pending = InvitePending(
             id=invite_code,

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -156,7 +156,6 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
         """Initialize a super user from env vars"""
         email = os.environ.get("SUPERUSER_EMAIL")
         password = os.environ.get("SUPERUSER_PASSWORD")
-        default_org = os.environ.get("DEFAULT_ORG", "My Organization")
         if not email:
             print("No superuser defined", flush=True)
             return
@@ -171,8 +170,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
                     email=email,
                     password=password,
                     is_superuser=True,
-                    newArchive=True,
-                    newArchiveName=default_org,
+                    newArchive=False,
                     is_verified=True,
                 )
             )
@@ -183,7 +181,10 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
             print(f"User {email} already exists", flush=True)
 
     async def create_non_super_user(
-        self, email: str, password: str, name: str = "New user"
+        self,
+        email: str,
+        password: str,
+        name: str = "New user",
     ):
         """create a regular user with given credentials"""
         if not email:

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -140,6 +140,9 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
         ):
             raise HTTPException(status_code=400, detail="Invalid Invite Token")
 
+        # Don't create a new org for registered users.
+        user.newArchive = False
+
         created_user = await super().create(user, safe, request)
         await self.on_after_register_custom(created_user, user, request)
         return created_user

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -156,6 +156,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
         """Initialize a super user from env vars"""
         email = os.environ.get("SUPERUSER_EMAIL")
         password = os.environ.get("SUPERUSER_PASSWORD")
+        default_org = os.environ.get("DEFAULT_ORG", "My Organization")
         if not email:
             print("No superuser defined", flush=True)
             return
@@ -171,6 +172,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
                     password=password,
                     is_superuser=True,
                     newArchive=True,
+                    newArchiveName=default_org,
                     is_verified=True,
                 )
             )
@@ -197,7 +199,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
                 email=email,
                 password=password,
                 is_superuser=False,
-                newArchive=True,
+                newArchive=False,
                 is_verified=True,
             )
             created_user = await super().create(user_create, safe=False, request=None)

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -217,7 +217,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
 
         print(f"User {user.id} has registered.")
 
-        if user_create.newArchive:
+        if user_create.newArchive is True:
             print(f"Creating new archive for {user.id}")
 
             archive_name = (

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -44,9 +44,11 @@ def admin_aid(admin_auth_headers):
         r = requests.get(f"{API_PREFIX}/archives", headers=admin_auth_headers)
         data = r.json()
         try:
-            return data["archives"][0]["id"]
+            for archive in data["archives"]:
+                if archive["default"] is True:
+                    return archive["id"]
         except:
-            print("Waiting for admin_aid")
+            print("Waiting for default org id")
             time.sleep(5)
 
 

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -11,7 +11,7 @@ def test_ensure_only_one_default_org(admin_auth_headers):
     default_orgs = [org for org in orgs if org["default"]]
     assert len(default_orgs) == 1
 
-    default_org_name = default_orgs[1]["name"]
+    default_org_name = default_orgs[0]["name"]
     orgs_with_same_name = [org for org in orgs if org["name"] == default_org_name]
     assert len(orgs_with_same_name) == 1
     
@@ -34,3 +34,24 @@ def test_rename_org(admin_auth_headers, admin_aid):
     assert r.status_code == 200
     data = r.json()
     assert data["name"] == UPDATED_NAME
+
+def test_create_org(admin_auth_headers):
+    NEW_ORG_NAME = "New Org"
+    r = requests.post(
+        f"{API_PREFIX}/archives/create",
+        headers=admin_auth_headers,
+        json={"name": NEW_ORG_NAME},
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["added"]
+
+    # Verify that org exists.
+    r = requests.get(f"{API_PREFIX}/archives", headers=admin_auth_headers)
+    assert r.status_code == 200
+    data = r.json()
+    org_names = []
+    for org in data["archives"]:
+        org_names.append(org["name"])
+    assert NEW_ORG_NAME in org_names

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -1,0 +1,36 @@
+import requests
+
+from .conftest import API_PREFIX
+
+
+def test_ensure_only_one_default_org(admin_auth_headers):
+    r = requests.get(f"{API_PREFIX}/archives", headers=admin_auth_headers)
+    data = r.json()
+
+    orgs = data["archives"]
+    default_orgs = [org for org in orgs if org["default"]]
+    assert len(default_orgs) == 1
+
+    default_org_name = default_orgs[1]["name"]
+    orgs_with_same_name = [org for org in orgs if org["name"] == default_org_name]
+    assert len(orgs_with_same_name) == 1
+    
+
+def test_rename_org(admin_auth_headers, admin_aid):
+    UPDATED_NAME = "updated org name"
+    rename_data = {"name": UPDATED_NAME}
+    r = requests.post(
+        f"{API_PREFIX}/archives/{admin_aid}/rename",
+        headers=admin_auth_headers,
+        json=rename_data,
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["updated"]
+
+    # Verify that name is now updated.
+    r = requests.get(f"{API_PREFIX}/archives/{admin_aid}", headers=admin_auth_headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["name"] == UPDATED_NAME

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -21,12 +21,9 @@ def test_list_archives(admin_auth_headers, admin_aid):
     assert len(archives) > 0
 
     archive_ids = []
-    archive_names = []
     for archive in archives:
         archive_ids.append(archive["id"])
-        archive_names.append(archive["name"])
     assert admin_aid in archive_ids
-    assert "My Organization" in archive_names
 
 
 def test_create_new_config(admin_auth_headers, admin_aid):

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -26,7 +26,7 @@ def test_list_archives(admin_auth_headers, admin_aid):
         archive_ids.append(archive["id"])
         archive_names.append(archive["name"])
     assert admin_aid in archive_ids
-    assert "admin's Archive" in archive_names
+    assert "My Organization" in archive_names
 
 
 def test_create_new_config(admin_auth_headers, admin_aid):

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -25,6 +25,8 @@ data:
 
   CRAWLER_LIVENESS_PORT: "{{ .Values.crawler_liveness_port | default 0 }}"
 
+  DEFAULT_ORG: "{{ .Values.default_org }}"
+
   JOB_IMAGE: "{{ .Values.api_image }}"
 
   {{- if .Values.crawler_pv_claim }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,6 +29,9 @@ superuser:
   # change or remove this
   password: PASSW0RD!
 
+# Set name for default organization created with superuser
+default_org: "My Organization"
+
 
 # API Image
 # =========================================


### PR DESCRIPTION
Related to #455

Connected to #457 

- Add `default` switch to `Archive` (org) model
- Set default org name via values.yaml
- Add check to ensure only one org with default org name exists
- Stop creating new orgs for new users
- Add new API endpoints for creating and renaming orgs
- Make `Archive.name` unique via index
- Make archive-less invites invite user to default org