### PR TITLE
Chart: split Crawl args into separate variables

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -67,7 +67,7 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  CRAWL_ARGS: "{{ .Values.crawler_args }} --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_restart_on_size_bytes }} --timeLimit {{ .Values.crawler_restart_on_time_seconds }} --healthCheckPort {{ .Values.crawler_liveness_port }}"
+  CRAWL_ARGS: "{{ .Values.crawler_args }} --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --healthCheckPort {{ .Values.crawler_liveness_port }}"
 
 ---
 apiVersion: v1

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -67,7 +67,7 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  CRAWL_ARGS: "{{ .Values.crawler_args }} --workers {{ .Values.crawler_browser_instances | default 1 }}"
+  CRAWL_ARGS: "{{ .Values.crawler_args }} --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_restart_on_size_bytes }} --timeLimit {{ .Values.crawler_restart_on_time_seconds }} --healthCheckPort {{ .Values.crawler_liveness_port }}"
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -142,16 +142,21 @@ crawler_args: "--logging stats,behaviors,debug --generateWACZ --text --collectio
 
 crawler_browser_instances: 2
 
-crawler_restart_on_size_bytes: 100000000000
-crawler_restart_on_time_seconds: 18000
-
 crawler_requests_cpu: "800m"
 crawler_limits_cpu: "1200m"
 
 crawler_requests_memory: "512Mi"
-crawler_limits_memory: "768Mi"
+crawler_limits_memory: "1024Mi"
 
-crawler_requests_storage: "5Gi"
+# minimum size allocated to each crawler
+# should be at least double crawl session size to ensure space for WACZ
+crawler_requests_storage: "22Gi"
+
+# max size at which crawler will commit current crawl session
+crawler_session_size_limit_bytes: "10000000000"
+
+# max time in seconds after which crawler will restart, if set
+crawler_session_time_limit_seconds: 18000
 
 crawler_liveness_port: 6065
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,9 +138,12 @@ crawler_namespace: "crawlers"
 crawl_retries: 1000
 
 # browsertrix-crawler args:
-crawler_args: "--timeout 120 --logging stats,behaviors,debug --generateWACZ --text --collection thecrawl --screencastPort 9037 --sizeLimit 100000000000 --timeLimit 18000 --healthCheckPort 6065 --waitOnDone"
+crawler_args: "--logging stats,behaviors,debug --generateWACZ --text --collection thecrawl --screencastPort 9037 --waitOnDone"
 
-crawler_browser_instances: 4
+crawler_browser_instances: 2
+
+crawler_restart_on_size_bytes: 100000000000
+crawler_restart_on_time_seconds: 18000
 
 crawler_requests_cpu: "800m"
 crawler_limits_cpu: "1200m"
@@ -148,7 +151,7 @@ crawler_limits_cpu: "1200m"
 crawler_requests_memory: "512Mi"
 crawler_limits_memory: "768Mi"
 
-crawler_requests_storage: "220Gi"
+crawler_requests_storage: "5Gi"
 
 crawler_liveness_port: 6065
 


### PR DESCRIPTION
Split out any overridable arguments for browsertrix crawler cmdline into individual values for easier overriding, including:
- crawl session size limit, set via "crawler_session_size_limit_bytes"
- crawl session time limit, set via "crawler_session_time_limit_seconds"
- page load timeout, removed to allow overriding per crawl
- health check port, configured directly via port setting

More reasonable initial defaults: set default crawl size limit to 10GB per WACZ, and default storage allocation to 22GB for crawl volume, default to 2 workers instead of 4.