### PR TITLE
Adds bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,6 +38,6 @@ body:
   - type: textarea
     attributes:
       label: Additional details
-      description: Add any other relevant information here
+      description: Add any other relevant information here, such as your local environment if you are running Browsertrix Cloud locally.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: If something isn't working as expected and you're sure your issue is reproducible, please file this type of issue!
+title: ""
+labels: ["type:bug"]
+body:
+  # Version number
+  - type: input
+    id: version
+    attributes:
+      label: Browsertrix Cloud Version
+      description: This can be found in the site footer
+      placeholder: "v1.5.0-beta.0-67d0c6a"
+    validations:
+      required: true
+  # What did the user expect to happen? What was the actual behavior?
+  - type: textarea
+    attributes:
+      label: What did you expect to happen? What happened instead?
+      description: |
+        "I was trying to modify the Page Load Timeout value in a saved workflow, however..."
+
+        Please submit any screenshots/videos that can be used to understand how to reproduce the issue. You can attach images by clicking this area to highlight it and then dragging files into the browser window.
+        
+        If your problem is related to crawling, or something wasn't captured in the way you expect please include a link to the finished crawl/workflow if possible.
+    validations:
+      required: true
+  # Step-by-step reproduction instructions
+  - type: textarea
+    attributes:
+      label: Step-by-step reproduction instructions
+      placeholder: |
+        1. Navigate to...
+        2. Click on...
+        3. See error...
+    validations:
+      required: true
+  # Additional details
+  - type: textarea
+    attributes:
+      label: Additional details
+      description: Add any other relevant information here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Allow issues to be created without a template
+blank_issues_enabled: true
+
+contact_links:
+  - name: Get help on our forum
+    url: https://forum.webrecorder.net/
+    about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!
+  # - name: Check out the docs
+  #   url: https://docs.browsertrix.cloud
+  #   about: Solutions to common questions may be available in the documentation!


### PR DESCRIPTION
Sometimes I'm lazy and I don't write good bug reports.  This form will force me to do that! 🙃  Will probably add a template for feature planning issues in the future too because consistency is nice.

### Fields
- Version number
- Expectations section (what did the user expect to happen, what actually happened)
- Reproduction steps
- Additional details section (sometimes more detail is required and to keep the above nicely formatted / scoped this is a good thing to have I find)

### Notes
- Keeps blank issues enabled
- AFAIK there's no good way of really testing these until they're committed?  I don't think you get the nice form preview in the PR reviewer which is a bit of a bummer.