### PR TITLE
backend: ensure cid is a UUID, remove unneeded inactive check on crawls

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -905,7 +905,7 @@ async def update_config_crawl_stats(crawl_configs, crawls, cid: uuid.UUID):
         "lastCrawlSize": None,
     }
 
-    match_query = {"cid": cid, "finished": {"$ne": None}, "inactive": {"$ne": True}}
+    match_query = {"cid": cid, "finished": {"$ne": None}}
     cursor = crawls.find(match_query).sort("finished", pymongo.DESCENDING)
     results = await cursor.to_list(length=10_000)
     if results:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -497,7 +497,7 @@ class BtrixOperator(K8sAPI):
 
         await update_crawl(self.crawls, crawl_id, **kwargs)
 
-        await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
+        await update_config_crawl_stats(self.crawl_configs, self.crawls, uuid.UUID(cid))
 
         if redis:
             await self.add_crawl_errors_to_db(redis, crawl_id)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -296,7 +296,7 @@ class BtrixOperator(K8sAPI):
         return true if db mark_finished update succeeds"""
         try:
             redis = await self._get_redis(redis_url)
-            await self.mark_finished(redis, crawl_id, cid, status, state)
+            await self.mark_finished(redis, crawl_id, uuid.UUID(cid), status, state)
             return True
         # pylint: disable=bare-except
         except:
@@ -497,7 +497,7 @@ class BtrixOperator(K8sAPI):
 
         await update_crawl(self.crawls, crawl_id, **kwargs)
 
-        await update_config_crawl_stats(self.crawl_configs, self.crawls, uuid.UUID(cid))
+        await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
 
         if redis:
             await self.add_crawl_errors_to_db(redis, crawl_id)


### PR DESCRIPTION
In cancel_crawl(), the cid was not a UUID, causing the update query to not match, and resulting in canceled crawls not being included as last crawl. This PR fixes the issue.