### PR TITLE
Allow configurable max pages per crawl in deployment settings

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -21,6 +21,8 @@ from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
 from .db import BaseMongoModel
 
+# pylint: disable=too-many-lines
+
 
 # ============================================================================
 class JobType(str, Enum):
@@ -223,7 +225,7 @@ class UpdateCrawlConfig(BaseModel):
 
 
 # ============================================================================
-# pylint: disable=too-many-instance-attributes,too-many-arguments
+# pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-public-methods
 class CrawlConfigOps:
     """Crawl Config Operations"""
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -779,6 +779,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
         description: Optional[str] = None,
         sortBy: Optional[str] = None,
         sortDirection: Optional[int] = -1,
+        runningOnly: Optional[bool] = True,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
@@ -799,7 +800,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
             None,
             userid=userid,
             cid=cid,
-            running_only=True,
+            running_only=runningOnly,
             state=state,
             first_seed=firstSeed,
             name=name,

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -54,6 +54,7 @@ def main():
         "defaultBehaviorTimeSeconds": int(
             os.environ.get("DEFAULT_BEHAVIOR_TIME_SECONDS", 300)
         ),
+        "maxPagesPerCrawl": int(os.environ.get("MAX_PAGES_PER_CRAWL", 0)),
     }
 
     invites = init_invites(mdb, email)

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -85,7 +85,8 @@ def admin_crawl_id(admin_auth_headers, default_org_id):
         "tags": ["wr-test-1", "wr-test-2"],
         "config": {
             "seeds": [{"url": "https://webrecorder.net/"}],
-            "limit": 1,
+            # limit now set via 'max_pages_per_crawl' global limit
+            # "limit": 1,
         },
     }
     r = requests.post(

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -86,6 +86,28 @@ def test_verify_update(crawler_auth_headers, default_org_id):
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
 
 
+def test_update_config_invalid_limit(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={
+            "config": {
+                "seeds": ["https://example.com/"],
+                "scopeType": "domain",
+                "limit": 10,
+            }
+        },
+    )
+
+    assert r.status_code == 400
+
+    data = r.json()
+
+    assert data["detail"] == "crawl_page_limit_exceeds_allowed"
+
+
 def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_data):
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -86,7 +86,7 @@ def test_verify_update(crawler_auth_headers, default_org_id):
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
 
 
-def test_update_config_invalid_limit(
+def test_update_config_invalid_format(
     crawler_auth_headers, default_org_id, sample_crawl_data
 ):
     r = requests.patch(
@@ -95,6 +95,24 @@ def test_update_config_invalid_limit(
         json={
             "config": {
                 "seeds": ["https://example.com/"],
+                "scopeType": "domain",
+                "limit": 10,
+            }
+        },
+    )
+
+    assert r.status_code == 422
+
+
+def test_update_config_invalid_limit(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={
+            "config": {
+                "seeds": [{"url": "https://example.com/"}],
                 "scopeType": "domain",
                 "limit": 10,
             }

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -31,7 +31,7 @@ def test_create_new_config_invalid_limit(admin_auth_headers, default_org_id):
     crawl_data = {
         "runNow": True,
         "name": "Test Crawl",
-        "config": {"seeds": ["https://webrecorder.net/"], "limit": 10},
+        "config": {"seeds": [{"url": "https://webrecorder.net/"}], "limit": 10},
     }
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",

--- a/backend/test/test_settings.py
+++ b/backend/test/test_settings.py
@@ -1,0 +1,17 @@
+import requests
+
+from .conftest import API_PREFIX
+
+
+def test_settings():
+    r = requests.get(f"{API_PREFIX}/settings")
+    assert r.status_code == 200
+
+    data = r.json()
+
+    assert data == {
+        "registrationEnabled": False,
+        "jwtTokenLifetime": 86400,
+        "defaultBehaviorTimeSeconds": 300,
+        "maxPagesPerCrawl": 2,
+    }

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -54,6 +54,8 @@ data:
 
   DEFAULT_BEHAVIOR_TIME_SECONDS: "{{ .Values.default_behavior_time_seconds }}"
 
+  MAX_PAGES_PER_CRAWL: "{{ .Values.max_pages_per_crawl | default 0 }}"
+
   WEB_CONCURRENCY: "{{ .Values.backend_workers | default 4 }}"
 
   IDLE_TIMEOUT: "{{ .Values.profile_browser_idle_seconds | default 60 }}"

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -20,3 +20,9 @@ superuser:
 
 
 local_service_port: 30870
+
+# test max pages per crawl global limit
+max_pages_per_crawl: 2
+
+registration_enabled: "0"
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,11 @@ jwt_token_lifetime_minutes: 1440
 # default time to run behaviors on each page (in seconds)
 default_behavior_time_seconds: 300
 
+# max pages per crawl
+# set to non-zero value to enforce global max pages per crawl limit
+# if set, each workflow can have a lower limit, but not higher
+max_pages_per_crawl: 0
+
 # if set to "1", allow inviting same user to same org multiple times
 allow_dupe_invites: "0"
 


### PR DESCRIPTION
- Cluster admin can set `max_pages_per_crawl` in the Helm chart settings to limit all crawl configs/workflows to at most that many pages.
- Backend will return an error if user sets limit greater than the max limit
- `/api/settings` returns current limit, if any, as `maxPagesPerCrawl`

New tests and some minor test fixes:
- test clusters sets a global `max_pages_per_crawl` to 2 pages, some other tests also use 1
- don't start an extra crawl just to add new crawl config, as already tested via fixtures
- /api/all/crawls endpoint was only showing running crawls, allow it to include all crawls for more consistent testing (as sometimes the check would run after crawls already stopped locally)

addresses part of #716