### PR TITLE
health readiness check: more tolerant health check

### DIFF
--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -63,9 +63,13 @@ spec:
 
           readinessProbe:
             httpGet:
-              path: /
-              port: 80
-             
+              path: /healthz
+              port: 8880
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
 ---
 
 apiVersion: v1

--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -1,6 +1,16 @@
 include ./resolvers/resolvers.conf;
 
 server {
+    listen 8880;
+
+    # health check for k8s
+    location /healthz {
+      return 200;
+    }
+}
+
+
+server {
     listen 80 default_server;
     server_name _;
     proxy_buffering off;
@@ -18,13 +28,13 @@ server {
 
     # fallback to index for any page
     error_page 404 /index.html;
-  
+
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;
     }
 
-    # used in both k8s and docker: RWP_BASE_URL set in Dockerfile
+    # serve replay service worker, RWP_BASE_URL set in Dockerfile
     location /replay/sw.js {
       add_header Content-Type application/javascript;
       return 200 'importScripts("${RWP_BASE_URL}sw.js");';


### PR DESCRIPTION
- Add dedicated /healthz endpoint on separate port for health check, instead of just checking index.html
- Show as invalid (eg. return 503) after three timeouts, not one (similar to ingress)
- Should remove sporadic 503s that where frontend is labeled as down when it isn't