### PR TITLE
Manage org member roles and invites

### DIFF
--- a/frontend/src/components/data-table.ts
+++ b/frontend/src/components/data-table.ts
@@ -1,6 +1,8 @@
 import { LitElement, html, css, TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 
+type CellContent = string | TemplateResult;
+
 /**
  * Styled data table
  *
@@ -12,6 +14,7 @@ import { property } from "lit/decorators.js";
  *     [html`1a`, html`1b`, html`1c`],
  *     [html`2a`, html`2b`, html`2c`],
  *   ]}
+ *   .columnWidths=${["100%", "20rem"]}
  * >
  * </btrix-data-table>
  * ```
@@ -55,7 +58,7 @@ export class DataTable extends LitElement {
       border-top: 1px solid var(--sl-panel-border-color);
     }
 
-    .cell.paddedSmall {
+    .cell.padSmall {
       padding: var(--sl-spacing-2x-small);
     }
 
@@ -70,18 +73,15 @@ export class DataTable extends LitElement {
       line-height: 1rem;
       text-transform: uppercase;
     }
-
-    .tbody .row {
-      line-height: 1.5rem;
-    }
   `;
 
   @property({ type: Array })
-  columns: TemplateResult[] = [];
+  columns: CellContent[] = [];
 
   @property({ type: Array })
-  rows: Array<TemplateResult[]> = [];
+  rows: Array<CellContent[]> = [];
 
+  // Array of CSS widths
   @property({ type: Array })
   columnWidths: string[] = [];
 
@@ -100,7 +100,7 @@ export class DataTable extends LitElement {
     `;
   }
 
-  private renderColumnHeader = (cell: TemplateResult, index: number) => html`
+  private renderColumnHeader = (cell: CellContent, index: number) => html`
     <div
       role="columnheader"
       class="cell padded"
@@ -112,14 +112,17 @@ export class DataTable extends LitElement {
     </div>
   `;
 
-  private renderRow = (cells: TemplateResult[]) => html`
+  private renderRow = (cells: CellContent[]) => html`
     <div role="row" class="row">${cells.map(this.renderCell)}</div>
   `;
 
-  private renderCell = (cell: TemplateResult) => {
-    const paddedSmall = cell.strings[0].startsWith("<sl-select");
+  private renderCell = (cell: CellContent) => {
+    const shouldPadSmall =
+      typeof cell === "string"
+        ? false
+        : cell.strings[0].startsWith("<sl-select");
     return html`
-      <div role="cell" class="cell ${paddedSmall ? "paddedSmall" : "padded"}">
+      <div role="cell" class="cell ${shouldPadSmall ? "padSmall" : "padded"}">
         ${cell}
       </div>
     `;

--- a/frontend/src/components/data-table.ts
+++ b/frontend/src/components/data-table.ts
@@ -120,7 +120,8 @@ export class DataTable extends LitElement {
     const shouldPadSmall =
       typeof cell === "string"
         ? false
-        : cell.strings[0].startsWith("<sl-select");
+        : // TODO better logic to check template component
+          cell.strings[0].startsWith("<sl-");
     return html`
       <div role="cell" class="cell ${shouldPadSmall ? "padSmall" : "padded"}">
         ${cell}

--- a/frontend/src/components/data-table.ts
+++ b/frontend/src/components/data-table.ts
@@ -1,0 +1,127 @@
+import { LitElement, html, css, TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+/**
+ * Styled data table
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-data-table
+ *   .columns=${[html`A`, html`B`, html`C`]}
+ *   .rows=${[
+ *     [html`1a`, html`1b`, html`1c`],
+ *     [html`2a`, html`2b`, html`2c`],
+ *   ]}
+ * >
+ * </btrix-data-table>
+ * ```
+ */
+export class DataTable extends LitElement {
+  static styles = css`
+    :host {
+      display: contents;
+    }
+
+    .table {
+      display: table;
+      table-layout: fixed;
+      font-family: var(--font-monostyle-family);
+      font-variation-settings: var(--font-monostyle-variation);
+      width: 100%;
+    }
+
+    .thead {
+      display: table-header-group;
+    }
+
+    .tbody {
+      display: table-row-group;
+    }
+
+    .row {
+      display: table-row;
+    }
+
+    .cell {
+      display: table-cell;
+      vertical-align: middle;
+    }
+
+    .cell:nth-of-type(n + 2) {
+      border-left: 1px solid var(--sl-panel-border-color);
+    }
+
+    .cell[role="cell"] {
+      border-top: 1px solid var(--sl-panel-border-color);
+    }
+
+    .cell.paddedSmall {
+      padding: var(--sl-spacing-2x-small);
+    }
+
+    .cell.padded {
+      padding: var(--sl-spacing-x-small);
+    }
+
+    .thead .row {
+      background-color: var(--sl-color-neutral-50);
+      color: var(--sl-color-neutral-700);
+      font-size: var(--sl-font-size-x-small);
+      line-height: 1rem;
+      text-transform: uppercase;
+    }
+
+    .tbody .row {
+      line-height: 1.5rem;
+    }
+  `;
+
+  @property({ type: Array })
+  columns: TemplateResult[] = [];
+
+  @property({ type: Array })
+  rows: Array<TemplateResult[]> = [];
+
+  @property({ type: Array })
+  columnWidths: string[] = [];
+
+  render() {
+    return html`
+      <div role="table" class="table">
+        <div role="rowgroup" class="thead">
+          <div role="row" class="row">
+            ${this.columns.map(this.renderColumnHeader)}
+          </div>
+        </div>
+        <div role="rowgroup" class="tbody">
+          ${this.rows.map(this.renderRow)}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderColumnHeader = (cell: TemplateResult, index: number) => html`
+    <div
+      role="columnheader"
+      class="cell padded"
+      style=${this.columnWidths[index]
+        ? `width: ${this.columnWidths[index]}`
+        : ""}
+    >
+      ${cell}
+    </div>
+  `;
+
+  private renderRow = (cells: TemplateResult[]) => html`
+    <div role="row" class="row">${cells.map(this.renderCell)}</div>
+  `;
+
+  private renderCell = (cell: TemplateResult) => {
+    const paddedSmall = cell.strings[0].startsWith("<sl-select");
+    return html`
+      <div role="cell" class="cell ${paddedSmall ? "paddedSmall" : "padded"}">
+        ${cell}
+      </div>
+    `;
+  };
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -101,6 +101,9 @@ import("./tag").then(({ Tag }) => {
 import("./dialog").then(({ Dialog }) => {
   customElements.define("btrix-dialog", Dialog);
 });
+import("./data-table").then(({ DataTable }) => {
+  customElements.define("btrix-data-table", DataTable);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -5,7 +5,7 @@ import type { CurrentUser } from "../types/user";
 import type { OrgData } from "../utils/orgs";
 import LiteElement, { html } from "../utils/LiteElement";
 
-import { isOwner } from "../utils/orgs";
+import { isAdmin } from "../utils/orgs";
 
 @localized()
 export class OrgsList extends LiteElement {
@@ -39,7 +39,7 @@ export class OrgsList extends LiteElement {
                 ${this.userInfo &&
                 org.users &&
                 (this.userInfo.isAdmin ||
-                  isOwner(org.users[this.userInfo.id].role))
+                  isAdmin(org.users[this.userInfo.id].role))
                   ? html`<sl-tag size="small" variant="primary"
                       >${msg("Admin")}</sl-tag
                     >`

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -391,8 +391,9 @@ export class Org extends LiteElement {
 
   private async removeMember(member: Member) {
     if (!this.org) return;
+    const isSelf = member.email === this.userInfo!.email;
     if (
-      member.email === this.userInfo!.email &&
+      isSelf &&
       !window.confirm(
         msg(
           str`Are you sure you want to remove yourself from ${this.org.name}?`
@@ -419,7 +420,12 @@ export class Org extends LiteElement {
         variant: "success",
         icon: "check2-circle",
       });
-      this.org = await this.getOrg(this.orgId);
+      if (isSelf) {
+        // FIXME better UX, this is the only page currently that doesn't require org...
+        this.navTo("/account/settings");
+      } else {
+        this.org = await this.getOrg(this.orgId);
+      }
     } catch (e: any) {
       console.debug(e);
 

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -226,15 +226,18 @@ export class OrgSettings extends LiteElement {
   }
 
   private renderUserRoleSelect(user: Member) {
+    // Consider superadmins owners
+    const userRole =
+      user.role === AccessCode.superadmin ? AccessCode.owner : user.role;
     return html`<sl-select
-      value=${user.role}
+      value=${userRole}
       size="small"
       @sl-select=${(e: CustomEvent) =>
         this.updateUserRole(user, Number(e.detail.item.value))}
     >
-      <sl-menu-item value=${AccessCode.owner}> ${"Admin"} </sl-menu-item>
-      <sl-menu-item value=${AccessCode.crawler}> ${"Crawler"} </sl-menu-item>
-      <sl-menu-item value=${AccessCode.viewer}> ${"Viewer"} </sl-menu-item>
+      <sl-menu-item value=${AccessCode.owner}>${"Admin"}</sl-menu-item>
+      <sl-menu-item value=${AccessCode.crawler}>${"Crawler"}</sl-menu-item>
+      <sl-menu-item value=${AccessCode.viewer}>${"Viewer"}</sl-menu-item>
     </sl-select>`;
   }
 

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -254,7 +254,7 @@ export class OrgSettings extends LiteElement {
     return html`<btrix-icon-button
       name="trash"
       @click=${() =>
-        isInvite ? this.deleteInvite(user) : this.removeMember(user)}
+        isInvite ? this.removeInvite(user) : this.removeMember(user)}
     ></btrix-icon-button>`;
   }
 

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -167,18 +167,21 @@ export class OrgSettings extends LiteElement {
   }
 
   private renderMembers() {
+    const columnWidths = ["100%", "12rem", "1.5rem"];
     return html`
       <section class="rounded border overflow-hidden">
         <btrix-data-table
           .columns=${[
-            html`<div class="w-52">${msg("Name")}</div>`,
+            msg("Name"),
             msg("Role", { desc: "Organization member's role" }),
+            "",
           ]}
           .rows=${Object.entries(this.org.users!).map(([id, user]) => [
-            html`<div>${user.name}</div>`,
+            user.name,
             this.renderUserRole(user),
+            this.renderRemoveUserButton(user),
           ])}
-          .columnWidths=${["100%", "20rem"]}
+          .columnWidths=${columnWidths}
         >
         </btrix-data-table>
       </section>
@@ -196,12 +199,14 @@ export class OrgSettings extends LiteElement {
                 .columns=${[
                   html`<div class="w-52">${msg("Email")}</div>`,
                   msg("Role", { desc: "Organization member's role" }),
+                  "",
                 ]}
                 .rows=${this.pendingInvites.map((user) => [
                   html`<div>${user.email}</div>`,
                   this.renderUserRole(user),
+                  this.renderRemoveUserButton(user),
                 ])}
-                .columnWidths=${["100%", "20rem"]}
+                .columnWidths=${columnWidths}
               >
               </btrix-data-table>
             </div>
@@ -227,6 +232,10 @@ export class OrgSettings extends LiteElement {
       <sl-menu-item value=${AccessCode.crawler}> ${"Crawler"} </sl-menu-item>
       <sl-menu-item value=${AccessCode.viewer}> ${"Viewer"} </sl-menu-item>
     </sl-select>`;
+  }
+
+  private renderRemoveUserButton(user: User) {
+    return html`<btrix-icon-button name="trash"></btrix-icon-button>`;
   }
 
   private hideInviteDialog() {

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -444,7 +444,7 @@ export class OrgSettings extends LiteElement {
         message: e.isApiError
           ? e.message
           : msg(
-              `Sorry, couldn't update role for ${
+              str`Sorry, couldn't update role for ${
                 "name" in user ? user.name : user.email
               } at this time.`
             ),
@@ -458,7 +458,9 @@ export class OrgSettings extends LiteElement {
     if (
       user.email === this.userInfo.email &&
       !window.confirm(
-        msg(`Are you sure you want to remove yourself from ${this.org.name}?`)
+        msg(
+          str`Are you sure you want to remove yourself from ${this.org.name}?`
+        )
       )
     ) {
       return;
@@ -495,7 +497,7 @@ export class OrgSettings extends LiteElement {
         message: e.isApiError
           ? e.message
           : msg(
-              `Sorry, couldn't remove ${
+              str`Sorry, couldn't remove ${
                 "name" in user ? user.name : user.email
               } at this time.`
             ),


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/527:
- View and delete pending invites
- Update user roles for members
- Remove members

Follows https://github.com/webrecorder/browsertrix-cloud/pull/575

### Manual testing
Prerequisites: User that is an org owner/admin of an org with multiple users. Invite members to org to test with.
1. Log in as org owner/admin
2. Go to "Org Settings" -> "Members"
  a. If existing pending invites, verify "Pending Invites" are shown.
  b. If no existing pending invites, invite a new user and then verify.
3. Click trash icon next to pending invite. Verify invite is removed
4. Select user role for existing member. Verify user role updates as expected
5. Click remove icon next to existing member. Verify member is removed from org
6. Self removal:
  a. Verify remove button is disabled if current user is only admin, only in one org, or only org member.
  b. Add another admin member and log in as other admin. Verify window shows confirmation whether to delete self

### Screenshots
**Org Settings Members panel:**
<img width="911" alt="Screen Shot 2023-02-08 at 3 46 29 PM" src="https://user-images.githubusercontent.com/4672952/217677540-c57c4527-2976-4f48-bd5e-fae11cb1a46a.png">

**Self remove button enabled when multiple admins:**
<img width="924" alt="Screen Shot 2023-02-08 at 3 46 40 PM" src="https://user-images.githubusercontent.com/4672952/217677598-3ff995b8-5664-43c2-b621-521f924bc303.png">

**Confirmation when removing self:**
<img width="929" alt="Screen Shot 2023-02-08 at 3 46 47 PM" src="https://user-images.githubusercontent.com/4672952/217677615-1e05cb94-184f-4a54-9cc1-5e3294515729.png">
