### PR TITLE
Fix crawl config name in "run now" alert

### DIFF
--- a/frontend/src/pages/org/crawl-configs-detail.ts
+++ b/frontend/src/pages/org/crawl-configs-detail.ts
@@ -596,12 +596,12 @@ export class CrawlTemplatesDetail extends LiteElement {
 
       this.notify({
         message: msg(
-          html`Started crawl from <strong>${this.crawlConfig!.name}</strong>.
+          html`Started crawl from <strong>${this.renderName()}</strong>.
             <br />
             <a
               class="underline hover:no-underline"
               href="/orgs/${this.orgId}/crawls/crawl/${data.started}#watch"
-              @click=${this.navLink.bind(this)}
+              @click="${this.navLink.bind(this)}"
               >Watch crawl</a
             >`
         ),


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/667 (regression introduced in https://github.com/webrecorder/browsertrix-cloud/pull/644)

### Manual testing
1. Log in and go to Crawl Configs view
2. Click into a crawl config without a custom name (i.e. one that uses a seed URL as its name)
3. Click "Actions" menu -> "Run Now". Verify alert renders name correctly