### PR TITLE
Adds h1 page titles, edits heading hierarchy, minor graphical tweaks and fixes

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -274,6 +274,7 @@ export class App extends LiteElement {
         >
           <div>
             <a
+              class="text-sm hover:text-neutral-400 font-medium"
               href=${homeHref}
               @click=${(e: any) => {
                 if (isAdmin) {
@@ -281,10 +282,9 @@ export class App extends LiteElement {
                 }
                 this.navLink(e);
               }}
-              ><h1 class="text-sm hover:text-neutral-400 font-medium">
-                ${msg("Browsertrix Cloud")}
-              </h1></a
             >
+              ${msg("Browsertrix Cloud")}
+            </a>
           </div>
 
           ${isAdmin

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -43,15 +43,19 @@ export class BrowserProfilesList extends LiteElement {
   }
 
   render() {
-    return html`<header class="mb-3 text-right">
+    return html`<header>
+        <div class="flex justify-between w-full h-8 mb-4">
+        <h1 class="text-xl font-semibold">${msg("Browser Profiles")}</h1>
         <sl-button
           href=${`/orgs/${this.orgId}/browser-profiles?new`}
           variant="primary"
+          size="small"
           @click=${this.navLink}
         >
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>
           ${msg("New Browser Profile")}
         </sl-button>
+        </div>
       </header>
 
       ${this.renderTable()}

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -108,7 +108,7 @@ export class CrawlTemplatesDetail extends LiteElement {
               `
             )}
           </h2>
-          <div class="flex-0 flex">
+          <div class="flex-0 flex justify-end">
             ${when(
               this.crawlConfig && !this.crawlConfig.inactive,
               () => html`

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -302,7 +302,7 @@ export class CrawlTemplatesList extends LiteElement {
     }
 
     return html`
-      <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         ${flow(...flowFns)(this.crawlTemplates)}
       </div>
     `;

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -109,10 +109,10 @@ export class CrawlTemplatesList extends LiteElement {
 
   render() {
     return html`
-    <header class="contents">
-    <div class="flex justify-between w-full h-8 mb-4">
-      <h1 class="text-xl font-semibold">${msg("Crawl Configs")}</h1>
-      <sl-button
+      <header class="contents">
+        <div class="flex justify-between w-full h-8 mb-4">
+          <h1 class="text-xl font-semibold">${msg("Crawl Configs")}</h1>
+          <sl-button
             href=${`/orgs/${this.orgId}/crawl-configs?new&jobType=`}
             variant="primary"
             size="small"
@@ -121,11 +121,11 @@ export class CrawlTemplatesList extends LiteElement {
             <sl-icon slot="prefix" name="plus-lg"></sl-icon>
             ${msg("New Crawl Config")}
           </sl-button>
-    </div>
-      <div class="sticky z-10 mb-3 top-2 p-4 bg-neutral-50 border rounded-lg">
-        ${this.renderControls()}
-      </div>
-    </header>
+        </div>
+        <div class="sticky z-10 mb-3 top-2 p-4 bg-neutral-50 border rounded-lg">
+          ${this.renderControls()}
+        </div>
+      </header>
 
       ${this.crawlTemplates
         ? this.crawlTemplates.length

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -109,9 +109,23 @@ export class CrawlTemplatesList extends LiteElement {
 
   render() {
     return html`
-      <div class="sticky z-10 mb-2 top-0 py-2 bg-neutral-0">
+    <header class="contents">
+    <div class="flex justify-between w-full h-8 mb-4">
+      <h1 class="text-xl font-semibold">${msg("Crawl Configs")}</h1>
+      <sl-button
+            href=${`/orgs/${this.orgId}/crawl-configs?new&jobType=`}
+            variant="primary"
+            size="small"
+            @click=${this.navLink}
+          >
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            ${msg("New Crawl Config")}
+          </sl-button>
+    </div>
+      <div class="sticky z-10 mb-3 top-2 p-4 bg-neutral-50 border rounded-lg">
         ${this.renderControls()}
       </div>
+    </header>
 
       ${this.crawlTemplates
         ? this.crawlTemplates.length
@@ -158,6 +172,7 @@ export class CrawlTemplatesList extends LiteElement {
           <sl-input
             class="w-full"
             slot="trigger"
+            size="small"
             placeholder=${msg("Search by name")}
             clearable
             ?disabled=${!this.crawlTemplates?.length}
@@ -165,17 +180,6 @@ export class CrawlTemplatesList extends LiteElement {
           >
             <sl-icon name="search" slot="prefix"></sl-icon>
           </sl-input>
-        </div>
-
-        <div class="grow-0 mb-4">
-          <sl-button
-            href=${`/orgs/${this.orgId}/crawl-configs?new&jobType=`}
-            variant="primary"
-            @click=${this.navLink}
-          >
-            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-            ${msg("New Crawl Config")}
-          </sl-button>
         </div>
       </div>
 

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -343,7 +343,7 @@ export class CrawlDetail extends LiteElement {
   private renderHeader() {
     return html`
       <header class="md:flex justify-between items-end">
-        <h2 class="text-xl font-semibold mb-3 md:mr-2">
+        <h1 class="text-xl font-semibold mb-4 md:mb-0 md:mr-2">
           ${msg(
             html`${this.crawl
               ? this.crawl.configName
@@ -352,7 +352,7 @@ export class CrawlDetail extends LiteElement {
                   style="width: 15em"
                 ></sl-skeleton>`}`
           )}
-        </h2>
+        </h1>
         <div
           class="grid gap-2 grid-flow-col ${this.isActive
             ? "justify-between"
@@ -520,7 +520,7 @@ export class CrawlDetail extends LiteElement {
 
   private renderPanel(title: any, content: any) {
     return html`
-      <h3 class="flex-0 text-lg font-semibold mb-2">${title}</h3>
+      <h2 class="flex-0 text-lg font-semibold mb-2">${title}</h2>
       <div class="flex-1 rounded-lg border p-5">${content}</div>
     `;
   }

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -217,10 +217,15 @@ export class CrawlsList extends LiteElement {
 
     return html`
       <main>
-        <header
-          class="sticky z-10 mb-3 top-2 p-2 bg-neutral-50 border rounded-lg"
-        >
-          ${this.renderControls()}
+        <header class="contents">
+          <div class="flex w-full h-8 mb-4">
+            <h1 class="text-xl font-semibold">${msg("Crawls")}</h1>
+          </div>
+          <div
+            class="sticky z-10 mb-3 top-2 p-4 bg-neutral-50 border rounded-lg"
+          >
+            ${this.renderControls()}
+          </div>
         </header>
         <section>
           ${this.crawls.length
@@ -261,6 +266,7 @@ export class CrawlsList extends LiteElement {
         <div class="col-span-1 md:col-span-2 lg:col-span-1">
           <sl-input
             class="w-full"
+            size="small"
             slot="trigger"
             placeholder=${msg("Search by Crawl Config name or ID")}
             clearable

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -103,7 +103,7 @@ export class OrgSettings extends LiteElement {
 
   render() {
     return html`<header class="mb-5">
-        <h2 class="text-xl font-semibold leading-10">${msg("Org Settings")}</h2>
+        <h1 class="text-xl font-semibold leading-8">${msg("Org Settings")}</h1>
       </header>
 
       <btrix-tab-list activePanel=${this.activePanel} ?hideIndicator=${true}>


### PR DESCRIPTION
Everything here should be compatible with #630 :)

### Main Pages + General
- Adds h1 page titles for all main pages
- Removes h1 from "Browsertrix Cloud" app title name
- Moves the New Crawl Config action into the title row from the search controls box
- Gives the Crawl Config search controls box the same style as the Crawls search controls box
- Adds +8px of padding to the search controls box to match mockups
- Search box: medium → small
- Title row control buttons: medium → small
- Fixes grid overflow on Crawl Configs list on mobile

### Details Pages
- h2 → h1 for crawl config and crawl detail pages
- h3 → h2 for crawl config and crawl detail pages
- Removes crawl title margin bottom at medium+ breakpoints on crawl details page
- Aligns crawl config details title row controls with end of flexbox on mobile to match crawl details controls in the same spot

### Screenshots

Crawls Page Title
<img width="1162" alt="Screenshot 2023-02-24 at 12 29 48 AM" src="https://user-images.githubusercontent.com/5672810/221099670-ab6542c1-fc05-4893-96d3-18e586e8d369.png">

Crawl Configs Page Title, Controls Bar, & Moved Button — Leaving the other updates to bring this in line with the Crawls page controls bar for a later date.
<img width="1147" alt="Screenshot 2023-02-24 at 12 30 50 AM" src="https://user-images.githubusercontent.com/5672810/221099795-9b075ced-0cac-46ae-9f3d-014e07fba9b9.png">

Crawl Config Details Title Row Actions Right Aligned on Mobile
<img width="447" alt="Screenshot 2023-02-24 at 12 31 57 AM" src="https://user-images.githubusercontent.com/5672810/221099964-6293b1c8-1f9a-4b7e-8da9-ef96d4048041.png">

Browser Profiles Page Title
<img width="1252" alt="Screenshot 2023-02-24 at 12 33 40 AM" src="https://user-images.githubusercontent.com/5672810/221100156-276bbe1f-85b1-43d1-af0f-eb5eebded284.png">