### PR TITLE
Upgrade to mongo 6 and use sortArray for workflow crawls (#764)

### DIFF
--- a/ansible/playbooks/do_setup.yml
+++ b/ansible/playbooks/do_setup.yml
@@ -31,7 +31,7 @@
       register: db_check
 
     - name: d_ocean | db | create mongodb database
-      ansible.builtin.command: doctl databases create {{ db_name }} --region {{ droplet_region }} --engine mongodb --version 5 --output json
+      ansible.builtin.command: doctl databases create {{ db_name }} --region {{ droplet_region }} --engine mongodb --version 6 --output json
       async: 1800
       poll: 60
       register: db_create_result

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -528,11 +528,9 @@ class CrawlConfigOps:
             {
                 "$set": {
                     "sortedCrawls": {
-                        "$function": {
-                            # pylint: disable=line-too-long
-                            "body": "function(arr) {return arr.sort((a,b) => (a.finished > b.finished) ? -1 : ((b.finished > a.finished) ? 1 : 0));}",
-                            "args": ["$finishedCrawls"],
-                            "lang": "js",
+                        "$sortArray": {
+                            "input": "$finishedCrawls",
+                            "sortBy": {"finished": -1},
                         }
                     }
                 }

--- a/backend/btrixcloud/version.py
+++ b/backend/btrixcloud/version.py
@@ -1,2 +1,2 @@
 """ current version """
-__version__ = "1.4.0"
+__version__ = "1.5.0-beta.0"

--- a/chart/templates/mongo.yaml
+++ b/chart/templates/mongo.yaml
@@ -101,16 +101,19 @@ spec:
               cpu: {{ .Values.mongo_requests_cpu }}
               memory: {{ .Values.mongo_requests_memory }}
 
-          # reenable for now with mongo 5.0.x
+          # should work with 6.0.x with longer timeout
           readinessProbe:
-            timeoutSeconds: 10
+            timeoutSeconds: 20
+            periodSeconds: 40
+            initialDelaySeconds: 5
             successThreshold: 1
-            failureThreshold: 2
+            failureThreshold: 5
             exec:
               command:
-                - mongo
+                - mongosh
                 - --eval
                 - db.adminCommand('ping')
+                - --quiet
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -99,7 +99,7 @@ mongo_local: true
 
 mongo_host: "local-mongo.default"
 
-mongo_image: "docker.io/library/mongo:5.0.11"
+mongo_image: "docker.io/library/mongo:6.0.5"
 mongo_pull_policy: "IfNotPresent"
 
 mongo_requests_cpu: "12m"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-frontend",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "main": "index.ts",
   "license": "AGPL-3.0-or-later",
   "dependencies": {


### PR DESCRIPTION
* Upgrade to mongo 6 and use  for workflow crawls

* update readiness probe with timeouts doubled, and failure threshold increased for slower 'mongosh' readiness check