### PR TITLE
Improves the crawl filter options CSS

### DIFF
--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -254,8 +254,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid md:grid-cols-3 grid-cols-2 gap-x-2 gap-y-2 items-center">
-        <div class="row-start-1 col-span-full">
+      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
+        <div class="row-start-1 col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"
@@ -272,8 +272,6 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-
-        <div class="row-start-2 md:row-start-1 col-span-2 md:col-auto grid md:grid-rows-1 gap-y-2 grid-cols-1 md:grid-cols-[fit-content(100%)fit-content(100%)]">
           <div class="grow flex items-center mr-2">
             <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
             <sl-select
@@ -349,7 +347,6 @@ export class CrawlsList extends LiteElement {
             ></sl-icon-button>
             </div>
           </div>
-        </div>
       </div>
 
       ${this.userId

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -274,8 +274,8 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="grow flex items-center">
-          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
+        <div class="flex items-center">
+          <div class="text-neutral-500 mx-2">${msg("View:")}</div>
           <sl-select
             class="flex-1 md:min-w-[14.5rem]"
             placement="bottom-end"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -254,7 +254,9 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
+      <div
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center"
+      >
         <div class="row-start-1 col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
@@ -272,46 +274,46 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-          <div class="grow flex items-center mr-2">
-            <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
-            <sl-select
-              class="flex-1 md:w-[14.5rem]"
-              placement="bottom-end"
-              distance="4"
-              size="small"
-              pill
-              .value=${this.filterByState}
-              multiple
-              max-tags-visible="1"
-              placeholder=${msg("All Crawls")}
-              @sl-change=${(e: CustomEvent) => {
-                const value = (e.target as SlSelect).value as CrawlState[];
-                this.filterByState = value;
-              }}
-            >
-              ${activeCrawlStates.map(
-                (state) => html`
-                  <sl-menu-item value=${state}>
-                    ${crawlState[state].label}</sl-menu-item
-                  >
-                `
-              )}
-              <sl-divider></sl-divider>
-              ${inactiveCrawlStates.map(
-                (state) => html`
-                  <sl-menu-item value=${state}>
-                    ${crawlState[state].label}</sl-menu-item
-                  >
-                `
-              )}
-            </sl-select>
-          </div>
+        <div class="grow flex items-center mr-2">
+          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
+          <sl-select
+            class="flex-1 md:w-[14.5rem]"
+            placement="bottom-end"
+            distance="4"
+            size="small"
+            pill
+            .value=${this.filterByState}
+            multiple
+            max-tags-visible="1"
+            placeholder=${msg("All Crawls")}
+            @sl-change=${(e: CustomEvent) => {
+              const value = (e.target as SlSelect).value as CrawlState[];
+              this.filterByState = value;
+            }}
+          >
+            ${activeCrawlStates.map(
+              (state) => html`
+                <sl-menu-item value=${state}>
+                  ${crawlState[state].label}</sl-menu-item
+                >
+              `
+            )}
+            <sl-divider></sl-divider>
+            ${inactiveCrawlStates.map(
+              (state) => html`
+                <sl-menu-item value=${state}>
+                  ${crawlState[state].label}</sl-menu-item
+                >
+              `
+            )}
+          </sl-select>
+        </div>
 
-          <div class="grow flex items-center">
-            <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
-              ${msg("Sort by:")}
-            </div>
-            <div class="grow flex">
+        <div class="grow flex items-center">
+          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
+            ${msg("Sort by:")}
+          </div>
+          <div class="grow flex">
             <sl-select
               class="flex-1 md:w-[9.2rem]"
               placement="bottom-end"
@@ -345,8 +347,8 @@ export class CrawlsList extends LiteElement {
                 };
               }}
             ></sl-icon-button>
-            </div>
           </div>
+        </div>
       </div>
 
       ${this.userId

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -277,7 +277,7 @@ export class CrawlsList extends LiteElement {
         <div class="grow flex items-center">
           <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
           <sl-select
-            class="flex-1 md:w-[14.5rem]"
+            class="flex-1 md:min-w-[14.5rem]"
             placement="bottom-end"
             distance="4"
             size="small"
@@ -315,7 +315,7 @@ export class CrawlsList extends LiteElement {
           </div>
           <div class="grow flex">
             <sl-select
-              class="flex-1 md:w-[9.2rem]"
+              class="flex-1 md:min-w-[9.2rem]"
               placement="bottom-end"
               distance="4"
               size="small"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -309,8 +309,8 @@ export class CrawlsList extends LiteElement {
           </sl-select>
         </div>
 
-        <div class="grow flex items-center">
-          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
+        <div class="flex items-center">
+          <div class="whitespace-nowrap text-neutral-500 mx-2">
             ${msg("Sort by:")}
           </div>
           <div class="grow flex">

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -254,8 +254,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
-        <div class="row-start-1 col-span-1">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center">
+        <div class="row-start-1 col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -273,79 +273,81 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
-          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
-          <sl-select
-            class="flex-1 md:w-[14.5rem]"
-            placement="bottom-end"
-            distance="4"
-            size="small"
-            pill
-            .value=${this.filterByState}
-            multiple
-            max-tags-visible="1"
-            placeholder=${msg("All Crawls")}
-            @sl-change=${(e: CustomEvent) => {
-              const value = (e.target as SlSelect).value as CrawlState[];
-              this.filterByState = value;
-            }}
-          >
-            ${activeCrawlStates.map(
-              (state) => html`
-                <sl-menu-item value=${state}>
-                  ${crawlState[state].label}</sl-menu-item
-                >
-              `
-            )}
-            <sl-divider></sl-divider>
-            ${inactiveCrawlStates.map(
-              (state) => html`
-                <sl-menu-item value=${state}>
-                  ${crawlState[state].label}</sl-menu-item
-                >
-              `
-            )}
-          </sl-select>
-        </div>
-
-        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
-          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
-            ${msg("Sort by:")}
+        <div class="flex row-start-2 md:row-start-1 col-span-2 md:col-auto">
+          <div class="flex-column grow md:flex items-center mr-2">
+            <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
+            <sl-select
+              class="flex-1 md:w-[14.5rem]"
+              placement="bottom-end"
+              distance="4"
+              size="small"
+              pill
+              .value=${this.filterByState}
+              multiple
+              max-tags-visible="1"
+              placeholder=${msg("All Crawls")}
+              @sl-change=${(e: CustomEvent) => {
+                const value = (e.target as SlSelect).value as CrawlState[];
+                this.filterByState = value;
+              }}
+            >
+              ${activeCrawlStates.map(
+                (state) => html`
+                  <sl-menu-item value=${state}>
+                    ${crawlState[state].label}</sl-menu-item
+                  >
+                `
+              )}
+              <sl-divider></sl-divider>
+              ${inactiveCrawlStates.map(
+                (state) => html`
+                  <sl-menu-item value=${state}>
+                    ${crawlState[state].label}</sl-menu-item
+                  >
+                `
+              )}
+            </sl-select>
           </div>
-          <div class="flex">
-          <sl-select
-            class="flex-1 md:w-[9.2rem]"
-            placement="bottom-end"
-            distance="4"
-            size="small"
-            pill
-            value=${this.orderBy.field}
-            @sl-select=${(e: any) => {
-              const field = e.detail.item.value as SortField;
-              this.orderBy = {
-                field: field,
-                direction:
-                  sortableFields[field].defaultDirection ||
-                  this.orderBy.direction,
-              };
-            }}
-          >
-            ${Object.entries(sortableFields).map(
-              ([value, { label }]) => html`
-                <sl-menu-item value=${value}>${label}</sl-menu-item>
-              `
-            )}
-          </sl-select>
-          <sl-icon-button
-            name="arrow-down-up"
-            label=${msg("Reverse sort")}
-            @click=${() => {
-              this.orderBy = {
-                ...this.orderBy,
-                direction: this.orderBy.direction === "asc" ? "desc" : "asc",
-              };
-            }}
-          ></sl-icon-button>
+
+          <div class="flex-column grow md:flex items-center">
+            <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
+              ${msg("Sort by:")}
+            </div>
+            <div class="flex">
+            <sl-select
+              class="flex-1 md:w-[9.2rem]"
+              placement="bottom-end"
+              distance="4"
+              size="small"
+              pill
+              value=${this.orderBy.field}
+              @sl-select=${(e: any) => {
+                const field = e.detail.item.value as SortField;
+                this.orderBy = {
+                  field: field,
+                  direction:
+                    sortableFields[field].defaultDirection ||
+                    this.orderBy.direction,
+                };
+              }}
+            >
+              ${Object.entries(sortableFields).map(
+                ([value, { label }]) => html`
+                  <sl-menu-item value=${value}>${label}</sl-menu-item>
+                `
+              )}
+            </sl-select>
+            <sl-icon-button
+              name="arrow-down-up"
+              label=${msg("Reverse sort")}
+              @click=${() => {
+                this.orderBy = {
+                  ...this.orderBy,
+                  direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+                };
+              }}
+            ></sl-icon-button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -352,7 +352,7 @@ export class CrawlsList extends LiteElement {
       </div>
 
       ${this.userId
-        ? html` <div class="h-6 mt-2 flex flex-row-reverse">
+        ? html` <div class="h-6 mt-2 flex justify-end">
             <label>
               <span class="text-neutral-500 text-xs mr-1"
                 >${msg("Show Only Mine")}</span

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -217,7 +217,7 @@ export class CrawlsList extends LiteElement {
     return html`
       <main>
         <header
-          class="sticky z-10 mb-3 top-0 p-2 bg-neutral-50 border rounded-lg"
+          class="sticky z-10 mb-3 top-2 p-2 bg-neutral-50 border rounded-lg"
         >
           ${this.renderControls()}
         </header>
@@ -254,8 +254,8 @@ export class CrawlsList extends LiteElement {
 
   private renderControls() {
     return html`
-      <div class="grid grid-cols-12 gap-y-2 gap-x-4 items-center">
-        <div class="col-span-12 md:col-span-5">
+      <div class="grid md:grid-cols-3 grid-cols-2 gap-x-2 gap-y-2 items-center">
+        <div class="row-start-1 col-span-full">
           <sl-input
             class="w-full"
             slot="trigger"
@@ -273,10 +273,10 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="col-span-12 md:col-span-4 flex items-center">
-          <div class="text-neutral-500 mr-2">${msg("View:")}</div>
+        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
+          <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
           <sl-select
-            class="flex-1"
+            class="flex-1 md:w-[14.5rem]"
             placement="bottom-end"
             distance="4"
             size="small"
@@ -308,12 +308,13 @@ export class CrawlsList extends LiteElement {
           </sl-select>
         </div>
 
-        <div class="col-span-12 md:col-span-3 flex items-center">
-          <div class="whitespace-nowrap text-neutral-500 mr-2">
+        <div class="flex-column md:flex items-center row-start-2 md:row-start-1 self-start">
+          <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
             ${msg("Sort by:")}
           </div>
+          <div class="flex">
           <sl-select
-            class="flex-1"
+            class="flex-1 md:w-[9.2rem]"
             placement="bottom-end"
             distance="4"
             size="small"
@@ -345,11 +346,12 @@ export class CrawlsList extends LiteElement {
               };
             }}
           ></sl-icon-button>
+          </div>
         </div>
       </div>
 
       ${this.userId
-        ? html` <div class="my-1 text-right">
+        ? html` <div class="h-6 mt-2 flex flex-row-reverse">
             <label>
               <span class="text-neutral-500 text-xs mr-1"
                 >${msg("Show Only Mine")}</span

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -273,8 +273,8 @@ export class CrawlsList extends LiteElement {
           </sl-input>
         </div>
 
-        <div class="flex row-start-2 md:row-start-1 col-span-2 md:col-auto">
-          <div class="flex-column grow md:flex items-center mr-2">
+        <div class="row-start-2 md:row-start-1 col-span-2 md:col-auto grid md:grid-rows-1 gap-y-2 grid-cols-1 md:grid-cols-[fit-content(100%)fit-content(100%)]">
+          <div class="grow flex items-center mr-2">
             <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
             <sl-select
               class="flex-1 md:w-[14.5rem]"
@@ -309,11 +309,11 @@ export class CrawlsList extends LiteElement {
             </sl-select>
           </div>
 
-          <div class="flex-column grow md:flex items-center">
+          <div class="grow flex items-center">
             <div class="whitespace-nowrap text-neutral-500 mr-2 ml-2">
               ${msg("Sort by:")}
             </div>
-            <div class="flex">
+            <div class="grow flex">
             <sl-select
               class="flex-1 md:w-[9.2rem]"
               placement="bottom-end"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -257,7 +257,7 @@ export class CrawlsList extends LiteElement {
       <div
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center"
       >
-        <div class="row-start-1 col-span-1 md:col-span-2 lg:col-span-1">
+        <div class="col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
             slot="trigger"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -274,7 +274,7 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
         </div>
-        <div class="grow flex items-center mr-2">
+        <div class="grow flex items-center">
           <div class="text-neutral-500 mr-2 ml-2">${msg("View:")}</div>
           <sl-select
             class="flex-1 md:w-[14.5rem]"


### PR DESCRIPTION
### Changes VS Sua's Update:
- Grid is now set based on the amount of items in the bar
- Dropdowns are now located on a single row on medium and are still two individual rows on small
- Bottom switch is now aligned with flexbox instead of text-align for future compatibility with selection control buttons
- Added a 0.5rem top value for position sticky so it's not right up against the top of the browser when scrolling

### Caveats

The dropdown's max width is set in REM values based on the amount of space the largest dropdown item (or combination) takes up.  This is not ideal as it is not able to adapt for translated text.  Advice appreciated! :)