### PR TITLE
Crawl config frontend fixes

### DIFF
--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -75,9 +75,15 @@ export class QueueExclusionTable extends LiteElement {
   }
 
   willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("exclusions") && this.exclusions) {
+    if (changedProperties.get("exclusions") && this.exclusions) {
+      if (
+        changedProperties.get("exclusions").toString() ===
+        this.exclusions.toString()
+      ) {
+        // Check list equality
+        return;
+      }
       this.exclusionToRemove = undefined;
-
       const prevVal = changedProperties.get("exclusions");
       if (prevVal) {
         const prevTotal = prevVal.length;
@@ -88,9 +94,14 @@ export class QueueExclusionTable extends LiteElement {
           this.page = lastPage;
         }
       }
-
       this.updatePageResults();
-    } else if (changedProperties.has("page")) {
+    } else if (changedProperties.get("page") && this.page) {
+      this.updatePageResults();
+    }
+  }
+
+  firstUpdated() {
+    if (this.exclusions) {
       this.updatePageResults();
     }
   }
@@ -167,9 +178,10 @@ export class QueueExclusionTable extends LiteElement {
 
   private renderItem = (
     exclusion: Exclusion,
-    index: number,
+    pageIndex: number,
     arr: Exclusion[]
   ) => {
+    const index = (this.page - 1) * this.pageSize + pageIndex;
     const [typeColClass, valueColClass, actionColClass] =
       this.getColumnClassNames(index + 1, arr.length);
 

--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -183,7 +183,7 @@ export class QueueExclusionTable extends LiteElement {
   ) => {
     const index = (this.page - 1) * this.pageSize + pageIndex;
     const [typeColClass, valueColClass, actionColClass] =
-      this.getColumnClassNames(index + 1, arr.length);
+      this.getColumnClassNames(pageIndex + 1, arr.length);
 
     return html`
       <tr

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -354,6 +354,9 @@ export class CrawlConfigEditor extends LiteElement {
     if (this.initialCrawlConfig.tags?.length) {
       formState.tags = this.initialCrawlConfig.tags;
     }
+    if (this.initialCrawlConfig.crawlTimeout) {
+      formState.crawlTimeoutMinutes = this.initialCrawlConfig.crawlTimeout / 60;
+    }
 
     return {
       jobName: this.initialCrawlConfig.name,
@@ -971,6 +974,7 @@ https://example.net`}
         <sl-input
           name="crawlTimeoutMinutes"
           label=${msg("Crawl Time Limit")}
+          value=${ifDefined(this.formState.crawlTimeoutMinutes ?? undefined)}
           placeholder=${msg("Unlimited")}
           type="number"
         >
@@ -1062,7 +1066,7 @@ https://example.net`}
           type="number"
           label=${msg("Page Time Limit")}
           placeholder=${msg("Unlimited")}
-          value=${ifDefined(this.formState.pageTimeoutMinutes || undefined)}
+          value=${ifDefined(this.formState.pageTimeoutMinutes ?? undefined)}
         >
           <span slot="suffix">${msg("minutes")}</span>
         </sl-input>

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -747,7 +747,7 @@ https://example.com/path`}
           ${this.renderFormCol(html`
             <btrix-queue-exclusion-table
               .exclusions=${this.formState.exclusions}
-              pageSize="10"
+              pageSize="30"
               editable
               removable
               @on-remove=${this.handleRemoveRegex}

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -1283,12 +1283,18 @@ https://example.net`}
   }
 
   private renderConfirmSettings = () => {
-    const crawlConfig = this.parseConfig();
-    const profileName = this.formState.browserProfile?.name;
     return html`
       <div class="col-span-1 md:col-span-5">
-        <btrix-config-details .crawlConfig=${{ ...crawlConfig, profileName }}>
-        </btrix-config-details>
+        ${when(this.progressState.activeTab === "confirmSettings", () => {
+          // Prevent parsing and rendering tab when not visible
+          const crawlConfig = this.parseConfig();
+          const profileName = this.formState.browserProfile?.name;
+
+          return html`<btrix-config-details
+            .crawlConfig=${{ ...crawlConfig, profileName }}
+          >
+          </btrix-config-details>`;
+        })}
       </div>
 
       ${when(this.formHasError, () =>

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -1283,9 +1283,10 @@ https://example.net`}
 
   private renderConfirmSettings = () => {
     const crawlConfig = this.parseConfig();
+    const profileName = this.formState.browserProfile?.name;
     return html`
       <div class="col-span-1 md:col-span-5">
-        <btrix-config-details .crawlConfig=${crawlConfig}>
+        <btrix-config-details .crawlConfig=${{ ...crawlConfig, profileName }}>
         </btrix-config-details>
       </div>
 

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -576,7 +576,8 @@ export class CrawlConfigEditor extends LiteElement {
                   ?disabled=${this.isSubmitting || this.formHasError}
                   ?loading=${this.isSubmitting}
                 >
-                  ${this.formState.runNow
+                  ${this.formState.scheduleType === "now" ||
+                  this.formState.runNow
                     ? msg("Save & Run Crawl")
                     : msg("Save & Schedule Crawl")}
                 </sl-button>`

--- a/frontend/src/pages/archive/types.ts
+++ b/frontend/src/pages/archive/types.ts
@@ -60,13 +60,13 @@ export type CrawlConfigParams = {
   scale: number;
   profileid: string | null;
   config: SeedConfig;
-  crawlTimeout: number | null;
+  crawlTimeout?: number | null;
   tags?: string[];
 };
 
 export type InitialCrawlConfig = Pick<
   CrawlConfigParams,
-  "name" | "profileid" | "schedule" | "tags"
+  "name" | "profileid" | "schedule" | "tags" | "crawlTimeout"
 > & {
   jobType?: JobType;
   config: Pick<


### PR DESCRIPTION
- Fixes https://github.com/webrecorder/browsertrix-cloud/issues/473 - Regression shows "Save & Schedule Crawl" instead of "Save & Run Crawl"
- Fixes https://github.com/webrecorder/browsertrix-cloud/issues/474 - Regression hides browser profile name on confirmation screen
- Fixes https://github.com/webrecorder/browsertrix-cloud/issues/475 - Editing paginated exclusions table behavior, + increase page size to 30
- Fixes https://github.com/webrecorder/browsertrix-cloud/issues/480 - Bug where previously saved `crawlTimeout` isn't shown on form