### PR TITLE
Make crawlconfig name optional

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -119,7 +119,7 @@ class CrawlConfig(BaseMongoModel):
 
     config: RawCrawlConfig
 
-    name: str
+    name: Optional[str]
 
     jobType: Optional[JobType] = JobType.CUSTOM
 
@@ -317,7 +317,7 @@ class CrawlConfigOps:
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
 
         # set update query
-        query = update.dict(exclude_unset=True, exclude_none=True)
+        query = update.dict(exclude_unset=True)
 
         if len(query) == 0:
             raise HTTPException(status_code=400, detail="no_update_data")

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -41,11 +41,11 @@ def test_add_update_crawl_config(
     assert data["name"] == UPDATED_NAME
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
 
-    # Verify that deleting tags works as well
+    # Verify that deleting tags and name works as well
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
         headers=crawler_auth_headers,
-        json={"tags": []},
+        json={"tags": [], "name": None},
     )
     assert r.status_code == 200
 
@@ -56,5 +56,5 @@ def test_add_update_crawl_config(
     assert r.status_code == 200
 
     data = r.json()
-    assert data["name"] == UPDATED_NAME
+    assert not data["name"]
     assert data["tags"] == []


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix-cloud/issues/574

This updates makes `name` optional for crawl configs and tests that setting an existing crawl config name to `None` works.