### PR TITLE
Yaml inventory file

### DIFF
--- a/ansible/inventory/hosts.example.yaml
+++ b/ansible/inventory/hosts.example.yaml
@@ -1,0 +1,23 @@
+---
+all:
+  children:
+    "deploy microk8s":
+      vars:
+        host_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+        domain_name: "{{ inventory_hostname }}"        
+        signing_subdomain: "{{ signing_subdomain }}"
+        signing_authtoken: "{{ 99999999 }}"
+        enable_signing: true
+        your_user: sysadmin
+        ansible_user: sysadmin
+        cert_email: infra@starlinglab.org
+
+
+        browsertrix_superuser_email: "someuser@example.com"
+        browsertrix_superuser_password: "this-should-be-changed"
+        browsertrix_default_org: "My Organization"
+        browsertrix_mongo_password: "this-should-be-changed"
+
+      hosts:
+        browsertrix.example.org:
+          signing_domain: "auth.browsertrix.example.org"

--- a/ansible/playbooks/install_microk8s.yml
+++ b/ansible/playbooks/install_microk8s.yml
@@ -4,7 +4,7 @@
 #
 - name: deploy microk8s 
   gather_facts: true
-  hosts: "{{ host_ip | default('inventory_hostname') }}"
+  hosts: all
   remote_user: "{{ your_user }}"
   become: true
   vars_files:


### PR DESCRIPTION
A yaml inventory file lets you configure browsertrix a bit easier then passing a million parameters in command line.

The only change that is needed in the ansible is `hosts: all`.
This will also work with the old ini style inventory file

Example of a yaml config file included.

Further optimization of this could be done with a defaults file 
(maybe in a future PR :))

deployment would be just

`ansible-playbook -i inventory/hosts.yml playbooks/install_microk8s.yml`
