### PR TITLE
Pre-compute workflow last crawl information

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -266,7 +266,7 @@ class CrawlConfigOps:
         self.crawl_ops = ops
 
     async def init_index(self):
-        """init index for crawls db"""
+        """init index for crawlconfigs db collection"""
         await self.crawl_configs.create_index(
             [("oid", pymongo.HASHED), ("inactive", pymongo.ASCENDING)]
         )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -196,6 +196,10 @@ class CrawlOps:
 
         self.presign_duration = int(os.environ.get("PRESIGN_DURATION_SECONDS", 3600))
 
+    async def init_index(self):
+        """init index for crawls db collection"""
+        await self.crawls.create_index([("finished", pymongo.DESCENDING)])
+
     async def list_crawls(
         self,
         org: Optional[Organization] = None,

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -13,7 +13,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0005"
+CURR_DB_VERSION = "0006"
 
 
 # ============================================================================

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -55,6 +55,7 @@ async def update_and_prepare_db(
     mdb,
     user_manager,
     org_ops,
+    crawl_ops,
     crawl_config_ops,
     coll_ops,
     invite_ops,
@@ -70,7 +71,7 @@ async def update_and_prepare_db(
     print("Database setup started", flush=True)
     if await run_db_migrations(mdb, user_manager):
         await drop_indexes(mdb)
-    await create_indexes(org_ops, crawl_config_ops, coll_ops, invite_ops)
+    await create_indexes(org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_ops)
     await user_manager.create_super_user()
     await org_ops.create_default_org()
     print("Database updated and ready", flush=True)
@@ -134,10 +135,11 @@ async def drop_indexes(mdb):
 
 
 # ============================================================================
-async def create_indexes(org_ops, crawl_config_ops, coll_ops, invite_ops):
+async def create_indexes(org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_ops):
     """Create database indexes."""
     print("Creating database indexes", flush=True)
     await org_ops.init_index()
+    await crawl_ops.init_index()
     await crawl_config_ops.init_index()
     await coll_ops.init_index()
     await invite_ops.init_index()

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -114,7 +114,7 @@ def main():
     if run_once_lock("btrix-init-db"):
         asyncio.create_task(
             update_and_prepare_db(
-                mdb, user_manager, org_ops, crawl_config_ops, coll_ops, invites
+                mdb, user_manager, org_ops, crawls, crawl_config_ops, coll_ops, invites
             )
         )
 

--- a/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
+++ b/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
@@ -1,0 +1,31 @@
+"""
+Migration 0006 - Precomputing workflow crawl stats
+"""
+from btrixcloud.crawlconfigs import update_config_crawl_stats
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0006"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Add data on workflow crawl statistics that was previously dynamically
+        computed when needed to the database.
+        """
+        crawl_configs = self.mdb["crawl_configs"]
+        crawls = self.mdb["crawls"]
+
+        configs = [res async for res in crawl_configs.find({})]
+        if not configs:
+            return
+
+        for config in configs:
+            await update_config_crawl_stats(crawl_configs, crawls, config["_id"])

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -207,7 +207,7 @@ def test_verify_revs_history(crawler_auth_headers, default_org_id):
     assert sorted_data[0]["config"]["scopeType"] == "prefix"
 
 
-def test_workflow_total_size(
+def test_workflow_total_size_and_last_crawl_stats(
     crawler_auth_headers, default_org_id, admin_crawl_id, crawler_crawl_id
 ):
     admin_crawl_cid = ""
@@ -224,6 +224,15 @@ def test_workflow_total_size(
         last_crawl_id = workflow.get("lastCrawlId")
         if last_crawl_id and last_crawl_id in (admin_crawl_id, crawler_crawl_id):
             assert workflow["totalSize"] > 0
+            assert workflow["crawlCount"] > 0
+
+            assert workflow["lastCrawlId"]
+            assert workflow["lastCrawlStartTime"]
+            assert workflow["lastStartedByName"]
+            assert workflow["lastCrawlTime"]
+            assert workflow["lastCrawlState"]
+            assert workflow["lastCrawlSize"] > 0
+
             if last_crawl_id == admin_crawl_id:
                 admin_crawl_cid = workflow["id"]
                 assert admin_crawl_cid
@@ -237,3 +246,11 @@ def test_workflow_total_size(
     assert r.status_code == 200
     data = r.json()
     assert data["totalSize"] > 0
+    assert data["crawlCount"] > 0
+
+    assert data["lastCrawlId"]
+    assert data["lastCrawlStartTime"]
+    assert data["lastStartedByName"]
+    assert data["lastCrawlTime"]
+    assert data["lastCrawlState"]
+    assert data["lastCrawlSize"] > 0

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -226,6 +226,7 @@ def test_workflow_total_size(
             assert workflow["totalSize"] > 0
             if last_crawl_id == admin_crawl_id:
                 admin_crawl_cid = workflow["id"]
+                assert admin_crawl_cid
         else:
             assert workflow["totalSize"] == 0
 


### PR DESCRIPTION
Fixes #805 

This PR moves some of the last crawl and total crawl fields that were previously computed in the GET workflows aggregation query into the CrawlConfig model, and updates them on completion of each crawl via the new Operator, as well as when crawls are deleted.

It also includes: 
- A database migration to populate the new CrawlConfig fields
- A new index on `Crawl.finished`
- Tests that have been expanded to ensure the new fields are populated in the workflow GET API endpoints