### PR TITLE
frontend: configure running with a fixed 'replay.json', auth headers …

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -217,7 +217,9 @@ class CrawlOps:
 
         self.crawl_configs.set_crawl_ops(self)
 
-        self.presign_duration = int(os.environ.get("PRESIGN_DURATION_SECONDS", 3600))
+        self.presign_duration_seconds = (
+            int(os.environ.get("PRESIGN_DURATION_MINUTES", 60)) * 60
+        )
 
     async def init_index(self):
         """init index for crawls db collection"""
@@ -460,7 +462,7 @@ class CrawlOps:
             print("no files")
             return
 
-        delta = timedelta(seconds=self.presign_duration)
+        delta = timedelta(seconds=self.presign_duration_seconds)
 
         updates = []
         out_files = []
@@ -472,7 +474,7 @@ class CrawlOps:
             if not presigned_url or now >= file_.expireAt:
                 exp = now + delta
                 presigned_url = await get_presigned_url(
-                    org, file_, self.crawl_manager, self.presign_duration
+                    org, file_, self.crawl_manager, self.presign_duration_seconds
                 )
                 updates.append(
                     (

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -62,6 +62,8 @@ data:
 
   RERUN_LAST_MIGRATION: "{{ .Values.rerun_last_migration }}"
 
+  PRESIGN_DURATION_MINUTES: "{{ .Values.storage_presign_duration_minutes | default 60 }}"
+
 
 ---
 apiVersion: v1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,4 @@
 # syntax=docker/dockerfile:1.4
-# central place to configure the production replayweb.page loading prefix
-ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
-
 FROM docker.io/library/node:16 as build_deps
 
 WORKDIR /app
@@ -30,10 +27,12 @@ COPY --link src ./src/
 ARG GIT_COMMIT_HASH
 ARG GIT_BRANCH_NAME
 ARG VERSION
+ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
 
 ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
     GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
-    VERSION=${VERSION}
+    VERSION=${VERSION} \
+    RWP_BASE_URL=${RWP_BASE_URL}
 
 # Prevent Docker caching node_modules
 RUN yarn build && \

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -571,11 +571,12 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderReplay() {
-    const bearer = this.authState?.headers?.Authorization?.split(" ", 2)[1];
+    //const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json?auth_bearer=${bearer}`;
+    const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json`;
 
-    // for now, just use the first file until multi-wacz support is fully implemented
-    const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json?auth_bearer=${bearer}`;
-    //const replaySource = this.crawl?.resources?.[0]?.path;
+    const headers = this.authState?.headers;
+
+    const config = JSON.stringify({headers});
 
     const canReplay = replaySource && this.hasFiles;
 
@@ -587,6 +588,7 @@ export class CrawlDetail extends LiteElement {
               <replay-web-page
                 source="${replaySource}"
                 coll="${ifDefined(this.crawl?.id)}"
+                config="${config}"
                 replayBase="/replay/"
                 noSandbox="true"
                 noCache="true"


### PR DESCRIPTION
…passed via separate config

wabac.js will reload the replay.json on 403 with new token (will be in next version of wabac.js) presign urls: make presign timeout configurable (in minutes), defaults to 60 mins dockerfile: fix configuring RWP_BASE_URL