### PR TITLE
Fix tag editor menu z-index

### DIFF
--- a/frontend/src/components/tag-input.ts
+++ b/frontend/src/components/tag-input.ts
@@ -71,7 +71,7 @@ export class TagInput extends LitElement {
       }
 
       sl-popup::part(popup) {
-        z-index: 2;
+        z-index: 3;
       }
 
       .shake {


### PR DESCRIPTION
Seems like this broke when we added the collection auto-add.  Setting to 3 fixes the issue.

**Before**
<img width="571" alt="Screenshot 2023-07-04 at 1 32 48 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/7789c870-ec2f-467d-922b-b058631d93cc">

**After**
<img width="529" alt="Screenshot 2023-07-04 at 1 54 17 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/cda85924-1127-4fc3-94fe-2273d10b8946">