### PR TITLE
Allow admin users to change org name

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -582,6 +582,7 @@ export class App extends LiteElement {
           class="w-full"
           @navigate=${this.onNavigateTo}
           @need-login=${this.onNeedLogin}
+          @update-user-info=${this.updateUserInfo}
           @notify="${this.onNotify}"
           .authState=${this.authService.authState}
           .userInfo=${this.userInfo}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -679,7 +679,10 @@ export class App extends LiteElement {
             tabName: "browser-profiles",
             label: msg("Browser Profiles"),
           })}
-          ${this.renderNavTab({ tabName: "members", label: msg("Members") })}
+          ${this.renderNavTab({
+            tabName: "settings",
+            label: msg("Org Settings"),
+          })}
         </nav>
       </div>
 

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -315,7 +315,7 @@ export class Org extends LiteElement {
 
       <div class="text-right">
         <sl-button
-          href=${`/orgs/${this.orgId}/members/add-member`}
+          href=${`/orgs/${this.orgId}/settings/add-member`}
           @click=${this.navLink}
           >${msg("Add Member")}</sl-button
         >

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -241,7 +241,10 @@ export class Org extends LiteElement {
 
   private renderOrgName() {
     if (!this.org) return;
-    return html`<form @submit=${this.onOrgNameSubmit}>
+    return html`<form
+      @submit=${this.onOrgNameSubmit}
+      @reset=${() => (this.isEditingOrgName = false)}
+    >
       <div class="flex">
         <div class="flex-1 mr-3">
           <sl-input
@@ -255,6 +258,9 @@ export class Org extends LiteElement {
         <div class="flex-0">
           ${this.isEditingOrgName
             ? html`
+                <sl-button type="reset" class="mr-1"
+                  >${msg("Cancel")}</sl-button
+                >
                 <sl-button type="submit" variant="primary"
                   >${msg("Save Changes")}</sl-button
                 >

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -77,6 +77,9 @@ export class Org extends LiteElement {
   @state()
   private isEditingOrgName = false;
 
+  @state()
+  private isSavingOrgName = false;
+
   async willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("orgId") && this.orgId) {
       try {
@@ -273,7 +276,11 @@ export class Org extends LiteElement {
             this.isEditingOrgName,
             () => html`
               <sl-button type="reset" class="mr-1">${msg("Cancel")}</sl-button>
-              <sl-button type="submit" variant="primary"
+              <sl-button
+                type="submit"
+                variant="primary"
+                ?disabled=${this.isSavingOrgName}
+                ?loading=${this.isSavingOrgName}
                 >${msg("Save Changes")}</sl-button
               >
             `,
@@ -395,6 +402,8 @@ export class Org extends LiteElement {
     if (!this.org) return;
     const { orgName } = serialize(e.target as HTMLFormElement);
 
+    this.isSavingOrgName = true;
+
     try {
       await this.apiFetch(`/orgs/${this.org.id}/rename`, this.authState!, {
         method: "POST",
@@ -412,6 +421,9 @@ export class Org extends LiteElement {
         ...this.org,
         name: orgName as string,
       };
+
+      this.isEditingOrgName = false;
+      this.dispatchEvent(new CustomEvent("update-user-info"));
     } catch (e) {
       console.debug(e);
       this.notify({
@@ -421,7 +433,7 @@ export class Org extends LiteElement {
       });
     }
 
-    this.isEditingOrgName = false;
+    this.isSavingOrgName = false;
   }
 
   onInviteSuccess(

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -1,5 +1,6 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
+import { when } from "lit/directives/when.js";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 
 import type { ViewState } from "../../utils/APIRouter";
@@ -240,43 +241,55 @@ export class Org extends LiteElement {
   }
 
   private renderOrgName() {
-    if (!this.org) return;
+    if (!this.org || !this.userInfo) return;
+    const memberInfo = (this.org.users ?? {})[this.userInfo.id];
+    if (!memberInfo || !isOwner(memberInfo.role)) {
+      return html`
+        <sl-input
+          label=${msg("Org Name")}
+          value=${this.org.name}
+          readonly
+        ></sl-input>
+      `;
+    }
+
     return html`<form
       @submit=${this.onOrgNameSubmit}
       @reset=${() => (this.isEditingOrgName = false)}
     >
-      <div class="flex">
+      <div class="flex items-end">
         <div class="flex-1 mr-3">
           <sl-input
             name="orgName"
+            label=${msg("Org Name")}
             autocomplete="off"
             value=${this.org.name}
             ?readonly=${!this.isEditingOrgName}
-            required
+            ?required=${this.isEditingOrgName}
           ></sl-input>
         </div>
         <div class="flex-0">
-          ${this.isEditingOrgName
-            ? html`
-                <sl-button type="reset" class="mr-1"
-                  >${msg("Cancel")}</sl-button
-                >
-                <sl-button type="submit" variant="primary"
-                  >${msg("Save Changes")}</sl-button
-                >
-              `
-            : html`
-                <sl-button
-                  @click=${(e: MouseEvent) => {
-                    this.isEditingOrgName = true;
-                    (e.target as SlButton)
-                      .closest("form")
-                      ?.querySelector("sl-input")
-                      ?.focus();
-                  }}
-                  >${msg("Edit")}</sl-button
-                >
-              `}
+          ${when(
+            this.isEditingOrgName,
+            () => html`
+              <sl-button type="reset" class="mr-1">${msg("Cancel")}</sl-button>
+              <sl-button type="submit" variant="primary"
+                >${msg("Save Changes")}</sl-button
+              >
+            `,
+            () => html`
+              <sl-button
+                @click=${(e: MouseEvent) => {
+                  this.isEditingOrgName = true;
+                  (e.target as SlButton)
+                    .closest("form")
+                    ?.querySelector("sl-input")
+                    ?.focus();
+                }}
+                >${msg("Edit")}</sl-button
+              >
+            `
+          )}
         </div>
       </div>
     </form>`;


### PR DESCRIPTION
Renames /members -> /settings, and allow org owners to edit the org name. Resolves https://github.com/webrecorder/browsertrix-cloud/issues/496

### Manual testing
1. Click "Org Settings". Verify org name and members are shown.
2. If logged in as org owner, click "Edit" and save changes. Verify new org name is saved. If not org owner, verify "Edit" button is hidden.

### Screenshots
**Non-org owner:**
<img width="1135" alt="Screen Shot 2023-01-18 at 7 15 07 PM" src="https://user-images.githubusercontent.com/4672952/213347512-d218b72f-5861-4e3a-887a-95dbff494267.png">

**Org owner:**
<img width="1152" alt="Screen Shot 2023-01-18 at 7 11 52 PM" src="https://user-images.githubusercontent.com/4672952/213347544-645f4666-5cf1-4550-9d58-e42b25b2ba42.png">
<img width="1125" alt="Screen Shot 2023-01-18 at 7 13 34 PM" src="https://user-images.githubusercontent.com/4672952/213347548-182ae7f0-9b51-4210-9fb2-749f07cc5a0a.png">

### Opinions
@Shrinks99 I deviated from the mockups a bit for 2 reasons:
- The container is pretty wide right now, so it seemed like we could fit the button on the same row. It also looked a bit odd with the current "Add Member" button right below it.
- There wasn't an intermediate step to edit the field in the mockups, which I think is necessary to give input focus without accidentally saving form values.