### PR TITLE
Paginate API list endpoints

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -6,12 +6,13 @@ from typing import Optional, List
 
 import pymongo
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi_pagination import Page, paginate
+from fastapi_pagination import paginate
 
 from pydantic import BaseModel, UUID4
 
 from .db import BaseMongoModel
 from .orgs import Organization
+from .pagination import Page
 
 
 # ============================================================================

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -12,10 +12,11 @@ from datetime import datetime
 import pymongo
 from pydantic import BaseModel, UUID4, conint, HttpUrl
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi_pagination import Page, paginate
+from fastapi_pagination import paginate
 
 from .users import User
 from .orgs import Organization, MAX_CRAWL_SCALE
+from .pagination import Page
 
 from .db import BaseMongoModel
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict, Union
 from datetime import datetime, timedelta
 
 from fastapi import Depends, HTTPException
+from fastapi_pagination import Page, paginate
 from pydantic import BaseModel, UUID4, conint, HttpUrl
 from redis import asyncio as aioredis, exceptions
 import pymongo
@@ -132,13 +133,6 @@ class ListCrawlOut(BaseMongoModel):
 
     firstSeed: Optional[str]
     seedCount: Optional[int] = 0
-
-
-# ============================================================================
-class ListCrawls(BaseModel):
-    """Response model for list of crawls"""
-
-    crawls: List[ListCrawlOut]
 
 
 # ============================================================================
@@ -657,7 +651,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep
 
-    @app.get("/orgs/all/crawls", tags=["crawls"], response_model=ListCrawls)
+    @app.get("/orgs/all/crawls", tags=["crawls"], response_model=Page[ListCrawlOut])
     async def list_crawls_admin(
         user: User = Depends(user_dep),
         userid: Optional[UUID4] = None,
@@ -666,23 +660,17 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
-        return ListCrawls(
-            crawls=await ops.list_crawls(
-                None, userid=userid, cid=cid, running_only=True
-            )
-        )
+        crawls = await ops.list_crawls(None, userid=userid, cid=cid, running_only=True)
+        return paginate(crawls)
 
-    @app.get("/orgs/{oid}/crawls", tags=["crawls"], response_model=ListCrawls)
+    @app.get("/orgs/{oid}/crawls", tags=["crawls"], response_model=Page[ListCrawlOut])
     async def list_crawls(
         org: Organization = Depends(org_viewer_dep),
         userid: Optional[UUID4] = None,
         cid: Optional[UUID4] = None,
     ):
-        return ListCrawls(
-            crawls=await ops.list_crawls(
-                org, userid=userid, cid=cid, running_only=False
-            )
-        )
+        crawls = await ops.list_crawls(org, userid=userid, cid=cid, running_only=False)
+        return paginate(crawls)
 
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/cancel",

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -10,7 +10,7 @@ from typing import Optional, List, Dict, Union
 from datetime import datetime, timedelta
 
 from fastapi import Depends, HTTPException
-from fastapi_pagination import Page, paginate
+from fastapi_pagination import paginate
 from pydantic import BaseModel, UUID4, conint, HttpUrl
 from redis import asyncio as aioredis, exceptions
 import pymongo
@@ -19,6 +19,7 @@ from .crawlconfigs import Seed
 from .db import BaseMongoModel
 from .users import User
 from .orgs import Organization, MAX_CRAWL_SCALE
+from .pagination import Page
 from .storages import get_presigned_url, delete_crawl_file_object
 
 

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -10,6 +10,7 @@ import asyncio
 from fastapi import FastAPI
 from fastapi.routing import APIRouter
 from fastapi.responses import JSONResponse
+from fastapi_pagination import add_pagination
 
 from .db import init_db, update_and_prepare_db
 
@@ -113,6 +114,8 @@ def main():
     )
 
     app.include_router(org_ops.router)
+
+    add_pagination(app)
 
     @app.get("/settings")
     async def get_settings():

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -11,7 +11,7 @@ from typing import Dict, Union, Literal, Optional, Any
 from pydantic import BaseModel, UUID4
 from pymongo.errors import AutoReconnect, DuplicateKeyError
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi_pagination import Page, paginate
+from fastapi_pagination import paginate
 
 from .db import BaseMongoModel
 
@@ -24,6 +24,8 @@ from .invites import (
     InviteToOrgRequest,
     UserRole,
 )
+
+from .pagination import Page
 
 # crawl scale for constraint
 MAX_CRAWL_SCALE = 3

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -1,0 +1,26 @@
+"""API pagination module
+
+These classes override fastapi-pagination's max page size of 50
+"""
+
+from typing import TypeVar, Generic
+
+from fastapi import Query
+
+from fastapi_pagination.default import Page as BasePage, Params as BaseParams
+
+T = TypeVar("T")
+
+
+# pylint: disable=too-few-public-methods
+class Params(BaseParams):
+    """Custom Params class to increase page size"""
+
+    size: int = Query(1_000, ge=1, le=2_000, description="Page size")
+
+
+# pylint: disable=too-few-public-methods
+class Page(BasePage[T], Generic[T]):
+    """Custom Page class to implement Params"""
+
+    __params_type__ = Params

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -8,11 +8,12 @@ import os
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Request, HTTPException
-from fastapi_pagination import Page, paginate
+from fastapi_pagination import paginate
 from pydantic import BaseModel, UUID4, HttpUrl
 import aiohttp
 
 from .orgs import Organization
+from .pagination import Page
 from .users import User
 
 from .db import BaseMongoModel

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -8,6 +8,7 @@ import os
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Request, HTTPException
+from fastapi_pagination import Page, paginate
 from pydantic import BaseModel, UUID4, HttpUrl
 import aiohttp
 
@@ -396,12 +397,13 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
         await browser_get_metadata(browserid, org)
         return browserid
 
-    @router.get("", response_model=List[Profile])
+    @router.get("", response_model=Page[Profile])
     async def list_profiles(
         org: Organization = Depends(org_crawl_dep),
         userid: Optional[UUID4] = None,
     ):
-        return await ops.list_profiles(org, userid)
+        profiles = await ops.list_profiles(org, userid)
+        return paginate(profiles)
 
     @router.post("", response_model=Profile)
     async def commit_browser_to_new(

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -24,9 +24,10 @@ from fastapi_users.authentication import (
     JWTStrategy,
 )
 from fastapi_users.db import MongoDBUserDatabase
-from fastapi_pagination import Page, paginate
+from fastapi_pagination import paginate
 
 from .invites import InvitePending, UserRole
+from .pagination import Page
 
 
 # ============================================================================

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -24,6 +24,7 @@ from fastapi_users.authentication import (
     JWTStrategy,
 )
 from fastapi_users.db import MongoDBUserDatabase
+from fastapi_pagination import Page, paginate
 
 from .invites import InvitePending, UserRole
 
@@ -463,13 +464,13 @@ def init_users_api(app, user_manager):
 
         return await user_manager.format_invite(invite)
 
-    @users_router.get("/invites", tags=["invites"])
+    @users_router.get("/invites", tags=["invites"], response_model=Page[InvitePending])
     async def get_pending_invites(user: User = Depends(current_active_user)):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         pending_invites = await user_manager.invites.get_pending_invites()
-        return {"pending_invites": pending_invites}
+        return paginate(pending_invites)
 
     app.include_router(users_router, prefix="/users", tags=["users"])
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 uvicorn
 fastapi==0.71.0
 fastapi-users[mongodb]==9.2.2
+fastapi-pagination==0.9.3
 loguru
 aiofiles
 kubernetes-asyncio==22.6.5

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -46,7 +46,7 @@ def default_org_id(admin_auth_headers):
         r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
         data = r.json()
         try:
-            for org in data["orgs"]:
+            for org in data["items"]:
                 if org["default"] is True:
                     return org["id"]
         except:
@@ -67,7 +67,7 @@ def non_default_org_id(admin_auth_headers):
         r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
         data = r.json()
         try:
-            for org in data["orgs"]:
+            for org in data["items"]:
                 if org["name"] == NON_DEFAULT_ORG_NAME:
                     return org["id"]
         except:

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -9,7 +9,8 @@ def test_get_config_by_user(crawler_auth_headers, default_org_id, crawler_userid
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["crawlConfigs"]) == 1
+    assert len(r.json()["items"]) == 1
+    assert r.json()["total"] == 1
 
 
 def test_ensure_crawl_and_admin_user_crawls(
@@ -21,7 +22,8 @@ def test_ensure_crawl_and_admin_user_crawls(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["crawls"]) == 2
+    assert len(r.json()["items"]) == 2
+    assert r.json()["total"] == 2
 
 
 def test_get_crawl_job_by_user(
@@ -31,7 +33,8 @@ def test_get_crawl_job_by_user(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["crawls"]) == 1
+    assert len(r.json()["items"]) == 1
+    assert r.json()["total"] == 1
 
 
 def test_get_crawl_job_by_config(
@@ -42,10 +45,12 @@ def test_get_crawl_job_by_config(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls?cid={admin_config_id}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["crawls"]) == 1
+    assert len(r.json()["items"]) == 1
+    assert r.json()["total"] == 1
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls?cid={crawler_config_id}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["crawls"]) == 1
+    assert len(r.json()["items"]) == 1
+    assert r.json()["total"] == 1

--- a/backend/test/test_invites.py
+++ b/backend/test/test_invites.py
@@ -10,7 +10,7 @@ def test_pending_invites(admin_auth_headers, default_org_id):
     r = requests.get(f"{API_PREFIX}/users/invites", headers=admin_auth_headers)
     assert r.status_code == 200
     data = r.json()
-    assert data["pending_invites"] == []
+    assert data["items"] == []
 
     # Add a pending invite and check it's returned
     INVITE_EMAIL = "invite-pending@example.com"
@@ -27,8 +27,9 @@ def test_pending_invites(admin_auth_headers, default_org_id):
     r = requests.get(f"{API_PREFIX}/users/invites", headers=admin_auth_headers)
     assert r.status_code == 200
     data = r.json()
-    invites = data["pending_invites"]
+    invites = data["items"]
     assert len(invites) == 1
+    assert data["total"] == 1
     invite = invites[0]
     assert invite["id"]
     assert invite["email"] == INVITE_EMAIL

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -9,8 +9,9 @@ from .conftest import API_PREFIX
 def test_ensure_only_one_default_org(admin_auth_headers):
     r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
     data = r.json()
+    assert data["total"] == 1
 
-    orgs = data["orgs"]
+    orgs = data["items"]
     default_orgs = [org for org in orgs if org["default"]]
     assert len(default_orgs) == 1
 
@@ -84,7 +85,7 @@ def test_create_org(admin_auth_headers):
     assert r.status_code == 200
     data = r.json()
     org_names = []
-    for org in data["orgs"]:
+    for org in data["items"]:
         org_names.append(org["name"])
     assert NEW_ORG_NAME in org_names
 
@@ -159,8 +160,9 @@ def test_get_pending_org_invites(
     )
     assert r.status_code == 200
     data = r.json()
-    invites = data["pending_invites"]
+    invites = data["items"]
     assert len(invites) == 1
+    assert data["total"] == 1
     invite = invites[0]
     assert invite["id"]
     assert invite["email"] == INVITE_EMAIL
@@ -211,9 +213,7 @@ def test_send_and_accept_org_invite(
     assert r.status_code == 200
     data = r.json()
     invites_matching_email = [
-        invite
-        for invite in data["pending_invites"]
-        if invite["email"] == expected_stored_email
+        invite for invite in data["items"] if invite["email"] == expected_stored_email
     ]
     token = invites_matching_email[0]["id"]
 
@@ -277,7 +277,7 @@ def test_delete_invite_by_email(admin_auth_headers, non_default_org_id):
     assert r.status_code == 200
     data = r.json()
     invites_matching_email = [
-        invite for invite in data["pending_invites"] if invite["email"] == INVITE_EMAIL
+        invite for invite in data["items"] if invite["email"] == INVITE_EMAIL
     ]
     assert len(invites_matching_email) == 0
 

--- a/backend/test/test_permissions.py
+++ b/backend/test/test_permissions.py
@@ -8,9 +8,10 @@ def test_admin_get_org_crawls(admin_auth_headers, default_org_id, admin_crawl_id
         f"{API_PREFIX}/orgs/{default_org_id}/crawls", headers=admin_auth_headers
     )
     data = r.json()
-    crawls = data["crawls"]
+    crawls = data["items"]
     crawl_ids = []
     assert len(crawls) > 0
+    assert data["total"] > 0
     for crawl in crawls:
         assert crawl["oid"] == default_org_id
         crawl_ids.append(crawl["id"])
@@ -22,9 +23,10 @@ def test_viewer_get_org_crawls(viewer_auth_headers, default_org_id, admin_crawl_
         f"{API_PREFIX}/orgs/{default_org_id}/crawls", headers=viewer_auth_headers
     )
     data = r.json()
-    crawls = data["crawls"]
+    crawls = data["items"]
     crawl_ids = []
     assert len(crawls) > 0
+    assert data["total"] > 0
     for crawl in crawls:
         assert crawl["oid"] == default_org_id
         crawl_ids.append(crawl["id"])

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -17,8 +17,9 @@ def test_list_orgs(admin_auth_headers, default_org_id):
     r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
     data = r.json()
 
-    orgs = data["orgs"]
+    orgs = data["items"]
     assert len(orgs) > 0
+    assert data["total"] > 0
 
     org_ids = []
     for org in orgs:
@@ -89,7 +90,7 @@ def test_crawls_include_seed_info(admin_auth_headers, default_org_id, admin_craw
         headers=admin_auth_headers,
     )
     data = r.json()
-    crawls = data["crawls"]
+    crawls = data["items"]
     assert crawls
     for crawl in crawls:
         assert crawl["firstSeed"]
@@ -100,7 +101,7 @@ def test_crawls_include_seed_info(admin_auth_headers, default_org_id, admin_craw
         headers=admin_auth_headers,
     )
     data = r.json()
-    crawls = data["crawls"]
+    crawls = data["items"]
     assert crawls
     for crawl in crawls:
         assert crawl["firstSeed"]

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -35,7 +35,7 @@ def default_org_id(admin_auth_headers):
         r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
         data = r.json()
         try:
-            for org in data["orgs"]:
+            for org in data["items"]:
                 if org["default"] is True:
                     return org["id"]
         except:

--- a/backend/test_nightly/test_invite_expiration.py
+++ b/backend/test_nightly/test_invite_expiration.py
@@ -24,7 +24,7 @@ def test_invites_expire(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     invites_matching_email = [
-        invite for invite in data["pending_invites"] if invite["email"] == INVITE_EMAIL
+        invite for invite in data["items"] if invite["email"] == INVITE_EMAIL
     ]
     assert len(invites_matching_email) == 1
 
@@ -40,6 +40,6 @@ def test_invites_expire(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     invites_matching_email = [
-        invite for invite in data["pending_invites"] if invite["email"] == INVITE_EMAIL
+        invite for invite in data["items"] if invite["email"] == INVITE_EMAIL
     ]
     assert len(invites_matching_email) == 0

--- a/frontend/src/components/select-browser-profile.ts
+++ b/frontend/src/components/select-browser-profile.ts
@@ -6,6 +6,7 @@ import orderBy from "lodash/fp/orderBy";
 import type { AuthState } from "../utils/AuthService";
 import LiteElement from "../utils/LiteElement";
 import type { Profile } from "../pages/org/types";
+import type { APIPaginatedList } from "../types/api";
 
 /**
  * Browser profile select dropdown
@@ -191,12 +192,12 @@ export class SelectBrowserProfile extends LiteElement {
   }
 
   private async getProfiles(): Promise<Profile[]> {
-    const data = await this.apiFetch(
+    const data: APIPaginatedList = await this.apiFetch(
       `/orgs/${this.orgId}/profiles`,
       this.authState!
     );
 
-    return data;
+    return data.items;
   }
 
   /**

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -7,6 +7,7 @@ import type { AuthState } from "../utils/AuthService";
 import type { CurrentUser } from "../types/user";
 import type { OrgData } from "../utils/orgs";
 import LiteElement, { html } from "../utils/LiteElement";
+import type { APIPaginatedList } from "../types/api";
 
 @localized()
 export class Home extends LiteElement {
@@ -263,9 +264,12 @@ export class Home extends LiteElement {
   }
 
   private async getOrgs(): Promise<OrgData[]> {
-    const data = await this.apiFetch("/orgs", this.authState!);
+    const data: APIPaginatedList = await this.apiFetch(
+      "/orgs",
+      this.authState!
+    );
 
-    return data.orgs;
+    return data.items;
   }
 
   private async onSubmitNewOrg(e: SubmitEvent) {

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -4,6 +4,7 @@ import { msg, localized, str } from "@lit/localize";
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { Profile } from "./types";
+import type { APIPaginatedList } from "../../types/api";
 
 /**
  * Usage:
@@ -45,16 +46,16 @@ export class BrowserProfilesList extends LiteElement {
   render() {
     return html`<header>
         <div class="flex justify-between w-full h-8 mb-4">
-        <h1 class="text-xl font-semibold">${msg("Browser Profiles")}</h1>
-        <sl-button
-          href=${`/orgs/${this.orgId}/browser-profiles?new`}
-          variant="primary"
-          size="small"
-          @click=${this.navLink}
-        >
-          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-          ${msg("New Browser Profile")}
-        </sl-button>
+          <h1 class="text-xl font-semibold">${msg("Browser Profiles")}</h1>
+          <sl-button
+            href=${`/orgs/${this.orgId}/browser-profiles?new`}
+            variant="primary"
+            size="small"
+            @click=${this.navLink}
+          >
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            ${msg("New Browser Profile")}
+          </sl-button>
         </div>
       </header>
 
@@ -385,12 +386,12 @@ export class BrowserProfilesList extends LiteElement {
   }
 
   private async getProfiles(): Promise<Profile[]> {
-    const data = await this.apiFetch(
+    const data: APIPaginatedList = await this.apiFetch(
       `/orgs/${this.orgId}/profiles`,
       this.authState!
     );
 
-    return data;
+    return data.items;
   }
 
   /**

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -19,6 +19,7 @@ import {
 } from "../../utils/cron";
 import "../../components/crawl-scheduler";
 import { SlCheckbox } from "@shoelace-style/shoelace";
+import type { APIPaginatedList } from "../../types/api";
 
 type RunningCrawlsMap = {
   /** Map of configId: crawlId */
@@ -584,14 +585,14 @@ export class CrawlTemplatesList extends LiteElement {
     const params =
       this.userId && this.filterByCurrentUser ? `?userid=${this.userId}` : "";
 
-    const data: { crawlConfigs: CrawlConfig[] } = await this.apiFetch(
+    const data: APIPaginatedList = await this.apiFetch(
       `/orgs/${this.orgId}/crawlconfigs${params}`,
       this.authState!
     );
 
     const runningCrawlsMap: RunningCrawlsMap = {};
 
-    data.crawlConfigs.forEach(({ id, currCrawlId }) => {
+    data.items.forEach(({ id, currCrawlId }) => {
       if (currCrawlId) {
         runningCrawlsMap[id] = currCrawlId;
       }
@@ -599,7 +600,7 @@ export class CrawlTemplatesList extends LiteElement {
 
     this.runningCrawlsMap = runningCrawlsMap;
 
-    return data.crawlConfigs;
+    return data.items;
   }
 
   /**

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -24,6 +24,7 @@ import type {
   CrawlConfig,
   InitialCrawlConfig,
 } from "./types";
+import type { APIPaginatedList } from "../../types/api";
 
 type CrawlSearchResult = {
   item: Crawl;
@@ -481,7 +482,7 @@ export class CrawlsList extends LiteElement {
 
     this.stopPollTimer();
     try {
-      const { crawls } = await this.getCrawls();
+      const crawls = await this.getCrawls();
 
       this.crawls = crawls;
       // Update search/filter collection
@@ -504,18 +505,18 @@ export class CrawlsList extends LiteElement {
     window.clearTimeout(this.timerId);
   }
 
-  private async getCrawls(): Promise<{ crawls: Crawl[] }> {
+  private async getCrawls(): Promise<Crawl[]> {
     const params =
       this.userId && this.filterByCurrentUser ? `?userid=${this.userId}` : "";
 
-    const data = await this.apiFetch(
+    const data: APIPaginatedList = await this.apiFetch(
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}${params}`,
       this.authState!
     );
 
     this.lastFetched = Date.now();
 
-    return data;
+    return data.items;
   }
 
   private async cancel(crawl: Crawl) {

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -9,6 +9,7 @@ import LiteElement, { html } from "../../utils/LiteElement";
 import { isAdmin, isCrawler, AccessCode } from "../../utils/orgs";
 import type { OrgData } from "../../utils/orgs";
 import type { CurrentUser } from "../../types/user";
+import type { APIPaginatedList } from "../../types/api";
 
 type Tab = "information" | "members";
 type User = {
@@ -358,10 +359,13 @@ export class OrgSettings extends LiteElement {
     return !formEl.querySelector("[data-invalid]");
   }
 
-  private getPendingInvites(): Promise<Invite[]> {
-    return this.apiFetch(`/orgs/${this.org.id}/invites`, this.authState!).then(
-      (data) => data.pending_invites
-    );
+  private async getPendingInvites(): Promise<Invite[]> {
+    const data: APIPaginatedList = await this.apiFetch(
+      `/orgs/${this.org.id}/invites`,
+      this.authState!
+    ).then((data) => data.pending_invites);
+
+    return data.items;
   }
 
   private async fetchPendingInvites() {

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -363,7 +363,7 @@ export class OrgSettings extends LiteElement {
     const data: APIPaginatedList = await this.apiFetch(
       `/orgs/${this.org.id}/invites`,
       this.authState!
-    ).then((data) => data.pending_invites);
+    );
 
     return data.items;
   }

--- a/frontend/src/pages/orgs.ts
+++ b/frontend/src/pages/orgs.ts
@@ -6,6 +6,7 @@ import type { CurrentUser } from "../types/user";
 import type { OrgData } from "../utils/orgs";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
+import type { APIPaginatedList } from "../types/api";
 
 @needLogin
 @localized()
@@ -63,8 +64,11 @@ export class Orgs extends LiteElement {
   }
 
   private async getOrgs(): Promise<OrgData[]> {
-    const data = await this.apiFetch("/orgs", this.authState!);
+    const data: APIPaginatedList = await this.apiFetch(
+      "/orgs",
+      this.authState!
+    );
 
-    return data.orgs;
+    return data.items;
   }
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,6 @@
+export type APIPaginatedList = {
+  items: any[];
+  total: number;
+  page: number;
+  size: number;
+};


### PR DESCRIPTION
Connected to #305 

This PR adds pagination to the API's list endpoints via the [fastapi-pagination](https://github.com/uriyyo/fastapi-pagination) package.

`fastapi-pagination` is pinned to 0.9.3, the latest release that plays nicely with pinned versions of fastapi and fastapi-users.

Frontend changes needed, as this introduces some breaking changes for the list API responses - namely, getting rid of the "custom" keys we've added (e.g. `"crawls": [crawl1, crawl2]`) in favor of paginated responses with a hardset `items` key, e.g.:

```
"items": [crawl1, crawl2],
"total": 2,
"page" 1,
"size": 1
```
In addition, the list collections endpoint has been modified more broadly to use new `CollOut` model for responses.

This PR implements custom overriden `Page` and `Params` classes to get around `fastapi-pagination`'s default max page size of 50, so that we can gradually introduce pagination in the frontend. This can likely eventually be removed.

Endpoints requiring frontend changes:

- [x] `GET /collections`
- [x] `GET /orgs`
- [x] `GET /orgs/all/crawls`
- [x] `GET /orgs/{oid}/crawls`
- [x] `GET /orgs/{oid}/crawlconfigs`
- [x] `GET /orgs/{oid}/invites`
- [x] `GET /profiles`
- [x] `GET /users/invites`
