### PR TITLE
Improve tag input keyboard navigation

### DIFF
--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -270,15 +270,25 @@ export class TagInput extends LitElement {
     const removeTag = () => {
       this.tags = this.tags.filter((v) => v !== content);
       this.dispatchChange();
-      this.input?.focus();
     };
     return html`
       <btrix-tag
         variant="primary"
         removable
-        @sl-remove=${removeTag}
+        @sl-remove=${() => {
+          removeTag();
+          this.input?.focus();
+        }}
         title=${content}
         tabindex="-1"
+        @keydown=${(e: KeyboardEvent) => {
+          if (e.key === "Backspace" || e.key === "Delete") {
+            removeTag();
+            const focusTarget = (e.target as HTMLElement)
+              .previousElementSibling;
+            if (focusTarget) (focusTarget as HTMLElement).focus();
+          }
+        }}
       >
         ${content}
       </btrix-tag>

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -339,6 +339,7 @@ export class TagInput extends LitElement {
   }
 
   private onPaste(e: ClipboardEvent) {
+    e.preventDefault();
     const text = e.clipboardData?.getData("text");
     if (text) {
       this.addTags(text.split(","));

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -435,7 +435,10 @@ export class TagInput extends LitElement {
     const input = e.target as HTMLInputElement;
     if (!input.value) {
       e.preventDefault();
-      const text = e.clipboardData?.getData("text");
+      const text = e.clipboardData
+        ?.getData("text")
+        .replace(/[\u200B-\u200D\uFEFF]/g, "")
+        .trim();
       if (text) {
         this.addTags(text.split(","));
       }

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -358,7 +358,15 @@ export class TagInput extends LitElement {
   private async addTags(tags: Tags) {
     await this.updateComplete;
     this.tags = union(
-      tags.map((v) => v.trim().toLocaleLowerCase()).filter((v) => v),
+      tags
+        .map((v) =>
+          v
+            // Remove zero-width characters
+            .replace(/[\u200B-\u200D\uFEFF]/g, "")
+            .trim()
+            .toLocaleLowerCase()
+        )
+        .filter((v) => v),
       this.tags
     );
     this.dispatchChange();

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -137,6 +137,9 @@ export class TagInput extends LitElement {
   @query("#input")
   private input?: HTMLInputElement;
 
+  @query("#dropdown")
+  private dropdown!: HTMLDivElement;
+
   @query("sl-menu")
   private menu!: SlMenu;
 
@@ -158,8 +161,18 @@ export class TagInput extends LitElement {
         this.setAttribute("data-invalid", "");
       }
     }
-    if (changedProperties.has("dropdownIsOpen") && this.dropdownIsOpen) {
-      this.combobox.reposition();
+    if (changedProperties.has("dropdownIsOpen")) {
+      if (this.dropdownIsOpen) {
+        this.combobox.reposition();
+      } else if (this.dropdownIsOpen === false) {
+        // Hide on CSS animation end
+        const onAnimationEnd = (e: AnimationEvent) => {
+          if (e.animationName !== "dropdownHide") return;
+          this.dropdownIsOpen = undefined;
+          this.dropdown.removeEventListener("animationend", onAnimationEnd);
+        };
+        this.dropdown.addEventListener("animationend", onAnimationEnd);
+      }
     }
   }
 

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -181,6 +181,17 @@ export class TagInput extends LitElement {
         <div
           class="input input--medium input--standard"
           @click=${this.onInputWrapperClick}
+          tabindex="-1"
+          @focusout=${(e: FocusEvent) => {
+            const currentTarget = e.currentTarget as SlMenuItem;
+            const relatedTarget = e.relatedTarget as HTMLElement;
+            if (
+              this.dropdownIsOpen &&
+              !currentTarget?.contains(relatedTarget)
+            ) {
+              this.dropdownIsOpen = false;
+            }
+          }}
         >
           ${this.renderTags()}
           <sl-popup

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -254,6 +254,7 @@ export class TagInput extends LitElement {
     const removeTag = () => {
       this.tags = this.tags.filter((v) => v !== content);
       this.dispatchChange();
+      this.input?.focus();
     };
     return html`
       <btrix-tag

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -1,7 +1,12 @@
 import { LitElement, html, css } from "lit";
 import { state, property, query } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
-import type { SlInput, SlMenu, SlPopup } from "@shoelace-style/shoelace";
+import type {
+  SlInput,
+  SlMenu,
+  SlMenuItem,
+  SlPopup,
+} from "@shoelace-style/shoelace";
 import inputCss from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
 import union from "lodash/fp/union";
 import debounce from "lodash/fp/debounce";
@@ -301,9 +306,14 @@ export class TagInput extends LitElement {
   }
 
   private onKeydown(e: KeyboardEvent) {
-    if (e.key === "ArrowDown") {
+    if (e.key === "ArrowDown" || (e.key === "Tab" && this.dropdownIsOpen)) {
       e.preventDefault();
-      this.menu?.querySelector("sl-menu-item")?.focus();
+      const menuItem = this.menu?.querySelector("sl-menu-item");
+      if (menuItem) {
+        // Reset roving tabindex set by shoelace
+        this.menu!.setCurrentItem(menuItem);
+        menuItem.focus();
+      }
       return;
     }
     if (e.key === "," || e.key === "Enter") {

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -437,6 +437,7 @@ export class TagInput extends LitElement {
       e.preventDefault();
       const text = e.clipboardData
         ?.getData("text")
+        // Remove zero-width characters
         .replace(/[\u200B-\u200D\uFEFF]/g, "")
         .trim();
       if (text) {

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -342,10 +342,13 @@ export class TagInput extends LitElement {
   }
 
   private onPaste(e: ClipboardEvent) {
-    e.preventDefault();
-    const text = e.clipboardData?.getData("text");
-    if (text) {
-      this.addTags(text.split(","));
+    const input = e.target as HTMLInputElement;
+    if (!input.value) {
+      e.preventDefault();
+      const text = e.clipboardData?.getData("text");
+      if (text) {
+        this.addTags(text.split(","));
+      }
     }
   }
 

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -268,6 +268,7 @@ export class TagInput extends LitElement {
 
   private onSelect(e: CustomEvent) {
     this.addTags([e.detail.item.value]);
+    this.input?.focus();
   }
 
   private onFocus(e: FocusEvent) {
@@ -280,16 +281,18 @@ export class TagInput extends LitElement {
 
   private onBlur(e: FocusEvent) {
     const relatedTarget = e.relatedTarget as HTMLElement;
-    if (this.menu?.contains(relatedTarget)) {
-      // Keep focus on form control if moving to menu selection
-      return;
-    }
-    if (
-      relatedTarget.tagName.includes("BUTTON") &&
-      relatedTarget.getAttribute("type") === "reset"
-    ) {
-      // Don't add tag if resetting form
-      return;
+    if (relatedTarget) {
+      if (this.menu?.contains(relatedTarget)) {
+        // Keep focus on form control if moving to menu selection
+        return;
+      }
+      if (
+        relatedTarget.tagName.includes("BUTTON") &&
+        relatedTarget.getAttribute("type") === "reset"
+      ) {
+        // Don't add tag if resetting form
+        return;
+      }
     }
     const input = e.target as HTMLInputElement;
     (input.parentElement as HTMLElement).classList.remove("input--focused");

--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -135,7 +135,7 @@ export class TagInput extends LitElement {
   private dropdownIsOpen?: boolean;
 
   @query("#input")
-  private input?: HTMLInputElement;
+  private input!: HTMLInputElement;
 
   @query("#dropdown")
   private dropdown!: HTMLDivElement;
@@ -177,7 +177,7 @@ export class TagInput extends LitElement {
   }
 
   reportValidity() {
-    this.input?.reportValidity();
+    this.input.reportValidity();
   }
 
   render() {
@@ -248,7 +248,7 @@ export class TagInput extends LitElement {
                   e.stopPropagation();
                   if (e.key === "Escape") {
                     this.dropdownIsOpen = false;
-                    this.input?.focus();
+                    this.input.focus();
                   }
                 }}
                 @sl-select=${this.onSelect}
@@ -290,7 +290,7 @@ export class TagInput extends LitElement {
         removable
         @sl-remove=${() => {
           removeTag();
-          this.input?.focus();
+          this.input.focus();
         }}
         title=${content}
         tabindex="-1"
@@ -310,7 +310,7 @@ export class TagInput extends LitElement {
 
   private onSelect(e: CustomEvent) {
     this.addTags([e.detail.item.value]);
-    this.input?.focus();
+    this.input.focus();
   }
 
   private onFocus(e: FocusEvent) {
@@ -429,7 +429,7 @@ export class TagInput extends LitElement {
 
   private onInputWrapperClick(e: MouseEvent) {
     if (e.target === e.currentTarget) {
-      this.input?.focus();
+      this.input.focus();
     }
   }
 

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -1,4 +1,6 @@
 import { css, html } from "lit";
+import { state, property, query } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import SLTag from "@shoelace-style/shoelace/dist/components/tag/tag.js";
 import tagStyles from "@shoelace-style/shoelace/dist/components/tag/tag.styles.js";
 
@@ -69,10 +71,13 @@ export class Tag extends SLTag {
     `,
   ];
 
+  @property({ type: String, noAccessor: true })
+  tabindex?: string;
+
   pill = true;
 
   render() {
     const template = super.render();
-    return html`<span tabindex="-1">${template}</span>`;
+    return html`<span tabindex=${ifDefined(this.tabindex)}>${template}</span>`;
   }
 }

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -21,17 +21,25 @@ export class Tag extends SLTag {
     css`
       :host {
         max-width: 100%;
-        /* outline: 0; */
       }
 
       :focus {
-        outline: 1px solid red !important;
+        outline: 0;
       }
 
       :focus .tag {
-        background-color: var(--sl-color-blue-400);
-        border-color: var(--sl-color-blue-400);
+        background-color: var(--sl-color-blue-500);
+        border-color: var(--sl-color-blue-500);
+      }
+
+      :focus .tag,
+      :focus .tag__remove {
         color: var(--sl-color-neutral-0);
+      }
+
+      .tag,
+      .tag__remove {
+        transition: background-color 0.1s, color 0.1s;
       }
 
       .tag {
@@ -52,12 +60,11 @@ export class Tag extends SLTag {
       .tag__remove {
         color: var(--sl-color-blue-600);
         border-radius: 100%;
-        transition: background-color 0.1s;
       }
 
       .tag__remove:hover {
         background-color: var(--sl-color-blue-600);
-        color: #fff;
+        color: var(--sl-color-neutral-0);
       }
     `,
   ];
@@ -66,6 +73,6 @@ export class Tag extends SLTag {
 
   render() {
     const template = super.render();
-    return html`<span tabindex="0">${template}</span>`;
+    return html`<span tabindex="-1">${template}</span>`;
   }
 }

--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -1,4 +1,4 @@
-import { css } from "lit";
+import { css, html } from "lit";
 import SLTag from "@shoelace-style/shoelace/dist/components/tag/tag.js";
 import tagStyles from "@shoelace-style/shoelace/dist/components/tag/tag.styles.js";
 
@@ -11,39 +11,61 @@ import tagStyles from "@shoelace-style/shoelace/dist/components/tag/tag.styles.j
  * ```
  */
 export class Tag extends SLTag {
-  static styles = css`
-    ${tagStyles}
+  static shadowRootOptions = {
+    ...SLTag.shadowRootOptions,
+    delegatesFocus: true,
+  };
 
-    :host {
-      max-width: 100%;
-    }
+  static styles = [
+    tagStyles,
+    css`
+      :host {
+        max-width: 100%;
+        /* outline: 0; */
+      }
 
-    .tag {
-      height: var(--tag-height, 1.5rem);
-      background-color: var(--sl-color-blue-100);
-      border-color: var(--sl-color-blue-500);
-      color: var(--sl-color-blue-600);
-      font-family: var(--sl-font-sans);
-    }
+      :focus {
+        outline: 1px solid red !important;
+      }
 
-    .tag__content {
-      max-width: 100%;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+      :focus .tag {
+        background-color: var(--sl-color-blue-400);
+        border-color: var(--sl-color-blue-400);
+        color: var(--sl-color-neutral-0);
+      }
 
-    .tag__remove {
-      color: var(--sl-color-blue-600);
-      border-radius: 100%;
-      transition: background-color 0.1s;
-    }
+      .tag {
+        height: var(--tag-height, 1.5rem);
+        background-color: var(--sl-color-blue-100);
+        border-color: var(--sl-color-blue-500);
+        color: var(--sl-color-blue-600);
+        font-family: var(--sl-font-sans);
+      }
 
-    .tag__remove:hover {
-      background-color: var(--sl-color-blue-600);
-      color: #fff;
-    }
-  `;
+      .tag__content {
+        max-width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .tag__remove {
+        color: var(--sl-color-blue-600);
+        border-radius: 100%;
+        transition: background-color 0.1s;
+      }
+
+      .tag__remove:hover {
+        background-color: var(--sl-color-blue-600);
+        color: #fff;
+      }
+    `,
+  ];
 
   pill = true;
+
+  render() {
+    const template = super.render();
+    return html`<span tabindex="0">${template}</span>`;
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/582:
- Re-focus on input after selection
- Delete tags with keyboard navigation
- Remove zero-width characters
- Fix being able to add tag with commas when pasting in Chrome

### Manual testing
Verify reports in [issue description](https://github.com/webrecorder/browsertrix-cloud/issues/582) are resolved as expected.

Manually tested in Chrome and Firefox, macOS