### PR TITLE
Fix microk8s CI

### DIFF
--- a/chart/test/microk8s-ci.yaml
+++ b/chart/test/microk8s-ci.yaml
@@ -4,3 +4,6 @@
 # use local images
 backend_image: "localhost:32000/webrecorder/browsertrix-backend:latest"
 frontend_image: "localhost:32000/webrecorder/browsertrix-frontend:latest"
+
+backend_pull_policy: "IfNotPresent"
+frontend_pull_policy: "IfNotPresent"


### PR DESCRIPTION
Fix regression introduced in https://github.com/webrecorder/browsertrix-cloud/commit/14b349443f7579191843d2e0c8f47aa355d1ce42 that was preventing microk8s CI from working as expected.