### PR TITLE
Serialize pending invites to return "id" not "_id"

### DIFF
--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -192,10 +192,11 @@ class InviteOps:
     async def get_pending_invites(self, org=None):
         """return list of pending invites."""
         if org:
-            invites = self.invites.find({"oid": org.id})
+            cursor = self.invites.find({"oid": org.id})
         else:
-            invites = self.invites.find()
-        return [invite async for invite in invites]
+            cursor = self.invites.find()
+        results = await cursor.to_list(length=1000)
+        return [InvitePending.from_dict(result) for result in results]
 
 
 def init_invites(mdb, email):

--- a/backend/test/test_invites.py
+++ b/backend/test/test_invites.py
@@ -27,7 +27,7 @@ def test_pending_invites(admin_auth_headers, default_org_id):
     invites = data["pending_invites"]
     assert len(invites) == 1
     invite = invites[0]
-    assert invite["_id"]
+    assert invite["id"]
     assert invite["email"] == INVITE_EMAIL
     assert invite["oid"] == default_org_id
     assert invite["created"]

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -147,7 +147,7 @@ def test_get_pending_org_invites(
     invites = data["pending_invites"]
     assert len(invites) == 1
     invite = invites[0]
-    assert invite["_id"]
+    assert invite["id"]
     assert invite["email"] == INVITE_EMAIL
     assert invite["oid"] == non_default_org_id
     assert invite["created"]


### PR DESCRIPTION
Connected to #535

This PR modifies `PendingInvite` serialization in `InviteOps.get_pending_invites` and makes that method work more like similar methods on other classes.

Resolves comment https://github.com/webrecorder/browsertrix-cloud/pull/541#issuecomment-1418348709