### PR TITLE
Crawl detail page update

### DIFF
--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -121,11 +121,11 @@ export class CrawlStatus extends LitElement {
       }
 
       case "partial_complete": {
-        icon = html`<sl-icon 
-          name="dash-circle" 
+        icon = html`<sl-icon
+          name="dash-circle"
           slot="prefix"
           style="color: var(--warning)"
-          ></sl-icon>`;
+        ></sl-icon>`;
         label = msg("Partial Complete");
         break;
       }

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -215,10 +215,9 @@ export class CrawlDetail extends LiteElement {
 
       <div class="mb-4">${this.renderHeader()}</div>
 
-      <hr class="mb-4"/>
+      <hr class="mb-4" />
 
       <main>
-
         <section class="grid grid-cols-6 gap-4">
           <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
           <div class="col-span-6 md:col-span-5">${sectionContent}</div>
@@ -573,13 +572,13 @@ export class CrawlDetail extends LiteElement {
     return html`
       <btrix-desc-list>
         <btrix-desc-list-item label=${msg("Status")}>
-        ${this.crawl
-          ? html`
-              <btrix-crawl-status
-                state=${this.crawl.state}
-              ></btrix-crawl-status>
-            `
-          : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+          ${this.crawl
+            ? html`
+                <btrix-crawl-status
+                  state=${this.crawl.state}
+                ></btrix-crawl-status>
+              `
+            : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Start Time")}>
           ${this.crawl
@@ -614,42 +613,42 @@ export class CrawlDetail extends LiteElement {
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Duration")}>
-        ${this.crawl
-              ? html`
-                  ${this.crawl.finished
-                    ? html`${RelativeDuration.humanize(
-                        new Date(`${this.crawl.finished}Z`).valueOf() -
-                          new Date(`${this.crawl.started}Z`).valueOf()
-                      )}`
-                    : html`
-                        <span class="text-purple-600">
-                          <btrix-relative-duration
-                            value=${`${this.crawl.started}Z`}
-                            unitCount="3"
-                            tickSeconds="1"
-                          ></btrix-relative-duration>
-                        </span>
-                      `}
-                `
-              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+          ${this.crawl
+            ? html`
+                ${this.crawl.finished
+                  ? html`${RelativeDuration.humanize(
+                      new Date(`${this.crawl.finished}Z`).valueOf() -
+                        new Date(`${this.crawl.started}Z`).valueOf()
+                    )}`
+                  : html`
+                      <span class="text-purple-600">
+                        <btrix-relative-duration
+                          value=${`${this.crawl.started}Z`}
+                          unitCount="3"
+                          tickSeconds="1"
+                        ></btrix-relative-duration>
+                      </span>
+                    `}
+              `
+            : html`<sl-skeleton class="h-5"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Size")}>
           ${this.crawl?.stats
-              ? html`
-                  <span
-                    class="font-mono tracking-tighter${this.isActive
-                      ? " text-purple-600"
-                      : ""}"
-                  >
-                    ${this.numberFormatter.format(+this.crawl.stats.done)}
-                    <span class="text-0-400">/</span>
-                    ${this.numberFormatter.format(+this.crawl.stats.found)}
-                  </span>
-                  <span> pages</span>
-                `
-              : this.crawl
-              ? html` <span class="text-0-400">${msg("Unknown")}</span> `
-              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+            ? html`
+                <span
+                  class="font-mono tracking-tighter${this.isActive
+                    ? " text-purple-600"
+                    : ""}"
+                >
+                  ${this.numberFormatter.format(+this.crawl.stats.done)}
+                  <span class="text-0-400">/</span>
+                  ${this.numberFormatter.format(+this.crawl.stats.found)}
+                </span>
+                <span> pages</span>
+              `
+            : this.crawl
+            ? html` <span class="text-0-400">${msg("Unknown")}</span> `
+            : html`<sl-skeleton class="h-5"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Initiator")}>
           ${this.crawl
@@ -670,9 +669,7 @@ export class CrawlDetail extends LiteElement {
             ? html`<btrix-copy-button
                   value=${this.crawl.id}
                 ></btrix-copy-button>
-                <code title=${this.crawl.id}
-                  >${this.crawl.id}</code
-                > `
+                <code title=${this.crawl.id}>${this.crawl.id}</code> `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
         ${this.showOrgLink

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -215,10 +215,9 @@ export class CrawlDetail extends LiteElement {
 
       <div class="mb-4">${this.renderHeader()}</div>
 
+      <hr class="mb-4"/>
+
       <main>
-        <section class="rounded-lg border mb-7">
-          ${this.renderSummary()}
-        </section>
 
         <section class="grid grid-cols-6 gap-4">
           <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
@@ -572,7 +571,16 @@ export class CrawlDetail extends LiteElement {
   private renderOverview() {
     return html`
       <btrix-desc-list>
-        <btrix-desc-list-item label=${msg("Started")}>
+        <btrix-desc-list-item label=${msg("Status")}>
+        ${this.crawl
+          ? html`
+              <btrix-crawl-status
+                state=${this.crawl.state}
+              ></btrix-crawl-status>
+            `
+          : html`<sl-skeleton class="h-6"></sl-skeleton>`}
+        </btrix-desc-list-item>
+        <btrix-desc-list-item label=${msg("Start Time")}>
           ${this.crawl
             ? html`
                 <sl-format-date
@@ -587,7 +595,7 @@ export class CrawlDetail extends LiteElement {
               `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Finished")}>
+        <btrix-desc-list-item label=${msg("Finish Time")}>
           ${this.crawl
             ? html`
                 ${this.crawl.finished
@@ -604,7 +612,45 @@ export class CrawlDetail extends LiteElement {
               `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Reason")}>
+        <btrix-desc-list-item label=${msg("Duration")}>
+        ${this.crawl
+              ? html`
+                  ${this.crawl.finished
+                    ? html`${RelativeDuration.humanize(
+                        new Date(`${this.crawl.finished}Z`).valueOf() -
+                          new Date(`${this.crawl.started}Z`).valueOf()
+                      )}`
+                    : html`
+                        <span class="text-purple-600">
+                          <btrix-relative-duration
+                            value=${`${this.crawl.started}Z`}
+                            unitCount="3"
+                            tickSeconds="1"
+                          ></btrix-relative-duration>
+                        </span>
+                      `}
+                `
+              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+        </btrix-desc-list-item>
+        <btrix-desc-list-item label=${msg("Size")}>
+          ${this.crawl?.stats
+              ? html`
+                  <span
+                    class="font-mono tracking-tighter${this.isActive
+                      ? " text-purple-600"
+                      : ""}"
+                  >
+                    ${this.numberFormatter.format(+this.crawl.stats.done)}
+                    <span class="text-0-400">/</span>
+                    ${this.numberFormatter.format(+this.crawl.stats.found)}
+                  </span>
+                  <span> pages</span>
+                `
+              : this.crawl
+              ? html` <span class="text-0-400">${msg("Unknown")}</span> `
+              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
+        </btrix-desc-list-item>
+        <btrix-desc-list-item label=${msg("Initiator")}>
           ${this.crawl
             ? html`
                 ${this.crawl.manual
@@ -614,7 +660,7 @@ export class CrawlDetail extends LiteElement {
                           >${this.crawl?.userName || this.crawl?.userid}</span
                         >`
                     )
-                  : msg(html`Scheduled run`)}
+                  : msg(html`Scheduled start`)}
               `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
@@ -623,7 +669,7 @@ export class CrawlDetail extends LiteElement {
             ? html`<btrix-copy-button
                   value=${this.crawl.id}
                 ></btrix-copy-button>
-                <code class="text-xs" title=${this.crawl.id}
+                <code title=${this.crawl.id}
                   >${this.crawl.id}</code
                 > `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -644,6 +644,10 @@ export class CrawlDetail extends LiteElement {
         <btrix-desc-list-item label=${msg("Size")}>
           ${this.crawl?.stats
             ? html`
+                <sl-format-bytes
+                  value=${this.crawl.stats.size}
+                  display="narrow"
+                ></sl-format-bytes><span>,</span>
                 <span
                   class="font-mono tracking-tighter${this.isActive
                     ? " text-purple-600"

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -461,6 +461,7 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
+  // renders the info bar, currently disabled
   private renderSummary() {
     return html`
       <dl class="grid grid-cols-4 gap-5 text-center p-3 text-sm">

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -108,7 +108,7 @@ export type Crawl = CrawlConfig & {
   finished?: string; // UTC ISO date
   state: CrawlState;
   scale: number;
-  stats: { done: string; found: string; size: number } | null;
+  stats: { done: string; found: string; size: string } | null;
   resources?: { name: string; path: string; hash: string; size: number }[];
   fileCount?: number;
   fileSize?: number;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -108,7 +108,7 @@ export type Crawl = CrawlConfig & {
   finished?: string; // UTC ISO date
   state: CrawlState;
   scale: number;
-  stats: { done: string; found: string } | null;
+  stats: { done: string; found: string; size: number } | null;
   resources?: { name: string; path: string; hash: string; size: number }[];
   fileCount?: number;
   fileSize?: number;


### PR DESCRIPTION
Updates in accordance with mockups to remove the info bar for crawl detail pages.  I think info bars need a bit of a rethink in the other places we use them but that will have to come at some undefined later date.  Until then, I'd like to push this change out to at least make the page more distinct than the Workflow details page for the next update.

## Changes

- Stops rendering the info bar
- Adds horizontal rule seperator
- Adds info bar data to overview panel

## Todo
- [x] List the total crawl size next to the page count (see mockup)
  - I may need help with this one, I couldn't get it to work :(
- Possibly refactor to remove running checks?  I assume that technically crawls still "run" and all... so maybe keeping those around is good.  The note here being, I didn't remove anything I copied from the info bar.