### PR TITLE
fix finished workflows incorrectly being displayed as running

### DIFF
--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -305,6 +305,15 @@ export class WorkflowListItem extends LitElement {
         </div>
         <div class="desc duration">
           ${this.safeRender((workflow) => {
+            if (workflow.lastCrawlTime && workflow.lastCrawlStartTime) {
+              return msg(
+                str`Finished in ${RelativeDuration.humanize(
+                  new Date(`${workflow.lastCrawlTime}Z`).valueOf() -
+                    new Date(`${workflow.lastCrawlStartTime}Z`).valueOf(),
+                  { compact: true }
+                )}`
+              );
+            }
             if (workflow.lastCrawlStartTime) {
               const diff =
                 new Date().valueOf() -
@@ -316,15 +325,6 @@ export class WorkflowListItem extends LitElement {
                 str`Running for ${RelativeDuration.humanize(diff, {
                   compact: true,
                 })}`
-              );
-            }
-            if (workflow.lastCrawlTime) {
-              return msg(
-                str`Finished in ${RelativeDuration.humanize(
-                  new Date(`${workflow.lastCrawlTime}Z`).valueOf() -
-                    new Date(`${workflow.lastCrawlStartTime}Z`).valueOf(),
-                  { compact: true }
-                )}`
               );
             }
             return notSpecified;


### PR DESCRIPTION
Due to an ordering bug in the logic from when curr* fields were removed, finished workflows are displayed as running:
<img width="1158" alt="Screen Shot 2023-06-06 at 6 14 00 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/973a2178-f464-4b96-b94f-067746607e7b">

This fixes it so that correct info is displayed:
<img width="1172" alt="Screen Shot 2023-06-06 at 6 17 09 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/86f6f2d6-2907-4ada-a9ff-b0176f161971">

