### PR TITLE
Minor visual / mockup alignment improvements

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -274,7 +274,7 @@ export class ConfigDetails extends LiteElement {
       >`;
     }
     return html`
-      <btrix-desc-list-item label=${label}> ${content} </btrix-desc-list-item>
+      <btrix-desc-list-item label=${label} class="break-all"> ${content} </btrix-desc-list-item>
     `;
   }
 }

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -95,7 +95,7 @@ export class CrawlTemplatesDetail extends LiteElement {
           <h2>
             ${this.crawlConfig?.name
               ? html`<span
-                  class="inline-block align-middle text-xl leading-10 mr-1"
+                  class="inline-block align-middle text-xl font-semibold leading-10 mr-1"
                   >${this.crawlConfig.name}</span
                 > `
               : ""}
@@ -149,7 +149,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         ${this.renderLastCrawl()} ${this.renderCurrentlyRunningNotice()}
 
         <div class="col-span-1">
-          <h3 class="text-lg font-medium text-neutral-700 mb-2">
+          <h3 class="text-lg font-semibold mb-2">
             ${msg("Crawl Settings")}
           </h3>
           <main class="border rounded-lg py-3 px-5">
@@ -375,7 +375,7 @@ export class CrawlTemplatesDetail extends LiteElement {
     if (!this.crawlConfig?.lastCrawlId) return;
     return html`
       <section class="col-span-1">
-        <h3 class="text-lg font-medium text-neutral-700 mb-2">
+        <h3 class="text-lg font-semibold mb-2">
           ${this.crawlConfig.currCrawlId
             ? msg("Last Completed Crawl")
             : msg("Latest Crawl")}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -330,7 +330,7 @@ export class CrawlDetail extends LiteElement {
   private renderHeader() {
     return html`
       <header class="md:flex justify-between">
-        <h2 class="text-xl font-medium mb-3 md:h-8">
+        <h2 class="text-xl font-semibold mb-3 md:h-8">
           ${msg(
             html`${this.crawl
                 ? this.crawl.configName
@@ -487,7 +487,7 @@ export class CrawlDetail extends LiteElement {
 
   private renderPanel(title: any, content: any) {
     return html`
-      <h3 class="flex-0 text-lg font-medium mb-2">${title}</h3>
+      <h3 class="flex-0 text-lg font-semibold mb-2">${title}</h3>
       <div class="flex-1 rounded-lg border p-5">${content}</div>
     `;
   }

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -305,7 +305,7 @@ export class CrawlDetail extends LiteElement {
       `;
     };
     return html`
-      <nav class="border-b md:border-b-0">
+      <nav class="border-b md:border-b-0 md:mt-10">
         <ul class="flex flex-row md:flex-col" role="menu">
           ${renderNavItem({ section: "overview", label: msg("Overview") })}
           ${renderNavItem({

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -332,7 +332,7 @@ export class CrawlDetail extends LiteElement {
       <header class="md:flex justify-between">
         <h2 class="text-xl font-medium mb-3 md:h-8">
           ${msg(
-            html`<span class="font-normal">Crawl of</span> ${this.crawl
+            html`${this.crawl
                 ? this.crawl.configName
                 : html`<sl-skeleton
                     class="inline-block"

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -68,7 +68,7 @@ export class OrgSettings extends LiteElement {
 
   render() {
     return html`<header class="mb-5">
-        <h2 class="text-xl font-medium leading-10">${msg("Org Settings")}</h2>
+        <h2 class="text-xl font-semibold leading-10">${msg("Org Settings")}</h2>
       </header>
 
       <btrix-tab-list activePanel=${this.activePanel} ?hideIndicator=${true}>

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -68,7 +68,7 @@ export class OrgSettings extends LiteElement {
 
   render() {
     return html`<header class="mb-5">
-        <h2 class="text-xl leading-10">${msg("Org Settings")}</h2>
+        <h2 class="text-xl font-medium leading-10">${msg("Org Settings")}</h2>
       </header>
 
       <btrix-tab-list activePanel=${this.activePanel} ?hideIndicator=${true}>


### PR DESCRIPTION
- Details nav is now aligned with the section border instead of the section title (matches mockup).

<img width="700" alt="Screenshot 2023-02-03 at 2 38 33 AM" src="https://user-images.githubusercontent.com/5672810/216540402-693d4079-ee92-42f6-b7a5-34c2c72f3900.png">

- Removes "Crawl of" beside crawl name on crawl details page

- Fixes org settings title font weight
- Changes title weights from `font-medium` → `font-semibold` to align with mockup type style of Inter's 600 wght axis.
  - `font-semibold` resolves to `--sl-font-weight-semibold: 500;` for some reason???  I cannot figure out why the heck this is.  The only time `--sl-font-weight-semibold` is mentioned in code it is set to 600??  This one truly has me stumped. :(

- Fixes #544 

<img width="1008" alt="Screenshot 2023-02-03 at 3 04 21 AM" src="https://user-images.githubusercontent.com/5672810/216546631-74aa0f0f-e908-4d8e-9183-9d859587d20b.png">
