### PR TITLE
Fix workflow limit empty values being set to `0`

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -63,19 +63,28 @@ export class ConfigDetails extends LiteElement {
     const renderTimeLimit = (
       valueSeconds?: number | null,
       fallbackValue?: number
-    ) =>
-      valueSeconds
-        ? RelativeDuration.humanize(valueSeconds * 1000, { verbose: true })
-        : typeof fallbackValue === "number"
-        ? html`<span class="text-neutral-400"
-            >${fallbackValue === Infinity
-              ? msg("Unlimited")
-              : RelativeDuration.humanize(fallbackValue * 1000, {
-                  verbose: true,
-                })}
-            ${msg("(default)")}</span
-          >`
-        : undefined;
+    ) => {
+      if (valueSeconds) {
+        return RelativeDuration.humanize(valueSeconds * 1000, {
+          verbose: true,
+        });
+      }
+      if (typeof fallbackValue === "number") {
+        let value = "";
+        if (fallbackValue === Infinity) {
+          value = msg("Unlimited");
+        } else if (fallbackValue === 0) {
+          value = msg("0 seconds");
+        } else {
+          value = RelativeDuration.humanize(fallbackValue * 1000, {
+            verbose: true,
+          });
+        }
+        return html`<span class="text-neutral-400"
+          >${value} ${msg("(default)")}</span
+        >`;
+      }
+    };
 
     return html`
       <section id="crawler-settings" class="mb-8">

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1810,8 +1810,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
         value = elem.value;
         break;
       case "sl-input": {
-        if ((elem as SlInput).type === "number" && elem.value !== "") {
-          value = +elem.value;
+        if ((elem as SlInput).type === "number") {
+          if (elem.value === "") {
+            value = undefined;
+          } else {
+            value = +elem.value;
+          }
         } else {
           value = elem.value;
         }

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -150,7 +150,7 @@ const getDefaultFormState = (): FormState => ({
   pageExtraDelaySeconds: null,
   scopeType: "host",
   exclusions: [],
-  pageLimit: undefined,
+  pageLimit: null,
   scale: 1,
   blockAds: true,
   lang: undefined,
@@ -2034,16 +2034,16 @@ https://archiveweb.page/images/${"logo.svg"}`}
       schedule: this.formState.scheduleType === "cron" ? this.utcSchedule : "",
       crawlTimeout: this.formState.crawlTimeoutMinutes
         ? this.formState.crawlTimeoutMinutes * 60
-        : 0,
+        : null,
       tags: this.formState.tags,
       config: {
         ...(this.jobType === "seed-crawl"
           ? this.parseSeededConfig()
           : this.parseUrlListConfig()),
-        behaviorTimeout: +(this.formState.behaviorTimeoutSeconds || ""),
-        pageLoadTimeout: +(this.formState.pageLoadTimeoutSeconds || ""),
-        pageExtraDelay: +(this.formState.pageExtraDelaySeconds || ""),
-        limit: this.formState.pageLimit ? +this.formState.pageLimit : undefined,
+        behaviorTimeout: this.formState.behaviorTimeoutSeconds,
+        pageLoadTimeout: this.formState.pageLoadTimeoutSeconds,
+        pageExtraDelay: this.formState.pageExtraDelaySeconds,
+        limit: this.formState.pageLimit,
         lang: this.formState.lang || "",
         blockAds: this.formState.blockAds,
         exclude: trimArray(this.formState.exclusions),

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1812,7 +1812,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       case "sl-input": {
         if ((elem as SlInput).type === "number") {
           if (elem.value === "") {
-            value = undefined;
+            value = null;
           } else {
             value = +elem.value;
           }


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/792

### Changes
- Sets empty limit values to `undefined` instead of `0`
- Waits for workflow to finish loading before re-rendering edit form as potential fix for edit form showing old workflow values (couldn't replicate this one, but fix should cover this edge case)

### Manual testing

1. Log in and go to Workflows -> New Workflow
2. Create new workflow without entering in values in Limits tab. Verify that Workflow detail page shows placeholders
3. Click Edit Workfow -> Limits. Verify limits still show placeholders
4. Add limits and save, and quickly go back to Edit Workflow. Verify limit values are shown as expected
5. Remove limits and save. Verify limits show placeholders again

### Follow-ups

Will need to apply revised `isLoading` logic to https://github.com/webrecorder/browsertrix-cloud/pull/775
