### PR TITLE
Inverts the autoscroll behavior setting to true by default

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -99,7 +99,7 @@ type FormState = {
   browserProfile: Profile | null;
   tags: Tags;
   description: WorkflowParams["description"];
-  disableAutoscrollBehavior: boolean;
+  autoscrollBehavior: boolean;
 };
 
 const getDefaultProgressState = (hasConfigId = false): ProgressState => {
@@ -168,7 +168,7 @@ const getDefaultFormState = (): FormState => ({
   browserProfile: null,
   tags: [],
   description: null,
-  disableAutoscrollBehavior: false,
+  autoscrollBehavior: true,
 });
 const defaultProgressState = getDefaultProgressState();
 const orderedTabNames = STEPS.filter(
@@ -503,9 +503,9 @@ export class CrawlConfigEditor extends LiteElement {
         Boolean(primarySeedConfig.extraHops || seedsConfig.extraHops) ?? true,
       pageLimit:
         this.initialWorkflow.config.limit ?? defaultFormState.pageLimit,
-      disableAutoscrollBehavior: this.initialWorkflow.config.behaviors
-        ? !this.initialWorkflow.config.behaviors.includes("autoscroll")
-        : defaultFormState.disableAutoscrollBehavior,
+      autoscrollBehavior: this.initialWorkflow.config.behaviors
+        ? this.initialWorkflow.config.behaviors.includes("autoscroll")
+        : defaultFormState.autoscrollBehavior,
       ...formState,
     };
   }
@@ -1239,14 +1239,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
         msg(`Limits how long behaviors can run on each page.`)
       )}
       ${this.renderFormCol(html`<sl-checkbox
-        name="disableAutoscrollBehavior"
-        ?checked=${this.formState.disableAutoscrollBehavior}
+        name="autoscrollBehavior"
+        ?checked=${this.formState.autoscrollBehavior}
       >
-        ${msg("Disable Auto-Scroll Behavior")}
+        ${msg("Auto-Scroll Behavior")}
       </sl-checkbox>`)}
       ${this.renderHelpTextCol(
         msg(
-          `Prevents browser from automatically scrolling until the end of the page.`
+          `When enabled the browser will automatically scroll to the end of the page.`
         ),
         false
       )}
@@ -2037,9 +2037,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
         lang: this.formState.lang || "",
         blockAds: this.formState.blockAds,
         exclude: trimArray(this.formState.exclusions),
-        behaviors: (this.formState.disableAutoscrollBehavior
-          ? DEFAULT_BEHAVIORS.slice(1)
-          : DEFAULT_BEHAVIORS
+        behaviors: (this.formState.autoscrollBehavior
+          ? DEFAULT_BEHAVIORS
+          : DEFAULT_BEHAVIORS.slice(1)
         ).join(","),
       },
     };


### PR DESCRIPTION
Followup on my note in #745, currently all our other check boxes turn features on when enabled whereas enabling this one turns a feature off.  For consistency I have reversed the states of the autoscroll checkbox so the page autoscrolls when it is checked and does not run the behavior when it is unchecked.  Checked is also now the default state.

### Screenshot
<img width="925" alt="Screenshot 2023-04-06 at 2 28 55 AM" src="https://user-images.githubusercontent.com/5672810/230290056-be76c93e-d0fc-4a3a-a3dc-325c28ba286d.png">

### Changes
- Reverses the state of the autoscroll behavior checkbox in the form
- Updates help text accordingly
- Renames `disableAutoscrollBehavior` → `autoscrollBehavior` to better represent its now inverted logic