### PR TITLE
Show critical errors in Crawl detail logs

### DIFF
--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -25,7 +25,7 @@ export class CrawlLogs extends LitElement {
       .row {
         display: grid;
         grid-template-columns: 9rem 4rem 5rem 1fr;
-        align-items: center;
+        line-height: 1.3;
       }
 
       .cell {
@@ -49,6 +49,10 @@ export class CrawlLogs extends LitElement {
         margin-top: var(--sl-spacing-large);
         margin-bottom: var(--sl-spacing-x-large);
       }
+
+      .message {
+        white-space: pre-wrap;
+      }
     `,
   ];
 
@@ -69,9 +73,6 @@ export class CrawlLogs extends LitElement {
         ${this.logs.items.map(
           (log: CrawlLog, idx) => html`
             <btrix-numbered-list-item>
-              <span slot="marker"
-                >${idx + 1 + (this.logs!.page - 1) * this.logs!.pageSize}.</span
-              >
               <div class="row">
                 <div>
                   <sl-format-date
@@ -90,7 +91,7 @@ export class CrawlLogs extends LitElement {
                   <span class="tag">${log.logLevel}</span>
                 </div>
                 <div>${log.context}</div>
-                <div class="truncate">${log.message}</div>
+                <div class="message">${log.message}</div>
               </div>
             </btrix-numbered-list-item>
           `

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -1,0 +1,80 @@
+import { LitElement, html, css } from "lit";
+import { property, state } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+
+import { truncate } from "../utils/css";
+
+@localized()
+export class CrawlLogs extends LitElement {
+  static styles = [
+    truncate,
+    css`
+      btrix-numbered-list {
+        font-size: var(--sl-font-size-x-small);
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: 9rem 4rem 5rem 1fr;
+      }
+
+      .cell {
+        padding-left: var(--sl-spacing-x-small);
+        padding-right: var(--sl-spacing-x-small);
+      }
+
+      .tag {
+        display: inline-block;
+        border-radius: var(--sl-border-radius-small);
+        padding: var(--sl-spacing-3x-small) var(--sl-spacing-2x-small);
+        text-transform: capitalize;
+        /* TODO handle non-errors */
+        background-color: var(--danger);
+        color: var(--sl-color-neutral-0);
+      }
+    `,
+  ];
+
+  @property({ type: Array })
+  logs: any[] = [];
+
+  render() {
+    return html`<btrix-numbered-list>
+      <btrix-numbered-list-header slot="header">
+        <div class="row">
+          <div class="cell">${msg("Date")}</div>
+          <div class="cell">${msg("Level")}</div>
+          <div class="cell">${msg("Context")}</div>
+          <div class="cell">${msg("Error Message")}</div>
+        </div>
+      </btrix-numbered-list-header>
+      ${this.logs.map(
+        (log, idx) => html`
+          <btrix-numbered-list-item>
+            <span slot="marker">${idx + 1}.</span>
+            <div class="row">
+              <div>
+                <sl-format-date
+                  date=${log.timestamp}
+                  month="2-digit"
+                  day="2-digit"
+                  year="2-digit"
+                  hour="2-digit"
+                  minute="2-digit"
+                  second="2-digit"
+                  hour-format="24"
+                >
+                </sl-format-date>
+              </div>
+              <div>
+                <span class="tag">${log.logLevel}</span>
+              </div>
+              <div>${log.context}</div>
+              <div class="truncate">${log.message}</div>
+            </div>
+          </btrix-numbered-list-item>
+        `
+      )}
+    </btrix-numbered-list>`;
+  }
+}

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -9,6 +9,7 @@ import type { APIPaginatedList } from "../types/api";
 type CrawlLog = {
   timestamp: string;
   logLevel: "error";
+  details: Record<string, any>;
   context: string;
   message: string;
 };
@@ -24,8 +25,9 @@ export class CrawlLogs extends LitElement {
 
       .row {
         display: grid;
-        grid-template-columns: 9rem 4rem 5rem 1fr;
+        grid-template-columns: 9rem 4rem 14rem 1fr;
         line-height: 1.3;
+        max-width: 800px;
       }
 
       .cell {
@@ -53,6 +55,13 @@ export class CrawlLogs extends LitElement {
       .message {
         white-space: pre-wrap;
       }
+
+      .url {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+      }
+
     `,
   ];
 
@@ -66,8 +75,8 @@ export class CrawlLogs extends LitElement {
           <div class="row">
             <div class="cell">${msg("Date")}</div>
             <div class="cell">${msg("Level")}</div>
-            <div class="cell">${msg("Context")}</div>
             <div class="cell">${msg("Error Message")}</div>
+            <div class="cell">${msg("Page URL")}</div>
           </div>
         </btrix-numbered-list-header>
         ${this.logs.items.map(
@@ -90,8 +99,8 @@ export class CrawlLogs extends LitElement {
                 <div>
                   <span class="tag">${log.logLevel}</span>
                 </div>
-                <div>${log.context}</div>
                 <div class="message">${log.message}</div>
+                <div class="url" title="${log.details?.page}">${log.details?.page}</div>
               </div>
             </btrix-numbered-list-item>
           `

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -100,7 +100,7 @@ export class CrawlLogs extends LitElement {
                   <span class="tag">${log.logLevel}</span>
                 </div>
                 <div class="message">${log.message}</div>
-                <div class="url" title="${log.details?.page}">${log.details?.page}</div>
+                <div class="url" title="${log.details?.page}"><a target="_blank" href="${log.details?.page}">${log.details?.page}</a></div>
               </div>
             </btrix-numbered-list-item>
           `

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -3,6 +3,15 @@ import { property, state } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 
 import { truncate } from "../utils/css";
+import type { APIPaginatedList } from "../types/api";
+import type { PageChangeEvent } from "./pagination";
+
+type CrawlLog = {
+  timestamp: string;
+  logLevel: "error";
+  context: string;
+  message: string;
+};
 
 @localized()
 export class CrawlLogs extends LitElement {
@@ -35,10 +44,11 @@ export class CrawlLogs extends LitElement {
     `,
   ];
 
-  @property({ type: Array })
-  logs: any[] = [];
+  @property({ type: Object })
+  logs?: APIPaginatedList;
 
   render() {
+    if (!this.logs) return;
     return html`<btrix-numbered-list>
       <btrix-numbered-list-header slot="header">
         <div class="row">
@@ -48,8 +58,8 @@ export class CrawlLogs extends LitElement {
           <div class="cell">${msg("Error Message")}</div>
         </div>
       </btrix-numbered-list-header>
-      ${this.logs.map(
-        (log, idx) => html`
+      ${this.logs.items.map(
+        (log: CrawlLog, idx) => html`
           <btrix-numbered-list-item>
             <span slot="marker">${idx + 1}.</span>
             <div class="row">

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -50,41 +50,47 @@ export class CrawlLogs extends LitElement {
   render() {
     if (!this.logs) return;
     return html`<btrix-numbered-list>
-      <btrix-numbered-list-header slot="header">
-        <div class="row">
-          <div class="cell">${msg("Date")}</div>
-          <div class="cell">${msg("Level")}</div>
-          <div class="cell">${msg("Context")}</div>
-          <div class="cell">${msg("Error Message")}</div>
-        </div>
-      </btrix-numbered-list-header>
-      ${this.logs.items.map(
-        (log: CrawlLog, idx) => html`
-          <btrix-numbered-list-item>
-            <span slot="marker">${idx + 1}.</span>
-            <div class="row">
-              <div>
-                <sl-format-date
-                  date=${log.timestamp}
-                  month="2-digit"
-                  day="2-digit"
-                  year="2-digit"
-                  hour="2-digit"
-                  minute="2-digit"
-                  second="2-digit"
-                  hour-format="24"
-                >
-                </sl-format-date>
+        <btrix-numbered-list-header slot="header">
+          <div class="row">
+            <div class="cell">${msg("Date")}</div>
+            <div class="cell">${msg("Level")}</div>
+            <div class="cell">${msg("Context")}</div>
+            <div class="cell">${msg("Error Message")}</div>
+          </div>
+        </btrix-numbered-list-header>
+        ${this.logs.items.map(
+          (log: CrawlLog, idx) => html`
+            <btrix-numbered-list-item>
+              <span slot="marker">${idx + 1}.</span>
+              <div class="row">
+                <div>
+                  <sl-format-date
+                    date=${log.timestamp}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="2-digit"
+                    minute="2-digit"
+                    second="2-digit"
+                    hour-format="24"
+                  >
+                  </sl-format-date>
+                </div>
+                <div>
+                  <span class="tag">${log.logLevel}</span>
+                </div>
+                <div>${log.context}</div>
+                <div class="truncate">${log.message}</div>
               </div>
-              <div>
-                <span class="tag">${log.logLevel}</span>
-              </div>
-              <div>${log.context}</div>
-              <div class="truncate">${log.message}</div>
-            </div>
-          </btrix-numbered-list-item>
-        `
-      )}
-    </btrix-numbered-list>`;
+            </btrix-numbered-list-item>
+          `
+        )}
+      </btrix-numbered-list>
+      <btrix-pagination
+        page=${this.logs.page}
+        totalCount=${this.logs.total}
+        size=${this.logs.pageSize}
+      >
+      </btrix-pagination> `;
   }
 }

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from "lit";
 import { property, state } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
 import { msg, localized, str } from "@lit/localize";
 
 import { truncate } from "../utils/css";
@@ -24,6 +25,7 @@ export class CrawlLogs extends LitElement {
       .row {
         display: grid;
         grid-template-columns: 9rem 4rem 5rem 1fr;
+        align-items: center;
       }
 
       .cell {

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -4,7 +4,6 @@ import { msg, localized, str } from "@lit/localize";
 
 import { truncate } from "../utils/css";
 import type { APIPaginatedList } from "../types/api";
-import type { PageChangeEvent } from "./pagination";
 
 type CrawlLog = {
   timestamp: string;
@@ -41,6 +40,13 @@ export class CrawlLogs extends LitElement {
         background-color: var(--danger);
         color: var(--sl-color-neutral-0);
       }
+
+      footer {
+        display: flex;
+        justify-content: center;
+        margin-top: var(--sl-spacing-large);
+        margin-bottom: var(--sl-spacing-x-large);
+      }
     `,
   ];
 
@@ -61,7 +67,9 @@ export class CrawlLogs extends LitElement {
         ${this.logs.items.map(
           (log: CrawlLog, idx) => html`
             <btrix-numbered-list-item>
-              <span slot="marker">${idx + 1}.</span>
+              <span slot="marker"
+                >${idx + 1 + (this.logs!.page - 1) * this.logs!.pageSize}.</span
+              >
               <div class="row">
                 <div>
                   <sl-format-date
@@ -86,11 +94,13 @@ export class CrawlLogs extends LitElement {
           `
         )}
       </btrix-numbered-list>
-      <btrix-pagination
-        page=${this.logs.page}
-        totalCount=${this.logs.total}
-        size=${this.logs.pageSize}
-      >
-      </btrix-pagination> `;
+      <footer>
+        <btrix-pagination
+          page=${this.logs.page}
+          totalCount=${this.logs.total}
+          size=${this.logs.pageSize}
+        >
+        </btrix-pagination>
+      </footer> `;
   }
 }

--- a/frontend/src/components/crawl-pending-exclusions.ts
+++ b/frontend/src/components/crawl-pending-exclusions.ts
@@ -87,20 +87,24 @@ export class CrawlPendingExclusions extends LiteElement {
     }
 
     return html`
-      <btrix-numbered-list
-        class="text-xs break-all"
-        .items=${this.pageResults.map((url, idx) => ({
-          order: idx + 1 + (this.page - 1) * this.pageSize,
-          content: html`<a
-            href=${url}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            >${url}</a
-          >`,
-        }))}
-        aria-live="polite"
-        style="--link-color: var(--sl-color-danger-600); --link-hover-color: var(--sl-color-danger-400);"
-      ></btrix-numbered-list>
+      <btrix-numbered-list class="text-xs break-all" aria-live="polite">
+        ${this.pageResults.map(
+          (url, idx) => html`
+            <btrix-numbered-list-item>
+              <span class="text-red-600" slot="marker"
+                >${idx + 1 + (this.page - 1) * this.pageSize}.</span
+              >
+              <a
+                class="text-red-600 hover:text-red-500"
+                href=${url}
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                >${url}</a
+              >
+            </btrix-numbered-list-item>
+          `
+        )}
+      </btrix-numbered-list>
     `;
   }
 }

--- a/frontend/src/components/crawl-queue.ts
+++ b/frontend/src/components/crawl-queue.ts
@@ -100,29 +100,28 @@ export class CrawlQueue extends LiteElement {
 
     if (!this.queue) return;
 
-    const excludedURLStyles = [
-      "--marker-color: var(--sl-color-danger-500)",
-      "--link-color: var(--sl-color-danger-500)",
-      "--link-hover-color: var(--sl-color-danger-400)",
-    ].join(";");
-
     return html`
-      <btrix-numbered-list
-        class="text-xs break-all"
-        .items=${this.queue.results.map((url, idx) => ({
-          order: idx + 1,
-          style: this.queue!.matched.some((v) => v === url)
-            ? excludedURLStyles
-            : "",
-          content: html`<a
-            href=${url}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            >${url}</a
-          >`,
-        }))}
-        aria-live="polite"
-      ></btrix-numbered-list>
+      <btrix-numbered-list class="text-xs break-all" aria-live="polite">
+        ${this.queue.results.map((url, idx) => {
+          const isMatch = this.queue!.matched.some((v) => v === url);
+          return html`
+            <btrix-numbered-list-item>
+              <span class="${isMatch ? "text-red-600" : ""}" slot="marker"
+                >${idx + 1}.</span
+              >
+              <a
+                class="${isMatch
+                  ? "text-red-500 hover:text-red-400"
+                  : "text-blue-500 hover:text-blue-400"}"
+                href=${url}
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                >${url}</a
+              >
+            </btrix-numbered-list-item>
+          `;
+        })}
+      </btrix-numbered-list>
 
       <footer class="text-center">
         ${when(

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -46,8 +46,9 @@ import("./queue-exclusion-form").then(({ QueueExclusionForm }) => {
 import("./queue-exclusion-table").then(({ QueueExclusionTable }) => {
   customElements.define("btrix-queue-exclusion-table", QueueExclusionTable);
 });
-import("./numbered-list").then(({ NumberedList }) => {
+import("./numbered-list").then(({ NumberedList, NumberedListItem }) => {
   customElements.define("btrix-numbered-list", NumberedList);
+  customElements.define("btrix-numbered-list-item", NumberedListItem);
 });
 import("./pagination").then(({ Pagination }) => {
   customElements.define("btrix-pagination", Pagination);

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -46,10 +46,13 @@ import("./queue-exclusion-form").then(({ QueueExclusionForm }) => {
 import("./queue-exclusion-table").then(({ QueueExclusionTable }) => {
   customElements.define("btrix-queue-exclusion-table", QueueExclusionTable);
 });
-import("./numbered-list").then(({ NumberedList, NumberedListItem }) => {
-  customElements.define("btrix-numbered-list", NumberedList);
-  customElements.define("btrix-numbered-list-item", NumberedListItem);
-});
+import("./numbered-list").then(
+  ({ NumberedList, NumberedListItem, NumberedListHeader }) => {
+    customElements.define("btrix-numbered-list", NumberedList);
+    customElements.define("btrix-numbered-list-item", NumberedListItem);
+    customElements.define("btrix-numbered-list-header", NumberedListHeader);
+  }
+);
 import("./pagination").then(({ Pagination }) => {
   customElements.define("btrix-pagination", Pagination);
 });

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -94,6 +94,9 @@ import("./workflow-list").then(({ WorkflowListItem, WorkflowList }) => {
   customElements.define("btrix-workflow-list-item", WorkflowListItem);
   customElements.define("btrix-workflow-list", WorkflowList);
 });
+import("./crawl-logs").then(({ CrawlLogs }) => {
+  customElements.define("btrix-crawl-logs", CrawlLogs);
+});
 import("./section-heading").then(({ SectionHeading }) => {
   customElements.define("btrix-section-heading", SectionHeading);
 });

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -1,12 +1,18 @@
+/**
+ * Styled numbered list
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-numbered-list>
+ *   <btrix-numbered-list-item>
+ *     <span slot="marker">1.</span> Content
+ *   </btrix-numbered-list-item>
+ * </btrix-numbered-list>
+ * ```
+ */
 import { LitElement, html, css } from "lit";
 import { property, queryAssignedElements } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-
-type ListItem = {
-  order?: number;
-  style?: string; // inline styles
-  content: any; // any lit template content
-};
 
 export class NumberedListItem extends LitElement {
   @property({ type: Boolean })
@@ -25,10 +31,6 @@ export class NumberedListItem extends LitElement {
     }
 
     .content {
-      --item-height: 1.5rem;
-      contain: paint;
-      contain-intrinsic-height: auto var(--item-height);
-      content-visibility: auto;
       border-left: var(--sl-panel-border-width) solid
         var(--sl-panel-border-color);
       border-right: var(--sl-panel-border-width) solid
@@ -84,18 +86,31 @@ export class NumberedListItem extends LitElement {
   }
 }
 
-/**
- * Styled numbered list
- *
- * Usage example:
- * ```ts
- * <btrix-numbered-list></btrix-numbered-list>
- * ```
- */
-export class NumberedList extends LitElement {
-  @property({ type: Array })
-  items: ListItem[] = [];
+export class NumberedListHeader extends LitElement {
+  static styles = css`
+    :host,
+    header {
+      display: contents;
+    }
 
+    .content {
+      grid-column: 2 / -1;
+      padding-top: var(--sl-spacing-x-small);
+      padding-bottom: var(--sl-spacing-x-small);
+      color: var(--sl-color-neutral-600);
+      font-size: var(--sl-font-size-x-small);
+      line-height: 1rem;
+    }
+  `;
+
+  render() {
+    return html`<header>
+      <div class="content"><slot></slot></div>
+    </header>`;
+  }
+}
+
+export class NumberedList extends LitElement {
   static styles = css`
     :host {
       display: block;
@@ -106,6 +121,10 @@ export class NumberedList extends LitElement {
       grid-template-columns: minmax(3ch, max-content) 1fr;
       grid-column-gap: var(--sl-spacing-x-small);
       align-items: center;
+    }
+
+    ol {
+      display: contents;
       font-family: var(--sl-font-mono);
       list-style-type: none;
       margin: 0;
@@ -118,9 +137,12 @@ export class NumberedList extends LitElement {
 
   render() {
     return html`
-      <ol class="list">
-        <slot @slotchange=${this.handleSlotchange}></slot>
-      </ol>
+      <div class="list">
+        <slot name="header"></slot>
+        <ol>
+          <slot @slotchange=${this.handleSlotchange}></slot>
+        </ol>
+      </div>
     `;
   }
 

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -117,7 +117,7 @@ export class NumberedList extends LitElement {
 
     .list {
       display: grid;
-      grid-template-columns: minmax(3ch, max-content) 1fr;
+      grid-template-columns: max-content 1fr;
       grid-column-gap: var(--sl-spacing-x-small);
       align-items: center;
     }

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -95,7 +95,6 @@ export class NumberedListHeader extends LitElement {
 
     .content {
       grid-column: 2 / -1;
-      padding-top: var(--sl-spacing-x-small);
       padding-bottom: var(--sl-spacing-x-small);
       color: var(--sl-color-neutral-600);
       font-size: var(--sl-font-size-x-small);

--- a/frontend/src/components/pagination.ts
+++ b/frontend/src/components/pagination.ts
@@ -314,6 +314,7 @@ export class Pagination extends LitElement {
     this.dispatchEvent(
       <PageChangeEvent>new CustomEvent("page-change", {
         detail: { page: page, pages: this.pages },
+        composed: true,
       })
     );
   }

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -56,6 +56,9 @@ export class CrawlDetail extends LiteElement {
   private crawl?: Crawl;
 
   @state()
+  private logs?: Crawl;
+
+  @state()
   private sectionName: SectionName = "overview";
 
   @state()
@@ -321,23 +324,24 @@ export class CrawlDetail extends LiteElement {
             icon: "link-replay",
             label: msg("Replay Crawl"),
           })}
-          ${!this.isActive
-            ? renderNavItem({
-                section: "files",
-                iconLibrary: "default",
-                icon: "folder-fill",
-                label: msg("Files"),
-              })
-            : ""}
+          ${renderNavItem({
+            section: "files",
+            iconLibrary: "default",
+            icon: "folder-fill",
+            label: msg("Files"),
+          })}
+          ${renderNavItem({
+            section: "logs",
+            iconLibrary: "default",
+            icon: "terminal-fill",
+            label: msg("Logs"),
+          })}
           ${renderNavItem({
             section: "config",
             iconLibrary: "default",
             icon: "file-code-fill",
             label: msg("Config"),
           })}
-          ${
-            /* renderNavItem({ section: "logs", iconLibrary:"default", icon: "terminal-fill", label: msg("Logs") }) */ ""
-          }
         </ul>
       </nav>
     `;
@@ -773,6 +777,11 @@ ${this.crawl?.notes}
         icon: "exclamation-octagon",
       });
     }
+    try {
+      this.logs = await this.getCrawlLogs();
+    } catch {
+      // Fail silently
+    }
   }
 
   private async getCrawl(): Promise<Crawl> {
@@ -780,6 +789,15 @@ ${this.crawl?.notes}
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
         this.crawlId
       }/replay.json`,
+      this.authState!
+    );
+
+    return data;
+  }
+
+  private async getCrawlLogs(): Promise<any> {
+    const data: any = await this.apiFetch(
+      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}/logs`,
       this.authState!
     );
 

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -162,7 +162,7 @@ export class CrawlDetail extends LiteElement {
         );
         break;
       case "logs":
-        sectionContent = this.renderPanel(msg("Logs"), this.renderLogs());
+        sectionContent = this.renderPanel(msg("Error Logs"), this.renderLogs());
         break;
       case "config":
         sectionContent = this.renderPanel(msg("Config"), this.renderConfig(), {
@@ -360,7 +360,7 @@ export class CrawlDetail extends LiteElement {
             section: "logs",
             iconLibrary: "default",
             icon: "terminal-fill",
-            label: msg("Logs"),
+            label: msg("Error Logs"),
           })}
           ${renderNavItem({
             section: "config",
@@ -782,7 +782,7 @@ ${this.crawl?.notes}
 
     if (!this.logs.total) {
       return html`<div class="border rounded-lg p-4">
-        <p class="text-sm text-neutral-400">${msg("No logs to display.")}</p>
+        <p class="text-sm text-neutral-400">${msg("No error logs to display.")}</p>
       </div>`;
     }
 

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -833,7 +833,9 @@ ${this.crawl?.notes}
 
   private async getCrawlLogs({ page = 1 } = {}): Promise<APIPaginatedList> {
     const data: APIPaginatedList = await this.apiFetch(
-      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}/errors`,
+      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
+        this.crawlId
+      }/errors?pageSize=${100}&page=${page}`,
       this.authState!
     );
 

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -779,42 +779,8 @@ ${this.crawl?.notes}
     if (!this.logs) {
       return html`TODO`;
     }
-    const gridClassName = "grid grid-cols-[9rem_4rem_5rem_1fr]";
-    return html`<btrix-numbered-list class="text-xs">
-      <btrix-numbered-list-header slot="header">
-        <div class=${gridClassName}>
-          <div class="px-2">${msg("Date")}</div>
-          <div class="px-2">${msg("Level")}</div>
-          <div class="px-2">${msg("Context")}</div>
-          <div class="px-2">${msg("Error Message")}</div>
-        </div>
-      </btrix-numbered-list-header>
-      ${this.logs.map(
-        (log, idx) => html`
-          <btrix-numbered-list-item>
-            <span slot="marker">${idx + 1}.</span>
-            <div class=${gridClassName}>
-              <div>
-                <sl-format-date
-                  date=${log.timestamp}
-                  month="2-digit"
-                  day="2-digit"
-                  year="2-digit"
-                  hour="2-digit"
-                  minute="2-digit"
-                  second="2-digit"
-                  hour-format="24"
-                >
-                </sl-format-date>
-              </div>
-              <div class="uppercase">${log.logLevel}</div>
-              <div>${log.context}</div>
-              <div class="truncate">${log.message}</div>
-            </div>
-          </btrix-numbered-list-item>
-        `
-      )}
-    </btrix-numbered-list>`;
+
+    return html` <btrix-crawl-logs .logs=${this.logs}></btrix-crawl-logs> `;
   }
 
   private renderConfig() {

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -146,26 +146,44 @@ export class CrawlDetail extends LiteElement {
       case "replay":
         sectionContent = this.renderPanel(
           msg("Replay Crawl"),
-          this.renderReplay()
+          this.renderReplay(),
+          {
+            "overflow-hidden": true,
+            "rounded-lg": true,
+            border: true,
+          }
         );
         break;
       case "files":
         sectionContent = this.renderPanel(
           msg("Download Files"),
-          this.renderFiles()
+          this.renderFiles(),
+          {
+            "p-4": true,
+            "rounded-lg": true,
+            border: true,
+          }
         );
         break;
       case "logs":
         sectionContent = this.renderPanel(msg("Logs"), this.renderLogs());
         break;
       case "config":
-        sectionContent = this.renderPanel(msg("Config"), this.renderConfig());
+        sectionContent = this.renderPanel(msg("Config"), this.renderConfig(), {
+          "p-4": true,
+          "rounded-lg": true,
+          border: true,
+        });
         break;
       default:
         sectionContent = html`
           <div class="grid gap-5 grid-cols-1 lg:grid-cols-2">
             <div class="col-span-1 flex flex-col">
-              ${this.renderPanel(msg("Overview"), this.renderOverview())}
+              ${this.renderPanel(msg("Overview"), this.renderOverview(), {
+                "p-4": true,
+                "rounded-lg": true,
+                border: true,
+              })}
             </div>
             <div class="col-span-1 flex flex-col">
               ${this.renderPanel(
@@ -193,7 +211,12 @@ export class CrawlDetail extends LiteElement {
                     `
                   )}
                 `,
-                this.renderMetadata()
+                this.renderMetadata(),
+                {
+                  "p-4": true,
+                  "rounded-lg": true,
+                  border: true,
+                }
               )}
             </div>
           </div>
@@ -461,19 +484,7 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
-  private renderPanel(title: any, content: any) {
-    let panelContainer;
-    switch (this.sectionName) {
-      case "replay":
-        panelContainer = html`
-          <div class="flex-1 rounded-lg border overflow-hidden">${content}</div>
-        `;
-        break;
-      default:
-        panelContainer = html`
-          <div class="flex-1 rounded-lg border p-5">${content}</div>
-        `;
-    }
+  private renderPanel(title: any, content: any, classes: any = {}) {
     return html`
       <h2
         id="exclusions"
@@ -481,7 +492,14 @@ export class CrawlDetail extends LiteElement {
       >
         ${title}
       </h2>
-      ${panelContainer}
+      <div
+        class=${classMap({
+          "flex-1": true,
+          ...classes,
+        })}
+      >
+        ${content}
+      </div>
     `;
   }
 
@@ -578,7 +596,7 @@ export class CrawlDetail extends LiteElement {
               ></replay-web-page>
             </div>`
           : html`
-              <p class="text-sm text-neutral-400">
+              <p class="text-sm text-neutral-400 p-4">
                 ${this.isActive
                   ? msg("No files yet.")
                   : msg("No files to replay.")}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -158,12 +158,7 @@ export class CrawlDetail extends LiteElement {
       case "files":
         sectionContent = this.renderPanel(
           msg("Download Files"),
-          this.renderFiles(),
-          {
-            "p-4": true,
-            "rounded-lg": true,
-            border: true,
-          }
+          this.renderFiles()
         );
         break;
       case "logs":
@@ -737,7 +732,7 @@ ${this.crawl?.notes}
     return html`
       ${this.hasFiles
         ? html`
-            <ul class="border rounded text-sm">
+            <ul class="border rounded-lg text-sm">
               ${this.crawl!.resources!.map(
                 (file) => html`
                   <li
@@ -782,6 +777,12 @@ ${this.crawl?.notes}
         class="w-full flex items-center justify-center my-24 text-3xl"
       >
         <sl-spinner></sl-spinner>
+      </div>`;
+    }
+
+    if (!this.logs.total) {
+      return html`<div class="border rounded-lg p-4">
+        <p class="text-sm text-neutral-400">${msg("No logs to display.")}</p>
       </div>`;
     }
 

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -10,6 +10,9 @@ import LiteElement, { html } from "../../utils/LiteElement";
 import { isActive } from "../../utils/crawler";
 import { CopyButton } from "../../components/copy-button";
 import type { Crawl, Workflow } from "./types";
+import { APIPaginatedList } from "../../types/api";
+
+type CrawlLog = any;
 
 const SECTIONS = [
   "overview",
@@ -56,7 +59,7 @@ export class CrawlDetail extends LiteElement {
   private crawl?: Crawl;
 
   @state()
-  private logs?: Crawl;
+  private logs?: CrawlLog[];
 
   @state()
   private sectionName: SectionName = "overview";
@@ -795,13 +798,13 @@ ${this.crawl?.notes}
     return data;
   }
 
-  private async getCrawlLogs(): Promise<any> {
-    const data: any = await this.apiFetch(
-      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}/logs`,
+  private async getCrawlLogs(): Promise<CrawlLog[]> {
+    const data: APIPaginatedList = await this.apiFetch(
+      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}/errors`,
       this.authState!
     );
 
-    return data;
+    return data.items;
   }
 
   private async cancel() {

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -13,8 +13,6 @@ import { CopyButton } from "../../components/copy-button";
 import type { Crawl, Workflow } from "./types";
 import { APIPaginatedList } from "../../types/api";
 
-type CrawlLog = any;
-
 const SECTIONS = [
   "overview",
   "watch",
@@ -63,7 +61,7 @@ export class CrawlDetail extends LiteElement {
   private crawl?: Crawl;
 
   @state()
-  private logs?: CrawlLog[];
+  private logs?: APIPaginatedList;
 
   @state()
   private sectionName: SectionName = "overview";
@@ -777,10 +775,19 @@ ${this.crawl?.notes}
 
   private renderLogs() {
     if (!this.logs) {
-      return html`TODO`;
+      return html`<div
+        class="w-full flex items-center justify-center my-24 text-3xl"
+      >
+        <sl-spinner></sl-spinner>
+      </div>`;
     }
 
-    return html` <btrix-crawl-logs .logs=${this.logs}></btrix-crawl-logs> `;
+    return html`
+      <btrix-crawl-logs
+        .logs=${this.logs}
+        @page-change=${console.log}
+      ></btrix-crawl-logs>
+    `;
   }
 
   private renderConfig() {
@@ -824,13 +831,13 @@ ${this.crawl?.notes}
     return data;
   }
 
-  private async getCrawlLogs(): Promise<CrawlLog[]> {
+  private async getCrawlLogs({ page = 1 } = {}): Promise<APIPaginatedList> {
     const data: APIPaginatedList = await this.apiFetch(
       `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${this.crawlId}/errors`,
       this.authState!
     );
 
-    return data.items;
+    return data;
   }
 
   private async cancel() {

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -2,6 +2,7 @@ import type { TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { classMap } from "lit/directives/class-map.js";
 import { msg, localized, str } from "@lit/localize";
 
 import { RelativeDuration } from "../../components/relative-duration";
@@ -25,6 +26,9 @@ const SECTIONS = [
 ] as const;
 type SectionName = (typeof SECTIONS)[number];
 
+const LOG_LEVEL_VARIANTS = {
+  error: "danger",
+} as const;
 const POLL_INTERVAL_SECONDS = 10;
 
 /**
@@ -754,7 +758,45 @@ ${this.crawl?.notes}
   }
 
   private renderLogs() {
-    return html`TODO`;
+    if (!this.logs) {
+      return html`TODO`;
+    }
+    const gridClassName = "grid grid-cols-[9rem_4rem_5rem_1fr]";
+    return html`<btrix-numbered-list class="text-xs">
+      <btrix-numbered-list-header slot="header">
+        <div class=${gridClassName}>
+          <div class="px-2">${msg("Date")}</div>
+          <div class="px-2">${msg("Level")}</div>
+          <div class="px-2">${msg("Context")}</div>
+          <div class="px-2">${msg("Error Message")}</div>
+        </div>
+      </btrix-numbered-list-header>
+      ${this.logs.map(
+        (log, idx) => html`
+          <btrix-numbered-list-item>
+            <span slot="marker">${idx + 1}.</span>
+            <div class=${gridClassName}>
+              <div>
+                <sl-format-date
+                  date=${log.timestamp}
+                  month="2-digit"
+                  day="2-digit"
+                  year="2-digit"
+                  hour="2-digit"
+                  minute="2-digit"
+                  second="2-digit"
+                  hour-format="24"
+                >
+                </sl-format-date>
+              </div>
+              <div class="uppercase">${log.logLevel}</div>
+              <div>${log.context}</div>
+              <div class="truncate">${log.message}</div>
+            </div>
+          </btrix-numbered-list-item>
+        `
+      )}
+    </btrix-numbered-list>`;
   }
 
   private renderConfig() {

--- a/frontend/src/utils/css.ts
+++ b/frontend/src/utils/css.ts
@@ -18,10 +18,9 @@ export const srOnly = css`
   }
 `;
 
-// From https://tailwindcss.com/docs/text-overflow#truncate
 export const truncate = css`
   .truncate {
-    overflow: hidden;
+    overflow: clip visible;
     text-overflow: ellipsis;
     white-space: nowrap;
   }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/330

<!-- Fixes #issue_number -->

### Changes

Adds new tab to crawl detail for viewing error logs

### Manual testing

1. Log in and go to Finished Crawls
2. Click a crawl -> Logs. Verify logs are shown
3. Go back to Crawls list and click through over crawl logs. Verify logs are paginated for >50 log items

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl Detail - Logs |  <img width="1145" alt="Screen Shot 2023-05-02 at 2 29 43 PM" src="https://user-images.githubusercontent.com/4672952/235795864-fc5e547b-3380-41bf-bc3c-6ffeb147d6c8.png"><br /><img width="937" alt="Screen Shot 2023-05-02 at 2 29 52 PM" src="https://user-images.githubusercontent.com/4672952/235795904-d779c224-f5f5-42ba-b729-603beeb34114.png"> |
| Crawl Detail - Logs (empty) | <img width="942" alt="Screen Shot 2023-05-02 at 2 30 23 PM" src="https://user-images.githubusercontent.com/4672952/235795953-18653f7a-ae77-4824-8342-33988e50445a.png"> |


<!-- ### Follow-ups -->
