### PR TITLE
Remove crawlconfig name from file suffixes

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -283,12 +283,10 @@ class CrawlConfigOps:
 
         crawlconfig = CrawlConfig.from_dict(data)
 
-        suffix = f"{self.sanitize(crawlconfig.name)}-{self.sanitize(user.name)}"
+        suffix = f"{self.sanitize(str(crawlconfig.id))}-{self.sanitize(user.name)}"
 
         # pylint: disable=line-too-long
-        out_filename = (
-            f"data/{self.sanitize(crawlconfig.name)}-@id/{suffix}-@ts-@hostsuffix.wacz"
-        )
+        out_filename = f"data/{self.sanitize(str(crawlconfig.id))}-@id/{suffix}-@ts-@hostsuffix.wacz"
 
         crawl_id = await self.crawl_manager.add_crawl_config(
             crawlconfig=crawlconfig,


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix-cloud/issues/574, follow-up to https://github.com/webrecorder/browsertrix-cloud/pull/588

This PR modifies the `out_filename` passed to `crawl_manager.add_crawl_config` to use the crawlconfig.id rather than crawlconfig.name so that crawl config names can be fully optional from creation.