### PR TITLE
Handle DuplicateKeyError on org rename requests

### DIFF
--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -407,7 +407,12 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
         org: Organization = Depends(org_owner_dep),
     ):
         org.name = rename.name
-        await ops.update(org)
+        try:
+            await ops.update(org)
+        except DuplicateKeyError:
+            raise HTTPException(
+                status_code=400, detail=f'Name "{rename.name}"" already taken'
+            )
 
         return {"updated": True}
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -410,6 +410,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
         try:
             await ops.update(org)
         except DuplicateKeyError:
+            # pylint: disable=raise-missing-from
             raise HTTPException(
                 status_code=400, detail=f'Name "{rename.name}"" already taken'
             )

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -411,9 +411,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
             await ops.update(org)
         except DuplicateKeyError:
             # pylint: disable=raise-missing-from
-            raise HTTPException(
-                status_code=400, detail='duplicate_org_name'
-            )
+            raise HTTPException(status_code=400, detail="duplicate_org_name")
 
         return {"updated": True}
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -412,7 +412,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
         except DuplicateKeyError:
             # pylint: disable=raise-missing-from
             raise HTTPException(
-                status_code=400, detail=f'Name "{rename.name}"" already taken'
+                status_code=400, detail='duplicate_org_name'
             )
 
         return {"updated": True}


### PR DESCRIPTION
This PR handles `pymongo.errors.DuplicateKeyError` exceptions that are thrown when trying to rename an org to a name that is already taken, and returns 400 with a custom message rather than causing an Internal Server Error.