### PR TITLE
Crawl config form panel UX enhancement & fix

### DIFF
--- a/frontend/src/components/tab-list.ts
+++ b/frontend/src/components/tab-list.ts
@@ -170,13 +170,9 @@ export class TabList extends LitElement {
 
     ul {
       display: flex;
-      margin: 0;
+      margin: 0 0 0 var(--track-width);
       list-style: none;
       padding: 0;
-    }
-
-    .progressable ul {
-      margin-left: var(--track-width);
     }
 
     @media only screen and (min-width: ${SCREEN_LG}px) {
@@ -205,9 +201,9 @@ export class TabList extends LitElement {
     }
 
     @media only screen and (min-width: ${SCREEN_LG}px) {
-      .progressable ul,
-      .progressable .track,
-      .progressable .indicator {
+      ul,
+      .track,
+      .indicator {
         display: block;
       }
     }
@@ -217,7 +213,7 @@ export class TabList extends LitElement {
   @property({ type: String })
   activePanel: string = DEFAULT_PANEL_ID;
 
-  // If panels are progressable, the current panel in progress
+  // If panels are linear, the current panel in progress
   @property({ type: String })
   progressPanel?: string;
 
@@ -278,7 +274,7 @@ export class TabList extends LitElement {
         @sl-resize=${() =>
           this.repositionIndicator(this.getTab(this.progressPanel))}
       >
-        <div class="nav ${this.progressPanel ? " progressable" : ""}">
+        <div class="nav ${this.progressPanel ? "linear" : "nonlinear"}">
           <div class="track" role="presentation">
             <div class="indicator" role="presentation"></div>
           </div>

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -57,7 +57,6 @@ const STEPS = [
 ] as const;
 type StepName = typeof STEPS[number];
 type TabState = {
-  enabled: boolean;
   completed: boolean;
   error: boolean;
 };
@@ -109,24 +108,20 @@ const getDefaultProgressState = (hasConfigId = false): ProgressState => {
     activeTab,
     currentStep: hasConfigId ? "confirmSettings" : "crawlSetup",
     tabs: {
-      crawlSetup: { enabled: true, error: false, completed: hasConfigId },
+      crawlSetup: { error: false, completed: hasConfigId },
       browserSettings: {
-        enabled: hasConfigId,
         error: false,
         completed: hasConfigId,
       },
       crawlScheduling: {
-        enabled: hasConfigId,
         error: false,
         completed: hasConfigId,
       },
       crawlInformation: {
-        enabled: hasConfigId,
         error: false,
         completed: hasConfigId,
       },
       confirmSettings: {
-        enabled: hasConfigId,
         error: false,
         completed: hasConfigId,
       },
@@ -482,18 +477,11 @@ export class CrawlConfigEditor extends LiteElement {
       }
     }
 
-    const { enabled } = this.progressState.tabs[tabName];
-    const isEnabled = isConfirmSettings
-      ? this.progressState.tabs.confirmSettings.enabled ||
-        this.progressState.tabs.crawlSetup.completed
-      : enabled;
-
     return html`
       <btrix-tab
         slot="nav"
         name="newJobConfig-${tabName}"
         class="whitespace-nowrap"
-        ?disabled=${!isEnabled}
         @click=${this.tabClickHandler(tabName)}
       >
         <sl-icon
@@ -1497,14 +1485,8 @@ https://example.net`}
       const { activeTab, tabs, currentStep } = this.progressState;
       const nextTab = STEPS[STEPS.indexOf(activeTab!) + 1] as StepName;
 
-      const isFirstTimeEnabled = !tabs[nextTab].enabled;
       const nextTabs = { ...tabs };
       let nextCurrentStep = currentStep;
-
-      if (isFirstTimeEnabled) {
-        nextTabs[nextTab].enabled = true;
-        nextCurrentStep = nextTab;
-      }
 
       nextTabs[activeTab!].completed = true;
       this.updateProgressState({

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -293,31 +293,35 @@ export class CrawlConfigEditor extends LiteElement {
             },
           });
         }
-      } else if (
-        changedProperties.get("progressState").activeTab !== "crawlSetup" &&
-        this.progressState.activeTab === "crawlSetup"
-      ) {
-        if (this.progressState.tabs.crawlSetup.error) {
-          // Show field validation styles
-          const requiredInput = this.formElem.querySelector(
-            "[data-required][data-invalid]"
-          ) as SlInput;
-          requiredInput?.setAttribute("data-user-invalid", "");
-          requiredInput?.focus();
-        }
       }
     }
   }
 
-  updated(changedProperties: Map<string, any>) {
+  async updated(changedProperties: Map<string, any>) {
     if (changedProperties.get("progressState") && this.progressState) {
       if (
         changedProperties.get("progressState").activeTab !==
         this.progressState.activeTab
       ) {
         this.scrollToPanelTop();
+
+        // Focus on first field in section
+        (
+          (await this.activeTabPanel)?.querySelector(
+            "sl-input, sl-textarea, sl-select, sl-radio-group"
+          ) as HTMLElement
+        )?.focus();
       }
     }
+  }
+
+  async firstUpdated() {
+    // Focus on first field in section
+    (
+      (await this.activeTabPanel)?.querySelector(
+        "sl-input, sl-textarea, sl-select, sl-radio-group"
+      ) as HTMLElement
+    )?.focus();
   }
 
   private initializeEditor() {

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -280,16 +280,31 @@ export class CrawlConfigEditor extends LiteElement {
     ) {
       this.initializeEditor();
     }
-    if (
-      changedProperties.get("progressState")?.activeTab === "crawlSetup" &&
-      this.progressState?.activeTab !== "crawlSetup"
-    ) {
-      if (!this.hasRequiredFields()) {
-        this.updateProgressState({
-          tabs: {
-            crawlSetup: { error: true },
-          },
-        });
+    if (changedProperties.get("progressState") && this.progressState) {
+      if (
+        changedProperties.get("progressState").activeTab === "crawlSetup" &&
+        this.progressState.activeTab !== "crawlSetup"
+      ) {
+        // Show that required tab has error even if input hasn't been touched
+        if (!this.hasRequiredFields()) {
+          this.updateProgressState({
+            tabs: {
+              crawlSetup: { error: true },
+            },
+          });
+        }
+      } else if (
+        changedProperties.get("progressState").activeTab !== "crawlSetup" &&
+        this.progressState.activeTab === "crawlSetup"
+      ) {
+        if (this.progressState.tabs.crawlSetup.error) {
+          // Show field validation styles
+          const requiredInput = this.formElem.querySelector(
+            "[data-required][data-invalid]"
+          ) as SlInput;
+          requiredInput?.setAttribute("data-user-invalid", "");
+          requiredInput?.focus();
+        }
       }
     }
   }
@@ -504,11 +519,17 @@ export class CrawlConfigEditor extends LiteElement {
         class="whitespace-nowrap"
         @click=${this.tabClickHandler(tabName)}
       >
-        <sl-icon
-          name=${iconProps.name}
-          library=${iconProps.library}
-          class="inline-block align-middle mr-1 text-base ${iconProps.class}"
-        ></sl-icon>
+        <sl-tooltip
+          content=${msg("Form section contains errors")}
+          ?disabled=${!isInvalid}
+          hoist
+        >
+          <sl-icon
+            name=${iconProps.name}
+            library=${iconProps.library}
+            class="inline-block align-middle mr-1 text-base ${iconProps.class}"
+          ></sl-icon>
+        </sl-tooltip>
         <span class="inline-block align-middle whitespace-normal">
           ${content}
         </span>

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -501,7 +501,7 @@ export class CrawlConfigEditor extends LiteElement {
     const iconProps = {
       name: "circle",
       library: "default",
-      class: "text-neutral-300",
+      class: "text-neutral-400",
     };
     if (isConfirmSettings) {
       iconProps.name = "info-circle";

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -62,7 +62,6 @@ type TabState = {
 };
 type Tabs = Record<StepName, TabState>;
 type ProgressState = {
-  currentStep: StepName;
   activeTab: StepName;
   tabs: Tabs;
 };
@@ -106,7 +105,6 @@ const getDefaultProgressState = (hasConfigId = false): ProgressState => {
 
   return {
     activeTab,
-    currentStep: hasConfigId ? "confirmSettings" : "crawlSetup",
     tabs: {
       crawlSetup: { error: false, completed: hasConfigId },
       browserSettings: {
@@ -410,7 +408,6 @@ export class CrawlConfigEditor extends LiteElement {
       >
         <btrix-tab-list
           activePanel="newJobConfig-${this.progressState.activeTab}"
-          progressPanel="newJobConfig-${this.progressState.currentStep}"
         >
           <header slot="header" class="flex justify-between items-baseline">
             <h3>${tabLabels[this.progressState.activeTab]}</h3>
@@ -609,7 +606,6 @@ export class CrawlConfigEditor extends LiteElement {
                         if (this.hasRequiredFields()) {
                           this.updateProgressState({
                             activeTab: "confirmSettings",
-                            currentStep: "confirmSettings",
                           });
                         } else {
                           this.nextStep();
@@ -1521,12 +1517,10 @@ https://example.net`}
     const isValid = this.checkCurrentPanelValidity();
 
     if (isValid) {
-      const { activeTab, currentStep } = this.progressState;
+      const { activeTab } = this.progressState;
       const nextTab = STEPS[STEPS.indexOf(activeTab!) + 1] as StepName;
       this.updateProgressState({
         activeTab: nextTab,
-        currentStep:
-          STEPS[Math.max(STEPS.indexOf(nextTab), STEPS.indexOf(currentStep))],
       });
     }
   }
@@ -1757,7 +1751,6 @@ https://example.net`}
   private updateProgressState(
     nextState: {
       activeTab?: ProgressState["activeTab"];
-      currentStep?: ProgressState["currentStep"];
       tabs?: {
         [K in StepName]?: Partial<TabState>;
       };

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -286,7 +286,10 @@ export class CrawlConfigEditor extends LiteElement {
         this.progressState.activeTab !== "crawlSetup"
       ) {
         // Show that required tab has error even if input hasn't been touched
-        if (!this.hasRequiredFields()) {
+        if (
+          !this.hasRequiredFields() &&
+          !this.progressState.tabs.crawlSetup.error
+        ) {
           this.updateProgressState({
             tabs: {
               crawlSetup: { error: true },
@@ -1464,6 +1467,7 @@ https://example.net`}
     // Check [data-user-invalid] instead of .invalid property
     // to validate only touched inputs
     if ("userInvalid" in el.dataset) {
+      if (this.progressState.tabs[currentTab].error) return;
       this.updateProgressState({
         tabs: {
           [currentTab]: { error: true },
@@ -1479,7 +1483,7 @@ https://example.net`}
     const panelEl = el.closest("btrix-tab-panel")!;
     const hasInvalid = panelEl.querySelector("[data-user-invalid]");
 
-    if (!hasInvalid) {
+    if (!hasInvalid && !this.progressState.tabs[currentTab].error) {
       this.updateProgressState({
         tabs: {
           [currentTab]: { error: false },

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -286,16 +286,10 @@ export class CrawlConfigEditor extends LiteElement {
       changedProperties.get("progressState")?.activeTab === "crawlSetup" &&
       this.progressState?.activeTab !== "crawlSetup"
     ) {
-      if (this.hasRequiredFields()) {
+      if (!this.hasRequiredFields()) {
         this.updateProgressState({
           tabs: {
-            crawlSetup: { completed: true },
-          },
-        });
-      } else {
-        this.updateProgressState({
-          tabs: {
-            crawlSetup: { error: true, completed: false },
+            crawlSetup: { error: true },
           },
         });
       }
@@ -503,7 +497,6 @@ export class CrawlConfigEditor extends LiteElement {
         iconProps.class = "text-base";
       } else if (completed) {
         iconProps.name = "check-circle";
-        iconProps.class = "text-success";
       }
     }
 
@@ -617,7 +610,6 @@ export class CrawlConfigEditor extends LiteElement {
                           this.updateProgressState({
                             activeTab: "confirmSettings",
                             currentStep: "confirmSettings",
-                            tabs: { crawlSetup: { completed: true } },
                           });
                         } else {
                           this.nextStep();
@@ -1535,9 +1527,6 @@ https://example.net`}
         activeTab: nextTab,
         currentStep:
           STEPS[Math.max(STEPS.indexOf(nextTab), STEPS.indexOf(currentStep))],
-        tabs: {
-          [activeTab]: { completed: true },
-        },
       });
     }
   }

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -1430,12 +1430,14 @@ https://example.net`}
     await this.updateComplete;
 
     const currentTab = this.progressState.activeTab as StepName;
-    const tabs = { ...this.progressState.tabs };
     // Check [data-user-invalid] instead of .invalid property
     // to validate only touched inputs
     if ("userInvalid" in el.dataset) {
-      tabs[currentTab].error = true;
-      this.updateProgressState({ tabs });
+      this.updateProgressState({
+        tabs: {
+          [currentTab]: { error: true },
+        },
+      });
     } else if (this.progressState.tabs[currentTab].error) {
       this.syncTabErrorState(el);
     }
@@ -1443,13 +1445,15 @@ https://example.net`}
 
   private syncTabErrorState(el: HTMLElement) {
     const currentTab = this.progressState.activeTab as StepName;
-    const tabs = { ...this.progressState.tabs };
     const panelEl = el.closest("btrix-tab-panel")!;
     const hasInvalid = panelEl.querySelector("[data-user-invalid]");
 
     if (!hasInvalid) {
-      tabs[currentTab].error = false;
-      this.updateProgressState({ tabs });
+      this.updateProgressState({
+        tabs: {
+          [currentTab]: { error: false },
+        },
+      });
     }
   }
 

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -282,6 +282,24 @@ export class CrawlConfigEditor extends LiteElement {
     ) {
       this.initializeEditor();
     }
+    if (
+      changedProperties.get("progressState")?.activeTab === "crawlSetup" &&
+      this.progressState?.activeTab !== "crawlSetup"
+    ) {
+      if (this.hasRequiredFields()) {
+        this.updateProgressState({
+          tabs: {
+            crawlSetup: { completed: true },
+          },
+        });
+      } else {
+        this.updateProgressState({
+          tabs: {
+            crawlSetup: { error: true, completed: false },
+          },
+        });
+      }
+    }
   }
 
   updated(changedProperties: Map<string, any>) {
@@ -1511,17 +1529,15 @@ https://example.net`}
     const isValid = this.checkCurrentPanelValidity();
 
     if (isValid) {
-      const { activeTab, tabs, currentStep } = this.progressState;
+      const { activeTab, currentStep } = this.progressState;
       const nextTab = STEPS[STEPS.indexOf(activeTab!) + 1] as StepName;
-
-      const nextTabs = { ...tabs };
-      let nextCurrentStep = currentStep;
-
-      nextTabs[activeTab!].completed = true;
       this.updateProgressState({
         activeTab: nextTab,
-        currentStep: nextCurrentStep,
-        tabs: nextTabs,
+        currentStep:
+          STEPS[Math.max(STEPS.indexOf(nextTab), STEPS.indexOf(currentStep))],
+        tabs: {
+          [activeTab]: { completed: true },
+        },
       });
     }
   }

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -1483,7 +1483,7 @@ https://example.net`}
     const panelEl = el.closest("btrix-tab-panel")!;
     const hasInvalid = panelEl.querySelector("[data-user-invalid]");
 
-    if (!hasInvalid && !this.progressState.tabs[currentTab].error) {
+    if (!hasInvalid && this.progressState.tabs[currentTab].error) {
       this.updateProgressState({
         tabs: {
           [currentTab]: { error: false },

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -286,9 +286,12 @@ export class CrawlConfigEditor extends LiteElement {
 
   updated(changedProperties: Map<string, any>) {
     if (changedProperties.get("progressState") && this.progressState) {
-      this.handleProgressStateChange(
-        changedProperties.get("progressState") as ProgressState
-      );
+      if (
+        changedProperties.get("progressState").activeTab !==
+        this.progressState.activeTab
+      ) {
+        this.scrollToPanelTop();
+      }
     }
   }
 
@@ -1334,15 +1337,12 @@ https://example.net`}
     return Boolean(this.formState.urlList);
   }
 
-  private async handleProgressStateChange(oldState: ProgressState) {
-    const { activeTab } = this.progressState;
-    if (oldState.activeTab !== activeTab) {
-      const activeTabPanel = (await this.activeTabPanel) as HTMLElement;
-      if (activeTabPanel && activeTabPanel.getBoundingClientRect().top < 0) {
-        activeTabPanel.scrollIntoView({
-          behavior: "smooth",
-        });
-      }
+  private async scrollToPanelTop() {
+    const activeTabPanel = (await this.activeTabPanel) as HTMLElement;
+    if (activeTabPanel && activeTabPanel.getBoundingClientRect().top < 0) {
+      activeTabPanel.scrollIntoView({
+        behavior: "smooth",
+      });
     }
   }
 

--- a/frontend/src/pages/archive/crawl-config-editor.ts
+++ b/frontend/src/pages/archive/crawl-config-editor.ts
@@ -430,6 +430,7 @@ export class CrawlConfigEditor extends LiteElement {
       >
         <btrix-tab-list
           activePanel="newJobConfig-${this.progressState.activeTab}"
+          progressPanel="newJobConfig-${this.progressState.activeTab}"
         >
           <header slot="header" class="flex justify-between items-baseline">
             <h3>${tabLabels[this.progressState.activeTab]}</h3>


### PR DESCRIPTION
Enables all crawl config steps by default and fixes error icon not synced with form. Also, entering a name is no longer required since it'll be computed by default either when the URL is entered or the config is saved, and checkmarks are only shown as the default state when editing a form.
- Resolves https://github.com/webrecorder/browsertrix-cloud/issues/483
- Fixes https://github.com/webrecorder/browsertrix-cloud/issues/484

### Manual testing
1. Go to "New Crawl Config" view. Verify all form sections are navigable
2. Click navigation on left without entering a seed URL. Verify "Crawl Setup" navigation button shows error icon.
3. Enter a seed URL. Verify error icon is replaced

### Demo
https://user-images.githubusercontent.com/4672952/212985241-95992093-5a04-4d05-9f5e-83061767d556.mov

### Screenshots
**Name field now optional:**
<img width="875" alt="Screen Shot 2023-01-16 at 6 19 02 PM" src="https://user-images.githubusercontent.com/4672952/212795490-65707fec-8257-43bb-b61f-fbc71aceea7f.png">