### PR TITLE
Support additional seed URLs and custom scope type

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -178,7 +178,7 @@ export class ConfigDetails extends LiteElement {
         `
       )}
       ${this.renderSetting(
-        msg("Include Linked Pages"),
+        msg("Include Any Linked Page"),
         Boolean(crawlConfig?.config.extraHops)
       )}
     `;

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -6,7 +6,7 @@ import RegexColorize from "regex-colorize";
 import ISO6391 from "iso-639-1";
 
 import LiteElement, { html } from "../utils/LiteElement";
-import type { CrawlConfig } from "../pages/org/types";
+import type { CrawlConfig, Seed, SeedConfig } from "../pages/org/types";
 import { humanizeSchedule } from "../utils/cron";
 
 /**
@@ -186,21 +186,29 @@ export class ConfigDetails extends LiteElement {
 
   private renderConfirmSeededSettings = () => {
     const crawlConfig = this.crawlConfig!;
+    const seedsConfig = crawlConfig.config;
+    const additionalUrlList = seedsConfig.seeds.slice(1);
+    let primarySeedConfig: SeedConfig | Seed = seedsConfig;
+    let primarySeedUrl = seedsConfig.seeds[0];
+    if (typeof seedsConfig.seeds[0] !== "string") {
+      primarySeedConfig = seedsConfig.seeds[0];
+      primarySeedUrl = primarySeedConfig.url;
+    }
+    const includeUrlList = primarySeedConfig.include || seedsConfig.include;
     return html`
-      ${this.renderSetting(
-        msg("Primary Seed URL"),
-        crawlConfig?.config.seeds[0]
-      )}
+      ${this.renderSetting(msg("Primary Seed URL"), primarySeedUrl)}
       ${this.renderSetting(
         msg("Crawl Scope"),
-        this.scopeTypeLabels[crawlConfig?.config.scopeType]
+        this.scopeTypeLabels[
+          primarySeedConfig.scopeType || seedsConfig.scopeType
+        ]
       )}
       ${this.renderSetting(
         msg("Extra URLs in Scope"),
-        crawlConfig?.config.include?.length
+        includeUrlList?.length
           ? html`
               <ul>
-                ${crawlConfig?.config.include.map(
+                ${includeUrlList.map(
                   (url: string) =>
                     staticHtml`<li class="regex">${unsafeStatic(
                       new RegexColorize().colorizeText(url)
@@ -212,11 +220,21 @@ export class ConfigDetails extends LiteElement {
       )}
       ${this.renderSetting(
         msg("Include Any Linked Page (“one hop out”)"),
-        Boolean(crawlConfig?.config.extraHops)
+        Boolean(primarySeedConfig.extraHops || seedsConfig.include)
+      )}
+      ${this.renderSetting(
+        msg("List of Additional URLs"),
+        additionalUrlList?.length
+          ? html`
+              <ul>
+                ${additionalUrlList.map((url) => html`<li>${url}</li>`)}
+              </ul>
+            `
+          : msg("None")
       )}
       ${this.renderSetting(
         msg("Max Pages"),
-        crawlConfig?.config.limit
+        seedsConfig.limit
           ? msg(str`${crawlConfig?.config.limit} pages`)
           : msg("Unlimited")
       )}

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -220,7 +220,7 @@ export class ConfigDetails extends LiteElement {
       )}
       ${this.renderSetting(
         msg("Include Any Linked Page (“one hop out”)"),
-        Boolean(primarySeedConfig.extraHops || seedsConfig.include)
+        Boolean(primarySeedConfig.extraHops ?? seedsConfig.extraHops)
       )}
       ${this.renderSetting(
         msg("List of Additional URLs"),
@@ -235,7 +235,7 @@ export class ConfigDetails extends LiteElement {
       ${this.renderSetting(
         msg("Max Pages"),
         seedsConfig.limit
-          ? msg(str`${crawlConfig?.config.limit} pages`)
+          ? msg(str`${primarySeedConfig.limit ?? seedsConfig.limit} pages`)
           : msg("Unlimited")
       )}
     `;

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1175,6 +1175,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             value=${this.formState.pageLimit ?? ""}
             min=${minPages}
             placeholder=${msg("Unlimited")}
+            clearable
           >
             <span slot="suffix">${msg("pages")}</span>
             <div slot="help-text">
@@ -1198,6 +1199,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               this.defaultBehaviorTimeoutMinutes
           )}
           ?disabled=${this.defaultBehaviorTimeoutMinutes === undefined}
+          min="1"
           required
         >
           <span slot="suffix">${msg("minutes")}</span>
@@ -1213,7 +1215,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
           label=${msg("Crawl Time Limit")}
           value=${ifDefined(this.formState.crawlTimeoutMinutes ?? undefined)}
           placeholder=${msg("Unlimited")}
+          min="1"
           type="number"
+          clearable
         >
           <span slot="suffix">${msg("minutes")}</span>
         </sl-input>
@@ -1690,7 +1694,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         value = elem.value;
         break;
       case "sl-input": {
-        if ((elem as SlInput).type === "number") {
+        if ((elem as SlInput).type === "number" && elem.value !== "") {
           value = +elem.value;
         } else {
           value = elem.value;
@@ -1762,16 +1766,19 @@ https://archiveweb.page/images/${"logo.svg"}`}
     const el = event.target as HTMLElement;
     const tagName = el.tagName.toLowerCase();
     if (tagName !== "sl-input") return;
-
     const { key } = event;
     if ((el as SlInput).type === "number") {
       // Prevent typing non-numeric keys
-      if (key.length === 1 && /\D/.test(key)) {
+      if (
+        !event.metaKey &&
+        !event.shiftKey &&
+        key.length === 1 &&
+        /\D/.test(key)
+      ) {
         event.preventDefault();
         return;
       }
     }
-
     if (
       key === "Enter" &&
       this.progressState.activeTab !== STEPS[STEPS.length - 1]

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -920,7 +920,7 @@ https://example.com/path`}
             <span class="text-blue-500 break-word"
               >${exampleDomain}${examplePathname}</span
             >
-            and links that stay within the same URL, e.g. hash anchor links:
+            hash anchor links, e.g.
             <span class="text-blue-500 break-word"
               >${exampleDomain}${examplePathname}</span
             ><span class="text-blue-500 font-medium break-word"
@@ -992,6 +992,9 @@ https://example.com/path`}
             })}
         >
           <div slot="help-text">${helpText}</div>
+          <sl-menu-item value="page-spa">
+            ${this.scopeTypeLabels["page-spa"]}
+          </sl-menu-item>
           <sl-menu-item value="prefix">
             ${this.scopeTypeLabels["prefix"]}
           </sl-menu-item>
@@ -1003,9 +1006,6 @@ https://example.com/path`}
           </sl-menu-item>
           <sl-menu-item value="custom">
             ${this.scopeTypeLabels["custom"]}
-          </sl-menu-item>
-          <sl-menu-item value="page-spa">
-            ${this.scopeTypeLabels["page-spa"]}
           </sl-menu-item>
         </sl-select>
       `)}

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1049,10 +1049,11 @@ https://example.net`}
         Crawl Scope.`,
         false
       )}
+      ${this.renderSectionHeading(msg("Additional URLs"))}
       ${this.renderFormCol(html`
         <sl-textarea
           name="urlList"
-          label=${msg("List of Additional URLs")}
+          label=${msg("List of URLs")}
           rows="3"
           autocomplete="off"
           value=${this.formState.urlList}

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1172,7 +1172,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
             value=${this.formState.pageLimit ?? ""}
             min=${minPages}
             placeholder=${msg("Unlimited")}
-            clearable
           >
             <span slot="suffix">${msg("pages")}</span>
             <div slot="help-text">
@@ -1214,7 +1213,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
           placeholder=${msg("Unlimited")}
           min="1"
           type="number"
-          clearable
         >
           <span slot="suffix">${msg("minutes")}</span>
         </sl-input>

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -468,11 +468,11 @@ export class CrawlConfigEditor extends LiteElement {
 
   render() {
     const tabLabels: Record<StepName, string> = {
-      crawlSetup: msg("Crawl Scope"),
-      crawlLimits: msg("Crawl Limits"),
+      crawlSetup: msg("Scope"),
+      crawlLimits: msg("Limits"),
       browserSettings: msg("Browser Settings"),
-      crawlScheduling: msg("Crawl Scheduling"),
-      crawlInformation: msg("Crawl Information"),
+      crawlScheduling: msg("Scheduling"),
+      crawlInformation: msg("Information"),
       confirmSettings: msg("Confirm Settings"),
     };
 
@@ -611,7 +611,7 @@ export class CrawlConfigEditor extends LiteElement {
   ) {
     return html`
       <div class="border rounded-lg flex flex-col h-full">
-        <div class="flex-1 p-6 grid grid-cols-1 md:grid-cols-5 gap-4">
+        <div class="flex-1 p-6 grid grid-cols-5 gap-4">
           ${content}
           ${when(this.serverError, () =>
             this.renderErrorAlert(this.serverError!)
@@ -718,19 +718,19 @@ export class CrawlConfigEditor extends LiteElement {
 
   private renderSectionHeading(content: TemplateResult | string) {
     return html`
-      <btrix-section-heading class="col-span-1 md:col-span-5">
+      <btrix-section-heading class="col-span-5">
         <h4>${content}</h4>
       </btrix-section-heading>
     `;
   }
 
   private renderFormCol = (content: TemplateResult) => {
-    return html`<div class="col-span-1 md:col-span-3">${content}</div> `;
+    return html`<div class="col-span-5 md:col-span-3">${content}</div> `;
   };
 
   private renderHelpTextCol(content: TemplateResult, padTop = true) {
     return html`
-      <div class="col-span-1 md:col-span-2 flex${padTop ? " pt-6" : ""}">
+      <div class="col-span-5 md:col-span-2 flex${padTop ? " pt-6" : ""}">
         <div class="text-base mr-2">
           <sl-icon name="info-circle"></sl-icon>
         </div>
@@ -1049,51 +1049,57 @@ https://example.net`}
         Crawl Scope.`,
         false
       )}
-      ${this.renderSectionHeading(msg("Additional URLs"))}
-      ${this.renderFormCol(html`
-        <sl-textarea
-          name="urlList"
-          label=${msg("List of URLs")}
-          rows="3"
-          autocomplete="off"
-          value=${this.formState.urlList}
-          placeholder=${`https://webrecorder.net/blog
+      <div class="col-span-5">
+        <btrix-details>
+          <span slot="title">${msg("Additional URLs")}</span>
+          <div class="grid grid-cols-5 gap-4 py-2">
+            ${this.renderFormCol(html`
+              <sl-textarea
+                name="urlList"
+                label=${msg("List of URLs")}
+                rows="3"
+                autocomplete="off"
+                value=${this.formState.urlList}
+                placeholder=${`https://webrecorder.net/blog
 https://archiveweb.page/images/${"logo.svg"}`}
-          @sl-input=${async (e: Event) => {
-            const inputEl = e.target as SlInput;
-            await inputEl.updateComplete;
-            if (
-              inputEl.invalid &&
-              !urlListToArray(inputEl.value).some((url) => !validURL(url))
-            ) {
-              inputEl.setCustomValidity("");
-              inputEl.helpText = "";
-            }
-          }}
-          @sl-blur=${async (e: Event) => {
-            const inputEl = e.target as SlInput;
-            await inputEl.updateComplete;
-            if (
-              inputEl.value &&
-              urlListToArray(inputEl.value).some((url) => !validURL(url))
-            ) {
-              const text = msg("Please fix invalid URL in list.");
-              inputEl.invalid = true;
-              inputEl.helpText = text;
-              inputEl.setCustomValidity(text);
-            } else {
-              await this.updateComplete;
-              if (!this.formState.jobName) {
-                this.setDefaultJobName();
-              }
-            }
-          }}
-        ></sl-textarea>
-      `)}
-      ${this.renderHelpTextCol(
-        html`The crawler will visit and record each URL listed here. Other links
-        on these pages will not be crawled.`
-      )}
+                @sl-input=${async (e: Event) => {
+                  const inputEl = e.target as SlInput;
+                  await inputEl.updateComplete;
+                  if (
+                    inputEl.invalid &&
+                    !urlListToArray(inputEl.value).some((url) => !validURL(url))
+                  ) {
+                    inputEl.setCustomValidity("");
+                    inputEl.helpText = "";
+                  }
+                }}
+                @sl-blur=${async (e: Event) => {
+                  const inputEl = e.target as SlInput;
+                  await inputEl.updateComplete;
+                  if (
+                    inputEl.value &&
+                    urlListToArray(inputEl.value).some((url) => !validURL(url))
+                  ) {
+                    const text = msg("Please fix invalid URL in list.");
+                    inputEl.invalid = true;
+                    inputEl.helpText = text;
+                    inputEl.setCustomValidity(text);
+                  } else {
+                    await this.updateComplete;
+                    if (!this.formState.jobName) {
+                      this.setDefaultJobName();
+                    }
+                  }
+                }}
+              ></sl-textarea>
+            `)}
+            ${this.renderHelpTextCol(
+              html`The crawler will visit and record each URL listed here. Other
+              links on these pages will not be crawled.`
+            )}
+          </div>
+        </btrix-details>
+      </div>
       ${this.renderSectionHeading(msg("Page Limits"))}
       ${this.renderFormCol(html`
         <sl-input
@@ -1447,7 +1453,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private renderErrorAlert(errorMessage: string | TemplateResult) {
     return html`
-      <div class="col-span-1 md:col-span-5">
+      <div class="col-span-5">
         <btrix-alert variant="danger">${errorMessage}</btrix-alert>
       </div>
     `;
@@ -1473,7 +1479,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     return html`
       ${errorAlert}
 
-      <div class="col-span-1 md:col-span-5">
+      <div class="col-span-5">
         ${when(this.progressState.activeTab === "confirmSettings", () => {
           // Prevent parsing and rendering tab when not visible
           const crawlConfig = this.parseConfig();

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -57,6 +57,7 @@ type NewCrawlConfigParams = CrawlConfigParams & {
 
 const STEPS = [
   "crawlSetup",
+  "crawlLimits",
   "browserSettings",
   "crawlScheduling",
   "crawlInformation",
@@ -114,6 +115,10 @@ const getDefaultProgressState = (hasConfigId = false): ProgressState => {
     activeTab,
     tabs: {
       crawlSetup: { error: false, completed: hasConfigId },
+      crawlLimits: {
+        error: false,
+        completed: hasConfigId,
+      },
       browserSettings: {
         error: false,
         completed: hasConfigId,
@@ -464,6 +469,7 @@ export class CrawlConfigEditor extends LiteElement {
   render() {
     const tabLabels: Record<StepName, string> = {
       crawlSetup: msg("Crawl Scope"),
+      crawlLimits: msg("Crawl Limits"),
       browserSettings: msg("Browser Settings"),
       crawlScheduling: msg("Crawl Scheduling"),
       crawlInformation: msg("Crawl Information"),
@@ -514,6 +520,9 @@ export class CrawlConfigEditor extends LiteElement {
               `,
               { isFirst: true }
             )}
+          </btrix-tab-panel>
+          <btrix-tab-panel name="newJobConfig-crawlLimits" class="scroll-m-3">
+            ${this.renderPanelContent(this.renderCrawlLimits())}
           </btrix-tab-panel>
           <btrix-tab-panel
             name="newJobConfig-browserSettings"
@@ -862,7 +871,6 @@ https://example.com/path`}
           )}
         `
       )}
-      ${this.renderCrawlScale()}
     `;
   };
 
@@ -1122,13 +1130,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
       ${this.renderHelpTextCol(
         html`Specify exclusion rules for what pages should not be visited.`
       )}
-      ${this.renderCrawlScale()}
     `;
   };
 
-  private renderCrawlScale() {
+  private renderCrawlLimits() {
     return html`
-      ${this.renderSectionHeading(msg("Crawl Limits"))}
       ${this.renderFormCol(html`
         <sl-input
           name="pageTimeoutMinutes"

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -835,7 +835,7 @@ https://example.com/path`}
         name="includeLinkedPages"
         ?checked=${this.formState.includeLinkedPages}
       >
-        ${msg("Include Linked Pages")}
+        ${msg("Include Any Linked Page")}
       </sl-checkbox>`)}
       ${this.renderHelpTextCol(
         html`If checked, the crawler will visit pages one link away from a Crawl

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1896,7 +1896,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
             this.defaultBehaviorTimeoutMinutes ??
             DEFAULT_BEHAVIOR_TIMEOUT_MINUTES) * 60,
         limit: this.formState.pageLimit ? +this.formState.pageLimit : null,
-        extraHops: this.formState.includeLinkedPages ? 1 : 0,
         lang: this.formState.lang || null,
         blockAds: this.formState.blockAds,
         exclude: trimExclusions(this.formState.exclusions),
@@ -1914,6 +1913,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     const config = {
       seeds: urlListToArray(this.formState.urlList),
       scopeType: "page" as FormState["scopeType"],
+      extraHops: this.formState.includeLinkedPages ? 1 : 0,
     };
 
     return config;
@@ -1938,6 +1938,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         this.formState.scopeType === "custom"
           ? includeUrlList.map((url) => `${regexEscape(url)}\/.*`)
           : [],
+      extraHops: this.formState.includeLinkedPages ? 1 : 0,
     };
     const config: SeedConfig = {
       seeds: [primarySeed, ...additionalSeedUrlList],

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -812,8 +812,6 @@ https://example.com/path`}
               <sl-menu-item value="domain">
                 ${this.scopeTypeLabels["domain"]}
               </sl-menu-item>
-              <sl-divider></sl-divider>
-              <sl-menu-label>${msg("Advanced Options")}</sl-menu-label>
               <sl-menu-item value="page-spa">
                 ${this.scopeTypeLabels["page-spa"]}
               </sl-menu-item>
@@ -1006,8 +1004,6 @@ https://example.com/path`}
           <sl-menu-item value="domain">
             ${this.scopeTypeLabels["domain"]}
           </sl-menu-item>
-          <sl-divider></sl-divider>
-          <sl-menu-label>${msg("Advanced Options")}</sl-menu-label>
           <sl-menu-item value="page-spa">
             ${this.scopeTypeLabels["page-spa"]}
           </sl-menu-item>

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -253,12 +253,12 @@ export class CrawlConfigEditor extends LiteElement {
   private readonly daysOfWeek = getLocalizedWeekDays();
 
   private readonly scopeTypeLabels: Record<FormState["scopeType"], string> = {
-    prefix: msg("Path Begins with This URL"),
+    prefix: msg("Pages in the Same Directory"),
     host: msg("Pages on This Domain"),
     domain: msg("Pages on This Domain & Subdomains"),
-    "page-spa": msg("Single Page App (In-Page Links Only)"),
+    "page-spa": msg("Hashtag Links Only"),
     page: msg("Page"),
-    custom: msg("Custom"),
+    custom: msg("Custom Page Prefix"),
     any: msg("Any"),
   };
 
@@ -875,7 +875,7 @@ https://example.com/path`}
   };
 
   private renderSeededCrawlSetup = () => {
-    const urlPlaceholder = "https://example.com";
+    const urlPlaceholder = "https://example.com/path/page.html";
     let exampleUrl = new URL(urlPlaceholder);
     if (this.formState.primarySeedUrl) {
       try {
@@ -892,14 +892,11 @@ https://example.com/path`}
     switch (this.formState.scopeType) {
       case "prefix":
         helpText = msg(
-          html`Will crawl all page URLs that begin with
-            <span class="text-blue-500 break-word"
-              >${exampleDomain}${examplePathname}</span
-            >, e.g.
+          html`Will crawl all pages and paths in the same directory, e.g.
             <span class="text-blue-500 break-word break-word"
-              >${exampleDomain}${examplePathname}</span
+              >${exampleDomain}</span
             ><span class="text-blue-500 font-medium break-word"
-              >/path/page.html</span
+              >/path/page-2</span
             >`
         );
         break;
@@ -1004,11 +1001,11 @@ https://example.com/path`}
           <sl-menu-item value="domain">
             ${this.scopeTypeLabels["domain"]}
           </sl-menu-item>
-          <sl-menu-item value="page-spa">
-            ${this.scopeTypeLabels["page-spa"]}
-          </sl-menu-item>
           <sl-menu-item value="custom">
             ${this.scopeTypeLabels["custom"]}
+          </sl-menu-item>
+          <sl-menu-item value="page-spa">
+            ${this.scopeTypeLabels["page-spa"]}
           </sl-menu-item>
         </sl-select>
       `)}
@@ -1963,7 +1960,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
       scopeType: this.formState.scopeType,
       include:
         this.formState.scopeType === "custom"
-          ? includeUrlList.map((url) => `${regexEscape(url)}\/.*`)
+          ? [
+              `${regexEscape(primarySeedUrl)}\/.*`,
+              ...includeUrlList.map((url) => `${regexEscape(url)}\/.*`),
+            ]
           : [],
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
     };

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -185,9 +185,12 @@ function validURL(url: string) {
   );
 }
 
-const trimExclusions = flow(uniq, compact);
-const urlListToArray = (str: string) =>
-  str.length ? str.trim().replace(/,/g, " ").split(/\s+/g) : [];
+const trimArray = flow(uniq, compact);
+const urlListToArray = flow(
+  (str: string) =>
+    str.length ? str.trim().replace(/,/g, " ").split(/\s+/g) : [],
+  trimArray
+);
 const DEFAULT_BEHAVIOR_TIMEOUT_MINUTES = 5;
 
 @localized()
@@ -944,6 +947,8 @@ https://example.com/path`}
         helpText = "";
         break;
     }
+    const exclusions = trimArray(this.formState.exclusions || []);
+    const additionalUrlList = urlListToArray(this.formState.urlList);
 
     return html`
       ${this.renderFormCol(html`
@@ -1048,32 +1053,51 @@ https://example.net`}
         Crawl Scope.`,
         false
       )}
-      ${this.renderFormCol(html`
-        <btrix-queue-exclusion-table
-          .exclusions=${this.formState.exclusions}
-          pageSize="10"
-          editable
-          removable
-          @on-remove=${this.handleRemoveRegex}
-          @on-change=${this.handleChangeRegex}
-        ></btrix-queue-exclusion-table>
-        <sl-button
-          class="w-full mt-1"
-          @click=${() =>
-            this.updateFormState({
-              exclusions: [""],
-            })}
+      <div class="col-span-5">
+        <btrix-details ?open=${exclusions.length > 0}>
+          <span slot="title"
+            >${msg("Exclusions")}
+            ${exclusions.length
+              ? html`<btrix-badge>${exclusions.length}</btrix-badge>`
+              : ""}</span
+          >
+          <div class="grid grid-cols-5 gap-4 py-2">
+            ${this.renderFormCol(html`
+              <btrix-queue-exclusion-table
+                label=""
+                .exclusions=${this.formState.exclusions}
+                pageSize="10"
+                editable
+                removable
+                @on-remove=${this.handleRemoveRegex}
+                @on-change=${this.handleChangeRegex}
+              ></btrix-queue-exclusion-table>
+              <sl-button
+                class="w-full mt-1"
+                @click=${() =>
+                  this.updateFormState({
+                    exclusions: [""],
+                  })}
+              >
+                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                <span class="text-neutral-600">${msg("Add More")}</span>
+              </sl-button>
+            `)}
+            ${this.renderHelpTextCol(
+              html`Specify exclusion rules for what pages should not be visited.`
+            )}
+          </div></btrix-details
         >
-          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-          <span class="text-neutral-600">${msg("Add More")}</span>
-        </sl-button>
-      `)}
-      ${this.renderHelpTextCol(
-        html`Specify exclusion rules for what pages should not be visited.`
-      )}
+      </div>
+
       <div class="col-span-5">
         <btrix-details>
-          <span slot="title">${msg("Additional URLs")}</span>
+          <span slot="title">
+            ${msg("Additional URLs")}
+            ${additionalUrlList.length
+              ? html`<btrix-badge>${additionalUrlList.length}</btrix-badge>`
+              : ""}
+          </span>
           <div class="grid grid-cols-5 gap-4 py-2">
             ${this.renderFormCol(html`
               <sl-textarea
@@ -1898,7 +1922,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         limit: this.formState.pageLimit ? +this.formState.pageLimit : null,
         lang: this.formState.lang || null,
         blockAds: this.formState.blockAds,
-        exclude: trimExclusions(this.formState.exclusions),
+        exclude: trimArray(this.formState.exclusions),
       },
     };
 

--- a/frontend/src/pages/org/types.ts
+++ b/frontend/src/pages/org/types.ts
@@ -28,23 +28,29 @@ export type Crawl = {
   completions?: number;
 };
 
+type ScopeType =
+  | "prefix"
+  | "host"
+  | "domain"
+  | "page"
+  | "page-spa"
+  | "any"
+  | "custom";
+
 export type Seed = {
-  scopeType:
-    | "prefix"
-    | "host"
-    | "domain"
-    | "page"
-    | "page-spa"
-    | "any"
-    | "custom";
+  url: string;
+  scopeType: ScopeType;
   include?: string[];
   exclude?: string[];
   limit?: number | null;
+  extraHops?: number | null;
 };
 
-export type SeedConfig = Seed & {
-  seeds: (string | ({ url: string } & Seed))[];
-  extraHops?: number | null;
+export type SeedConfig = Pick<
+  Seed,
+  "scopeType" | "include" | "exclude" | "limit" | "extraHops"
+> & {
+  seeds: (string | Seed)[];
   lang?: string | null;
   blockAds?: boolean;
   behaviorTimeout?: number | null;

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -18,6 +18,7 @@ import "@shoelace-style/shoelace/dist/components/resize-observer/resize-observer
 import "@shoelace-style/shoelace/dist/components/select/select";
 import "@shoelace-style/shoelace/dist/components/switch/switch";
 import "@shoelace-style/shoelace/dist/components/textarea/textarea";
+import "@shoelace-style/shoelace/dist/components/mutation-observer/mutation-observer";
 import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/dialog/dialog"
 );


### PR DESCRIPTION
Updates to "Seeded URL" crawl job config:
- Support setting seed URLs besides primary/start seed URL
- Only show include list ("Extra URLs") when "Custom" scope type is selected
- Moves "Page/Crawl Limits" to own tab/step and validate "Max Pages" based on number of seed URLs in URL list
- Make exclusions table collapsible
- Move `extraHops` to primary seed config
- Removed `Advanced Options` scope type divider

Resolves https://github.com/webrecorder/browsertrix-cloud/issues/493.

### Manual testing
1. Log in and go to new crawl config page
2. Choose "Seeded Crawl". Verify "Extra URLs in Scope" is not visible.
3. Choose "Custom" from "Start URL Scope". Verify "Extra URLs in Scope" is shown.
4. Enter "Extra URLs in Scope" and "Additional URLs" -> "List of URLs"
5. Go to "Limit" and enter "Max Pages". Verify that entering less than number of URLs triggers an error
6. Save config. Verify config saves and crawls as expected.
7. Go to Crawl Configs list. Verify existing crawl configs are not impacted by this change.

### Screenshots
**Seeded Crawl Scope:**
<img width="914" alt="Screen Shot 2023-02-01 at 3 28 11 PM" src="https://user-images.githubusercontent.com/4672952/216190890-ac6ca39e-b998-4d87-b12e-b6a964580aa7.png">

**Custom option in Scope Type:**
<img width="532" alt="Screen Shot 2023-02-01 at 3 31 16 PM" src="https://user-images.githubusercontent.com/4672952/216191288-c65bd2ba-449b-473c-85f9-9f3d695c553e.png">

**Crawl Limits:**
<img width="913" alt="Screen Shot 2023-02-01 at 11 47 02 AM" src="https://user-images.githubusercontent.com/4672952/216147857-d1302094-a3fb-4398-9de1-38f603e69b76.png">