### PR TITLE
tests: fixes for crawl cancel + crawl stopped

### DIFF
--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Start Cluster with Helm
         run: |
-          helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml --set invite_expire_seconds=10 btrix ./chart/
+          helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml --set invite_expire_seconds=10 --set max_pages_per_crawl=1000 btrix ./chart/
 
       - name: Install Python
         uses: actions/setup-python@v3

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Start Cluster with Helm
         run: |
-          helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml --set invite_expire_seconds=10 --set max_pages_per_crawl=1000 btrix ./chart/
+          helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml --set invite_expire_seconds=10 --set max_pages_per_crawl=10 btrix ./chart/
 
       - name: Install Python
         uses: actions/setup-python@v3

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -1,7 +1,6 @@
 name: Nightly tests (K3d)
 
 on:
-  push:
   schedule:
     # Run daily at 8am UTC
     - cron:  '0 8 * * *'

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -1,6 +1,7 @@
 name: Nightly tests (K3d)
 
 on:
+  push:
   schedule:
     # Run daily at 8am UTC
     - cron:  '0 8 * * *'

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -93,7 +93,7 @@ class Crawl(CrawlConfigCore):
 
     state: str
 
-    stats: Optional[Dict[str, str]]
+    stats: Optional[Dict[str, int]]
 
     files: Optional[List[CrawlFile]] = []
 
@@ -140,7 +140,7 @@ class ListCrawlOut(BaseMongoModel):
 
     state: str
 
-    stats: Optional[Dict[str, str]]
+    stats: Optional[Dict[str, int]]
 
     fileSize: int = 0
     fileCount: int = 0

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -479,7 +479,6 @@ class BtrixOperator(K8sAPI):
 
         # check if all crawlers failed
         if failed >= crawl.scale:
-
             # if stopping, and no pages finished, mark as canceled
             if crawl.stopping and not status.pagesDone:
                 state = "canceled"

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -184,7 +184,7 @@ def _crawler_create_config_only(crawler_auth_headers, default_org_id):
         "config": {
             "seeds": [{"url": "https://webrecorder.net/"}],
             "pageExtraDelay": 20,
-            "limit": 4
+            "limit": 4,
         },
     }
     r = requests.post(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -183,8 +183,8 @@ def _crawler_create_config_only(crawler_auth_headers, default_org_id):
         "description": "crawler test crawl",
         "config": {
             "seeds": [{"url": "https://webrecorder.net/"}],
-            "pageExtraDelay": 5,
-            "limit": 4,
+            "pageExtraDelay": 20,
+            "limit": 4
         },
     }
     r = requests.post(

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -139,7 +139,7 @@ def test_verify_wacz():
     assert '"https://webrecorder.net/"' in pages
 
     # 1 seed page + header line
-    assert len(pages.strip().split("\n")) == 1
+    assert len(pages.strip().split("\n")) == 2
 
     # 1 other page
     pages = z.open("pages/extraPages.jsonl").read().decode("utf-8")

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -139,14 +139,14 @@ def test_verify_wacz():
     assert '"https://webrecorder.net/"' in pages
 
     # 1 seed page + header line
-    assert len(pages.strip().split("\n")) == 2
+    assert len(pages.strip().split("\n")) == 1
 
     # 1 other page
     pages = z.open("pages/extraPages.jsonl").read().decode("utf-8")
     assert '"https://webrecorder.net/blog"' in pages
 
-    # 1 other page + header line
-    assert len(pages.strip().split("\n")) == 2
+    # 3 other page + header line
+    assert len(pages.strip().split("\n")) == 4
 
 
 def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):

--- a/backend/test/test_settings.py
+++ b/backend/test/test_settings.py
@@ -13,6 +13,6 @@ def test_settings():
         "registrationEnabled": False,
         "jwtTokenLifetime": 86400,
         "defaultBehaviorTimeSeconds": 300,
-        "maxPagesPerCrawl": 2,
+        "maxPagesPerCrawl": 4,
         "defaultPageLoadTimeSeconds": 120,
     }

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -17,7 +17,7 @@ def get_crawl(org_id, auth_headers, crawl_id):
     return r.json()
 
 
-def _test_start_crawl_to_cancel(
+def test_start_crawl_to_cancel(
     default_org_id, crawler_config_id_only, crawler_auth_headers
 ):
     r = requests.post(
@@ -33,7 +33,7 @@ def _test_start_crawl_to_cancel(
     crawl_id = data["started"]
 
 
-def _test_cancel_crawl(default_org_id, crawler_auth_headers):
+def test_cancel_crawl(default_org_id, crawler_auth_headers):
     data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
     while data["state"] == "starting":
         time.sleep(5)

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -90,7 +90,7 @@ def test_start_crawl_and_stop_immediately(
     while data["state"] in ("starting", "running", "waiting"):
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
-    assert data["state"] == "canceled"
+    assert data["state"] in ("canceled", "partial_complete")
     assert data["stopping"] == True
 
 

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -93,6 +93,7 @@ def test_start_crawl_and_stop_immediately(
     assert data["state"] == "canceled"
     assert data["stopping"] == True
 
+
 def test_start_crawl_to_stop_partial(
     default_org_id, crawler_config_id_only, crawler_auth_headers
 ):
@@ -109,7 +110,9 @@ def test_start_crawl_to_stop_partial(
     crawl_id = data["started"]
 
 
-def test_stop_crawl_partial(default_org_id, crawler_config_id_only, crawler_auth_headers):
+def test_stop_crawl_partial(
+    default_org_id, crawler_config_id_only, crawler_auth_headers
+):
     data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
     done = False
     while not done:

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -232,8 +232,11 @@ def error_crawl_id(admin_auth_headers, default_org_id):
         "runNow": True,
         "name": "Youtube crawl with errors",
         "config": {
-            "seeds": [{"url": "https://www.youtube.com/watch?v=Sh-x3QmbRZc"}],
-            "limit": 10,
+            "seeds": [
+                {"url": "https://invalid.webrecorder.net/"},
+                {"url": "https://invalid-2.webrecorder.net/"},
+            ],
+            "limit": 1,
         },
     }
     r = requests.post(

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -6,7 +6,7 @@ frontend_pull_policy: "Never"
 
 default_crawl_filename_template: "@ts-testing-@hostsuffix.wacz"
 
-operator_resync_seconds: 5
+operator_resync_seconds: 1
 
 mongo_auth:
   # specify either username + password (for local mongo)

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -6,7 +6,11 @@ frontend_pull_policy: "Never"
 
 default_crawl_filename_template: "@ts-testing-@hostsuffix.wacz"
 
-operator_resync_seconds: 1
+operator_resync_seconds: 3
+
+frontend_limits_cpu: "30m"
+
+frontend_limits_memory: "40Mi"
 
 mongo_auth:
   # specify either username + password (for local mongo)

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -8,10 +8,6 @@ default_crawl_filename_template: "@ts-testing-@hostsuffix.wacz"
 
 operator_resync_seconds: 3
 
-frontend_limits_cpu: "30m"
-
-frontend_limits_memory: "40Mi"
-
 mongo_auth:
   # specify either username + password (for local mongo)
   username: root

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -26,7 +26,7 @@ superuser:
 local_service_port: 30870
 
 # test max pages per crawl global limit
-max_pages_per_crawl: 2
+max_pages_per_crawl: 4
 
 registration_enabled: "0"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -94,10 +94,10 @@ frontend_image: "docker.io/webrecorder/browsertrix-frontend:latest"
 frontend_pull_policy: "Always"
 
 frontend_requests_cpu: "3m"
-frontend_limits_cpu: "10m"
+frontend_limits_cpu: "30m"
 
 frontend_requests_memory: "12Mi"
-frontend_limits_memory: "20Mi"
+frontend_limits_memory: "40Mi"
 
 # if set, maps nginx to a fixed port on host machine
 # must be between 30000 - 32767


### PR DESCRIPTION
- fix cancel crawl test by ensuring state is not running or waiting
- fix stop crawl test by ensuring stop is only initiated after at least one page has been crawled, otherwise result may be failed, as no crawl data has been crawled yet (separate fix in crawler to avoid loop if stopped before any data written webrecorder/browsertrix-crawler#314)
- bump page limit to 4 for tests to ensure crawl is partially complete, not fully complete when stopping