### PR TITLE
Updates crawl type descriptions

### DIFF
--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -442,7 +442,7 @@ export class CrawlConfigEditor extends LiteElement {
 
   render() {
     const tabLabels: Record<StepName, string> = {
-      crawlSetup: msg("Crawl Setup"),
+      crawlSetup: msg("Crawl Scope"),
       browserSettings: msg("Browser Settings"),
       crawlScheduling: msg("Crawl Scheduling"),
       crawlInformation: msg("Crawl Information"),
@@ -944,7 +944,7 @@ https://example.com/path`}
       ${this.renderFormCol(html`
         <sl-select
           name="scopeType"
-          label=${msg("Crawl Scope")}
+          label=${msg("Start URL Scope")}
           defaultValue=${this.formState.scopeType}
           value=${this.formState.scopeType}
           @sl-select=${(e: Event) =>
@@ -987,7 +987,7 @@ https://example.net`}
         ></sl-textarea>
       `)}
       ${this.renderHelpTextCol(
-        html`Crawl pages outside of Crawl Scope that begin with these URLs.`
+        html`If the crawler finds pages outside of the Start URL Scope they will only be saved if they begin with URLs listed here.`
       )}
       ${this.renderFormCol(html`
         <sl-checkbox
@@ -1096,8 +1096,8 @@ https://example.net`}
         </sl-radio-group>
       `)}
       ${this.renderHelpTextCol(
-        html`Increasing parallel crawler instances will speed up crawls, but
-        take up more system resources.`
+        html`Increasing parallel crawler instances can speed up crawls, but
+        may increase the chances of getting rate limited.`
       )}
     `;
   }

--- a/frontend/src/pages/org/crawl-configs-new.ts
+++ b/frontend/src/pages/org/crawl-configs-new.ts
@@ -148,7 +148,7 @@ export class CrawlTemplatesNew extends LiteElement {
               <div class="text-lg font-medium my-3">${msg("URL List")}</div>
               <p class="text-sm text-neutral-500">
                 ${msg(
-                  "The crawler visits every URL you tell it to and optionally every URL linked on those pages."
+                  "The crawler visits every URL specified in a list, and optionally every URL linked on those pages."
                 )}
               </p>
             </figcaption>
@@ -169,7 +169,7 @@ export class CrawlTemplatesNew extends LiteElement {
               <div class="text-lg font-medium my-3">${msg("Seeded Crawl")}</div>
               <p class="text-sm text-neutral-500">
                 ${msg(
-                  "The crawler automatically finds new pages and archives them."
+                  "The crawler automatically discovers and archives pages starting from a single seed URL."
                 )}
               </p>
             </figcaption>


### PR DESCRIPTION
Improvements based on Nicholas' feedback.

- Renames the first step as `Crawl Scope` from `Crawl Setup`.  Technically this whole process is setting up crawls, `Crawl Scope` should be more descriptive.
- Changes the help text regarding crawler instances to mention rate limiting instead of the amount of resources it takes up on our end which isn't terribly relevant to users.