### PR TITLE
Add pageSize to pagination output format

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -191,7 +191,7 @@ def init_collections_api(mdb, crawls, orgs, crawl_manager):
         collections, total = await colls.list_collections(
             org.id, page_size=pageSize, page=page
         )
-        return paginated_format(collections, total, page)
+        return paginated_format(collections, total, page, pageSize)
 
     @router.get("/$all")
     async def get_collection_all(org: Organization = Depends(org_viewer_dep)):

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -933,7 +933,7 @@ def init_crawl_config_api(
             sort_by=sortBy,
             sort_direction=sortDirection,
         )
-        return paginated_format(crawl_configs, total, page)
+        return paginated_format(crawl_configs, total, page, pageSize)
 
     @router.get("/tags")
     async def get_crawl_config_tags(org: Organization = Depends(org_viewer_dep)):
@@ -954,12 +954,12 @@ def init_crawl_config_api(
         dependencies=[Depends(org_viewer_dep)],
     )
     async def get_crawl_config_revisions(
-        cid: str, page_size: int = DEFAULT_PAGE_SIZE, page: int = 1
+        cid: str, pageSize: int = DEFAULT_PAGE_SIZE, page: int = 1
     ):
         revisions, total = await ops.get_crawl_config_revs(
-            uuid.UUID(cid), page_size=page_size, page=page
+            uuid.UUID(cid), page_size=pageSize, page=page
         )
-        return paginated_format(revisions, total, page)
+        return paginated_format(revisions, total, page, pageSize)
 
     @router.post("/")
     async def add_crawl_config(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -810,7 +810,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
             sort_by=sortBy,
             sort_direction=sortDirection,
         )
-        return paginated_format(crawls, total, page)
+        return paginated_format(crawls, total, page, pageSize)
 
     @app.get("/orgs/{oid}/crawls", tags=["crawls"])
     async def list_crawls(
@@ -853,7 +853,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
             sort_by=sortBy,
             sort_direction=sortDirection,
         )
-        return paginated_format(crawls, total, page)
+        return paginated_format(crawls, total, page, pageSize)
 
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/cancel",

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -420,7 +420,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
         serialized_results = [
             await res.serialize_for_user(user, user_manager) for res in results
         ]
-        return paginated_format(serialized_results, total, page)
+        return paginated_format(serialized_results, total, page, pageSize)
 
     @app.post("/orgs/create", tags=["organizations"])
     async def create_org(
@@ -517,7 +517,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
         pending_invites, total = await user_manager.invites.get_pending_invites(
             org, page_size=pageSize, page=page
         )
-        return paginated_format(pending_invites, total, page)
+        return paginated_format(pending_invites, total, page, pageSize)
 
     @router.post("/invites/delete", tags=["invites"])
     async def delete_invite(

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -5,6 +5,11 @@ from typing import Any, List, Optional
 DEFAULT_PAGE_SIZE = 1_000
 
 
-def paginated_format(items: Optional[List[Any]], total: int, page: int = 1):
+def paginated_format(
+    items: Optional[List[Any]],
+    total: int,
+    page: int = 1,
+    page_size: int = DEFAULT_PAGE_SIZE,
+):
     """Return items in paged format."""
-    return {"items": items, "total": total, "page": page}
+    return {"items": items, "total": total, "page": page, "pageSize": page_size}

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -421,7 +421,7 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
         profiles, total = await ops.list_profiles(
             org, userid, page_size=pageSize, page=page
         )
-        return paginated_format(profiles, total, page)
+        return paginated_format(profiles, total, page, pageSize)
 
     @router.post("", response_model=Profile)
     async def commit_browser_to_new(

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -483,7 +483,7 @@ def init_users_api(app, user_manager):
         pending_invites, total = await user_manager.invites.get_pending_invites(
             page_size=pageSize, page=page
         )
-        return paginated_format(pending_invites, total, page)
+        return paginated_format(pending_invites, total, page, pageSize)
 
     app.include_router(users_router, prefix="/users", tags=["users"])
 


### PR DESCRIPTION
Adds `pageSize` to the output for paginated list API endpoints, correcting an oversight in https://github.com/webrecorder/browsertrix-cloud/pull/724.