### PR TITLE
Future of the User Guide page & Org Settings docs!

### DIFF
--- a/docs/develop/docs.md
+++ b/docs/develop/docs.md
@@ -40,6 +40,8 @@ Webrecorder is a global team but we use American English when writing documentat
 
 In a list of three or more items, the list item proceeding the word "and" should have a comma placed after it clarifying that the final item in the list is not a part of the previous item.
 
+##### Example
+
 | Use                           | Don't use                    |
 | ----------------------------- | ---------------------------- |
 | One, two, three, and four.    | One, two, three and four.    |
@@ -49,13 +51,27 @@ In a list of three or more items, the list item proceeding the word "and" should
 
 Avoid using acronyms when reuse is not frequent enough to warrant space savings. When acronyms must be used, spell the full phrase first and include the acronym in parentheses `()` the first time it is used in each document.  This can be omitted for extremely common acronyms such as "URL" or "HTTP".
 
+##### Example
+
 > When running in a Virtual Machine (VM), use the....
 
 ### Headings
 
 All headings should be set in [title case](https://en.wikipedia.org/wiki/Title_case).
 
+##### Example
+
 > Indiana Jones and the Raiders of the Lost Ark
+
+### Referencing Features and Their Options
+
+Controls with multiple options should have their options referenced as `in-line code blocks`.
+
+Setting names referenced outside of a heading should be Capitalized and set in _italics_.
+
+##### Example
+
+> Sets the day of the week for which crawls scheduled with a `Weekly` _Frequency_ will run.
 
 ### Markdown Formatting
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -58,13 +58,14 @@
 /* Custom menu item hover */
 
 .md-tabs__link {
+    font-family: var(--md-code-font);
     font-weight: 400;
     opacity: .9;
     transition: .4s cubic-bezier(.1,.7,.1,1),opacity .25s
 }
 
 .md-tabs__link:hover {
-    font-weight: 500;
+    font-weight: 600;
 }
 
 /* Custom body typography rules */

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -12,6 +12,8 @@ If you have been sent an [invite](org-settings#members), enter a password and na
 
 If the server has enabled signups and you have been given a registration link, enter your email address, password, and name to create a new account. Your account will be added to the server's default organization.
 
+---
+
 ## Automated Crawling
 
 A Workflow must be created in order to crawl websites automatically. Workflows can be created on the Crawling page found in the main navigation menu. A detailed list of all available workflow configuration options can be found on the [Crawl Workflow Setup](workflow-setup) page.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,15 +1,7 @@
 # Getting Started
 
-Welcome to Browsertrix Cloud. This Guide will cover various aspects of using Browsertrix Cloud.
+This section covers usage of Browsertrix Cloud.
 
+## Automated Crawling
 
-## Creating an Account
-
-- If you have been given an invite, you can create an account for that email address. Choose a password and name to create a new account.
-
-- If you have been given a registration link, you can enter your email address, password and name to create a new account.
-
-
-## Quick Start
-
-Once you've registrated, your account will have an `[Your Name's Archive]` where you can create workflows to run crawls!
+A Workflow must be created in order to crawl websites automatically. Workflows can be created on the Crawling page found in the main navigation menu. A detailed list of all available workflow configuration options can be found on the [Workflow Setup](workflow-setup) page.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,7 +1,17 @@
 # Getting Started
 
-This section covers usage of Browsertrix Cloud.
+## Signup
+
+For all signup options the Name field cannot currently be changed later.
+
+### Invite Link
+
+If you have been sent an [invite](org-settings#members), enter a password and name to create a new account. Your account will be added to the organization you were invited to by an organization admin.
+
+### Open Registration
+
+If the server has enabled signups and you have been given a registration link, enter your email address, password, and name to create a new account. Your account will be added to the server's default organization.
 
 ## Automated Crawling
 
-A Workflow must be created in order to crawl websites automatically. Workflows can be created on the Crawling page found in the main navigation menu. A detailed list of all available workflow configuration options can be found on the [Workflow Setup](workflow-setup) page.
+A Workflow must be created in order to crawl websites automatically. Workflows can be created on the Crawling page found in the main navigation menu. A detailed list of all available workflow configuration options can be found on the [Crawl Workflow Setup](workflow-setup) page.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -8,8 +8,8 @@ This page lets you change the organization's name. This name must be unique.
 
 ## Members
 
-This page lists all current members who have access to the organization, as well as any invited members who have not yet accepted the invitation to join the organization. In the _Active Members_ table Admins can change the permission level of all users in the organization, including other Admins. At least one user must be an Admin. Admins can also remove members by pressing the trash button.
+This page lists all current members who have access to the organization, as well as any invited members who have not yet accepted an invitation to join the organization. In the _Active Members_ table, Admins can change the permission level of all users in the organization, including other Admins. At least one user must be an Admin per-organization. Admins can also remove members by pressing the trash button.
 
-New members can be invited by pressing the `Invite New Member` button. Enter the email address associated with the user, select the appropriate role, and press `Invite` to send a link to join the organization via email.
+Admins can add new members to the organization by pressing the `Invite New Member` button. Enter the email address associated with the user, select the appropriate role, and press `Invite` to send a link to join the organization via email.
 
 Sent invites can be invalidated by pressing the trash button in the relevant _Pending Invites_ table row.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -11,3 +11,5 @@ This page lets you change the organization's name. This name must be unique.
 This page lists all current members who have access to the organization, as well as any invited members who have not yet accepted the invitation to join the organization. In the _Active Members_ table Admins can change the permission level of all users in the organization, including other Admins. At least one user must be an Admin. Admins can also remove members by pressing the trash button.
 
 New members can be invited by pressing the `Invite New Member` button. Enter the email address associated with the user, select the appropriate role, and press `Invite` to send a link to join the organization via email.
+
+Sent invites can be invalidated by pressing the trash button in the relevant _Pending Invites_ table row.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -10,4 +10,4 @@ This page lets you change the organization's name. This name must be unique.
 
 This page lists all current members who have access to the organization, as well as any invited members who have not yet accepted the invitation to join the organization. In the _Active Members_ table Admins can change the permission level of all users in the organization, including other Admins. At least one user must be an Admin. Admins can also remove members by pressing the trash button.
 
-New members can be invited by pressing the `Invite New Member` button. Enter the email address associated with the user, select the appropriate role, and press `Invite` to send an invite to that user.
+New members can be invited by pressing the `Invite New Member` button. Enter the email address associated with the user, select the appropriate role, and press `Invite` to send a link to join the organization via email.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -1,0 +1,13 @@
+# Org Settings
+
+The Org Settings page is only available to organization Admins. It can be found in the main navigation menu.
+
+## Org Information
+
+This page lets you change the organization's name. This name must be unique.
+
+## Members
+
+This page lists all current members who have access to the organization, as well as any invited members who have not yet accepted the invitation to join the organization. In the _Active Members_ table Admins can change the permission level of all users in the organization, including other Admins. At least one user must be an Admin. Admins can also remove members by pressing the trash button.
+
+New members can be invited by pressing the `Invite New Member` button. Enter the email address associated with the user, select the appropriate role, and press `Invite` to send an invite to that user.

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -159,11 +159,11 @@ Set how often a scheduled crawl will run.
 
 ### Day
 
-For crawls scheduled with a `Weekly` _Frequency_, sets the day of the week for which the crawl will run.
+Sets the day of the week for which crawls scheduled with a `Weekly` _Frequency_ will run.
 
 ### Date
 
-For crawls scheduled with a `Monthly` _Frequency_, sets the date of the month for which the crawl will run.
+Sets the date of the month for which crawls scheduled with a `Monthly` _Frequency_ will run.
 
 ### Start Time
 

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -1,6 +1,6 @@
-# Workflow Setup
+# Crawl Workflow Setup
 
-The first step in creating a new workflow is to choose what type of crawl you want to run. Crawl types are fixed and cannot be converted or changed later.
+The first step in creating a new crawl workflow is to choose what type of crawl you want to run. Crawl types are fixed and cannot be converted or changed later.
 
 `URL List`{ .badge-blue }
 :   The crawler visits every URL specified in a list, and optionally every URL linked on those pages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
   - User Guide:
       - user-guide/index.md
       - user-guide/workflow-setup.md
+      - user-guide/org-settings.md
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
The User Guide page will now serve as a collection of key documentation pages that new users will need to reference most to have a solid understanding of the application.

Currently it only lists the Workflow Setup page, more to come!

### Changes
- Adds Org Settings documentation!
- Adds styling information for referencing controls with `multiple options` and _setting names referenced outside of headings_.
- Minor updates to wording in one line of Workflow Settings
- Changes the nav font to Recursive due to its fixed glyph widths across weights.  Now the text doesn't move around on hover anymore!

### Things to pay attention to!
- I use the full "organization" here but should we just use "org"?  That's mostly what we do in the app?