### PR TITLE
operator and config update fixes:

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -622,7 +622,11 @@ class CrawlConfigOps:
 
     async def update_crawl_stats(self, cid: uuid.UUID):
         """Update crawl count, total size, and last crawl information for config."""
-        await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
+        result = await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
+        if not result:
+            raise HTTPException(
+                status_code=404, detail=f"Crawl Config '{cid}' not found to update"
+            )
 
     def _add_curr_crawl_stats(self, crawlconfig, crawl):
         """Add stats from current running crawl, if any"""
@@ -920,11 +924,6 @@ async def update_config_crawl_stats(crawl_configs, crawls, cid: uuid.UUID):
         {"$set": update_query},
         return_document=pymongo.ReturnDocument.AFTER,
     )
-
-    if not result:
-        raise HTTPException(
-            status_code=404, detail=f"Crawl Config '{cid}' not found to update"
-        )
 
     return result
 

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -67,10 +67,12 @@ def test_get_configs_by_description(
         assert config["description"] == description
 
 
-def test_get_configs_by_schedule_true(crawler_auth_headers, default_org_id, crawler_crawl_id):
+def test_get_configs_by_schedule_true(
+    crawler_auth_headers, default_org_id, crawler_crawl_id
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?schedule=True",
-        headers=crawler_auth_headers
+        headers=crawler_auth_headers,
     )
     data = r.json()
     assert data["total"] == 1
@@ -78,10 +80,12 @@ def test_get_configs_by_schedule_true(crawler_auth_headers, default_org_id, craw
     assert workflow.get("schedule") not in ("", None)
 
 
-def test_get_configs_by_schedule_false(crawler_auth_headers, default_org_id, crawler_crawl_id):
+def test_get_configs_by_schedule_false(
+    crawler_auth_headers, default_org_id, crawler_crawl_id
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?schedule=False",
-        headers=crawler_auth_headers
+        headers=crawler_auth_headers,
     )
     data = r.json()
     assert data["total"] >= 1


### PR DESCRIPTION
- just pass cid from operator for consistency, don't load crawl from update_crawl (different object)
- don't throw in update_config_crawl_stats() to avoid exception in operator, only throw in crawlconfigs api