### PR TITLE
Fix nightly tests

### DIFF
--- a/backend/test_nightly/test_crawlconfig_crawl_stats.py
+++ b/backend/test_nightly/test_crawlconfig_crawl_stats.py
@@ -56,7 +56,7 @@ def test_crawlconfig_crawl_stats(admin_auth_headers, default_org_id, crawl_confi
     data = r.json()
     assert data["crawlAttemptCount"] == 2
     assert data["crawlCount"] == 1
-    assert data["lastCrawlId"] == first_crawl_id
+    assert data["lastCrawlId"] == crawl_id
     assert data["lastCrawlState"] == "complete"
     assert data["lastCrawlTime"] == first_crawl_finished
 

--- a/backend/test_nightly/test_invite_expiration.py
+++ b/backend/test_nightly/test_invite_expiration.py
@@ -1,4 +1,5 @@
 import requests
+import time
 
 from .conftest import API_PREFIX
 


### PR DESCRIPTION
Now that nightly tests are running nightly, we can see that two of the tests are failing due to small defects (a missing import, a typo). This PR fixes those.