### PR TITLE
Persist "show only mine" across page refresh

### DIFF
--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -72,7 +72,7 @@ export class CrawlTemplatesList extends LiteElement {
   };
 
   @state()
-  private filterByCurrentUser = true;
+  private filterByCurrentUser = false;
 
   @state()
   private searchBy: string = "";

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -25,7 +25,8 @@ type RunningCrawlsMap = {
   [configId: string]: string;
 };
 
-const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser";
+const FILTER_BY_CURRENT_USER_STORAGE_KEY =
+  "btrix.filterByCurrentUser.crawlConfigs";
 const MIN_SEARCH_LENGTH = 2;
 const sortableFieldLabels = {
   created_desc: msg("Newest"),

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -25,6 +25,7 @@ type RunningCrawlsMap = {
   [configId: string]: string;
 };
 
+const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser";
 const MIN_SEARCH_LENGTH = 2;
 const sortableFieldLabels = {
   created_desc: msg("Newest"),
@@ -87,6 +88,13 @@ export class CrawlTemplatesList extends LiteElement {
     threshold: 0.2, // stricter; default is 0.6
   });
 
+  constructor() {
+    super();
+    this.filterByCurrentUser =
+      window.sessionStorage.getItem(FILTER_BY_CURRENT_USER_STORAGE_KEY) ===
+      "true";
+  }
+
   protected async willUpdate(changedProperties: Map<string, any>) {
     if (
       changedProperties.has("orgId") ||
@@ -104,6 +112,12 @@ export class CrawlTemplatesList extends LiteElement {
           icon: "exclamation-octagon",
         });
       }
+    }
+    if (changedProperties.has("filterByCurrentUser")) {
+      window.sessionStorage.setItem(
+        FILTER_BY_CURRENT_USER_STORAGE_KEY,
+        this.filterByCurrentUser.toString()
+      );
     }
   }
 

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -31,7 +31,7 @@ type CrawlSearchResult = {
 type SortField = "started" | "finished" | "configName" | "fileSize";
 type SortDirection = "asc" | "desc";
 
-const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser";
+const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser.crawls";
 const POLL_INTERVAL_SECONDS = 10;
 const MIN_SEARCH_LENGTH = 2;
 const sortableFields: Record<

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -113,7 +113,7 @@ export class CrawlsList extends LiteElement {
   };
 
   @state()
-  private filterByCurrentUser = true;
+  private filterByCurrentUser = false;
 
   @state()
   private filterByState: CrawlState[] = [];

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -31,6 +31,7 @@ type CrawlSearchResult = {
 type SortField = "started" | "finished" | "configName" | "fileSize";
 type SortDirection = "asc" | "desc";
 
+const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser";
 const POLL_INTERVAL_SECONDS = 10;
 const MIN_SEARCH_LENGTH = 2;
 const sortableFields: Record<
@@ -153,6 +154,13 @@ export class CrawlsList extends LiteElement {
       crawlsResults
     ) as CrawlSearchResult[];
 
+  constructor() {
+    super();
+    this.filterByCurrentUser =
+      window.sessionStorage.getItem(FILTER_BY_CURRENT_USER_STORAGE_KEY) ===
+      "true";
+  }
+
   protected willUpdate(changedProperties: Map<string, any>) {
     if (
       changedProperties.has("shouldFetch") ||
@@ -168,6 +176,13 @@ export class CrawlsList extends LiteElement {
         this.fetchCrawls();
       } else {
         this.stopPollTimer();
+      }
+
+      if (changedProperties.has("filterByCurrentUser")) {
+        window.sessionStorage.setItem(
+          FILTER_BY_CURRENT_USER_STORAGE_KEY,
+          this.filterByCurrentUser.toString()
+        );
       }
     }
   }


### PR DESCRIPTION
Remembers the value for "Show only mine" in crawls and crawl configs across navigation and page refreshes, until the user is logged out. Also, updates toggle to be off by default. Resolves https://github.com/webrecorder/browsertrix-cloud/issues/546

### Manual testing
1. Go to Crawls list. Verify "Show only mine" toggle is off
2. Toggle on, navigate to another page, and navigate back. Verify "Show only mine" toggle is still on
3. Repeat for Crawl Configs toggle.
4. Refresh page. Verify toggle value is last set value