### PR TITLE
Allow superadmins to create org from UI

### DIFF
--- a/frontend/src/components/invite-form.ts
+++ b/frontend/src/components/invite-form.ts
@@ -55,7 +55,7 @@ export class InviteForm extends LiteElement {
 
         <div>
           <sl-button
-            variant="primary"
+            size="small"
             type="submit"
             ?loading=${this.isSubmitting}
             ?disabled=${this.isSubmitting}

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -41,7 +41,7 @@ export class OrgsList extends LiteElement {
                 (this.userInfo.isAdmin ||
                   isOwner(org.users[this.userInfo.id].role))
                   ? html`<sl-tag size="small" variant="primary"
-                      >${msg("Owner")}</sl-tag
+                      >${msg("Admin")}</sl-tag
                     >`
                   : ""}
               </li>

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -268,7 +268,14 @@ export class App extends LiteElement {
           class="max-w-screen-lg mx-auto pl-3 box-border h-12 flex items-center justify-between"
         >
           <div>
-            <a href="${homeHref}" @click="${this.navLink}"
+            <a
+              href=${homeHref}
+              @click=${(e: any) => {
+                if (isAdmin) {
+                  this.selectedOrgId = undefined;
+                }
+                this.navLink(e);
+              }}
               ><h1 class="text-sm hover:text-neutral-400 font-medium">
                 ${msg("Browsertrix Cloud")}
               </h1></a
@@ -280,6 +287,15 @@ export class App extends LiteElement {
                 <div
                   class="text-xs md:text-sm grid grid-flow-col gap-3 md:gap-5 items-center"
                 >
+                  <a
+                    class="text-neutral-500 hover:text-neutral-400 font-medium"
+                    href="/"
+                    @click=${(e: any) => {
+                      this.selectedOrgId = undefined;
+                      this.navLink(e);
+                    }}
+                    >${msg("Dashboard")}</a
+                  >
                   <a
                     class="text-neutral-500 hover:text-neutral-400 font-medium"
                     href="/crawls"
@@ -366,7 +382,13 @@ export class App extends LiteElement {
         <sl-menu
           @sl-select=${(e: CustomEvent) => {
             const { value } = e.detail.item;
-            this.navigate(`/orgs/${value}${value ? "/crawls" : ""}`);
+            if (value) {
+              this.navigate(`/orgs/${value}/crawls`);
+            } else {
+              this.selectedOrgId = undefined;
+              this.navigate(`/`);
+            }
+
             if (this.userInfo) {
               this.persistUserSettings(this.userInfo.id, { orgId: value });
             } else {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -272,7 +272,7 @@ export class App extends LiteElement {
               href=${homeHref}
               @click=${(e: any) => {
                 if (isAdmin) {
-                  this.selectedOrgId = undefined;
+                  this.clearSelectedOrg();
                 }
                 this.navLink(e);
               }}
@@ -291,7 +291,7 @@ export class App extends LiteElement {
                     class="text-neutral-500 hover:text-neutral-400 font-medium"
                     href="/"
                     @click=${(e: any) => {
-                      this.selectedOrgId = undefined;
+                      this.clearSelectedOrg();
                       this.navLink(e);
                     }}
                     >${msg("Dashboard")}</a
@@ -384,15 +384,14 @@ export class App extends LiteElement {
             const { value } = e.detail.item;
             if (value) {
               this.navigate(`/orgs/${value}/crawls`);
+              if (this.userInfo) {
+                this.persistUserSettings(this.userInfo.id, { orgId: value });
+              }
             } else {
-              this.selectedOrgId = undefined;
+              if (this.userInfo) {
+                this.clearSelectedOrg();
+              }
               this.navigate(`/`);
-            }
-
-            if (this.userInfo) {
-              this.persistUserSettings(this.userInfo.id, { orgId: value });
-            } else {
-              console.debug("User info not set");
             }
           }}
         >
@@ -566,6 +565,11 @@ export class App extends LiteElement {
           class="w-full md:bg-neutral-50"
           @navigate=${this.onNavigateTo}
           @logged-in=${this.onLoggedIn}
+          @update-user-info=${(e: CustomEvent) => {
+            e.stopPropagation();
+            this.updateUserInfo();
+          }}
+          @notify="${this.onNotify}"
           .authState=${this.authService.authState}
           .userInfo=${this.userInfo}
           .orgId=${this.selectedOrgId}
@@ -899,6 +903,13 @@ export class App extends LiteElement {
 
   private unpersistUserSettings(userId: string) {
     window.localStorage.removeItem(`${App.storageKey}.${userId}`);
+  }
+
+  private clearSelectedOrg() {
+    this.selectedOrgId = undefined;
+    if (this.userInfo) {
+      this.persistUserSettings(this.userInfo.id, { orgId: "" });
+    }
   }
 }
 

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -6,7 +6,7 @@ import type { ViewState } from "../../utils/APIRouter";
 import type { AuthState } from "../../utils/AuthService";
 import type { CurrentUser } from "../../types/user";
 import type { OrgData } from "../../utils/orgs";
-import { isOwner, isCrawler } from "../../utils/orgs";
+import { isAdmin, isCrawler } from "../../utils/orgs";
 import LiteElement, { html } from "../../utils/LiteElement";
 import { needLogin } from "../../utils/auth";
 import "./crawl-configs-detail";
@@ -67,9 +67,9 @@ export class Org extends LiteElement {
     return this.userInfo.orgs.find(({ id }) => id === this.orgId)!;
   }
 
-  get isOwner() {
+  get isAdmin() {
     const userOrg = this.userOrg;
-    if (userOrg) return isOwner(userOrg.role);
+    if (userOrg) return isAdmin(userOrg.role);
     return false;
   }
 
@@ -125,7 +125,7 @@ export class Org extends LiteElement {
         tabPanelContent = this.renderBrowserProfiles();
         break;
       case "settings": {
-        if (this.isOwner) {
+        if (this.isAdmin) {
           tabPanelContent = this.renderOrgSettings();
           break;
         }
@@ -167,7 +167,7 @@ export class Org extends LiteElement {
               label: msg("Browser Profiles"),
             })
           )}
-          ${when(this.isOwner, () =>
+          ${when(this.isAdmin || this.userInfo?.isAdmin, () =>
             this.renderNavTab({
               tabName: "settings",
               label: msg("Org Settings"),

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -1,7 +1,8 @@
 // From UserRole in backend
-export type UserRole = "viewer" | "crawler" | "owner";
+export type UserRole = "viewer" | "crawler" | "owner" | "superadmin";
 
 export const AccessCode: Record<UserRole, number> = {
+  superadmin: 100,
   viewer: 10,
   crawler: 20,
   owner: 40,

--- a/frontend/src/utils/orgs.ts
+++ b/frontend/src/utils/orgs.ts
@@ -7,6 +7,12 @@ export function isOwner(accessCode?: typeof AccessCode[UserRole]): boolean {
   return accessCode === AccessCode.owner;
 }
 
+export function isAdmin(accessCode?: typeof AccessCode[UserRole]): boolean {
+  if (!accessCode) return false;
+
+  return accessCode >= AccessCode.owner;
+}
+
 export function isCrawler(accessCode?: typeof AccessCode[UserRole]): boolean {
   if (!accessCode) return false;
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/516:
- Add "New Org" form to superadmin dashboard
- Fix superadmin permission (resolves https://github.com/webrecorder/browsertrix-cloud/issues/538)
- Fix links to dashboard

### Screenshots
**Add button on admin dashboard:**
<img width="751" alt="Screen Shot 2023-02-06 at 11 22 34 AM" src="https://user-images.githubusercontent.com/4672952/217068769-43f2a964-eee4-4e77-836d-b9120daf872a.png">

**Dialog:**
<img width="514" alt="Screen Shot 2023-02-06 at 11 22 39 AM" src="https://user-images.githubusercontent.com/4672952/217068780-2b022684-b47b-4584-8c5c-7c2c7fea1670.png">

### Follow-ups
The superadmin org setting permission fix done in preparation for showing superadmin link to new org in order to invite members. This requires an API change to return new org ID from the `/orgs/create` response.