### PR TITLE
Improve sorting workflows by lastUpdated

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -487,7 +487,7 @@ class CrawlConfigOps:
         description: str = None,
         tags: Optional[List[str]] = None,
         schedule: Optional[bool] = None,
-        sort_by: str = None,
+        sort_by: str = "lastRun",
         sort_direction: int = -1,
     ):
         """Get all crawl configs for an organization is a member of"""

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -193,6 +193,8 @@ class CrawlConfig(CrawlConfigCore):
 
     lastRun: Optional[datetime]
 
+    isCrawlRunning: Optional[bool] = False
+
     def get_raw_config(self):
         """serialize config for browsertrix-crawler"""
         return self.config.dict(exclude_unset=True, exclude_none=True)
@@ -922,6 +924,7 @@ async def set_config_current_crawl_info(
                 "lastCrawlStartTime": crawl_start,
                 "lastCrawlTime": None,
                 "lastRun": crawl_start,
+                "isCrawlRunning": True,
             }
         },
         return_document=pymongo.ReturnDocument.AFTER,
@@ -949,6 +952,7 @@ async def update_config_crawl_stats(crawl_configs, crawls, cid: uuid.UUID):
         "lastCrawlState": None,
         "lastCrawlSize": None,
         "lastCrawlStopping": False,
+        "isCrawlRunning": False,
     }
 
     match_query = {"cid": cid, "finished": {"$ne": None}}

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -537,6 +537,7 @@ class CrawlConfigOps:
                 "modified",
                 "firstSeed",
                 "lastCrawlTime",
+                "lastCrawlStartTime",
                 "lastRun",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
@@ -547,7 +548,12 @@ class CrawlConfigOps:
 
             # Add modified as final sort key to give some order to workflows that
             # haven't been run yet.
-            if sort_by in ("firstSeed", "lastCrawlTime", "lastRun"):
+            if sort_by in (
+                "firstSeed",
+                "lastCrawlTime",
+                "lastCrawlStartTime",
+                "lastRun",
+            ):
                 sort_query = {sort_by: sort_direction, "modified": sort_direction}
 
             aggregate.extend([{"$sort": sort_query}])

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -862,7 +862,7 @@ async def add_new_crawl(
     )
 
     try:
-        result = crawls.insert_one(crawl.to_dict())
+        result = await crawls.insert_one(crawl.to_dict())
         return {"id": str(result.inserted_id), "started": started}
     except pymongo.errors.DuplicateKeyError:
         # print(f"Crawl Already Added: {crawl.id} - {crawl.state}")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, UUID4, conint, HttpUrl
 from redis import asyncio as aioredis, exceptions
 import pymongo
 
-from .crawlconfigs import Seed, CrawlConfigCore, CrawlConfig, UpdateCrawlConfig
+from .crawlconfigs import Seed, CrawlConfigCore, CrawlConfig, UpdateCrawlConfig, set_curr_crawl
 from .db import BaseMongoModel
 from .orgs import Organization, MAX_CRAWL_SCALE
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
@@ -536,7 +536,13 @@ class CrawlOps:
 
     async def add_new_crawl(self, crawl_id: str, crawlconfig: CrawlConfig, user: User):
         """initialize new crawl"""
-        return await add_new_crawl(self.crawls, crawl_id, crawlconfig, user.id)
+        new_crawl = await add_new_crawl(self.crawls, crawl_id, crawlconfig, user.id)
+        return await set_curr_crawl(
+            self.crawl_configs.crawl_configs,
+            crawlconfig.id,
+            new_crawl["id"],
+            new_crawl["started"],
+        )
 
     async def update_crawl(self, crawl_id: str, org: Organization, update: UpdateCrawl):
         """Update existing crawl (tags and notes only for now)"""
@@ -835,6 +841,8 @@ async def add_new_crawl(
     crawls, crawl_id: str, crawlconfig: CrawlConfig, userid: UUID4, manual=True
 ):
     """initialize new crawl"""
+    started = ts_now()
+
     crawl = Crawl(
         id=crawl_id,
         state="starting",
@@ -849,13 +857,13 @@ async def add_new_crawl(
         schedule=crawlconfig.schedule,
         crawlTimeout=crawlconfig.crawlTimeout,
         manual=manual,
-        started=ts_now(),
+        started=started,
         tags=crawlconfig.tags,
     )
 
     try:
-        await crawls.insert_one(crawl.to_dict())
-        return True
+        result = crawls.insert_one(crawl.to_dict())
+        return {"id": str(result.inserted_id), "started": started}
     except pymongo.errors.DuplicateKeyError:
         # print(f"Crawl Already Added: {crawl.id} - {crawl.state}")
         return False

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -18,7 +18,13 @@ from pydantic import BaseModel, UUID4, conint, HttpUrl
 from redis import asyncio as aioredis, exceptions
 import pymongo
 
-from .crawlconfigs import Seed, CrawlConfigCore, CrawlConfig, UpdateCrawlConfig, set_curr_crawl
+from .crawlconfigs import (
+    Seed,
+    CrawlConfigCore,
+    CrawlConfig,
+    UpdateCrawlConfig,
+    set_config_current_crawl_info,
+)
 from .db import BaseMongoModel
 from .orgs import Organization, MAX_CRAWL_SCALE
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
@@ -537,7 +543,7 @@ class CrawlOps:
     async def add_new_crawl(self, crawl_id: str, crawlconfig: CrawlConfig, user: User):
         """initialize new crawl"""
         new_crawl = await add_new_crawl(self.crawls, crawl_id, crawlconfig, user.id)
-        return await set_curr_crawl(
+        return await set_config_current_crawl_info(
             self.crawl_configs.crawl_configs,
             crawlconfig.id,
             new_crawl["id"],

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -46,8 +46,9 @@ class ScheduledJob(K8sAPI):
         new_crawl = await add_new_crawl(
             self.crawls, crawl_id, crawlconfig, uuid.UUID(userid), manual=False
         )
-        return await set_curr_crawl(
-            self.crawl_configs.crawl_configs,
+        # pylint: disable=duplicate-code
+        await set_curr_crawl(
+            self.crawlconfigs.crawl_configs,
             crawlconfig.id,
             new_crawl["id"],
             new_crawl["started"],

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -6,7 +6,7 @@ import uuid
 
 from .k8sapi import K8sAPI
 from .db import init_db
-from .crawlconfigs import get_crawl_config, inc_crawl_count
+from .crawlconfigs import get_crawl_config, inc_crawl_count, set_curr_crawl
 from .crawls import add_new_crawl
 from .utils import register_exit_handler
 
@@ -43,8 +43,14 @@ class ScheduledJob(K8sAPI):
 
         # db create
         await inc_crawl_count(self.crawlconfigs, crawlconfig.id)
-        await add_new_crawl(
+        new_crawl = await add_new_crawl(
             self.crawls, crawl_id, crawlconfig, uuid.UUID(userid), manual=False
+        )
+        return await set_curr_crawl(
+            self.crawl_configs.crawl_configs,
+            crawlconfig.id,
+            new_crawl["id"],
+            new_crawl["started"],
         )
 
         print("Crawl Created: " + crawl_id)

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -6,7 +6,11 @@ import uuid
 
 from .k8sapi import K8sAPI
 from .db import init_db
-from .crawlconfigs import get_crawl_config, inc_crawl_count, set_curr_crawl
+from .crawlconfigs import (
+    get_crawl_config,
+    inc_crawl_count,
+    set_config_current_crawl_info,
+)
 from .crawls import add_new_crawl
 from .utils import register_exit_handler
 
@@ -47,7 +51,7 @@ class ScheduledJob(K8sAPI):
             self.crawls, crawl_id, crawlconfig, uuid.UUID(userid), manual=False
         )
         # pylint: disable=duplicate-code
-        await set_curr_crawl(
+        await set_config_current_crawl_info(
             self.crawlconfigs.crawl_configs,
             crawlconfig.id,
             new_crawl["id"],

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -495,7 +495,10 @@ class BtrixOperator(K8sAPI):
         if stats:
             kwargs["stats"] = stats
 
-        await update_crawl(self.crawls, crawl_id, **kwargs)
+        crawl = await update_crawl(self.crawls, crawl_id, **kwargs)
+        crawl_cid = crawl.get("cid")
+
+        await update_config_crawl_stats(self.crawl_configs, self.crawls, crawl_cid)
 
         await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -495,7 +495,7 @@ class BtrixOperator(K8sAPI):
         if stats:
             kwargs["stats"] = stats
 
-        crawl = await update_crawl(self.crawls, crawl_id, **kwargs)
+        await update_crawl(self.crawls, crawl_id, **kwargs)
 
         await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -496,9 +496,6 @@ class BtrixOperator(K8sAPI):
             kwargs["stats"] = stats
 
         crawl = await update_crawl(self.crawls, crawl_id, **kwargs)
-        crawl_cid = crawl.get("cid")
-
-        await update_config_crawl_stats(self.crawl_configs, self.crawls, crawl_cid)
 
         await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
 

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -232,6 +232,7 @@ def test_workflow_total_size_and_last_crawl_stats(
             assert workflow["lastStartedByName"]
             assert workflow["lastCrawlTime"]
             assert workflow["lastCrawlState"]
+            assert workflow["lastUpdated"]
             assert workflow["lastCrawlSize"] > 0
 
             if last_crawl_id == admin_crawl_id:
@@ -254,4 +255,5 @@ def test_workflow_total_size_and_last_crawl_stats(
     assert data["lastStartedByName"]
     assert data["lastCrawlTime"]
     assert data["lastCrawlState"]
+    assert data["lastUpdated"]
     assert data["lastCrawlSize"] > 0

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -232,7 +232,7 @@ def test_workflow_total_size_and_last_crawl_stats(
             assert workflow["lastStartedByName"]
             assert workflow["lastCrawlTime"]
             assert workflow["lastCrawlState"]
-            assert workflow["lastUpdated"]
+            assert workflow["lastRun"]
             assert workflow["lastCrawlSize"] > 0
 
             if last_crawl_id == admin_crawl_id:
@@ -255,5 +255,5 @@ def test_workflow_total_size_and_last_crawl_stats(
     assert data["lastStartedByName"]
     assert data["lastCrawlTime"]
     assert data["lastCrawlState"]
-    assert data["lastUpdated"]
+    assert data["lastRun"]
     assert data["lastCrawlSize"] > 0

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -457,9 +457,9 @@ def test_sort_crawl_configs(
             assert config_last_time >= last_crawl_time
         last_crawl_time = config_last_time
 
-    # Sort by lastUpdated
+    # Sort by lastRun
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastUpdated",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastRun",
         headers=crawler_auth_headers,
     )
     data = r.json()
@@ -467,7 +467,7 @@ def test_sort_crawl_configs(
 
     last_updated_time = None
     for config in items:
-        config_last_updated = config.get("lastUpdated")
+        config_last_updated = config.get("lastRun")
         if not config_last_updated:
             continue
         elif last_updated_time and config_last_updated:
@@ -476,7 +476,7 @@ def test_sort_crawl_configs(
 
     # Sort by lastCrawlTime, ascending
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastUpdated&sortDirection=1",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastRun&sortDirection=1",
         headers=crawler_auth_headers,
     )
     data = r.json()
@@ -484,7 +484,7 @@ def test_sort_crawl_configs(
 
     last_updated_time = None
     for config in items:
-        config_last_updated = config.get("lastUpdated")
+        config_last_updated = config.get("lastRun")
         if not config_last_updated:
             continue
         elif last_updated_time and config_last_updated:

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -457,6 +457,40 @@ def test_sort_crawl_configs(
             assert config_last_time >= last_crawl_time
         last_crawl_time = config_last_time
 
+    # Sort by lastCrawlStartTime
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastCrawlStartTime",
+        headers=crawler_auth_headers,
+    )
+    data = r.json()
+    items = data["items"]
+
+    last_crawl_time = None
+    for config in items:
+        config_last_time = config.get("lastCrawlStartTime")
+        if not config_last_time:
+            continue
+        elif last_crawl_time and config_last_time:
+            assert config_last_time <= last_crawl_time
+        last_crawl_time = config_last_time
+
+    # Sort by lastCrawlStartTime, ascending
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastCrawlStartTime&sortDirection=1",
+        headers=crawler_auth_headers,
+    )
+    data = r.json()
+    items = data["items"]
+
+    last_crawl_time = None
+    for config in items:
+        config_last_time = config.get("lastCrawlStartTime")
+        if not config_last_time:
+            continue
+        elif last_crawl_time and config_last_time:
+            assert config_last_time >= last_crawl_time
+        last_crawl_time = config_last_time
+
     # Sort by lastRun
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastRun",
@@ -474,7 +508,7 @@ def test_sort_crawl_configs(
             assert config_last_updated <= last_updated_time
         last_updated_time = config_last_updated
 
-    # Sort by lastCrawlTime, ascending
+    # Sort by lastRun, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastRun&sortDirection=1",
         headers=crawler_auth_headers,

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -431,18 +431,13 @@ def test_sort_crawl_configs(
     data = r.json()
     items = data["items"]
 
-    curr_crawl_time = None
     last_crawl_time = None
     for config in items:
-        config_curr_time = config.get("currCrawlStartTime")
         config_last_time = config.get("lastCrawlTime")
-        if not config_curr_time or config_last_time:
+        if not config_last_time:
             continue
-        if curr_crawl_time and config_curr_time:
-            assert config_curr_time <= curr_crawl_time
         elif last_crawl_time and config_last_time:
             assert config_last_time <= last_crawl_time
-        curr_crawl_time = config_curr_time
         last_crawl_time = config_last_time
 
     # Sort by lastCrawlTime, ascending
@@ -453,19 +448,48 @@ def test_sort_crawl_configs(
     data = r.json()
     items = data["items"]
 
-    curr_crawl_time = None
     last_crawl_time = None
     for config in items:
-        config_curr_time = config.get("currCrawlStartTime")
         config_last_time = config.get("lastCrawlTime")
-        if not config_curr_time or config_last_time:
+        if not config_last_time:
             continue
-        if curr_crawl_time and config_curr_time:
-            assert config_curr_time >= curr_crawl_time
         elif last_crawl_time and config_last_time:
             assert config_last_time >= last_crawl_time
-        curr_crawl_time = config_curr_time
         last_crawl_time = config_last_time
+
+    # Sort by lastUpdated
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastUpdated",
+        headers=crawler_auth_headers,
+    )
+    data = r.json()
+    items = data["items"]
+
+    last_updated_time = None
+    for config in items:
+        config_last_updated = config.get("lastUpdated")
+        if not config_last_updated:
+            continue
+        elif last_updated_time and config_last_updated:
+            assert config_last_updated <= last_updated_time
+        last_updated_time = config_last_updated
+
+    # Sort by lastCrawlTime, ascending
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=lastUpdated&sortDirection=1",
+        headers=crawler_auth_headers,
+    )
+    data = r.json()
+    items = data["items"]
+
+    last_updated_time = None
+    for config in items:
+        config_last_updated = config.get("lastUpdated")
+        if not config_last_updated:
+            continue
+        elif last_updated_time and config_last_updated:
+            assert config_last_updated >= last_updated_time
+        last_updated_time = config_last_updated
 
     # Invalid sort value
     r = requests.get(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -431,13 +431,19 @@ def test_sort_crawl_configs(
     data = r.json()
     items = data["items"]
 
+    curr_crawl_time = None
     last_crawl_time = None
     for config in items:
-        if not config.get("lastCrawlTime"):
+        config_curr_time = config.get("currCrawlStartTime")
+        config_last_time = config.get("lastCrawlTime")
+        if not config_curr_time or config_last_time:
             continue
-        if last_crawl_time:
-            assert config["lastCrawlTime"] <= last_crawl_time
-        last_crawl_time = config["lastCrawlTime"]
+        if curr_crawl_time and config_curr_time:
+            assert config_curr_time <= curr_crawl_time
+        elif last_crawl_time and config_last_time:
+            assert config_last_time <= last_crawl_time
+        curr_crawl_time = config_curr_time
+        last_crawl_time = config_last_time
 
     # Sort by lastCrawlTime, ascending
     r = requests.get(
@@ -447,13 +453,19 @@ def test_sort_crawl_configs(
     data = r.json()
     items = data["items"]
 
+    curr_crawl_time = None
     last_crawl_time = None
     for config in items:
-        if not config.get("lastCrawlTime"):
+        config_curr_time = config.get("currCrawlStartTime")
+        config_last_time = config.get("lastCrawlTime")
+        if not config_curr_time or config_last_time:
             continue
-        if last_crawl_time:
-            assert config["lastCrawlTime"] >= last_crawl_time
-        last_crawl_time = config["lastCrawlTime"]
+        if curr_crawl_time and config_curr_time:
+            assert config_curr_time >= curr_crawl_time
+        elif last_crawl_time and config_last_time:
+            assert config_last_time >= last_crawl_time
+        curr_crawl_time = config_curr_time
+        last_crawl_time = config_last_time
 
     # Invalid sort value
     r = requests.get(

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -255,7 +255,7 @@ export class WorkflowListItem extends LitElement {
       role="button"
       href=${`/orgs/${this.workflow?.oid}/workflows/crawl/${
         this.workflow?.id
-      }#${this.workflow?.lastCrawlState === "running" ? "watch" : "artifacts"}`}
+      }#${this.workflow?.isCrawlRunning ? "watch" : "artifacts"}`}
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;
@@ -332,7 +332,7 @@ export class WorkflowListItem extends LitElement {
       <div class="col">
         <div class="detail">
           ${this.safeRender((workflow) => {
-            if (workflow.totalSize && workflow.lastCrawlSize && workflow.lastCrawlState === "running") {
+            if (workflow.isCrawlRunning && workflow.totalSize && workflow.lastCrawlSize) {
               return html`<sl-format-bytes
                   value=${workflow.totalSize}
                   display="narrow"
@@ -351,7 +351,7 @@ export class WorkflowListItem extends LitElement {
                   display="narrow"
                 ></sl-format-bytes>`;
             }
-            if (workflow.lastCrawlState === "running" && workflow.lastCrawlSize) {
+            if (workflow.isCrawlRunning && workflow.lastCrawlSize) {
               return html`<span class="currCrawlSize">
                 <sl-format-bytes
                   value=${workflow.lastCrawlSize}

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -255,7 +255,7 @@ export class WorkflowListItem extends LitElement {
       role="button"
       href=${`/orgs/${this.workflow?.oid}/workflows/crawl/${
         this.workflow?.id
-      }#${this.workflow?.currCrawlId ? "watch" : "artifacts"}`}
+      }#${this.workflow?.lastCrawlState === "running" ? "watch" : "artifacts"}`}
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;
@@ -294,20 +294,19 @@ export class WorkflowListItem extends LitElement {
             (workflow) =>
               html`
                 <btrix-crawl-status
-                  state=${workflow.currCrawlState ||
-                  workflow.lastCrawlState ||
+                  state=${workflow.lastCrawlState ||
                   msg("No Crawls Yet")}
-                  ?stopping=${workflow.currCrawlStopping}
+                  ?stopping=${workflow.lastCrawlStopping}
                 ></btrix-crawl-status>
               `
           )}
         </div>
         <div class="desc duration">
           ${this.safeRender((workflow) => {
-            if (workflow.currCrawlStartTime) {
+            if (workflow.lastCrawlStartTime) {
               const diff =
                 new Date().valueOf() -
-                new Date(`${workflow.currCrawlStartTime}Z`).valueOf();
+                new Date(`${workflow.lastCrawlStartTime}Z`).valueOf();
               if (diff < 1000) {
                 return "";
               }
@@ -333,7 +332,7 @@ export class WorkflowListItem extends LitElement {
       <div class="col">
         <div class="detail">
           ${this.safeRender((workflow) => {
-            if (workflow.totalSize && workflow.currCrawlSize) {
+            if (workflow.totalSize && workflow.lastCrawlSize && workflow.lastCrawlState === "running") {
               return html`<sl-format-bytes
                   value=${workflow.totalSize}
                   display="narrow"
@@ -341,15 +340,21 @@ export class WorkflowListItem extends LitElement {
                 <span class="currCrawlSize">
                   +
                   <sl-format-bytes
-                    value=${workflow.currCrawlSize}
+                    value=${workflow.lastCrawlSize}
                     display="narrow"
                   ></sl-format-bytes>
                 </span>`;
             }
-            if (workflow.currCrawlSize) {
+            if (workflow.totalSize && workflow.lastCrawlSize) {
+              return html`<sl-format-bytes
+                  value=${workflow.totalSize}
+                  display="narrow"
+                ></sl-format-bytes>`;
+            }
+            if (workflow.lastCrawlState === "running" && workflow.lastCrawlSize) {
               return html`<span class="currCrawlSize">
                 <sl-format-bytes
-                  value=${workflow.currCrawlSize}
+                  value=${workflow.lastCrawlSize}
                   display="narrow"
                 ></sl-format-bytes>
               </span>`;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -63,13 +63,13 @@ export class WorkflowDetail extends LiteElement {
   private crawls?: APIPaginatedList; // Only inactive crawls
 
   @state()
-  private currentCrawlId: Workflow["currCrawlId"] = null;
+  private lastCrawlId: Workflow["lastCrawlId"] = null;
 
   @state()
-  private currentCrawlStartTime: Workflow["currCrawlStartTime"] = null;
+  private lastCrawlStartTime: Workflow["lastCrawlStartTime"] = null;
 
   @state()
-  private currentCrawlStats?: Crawl["stats"];
+  private lastCrawlStats?: Crawl["stats"];
 
   @state()
   private activePanel: Tab = SECTIONS[0];
@@ -150,8 +150,8 @@ export class WorkflowDetail extends LiteElement {
       this.stopPoll();
     }
     if (
-      changedProperties.get("currentCrawlId") &&
-      !this.currentCrawlId &&
+      changedProperties.get("lastCrawlId") &&
+      !this.lastCrawlId &&
       this.activePanel === "watch"
     ) {
       this.handleCrawlRunEnd();
@@ -244,9 +244,9 @@ export class WorkflowDetail extends LiteElement {
     try {
       this.getWorkflowPromise = this.getWorkflow();
       this.workflow = await this.getWorkflowPromise;
-      this.currentCrawlId = this.workflow.currCrawlId;
-      this.currentCrawlStartTime = this.workflow.currCrawlStartTime;
-      if (this.currentCrawlId) {
+      this.lastCrawlId = this.workflow.lastCrawlId;
+      this.lastCrawlStartTime = this.workflow.lastCrawlStartTime;
+      if (this.lastCrawlId) {
         this.fetchCurrentCrawlStats();
       }
     } catch (e: any) {
@@ -417,7 +417,7 @@ export class WorkflowDetail extends LiteElement {
       </btrix-observable>
 
       ${this.renderTab("artifacts")}
-      ${this.renderTab("watch", { disabled: !this.currentCrawlId })}
+      ${this.renderTab("watch", { disabled: !this.lastCrawlId })}
       ${this.renderTab("settings")}
 
       <btrix-tab-panel name="artifacts"
@@ -428,7 +428,7 @@ export class WorkflowDetail extends LiteElement {
           this.getWorkflowPromise?.then(
             () => html`
               ${when(this.activePanel === "watch", () =>
-                this.currentCrawlId
+                this.lastCrawlId
                   ? html` <div class="border rounded-lg py-2 mb-5 h-14">
                         ${this.renderCurrentCrawl()}
                       </div>
@@ -455,7 +455,7 @@ export class WorkflowDetail extends LiteElement {
           () =>
             html`
               <span class="text-neutral-500"
-                >(${this.crawls!.total.toLocaleString()}${this.currentCrawlId
+                >(${this.crawls!.total.toLocaleString()}${this.workflow?.lastCrawlState === "running"
                   ? html`<span class="text-success"> + 1</span>`
                   : ""})</span
               >
@@ -479,7 +479,7 @@ export class WorkflowDetail extends LiteElement {
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
         <sl-button
           size="small"
-          ?disabled=${this.workflow?.currCrawlState !== "running"}
+          ?disabled=${this.workflow?.lastCrawlState !== "running"}
           @click=${() => (this.openDialogName = "scale")}
         >
           <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
@@ -545,15 +545,15 @@ export class WorkflowDetail extends LiteElement {
 
     return html`
       ${when(
-        this.currentCrawlId,
+        this.workflow?.lastCrawlState === "running",
         () => html`
           <sl-button-group class="mr-2">
             <sl-button
               size="small"
               @click=${() => (this.openDialogName = "stop")}
-              ?disabled=${!this.currentCrawlId ||
+              ?disabled=${!this.lastCrawlId ||
               this.isCancelingOrStoppingCrawl ||
-              this.workflow?.currCrawlStopping}
+              this.workflow?.lastCrawlStopping}
             >
               <sl-icon name="dash-circle" slot="prefix"></sl-icon>
               <span>${msg("Stop")}</span>
@@ -561,7 +561,7 @@ export class WorkflowDetail extends LiteElement {
             <sl-button
               size="small"
               @click=${() => (this.openDialogName = "cancel")}
-              ?disabled=${!this.currentCrawlId ||
+              ?disabled=${!this.lastCrawlId ||
               this.isCancelingOrStoppingCrawl}
             >
               <sl-icon
@@ -592,13 +592,13 @@ export class WorkflowDetail extends LiteElement {
         >
         <sl-menu>
           ${when(
-            this.currentCrawlId,
+            this.workflow?.lastCrawlState === "running",
             // HACK shoelace doesn't current have a way to override non-hover
             // color without resetting the --sl-color-neutral-700 variable
             () => html`
               <sl-menu-item
                 @click=${() => (this.openDialogName = "stop")}
-                ?disabled=${workflow.currCrawlStopping ||
+                ?disabled=${workflow.lastCrawlStopping ||
                 this.isCancelingOrStoppingCrawl}
               >
                 <sl-icon name="dash-circle" slot="prefix"></sl-icon>
@@ -624,7 +624,7 @@ export class WorkflowDetail extends LiteElement {
             `
           )}
           ${when(
-            workflow.currCrawlState === "running",
+            workflow.lastCrawlState === "running",
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item @click=${() => (this.openDialogName = "scale")}>
@@ -660,7 +660,7 @@ export class WorkflowDetail extends LiteElement {
             <sl-icon name="files" slot="prefix"></sl-icon>
             ${msg("Duplicate Workflow")}
           </sl-menu-item>
-          ${when(!this.currentCrawlId, () => {
+          ${when(!this.lastCrawlId, () => {
             const shouldDeactivate = workflow.crawlCount && !workflow.inactive;
             return html`
           <sl-divider></sl-divider>
@@ -693,10 +693,9 @@ export class WorkflowDetail extends LiteElement {
           msg("Status"),
           () => html`
             <btrix-crawl-status
-              state=${this.workflow!.currCrawlState ||
-              this.workflow!.lastCrawlState ||
+              state=${this.workflow!.lastCrawlState ||
               msg("No Crawls Yet")}
-              ?stopping=${this.workflow?.currCrawlStopping}
+              ?stopping=${this.workflow?.lastCrawlStopping}
             ></btrix-crawl-status>
           `
         )}
@@ -805,7 +804,7 @@ export class WorkflowDetail extends LiteElement {
         </div>
 
         ${when(
-          this.currentCrawlId,
+          this.workflow?.lastCrawlState === "running",
           () => html`<div class="mb-4">
             <btrix-alert variant="success" class="text-sm">
               ${msg(
@@ -887,28 +886,28 @@ export class WorkflowDetail extends LiteElement {
     return html`
       <dl class="px-3 md:px-0 md:flex justify-evenly">
         ${this.renderDetailItem(msg("Pages Crawled"), () =>
-          this.currentCrawlStats
+          this.lastCrawlStats
             ? msg(
                 str`${this.numberFormatter.format(
-                  +(this.currentCrawlStats.done || 0)
+                  +(this.lastCrawlStats.done || 0)
                 )} / ${this.numberFormatter.format(
-                  +(this.currentCrawlStats.found || 0)
+                  +(this.lastCrawlStats.found || 0)
                 )}`
               )
             : html`<sl-spinner></sl-spinner>`
         )}
         ${this.renderDetailItem(msg("Run Duration"), () =>
-          this.currentCrawlStartTime
+          this.lastCrawlStartTime
             ? RelativeDuration.humanize(
                 new Date().valueOf() -
-                  new Date(`${this.currentCrawlStartTime}Z`).valueOf()
+                  new Date(`${this.lastCrawlStartTime}Z`).valueOf()
               )
             : skeleton
         )}
         ${this.renderDetailItem(msg("Crawl Size"), () =>
           this.workflow
             ? html`<sl-format-bytes
-                value=${this.workflow.currCrawlSize || 0}
+                value=${this.workflow.lastCrawlSize || 0}
                 display="narrow"
               ></sl-format-bytes>`
             : skeleton
@@ -923,12 +922,12 @@ export class WorkflowDetail extends LiteElement {
   };
 
   private renderWatchCrawl = () => {
-    if (!this.authState || !this.workflow?.currCrawlState) return "";
+    if (!this.authState || !(this.workflow?.lastCrawlState)) return "";
 
-    const isStarting = this.workflow.currCrawlState === "starting";
-    const isWaiting = this.workflow.currCrawlState === "waiting";
-    const isRunning = this.workflow.currCrawlState === "running";
-    const isStopping = this.workflow.currCrawlStopping;
+    const isStarting = this.workflow.lastCrawlState === "starting";
+    const isWaiting = this.workflow.lastCrawlState === "waiting";
+    const isRunning = this.workflow.lastCrawlState === "running";
+    const isStopping = this.workflow.lastCrawlStopping;
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`
@@ -942,7 +941,7 @@ export class WorkflowDetail extends LiteElement {
                   )}
             </p>
           </div>`
-        : isActive(this.workflow.currCrawlState)
+        : isActive(this.workflow.lastCrawlState)
         ? html`
             ${isStopping
               ? html`
@@ -962,7 +961,7 @@ export class WorkflowDetail extends LiteElement {
             <btrix-screencast
               authToken=${authToken}
               orgId=${this.orgId}
-              crawlId=${this.currentCrawlId}
+              crawlId=${this.lastCrawlId}
               scale=${this.workflow!.scale}
             ></btrix-screencast>
           </div>
@@ -1048,11 +1047,11 @@ export class WorkflowDetail extends LiteElement {
       </header>
 
       ${when(
-        this.currentCrawlId,
+        this.lastCrawlId,
         () => html`
           <btrix-crawl-queue
             orgId=${this.orgId}
-            crawlId=${this.currentCrawlId}
+            crawlId=${this.lastCrawlId}
             .authState=${this.authState}
           ></btrix-crawl-queue>
         `
@@ -1069,10 +1068,10 @@ export class WorkflowDetail extends LiteElement {
         ${this.workflow && this.isDialogVisible
           ? html`<btrix-exclusion-editor
               orgId=${this.orgId}
-              crawlId=${ifDefined(this.currentCrawlId)}
+              crawlId=${ifDefined(this.lastCrawlId)}
               .config=${this.workflow.config}
               .authState=${this.authState}
-              ?isActiveCrawl=${isActive(this.workflow.currCrawlState!)}
+              ?isActiveCrawl=${isActive(this.workflow.lastCrawlState!)}
               @on-success=${this.handleExclusionChange}
             ></btrix-exclusion-editor>`
           : ""}
@@ -1159,12 +1158,12 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private async scale(value: Crawl["scale"]) {
-    if (!this.currentCrawlId) return;
+    if (!this.lastCrawlId) return;
     this.isSubmittingUpdate = true;
 
     try {
       const data = await this.apiFetch(
-        `/orgs/${this.orgId}/crawls/${this.currentCrawlId}/scale`,
+        `/orgs/${this.orgId}/crawls/${this.lastCrawlId}/scale`,
         this.authState!,
         {
           method: "POST",
@@ -1233,12 +1232,12 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private async fetchCurrentCrawlStats() {
-    if (!this.currentCrawlId) return;
+    if (!this.lastCrawlId) return;
 
     try {
       // TODO see if API can pass stats in GET workflow
-      const { stats } = await this.getCrawl(this.currentCrawlId);
-      this.currentCrawlStats = stats;
+      const { stats } = await this.getCrawl(this.lastCrawlId);
+      this.lastCrawlStats = stats;
     } catch (e) {
       // TODO handle error
       console.debug(e);
@@ -1349,13 +1348,13 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private async cancel() {
-    if (!this.currentCrawlId) return;
+    if (!this.lastCrawlId) return;
 
     this.isCancelingOrStoppingCrawl = true;
 
     try {
       const data = await this.apiFetch(
-        `/orgs/${this.orgId}/crawls/${this.currentCrawlId}/cancel`,
+        `/orgs/${this.orgId}/crawls/${this.lastCrawlId}/cancel`,
         this.authState!,
         {
           method: "POST",
@@ -1378,13 +1377,13 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private async stop() {
-    if (!this.currentCrawlId) return;
+    if (!this.lastCrawlId) return;
 
     this.isCancelingOrStoppingCrawl = true;
 
     try {
       const data = await this.apiFetch(
-        `/orgs/${this.orgId}/crawls/${this.currentCrawlId}/stop`,
+        `/orgs/${this.orgId}/crawls/${this.lastCrawlId}/stop`,
         this.authState!,
         {
           method: "POST",
@@ -1415,9 +1414,9 @@ export class WorkflowDetail extends LiteElement {
           method: "POST",
         }
       );
-      this.currentCrawlId = data.started;
+      this.lastCrawlId = data.started;
       // remove 'Z' from timestamp to match API response
-      this.currentCrawlStartTime = new Date().toISOString().slice(0, -1);
+      this.lastCrawlStartTime = new Date().toISOString().slice(0, -1);
       this.fetchWorkflow();
       this.goToTab("watch");
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -455,7 +455,7 @@ export class WorkflowDetail extends LiteElement {
           () =>
             html`
               <span class="text-neutral-500"
-                >(${this.crawls!.total.toLocaleString()}${this.workflow?.lastCrawlState === "running"
+                >(${this.crawls!.total.toLocaleString()}${this.workflow?.isCrawlRunning
                   ? html`<span class="text-success"> + 1</span>`
                   : ""})</span
               >
@@ -479,7 +479,7 @@ export class WorkflowDetail extends LiteElement {
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
         <sl-button
           size="small"
-          ?disabled=${this.workflow?.lastCrawlState !== "running"}
+          ?disabled=${this.workflow?.isCrawlRunning}
           @click=${() => (this.openDialogName = "scale")}
         >
           <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
@@ -545,7 +545,7 @@ export class WorkflowDetail extends LiteElement {
 
     return html`
       ${when(
-        this.workflow?.lastCrawlState === "running",
+        this.workflow?.isCrawlRunning,
         () => html`
           <sl-button-group class="mr-2">
             <sl-button
@@ -592,7 +592,7 @@ export class WorkflowDetail extends LiteElement {
         >
         <sl-menu>
           ${when(
-            this.workflow?.lastCrawlState === "running",
+            this.workflow?.isCrawlRunning,
             // HACK shoelace doesn't current have a way to override non-hover
             // color without resetting the --sl-color-neutral-700 variable
             () => html`
@@ -624,7 +624,7 @@ export class WorkflowDetail extends LiteElement {
             `
           )}
           ${when(
-            workflow.lastCrawlState === "running",
+            workflow.isCrawlRunning,
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item @click=${() => (this.openDialogName = "scale")}>
@@ -804,7 +804,7 @@ export class WorkflowDetail extends LiteElement {
         </div>
 
         ${when(
-          this.workflow?.lastCrawlState === "running",
+          this.workflow?.isCrawlRunning,
           () => html`<div class="mb-4">
             <btrix-alert variant="success" class="text-sm">
               ${msg(

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -355,7 +355,7 @@ export class WorkflowsList extends LiteElement {
   private renderMenuItems(workflow: Workflow) {
     return html`
       ${when(
-        workflow.lastCrawlState === "running",
+        workflow.isCrawlRunning,
         // HACK shoelace doesn't current have a way to override non-hover
         // color without resetting the --sl-color-neutral-700 variable
         () => html`
@@ -385,7 +385,7 @@ export class WorkflowsList extends LiteElement {
         `
       )}
       ${when(
-        workflow.lastCrawlState === "running",
+        workflow.isCrawlRunning,
         // HACK shoelace doesn't current have a way to override non-hover
         // color without resetting the --sl-color-neutral-700 variable
         () => html`
@@ -438,7 +438,7 @@ export class WorkflowsList extends LiteElement {
         <sl-icon name="files" slot="prefix"></sl-icon>
         ${msg("Duplicate Workflow")}
       </sl-menu-item>
-      ${when(workflow.lastCrawlState !== "running", () => {
+      ${when(workflow.isCrawlRunning, () => {
         const shouldDeactivate = workflow.crawlCount && !workflow.inactive;
         return html`
           <sl-divider></sl-divider>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -355,20 +355,20 @@ export class WorkflowsList extends LiteElement {
   private renderMenuItems(workflow: Workflow) {
     return html`
       ${when(
-        workflow.currCrawlId,
+        workflow.lastCrawlState === "running",
         // HACK shoelace doesn't current have a way to override non-hover
         // color without resetting the --sl-color-neutral-700 variable
         () => html`
           <sl-menu-item
-            @click=${() => this.stop(workflow.currCrawlId)}
-            ?disabled=${workflow.currCrawlStopping}
+            @click=${() => this.stop(workflow.lastCrawlId)}
+            ?disabled=${workflow.lastCrawlStopping}
           >
             <sl-icon name="dash-circle" slot="prefix"></sl-icon>
             ${msg("Stop Crawl")}
           </sl-menu-item>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
-            @click=${() => this.cancel(workflow.currCrawlId)}
+            @click=${() => this.cancel(workflow.lastCrawlId)}
           >
             <sl-icon name="x-octagon" slot="prefix"></sl-icon>
             ${msg("Cancel & Discard Crawl")}
@@ -385,7 +385,9 @@ export class WorkflowsList extends LiteElement {
         `
       )}
       ${when(
-        workflow.currCrawlState === "running",
+        workflow.lastCrawlState === "running",
+        // HACK shoelace doesn't current have a way to override non-hover
+        // color without resetting the --sl-color-neutral-700 variable
         () => html`
           <sl-divider></sl-divider>
           <sl-menu-item
@@ -436,7 +438,7 @@ export class WorkflowsList extends LiteElement {
         <sl-icon name="files" slot="prefix"></sl-icon>
         ${msg("Duplicate Workflow")}
       </sl-menu-item>
-      ${when(!workflow.currCrawlId, () => {
+      ${when(workflow.lastCrawlState !== "running", () => {
         const shouldDeactivate = workflow.crawlCount && !workflow.inactive;
         return html`
           <sl-divider></sl-divider>
@@ -482,7 +484,6 @@ export class WorkflowsList extends LiteElement {
     return new Date(
       Math.max(
         ...[
-          workflow.currCrawlStartTime,
           workflow.lastCrawlTime,
           workflow.lastCrawlStartTime,
           workflow.modified,
@@ -597,7 +598,7 @@ export class WorkflowsList extends LiteElement {
     }
   }
 
-  private async cancel(crawlId: Workflow["currCrawlId"]) {
+  private async cancel(crawlId: Workflow["lastCrawlId"]) {
     if (!crawlId) return;
     if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
       const data = await this.apiFetch(
@@ -619,7 +620,7 @@ export class WorkflowsList extends LiteElement {
     }
   }
 
-  private async stop(crawlId: Workflow["currCrawlId"]) {
+  private async stop(crawlId: Workflow["lastCrawlId"]) {
     if (!crawlId) return;
     if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
       const data = await this.apiFetch(

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -71,6 +71,7 @@ export type Workflow = CrawlConfig & {
   totalSize: string | null;
   inactive: boolean;
   firstSeed: string;
+  isCrawlRunning: boolean | null;
 };
 
 export type Profile = {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -61,17 +61,13 @@ export type Workflow = CrawlConfig & {
   modified: string; // Date string
   crawlCount: number;
   crawlAttemptCount: number;
-  lastCrawlId: string; // last finished crawl
-  lastCrawlStartTime: string;
-  lastCrawlTime: string; // when last crawl finished
+  lastCrawlId: string | null; // last finished or current crawl
+  lastCrawlStartTime: string | null;
+  lastCrawlTime: string | null; // when last crawl finished
   lastCrawlState: CrawlState;
   lastCrawlSize: number | null;
   lastStartedByName: string | null;
-  currCrawlId: string | null;
-  currCrawlState: CrawlState | null;
-  currCrawlStartTime: string | null;
-  currCrawlSize: number | null;
-  currCrawlStopping: boolean | null;
+  lastCrawlStopping: boolean | null;
   totalSize: string | null;
   inactive: boolean;
   firstSeed: string;


### PR DESCRIPTION
Fixes #821 

This PR introduces a new `sortBy=lastRun` option for the workflow/crawlconfig list API endpoint, and adds `lastUpdated` to the database as a field equal to `currCrawlStartTime` if a crawl is currently running in the workflow, and then `lastCrawlTime` (finished) when the crawl completes. An index has also been added to make this sorting speedy.

For sorting by `firstSeed`, `lastCrawlTime`, or `lastRun`, a final sort key of `modified` is added to give order to workflows that haven't run yet that would otherwise be unordered at the bottom of the list.

Earlier commits in this PR show a previous approach, which was that sorting on workflows on `lastCrawlTime` actually sorted on a new index of `currCrawlStartTime` and `lastCrawlTime`, which allowed currently running crawls to be displayed first in the list when sorted in the default (descending) order. However, this meant that the frontend didn't have a consistently returned `lastRun` value that matched the sort order to display, which is an issue because the list view in the frontend doesn't have room to display multiple timestamps. We'll want to squash before merging but I've kept those commits here for comparison in review.