### PR TITLE
Minor Frontend Visual Updates

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -451,6 +451,8 @@ export class CrawlList extends LitElement {
         border: 1px solid var(--sl-panel-border-color);
         border-radius: var(--sl-border-radius-medium);
         overflow: hidden;
+        margin-left: var(--row-offset);
+        margin-right: var(--row-offset);
       }
 
       .row {

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -269,7 +269,7 @@ export class BrowserProfilesDetail extends LiteElement {
   private renderMenu() {
     return html`
       <sl-dropdown placement="bottom-end" distance="4">
-        <sl-button slot="trigger" caret>${msg("Actions")}</sl-button>
+        <sl-button size="small" slot="trigger" caret>${msg("Actions")}</sl-button>
 
         <ul
           class="text-left text-sm text-neutral-800 bg-white whitespace-nowrap"
@@ -285,7 +285,7 @@ export class BrowserProfilesDetail extends LiteElement {
           >
             <sl-icon
               class="inline-block align-middle px-1"
-              name="pencil-square"
+              name="pencil"
             ></sl-icon>
             <span class="inline-block align-middle pr-2"
               >${msg("Edit name & description")}</span
@@ -314,7 +314,7 @@ export class BrowserProfilesDetail extends LiteElement {
           >
             <sl-icon
               class="inline-block align-middle px-1"
-              name="file-earmark-x"
+              name="trash3"
             ></sl-icon>
             <span class="inline-block align-middle pr-2">${msg("Delete")}</span>
           </li>

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -178,7 +178,7 @@ export class BrowserProfilesList extends LiteElement {
           >
             <sl-icon
               class="inline-block align-middle px-1"
-              name="file-earmark-x"
+              name="trash3"
             ></sl-icon>
             <span class="inline-block align-middle pr-2">${msg("Delete")}</span>
           </li>

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -139,7 +139,7 @@ export class BrowserProfilesList extends LiteElement {
 
   private renderMenu(data: Profile) {
     return html`
-      <sl-dropdown @click=${(e: Event) => e.preventDefault()}>
+      <sl-dropdown hoist="true" @click=${(e: Event) => e.preventDefault()}>
         <sl-icon-button
           slot="trigger"
           name="three-dots"

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -440,7 +440,7 @@ export class CrawlDetail extends LiteElement {
                 style="--sl-color-neutral-700: var(--danger)"
                 @click=${() => this.deleteCrawl()}
               >
-                <sl-icon name="trash" slot="prefix"></sl-icon>
+                <sl-icon name="trash3" slot="prefix"></sl-icon>
                 ${msg("Delete Crawl")}
               </sl-menu-item>
             `

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -473,7 +473,7 @@ export class WorkflowDetail extends LiteElement {
             @click=${() =>
               shouldDeactivate ? this.deactivate() : this.delete()}
           >
-            <sl-icon name="trash" slot="prefix"></sl-icon>
+            <sl-icon name="trash3" slot="prefix"></sl-icon>
             ${
               shouldDeactivate
                 ? msg("Deactivate Workflow")

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -443,7 +443,7 @@ export class WorkflowsList extends LiteElement {
                 ? this.deactivate(workflow)
                 : this.delete(workflow)}
           >
-            <sl-icon name="trash" slot="prefix"></sl-icon>
+            <sl-icon name="trash3" slot="prefix"></sl-icon>
             ${shouldDeactivate
               ? msg("Deactivate Workflow")
               : msg("Delete Workflow")}


### PR DESCRIPTION
## Changes

- Changes `trash` for `trash3` (mockup alignment fix) which I believe wasn't originally available in the version of bootstrap-icons we were using but now it is and I like the tapered edges better 🙃 
- Makes browser profiles action button small to fit with the rest of the dropdown components used elsewhere
- Changes previous file-earmark delete icon to trash icons used everywhere else for delete actions
- Adds margin to crawls list to mirror the workflows list
- Fixes visual glitch with the dropdown actions menus where the icon buttons would show through the dropdown when enabled

## Relevant Screenshots

**Before**

Dots can be seen through dropdown
<img width="977" alt="Screenshot 2023-05-01 at 3 40 21 AM" src="https://user-images.githubusercontent.com/5672810/235424146-523dbb08-0df0-4b7b-a403-6d342b35f653.png">

List items are right in line with the controls bar
<img width="1354" alt="Screenshot 2023-05-01 at 3 44 06 AM" src="https://user-images.githubusercontent.com/5672810/235424514-0ec1e4fb-3cf2-4ec6-b692-88079c2096ce.png">


**After**

No more dots!  Also new delete icon.
<img width="896" alt="Screenshot 2023-05-01 at 3 40 07 AM" src="https://user-images.githubusercontent.com/5672810/235424200-3a1afa70-ac63-4ff3-a800-06209bf3673e.png">

List items are in line with the control bar _corner_ :D
<img width="645" alt="Add Margin" src="https://user-images.githubusercontent.com/5672810/235424221-4dde068c-d27f-468c-8c52-3d1136313e9a.png">