### PR TITLE
backend: make crawlconfigs mutable! (#656)

### DIFF
--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -338,6 +338,7 @@ class CrawlJob(ABC):
             id=self.job_id,
             state=state,
             config=crawlconfig.config,
+            jobType=crawlconfig.jobType,
             profileid=crawlconfig.profileid,
             cid_rev=crawlconfig.rev,
             schedule=crawlconfig.schedule,

--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -47,6 +47,8 @@ class CrawlJob(ABC):
         self.cid = uuid.UUID(os.environ["CRAWL_CONFIG_ID"])
         self.userid = uuid.UUID(os.environ["USER_ID"])
 
+        self.rev = int(os.environ["REV"])
+
         self.is_manual = os.environ.get("RUN_MANUAL") == "1"
         self.tags = os.environ.get("TAGS", "").split(",")
 
@@ -337,6 +339,7 @@ class CrawlJob(ABC):
             state=state,
             config=crawlconfig.config,
             profileid=crawlconfig.profileid,
+            cid_rev=crawlconfig.rev,
             schedule=crawlconfig.schedule,
             crawlTimeout=crawlconfig.crawlTimeout,
             userid=self.userid,

--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -83,9 +83,7 @@ class CrawlJob(ABC):
         crawlconfig = None
 
         try:
-            result = await self.crawl_configs.find_one(
-                {"_id": self.cid}
-            )
+            result = await self.crawl_configs.find_one({"_id": self.cid})
             crawlconfig = CrawlConfig.from_dict(result)
 
         # pylint: disable=broad-except

--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -85,13 +85,11 @@ class CrawlJob(ABC):
         try:
             result = await self.crawl_configs.find_one({"_id": self.cid})
             crawlconfig = CrawlConfig.from_dict(result)
+            self.scale = self._get_crawl_scale(crawl) or crawlconfig.scale
 
         # pylint: disable=broad-except
         except Exception as exc:
             print(exc)
-
-        if crawl:
-            self.scale = crawl.spec.replicas
 
         # if doesn't exist, create, using scale from config
         if not crawl:
@@ -397,6 +395,10 @@ class CrawlJob(ABC):
     @abstractmethod
     async def _get_crawl(self):
         """get runnable object representing this crawl"""
+
+    @abstractmethod
+    def _get_crawl_scale(self, crawl):
+        """get scale from crawl, if any"""
 
     @abstractmethod
     async def _do_scale(self, new_scale):

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -596,8 +596,8 @@ class CrawlConfigOps:
 
         return {"success": True, "status": status}
 
-    async def add_remove_exclusion(self, regex, cid, org, user, add=True):
-        """create a copy of existing crawl config, with added exclusion regex"""
+    async def add_or_remove_exclusion(self, regex, cid, org, user, add=True):
+        """added or remove regex to crawl config"""
         # get crawl config
         crawl_config = await self.get_crawl_config(cid, org, active_only=False)
 
@@ -623,9 +623,7 @@ class CrawlConfigOps:
 
         await self.update_crawl_config(cid, org, user, update_config)
 
-        # pylint: disable=fixme
-        # todo: just return success here later
-        return cid
+        return crawl_config.config
 
     async def get_crawl_config_tags(self, org):
         """get distinct tags from all crawl configs for this org"""

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -635,7 +635,7 @@ class CrawlConfigOps:
             )
 
         if await self.get_running_crawl(crawlconfig):
-            raise HTTPException(status_code=400, detail=f"crawl_already_running")
+            raise HTTPException(status_code=400, detail="crawl_already_running")
 
         crawl_id = None
         try:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -653,6 +653,7 @@ class CrawlConfigOps:
                 crawlconfig, userid=str(user.id)
             )
             await self.add_new_crawl(crawl_id, crawlconfig)
+            return crawl_id
 
         except Exception as exc:
             # pylint: disable=raise-missing-from

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -286,7 +286,9 @@ class CrawlConfigOps:
         add = self.crawl_ops.add_new_crawl(crawl_id, crawlconfig)
         await asyncio.gather(inc, add)
 
-    async def update_crawl_config(self, cid: uuid.UUID, user: User, update: UpdateCrawlConfig):
+    async def update_crawl_config(
+        self, cid: uuid.UUID, user: User, update: UpdateCrawlConfig
+    ):
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
 
         # set update query
@@ -321,15 +323,14 @@ class CrawlConfigOps:
             )
 
         # update schedule in crawl manager first
-        if (update.schedule is not None or
-            update.scale is not None or
-            update.config is not None):
-
+        if (
+            update.schedule is not None
+            or update.scale is not None
+            or update.config is not None
+        ):
             crawlconfig = CrawlConfig.from_dict(result)
             try:
-                await self.crawl_manager.update_crawl_config(
-                    crawlconfig, update
-                )
+                await self.crawl_manager.update_crawl_config(crawlconfig, update)
             except Exception as exc:
                 print(exc, flush=True)
                 # pylint: disable=raise-missing-from

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -207,6 +207,7 @@ class UpdateCrawlConfig(BaseModel):
     # crawl data: revision tracked
     schedule: Optional[str]
     profileid: Optional[str]
+    crawlTimeout: Optional[int]
     scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
     config: Optional[RawCrawlConfig]
 
@@ -355,6 +356,7 @@ class CrawlConfigOps:
             update.schedule is not None
             or update.scale is not None
             or update.config is not None
+            or update.crawlTimeout is not None
         )
 
         if is_crawl_update:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -110,8 +110,6 @@ class CrawlConfigIn(BaseModel):
     crawlTimeout: Optional[int] = 0
     scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
 
-    oldId: Optional[UUID4]
-
 
 # ============================================================================
 class CrawlConfig(BaseMongoModel):
@@ -137,12 +135,12 @@ class CrawlConfig(BaseMongoModel):
 
     userid: UUID4
 
+    useridLastModified: Optional[UUID4]
+
     profileid: Optional[UUID4]
 
     crawlAttemptCount: Optional[int] = 0
 
-    newId: Optional[UUID4]
-    oldId: Optional[UUID4]
     inactive: Optional[bool] = False
 
     def get_raw_config(self):
@@ -180,6 +178,8 @@ class UpdateCrawlConfig(BaseModel):
     profileid: Optional[str]
     scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
     tags: Optional[List[str]] = []
+
+    config: Optional[RawCrawlConfig]
 
 
 # ============================================================================
@@ -233,17 +233,14 @@ class CrawlConfigOps:
         config: CrawlConfigIn,
         org: Organization,
         user: User,
-        for_running_crawl=False,
     ):
         """Add new crawl config"""
         data = config.dict()
         data["oid"] = org.id
         data["userid"] = user.id
+        data["useridLastModified"] = user.id
         data["_id"] = uuid.uuid4()
         data["created"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
-
-        if for_running_crawl:
-            data["crawlAttemptCount"] = 1
 
         profile_filename = None
         if config.profileid:
@@ -255,22 +252,6 @@ class CrawlConfigOps:
 
         if config.colls:
             data["colls"] = await self.coll_ops.find_collections(org.id, config.colls)
-
-        old_id = data.get("oldId")
-
-        if old_id:
-            old_config = await self.get_crawl_config(old_id, org)
-            async with await self.dbclient.start_session() as sesh:
-                async with sesh.start_transaction():
-                    if (
-                        await self.make_inactive_or_delete(
-                            old_config, data["_id"], for_running_crawl=for_running_crawl
-                        )
-                        == "deleted"
-                    ):
-                        data["oldId"] = old_config.oldId
-
-                    result = await self.crawl_configs.insert_one(data)
 
         else:
             result = await self.crawl_configs.insert_one(data)
@@ -305,11 +286,12 @@ class CrawlConfigOps:
         add = self.crawl_ops.add_new_crawl(crawl_id, crawlconfig)
         await asyncio.gather(inc, add)
 
-    async def update_crawl_config(self, cid: uuid.UUID, update: UpdateCrawlConfig):
+    async def update_crawl_config(self, cid: uuid.UUID, user: User, update: UpdateCrawlConfig):
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
 
         # set update query
         query = update.dict(exclude_unset=True)
+        query["useridLastModified"] = user.id
 
         if len(query) == 0:
             raise HTTPException(status_code=400, detail="no_update_data")
@@ -322,6 +304,9 @@ class CrawlConfigOps:
                 update.profileid = (
                     await self.profiles.get_profile(update.profileid)
                 ).id
+
+        if update.config is not None:
+            query["config"] = update.config.dict()
 
         # update in db
         result = await self.crawl_configs.find_one_and_update(
@@ -336,11 +321,14 @@ class CrawlConfigOps:
             )
 
         # update schedule in crawl manager first
-        if update.schedule is not None or update.scale is not None:
+        if (update.schedule is not None or
+            update.scale is not None or
+            update.config is not None):
+
             crawlconfig = CrawlConfig.from_dict(result)
             try:
-                await self.crawl_manager.update_crawlconfig_schedule_or_scale(
-                    crawlconfig, update.scale, update.schedule
+                await self.crawl_manager.update_crawl_config(
+                    crawlconfig, update
                 )
             except Exception as exc:
                 print(exc, flush=True)
@@ -485,42 +473,27 @@ class CrawlConfigOps:
     async def make_inactive_or_delete(
         self,
         crawlconfig: CrawlConfig,
-        new_id: uuid.UUID = None,
-        for_running_crawl=False,
     ):
         """Make config inactive if crawls exist, otherwise move to inactive list"""
 
         query = {"inactive": True}
 
-        if new_id:
-            crawlconfig.newId = query["newId"] = new_id
-
         is_running = await self.get_running_crawl(crawlconfig) is not None
 
-        if is_running != for_running_crawl:
+        if is_running:
             raise HTTPException(status_code=400, detail="crawl_running_cant_deactivate")
 
         # set to either "deleted" or "deactivated"
         status = None
 
-        other_crawl_count = crawlconfig.crawlAttemptCount
-        # don't count current crawl, if for running crawl
-        if for_running_crawl:
-            other_crawl_count -= 1
-
         # if no crawls have been run, actually delete
-        if not other_crawl_count:
+        if not crawlconfig.crawlAttemptCount:
             result = await self.crawl_configs.delete_one(
                 {"_id": crawlconfig.id, "oid": crawlconfig.oid}
             )
 
             if result.deleted_count != 1:
                 raise HTTPException(status_code=404, detail="failed_to_delete")
-
-            if crawlconfig.oldId:
-                await self.crawl_configs.find_one_and_update(
-                    {"_id": crawlconfig.oldId}, {"$set": query}
-                )
 
             status = "deleted"
 
@@ -547,7 +520,7 @@ class CrawlConfigOps:
 
         return {"success": True, "status": status}
 
-    async def copy_add_remove_exclusion(self, regex, cid, org, user, add=True):
+    async def add_remove_exclusion(self, regex, cid, org, user, add=True):
         """create a copy of existing crawl config, with added exclusion regex"""
         # get crawl config
         crawl_config = await self.get_crawl_config(cid, org, active_only=False)
@@ -570,17 +543,12 @@ class CrawlConfigOps:
 
         crawl_config.config.exclude = exclude
 
-        # create new config
-        new_config = CrawlConfigIn(**crawl_config.serialize())
+        update_config = UpdateCrawlConfig(config=crawl_config.config)
 
-        # pylint: disable=invalid-name
-        new_config.oldId = crawl_config.id
+        await self.update_crawl_config(cid, user, update_config)
 
-        result, _ = await self.add_crawl_config(
-            new_config, org, user, for_running_crawl=True
-        )
-
-        return result.inserted_id
+        # todo: just return success here later
+        return cid
 
     async def get_crawl_config_tags(self, org):
         """get distinct tags from all crawl configs for this org"""
@@ -629,8 +597,9 @@ def init_crawl_config_api(
     async def update_crawl_config(
         update: UpdateCrawlConfig,
         cid: str,
+        user: User = Depends(user_dep),
     ):
-        return await ops.update_crawl_config(uuid.UUID(cid), update)
+        return await ops.update_crawl_config(uuid.UUID(cid), user, update)
 
     @router.post("/{cid}/run")
     async def run_now(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -348,7 +348,7 @@ class CrawlConfigOps:
             or update.crawlTimeout is not None
         )
 
-        if is_crawl_update:
+        if is_crawl_update or update.profileid:
             orig_dict = orig_crawl_config.dict(exclude_unset=True, exclude_none=True)
             orig_dict["cid"] = orig_dict.pop("id", cid)
             orig_dict["id"] = uuid.uuid4()
@@ -472,7 +472,6 @@ class CrawlConfigOps:
 
         cursor = self.crawl_configs.find(query, projection=["_id", "name"])
         results = await cursor.to_list(length=1000)
-        print("for profile", profileid, query, results)
         results = [CrawlConfigIdNameOut.from_dict(res) for res in results]
         return results
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -369,7 +369,9 @@ class CrawlConfigOps:
         changed = changed or self.check_attr_changed(orig_crawl_config, update, "scale")
 
         changed = changed or (
-            self.check_attr_changed(orig_crawl_config, update, "profileid")
+            update.profileid is not None
+            and update.profileid != orig_crawl_config.profileid
+            and ((not update.profileid) != (not orig_crawl_config.profileid))
         )
 
         metadata_changed = self.check_attr_changed(orig_crawl_config, update, "name")

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -110,9 +110,6 @@ class CrawlConfigIn(BaseModel):
     crawlTimeout: Optional[int] = 0
     scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
 
-    # for now, until frontend is changed
-    oldId: Optional[UUID4]
-
 
 # ============================================================================
 class ConfigRevision(BaseMongoModel):
@@ -273,20 +270,6 @@ class CrawlConfigOps:
         user: User,
     ):
         """Add new crawl config"""
-
-        # for now, to support frontend update logic
-        if config.oldId:
-            cid = config.oldId
-            await self.update_crawl_config(
-                cid, org, user, update=UpdateCrawlConfig(**config.dict())
-            )
-
-            crawl_id = None
-            if config.runNow:
-                crawl_id = await self.run_now(cid, org, user)
-
-            return cid, crawl_id
-
         data = config.dict()
         data["oid"] = org.id
         data["createdBy"] = user.id

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -148,7 +148,7 @@ class CrawlConfig(BaseMongoModel):
     jobType: Optional[JobType] = JobType.CUSTOM
 
     created: datetime
-    createdBy: UUID4
+    createdBy: Optional[UUID4]
 
     modified: Optional[datetime]
     modifiedBy: Optional[UUID4]

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -548,6 +548,7 @@ class CrawlConfigOps:
 
         await self.update_crawl_config(cid, user, update_config)
 
+        # pylint: disable=fixme
         # todo: just return success here later
         return cid
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -101,7 +101,7 @@ class BaseCrawlManager(ABC):
             STORE_PATH=storage_path,
             STORE_FILENAME=out_filename,
             STORAGE_NAME=storage_name,
-            USER_ID=str(crawlconfig.userid),
+            USER_ID=str(crawlconfig.modifiedBy),
             ORG_ID=str(crawlconfig.oid),
             CRAWL_CONFIG_ID=str(crawlconfig.id),
             PROFILE_FILENAME=profile_filename,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -180,7 +180,7 @@ class BaseCrawlManager(ABC):
             "id": job_id,
             "cid": str(crawlconfig.id),
             "rev": str(crawlconfig.rev),
-            "userid": str(crawlconfig.userid),
+            "userid": str(crawlconfig.modifiedBy),
             "oid": str(crawlconfig.oid),
             "job_image": self.job_image,
             "job_pull_policy": self.job_pull_policy,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -123,7 +123,7 @@ class BaseCrawlManager(ABC):
 
         return await self._create_manual_job(crawlconfig)
 
-    async def update_crawl_config(self, crawlconfig, update):
+    async def update_crawl_config(self, crawlconfig, update, profile_filename=None):
         """Update the schedule or scale for existing crawl config"""
 
         has_sched_update = update.schedule is not None
@@ -133,8 +133,10 @@ class BaseCrawlManager(ABC):
         if has_sched_update:
             await self._update_scheduled_job(crawlconfig)
 
-        if has_scale_update or has_config_update:
-            await self._update_config_map(crawlconfig, update.scale, has_config_update)
+        if has_scale_update or has_config_update or profile_filename:
+            await self._update_config_map(
+                crawlconfig, update.scale, profile_filename, has_config_update
+            )
 
         return True
 
@@ -194,7 +196,9 @@ class BaseCrawlManager(ABC):
 
         return self.templates.env.get_template("crawl_job.yaml").render(params)
 
-    async def _update_config_map(self, crawlconfig, scale=None, update_config=False):
+    async def _update_config_map(
+        self, crawlconfig, scale=None, profile_filename=None, update_config=False
+    ):
         """update initial scale and crawler config in config, if needed (k8s only)"""
 
     @abstractmethod

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -123,9 +123,7 @@ class BaseCrawlManager(ABC):
 
         return await self._create_manual_job(crawlconfig)
 
-    async def update_crawl_config(
-        self, crawlconfig, update
-    ):
+    async def update_crawl_config(self, crawlconfig, update):
         """Update the schedule or scale for existing crawl config"""
 
         has_sched_update = update.schedule is not None

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -179,6 +179,7 @@ class BaseCrawlManager(ABC):
         params = {
             "id": job_id,
             "cid": str(crawlconfig.id),
+            "rev": str(crawlconfig.rev),
             "userid": str(crawlconfig.userid),
             "oid": str(crawlconfig.oid),
             "job_image": self.job_image,

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -613,9 +613,7 @@ class CrawlOps:
 
         cid = raw.get("cid")
 
-        await self.crawl_configs.add_remove_exclusion(
-            regex, cid, org, user, add=True
-        )
+        await self.crawl_configs.add_remove_exclusion(regex, cid, org, user, add=True)
 
         # restart crawl pods
         restart_c = self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
@@ -634,9 +632,7 @@ class CrawlOps:
 
         cid = raw.get("cid")
 
-        await self.crawl_configs.add_remove_exclusion(
-            regex, cid, org, user, add=False
-        )
+        await self.crawl_configs.add_remove_exclusion(regex, cid, org, user, add=False)
 
         # restart crawl pods
         await self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -416,7 +416,7 @@ class CrawlOps:
         crawl = Crawl(
             id=crawl_id,
             state="starting",
-            userid=crawlconfig.userid,
+            userid=crawlconfig.modifiedBy,
             oid=crawlconfig.oid,
             cid=crawlconfig.id,
             cid_rev=crawlconfig.rev,

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -85,7 +85,6 @@ class Crawl(BaseMongoModel):
     state: str
 
     scale: conint(ge=1, le=MAX_CRAWL_SCALE) = 1
-    completions: Optional[int] = 0
     crawlTimeout: Optional[int] = 0
 
     stats: Optional[Dict[str, str]]
@@ -609,41 +608,41 @@ class CrawlOps:
             redis_url, encoding="utf-8", decode_responses=True
         )
 
-    async def add_exclusion(self, crawl_id, regex, org, user):
-        """create new config with additional exclusion, copying existing config"""
+    async def add_or_remove_exclusion(self, crawl_id, regex, org, user, add):
+        """add new exclusion to config or remove exclusion from config
+        for given crawl_id, update config on crawl"""
 
-        raw = await self.get_crawl_raw(crawl_id, org)
+        crawlraw = await self.crawls.find_one({"_id": crawl_id}, {"cid": True})
 
-        cid = raw.get("cid")
+        cid = crawlraw.get("cid")
 
-        await self.crawl_configs.add_remove_exclusion(regex, cid, org, user, add=True)
+        new_config = await self.crawl_configs.add_or_remove_exclusion(
+            regex, cid, org, user, add
+        )
+
+        await self.crawls.find_one_and_update(
+            {"_id": crawl_id, "oid": org.id}, {"$set": {"config": new_config}}
+        )
+
+        resp = {"success": True}
+
+        # pylint: disable=fixme
+        # todo: remove new_cid once frontend is updated
+        resp["new_cid"] = cid
 
         # restart crawl pods
         restart_c = self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
 
-        filter_q = self.filter_crawl_queue(crawl_id, regex)
+        if add:
+            filter_q = self.filter_crawl_queue(crawl_id, regex)
 
-        _, num_removed = await asyncio.gather(restart_c, filter_q)
+            _, num_removed = await asyncio.gather(restart_c, filter_q)
+            resp["num_removed"] = num_removed
 
-        # pylint: disable=fixme
-        # todo: remove new_cid once frontend is updated
-        return {"new_cid": cid, "num_removed": num_removed}
+        else:
+            await restart_c
 
-    async def remove_exclusion(self, crawl_id, regex, org, user):
-        """create new config with exclusion removed, copying existing config"""
-
-        raw = await self.get_crawl_raw(crawl_id, org)
-
-        cid = raw.get("cid")
-
-        await self.crawl_configs.add_remove_exclusion(regex, cid, org, user, add=False)
-
-        # restart crawl pods
-        await self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
-
-        # pylint: disable=fixme
-        # todo: remove new_cid once frontend is updated
-        return {"new_cid": cid, "success": True}
+        return resp
 
 
 # ============================================================================
@@ -832,7 +831,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ):
-        return await ops.add_exclusion(crawl_id, regex, org, user)
+        return await ops.add_or_remove_exclusion(crawl_id, regex, org, user, add=True)
 
     @app.delete(
         "/orgs/{oid}/crawls/{crawl_id}/exclusions",
@@ -844,7 +843,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ):
-        return await ops.remove_exclusion(crawl_id, regex, org, user)
+        return await ops.add_or_remove_exclusion(crawl_id, regex, org, user, add=False)
 
     return ops
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -626,10 +626,6 @@ class CrawlOps:
 
         resp = {"success": True}
 
-        # pylint: disable=fixme
-        # todo: remove new_cid once frontend is updated
-        resp["new_cid"] = cid
-
         # restart crawl pods
         restart_c = self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -70,6 +70,8 @@ class Crawl(BaseMongoModel):
     oid: UUID4
     cid: UUID4
 
+    cid_rev: int = 0
+
     # schedule: Optional[str]
     manual: Optional[bool]
 
@@ -418,6 +420,7 @@ class CrawlOps:
             userid=crawlconfig.userid,
             oid=crawlconfig.oid,
             cid=crawlconfig.id,
+            cid_rev=crawlconfig.rev,
             scale=crawlconfig.scale,
             config=crawlconfig.config,
             profileid=crawlconfig.profileid,

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, UUID4, conint, HttpUrl
 from redis import asyncio as aioredis, exceptions
 import pymongo
 
-from .crawlconfigs import Seed
+from .crawlconfigs import Seed, RawCrawlConfig
 from .db import BaseMongoModel
 from .users import User
 from .orgs import Organization, MAX_CRAWL_SCALE
@@ -76,10 +76,15 @@ class Crawl(BaseMongoModel):
     started: datetime
     finished: Optional[datetime]
 
+    config: RawCrawlConfig
+    profileid: Optional[UUID4]
+    schedule: Optional[str] = ""
+
     state: str
 
     scale: conint(ge=1, le=MAX_CRAWL_SCALE) = 1
     completions: Optional[int] = 0
+    crawlTimeout: Optional[int] = 0
 
     stats: Optional[Dict[str, str]]
 
@@ -414,6 +419,10 @@ class CrawlOps:
             oid=crawlconfig.oid,
             cid=crawlconfig.id,
             scale=crawlconfig.scale,
+            config=crawlconfig.config,
+            profileid=crawlconfig.profileid,
+            schedule=crawlconfig.schedule,
+            crawlTimeout=crawlconfig.crawlTimeout,
             manual=True,
             started=ts_now(),
             tags=crawlconfig.tags,
@@ -604,22 +613,19 @@ class CrawlOps:
 
         cid = raw.get("cid")
 
-        new_cid = await self.crawl_configs.copy_add_remove_exclusion(
+        await self.crawl_configs.add_remove_exclusion(
             regex, cid, org, user, add=True
         )
 
-        await self.crawls.find_one_and_update(
-            {"_id": crawl_id}, {"$set": {"cid": new_cid}}
-        )
-
         # restart crawl pods
-        change_c = self.crawl_manager.change_crawl_config(crawl_id, org.id, new_cid)
+        restart_c = self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
 
         filter_q = self.filter_crawl_queue(crawl_id, regex)
 
-        _, num_removed = await asyncio.gather(change_c, filter_q)
+        _, num_removed = await asyncio.gather(restart_c, filter_q)
 
-        return {"new_cid": new_cid, "num_removed": num_removed}
+        # todo: remove new_cid once frontend is updated
+        return {"new_cid": cid, "num_removed": num_removed}
 
     async def remove_exclusion(self, crawl_id, regex, org, user):
         """create new config with exclusion removed, copying existing config"""
@@ -628,18 +634,15 @@ class CrawlOps:
 
         cid = raw.get("cid")
 
-        new_cid = await self.crawl_configs.copy_add_remove_exclusion(
+        await self.crawl_configs.add_remove_exclusion(
             regex, cid, org, user, add=False
         )
 
-        await self.crawls.find_one_and_update(
-            {"_id": crawl_id}, {"$set": {"cid": new_cid}}
-        )
-
         # restart crawl pods
-        await self.crawl_manager.change_crawl_config(crawl_id, org.id, new_cid)
+        await self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
 
-        return {"new_cid": new_cid}
+        # todo: remove new_cid once frontend is updated
+        return {"new_cid": cid, "success": True}
 
 
 # ============================================================================

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -622,6 +622,7 @@ class CrawlOps:
 
         _, num_removed = await asyncio.gather(restart_c, filter_q)
 
+        # pylint: disable=fixme
         # todo: remove new_cid once frontend is updated
         return {"new_cid": cid, "num_removed": num_removed}
 
@@ -637,6 +638,7 @@ class CrawlOps:
         # restart crawl pods
         await self.crawl_manager.rollover_restart_crawl(crawl_id, org.id)
 
+        # pylint: disable=fixme
         # todo: remove new_cid once frontend is updated
         return {"new_cid": cid, "success": True}
 

--- a/backend/btrixcloud/k8s/crawl_job.py
+++ b/backend/btrixcloud/k8s/crawl_job.py
@@ -45,13 +45,7 @@ class K8SCrawlJob(K8SJobMixin, CrawlJob):
         now = str(now.isoformat("T") + "Z")
         patch_config = {
             "spec": {
-                "template": {
-                    "metadata": {
-                        "annotations": {
-                            "btrix.restartedAt": now
-                        }
-                    }
-                }
+                "template": {"metadata": {"annotations": {"btrix.restartedAt": now}}}
             }
         }
 

--- a/backend/btrixcloud/k8s/crawl_job.py
+++ b/backend/btrixcloud/k8s/crawl_job.py
@@ -65,6 +65,11 @@ class K8SCrawlJob(K8SJobMixin, CrawlJob):
         except:
             return None
 
+    def _get_crawl_scale(self, crawl):
+        """get scale from crawl, if any"""
+
+        return crawl.spec.replicas if crawl else 0
+
     async def _send_shutdown_signal(self, signame):
         pods = await self.core_api.list_namespaced_pod(
             namespace=self.namespace,

--- a/backend/btrixcloud/k8s/k8sman.py
+++ b/backend/btrixcloud/k8s/k8sman.py
@@ -317,7 +317,9 @@ class K8SManager(BaseCrawlManager, K8sAPI):
             config_map.data["INITIAL_SCALE"] = str(scale)
 
         if update_config:
-            config_map.data["crawl-config.json"] = json.dumps(crawlconfig.get_raw_config())
+            config_map.data["crawl-config.json"] = json.dumps(
+                crawlconfig.get_raw_config()
+            )
 
         await self.core_api.patch_namespaced_config_map(
             name=config_map.metadata.name, namespace=self.namespace, body=config_map

--- a/backend/btrixcloud/k8s/k8sman.py
+++ b/backend/btrixcloud/k8s/k8sman.py
@@ -308,13 +308,18 @@ class K8SManager(BaseCrawlManager, K8sAPI):
             namespace=self.namespace, body=cron_job
         )
 
-    async def _update_config_map(self, crawlconfig, scale=None, update_config=False):
+    async def _update_config_map(
+        self, crawlconfig, scale=None, profile_filename=None, update_config=False
+    ):
         config_map = await self.core_api.read_namespaced_config_map(
             name=f"crawl-config-{crawlconfig.id}", namespace=self.namespace
         )
 
         if scale is not None:
             config_map.data["INITIAL_SCALE"] = str(scale)
+
+        if profile_filename is not None:
+            config_map.data["PROFILE_FILENAME"] = profile_filename
 
         if update_config:
             config_map.data["crawl-config.json"] = json.dumps(

--- a/backend/btrixcloud/k8s/k8sman.py
+++ b/backend/btrixcloud/k8s/k8sman.py
@@ -308,12 +308,16 @@ class K8SManager(BaseCrawlManager, K8sAPI):
             namespace=self.namespace, body=cron_job
         )
 
-    async def _update_config_initial_scale(self, crawlconfig, scale):
+    async def _update_config_map(self, crawlconfig, scale=None, update_config=False):
         config_map = await self.core_api.read_namespaced_config_map(
             name=f"crawl-config-{crawlconfig.id}", namespace=self.namespace
         )
 
-        config_map.data["INITIAL_SCALE"] = str(scale)
+        if scale is not None:
+            config_map.data["INITIAL_SCALE"] = str(scale)
+
+        if update_config:
+            config_map.data["crawl-config.json"] = json.dumps(crawlconfig.get_raw_config())
 
         await self.core_api.patch_namespaced_config_map(
             name=config_map.metadata.name, namespace=self.namespace, body=config_map

--- a/backend/btrixcloud/k8s/templates/crawl_job.yaml
+++ b/backend/btrixcloud/k8s/templates/crawl_job.yaml
@@ -70,6 +70,9 @@ spec:
             - name: CRAWL_CONFIG_ID
               value: "{{ cid }}"
 
+            - name: REV
+              value: "{{ rev }}"
+
             - name: TAGS
               value: "{{ tags }}"
 

--- a/backend/btrixcloud/migrations/__init__.py
+++ b/backend/btrixcloud/migrations/__init__.py
@@ -43,7 +43,7 @@ class BaseMigration:
         # Databases from prior to migrations will not have a version set.
         if not db_version:
             return True
-        if db_version < self.migration_version:
+        if db_version <= self.migration_version:
             return True
         return False
 

--- a/backend/btrixcloud/migrations/__init__.py
+++ b/backend/btrixcloud/migrations/__init__.py
@@ -4,6 +4,10 @@ BaseMigration class to subclass in each migration module
 from pymongo.errors import OperationFailure
 
 
+class MigrationError(Exception):
+    """Custom migration exception class"""
+
+
 class BaseMigration:
     """Base Migration class."""
 

--- a/backend/btrixcloud/migrations/__init__.py
+++ b/backend/btrixcloud/migrations/__init__.py
@@ -43,7 +43,7 @@ class BaseMigration:
         # Databases from prior to migrations will not have a version set.
         if not db_version:
             return True
-        if db_version <= self.migration_version:
+        if db_version < self.migration_version:
             return True
         return False
 

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -33,8 +33,12 @@ class Migration(BaseMigration):
 
         utc_now_datetime = datetime.utcnow().replace(microsecond=0, tzinfo=None)
 
-        await crawl_configs.update_many({}, [{"$set": {"createdBy": "$userid"}}])
-        await crawl_configs.update_many({}, [{"$set": {"modifiedBy": "$userid"}}])
+        await crawl_configs.update_many(
+            {"createdBy": None}, [{"$set": {"createdBy": "$userid"}}]
+        )
+        await crawl_configs.update_many(
+            {"modifiedBy": None}, [{"$set": {"modifiedBy": "$userid"}}]
+        )
         await crawl_configs.update_many({}, {"$unset": {"userid": 1}})
         await crawl_configs.update_many(
             {"created": None}, {"$set": {"created": utc_now_datetime}}
@@ -62,6 +66,7 @@ class Migration(BaseMigration):
                         "profileid": config_result["profileid"],
                         "schedule": config_result["schedule"],
                         "crawlTimeout": config_result["crawlTimeout"],
+                        "jobType": config_result["jobType"],
                     }
                 },
             )

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -1,0 +1,102 @@
+"""
+Migration 0003 - Mutable crawl configs and crawl revision history
+"""
+from datetime import datetime
+
+from btrixcloud.crawlconfigs import CrawlConfig
+from btrixcloud.crawls import Crawl
+from btrixcloud.migrations import BaseMigration, MigrationError
+
+
+MIGRATION_VERSION = "0003"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Set new crawl_configs fields and add config details to crawls.
+        """
+        crawls = self.mdb["crawls"]
+        crawl_configs = self.mdb["crawl_configs"]
+
+        # Return early if there are no configs
+        crawl_config_results = [res async for res in crawl_configs.find({})]
+        if not crawl_config_results:
+            return
+
+        utc_now_datetime = datetime.utcnow().replace(microsecond=0, tzinfo=None)
+
+        await crawl_configs.update_many({}, [{"$set": {"useridCreated": "$userid"}}])
+        await crawl_configs.update_many(
+            {"created": None}, {"$set": {"created": utc_now_datetime}}
+        )
+        await crawl_configs.update_many({}, [{"$set": {"modified": "$created"}}])
+        await crawl_configs.update_many({}, {"$set": {"rev": 0}})
+
+        # Return early if there are no crawls
+        crawl_results = [res async for res in crawls.find({})]
+        if not crawl_results:
+            return
+
+        await crawls.update_many({}, {"$set": {"cid_rev": 0}})
+
+        for crawl_result in crawl_results:
+            config_result = await crawl_configs.find_one({"_id": crawl_result["cid"]})
+            await crawls.find_one_and_update(
+                {"_id": crawl_result["_id"]},
+                {
+                    "$set": {
+                        "config": config_result["config"],
+                        "profileid": config_result["profileid"],
+                        "schedule": config_result["schedule"],
+                        "crawlTimeout": config_result["crawlTimeout"],
+                    }
+                },
+            )
+
+        # Test that migration went as expected
+        sample_config_result = await crawl_configs.find_one({})
+        sample_config = CrawlConfig.from_dict(sample_config_result)
+        if sample_config.useridCreated != sample_config.userid:
+            raise MigrationError(
+                "Crawl config useridCreated set incorrectly by migration"
+            )
+        if sample_config.modified != sample_config.created:
+            raise MigrationError(
+                "Crawl config modified set incorrectly by migration - should be equal to created"
+            )
+        if sample_config.rev != 0:
+            raise MigrationError("Crawl config rev set incorrectly by migration")
+
+        no_created_results = await crawl_configs.find_one({"created": None})
+        if no_created_results:
+            raise MigrationError("Crawl config created not set by migration")
+
+        sample_crawl_result = await crawls.find_one({})
+        sample_crawl = Crawl.from_dict(sample_crawl_result)
+        if sample_crawl.cid_rev != 0:
+            raise MigrationError("Crawl cid_rev set incorrectly by migration")
+
+        matching_config_result = await crawl_configs.find_one({"_id": sample_crawl.cid})
+        matching_config = CrawlConfig.from_dict(matching_config_result)
+        if sample_crawl.profileid != matching_config.profileid:
+            raise MigrationError(
+                f"Crawl profileid {sample_crawl.profileid} doesn't match config"
+            )
+        if sample_crawl.schedule != matching_config.schedule:
+            raise MigrationError(
+                f"Crawl schedule {sample_crawl.schedule} doesn't match config"
+            )
+        if sample_crawl.crawlTimeout != matching_config.crawlTimeout:
+            raise MigrationError(
+                f"Crawl timeout {sample_crawl.crawlTimeout} doesn't match config"
+            )
+
+        if not sample_crawl.config.seeds:
+            raise MigrationError("Crawl config missing after migration")

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -51,6 +51,9 @@ class Migration(BaseMigration):
 
         for crawl_result in crawl_results:
             config_result = await crawl_configs.find_one({"_id": crawl_result["cid"]})
+            if not config_result:
+                continue
+
             await crawls.find_one_and_update(
                 {"_id": crawl_result["_id"]},
                 {

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -22,9 +22,9 @@ class Migration(BaseMigration):
 
         Set new crawl_configs fields and add config details to crawls.
         """
+        # pylint: disable=too-many-locals
         crawls = self.mdb["crawls"]
         crawl_configs = self.mdb["crawl_configs"]
-        users = self.mdb["users"]
 
         # Return early if there are no configs
         crawl_config_results = [res async for res in crawl_configs.find({})]

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -22,7 +22,7 @@ class Migration(BaseMigration):
 
         Set new crawl_configs fields and add config details to crawls.
         """
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals, too-many-branches
         crawls = self.mdb["crawls"]
         crawl_configs = self.mdb["crawl_configs"]
 

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -22,6 +22,21 @@ def test_add_crawl_config(crawler_auth_headers, default_org_id, sample_crawl_dat
     cid = data["added"]
 
 
+def test_update_name_only(crawler_auth_headers, default_org_id):
+    # update name only
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={"name": "updated name 1"},
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["success"]
+    assert data["metadata_changed"] == True
+    assert data["settings_changed"] == False
+
+
 def test_update_crawl_config_name_and_tags(crawler_auth_headers, default_org_id):
     # Update crawl config
     r = requests.patch(
@@ -33,6 +48,8 @@ def test_update_crawl_config_name_and_tags(crawler_auth_headers, default_org_id)
 
     data = r.json()
     assert data["success"]
+    assert data["metadata_changed"] == True
+    assert data["settings_changed"] == False
 
 
 def test_verify_update(crawler_auth_headers, default_org_id):
@@ -67,6 +84,21 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
     assert data["config"]["scopeType"] == "domain"
 
 
+def test_update_config_no_changes(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={"config": {"seeds": ["https://example.com/"], "scopeType": "domain"}},
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["settings_changed"] == False
+    assert data["metadata_changed"] == False
+
+
 def test_update_crawl_timeout(crawler_auth_headers, default_org_id, sample_crawl_data):
     # Verify that updating crawl timeout works
     r = requests.patch(
@@ -75,6 +107,10 @@ def test_update_crawl_timeout(crawler_auth_headers, default_org_id, sample_crawl
         json={"crawlTimeout": 60},
     )
     assert r.status_code == 200
+    data = r.json()
+
+    assert data["settings_changed"] == True
+    assert data["metadata_changed"] == False
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -67,6 +67,26 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
     assert data["config"]["scopeType"] == "domain"
 
 
+def test_update_crawl_timeout(crawler_auth_headers, default_org_id, sample_crawl_data):
+    # Verify that updating crawl timeout works
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={"crawlTimeout": 60},
+    )
+    assert r.status_code == 200
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+
+    assert data["crawlTimeout"] == 60
+
+
 def test_verify_delete_tags(crawler_auth_headers, default_org_id):
     # Verify that deleting tags and name works as well
     r = requests.patch(
@@ -95,5 +115,6 @@ def test_verify_revs_history(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
 
     data = r.json()
-    assert len(data) == 1
-    assert data[0]["config"]["scopeType"] == "prefix"
+    assert len(data) == 2
+    sorted_data = sorted(data, key=lambda revision: revision["rev"])
+    assert sorted_data[0]["config"]["scopeType"] == "prefix"

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -3,9 +3,12 @@ import requests
 from .conftest import API_PREFIX
 
 
-def test_add_update_crawl_config(
-    crawler_auth_headers, default_org_id, sample_crawl_data
-):
+cid = None
+UPDATED_NAME = "Updated name"
+UPDATED_TAGS = ["tag3", "tag4"]
+
+
+def test_add_crawl_config(crawler_auth_headers, default_org_id, sample_crawl_data):
     # Create crawl config
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
@@ -15,11 +18,12 @@ def test_add_update_crawl_config(
     assert r.status_code == 200
 
     data = r.json()
+    global cid
     cid = data["added"]
 
+
+def test_update_crawl_config_name_and_tags(crawler_auth_headers, default_org_id):
     # Update crawl config
-    UPDATED_NAME = "Updated name"
-    UPDATED_TAGS = ["tag3", "tag4"]
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
         headers=crawler_auth_headers,
@@ -30,6 +34,8 @@ def test_add_update_crawl_config(
     data = r.json()
     assert data["success"]
 
+
+def test_verify_update(crawler_auth_headers, default_org_id):
     # Verify update was successful
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
@@ -41,6 +47,27 @@ def test_add_update_crawl_config(
     assert data["name"] == UPDATED_NAME
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
 
+
+def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_data):
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={"config": {"seeds": ["https://example.com/"], "scopeType": "domain"}},
+    )
+    assert r.status_code == 200
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+
+    assert data["config"]["scopeType"] == "domain"
+
+
+def test_verify_delete_tags(crawler_auth_headers, default_org_id):
     # Verify that deleting tags and name works as well
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
@@ -58,3 +85,15 @@ def test_add_update_crawl_config(
     data = r.json()
     assert not data["name"]
     assert data["tags"] == []
+
+
+def test_verify_revs_history(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/revs",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert len(data) == 1
+    assert data[0]["config"]["scopeType"] == "prefix"

--- a/backend/test/test_filter_results.py
+++ b/backend/test/test_filter_results.py
@@ -40,7 +40,6 @@ def test_get_crawl_job_by_user(
 def test_get_crawl_job_by_config(
     crawler_auth_headers, default_org_id, admin_config_id, crawler_config_id
 ):
-
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls?cid={admin_config_id}",
         headers=crawler_auth_headers,

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -6,7 +6,7 @@ import RegexColorize from "regex-colorize";
 import ISO6391 from "iso-639-1";
 
 import LiteElement, { html } from "../utils/LiteElement";
-import type { CrawlConfig, Seed, SeedConfig } from "../pages/org/types";
+import type { CrawlConfigCore, Seed, SeedConfig } from "../pages/org/types";
 import { humanizeSchedule } from "../utils/cron";
 
 /**
@@ -20,7 +20,7 @@ import { humanizeSchedule } from "../utils/cron";
 @localized()
 export class ConfigDetails extends LiteElement {
   @property({ type: Object })
-  crawlConfig?: CrawlConfig;
+  crawlConfig?: CrawlConfigCore;
 
   @property({ type: Boolean })
   anchorLinks = false;
@@ -30,7 +30,7 @@ export class ConfigDetails extends LiteElement {
   hideTags = false;
 
   private readonly scopeTypeLabels: Record<
-    CrawlConfig["config"]["scopeType"],
+    CrawlConfigCore["config"]["scopeType"],
     string
   > = {
     prefix: msg("Path Begins with This URL"),

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -406,8 +406,7 @@ export class CrawlListItem extends LitElement {
   }
 
   private renderName(crawl: Crawl) {
-    if (crawl.configName)
-      return html`<span class="truncate">${crawl.configName}</span>`;
+    if (crawl.name) return html`<span class="truncate">${crawl.name}</span>`;
     if (!crawl.firstSeed)
       return html`<span class="truncate">${crawl.id}</span>`;
     const remainder = crawl.seedCount - 1;

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1889,7 +1889,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       jobType: this.jobType || "custom",
       name: this.formState.jobName || "",
       scale: this.formState.scale,
-      profileid: this.formState.browserProfile?.id || null,
+      profileid: this.formState.browserProfile?.id || "",
       runNow: this.formState.runNow || this.formState.scheduleType === "now",
       schedule: this.formState.scheduleType === "cron" ? this.utcSchedule : "",
       crawlTimeout: this.formState.crawlTimeoutMinutes
@@ -1904,8 +1904,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
           (this.formState.pageTimeoutMinutes ??
             this.defaultBehaviorTimeoutMinutes ??
             DEFAULT_BEHAVIOR_TIMEOUT_MINUTES) * 60,
-        limit: this.formState.pageLimit ? +this.formState.pageLimit : null,
-        lang: this.formState.lang || null,
+        limit: this.formState.pageLimit ? +this.formState.pageLimit : undefined,
+        lang: this.formState.lang || "",
         blockAds: this.formState.blockAds,
         exclude: trimArray(this.formState.exclusions),
       },

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -43,7 +43,7 @@ import type {
   TagsChangeEvent,
 } from "../../components/tag-input";
 import type {
-  CrawlConfigCore,
+  CrawlConfigParams,
   Profile,
   InitialCrawlConfig,
   JobType,
@@ -51,7 +51,7 @@ import type {
   SeedConfig,
 } from "./types";
 
-type NewCrawlConfigParams = CrawlConfigCore & {
+type NewCrawlConfigParams = CrawlConfigParams & {
   runNow: boolean;
 };
 
@@ -80,12 +80,12 @@ type FormState = {
   customIncludeUrlList: string;
   crawlTimeoutMinutes: number | null;
   pageTimeoutMinutes: number | null;
-  scopeType: CrawlConfigCore["config"]["scopeType"];
-  exclusions: CrawlConfigCore["config"]["exclude"];
-  pageLimit: CrawlConfigCore["config"]["limit"];
-  scale: CrawlConfigCore["scale"];
-  blockAds: CrawlConfigCore["config"]["blockAds"];
-  lang: CrawlConfigCore["config"]["lang"];
+  scopeType: CrawlConfigParams["config"]["scopeType"];
+  exclusions: CrawlConfigParams["config"]["exclude"];
+  pageLimit: CrawlConfigParams["config"]["limit"];
+  scale: CrawlConfigParams["scale"];
+  blockAds: CrawlConfigParams["config"]["blockAds"];
+  lang: CrawlConfigParams["config"]["lang"];
   scheduleType: "now" | "date" | "cron" | "none";
   scheduleFrequency: "daily" | "weekly" | "monthly";
   scheduleDayOfMonth: number;
@@ -96,7 +96,7 @@ type FormState = {
     period: "AM" | "PM";
   };
   runNow: boolean;
-  jobName: CrawlConfigCore["name"];
+  jobName: CrawlConfigParams["name"];
   browserProfile: Profile | null;
   tags: Tags;
 };

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -43,7 +43,7 @@ import type {
   TagsChangeEvent,
 } from "../../components/tag-input";
 import type {
-  CrawlConfigParams,
+  CrawlConfigCore,
   Profile,
   InitialCrawlConfig,
   JobType,
@@ -51,7 +51,7 @@ import type {
   SeedConfig,
 } from "./types";
 
-type NewCrawlConfigParams = CrawlConfigParams & {
+type NewCrawlConfigParams = CrawlConfigCore & {
   runNow: boolean;
 };
 
@@ -80,12 +80,12 @@ type FormState = {
   customIncludeUrlList: string;
   crawlTimeoutMinutes: number | null;
   pageTimeoutMinutes: number | null;
-  scopeType: CrawlConfigParams["config"]["scopeType"];
-  exclusions: CrawlConfigParams["config"]["exclude"];
-  pageLimit: CrawlConfigParams["config"]["limit"];
-  scale: CrawlConfigParams["scale"];
-  blockAds: CrawlConfigParams["config"]["blockAds"];
-  lang: CrawlConfigParams["config"]["lang"];
+  scopeType: CrawlConfigCore["config"]["scopeType"];
+  exclusions: CrawlConfigCore["config"]["exclude"];
+  pageLimit: CrawlConfigCore["config"]["limit"];
+  scale: CrawlConfigCore["scale"];
+  blockAds: CrawlConfigCore["config"]["blockAds"];
+  lang: CrawlConfigCore["config"]["lang"];
   scheduleType: "now" | "date" | "cron" | "none";
   scheduleFrequency: "daily" | "weekly" | "monthly";
   scheduleDayOfMonth: number;
@@ -96,7 +96,7 @@ type FormState = {
     period: "AM" | "PM";
   };
   runNow: boolean;
-  jobName: CrawlConfigParams["name"];
+  jobName: CrawlConfigCore["name"];
   browserProfile: Profile | null;
   tags: Tags;
 };

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -44,17 +44,21 @@ export class CrawlTemplatesDetail extends LiteElement {
   };
 
   willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("crawlConfigId") && this.crawlConfigId) {
+    if (
+      (changedProperties.has("crawlConfigId") && this.crawlConfigId) ||
+      (changedProperties.get("isEditing") === true && this.isEditing === false)
+    ) {
       this.initializeCrawlTemplate();
     }
   }
 
   protected updated(changedProperties: Map<string, any>) {
     if (
-      changedProperties.has("crawlConfig") &&
-      !changedProperties.get("crawlConfig") &&
-      this.crawlConfig &&
-      window.location.hash
+      (changedProperties.has("crawlConfig") &&
+        !changedProperties.get("crawlConfig") &&
+        this.crawlConfig &&
+        window.location.hash) ||
+      (changedProperties.get("isEditing") === true && this.isEditing === false)
     ) {
       // Show section once crawl config is done rendering
       document.querySelector(window.location.hash)?.scrollIntoView();
@@ -133,20 +137,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                 </sl-tooltip>
 
                 ${this.renderMenu()}
-              `,
-              () =>
-                this.crawlConfig?.newId
-                  ? html`
-                      <sl-button
-                        size="small"
-                        variant="text"
-                        @click=${this.getNewerVersion}
-                      >
-                        <sl-icon slot="suffix" name="arrow-right"></sl-icon>
-                        ${msg("Newer Version")}
-                      </sl-button>
-                    `
-                  : ""
+              `
             )}
           </div>
         </header>
@@ -451,12 +442,6 @@ export class CrawlTemplatesDetail extends LiteElement {
       html`${firstSeed}
         <span class="text-neutral-500">+${remainderCount} URLs</span>`
     );
-  }
-
-  private getNewerVersion() {
-    const versionId = this.crawlConfig?.newId;
-    if (!versionId) return;
-    this.navTo(`/orgs/${this.orgId}/crawl-configs/config/${versionId}`);
   }
 
   private async getCrawlTemplate(configId: string): Promise<CrawlConfig> {

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -475,6 +475,7 @@ export class CrawlTemplatesDetail extends LiteElement {
       jobType: this.crawlConfig.jobType,
       schedule: this.crawlConfig.schedule,
       tags: this.crawlConfig.tags,
+      crawlTimeout: this.crawlConfig.crawlTimeout,
     };
 
     this.navTo(

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -353,7 +353,7 @@ export class CrawlTemplatesDetail extends LiteElement {
         )}
         ${this.renderDetailItem(
           msg("Created By"),
-          () => this.crawlConfig!.userName
+          () => this.crawlConfig!.createdByName
         )}
         ${this.renderDetailItem(
           msg("Created At"),

--- a/frontend/src/pages/org/crawl-configs-list.ts
+++ b/frontend/src/pages/org/crawl-configs-list.ts
@@ -662,6 +662,7 @@ export class CrawlTemplatesList extends LiteElement {
       jobType: crawlConfig.jobType,
       schedule: crawlConfig.schedule,
       tags: crawlConfig.tags,
+      crawlTimeout: crawlConfig.crawlTimeout,
     };
 
     this.navTo(

--- a/frontend/src/pages/org/crawl-configs-new.ts
+++ b/frontend/src/pages/org/crawl-configs-new.ts
@@ -20,6 +20,8 @@ const defaultValue = {
     scopeType: "prefix",
     exclude: [""],
   },
+  tags: [],
+  crawlTimeout: null,
 } as InitialCrawlConfig;
 
 /**

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -264,7 +264,7 @@ export class CrawlDetail extends LiteElement {
         style="width: 15em"
       ></sl-skeleton>`;
 
-    if (this.crawl.configName) return this.crawl.configName;
+    if (this.crawl.name) return this.crawl.name;
     if (!this.crawl.firstSeed) return this.crawl.id;
     const remainder = this.crawl.seedCount - 1;
     let crawlName: any = html`<span class="break-words"
@@ -450,64 +450,59 @@ export class CrawlDetail extends LiteElement {
           role="menu"
         >
           ${when(
-            this.crawl.config && !this.crawl.config.inactive,
+            !this.isActive,
             () => html`
-              ${when(
-                !this.isActive,
-                () => html`
-                  <li
-                    class="p-2 text-purple-500 hover:bg-purple-500 hover:text-white cursor-pointer"
-                    role="menuitem"
-                    @click=${(e: any) => {
-                      this.runNow();
-                      e.target.closest("sl-dropdown").hide();
-                    }}
-                  >
-                    <sl-icon
-                      class="inline-block align-middle mr-1"
-                      name="arrow-clockwise"
-                    ></sl-icon>
-                    <span class="inline-block align-middle">
-                      ${msg("Re-run crawl")}
-                    </span>
-                  </li>
-                  <li
-                    class="p-2 hover:bg-zinc-100 cursor-pointer"
-                    role="menuitem"
-                    @click=${(e: any) => {
-                      this.openMetadataEditor();
-                      e.target.closest("sl-dropdown").hide();
-                    }}
-                  >
-                    <sl-icon
-                      class="inline-block align-middle mr-1"
-                      name="pencil"
-                    ></sl-icon>
-                    <span class="inline-block align-middle">
-                      ${msg("Edit Metadata")}
-                    </span>
-                  </li>
-                `
-              )}
-              ${when(
-                !this.isActive,
-                () => html`
-                  <hr />
-                  <li
-                    class="p-2 hover:bg-zinc-100 cursor-pointer"
-                    role="menuitem"
-                    @click=${() => {
-                      this.navTo(
-                        `/orgs/${this.crawl?.oid}/crawl-configs/config/${this.crawl?.cid}?edit`
-                      );
-                    }}
-                  >
-                    <span class="inline-block align-middle">
-                      ${msg("Edit Crawl Config")}
-                    </span>
-                  </li>
-                `
-              )}
+              <li
+                class="p-2 text-purple-500 hover:bg-purple-500 hover:text-white cursor-pointer"
+                role="menuitem"
+                @click=${(e: any) => {
+                  this.runNow();
+                  e.target.closest("sl-dropdown").hide();
+                }}
+              >
+                <sl-icon
+                  class="inline-block align-middle mr-1"
+                  name="arrow-clockwise"
+                ></sl-icon>
+                <span class="inline-block align-middle">
+                  ${msg("Re-run crawl")}
+                </span>
+              </li>
+              <li
+                class="p-2 hover:bg-zinc-100 cursor-pointer"
+                role="menuitem"
+                @click=${(e: any) => {
+                  this.openMetadataEditor();
+                  e.target.closest("sl-dropdown").hide();
+                }}
+              >
+                <sl-icon
+                  class="inline-block align-middle mr-1"
+                  name="pencil"
+                ></sl-icon>
+                <span class="inline-block align-middle">
+                  ${msg("Edit Metadata")}
+                </span>
+              </li>
+            `
+          )}
+          ${when(
+            !this.isActive,
+            () => html`
+              <hr />
+              <li
+                class="p-2 hover:bg-zinc-100 cursor-pointer"
+                role="menuitem"
+                @click=${() => {
+                  this.navTo(
+                    `/orgs/${this.crawl?.oid}/crawl-configs/config/${this.crawl?.cid}?edit`
+                  );
+                }}
+              >
+                <span class="inline-block align-middle">
+                  ${msg("Edit Crawl Config")}
+                </span>
+              </li>
             `
           )}
           <li
@@ -675,7 +670,7 @@ export class CrawlDetail extends LiteElement {
       <btrix-exclusion-editor
         orgId=${ifDefined(this.crawl?.oid)}
         crawlId=${ifDefined(this.crawl?.id)}
-        .config=${this.crawl?.config.config}
+        .config=${this.crawl?.config}
         .authState=${this.authState}
         ?isActiveCrawl=${this.crawl && this.isActive}
         @on-success=${this.handleExclusionChange}
@@ -890,7 +885,7 @@ ${this.crawl?.notes}
     if (!this.crawl?.config) return "";
     return html`
       <btrix-config-details
-        .crawlConfig=${this.crawl.config}
+        .crawlConfig=${this.crawl}
         hideTags
       ></btrix-config-details>
     `;

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -49,13 +49,7 @@ export class CrawlDetail extends LiteElement {
   crawlId?: string;
 
   @state()
-  private crawlTemplateId?: string;
-
-  @state()
   private crawl?: Crawl;
-
-  @state()
-  private crawlConfig?: CrawlConfig;
 
   @state()
   private sectionName: SectionName = "overview";
@@ -96,7 +90,7 @@ export class CrawlDetail extends LiteElement {
       throw new Error("Crawls base URL not defined");
     }
 
-    this.fetchData();
+    this.fetchCrawl();
   }
 
   willUpdate(changedProperties: Map<string, any>) {
@@ -104,9 +98,8 @@ export class CrawlDetail extends LiteElement {
 
     if (prevId && prevId !== this.crawlId) {
       // Handle update on URL change, e.g. from re-run
-      this.crawlTemplateId = "";
       this.stopPollTimer();
-      this.fetchData();
+      this.fetchCrawl();
     } else {
       const prevCrawl = changedProperties.get("crawl");
 
@@ -457,7 +450,7 @@ export class CrawlDetail extends LiteElement {
           role="menu"
         >
           ${when(
-            this.crawlConfig && !this.crawlConfig.inactive,
+            this.crawl.config && !this.crawl.config.inactive,
             () => html`
               ${when(
                 !this.isActive,
@@ -505,7 +498,7 @@ export class CrawlDetail extends LiteElement {
                     role="menuitem"
                     @click=${() => {
                       this.navTo(
-                        `/orgs/${this.crawl?.oid}/crawl-configs/config/${this.crawlTemplateId}?edit`
+                        `/orgs/${this.crawl?.oid}/crawl-configs/config/${this.crawl?.cid}?edit`
                       );
                     }}
                   >
@@ -531,7 +524,7 @@ export class CrawlDetail extends LiteElement {
             class="p-2 hover:bg-zinc-100 cursor-pointer"
             role="menuitem"
             @click=${(e: any) => {
-              CopyButton.copyToClipboard(this.crawlTemplateId || "");
+              CopyButton.copyToClipboard(this.crawl?.cid || "");
               closeDropdown(e);
             }}
           >
@@ -682,7 +675,7 @@ export class CrawlDetail extends LiteElement {
       <btrix-exclusion-editor
         orgId=${ifDefined(this.crawl?.oid)}
         crawlId=${ifDefined(this.crawl?.id)}
-        .config=${this.crawlConfig?.config}
+        .config=${this.crawl?.config.config}
         .authState=${this.authState}
         ?isActiveCrawl=${this.crawl && this.isActive}
         @on-success=${this.handleExclusionChange}
@@ -894,10 +887,10 @@ ${this.crawl?.notes}
   }
 
   private renderConfig() {
-    if (!this.crawlConfig) return "";
+    if (!this.crawl?.config) return "";
     return html`
       <btrix-config-details
-        .crawlConfig=${this.crawlConfig}
+        .crawlConfig=${this.crawl.config}
         hideTags
       ></btrix-config-details>
     `;
@@ -971,22 +964,12 @@ ${this.crawl?.notes}
     `;
   }
 
-  private async fetchData({ parallel }: { parallel?: boolean } = {}) {
-    if (parallel) {
-      this.fetchCrawl();
-    } else {
-      await this.fetchCrawl();
-    }
-    this.fetchCrawlTemplate();
-  }
-
   /**
    * Fetch crawl and update internal state
    */
   private async fetchCrawl(): Promise<void> {
     try {
       this.crawl = await this.getCrawl();
-      this.crawlTemplateId = this.crawlTemplateId || this.crawl.cid;
 
       if (this.isActive) {
         // Restart timer for next poll
@@ -1011,30 +994,6 @@ ${this.crawl?.notes}
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
         this.crawlId
       }/replay.json`,
-      this.authState!
-    );
-
-    return data;
-  }
-
-  /**
-   * Fetch crawl config and update internal state
-   */
-  private async fetchCrawlTemplate(): Promise<void> {
-    try {
-      this.crawlConfig = await this.getCrawlTemplate();
-    } catch {
-      // Fail silently since page will mostly still function
-    }
-  }
-
-  private async getCrawlTemplate(): Promise<CrawlConfig> {
-    if (!this.crawl) {
-      throw new Error("missing crawl");
-    }
-
-    const data: CrawlConfig = await this.apiFetch(
-      `/orgs/${this.crawl.oid}/crawlconfigs/${this.crawlTemplateId}`,
       this.authState!
     );
 
@@ -1136,32 +1095,8 @@ ${this.crawl?.notes}
     if (!this.crawl) return;
 
     try {
-      // Get crawl config to check if crawl is already running
-      const crawlTemplate = await this.getCrawlTemplate();
-
-      if (crawlTemplate.currCrawlId) {
-        this.notify({
-          message: msg(
-            html`Crawl of <strong>${this.renderName()}</strong> is already
-              running.
-              <br />
-              <a
-                class="underline hover:no-underline"
-                href="/orgs/${this.crawl
-                  .oid}/crawls/crawl/${crawlTemplate.currCrawlId}"
-                @click=${this.navLink.bind(this)}
-                >View crawl</a
-              >`
-          ),
-          variant: "warning",
-          icon: "exclamation-triangle",
-        });
-
-        return;
-      }
-
       const data = await this.apiFetch(
-        `/orgs/${this.crawl.oid}/crawlconfigs/${this.crawlTemplateId}/run`,
+        `/orgs/${this.crawl.oid}/crawlconfigs/${this.crawl.cid}/run`,
         this.authState!,
         {
           method: "POST",
@@ -1180,12 +1115,23 @@ ${this.crawl?.notes}
         icon: "check2-circle",
         duration: 8000,
       });
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't run crawl at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
+    } catch (e: any) {
+      if (e.isApiError && e.message === "crawl_already_running") {
+        this.notify({
+          message: msg(
+            html`Crawl of <strong>${this.renderName()}</strong> is already
+              running.`
+          ),
+          variant: "warning",
+          icon: "exclamation-triangle",
+        });
+      } else {
+        this.notify({
+          message: msg("Sorry, couldn't run crawl at this time."),
+          variant: "danger",
+          icon: "exclamation-octagon",
+        });
+      }
     }
   }
 
@@ -1228,9 +1174,7 @@ ${this.crawl?.notes}
   }
 
   private handleExclusionChange(e: CustomEvent) {
-    const { cid } = e.detail;
-    this.crawlTemplateId = cid;
-    this.fetchData({ parallel: true });
+    this.fetchCrawl();
   }
 
   private stopPollTimer() {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -584,7 +584,7 @@ export class CrawlsList extends LiteElement {
     if (crawlTemplate?.currCrawlId) {
       this.notify({
         message: msg(
-          html`Crawl of <strong>${crawl.configName}</strong> is already running.
+          html`Crawl of <strong>${crawl.name}</strong> is already running.
             <br />
             <a
               class="underline hover:no-underline"
@@ -615,7 +615,7 @@ export class CrawlsList extends LiteElement {
 
       this.notify({
         message: msg(
-          html`Started crawl from <strong>${crawl.configName}</strong>.
+          html`Started crawl from <strong>${crawl.name}</strong>.
             <br />
             <a
               class="underline hover:no-underline"
@@ -658,7 +658,7 @@ export class CrawlsList extends LiteElement {
   private async deleteCrawl(crawl: Crawl) {
     if (
       !window.confirm(
-        msg(str`Are you sure you want to delete crawl of ${crawl.configName}?`)
+        msg(str`Are you sure you want to delete crawl of ${crawl.name}?`)
       )
     ) {
       return;

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -714,6 +714,7 @@ export class CrawlsList extends LiteElement {
       jobType: template.jobType,
       schedule: template.schedule,
       tags: template.tags,
+      crawlTimeout: template.crawlTimeout,
     };
 
     this.navTo(

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -1,37 +1,3 @@
-export type CrawlState =
-  | "starting"
-  | "running"
-  | "complete"
-  | "failed"
-  | "partial_complete"
-  | "timed_out"
-  | "stopping"
-  | "canceled";
-
-export type Crawl = {
-  id: string;
-  userid: string;
-  userName: string;
-  oid: string;
-  cid: string;
-  configName: string;
-  schedule: string;
-  manual: boolean;
-  started: string; // UTC ISO date
-  finished?: string; // UTC ISO date
-  state: CrawlState;
-  scale: number;
-  stats: { done: string; found: string } | null;
-  resources?: { name: string; path: string; hash: string; size: number }[];
-  fileCount?: number;
-  fileSize?: number;
-  completions?: number;
-  tags: string[];
-  notes: string | null;
-  firstSeed: string;
-  seedCount: number;
-};
-
 type ScopeType =
   | "prefix"
   | "host"
@@ -91,9 +57,12 @@ export type CrawlConfig = CrawlConfigParams & {
   id: string;
   oid: string;
   jobType: JobType;
-  userid: string;
-  userName: string | null;
-  created: string;
+  createdBy: string; // User ID
+  createdByName: string | null; // User full name
+  created: string; // Date string
+  modifiedBy: string; // User ID
+  modifiedByName: string | null; // User full name
+  modified: string; // Date string
   crawlCount: number;
   crawlAttemptCount: number;
   lastCrawlId: string;
@@ -114,4 +83,39 @@ export type Profile = {
   baseProfileName: string;
   oid: string;
   crawlconfigs: { id: string; name: string }[];
+};
+
+export type CrawlState =
+  | "starting"
+  | "running"
+  | "complete"
+  | "failed"
+  | "partial_complete"
+  | "timed_out"
+  | "stopping"
+  | "canceled";
+
+export type Crawl = {
+  id: string;
+  userid: string;
+  userName: string;
+  oid: string;
+  cid: string;
+  configName: string;
+  schedule: string;
+  manual: boolean;
+  started: string; // UTC ISO date
+  finished?: string; // UTC ISO date
+  state: CrawlState;
+  scale: number;
+  stats: { done: string; found: string } | null;
+  resources?: { name: string; path: string; hash: string; size: number }[];
+  fileCount?: number;
+  fileSize?: number;
+  completions?: number;
+  tags: string[];
+  notes: string | null;
+  firstSeed: string;
+  seedCount: number;
+  config: CrawlConfig;
 };

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -100,8 +100,6 @@ export type CrawlConfig = CrawlConfigParams & {
   lastCrawlTime: string;
   lastCrawlState: CrawlState;
   currCrawlId: string;
-  newId: string | null;
-  oldId: string | null;
   inactive: boolean;
   profileName: string | null;
 };

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -29,17 +29,20 @@ export type SeedConfig = Pick<
 
 export type JobType = "url-list" | "seed-crawl" | "custom";
 
-export type CrawlConfigCore = {
-  oid: string;
+export type CrawlConfigParams = {
   jobType: JobType;
   name: string;
   schedule: string;
   scale: number;
   profileid: string | null;
-  profileName: string | null;
   config: SeedConfig;
-  crawlTimeout: number | null;
   tags: string[];
+  crawlTimeout: number | null;
+};
+
+export type CrawlConfigCore = CrawlConfigParams & {
+  oid: string;
+  profileName: string | null;
 };
 
 export type InitialCrawlConfig = Pick<

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -38,7 +38,7 @@ export type CrawlConfigCore = {
   profileid: string | null;
   profileName: string | null;
   config: SeedConfig;
-  crawlTimeout?: number | null;
+  crawlTimeout: number | null;
   tags: string[];
 };
 

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -29,34 +29,34 @@ export type SeedConfig = Pick<
 
 export type JobType = "url-list" | "seed-crawl" | "custom";
 
-export type CrawlConfigParams = {
+export type CrawlConfigCore = {
+  oid: string;
   jobType: JobType;
   name: string;
   schedule: string;
   scale: number;
   profileid: string | null;
+  profileName: string | null;
   config: SeedConfig;
   crawlTimeout?: number | null;
-  tags?: string[];
+  tags: string[];
 };
 
 export type InitialCrawlConfig = Pick<
-  CrawlConfigParams,
+  CrawlConfigCore,
   "name" | "profileid" | "schedule" | "tags" | "crawlTimeout"
 > & {
   jobType?: JobType;
   config: Pick<
-    CrawlConfigParams["config"],
+    CrawlConfigCore["config"],
     "seeds" | "scopeType" | "exclude" | "behaviorTimeout"
   > & {
-    extraHops?: CrawlConfigParams["config"]["extraHops"];
+    extraHops?: CrawlConfigCore["config"]["extraHops"];
   };
 };
 
-export type CrawlConfig = CrawlConfigParams & {
+export type CrawlConfig = CrawlConfigCore & {
   id: string;
-  oid: string;
-  jobType: JobType;
   createdBy: string; // User ID
   createdByName: string | null; // User full name
   created: string; // Date string
@@ -70,7 +70,6 @@ export type CrawlConfig = CrawlConfigParams & {
   lastCrawlState: CrawlState;
   currCrawlId: string;
   inactive: boolean;
-  profileName: string | null;
 };
 
 export type Profile = {
@@ -95,13 +94,12 @@ export type CrawlState =
   | "stopping"
   | "canceled";
 
-export type Crawl = {
+export type Crawl = CrawlConfigCore & {
   id: string;
   userid: string;
   userName: string;
   oid: string;
   cid: string;
-  configName: string;
   schedule: string;
   manual: boolean;
   started: string; // UTC ISO date
@@ -113,9 +111,7 @@ export type Crawl = {
   fileCount?: number;
   fileSize?: number;
   completions?: number;
-  tags: string[];
   notes: string | null;
   firstSeed: string;
   seedCount: number;
-  config: CrawlConfig;
 };


### PR DESCRIPTION
- crawlconfig PATCH /{id} can now receive a new JSON config to replace the old one (in addition to scale, schedule, tags)
- exclusions: add / remove APIs mutate the current crawlconfig, do not result in a new crawlconfig created
- k8s: crawlconfig json is updated along with scale
- k8s: stateful set is restarted by updating annotation, instead of changing template
- crawl object: now has 'config', as well as 'profileid', 'schedule', and 'crawlTimeout' properties to ensure anything that is changeable is stored on the crawl
- crawlconfig object: remove 'oldId', 'newId', disallow deactivating/deleting while crawl is running

Still do:
This change will require a DB migration, to remove crawlconfig props, and populate new props on the crawl