### PR TITLE
Rework collections to track collections in Crawl

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -370,12 +370,6 @@ async def add_successful_crawl_to_collections(
 
 
 # ============================================================================
-async def remove_failed_crawl_from_collections(crawls, crawl_id: str):
-    """Removed cancelled or failed crawl from all collections."""
-    await crawls.find_one_and_update({"_id": crawl_id}, {"$set": {"collections": []}})
-
-
-# ============================================================================
 # pylint: disable=too-many-locals
 def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
     """init collections api"""

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -193,13 +193,7 @@ class CollectionOps:
             result["resources"] = await self.get_collection_crawl_resources(
                 coll_id, org
             )
-        return await self._get_annotated_coll_out(result)
-
-    async def _get_annotated_coll_out(self, result):
-        """Add crawlCount to db collection result and return CollOut."""
-        crawl_ids = await self.crawl_ops.get_crawls_in_collection(result["_id"])
-        result["crawlCount"] = len(crawl_ids)
-        return CollOut.from_dict(result)
+        return await CollOut.from_dict(result)
 
     async def find_collections(self, oid: uuid.UUID, names: List[str]):
         """Find all collections for org given a list of names"""

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -387,6 +387,25 @@ async def update_crawl_collections(collections, crawls, crawl_id: str):
 
 
 # ============================================================================
+async def add_successful_crawl_to_auto_add_collections(crawls, crawl_id: str):
+    """Add successful crawl to its auto-add collections."""
+    await crawls.find_one_and_update(
+        {"_id": crawl_id},
+        {
+            "$set": {
+                "collections": {
+                    "$reduce": {
+                        "input": "$autoAddCollections",
+                        "initialValue": [],
+                        "in": {"$concatArrays": ["$$value", "$$this"]},
+                    }
+                }
+            }
+        },
+    )
+
+
+# ============================================================================
 async def remove_failed_crawl_from_collections(crawls, crawl_id: str):
     """Removed cancelled or failed crawl from all collections."""
     await crawls.find_one_and_update({"_id": crawl_id}, {"$set": {"collections": []}})

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -387,22 +387,17 @@ async def update_crawl_collections(collections, crawls, crawl_id: str):
 
 
 # ============================================================================
-async def add_successful_crawl_to_auto_add_collections(crawls, crawl_id: str):
+async def add_successful_crawl_to_auto_add_collections(
+    crawls, crawl_configs, crawl_id: str, cid: uuid.UUID
+):
     """Add successful crawl to its auto-add collections."""
-    await crawls.find_one_and_update(
-        {"_id": crawl_id},
-        {
-            "$set": {
-                "collections": {
-                    "$reduce": {
-                        "input": "$autoAddCollections",
-                        "initialValue": [],
-                        "in": {"$concatArrays": ["$$value", "$$this"]},
-                    }
-                }
-            }
-        },
-    )
+    workflow = await crawl_configs.find_one({"_id": cid})
+    collections = workflow.get("autoAddCollections")
+    if collections:
+        await crawls.find_one_and_update(
+            {"_id": crawl_id},
+            {"$set": {"collections": collections}},
+        )
 
 
 # ============================================================================

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -387,17 +387,18 @@ async def update_crawl_collections(collections, crawls, crawl_id: str):
 
 
 # ============================================================================
-async def add_successful_crawl_to_auto_add_collections(
-    crawls, crawl_configs, crawl_id: str, cid: uuid.UUID
+async def add_successful_crawl_to_collections(
+    crawls, crawl_configs, collections, crawl_id: str, cid: uuid.UUID
 ):
     """Add successful crawl to its auto-add collections."""
     workflow = await crawl_configs.find_one({"_id": cid})
-    collections = workflow.get("autoAddCollections")
-    if collections:
+    auto_add_collections = workflow.get("autoAddCollections")
+    if auto_add_collections:
         await crawls.find_one_and_update(
             {"_id": crawl_id},
-            {"$set": {"collections": collections}},
+            {"$set": {"collections": auto_add_collections}},
         )
+        await update_crawl_collections(collections, crawls, crawl_id)
 
 
 # ============================================================================

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -195,24 +195,6 @@ class CollectionOps:
             )
         return CollOut.from_dict(result)
 
-    async def find_collections(self, oid: uuid.UUID, names: List[str]):
-        """Find all collections for org given a list of names"""
-        cursor = self.collections.find(
-            {"oid": oid, "name": {"$in": names}}, projection=["_id", "name"]
-        )
-        results = await cursor.to_list(length=1000)
-        if len(results) != len(names):
-            for result in results:
-                names.remove(result["name"])
-
-            if names:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Specified collection(s) not found: {', '.join(names)}",
-                )
-
-        return [result["name"] for result in results]
-
     async def list_collections(
         self,
         oid: uuid.UUID,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -226,7 +226,6 @@ class CollectionOps:
         page: int = 1,
         sort_by: str = None,
         sort_direction: int = 1,
-        crawl_count: bool = True,
         name: Optional[str] = None,
     ):
         """List all collections for org"""
@@ -241,31 +240,6 @@ class CollectionOps:
             match_query["name"] = name
 
         aggregate = [{"$match": match_query}]
-
-        if crawl_count:
-            aggregate.extend(
-                [
-                    {
-                        "$lookup": {
-                            "from": "crawls",
-                            "let": {"collection_id": "$_id"},
-                            "pipeline": [
-                                {
-                                    "$match": {
-                                        "$expr": {
-                                            "$in": ["$$collection_id", "$collections"]
-                                        }
-                                    }
-                                }
-                            ],
-                            "as": "collectionCrawls",
-                        }
-                    },
-                    {"$set": {"crawlCount": {"$size": "$collectionCrawls"}}},
-                ]
-            )
-        else:
-            aggregate.extend([{"$set": {"crawlCount": None}}])
 
         if sort_by:
             if sort_by not in ("name", "description"):
@@ -437,7 +411,6 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
         sortBy: str = None,
         sortDirection: int = 1,
         name: Optional[str] = None,
-        crawlCount: Optional[bool] = True,
     ):
         collections, total = await colls.list_collections(
             org.id,
@@ -445,7 +418,6 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
             page=page,
             sort_by=sortBy,
             sort_direction=sortDirection,
-            crawl_count=crawlCount,
             name=name,
         )
         return paginated_format(collections, total, page, pageSize)

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -236,9 +236,7 @@ class CollectionOps:
 
     async def delete_collection(self, coll_id: uuid.UUID, org: Organization):
         """Delete collection and remove from associated crawls."""
-        crawl_ids = await self.crawls.get_crawls_in_collection(coll_id)
-        for crawl_id in crawl_ids:
-            await self.crawls.remove_from_collection(crawl_id, coll_id)
+        await self.crawls.remove_collection_from_all_crawls(coll_id)
 
         result = await self.collections.delete_one({"_id": coll_id, "oid": org.id})
         if result.deleted_count < 1:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -193,7 +193,7 @@ class CollectionOps:
             result["resources"] = await self.get_collection_crawl_resources(
                 coll_id, org
             )
-        return await CollOut.from_dict(result)
+        return CollOut.from_dict(result)
 
     async def find_collections(self, oid: uuid.UUID, names: List[str]):
         """Find all collections for org given a list of names"""

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -231,6 +231,7 @@ class UpdateCrawlConfig(BaseModel):
     name: Optional[str]
     tags: Optional[List[str]]
     description: Optional[str]
+    autoAddCollections: Optional[List[UUID4]]
 
     # crawl data: revision tracked
     schedule: Optional[str]
@@ -412,6 +413,11 @@ class CrawlConfigOps:
         metadata_changed = metadata_changed or (
             update.tags is not None
             and ",".join(orig_crawl_config.tags) != ",".join(update.tags)
+        )
+        metadata_changed = metadata_changed or (
+            update.autoAddCollections is not None
+            and sorted(orig_crawl_config.autoAddCollections)
+            != sorted(update.autoAddCollections)
         )
 
         if not changed and not metadata_changed:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -111,7 +111,7 @@ class CrawlConfigIn(BaseModel):
 
     profileid: Optional[str]
 
-    colls: Optional[List[UUID4]] = []
+    autoAddCollections: Optional[List[UUID4]] = []
     tags: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
@@ -173,7 +173,7 @@ class CrawlConfig(CrawlConfigCore):
     modified: Optional[datetime]
     modifiedBy: Optional[UUID4]
 
-    colls: Optional[List[UUID4]] = []
+    autoAddCollections: Optional[List[UUID4]] = []
 
     inactive: Optional[bool] = False
 
@@ -334,8 +334,8 @@ class CrawlConfigOps:
             config.profileid, org
         )
 
-        if config.colls:
-            data["colls"] = config.colls
+        if config.autoAddCollections:
+            data["autoAddCollections"] = config.autoAddCollections
 
         result = await self.crawl_configs.insert_one(data)
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -111,7 +111,7 @@ class CrawlConfigIn(BaseModel):
 
     profileid: Optional[str]
 
-    colls: Optional[List[str]] = []
+    colls: Optional[List[UUID4]] = []
     tags: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
@@ -173,7 +173,7 @@ class CrawlConfig(CrawlConfigCore):
     modified: Optional[datetime]
     modifiedBy: Optional[UUID4]
 
-    colls: Optional[List[str]] = []
+    colls: Optional[List[UUID4]] = []
 
     inactive: Optional[bool] = False
 
@@ -335,7 +335,7 @@ class CrawlConfigOps:
         )
 
         if config.colls:
-            data["colls"] = await self.coll_ops.find_collections(org.id, config.colls)
+            data["colls"] = config.colls
 
         result = await self.crawl_configs.insert_one(data)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -833,7 +833,8 @@ class CrawlOps:
         """Add crawls to collection."""
         for crawl_id in crawl_ids:
             crawl_raw = await self.get_crawl_raw(crawl_id, org)
-            if crawl_id in crawl_raw.get("collections"):
+            crawl_collections = crawl_raw.get("collections")
+            if collections and crawl_id in crawl_collections:
                 raise HTTPException(
                     status_code=400, detail="crawl_already_in_collection"
                 )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -863,12 +863,6 @@ class CrawlOps:
         if result.modified_count < 1:
             raise HTTPException(status_code=404, detail="crawls_not_found")
 
-    async def get_crawls_in_collection(self, collection_id: uuid.UUID):
-        """Get list of ids for crawls in a given collection."""
-        cursor = self.crawls.find({"collections": collection_id})
-        crawls = await cursor.to_list(length=10_000)
-        return [crawl["_id"] for crawl in crawls]
-
 
 # ============================================================================
 async def add_new_crawl(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -886,6 +886,7 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
+        collections=crawlconfig.colls,
     )
 
     try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -192,7 +192,7 @@ class UpdateCrawl(BaseModel):
 class CrawlOps:
     """Crawl Ops"""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods
     def __init__(self, mdb, users, crawl_manager, crawl_configs, orgs):
         self.crawls = mdb["crawls"]
         self.collections = mdb["collections"]
@@ -828,6 +828,15 @@ class CrawlOps:
         )
         if not result:
             raise HTTPException(status_code=404, detail="crawl_not_found")
+
+    async def remove_collection_from_all_crawls(self, collection_id: uuid.UUID):
+        """Remove collection id from all crawls it's currently in."""
+        result = await self.crawls.update_many(
+            {"collections": collection_id},
+            {"$pull": {"collections": collection_id}},
+        )
+        if result.modified_count < 1:
+            raise HTTPException(status_code=404, detail="crawls_not_found")
 
     async def get_crawls_in_collection(self, collection_id: uuid.UUID):
         """Get list of ids for crawls in a given collection."""

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -166,6 +166,11 @@ class ListCrawlOut(BaseMongoModel):
 
     collections: Optional[List[UUID4]] = []
 
+
+# ============================================================================
+class ListCrawlOutWithResources(ListCrawlOut):
+    """Crawl output model used internally with files and resources."""
+
     files: Optional[List[CrawlFile]] = []
     resources: Optional[List[CrawlFileOut]] = []
 
@@ -342,9 +347,13 @@ class CrawlOps:
         except (IndexError, ValueError):
             total = 0
 
+        cls = ListCrawlOut
+        if resources:
+            cls = ListCrawlOutWithResources
+
         crawls = []
         for result in items:
-            crawl = ListCrawlOut.from_dict(result)
+            crawl = cls.from_dict(result)
             crawl = await self._resolve_crawl_refs(
                 crawl, org, add_first_seed=False, resources=resources
             )
@@ -434,9 +443,6 @@ class CrawlOps:
             crawl.resources = await self._resolve_signed_urls(
                 crawl.files, org, crawl.id
             )
-
-        if crawl.files:
-            crawl.files = None
 
         return crawl
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -886,7 +886,7 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
-        collections=crawlconfig.colls,
+        collections=crawlconfig.autoAddCollections,
     )
 
     try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -113,9 +113,6 @@ class Crawl(CrawlConfigCore):
 
     collections: Optional[List[UUID4]] = []
 
-    # Auto-added collections tracked here until crawl successfully finishes
-    autoAddCollections: Optional[List[UUID4]] = []
-
 
 # ============================================================================
 class CrawlOut(Crawl):
@@ -895,7 +892,6 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
-        autoAddCollections=crawlconfig.autoAddCollections,
     )
 
     try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -113,6 +113,9 @@ class Crawl(CrawlConfigCore):
 
     collections: Optional[List[UUID4]] = []
 
+    # Auto-added collections tracked here until crawl successfully finishes
+    autoAddCollections: Optional[List[UUID4]] = []
+
 
 # ============================================================================
 class CrawlOut(Crawl):
@@ -238,7 +241,7 @@ class CrawlOps:
         resources: bool = False,
     ):
         """List all finished crawls from the db"""
-        # pylint: disable=too-many-locals,too-many-branches
+        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         # Zero-index page for query
         page = page - 1
         skip = page * page_size
@@ -892,7 +895,7 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
-        collections=crawlconfig.autoAddCollections,
+        autoAddCollections=crawlconfig.autoAddCollections,
     )
 
     try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -834,7 +834,7 @@ class CrawlOps:
         for crawl_id in crawl_ids:
             crawl_raw = await self.get_crawl_raw(crawl_id, org)
             crawl_collections = crawl_raw.get("collections")
-            if collections and crawl_id in crawl_collections:
+            if crawl_collections and crawl_id in crawl_collections:
                 raise HTTPException(
                     status_code=400, detail="crawl_already_in_collection"
                 )

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -13,7 +13,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0006"
+CURR_DB_VERSION = "0007"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
+++ b/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
@@ -36,6 +36,9 @@ class Migration(BaseMigration):
             except Exception as err:
                 print(f"Unable to update workflow {config_id}: {err}", flush=True)
 
+        # Make sure crawls have collections array
+        await crawls.update_many({"collections": None}, {"$set": {"collections": []}})
+
         # Rename colls to autoAddCollections
         await crawl_configs.update_many({}, {"$unset": {"autoAddCollections": 1}})
         await crawl_configs.update_many(

--- a/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
+++ b/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
@@ -37,5 +37,8 @@ class Migration(BaseMigration):
                 print(f"Unable to update workflow {config_id}: {err}", flush=True)
 
         # Rename colls to autoAddCollections
-        await crawl_configs.update_many({}, {"$set": {"autoAddCollections": "$colls"}})
+        await crawl_configs.update_many({}, {"$unset": {"autoAddCollections": 1}})
+        await crawl_configs.update_many(
+            {}, {"$rename": {"colls": "autoAddCollections"}}
+        )
         await crawl_configs.update_many({}, {"$unset": {"colls": 1}})

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -507,6 +507,12 @@ class BtrixOperator(K8sAPI):
         if crawl:
             await self.inc_crawl_complete_stats(crawl, finished)
 
+        kwargs = {"state": state, "finished": finished}
+        if stats:
+            kwargs["stats"] = stats
+
+        await update_crawl(self.crawls, crawl_id, **kwargs)
+
         asyncio.create_task(
             self.do_crawl_finished_tasks(redis, crawl_id, cid, state, stats, finished)
         )
@@ -518,12 +524,6 @@ class BtrixOperator(K8sAPI):
         self, redis, crawl_id, cid, state, stats, finished
     ):
         """Run tasks after crawl completes in asyncio.task coroutine."""
-        kwargs = {"state": state, "finished": finished}
-        if stats:
-            kwargs["stats"] = stats
-
-        await update_crawl(self.crawls, crawl_id, **kwargs)
-
         await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
 
         if redis:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -514,14 +514,14 @@ class BtrixOperator(K8sAPI):
         await update_crawl(self.crawls, crawl_id, **kwargs)
 
         asyncio.create_task(
-            self.do_crawl_finished_tasks(redis, crawl_id, cid, state, stats, finished)
+            self.do_crawl_finished_tasks(redis, crawl_id, cid, state)
         )
 
         return status
 
     # pylint: disable=too-many-arguments
     async def do_crawl_finished_tasks(
-        self, redis, crawl_id, cid, state, stats, finished
+        self, redis, crawl_id, cid, state
     ):
         """Run tasks after crawl completes in asyncio.task coroutine."""
         await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -20,8 +20,7 @@ from .k8sapi import K8sAPI
 from .db import init_db
 from .orgs import inc_org_stats
 from .colls import (
-    add_successful_crawl_to_auto_add_collections,
-    remove_failed_crawl_from_collections,
+    add_successful_crawl_to_collections,
     update_crawl_collections,
 )
 from .crawlconfigs import update_config_crawl_stats
@@ -534,12 +533,9 @@ class BtrixOperator(K8sAPI):
             await self.add_crawl_errors_to_db(redis, crawl_id)
 
         if state in SUCCESSFUL_STATES:
-            await add_successful_crawl_to_auto_add_collections(
-                self.crawls, self.crawl_configs, crawl_id, cid
+            await add_successful_crawl_to_collections(
+                self.crawls, self.crawl_configs, self.collections, crawl_id, cid
             )
-            await update_crawl_collections(self.collections, self.crawls, crawl_id)
-        else:
-            await remove_failed_crawl_from_collections(self.crawls, crawl_id)
 
     async def inc_crawl_complete_stats(self, crawl, finished):
         """Increment Crawl Stats"""

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -19,10 +19,7 @@ from .k8sapi import K8sAPI
 
 from .db import init_db
 from .orgs import inc_org_stats
-from .colls import (
-    add_successful_crawl_to_collections,
-    update_crawl_collections,
-)
+from .colls import add_successful_crawl_to_collections
 from .crawlconfigs import update_config_crawl_stats
 from .crawls import (
     CrawlFile,

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -513,16 +513,12 @@ class BtrixOperator(K8sAPI):
 
         await update_crawl(self.crawls, crawl_id, **kwargs)
 
-        asyncio.create_task(
-            self.do_crawl_finished_tasks(redis, crawl_id, cid, state)
-        )
+        asyncio.create_task(self.do_crawl_finished_tasks(redis, crawl_id, cid, state))
 
         return status
 
     # pylint: disable=too-many-arguments
-    async def do_crawl_finished_tasks(
-        self, redis, crawl_id, cid, state
-    ):
+    async def do_crawl_finished_tasks(self, redis, crawl_id, cid, state):
         """Run tasks after crawl completes in asyncio.task coroutine."""
         await update_config_crawl_stats(self.crawl_configs, self.crawls, cid)
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -534,7 +534,9 @@ class BtrixOperator(K8sAPI):
             await self.add_crawl_errors_to_db(redis, crawl_id)
 
         if state in SUCCESSFUL_STATES:
-            await add_successful_crawl_to_auto_add_collections(self.crawls, crawl_id)
+            await add_successful_crawl_to_auto_add_collections(
+                self.crawls, self.crawl_configs, crawl_id, cid
+            )
             await update_crawl_collections(self.collections, self.crawls, crawl_id)
         else:
             await remove_failed_crawl_from_collections(self.crawls, crawl_id)

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -298,9 +298,9 @@ def auto_add_crawl_id(crawler_auth_headers, default_org_id, auto_add_collection_
         "runNow": True,
         "name": "Auto Add",
         "description": "For testing auto-adding new workflow crawls to collections",
+        "autoAddCollections": [auto_add_collection_id],
         "config": {
             "seeds": [{"url": "https://webrecorder.net/"}],
-            "colls": [auto_add_collection_id],
         },
     }
     r = requests.post(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -205,6 +205,7 @@ def crawler_crawl_id(crawler_auth_headers, default_org_id):
         "runNow": True,
         "name": "Crawler User Test Crawl",
         "description": "crawler test crawl",
+        "tags": ["wr-test-2"],
         "config": {"seeds": [{"url": "https://webrecorder.net/"}], "limit": 1},
     }
     r = requests.post(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -17,6 +17,7 @@ CRAWLER_PW = "crawlerPASSWORD!"
 
 _admin_config_id = None
 _crawler_config_id = None
+_auto_add_config_id = None
 
 NON_DEFAULT_ORG_NAME = "Non-default org"
 
@@ -277,3 +278,54 @@ def sample_crawl_data():
         "config": {"seeds": [{"url": "https://example.com/"}]},
         "tags": ["tag1", "tag2"],
     }
+
+
+@pytest.fixture(scope="session")
+def auto_add_collection_id(crawler_auth_headers, default_org_id):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=crawler_auth_headers,
+        json={"name": "Auto Add Collection"},
+    )
+    assert r.status_code == 200
+    return r.json()["added"]["id"]
+
+
+@pytest.fixture(scope="session")
+def auto_add_crawl_id(crawler_auth_headers, default_org_id, auto_add_collection_id):
+    # Start crawl.
+    crawl_data = {
+        "runNow": True,
+        "name": "Auto Add",
+        "description": "For testing auto-adding new workflow crawls to collections",
+        "config": {
+            "seeds": [{"url": "https://webrecorder.net/"}],
+            "colls": [auto_add_collection_id],
+        },
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
+        headers=crawler_auth_headers,
+        json=crawl_data,
+    )
+    data = r.json()
+
+    global _auto_add_config_id
+    _auto_add_config_id = data["added"]
+
+    crawl_id = data["run_now_job"]
+    # Wait for it to complete and then return crawl ID
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data["state"] == "complete":
+            return crawl_id
+        time.sleep(5)
+
+
+@pytest.fixture(scope="session")
+def auto_add_config_id(auto_add_crawl_id):
+    return _auto_add_config_id

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -83,7 +83,8 @@ def test_update_collection(
     assert data["id"] == _coll_id
     assert data["name"] == COLLECTION_NAME
     assert data["description"] == DESCRIPTION
-    assert data["crawlCount"] >= 0
+    assert data["crawlCount"] == 1
+    assert data["pageCount"] > 0
     global modified
     modified = data["modified"]
     assert modified
@@ -146,7 +147,9 @@ def test_add_remove_crawl_from_collection(
     data = r.json()
     assert data["id"] == _coll_id
     assert data["crawlCount"] == 2
+    assert data["pageCount"] > 0
     assert data["modified"] >= modified
+    assert data["tags"] == ["wr-test-2", "wr-test-1"]
 
     # Verify it was added
     r = requests.get(
@@ -165,7 +168,9 @@ def test_add_remove_crawl_from_collection(
     data = r.json()
     assert data["id"] == _coll_id
     assert data["crawlCount"] == 0
+    assert data["pageCount"] == 0
     assert data["modified"] >= modified
+    assert data.get("tags", []) == []
 
     # Verify they were removed
     r = requests.get(
@@ -190,7 +195,9 @@ def test_add_remove_crawl_from_collection(
     data = r.json()
     assert data["id"] == _coll_id
     assert data["crawlCount"] == 2
+    assert data["pageCount"] > 0
     assert data["modified"] >= modified
+    assert data["tags"] == ["wr-test-2", "wr-test-1"]
 
 
 def test_get_collection(crawler_auth_headers, default_org_id):
@@ -205,7 +212,9 @@ def test_get_collection(crawler_auth_headers, default_org_id):
     assert data["oid"] == default_org_id
     assert data["description"] == DESCRIPTION
     assert data["crawlCount"] == 2
+    assert data["pageCount"] > 0
     assert data["modified"] >= modified
+    assert data["tags"] == ["wr-test-2", "wr-test-1"]
 
 
 def test_get_collection_replay(
@@ -222,7 +231,9 @@ def test_get_collection_replay(
     assert data["oid"] == default_org_id
     assert data["description"] == DESCRIPTION
     assert data["crawlCount"] == 2
+    assert data["pageCount"] > 0
     assert data["modified"] >= modified
+    assert data["tags"] == ["wr-test-2", "wr-test-1"]
 
     resources = data["resources"]
     assert resources
@@ -251,7 +262,9 @@ def test_list_collections(
     assert first_coll["oid"] == default_org_id
     assert first_coll["description"] == DESCRIPTION
     assert first_coll["crawlCount"] == 2
+    assert first_coll["pageCount"] > 0
     assert first_coll["modified"]
+    assert first_coll["tags"] == ["wr-test-2", "wr-test-1"]
 
     second_coll = [coll for coll in items if coll["name"] == SECOND_COLLECTION_NAME][0]
     assert second_coll["id"]
@@ -259,23 +272,9 @@ def test_list_collections(
     assert second_coll["oid"] == default_org_id
     assert second_coll.get("description") is None
     assert second_coll["crawlCount"] == 1
+    assert second_coll["pageCount"] > 0
     assert second_coll["modified"]
-
-
-def test_list_collections_no_crawl_count(
-    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
-):
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections?crawlCount=False",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    data = r.json()
-    assert data["total"] == 2
-    items = data["items"]
-    assert len(items) == 2
-    for coll in items:
-        assert coll.get("crawlCount") is None
+    assert second_coll["tags"] == ["wr-test-2"]
 
 
 def test_filter_sort_collections(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -199,15 +199,22 @@ def test_get_collection(crawler_auth_headers, default_org_id):
     assert data["modified"] >= modified
 
 
-def test_get_collection_crawl_resources(
+def test_get_collection_replay(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/crawl-resources",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/replay.json",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
+    assert data["id"] == _coll_id
+    assert data["name"] == UPDATED_NAME
+    assert data["oid"] == default_org_id
+    assert data["description"] == DESCRIPTION
+    assert data["crawlCount"] == 2
+    assert data["modified"] >= modified
+
     resources = data["resources"]
     assert resources
     for resource in resources:

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -28,6 +28,13 @@ def test_create_collection(
     global _coll_id
     _coll_id = data["added"]["id"]
 
+    # Verify crawl in collection
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert _coll_id in r.json()["collections"]
+
 
 def test_create_collection_taken_name(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
@@ -65,7 +72,6 @@ def test_update_collection(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/update",
         headers=crawler_auth_headers,
         json={
-            "crawlIds": [crawler_crawl_id, admin_crawl_id],
             "description": DESCRIPTION,
         },
     )
@@ -74,7 +80,6 @@ def test_update_collection(
     assert data["id"] == _coll_id
     assert data["name"] == COLLECTION_NAME
     assert data["description"] == DESCRIPTION
-    assert sorted(data["crawlIds"]) == sorted([admin_crawl_id, crawler_crawl_id])
 
 
 def test_rename_collection(
@@ -117,37 +122,66 @@ def test_rename_collection_taken_name(
     assert r.json()["detail"] == "collection_name_taken"
 
 
-def test_remove_crawl_from_collection(
+def test_add_remove_crawl_from_collection(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
 ):
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/remove?crawlId={admin_crawl_id}",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlIds"] == [crawler_crawl_id]
-
-
-def test_add_crawl_to_collection(
-    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
-):
+    # Add crawl
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/add?crawlId={admin_crawl_id}",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
+    assert r.json()["success"]
+
+    # Verify it was added
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert _coll_id in r.json()["collections"]
+
+    # Remove crawl
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/remove?crawlId={admin_crawl_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+    # Verify it was removed
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert _coll_id not in r.json()["collections"]
+
+    # Add crawl back for further tests
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/add?crawlId={admin_crawl_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+
+def test_get_collection(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
     data = r.json()
     assert data["id"] == _coll_id
-    assert sorted(data["crawlIds"]) == sorted([admin_crawl_id, crawler_crawl_id])
+    assert data["name"] == UPDATED_NAME
+    assert data["oid"] == default_org_id
+    assert data["description"] == DESCRIPTION
 
 
-def test_get_collection(
+def test_get_collection_crawl_resources(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/crawl-resources",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -158,7 +192,6 @@ def test_get_collection(
         assert resource["name"]
         assert resource["path"]
         assert resource["size"]
-        assert resource["crawlId"] in (crawler_crawl_id, admin_crawl_id)
 
 
 def test_list_collections(
@@ -179,14 +212,12 @@ def test_list_collections(
     assert first_coll["name"] == UPDATED_NAME
     assert first_coll["oid"] == default_org_id
     assert first_coll["description"] == DESCRIPTION
-    assert sorted(first_coll["crawlIds"]) == sorted([crawler_crawl_id, admin_crawl_id])
 
     second_coll = [coll for coll in items if coll["name"] == SECOND_COLLECTION_NAME][0]
     assert second_coll["id"]
     assert second_coll["name"] == SECOND_COLLECTION_NAME
     assert second_coll["oid"] == default_org_id
     assert second_coll.get("description") is None
-    assert second_coll["crawlIds"] == [crawler_crawl_id]
 
 
 def test_filter_sort_collections(
@@ -209,7 +240,6 @@ def test_filter_sort_collections(
     assert coll["name"] == SECOND_COLLECTION_NAME
     assert coll["oid"] == default_org_id
     assert coll.get("description") is None
-    assert coll["crawlIds"] == [crawler_crawl_id]
 
     # Test sorting by name, ascending (default)
     r = requests.get(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -179,6 +179,7 @@ def test_get_collection(crawler_auth_headers, default_org_id):
     assert data["name"] == UPDATED_NAME
     assert data["oid"] == default_org_id
     assert data["description"] == DESCRIPTION
+    assert data["crawlCount"] == 2
 
 
 def test_get_collection_crawl_resources(
@@ -216,12 +217,30 @@ def test_list_collections(
     assert first_coll["name"] == UPDATED_NAME
     assert first_coll["oid"] == default_org_id
     assert first_coll["description"] == DESCRIPTION
+    assert first_coll["crawlCount"] == 2
 
     second_coll = [coll for coll in items if coll["name"] == SECOND_COLLECTION_NAME][0]
     assert second_coll["id"]
     assert second_coll["name"] == SECOND_COLLECTION_NAME
     assert second_coll["oid"] == default_org_id
     assert second_coll.get("description") is None
+    assert second_coll["crawlCount"] == 1
+
+
+def test_list_collections_no_crawl_count(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?crawlCount=False",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+    items = data["items"]
+    assert len(items) == 2
+    for coll in items:
+        assert coll.get("crawlCount") is None
 
 
 def test_filter_sort_collections(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -175,17 +175,23 @@ def test_get_crawls_by_description(
         assert crawl["description"] == description
 
 
-def test_get_crawls_by_collection_name(
+def test_get_crawls_by_collection_id(
     crawler_auth_headers, default_org_id, crawler_crawl_id
 ):
     encoded_collection = urllib.parse.quote(COLLECTION_NAME)
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls?collection={encoded_collection}",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?name={encoded_collection}",
+        headers=crawler_auth_headers,
+    )
+    collection_id = r.json()["items"][0]["id"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?collectionId={collection_id}",
         headers=crawler_auth_headers,
     )
     assert r.json()["total"] >= 1
     for crawl in r.json()["items"]:
-        assert COLLECTION_NAME in crawl["collections"]
+        assert collection_id in crawl["collections"]
 
 
 def test_sort_crawls(

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -206,18 +206,6 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
 def test_delete_crawls_crawler(
     crawler_auth_headers, default_org_id, admin_crawl_id, crawler_crawl_id
 ):
-    # Test that crawl is in collection before deleting
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    data = r.json()
-    collection = [coll for coll in data["items"] if coll["name"] == COLLECTION_NAME][0]
-    crawl_ids = collection["crawlIds"]
-    assert admin_crawl_id in crawl_ids
-    assert crawler_crawl_id in crawl_ids
-
     # Test that crawler user can't delete another user's crawls
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/delete",
@@ -237,18 +225,6 @@ def test_delete_crawls_crawler(
     assert r.status_code == 200
     data = r.json()
     assert data["deleted"] == 1
-
-    # Test that crawl is no longer in collection
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    data = r.json()
-    collection = [coll for coll in data["items"] if coll["name"] == COLLECTION_NAME][0]
-    crawl_ids = collection["crawlIds"]
-    assert admin_crawl_id in crawl_ids
-    assert crawler_crawl_id not in crawl_ids
 
     # Test that crawl is not found after deleting
     r = requests.get(

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -19,7 +19,7 @@ def test_workflow_crawl_auto_added_to_collection(
     assert auto_add_collection_id in r.json()["collections"]
 
 
-def test_workflow_crawl_auto_added_to_collection(
+def test_workflow_crawl_auto_added_subsequent_runs(
     crawler_auth_headers,
     default_org_id,
     auto_add_collection_id,

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -1,0 +1,54 @@
+import requests
+import time
+
+from .conftest import API_PREFIX
+
+
+def test_workflow_crawl_auto_added_to_collection(
+    crawler_auth_headers,
+    default_org_id,
+    auto_add_collection_id,
+    auto_add_crawl_id,
+):
+    # Verify that crawl is in collection
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{auto_add_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert auto_add_collection_id in r.json()["collections"]
+
+
+def test_workflow_crawl_auto_added_to_collection(
+    crawler_auth_headers,
+    default_org_id,
+    auto_add_collection_id,
+    auto_add_crawl_id,
+    auto_add_config_id,
+):
+    # Run workflow again and make sure new crawl is also in collection
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{auto_add_config_id}/run",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("started")
+    crawl_id = data["started"]
+
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data["state"] == "complete":
+            break
+        time.sleep(5)
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert auto_add_collection_id in r.json()["collections"]


### PR DESCRIPTION
Fixes #870 
Fixes #869 
Fixes #853 
Fixes #862
Fixes #849

- Track collection ids in Crawl model rather than other way around
- Add modified field to Collection model and update it when collection changes
- Add collection delete API endpoint
- Rework existing methods to reflect changes to collection crawl tracking
- Auto-add workflow crawls to collection with `CrawlConfig.autoAddCollection` field
- Pre-compute collection stats (crawlCount, pageCount, tags)
- Migration to rename `CrawlConfig.colls` to `CrawlConfig.autoAddCollections` and pre-compute workflow stats to populate `crawlSuccessfulCount`

Changes:
- Can no longer change crawls in collection via collection update method (name and description only)
- `/collection/{coll_id}/add` and `/remove` are now POSTs that accept a list of `crawlIds`
- Collection filter on crawls list is now collection_id, not collection_name
- GET `/orgs/{oid}/collections/{coll_id}` now returns collection metadata
- GET `/orgs/{oid}/collections/{coll_id}/replay.json` added for replay

NOTE: This is a BREAKING CHANGE. Collections created previously on development instances will need to be removed entirely. Since no collection features have been deployed in production yet we may not need a migration but @ikreymer that is something to consider.