### PR TITLE
Improve Page Time Limit UX

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -89,6 +89,12 @@ export class ConfigDetails extends LiteElement {
             () => this.renderSetting(msg("Exclusions"), msg("None"))
           )}
           ${this.renderSetting(
+            msg("Page Time Limit"),
+            crawlConfig?.config.behaviorTimeout
+              ? msg(str`${crawlConfig?.config.behaviorTimeout / 60} minute(s)`)
+              : msg("None")
+          )}
+          ${this.renderSetting(
             msg("Crawl Time Limit"),
             crawlConfig?.crawlTimeout
               ? msg(str`${crawlConfig?.crawlTimeout / 60} minute(s)`)
@@ -111,9 +117,9 @@ export class ConfigDetails extends LiteElement {
               crawlConfig?.profileid,
               () => html`<a
                 class="text-blue-500 hover:text-blue-600"
-                href=${`/orgs/${
-                  crawlConfig!.oid
-                }/browser-profiles/profile/${crawlConfig!.profileid}`}
+                href=${`/orgs/${crawlConfig!.oid}/browser-profiles/profile/${
+                  crawlConfig!.profileid
+                }`}
                 @click=${this.navLink}
               >
                 ${crawlConfig?.profileName}
@@ -128,12 +134,6 @@ export class ConfigDetails extends LiteElement {
           ${this.renderSetting(
             msg("Language"),
             ISO6391.getName(crawlConfig?.config.lang!)
-          )}
-          ${this.renderSetting(
-            msg("Page Time Limit"),
-            crawlConfig?.config.behaviorTimeout
-              ? msg(str`${crawlConfig?.config.behaviorTimeout / 60} minute(s)`)
-              : msg("None")
           )}
         </btrix-desc-list>
       </section>

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1031,9 +1031,9 @@ https://example.net`}
           placeholder=${msg("Unlimited")}
           value=${ifDefined(
             this.formState.pageTimeoutMinutes ??
-              this.defaultBehaviorTimeoutMinutes ??
-              DEFAULT_BEHAVIOR_TIMEOUT_MINUTES
+              this.defaultBehaviorTimeoutMinutes
           )}
+          ?disabled=${this.defaultBehaviorTimeoutMinutes === undefined}
         >
           <span slot="suffix">${msg("minutes")}</span>
         </sl-input>
@@ -1819,11 +1819,15 @@ https://example.net`}
   private async fetchAPIDefaults() {
     try {
       const data = await this.apiFetch("/settings", this.authState!);
-      this.defaultBehaviorTimeoutMinutes = data.defaultBehaviorTimeSeconds / 60;
-    } catch (e: any) {
-      if (e.isApiError) {
-        console.log("apiError");
+      if (data.defaultBehaviorTimeSeconds) {
+        this.defaultBehaviorTimeoutMinutes =
+          data.defaultBehaviorTimeSeconds / 60;
+      } else {
+        this.defaultBehaviorTimeoutMinutes = DEFAULT_BEHAVIOR_TIMEOUT_MINUTES;
       }
+    } catch (e: any) {
+      console.debug(e);
+      this.defaultBehaviorTimeoutMinutes = DEFAULT_BEHAVIOR_TIMEOUT_MINUTES;
     }
   }
 }

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1038,6 +1038,7 @@ https://example.net`}
               this.defaultBehaviorTimeoutMinutes
           )}
           ?disabled=${this.defaultBehaviorTimeoutMinutes === undefined}
+          required
         >
           <span slot="suffix">${msg("minutes")}</span>
         </sl-input>

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -400,8 +400,12 @@ export class CrawlConfigEditor extends LiteElement {
     if (this.initialCrawlConfig.tags?.length) {
       formState.tags = this.initialCrawlConfig.tags;
     }
-    if (this.initialCrawlConfig.crawlTimeout) {
+    if (typeof this.initialCrawlConfig.crawlTimeout === "number") {
       formState.crawlTimeoutMinutes = this.initialCrawlConfig.crawlTimeout / 60;
+    }
+    if (typeof this.initialCrawlConfig.config.behaviorTimeout === "number") {
+      formState.pageTimeoutMinutes =
+        this.initialCrawlConfig.config.behaviorTimeout / 60;
     }
 
     return {

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1018,6 +1018,21 @@ https://example.net`}
       ${this.renderSectionHeading(msg("Crawl Limits"))}
       ${this.renderFormCol(html`
         <sl-input
+          name="pageTimeoutMinutes"
+          type="number"
+          label=${msg("Page Time Limit")}
+          placeholder=${msg("Unlimited")}
+          value=${ifDefined(this.formState.pageTimeoutMinutes ?? undefined)}
+        >
+          <span slot="suffix">${msg("minutes")}</span>
+        </sl-input>
+      `)}
+      ${this.renderHelpTextCol(
+        html`Adds a hard time limit for how long the crawler can spend on a
+        single webpage.`
+      )}
+      ${this.renderFormCol(html`
+        <sl-input
           name="crawlTimeoutMinutes"
           label=${msg("Crawl Time Limit")}
           value=${ifDefined(this.formState.crawlTimeoutMinutes ?? undefined)}
@@ -1104,22 +1119,6 @@ https://example.net`}
       ${this.renderHelpTextCol(
         html`Websites that observe the browser’s language setting may serve
         content in that language if available.`
-      )}
-      ${this.renderSectionHeading(msg("On-Page Behavior"))}
-      ${this.renderFormCol(html`
-        <sl-input
-          name="pageTimeoutMinutes"
-          type="number"
-          label=${msg("Page Time Limit")}
-          placeholder=${msg("Unlimited")}
-          value=${ifDefined(this.formState.pageTimeoutMinutes ?? undefined)}
-        >
-          <span slot="suffix">${msg("minutes")}</span>
-        </sl-input>
-      `)}
-      ${this.renderHelpTextCol(
-        html`Adds a hard time limit for how long the crawler can spend on a
-        single webpage.`
       )}
     `;
   }
@@ -1638,9 +1637,7 @@ https://example.net`}
       if (crawlId) {
         this.navTo(`/orgs/${this.orgId}/crawls/crawl/${crawlId}`);
       } else {
-        this.navTo(
-          `/orgs/${this.orgId}/crawl-templates/config/${data.added}`
-        );
+        this.navTo(`/orgs/${this.orgId}/crawl-templates/config/${data.added}`);
       }
     } catch (e: any) {
       if (e?.isApiError) {

--- a/frontend/src/pages/org/types.ts
+++ b/frontend/src/pages/org/types.ts
@@ -71,7 +71,7 @@ export type InitialCrawlConfig = Pick<
   jobType?: JobType;
   config: Pick<
     CrawlConfigParams["config"],
-    "seeds" | "scopeType" | "exclude"
+    "seeds" | "scopeType" | "exclude" | "behaviorTimeout"
   > & {
     extraHops?: CrawlConfigParams["config"]["extraHops"];
   };


### PR DESCRIPTION
Moves page time limit to above "Crawl Time Limit" (resolves https://github.com/webrecorder/browsertrix-cloud/issues/485) and uses default value from API settings (resolves https://github.com/webrecorder/browsertrix-cloud/issues/497)

### Manual testing
1. Go to New Crawl Config flow. Verify that Page Time Limit shows in correct place and shows default value.
2. Edit value and save config. Verify Page Time Limit is shown in correct place of detail view.
3. Edit config. Verify Page Limit value is shown as expected.

### Screenshots
**New Crawl Config form:**
<img width="878" alt="Screen Shot 2023-01-18 at 4 54 38 PM" src="https://user-images.githubusercontent.com/4672952/213338175-2af206ec-8507-43f5-87a5-6f32817fcbeb.png">
