### PR TITLE
Backend API consistency pass

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -422,7 +422,7 @@ class CrawlConfigOps:
 
         if not changed and not metadata_changed:
             return {
-                "success": True,
+                "updated": True,
                 "settings_changed": changed,
                 "metadata_changed": metadata_changed,
             }
@@ -474,7 +474,7 @@ class CrawlConfigOps:
                 )
 
         return {
-            "success": True,
+            "updated": True,
             "settings_changed": changed,
             "metadata_changed": metadata_changed,
         }
@@ -1150,7 +1150,7 @@ def init_crawl_config_api(
         user: User = Depends(user_dep),
     ):
         cid, new_job_name = await ops.add_crawl_config(config, org, user)
-        return {"added": str(cid), "run_now_job": new_job_name}
+        return {"added": True, "id": str(cid), "run_now_job": new_job_name}
 
     @router.patch("/{cid}", dependencies=[Depends(org_crawl_dep)])
     async def update_crawl_config(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -582,7 +582,7 @@ class CrawlOps:
         if not result:
             raise HTTPException(status_code=404, detail=f"Crawl '{crawl_id}' not found")
 
-        return {"success": True}
+        return {"updated": True}
 
     async def update_crawl_scale(
         self, crawl_id: str, org: Organization, crawl_scale: CrawlScale, user: User

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -423,7 +423,7 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
         )
         return paginated_format(profiles, total, page, pageSize)
 
-    @router.post("", response_model=Profile)
+    @router.post("")
     async def commit_browser_to_new(
         browser_commit: ProfileCreateUpdate,
         org: Organization = Depends(org_crawl_dep),

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -239,7 +239,7 @@ class ProfileOps:
             {"_id": profile.id}, {"$set": profile.to_dict()}, upsert=True
         )
 
-        return profile
+        return {"added": True, "id": str(profile.id)}
 
     async def update_profile_metadata(
         self, profileid: UUID4, update: ProfileCreateUpdate
@@ -254,7 +254,7 @@ class ProfileOps:
         ):
             raise HTTPException(status_code=404, detail="profile_not_found")
 
-        return {"success": True}
+        return {"updated": True}
 
     async def list_profiles(
         self,
@@ -446,7 +446,7 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
 
             await ops.commit_to_profile(browser_commit, metadata, profileid)
 
-        return {"success": True}
+        return {"updated": True}
 
     @router.get("/{profileid}", response_model=ProfileWithCrawlConfigs)
     async def get_profile(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -98,7 +98,7 @@ def admin_crawl_id(admin_auth_headers, default_org_id):
     data = r.json()
 
     global _admin_config_id
-    _admin_config_id = data["added"]
+    _admin_config_id = data["id"]
 
     crawl_id = data["run_now_job"]
     # Wait for it to complete and then return crawl ID
@@ -196,7 +196,7 @@ def _crawler_create_config_only(crawler_auth_headers, default_org_id):
     data = r.json()
 
     global _crawler_config_id
-    _crawler_config_id = data["added"]
+    _crawler_config_id = data["id"]
 
 
 @pytest.fixture(scope="session")
@@ -217,7 +217,7 @@ def crawler_crawl_id(crawler_auth_headers, default_org_id):
     data = r.json()
 
     global _crawler_config_id
-    _crawler_config_id = data["added"]
+    _crawler_config_id = data["id"]
 
     crawl_id = data["run_now_job"]
     # Wait for it to complete and then return crawl ID
@@ -288,7 +288,7 @@ def auto_add_collection_id(crawler_auth_headers, default_org_id):
         json={"name": "Auto Add Collection"},
     )
     assert r.status_code == 200
-    return r.json()["added"]["id"]
+    return r.json()["id"]
 
 
 @pytest.fixture(scope="session")
@@ -311,7 +311,7 @@ def auto_add_crawl_id(crawler_auth_headers, default_org_id, auto_add_collection_
     data = r.json()
 
     global _auto_add_config_id
-    _auto_add_config_id = data["added"]
+    _auto_add_config_id = data["id"]
 
     crawl_id = data["run_now_job"]
     # Wait for it to complete and then return crawl ID

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -26,10 +26,11 @@ def test_create_collection(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["added"]["name"] == COLLECTION_NAME
+    assert data["added"]
+    assert data["name"] == COLLECTION_NAME
 
     global _coll_id
-    _coll_id = data["added"]["id"]
+    _coll_id = data["id"]
 
     # Verify crawl in collection
     r = requests.get(
@@ -71,15 +72,23 @@ def test_create_collection_empty_name(
 def test_update_collection(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
 ):
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/update",
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
         headers=crawler_auth_headers,
         json={
             "description": DESCRIPTION,
         },
     )
     assert r.status_code == 200
+    assert r.json()["updated"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
     data = r.json()
+
     assert data["id"] == _coll_id
     assert data["name"] == COLLECTION_NAME
     assert data["description"] == DESCRIPTION
@@ -93,13 +102,23 @@ def test_update_collection(
 def test_rename_collection(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
 ):
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/update",
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
         headers=crawler_auth_headers,
-        json={"name": UPDATED_NAME},
+        json={
+            "name": UPDATED_NAME,
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["updated"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+        headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
+
     assert data["id"] == _coll_id
     assert data["name"] == UPDATED_NAME
     assert data["modified"] >= modified
@@ -119,14 +138,15 @@ def test_rename_collection_taken_name(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["added"]["name"] == SECOND_COLLECTION_NAME
+    assert data["added"]
+    assert data["name"] == SECOND_COLLECTION_NAME
 
     global _second_coll_id
-    _second_coll_id = data["added"]["id"]
+    _second_coll_id = data["id"]
 
     # Try to rename first coll to second collection's name
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/update",
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
         headers=crawler_auth_headers,
         json={"name": SECOND_COLLECTION_NAME},
     )
@@ -406,7 +426,8 @@ def test_delete_collection(crawler_auth_headers, default_org_id, crawler_crawl_i
     )
     assert r.status_code == 200
     data = r.json()
-    coll_id = data["added"]["id"]
+    assert data["added"]
+    coll_id = data["id"]
 
     r = requests.delete(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{coll_id}",

--- a/backend/test/test_crawl_config_search_values.py
+++ b/backend/test/test_crawl_config_search_values.py
@@ -30,6 +30,7 @@ def test_create_new_config_1(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     assert data["added"]
+    assert data["id"]
     assert data["run_now_job"] == None
 
 
@@ -59,6 +60,7 @@ def test_create_new_config_2(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     assert data["added"]
+    assert data["id"]
     assert data["run_now_job"] == None
 
 
@@ -94,6 +96,7 @@ def test_create_new_config_3_duplicates(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     assert data["added"]
+    assert data["id"]
     assert data["run_now_job"] == None
 
 

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -26,10 +26,11 @@ def test_create_new_config_1(admin_auth_headers, default_org_id):
 
     data = r.json()
     assert data["added"]
+    assert data["id"]
     assert data["run_now_job"] == None
 
     global new_cid_1
-    new_cid_1 = data["added"]
+    new_cid_1 = data["id"]
 
 
 def test_get_config_1(admin_auth_headers, default_org_id):
@@ -60,10 +61,11 @@ def test_create_new_config_2(admin_auth_headers, default_org_id):
 
     data = r.json()
     assert data["added"]
+    assert data["id"]
     assert data["run_now_job"] == None
 
     global new_cid_2
-    new_cid_2 = data["added"]
+    new_cid_2 = data["id"]
 
 
 def test_get_config_by_tag_2(admin_auth_headers, default_org_id):

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -26,7 +26,7 @@ def test_add_crawl_config(crawler_auth_headers, default_org_id, sample_crawl_dat
 
     data = r.json()
     global cid
-    cid = data["added"]
+    cid = data["id"]
 
 
 def test_update_name_only(crawler_auth_headers, default_org_id):
@@ -39,7 +39,7 @@ def test_update_name_only(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
 
     data = r.json()
-    assert data["success"]
+    assert data["updated"]
     assert data["metadata_changed"] == True
     assert data["settings_changed"] == False
 
@@ -54,7 +54,7 @@ def test_update_desription_only(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
 
     data = r.json()
-    assert data["success"]
+    assert data["updated"]
     assert data["metadata_changed"] == True
     assert data["settings_changed"] == False
 
@@ -73,7 +73,7 @@ def test_update_crawl_config_metadata(crawler_auth_headers, default_org_id):
     data = r.json()
 
     global _coll_id
-    _coll_id = data["added"]["id"]
+    _coll_id = data["id"]
     assert _coll_id
 
     # Update crawl config
@@ -90,7 +90,7 @@ def test_update_crawl_config_metadata(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
 
     data = r.json()
-    assert data["success"]
+    assert data["updated"]
     assert data["metadata_changed"] == True
     assert data["settings_changed"] == False
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -204,7 +204,7 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["success"]
+    assert data["updated"]
 
     # Verify update was successful
     r = requests.get(

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -123,7 +123,7 @@ def crawl_config_info(admin_auth_headers, default_org_id):
     )
     data = r.json()
 
-    crawl_config_id = data["added"]
+    crawl_config_id = data["id"]
     crawl_id = data["run_now_job"]
     while True:
         r = requests.get(

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -25,8 +25,9 @@ def test_run_two_only_one_concurrent(org_with_quotas, admin_auth_headers):
     global crawl_id_b
     crawl_id_b = run_crawl(org_with_quotas, admin_auth_headers)
 
-    while (
-        get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) in ("starting", "waiting_capacity")
+    while get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) in (
+        "starting",
+        "waiting_capacity",
     ):
         time.sleep(2)
 

--- a/frontend/src/components/crawl-metadata-editor.ts
+++ b/frontend/src/components/crawl-metadata-editor.ts
@@ -183,7 +183,7 @@ export class CrawlMetadataEditor extends LiteElement {
         }
       );
 
-      if (!data.success) {
+      if (!data.updated) {
         throw data;
       }
 

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -567,7 +567,7 @@ export class BrowserProfilesDetail extends LiteElement {
         }
       );
 
-      if (data.success === true) {
+      if (data.updated === true) {
         this.notify({
           message: msg("Successfully saved browser profile."),
           variant: "success",
@@ -612,7 +612,7 @@ export class BrowserProfilesDetail extends LiteElement {
         }
       );
 
-      if (data.success === true) {
+      if (data.updated === true) {
         this.notify({
           message: msg("Successfully saved browser profile."),
           variant: "success",

--- a/frontend/src/pages/org/collection-edit.ts
+++ b/frontend/src/pages/org/collection-edit.ts
@@ -87,18 +87,18 @@ export class CollectionEdit extends LiteElement {
 
     try {
       if (oldCrawlIds && oldCrawlIds) {
-        this.collection = await this.saveCrawlSelection({
+        await this.saveCrawlSelection({
           crawlIds,
           oldCrawlIds,
         });
       } else {
-        this.collection = await this.saveMetadata({ name, description });
+        await this.saveMetadata({ name, description });
       }
 
       this.notify({
         message: msg(
           html`Successfully updated
-            <strong>${this.collection!.name}</strong> Collection.`
+            <strong>${name}</strong> Collection.`
         ),
         variant: "success",
         icon: "check2-circle",
@@ -119,10 +119,10 @@ export class CollectionEdit extends LiteElement {
 
   private saveMetadata(values: { name: string; description: string | null }) {
     return this.apiFetch(
-      `/orgs/${this.orgId}/collections/${this.collectionId}/update`,
+      `/orgs/${this.orgId}/collections/${this.collectionId}`,
       this.authState!,
       {
-        method: "POST",
+        method: "PATCH",
         body: JSON.stringify(values),
       }
     );

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -70,7 +70,7 @@ export class CollectionsNew extends LiteElement {
 
       this.notify({
         message: msg(
-          str`Successfully created "${data.added.name}" Collection.`
+          str`Successfully created "${data.name}" Collection.`
         ),
         variant: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1968,7 +1968,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       });
 
       this.navTo(
-        `/orgs/${this.orgId}/workflows/crawl/${this.configId || data.added}${
+        `/orgs/${this.orgId}/workflows/crawl/${this.configId || data.id}${
           crawlId ? "#watch" : ""
         }`
       );


### PR DESCRIPTION
Fixes #900 

Crawl and invite delete endpoints are currently `POST`s with message bodies (rather than `DELETE`s, like the other delete <object> endpoints). We've decided to leave these as-is rather than try to move the POSTed data in query parameters. All other delete endpoints are `DELETE`s.

Changes to the backend endpoints also have corresponding updates to tests and conftest fixtures as well as the frontend.

Done:

- Make add <object> endpoints consistently return `{"added": True}`, as well as additional fields if helpful (e.g. id, name)
- Make update <object> endpoints consistently return `{"updated": True}`

