### PR TITLE
Fix workflow total size

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -693,6 +693,7 @@ class CrawlConfigOps:
             cid=crawlconfig.id
         )
         crawlconfig.crawlCount = crawl_stats["crawl_count"]
+        crawlconfig.totalSize = crawl_stats["total_size"]
         crawlconfig.lastCrawlId = crawl_stats["last_crawl_id"]
         crawlconfig.lastCrawlStartTime = crawl_stats["last_crawl_started"]
         crawlconfig.lastCrawlTime = crawl_stats["last_crawl_finished"]

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -570,9 +570,9 @@ class CrawlConfigOps:
                     "totalSize": {
                         "$sum": {
                             "$map": {
-                              "input": "$sortedCrawls.files",
-                              "as": "crawlFile",
-                              "in": {"$arrayElemAt": ["$$crawlFile.size", 0]}
+                                "input": "$sortedCrawls.files",
+                                "as": "crawlFile",
+                                "in": {"$arrayElemAt": ["$$crawlFile.size", 0]},
                             }
                         }
                     }

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -199,6 +199,8 @@ class CrawlConfigOut(CrawlConfig):
 
     firstSeed: Optional[str]
 
+    totalSize: Optional[int] = 0
+
     crawlCount: Optional[int] = 0
     lastCrawlId: Optional[str]
     lastCrawlStartTime: Optional[datetime]
@@ -563,8 +565,19 @@ class CrawlConfigOps:
                     }
                 }
             },
-            # total size
-            # {"$set": {"totalSize": {"$sum": "$$finishedCrawls.$$files.size"}}},
+            {
+                "$set": {
+                    "totalSize": {
+                        "$sum": {
+                            "$map": {
+                              "input": "$sortedCrawls.files",
+                              "as": "crawlFile",
+                              "in": {"$arrayElemAt": ["$$crawlFile.size", 0]}
+                            }
+                        }
+                    }
+                }
+            },
             # unset
             {"$unset": ["lastCrawl"]},
             {"$unset": ["sortedCrawls"]},

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -412,7 +412,7 @@ class CrawlOps:
             for res in results:
                 files = [CrawlFile(**data) for data in res["files"]]
                 crawl_files.extend(files)
-            stats["total_size"] = sum([crawl_file.size for crawl_file in crawl_files])
+            stats["total_size"] = sum(crawl_file.size for crawl_file in crawl_files)
 
         return stats
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -408,11 +408,12 @@ class CrawlOps:
             if user:
                 stats["last_started_by"] = user.name
 
-            crawl_files = []
+            total_size = 0
             for res in results:
-                files = [CrawlFile(**data) for data in res["files"]]
-                crawl_files.extend(files)
-            stats["total_size"] = sum(crawl_file.size for crawl_file in crawl_files)
+                files = res["files"]
+                for file in files:
+                    total_size += file["size"]
+            stats["total_size"] = total_size
 
         return stats
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -384,6 +384,7 @@ class CrawlOps:
         """Get crawl statistics for a crawl_config with id cid."""
         stats = {
             "crawl_count": 0,
+            "total_size": 0,
             "last_crawl_id": None,
             "last_crawl_started": None,
             "last_crawl_finished": None,
@@ -406,6 +407,12 @@ class CrawlOps:
             user = await self.user_manager.get(last_crawl.userid)
             if user:
                 stats["last_started_by"] = user.name
+
+            crawl_files = []
+            for res in results:
+                files = [CrawlFile(**data) for data in res["files"]]
+                crawl_files.extend(files)
+            stats["total_size"] = sum([crawl_file.size for crawl_file in crawl_files])
 
         return stats
 

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -228,7 +228,7 @@ def test_workflow_total_size(crawler_auth_headers, default_org_id, admin_crawl_i
             assert workflow["totalSize"] == 0
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{admin_crawl_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{admin_crawl_cid}",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -205,3 +205,25 @@ def test_verify_revs_history(crawler_auth_headers, default_org_id):
     assert len(items) == 2
     sorted_data = sorted(items, key=lambda revision: revision["rev"])
     assert sorted_data[0]["config"]["scopeType"] == "prefix"
+
+
+def test_workflow_total_size(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] > 0
+    items = data["items"]
+    for workflow in items
+        assert workflow["totalSize"] > 0
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["totalSize"] > 0

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -233,5 +233,4 @@ def test_workflow_total_size(crawler_auth_headers, default_org_id, admin_crawl_i
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 1
-    assert data["items"][0]["totalSize"] > 0
+    assert data["totalSize"] > 0

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -216,7 +216,7 @@ def test_workflow_total_size(crawler_auth_headers, default_org_id):
     data = r.json()
     assert data["total"] > 0
     items = data["items"]
-    for workflow in items
+    for workflow in items:
         assert workflow["totalSize"] > 0
 
     r = requests.get(


### PR DESCRIPTION
Fixes #782 

This PR adds the total size of all crawl files associated with a workflow to the crawlconfig GET endpoints (list and single workflow).

Related to https://github.com/webrecorder/browsertrix-cloud/issues/720