### PR TITLE
Crawl details "Crawl Scale" → "Crawler Instances"

### DIFF
--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -852,8 +852,8 @@ export class CrawlDetail extends LiteElement {
     ];
 
     return html`
-      <div class="text-center">
-        <sl-radio-group value=${this.crawl.scale}>
+      <div>
+        <sl-radio-group value=${this.crawl.scale} help-text="Increasing parallel crawler instances can speed up crawls, but may increase the chances of getting rate limited.">
           ${scaleOptions.map(
             ({ value, label }) => html`
               <sl-radio-button

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -853,7 +853,7 @@ export class CrawlDetail extends LiteElement {
 
     return html`
       <div>
-        <sl-radio-group value=${this.crawl.scale} help-text="Increasing parallel crawler instances can speed up crawls, but may increase the chances of getting rate limited.">
+        <sl-radio-group value=${this.crawl.scale} help-text=${msg("Increasing parallel crawler instances can speed up crawls, but may increase the chances of getting rate limited.")}>
           ${scaleOptions.map(
             ({ value, label }) => html`
               <sl-radio-button

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -256,7 +256,7 @@ export class CrawlDetail extends LiteElement {
       </main>
 
       <btrix-dialog
-        label=${msg("Change Crawler Instances")}
+        label=${msg("Edit Crawler Instances")}
         ?open=${this.openDialogName === "scale"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
         @sl-show=${() => (this.isDialogVisible = true)}
@@ -356,7 +356,7 @@ export class CrawlDetail extends LiteElement {
                     }}
                   >
                     <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
-                    <span> ${msg("Scale")} </span>
+                    <span> ${msg("Crawler Instances")} </span>
                   </sl-button>
                   <sl-button size="small" @click=${this.stop}>
                     <sl-icon name="slash-circle" slot="prefix"></sl-icon>
@@ -858,6 +858,7 @@ export class CrawlDetail extends LiteElement {
             ({ value, label }) => html`
               <sl-radio-button
                 value=${value}
+                size="small"
                 @click=${() => this.scale(value)}
                 ?disabled=${this.isSubmittingUpdate}
                 >${label}</sl-radio-button


### PR DESCRIPTION
- Changes name to match crawl config label
- Makes the buttons small
- Adds help text to mirror the crawl config help text for the same control.

### Screenshots

<img width="490" alt="Screenshot 2023-02-09 at 12 41 51 AM" src="https://user-images.githubusercontent.com/5672810/217728203-e34f9edb-9f72-42c7-8518-55b3bdc27dd2.png">

<img width="538" alt="Screenshot 2023-02-09 at 12 58 01 AM" src="https://user-images.githubusercontent.com/5672810/217730777-651bd024-5c5e-4735-98d5-4ba23a850dbc.png">
