### PR TITLE
Crawl workflow detail page improvements

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -20,8 +20,9 @@ import {
 } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import { msg, localized, str } from "@lit/localize";
-import type { SlIconButton, SlMenu } from "@shoelace-style/shoelace";
+import type { SlMenu } from "@shoelace-style/shoelace";
 
+import type { Button } from "./button";
 import { RelativeDuration } from "./relative-duration";
 import type { Crawl } from "../types/crawler";
 import { srOnly, truncate, dropdown } from "../utils/css";
@@ -190,7 +191,7 @@ export class CrawlListItem extends LitElement {
   dropdown!: HTMLElement;
 
   @query(".dropdownTrigger")
-  dropdownTrigger!: SlIconButton;
+  dropdownTrigger!: Button;
 
   @queryAssignedElements({ selector: "sl-menu", slot: "menu" })
   private menuArr!: Array<SlMenu>;
@@ -336,10 +337,10 @@ export class CrawlListItem extends LitElement {
       </div>
       <div class="col action">
         <slot name="menuTrigger">
-          <sl-icon-button
+          <btrix-button
             class="dropdownTrigger"
-            name="three-dots-vertical"
             label=${msg("Actions")}
+            icon
             @click=${(e: MouseEvent) => {
               // Prevent anchor link default behavior
               e.preventDefault();
@@ -361,7 +362,9 @@ export class CrawlListItem extends LitElement {
               }
               this.dropdownIsOpen = false;
             }}
-          ></sl-icon-button>
+          >
+            <sl-icon name="three-dots-vertical"></sl-icon>
+          </btrix-button>
         </slot>
       </div>
     </a>`;
@@ -443,6 +446,11 @@ export class CrawlList extends LitElement {
     columnCss,
     hostVars,
     css`
+      .listHeader, .list {
+        margin-left: var(--row-offset);
+        margin-right: var(--row-offset);
+      }
+
       .listHeader {
         line-height: 1;
       }
@@ -451,8 +459,6 @@ export class CrawlList extends LitElement {
         border: 1px solid var(--sl-panel-border-color);
         border-radius: var(--sl-border-radius-medium);
         overflow: hidden;
-        margin-left: var(--row-offset);
-        margin-right: var(--row-offset);
       }
 
       .row {

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -253,7 +253,9 @@ export class WorkflowListItem extends LitElement {
     return html`<a
       class="item row"
       role="button"
-      href=${`/orgs/${this.workflow?.oid}/workflows/crawl/${this.workflow?.id}`}
+      href=${`/orgs/${this.workflow?.oid}/workflows/crawl/${
+        this.workflow?.id
+      }#${this.workflow?.currCrawlId ? "watch" : "artifacts"}`}
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -79,7 +79,7 @@ export class WorkflowDetail extends LiteElement {
   private isAttemptCancel: boolean = false;
 
   @state()
-  private isCancelingOrDeletingCrawl: boolean = false;
+  private isCancelingOrStoppingCrawl: boolean = false;
 
   @state()
   private filterBy: Partial<Record<keyof Crawl, any>> = {};
@@ -280,7 +280,7 @@ export class WorkflowDetail extends LiteElement {
           <sl-button
             size="small"
             variant="primary"
-            ?loading=${this.isCancelingOrDeletingCrawl}
+            ?loading=${this.isCancelingOrStoppingCrawl}
             @click=${async () => {
               await this.cancel();
               this.isAttemptCancel = false;
@@ -397,6 +397,7 @@ export class WorkflowDetail extends LiteElement {
             size="small"
             @click=${() => this.stop()}
             ?disabled=${!this.workflow?.currCrawlId ||
+            this.isCancelingOrStoppingCrawl ||
             this.workflow?.currCrawlState === "stopping"}
           >
             <sl-icon name="dash-circle" slot="prefix"></sl-icon>
@@ -405,7 +406,8 @@ export class WorkflowDetail extends LiteElement {
           <sl-button
             size="small"
             @click=${() => this.requestCancelCrawl()}
-            ?disabled=${!this.workflow?.currCrawlId}
+            ?disabled=${!this.workflow?.currCrawlId ||
+            this.isCancelingOrStoppingCrawl}
           >
             <sl-icon
               name="x-octagon"
@@ -478,13 +480,15 @@ export class WorkflowDetail extends LiteElement {
             () => html`
               <sl-menu-item
                 @click=${() => this.stop()}
-                ?disabled=${workflow.currCrawlState === "stopping"}
+                ?disabled=${workflow.currCrawlState === "stopping" ||
+                this.isCancelingOrStoppingCrawl}
               >
                 <sl-icon name="dash-circle" slot="prefix"></sl-icon>
                 ${msg("Stop Crawl")}
               </sl-menu-item>
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--danger)"
+                ?disabled=${this.isCancelingOrStoppingCrawl}
                 @click=${() => this.requestCancelCrawl()}
               >
                 <sl-icon name="x-octagon" slot="prefix"></sl-icon>
@@ -1180,7 +1184,7 @@ export class WorkflowDetail extends LiteElement {
   private async cancel() {
     if (!this.workflow?.currCrawlId) return;
 
-    this.isCancelingOrDeletingCrawl = true;
+    this.isCancelingOrStoppingCrawl = true;
 
     try {
       const data = await this.apiFetch(
@@ -1203,13 +1207,13 @@ export class WorkflowDetail extends LiteElement {
       });
     }
 
-    this.isCancelingOrDeletingCrawl = false;
+    this.isCancelingOrStoppingCrawl = false;
   }
 
   private async stop() {
     if (!this.workflow?.currCrawlId) return;
 
-    this.isCancelingOrDeletingCrawl = true;
+    this.isCancelingOrStoppingCrawl = true;
 
     try {
       const data = await this.apiFetch(
@@ -1232,7 +1236,7 @@ export class WorkflowDetail extends LiteElement {
       });
     }
 
-    this.isCancelingOrDeletingCrawl = false;
+    this.isCancelingOrStoppingCrawl = false;
   }
 
   private async runNow(): Promise<void> {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -156,17 +156,18 @@ export class WorkflowDetail extends LiteElement {
 
   updated(changedProperties: Map<string, any>) {
     const prevWorkflow = changedProperties.get("workflow");
-    if (prevWorkflow?.currCrawlId && !this.workflow?.currCrawlId) {
+    if (
+      prevWorkflow?.currCrawlId &&
+      !this.workflow?.currCrawlId &&
+      this.activePanel === "watch"
+    ) {
       this.goToTab(DEFAULT_SECTION, { replace: true });
     }
   }
 
   private getActivePanelFromHash = () => {
     const hashValue = window.location.hash.slice(1);
-    if (
-      SECTIONS.includes(hashValue as any) &&
-      !(hashValue === "watch" && !this.workflow?.currCrawlId)
-    ) {
+    if (SECTIONS.includes(hashValue as any)) {
       this.activePanel = hashValue as Tab;
     } else {
       this.goToTab(DEFAULT_SECTION, { replace: true });

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -341,17 +341,35 @@ export class WorkflowDetail extends LiteElement {
     }
     if (this.activePanel === "watch") {
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
-        <sl-button
-          size="small"
-          ?disabled=${this.workflow?.currCrawlState !== "running"}
-          @click=${() => {
-            this.openDialogName = "scale";
-            this.isDialogVisible = true;
-          }}
-        >
-          <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
-          <span> ${msg("Crawler Instances")} </span>
-        </sl-button>`;
+        <sl-button-group>
+          <sl-button
+            size="small"
+            ?disabled=${this.workflow?.currCrawlState !== "running"}
+            @click=${() => {
+              this.openDialogName = "scale";
+              this.isDialogVisible = true;
+            }}
+          >
+            <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
+            <span> ${msg("Edit Instances")} </span>
+          </sl-button>
+          <sl-button
+            size="small"
+            @click=${() => this.stop()}
+            ?disabled=${this.workflow?.currCrawlState === "stopping"}
+          >
+            <sl-icon name="dash-circle" slot="prefix"></sl-icon>
+            <span>${msg("Stop")}</span>
+          </sl-button>
+          <sl-button size="small" @click=${() => this.cancel()}>
+            <sl-icon
+              name="x-octagon"
+              slot="prefix"
+              class="text-danger"
+            ></sl-icon>
+            <span class="text-danger">${msg("Cancel")}</span>
+          </sl-button>
+        </sl-button-group>`;
     }
 
     return html`<h3>${this.tabLabels[this.activePanel]}</h3>`;
@@ -1101,7 +1119,13 @@ export class WorkflowDetail extends LiteElement {
 
   private async cancel() {
     if (!this.workflow?.currCrawlId) return;
-    if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
+    if (
+      window.confirm(
+        msg(
+          "Are you sure you want to cancel the crawl? Canceling will discard all crawl artifact data, including pages crawled so far."
+        )
+      )
+    ) {
       const data = await this.apiFetch(
         `/orgs/${this.orgId}/crawls/${this.workflow.currCrawlId}/cancel`,
         this.authState!,
@@ -1123,7 +1147,13 @@ export class WorkflowDetail extends LiteElement {
 
   private async stop() {
     if (!this.workflow?.currCrawlId) return;
-    if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
+    if (
+      window.confirm(
+        msg(
+          "Are you sure you want to stop the crawl? The pages crawled so far will be preserved and the crawl will be marked as incomplete."
+        )
+      )
+    ) {
       const data = await this.apiFetch(
         `/orgs/${this.orgId}/crawls/${this.workflow.currCrawlId}/stop`,
         this.authState!,

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -313,10 +313,18 @@ export class WorkflowDetail extends LiteElement {
     if (!this.activePanel) return;
     if (this.activePanel === "artifacts") {
       return html`<h3>
-        ${this.workflow?.crawlCount === 1
-          ? msg(str`${this.workflow?.crawlCount} Crawl`)
-          : msg(str`${this.workflow?.crawlCount} Crawls`)}
-      </h3>`;
+          ${this.workflow?.crawlCount === 1
+            ? msg(str`${this.workflow?.crawlCount} Crawl`)
+            : msg(str`${this.workflow?.crawlCount} Crawls`)}
+        </h3>
+        <sl-button
+          size="small"
+          @click=${() => this.runNow()}
+          ?disabled=${this.workflow?.currCrawlId}
+        >
+          <sl-icon name="play" slot="prefix"></sl-icon>
+          <span>${msg("Run")}</span>
+        </sl-button>`;
     }
     if (this.activePanel === "settings") {
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -318,7 +318,19 @@ export class WorkflowDetail extends LiteElement {
           : msg(str`${this.workflow?.crawlCount} Crawls`)}
       </h3>`;
     }
-
+    if (this.activePanel === "settings") {
+      return html` <h3>${this.tabLabels[this.activePanel]}</h3>
+        <sl-button
+          size="small"
+          @click=${() =>
+            this.navTo(
+              `/orgs/${this.workflow?.oid}/workflows/crawl/${this.workflow?.id}?edit`
+            )}
+        >
+          <sl-icon name="gear" slot="prefix"></sl-icon>
+          <span>${msg("Edit")}</span>
+        </sl-button>`;
+    }
     if (this.activePanel === "watch") {
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
         <sl-button
@@ -384,7 +396,7 @@ export class WorkflowDetail extends LiteElement {
     const workflow = this.workflow;
 
     return html`
-      <sl-dropdown placement="bottom-end" distance="4">
+      <sl-dropdown placement="bottom-end" distance="4" hoist>
         <sl-button slot="trigger" size="small" caret
           >${msg("Actions")}</sl-button
         >

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -403,7 +403,7 @@ export class WorkflowDetail extends LiteElement {
           </sl-button>
           <sl-button
             size="small"
-            @click=${() => this.attemptCancel()}
+            @click=${() => this.requestCancelCrawl()}
             ?disabled=${!this.workflow?.currCrawlId}
           >
             <sl-icon
@@ -484,7 +484,7 @@ export class WorkflowDetail extends LiteElement {
               </sl-menu-item>
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--danger)"
-                @click=${() => this.attemptCancel()}
+                @click=${() => this.requestCancelCrawl()}
               >
                 <sl-icon name="x-octagon" slot="prefix"></sl-icon>
                 ${msg("Cancel & Discard Crawl")}
@@ -975,7 +975,7 @@ export class WorkflowDetail extends LiteElement {
     this.fetchWorkflow();
   }
 
-  private attemptCancel() {
+  private requestCancelCrawl() {
     const pagesDone = this.currentCrawl?.stats?.done;
     if (pagesDone && +pagesDone > 0) {
       this.isAttemptCancel = true;

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -227,40 +227,40 @@ export class WorkflowsList extends LiteElement {
 
         <div class="flex items-center w-full md:w-fit">
           <div class="whitespace-nowrap text-sm text-0-500 mr-2">
-              ${msg("Sort by:")}
-            </div>
-            <sl-select
-              class="flex-1 md:min-w-[9.2rem]"
-              size="small"
-              pill
-              value=${this.orderBy.field}
-              @sl-select=${(e: any) => {
-                const field = e.detail.item.value as SortField;
-                this.orderBy = {
-                  field: field,
-                  direction:
-                    sortableFields[field].defaultDirection ||
-                    this.orderBy.direction,
-                };
-              }}
-            >
-              ${Object.entries(sortableFields).map(
-                ([value, { label }]) => html`
-                  <sl-menu-item value=${value}>${label}</sl-menu-item>
-                `
-              )}
-            </sl-select>
-            <sl-icon-button
-              name="arrow-down-up"
-              label=${msg("Reverse sort")}
-              @click=${() => {
-                this.orderBy = {
-                  ...this.orderBy,
-                  direction: this.orderBy.direction === "asc" ? "desc" : "asc",
-                };
-              }}
-            ></sl-icon-button>
+            ${msg("Sort by:")}
           </div>
+          <sl-select
+            class="flex-1 md:min-w-[9.2rem]"
+            size="small"
+            pill
+            value=${this.orderBy.field}
+            @sl-select=${(e: any) => {
+              const field = e.detail.item.value as SortField;
+              this.orderBy = {
+                field: field,
+                direction:
+                  sortableFields[field].defaultDirection ||
+                  this.orderBy.direction,
+              };
+            }}
+          >
+            ${Object.entries(sortableFields).map(
+              ([value, { label }]) => html`
+                <sl-menu-item value=${value}>${label}</sl-menu-item>
+              `
+            )}
+          </sl-select>
+          <sl-icon-button
+            name="arrow-down-up"
+            label=${msg("Reverse sort")}
+            @click=${() => {
+              this.orderBy = {
+                ...this.orderBy,
+                direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+              };
+            }}
+          ></sl-icon-button>
+        </div>
       </div>
 
       <div class="flex flex-wrap items-center justify-between">
@@ -298,7 +298,9 @@ export class WorkflowsList extends LiteElement {
         </div>
         <div class="flex items-center justify-end">
           <label>
-            <span class="text-neutral-500 mr-1 text-xs">${msg("Show Only Mine")}</span>
+            <span class="text-neutral-500 mr-1 text-xs"
+              >${msg("Show Only Mine")}</span
+            >
             <sl-switch
               @sl-change=${(e: CustomEvent) =>
                 (this.filterByCurrentUser = (e.target as SlCheckbox).checked)}
@@ -655,7 +657,7 @@ export class WorkflowsList extends LiteElement {
             <br />
             <a
               class="underline hover:no-underline"
-              href="/orgs/${this.orgId}/workflows/crawl/${workflow.id}"
+              href="/orgs/${this.orgId}/workflows/crawl/${workflow.id}#watch"
               @click=${this.navLink.bind(this)}
               >Watch crawl</a
             >`


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/817

<!-- Fixes #issue_number -->

### Changes

- Adds relevant action buttons to each Workflow detail tab header
- Adds "Delete" action menu item to crawls in Crawls tab
- Prevent automatically switching to "Watch" tab after running crawl from detail page
- Removes "Stop" confirmation prompt and only shows "Cancel" confirmation prompt if there are one or more pages crawled (Note: I had this change in my notes but don't remember if it came from specific review feedback, so this change may be up for discussion.)
- Replaces "Cancel" confirmation prompt with web component dialog (partially addresses https://github.com/webrecorder/browsertrix-cloud/issues/619)
- Fixes hash routing to fix going back with browser back button

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail - Crawls | <img width="1128" alt="Screen Shot 2023-05-03 at 6 44 49 PM" src="https://user-images.githubusercontent.com/4672952/236091243-c9126fb1-f69c-42a2-a1c3-5cd5a1d8387e.png"> |
| Workflow Detail - Crawls - Action menu | <img width="1027" alt="Screen Shot 2023-05-03 at 6 44 57 PM" src="https://user-images.githubusercontent.com/4672952/236091291-dc19d94f-25f5-43c3-9572-b12db42f773d.png"> |
| Workflow Detail - Settings | <img width="1123" alt="Screen Shot 2023-05-03 at 6 44 38 PM" src="https://user-images.githubusercontent.com/4672952/236091252-4d522e05-fd58-4817-99fa-aa40253682cc.png"> |
| Workflow Detail - Watch | <img width="1136" alt="Screen Shot 2023-05-03 at 6 44 21 PM" src="https://user-images.githubusercontent.com/4672952/236091269-e1d9decf-7d60-420b-bf5c-885785a40bc7.png"> |
| Workflow Detail - Watch - Cancel Crawl dialog | <img width="522" alt="Screen Shot 2023-05-03 at 6 45 57 PM" src="https://user-images.githubusercontent.com/4672952/236091283-55967369-626b-4348-a580-df1bee979510.png"> |



<!-- ### Follow-ups -->
