### PR TITLE
Add org role to /users/me-with-orgs

### DIFF
--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -19,6 +19,7 @@ class UserRole(IntEnum):
     VIEWER = 10
     CRAWLER = 20
     OWNER = 40
+    SUPERADMIN = 100
 
 
 # ============================================================================

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -25,7 +25,7 @@ from fastapi_users.authentication import (
 )
 from fastapi_users.db import MongoDBUserDatabase
 
-from .invites import InvitePending, InviteRequest
+from .invites import InvitePending, InviteRequest, UserRole
 
 
 # ============================================================================
@@ -426,7 +426,9 @@ def init_users_api(app, user_manager):
                     "id": org.id,
                     "name": org.name,
                     "default": org.default,
-                    "role": org.users.get(str(user.id)),
+                    "role": UserRole.SUPERADMIN
+                    if user.is_superuser
+                    else org.users.get(str(user.id)),
                 }
                 for org in user_orgs
             ]

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -422,7 +422,12 @@ def init_users_api(app, user_manager):
         user_orgs = await user_manager.org_ops.get_orgs_for_user(user)
         if user_orgs:
             user_info["orgs"] = [
-                {"id": org.id, "name": org.name, "default": org.default}
+                {
+                    "id": org.id,
+                    "name": org.name,
+                    "default": org.default,
+                    "role": org.users.get(str(user.id)),
+                }
                 for org in user_orgs
             ]
         print(f"user info with orgs: {user_info}", flush=True)

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -1,6 +1,6 @@
 import requests
 
-from .conftest import API_PREFIX
+from .conftest import API_PREFIX, CRAWLER_USERNAME
 
 
 def test_create_super_user(admin_auth_headers):
@@ -17,3 +17,28 @@ def test_create_non_super_user(viewer_auth_headers):
     token = auth.replace("Bearer ", "")
     assert token != "None"
     assert len(token) > 4
+
+
+def test_me_with_orgs(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/users/me-with-orgs",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["email"] == CRAWLER_USERNAME
+    assert data["id"]
+    assert data["is_active"]
+    assert data["is_superuser"] is False
+    assert data["is_verified"] is True
+    assert data["name"] == "new-crawler"
+
+    orgs = data["orgs"]
+    assert len(orgs) == 1
+
+    default_org = orgs[0]
+    assert default_org["id"] == default_org_id
+    assert default_org["name"]
+    assert default_org["default"]
+    assert default_org["role"] == 20


### PR DESCRIPTION
Connected to #525 

Adds the user's role for each org in `GET /api/users/me-with-orgs` and a unit test.

FYI for superusers this will be `None`/`null` as they don't have defined roles for the orgs.