### PR TITLE
Use new crawl config update API

### DIFF
--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -44,17 +44,21 @@ export class CrawlTemplatesDetail extends LiteElement {
   };
 
   willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("crawlConfigId") && this.crawlConfigId) {
+    if (
+      (changedProperties.has("crawlConfigId") && this.crawlConfigId) ||
+      (changedProperties.get("isEditing") === true && this.isEditing === false)
+    ) {
       this.initializeCrawlTemplate();
     }
   }
 
   protected updated(changedProperties: Map<string, any>) {
     if (
-      changedProperties.has("crawlConfig") &&
-      !changedProperties.get("crawlConfig") &&
-      this.crawlConfig &&
-      window.location.hash
+      (changedProperties.has("crawlConfig") &&
+        !changedProperties.get("crawlConfig") &&
+        this.crawlConfig &&
+        window.location.hash) ||
+      (changedProperties.get("isEditing") === true && this.isEditing === false)
     ) {
       // Show section once crawl config is done rendering
       document.querySelector(window.location.hash)?.scrollIntoView();

--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -133,20 +133,7 @@ export class CrawlTemplatesDetail extends LiteElement {
                 </sl-tooltip>
 
                 ${this.renderMenu()}
-              `,
-              () =>
-                this.crawlConfig?.newId
-                  ? html`
-                      <sl-button
-                        size="small"
-                        variant="text"
-                        @click=${this.getNewerVersion}
-                      >
-                        <sl-icon slot="suffix" name="arrow-right"></sl-icon>
-                        ${msg("Newer Version")}
-                      </sl-button>
-                    `
-                  : ""
+              `
             )}
           </div>
         </header>
@@ -455,12 +442,6 @@ export class CrawlTemplatesDetail extends LiteElement {
       html`${firstSeed}
         <span class="text-neutral-500">+${remainderCount} URLs</span>`
     );
-  }
-
-  private getNewerVersion() {
-    const versionId = this.crawlConfig?.newId;
-    if (!versionId) return;
-    this.navTo(`/orgs/${this.orgId}/crawl-configs/config/${versionId}`);
   }
 
   private async getCrawlTemplate(configId: string): Promise<CrawlConfig> {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -100,8 +100,6 @@ export type CrawlConfig = CrawlConfigParams & {
   lastCrawlTime: string;
   lastCrawlState: CrawlState;
   currCrawlId: string;
-  newId: string | null;
-  oldId: string | null;
   inactive: boolean;
   profileName: string | null;
 };


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/657:
- Switch POST endpoint for config to PATCH
- Remove link to previous config version that uses `oldId`