### PR TITLE
crawler arguments fixes:

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -67,10 +67,7 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  #CRAWL_ARGS: "{{ .Values.crawler_args }} --redisStoreUrl {{ .Values.redis_url }}"
-  CRAWL_ARGS: "{{ .Values.crawler_args }}"
-  #WEBHOOK_URL: "{{ .Values.redis_url }}/crawls-done"
-
+  CRAWL_ARGS: "{{ .Values.crawler_args }} --workers {{ .Values.crawler_browser_instances | default 1 }}"
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,7 +138,9 @@ crawler_namespace: "crawlers"
 crawl_retries: 1000
 
 # browsertrix-crawler args:
-crawler_args: "--timeout 120 --logging stats,behaviors,debug --generateWACZ --text --workers 4 --collection thecrawl --screencastPort 9037 --sizeLimit 100000000000 --timeLimit 18000 --healthCheckPort 6065 --waitOnDone --behaviorTimeout 300"
+crawler_args: "--timeout 120 --logging stats,behaviors,debug --generateWACZ --text --collection thecrawl --screencastPort 9037 --sizeLimit 100000000000 --timeLimit 18000 --healthCheckPort 6065 --waitOnDone"
+
+crawler_browser_instances: 4
 
 crawler_requests_cpu: "800m"
 crawler_limits_cpu: "1200m"


### PR DESCRIPTION
- partial fix to #321, don't hard-code behavior limit into crawler args
- allow setting number of crawler browser instances via 'crawler_browser_instances' to avoid having to override the full crawler args