### PR TITLE
Fix workflow edit page not loading

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -103,8 +103,6 @@ export class WorkflowDetail extends LiteElement {
 
   private isPanelHeaderVisible?: boolean;
 
-  // Use to cancel requests
-  private getWorkflowController: AbortController | null = null;
   private getWorkflowPromise?: Promise<Workflow>;
 
   private readonly jobTypeLabels: Record<JobType, string> = {
@@ -264,13 +262,6 @@ export class WorkflowDetail extends LiteElement {
       this.timerId = window.setTimeout(() => {
         this.fetchWorkflow();
       }, 1000 * POLL_INTERVAL_SECONDS);
-    }
-  }
-
-  private cancelInProgressGetWorkflow() {
-    if (this.getWorkflowController) {
-      this.getWorkflowController.abort(ABORT_REASON_CANCLED);
-      this.getWorkflowController = null;
     }
   }
 
@@ -1198,15 +1189,10 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private async getWorkflow(): Promise<Workflow> {
-    this.getWorkflowController = new AbortController();
     const data: Workflow = await this.apiFetch(
       `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
-      this.authState!,
-      {
-        signal: this.getWorkflowController.signal,
-      }
+      this.authState!
     );
-    this.getWorkflowController = null;
     return data;
   }
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1254,7 +1254,6 @@ export class WorkflowDetail extends LiteElement {
 
   private stopPoll() {
     window.clearTimeout(this.timerId);
-    this.cancelInProgressGetWorkflow();
   }
 
   private async getCrawl(crawlId: Crawl["id"]): Promise<Crawl> {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -173,6 +173,8 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private getActivePanelFromHash = () => {
+    if (this.isEditing) return;
+
     const hashValue = window.location.hash.slice(1);
     if (SECTIONS.includes(hashValue as any)) {
       this.activePanel = hashValue as Tab;


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/847

### Changes

Fixes a regression introduced in https://github.com/webrecorder/browsertrix-cloud/pull/841 by removing an unused request abort controller. The abort controller was added in order to prevent showing stale workflow data--however, the change ended up being superceded by implementation of `this.getWorkflowPromise`.

The abort controller had an unintended side effect immediately canceling the API call when loading the edit page due to when properties changed in the Lit lifecycle. Clicking "Edit" from the detail page works because the workflow is already loaded at that point.

### Manual testing

1. Log in and go to "Crawling"
2. Click ... -> "Edit Workflow Settings." Verify page loads

### Follow-ups

Could be refactored further to have a separate page component for the edit page and detail page. Originally, the single component made sense since edits were done through modals, but now the entire UI changes between detail and edit, and it'd be better not to build too much on top of `isEditing`.