### PR TITLE
Disable editing crawl config of running crawls

### DIFF
--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -110,7 +110,9 @@ export class CrawlTemplatesDetail extends LiteElement {
           </h2>
           <div class="flex-0 flex">
             ${when(
-              this.crawlConfig && !this.crawlConfig.inactive,
+              this.crawlConfig &&
+                !this.crawlConfig.inactive &&
+                !this.crawlConfig.currCrawlId,
               () => html`
                 <sl-button
                   href=${`/orgs/${this.orgId}/crawl-configs/config/${
@@ -143,16 +145,16 @@ export class CrawlTemplatesDetail extends LiteElement {
           </div>
         </header>
 
+        ${this.renderCurrentlyRunningNotice()}
+
         <section class="col-span-1 border rounded-lg py-2">
           ${this.renderDetails()}
         </section>
 
-        ${this.renderLastCrawl()} ${this.renderCurrentlyRunningNotice()}
+        ${this.renderLastCrawl()}
 
         <div class="col-span-1">
-          <h3 class="text-lg font-semibold mb-2">
-            ${msg("Crawl Settings")}
-          </h3>
+          <h3 class="text-lg font-semibold mb-2">${msg("Crawl Settings")}</h3>
           <main class="border rounded-lg py-3 px-5">
             <btrix-config-details
               .crawlConfig=${this.crawlConfig}
@@ -299,7 +301,9 @@ export class CrawlTemplatesDetail extends LiteElement {
 
     return html`
       <sl-dropdown placement="bottom-end" distance="4">
-        <sl-button slot="trigger" size="small" caret>${msg("Actions")}</sl-button>
+        <sl-button slot="trigger" size="small" caret
+          >${msg("Actions")}</sl-button
+        >
 
         <ul
           class="text-left text-sm text-neutral-800 bg-white whitespace-nowrap"

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -110,22 +110,29 @@ export class CrawlTemplatesDetail extends LiteElement {
           </h2>
           <div class="flex-0 flex">
             ${when(
-              this.crawlConfig &&
-                !this.crawlConfig.inactive &&
-                !this.crawlConfig.currCrawlId,
+              this.crawlConfig && !this.crawlConfig.inactive,
               () => html`
-                <sl-button
-                  href=${`/orgs/${this.orgId}/crawl-configs/config/${
-                    this.crawlConfig!.id
-                  }?edit`}
-                  variant="primary"
-                  size="small"
-                  class="mr-2"
-                  @click=${this.navLink}
+                <sl-tooltip
+                  content=${msg(
+                    "Crawl config cannot be edited while crawl is running."
+                  )}
+                  ?disabled=${!this.crawlConfig!.currCrawlId}
                 >
-                  <sl-icon slot="prefix" name="gear"></sl-icon>
-                  ${msg("Edit Crawl Config")}
-                </sl-button>
+                  <sl-button
+                    href=${`/orgs/${this.orgId}/crawl-configs/config/${
+                      this.crawlConfig!.id
+                    }?edit`}
+                    variant="primary"
+                    size="small"
+                    class="mr-2"
+                    @click=${this.navLink}
+                    ?disabled=${this.crawlConfig!.currCrawlId}
+                  >
+                    <sl-icon slot="prefix" name="gear"></sl-icon>
+                    ${msg("Edit Crawl Config")}
+                  </sl-button>
+                </sl-tooltip>
+
                 ${this.renderMenu()}
               `,
               () =>
@@ -239,7 +246,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       `,
     ];
 
-    if (!this.crawlConfig.inactive) {
+    if (!this.crawlConfig.inactive && !this.crawlConfig.currCrawlId) {
       menuItems.unshift(html`
         <li
           class="p-2 hover:bg-purple-50 cursor-pointer text-purple-600"
@@ -259,7 +266,11 @@ export class CrawlTemplatesDetail extends LiteElement {
       `);
     }
 
-    if (this.crawlConfig.crawlCount && !this.crawlConfig.inactive) {
+    if (
+      this.crawlConfig.crawlCount &&
+      !this.crawlConfig.inactive &&
+      !this.crawlConfig.currCrawlId
+    ) {
       menuItems.push(html`
         <li
           class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"
@@ -281,7 +292,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       `);
     }
 
-    if (!this.crawlConfig.crawlCount) {
+    if (!this.crawlConfig.crawlCount && !this.crawlConfig.currCrawlId) {
       menuItems.push(html`
         <li
           class="p-2 text-danger hover:bg-danger hover:text-white cursor-pointer"

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -448,7 +448,7 @@ export class CrawlTemplatesList extends LiteElement {
       `,
     ];
 
-    if (!t.inactive) {
+    if (!t.inactive && !this.runningCrawlsMap[t.id]) {
       menuItems.unshift(html`
         <li
           class="p-2 hover:bg-zinc-100 cursor-pointer"

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -447,20 +447,25 @@ export class CrawlDetail extends LiteElement {
                   ${msg("Edit Metadata")}
                 </span>
               </li>
-              <hr />
-              <li
-                class="p-2 hover:bg-zinc-100 cursor-pointer"
-                role="menuitem"
-                @click=${() => {
-                  this.navTo(
-                    `/orgs/${this.crawl?.oid}/crawl-configs/config/${this.crawlTemplateId}?edit`
-                  );
-                }}
-              >
-                <span class="inline-block align-middle">
-                  ${msg("Edit Crawl Config")}
-                </span>
-              </li>
+              ${when(
+                !this.isActive,
+                () => html`
+                  <hr />
+                  <li
+                    class="p-2 hover:bg-zinc-100 cursor-pointer"
+                    role="menuitem"
+                    @click=${() => {
+                      this.navTo(
+                        `/orgs/${this.crawl?.oid}/crawl-configs/config/${this.crawlTemplateId}?edit`
+                      );
+                    }}
+                  >
+                    <span class="inline-block align-middle">
+                      ${msg("Edit Crawl Config")}
+                    </span>
+                  </li>
+                `
+              )}
             `
           )}
           <li

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -212,12 +212,22 @@ export class CrawlDetail extends LiteElement {
                 html`
                   <div class="flex items-center justify-between">
                     ${msg("Metadata")}
-                    <sl-icon-button
-                      class="text-base"
-                      name="pencil"
-                      @click=${this.openMetadataEditor}
-                      aria-label=${msg("Edit Metadata")}
-                    ></sl-icon-button>
+                    <sl-tooltip
+                      content=${msg(
+                        "Metadata cannot be edited while crawl is running."
+                      )}
+                      ?disabled=${!this.isActive}
+                    >
+                      <sl-icon-button
+                        class=${`text-base${
+                          this.isActive ? " cursor-not-allowed" : ""
+                        }`}
+                        name="pencil"
+                        @click=${this.openMetadataEditor}
+                        aria-label=${msg("Edit Metadata")}
+                        ?disabled=${this.isActive}
+                      ></sl-icon-button>
+                    </sl-tooltip>
                   </div>
                 `,
                 this.renderMetadata()
@@ -429,24 +439,24 @@ export class CrawlDetail extends LiteElement {
                       ${msg("Re-run crawl")}
                     </span>
                   </li>
+                  <li
+                    class="p-2 hover:bg-zinc-100 cursor-pointer"
+                    role="menuitem"
+                    @click=${(e: any) => {
+                      this.openMetadataEditor();
+                      e.target.closest("sl-dropdown").hide();
+                    }}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle mr-1"
+                      name="pencil"
+                    ></sl-icon>
+                    <span class="inline-block align-middle">
+                      ${msg("Edit Metadata")}
+                    </span>
+                  </li>
                 `
               )}
-              <li
-                class="p-2 hover:bg-zinc-100 cursor-pointer"
-                role="menuitem"
-                @click=${(e: any) => {
-                  this.openMetadataEditor();
-                  e.target.closest("sl-dropdown").hide();
-                }}
-              >
-                <sl-icon
-                  class="inline-block align-middle mr-1"
-                  name="pencil"
-                ></sl-icon>
-                <span class="inline-block align-middle">
-                  ${msg("Edit Metadata")}
-                </span>
-              </li>
               ${when(
                 !this.isActive,
                 () => html`


### PR DESCRIPTION
Removes menu items and buttons that pertain to editing a crawl config if a crawl is currently running. Partially addresses https://github.com/webrecorder/browsertrix-cloud/issues/574.

### Manual testing
1. Log in and go to crawls page
2. Start a crawl. Verify the following:
- "Edit Crawl Config" button and action menu on the crawl config detail page is disabled
- "Edit crawl config" menu item is hidden from crawl config list view action menu
- "Edit crawl config" and "Edit metadata" menu items are hidden from crawl detail action menu
- Metadata edit pencil icon in crawl detail action menu is disabled

### Screenshots
**Crawl config detail header:**
<img width="390" alt="Screen Shot 2023-02-21 at 9 05 50 PM" src="https://user-images.githubusercontent.com/4672952/220511073-fd5b8786-077e-4ef9-a8c0-c6a7075adc64.png">

**Crawl detail "Metadata" header:**
<img width="338" alt="Screen Shot 2023-02-21 at 8 56 16 PM" src="https://user-images.githubusercontent.com/4672952/220510574-ee94d2f8-3dcf-4430-b4a2-8797ab2511d6.png">
