### PR TITLE
Add frontend support for auto-adding collections to workflows

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -216,20 +216,11 @@ class CollectionOps:
         if name:
             match_query["name"] = name
 
-        aggregate = [{"$match": match_query}]
+        elif name_prefix:
+            regex_pattern = f"^{name_prefix}"
+            match_query["name"] = {"$regex": regex_pattern, "$options": "i"}
 
-        if name_prefix:
-            regex_pattern = f"/^{name_prefix}/i"
-            aggregate.extend(
-                [
-                    {
-                        "$regexMatch": {
-                            "input": "$name",
-                            "regex": regex_pattern,
-                        }
-                    }
-                ]
-            )
+        aggregate = [{"$match": match_query}]
 
         if sort_by:
             if sort_by not in ("modified", "name", "description"):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -203,6 +203,7 @@ class CollectionOps:
         sort_by: str = None,
         sort_direction: int = 1,
         name: Optional[str] = None,
+        name_prefix: Optional[str] = None,
     ):
         """List all collections for org"""
         # pylint: disable=too-many-locals
@@ -216,6 +217,19 @@ class CollectionOps:
             match_query["name"] = name
 
         aggregate = [{"$match": match_query}]
+
+        if name_prefix:
+            regex_pattern = f"/^{name_prefix}/i"
+            aggregate.extend(
+                [
+                    {
+                        "$regexMatch": {
+                            "input": "$name",
+                            "regex": regex_pattern,
+                        }
+                    }
+                ]
+            )
 
         if sort_by:
             if sort_by not in ("modified", "name", "description"):
@@ -384,6 +398,7 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
         sortBy: str = None,
         sortDirection: int = 1,
         name: Optional[str] = None,
+        namePrefix: Optional[str] = None,
     ):
         collections, total = await colls.list_collections(
             org.id,
@@ -392,6 +407,7 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
             sort_by=sortBy,
             sort_direction=sortDirection,
             name=name,
+            name_prefix=namePrefix,
         )
         return paginated_format(collections, total, page, pageSize)
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -298,6 +298,44 @@ def test_filter_sort_collections(
     assert coll["oid"] == default_org_id
     assert coll.get("description") is None
 
+    # Test filtering by name prefix
+    name_prefix = SECOND_COLLECTION_NAME[0:4]
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?namePrefix={name_prefix}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+
+    items = data["items"]
+    assert len(items) == 1
+
+    coll = items[0]
+    assert coll["id"]
+    assert coll["name"] == SECOND_COLLECTION_NAME
+    assert coll["oid"] == default_org_id
+    assert coll.get("description") is None
+
+    # Test filtering by name prefix (case insensitive)
+    name_prefix = name_prefix.upper()
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?namePrefix={name_prefix}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+
+    items = data["items"]
+    assert len(items) == 1
+
+    coll = items[0]
+    assert coll["id"]
+    assert coll["name"] == SECOND_COLLECTION_NAME
+    assert coll["oid"] == default_org_id
+    assert coll.get("description") is None
+
     # Test sorting by name, ascending (default)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections?sortBy=name",

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -186,3 +186,7 @@ Leave optional notes about the workflow's configuration.
 ### Tags
 
 Apply tags to the workflow. Tags applied to the workflow will propigate to every crawl created with it at the time of crawl creation.
+
+### Collection Auto-Add
+
+Search for and specify collections that this crawl workflow should automatically add content to as soon as crawls finish running. Cancelled and Failed crawls will not be automatically added to collections.

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -271,7 +271,10 @@ export class ConfigDetails extends LiteElement {
               ? this.collections.map(
                   (coll) =>
                     html`<sl-tag class="mt-1 mr-2" variant="neutral">
-                      ${coll.name} (${msg(str`${coll.crawlCount} Crawls`)})
+                      ${coll.name}
+                      <span class="pl-1 font-monostyle text-xs">
+                        (${msg(str`${coll.crawlCount} Crawls`)})
+                      </span>
                     </sl-tag>`
                 )
               : undefined

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -269,13 +269,10 @@ export class ConfigDetails extends LiteElement {
             msg("Collections"),
             this.collections.length
               ? this.collections.map(
-                  (coll: Collection) => {
-                    return html`<p>${coll.name}
-                      <span class="pl-1 font-monostyle text-xs">
-                        (${msg(str`${coll.crawlCount} Crawls`)})
-                      </span></p>
-                    `;
-                  }
+                  (coll) =>
+                    html`<sl-tag class="mt-1 mr-2" variant="neutral">
+                      ${coll.name} (${msg(str`${coll.crawlCount} Crawls`)})
+                    </sl-tag>`
                 )
               : undefined
           )}

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -237,10 +237,18 @@ export class CollectionsAdd extends LiteElement {
     const data: CollectionSearchResults | undefined = await this.fetchCollectionsByPrefix(this.searchByValue);
     let searchResults: CollectionList = [];
     if (data && data.items.length) {
-      searchResults = data.items;
+      searchResults = this.filterOutSelectedCollections(data.items);
     }
     this.searchResults = searchResults;
   }) as any;
+
+  private filterOutSelectedCollections(results: CollectionList) {
+    return results.filter((result) => {
+      return this.collections.every((coll) => {
+        return coll.id !== result.id;
+      });
+    });
+  }
 
   private async fetchCollectionsByPrefix(namePrefix: string) {
     try {

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -14,9 +14,6 @@ import type {
   APISortQuery,
 } from "../../types/api";
 
-type SortField = "_lastUpdated" | "_name";
-type SortDirection = "asc" | "desc";
-
 const INITIAL_PAGE_SIZE = 10;
 const MIN_SEARCH_LENGTH = 2;
 
@@ -281,7 +278,6 @@ export class CollectionsAdd extends LiteElement {
 
   private async dispatchChange() {
     await this.updateComplete;
-    console.log(`Dispatching change with collection ids: ${this.collectionIds}`);
     this.dispatchEvent(
       <CollectionsChangeEvent>new CustomEvent("collections-change", {
         detail: { collections: this.collectionIds },

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -1,0 +1,346 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import { when } from "lit/directives/when.js";
+import debounce from "lodash/fp/debounce";
+import Fuse from "fuse.js";
+import type { SlMenuItem } from "@shoelace-style/shoelace";
+import queryString from "query-string";
+
+import type { AuthState } from "../../utils/AuthService";
+import type { Collection, CollectionList } from "../../types/collection";
+import LiteElement, { html } from "../../utils/LiteElement";
+import type {
+  APIPaginatedList,
+  APIPaginationQuery,
+  APISortQuery,
+} from "../../types/api";
+
+type SortField = "_lastUpdated" | "_name";
+type SortDirection = "asc" | "desc";
+
+const INITIAL_PAGE_SIZE = 10;
+const MIN_SEARCH_LENGTH = 2;
+
+type SearchFields = "name";
+type SearchResult = {
+  item: {
+    key: SearchFields;
+    value: string;
+  };
+};
+
+type CollectionSearchResults = APIPaginatedList & {
+  items: CollectionList;
+}
+
+const sortableFields: Record<
+  SortField,
+  { label: string; defaultDirection?: SortDirection }
+> = {
+  _lastUpdated: {
+    label: msg("Last Updated"),
+    defaultDirection: "desc",
+  },
+  _name: {
+    label: msg("Name"),
+    defaultDirection: "asc",
+  },
+};
+
+export type CollectionsChangeEvent = CustomEvent<{
+  collections: string[];
+}>;
+
+/**
+ * Usage:
+ * ```ts
+ * <btrix-collections-add
+ *   .authState=${this.authState}
+ *   .initialCollections=${[]}
+ *   .orgId=${this.orgId}
+ *   .configId=${this.configId}
+ *   @collections-change=${console.log}
+ * ></btrix-collections-add>
+ * ```
+ * @events collections-change
+ */
+@localized()
+export class CollectionsAdd extends LiteElement {
+  @property({ type: Object })
+  authState!: AuthState;
+
+  @property({ type: Array })
+  initialCollections?: CollectionList;
+
+  @property({ type: String })
+  orgId!: string;
+
+  @property({ type: String })
+  configId!: string;
+
+  @state()
+  private collections: CollectionList = [];
+
+  @state()
+  private collectionIds: string[] = [];
+
+  @state()
+  private searchByValue: string = "";
+
+  private get hasSearchStr() {
+    return this.searchByValue.length >= MIN_SEARCH_LENGTH;
+  }
+
+  private get selectedSearchFilterKey() {
+    return Object.keys(this.fieldLabels).find((key) =>
+      Boolean((this.searchByValue as any)[key])
+    );
+  }
+
+  private readonly fieldLabels: Record<SearchFields, string> = {
+    name: msg("Name")
+  };
+
+  @state()
+  private verifiedSearchName: string = "";
+
+  @state()
+  private searchResultsOpen = false;
+
+  @state()
+  private orderCollectionsBy: {
+    field: SortField;
+    direction: SortDirection;
+  } = {
+    field: "_name",
+    direction: sortableFields["_name"].defaultDirection!,
+  };
+
+  // For fuzzy search:
+  private fuse = new Fuse([], {
+    keys: ["value"],
+    shouldSort: false,
+    threshold: 0.2, // stricter; default is 0.6
+  });
+
+  connectedCallback() {
+    if (this.initialCollections) {
+      this.collections = this.initialCollections;
+    }
+    super.connectedCallback();
+  }
+
+  protected async willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("orgId") && this.orgId) {
+      this.fetchSearchValues();
+    }
+  }
+
+  render() {
+    return html`
+      <div class="form-control form-control--has-label">
+        <label
+          class="form-control__label"
+          part="form-control-label"
+          for="input"
+        >
+          <slot name="label">${msg("Collection Auto-Add")}</slot>
+        </label>
+        <div class="mb-2 mt-2 p-2 bg-neutral-50 border rounded-lg">
+          ${this.renderSearch()}
+        </div>
+
+        ${when(
+          this.collections,
+          () =>
+            this.collections.length
+              ? html`
+                  <div class="mb-2">
+                    <ul class="contents">
+                      ${this.collections.map(this.renderCollectionItem)}
+                    </ul>
+                  </div>
+                `
+              : html`
+                  <div class="mb-2">
+                    <p class="text-center text-0-500">
+                      ${msg("Search for a Collection to auto-add crawls")}
+                    </p>
+                  </div>
+                `)}
+      </div>`;
+  }
+
+  private renderSearch() {
+    return html`
+      <btrix-combobox
+        ?open=${this.searchResultsOpen}
+        @request-close=${() => {
+          this.searchResultsOpen = false;
+          this.searchByValue = "";
+        }}
+        @sl-select=${async (e: CustomEvent) => {
+          this.searchResultsOpen = false;
+          const item = e.detail.item as SlMenuItem;
+          const key = item.dataset["key"] as SearchFields;
+          const coll = await this.fetchCollection(item.value);
+          if (coll && this.collectionIds.indexOf(coll.id) === -1) {
+            this.collections.push(coll);
+            this.collectionIds.push(coll.id);
+            await this.dispatchChange();
+          }
+          await this.updateComplete;
+        }}
+      >
+        <sl-input
+          size="small"
+          placeholder=${msg("Search by Collection name")}
+          clearable
+          value=${this.searchByValue}
+          @sl-clear=${() => {
+            this.searchResultsOpen = false;
+            this.onSearchInput.cancel();
+          }}
+          @sl-input=${this.onSearchInput}
+        >
+          <sl-icon name="search" slot="prefix"></sl-icon>
+        </sl-input>
+        ${this.renderSearchResults()}
+      </btrix-combobox>
+    `;
+  }
+
+  private renderSearchResults() {
+    if (!this.hasSearchStr) {
+      return html`
+        <sl-menu-item slot="menu-item" disabled
+          >${msg("Start typing to search Collections.")}</sl-menu-item
+        >
+      `;
+    }
+
+    const searchResults = this.fuse.search(this.searchByValue).slice(0, 10);
+    if (!searchResults.length) {
+      return html`
+        <sl-menu-item slot="menu-item" disabled
+          >${msg("No matching Collections found.")}</sl-menu-item
+        >
+      `;
+    }
+
+    return html`
+      ${searchResults.map(
+        ({ item }: SearchResult) => html`
+          <sl-menu-item
+            slot="menu-item"
+            data-key=${item.key}
+            value=${item.value}
+          >
+            ${item.value}
+          </sl-menu-item>
+        `
+      )}
+    `;
+  }
+
+  private renderCollectionItem(collection: Collection) {
+    // TODO: Make X icon functional
+    const crawlCountMessage = msg(str`${collection.crawlCount} Crawls`);
+    return html`<li class="mt-1 p-2 pl-5 pr-5 border rounded-sm">
+        ${collection.name}
+        <span class="float-right">
+          <span class="text-neutral-500 text-xs font-monostyle">${crawlCountMessage}</span>
+          <sl-icon
+            class="ml-3"
+            name="x-lg"
+            @click=${() => {
+              // TODO: Implement removal from this.collections and this.collectionIds
+              console.log(`Will remove ${collection.id}`);
+            }}></sl-icon>
+        </span>
+      </li>`;
+  }
+
+  private onSearchInput = debounce(200)((e: any) => {
+    this.searchByValue = e.target.value.trim();
+
+    if (this.searchResultsOpen === false && this.hasSearchStr) {
+      this.searchResultsOpen = true;
+    }
+  }) as any;
+
+  private async fetchSearchValues() {
+    try {
+      const { names } = await this.apiFetch(
+        `/orgs/${this.orgId}/collections/search-values`,
+        this.authState!
+      );
+
+      // Update search/filter collection
+      const toSearchItem =
+        (key: SearchFields) =>
+        (value: string): SearchResult["item"] => ({
+          key,
+          value,
+        });
+      this.fuse.setCollection([
+        ...names.map(toSearchItem("name")),
+      ] as any);
+    } catch (e) {
+      console.debug(e);
+    }
+  }
+
+  private async fetchCollection(name: string) {
+    if (!this.configId) return;
+
+    try {
+      const results: CollectionSearchResults = await this.getCollections({
+        oid: this.orgId,
+        name: name,
+        sortBy: "name",
+        pageSize: INITIAL_PAGE_SIZE,
+      });
+      if (results?.items) {
+        return results.items[0];
+      }
+    } catch {
+      this.notify({
+        message: msg(
+          "Sorry, couldn't retrieve Collections at this time."
+        ),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async getCollections(
+    params: Partial<{
+      oid?: string;
+      name?: string;
+    }> &
+      APIPaginationQuery &
+      APISortQuery
+  ): Promise<APIPaginatedList> {
+    const query = queryString.stringify(params || {}, {
+      arrayFormat: "comma",
+    });
+    const data: APIPaginatedList = await this.apiFetch(
+      `/orgs/${this.orgId}/collections?${query}`,
+      this.authState!
+    );
+
+    return data;
+  }
+
+  private async dispatchChange() {
+    await this.updateComplete;
+    this.dispatchEvent(
+      <CollectionsChangeEvent>new CustomEvent("collections-change", {
+        detail: { collections: this.collectionIds },
+      })
+    );
+  }
+}
+customElements.define("btrix-collections-add", CollectionsAdd);

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -47,7 +47,7 @@ export class CollectionsAdd extends LiteElement {
   authState!: AuthState;
 
   @property({ type: Array })
-  initialCollections?: CollectionList;
+  initialCollections?: string[];
 
   @property({ type: String })
   orgId!: string;
@@ -74,10 +74,11 @@ export class CollectionsAdd extends LiteElement {
   @state()
   private searchResultsOpen = false;
 
-  connectedCallback() {
+  async connectedCallback() {
     if (this.initialCollections) {
-      this.collections = this.initialCollections;
+      this.collectionIds = this.initialCollections;
     }
+    await this.initializeCollectionsFromIds();
     super.connectedCallback();
   }
 
@@ -190,7 +191,6 @@ export class CollectionsAdd extends LiteElement {
           `;
         }
       )}
-
     `;
   }
 
@@ -266,8 +266,22 @@ export class CollectionsAdd extends LiteElement {
     return data;
   }
 
+  private async initializeCollectionsFromIds() {
+    for (let i = 0; i < this.collectionIds?.length; i++) {
+      const collId = this.collectionIds[i];
+      const data: Collection = await this.apiFetch(
+        `/orgs/${this.orgId}/collections/${collId}`,
+        this.authState!
+      );
+      if (data) {
+        this.collections.push(data);
+      }
+    }
+  }
+
   private async dispatchChange() {
     await this.updateComplete;
+    console.log(`Dispatching change with collection ids: ${this.collectionIds}`);
     this.dispatchEvent(
       <CollectionsChangeEvent>new CustomEvent("collections-change", {
         detail: { collections: this.collectionIds },

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -177,12 +177,13 @@ export class CollectionsAdd extends LiteElement {
         (item: Collection) => {
           return html`
             <sl-menu-item
+              class="w-full"
               slot="menu-item"
               data-key=${item.id}
             >
-              <div class="flex basis-full items-center">
-                <div class="flex-none w-80">${item.name}</div>
-                <div class="flex-auto ml-3 justify-self-end text-neutral-500 text-xs font-monostyle">
+              <div class="flex w-full gap-2 items-center">
+                <div class="justify-self-stretch grow truncate">${item.name}</div>
+                <div class="flex-auto text-right text-neutral-500 text-xs font-monostyle">
                   ${msg(str`${item.crawlCount} Crawls`)}
                 </div>
               </div>
@@ -195,13 +196,12 @@ export class CollectionsAdd extends LiteElement {
 
   private renderCollectionItem(collection: Collection) {
     return html`<li class="mt-1 p-2 pl-5 pr-5 border rounded-sm">
-        <div class="flex flex-row justify-between items-center">
-          <div class="w-80">${collection.name}</div>
-          <div class="ml-3 justify-self-end text-neutral-500 text-xs font-monostyle">
+        <div class="flex flex-row gap-2 justify-between items-center">
+          <div class="justify-self-stretch grow truncate">${collection.name}</div>
+          <div class="text-neutral-500 text-xs text-right font-monostyle">
             ${msg(str`${collection.crawlCount} Crawls`)}
           </div>
           <sl-icon-button
-            class="ml-3"
             name="x-lg"
             data-key=${collection.id}
             @click=${this.removeCollection}>

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -100,7 +100,7 @@ export class CollectionsAdd extends LiteElement {
               ? html`
                   <div class="mb-2">
                     <ul class="contents">
-                      ${this.collections.map(this.renderCollectionItem)}
+                      ${this.collections.map(this.renderCollectionItem, this)}
                     </ul>
                   </div>
                 `
@@ -192,8 +192,6 @@ export class CollectionsAdd extends LiteElement {
   }
 
   private renderCollectionItem(collection: Collection) {
-    // TODO: Clicking on remove button doesn't work - 
-    // TypeError: Cannot read property 'removeCollection' of undefined
     return html`<li class="mt-1 p-2 pl-5 pr-5 border rounded-sm">
         ${collection.name}
         <span class="float-right inline-block align-middle">
@@ -204,17 +202,15 @@ export class CollectionsAdd extends LiteElement {
             class="ml-3 align-middle"
             name="x-lg"
             data-key=${collection.id}
-            @click=${() => this.removeCollection}></sl-icon-button>
+            @click=${this.removeCollection}></sl-icon-button>
         </span>
       </li>`;
   }
 
-  private removeCollection(event: Event) {
+  private async removeCollection(event: Event) {
     const target = event.currentTarget as HTMLElement;
     const collectionId = target.getAttribute("data-key");
     if (collectionId) {
-      console.log(collectionId);
-      console.log(`Removing from collections: ${collectionId}`);
       const collIdIndex = this.collectionIds.indexOf(collectionId);
       if (collIdIndex > -1) {
         this.collectionIds.splice(collIdIndex, 1);
@@ -224,6 +220,7 @@ export class CollectionsAdd extends LiteElement {
         this.collections.splice(collIndex, 1);
       }
     }
+    await this.requestUpdate();
   }
 
   private onSearchInput = debounce(200)(async (e: any) => {

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -177,13 +177,12 @@ export class CollectionsAdd extends LiteElement {
         (item: Collection) => {
           return html`
             <sl-menu-item
-              class="flex"
               slot="menu-item"
               data-key=${item.id}
             >
-              <div class="flex flex-row justify-between items-center">
-                <div class="w-80">${item.name}</div>
-                <div class="ml-3 justify-self-end text-neutral-500 text-xs font-monostyle">
+              <div class="flex basis-full items-center">
+                <div class="flex-none w-80">${item.name}</div>
+                <div class="flex-auto ml-3 justify-self-end text-neutral-500 text-xs font-monostyle">
                   ${msg(str`${item.crawlCount} Crawls`)}
                 </div>
               </div>

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -177,13 +177,16 @@ export class CollectionsAdd extends LiteElement {
         (item: Collection) => {
           return html`
             <sl-menu-item
+              class="flex"
               slot="menu-item"
               data-key=${item.id}
             >
-              ${item.name}
-              <span class="float-right font-monostyle text-xs">
-                ${msg(str`${item.crawlCount} Crawls`)}
-              </span>
+              <div class="flex flex-row justify-between items-center">
+                <div class="w-80">${item.name}</div>
+                <div class="ml-3 justify-self-end text-neutral-500 text-xs font-monostyle">
+                  ${msg(str`${item.crawlCount} Crawls`)}
+                </div>
+              </div>
             </sl-menu-item>
           `;
         }
@@ -193,17 +196,18 @@ export class CollectionsAdd extends LiteElement {
 
   private renderCollectionItem(collection: Collection) {
     return html`<li class="mt-1 p-2 pl-5 pr-5 border rounded-sm">
-        ${collection.name}
-        <span class="float-right inline-block align-middle">
-          <span class="text-neutral-500 text-xs font-monostyle">
+        <div class="flex flex-row justify-between items-center">
+          <div class="w-80">${collection.name}</div>
+          <div class="ml-3 justify-self-end text-neutral-500 text-xs font-monostyle">
             ${msg(str`${collection.crawlCount} Crawls`)}
-          </span>
+          </div>
           <sl-icon-button
-            class="ml-3 align-middle"
+            class="ml-3"
             name="x-lg"
             data-key=${collection.id}
-            @click=${this.removeCollection}></sl-icon-button>
-        </span>
+            @click=${this.removeCollection}>
+          </sl-icon-button>
+        </dib>
       </li>`;
   }
 

--- a/frontend/src/pages/org/collections-add.ts
+++ b/frontend/src/pages/org/collections-add.ts
@@ -2,7 +2,7 @@ import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import { when } from "lit/directives/when.js";
 import debounce from "lodash/fp/debounce";
-import type { SlMenuItem } from "@shoelace-style/shoelace";
+import type { SlMenuItem, SlIconButton } from "@shoelace-style/shoelace";
 import queryString from "query-string";
 
 import type { AuthState } from "../../utils/AuthService";
@@ -192,21 +192,38 @@ export class CollectionsAdd extends LiteElement {
   }
 
   private renderCollectionItem(collection: Collection) {
-    // TODO: Make X icon functional
-    const crawlCountMessage = msg(str`${collection.crawlCount} Crawls`);
+    // TODO: Clicking on remove button doesn't work - 
+    // TypeError: Cannot read property 'removeCollection' of undefined
     return html`<li class="mt-1 p-2 pl-5 pr-5 border rounded-sm">
         ${collection.name}
-        <span class="float-right">
-          <span class="text-neutral-500 text-xs font-monostyle">${crawlCountMessage}</span>
-          <sl-icon
-            class="ml-3"
+        <span class="float-right inline-block align-middle">
+          <span class="text-neutral-500 text-xs font-monostyle">
+            ${msg(str`${collection.crawlCount} Crawls`)}
+          </span>
+          <sl-icon-button
+            class="ml-3 align-middle"
             name="x-lg"
-            @click=${() => {
-              // TODO: Implement removal from this.collections and this.collectionIds
-              console.log(`Will remove ${collection.id}`);
-            }}></sl-icon>
+            data-key=${collection.id}
+            @click=${() => this.removeCollection}></sl-icon-button>
         </span>
       </li>`;
+  }
+
+  private removeCollection(event: Event) {
+    const target = event.currentTarget as HTMLElement;
+    const collectionId = target.getAttribute("data-key");
+    if (collectionId) {
+      console.log(collectionId);
+      console.log(`Removing from collections: ${collectionId}`);
+      const collIdIndex = this.collectionIds.indexOf(collectionId);
+      if (collIdIndex > -1) {
+        this.collectionIds.splice(collIdIndex, 1);
+      }
+      const collIndex = this.collections.findIndex(collection => collection.id === collectionId);
+      if (collIndex > -1) {
+        this.collections.splice(collIndex, 1);
+      }
+    }
   }
 
   private onSearchInput = debounce(200)(async (e: any) => {

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -854,7 +854,8 @@ ${this.crawl?.notes}
     if (!this.crawl?.config) return "";
     return html`
       <btrix-config-details
-        .crawlConfig=${this.crawl}
+        .authState=${this.authState!}
+        .crawlConfig=${{ ...this.crawl, autoAddCollections: this.crawl.collections }}
         hideTags
       ></btrix-config-details>
     `;

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -14,6 +14,7 @@ import "./workflows-list";
 import "./workflows-new";
 import "./crawl-detail";
 import "./crawls-list";
+import "./collections-add";
 import "./collections-list";
 import "./collections-new";
 import "./collection-edit";

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1146,6 +1146,7 @@ export class WorkflowDetail extends LiteElement {
   private renderSettings() {
     return html`<section class="border rounded-lg py-3 px-5">
       <btrix-config-details
+        .authState=${this.authState!}
         .crawlConfig=${this.workflow}
         anchorLinks
       ></btrix-config-details>

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1707,7 +1707,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
           const profileName = this.formState.browserProfile?.name;
 
           return html`<btrix-config-details
-            .crawlConfig=${{ ...crawlConfig, profileName }}
+            .authState=${this.authState!}
+            .crawlConfig=${{ ...crawlConfig, profileName, oid: this.orgId }}
           >
           </btrix-config-details>`;
         })}

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -40,6 +40,7 @@ import type {
   Tags,
   TagsChangeEvent,
 } from "../../components/tag-input";
+import type { CollectionsChangeEvent } from "./collections-add";
 import type {
   WorkflowParams,
   Profile,
@@ -47,6 +48,7 @@ import type {
   Seed,
   SeedConfig,
 } from "./types";
+import type { CollectionList } from "../../types/collection";
 
 type NewCrawlConfigParams = WorkflowParams & {
   runNow: boolean;
@@ -99,6 +101,7 @@ type FormState = {
   jobName: WorkflowParams["name"];
   browserProfile: Profile | null;
   tags: Tags;
+  collections: string[];
   description: WorkflowParams["description"];
   autoscrollBehavior: boolean;
 };
@@ -169,6 +172,7 @@ const getDefaultFormState = (): FormState => ({
   jobName: "",
   browserProfile: null,
   tags: [],
+  collections: [],
   description: null,
   autoscrollBehavior: true,
 });
@@ -495,6 +499,7 @@ export class CrawlConfigEditor extends LiteElement {
       scheduleFrequency: defaultFormState.scheduleFrequency,
       runNow: defaultFormState.runNow,
       tags: this.initialWorkflow.tags,
+      collections: defaultFormState.collections,
       jobName: this.initialWorkflow.name || defaultFormState.jobName,
       description: this.initialWorkflow.description,
       browserProfile: this.initialWorkflow.profileid
@@ -1637,6 +1642,28 @@ https://archiveweb.page/images/${"logo.svg"}`}
         msg(`Create or assign this crawl (and its outputs) to one or more tags
         to help organize your archived data.`)
       )}
+      ${this.renderFormCol(
+        html`
+          <btrix-collections-add
+            .authState=${this.authState}
+            .initialCollections=${this.formState.collections}
+            .orgId=${this.orgId}
+            .configId=${this.configId}
+            @collections-change=${(e: CollectionsChangeEvent) =>
+              this.updateFormState(
+                {
+                  collections: e.detail.collections,
+                },
+                true
+              )}
+          ></btrix-collections-add>
+        `
+      )}
+      ${this.renderHelpTextCol(
+        msg(`Automatically add crawls from this workflow to one or more collections
+          as soon as they complete.
+          Individual crawls can be selected from within the collection later.`)
+      )}
     `;
   }
 
@@ -2056,6 +2083,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ? this.formState.crawlTimeoutMinutes * 60
         : null,
       tags: this.formState.tags,
+      autoAddCollections: this.formState.collections,
       config: {
         ...(this.jobType === "seed-crawl"
           ? this.parseSeededConfig()

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -101,7 +101,7 @@ type FormState = {
   jobName: WorkflowParams["name"];
   browserProfile: Profile | null;
   tags: Tags;
-  collections: string[];
+  autoAddCollections: string[];
   description: WorkflowParams["description"];
   autoscrollBehavior: boolean;
 };
@@ -172,7 +172,7 @@ const getDefaultFormState = (): FormState => ({
   jobName: "",
   browserProfile: null,
   tags: [],
-  collections: [],
+  autoAddCollections: [],
   description: null,
   autoscrollBehavior: true,
 });
@@ -472,6 +472,11 @@ export class CrawlConfigEditor extends LiteElement {
     if (this.initialWorkflow.tags?.length) {
       formState.tags = this.initialWorkflow.tags;
     }
+
+    if (this.initialWorkflow.autoAddCollections?.length) {
+      formState.autoAddCollections = this.initialWorkflow.autoAddCollections;
+    }
+
     const secondsToMinutes = (value: any, fallback: number | null) => {
       if (typeof value === "number" && value > 0) return value / 60;
       return fallback;
@@ -499,7 +504,7 @@ export class CrawlConfigEditor extends LiteElement {
       scheduleFrequency: defaultFormState.scheduleFrequency,
       runNow: defaultFormState.runNow,
       tags: this.initialWorkflow.tags,
-      collections: defaultFormState.collections,
+      autoAddCollections: this.initialWorkflow.autoAddCollections,
       jobName: this.initialWorkflow.name || defaultFormState.jobName,
       description: this.initialWorkflow.description,
       browserProfile: this.initialWorkflow.profileid
@@ -1646,13 +1651,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
         html`
           <btrix-collections-add
             .authState=${this.authState}
-            .initialCollections=${this.formState.collections}
+            .initialCollections=${this.formState.autoAddCollections}
             .orgId=${this.orgId}
             .configId=${this.configId}
             @collections-change=${(e: CollectionsChangeEvent) =>
               this.updateFormState(
                 {
-                  collections: e.detail.collections,
+                  autoAddCollections: e.detail.collections,
                 },
                 true
               )}
@@ -2083,7 +2088,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ? this.formState.crawlTimeoutMinutes * 60
         : null,
       tags: this.formState.tags,
-      autoAddCollections: this.formState.collections,
+      autoAddCollections: this.formState.autoAddCollections,
       config: {
         ...(this.jobType === "seed-crawl"
           ? this.parseSeededConfig()

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -28,6 +28,7 @@ const defaultValue = {
   crawlTimeout: null,
   jobType: undefined,
   scale: 1,
+  autoAddCollections: []
 } as WorkflowParams;
 
 /**

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -10,6 +10,8 @@ export type Collection = {
   resources: string[];
 };
 
+export type CollectionList = Collection[];
+
 export type CollectionSearchValues = {
   names: string[];
 }

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -44,6 +44,7 @@ export type WorkflowParams = {
   tags: string[];
   crawlTimeout: number | null;
   description: string | null;
+  autoAddCollections: string[];
 };
 
 export type CrawlConfig = WorkflowParams & {
@@ -73,6 +74,7 @@ export type Workflow = CrawlConfig & {
   inactive: boolean;
   firstSeed: string;
   isCrawlRunning: boolean | null;
+  autoAddCollections: string[];
 };
 
 export type Profile = {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -122,4 +122,5 @@ export type Crawl = CrawlConfig & {
   firstSeed: string;
   seedCount: number;
   stopping: boolean;
+  collections: string[];
 };


### PR DESCRIPTION
Fixes #850 

- Adds collections search and list to workflow editor
- Adds collections to workflow details component
- Adds `namePrefix` filter to backend `GET /orgs/{oid}/collections` endpoint to support case-insensitive searching of collections

## Notes

- I took some liberty with how to display the collections in the workflow details/review panel, feedback and changes are very welcome. Currently they're using `sl-tag` components, not pilled to differentiate from our btrix-tags
- The search will only work as-expected with a local backend or a backend deployed from this branch, since this PR also introduces the `namePrefix` filter on the backend for the collections list API endpoint. If you try it with another backend (e.g. current dev instance), each search will return all collections since it doesn't recognize the filter.

## Screenshots

### Collection search (workflow editor)

<img width="527" alt="Screen Shot 2023-06-09 at 12 16 12 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/93647c2a-6ae5-4f84-b157-3d8591746c0d">

### Collection list (workflow editor)

<img width="1134" alt="Screen Shot 2023-06-09 at 12 16 33 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/dbcde7de-71ac-4886-a23c-549329a7e456">

### Workflow details

<img width="1142" alt="Screen Shot 2023-06-09 at 12 17 34 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/adef5d28-958e-4037-9b43-16b807d1feef">



