### PR TITLE
Fix migration to avoid jobType KeyError

### DIFF
--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -63,9 +63,9 @@ class Migration(BaseMigration):
                 {
                     "$set": {
                         "config": config_result["config"],
-                        "profileid": config_result["profileid"],
-                        "schedule": config_result["schedule"],
-                        "crawlTimeout": config_result["crawlTimeout"],
+                        "profileid": config_result.get("profileid"),
+                        "schedule": config_result.get("schedule"),
+                        "crawlTimeout": config_result.get("crawlTimeout"),
                         "jobType": config_result.get("jobType"),
                     }
                 },

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -66,7 +66,7 @@ class Migration(BaseMigration):
                         "profileid": config_result["profileid"],
                         "schedule": config_result["schedule"],
                         "crawlTimeout": config_result["crawlTimeout"],
-                        "jobType": config_result["jobType"],
+                        "jobType": config_result.get("jobType"),
                     }
                 },
             )


### PR DESCRIPTION
Fixes #715 

Because `jobType` is optional for crawlconfigs, using `.get()` will avoid a KeyError if `jobType` is `None`, without changing the underlying user data or assuming a job type for configs that don't have them.

Other optional config fields have been similarly changed to avoid KeyErrors for them as well.