### PR TITLE
browser api: return additional data in profile /browser/<id> endpoint

### DIFF
--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -168,7 +168,8 @@ class ProfileOps:
         }
 
         url = f"{scheme}://{host}/browser/{browserid}/?{urlencode(params)}"
-        return {"url": url}
+        params["url"] = url
+        return params
 
     async def ping_profile_browser(self, browserid):
         """ping profile browser to keep it running"""


### PR DESCRIPTION
To support #533, expose additional api data for connecting to VNC WS in /browser/<browser> endpoint