### PR TITLE
Auto-add workflow crawls to collections

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -111,7 +111,7 @@ class CrawlConfigIn(BaseModel):
 
     profileid: Optional[str]
 
-    colls: Optional[List[UUID4]] = []
+    autoAddCollections: Optional[List[UUID4]] = []
     tags: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
@@ -173,7 +173,7 @@ class CrawlConfig(CrawlConfigCore):
     modified: Optional[datetime]
     modifiedBy: Optional[UUID4]
 
-    colls: Optional[List[UUID4]] = []
+    autoAddCollections: Optional[List[UUID4]] = []
 
     inactive: Optional[bool] = False
 
@@ -334,8 +334,8 @@ class CrawlConfigOps:
             config.profileid, org
         )
 
-        if config.colls:
-            data["colls"] = config.colls
+        if config.autoAddCollections:
+            data["autoAddCollections"] = config.autoAddCollections
 
         result = await self.crawl_configs.insert_one(data)
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -111,7 +111,7 @@ class CrawlConfigIn(BaseModel):
 
     profileid: Optional[str]
 
-    colls: Optional[List[str]] = []
+    colls: Optional[List[UUID4]] = []
     tags: Optional[List[str]] = []
 
     crawlTimeout: Optional[int] = 0
@@ -173,7 +173,7 @@ class CrawlConfig(CrawlConfigCore):
     modified: Optional[datetime]
     modifiedBy: Optional[UUID4]
 
-    colls: Optional[List[str]] = []
+    colls: Optional[List[UUID4]] = []
 
     inactive: Optional[bool] = False
 
@@ -335,7 +335,7 @@ class CrawlConfigOps:
         )
 
         if config.colls:
-            data["colls"] = await self.coll_ops.find_collections(org.id, config.colls)
+            data["colls"] = config.colls
 
         result = await self.crawl_configs.insert_one(data)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -868,7 +868,7 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
-        collections=crawlconfig.colls,
+        collections=crawlconfig.autoAddCollections,
     )
 
     try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -868,6 +868,7 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
+        collections=crawlconfig.colls,
     )
 
     try:

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -13,7 +13,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0006"
+CURR_DB_VERSION = "0007"
 
 
 # ============================================================================

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -297,9 +297,9 @@ def auto_add_crawl_id(crawler_auth_headers, default_org_id, auto_add_collection_
         "runNow": True,
         "name": "Auto Add",
         "description": "For testing auto-adding new workflow crawls to collections",
+        "autoAddCollections": [auto_add_collection_id],
         "config": {
             "seeds": [{"url": "https://webrecorder.net/"}],
-            "colls": [auto_add_collection_id],
         },
     }
     r = requests.post(

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -19,7 +19,7 @@ def test_workflow_crawl_auto_added_to_collection(
     assert auto_add_collection_id in r.json()["collections"]
 
 
-def test_workflow_crawl_auto_added_to_collection(
+def test_workflow_crawl_auto_added_subsequent_runs(
     crawler_auth_headers,
     default_org_id,
     auto_add_collection_id,

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -1,0 +1,54 @@
+import requests
+import time
+
+from .conftest import API_PREFIX
+
+
+def test_workflow_crawl_auto_added_to_collection(
+    crawler_auth_headers,
+    default_org_id,
+    auto_add_collection_id,
+    auto_add_crawl_id,
+):
+    # Verify that crawl is in collection
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{auto_add_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert auto_add_collection_id in r.json()["collections"]
+
+
+def test_workflow_crawl_auto_added_to_collection(
+    crawler_auth_headers,
+    default_org_id,
+    auto_add_collection_id,
+    auto_add_crawl_id,
+    auto_add_config_id,
+):
+    # Run workflow again and make sure new crawl is also in collection
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{auto_add_config_id}/run",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("started")
+    crawl_id = data["started"]
+
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data["state"] == "complete":
+            break
+        time.sleep(5)
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert auto_add_collection_id in r.json()["collections"]


### PR DESCRIPTION
Fixes #849 

Rebase on main once #878 is merged

Crawls created by a workflow are automatically added to collections specified in `CrawlConfig.autoAddCollections`.