### PR TITLE
Improve new config navigation UX

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -578,6 +578,7 @@ export class App extends LiteElement {
       case "browser":
       case "crawlTemplate":
       case "crawlTemplateEdit":
+      case "crawlTemplateNew":
         return html`<btrix-org
           class="w-full"
           @navigate=${this.onNavigateTo}
@@ -593,7 +594,8 @@ export class App extends LiteElement {
           crawlConfigId=${this.viewState.params.crawlConfigId}
           crawlId=${this.viewState.params.crawlId}
           ?isAddingMember=${this.viewState.route === "orgAddMember"}
-          ?isNewResourceTab=${this.viewState.route === "orgNewResourceTab"}
+          ?isNewResourceTab=${this.viewState.route === "orgNewResourceTab" ||
+          this.viewState.route === "crawlTemplateNew"}
           ?isEditing=${"edit" in this.viewState.params}
         ></btrix-org>`;
 

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -100,7 +100,7 @@ type FormState = {
 
 const getDefaultProgressState = (hasConfigId = false): ProgressState => {
   let activeTab: StepName = "crawlSetup";
-  if (hasConfigId && window.location.hash) {
+  if (window.location.hash) {
     const hashValue = window.location.hash.slice(1);
 
     if (STEPS.includes(hashValue as any)) {

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -459,9 +459,12 @@ export class CrawlTemplatesDetail extends LiteElement {
       tags: this.crawlConfig.tags,
     };
 
-    this.navTo(`/orgs/${this.orgId}/crawl-configs/new`, {
-      crawlTemplate,
-    });
+    this.navTo(
+      `/orgs/${this.orgId}/crawl-configs/new?jobType=${crawlTemplate.jobType}`,
+      {
+        crawlTemplate,
+      }
+    );
 
     this.notify({
       message: msg(str`Copied crawl configuration to new template.`),

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -169,7 +169,7 @@ export class CrawlTemplatesList extends LiteElement {
 
         <div class="grow-0 mb-4">
           <sl-button
-            href=${`/orgs/${this.orgId}/crawl-configs/new`}
+            href=${`/orgs/${this.orgId}/crawl-configs/new?jobType`}
             variant="primary"
             @click=${this.navLink}
           >
@@ -611,9 +611,12 @@ export class CrawlTemplatesList extends LiteElement {
       tags: template.tags,
     };
 
-    this.navTo(`/orgs/${this.orgId}/crawl-configs/new`, {
-      crawlTemplate,
-    });
+    this.navTo(
+      `/orgs/${this.orgId}/crawl-configs/new?jobType=${crawlTemplate.jobType}`,
+      {
+        crawlTemplate,
+      }
+    );
 
     this.notify({
       message: msg(str`Copied crawl configuration to new template.`),

--- a/frontend/src/pages/org/crawl-configs-new.ts
+++ b/frontend/src/pages/org/crawl-configs-new.ts
@@ -50,6 +50,14 @@ export class CrawlTemplatesNew extends LiteElement {
   @state()
   private jobType?: JobType;
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (!this.jobType) {
+      const url = new URL(window.location.href);
+      this.jobType = (url.searchParams.get("jobType") as JobType) || undefined;
+    }
+  }
+
   private renderHeader() {
     return html`
       <nav class="mb-5">
@@ -116,10 +124,14 @@ export class CrawlTemplatesNew extends LiteElement {
       <div
         class="border rounded p-8 md:py-12 flex flex-col md:flex-row items-start justify-evenly"
       >
-        <div
+        <a
           role="button"
           class="jobTypeButton"
-          @click=${() => (this.jobType = "url-list")}
+          href=${`/orgs/${this.orgId}/crawl-templates/config/new?jobType=url-list`}
+          @click=${(e: any) => {
+            this.navLink(e);
+            this.jobType = "url-list";
+          }}
         >
           <figure class="w-64 m-4">
             <img class="transition-transform" src=${urlListSvg} />
@@ -132,11 +144,15 @@ export class CrawlTemplatesNew extends LiteElement {
               </p>
             </figcaption>
           </figure>
-        </div>
-        <div
+        </a>
+        <a
           role="button"
           class="jobTypeButton"
-          @click=${() => (this.jobType = "seed-crawl")}
+          href=${`/orgs/${this.orgId}/crawl-templates/config/new?jobType=seed-crawl`}
+          @click=${(e: any) => {
+            this.navLink(e);
+            this.jobType = "seed-crawl";
+          }}
         >
           <figure class="w-64 m-4">
             <img class="transition-transform" src=${seededCrawlSvg} />
@@ -149,7 +165,7 @@ export class CrawlTemplatesNew extends LiteElement {
               </p>
             </figcaption>
           </figure>
-        </div>
+        </a>
       </div>
     `;
   }

--- a/frontend/src/pages/org/crawl-configs-new.ts
+++ b/frontend/src/pages/org/crawl-configs-new.ts
@@ -62,7 +62,8 @@ export class CrawlTemplatesNew extends LiteElement {
     let href = `/orgs/${this.orgId}/crawl-configs`;
     let label = msg("Back to Crawl Configs");
 
-    if (this.jobType) {
+    // Allow user to go back to choose crawl type if new (not duplicated) config
+    if (this.jobType && !this.initialCrawlTemplate.jobType) {
       href = `/orgs/${this.orgId}/crawl-configs/new`;
       label = msg("Choose Crawl Type");
     }

--- a/frontend/src/pages/org/crawl-configs-new.ts
+++ b/frontend/src/pages/org/crawl-configs-new.ts
@@ -59,20 +59,28 @@ export class CrawlTemplatesNew extends LiteElement {
   }
 
   private renderHeader() {
+    let href = `/orgs/${this.orgId}/crawl-configs`;
+    let label = msg("Back to Crawl Configs");
+
+    if (this.jobType) {
+      href = `/orgs/${this.orgId}/crawl-configs/new`;
+      label = msg("Choose Crawl Type");
+    }
     return html`
       <nav class="mb-5">
         <a
           class="text-gray-600 hover:text-gray-800 text-sm font-medium"
-          href=${`/orgs/${this.orgId}/crawl-configs`}
-          @click=${this.navLink}
+          href=${href}
+          @click=${(e: any) => {
+            this.navLink(e);
+            this.jobType = undefined;
+          }}
         >
           <sl-icon
             name="arrow-left"
             class="inline-block align-middle"
           ></sl-icon>
-          <span class="inline-block align-middle"
-            >${msg("Back to Crawl Configs")}</span
-          >
+          <span class="inline-block align-middle">${label}</span>
         </a>
       </nav>
     `;
@@ -127,7 +135,7 @@ export class CrawlTemplatesNew extends LiteElement {
         <a
           role="button"
           class="jobTypeButton"
-          href=${`/orgs/${this.orgId}/crawl-templates/config/new?jobType=url-list`}
+          href=${`/orgs/${this.orgId}/crawl-configs/new?jobType=url-list`}
           @click=${(e: any) => {
             this.navLink(e);
             this.jobType = "url-list";
@@ -148,7 +156,7 @@ export class CrawlTemplatesNew extends LiteElement {
         <a
           role="button"
           class="jobTypeButton"
-          href=${`/orgs/${this.orgId}/crawl-templates/config/new?jobType=seed-crawl`}
+          href=${`/orgs/${this.orgId}/crawl-configs/new?jobType=seed-crawl`}
           @click=${(e: any) => {
             this.navLink(e);
             this.jobType = "seed-crawl";

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -736,9 +736,12 @@ export class CrawlsList extends LiteElement {
       tags: template.tags,
     };
 
-    this.navTo(`/orgs/${crawl.oid}/crawl-configs/new`, {
-      crawlTemplate,
-    });
+    this.navTo(
+      `/orgs/${crawl.oid}/crawl-configs/new?jobType=${crawlTemplate.jobType}`,
+      {
+        crawlTemplate,
+      }
+    );
 
     this.notify({
       message: msg(str`Copied crawl configuration to new template.`),

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
     "/orgs/:id/:tab/profile/browser/:browserId?name&description&profileId&navigateUrl",
   crawlTemplate: "/orgs/:id/:tab/config/:crawlConfigId",
   crawlTemplateEdit: "/orgs/:id/:tab/config/:crawlConfigId?edit",
+  crawlTemplateNew: "/orgs/:id/:tab/config/new?jobType",
   users: "/users",
   usersInvite: "/users/invite",
   crawls: "/crawls",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -19,7 +19,7 @@ export const ROUTES = {
     "/orgs/:id/:tab/profile/browser/:browserId?name&description&profileId&navigateUrl",
   crawlTemplate: "/orgs/:id/:tab/config/:crawlConfigId",
   crawlTemplateEdit: "/orgs/:id/:tab/config/:crawlConfigId?edit",
-  crawlTemplateNew: "/orgs/:id/:tab/config/new?jobType",
+  crawlTemplateNew: "/orgs/:id/:tab/new?jobType",
   users: "/users",
   usersInvite: "/users/invite",
   crawls: "/crawls",


### PR DESCRIPTION
- Allow user to click "back" to change crawl type
- Retains job type state in URL across refreshes
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/492

### Manual testing
1. Go to New Crawl Config. Choose job type
2. Refresh page. Verify job type is still selected
3. Click "Back to Choose Crawl Type". Verify you're taken back to selection view
4. Duplicate a crawl config. Verify back button remains "Back to Crawl Configs"

### Screenshots
<img width="1157" alt="Screen Shot 2023-01-18 at 8 05 15 PM" src="https://user-images.githubusercontent.com/4672952/213352626-a4b52a3a-1b20-404a-b423-593b67f33106.png">
