### PR TITLE
Autocomplete tag options

### DIFF
--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -10,6 +10,9 @@ export type Tags = string[];
 export type TagsChangeEvent = CustomEvent<{
   tags: string[];
 }>;
+export type TagInputEvent = CustomEvent<{
+  value: string;
+}>;
 
 /**
  * Usage:
@@ -20,6 +23,7 @@ export type TagsChangeEvent = CustomEvent<{
  * ></btrix-tag-input>
  * ```
  *
+ * @events tag-input
  * @events tags-change
  */
 @localized()
@@ -110,6 +114,9 @@ export class TagInput extends LitElement {
   @property({ type: Array })
   initialTags?: Tags;
 
+  @property({ type: Array })
+  tagOptions: Tags = [];
+
   @property({ type: Boolean })
   disabled = false;
 
@@ -125,9 +132,6 @@ export class TagInput extends LitElement {
 
   @state()
   private dropdownIsOpen?: boolean;
-
-  @state()
-  private tagOptions: Tags = [];
 
   @query("#input")
   private input?: HTMLInputElement;
@@ -300,8 +304,12 @@ export class TagInput extends LitElement {
     this.inputValue = input.value;
     if (input.value.length) {
       this.dropdownIsOpen = true;
-      this.tagOptions = await this.getOptions();
     }
+    this.dispatchEvent(
+      <TagInputEvent>new CustomEvent("tag-input", {
+        detail: { value: input.value },
+      })
+    );
   }) as any;
 
   private onKeyup(e: KeyboardEvent) {
@@ -345,11 +353,5 @@ export class TagInput extends LitElement {
         detail: { tags: this.tags },
       })
     );
-  }
-
-  private async getOptions() {
-    // TODO actual API call
-    // https://github.com/webrecorder/browsertrix-cloud/issues/453
-    return [];
   }
 }

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -304,6 +304,8 @@ export class TagInput extends LitElement {
     this.inputValue = input.value;
     if (input.value.length) {
       this.dropdownIsOpen = true;
+    } else {
+      this.dropdownIsOpen = false;
     }
     this.dispatchEvent(
       <TagInputEvent>new CustomEvent("tag-input", {

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -312,6 +312,9 @@ export class CrawlConfigEditor extends LiteElement {
         }
       }
     }
+    if (changedProperties.get("orgId") && this.orgId) {
+      this.fetchTags();
+    }
   }
 
   async updated(changedProperties: Map<string, any>) {
@@ -1714,6 +1717,7 @@ https://example.net`}
   };
 
   private async fetchTags() {
+    this.tagOptions = [];
     try {
       const tags = await this.apiFetch(
         `/orgs/${this.orgId}/crawlconfigs/tags`,


### PR DESCRIPTION
Autocomplete tag options in "Crawl Information" section of crawl config editor. Fuzzy search with limit of 3 items shown. Caveat, tag options are only fetched once when the form loads for performance, since filtering is handled on the frontend. We could change this later if highly collaborative organizations are having issues with stale tag options.

Resolves https://github.com/webrecorder/browsertrix-cloud/issues/453.

### Demo
https://user-images.githubusercontent.com/4672952/213341704-50e79578-a932-4d09-bf31-46d76de0e967.mov

