### PR TITLE
Change copy text button → icon button

### DIFF
--- a/frontend/src/components/copy-button.ts
+++ b/frontend/src/components/copy-button.ts
@@ -40,12 +40,15 @@ export class CopyButton extends LitElement {
 
   render() {
     return html`
-      <sl-button
-        size="small"
-        @click=${this.onClick}
-        ?disabled=${!this.value && !this.getValue}
-        >${this.isCopied ? msg("Copied") : msg("Copy")}</sl-button
-      >
+      <sl-tooltip content=${this.isCopied ? msg("Copied to clipboard!") : msg("Copy")}>
+        <sl-icon-button
+          size="small"
+          name=${this.isCopied ? "check-lg" : "files"}
+          label=${msg("Copy to clipboard")}
+          @click=${this.onClick}
+          ?disabled=${!this.value && !this.getValue}
+          ></sl-icon-button>
+      </sl-tooltip>
     `;
   }
 

--- a/frontend/src/components/copy-button.ts
+++ b/frontend/src/components/copy-button.ts
@@ -62,6 +62,8 @@ export class CopyButton extends LitElement {
 
     this.timeoutId = window.setTimeout(() => {
       this.isCopied = false;
+      const button = this.shadowRoot?.querySelector('sl-icon-button');
+      button?.blur(); // Remove focus from the button to set it back to its default state
     }, 3000);
   }
 }


### PR DESCRIPTION
## Changes
- Converts to icon button
- Adds tooltip
- Adds accessibility label field
- Adds a `blur()` method to return the button to its default state and remove focus after the timer is complete

## Screenshots

**Default**
<img width="1317" alt="Screenshot 2023-04-29 at 5 18 17 PM" src="https://user-images.githubusercontent.com/5672810/235324716-f2b73685-87cd-4502-a59e-4fd5b367e33b.png">

**Hover**
<img width="1361" alt="Screenshot 2023-04-29 at 5 18 22 PM" src="https://user-images.githubusercontent.com/5672810/235324715-db8acce9-a50d-4ac8-9f9f-9f815ec00712.png">

**Clicked**
<img width="1705" alt="Screenshot 2023-04-29 at 5 18 31 PM" src="https://user-images.githubusercontent.com/5672810/235324713-69aabcf7-10f4-4e19-8aa1-5c9d66f53883.png">


