### PR TITLE
Removes webkit `<summary>` element triangle

### DIFF
--- a/frontend/src/components/details.ts
+++ b/frontend/src/components/details.ts
@@ -29,6 +29,10 @@ export class Details extends LitElement {
       display: block;
     }
 
+    summary::-webkit-details-marker {
+      display: none;
+    }
+
     summary {
       color: var(--sl-color-neutral-500);
       margin-bottom: var(--sl-spacing-2x-small);


### PR DESCRIPTION
Closes #851 

**Before (Webkit only)**

<img width="510" alt="Screenshot 2023-05-16 at 1 23 24 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/fd95615d-1a84-4238-8a7c-6ea685546898">

**After (All browsers)**

<img width="529" alt="Screenshot 2023-05-16 at 1 33 15 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/4285490c-ddfc-407b-8cd3-e3437c588b75">
