### PR TITLE
Fix ResizeObserver loop error

### DIFF
--- a/frontend/src/components/combobox.ts
+++ b/frontend/src/components/combobox.ts
@@ -76,7 +76,6 @@ export class Combobox extends LitElement {
       <sl-popup
         placement="bottom-start"
         shift
-        sync="width"
         strategy="fixed"
         ?active=${this.isActive}
         @keydown=${this.onKeydown}
@@ -147,6 +146,16 @@ export class Combobox extends LitElement {
   private async openDropdown() {
     this.isActive = true;
     await this.combobox?.updateComplete;
+
+    // Manually sync dropdown width instead of using `sync="width"`
+    // to get around ResizeObserver loop error
+    if (this.anchor?.length && this.dropdown) {
+      const anchorWidth = this.anchor[0].clientWidth;
+      if (anchorWidth) {
+        this.dropdown.style.width = `${anchorWidth}px`;
+      }
+    }
+
     this.dropdown?.classList.add("animateShow");
     this.dropdown?.classList.remove("hidden");
   }

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -294,7 +294,7 @@ export class CrawlsList extends LiteElement {
           <div class="text-neutral-500 mx-2">${msg("View:")}</div>
           <sl-select
             id="stateSelect"
-            class="flex-1 md:min-w-[14.5rem]"
+            class="flex-1 md:w-[14.5rem]"
             size="small"
             pill
             multiple
@@ -321,7 +321,7 @@ export class CrawlsList extends LiteElement {
           </div>
           <div class="grow flex">
             <sl-select
-              class="flex-1 md:min-w-[9.2rem]"
+              class="flex-1 md:w-[9.2rem]"
               size="small"
               pill
               value=${this.orderBy.field}


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/901

### Changes

Adds width to crawls list controls to [fix an infinite resize loop](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors) and manually resizes `btrix-combobox` dropdown width to get around the same infinite loop issue. `ResizeObserver` is used by Shoelace under the hood, so it's possible that we could revert these changes if the issues are fixed in the library.