### PR TITLE
Use helm tpl to include diskUtilization value in crawler_args

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -71,7 +71,7 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  CRAWL_ARGS: "{{ .Values.crawler_args }} --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }}"
+  CRAWL_ARGS: "--workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --waitOnDone --collection thecrawl --screencastPort 9037"
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,7 +25,13 @@ default_page_load_time_seconds: 120
 # this percentage of total, crawls will gracefully stop to prevent the
 # disk from being filled
 # This should be a string so that it can be included in crawler_args
-disk_utilization_threshold: "90"
+disk_utilization_threshold: 90
+
+# crawler logging flags
+crawler_logging_opts: "stats,behaviors,debug"
+
+# to enable, set to a value other than 'false'
+crawler_extract_full_text: false
 
 # max pages per crawl
 # set to non-zero value to enforce global max pages per crawl limit
@@ -162,9 +168,6 @@ crawler_namespace: "crawlers"
 
 # num retries
 crawl_retries: 1000
-
-# browsertrix-crawler args:
-crawler_args: "--logging stats,behaviors,debug --generateWACZ --text --collection thecrawl --screencastPort 9037 --logErrorsToRedis --diskUtilization {{ tpl .Values.disk_utilization_threshold . }} --waitOnDone"
 
 crawler_browser_instances: 2
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,7 +24,8 @@ default_page_load_time_seconds: 120
 # disk utilization threshold percentage - when used disk space passes
 # this percentage of total, crawls will gracefully stop to prevent the
 # disk from being filled
-disk_utilization_threshold: 90
+# This should be a string so that it can be included in crawler_args
+disk_utilization_threshold: "90"
 
 # max pages per crawl
 # set to non-zero value to enforce global max pages per crawl limit
@@ -163,7 +164,7 @@ crawler_namespace: "crawlers"
 crawl_retries: 1000
 
 # browsertrix-crawler args:
-crawler_args: "--logging stats,behaviors,debug --generateWACZ --text --collection thecrawl --screencastPort 9037 --logErrorsToRedis --diskUtilization {{ .Values.disk_utilization_threshold | default 90 }} --waitOnDone"
+crawler_args: "--logging stats,behaviors,debug --generateWACZ --text --collection thecrawl --screencastPort 9037 --logErrorsToRedis --diskUtilization {{ tpl .Values.disk_utilization_threshold . }} --waitOnDone"
 
 crawler_browser_instances: 2
 


### PR DESCRIPTION
Related to #787 , where @anjackson pointed out that the way we were including `disk_utilization_threshold` in `crawler_args` wasn't working as intended.

For further reference, see: https://itnext.io/reference-other-values-in-helm-chart-values-file-19d44d9276c7