### PR TITLE
Edit crawl notes from crawl detail view

### DIFF
--- a/frontend/src/components/desc-list.ts
+++ b/frontend/src/components/desc-list.ts
@@ -51,7 +51,7 @@ export class DescList extends LitElement {
   static styles = css`
     dl {
       display: grid;
-      grid-template-columns: auto;
+      grid-template-columns: 100%;
       grid-gap: 1rem;
       margin: 0;
     }

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -14,6 +14,10 @@ export class Tag extends SLTag {
   static styles = css`
     ${tagStyles}
 
+    :host {
+      max-width: 100%;
+    }
+
     .tag {
       height: var(--tag-height, 1.5rem);
       background-color: var(--sl-color-blue-100);

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -772,7 +772,10 @@ export class CrawlDetail extends LiteElement {
             () =>
               when(
                 this.crawl!.notes?.length,
-                () => html`<div>${this.crawl!.notes}</div>`,
+                () => html`<pre class="whitespace-pre-line">
+${this.crawl?.notes}
+                </pre
+                >`,
                 () => noneText
               ),
             () => html`<sl-skeleton></sl-skeleton>`

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -772,7 +772,7 @@ export class CrawlDetail extends LiteElement {
             () =>
               when(
                 this.crawl!.notes?.length,
-                () => html`<pre class="whitespace-pre-line">
+                () => html`<pre class="whitespace-pre-line font-sans">
 ${this.crawl?.notes}
                 </pre
                 >`,

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -209,15 +209,16 @@ export class CrawlDetail extends LiteElement {
               ${this.renderPanel(
                 html`
                   <div class="flex items-center justify-between">
-                    ${msg("Tags")}
+                    ${msg("Metadata")}
                     <sl-icon-button
                       class="text-base"
                       name="pencil"
-                      @click=${this.openDetailEditor}
+                      @click=${this.openMetadataEditor}
+                      aria-label=${msg("Edit Metadata")}
                     ></sl-icon-button>
                   </div>
                 `,
-                this.renderDetails()
+                this.renderMetadata()
               )}
             </div>
           </div>
@@ -266,7 +267,7 @@ export class CrawlDetail extends LiteElement {
       </btrix-dialog>
 
       <btrix-dialog
-        label=${msg("Edit Tags")}
+        label=${msg("Edit Metadata")}
         ?open=${this.openDialogName === "details"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
         @sl-show=${() => (this.isDialogVisible = true)}
@@ -333,11 +334,11 @@ export class CrawlDetail extends LiteElement {
         <h2 class="text-xl font-semibold mb-3 md:mr-2">
           ${msg(
             html`${this.crawl
-                ? this.crawl.configName
-                : html`<sl-skeleton
-                    class="inline-block"
-                    style="width: 15em"
-                  ></sl-skeleton>`}`
+              ? this.crawl.configName
+              : html`<sl-skeleton
+                  class="inline-block"
+                  style="width: 15em"
+                ></sl-skeleton>`}`
           )}
         </h2>
         <div
@@ -432,7 +433,7 @@ export class CrawlDetail extends LiteElement {
                 class="p-2 hover:bg-zinc-100 cursor-pointer"
                 role="menuitem"
                 @click=${(e: any) => {
-                  this.openDetailEditor();
+                  this.openMetadataEditor();
                   e.target.closest("sl-dropdown").hide();
                 }}
               >
@@ -441,7 +442,7 @@ export class CrawlDetail extends LiteElement {
                   name="pencil"
                 ></sl-icon>
                 <span class="inline-block align-middle">
-                  ${msg("Edit Tags")}
+                  ${msg("Edit Metadata")}
                 </span>
               </li>
               <hr />
@@ -759,7 +760,7 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
-  private renderDetails() {
+  private renderMetadata() {
     return html`
       <btrix-desc-list>
         <btrix-desc-list-item label=${msg("Tags")}>
@@ -1065,7 +1066,7 @@ export class CrawlDetail extends LiteElement {
     }
   }
 
-  private openDetailEditor() {
+  private openMetadataEditor() {
     this.fetchTags();
     this.openDialogName = "details";
   }

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -112,6 +112,8 @@ const theme = css`
   sl-select::part(form-control-help-text) {
     margin-top: var(--sl-spacing-x-small);
     font-weight: 400;
+    /* Enable controlling help text text alignment from parent */
+    text-align: var(--help-text-align, left);
   }
 
   /* Elevate select and buttons */

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -26,7 +26,8 @@ export type Crawl = {
   fileCount?: number;
   fileSize?: number;
   completions?: number;
-  tags?: string[];
+  tags: string[];
+  notes: string | null;
 };
 
 type ScopeType =


### PR DESCRIPTION
Allows users to add and edit crawl notes from the crawl detail metadata panel. Resolves https://github.com/webrecorder/browsertrix-cloud/issues/367, which closes https://github.com/webrecorder/browsertrix-cloud/issues/310.

### Manual testing
1. Log in and click into a crawl detail page. Verify "Notes" are shown in the "Metadata" column
2. Click pencil icon next to Metadata header. Verify notes textarea is shown in dialog
3. Edit notes field. Verify maximum length constraint: help text updates when over max, and form does not submit when over max
4. Enter valid notes and save. Verify notes are shown in Metadata column with newlines intact.

### Screenshots
**No notes:**
<img width="475" alt="Screen Shot 2023-02-13 at 12 27 28 PM" src="https://user-images.githubusercontent.com/4672952/218567637-df3e060f-4fc8-467d-8173-886a226ecb00.png">

**Entered notes:**
<img width="527" alt="Screen Shot 2023-02-13 at 12 20 24 PM" src="https://user-images.githubusercontent.com/4672952/218567699-e5472c38-c4f7-4552-8ccf-386c3c59542b.png">

**Constraint validation demo:**

https://user-images.githubusercontent.com/4672952/218567960-374eee66-218f-427d-8b6e-6f7f68808f9e.mov



**Saved notes:**
<img width="467" alt="Screen Shot 2023-02-13 at 12 32 58 PM" src="https://user-images.githubusercontent.com/4672952/218568457-44d30d76-35a7-426a-8c02-b49a37940d12.png">
