### PR TITLE
Update collections backend API

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -196,18 +196,11 @@ class CollectionOps:
         for crawl_id in coll.crawl_ids:
             org = await self.orgs.get_org_by_id(oid)
             crawl = await self.crawls.get_crawl(crawl_id, org)
-            if not crawl.files:
+            if not crawl.resources:
                 continue
 
-            for file_ in crawl.files:
-                if file_.def_storage_name:
-                    storage_prefix = (
-                        await self.crawl_manager.get_default_storage_access_endpoint(
-                            file_.def_storage_name
-                        )
-                    )
-                    file_.filename = storage_prefix + file_.filename
-                all_files.append(file_.dict(exclude={"def_storage_name"}))
+            for resource in crawl.resources:
+                all_files.append(resource)
 
         return {"resources": all_files}
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -5,7 +5,7 @@ import uuid
 from typing import Optional, List
 
 import pymongo
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
 
 from pydantic import BaseModel, UUID4
 
@@ -22,6 +22,8 @@ class Collection(BaseMongoModel):
 
     oid: UUID4
 
+    crawl_ids: Optional[List[str]] = []
+
     description: Optional[str]
 
 
@@ -31,13 +33,21 @@ class CollIn(BaseModel):
 
     name: str
     description: Optional[str]
+    crawl_ids: Optional[List[str]] = []
 
 
 # ============================================================================
-class CollOut(BaseMongoModel):
-    """Collection API output model"""
+class UpdateColl(BaseModel):
+    """Update collection"""
 
-    id: UUID4
+    crawl_ids: Optional[List[str]] = []
+    description: Optional[str]
+
+
+# ============================================================================
+class RenameColl(BaseModel):
+    """Rename collection"""
+
     name: str
 
 
@@ -45,11 +55,12 @@ class CollOut(BaseMongoModel):
 class CollectionOps:
     """ops for working with named collections of crawls"""
 
-    def __init__(self, mdb, crawls, crawl_manager):
+    def __init__(self, mdb, crawls, crawl_manager, orgs):
         self.collections = mdb["collections"]
 
         self.crawls = crawls
         self.crawl_manager = crawl_manager
+        self.orgs = orgs
 
     async def init_index(self):
         """init lookup index"""
@@ -57,27 +68,88 @@ class CollectionOps:
             [("oid", pymongo.ASCENDING), ("name", pymongo.ASCENDING)], unique=True
         )
 
-    async def add_collection(self, oid: uuid.UUID, name: str, description=None):
-        """add new collection"""
-        coll = Collection(id=uuid.uuid4(), oid=oid, name=name, description=description)
+    async def add_collection(
+        self,
+        oid: uuid.UUID,
+        name: str,
+        crawl_ids: Optional[List[str]],
+        description: str = None,
+    ):
+        """Add new collection"""
+        crawl_ids = crawl_ids if crawl_ids else []
+        coll = Collection(
+            id=uuid.uuid4(),
+            oid=oid,
+            name=name,
+            crawl_ids=crawl_ids,
+            description=description,
+        )
         try:
-            res = await self.collections.insert_one(coll.to_dict())
-            return res.inserted_id
-
+            await self.collections.insert_one(coll.to_dict())
+            return {"added": name}
         except pymongo.errors.DuplicateKeyError:
-            res = await self.collections.find_one_and_update(
-                {"oid": oid, "name": name},
-                {"$set": {"name": name, "description": description}},
-            )
-            return str(res["_id"])
+            # pylint: disable=raise-missing-from
+            raise HTTPException(status_code=400, detail="collection_already_exists")
 
-    async def find_collection(self, oid: uuid.UUID, name: str):
-        """find collection by org + name"""
-        res = await self.collections.find_one({"org": oid, "name": name})
+    async def update_collection(self, oid: uuid.UUID, name: str, update: UpdateColl):
+        """Update collection"""
+        query = update.dict(exclude_unset=True)
+
+        if len(query) == 0:
+            raise HTTPException(status_code=400, detail="no_update_data")
+
+        result = await self.collections.find_one_and_update(
+            {"name": name, "oid": oid},
+            {"$set": query},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        if not result:
+            raise HTTPException(status_code=404, detail="collection_not_found")
+
+        return result
+
+    async def rename_collection(self, oid: uuid.UUID, name: str, new_name: str):
+        """Rename collection"""
+        result = await self.collections.find_one_and_update(
+            {"name": name, "oid": oid},
+            {"$set": {"name": new_name}},
+        )
+        if not result:
+            raise HTTPException(status_code=404, detail="collection_not_found")
+
+        return new_name
+
+    async def add_crawl_to_collection(self, oid: uuid.UUID, name: str, crawl_id: str):
+        """Add crawl to collection"""
+        result = await self.collections.find_one_and_update(
+            {"name": name, "oid": oid},
+            {"$push": {"crawl_ids": crawl_id}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        if not result:
+            raise HTTPException(status_code=404, detail="collection_not_found")
+        return result
+
+    async def remove_crawl_from_collection(
+        self, oid: uuid.UUID, name: str, crawl_id: str
+    ):
+        """Remove crawl from collection"""
+        result = await self.collections.find_one_and_update(
+            {"name": name, "oid": oid},
+            {"$pull": {"crawl_ids": crawl_id}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+        if not result:
+            raise HTTPException(status_code=404, detail="collection_not_found")
+        return result
+
+    async def get_collection(self, oid: uuid.UUID, name: str):
+        """Get collection by org + name"""
+        res = await self.collections.find_one({"name": name, "oid": oid})
         return Collection.from_dict(res) if res else None
 
     async def find_collections(self, oid: uuid.UUID, names: List[str]):
-        """find all collections for org given a list of names"""
+        """Find all collections for org given a list of names"""
         cursor = self.collections.find(
             {"oid": oid, "name": {"$in": names}}, projection=["_id", "name"]
         )
@@ -92,12 +164,12 @@ class CollectionOps:
                     detail=f"Specified collection(s) not found: {', '.join(names)}",
                 )
 
-        return [result["_id"] for result in results]
+        return [result["name"] for result in results]
 
     async def list_collections(
         self, oid: uuid.UUID, page_size: int = DEFAULT_PAGE_SIZE, page: int = 1
     ):
-        """list all collections for org"""
+        """List all collections for org"""
         # Zero-index page for query
         page = page - 1
         skip = page * page_size
@@ -106,83 +178,49 @@ class CollectionOps:
 
         total = await self.collections.count_documents(match_query)
 
-        cursor = self.collections.find(
-            match_query, projection=["_id", "name"], skip=skip, limit=page_size
-        )
+        cursor = self.collections.find(match_query, skip=skip, limit=page_size)
         results = await cursor.to_list(length=page_size)
-        collections = [CollOut.from_dict(res) for res in results]
+        collections = [Collection.from_dict(res) for res in results]
 
         return collections, total
 
-    async def get_collection_crawls(self, oid: uuid.UUID, name: str = None):
-        """find collection and get all crawls by collection name per org"""
-        collid = None
-        if name:
-            coll = await self.find_collection(oid, name)
-            if not coll:
-                return None
+    async def get_collection_crawls(self, oid: uuid.UUID, name: str):
+        """Find collection and get all crawls by collection name per org"""
 
-            collid = coll.id
+        coll = self.get_collection(oid, name)
+        if not coll:
+            raise HTTPException(status_code=404, detail="collection_not_found")
 
-        crawls = await self.crawls.list_finished_crawls(oid=oid, collid=collid)
-        all_files = []
-        for crawl in crawls:
-            if not crawl.files:
-                continue
+        collection_crawls = {}
 
-            for file_ in crawl.files:
-                if file_.def_storage_name:
-                    storage_prefix = (
-                        await self.crawl_manager.get_default_storage_access_endpoint(
-                            file_.def_storage_name
-                        )
-                    )
-                    file_.filename = storage_prefix + file_.filename
+        for crawl_id in coll.crawl_ids:
+            org = self.orgs.get_org_by_id(oid)
+            crawl = self.crawls.get_crawl(crawl_id, org)
+            collection_crawls[crawl_id] = crawl.resources
 
-                all_files.append(file_.dict(exclude={"def_storage_name"}))
-
-        return {"resources": all_files}
+        return collection_crawls
 
 
 # ============================================================================
-def init_collections_api(mdb, crawls, orgs, crawl_manager):
+# pylint: disable=too-many-locals
+def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
     """init collections api"""
     # pylint: disable=invalid-name
 
-    colls = CollectionOps(mdb, crawls, crawl_manager)
+    colls = CollectionOps(mdb, crawls, crawl_manager, orgs)
 
     org_crawl_dep = orgs.org_crawl_dep
     org_viewer_dep = orgs.org_viewer_dep
 
-    router = APIRouter(
-        prefix="/collections",
-        dependencies=[Depends(org_crawl_dep)],
-        responses={404: {"description": "Not found"}},
-        tags=["collections"],
-    )
-
-    @router.post("")
+    @app.post("/orgs/{oid}/collections", tags=["collections"])
     async def add_collection(
         new_coll: CollIn, org: Organization = Depends(org_crawl_dep)
     ):
-        coll_id = None
-        if new_coll.name == "$all":
-            raise HTTPException(status_code=400, detail="Invalid Name")
+        return await colls.add_collection(
+            org.id, new_coll.name, new_coll.crawl_ids, new_coll.description
+        )
 
-        try:
-            coll_id = await colls.add_collection(
-                org.id, new_coll.name, new_coll.description
-            )
-
-        except Exception as exc:
-            # pylint: disable=raise-missing-from
-            raise HTTPException(
-                status_code=400, detail=f"Error Updating Collection: {exc}"
-            )
-
-        return {"collection": coll_id}
-
-    @router.get("")
+    @app.get("/orgs/{oid}/collections", tags=["collections"])
     async def list_collection_all(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
@@ -193,11 +231,15 @@ def init_collections_api(mdb, crawls, orgs, crawl_manager):
         )
         return paginated_format(collections, total, page, pageSize)
 
-    @router.get("/$all")
+    @app.get("/orgs/{oid}/collections/$all", tags=["collections"])
     async def get_collection_all(org: Organization = Depends(org_viewer_dep)):
+        results = {}
         try:
-            results = await colls.get_collection_crawls(org.id)
-
+            all_collections, _ = colls.list_collections(org.id, page_size=10_000)
+            for collection in all_collections:
+                results[collection.name] = await colls.get_collection_crawls(
+                    org.id, str(collection.id)
+                )
         except Exception as exc:
             # pylint: disable=raise-missing-from
             raise HTTPException(
@@ -206,12 +248,10 @@ def init_collections_api(mdb, crawls, orgs, crawl_manager):
 
         return results
 
-    @router.get("/{coll_name}")
-    async def get_collection(
-        coll_name: str, org: Organization = Depends(org_viewer_dep)
-    ):
+    @app.get("/orgs/{oid}/collections/{name}", tags=["collections"])
+    async def get_collection(name: str, org: Organization = Depends(org_viewer_dep)):
         try:
-            results = await colls.get_collection_crawls(org.id, coll_name)
+            results = await colls.get_collection_crawls(org.id, name)
 
         except Exception as exc:
             # pylint: disable=raise-missing-from
@@ -219,13 +259,31 @@ def init_collections_api(mdb, crawls, orgs, crawl_manager):
                 status_code=400, detail=f"Error Listing Collection: {exc}"
             )
 
-        if not results:
-            raise HTTPException(
-                status_code=404, detail=f"Collection {coll_name} not found"
-            )
-
         return results
 
-    orgs.router.include_router(router)
+    @app.post("/orgs/{oid}/collections/{name}/update", tags=["collections"])
+    async def update_collection(
+        name: str, update: UpdateColl, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await colls.update_collection(org.id, name, update)
+
+    @app.post("/orgs/{oid}/collections/{name}/rename", tags=["collections"])
+    async def rename_collection(
+        name: str, rename: RenameColl, org: Organization = Depends(org_crawl_dep)
+    ):
+        await colls.rename_collection(org.id, name, rename.name)
+        return {"renamed": rename.name}
+
+    @app.get("/orgs/{oid}/collections/{name}/add", tags=["collections"])
+    async def add_crawl_to_collection(
+        crawlId: str, name: str, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await colls.add_crawl_to_collection(org.id, name, crawlId)
+
+    @app.get("/orgs/{oid}/collections/{name}/remove", tags=["collections"])
+    async def remove_crawl_from_collection(
+        crawlId: str, name: str, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await colls.remove_crawl_from_collection(org.id, name, crawlId)
 
     return colls

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -187,15 +187,15 @@ class CollectionOps:
     async def get_collection_crawls(self, oid: uuid.UUID, name: str):
         """Find collection and get all crawls by collection name per org"""
 
-        coll = self.get_collection(oid, name)
+        coll = await self.get_collection(oid, name)
         if not coll:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
         collection_crawls = {}
 
         for crawl_id in coll.crawl_ids:
-            org = self.orgs.get_org_by_id(oid)
-            crawl = self.crawls.get_crawl(crawl_id, org)
+            org = await self.orgs.get_org_by_id(oid)
+            crawl = await self.crawls.get_crawl(crawl_id, org)
             collection_crawls[crawl_id] = crawl.resources
 
         return collection_crawls

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -22,7 +22,7 @@ class Collection(BaseMongoModel):
 
     oid: UUID4
 
-    crawl_ids: Optional[List[str]] = []
+    crawlIds: Optional[List[str]] = []
 
     description: Optional[str]
 
@@ -33,14 +33,14 @@ class CollIn(BaseModel):
 
     name: str
     description: Optional[str]
-    crawl_ids: Optional[List[str]] = []
+    crawlIds: Optional[List[str]] = []
 
 
 # ============================================================================
 class UpdateColl(BaseModel):
     """Update collection"""
 
-    crawl_ids: Optional[List[str]] = []
+    crawlIds: Optional[List[str]] = []
     description: Optional[str]
 
 
@@ -81,7 +81,7 @@ class CollectionOps:
             id=uuid.uuid4(),
             oid=oid,
             name=name,
-            crawl_ids=crawl_ids,
+            crawlIds=crawl_ids,
             description=description,
         )
         try:
@@ -123,7 +123,7 @@ class CollectionOps:
         """Add crawl to collection"""
         result = await self.collections.find_one_and_update(
             {"name": name, "oid": oid},
-            {"$push": {"crawl_ids": crawl_id}},
+            {"$push": {"crawlIds": crawl_id}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
         if not result:
@@ -136,7 +136,7 @@ class CollectionOps:
         """Remove crawl from collection"""
         result = await self.collections.find_one_and_update(
             {"name": name, "oid": oid},
-            {"$pull": {"crawl_ids": crawl_id}},
+            {"$pull": {"crawlIds": crawl_id}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
         if not result:
@@ -193,7 +193,7 @@ class CollectionOps:
 
         all_files = []
 
-        for crawl_id in coll.crawl_ids:
+        for crawl_id in coll.crawlIds:
             org = await self.orgs.get_org_by_id(oid)
             crawl = await self.crawls.get_crawl(crawl_id, org)
             if not crawl.resources:
@@ -221,7 +221,7 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
         new_coll: CollIn, org: Organization = Depends(org_crawl_dep)
     ):
         return await colls.add_collection(
-            org.id, new_coll.name, new_coll.crawl_ids, new_coll.description
+            org.id, new_coll.name, new_coll.crawlIds, new_coll.description
         )
 
     @app.get("/orgs/{oid}/collections", tags=["collections"])

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -174,7 +174,7 @@ class CollectionOps:
         page = page - 1
         skip = page * page_size
 
-        match_query = {"org": oid}
+        match_query = {"oid": oid}
 
         total = await self.collections.count_documents(match_query)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -98,8 +98,6 @@ class Crawl(CrawlConfigCore):
 
     files: Optional[List[CrawlFile]] = []
 
-    colls: Optional[List[str]] = []
-
     notes: Optional[str]
 
 
@@ -191,15 +189,10 @@ class CrawlOps:
 
         self.presign_duration = int(os.environ.get("PRESIGN_DURATION_SECONDS", 3600))
 
-    async def init_index(self):
-        """init index for crawls db"""
-        await self.crawls.create_index("colls")
-
     async def list_crawls(
         self,
         org: Optional[Organization] = None,
         cid: uuid.UUID = None,
-        collid: uuid.UUID = None,
         userid: uuid.UUID = None,
         crawl_id: str = None,
         running_only=False,
@@ -226,9 +219,6 @@ class CrawlOps:
 
         if cid:
             query["cid"] = cid
-
-        if collid:
-            query["colls"] = collid
 
         if userid:
             query["userid"] = userid

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -266,7 +266,7 @@ class CrawlOps:
                     "from": "collections",
                     "let": {"crawl_id": {"$toString": "$_id"}},
                     "pipeline": [
-                        {"$match": {"$expr": {"$in": ["$$crawl_id", "$crawl_ids"]}}}
+                        {"$match": {"$expr": {"$in": ["$$crawl_id", "$crawlIds"]}}}
                     ],
                     "as": "colls",
                 },
@@ -434,7 +434,7 @@ class CrawlOps:
             crawl.collections = [
                 coll["name"]
                 async for coll in self.collections.find(
-                    {"crawl_ids": {"$in": [crawl.id]}}
+                    {"crawlIds": {"$in": [crawl.id]}}
                 )
             ]
 
@@ -799,12 +799,12 @@ class CrawlOps:
         """Remove crawl with given crawl_id from all collections it belongs to"""
         collections = [
             coll["name"]
-            async for coll in self.collections.find({"crawl_ids": {"$in": [crawl_id]}})
+            async for coll in self.collections.find({"crawlIds": {"$in": [crawl_id]}})
         ]
         for collection_name in collections:
             await self.collections.find_one_and_update(
                 {"name": collection_name, "oid": oid},
-                {"$pull": {"crawl_ids": crawl_id}},
+                {"$pull": {"crawlIds": crawl_id}},
             )
 
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -73,6 +73,7 @@ class CrawlFileOut(BaseModel):
     path: str
     hash: str
     size: int
+    crawlId: Optional[str]
 
 
 # ============================================================================
@@ -369,7 +370,7 @@ class CrawlOps:
 
             del res["files"]
 
-            res["resources"] = await self._resolve_signed_urls(files, org)
+            res["resources"] = await self._resolve_signed_urls(files, org, crawlid)
 
         crawl = CrawlOut.from_dict(res)
 
@@ -443,7 +444,9 @@ class CrawlOps:
 
         return crawl
 
-    async def _resolve_signed_urls(self, files, org: Organization):
+    async def _resolve_signed_urls(
+        self, files, org: Organization, crawl_id: Optional[str] = None
+    ):
         if not files:
             print("no files")
             return
@@ -480,6 +483,7 @@ class CrawlOps:
                     path=presigned_url,
                     hash=file_.hash,
                     size=file_.size,
+                    crawlId=crawl_id,
                 )
             )
 

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -54,7 +54,6 @@ async def update_and_prepare_db(
     user_manager,
     org_ops,
     crawl_config_ops,
-    crawls_ops,
     coll_ops,
     invite_ops,
 ):
@@ -69,7 +68,7 @@ async def update_and_prepare_db(
     """
     if await run_db_migrations(mdb):
         await drop_indexes(mdb)
-    await create_indexes(org_ops, crawl_config_ops, crawls_ops, coll_ops, invite_ops)
+    await create_indexes(org_ops, crawl_config_ops, coll_ops, invite_ops)
     await user_manager.create_super_user()
     await org_ops.create_default_org()
     print("Database updated and ready", flush=True)
@@ -122,12 +121,11 @@ async def drop_indexes(mdb):
 
 
 # ============================================================================
-async def create_indexes(org_ops, crawl_config_ops, crawls_ops, coll_ops, invite_ops):
+async def create_indexes(org_ops, crawl_config_ops, coll_ops, invite_ops):
     """Create database indexes."""
     print("Creating database indexes", flush=True)
     await org_ops.init_index()
     await crawl_config_ops.init_index()
-    await crawls_ops.init_index()
     await coll_ops.init_index()
     await invite_ops.init_index()
 

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -106,13 +106,13 @@ def main():
         current_active_user,
     )
 
-    coll_ops = init_collections_api(mdb, crawls, org_ops, crawl_manager)
+    coll_ops = init_collections_api(app, mdb, crawls, org_ops, crawl_manager)
 
     crawl_config_ops.set_coll_ops(coll_ops)
 
     asyncio.create_task(
         update_and_prepare_db(
-            mdb, user_manager, org_ops, crawl_config_ops, crawls, coll_ops, invites
+            mdb, user_manager, org_ops, crawl_config_ops, coll_ops, invites
         )
     )
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -4,6 +4,7 @@ from .conftest import API_PREFIX
 
 COLLECTION_NAME = "Test collection"
 UPDATED_NAME = "Updated tést cöllection"
+SECOND_COLLECTION_NAME = "second-collection"
 DESCRIPTION = "Test description"
 
 
@@ -76,3 +77,63 @@ def test_add_crawl_to_collection(
     assert r.status_code == 200
     data = r.json()
     assert sorted(data["crawl_ids"]) == sorted([admin_crawl_id, crawler_crawl_id])
+
+
+def test_get_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{UPDATED_NAME}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    resources = data["resources"]
+    assert resources
+    for resource in resources:
+        assert resource["name"]
+        assert resource["path"]
+        assert resource["size"]
+        assert resource["crawlId"] in (crawler_crawl_id, admin_crawl_id)
+
+
+def test_list_collections(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    # Add second collection
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=crawler_auth_headers,
+        json={
+            "crawl_ids": [crawler_crawl_id],
+            "name": SECOND_COLLECTION_NAME,
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["added"] == SECOND_COLLECTION_NAME
+
+    # Test endpoint
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections", headers=crawler_auth_headers
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+
+    items = data["items"]
+    assert len(items) == 2
+
+    first_coll = [coll for coll in items if coll["name"] == UPDATED_NAME][0]
+    assert first_coll["id"]
+    assert first_coll["name"] == UPDATED_NAME
+    assert first_coll["oid"] == default_org_id
+    assert first_coll["description"] == DESCRIPTION
+    assert sorted(first_coll["crawl_ids"]) == sorted([crawler_crawl_id, admin_crawl_id])
+
+    second_coll = [coll for coll in items if coll["name"] == SECOND_COLLECTION_NAME][0]
+    assert second_coll["id"]
+    assert second_coll["name"] == SECOND_COLLECTION_NAME
+    assert second_coll["oid"] == default_org_id
+    assert second_coll.get("description") is None
+    assert second_coll["crawl_ids"] == [crawler_crawl_id]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -15,7 +15,7 @@ def test_create_collection(
         f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=crawler_auth_headers,
         json={
-            "crawl_ids": [crawler_crawl_id],
+            "crawlIds": [crawler_crawl_id],
             "name": COLLECTION_NAME,
         },
     )
@@ -31,7 +31,7 @@ def test_update_collection(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}/update",
         headers=crawler_auth_headers,
         json={
-            "crawl_ids": [crawler_crawl_id, admin_crawl_id],
+            "crawlIds": [crawler_crawl_id, admin_crawl_id],
             "description": DESCRIPTION,
         },
     )
@@ -39,7 +39,7 @@ def test_update_collection(
     data = r.json()
     assert data["name"] == COLLECTION_NAME
     assert data["description"] == DESCRIPTION
-    assert sorted(data["crawl_ids"]) == sorted([admin_crawl_id, crawler_crawl_id])
+    assert sorted(data["crawlIds"]) == sorted([admin_crawl_id, crawler_crawl_id])
 
 
 def test_rename_collection(
@@ -64,7 +64,7 @@ def test_remove_crawl_from_collection(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["crawl_ids"] == [crawler_crawl_id]
+    assert data["crawlIds"] == [crawler_crawl_id]
 
 
 def test_add_crawl_to_collection(
@@ -76,7 +76,7 @@ def test_add_crawl_to_collection(
     )
     assert r.status_code == 200
     data = r.json()
-    assert sorted(data["crawl_ids"]) == sorted([admin_crawl_id, crawler_crawl_id])
+    assert sorted(data["crawlIds"]) == sorted([admin_crawl_id, crawler_crawl_id])
 
 
 def test_get_collection(
@@ -105,7 +105,7 @@ def test_list_collections(
         f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=crawler_auth_headers,
         json={
-            "crawl_ids": [crawler_crawl_id],
+            "crawlIds": [crawler_crawl_id],
             "name": SECOND_COLLECTION_NAME,
         },
     )
@@ -129,11 +129,11 @@ def test_list_collections(
     assert first_coll["name"] == UPDATED_NAME
     assert first_coll["oid"] == default_org_id
     assert first_coll["description"] == DESCRIPTION
-    assert sorted(first_coll["crawl_ids"]) == sorted([crawler_crawl_id, admin_crawl_id])
+    assert sorted(first_coll["crawlIds"]) == sorted([crawler_crawl_id, admin_crawl_id])
 
     second_coll = [coll for coll in items if coll["name"] == SECOND_COLLECTION_NAME][0]
     assert second_coll["id"]
     assert second_coll["name"] == SECOND_COLLECTION_NAME
     assert second_coll["oid"] == default_org_id
     assert second_coll.get("description") is None
-    assert second_coll["crawl_ids"] == [crawler_crawl_id]
+    assert second_coll["crawlIds"] == [crawler_crawl_id]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1,0 +1,78 @@
+import requests
+
+from .conftest import API_PREFIX
+
+COLLECTION_NAME = "Test collection"
+UPDATED_NAME = "Updated tést cöllection"
+DESCRIPTION = "Test description"
+
+
+def test_create_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=crawler_auth_headers,
+        json={
+            "crawl_ids": [crawler_crawl_id],
+            "name": COLLECTION_NAME,
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["added"] == COLLECTION_NAME
+
+
+def test_update_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}/update",
+        headers=crawler_auth_headers,
+        json={
+            "crawl_ids": [crawler_crawl_id, admin_crawl_id],
+            "description": DESCRIPTION,
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["name"] == COLLECTION_NAME
+    assert data["description"] == DESCRIPTION
+    assert sorted(data["crawl_ids"]) == sorted([admin_crawl_id, crawler_crawl_id])
+
+
+def test_rename_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}/rename",
+        headers=crawler_auth_headers,
+        json={"name": UPDATED_NAME},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["renamed"] == UPDATED_NAME
+
+
+def test_remove_crawl_from_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{UPDATED_NAME}/remove?crawlId={admin_crawl_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["crawl_ids"] == [crawler_crawl_id]
+
+
+def test_add_crawl_to_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{UPDATED_NAME}/add?crawlId={admin_crawl_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert sorted(data["crawl_ids"]) == sorted([admin_crawl_id, crawler_crawl_id])

--- a/backend/test/test_crawl_config_search_values.py
+++ b/backend/test/test_crawl_config_search_values.py
@@ -39,9 +39,15 @@ def test_get_search_values_1(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert data["names"] == [NAME_1]
-    assert data["descriptions"] == [DESCRIPTION_1]
-    assert data["firstSeeds"] == [FIRST_SEED_1]
+    assert sorted(data["names"]) == sorted(
+        [NAME_1, "Admin Test Crawl", "Crawler User Test Crawl"]
+    )
+    assert sorted(data["descriptions"]) == sorted(
+        ["Admin Test Crawl description", "crawler test crawl", DESCRIPTION_1]
+    )
+    assert sorted(data["firstSeeds"]) == sorted(
+        ["https://webrecorder.net/", FIRST_SEED_1]
+    )
 
 
 def test_create_new_config_2(admin_auth_headers, default_org_id):
@@ -62,9 +68,20 @@ def test_get_search_values_2(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert sorted(data["names"]) == [NAME_1, NAME_2]
-    assert sorted(data["descriptions"]) == [DESCRIPTION_1, DESCRIPTION_2]
-    assert sorted(data["firstSeeds"]) == [FIRST_SEED_1, FIRST_SEED_2]
+    assert sorted(data["names"]) == sorted(
+        [NAME_1, NAME_2, "Admin Test Crawl", "Crawler User Test Crawl"]
+    )
+    assert sorted(data["descriptions"]) == sorted(
+        [
+            "Admin Test Crawl description",
+            "crawler test crawl",
+            DESCRIPTION_1,
+            DESCRIPTION_2,
+        ]
+    )
+    assert sorted(data["firstSeeds"]) == sorted(
+        ["https://webrecorder.net/", FIRST_SEED_1, FIRST_SEED_2]
+    )
 
 
 def test_create_new_config_3_duplicates(admin_auth_headers, default_org_id):
@@ -87,6 +104,17 @@ def test_get_search_values_3(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert sorted(data["names"]) == [NAME_1, NAME_2]
-    assert sorted(data["descriptions"]) == [DESCRIPTION_1, DESCRIPTION_2]
-    assert sorted(data["firstSeeds"]) == [FIRST_SEED_1, FIRST_SEED_2]
+    assert sorted(data["names"]) == sorted(
+        [NAME_1, NAME_2, "Admin Test Crawl", "Crawler User Test Crawl"]
+    )
+    assert sorted(data["descriptions"]) == sorted(
+        [
+            "Admin Test Crawl description",
+            "crawler test crawl",
+            DESCRIPTION_1,
+            DESCRIPTION_2,
+        ]
+    )
+    assert sorted(data["firstSeeds"]) == sorted(
+        ["https://webrecorder.net/", FIRST_SEED_1, FIRST_SEED_2]
+    )

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -45,7 +45,8 @@ def test_get_config_by_tag_1(admin_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/tags",
         headers=admin_auth_headers,
     )
-    assert r.json() == ["tag-1", "tag-2"]
+    data = r.json()
+    assert sorted(data) == ["tag-1", "tag-2", "wr-test-1", "wr-test-2"]
 
 
 def test_create_new_config_2(admin_auth_headers, default_org_id):
@@ -70,7 +71,15 @@ def test_get_config_by_tag_2(admin_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/tags",
         headers=admin_auth_headers,
     )
-    assert r.json() == ["tag-0", "tag-1", "tag-2", "tag-3"]
+    data = r.json()
+    assert sorted(data) == [
+        "tag-0",
+        "tag-1",
+        "tag-2",
+        "tag-3",
+        "wr-test-1",
+        "wr-test-2",
+    ]
 
 
 def test_get_config_2(admin_auth_headers, default_org_id):

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -10,8 +10,8 @@ def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 1
-    assert r.json()["total"] == 1
+    assert len(r.json()["items"]) == 2
+    assert r.json()["total"] == 2
 
 
 def test_get_config_by_modified_by(
@@ -22,8 +22,8 @@ def test_get_config_by_modified_by(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?modifiedBy={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 1
-    assert r.json()["total"] == 1
+    assert len(r.json()["items"]) == 2
+    assert r.json()["total"] == 2
 
 
 def test_get_configs_by_first_seed(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -2,6 +2,7 @@ import requests
 import urllib.parse
 
 from .conftest import API_PREFIX
+from .test_collections import UPDATED_NAME as COLLECTION_NAME
 
 
 def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_userid):
@@ -146,6 +147,19 @@ def test_get_crawls_by_description(
     assert r.json()["total"] >= 1
     for crawl in r.json()["items"]:
         assert crawl["description"] == description
+
+
+def test_get_crawls_by_collection_name(
+    crawler_auth_headers, default_org_id, crawler_crawl_id
+):
+    encoded_collection = urllib.parse.quote(COLLECTION_NAME)
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?collection={encoded_collection}",
+        headers=crawler_auth_headers,
+    )
+    assert r.json()["total"] >= 1
+    for crawl in r.json()["items"]:
+        assert COLLECTION_NAME in crawl["collections"]
 
 
 def test_sort_crawls(

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -203,13 +203,15 @@ def test_delete_crawls_crawler(
 ):
     # Test that crawl is in collection before deleting
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
-    assert data[admin_crawl_id]
-    assert data[crawler_crawl_id]
+    collection = [coll for coll in data["items"] if coll["name"] == COLLECTION_NAME][0]
+    crawl_ids = collection["crawlIds"]
+    assert admin_crawl_id in crawl_ids
+    assert crawler_crawl_id in crawl_ids
 
     # Test that crawler user can't delete another user's crawls
     r = requests.post(
@@ -233,13 +235,15 @@ def test_delete_crawls_crawler(
 
     # Test that crawl is no longer in collection
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
-    assert data[admin_crawl_id]
-    assert data.get("crawler_crawl_id") is None
+    collection = [coll for coll in data["items"] if coll["name"] == COLLECTION_NAME][0]
+    crawl_ids = collection["crawlIds"]
+    assert admin_crawl_id in crawl_ids
+    assert crawler_crawl_id not in crawl_ids
 
     # Test that crawl is not found after deleting
     r = requests.get(

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -5,6 +5,7 @@ import io
 import zipfile
 
 from .conftest import API_PREFIX, HOST_PREFIX
+from .test_collections import UPDATED_NAME as COLLECTION_NAME
 
 wacz_path = None
 wacz_size = None
@@ -200,6 +201,16 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
 def test_delete_crawls_crawler(
     crawler_auth_headers, default_org_id, admin_crawl_id, crawler_crawl_id
 ):
+    # Test that crawl is in collection before deleting
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data[admin_crawl_id]
+    assert data[crawler_crawl_id]
+
     # Test that crawler user can't delete another user's crawls
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/delete",
@@ -220,6 +231,17 @@ def test_delete_crawls_crawler(
     data = r.json()
     assert data["deleted"] == 1
 
+    # Test that crawl is no longer in collection
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{COLLECTION_NAME}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data[admin_crawl_id]
+    assert data.get("crawler_crawl_id") is None
+
+    # Test that crawl is not found after deleting
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}",
         headers=crawler_auth_headers,


### PR DESCRIPTION
Fixes #626 

- Rework collections to store references to crawl_ids rather than the other way around
- Add API endpoints to update and rename collections, as well to add/remove a crawl_id from a collection
- Add collection names to get/list crawl API endpoints
- Remove crawl from all collections when the crawl is deleted