### PR TITLE
Fix browser profile origins sidebar overlap

### DIFF
--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -112,7 +112,7 @@ export class ProfileBrowser extends LiteElement {
         <div
           class="${this.isFullscreen
             ? "w-screen h-screen"
-            : "aspect-4/3 border-t"} relative bg-neutral-50 overflow-hidden"
+            : "aspect-video border-t"} relative bg-neutral-50 overflow-hidden"
           aria-live="polite"
         >
           ${this.renderBrowser()}

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -120,7 +120,7 @@ export class ProfileBrowser extends LiteElement {
             id="profileBrowserSidebar"
             class="${hiddenClassList.join(
               " "
-            )} lg:absolute top-0 right-0 bottom-0 lg:w-80 lg:p-4 flex transition-all duration-300 ease-out"
+            )} lg:absolute top-0 right-0 bottom-0 lg:w-80 lg:p-3 flex transition-all duration-300 ease-out"
           >
             <div
               class="shadow-lg overflow-auto border rounded-lg bg-white flex-1"

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -92,7 +92,7 @@ export class ProfileBrowser extends LiteElement {
         >
           ${this.renderBrowser()}
         </div>
-        <div class="flex-0 border rounded-lg lg:w-72">
+        <div class="flex-0 border rounded-lg lg:w-72 bg-white">
           ${document.fullscreenEnabled ? this.renderFullscreenButton() : ""}
           ${this.renderOrigins()} ${this.renderNewOrigins()}
         </div>

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -92,9 +92,8 @@ export class ProfileBrowser extends LiteElement {
       changedProperties.get("showOriginSidebar") !== undefined
     ) {
       const hiddenClassList = [
-        "translate-x-full",
-        "pl-8",
-        "opacity-50",
+        "translate-x-2/3",
+        "opacity-0",
         "pointer-events-none",
       ];
       if (this.showOriginSidebar) {
@@ -116,9 +115,13 @@ export class ProfileBrowser extends LiteElement {
           ${this.renderBrowser()}
           <div
             id="profileBrowserSidebar"
-            class="lg:absolute lg:top-4 lg:bottom-4 lg:right-0 lg:mr-4 lg:w-72 shadow-lg overflow-auto border rounded-lg bg-white transition-all duration-300"
+            class="lg:absolute top-0 right-0 bottom-0 p-4 lg:w-80 flex transition-all duration-300 ease-out"
           >
-            ${this.renderOrigins()} ${this.renderNewOrigins()}
+            <div
+              class="shadow-lg overflow-auto border rounded-lg bg-white flex-1"
+            >
+              ${this.renderOrigins()} ${this.renderNewOrigins()}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -7,6 +7,7 @@ import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
 
 const POLL_INTERVAL_SECONDS = 2;
+const hiddenClassList = ["translate-x-2/3", "opacity-0", "pointer-events-none"];
 
 /**
  * View embedded profile browser
@@ -54,7 +55,7 @@ export class ProfileBrowser extends LiteElement {
   private isFullscreen = false;
 
   @state()
-  private showOriginSidebar = true;
+  private showOriginSidebar = false;
 
   @state()
   private newOrigins: string[] = [];
@@ -91,16 +92,16 @@ export class ProfileBrowser extends LiteElement {
       changedProperties.has("showOriginSidebar") &&
       changedProperties.get("showOriginSidebar") !== undefined
     ) {
-      const hiddenClassList = [
-        "translate-x-2/3",
-        "opacity-0",
-        "pointer-events-none",
-      ];
-      if (this.showOriginSidebar) {
-        this.sidebar?.classList.remove(...hiddenClassList);
-      } else {
-        this.sidebar?.classList.add(...hiddenClassList);
-      }
+      this.animateSidebar();
+    }
+  }
+
+  private animateSidebar() {
+    if (!this.sidebar) return;
+    if (this.showOriginSidebar) {
+      this.sidebar.classList.remove(...hiddenClassList);
+    } else {
+      this.sidebar.classList.add(...hiddenClassList);
     }
   }
 
@@ -109,13 +110,17 @@ export class ProfileBrowser extends LiteElement {
       <div id="interactive-browser" class="w-full">
         ${this.renderControlBar()}
         <div
-          class="relative aspect-video border rounded-lg bg-neutral-50 overflow-hidden mb-3"
+          class="${this.isFullscreen
+            ? "w-screen h-screen"
+            : "aspect-4/3 border-t"} relative bg-neutral-50 overflow-hidden"
           aria-live="polite"
         >
           ${this.renderBrowser()}
           <div
             id="profileBrowserSidebar"
-            class="lg:absolute top-0 right-0 bottom-0 p-4 lg:w-80 flex transition-all duration-300 ease-out"
+            class="${hiddenClassList.join(
+              " "
+            )} lg:absolute top-0 right-0 bottom-0 lg:w-80 lg:p-4 flex transition-all duration-300 ease-out"
           >
             <div
               class="shadow-lg overflow-auto border rounded-lg bg-white flex-1"
@@ -142,8 +147,9 @@ export class ProfileBrowser extends LiteElement {
         </div>
       `;
     }
+
     return html`
-      <div class="text-right text-base mb-2">
+      <div class="text-right text-base p-1">
         ${this.renderSidebarButton()}
         <sl-icon-button
           name="arrows-fullscreen"

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -85,14 +85,14 @@ export class ProfileBrowser extends LiteElement {
 
   render() {
     return html`
-      <div id="interactive-browser" class="">
+      <div id="interactive-browser" class="lg:flex w-full">
         <div
-          class="border w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
+          class="flex-1 aspect-4/3 border rounded-lg bg-neutral-50 overflow-hidden mb-3 lg:mb-0 lg:mr-5"
           aria-live="polite"
         >
           ${this.renderBrowser()}
         </div>
-        <div class="border">
+        <div class="flex-0 border rounded-lg lg:w-72">
           ${document.fullscreenEnabled ? this.renderFullscreenButton() : ""}
           ${this.renderOrigins()} ${this.renderNewOrigins()}
         </div>

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -63,6 +63,9 @@ export class ProfileBrowser extends LiteElement {
   @query("#profileBrowserSidebar")
   private sidebar?: HTMLElement;
 
+  @query("iframe")
+  private iframe?: HTMLIFrameElement;
+
   private pollTimerId?: number;
 
   connectedCallback() {
@@ -112,7 +115,7 @@ export class ProfileBrowser extends LiteElement {
         <div
           class="${this.isFullscreen
             ? "w-screen h-screen"
-            : "aspect-video border-t"} relative bg-neutral-50 overflow-hidden"
+            : "aspect-4/3 border-t"} relative bg-neutral-50 overflow-hidden"
           aria-live="polite"
         >
           ${this.renderBrowser()}
@@ -174,7 +177,6 @@ export class ProfileBrowser extends LiteElement {
         title=${msg("Interactive browser for creating browser profile")}
         src=${this.iframeSrc}
         @load=${this.onIframeLoad}
-        ${ref((el) => this.onIframeRef(el as HTMLIFrameElement))}
       ></iframe>`;
     }
 
@@ -382,7 +384,9 @@ export class ProfileBrowser extends LiteElement {
 
   private onIframeLoad() {
     this.isIframeLoaded = true;
-
+    try {
+      this.iframe?.contentWindow?.localStorage.setItem("uiTheme", '"default"');
+    } catch (e) {}
     this.dispatchEvent(new CustomEvent("load", { detail: this.iframeSrc }));
   }
 
@@ -393,15 +397,4 @@ export class ProfileBrowser extends LiteElement {
       this.isFullscreen = false;
     }
   };
-
-  private onIframeRef(el: HTMLIFrameElement) {
-    if (!el) return;
-
-    el.addEventListener("load", () => {
-      // TODO see if we can make this work locally without CORs errors
-      try {
-        el.contentWindow?.localStorage.setItem("uiTheme", '"default"');
-      } catch (e) {}
-    });
-  }
 }

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -1,6 +1,5 @@
 // import { LitElement, html } from "lit";
 import { property, state, query } from "lit/decorators.js";
-import { ref } from "lit/directives/ref.js";
 import { msg, localized, str } from "@lit/localize";
 
 import type { AuthState } from "../utils/AuthService";
@@ -63,6 +62,9 @@ export class ProfileBrowser extends LiteElement {
   @query("#profileBrowserSidebar")
   private sidebar?: HTMLElement;
 
+  @query("#iframeWrapper")
+  private iframeWrapper?: HTMLElement;
+
   @query("iframe")
   private iframe?: HTMLIFrameElement;
 
@@ -110,12 +112,13 @@ export class ProfileBrowser extends LiteElement {
 
   render() {
     return html`
-      <div id="interactive-browser" class="w-full">
+      <div id="interactive-browser" class="w-full h-full flex flex-col">
         ${this.renderControlBar()}
         <div
+          id="iframeWrapper"
           class="${this.isFullscreen
             ? "w-screen h-screen"
-            : "aspect-4/3 border-t"} relative bg-neutral-50 overflow-hidden"
+            : "border-t"} flex-1 relative bg-neutral-50 overflow-hidden"
           aria-live="polite"
         >
           ${this.renderBrowser()}
@@ -390,7 +393,7 @@ export class ProfileBrowser extends LiteElement {
     this.dispatchEvent(new CustomEvent("load", { detail: this.iframeSrc }));
   }
 
-  private onFullscreenChange = () => {
+  private onFullscreenChange = async () => {
     if (document.fullscreenElement) {
       this.isFullscreen = true;
     } else {

--- a/frontend/src/components/profile-browser.ts
+++ b/frontend/src/components/profile-browser.ts
@@ -26,10 +26,6 @@ const POLL_INTERVAL_SECONDS = 2;
  */
 @localized()
 export class ProfileBrowser extends LiteElement {
-  // TODO remove sidebar constaint once devtools panel
-  // is hidden on the backend
-  static SIDE_BAR_WIDTH = 288;
-
   @property({ type: Object })
   authState!: AuthState;
 
@@ -89,20 +85,16 @@ export class ProfileBrowser extends LiteElement {
 
   render() {
     return html`
-      <div id="interactive-browser" class="lg:flex relative">
-        <div class="grow lg:rounded-lg border overflow-hidden bg-slate-50">
-          <div
-            class="w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
-            aria-live="polite"
-          >
-            ${this.renderBrowser()}
-          </div>
-          <div
-            class="rounded-b lg:rounded-b-none lg:rounded-r border w-72  bg-white absolute h-full top-0 right-0"
-          >
-            ${document.fullscreenEnabled ? this.renderFullscreenButton() : ""}
-            ${this.renderOrigins()} ${this.renderNewOrigins()}
-          </div>
+      <div id="interactive-browser" class="">
+        <div
+          class="border w-full ${this.isFullscreen ? "h-screen" : "h-96"}"
+          aria-live="polite"
+        >
+          ${this.renderBrowser()}
+        </div>
+        <div class="border">
+          ${document.fullscreenEnabled ? this.renderFullscreenButton() : ""}
+          ${this.renderOrigins()} ${this.renderNewOrigins()}
         </div>
       </div>
     `;
@@ -111,14 +103,9 @@ export class ProfileBrowser extends LiteElement {
   private renderBrowser() {
     if (this.hasFetchError) {
       return html`
-        <div style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;">
-          <btrix-alert
-            variant="danger"
-            style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
-          >
-            ${msg(`The interactive browser is not available.`)}
-          </btrix-alert>
-        </div>
+        <btrix-alert variant="danger">
+          ${msg(`The interactive browser is not available.`)}
+        </btrix-alert>
       `;
     }
 
@@ -134,10 +121,7 @@ export class ProfileBrowser extends LiteElement {
 
     if (this.browserId && !this.isIframeLoaded) {
       return html`
-        <div
-          class="w-full h-full flex items-center justify-center text-3xl"
-          style="padding-right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
-        >
+        <div class="w-full h-full flex items-center justify-center text-3xl">
           <sl-spinner></sl-spinner>
         </div>
       `;
@@ -381,12 +365,7 @@ export class ProfileBrowser extends LiteElement {
     el.addEventListener("load", () => {
       // TODO see if we can make this work locally without CORs errors
       try {
-        //el.style.width = "132%";
         el.contentWindow?.localStorage.setItem("uiTheme", '"default"');
-        el.contentWindow?.localStorage.setItem(
-          "InspectorView.screencastSplitViewState",
-          `{"vertical":{"size":${ProfileBrowser.SIDE_BAR_WIDTH}}}`
-        );
       } catch (e) {}
     });
   }

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -222,7 +222,9 @@ export class BrowserProfilesDetail extends LiteElement {
               .origins=${this.profile?.origins}
               @load=${() => (this.isBrowserLoaded = true)}
             ></btrix-profile-browser>
+          </main>
 
+          <main class="relative">
             ${this.browserId || this.isBrowserLoading
               ? ""
               : html`

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -174,7 +174,7 @@ export class BrowserProfilesDetail extends LiteElement {
           <h3 class="text-lg font-medium">${msg("Browser Profile")}</h3>
         </header>
 
-        <div class="rounded p-2 bg-slate-50">
+        <div>
           <div class="mb-2 flex justify-between items-center">
             <div class="text-sm text-neutral-500 mx-1">
               ${this.browserId
@@ -227,7 +227,7 @@ export class BrowserProfilesDetail extends LiteElement {
               ? ""
               : html`
                   <div
-                    class="outline absolute top-0 left-0 h-full flex flex-col items-center justify-center"
+                    class="absolute top-3 left-4 right-80 aspect-4/3 flex flex-col items-center justify-center"
                   >
                     <p class="mb-4 text-neutral-600 max-w-prose">
                       ${msg(

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -177,15 +177,18 @@ export class BrowserProfilesDetail extends LiteElement {
           ${when(
             this.browserId || this.isBrowserLoading,
             () => html`
-              <div class="border rounded-lg overflow-hidden">
+              <div
+                class="border rounded-lg overflow-hidden h-screen flex flex-col"
+              >
                 <btrix-profile-browser
+                  class="flex-1"
                   .authState=${this.authState}
                   orgId=${this.orgId}
                   browserId=${ifDefined(this.browserId)}
                   .origins=${this.profile?.origins}
                   @load=${() => (this.isBrowserLoaded = true)}
                 ></btrix-profile-browser>
-                <div class="border-t">
+                <div class="flex-0 border-t">
                   ${this.renderBrowserProfileControls()}
                 </div>
               </div>

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -227,8 +227,7 @@ export class BrowserProfilesDetail extends LiteElement {
               ? ""
               : html`
                   <div
-                    class="absolute top-0 left-0 h-full flex flex-col items-center justify-center"
-                    style="right: ${ProfileBrowser.SIDE_BAR_WIDTH}px;"
+                    class="outline absolute top-0 left-0 h-full flex flex-col items-center justify-center"
                   >
                     <p class="mb-4 text-neutral-600 max-w-prose">
                       ${msg(

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -103,12 +103,14 @@ export class BrowserProfilesNew extends LiteElement {
         </sl-button>
       </div>
 
-      <btrix-profile-browser
-        .authState=${this.authState}
-        orgId=${this.orgId}
-        browserId=${this.browserId}
-        initialNavigateUrl=${ifDefined(this.params.navigateUrl)}
-      ></btrix-profile-browser>
+      <div class="border rounded-lg">
+        <btrix-profile-browser
+          .authState=${this.authState}
+          orgId=${this.orgId}
+          browserId=${this.browserId}
+          initialNavigateUrl=${ifDefined(this.params.navigateUrl)}
+        ></btrix-profile-browser>
+      </div>
 
       <sl-dialog
         label=${msg(str`Save Browser Profile`)}
@@ -196,9 +198,7 @@ export class BrowserProfilesNew extends LiteElement {
         icon: "check2-circle",
       });
 
-      this.navTo(
-        `/orgs/${this.orgId}/browser-profiles/profile/${data.id}`
-      );
+      this.navTo(`/orgs/${this.orgId}/browser-profiles/profile/${data.id}`);
     } catch (e) {
       this.isSubmitting = false;
 

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -88,23 +88,26 @@ export class BrowserProfilesNew extends LiteElement {
           `
         : ""}
 
-      <div class="flex items-center justify-between mb-3 p-2 bg-slate-50">
-        <p class="text-sm text-slate-600 mr-3 p-1">
-          ${msg(
-            "Interact with the browsing tool to record your browser profile. You will complete and save your profile in the next step."
-          )}
-        </p>
-
-        <sl-button
-          variant="primary"
-          @click=${() => (this.isDialogVisible = true)}
+      <div class="h-screen flex flex-col">
+        <div
+          class="flex-0 flex items-center justify-between mb-3 p-2 bg-slate-50"
         >
-          ${msg("Next")}
-        </sl-button>
-      </div>
+          <p class="text-sm text-slate-600 mr-3 p-1">
+            ${msg(
+              "Interact with the browsing tool to record your browser profile. You will complete and save your profile in the next step."
+            )}
+          </p>
 
-      <div class="border rounded-lg">
+          <sl-button
+            variant="primary"
+            @click=${() => (this.isDialogVisible = true)}
+          >
+            ${msg("Next")}
+          </sl-button>
+        </div>
+
         <btrix-profile-browser
+          class="flex-1 border rounded-lg overflow-hidden"
           .authState=${this.authState}
           orgId=${this.orgId}
           browserId=${this.browserId}


### PR DESCRIPTION
Update browser profile sidebar UI to prevent overlap & refresh UI. Functionality related to editing & saving has been preserved, with some layout updates.

Fixes https://github.com/webrecorder/browsertrix-cloud/issues/517, addresses some of https://github.com/webrecorder/browsertrix-cloud/issues/438

### Screenshots
<img width="1121" alt="Screen Shot 2023-01-30 at 12 14 05 PM" src="https://user-images.githubusercontent.com/4672952/215585742-0b99d982-1136-4073-ae4e-7cd18d2460bd.png">
<img width="1125" alt="Screen Shot 2023-01-30 at 12 15 15 PM" src="https://user-images.githubusercontent.com/4672952/215585748-4b6d0f4c-7b2e-4a02-8766-59d93f4332d6.png">
<img width="1128" alt="Screen Shot 2023-01-30 at 12 15 19 PM" src="https://user-images.githubusercontent.com/4672952/215585751-337f8a65-2159-45e2-b888-82c4b950f42e.png">
