### PR TITLE
CrawlConfig migration and crawl stats query optimization

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -432,21 +432,13 @@ class CrawlConfigOps:
 
     async def _annotate_with_crawl_stats(self, crawlconfig: CrawlConfigOut):
         """Annotate crawlconfig with information about associated crawls"""
-        crawls = await self.crawl_ops.list_crawls(cid=crawlconfig.id)
-
-        crawlconfig.crawlCount = len(crawls)
-
-        finished_crawls = [crawl for crawl in crawls if crawl.finished]
-        if not finished_crawls:
-            return crawlconfig
-
-        sorted_crawls = sorted(finished_crawls, key=lambda crawl: crawl.finished)
-        last_crawl = sorted_crawls[-1]
-
-        crawlconfig.lastCrawlId = str(last_crawl.id)
-        crawlconfig.lastCrawlTime = last_crawl.finished
-        crawlconfig.lastCrawlState = last_crawl.state
-
+        crawl_stats = await self.crawl_ops.get_latest_crawl_and_count_by_config(
+            cid=crawlconfig.id
+        )
+        crawlconfig.crawlCount = crawl_stats["crawl_count"]
+        crawlconfig.lastCrawlId = crawl_stats["last_crawl_id"]
+        crawlconfig.lastCrawlTime = crawl_stats["last_crawl_finished"]
+        crawlconfig.lastCrawlState = crawl_stats["last_crawl_state"]
         return crawlconfig
 
     async def get_crawl_config_out(self, cid: uuid.UUID, org: Organization):

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -139,15 +139,6 @@ class CrawlConfig(BaseMongoModel):
 
     crawlAttemptCount: Optional[int] = 0
 
-    # These fields would ideally be in CrawlConfigOut, but are being
-    # kept here to prevent the need for a migration. Eventually, we
-    # may want to add a migration and move them, as these values are
-    # now generated dynamically in API endpoints as needed.
-    crawlCount: Optional[int] = 0
-    lastCrawlId: Optional[str]
-    lastCrawlTime: Optional[datetime]
-    lastCrawlState: Optional[str]
-
     newId: Optional[UUID4]
     oldId: Optional[UUID4]
     inactive: Optional[bool] = False
@@ -164,6 +155,11 @@ class CrawlConfigOut(CrawlConfig):
     currCrawlId: Optional[str]
     profileName: Optional[str]
     userName: Optional[str]
+
+    crawlCount: Optional[int] = 0
+    lastCrawlId: Optional[str]
+    lastCrawlTime: Optional[datetime]
+    lastCrawlState: Optional[str]
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/__init__.py
+++ b/backend/btrixcloud/migrations/__init__.py
@@ -49,10 +49,6 @@ class BaseMigration:
             "Not implemented in base class - implement in subclass"
         )
 
-    def migrate_down(self):
-        """Perform migration down."""
-        raise NotImplementedError("Downward migrations not yet added")
-
     async def run(self):
         """Run migrations."""
         if await self.migrate_up_needed():

--- a/backend/btrixcloud/migrations/__init__.py
+++ b/backend/btrixcloud/migrations/__init__.py
@@ -1,0 +1,72 @@
+"""
+BaseMigration class to subclass in each migration module
+"""
+from pymongo.errors import OperationFailure
+
+
+class BaseMigration:
+    """Base Migration class."""
+
+    def __init__(self, mdb, migration_version="0001"):
+        self.mdb = mdb
+        self.migration_version = migration_version
+
+    async def get_db_version(self):
+        """Get current db version from database."""
+        db_version = None
+        version_collection = self.mdb["version"]
+        version_record = await version_collection.find_one()
+        if not version_record:
+            return db_version
+        try:
+            db_version = version_record["version"]
+        except KeyError:
+            pass
+        return db_version
+
+    async def set_db_version(self):
+        """Set db version to migration_version."""
+        version_collection = self.mdb["version"]
+        await version_collection.find_one_and_update(
+            {}, {"$set": {"version": self.migration_version}}, upsert=True
+        )
+
+    async def migrate_up_needed(self):
+        """Verify migration up is needed and return boolean indicator."""
+        db_version = await self.get_db_version()
+        print(f"Current database version before migration: {db_version}")
+        print(f"Migration available to apply: {self.migration_version}")
+        # Databases from prior to migrations will not have a version set.
+        if not db_version:
+            return True
+        if db_version < self.migration_version:
+            return True
+        return False
+
+    async def migrate_up(self):
+        """Perform migration up."""
+        raise NotImplementedError(
+            "Not implemented in base class - implement in subclass"
+        )
+
+    def migrate_down(self):
+        """Perform migration down."""
+        raise NotImplementedError("Downward migrations not yet added")
+
+    async def run(self):
+        """Run migrations."""
+        if await self.migrate_up_needed():
+            print("Performing migration up", flush=True)
+            try:
+                await self.migrate_up()
+                await self.set_db_version()
+            except OperationFailure as err:
+                print(f"Error running migration {self.migration_version}: {err}")
+                return False
+
+        else:
+            print("No migration to apply - skipping", flush=True)
+            return False
+
+        print(f"Database successfully migrated to {self.migration_version}", flush=True)
+        return True

--- a/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
+++ b/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
@@ -5,10 +5,14 @@ import os
 
 from pymongo.errors import OperationFailure
 
+from btrixcloud.migrations import BaseMigration
 from btrixcloud.k8s.k8sapi import K8sAPI
 
 
-class Migration:
+MIGRATION_VERSION = "0001"
+
+
+class Migration(BaseMigration):
     """Migration class."""
 
     COLLECTIONS_AID_TO_OID = [
@@ -19,42 +23,8 @@ class Migration:
         "profiles",
     ]
 
-    MIGRATION_VERSION = "0001"
-
-    def __init__(self, mdb):
-        self.mdb = mdb
-
-    async def get_db_version(self):
-        """Get current db version from database."""
-        db_version = None
-        version_collection = self.mdb["version"]
-        version_record = await version_collection.find_one()
-        if not version_record:
-            return db_version
-        try:
-            db_version = version_record["version"]
-        except KeyError:
-            pass
-        return db_version
-
-    async def set_db_version(self):
-        """Set db version to version_number."""
-        version_collection = self.mdb["version"]
-        await version_collection.find_one_and_update(
-            {}, {"$set": {"version": self.MIGRATION_VERSION}}, upsert=True
-        )
-
-    async def migrate_up_needed(self):
-        """Verify migration up is needed and return boolean indicator."""
-        db_version = await self.get_db_version()
-        print(f"Current database version before migration: {db_version}")
-        print(f"Migration available to apply: {self.MIGRATION_VERSION}")
-        # Databases from prior to migrations will not have a version set.
-        if not db_version:
-            return True
-        if db_version < self.MIGRATION_VERSION:
-            return True
-        return False
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
 
     async def migrate_up(self):
         """Perform migration up."""
@@ -98,25 +68,3 @@ class Migration:
             await k8s_api_instance.core_api.patch_namespaced_config_map(
                 name=item_name, namespace=crawler_namespace, body=item
             )
-
-    def migrate_down(self):
-        """Perform migration down."""
-        raise NotImplementedError("Downward migrations not yet added")
-
-    async def run(self):
-        """Run migrations."""
-        if await self.migrate_up_needed():
-            print("Performing migration up", flush=True)
-            try:
-                await self.migrate_up()
-                await self.set_db_version()
-            except OperationFailure as err:
-                print(f"Error running migration {self.MIGRATION_VERSION}: {err}")
-                return False
-
-        else:
-            print("No migration to apply - skipping", flush=True)
-            return False
-
-        print(f"Database successfully migrated to {self.MIGRATION_VERSION}", flush=True)
-        return True

--- a/backend/btrixcloud/migrations/migration_0002_crawlconfig_crawlstats.py
+++ b/backend/btrixcloud/migrations/migration_0002_crawlconfig_crawlstats.py
@@ -1,0 +1,27 @@
+"""
+Migration 0002 - Dropping CrawlConfig crawl stats
+"""
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0002"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Drop crawl statistics fields from crawl_config collection documents
+        as these are now generated dynamically from a join as needed in API
+        endpoints.
+        """
+        crawl_configs = self.mdb["crawl_configs"]
+        await crawl_configs.update_many({}, {"$unset": {"crawlCount": 1}})
+        await crawl_configs.update_many({}, {"$unset": {"lastCrawlId": 1}})
+        await crawl_configs.update_many({}, {"$unset": {"lastCrawlTime": 1}})
+        await crawl_configs.update_many({}, {"$unset": {"lastCrawlState": 1}})


### PR DESCRIPTION
Connected to #622 

This follow-up PR adds a migration to remove crawl statistics from the `CrawlConfig` model and optimizes the query to retrieve statistics from a config's associated crawls.

Tested manually and via running `nightly_tests/test_crawlconfig_crawl_stats` locally.