### PR TITLE
Optimize workflow statistics updates

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1045,7 +1045,14 @@ async def stats_recompute_last(
 
     result = await crawl_configs.find_one_and_update(
         {"_id": cid, "inactive": {"$ne": True}},
-        {"$set": update_query, "$inc": {"totalSize": size, "crawlCount": inc_crawls}},
+        {
+            "$set": update_query,
+            "$inc": {
+                "totalSize": size,
+                "crawlCount": inc_crawls,
+                "crawlSuccessfulCount": inc_crawls,
+            },
+        },
     )
 
     return result

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -880,13 +880,16 @@ async def add_new_crawl(
 
 
 # ============================================================================
-async def update_crawl(crawls, crawl_id, **kwargs):
-    """update crawl state in db"""
-    return await crawls.find_one_and_update(
-        {"_id": crawl_id},
+async def update_crawl_state_if_changed(crawls, crawl_id, state, **kwargs):
+    """update crawl state and other properties in db if state has changed"""
+    kwargs["state"] = state
+    res = await crawls.find_one_and_update(
+        {"_id": crawl_id, "state": {"$ne": state}},
         {"$set": kwargs},
         return_document=pymongo.ReturnDocument.AFTER,
     )
+    print("** UPDATE", crawl_id, state, res is not None)
+    return res
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
+++ b/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
@@ -1,7 +1,7 @@
 """
 Migration 0006 - Precomputing workflow crawl stats
 """
-from btrixcloud.crawlconfigs import update_config_crawl_stats
+from btrixcloud.crawlconfigs import stats_recompute_all
 from btrixcloud.migrations import BaseMigration
 
 
@@ -31,7 +31,7 @@ class Migration(BaseMigration):
         for config in configs:
             config_id = config["_id"]
             try:
-                await update_config_crawl_stats(crawl_configs, crawls, config_id)
+                await stats_recompute_all(crawl_configs, crawls, config_id)
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(f"Unable to update workflow {config_id}: {err}", flush=True)

--- a/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
+++ b/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
@@ -4,7 +4,7 @@ Migration 0007 - Workflows changes
 - Rename colls to autoAddCollections 
 - Re-calculate workflow crawl stats to populate crawlSuccessfulCount
 """
-from btrixcloud.crawlconfigs import update_config_crawl_stats
+from btrixcloud.crawlconfigs import stats_recompute_all
 from btrixcloud.migrations import BaseMigration
 
 
@@ -31,7 +31,7 @@ class Migration(BaseMigration):
         for config in configs:
             config_id = config["_id"]
             try:
-                await update_config_crawl_stats(crawl_configs, crawls, config_id)
+                await stats_recompute_all(crawl_configs, crawls, config_id)
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(f"Unable to update workflow {config_id}: {err}", flush=True)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -20,7 +20,7 @@ from .k8sapi import K8sAPI
 from .db import init_db
 from .orgs import inc_org_stats
 from .colls import add_successful_crawl_to_collections
-from .crawlconfigs import update_config_crawl_stats
+from .crawlconfigs import stats_recompute_last
 from .crawls import (
     CrawlFile,
     CrawlCompleteIn,
@@ -505,6 +505,12 @@ class BtrixOperator(K8sAPI):
         self, redis, crawl_id, cid, status, state, crawl=None, stats=None
     ):
         """mark crawl as finished, set finished timestamp and final state"""
+
+        # already marked as finished
+        if status.state == state:
+            print("already finished, ignoring mark_finished")
+            return status
+
         finished = dt_now()
 
         status.state = state

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -85,7 +85,7 @@ class CrawlSpec(BaseModel):
 class CrawlStatus(BaseModel):
     """status from k8s CrawlJob object"""
 
-    state: str = "new"
+    state: str = "starting"
     pagesFound: int = 0
     pagesDone: int = 0
     size: str = ""
@@ -202,8 +202,6 @@ class BtrixOperator(K8sAPI):
         if has_crawl_children:
             pods = data.related[POD]
             status = await self.sync_crawl_state(redis_url, crawl, status, pods)
-        elif not status.finished:
-            status.state = "starting"
 
         if status.finished:
             return await self.handle_finished_delete_if_needed(crawl_id, status, spec)

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -1,3 +1,5 @@
+import time
+
 import requests
 
 from .conftest import API_PREFIX
@@ -9,6 +11,7 @@ UPDATED_DESCRIPTION = "Updated description"
 UPDATED_TAGS = ["tag3", "tag4"]
 
 _coll_id = None
+_admin_crawl_cid = None
 
 
 def test_add_crawl_config(crawler_auth_headers, default_org_id, sample_crawl_data):
@@ -231,8 +234,6 @@ def test_verify_revs_history(crawler_auth_headers, default_org_id):
 def test_workflow_total_size_and_last_crawl_stats(
     crawler_auth_headers, default_org_id, admin_crawl_id, crawler_crawl_id
 ):
-    admin_crawl_cid = ""
-
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs",
         headers=crawler_auth_headers,
@@ -257,13 +258,14 @@ def test_workflow_total_size_and_last_crawl_stats(
             assert workflow["lastCrawlSize"] > 0
 
             if last_crawl_id == admin_crawl_id:
-                admin_crawl_cid = workflow["id"]
-                assert admin_crawl_cid
+                global _admin_crawl_cid
+                _admin_crawl_cid = workflow["id"]
+                assert _admin_crawl_cid
         else:
             assert workflow["totalSize"] == 0
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{admin_crawl_cid}",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{_admin_crawl_cid}",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -279,3 +281,87 @@ def test_workflow_total_size_and_last_crawl_stats(
     assert data["lastCrawlState"]
     assert data["lastRun"]
     assert data["lastCrawlSize"] > 0
+
+
+def test_incremental_workflow_total_size_and_last_crawl_stats(
+    crawler_auth_headers, default_org_id, admin_crawl_id, crawler_crawl_id
+):
+    # Get baseline values
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{_admin_crawl_cid}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["crawlCount"] == 1
+    assert data["crawlSuccessfulCount"] == 1
+    total_size = data["totalSize"]
+    last_crawl_id = data["lastCrawlId"]
+    last_crawl_started = data["lastCrawlStartTime"]
+    last_crawl_finished = data["lastCrawlTime"]
+    last_run = data["lastRun"]
+
+    # Run new crawl in this workflow
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{_admin_crawl_cid}/run",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawl_id = r.json()["started"]
+
+    # Wait for it to complete
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data["state"] == "complete":
+            break
+        time.sleep(5)
+
+    # Give time for stats to re-compute
+    time.sleep(10)
+
+    # Re-check stats
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{_admin_crawl_cid}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["crawlCount"] == 2
+    assert data["crawlSuccessfulCount"] == 2
+    assert data["totalSize"] > total_size
+    assert data["lastCrawlId"] == crawl_id
+    assert data["lastCrawlStartTime"] > last_crawl_started
+    assert data["lastCrawlTime"] > last_crawl_finished
+    assert data["lastRun"] > last_run
+
+    # Delete new crawl
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/delete",
+        headers=crawler_auth_headers,
+        json={"crawl_ids": [crawl_id]},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["deleted"] == 1
+
+    # Re-check stats
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{_admin_crawl_cid}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["crawlCount"] == 1
+    assert data["crawlSuccessfulCount"] == 1
+    assert data["totalSize"] == total_size
+    assert data["lastCrawlId"] == last_crawl_id
+    assert data["lastCrawlStartTime"] == last_crawl_started
+    assert data["lastCrawlTime"] == last_crawl_finished
+    assert data["lastRun"] == last_run

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -91,7 +91,7 @@ def test_start_crawl_and_stop_immediately(
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] in ("canceled", "partial_complete")
-    assert data["stopping"] == True
+    assert data["stopping"] == False
 
 
 def test_start_crawl_to_stop_partial(
@@ -151,6 +151,6 @@ def test_stop_crawl_partial(
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] == "partial_complete"
-    assert data["stopping"] == True
+    assert data["stopping"] == False
 
     assert len(data["resources"]) == 1

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -91,7 +91,7 @@ def test_start_crawl_and_stop_immediately(
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] in ("canceled", "partial_complete")
-    assert data["stopping"] == False
+    assert data["stopping"] == True
 
 
 def test_start_crawl_to_stop_partial(
@@ -150,7 +150,7 @@ def test_stop_crawl_partial(
     while data["state"] == "running":
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
-    assert data["state"] == "partial_complete"
-    assert data["stopping"] == False
+    assert data["state"] in ("partial_complete", "complete")
+    assert data["stopping"] == True
 
     assert len(data["resources"]) == 1


### PR DESCRIPTION
Fixes #861 

(This resolves it for workflows; for crawls, file count and total size are still being generated dynamically for crawls - I've split addressing that off into its own issue: https://github.com/webrecorder/browsertrix-cloud/issues/893)

This PR optimizes workflow statistics updates in the `CrawlConfig` model by making them incremental when possible (e.g. when a crawl finishes or is deleted) rather than re-computing the stats for all of the crawls in a workflow together.

The last commit also resolves an issue with the asyncio task for post-crawl updates in the operator, by adding a per-crawl lock to ensure that the update only runs once per crawl rather than simultaneously in multiple workers. We may want to keep this commit separate when merging.

Tests have been added for the incremental updates on crawl completion and deletion, which is how the issue with the asyncio task was caught.
