### PR TITLE
Set max pages to API default

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -192,7 +192,7 @@ const urlListToArray = flow(
   trimArray
 );
 const DEFAULT_BEHAVIOR_TIMEOUT_MINUTES = 5;
-const DEFAULT_MAX_PAGES_PER_CRAWL = 100 * 1000;
+const DEFAULT_MAX_PAGES_PER_CRAWL = Infinity;
 
 @localized()
 export class CrawlConfigEditor extends LiteElement {
@@ -1177,7 +1177,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
             value=${this.formState.pageLimit || ""}
             min=${minPages}
             max=${this.orgDefaults.maxPagesPerCrawl}
-            placeholder=${msg("Maximum Allowed")}
+            placeholder=${this.orgDefaults.maxPagesPerCrawl === Infinity
+              ? msg("Unlimited")
+              : this.orgDefaults.maxPagesPerCrawl.toLocaleString()}
             @sl-input=${async (e: CustomEvent) => {
               const inputEl = e.target as SlInput;
               await inputEl.updateComplete;

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -220,7 +220,9 @@ export class CrawlConfigEditor extends LiteElement {
   private progressState!: ProgressState;
 
   @state()
-  private defaultBehaviorTimeoutMinutes?: number;
+  private orgDefaults = {
+    behaviorTimeoutMinutes: DEFAULT_BEHAVIOR_TIMEOUT_MINUTES,
+  };
 
   @state()
   private formState!: FormState;
@@ -1195,9 +1197,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
           placeholder=${msg("Unlimited")}
           value=${ifDefined(
             this.formState.pageTimeoutMinutes ??
-              this.defaultBehaviorTimeoutMinutes
+              this.orgDefaults.behaviorTimeoutMinutes
           )}
-          ?disabled=${this.defaultBehaviorTimeoutMinutes === undefined}
+          ?disabled=${this.orgDefaults.behaviorTimeoutMinutes === undefined}
           min="1"
           required
         >
@@ -1928,7 +1930,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           : this.parseUrlListConfig()),
         behaviorTimeout:
           (this.formState.pageTimeoutMinutes ??
-            this.defaultBehaviorTimeoutMinutes ??
+            this.orgDefaults.behaviorTimeoutMinutes ??
             DEFAULT_BEHAVIOR_TIMEOUT_MINUTES) * 60,
         limit: this.formState.pageLimit ? +this.formState.pageLimit : undefined,
         lang: this.formState.lang || "",
@@ -1943,7 +1945,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   private parseUrlListConfig(): NewCrawlConfigParams["config"] {
     const config = {
       seeds: urlListToArray(this.formState.urlList).map((seedUrl) => {
-        const newSeed: Seed = {url: seedUrl, scopeType: "page"};
+        const newSeed: Seed = { url: seedUrl, scopeType: "page" };
         return newSeed;
       }),
       scopeType: "page" as FormState["scopeType"],
@@ -1960,9 +1962,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
       : [];
     const additionalSeedUrlList = this.formState.urlList
       ? urlListToArray(this.formState.urlList).map((seedUrl) => {
-        const newSeed: Seed = {url: seedUrl, scopeType: "page"};
-        return newSeed;
-      })
+          const newSeed: Seed = { url: seedUrl, scopeType: "page" };
+          return newSeed;
+        })
       : [];
     const primarySeed: Seed = {
       url: primarySeedUrl,
@@ -2016,18 +2018,17 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private async fetchAPIDefaults() {
+    const orgDefaults = { ...this.orgDefaults };
     try {
       const data = await this.apiFetch("/settings", this.authState!);
       if (data.defaultBehaviorTimeSeconds) {
-        this.defaultBehaviorTimeoutMinutes =
+        orgDefaults.behaviorTimeoutMinutes =
           data.defaultBehaviorTimeSeconds / 60;
-      } else {
-        this.defaultBehaviorTimeoutMinutes = DEFAULT_BEHAVIOR_TIMEOUT_MINUTES;
       }
     } catch (e: any) {
       console.debug(e);
-      this.defaultBehaviorTimeoutMinutes = DEFAULT_BEHAVIOR_TIMEOUT_MINUTES;
     }
+    this.orgDefaults = orgDefaults;
   }
 }
 

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1179,7 +1179,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
             max=${this.orgDefaults.maxPagesPerCrawl}
             placeholder=${this.orgDefaults.maxPagesPerCrawl === Infinity
               ? msg("Unlimited")
-              : this.orgDefaults.maxPagesPerCrawl.toLocaleString()}
+              : msg(
+                  str`Maximum Allowed (${this.orgDefaults.maxPagesPerCrawl.toLocaleString()})`
+                )}
             @sl-input=${async (e: CustomEvent) => {
               const inputEl = e.target as SlInput;
               await inputEl.updateComplete;
@@ -1196,14 +1198,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
                           str`Minimum ${minPages.toLocaleString()} pages per crawl`
                         );
                 } else if (value > this.orgDefaults.maxPagesPerCrawl) {
-                  helpText =
-                    this.orgDefaults.maxPagesPerCrawl === 1
-                      ? msg(
-                          str`Maximum ${this.orgDefaults.maxPagesPerCrawl.toLocaleString()} page per crawl`
-                        )
-                      : msg(
-                          str`Maximum ${this.orgDefaults.maxPagesPerCrawl.toLocaleString()} pages per crawl`
-                        );
+                  helpText = msg(
+                    str`Maximum ${this.orgDefaults.maxPagesPerCrawl.toLocaleString()} pages per crawl`
+                  );
                 }
               }
               inputEl.helpText = helpText;
@@ -2048,7 +2045,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
   private async fetchAPIDefaults() {
     const orgDefaults = { ...this.orgDefaults };
     try {
-      const data = await this.apiFetch("/settings", this.authState!);
+      const resp = await fetch("/api/settings", {
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!resp.ok) {
+        throw new Error(resp.statusText);
+      }
+      const data = await resp.json();
       if (data.defaultBehaviorTimeSeconds) {
         orgDefaults.behaviorTimeoutMinutes =
           data.defaultBehaviorTimeSeconds / 60;


### PR DESCRIPTION
Resolves #716

<!-- Fixes #issue_number -->

### Changes

Uses admin-set value from API global settings if specified (greater than 0) to determine maximum value for "Max Pages", otherwise uses current default of infinity (i.e. "unlimited")

### Manual testing

1. Log in to dev instance and go to New Workflow view
2. Click "Limits" tab. Verify "Max Pages" placeholder is `100,000`, and you are unable to more than 100,000 pages

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Workflow - Limit tab | <img width="526" alt="Screen Shot 2023-04-03 at 8 07 25 PM" src="https://user-images.githubusercontent.com/4672952/229678715-fe157bdb-c48b-4598-967e-2d99f32b4f85.png"><img width="520" alt="Screen Shot 2023-04-03 at 6 05 44 PM" src="https://user-images.githubusercontent.com/4672952/229659909-1dc948c3-a409-4696-8c1e-c0775a7586c5.png"> |
| New Workflow - Review tab | <img width="277" alt="Screen Shot 2023-04-03 at 8 07 35 PM" src="https://user-images.githubusercontent.com/4672952/229678786-cf020356-fd5a-462c-a290-826d32899e32.png"> |



<!-- ### Follow-ups -->
