### PR TITLE
Fix Extra URLs in Scope

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -422,13 +422,13 @@ export class CrawlConfigEditor extends LiteElement {
         formState.primarySeedUrl = primarySeedConfig.url;
       }
       if (
-        primarySeedConfig.scopeType === "custom" &&
         primarySeedConfig.include?.length
       ) {
         formState.customIncludeUrlList = primarySeedConfig.include
           // Unescape regex
           .map((url) => url.replace(/(\\|\/\.\*)/g, ""))
           .join("\n");
+        formState.scopeType = "custom";
       }
       const additionalSeeds = seeds.slice(1);
       if (additionalSeeds.length) {
@@ -1044,7 +1044,7 @@ https://example.com/path`}
         msg(`Tells the crawler which pages it can visit.`)
       )}
       ${when(
-        ["host", "domain", "custom", "any"].includes(this.formState.scopeType),
+        ["prefix", "host", "domain", "custom"].includes(this.formState.scopeType),
         () => html`
           ${this.renderFormCol(html`
             <sl-input
@@ -2110,19 +2110,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
       : [];
     const primarySeed: Seed = {
       url: primarySeedUrl,
-      scopeType: this.formState.scopeType,
+      scopeType: this.formState.scopeType === "custom" ? "prefix" : this.formState.scopeType,
       include:
         this.formState.scopeType === "custom"
           ? [
-              `${regexEscape(primarySeedUrl)}\/.*`,
-              ...includeUrlList.map((url) => `${regexEscape(url)}\/.*`),
+              ...includeUrlList.map((url) => regexEscape(url)),
             ]
           : [],
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
     };
 
     if (
-      ["host", "domain", "custom", "any"].includes(this.formState.scopeType)
+      ["prefix", "host", "domain", "custom"].includes(this.formState.scopeType)
     ) {
       primarySeed.depth = this.formState.maxScopeDepth;
     }

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -103,6 +103,8 @@ type FormState = {
   autoscrollBehavior: boolean;
 };
 
+const DEPTH_SUPPORTED_SCOPES = ["prefix", "host", "domain", "custom", "any"];
+
 const getDefaultProgressState = (hasConfigId = false): ProgressState => {
   let activeTab: StepName = "crawlSetup";
   if (window.location.hash) {
@@ -1044,7 +1046,7 @@ https://example.com/path`}
         msg(`Tells the crawler which pages it can visit.`)
       )}
       ${when(
-        ["prefix", "host", "domain", "custom"].includes(this.formState.scopeType),
+        DEPTH_SUPPORTED_SCOPES.includes(this.formState.scopeType),
         () => html`
           ${this.renderFormCol(html`
             <sl-input
@@ -2120,9 +2122,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
     };
 
-    if (
-      ["prefix", "host", "domain", "custom"].includes(this.formState.scopeType)
-    ) {
+    if (DEPTH_SUPPORTED_SCOPES.includes(this.formState.scopeType)) {
       primarySeed.depth = this.formState.maxScopeDepth;
     }
 

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -2128,9 +2128,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
     const config = {
       seeds: [primarySeed, ...additionalSeedUrlList],
-      scopeType: additionalSeedUrlList.length
-        ? "page"
-        : this.formState.scopeType,
+      scopeType: this.formState.scopeType,
     };
     return config;
   }

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -430,6 +430,8 @@ export class CrawlConfigEditor extends LiteElement {
           // Unescape regex
           .map((url) => url.replace(/(\\|\/\.\*)/g, ""))
           .join("\n");
+        // if we have additional include URLs, set to "custom" scope here
+        // to indicate 'Custom Page Prefix' option
         formState.scopeType = "custom";
       }
       const additionalSeeds = seeds.slice(1);
@@ -2112,6 +2114,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
       : [];
     const primarySeed: Seed = {
       url: primarySeedUrl,
+      // the 'custom' scope here indicates we have extra URLs, actually set to 'prefix' 
+      // scope on backend to ensure seed URL is also added as part of standard prefix scope
       scopeType: this.formState.scopeType === "custom" ? "prefix" : this.formState.scopeType,
       include:
         this.formState.scopeType === "custom"


### PR DESCRIPTION
This PR fixes #873:
- Removes the `/.*` added at end of urls for `include` list, don't want to force trailing slash and no need for .* as this applies to first match
- For 'Custom Page Prefix', use `prefix` scopeType to automatically include the base seed URL so don't need to include it again in `includes` (supported via webrecorder/browsertrix-crawler#318)
- On load, sets base scopeType to `custom` if extra URLs are set - on backend, this scopeType is overridden by per-seed scopeTypes provided for each seed.
- Show 'max depth' setting for all except page/page-spa scopeTypes (supported on backend for all, but doesn't make sense for single page / spa mode)