### PR TITLE
Automate issue project status

### DIFF
--- a/.github/workflows/project-assign-issue.yml
+++ b/.github/workflows/project-assign-issue.yml
@@ -1,0 +1,15 @@
+name: Update assigned issues in Webrecorder Projects
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  move-issue-column:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.3
+        with:
+          project: Webrecorder Projects
+          column: Todo
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-new-issue.yml
+++ b/.github/workflows/project-new-issue.yml
@@ -1,0 +1,15 @@
+name: Assign new issues to Webrecorder Projects
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  move-issue-column:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.3
+        with:
+          project: Webrecorder Projects
+          column: Triage
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Adds new issues to "Webrecorder Projects" in "Triage" column
- Moves issue to "Todo" column when assigned

Resolves https://github.com/webrecorder/browsertrix-cloud/issues/658.

Note: The "Done" column automation is still handled by [project settings](https://github.com/orgs/webrecorder/projects/9/workflows/2688790). Could move it to GH workflow if that gets confusing.