### PR TITLE
Set stop-crawl in redis from operator when crawl is stopped

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -613,6 +613,10 @@ class CrawlOps:
         """stop or cancel specified crawl"""
         result = None
         try:
+            if graceful:
+                redis = await self.get_redis(crawl_id)
+                redis.set(f"{crawl_id}:crawl-stop", "1")
+
             result = await self.crawl_manager.shutdown_crawl(
                 crawl_id, org.id_str, graceful=graceful
             )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -7,7 +7,6 @@ import uuid
 import os
 import json
 import re
-import time
 import urllib.parse
 
 from typing import Optional, List, Dict, Union

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -613,20 +613,6 @@ class CrawlOps:
     async def shutdown_crawl(self, crawl_id: str, org: Organization, graceful: bool):
         """stop or cancel specified crawl"""
         result = None
-        redis_err = (
-            "Unable to connect to redis to set crawl-stop. Trying again in 1 second"
-        )
-
-        if graceful:
-            while True:
-                try:
-                    redis = await self.get_redis(crawl_id)
-                    redis.set(f"{crawl_id}:crawl-stop", "1")
-                    break
-                except exceptions.ConnectionError:
-                    print(redis_err, flush=True)
-                    time.sleep(1)
-
         try:
             result = await self.crawl_manager.shutdown_crawl(
                 crawl_id, org.id_str, graceful=graceful

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -364,7 +364,7 @@ class BtrixOperator(K8sAPI):
             )
 
         if crawl.stopping:
-            await redis.set(f"{crawl.id}:stop-crawl", "1")
+            await redis.set(f"{crawl.id}:crawl-stop", "1")
 
         # optimization: don't update db once crawl is already running
         # will set stats at when crawl is finished, otherwise can read

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -364,7 +364,7 @@ class BtrixOperator(K8sAPI):
             )
 
         if crawl.stopping:
-            await redis.set(f"{crawl.id}:stopping", "1")
+            await redis.set(f"{crawl.id}:stop-crawl", "1")
 
         # optimization: don't update db once crawl is already running
         # will set stats at when crawl is finished, otherwise can read


### PR DESCRIPTION
Update in Btrix Cloud corresponding to https://github.com/webrecorder/browsertrix-crawler/pull/303 in crawler.

This doesn't yet change the logic of statuses to include the new statuses in https://github.com/webrecorder/browsertrix-crawler/pull/303 via `replay.json`, though I can add that in this PR if desired.

