### PR TITLE
Add back GET /users/invite/{token} used by frontend

### DIFF
--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -446,6 +446,11 @@ def init_users_api(app, user_manager):
         print(f"user info with orgs: {user_info}", flush=True)
         return user_info
 
+    @users_router.get("/invite/{token}", tags=["invites"])
+    async def get_invite_info(token: str, email: str):
+        invite = await user_manager.invites.get_valid_invite(uuid.UUID(token), email)
+        return await user_manager.format_invite(invite)
+
     @users_router.get("/me/invite/{token}", tags=["invites"])
     async def get_existing_user_invite_info(
         token: str, user: User = Depends(current_active_user)


### PR DESCRIPTION
This commit re-adds the `GET /users/invite/{token}` endpoint removed in https://github.com/webrecorder/browsertrix-cloud/commit/103d91556f7accd540edd3aba876b16d1edf1e40 along with non-org-scoped invites, but which is used by the frontend in joining/accepting invites.