### PR TITLE
Concurrent Crawl Limit

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -84,6 +84,10 @@ jobs:
       - name: Run Tests
         run: pytest -vv ./backend/test/*.py
 
-      - name: Print Backend Logs
+      - name: Print Backend Logs (API)
         if: ${{ failure() }}
-        run: kubectl logs svc/browsertrix-cloud-backend
+        run: kubectl logs svc/browsertrix-cloud-backend -c api
+
+      - name: Print Backend Logs (Operator)
+        if: ${{ failure() }}
+        run: kubectl logs svc/browsertrix-cloud-backend -c op

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -125,7 +125,12 @@ class CrawlManager(K8sAPI):
         cid = str(crawlconfig.id)
 
         return await self.new_crawl_job(
-            cid, userid, crawlconfig.scale, crawlconfig.crawlTimeout, manual=True
+            cid,
+            userid,
+            crawlconfig.oid,
+            crawlconfig.scale,
+            crawlconfig.crawlTimeout,
+            manual=True,
         )
 
     async def update_crawl_config(self, crawlconfig, update, profile_filename=None):
@@ -275,9 +280,7 @@ class CrawlManager(K8sAPI):
             patch = {"stopping": True}
             return await self._patch_job(crawl_id, patch)
 
-        await self.delete_crawl_job(crawl_id)
-
-        return {"success": True}
+        return await self.delete_crawl_job(crawl_id)
 
     async def delete_crawl_configs_for_org(self, org):
         """Delete all crawl configs for given org"""

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -643,7 +643,7 @@ class CrawlOps:
             if not graceful:
                 await self.update_crawl_state(crawl_id, "canceled")
                 crawl = await self.get_crawl_raw(crawl_id, org)
-                await self.crawl_configs.update_crawl_stats(crawl["cid"])
+                await self.crawl_configs.stats_recompute_remove_crawl(crawl["cid"], 0)
                 return {"success": True}
 
         # return whatever detail may be included in the response

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -920,7 +920,7 @@ async def update_crawl_state_if_changed(crawls, crawl_id, state, **kwargs):
         {"$set": kwargs},
         return_document=pymongo.ReturnDocument.AFTER,
     )
-    print("** UPDATE", crawl_id, state, res is not None)
+    print("** crawl state changed?", crawl_id, state, res is not None)
     return res
 
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -917,12 +917,11 @@ async def update_crawl_state_if_allowed(
 ):
     """update crawl state and other properties in db if state has changed"""
     kwargs["state"] = state
-    res = await crawls.find_one_and_update(
-        {"_id": crawl_id, "state": {"$in": list(allowed_from)}},
-        {"$set": kwargs},
-        return_document=pymongo.ReturnDocument.BEFORE,
-    )
-    return res
+    query = {"_id": crawl_id}
+    if allowed_from:
+        query["state"] = {"$in": allowed_from}
+
+    return await crawls.find_one_and_update(query, {"$set": kwargs})
 
 
 # ============================================================================

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -35,7 +35,12 @@ from .utils import dt_now, ts_now, get_redis_crawl_stats, parse_jsonl_error_mess
 
 RUNNING_STATES = ("running", "pending-wait", "generate-wacz", "uploading-wacz")
 
-RUNNING_AND_STARTING_STATES = ("starting", "waiting", *RUNNING_STATES)
+RUNNING_AND_STARTING_STATES = (
+    "starting",
+    "waiting_capacity",
+    "waiting_org_limit",
+    *RUNNING_STATES,
+)
 
 NON_RUNNING_STATES = ("complete", "canceled", "partial_complete", "timed_out", "failed")
 
@@ -599,7 +604,7 @@ class CrawlOps:
         await self.crawls.find_one_and_update(
             {
                 "_id": crawl_id,
-                "state": {"$in": ["running", "starting", "canceling", "stopping"]},
+                "state": {"$in": RUNNING_AND_STARTING_STATES},
             },
             {"$set": data},
         )
@@ -629,9 +634,11 @@ class CrawlOps:
 
         # if job no longer running, canceling is considered success,
         # but graceful stoppage is not possible, so would be a failure
-        if result.get("error") == "job_not_running":
+        if result.get("error") == "Not Found":
             if not graceful:
                 await self.update_crawl_state(crawl_id, "canceled")
+                crawl = await self.get_crawl_raw(crawl_id, org)
+                await self.crawl_configs.update_crawl_stats(crawl["cid"])
                 return {"success": True}
 
         # return whatever detail may be included in the response

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -46,7 +46,9 @@ FAILED_STATES = ("canceled", "failed")
 
 SUCCESSFUL_STATES = ("complete", "partial_complete", "timed_out")
 
-ALL_CRAWL_STATES = (*RUNNING_AND_STARTING_STATES, *FAILED_STATES, *SUCCESSFUL_STATES)
+NON_RUNNING_STATES = (*FAILED_STATES, *SUCCESSFUL_STATES)
+
+ALL_CRAWL_STATES = (*RUNNING_AND_STARTING_STATES, *NON_RUNNING_STATES)
 
 
 # ============================================================================

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -917,10 +917,16 @@ async def update_crawl_state_if_allowed(
     res = await crawls.find_one_and_update(
         {"_id": crawl_id, "state": {"$in": list(allowed_from)}},
         {"$set": kwargs},
-        return_document=pymongo.ReturnDocument.AFTER,
+        return_document=pymongo.ReturnDocument.BEFORE,
     )
-    print("** crawl state changed?", crawl_id, state, res is not None)
     return res
+
+
+# ============================================================================
+async def get_crawl_state(crawls, crawl_id):
+    """return current crawl state of a crawl"""
+    res = await crawls.find_one({"_id": crawl_id})
+    return res and res.get("state")
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -37,12 +37,13 @@ class ScheduledJob(K8sAPI):
         userid = data["USER_ID"]
         scale = int(data.get("INITIAL_SCALE", 0))
         crawl_timeout = int(data.get("CRAWL_TIMEOUT", 0))
+        oid = data["ORG_ID"]
 
         crawlconfig = await get_crawl_config(self.crawlconfigs, uuid.UUID(self.cid))
 
         # k8s create
         crawl_id = await self.new_crawl_job(
-            self.cid, userid, scale, crawl_timeout, manual=False
+            self.cid, userid, oid, scale, crawl_timeout, manual=False
         )
 
         # db create

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -591,14 +591,15 @@ class BtrixOperator(K8sAPI):
         if stats:
             kwargs["stats"] = stats
 
+        if not status.finished:
+            status.finished = to_k8s_date(finished)
+
         # if set_state returns false, already set to same status, return
         if not await self.set_state(
             state, status, crawl_id, allowed_from=["running"], **kwargs
         ):
             print("already finished, ignoring mark_finished")
             return status
-
-        status.finished = to_k8s_date(finished)
 
         if crawl:
             await self.inc_crawl_complete_stats(crawl, finished)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -272,7 +272,9 @@ class BtrixOperator(K8sAPI):
                 status.finished = to_k8s_date(finished)
 
         if status.state != state:
-            print(f"Not setting state: {status.state} -> {state}, {crawl_id} not allowed")
+            print(
+                f"Not setting state: {status.state} -> {state}, {crawl_id} not allowed"
+            )
         return False
 
     def load_from_yaml(self, filename, params):

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -82,7 +82,7 @@ class S3Storage(BaseModel):
 class OrgQuotas(BaseModel):
     """Organization quotas (settable by superadmin)"""
 
-    maxParallelCrawls: Optional[int] = 0
+    maxConcurrentCrawls: Optional[int] = 0
 
 
 # ============================================================================
@@ -388,12 +388,12 @@ async def inc_org_stats(orgs, oid, duration):
 
 
 # ============================================================================
-async def get_max_parallel_crawls(orgs, oid):
-    """return max allowed parallel crawls, if any"""
+async def get_max_concurrent_crawls(orgs, oid):
+    """return max allowed concurrent crawls, if any"""
     org = await orgs.find_one({"_id": oid})
     if org:
         org = Organization.from_dict(org)
-        return org.quotas.maxParallelCrawls
+        return org.quotas.maxConcurrentCrawls
     return 0
 
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -471,9 +471,10 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
             users={},
             storage=DefaultStorage(name="default", path=storage_path),
         )
-        await ops.add_org(org)
+        if not await ops.add_org(org):
+            return {"added": False, "error": "already_exists"}
 
-        return {"added": True}
+        return {"id": id_, "added": True}
 
     @router.get("", tags=["organizations"])
     async def get_org(

--- a/backend/btrixcloud/templates/crawl_job.yaml
+++ b/backend/btrixcloud/templates/crawl_job.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     crawl: "{{ id }}"
     role: "job"
+    oid: "{{ oid }}"
+    userid: "{{ userid }}"
 
 spec:
   selector:
@@ -14,6 +16,7 @@ spec:
   id: "{{ id }}"
   userid: "{{ userid }}"
   cid: "{{ cid }}"
+  oid: "{{ oid }}"
   scale: {{ scale }}
   ttlSecondsAfterFinished: 30
 

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -48,7 +48,7 @@ def test_cancel_crawl(default_org_id, crawler_auth_headers):
 
     data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
-    while data["state"] in ("running", "waiting"):
+    while data["state"] in ("running", "waiting_capacity"):
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] == "canceled"
@@ -87,7 +87,7 @@ def test_start_crawl_and_stop_immediately(
     )
     assert r.json()["lastCrawlStopping"] == True
 
-    while data["state"] in ("starting", "running", "waiting"):
+    while data["state"] in ("starting", "running", "waiting_capacity"):
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] in ("canceled", "partial_complete")

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import requests
 import time
+import datetime
 
 
 HOST_PREFIX = "http://127.0.0.1:30870"
@@ -257,3 +258,14 @@ def error_crawl_id(admin_auth_headers, default_org_id):
         if data["state"] == "complete":
             return crawl_id
         time.sleep(5)
+
+
+@pytest.fixture(scope="session")
+def org_with_quotas(admin_auth_headers):
+    name = "Quota Org " + datetime.datetime.utcnow().isoformat()
+    r = requests.post(
+        f"{API_PREFIX}/orgs/create", headers=admin_auth_headers, json={"name": name}
+    )
+    data = r.json()
+
+    return data["id"]

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -28,7 +28,7 @@ def test_run_two_only_one_concurrent(org_with_quotas, admin_auth_headers):
     while (
         get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) == "starting"
     ):
-        time.sleep(5)
+        time.sleep(2)
 
     assert (
         get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) == "running"
@@ -37,7 +37,7 @@ def test_run_two_only_one_concurrent(org_with_quotas, admin_auth_headers):
     while (
         get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers) == "starting"
     ):
-        time.sleep(5)
+        time.sleep(2)
 
     assert (
         get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers)
@@ -56,7 +56,7 @@ def test_cancel_and_run_other(org_with_quotas, admin_auth_headers):
     while (
         get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) != "canceled"
     ):
-        time.sleep(5)
+        time.sleep(2)
 
     while (
         get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers)
@@ -69,6 +69,13 @@ def test_cancel_and_run_other(org_with_quotas, admin_auth_headers):
         "running",
     )
 
+    # cancel second crawl as well
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawls/{crawl_id_b}/cancel",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    assert data["success"] == True
 
 def run_crawl(org_id, headers):
     crawl_data = {

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -7,11 +7,11 @@ crawl_id_a = None
 crawl_id_b = None
 
 
-def test_set_parallel_crawl_limit(org_with_quotas, admin_auth_headers):
+def test_set_concurrent_crawl_limit(org_with_quotas, admin_auth_headers):
     r = requests.post(
         f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
         headers=admin_auth_headers,
-        json={"maxParallelCrawls": 1},
+        json={"maxConcurrentCrawls": 1},
     )
     data = r.json()
     assert data.get("updated") == True

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -1,0 +1,99 @@
+import requests
+import time
+
+from .conftest import API_PREFIX
+
+crawl_id_a = None
+crawl_id_b = None
+
+
+def test_set_parallel_crawl_limit(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={"maxParallelCrawls": 1},
+    )
+    data = r.json()
+    assert data.get("updated") == True
+
+
+def test_run_two_only_one_concurrent(org_with_quotas, admin_auth_headers):
+    global crawl_id_a
+    crawl_id_a = run_crawl(org_with_quotas, admin_auth_headers)
+    time.sleep(1)
+
+    global crawl_id_b
+    crawl_id_b = run_crawl(org_with_quotas, admin_auth_headers)
+
+    while (
+        get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) == "starting"
+    ):
+        time.sleep(5)
+
+    assert (
+        get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) == "running"
+    )
+
+    while (
+        get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers) == "starting"
+    ):
+        time.sleep(5)
+
+    assert (
+        get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers)
+        == "waiting_org_limit"
+    )
+
+
+def test_cancel_and_run_other(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawls/{crawl_id_a}/cancel",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    assert data["success"] == True
+
+    while (
+        get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) != "canceled"
+    ):
+        time.sleep(5)
+
+    while (
+        get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers)
+        == "waiting_org_limit"
+    ):
+        time.sleep(5)
+
+    assert get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers) in (
+        "starting",
+        "running",
+    )
+
+
+def run_crawl(org_id, headers):
+    crawl_data = {
+        "runNow": True,
+        "name": "Concurrent Crawl",
+        "config": {
+            "seeds": [{"url": "https://specs.webrecorder.net/"}],
+            "limit": 1,
+        },
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_id}/crawlconfigs/",
+        headers=headers,
+        json=crawl_data,
+    )
+    data = r.json()
+
+    return data["run_now_job"]
+
+
+def get_crawl_status(org_id, crawl_id, headers):
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
+            headers=headers,
+        )
+        data = r.json()
+        return data["state"]

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -77,6 +77,7 @@ def test_cancel_and_run_other(org_with_quotas, admin_auth_headers):
     data = r.json()
     assert data["success"] == True
 
+
 def run_crawl(org_id, headers):
     crawl_data = {
         "runNow": True,

--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -79,14 +79,15 @@ export class CrawlStatus extends LitElement {
         break;
       }
 
-      case "waiting": {
+      case "waiting_capacity":
+      case "waiting_org_limit": {
         icon = html`<sl-icon
           name="hourglass-split"
           class="animatePulse"
           slot="prefix"
           style="color: var(--sl-color-purple-600)"
         ></sl-icon>`;
-        label = msg("Waiting");
+        label = state === "waiting_capacity" ? msg("Waiting (At Capacity)") : msg("Waiting (Crawl Limit)");
         break;
       }
 

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -7,6 +7,7 @@ import LiteElement, { html } from "../utils/LiteElement";
 
 import { isAdmin } from "../utils/orgs";
 import { DASHBOARD_ROUTE } from "../routes";
+import { SlInput } from "@shoelace-style/shoelace";
 
 @localized()
 export class OrgsList extends LiteElement {
@@ -22,6 +23,9 @@ export class OrgsList extends LiteElement {
   @property({ type: Boolean })
   skeleton? = false;
 
+  @property({ type: Object })
+  currOrg?: OrgData | null = null;
+
   render() {
     if (this.skeleton) {
       return this.renderSkeleton();
@@ -30,8 +34,61 @@ export class OrgsList extends LiteElement {
     return html`
       <ul class="border rounded-lg overflow-hidden">
         ${this.orgList?.map(this.renderOrg)}
+        ${this.renderOrgQuotas()}
       </ul>
     `;
+  }
+
+  private renderOrgQuotas() {
+    if (!this.currOrg) {
+      return html``;
+    }
+
+    return html`
+    <sl-dialog
+      label=${msg(str`Quotas for: ${this.currOrg.name}`)}
+      ?open=${!!this.currOrg}
+    @sl-request-close=${() => (this.currOrg = null)}
+  >
+  ${Object.entries(this.currOrg.quotas).map(([key, value]) => {
+    return html`
+    <sl-input
+    name=${key}
+    value=${value}
+    type="number"
+    @sl-input="${this.onUpdateQuota}"
+    ><span slot="prefix">${msg(key)}</span></sl-input>`;
+  })}
+  <sl-button @click="${this.onSubmitQuotas}" class="mt-2" variant="primary">Update Quotas</sl-button>
+
+  </sl-dialog>
+    `;
+  }
+
+  private onUpdateQuota(e: CustomEvent) {
+    const inputEl = e.target as SlInput;
+    const quotas = this.currOrg?.quotas;
+    if (quotas) {
+      quotas[inputEl.name] = Number(inputEl.value);
+    }
+  }
+
+  private onSubmitQuotas() {
+    if (this.currOrg) {
+      this.dispatchEvent(new CustomEvent("update-quotas", {detail: this.currOrg}));
+    }
+    this.currOrg = null;
+  }
+
+  private showQuotas(org: OrgData) {
+    const stop = (e: Event) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.currOrg = org;
+      return false;
+    };
+
+    return stop;
   }
 
   private renderOrg = (org: OrgData) => {
@@ -52,10 +109,15 @@ export class OrgsList extends LiteElement {
         <div class="font-medium mr-2 transition-colors">
           ${defaultLabel}${org.name}
         </div>
-        <div class="text-xs text-neutral-400">
-          ${memberCount === 1
-            ? msg(`1 member`)
-            : msg(str`${memberCount} members`)}
+        <div class="flex flex-row items-center">
+          <sl-button size="small" class="mr-3" @click="${this.showQuotas(org)}">
+          <sl-icon name="gear" slot="prefix"></sl-icon>
+          </sl-button>
+          <div class="text-xs text-neutral-400">
+            ${memberCount === 1
+              ? msg(`1 member`)
+              : msg(str`${memberCount} members`)}
+          </div>
         </div>
       </li>
     `;

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -57,7 +57,7 @@ export class OrgsList extends LiteElement {
     value=${value}
     type="number"
     @sl-input="${this.onUpdateQuota}"
-    ><span slot="prefix">${msg(key)}</span></sl-input>`;
+    ><span slot="prefix">${key}</span></sl-input>`;
   })}
   <sl-button @click="${this.onSubmitQuotas}" class="mt-2" variant="primary">Update Quotas</sl-button>
 

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -164,6 +164,7 @@ export class Home extends LiteElement {
               .defaultOrg=${ifDefined(
                 this.userInfo?.orgs.find((org) => org.default === true)
               )}
+              @update-quotas=${this.onUpdateOrgQuotas}
             ></btrix-orgs-list>
           </section>
         </div>
@@ -312,6 +313,15 @@ export class Home extends LiteElement {
     }
 
     this.isSubmittingNewOrg = false;
+  }
+
+  async onUpdateOrgQuotas(e: CustomEvent) {
+    const org = e.detail as OrgData;
+
+    await this.apiFetch(`/orgs/${org.id}/quotas`, this.authState!, {
+      method: "POST",
+      body: JSON.stringify(org.quotas),
+    });
   }
 
   async checkFormValidity(formEl: HTMLFormElement) {

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -90,7 +90,8 @@ export class CrawlDetail extends LiteElement {
     return (
       this.crawl.state === "running" ||
       this.crawl.state === "starting" ||
-      this.crawl.state === "waiting" ||
+      this.crawl.state === "waiting_capacity" ||
+      this.crawl.state === "waiting_org_limit" ||
       this.crawl.state === "stopping"
     );
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -926,7 +926,7 @@ export class WorkflowDetail extends LiteElement {
 
     let waitingMsg = null;
 
-    switch (this.workflow.currCrawlState) {
+    switch (this.workflow.lastCrawlState) {
       case "starting":
         waitingMsg = msg("Crawl starting...");
         break;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -924,21 +924,31 @@ export class WorkflowDetail extends LiteElement {
   private renderWatchCrawl = () => {
     if (!this.authState || !(this.workflow?.lastCrawlState)) return "";
 
-    const isStarting = this.workflow.lastCrawlState === "starting";
-    const isWaiting = this.workflow.lastCrawlState === "waiting";
+    let waitingMsg = null;
+
+    switch (this.workflow.currCrawlState) {
+      case "starting":
+        waitingMsg = msg("Crawl starting...");
+        break;
+
+      case "waiting_capacity":
+        waitingMsg = msg("Crawl waiting for available resources before it can start...");
+        break;
+
+      case "waiting_org_limit":
+        waitingMsg = msg("Crawl waiting for others to finish, concurrent limit per Organization reached...");
+        break;
+    }
+
     const isRunning = this.workflow.lastCrawlState === "running";
     const isStopping = this.workflow.lastCrawlStopping;
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`
-      ${isStarting || isWaiting
+      ${waitingMsg
         ? html`<div class="rounded border p-3">
             <p class="text-sm text-neutral-600 motion-safe:animate-pulse">
-              ${isStarting
-                ? msg("Crawl starting...")
-                : msg(
-                    "Crawl waiting for available resources before it can start..."
-                  )}
+              ${waitingMsg}
             </p>
           </div>`
         : isActive(this.workflow.lastCrawlState)

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -88,7 +88,8 @@ export type Profile = {
 
 export type CrawlState =
   | "starting"
-  | "waiting"
+  | "waiting_capacity"
+  | "waiting_org_limit"
   | "running"
   | "complete"
   | "failed"

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -11,6 +11,7 @@ export const AccessCode: Record<UserRole, number> = {
 export type OrgData = {
   id: string;
   name: string;
+  quotas: Record<string, number>;
   users?: {
     [id: string]: {
       role: (typeof AccessCode)[UserRole];

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -1,7 +1,8 @@
 import type { CrawlState } from "../types/crawler";
 export const activeCrawlStates: CrawlState[] = [
   "starting",
-  "waiting",
+  "waiting_org_limit",
+  "waiting_capacity",
   "running",
   "stopping",
 ];


### PR DESCRIPTION
This PR covers both backend and frontend side of crawl concurrency per Organization.
It introduces a new crawl status, `waiting_org_list` and renames previous `waiting` -> `waiting_capacity`
The frontend displays this state as follows:
<img width="1180" alt="Screen Shot 2023-05-25 at 11 11 43 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/6b5f8ecb-78fc-4e76-98e4-f1657d190916">

The limit is set on the Organization object, as `maxParallelCrawls` field on the new `quotas` field, now included in each Organization.
The `org/quotas` endpoint allows configuring the quotas object.

The superadmin org page now has quotas popup, where all the available quotas can be configured:
<img width="692" alt="Screen Shot 2023-05-25 at 11 13 13 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/a1964ec1-6e24-4b9d-8d00-3c8b773da1ae">

Clicking the gear will show the popup, listing all the available quotas:
<img width="901" alt="Screen Shot 2023-05-25 at 11 14 06 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/8bf81e93-4571-4f47-bdd2-92e9a9f72984">

The `maxParallelCrawls` is the only field so far, adding additional fields to `quotas` on the backend will automatically expose them in this popup.
 
### Backend Implementation

The parallel crawl limit is enforced by the operator per organization. As part of this, the orgid is included as part of each crawljob. The operator sync method now includes all the running crawljobs for the org (sorted by creationTimestamp by default), and if quota is set, checks to see if each job is <=N order, and any jobs >N are set to `waiting_org_limit`.
(Canceled / not running jobs are excluded from the count).