### PR TITLE
Add notes to crawl and crawl updates

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -86,6 +86,8 @@ class Crawl(BaseMongoModel):
     colls: Optional[List[str]] = []
     tags: Optional[List[str]] = []
 
+    notes: Optional[str]
+
 
 # ============================================================================
 class CrawlOut(Crawl):
@@ -124,6 +126,8 @@ class ListCrawlOut(BaseMongoModel):
     colls: Optional[List[str]] = []
     tags: Optional[List[str]] = []
 
+    notes: Optional[str]
+
 
 # ============================================================================
 class ListCrawls(BaseModel):
@@ -149,9 +153,10 @@ class CrawlCompleteIn(BaseModel):
 
 # ============================================================================
 class UpdateCrawl(BaseModel):
-    """Update crawl tags"""
+    """Update crawl"""
 
     tags: Optional[List[str]] = []
+    notes: Optional[str]
 
 
 # ============================================================================
@@ -376,7 +381,7 @@ class CrawlOps:
             return False
 
     async def update_crawl(self, crawl_id: str, org: Organization, update: UpdateCrawl):
-        """Update existing crawl (tags only for now)"""
+        """Update existing crawl (tags and notes only for now)"""
         query = update.dict(exclude_unset=True, exclude_none=True)
 
         if len(query) == 0:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -382,7 +382,7 @@ class CrawlOps:
 
     async def update_crawl(self, crawl_id: str, org: Organization, update: UpdateCrawl):
         """Update existing crawl (tags and notes only for now)"""
-        query = update.dict(exclude_unset=True, exclude_none=True)
+        query = update.dict(exclude_unset=True)
 
         if len(query) == 0:
             raise HTTPException(status_code=400, detail="no_update_data")

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -138,8 +138,7 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
         headers=admin_auth_headers,
-        # Omitted and None values are ignored, so set notes to empty string.
-        json={"tags": [], "notes": ""},
+        json={"tags": [], "notes": None},
     )
     assert r.status_code == 200
 
@@ -150,4 +149,4 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     assert r.status_code == 200
     data = r.json()
     assert data["tags"] == []
-    assert data["notes"] == ""
+    assert not data["notes"]


### PR DESCRIPTION
Connected to and fixes #366 

Adds optional `notes` field to Crawl and CrawlListOut models and make it update-able via existing crawl update API endpoint.