### PR TITLE
Fix crawl /errors API endpoint

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -780,10 +780,11 @@ class CrawlOps:
         # Zero-index page for query
         page = page - 1
         skip = page * page_size
+        upper_bound = skip + page_size - 1
 
         try:
             redis = await self.get_redis(crawl_id)
-            errors = await redis.lrange(f"{crawl_id}:e", skip, page_size)
+            errors = await redis.lrange(f"{crawl_id}:e", skip, upper_bound)
         except exceptions.ConnectionError:
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=503, detail="redis_connection_error")
@@ -1240,7 +1241,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
 
         if crawl.finished:
             skip = (page - 1) * pageSize
-            upper_bound = skip + pageSize - 1
+            upper_bound = skip + pageSize
             errors = crawl.errors[skip:upper_bound]
             parsed_errors = parse_jsonl_error_messages(errors)
             total = len(parsed_errors)


### PR DESCRIPTION
Fixes to the /errors API endpoint:

- Fix upper bounds for retrieving crawl errors to return correct number of errors per page.
- Fix total to be count of all errors, not just on page.

Tested while crawls are running and after they complete.