### PR TITLE
Add stop crawl confirmation dialog

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -285,7 +285,7 @@ export class WorkflowDetail extends LiteElement {
         @sl-after-hide=${() => (this.isDialogVisible = false)}
       >
         ${msg(
-          "Pages crawled so far will be saved but incomplete. Are you sure you want to stop crawling?"
+          "Pages crawled so far will be saved and marked as incomplete. Are you sure you want to stop crawling?"
         )}
         <div slot="footer" class="flex justify-between">
           <sl-button

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -278,6 +278,34 @@ export class WorkflowDetail extends LiteElement {
       </div>
 
       <btrix-dialog
+        label=${msg("Stop Crawl?")}
+        ?open=${this.openDialogName === "stop"}
+        @sl-request-close=${() => (this.openDialogName = undefined)}
+        @sl-show=${this.showDialog}
+        @sl-after-hide=${() => (this.isDialogVisible = false)}
+      >
+        ${msg(
+          "Pages crawled so far will be saved but incomplete. Are you sure you want to stop crawling?"
+        )}
+        <div slot="footer" class="flex justify-between">
+          <sl-button
+            size="small"
+            @click=${() => (this.openDialogName = undefined)}
+            >Keep Crawling</sl-button
+          >
+          <sl-button
+            size="small"
+            variant="primary"
+            ?loading=${this.isCancelingOrStoppingCrawl}
+            @click=${async () => {
+              await this.stop();
+              this.openDialogName = undefined;
+            }}
+            >Stop Crawling</sl-button
+          >
+        </div>
+      </btrix-dialog>
+      <btrix-dialog
         label=${msg("Cancel Crawl?")}
         ?open=${this.openDialogName === "cancel"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
@@ -408,7 +436,7 @@ export class WorkflowDetail extends LiteElement {
           </sl-button>
           <sl-button
             size="small"
-            @click=${() => this.stop()}
+            @click=${() => (this.openDialogName = "stop")}
             ?disabled=${!this.workflow?.currCrawlId ||
             this.isCancelingOrStoppingCrawl ||
             this.workflow?.currCrawlStopping}
@@ -492,7 +520,7 @@ export class WorkflowDetail extends LiteElement {
             // color without resetting the --sl-color-neutral-700 variable
             () => html`
               <sl-menu-item
-                @click=${() => this.stop()}
+                @click=${() => (this.openDialogName = "stop")}
                 ?disabled=${workflow.currCrawlStopping ||
                 this.isCancelingOrStoppingCrawl}
               >
@@ -982,7 +1010,6 @@ export class WorkflowDetail extends LiteElement {
 
   private showDialog = async () => {
     await this.getWorkflowPromise;
-    await this.updateComplete;
     this.isDialogVisible = true;
   };
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -980,7 +980,10 @@ export class WorkflowDetail extends LiteElement {
               <sl-radio-button
                 value=${value}
                 size="small"
-                @click=${() => this.scale(value)}
+                @click=${async () => {
+                  await this.scale(value);
+                  this.openDialogName = undefined;
+                }}
                 ?disabled=${this.isSubmittingUpdate}
                 >${label}</sl-radio-button
               >
@@ -1041,9 +1044,6 @@ export class WorkflowDetail extends LiteElement {
       } else {
         throw new Error("unhandled API response");
       }
-
-      this.openDialogName = undefined;
-      this.isDialogVisible = false;
     } catch {
       this.notify({
         message: msg("Sorry, couldn't change crawl scale at this time."),


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/832

<!-- Fixes #issue_number -->

### Changes

- Shows user confirmation dialog when stopping a crawl
- Refactors dialog open & close to wait for any GET requests to a workflow to resolve before showing content

### Manual testing

1. Log in and go to Crawling
2. Click into a Workflow
3. Click Actions -> Run Crawl
4. Click Actions -> Stop. Verify confirmation dialog is shown
5. Click "Keep Crawling". Verify confirmation dialog closes
6. Go to Watch tab and click "Stop". Verify confirmation dialog is shown
7. Click "Stop Crawling". Verify crawl stops

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail | <img width="518" alt="Screen Shot 2023-05-09 at 5 45 52 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/0b77a8b4-216a-4d0b-8080-8e5990a38ff8"> |

I based the confirmation text on the cancel dialog pattern of indicating the effects of stopping a crawl. Open to suggestions.

<!-- ### Follow-ups -->
