### PR TITLE
Improve Recursive font declaration

### DIFF
--- a/frontend/src/assets/fonts/Recursive/recursive.css
+++ b/frontend/src/assets/fonts/Recursive/recursive.css
@@ -1,8 +1,9 @@
 @font-face {
   font-family: 'Recursive var';
-  font-weight: 400;
+  font-weight: 300 1000;
   font-display: swap;
-  font-style: normal;
+  font-style: oblique 0deg 15deg;
   font-variation-settings: 'MONO' 1, 'CASL' 0, 'slnt' 0, 'CRSV' 0;
   src: url("./Recursive_VF.woff2?v=1.085") format("woff2");
+  font-feature-settings: "ss02", "ss08", "ss12";
 }

--- a/frontend/src/assets/fonts/Recursive/recursive.css
+++ b/frontend/src/assets/fonts/Recursive/recursive.css
@@ -1,3 +1,4 @@
+/* See https://github.com/arrowtype/recursive/tree/main#opentype-features for font-feature-settings examples & more configuration info */
 @font-face {
   font-family: 'Recursive var';
   font-weight: 300 1000;


### PR DESCRIPTION
- Enables stylistic sets
  - ss02: Single story `g`
  - ss08: No serif `L` & `Z`
  - ss12: Simplified mono `@`

Does not enable the single story `a` for alignment with Inter as unlike the docs, monospaced text is used pretty interchangeably with sans-serif text in the app and I liked how this looked better.

For reference on these changes, please consult [this helpful image!](https://github.com/arrowtype/recursive/blob/main/specimens/repo-artwork/recursive-v1.064-opentype_features.png)