### PR TITLE
Removes extra padding around replay window & small file list style update

### DIFF
--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -121,11 +121,11 @@ export class CrawlStatus extends LitElement {
       }
 
       case "partial_complete": {
-        icon = html`<sl-icon 
-          name="dash-circle" 
+        icon = html`<sl-icon
+          name="dash-circle"
           slot="prefix"
           style="color: var(--warning)"
-          ></sl-icon>`;
+        ></sl-icon>`;
         label = msg("Partial Complete");
         break;
       }

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -716,7 +716,11 @@ ${this.crawl?.notes}
                   <li
                     class="flex justify-between p-3 border-t first:border-t-0"
                   >
-                    <div class="whitespace-nowrap truncate">
+                    <div class="whitespace-nowrap truncate flex items-center">
+                      <sl-icon
+                      name="file-earmark-zip-fill"
+                      class="h-4 pr-2 shrink-0 text-neutral-600"
+                      ></sl-icon>
                       <a
                         class="text-primary hover:underline"
                         href=${file.path}
@@ -725,7 +729,7 @@ ${this.crawl?.notes}
                         >${file.name.slice(file.name.lastIndexOf("/") + 1)}
                       </a>
                     </div>
-                    <div class="whitespace-nowrap">
+                    <div class="whitespace-nowrap text-sm font-mono text-neutral-400">
                       <sl-format-bytes value=${file.size}></sl-format-bytes>
                     </div>
                   </li>

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -451,6 +451,18 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderPanel(title: any, content: any) {
+    let panelContainer;
+    switch (this.sectionName) {
+      case "replay":
+        panelContainer = html`
+          <div class="flex-1 rounded-lg border overflow-hidden">${content}</div>
+        `;
+      break;
+      default:
+        panelContainer = html`
+          <div class="flex-1 rounded-lg border p-5">${content}</div>
+        `;
+    }
     return html`
       <h2
         id="exclusions"
@@ -458,7 +470,7 @@ export class CrawlDetail extends LiteElement {
       >
         ${title}
       </h2>
-      <div class="flex-1 rounded-lg border p-5">${content}</div>
+      ${panelContainer}
     `;
   }
 
@@ -547,7 +559,7 @@ export class CrawlDetail extends LiteElement {
         canReplay
           ? html`<div
               id="replay-crawl"
-              class="aspect-4/3 rounded border overflow-hidden"
+              class="aspect-4/3 overflow-hidden"
             >
               <replay-web-page
                 source="${replaySource}"

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -457,7 +457,7 @@ export class CrawlDetail extends LiteElement {
         panelContainer = html`
           <div class="flex-1 rounded-lg border overflow-hidden">${content}</div>
         `;
-      break;
+        break;
       default:
         panelContainer = html`
           <div class="flex-1 rounded-lg border p-5">${content}</div>
@@ -557,10 +557,7 @@ export class CrawlDetail extends LiteElement {
       <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
       ${
         canReplay
-          ? html`<div
-              id="replay-crawl"
-              class="aspect-4/3 overflow-hidden"
-            >
+          ? html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
               <replay-web-page
                 source="${replaySource}"
                 coll="${ifDefined(this.crawl?.id)}"
@@ -718,8 +715,8 @@ ${this.crawl?.notes}
                   >
                     <div class="whitespace-nowrap truncate flex items-center">
                       <sl-icon
-                      name="file-earmark-zip-fill"
-                      class="h-4 pr-2 shrink-0 text-neutral-600"
+                        name="file-earmark-zip-fill"
+                        class="h-4 pr-2 shrink-0 text-neutral-600"
                       ></sl-icon>
                       <a
                         class="text-primary hover:underline"
@@ -729,7 +726,9 @@ ${this.crawl?.notes}
                         >${file.name.slice(file.name.lastIndexOf("/") + 1)}
                       </a>
                     </div>
-                    <div class="whitespace-nowrap text-sm font-mono text-neutral-400">
+                    <div
+                      class="whitespace-nowrap text-sm font-mono text-neutral-400"
+                    >
                       <sl-format-bytes value=${file.size}></sl-format-bytes>
                     </div>
                   </li>


### PR DESCRIPTION
### Changes

- Adds a check before the block of HTML that adds 16px of padding and tells it not to add that if it's the replay page.
- Adds an icon to the file picker & changes the font & colour for the size.

**Before:**
<img width="1162" alt="Screenshot 2023-04-26 at 11 51 19 PM" src="https://user-images.githubusercontent.com/5672810/234755154-74ae82fa-311f-41a8-8e7c-5655a65d70be.png">

<img width="947" alt="Screenshot 2023-04-27 at 12 12 35 AM" src="https://user-images.githubusercontent.com/5672810/234757630-aa42a8c3-8355-4d90-954e-3f42b6a74893.png">

**After:**
<img width="1164" alt="Screenshot 2023-04-26 at 11 50 44 PM" src="https://user-images.githubusercontent.com/5672810/234755167-6e0fd9fb-2fab-4bfa-ba81-6a8f3ce701dd.png">

<img width="961" alt="Screenshot 2023-04-27 at 12 12 21 AM" src="https://user-images.githubusercontent.com/5672810/234757649-32083c46-a1f2-46ac-9756-5adc220dd3dc.png">

