### PR TITLE
frontend crawl stopping improvements (#836)

### DIFF
--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -46,10 +46,6 @@ export class CrawlStatus extends LitElement {
         line-height: 1rem;
       }
 
-      .stopping {
-        margin-left: var(--sl-spacing-x-small);
-      }
-
       sl-skeleton {
         width: 4em;
       }

--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -180,7 +180,8 @@ export class CrawlStatus extends LitElement {
   }
 
   render() {
-    const { icon, label } = CrawlStatus.getContent(this.state);
+    const state = this.stopping && this.state === "running" ? "stopping" : this.state;
+    const { icon, label } = CrawlStatus.getContent(state);
     if (this.hideLabel) {
       return html`<div class="icon-only">
         <sl-tooltip content=${label}
@@ -191,14 +192,6 @@ export class CrawlStatus extends LitElement {
     if (label) {
       return html`<div class="wrapper with-label">
         ${icon}<span class="label">${label}</span>
-        ${this.stopping ? html`
-        <sl-icon
-          name="dash-circle"
-          class="stopping animatePulse"
-          title="Stopping Crawl..."
-          slot="prefix"
-          style="color: var(--sl-color-orange-600)"
-        ></sl-icon>` : ``}
       </div>`;
     }
     return html`<div class="wrapper with-label">

--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -15,6 +15,9 @@ export class CrawlStatus extends LitElement {
   @property({ type: Boolean })
   hideLabel = false;
 
+  @property({ type: Boolean })
+  stopping = false;
+
   static styles = [
     animatePulse,
     css`
@@ -41,6 +44,10 @@ export class CrawlStatus extends LitElement {
       .label {
         height: 1rem;
         line-height: 1rem;
+      }
+
+      .stopping {
+        margin-left: var(--sl-spacing-x-small);
       }
 
       sl-skeleton {
@@ -184,6 +191,14 @@ export class CrawlStatus extends LitElement {
     if (label) {
       return html`<div class="wrapper with-label">
         ${icon}<span class="label">${label}</span>
+        ${this.stopping ? html`
+        <sl-icon
+          name="dash-circle"
+          class="stopping animatePulse"
+          title="Stopping Crawl..."
+          slot="prefix"
+          style="color: var(--sl-color-orange-600)"
+        ></sl-icon>` : ``}
       </div>`;
     }
     return html`<div class="wrapper with-label">

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -297,6 +297,7 @@ export class WorkflowListItem extends LitElement {
                   state=${workflow.currCrawlState ||
                   workflow.lastCrawlState ||
                   msg("No Crawls Yet")}
+                  ?stopping=${workflow.currCrawlStopping}
                 ></btrix-crawl-status>
               `
           )}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -398,7 +398,7 @@ export class WorkflowDetail extends LiteElement {
             @click=${() => this.stop()}
             ?disabled=${!this.workflow?.currCrawlId ||
             this.isCancelingOrStoppingCrawl ||
-            this.workflow?.currCrawlState === "stopping"}
+            this.workflow?.currCrawlStopping}
           >
             <sl-icon name="dash-circle" slot="prefix"></sl-icon>
             <span>${msg("Stop")}</span>
@@ -480,7 +480,7 @@ export class WorkflowDetail extends LiteElement {
             () => html`
               <sl-menu-item
                 @click=${() => this.stop()}
-                ?disabled=${workflow.currCrawlState === "stopping" ||
+                ?disabled=${workflow.currCrawlStopping ||
                 this.isCancelingOrStoppingCrawl}
               >
                 <sl-icon name="dash-circle" slot="prefix"></sl-icon>
@@ -586,6 +586,7 @@ export class WorkflowDetail extends LiteElement {
               state=${this.workflow!.currCrawlState ||
               this.workflow!.lastCrawlState ||
               msg("No Crawls Yet")}
+              ?stopping=${this.workflow?.currCrawlStopping}
             ></btrix-crawl-status>
           `
         )}
@@ -796,7 +797,7 @@ export class WorkflowDetail extends LiteElement {
     const isStarting = this.workflow.currCrawlState === "starting";
     const isWaiting = this.workflow.currCrawlState === "waiting";
     const isRunning = this.workflow.currCrawlState === "running";
-    const isStopping = this.workflow.currCrawlState === "stopping";
+    const isStopping = this.workflow.currCrawlStopping;
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -361,7 +361,7 @@ export class WorkflowsList extends LiteElement {
         () => html`
           <sl-menu-item
             @click=${() => this.stop(workflow.currCrawlId)}
-            ?disabled=${workflow.currCrawlState === "stopping"}
+            ?disabled=${workflow.currCrawlStopping}
           >
             <sl-icon name="dash-circle" slot="prefix"></sl-icon>
             ${msg("Stop Crawl")}

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -71,6 +71,7 @@ export type Workflow = CrawlConfig & {
   currCrawlState: CrawlState | null;
   currCrawlStartTime: string | null;
   currCrawlSize: number | null;
+  currCrawlStopping: boolean | null;
   totalSize: string | null;
   inactive: boolean;
   firstSeed: string;
@@ -119,4 +120,5 @@ export type Crawl = CrawlConfig & {
   notes: string | null;
   firstSeed: string;
   seedCount: number;
+  stopping: boolean;
 };


### PR DESCRIPTION
This PR follows the backend work in #837 and adds an extra indicator icon to show that a crawl is stopping, separate from its current mode.
This is needed as the crawl may stay in 'running' for a bit, or in soon-to-be-added uploading or generating wacz states, while being stopped. This allows the user to see that the crawl is being stopped, w/o changing status to 'stopping' and losing the actual state of the crawl.

Stopping in workflow list view:
<img width="1177" alt="Screen Shot 2023-05-06 at 8 51 40 PM" src="https://user-images.githubusercontent.com/1015759/236661236-e608d994-0dd4-4bfa-a9b1-b9421e0ed837.png">

Stopping in workflow detail:
<img width="1275" alt="Screen Shot 2023-05-06 at 8 49 55 PM" src="https://user-images.githubusercontent.com/1015759/236661251-99e606b2-0b72-4eba-a63d-9a0444008356.png">
