### PR TITLE
Add new /users/me-with-orgs API endpoint

### DIFF
--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -407,6 +407,27 @@ def init_users_api(app, user_manager):
 
     users_router = fastapi_users.get_users_router()
 
+    @users_router.get("/me-with-orgs", tags=["users"])
+    async def me_with_org_info(user: User = Depends(current_active_user)):
+        """/users/me with orgs user belongs to."""
+        user_info = {
+            "id": user.id,
+            "email": user.email,
+            "name": user.name,
+            "orgs": [],
+            "is_active": user.is_active,
+            "is_superuser": user.is_superuser,
+            "is_verified": user.is_verified,
+        }
+        user_orgs = await user_manager.org_ops.get_orgs_for_user(user)
+        if user_orgs:
+            user_info["orgs"] = [
+                {"id": org.id, "name": org.name, "default": org.default}
+                for org in user_orgs
+            ]
+        print(f"user info with orgs: {user_info}", flush=True)
+        return user_info
+
     @users_router.post("/invite", tags=["invites"])
     async def invite_user(
         invite: InviteRequest,

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -856,7 +856,7 @@ export class App extends LiteElement {
   }
 
   getUserInfo(): Promise<APIUser> {
-    return this.apiFetch("/users/me", this.authService.authState!);
+    return this.apiFetch("/users/me-with-orgs", this.authService.authState!);
   }
 
   private clearUser() {


### PR DESCRIPTION
Connected to #437 

This PR adds a new `GET /users/me-with-orgs` API endpoint that is identical to `GET /users/me` but with the name, id, and `default` of each org a user belongs to.

This also modifies the frontend's `getUserInfo` method to fetch from the new endpoint rather than `/users/me`