### PR TITLE
Fix app not rendering with bad auth storage states

### DIFF
--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -6,11 +6,13 @@ import { App } from "./index";
 
 describe("browsertrix-app", () => {
   beforeEach(() => {
-    stub(window.sessionStorage, "setItem");
+    AuthService.broadcastChannel = new BroadcastChannel(AuthService.storageKey);
+    window.sessionStorage.clear();
     stub(window.history, "pushState");
   });
 
   afterEach(() => {
+    AuthService.broadcastChannel.close();
     restore();
   });
 

--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -1,6 +1,5 @@
 import { spy, stub, mock, restore } from "sinon";
 import { fixture, expect } from "@open-wc/testing";
-// import { expect } from "@esm-bundle/chai";
 
 import AuthService from "./utils/AuthService";
 import { App } from "./index";
@@ -8,23 +7,7 @@ import { App } from "./index";
 describe("browsertrix-app", () => {
   beforeEach(() => {
     stub(window.sessionStorage, "setItem");
-    stub(App.prototype, "getUserInfo").callsFake(() =>
-      Promise.resolve({
-        id: "test_id",
-        email: "test-user@example.com",
-        name: "Test User",
-        is_verified: false,
-        is_superuser: false,
-        orgs: [
-          {
-            id: "test_org_id",
-            name: "test org",
-            role: 10,
-            email: "test@org.org",
-          },
-        ],
-      })
-    );
+    stub(window.history, "pushState");
   });
 
   afterEach(() => {
@@ -34,6 +17,24 @@ describe("browsertrix-app", () => {
   it("is defined", async () => {
     const el = await fixture("<browsertrix-app></browsertrix-app>");
     expect(el).instanceOf(App);
+  });
+
+  it("renders home when authenticated", async () => {
+    stub(AuthService, "initSessionStorage").returns(
+      Promise.resolve({
+        headers: { Authorization: "_fake_headers_" },
+        tokenExpiresAt: 0,
+        username: "test-auth@example.com",
+      })
+    );
+    const el = await fixture("<browsertrix-app></browsertrix-app>");
+    expect(el).lightDom.descendants("btrix-home");
+  });
+
+  it("renders when `AuthService.initSessionStorage` rejects", async () => {
+    stub(AuthService, "initSessionStorage").returns(Promise.reject());
+    const el = await fixture("<browsertrix-app></browsertrix-app>");
+    expect(el).lightDom.descendants("btrix-home");
   });
 
   // TODO move tests to AuthService
@@ -58,6 +59,23 @@ describe("browsertrix-app", () => {
   });
 
   it("sets user info", async () => {
+    stub(App.prototype, "getUserInfo").callsFake(() =>
+      Promise.resolve({
+        id: "test_id",
+        email: "test-user@example.com",
+        name: "Test User",
+        is_verified: false,
+        is_superuser: false,
+        orgs: [
+          {
+            id: "test_org_id",
+            name: "test org",
+            role: 10,
+            email: "test@org.org",
+          },
+        ],
+      })
+    );
     stub(AuthService.prototype, "startFreshnessCheck");
     stub(window.sessionStorage, "getItem").callsFake((key) => {
       if (key === "btrix.auth")

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -12,7 +12,7 @@ import type { OrgTab } from "./pages/org";
 import type { NotifyEvent, NavigateEvent } from "./utils/LiteElement";
 import LiteElement, { html } from "./utils/LiteElement";
 import APIRouter from "./utils/APIRouter";
-import AuthService from "./utils/AuthService";
+import AuthService, { AuthState } from "./utils/AuthService";
 import type { LoggedInEvent } from "./utils/AuthService";
 import type { ViewState } from "./utils/APIRouter";
 import type { CurrentUser, UserOrg } from "./types/user";
@@ -91,7 +91,12 @@ export class App extends LiteElement {
   private selectedOrgId?: string;
 
   async connectedCallback() {
-    const authState = await AuthService.initSessionStorage();
+    let authState: AuthState = null;
+    try {
+      authState = await AuthService.initSessionStorage();
+    } catch (e: any) {
+      console.debug(e);
+    }
     this.syncViewState();
     if (this.viewState.route === "org") {
       this.selectedOrgId = this.viewState.params.orgId;

--- a/frontend/src/utils/AuthService.test.ts
+++ b/frontend/src/utils/AuthService.test.ts
@@ -1,0 +1,61 @@
+import { spy, stub, mock, restore } from "sinon";
+import { fixture, expect } from "@open-wc/testing";
+
+import AuthService from "./AuthService";
+
+describe("AuthService", () => {
+  beforeEach(() => {
+    AuthService.broadcastChannel = new BroadcastChannel(AuthService.storageKey);
+    window.sessionStorage.clear();
+    stub(window.history, "pushState");
+  });
+
+  afterEach(() => {
+    AuthService.broadcastChannel.close();
+    restore();
+  });
+
+  describe("#initSessionStorage", () => {
+    it("returns auth in session storage", async () => {
+      stub(window.sessionStorage, "getItem").returns(
+        JSON.stringify({
+          headers: { Authorization: "_fake_headers_" },
+          tokenExpiresAt: "_fake_tokenExpiresAt_",
+          username: "test-auth@example.com",
+        })
+      );
+      const result = await AuthService.initSessionStorage();
+      expect(result).to.deep.equal({
+        headers: { Authorization: "_fake_headers_" },
+        tokenExpiresAt: "_fake_tokenExpiresAt_",
+        username: "test-auth@example.com",
+      });
+    });
+    it("returns auth from another tab", async () => {
+      stub(window.sessionStorage, "getItem");
+      const otherTabChannel = new BroadcastChannel(AuthService.storageKey);
+      otherTabChannel.addEventListener("message", () => {
+        otherTabChannel.postMessage({
+          name: "responding_auth",
+          auth: {
+            headers: { Authorization: "_fake_headers_from_tab_" },
+            tokenExpiresAt: "_fake_tokenExpiresAt_from_tab_",
+            username: "test-auth@example.com_from_tab_",
+          },
+        });
+      });
+      const result = await AuthService.initSessionStorage();
+      expect(result).to.deep.equal({
+        headers: { Authorization: "_fake_headers_from_tab_" },
+        tokenExpiresAt: "_fake_tokenExpiresAt_from_tab_",
+        username: "test-auth@example.com_from_tab_",
+      });
+      otherTabChannel.close();
+    });
+    it("resolves without stored auth or another tab", async () => {
+      stub(window.sessionStorage, "getItem");
+      const result = await AuthService.initSessionStorage();
+      expect(result).to.equal(null);
+    });
+  });
+});

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -27,10 +27,6 @@ export interface LoggedInEvent<T = LoggedInEventDetail> extends CustomEvent {
   readonly detail: T;
 }
 
-type HasAuthStorageData = {
-  auth: boolean;
-};
-
 type AuthRequestEventData = {
   name: "requesting_auth";
 };

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -171,13 +171,6 @@ export default class AuthService {
       }
     );
 
-    // NOTE beforeunload being called isn't guaranteed, which
-    // may lead to subtle bugs where the value exists in
-    // localstorage but the app is not actually authenticated.
-    window.addEventListener("beforeunload", () => {
-      window.localStorage.removeItem(AuthService.storageKey);
-    });
-
     return authState;
   }
 
@@ -195,33 +188,26 @@ export default class AuthService {
    * Retrieve shared session from another tab/window
    **/
   private static async getSharedSessionAuth(): Promise<AuthState> {
-    let timeoutPromise;
     const broadcastPromise = new Promise((resolve) => {
       // Check if there's any authenticated tabs
-      const value = window.localStorage.getItem(AuthService.storageKey);
-      if (value && (JSON.parse(value) as HasAuthStorageData).auth) {
-        // Ask for auth
-        AuthService.broadcastChannel.postMessage(<AuthRequestEventData>{
-          name: "requesting_auth",
-        });
-        // Wait for another tab to respond
-        const cb = ({ data }: any) => {
-          if (data.name === "responding_auth") {
-            AuthService.broadcastChannel.removeEventListener("message", cb);
-            resolve(data.auth);
-          }
-        };
-        AuthService.broadcastChannel.addEventListener("message", cb);
-        // Ensure that `getSharedSessionAuth` is resolved within a reasonable
-        // timeframe, even if another window/tab doesn't respond:
-        timeoutPromise = new Promise((resolve) => {
-          window.setTimeout(() => {
-            resolve(null);
-          }, 10);
-        });
-      } else {
+      AuthService.broadcastChannel.postMessage(<AuthRequestEventData>{
+        name: "requesting_auth",
+      });
+      // Wait for another tab to respond
+      const cb = ({ data }: any) => {
+        if (data.name === "responding_auth") {
+          AuthService.broadcastChannel.removeEventListener("message", cb);
+          resolve(data.auth);
+        }
+      };
+      AuthService.broadcastChannel.addEventListener("message", cb);
+    });
+    // Ensure that `getSharedSessionAuth` is resolved within a reasonable
+    // timeframe, even if another window/tab doesn't respond:
+    const timeoutPromise = new Promise((resolve) => {
+      window.setTimeout(() => {
         resolve(null);
-      }
+      }, 10);
     });
 
     return Promise.race([broadcastPromise, timeoutPromise]).then(
@@ -254,16 +240,11 @@ export default class AuthService {
   }
 
   saveLogin(auth: Auth) {
-    window.localStorage.setItem(
-      AuthService.storageKey,
-      JSON.stringify(<HasAuthStorageData>{ auth: true })
-    );
     this.persist(auth);
     this.startFreshnessCheck();
   }
 
   logout() {
-    window.localStorage.removeItem(AuthService.storageKey);
     this.cancelFreshnessCheck();
     this.revoke();
   }


### PR DESCRIPTION
Auth can currently get into a bad state in two ways:
1. The localstorage `{auth:true}` value that determines whether there is more than one tab open is not properly removed on the window `beforeunload` (which is probable given the [nature of beforeunload](https://developer.chrome.com/blog/page-lifecycle-api/#the-beforeunload-event).)
2. An error is thrown during session storage and broadcast API initialization, in which `connectedcallback` is never called.

This PR fixes https://github.com/webrecorder/browsertrix-cloud/issues/592 by removing the check for `{auth:true}` altogether and instead implementing a short timeout that ensures auth initialization always completes. The second state doesn't seem to be the source of the reported error, but is an additional check to make sure the app always renders.

### Manual testing
Run app with `yarn start` and try the following:
- Verify logging into one tab logs in another open tab
- Verify logging out of one tab logs out all other tabs
- Verify login persist on page refresh
- When logged into one tab, verify opening another tab will log it in
- After closing all tabs, verify the first new tab opened to the app is logged out