### PR TITLE
Fix superadmin running crawls views

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -27,6 +27,7 @@ import { RelativeDuration } from "./relative-duration";
 import type { Crawl } from "../types/crawler";
 import { srOnly, truncate, dropdown } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
+import { isActive } from "../utils/crawler";
 
 const mediumBreakpointCss = css`30rem`;
 const largeBreakpointCss = css`60rem`;
@@ -219,12 +220,13 @@ export class CrawlListItem extends LitElement {
   }
 
   renderRow() {
+    const hash = this.crawl && isActive(this.crawl.state) ? "#watch" : "";
     return html`<a
       class="item row"
       role="button"
       href=${`${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/crawl`}/${
         this.crawl?.id
-      }`}
+      }${hash}`}
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -705,7 +705,7 @@ export class App extends LiteElement {
             @submit=${(e: any) => {
               e.preventDefault();
               const id = new FormData(e.target).get("crawlId") as string;
-              this.navigate(`/crawls/crawl/${id}`);
+              this.navigate(`/crawls/crawl/${id}#watch`);
               e.target.closest("sl-dropdown").hide();
             }}
           >

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -704,9 +704,8 @@ export class App extends LiteElement {
           <form
             @submit=${(e: any) => {
               e.preventDefault();
-              const id = new FormData(e.target).get("crawlId");
-              this.navigate(`/crawls/crawl/${id}`);
-              e.target.closest("sl-dropdown").hide();
+              const id = new FormData(e.target).get("crawlId") as string;
+              this.jumpToCrawl(id);
             }}
           >
             <div class="flex flex-wrap items-center">
@@ -729,6 +728,18 @@ export class App extends LiteElement {
         </div>
       </sl-dropdown>
     `;
+  }
+
+  private async jumpToCrawl(crawlId: string) {
+    try {
+      const crawl = await this.apiFetch(
+        `/orgs/all/crawls/${crawlId}/replay.json`,
+        this.authService.authState!
+      );
+      this.navigate(`/orgs/${crawl.oid}/workflows/crawl/${crawl.cid}#watch`);
+    } catch (e) {
+      console.debug(e);
+    }
   }
 
   onLogOut(event: CustomEvent<{ redirect?: boolean } | null>) {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -705,7 +705,8 @@ export class App extends LiteElement {
             @submit=${(e: any) => {
               e.preventDefault();
               const id = new FormData(e.target).get("crawlId") as string;
-              this.jumpToCrawl(id);
+              this.navigate(`/crawls/crawl/${id}`);
+              e.target.closest("sl-dropdown").hide();
             }}
           >
             <div class="flex flex-wrap items-center">
@@ -728,18 +729,6 @@ export class App extends LiteElement {
         </div>
       </sl-dropdown>
     `;
-  }
-
-  private async jumpToCrawl(crawlId: string) {
-    try {
-      const crawl = await this.apiFetch(
-        `/orgs/all/crawls/${crawlId}/replay.json`,
-        this.authService.authState!
-      );
-      this.navigate(`/orgs/${crawl.oid}/workflows/crawl/${crawl.cid}#watch`);
-    } catch (e) {
-      console.debug(e);
-    }
   }
 
   onLogOut(event: CustomEvent<{ redirect?: boolean } | null>) {

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -42,6 +42,8 @@ export class Crawls extends LiteElement {
       .authState=${this.authState!}
       crawlsBaseUrl=${ROUTES.crawls}
       crawlsAPIBaseUrl="/orgs/all/crawls"
+      isCrawler
+      isAdminView
       shouldFetch
     ></btrix-crawls-list>`;
   }

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -4,18 +4,28 @@ import { msg, localized, str } from "@lit/localize";
 import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
+import type { Crawl } from "../types/crawler";
 import { ROUTES } from "../routes";
-import "./org/crawl-detail";
+import "./org/workflow-detail";
 import "./org/crawls-list";
 
 @needLogin
 @localized()
 export class Crawls extends LiteElement {
   @property({ type: Object })
-  authState?: AuthState;
+  authState!: AuthState;
 
   @property({ type: String })
   crawlId?: string;
+
+  @state()
+  private crawl?: Crawl;
+
+  willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("crawlId") && this.crawlId) {
+      this.fetchWorkflowId();
+    }
+  }
 
   render() {
     return html` <div
@@ -26,25 +36,44 @@ export class Crawls extends LiteElement {
   }
 
   private renderDetail() {
+    if (!this.crawl) return;
+
     return html`
-      <btrix-crawl-detail
+      <btrix-workflow-detail
         .authState=${this.authState!}
-        crawlId=${this.crawlId!}
-        crawlsBaseUrl=${ROUTES.crawls}
-        crawlsAPIBaseUrl="/orgs/all/crawls"
-        showOrgLink
-      ></btrix-crawl-detail>
+        orgId=${this.crawl.oid}
+        workflowId=${this.crawl.cid}
+        initialActivePanel="watch"
+        isCrawler
+      ></btrix-workflow-detail>
     `;
   }
 
   private renderList() {
     return html`<btrix-crawls-list
-      .authState=${this.authState!}
+      .authState=${this.authState}
       crawlsBaseUrl=${ROUTES.crawls}
       crawlsAPIBaseUrl="/orgs/all/crawls"
       isCrawler
       isAdminView
       shouldFetch
     ></btrix-crawls-list>`;
+  }
+
+  private async fetchWorkflowId() {
+    try {
+      this.crawl = await this.getCrawl();
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  private async getCrawl(): Promise<Crawl> {
+    const data: Crawl = await this.apiFetch(
+      `/orgs/all/crawls/${this.crawlId}/replay.json`,
+      this.authState!
+    );
+
+    return data;
   }
 }

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -472,7 +472,7 @@ export class CrawlsList extends LiteElement {
     if (!this.crawls) return;
 
     return html`
-      <btrix-crawl-list>
+      <btrix-crawl-list baseUrl=${this.isAdminView ? "/crawls/crawl" : ""}>
         ${this.crawls.items.map(this.renderCrawlItem)}
       </btrix-crawl-list>
 

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -539,6 +539,10 @@ export class CrawlsList extends LiteElement {
         <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
         ${msg("Copy Workflow ID")}
       </sl-menu-item>
+      <sl-menu-item @click=${() => CopyButton.copyToClipboard(crawl.id)}>
+        <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
+        ${msg("Copy Crawl ID")}
+      </sl-menu-item>
       <sl-menu-item
         @click=${() => CopyButton.copyToClipboard(crawl.tags.join(","))}
         ?disabled=${!crawl.tags.length}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1,6 +1,7 @@
 import type { HTMLTemplateResult, TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
+import { until } from "lit/directives/until.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import queryString from "query-string";
@@ -424,16 +425,22 @@ export class WorkflowDetail extends LiteElement {
       <btrix-tab-panel name="artifacts"
         >${this.renderArtifacts()}</btrix-tab-panel
       >
-      <btrix-tab-panel name="watch"
-        >${when(this.activePanel === "watch", () =>
-          this.currentCrawlId
-            ? html` <div class="border rounded-lg py-2 mb-5 h-14">
-                  ${this.renderCurrentCrawl()}
-                </div>
-                ${this.renderWatchCrawl()}`
-            : this.renderInactiveWatchCrawl()
-        )}</btrix-tab-panel
-      >
+      <btrix-tab-panel name="watch">
+        ${until(
+          this.getWorkflowPromise?.then(
+            () => html`
+              ${when(this.activePanel === "watch", () =>
+                this.currentCrawlId
+                  ? html` <div class="border rounded-lg py-2 mb-5 h-14">
+                        ${this.renderCurrentCrawl()}
+                      </div>
+                      ${this.renderWatchCrawl()}`
+                  : this.renderInactiveWatchCrawl()
+              )}
+            `
+          )
+        )}
+      </btrix-tab-panel>
       <btrix-tab-panel name="settings">
         ${this.renderSettings()}
       </btrix-tab-panel>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -496,7 +496,7 @@ export class WorkflowDetail extends LiteElement {
     return html`
       <a
         slot="nav"
-        href=${`/orgs/${this.orgId}/workflows/crawl/${this.workflow?.id}#${tabName}`}
+        href=${`${window.location.pathname}#${tabName}`}
         class="block font-medium rounded-sm mb-2 mr-2 p-2 transition-all ${className}"
         aria-selected=${isActive}
         aria-disabled=${disabled}
@@ -806,7 +806,7 @@ export class WorkflowDetail extends LiteElement {
               ${msg(
                 html`Crawl is currently running.
                   <a
-                    href="${`/orgs/${this.orgId}/workflows/crawl/${this.workflow?.id}#watch`}"
+                    href="${`${window.location.pathname}#watch`}"
                     class="underline hover:no-underline"
                     >Watch Crawl Progress</a
                   >`


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/845

### Changes

- Updates superadmin "Running Crawls" to show active crawls (starting, waiting, running, stopping) and sort by start by default
- Navigates to crawl workflow watch view on clicking crawl item
- Adds "Copy Crawl ID" to crawl actions for easy paste into "Jump to crawl"
- Navigates to crawl workflow watch when jumping to crawl

### Manual testing

1. Log in as superadmin.
2. Start a crawl if one isn't running
3. Click "Running Crawls". Verify running crawl is shown
4. Click "View:" dropdown and select status filter. Verify view updates as expected
5. Click into crawl. Verify you're taken to the Watch page
6. Click side tab navigation. Verify navigation works as expected
7. Click "Stop". Verify crawl stops
8. Run another crawl and "Cancel". Verify crawl cancels
9. Run another crawl and click ... crawl item actions icon -> "Copy Crawl ID"
10. Click "Jump to Crawl" and enter copied crawl ID. Verify you're taken to the Watch page
11. Log out and log back in as a regular user. Regression test "Finished Crawls" list

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Running Crawls | <img width="1135" alt="Screen Shot 2023-05-10 at 8 23 47 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/7c3838ab-a3b7-4894-b8d1-59c94bb7f87b"> |
| Running Crawls - Status filter | <img width="304" alt="Screen Shot 2023-05-10 at 8 24 53 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/53d5204b-9e99-48f0-a0c0-41b149a05bbd"> |
| Running Crawls - Crawl menu | <img width="212" alt="Screen Shot 2023-05-10 at 8 23 51 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/f9547869-cd5d-4fbd-946d-c727b8baef47"> |


### Follow-ups

These changes apply the minimum viable fix for running crawls to be shown again. The superadmin view needs a few follow-ups [per Discord thread](https://discord.com/channels/895426029194207262/910966759165657161/1106025999746998342) to be fully functional:
- API update: `/orgs/all/crawlconfigs` endpoints in order to show running workflows (as opposed to crawl items) and for search to work
- Frontend update: Add back search, show running workflows, jump by workflow ID or crawl ID
- UX considerations: Best approaches for superadmin view, for it to be useful for debugging running crawls