### PR TITLE
Disable copy tags menu item if no tags

### DIFF
--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -210,20 +210,23 @@ export class CrawlsList extends LiteElement {
           </div>
         </header>
         <section>
-          ${this.crawls.length
-            ? this.renderCrawlList()
-            : html`
+          ${
+            this.crawls.length
+              ? this.renderCrawlList()
+              : html`
                 <div class="border-t border-b py-5">
                   <p class="text-center text-neutral-500">
                     ${msg("No crawls yet.")}
                   </p>
                 </div>
-              `}
+              `
+          }
         </section>
         <footer class="m-2">
           <span class="text-0-400 text-xs">
-            ${this.lastFetched
-              ? msg(html`Last updated:
+            ${
+              this.lastFetched
+                ? msg(html`Last updated:
                   <sl-format-date
                     date="${new Date(this.lastFetched).toString()}"
                     month="2-digit"
@@ -233,7 +236,8 @@ export class CrawlsList extends LiteElement {
                     minute="numeric"
                     second="numeric"
                   ></sl-format-date>`)
-              : ""}
+                : ""
+            }
           </span>
         </footer>
       </main>
@@ -326,8 +330,9 @@ export class CrawlsList extends LiteElement {
         </div>
       </div>
 
-      ${this.userId
-        ? html` <div class="h-6 mt-2 flex justify-end">
+      ${
+        this.userId
+          ? html` <div class="h-6 mt-2 flex justify-end">
             <label>
               <span class="text-neutral-500 text-xs mr-1"
                 >${msg("Show Only Mine")}</span
@@ -339,7 +344,8 @@ export class CrawlsList extends LiteElement {
               ></sl-switch>
             </label>
           </div>`
-        : ""}
+          : ""
+      }
     `;
   }
 
@@ -471,6 +477,7 @@ export class CrawlsList extends LiteElement {
       </sl-menu-item>
       <sl-menu-item
         @click=${() => CopyButton.copyToClipboard(crawl.tags.join(","))}
+        ?disabled=${!crawl.tags.length}
       >
         <sl-icon name="tags" slot="prefix"></sl-icon>
         ${msg("Copy Tags")}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/705.

### Manual testing
1. Log in and go to "Crawls" list
2. Find crawl without any tags. Click "..." menu button. Verify "Copy Tags" is disabled

### Screenshots
<img width="193" alt="Screen Shot 2023-03-16 at 6 03 13 PM" src="https://user-images.githubusercontent.com/4672952/225786106-e0e0aa0f-bc02-4840-96f2-d45e12aa9035.png">
