### PR TITLE
Update crawls list control bar UI

### DIFF
--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -274,8 +274,8 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="flex row-start-2 md:row-start-1 col-span-2 md:col-auto">
-          <div class="flex-column grow md:flex items-center mr-2">
+        <div class="row-start-2 md:row-start-1 col-span-2 md:col-auto grid md:grid-rows-1 gap-y-2 grid-cols-1 md:grid-cols-[fit-content(100%)fit-content(100%)]">
+          <div class="grow flex items-center mr-2">
             <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
             <sl-select
               class="flex-1 md:w-[14.5rem]"
@@ -310,11 +310,11 @@ export class CrawlsList extends LiteElement {
             </sl-select>
           </div>
 
-          <div class="flex-column grow md:flex items-center">
+          <div class="grow flex items-center">
             <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
               ${msg("Sort by:")}
             </div>
-            <div class="flex">
+            <div class="grow flex">
             <sl-select
               class="flex-1 md:w-[9.2rem]"
               placement="bottom-end"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -275,8 +275,8 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="grow flex items-center">
-          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
+        <div class="flex items-center">
+          <div class="text-neutral-500 mx-2">${msg("View:")}</div>
           <sl-select
             class="flex-1 md:min-w-[14.5rem]"
             placement="bottom-end"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -218,7 +218,7 @@ export class CrawlsList extends LiteElement {
     return html`
       <main>
         <header
-          class="sticky z-10 mb-3 top-0 p-2 bg-neutral-50 border rounded-lg"
+          class="sticky z-10 mb-3 top-2 p-2 bg-neutral-50 border rounded-lg"
         >
           ${this.renderControls()}
         </header>
@@ -255,8 +255,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-12 gap-y-2 gap-x-4 items-center">
-        <div class="col-span-12 md:col-span-5">
+      <div class="grid md:grid-cols-3 grid-cols-2 gap-x-2 gap-y-2 items-center">
+        <div class="row-start-1 col-span-full">
           <sl-input
             class="w-full"
             slot="trigger"
@@ -274,10 +274,10 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="col-span-12 md:col-span-4 flex items-center">
-          <div class="text-neutral-500 mr-2">${msg("View:")}</div>
+        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
+          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
           <sl-select
-            class="flex-1"
+            class="flex-1 md:w-[14.5rem]"
             placement="bottom-end"
             distance="4"
             size="small"
@@ -309,12 +309,13 @@ export class CrawlsList extends LiteElement {
           </sl-select>
         </div>
 
-        <div class="col-span-12 md:col-span-3 flex items-center">
-          <div class="whitespace-nowrap text-neutral-500 mr-2">
+        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
+          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
             ${msg("Sort by:")}
           </div>
+          <div class="flex">
           <sl-select
-            class="flex-1"
+            class="flex-1 md:w-[9.2rem]"
             placement="bottom-end"
             distance="4"
             size="small"
@@ -346,11 +347,12 @@ export class CrawlsList extends LiteElement {
               };
             }}
           ></sl-icon-button>
+          </div>
         </div>
       </div>
 
       ${this.userId
-        ? html` <div class="my-1 text-right">
+        ? html` <div class="h-6 mt-2 flex flex-row-reverse">
             <label>
               <span class="text-neutral-500 text-xs mr-1"
                 >${msg("Show Only Mine")}</span

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -255,8 +255,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
-        <div class="row-start-1 col-span-1">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
+        <div class="row-start-1 col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -3,6 +3,11 @@ import { state, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import { when } from "lit/directives/when.js";
+import type {
+  SlCheckbox,
+  SlMenuItem,
+  SlSelect,
+} from "@shoelace-style/shoelace";
 import debounce from "lodash/fp/debounce";
 import flow from "lodash/fp/flow";
 import map from "lodash/fp/map";
@@ -19,14 +24,12 @@ import type {
   CrawlConfig,
   InitialCrawlConfig,
 } from "./types";
-import { SlCheckbox } from "@shoelace-style/shoelace";
 
 type CrawlSearchResult = {
   item: Crawl;
 };
 type SortField = "started" | "finished" | "configName" | "fileSize";
 type SortDirection = "asc" | "desc";
-type FilterField = "state";
 
 const POLL_INTERVAL_SECONDS = 10;
 const MIN_SEARCH_LENGTH = 2;
@@ -51,6 +54,15 @@ const sortableFields: Record<
     defaultDirection: "desc",
   },
 };
+
+const activeCrawlStates: CrawlState[] = ["starting", "running", "stopping"];
+const inactiveCrawlStates: CrawlState[] = [
+  "complete",
+  "canceled",
+  "partial_complete",
+  "timed_out",
+  "failed",
+];
 const crawlState: Record<CrawlState, { label: string; icon?: TemplateResult }> =
   {
     starting: {
@@ -62,7 +74,7 @@ const crawlState: Record<CrawlState, { label: string; icon?: TemplateResult }> =
       icon: html``,
     },
     complete: {
-      label: msg("Complete"),
+      label: msg("Completed"),
       icon: html``,
     },
     failed: {
@@ -88,11 +100,7 @@ const crawlState: Record<CrawlState, { label: string; icon?: TemplateResult }> =
   };
 
 function isActive(crawl: Crawl) {
-  return (
-    crawl.state === "running" ||
-    crawl.state === "starting" ||
-    crawl.state === "stopping"
-  );
+  return activeCrawlStates.includes(crawl.state);
 }
 
 /**
@@ -143,13 +151,7 @@ export class CrawlsList extends LiteElement {
   private filterByCurrentUser = true;
 
   @state()
-  private filterBy: {
-    field: FilterField | null;
-    value: CrawlState | undefined;
-  } = {
-    field: null,
-    value: undefined,
-  };
+  private filterByState: CrawlState[] = [];
 
   @state()
   private searchBy: string = "";
@@ -167,10 +169,9 @@ export class CrawlsList extends LiteElement {
   private numberFormatter = new Intl.NumberFormat();
 
   private filterCrawls = (crawls: Crawl[]) =>
-    this.filterBy.field
-      ? crawls.filter(
-          (crawl) =>
-            crawl[this.filterBy.field as FilterField] === this.filterBy.value
+    this.filterByState.length
+      ? crawls.filter((crawl) =>
+          this.filterByState.some((state) => crawl.state === state)
         )
       : crawls;
 
@@ -255,7 +256,7 @@ export class CrawlsList extends LiteElement {
   private renderControls() {
     return html`
       <div class="grid grid-cols-12 gap-y-2 gap-x-4 items-center">
-        <div class="col-span-12 md:col-span-6">
+        <div class="col-span-12 md:col-span-5">
           <sl-input
             class="w-full"
             slot="trigger"
@@ -273,7 +274,7 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="col-span-12 md:col-span-3 flex items-center">
+        <div class="col-span-12 md:col-span-4 flex items-center">
           <div class="text-neutral-500 mr-2">${msg("View:")}</div>
           <sl-select
             class="flex-1"
@@ -281,33 +282,27 @@ export class CrawlsList extends LiteElement {
             distance="4"
             size="small"
             pill
-            value=${this.filterBy.value}
-            clearable
-            @sl-select=${(e: any) => {
-              const value = e.detail.item.value as CrawlState;
-              if (value) {
-                this.filterBy = {
-                  field: "state",
-                  value: value,
-                };
-              } else {
-                this.filterBy = {
-                  field: null,
-                  value: undefined,
-                };
-              }
+            .value=${this.filterByState}
+            multiple
+            max-tags-visible="1"
+            placeholder=${msg("All Crawls")}
+            @sl-change=${(e: CustomEvent) => {
+              const value = (e.target as SlSelect).value as CrawlState[];
+              this.filterByState = value;
             }}
           >
-            <sl-menu-item>${msg("All Statuses")}</sl-menu-item>
-            <sl-divider></sl-divider>
-            ${Object.entries(crawlState).map(
-              ([value, { label, icon }]) => html`
-                <sl-menu-item
-                  value=${value}
-                  ?checked=${value === this.filterBy.field}
+            ${activeCrawlStates.map(
+              (state) => html`
+                <sl-menu-item value=${state}>
+                  ${crawlState[state].label}</sl-menu-item
                 >
-                  <div slot="prefix">${icon}</div>
-                  ${label}</sl-menu-item
+              `
+            )}
+            <sl-divider></sl-divider>
+            ${inactiveCrawlStates.map(
+              (state) => html`
+                <sl-menu-item value=${state}>
+                  ${crawlState[state].label}</sl-menu-item
                 >
               `
             )}
@@ -337,11 +332,7 @@ export class CrawlsList extends LiteElement {
           >
             ${Object.entries(sortableFields).map(
               ([value, { label }]) => html`
-                <sl-menu-item
-                  value=${value}
-                  ?checked=${value === this.orderBy.field}
-                  >${label}</sl-menu-item
-                >
+                <sl-menu-item value=${value}>${label}</sl-menu-item>
               `
             )}
           </sl-select>
@@ -397,7 +388,7 @@ export class CrawlsList extends LiteElement {
             <button
               class="text-neutral-500 font-medium underline hover:no-underline"
               @click=${() => {
-                this.filterBy = { field: null, value: undefined };
+                this.filterByState = [];
                 this.onSearchInput.cancel();
                 this.searchBy = "";
               }}

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -393,7 +393,7 @@ export class CrawlsList extends LiteElement {
                 this.searchBy = "";
               }}
             >
-              ${msg("Clear all Filters")}
+              ${msg("Clear all filters")}
             </button>
           </p>
 

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -274,79 +274,81 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
-          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
-          <sl-select
-            class="flex-1 md:w-[14.5rem]"
-            placement="bottom-end"
-            distance="4"
-            size="small"
-            pill
-            .value=${this.filterByState}
-            multiple
-            max-tags-visible="1"
-            placeholder=${msg("All Crawls")}
-            @sl-change=${(e: CustomEvent) => {
-              const value = (e.target as SlSelect).value as CrawlState[];
-              this.filterByState = value;
-            }}
-          >
-            ${activeCrawlStates.map(
-              (state) => html`
-                <sl-menu-item value=${state}>
-                  ${crawlState[state].label}</sl-menu-item
-                >
-              `
-            )}
-            <sl-divider></sl-divider>
-            ${inactiveCrawlStates.map(
-              (state) => html`
-                <sl-menu-item value=${state}>
-                  ${crawlState[state].label}</sl-menu-item
-                >
-              `
-            )}
-          </sl-select>
-        </div>
-
-        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
-          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
-            ${msg("Sort by:")}
+        <div class="flex row-start-2 md:row-start-1 col-span-2 md:col-auto">
+          <div class="flex-column grow md:flex items-center mr-2">
+            <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
+            <sl-select
+              class="flex-1 md:w-[14.5rem]"
+              placement="bottom-end"
+              distance="4"
+              size="small"
+              pill
+              .value=${this.filterByState}
+              multiple
+              max-tags-visible="1"
+              placeholder=${msg("All Crawls")}
+              @sl-change=${(e: CustomEvent) => {
+                const value = (e.target as SlSelect).value as CrawlState[];
+                this.filterByState = value;
+              }}
+            >
+              ${activeCrawlStates.map(
+                (state) => html`
+                  <sl-menu-item value=${state}>
+                    ${crawlState[state].label}</sl-menu-item
+                  >
+                `
+              )}
+              <sl-divider></sl-divider>
+              ${inactiveCrawlStates.map(
+                (state) => html`
+                  <sl-menu-item value=${state}>
+                    ${crawlState[state].label}</sl-menu-item
+                  >
+                `
+              )}
+            </sl-select>
           </div>
-          <div class="flex">
-          <sl-select
-            class="flex-1 md:w-[9.2rem]"
-            placement="bottom-end"
-            distance="4"
-            size="small"
-            pill
-            value=${this.orderBy.field}
-            @sl-select=${(e: any) => {
-              const field = e.detail.item.value as SortField;
-              this.orderBy = {
-                field: field,
-                direction:
-                  sortableFields[field].defaultDirection ||
-                  this.orderBy.direction,
-              };
-            }}
-          >
-            ${Object.entries(sortableFields).map(
-              ([value, { label }]) => html`
-                <sl-menu-item value=${value}>${label}</sl-menu-item>
-              `
-            )}
-          </sl-select>
-          <sl-icon-button
-            name="arrow-down-up"
-            label=${msg("Reverse sort")}
-            @click=${() => {
-              this.orderBy = {
-                ...this.orderBy,
-                direction: this.orderBy.direction === "asc" ? "desc" : "asc",
-              };
-            }}
-          ></sl-icon-button>
+
+          <div class="flex-column grow md:flex items-center">
+            <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
+              ${msg("Sort by:")}
+            </div>
+            <div class="flex">
+            <sl-select
+              class="flex-1 md:w-[9.2rem]"
+              placement="bottom-end"
+              distance="4"
+              size="small"
+              pill
+              value=${this.orderBy.field}
+              @sl-select=${(e: any) => {
+                const field = e.detail.item.value as SortField;
+                this.orderBy = {
+                  field: field,
+                  direction:
+                    sortableFields[field].defaultDirection ||
+                    this.orderBy.direction,
+                };
+              }}
+            >
+              ${Object.entries(sortableFields).map(
+                ([value, { label }]) => html`
+                  <sl-menu-item value=${value}>${label}</sl-menu-item>
+                `
+              )}
+            </sl-select>
+            <sl-icon-button
+              name="arrow-down-up"
+              label=${msg("Reverse sort")}
+              @click=${() => {
+                this.orderBy = {
+                  ...this.orderBy,
+                  direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+                };
+              }}
+            ></sl-icon-button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -275,7 +275,7 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="grow flex items-center mr-2">
+        <div class="grow flex items-center">
           <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
           <sl-select
             class="flex-1 md:w-[14.5rem]"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -278,7 +278,7 @@ export class CrawlsList extends LiteElement {
         <div class="grow flex items-center">
           <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
           <sl-select
-            class="flex-1 md:w-[14.5rem]"
+            class="flex-1 md:min-w-[14.5rem]"
             placement="bottom-end"
             distance="4"
             size="small"
@@ -316,7 +316,7 @@ export class CrawlsList extends LiteElement {
           </div>
           <div class="grow flex">
             <sl-select
-              class="flex-1 md:w-[9.2rem]"
+              class="flex-1 md:min-w-[9.2rem]"
               placement="bottom-end"
               distance="4"
               size="small"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -258,7 +258,7 @@ export class CrawlsList extends LiteElement {
       <div
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center"
       >
-        <div class="row-start-1 col-span-1 md:col-span-2 lg:col-span-1">
+        <div class="col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -18,19 +18,31 @@ import { SlCheckbox } from "@shoelace-style/shoelace";
 type CrawlSearchResult = {
   item: Crawl;
 };
+type SortField = "started" | "finished" | "configName" | "fileSize";
+type SortDirection = "asc" | "desc";
 
 const POLL_INTERVAL_SECONDS = 10;
 const MIN_SEARCH_LENGTH = 2;
-const sortableFieldLabels = {
-  started_desc: msg("Newest"),
-  started_asc: msg("Oldest"),
-  finished_desc: msg("Recently Updated"),
-  finished_asc: msg("Oldest Finished"),
-  state: msg("Status"),
-  configName: msg("Crawl Name"),
-  cid: msg("Crawl Config ID"),
-  fileSize_asc: msg("Smallest Files"),
-  fileSize_desc: msg("Largest Files"),
+const sortableFields: Record<
+  SortField,
+  { label: string; defaultDirection?: SortDirection }
+> = {
+  started: {
+    label: msg("Date Created"),
+    defaultDirection: "desc",
+  },
+  finished: {
+    label: msg("Date Completed"),
+    defaultDirection: "desc",
+  },
+  configName: {
+    label: msg("Crawl Name"),
+    defaultDirection: "desc",
+  },
+  fileSize: {
+    label: msg("File Size"),
+    defaultDirection: "desc",
+  },
 };
 
 function isActive(crawl: Crawl) {
@@ -78,8 +90,8 @@ export class CrawlsList extends LiteElement {
 
   @state()
   private orderBy: {
-    field: "started";
-    direction: "asc" | "desc";
+    field: SortField;
+    direction: SortDirection;
   } = {
     field: "started",
     direction: "desc",
@@ -215,10 +227,12 @@ export class CrawlsList extends LiteElement {
             placement="bottom-end"
             distance="4"
             @sl-select=${(e: any) => {
-              const [field, direction] = e.detail.item.value.split("_");
+              const field = e.detail.item.value as SortField;
               this.orderBy = {
                 field: field,
-                direction: direction,
+                direction:
+                  sortableFields[field].defaultDirection ||
+                  this.orderBy.direction,
               };
             }}
           >
@@ -228,18 +242,14 @@ export class CrawlsList extends LiteElement {
               pill
               caret
               ?disabled=${!this.crawls?.length}
-              >${(sortableFieldLabels as any)[this.orderBy.field] ||
-              sortableFieldLabels[
-                `${this.orderBy.field}_${this.orderBy.direction}`
-              ]}</sl-button
+              >${sortableFields[this.orderBy.field].label}</sl-button
             >
             <sl-menu>
-              ${Object.entries(sortableFieldLabels).map(
-                ([value, label]) => html`
+              ${Object.entries(sortableFields).map(
+                ([value, { label }]) => html`
                   <sl-menu-item
                     value=${value}
-                    ?checked=${value ===
-                    `${this.orderBy.field}_${this.orderBy.direction}`}
+                    ?checked=${value === this.orderBy.field}
                     >${label}</sl-menu-item
                   >
                 `

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -255,7 +255,9 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
+      <div
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center"
+      >
         <div class="row-start-1 col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
@@ -273,46 +275,46 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-          <div class="grow flex items-center mr-2">
-            <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
-            <sl-select
-              class="flex-1 md:w-[14.5rem]"
-              placement="bottom-end"
-              distance="4"
-              size="small"
-              pill
-              .value=${this.filterByState}
-              multiple
-              max-tags-visible="1"
-              placeholder=${msg("All Crawls")}
-              @sl-change=${(e: CustomEvent) => {
-                const value = (e.target as SlSelect).value as CrawlState[];
-                this.filterByState = value;
-              }}
-            >
-              ${activeCrawlStates.map(
-                (state) => html`
-                  <sl-menu-item value=${state}>
-                    ${crawlState[state].label}</sl-menu-item
-                  >
-                `
-              )}
-              <sl-divider></sl-divider>
-              ${inactiveCrawlStates.map(
-                (state) => html`
-                  <sl-menu-item value=${state}>
-                    ${crawlState[state].label}</sl-menu-item
-                  >
-                `
-              )}
-            </sl-select>
-          </div>
+        <div class="grow flex items-center mr-2">
+          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
+          <sl-select
+            class="flex-1 md:w-[14.5rem]"
+            placement="bottom-end"
+            distance="4"
+            size="small"
+            pill
+            .value=${this.filterByState}
+            multiple
+            max-tags-visible="1"
+            placeholder=${msg("All Crawls")}
+            @sl-change=${(e: CustomEvent) => {
+              const value = (e.target as SlSelect).value as CrawlState[];
+              this.filterByState = value;
+            }}
+          >
+            ${activeCrawlStates.map(
+              (state) => html`
+                <sl-menu-item value=${state}>
+                  ${crawlState[state].label}</sl-menu-item
+                >
+              `
+            )}
+            <sl-divider></sl-divider>
+            ${inactiveCrawlStates.map(
+              (state) => html`
+                <sl-menu-item value=${state}>
+                  ${crawlState[state].label}</sl-menu-item
+                >
+              `
+            )}
+          </sl-select>
+        </div>
 
-          <div class="grow flex items-center">
-            <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
-              ${msg("Sort by:")}
-            </div>
-            <div class="grow flex">
+        <div class="grow flex items-center">
+          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
+            ${msg("Sort by:")}
+          </div>
+          <div class="grow flex">
             <sl-select
               class="flex-1 md:w-[9.2rem]"
               placement="bottom-end"
@@ -346,8 +348,8 @@ export class CrawlsList extends LiteElement {
                 };
               }}
             ></sl-icon-button>
-            </div>
           </div>
+        </div>
       </div>
 
       ${this.userId

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -255,8 +255,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid md:grid-cols-3 grid-cols-2 gap-x-2 gap-y-2 items-center">
-        <div class="row-start-1 col-span-full">
+      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
+        <div class="row-start-1 col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"
@@ -273,8 +273,6 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-
-        <div class="row-start-2 md:row-start-1 col-span-2 md:col-auto grid md:grid-rows-1 gap-y-2 grid-cols-1 md:grid-cols-[fit-content(100%)fit-content(100%)]">
           <div class="grow flex items-center mr-2">
             <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
             <sl-select
@@ -350,7 +348,6 @@ export class CrawlsList extends LiteElement {
             ></sl-icon-button>
             </div>
           </div>
-        </div>
       </div>
 
       ${this.userId

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -353,7 +353,7 @@ export class CrawlsList extends LiteElement {
       </div>
 
       ${this.userId
-        ? html` <div class="h-6 mt-2 flex flex-row-reverse">
+        ? html` <div class="h-6 mt-2 flex justify-end">
             <label>
               <span class="text-neutral-500 text-xs mr-1"
                 >${msg("Show Only Mine")}</span

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -310,8 +310,8 @@ export class CrawlsList extends LiteElement {
           </sl-select>
         </div>
 
-        <div class="grow flex items-center">
-          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
+        <div class="flex items-center">
+          <div class="whitespace-nowrap text-neutral-500 mx-2">
             ${msg("Sort by:")}
           </div>
           <div class="grow flex">


### PR DESCRIPTION
- Simplifies "Sort by" options (resolves https://github.com/webrecorder/browsertrix-cloud/issues/449)
- Adds crawl state (aka status) multi-select filter

### Manual testing
1. Run app and log in
2. Go to Crawls list view. Verify "View" filter defaults to "All Crawls" and "Sort by" defaults to "Date Created"
3. Select options from "View" filter. Verify crawls filter as expected
4. Sort crawls by dropdown options. Verify crawls are sorted as expected, and clicking the alternate sort icon with 2 arrows reverses the sort order.

### Screenshots
**Crawls list control bar:**
<img width="1118" alt="Screen Shot 2023-02-16 at 5 34 25 PM" src="https://user-images.githubusercontent.com/4672952/219512475-cc48d432-dfb8-4903-8c02-f6dd4a571577.png">

**Multiple status options selected:**
<img width="368" alt="Screen Shot 2023-02-16 at 5 35 47 PM" src="https://user-images.githubusercontent.com/4672952/219512521-f41cf77b-2860-4918-a530-3691f35edd25.png">

**Sort options:**
<img width="271" alt="Screen Shot 2023-02-16 at 5 36 35 PM" src="https://user-images.githubusercontent.com/4672952/219512594-3f2f2569-a8f3-4df9-bd98-27c3c354a49a.png">

**Empty state:**
<img width="1136" alt="Screen Shot 2023-02-16 at 5 35 58 PM" src="https://user-images.githubusercontent.com/4672952/219512624-d5fc3a79-e391-4adf-8a79-d853f8a005b0.png">

#### Differences from mockups:
- Added an empty state for when no crawls match -- could be improved & standardized later
- Using default Shoelace multi-select, which styles selected options into "tags" -- should be improved later
- No icons next to statuses, can be addressed with https://github.com/webrecorder/browsertrix-cloud/issues/608