### PR TITLE
Fix issue where users are added to default org as admin

### DIFF
--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -81,7 +81,7 @@ class InviteOps:
                 status_code=403, detail="This user has already been invited"
             )
 
-        # Invitations to a specific org via API must invite role, so if it's
+        # Invitations to a specific org via API must include role, so if it's
         # absent assume this is a general invitation from superadmin.
         if not new_user_invite.role:
             new_user_invite.role = UserRole.OWNER

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -278,7 +278,7 @@ class OrgOps:
         new_user_invite = await self.invites.get_valid_invite(invite_token, user.email)
         await self.add_user_by_invite(new_user_invite, user)
         await self.invites.remove_invite(invite_token)
-        return True
+        return new_user_invite
 
     async def add_user_by_invite(self, invite: InvitePending, user: User):
         """Add user to an org from an InvitePending, if any.


### PR DESCRIPTION
Connected to #531 

Users should only be added as to the default org with Owner permissions if they are not specifically being invited to another org. This commit fixes the logic in the post-registration callback to make this the case.

I've tested this manually myself to make sure that:

1. the issue is solved, and users invited to a specific org are not also added to default org as an admin/Owner
2. a user invited generally (i.e. not to a specific organization with a defined role) is still added to the default org as an admin/Owner

The invite workflow as we have it makes writing unit tests for this difficult, but this would be a good candidate for automated testing with Playwright down the road.