### PR TITLE
Add crawlSuccessfulCount to workflows

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -175,13 +175,14 @@ class CrawlConfig(CrawlConfigCore):
 
     colls: Optional[List[str]] = []
 
-    crawlAttemptCount: Optional[int] = 0
-
     inactive: Optional[bool] = False
 
     rev: int = 0
 
+    crawlAttemptCount: Optional[int] = 0
     crawlCount: Optional[int] = 0
+    crawlSuccessfulCount: Optional[int] = 0
+
     totalSize: Optional[int] = 0
 
     lastCrawlId: Optional[str]
@@ -896,6 +897,7 @@ async def update_config_crawl_stats(crawl_configs, crawls, cid: uuid.UUID):
     """re-calculate and update crawl statistics for config"""
     update_query = {
         "crawlCount": 0,
+        "crawlSuccessfulCount": 0,
         "totalSize": 0,
         "lastCrawlId": None,
         "lastCrawlStartTime": None,
@@ -910,6 +912,10 @@ async def update_config_crawl_stats(crawl_configs, crawls, cid: uuid.UUID):
     results = await cursor.to_list(length=10_000)
     if results:
         update_query["crawlCount"] = len(results)
+
+        update_query["crawlSuccessfulCount"] = len(
+            [res for res in results if res["state"] not in ("canceled", "failed")]
+        )
 
         last_crawl = results[0]
         update_query["lastCrawlId"] = str(last_crawl.get("_id"))

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -226,6 +226,7 @@ def test_workflow_total_size_and_last_crawl_stats(
         if last_crawl_id and last_crawl_id in (admin_crawl_id, crawler_crawl_id):
             assert workflow["totalSize"] > 0
             assert workflow["crawlCount"] > 0
+            assert workflow["crawlSuccessfulCount"] > 0
 
             assert workflow["lastCrawlId"]
             assert workflow["lastCrawlStartTime"]
@@ -248,6 +249,7 @@ def test_workflow_total_size_and_last_crawl_stats(
     data = r.json()
     assert data["totalSize"] > 0
     assert data["crawlCount"] > 0
+    assert data["crawlSuccessfulCount"] > 0
 
     assert data["lastCrawlId"]
     assert data["lastCrawlStartTime"]


### PR DESCRIPTION
Fixes #868 

One thing to note: in existing installations with data from https://github.com/webrecorder/browsertrix-cloud/pull/826, this would require re-running migration 0006 to populate the new `crawlSuccessfulCount` in the database (since that migration just calls the update method, it will work without changes needed). Since that's just getting merged today, however, probably a non-issue for existing deployments :)