### PR TITLE
Add collection sorting and filtering

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -303,19 +303,13 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
 
         return results
 
-    @app.get(
-        "/orgs/{oid}/collections/names",
-        tags=["collections"]
-    )
+    @app.get("/orgs/{oid}/collections/names", tags=["collections"])
     async def get_collection_names(
         org: Organization = Depends(org_viewer_dep),
     ):
         return await colls.get_collection_names(org)
 
-    @app.get(
-        "/orgs/{oid}/collections/{coll_id}",
-        tags=["collections"]
-    )
+    @app.get("/orgs/{oid}/collections/{coll_id}", tags=["collections"])
     async def get_collection_crawls(
         coll_id: uuid.UUID, org: Organization = Depends(org_viewer_dep)
     ):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -64,6 +64,11 @@ class CollectionOps:
             [("oid", pymongo.ASCENDING), ("name", pymongo.ASCENDING)], unique=True
         )
 
+        await self.collections.create_index(
+            [("oid", pymongo.ASCENDING), ("description", pymongo.ASCENDING)],
+            unique=True,
+        )
+
     async def add_collection(
         self,
         oid: uuid.UUID,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -161,7 +161,7 @@ class CollectionOps:
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: str = None,
-        sort_direction: int = -1,
+        sort_direction: int = 1,
         name: Optional[str] = None,
     ):
         """List all collections for org"""
@@ -245,7 +245,7 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sortBy: str = None,
-        sortDirection: int = -1,
+        sortDirection: int = 1,
         name: Optional[str] = None,
     ):
         collections, total = await colls.list_collections(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -212,6 +212,10 @@ class CollectionOps:
 
         return {"resources": all_files}
 
+    async def get_collection_names(self, org: Organization):
+        """Return list of collection names"""
+        return await self.collections.distinct("name", {"oid": org.id})
+
 
 # ============================================================================
 # pylint: disable=too-many-locals
@@ -275,8 +279,17 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
         return results
 
     @app.get(
+        "/orgs/{oid}/collections/names",
+        tags=["collections"]
+    )
+    async def get_collection_names(
+        org: Organization = Depends(org_viewer_dep),
+    ):
+        return await colls.get_collection_names(org)
+
+    @app.get(
         "/orgs/{oid}/collections/{coll_id}",
-        tags=["collections"],
+        tags=["collections"]
     )
     async def get_collection_crawls(
         coll_id: uuid.UUID, org: Organization = Depends(org_viewer_dep)

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -525,7 +525,7 @@ class CrawlConfigOps:
             aggregate.extend([{"$match": {"firstSeed": first_seed}}])
 
         if sort_by:
-            if sort_by not in ("created, modified, firstSeed, lastCrawlTime"):
+            if sort_by not in ("created", "modified", "firstSeed", "lastCrawlTime"):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -206,10 +206,10 @@ def test_filter_sort_collections(
 
     coll = items[0]
     assert coll["id"]
-    assert second_coll["name"] == SECOND_COLLECTION_NAME
-    assert second_coll["oid"] == default_org_id
-    assert second_coll.get("description") is None
-    assert second_coll["crawlIds"] == [crawler_crawl_id]
+    assert coll["name"] == SECOND_COLLECTION_NAME
+    assert coll["oid"] == default_org_id
+    assert coll.get("description") is None
+    assert coll["crawlIds"] == [crawler_crawl_id]
 
     # Test sorting by name, ascending (default)
     r = requests.get(
@@ -221,8 +221,8 @@ def test_filter_sort_collections(
     assert data["total"] == 2
 
     items = data["items"]
-    assert item[0]["name"] == SECOND_COLLECTION_NAME
-    assert item[1]["name"] == UPDATED_NAME
+    assert items[0]["name"] == SECOND_COLLECTION_NAME
+    assert items[1]["name"] == UPDATED_NAME
 
     # Test sorting by name, descending
     r = requests.get(
@@ -234,8 +234,8 @@ def test_filter_sort_collections(
     assert data["total"] == 2
 
     items = data["items"]
-    assert item[0]["name"] == UPDATED_NAME
-    assert item[1]["name"] == SECOND_COLLECTION_NAME
+    assert items[0]["name"] == UPDATED_NAME
+    assert items[1]["name"] == SECOND_COLLECTION_NAME
 
     # Test sorting by description, ascending (default)
     r = requests.get(
@@ -247,10 +247,10 @@ def test_filter_sort_collections(
     assert data["total"] == 2
 
     items = data["items"]
-    assert item[0]["name"] == SECOND_COLLECTION_NAME
-    assert item[0].get("description") is None
-    assert item[1]["name"] == UPDATED_NAME
-    assert item[1]["description"] == DESCRIPTION
+    assert items[0]["name"] == SECOND_COLLECTION_NAME
+    assert items[0].get("description") is None
+    assert items[1]["name"] == UPDATED_NAME
+    assert items[1]["description"] == DESCRIPTION
 
     # Test sorting by description, descending
     r = requests.get(
@@ -262,7 +262,7 @@ def test_filter_sort_collections(
     assert data["total"] == 2
 
     items = data["items"]
-    assert item[0]["name"] == UPDATED_NAME
-    assert item[0]["description"] == DESCRIPTION
-    assert item[1]["name"] == SECOND_COLLECTION_NAME
-    assert item[1].get("description") is None
+    assert items[0]["name"] == UPDATED_NAME
+    assert items[0]["description"] == DESCRIPTION
+    assert items[1]["name"] == SECOND_COLLECTION_NAME
+    assert items[1].get("description") is None

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -187,3 +187,82 @@ def test_list_collections(
     assert second_coll["oid"] == default_org_id
     assert second_coll.get("description") is None
     assert second_coll["crawlIds"] == [crawler_crawl_id]
+
+
+def test_filter_sort_collections(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    # Test filtering by name
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?name={SECOND_COLLECTION_NAME}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+
+    items = data["items"]
+    assert len(items) == 1
+
+    coll = items[0]
+    assert coll["id"]
+    assert second_coll["name"] == SECOND_COLLECTION_NAME
+    assert second_coll["oid"] == default_org_id
+    assert second_coll.get("description") is None
+    assert second_coll["crawlIds"] == [crawler_crawl_id]
+
+    # Test sorting by name, ascending (default)
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?sortBy=name",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+
+    items = data["items"]
+    assert item[0]["name"] == SECOND_COLLECTION_NAME
+    assert item[1]["name"] == UPDATED_NAME
+
+    # Test sorting by name, descending
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?sortBy=name&sortDirection=-1",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+
+    items = data["items"]
+    assert item[0]["name"] == UPDATED_NAME
+    assert item[1]["name"] == SECOND_COLLECTION_NAME
+
+    # Test sorting by description, ascending (default)
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?sortBy=description",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+
+    items = data["items"]
+    assert item[0]["name"] == SECOND_COLLECTION_NAME
+    assert item[0].get("description") is None
+    assert item[1]["name"] == UPDATED_NAME
+    assert item[1]["description"] == DESCRIPTION
+
+    # Test sorting by description, descending
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?sortBy=description&sortDirection=-1",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+
+    items = data["items"]
+    assert item[0]["name"] == UPDATED_NAME
+    assert item[0]["description"] == DESCRIPTION
+    assert item[1]["name"] == SECOND_COLLECTION_NAME
+    assert item[1].get("description") is None


### PR DESCRIPTION
Fixes #844 

This PR adds sorting and filtering collections based on `name` and `description`. Unlike other API endpoints, I've set ascending order to be the default since we're working with alphanumeric characters and not timestamps.

In order to get the expected sort order with UTF-8 characters, I've had to add a collation that sets the locale to `en`. We may want to make this configurable based on the interface language once we have proper localization in place.