### PR TITLE
add authsign block to microk8s playbook

### DIFF
--- a/ansible/group_vars/microk8s/btrix_values.j2
+++ b/ansible/group_vars/microk8s/btrix_values.j2
@@ -11,6 +11,11 @@ ingress:
   tls: true
 
 # optional second-host for signing archives
+{% if enable_signing %}
 signer:
   enabled: true
-  host: "second-host.{{ domain }}"
+  host: {{ signing_domain }}
+  cert_email: {{ cert_email }}
+  image_pull_policy: "IfNotPresent"
+  auth_token: {{ signing_authtoken }}
+{% endif %}


### PR DESCRIPTION
fixes issues in #773, authsign not working, by exposing full authsign config in microk8s ansible.