### PR TITLE
Make nightly tests run nightly, not monthly

### DIFF
--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -3,7 +3,7 @@ name: Nightly tests (K3d)
 on:
   schedule:
     # Run daily at 8am UTC
-    - cron:  '0 8 1 * *'
+    - cron:  '0 8 * * *'
 
 jobs:
   btrix-k3d-nightly-test:


### PR DESCRIPTION
This PR adjusts the cron syntax so that nightly tests run daily as expected rather than only one first day of the month.