### PR TITLE
Additional improvements to btrix helper for microk8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ private.yml
 # microk8s playbook hosts
 hosts
 chart/local.yaml
+backend.tar
+frontend.tar

--- a/btrix
+++ b/btrix
@@ -42,11 +42,17 @@ bootstrap(){
 }
 
 bootstrapMicrok8s(){
+    export REGISTRY=localhost:32000/
+
     echo "Building backend..."
     ./scripts/build-backend.sh
+    docker save localhost:32000/webrecorder/browsertrix-backend:latest > backend.tar
+    microk8s ctr image import backend.tar
 
     echo "Building frontend..."
     ./scripts/build-frontend.sh
+    docker save localhost:32000/webrecorder/browsertrix-frontend:latest > frontend.tar
+    microk8s ctr image import frontend.tar
 
     echo "Installing..."
     microk8s helm upgrade --install -f ./chart/values.yaml -f ./chart/local.yaml btrix ./chart


### PR DESCRIPTION
I'm not sure if it's just my local microk8s instance or a broader issue, but I wasn't able to use the microk8s registry for local images. After trying a few things, what seems to work best is loading locally built images as a tarball, as documented here: https://microk8s.io/docs/registry-images

This PR implements this process for microk8s in the `./btrix bootstrap` and `./btrix reset` commands and adds the tarballs to gitignore to prevent accidentally committing them.

We may want to see if other microk8s users have the same issue with the microk8s registry and if so change the cloud documentation for local images accordingly.