### PR TITLE
Improve superadmin invite UI

### DIFF
--- a/frontend/src/components/invite-form.ts
+++ b/frontend/src/components/invite-form.ts
@@ -65,10 +65,11 @@ export class InviteForm extends LiteElement {
         <div class="mb-5">
           <sl-select
             label=${msg("Organization")}
-            value=${this.defaultOrg ? this.defaultOrg.id : ""}
+            value=${this.defaultOrg ? this.defaultOrg.id : sortedOrgs[0]?.id}
             @sl-select=${(e: CustomEvent) => {
               this.selectedOrgId = e.detail.item.value;
             }}
+            ?disabled=${sortedOrgs.length === 1}
             required
           >
             ${sortedOrgs.map(

--- a/frontend/src/components/invite-form.ts
+++ b/frontend/src/components/invite-form.ts
@@ -113,6 +113,9 @@ export class InviteForm extends LiteElement {
     event.preventDefault();
     if (!this.authState || !this.selectedOrgId) return;
 
+    const formEl = event.target as HTMLFormElement;
+    if (!(await this.checkFormValidity(formEl))) return;
+
     this.serverError = undefined;
     this.isSubmitting = true;
 
@@ -149,5 +152,10 @@ export class InviteForm extends LiteElement {
     }
 
     this.isSubmitting = false;
+  }
+
+  async checkFormValidity(formEl: HTMLFormElement) {
+    await this.updateComplete;
+    return !formEl.querySelector("[data-invalid]");
   }
 }

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -1,7 +1,7 @@
 import { state, property } from "lit/decorators.js";
-import { msg, localized } from "@lit/localize";
+import { msg, localized, str } from "@lit/localize";
 
-import type { CurrentUser } from "../types/user";
+import type { CurrentUser, UserOrg } from "../types/user";
 import type { OrgData } from "../utils/orgs";
 import LiteElement, { html } from "../utils/LiteElement";
 
@@ -15,6 +15,9 @@ export class OrgsList extends LiteElement {
   @property({ type: Array })
   orgList: OrgData[] = [];
 
+  @property({ type: Object })
+  defaultOrg?: UserOrg;
+
   @property({ type: Boolean })
   skeleton? = false;
 
@@ -25,23 +28,37 @@ export class OrgsList extends LiteElement {
 
     return html`
       <ul class="border rounded-lg overflow-hidden">
-        ${this.orgList?.map(
-          (org) =>
-            html`
-              <li
-                class="p-3 bg-white border-t first:border-t-0 text-primary hover:text-indigo-400"
-                role="button"
-                @click=${this.makeOnOrgClick(org)}
-              >
-                <span class="font-medium mr-2 transition-colors"
-                  >${org.name}</span
-                >
-              </li>
-            `
-        )}
+        ${this.orgList?.map(this.renderOrg)}
       </ul>
     `;
   }
+
+  private renderOrg = (org: OrgData) => {
+    let defaultLabel: any;
+    if (this.defaultOrg && org.id === this.defaultOrg.id) {
+      defaultLabel = html`<sl-tag size="small" variant="primary" class="mr-2"
+        >${msg("Default")}</sl-tag
+      >`;
+    }
+    const memberCount = Object.keys(org.users || {}).length;
+
+    return html`
+      <li
+        class="p-3 bg-white border-t first:border-t-0 text-primary hover:text-indigo-400 flex items-center justify-between"
+        role="button"
+        @click=${this.makeOnOrgClick(org)}
+      >
+        <div class="font-medium mr-2 transition-colors">
+          ${defaultLabel}${org.name}
+        </div>
+        <div class="text-xs text-neutral-400">
+          ${memberCount === 1
+            ? msg(`1 member`)
+            : msg(str`${memberCount} members`)}
+        </div>
+      </li>
+    `;
+  };
 
   private renderSkeleton() {
     return html`

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -29,21 +29,13 @@ export class OrgsList extends LiteElement {
           (org) =>
             html`
               <li
-                class="p-3 md:p-6 bg-white border-t first:border-t-0 text-primary hover:text-indigo-400"
+                class="p-3 bg-white border-t first:border-t-0 text-primary hover:text-indigo-400"
                 role="button"
                 @click=${this.makeOnOrgClick(org)}
               >
                 <span class="font-medium mr-2 transition-colors"
                   >${org.name}</span
                 >
-                ${this.userInfo &&
-                org.users &&
-                (this.userInfo.isAdmin ||
-                  isAdmin(org.users[this.userInfo.id].role))
-                  ? html`<sl-tag size="small" variant="primary"
-                      >${msg("Admin")}</sl-tag
-                    >`
-                  : ""}
               </li>
             `
         )}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -621,6 +621,7 @@ export class App extends LiteElement {
             return html`<btrix-users-invite
               class="w-full max-w-screen-lg mx-auto p-2 md:py-8 box-border"
               @navigate="${this.onNavigateTo}"
+              @logged-in=${this.onLoggedIn}
               @need-login="${this.onNeedLogin}"
               .authState="${this.authService.authState}"
               .userInfo="${this.userInfo}"

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -165,7 +165,9 @@ export class Home extends LiteElement {
         </div>
         <div class="col-span-3 md:col-span-1">
           <section class="md:border md:rounded-lg md:bg-white p-3 md:p-8">
-            <h2 class="text-lg font-medium mb-3">${msg("Invite a User")}</h2>
+            <h2 class="text-lg font-medium mb-3">
+              ${msg("Invite User to Org")}
+            </h2>
             ${this.renderInvite()}
           </section>
         </div>
@@ -247,14 +249,10 @@ export class Home extends LiteElement {
       (org) => org.default === true
     ) || { name: "" };
     return html`
-      <p class="text-xs text-neutral-500 mb-4">
-        ${msg(
-          html`Users will be added to the default organization
-            <strong class="font-semibold">${defaultOrg.name}</strong>.`
-        )}
-      </p>
       <btrix-invite-form
         .authState=${this.authState}
+        .orgs=${this.orgList}
+        .defaultOrg=${defaultOrg || null}
         @success=${() => (this.isInviteComplete = true)}
       ></btrix-invite-form>
     `;

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -1,4 +1,5 @@
 import { state, property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 
@@ -156,12 +157,15 @@ export class Home extends LiteElement {
             <btrix-orgs-list
               .userInfo=${this.userInfo}
               .orgList=${this.orgList}
+              .defaultOrg=${ifDefined(
+                this.userInfo?.orgs.find((org) => org.default === true)
+              )}
             ></btrix-orgs-list>
           </section>
         </div>
         <div class="col-span-3 md:col-span-1">
           <section class="md:border md:rounded-lg md:bg-white p-3 md:p-8">
-            <h2 class="text-lg font-medium mb-4">${msg("Invite a User")}</h2>
+            <h2 class="text-lg font-medium mb-3">${msg("Invite a User")}</h2>
             ${this.renderInvite()}
           </section>
         </div>
@@ -239,7 +243,16 @@ export class Home extends LiteElement {
       `;
     }
 
+    const defaultOrg = this.userInfo?.orgs.find(
+      (org) => org.default === true
+    ) || { name: "" };
     return html`
+      <p class="text-xs text-neutral-500 mb-4">
+        ${msg(
+          html`Users will be added to the default organization
+            <strong class="font-semibold">${defaultOrg.name}</strong>.`
+        )}
+      </p>
       <btrix-invite-form
         .authState=${this.authState}
         @success=${() => (this.isInviteComplete = true)}

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -139,8 +139,8 @@ export class Home extends LiteElement {
         </form>
       </section>
 
-      <div class="grid grid-cols-3 gap-8">
-        <div class="col-span-3 md:col-span-2">
+      <div class="grid grid-cols-5 gap-8">
+        <div class="col-span-5 md:col-span-3">
           <section>
             <header class="flex items-start justify-between">
               <h2 class="text-lg font-medium mb-3 mt-2">
@@ -163,7 +163,7 @@ export class Home extends LiteElement {
             ></btrix-orgs-list>
           </section>
         </div>
-        <div class="col-span-3 md:col-span-1">
+        <div class="col-span-5 md:col-span-2">
           <section class="md:border md:rounded-lg md:bg-white p-3 md:p-8">
             <h2 class="text-lg font-medium mb-3">
               ${msg("Invite User to Org")}

--- a/frontend/src/pages/users-invite.ts
+++ b/frontend/src/pages/users-invite.ts
@@ -1,15 +1,20 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
+import { CurrentUser } from "../types/user";
 
 @needLogin
 @localized()
 export class UsersInvite extends LiteElement {
   @property({ type: Object })
   authState?: AuthState;
+
+  @property({ type: Object })
+  userInfo?: CurrentUser;
 
   @state()
   private invitedEmail?: string;
@@ -40,6 +45,10 @@ export class UsersInvite extends LiteElement {
         <h2 class="text-lg font-medium mb-4">${msg("Invite Users")}</h2>
         <btrix-invite-form
           .authState=${this.authState}
+          .orgs=${this.userInfo?.orgs || []}
+          .defaultOrg=${ifDefined(
+            this.userInfo?.orgs.find((org) => org.default === true)
+          )}
           @success=${this.onSuccess}
         ></btrix-invite-form>
       </main>


### PR DESCRIPTION
Allows superadmins to choose org to invite a user to, rather than adding invite to default organization. Closes https://github.com/webrecorder/browsertrix-cloud/issues/464

### Manual testing
1. Run app `yarn start`
2. Log in as superadmin (`dev@webrecorder.org`)
3. Go to admin dashboard: http://localhost:9870/. Verify "Organization" select shows in "Invite User to Org" panel with correct options
4. Choose organization and invite email address that you have access to. Verify invite successfully sends.
5. Go to email address inbox. Verify invite is sent to the correct organization.
6. Go to users invite: http://localhost:9870/users/invite and repeat 4-5.

### Screenshots
**Dashboard panel:**
<img width="373" alt="Screen Shot 2023-02-08 at 1 38 18 PM" src="https://user-images.githubusercontent.com/4672952/217664009-b3dc6d09-02c1-4463-8037-49da53826438.png">

**Users invite page panel:**
<img width="1149" alt="Screen Shot 2023-02-08 at 1 39 57 PM" src="https://user-images.githubusercontent.com/4672952/217664052-ff6d32b3-77ee-4edb-81cc-c6a2464d42cd.png">
