### PR TITLE
Limit organization name length

### DIFF
--- a/frontend/src/components/crawl-metadata-editor.ts
+++ b/frontend/src/components/crawl-metadata-editor.ts
@@ -9,8 +9,6 @@ import LiteElement, { html } from "../utils/LiteElement";
 import { maxLengthValidator } from "../utils/form";
 import type { Crawl } from "../types/crawler";
 
-const CRAWL_NOTES_MAXLENGTH = 500;
-
 /**
  * Usage:
  * ```ts
@@ -55,6 +53,8 @@ export class CrawlMetadataEditor extends LiteElement {
     threshold: 0.2, // stricter; default is 0.6
   });
 
+  private validateCrawlNotesMax = maxLengthValidator(500);
+
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("open") && this.open) {
       this.fetchTags();
@@ -81,7 +81,7 @@ export class CrawlMetadataEditor extends LiteElement {
   private renderEditMetadata() {
     if (!this.crawl) return;
 
-    const { helpText, validate } = maxLengthValidator(CRAWL_NOTES_MAXLENGTH);
+    const { helpText, validate } = this.validateCrawlNotesMax;
     return html`
       <form
         id="crawlDetailsForm"

--- a/frontend/src/components/crawl-metadata-editor.ts
+++ b/frontend/src/components/crawl-metadata-editor.ts
@@ -89,7 +89,7 @@ export class CrawlMetadataEditor extends LiteElement {
         @reset=${this.requestClose}
       >
         <sl-textarea
-          class="mb-3"
+          class="mb-3 with-max-help-text"
           name="crawlNotes"
           label=${msg("Notes")}
           value=${this.crawl.notes || ""}
@@ -97,7 +97,6 @@ export class CrawlMetadataEditor extends LiteElement {
           autocomplete="off"
           resize="auto"
           help-text=${helpText}
-          style="--help-text-align: right"
           @sl-input=${validate}
         ></sl-textarea>
         <btrix-tag-input

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -379,10 +379,13 @@ export class App extends LiteElement {
       return;
     }
 
+    // Limit org name display for orgs created before org name max length restriction
+    const orgNameLength = 50;
+
     return html`
       <sl-dropdown placement="bottom-end">
         <sl-button slot="trigger" variant="text" size="small" caret
-          >${selectedOption.name}</sl-button
+          >${selectedOption.name.slice(0, orgNameLength)}</sl-button
         >
         <sl-menu
           @sl-select=${(e: CustomEvent) => {
@@ -414,7 +417,7 @@ export class App extends LiteElement {
               <sl-menu-item
                 value=${org.id}
                 ?checked=${org.id === selectedOption.id}
-                >${org.name}</sl-menu-item
+                >${org.name.slice(0, orgNameLength)}</sl-menu-item
               >
             `
           )}

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -8,6 +8,7 @@ import type { CurrentUser } from "../types/user";
 import type { OrgData } from "../utils/orgs";
 import LiteElement, { html } from "../utils/LiteElement";
 import type { APIPaginatedList } from "../types/api";
+import { maxLengthValidator } from "../utils/form";
 
 @localized()
 export class Home extends LiteElement {
@@ -34,6 +35,8 @@ export class Home extends LiteElement {
 
   @state()
   private isSubmittingNewOrg = false;
+
+  private validateOrgNameLength = maxLengthValidator(50);
 
   connectedCallback() {
     if (this.authState) {
@@ -190,11 +193,14 @@ export class Home extends LiteElement {
               >
                 <div class="mb-5">
                   <sl-input
+                    class="with-max-help-text"
                     name="name"
                     label=${msg("Org Name")}
                     placeholder=${msg("My Organization")}
                     autocomplete="off"
                     required
+                    help-text=${this.validateOrgNameLength.helpText}
+                    @sl-input=${this.validateOrgNameLength.validate}
                   >
                   </sl-input>
                 </div>

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -36,7 +36,7 @@ export class Home extends LiteElement {
   @state()
   private isSubmittingNewOrg = false;
 
-  private validateOrgNameLength = maxLengthValidator(50);
+  private validateOrgNameMax = maxLengthValidator(50);
 
   connectedCallback() {
     if (this.authState) {
@@ -199,8 +199,8 @@ export class Home extends LiteElement {
                     placeholder=${msg("My Organization")}
                     autocomplete="off"
                     required
-                    help-text=${this.validateOrgNameLength.helpText}
-                    @sl-input=${this.validateOrgNameLength.validate}
+                    help-text=${this.validateOrgNameMax.helpText}
+                    @sl-input=${this.validateOrgNameMax.validate}
                   >
                   </sl-input>
                 </div>

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -1444,6 +1444,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     return html`
       ${this.renderFormCol(html`
         <sl-input
+          class="with-max-help-text"
           name="jobName"
           label=${msg("Name")}
           autocomplete="off"
@@ -1452,7 +1453,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
           })}
           value=${this.formState.jobName}
           help-text=${helpText}
-          style="--help-text-align: right"
           @sl-input=${validate}
         ></sl-input>
       `)}

--- a/frontend/src/pages/org/crawl-config-editor.ts
+++ b/frontend/src/pages/org/crawl-config-editor.ts
@@ -234,6 +234,8 @@ export class CrawlConfigEditor extends LiteElement {
     threshold: 0.2, // stricter; default is 0.6
   });
 
+  private validateNameMax = maxLengthValidator(50);
+
   private get formHasError() {
     return (
       !this.hasRequiredFields() ||
@@ -1438,7 +1440,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   };
 
   private renderJobMetadata() {
-    const { helpText, validate } = maxLengthValidator(50);
+    const { helpText, validate } = this.validateNameMax;
     return html`
       ${this.renderFormCol(html`
         <sl-input

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -91,7 +91,7 @@ export class OrgSettings extends LiteElement {
     };
   }
 
-  private validateOrgNameLength = maxLengthValidator(50);
+  private validateOrgNameMax = maxLengthValidator(50);
 
   async willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("isAddingMember") && this.isAddingMember) {
@@ -174,8 +174,8 @@ export class OrgSettings extends LiteElement {
           autocomplete="off"
           value=${this.org.name}
           required
-          help-text=${this.validateOrgNameLength.helpText}
-          @sl-input=${this.validateOrgNameLength.validate}
+          help-text=${this.validateOrgNameMax.helpText}
+          @sl-input=${this.validateOrgNameMax.validate}
         ></sl-input>
         <sl-button
           class="inline-control-button"

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -165,32 +165,28 @@ export class OrgSettings extends LiteElement {
 
   private renderInformation() {
     return html`<div class="rounded border p-5">
-      <form @submit=${this.onOrgNameSubmit}>
-        <div class="flex">
-          <div class="flex-1 mr-3">
-            <sl-input
-              name="orgName"
-              size="small"
-              label=${msg("Org Name")}
-              autocomplete="off"
-              value=${this.org.name}
-              required
-              help-text=${this.validateOrgNameLength.helpText}
-              style="--help-text-align: right"
-              @sl-input=${this.validateOrgNameLength.validate}
-            ></sl-input>
-          </div>
-          <div class="flex-07">
-            <sl-button
-              type="submit"
-              size="small"
-              variant="primary"
-              ?disabled=${this.isSavingOrgName}
-              ?loading=${this.isSavingOrgName}
-              >${msg("Save Changes")}</sl-button
-            >
-          </div>
-        </div>
+      <form class="inline-control-form" @submit=${this.onOrgNameSubmit}>
+        <sl-input
+          class="inline-control-input"
+          name="orgName"
+          size="small"
+          label=${msg("Org Name")}
+          autocomplete="off"
+          value=${this.org.name}
+          required
+          help-text=${this.validateOrgNameLength.helpText}
+          style="--help-text-align: right"
+          @sl-input=${this.validateOrgNameLength.validate}
+        ></sl-input>
+        <sl-button
+          class="inline-control-button"
+          type="submit"
+          size="small"
+          variant="primary"
+          ?disabled=${this.isSavingOrgName}
+          ?loading=${this.isSavingOrgName}
+          >${msg("Save Changes")}</sl-button
+        >
       </form>
     </div>`;
   }

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -167,7 +167,7 @@ export class OrgSettings extends LiteElement {
     return html`<div class="rounded border p-5">
       <form class="inline-control-form" @submit=${this.onOrgNameSubmit}>
         <sl-input
-          class="inline-control-input"
+          class="inline-control-input with-max-help-text"
           name="orgName"
           size="small"
           label=${msg("Org Name")}
@@ -175,7 +175,6 @@ export class OrgSettings extends LiteElement {
           value=${this.org.name}
           required
           help-text=${this.validateOrgNameLength.helpText}
-          style="--help-text-align: right"
           @sl-input=${this.validateOrgNameLength.validate}
         ></sl-input>
         <sl-button

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -10,6 +10,7 @@ import { isAdmin, isCrawler, AccessCode } from "../../utils/orgs";
 import type { OrgData } from "../../utils/orgs";
 import type { CurrentUser } from "../../types/user";
 import type { APIPaginatedList } from "../../types/api";
+import { maxLengthValidator } from "../../utils/form";
 
 type Tab = "information" | "members";
 type User = {
@@ -90,6 +91,8 @@ export class OrgSettings extends LiteElement {
     };
   }
 
+  private validateOrgNameLength = maxLengthValidator(50);
+
   async willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("isAddingMember") && this.isAddingMember) {
       this.isAddMemberFormVisible = true;
@@ -163,7 +166,7 @@ export class OrgSettings extends LiteElement {
   private renderInformation() {
     return html`<div class="rounded border p-5">
       <form @submit=${this.onOrgNameSubmit}>
-        <div class="flex items-end">
+        <div class="flex">
           <div class="flex-1 mr-3">
             <sl-input
               name="orgName"
@@ -172,9 +175,12 @@ export class OrgSettings extends LiteElement {
               autocomplete="off"
               value=${this.org.name}
               required
+              help-text=${this.validateOrgNameLength.helpText}
+              style="--help-text-align: right"
+              @sl-input=${this.validateOrgNameLength.validate}
             ></sl-input>
           </div>
-          <div class="flex-0">
+          <div class="flex-07">
             <sl-button
               type="submit"
               size="small"

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -214,6 +214,11 @@ const theme = css`
     grid-area: button;
   }
 
+  /* Inputs with "Max N characters" help text */
+  .with-max-help-text {
+    --help-text-align: right;
+  }
+
   /* Aesthetically closer to monospaced font: */
   .font-monostyle {
     font-family: var(--font-monostyle-family);

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -181,6 +181,39 @@ const theme = css`
     min-width: min-content;
   }
 
+  /* For single-input forms with submit button inline */
+  /* Requires form control and button to be direct children */
+  .inline-control-input,
+  .inline-control-input::part(form-control) {
+    display: contents;
+  }
+
+  .inline-control-form {
+    display: grid;
+    grid-template-areas:
+      "label ."
+      "input button"
+      "help-text .";
+    grid-template-columns: 1fr max-content;
+    column-gap: var(--sl-spacing-small);
+  }
+
+  .inline-control-input::part(form-control-label) {
+    grid-area: label;
+  }
+
+  .inline-control-input::part(form-control-input) {
+    grid-area: input;
+  }
+
+  .inline-control-input::part(form-control-help-text) {
+    grid-area: help-text;
+  }
+
+  .inline-control-button {
+    grid-area: button;
+  }
+
   /* Aesthetically closer to monospaced font: */
   .font-monostyle {
     font-family: var(--font-monostyle-family);


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/590:
- Limit length to 50 when creating or updating org (same as crawl config name length)
- Limit display length for orgs created before restriction
- Minor refactor for consistent usage of `maxLengthValidator`

### Manual testing
1. Log in as superadmin user
2. Click "Create Org" and enter org name. Verify you're unable to save org name with more than 50 characters
3. Click "All Organizations" dropdown in app bar. Verify that org names are not longer than 50 characters
4. Log out and log in as normal user
5. Go to "Org Settings" and enter org name. Verify you're unable to save org name with more than 50 characters

### Screenshots
**Superadmin create org dialog:**
<img width="520" alt="Screen Shot 2023-03-06 at 9 24 28 AM" src="https://user-images.githubusercontent.com/4672952/223188021-1191d81c-5d78-457e-9664-d9046e142741.png">

**User with multiple orgs dropdown:**
<img width="383" alt="Screen Shot 2023-03-06 at 9 40 28 AM" src="https://user-images.githubusercontent.com/4672952/223188515-4d041333-0a6f-42f4-8442-3581a8ed707f.png">


**Org settings name input:**
<img width="921" alt="Screen Shot 2023-03-06 at 9 24 41 AM" src="https://user-images.githubusercontent.com/4672952/223188166-c9bbf944-848e-4c9e-a8d9-d0a11a47f94b.png">

**Org settings name validation:**
<img width="736" alt="Screen Shot 2023-03-06 at 9 24 56 AM" src="https://user-images.githubusercontent.com/4672952/223188229-cbbc2a75-a549-4653-b00e-63ee1195111b.png">
