### PR TITLE
Hide file size when crawl is running

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -127,6 +127,10 @@ export class CrawlListItem extends LitElement {
         line-height: 1.4;
       }
 
+      .unknownValue {
+        color: var(--sl-color-neutral-500);
+      }
+
       .name {
         overflow: hidden;
         text-overflow: ellipsis;
@@ -248,10 +252,12 @@ export class CrawlListItem extends LitElement {
       </div>
       <div class="col">
         <div class="detail">
-          ${this.safeRender(
-            (crawl) => html`<sl-format-bytes
-              value=${crawl.fileSize || 0}
-            ></sl-format-bytes>`
+          ${this.safeRender((crawl) =>
+            isActive
+              ? html`<span class="unknownValue">${msg("In Progress")}</span>`
+              : html`<sl-format-bytes
+                  value=${crawl.fileSize || 0}
+                ></sl-format-bytes>`
           )}
         </div>
         <div class="desc">


### PR DESCRIPTION
The backend API doesn't currently support file size for running crawls. Replaces the `0 byte` with relevant text. (No GH issue.)

### Screenshots
<img width="1090" alt="Screen Shot 2023-02-27 at 1 47 47 PM" src="https://user-images.githubusercontent.com/4672952/221693684-32901e4f-ae32-48b5-b5e5-07156b3e2ab4.png">
