### PR TITLE
Leave trailing slash in seed URLs

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1951,10 +1951,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private parseSeededConfig(): NewCrawlConfigParams["config"] {
-    const primarySeedUrl =
-      this.formState.scopeType === "domain"
-        ? this.formState.primarySeedUrl.replace(/\/$/, "")
-        : this.formState.primarySeedUrl;
+    const primarySeedUrl = this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeUrlList
       ? urlListToArray(this.formState.customIncludeUrlList)
       : [];

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1951,16 +1951,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private parseSeededConfig(): NewCrawlConfigParams["config"] {
-    const primarySeedUrl = this.formState.primarySeedUrl.replace(/\/$/, "");
+    const primarySeedUrl = this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeUrlList
-      ? urlListToArray(this.formState.customIncludeUrlList).map((str) =>
-          str.replace(/\/$/, "")
-        )
+      ? urlListToArray(this.formState.customIncludeUrlList)
       : [];
     const additionalSeedUrlList = this.formState.urlList
-      ? urlListToArray(this.formState.urlList).map((str) =>
-          str.replace(/\/$/, "")
-        )
+      ? urlListToArray(this.formState.urlList)
       : [];
     const primarySeed: Seed = {
       url: primarySeedUrl,

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1951,7 +1951,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private parseSeededConfig(): NewCrawlConfigParams["config"] {
-    const primarySeedUrl = this.formState.primarySeedUrl;
+    const primarySeedUrl =
+      this.formState.scopeType === "domain"
+        ? this.formState.primarySeedUrl.replace(/\/$/, "")
+        : this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeUrlList
       ? urlListToArray(this.formState.customIncludeUrlList)
       : [];


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/723 by keeping user-entered trailing slashes.