### PR TITLE
backend: Fix for total crawl time limit.

### DIFF
--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -57,9 +57,9 @@ class CrawlJob(ABC):
         self.storage_path = os.environ.get("STORE_PATH")
         self.storage_name = os.environ.get("STORAGE_NAME")
 
-        self.crawl_timeout = os.environ.get("CRAWL_TIMEOUT")
-        if self.crawl_timeout:
-            self.crawl_timeout = datetime.fromisoformat(self.crawl_timeout)
+        self.crawl_expire_time = os.environ.get("CRAWL_EXPIRE_TIME")
+        if self.crawl_expire_time:
+            self.crawl_expire_time = datetime.fromisoformat(self.crawl_expire_time)
 
         self.last_done = None
         self.last_found = None
@@ -145,11 +145,14 @@ class CrawlJob(ABC):
                 # check crawl status
                 await self.check_crawl_status()
 
-                if self.crawl_timeout and datetime.utcnow() > self.crawl_timeout:
+                if (
+                    self.crawl_expire_time
+                    and datetime.utcnow() > self.crawl_expire_time
+                ):
                     res = await self.graceful_shutdown()
                     if res.get("success"):
                         print(
-                            "Job duration expired at {self.crawl_timeout}, "
+                            "Job duration expired at {self.crawl_expire_time}, "
                             + "gracefully stopping crawl"
                         )
 

--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -57,6 +57,10 @@ class CrawlJob(ABC):
         self.storage_path = os.environ.get("STORE_PATH")
         self.storage_name = os.environ.get("STORAGE_NAME")
 
+        self.crawl_timeout = os.environ.get("CRAWL_TIMEOUT")
+        if self.crawl_timeout:
+            self.crawl_timeout = datetime.fromisoformat(self.crawl_timeout)
+
         self.last_done = None
         self.last_found = None
         self.redis = None
@@ -140,6 +144,14 @@ class CrawlJob(ABC):
 
                 # check crawl status
                 await self.check_crawl_status()
+
+                if self.crawl_timeout and datetime.utcnow() > self.crawl_timeout:
+                    res = await self.graceful_shutdown()
+                    if res.get("success"):
+                        print(
+                            "Job duration expired at {self.crawl_timeout}, "
+                            + "gracefully stopping crawl"
+                        )
 
             # pylint: disable=broad-except
             except Exception as exc:

--- a/backend/btrixcloud/crawl_job.py
+++ b/backend/btrixcloud/crawl_job.py
@@ -145,18 +145,7 @@ class CrawlJob(ABC):
                 # check crawl status
                 await self.check_crawl_status()
 
-                if (
-                    self.crawl_expire_time
-                    and datetime.utcnow() > self.crawl_expire_time
-                ):
-                    res = await self.graceful_shutdown()
-                    if res.get("success"):
-                        print(
-                            "Job duration expired at {self.crawl_expire_time}, "
-                            + "gracefully stopping crawl"
-                        )
-
-            # pylint: disable=broad-except
+                # pylint: disable=broad-except
             except Exception as exc:
                 print(f"Retrying crawls done loop: {exc}")
                 await asyncio.sleep(10)
@@ -188,6 +177,15 @@ class CrawlJob(ABC):
             await self.fail_crawl()
 
             await self.delete_crawl()
+
+        # check crawl expiry
+        if self.crawl_expire_time and datetime.utcnow() > self.crawl_expire_time:
+            res = await self.graceful_shutdown()
+            if res.get("success"):
+                print(
+                    "Job duration expired at {self.crawl_expire_time}, "
+                    + "gracefully stopping crawl"
+                )
 
     async def delete_crawl(self):
         """delete crawl stateful sets, services and pvcs"""

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -179,12 +179,12 @@ class BaseCrawlManager(ABC):
 
     async def _load_job_template(self, crawlconfig, job_id, manual, schedule=None):
         if crawlconfig.crawlTimeout:
-            crawl_timeout = datetime.datetime.utcnow() + datetime.timedelta(
+            crawl_expire_time = datetime.datetime.utcnow() + datetime.timedelta(
                 seconds=crawlconfig.crawlTimeout
             )
-            crawl_timeout = crawl_timeout.isoformat()
+            crawl_expire_time = crawl_expire_time.isoformat()
         else:
-            crawl_timeout = ""
+            crawl_expire_time = ""
 
         params = {
             "id": job_id,
@@ -192,7 +192,7 @@ class BaseCrawlManager(ABC):
             "rev": str(crawlconfig.rev),
             "userid": str(crawlconfig.modifiedBy),
             "oid": str(crawlconfig.oid),
-            "crawl_timeout_exact": crawl_timeout,
+            "crawl_expire_time": crawl_expire_time,
             "job_image": self.job_image,
             "job_pull_policy": self.job_pull_policy,
             "manual": "1" if manual else "0",

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -178,12 +178,21 @@ class BaseCrawlManager(ABC):
         return crawl_id
 
     async def _load_job_template(self, crawlconfig, job_id, manual, schedule=None):
+        if crawlconfig.crawlTimeout:
+            crawl_timeout = datetime.datetime.utcnow() + datetime.timedelta(
+                seconds=crawlconfig.crawlTimeout
+            )
+            crawl_timeout = crawl_timeout.isoformat()
+        else:
+            crawl_timeout = ""
+
         params = {
             "id": job_id,
             "cid": str(crawlconfig.id),
             "rev": str(crawlconfig.rev),
             "userid": str(crawlconfig.modifiedBy),
             "oid": str(crawlconfig.oid),
+            "crawl_timeout_exact": crawl_timeout,
             "job_image": self.job_image,
             "job_pull_policy": self.job_pull_policy,
             "manual": "1" if manual else "0",

--- a/backend/btrixcloud/k8s/templates/crawl_job.yaml
+++ b/backend/btrixcloud/k8s/templates/crawl_job.yaml
@@ -76,6 +76,9 @@ spec:
             - name: TAGS
               value: "{{ tags }}"
 
+            - name: CRAWL_TIMEOUT
+              value: "{{ crawl_timeout }}"
+
             - name: STORE_PATH
               valueFrom:
                 configMapKeyRef:

--- a/backend/btrixcloud/k8s/templates/crawl_job.yaml
+++ b/backend/btrixcloud/k8s/templates/crawl_job.yaml
@@ -76,8 +76,8 @@ spec:
             - name: TAGS
               value: "{{ tags }}"
 
-            - name: CRAWL_TIMEOUT
-              value: "{{ crawl_timeout }}"
+            - name: CRAWL_EXPIRE_TIME
+              value: "{{ crawl_expire_time }}"
 
             - name: STORE_PATH
               valueFrom:


### PR DESCRIPTION
The overall behavior is the equivalent of clicking 'Stop Crawl' after the specified time has elapsed.
Note that the crawl may not have started yet, or may not have started later when the time limit is reached.
The crawl is also given a chance to shut down gracefully, so the exact running time may be shorter or longer than the limit.

This seems like a reasonable trade-off given the limitations.