### PR TITLE
Only drop/recreate indexes on app startup only if migrations have been run

### DIFF
--- a/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
+++ b/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
@@ -112,10 +112,11 @@ class Migration:
                 await self.set_db_version()
             except OperationFailure as err:
                 print(f"Error running migration {self.MIGRATION_VERSION}: {err}")
-                return
+                return False
 
         else:
             print("No migration to apply - skipping", flush=True)
-            return
+            return False
 
         print(f"Database successfully migrated to {self.MIGRATION_VERSION}", flush=True)
+        return True


### PR DESCRIPTION
This PR modifies the app startup database updating routine a bit to only drop indexes if migrations have been run.

`create_indexes` is still called each time `update_and_prepare_db()` runs because it's idempotent - `<collection>.create_index()` only creates an index if it doesn't already exist, and otherwise just returns without creating a duplicate.