### PR TITLE
List crawls, uploads, and all objects in UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,7 +126,7 @@
     }
   },
   "engines": {
-    "node": ">=16 <20"
+    "node": ">=16"
   },
   "resolutions": {
     "**/playwright": "1.32.1"

--- a/frontend/src/components/button.ts
+++ b/frontend/src/components/button.ts
@@ -1,4 +1,7 @@
-import { LitElement, html, css } from "lit";
+/* eslint-disable lit/binding-positions */
+/* eslint-disable lit/no-invalid-html */
+import { LitElement, css } from "lit";
+import { html, literal } from "lit/static-html.js";
 import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -20,6 +23,9 @@ export class Button extends LitElement {
 
   @property({ type: String })
   label?: string;
+
+  @property({ type: String })
+  href?: string;
 
   @property({ type: Boolean })
   raised = false;
@@ -43,7 +49,7 @@ export class Button extends LitElement {
       font-size: 1rem;
     }
 
-    button {
+    .button {
       all: unset;
       display: flex;
       align-items: center;
@@ -58,16 +64,21 @@ export class Button extends LitElement {
         transform 0.15s;
     }
 
-    button[disabled] {
+    .button[disabled] {
       cursor: not-allowed;
       background-color: var(--sl-color-neutral-100) !important;
       color: var(--sl-color-neutral-300) !important;
     }
 
-    button.icon {
+    .button.icon {
       min-width: 1.5rem;
       min-height: 1.5rem;
       padding: 0 var(--sl-spacing-2x-small);
+    }
+
+    .button:not(.icon) {
+      height: var(--sl-input-height-small);
+      padding: 0 var(--sl-spacing-x-small);
     }
 
     .raised {
@@ -98,7 +109,7 @@ export class Button extends LitElement {
     }
 
     .neutral {
-      color: var(--sl-color-neutral-500);
+      color: var(--sl-color-neutral-600);
     }
 
     .neutral:hover {
@@ -107,9 +118,11 @@ export class Button extends LitElement {
   `;
 
   render() {
-    return html`<button
-      type="submit"
+    const tag = this.href ? literal`a` : literal`button`;
+    return html`<${tag}
+      type=${this.type === "submit" ? "submit" : "button"}
       class=${classMap({
+        button: true,
         [this.variant]: true,
         icon: this.icon,
         raised: this.raised,
@@ -119,7 +132,7 @@ export class Button extends LitElement {
       @click=${this.handleClick}
     >
       ${this.loading ? html`<sl-spinner></sl-spinner>` : html`<slot></slot>`}
-    </button>`;
+    </${tag}>`;
   }
 
   private handleClick(e: MouseEvent) {

--- a/frontend/src/components/button.ts
+++ b/frontend/src/components/button.ts
@@ -52,6 +52,7 @@ export class Button extends LitElement {
     .button {
       all: unset;
       display: flex;
+      gap: var(--sl-spacing-x-small);
       align-items: center;
       justify-content: center;
       border-radius: var(--sl-border-radius-small);

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -28,6 +28,7 @@ import type { Crawl } from "../types/crawler";
 import { srOnly, truncate, dropdown } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { isActive } from "../utils/crawler";
+import type { DataListType } from "../pages/org/crawls-list";
 
 const mediumBreakpointCss = css`30rem`;
 const largeBreakpointCss = css`60rem`;
@@ -221,12 +222,14 @@ export class CrawlListItem extends LitElement {
 
   renderRow() {
     const hash = this.crawl && isActive(this.crawl.state) ? "#watch" : "";
+    const dataListType: DataListType =
+      this.crawl?.type === "upload" ? "uploads" : "all";
     return html`<a
       class="item row"
       role="button"
       href=${`${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/crawl`}/${
         this.crawl?.id
-      }${hash}`}
+      }?dataListType=${dataListType}${hash}`}
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;
@@ -448,7 +451,8 @@ export class CrawlList extends LitElement {
     columnCss,
     hostVars,
     css`
-      .listHeader, .list {
+      .listHeader,
+      .list {
         margin-left: var(--row-offset);
         margin-right: var(--row-offset);
       }
@@ -464,7 +468,7 @@ export class CrawlList extends LitElement {
       }
 
       .row {
-        display none;
+        display: none;
         font-size: var(--sl-font-size-x-small);
         color: var(--sl-color-neutral-600);
       }

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -28,7 +28,6 @@ import type { Crawl } from "../types/crawler";
 import { srOnly, truncate, dropdown } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { isActive } from "../utils/crawler";
-import type { DataListType } from "../pages/org/crawls-list";
 
 const mediumBreakpointCss = css`30rem`;
 const largeBreakpointCss = css`60rem`;
@@ -222,14 +221,13 @@ export class CrawlListItem extends LitElement {
 
   renderRow() {
     const hash = this.crawl && isActive(this.crawl.state) ? "#watch" : "";
-    const dataListType: DataListType =
-      this.crawl?.type === "upload" ? "uploads" : "all";
+    const artifactType = this.crawl?.type || "crawl";
     return html`<a
       class="item row"
       role="button"
       href=${`${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/crawl`}/${
         this.crawl?.id
-      }?dataListType=${dataListType}${hash}`}
+      }?artifactType=${artifactType}${hash}`}
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -250,6 +250,7 @@ export class CrawlListItem extends LitElement {
               <btrix-crawl-status
                 state=${workflow.state}
                 hideLabel
+                ?isUpload=${workflow.type === "upload"}
               ></btrix-crawl-status>
               <slot name="id">${this.renderName(workflow)}</slot>
             `

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -318,6 +318,10 @@ export class CrawlListItem extends LitElement {
           </div>`;
         })}
         ${this.safeRender((crawl) => {
+          if (crawl.type === "upload") {
+            // TODO add back once API supports page count
+            return;
+          }
           if (crawl.finished) {
             const pagesComplete = +(crawl.stats?.done || 0);
             return html`

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -512,11 +512,11 @@ export class CrawlList extends LitElement {
   render() {
     return html` <div class="listHeader row">
         <div class="col">
-          <slot name="idCol">${msg("Workflow")}</slot>
+          <slot name="idCol">${msg("Name")}</slot>
         </div>
         <div class="col">${msg("Finished")}</div>
         <div class="col">${msg("Size")}</div>
-        <div class="col">${msg("Started By")}</div>
+        <div class="col">${msg("Created By")}</div>
         <div class="col action">
           <span class="srOnly">${msg("Actions")}</span>
         </div>

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -509,6 +509,9 @@ export class CrawlList extends LitElement {
   @property({ type: String, noAccessor: true })
   baseUrl?: string;
 
+  @property({ type: String })
+  artifactType: Crawl["type"] = null;
+
   @queryAssignedElements({ selector: "btrix-crawl-list-item" })
   listItems!: Array<HTMLElement>;
 
@@ -517,7 +520,9 @@ export class CrawlList extends LitElement {
         <div class="col">
           <slot name="idCol">${msg("Name")}</slot>
         </div>
-        <div class="col">${msg("Finished")}</div>
+        <div class="col">
+          ${this.artifactType === "upload" ? msg("Uploaded") : msg("Finished")}
+        </div>
         <div class="col">${msg("Size")}</div>
         <div class="col">${msg("Created By")}</div>
         <div class="col action">

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -278,7 +278,7 @@ export class CrawlListItem extends LitElement {
           )}
         </div>
         ${this.safeRender((crawl) =>
-          crawl.finished
+          crawl.finished && crawl.type === "crawl"
             ? html`<div class="desc truncate">
                 ${msg(
                   str`in ${RelativeDuration.humanize(
@@ -524,7 +524,11 @@ export class CrawlList extends LitElement {
           ${this.artifactType === "upload" ? msg("Uploaded") : msg("Finished")}
         </div>
         <div class="col">${msg("Size")}</div>
-        <div class="col">${msg("Created By")}</div>
+        <div class="col">
+          ${this.artifactType === "upload"
+            ? msg("Uploaded By")
+            : msg("Started By")}
+        </div>
         <div class="col action">
           <span class="srOnly">${msg("Actions")}</span>
         </div>

--- a/frontend/src/components/crawl-metadata-editor.ts
+++ b/frontend/src/components/crawl-metadata-editor.ts
@@ -175,7 +175,9 @@ export class CrawlMetadataEditor extends LiteElement {
 
     try {
       const data = await this.apiFetch(
-        `/orgs/${this.crawl!.oid}/crawls/${this.crawl.id}`,
+        `/orgs/${this.crawl!.oid}/${
+          this.crawl!.type === "crawl" ? "crawls" : "uploads"
+        }/${this.crawl.id}`,
         this.authState!,
         {
           method: "PATCH",

--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -16,6 +16,9 @@ export class CrawlStatus extends LitElement {
   hideLabel = false;
 
   @property({ type: Boolean })
+  isUpload = false;
+
+  @property({ type: Boolean })
   stopping = false;
 
   static styles = [
@@ -54,7 +57,10 @@ export class CrawlStatus extends LitElement {
 
   // TODO look into customizing sl-select multi-select
   // instead of separate utility function?
-  static getContent(state?: CrawlState): {
+  static getContent(
+    state?: CrawlState,
+    isUpload?: boolean
+  ): {
     icon: TemplateResult;
     label: string;
   } {
@@ -87,7 +93,10 @@ export class CrawlStatus extends LitElement {
           slot="prefix"
           style="color: var(--sl-color-purple-600)"
         ></sl-icon>`;
-        label = state === "waiting_capacity" ? msg("Waiting (At Capacity)") : msg("Waiting (Crawl Limit)");
+        label =
+          state === "waiting_capacity"
+            ? msg("Waiting (At Capacity)")
+            : msg("Waiting (Crawl Limit)");
         break;
       }
 
@@ -117,7 +126,7 @@ export class CrawlStatus extends LitElement {
 
       case "complete": {
         icon = html`<sl-icon
-          name="check-circle"
+          name=${isUpload ? "upload" : "check-circle"}
           slot="prefix"
           style="color: var(--success)"
         ></sl-icon>`;
@@ -127,7 +136,7 @@ export class CrawlStatus extends LitElement {
 
       case "failed": {
         icon = html`<sl-icon
-          name="exclamation-triangle"
+          name=${isUpload ? "upload" : "exclamation-triangle"}
           slot="prefix"
           style="color: var(--danger)"
         ></sl-icon>`;
@@ -177,8 +186,9 @@ export class CrawlStatus extends LitElement {
   }
 
   render() {
-    const state = this.stopping && this.state === "running" ? "stopping" : this.state;
-    const { icon, label } = CrawlStatus.getContent(state);
+    const state =
+      this.stopping && this.state === "running" ? "stopping" : this.state;
+    const { icon, label } = CrawlStatus.getContent(state, this.isUpload);
     if (this.hideLabel) {
       return html`<div class="icon-only">
         <sl-tooltip content=${label}

--- a/frontend/src/components/crawl-status.ts
+++ b/frontend/src/components/crawl-status.ts
@@ -130,7 +130,7 @@ export class CrawlStatus extends LitElement {
           slot="prefix"
           style="color: var(--success)"
         ></sl-icon>`;
-        label = msg("Complete");
+        label = isUpload ? msg("Uploaded") : msg("Complete");
         break;
       }
 

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -54,6 +54,7 @@ export class Crawls extends LiteElement {
       .authState=${this.authState}
       crawlsBaseUrl=${ROUTES.crawls}
       crawlsAPIBaseUrl="/orgs/all/crawls"
+      artifactType="crawl"
       isCrawler
       isAdminView
       shouldFetch

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -239,7 +239,7 @@ export class CrawlDetail extends LiteElement {
           <span class="inline-block align-middle"
             >${isWorkflowArtifact
               ? msg("Back to Crawl Workflow")
-              : msg("Back to Archive Data")}</span
+              : msg("Back to Web Archives")}</span
           >
         </a>
       </div>

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -49,8 +49,14 @@ export class CrawlDetail extends LiteElement {
   @property({ type: String })
   crawlsAPIBaseUrl?: string;
 
+  @property({ type: String })
+  crawlType: Crawl["type"] = null;
+
   @property({ type: Boolean })
   showOrgLink = false;
+
+  @property({ type: String })
+  orgId!: string;
 
   @property({ type: String })
   crawlId!: string;
@@ -309,11 +315,7 @@ export class CrawlDetail extends LiteElement {
       const isActive = section === this.sectionName;
       const baseUrl = window.location.pathname.split("#")[0];
       return html`
-        <li
-          class="relative grow"
-          role="menuitem"
-          aria-selected=${isActive.toString()}
-        >
+        <li class="relative grow" role="menuitem" aria-selected="${isActive}">
           <a
             class="flex gap-2 flex-col md:flex-row items-center font-semibold rounded-md h-full p-2 ${isActive
               ? "text-blue-600 bg-blue-100 shadow-sm"
@@ -674,7 +676,7 @@ export class CrawlDetail extends LiteElement {
           ${this.crawl?.stats
             ? html`
                 <sl-format-bytes
-                  value=${this.crawl.stats.size}
+                  value=${+this.crawl.stats.size}
                   display="narrow"
                 ></sl-format-bytes
                 ><span>,</span>
@@ -885,12 +887,13 @@ ${this.crawl?.notes}
   }
 
   private async getCrawl(): Promise<Crawl> {
-    const data: Crawl = await this.apiFetch(
-      `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
-        this.crawlId
-      }/replay.json`,
-      this.authState!
-    );
+    const apiPath =
+      this.crawlType === "upload"
+        ? `/orgs/${this.orgId}/uploads/${this.crawlId}`
+        : `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
+            this.crawlId
+          }/replay.json`;
+    const data: Crawl = await this.apiFetch(apiPath, this.authState!);
 
     return data;
   }

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -320,7 +320,7 @@ export class CrawlDetail extends LiteElement {
             class="flex gap-2 flex-col md:flex-row items-center font-semibold rounded-md h-full p-2 ${isActive
               ? "text-blue-600 bg-blue-100 shadow-sm"
               : "text-neutral-600 hover:bg-blue-50"}"
-            href=${`${baseUrl}#${section}`}
+            href=${`${baseUrl}${window.location.search}#${section}`}
             @click=${() => (this.sectionName = section)}
           >
             <sl-icon

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -358,12 +358,14 @@ export class CrawlDetail extends LiteElement {
             icon: "folder-fill",
             label: msg("Files"),
           })}
-          ${renderNavItem({
-            section: "logs",
-            iconLibrary: "default",
-            icon: "terminal-fill",
-            label: msg("Error Logs"),
-          })}
+          ${when(this.crawlType === "crawl", () =>
+            renderNavItem({
+              section: "logs",
+              iconLibrary: "default",
+              icon: "terminal-fill",
+              label: msg("Error Logs"),
+            })
+          )}
           ${renderNavItem({
             section: "config",
             iconLibrary: "default",
@@ -909,6 +911,9 @@ ${this.crawl?.notes}
   private async fetchCrawlLogs(
     params: Partial<APIPaginatedList> = {}
   ): Promise<void> {
+    if (this.crawlType !== "crawl") {
+      return;
+    }
     try {
       this.logs = await this.getCrawlLogs(params);
     } catch {

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -460,15 +460,14 @@ export class CrawlDetail extends LiteElement {
                 <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
                 ${msg("Go to Workflow")}
               </sl-menu-item>
+              <sl-menu-item
+                @click=${() => CopyButton.copyToClipboard(this.crawl!.cid)}
+              >
+                <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
+                ${msg("Copy Workflow ID")}
+              </sl-menu-item>
             `
           )}
-
-          <sl-menu-item
-            @click=${() => CopyButton.copyToClipboard(this.crawl!.cid)}
-          >
-            <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
-            ${msg("Copy Workflow ID")}
-          </sl-menu-item>
           <sl-menu-item
             @click=${() =>
               CopyButton.copyToClipboard(this.crawl!.tags.join(", "))}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -441,15 +441,23 @@ export class CrawlDetail extends LiteElement {
               <sl-divider></sl-divider>
             `
           )}
-          <sl-menu-item
-            @click=${() =>
-              this.navTo(
-                `/orgs/${this.crawl!.oid}/workflows/crawl/${this.crawl!.cid}`
-              )}
-          >
-            <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
-            ${msg("Go to Workflow")}
-          </sl-menu-item>
+          ${when(
+            this.crawlType === "crawl",
+            () => html`
+              <sl-menu-item
+                @click=${() =>
+                  this.navTo(
+                    `/orgs/${this.crawl!.oid}/workflows/crawl/${
+                      this.crawl!.cid
+                    }`
+                  )}
+              >
+                <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
+                ${msg("Go to Workflow")}
+              </sl-menu-item>
+            `
+          )}
+
           <sl-menu-item
             @click=${() => CopyButton.copyToClipboard(this.crawl!.cid)}
           >

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -239,7 +239,7 @@ export class CrawlDetail extends LiteElement {
           <span class="inline-block align-middle"
             >${isWorkflowArtifact
               ? msg("Back to Crawl Workflow")
-              : msg("Back to Finished Crawls")}</span
+              : msg("Back to Archive Data")}</span
           >
         </a>
       </div>
@@ -576,7 +576,7 @@ export class CrawlDetail extends LiteElement {
 
     const headers = this.authState?.headers;
 
-    const config = JSON.stringify({headers});
+    const config = JSON.stringify({ headers });
 
     const canReplay = replaySource && this.hasFiles;
 
@@ -676,7 +676,8 @@ export class CrawlDetail extends LiteElement {
                 <sl-format-bytes
                   value=${this.crawl.stats.size}
                   display="narrow"
-                ></sl-format-bytes><span>,</span>
+                ></sl-format-bytes
+                ><span>,</span>
                 <span
                   class="font-mono tracking-tighter${this.isActive
                     ? " text-purple-600"
@@ -834,7 +835,9 @@ ${this.crawl?.notes}
 
     if (!this.logs.total) {
       return html`<div class="border rounded-lg p-4">
-        <p class="text-sm text-neutral-400">${msg("No error logs to display.")}</p>
+        <p class="text-sm text-neutral-400">
+          ${msg("No error logs to display.")}
+        </p>
       </div>`;
     }
 
@@ -857,7 +860,10 @@ ${this.crawl?.notes}
     return html`
       <btrix-config-details
         .authState=${this.authState!}
-        .crawlConfig=${{ ...this.crawl, autoAddCollections: this.crawl.collections }}
+        .crawlConfig=${{
+          ...this.crawl,
+          autoAddCollections: this.crawl.collections,
+        }}
         hideTags
       ></btrix-config-details>
     `;

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -990,7 +990,9 @@ ${this.crawl?.notes}
 
     try {
       const data = await this.apiFetch(
-        `/orgs/${this.crawl!.oid}/crawls/delete`,
+        `/orgs/${this.crawl!.oid}/${
+          this.crawl!.type === "crawl" ? "crawls" : "uploads"
+        }/delete`,
         this.authState!,
         {
           method: "POST",

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -513,77 +513,6 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
-  // renders the info bar, currently disabled
-  private renderSummary() {
-    return html`
-      <dl class="grid grid-cols-4 gap-5 text-center p-3 text-sm">
-        <div class="col-span-2 md:col-span-1">
-          <dt class="text-xs text-0-600">${msg("Status")}</dt>
-          <dd>
-            ${this.crawl
-              ? html`
-                  <btrix-crawl-status
-                    state=${this.crawl.state}
-                  ></btrix-crawl-status>
-                `
-              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
-          </dd>
-        </div>
-        <div class="col-span-2 md:col-span-1">
-          <dt class="text-xs text-0-600">${msg("Pages Crawled")}</dt>
-          <dd>
-            ${this.crawl?.stats
-              ? html`
-                  <span
-                    class="font-mono tracking-tighter${this.isActive
-                      ? " text-purple-600"
-                      : ""}"
-                  >
-                    ${this.numberFormatter.format(+this.crawl.stats.done)}
-                    <span class="text-0-400">/</span>
-                    ${this.numberFormatter.format(+this.crawl.stats.found)}
-                  </span>
-                `
-              : this.crawl
-              ? html` <span class="text-0-400">${msg("Unknown")}</span> `
-              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
-          </dd>
-        </div>
-        <div class="col-span-2 md:col-span-1">
-          <dt class="text-xs text-0-600">${msg("Run Duration")}</dt>
-          <dd>
-            ${this.crawl
-              ? html`
-                  ${this.crawl.finished
-                    ? html`${RelativeDuration.humanize(
-                        new Date(`${this.crawl.finished}Z`).valueOf() -
-                          new Date(`${this.crawl.started}Z`).valueOf()
-                      )}`
-                    : html`
-                        <span class="text-purple-600">
-                          <btrix-relative-duration
-                            value=${`${this.crawl.started}Z`}
-                            unitCount="3"
-                            tickSeconds="1"
-                          ></btrix-relative-duration>
-                        </span>
-                      `}
-                `
-              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
-          </dd>
-        </div>
-        <div class="col-span-2 md:col-span-1">
-          <dt class="text-xs text-0-600">${msg("Crawler Instances")}</dt>
-          <dd>
-            ${this.crawl
-              ? this.crawl?.scale
-              : html`<sl-skeleton class="h-5"></sl-skeleton>`}
-          </dd>
-        </div>
-      </dl>
-    `;
-  }
-
   private renderReplay() {
     //const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json?auth_bearer=${bearer}`;
     const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json`;
@@ -628,62 +557,80 @@ export class CrawlDetail extends LiteElement {
             ? html`
                 <btrix-crawl-status
                   state=${this.crawl.state}
+                  ?isUpload=${this.crawl.type === "upload"}
                 ></btrix-crawl-status>
               `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Start Time")}>
-          ${this.crawl
+        ${when(this.crawl, () =>
+          this.crawl!.type === "upload"
             ? html`
-                <sl-format-date
-                  date=${`${this.crawl.started}Z` /** Z for UTC */}
-                  month="2-digit"
-                  day="2-digit"
-                  year="2-digit"
-                  hour="numeric"
-                  minute="numeric"
-                  time-zone-name="short"
-                ></sl-format-date>
+                <btrix-desc-list-item label=${msg("Uploaded")}>
+                  <sl-format-date
+                    date=${`${this.crawl!.finished}Z` /** Z for UTC */}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="numeric"
+                    minute="numeric"
+                    time-zone-name="short"
+                  ></sl-format-date>
+                </btrix-desc-list-item>
               `
-            : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-        </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Finish Time")}>
-          ${this.crawl
-            ? html`
-                ${this.crawl.finished
-                  ? html`<sl-format-date
-                      date=${`${this.crawl.finished}Z` /** Z for UTC */}
-                      month="2-digit"
-                      day="2-digit"
-                      year="2-digit"
-                      hour="numeric"
-                      minute="numeric"
-                      time-zone-name="short"
-                    ></sl-format-date>`
-                  : html`<span class="text-0-400">${msg("Pending")}</span>`}
+            : html`
+                <btrix-desc-list-item label=${msg("Start Time")}>
+                  <sl-format-date
+                    date=${`${this.crawl!.started}Z` /** Z for UTC */}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="numeric"
+                    minute="numeric"
+                    time-zone-name="short"
+                  ></sl-format-date>
+                </btrix-desc-list-item>
+                <btrix-desc-list-item label=${msg("Finish Time")}>
+                  ${this.crawl!.finished
+                    ? html`<sl-format-date
+                        date=${`${this.crawl!.finished}Z` /** Z for UTC */}
+                        month="2-digit"
+                        day="2-digit"
+                        year="2-digit"
+                        hour="numeric"
+                        minute="numeric"
+                        time-zone-name="short"
+                      ></sl-format-date>`
+                    : html`<span class="text-0-400">${msg("Pending")}</span>`}
+                </btrix-desc-list-item>
+                <btrix-desc-list-item label=${msg("Duration")}>
+                  ${this.crawl!.finished
+                    ? html`${RelativeDuration.humanize(
+                        new Date(`${this.crawl!.finished}Z`).valueOf() -
+                          new Date(`${this.crawl!.started}Z`).valueOf()
+                      )}`
+                    : html`
+                        <span class="text-purple-600">
+                          <btrix-relative-duration
+                            value=${`${this.crawl!.started}Z`}
+                            unitCount="3"
+                            tickSeconds="1"
+                          ></btrix-relative-duration>
+                        </span>
+                      `}
+                </btrix-desc-list-item>
+                <btrix-desc-list-item label=${msg("Initiator")}>
+                  ${this.crawl!.manual
+                    ? msg(
+                        html`Manual start by
+                          <span
+                            >${this.crawl!.userName || this.crawl!.userid}</span
+                          >`
+                      )
+                    : msg(html`Scheduled start`)}
+                </btrix-desc-list-item>
               `
-            : html`<sl-skeleton class="h-6"></sl-skeleton>`}
-        </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Duration")}>
-          ${this.crawl
-            ? html`
-                ${this.crawl.finished
-                  ? html`${RelativeDuration.humanize(
-                      new Date(`${this.crawl.finished}Z`).valueOf() -
-                        new Date(`${this.crawl.started}Z`).valueOf()
-                    )}`
-                  : html`
-                      <span class="text-purple-600">
-                        <btrix-relative-duration
-                          value=${`${this.crawl.started}Z`}
-                          unitCount="3"
-                          tickSeconds="1"
-                        ></btrix-relative-duration>
-                      </span>
-                    `}
-              `
-            : html`<sl-skeleton class="h-5"></sl-skeleton>`}
-        </btrix-desc-list-item>
+        )}
+
         <btrix-desc-list-item label=${msg("Size")}>
           ${this.crawl
             ? html`${this.crawl.fileSize
@@ -710,20 +657,6 @@ export class CrawlDetail extends LiteElement {
                       : ""}`
                 : html`<span class="text-0-400">${msg("Unknown")}</span>`}`
             : html`<sl-skeleton class="h-5"></sl-skeleton>`}
-        </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Initiator")}>
-          ${this.crawl
-            ? html`
-                ${this.crawl.manual
-                  ? msg(
-                      html`Manual start by
-                        <span
-                          >${this.crawl?.userName || this.crawl?.userid}</span
-                        >`
-                    )
-                  : msg(html`Scheduled start`)}
-              `
-            : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Crawl ID")}>
           ${this.crawl

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -686,26 +686,30 @@ export class CrawlDetail extends LiteElement {
             : html`<sl-skeleton class="h-5"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Size")}>
-          ${this.crawl?.stats
-            ? html`
-                <sl-format-bytes
-                  value=${+this.crawl.stats.size}
-                  display="narrow"
-                ></sl-format-bytes
-                ><span>,</span>
-                <span
-                  class="font-mono tracking-tighter${this.isActive
-                    ? " text-purple-600"
-                    : ""}"
-                >
-                  ${this.numberFormatter.format(+this.crawl.stats.done)}
-                  <span class="text-0-400">/</span>
-                  ${this.numberFormatter.format(+this.crawl.stats.found)}
-                </span>
-                <span> pages</span>
-              `
-            : this.crawl
-            ? html` <span class="text-0-400">${msg("Unknown")}</span> `
+          ${this.crawl
+            ? html`${this.crawl.fileSize
+                ? html`<sl-format-bytes
+                      value=${this.crawl.fileSize || 0}
+                      display="narrow"
+                    ></sl-format-bytes
+                    >${this.crawl.stats
+                      ? html`<span>,</span
+                          ><span
+                            class="font-mono tracking-tighter${this.isActive
+                              ? " text-purple-600"
+                              : ""}"
+                          >
+                            ${this.numberFormatter.format(
+                              +this.crawl.stats.done
+                            )}
+                            <span class="text-0-400">/</span>
+                            ${this.numberFormatter.format(
+                              +this.crawl.stats.found
+                            )}
+                          </span>
+                          <span> pages</span>`
+                      : ""}`
+                : html`<span class="text-0-400">${msg("Unknown")}</span>`}`
             : html`<sl-skeleton class="h-5"></sl-skeleton>`}
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Initiator")}>

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -245,7 +245,7 @@ export class CrawlDetail extends LiteElement {
           <span class="inline-block align-middle"
             >${isWorkflowArtifact
               ? msg("Back to Crawl Workflow")
-              : msg("Back to Web Archives")}</span
+              : msg("Back to Archived Data")}</span
           >
         </a>
       </div>

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -358,20 +358,23 @@ export class CrawlDetail extends LiteElement {
             icon: "folder-fill",
             label: msg("Files"),
           })}
-          ${when(this.crawlType === "crawl", () =>
-            renderNavItem({
-              section: "logs",
-              iconLibrary: "default",
-              icon: "terminal-fill",
-              label: msg("Error Logs"),
-            })
+          ${when(
+            this.crawlType === "crawl",
+            () => html`
+              ${renderNavItem({
+                section: "logs",
+                iconLibrary: "default",
+                icon: "terminal-fill",
+                label: msg("Error Logs"),
+              })}
+              ${renderNavItem({
+                section: "config",
+                iconLibrary: "default",
+                icon: "file-code-fill",
+                label: msg("Config"),
+              })}
+            `
           )}
-          ${renderNavItem({
-            section: "config",
-            iconLibrary: "default",
-            icon: "file-code-fill",
-            label: msg("Config"),
-          })}
         </ul>
       </nav>
     `;

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -514,14 +514,16 @@ export class CrawlDetail extends LiteElement {
   }
 
   private renderReplay() {
-    //const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json?auth_bearer=${bearer}`;
-    const replaySource = `/api/orgs/${this.crawl?.oid}/crawls/${this.crawlId}/replay.json`;
+    if (!this.crawl) return;
+    const replaySource = `/api/orgs/${this.crawl.oid}/${
+      this.crawl.type === "upload" ? "uploads" : "crawls"
+    }/${this.crawlId}/replay.json`;
 
     const headers = this.authState?.headers;
 
     const config = JSON.stringify({ headers });
 
-    const canReplay = replaySource && this.hasFiles;
+    const canReplay = this.hasFiles;
 
     return html`
       <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
@@ -838,7 +840,7 @@ ${this.crawl?.notes}
   private async getCrawl(): Promise<Crawl> {
     const apiPath =
       this.artifactType === "upload"
-        ? `/orgs/${this.orgId}/uploads/${this.crawlId}`
+        ? `/orgs/${this.orgId}/uploads/${this.crawlId}/replay.json`
         : `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
             this.crawlId
           }/replay.json`;

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -50,7 +50,7 @@ export class CrawlDetail extends LiteElement {
   crawlsAPIBaseUrl?: string;
 
   @property({ type: String })
-  crawlType: Crawl["type"] = null;
+  artifactType: Crawl["type"] = null;
 
   @property({ type: Boolean })
   showOrgLink = false;
@@ -359,7 +359,7 @@ export class CrawlDetail extends LiteElement {
             label: msg("Files"),
           })}
           ${when(
-            this.crawlType === "crawl",
+            this.artifactType === "crawl",
             () => html`
               ${renderNavItem({
                 section: "logs",
@@ -447,7 +447,7 @@ export class CrawlDetail extends LiteElement {
             `
           )}
           ${when(
-            this.crawlType === "crawl",
+            this.artifactType === "crawl",
             () => html`
               <sl-menu-item
                 @click=${() =>
@@ -904,7 +904,7 @@ ${this.crawl?.notes}
 
   private async getCrawl(): Promise<Crawl> {
     const apiPath =
-      this.crawlType === "upload"
+      this.artifactType === "upload"
         ? `/orgs/${this.orgId}/uploads/${this.crawlId}`
         : `${this.crawlsAPIBaseUrl || this.crawlsBaseUrl}/${
             this.crawlId
@@ -917,7 +917,7 @@ ${this.crawl?.notes}
   private async fetchCrawlLogs(
     params: Partial<APIPaginatedList> = {}
   ): Promise<void> {
-    if (this.crawlType !== "crawl") {
+    if (this.artifactType !== "crawl") {
       return;
     }
     try {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -32,6 +32,11 @@ type SearchResult = {
 };
 type SortField = "started" | "finished" | "firstSeed" | "fileSize";
 type SortDirection = "asc" | "desc";
+export type DataListType =
+  | "all"
+  | "finished-crawls"
+  | "running-crawls"
+  | "uploads";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_PAGE_SIZE = 30;
@@ -100,6 +105,9 @@ export class CrawlsList extends LiteElement {
   // e.g. `/org/${this.orgId}/crawls`
   @property({ type: String })
   crawlsAPIBaseUrl?: string;
+
+  @property({ type: String })
+  dataListType: DataListType = "all";
 
   /**
    * Fetch & refetch data when needed,
@@ -236,14 +244,47 @@ export class CrawlsList extends LiteElement {
     }
 
     const hasCrawlItems = this.crawls.items.length;
+    const listTypes: { listType: DataListType; label: string }[] = [
+      {
+        listType: "all",
+        label: msg("All"),
+      },
+      {
+        listType: "finished-crawls",
+        label: msg("Finished Crawls"),
+      },
+      {
+        listType: "uploads",
+        label: msg("Uploads"),
+      },
+    ];
+
+    // TODO only running crawls
+    if (this.isAdminView) {
+      listTypes.push({
+        listType: "running-crawls",
+        label: msg("Running Crawls"),
+      });
+    }
 
     return html`
       <main>
         <header class="contents">
-          <div class="flex w-full h-8 mb-4">
-            <h1 class="text-xl font-semibold">
-              ${this.isAdminView ? msg("Running Crawls") : msg("Archive Data")}
-            </h1>
+          <div class="flex w-full pb-3 mb-3 border-b">
+            <h1 class="text-xl font-semibold h-8">${msg("Archive Data")}</h1>
+          </div>
+          <div class="flex gap-2 mb-3">
+            ${listTypes.map(({ label, listType }) => {
+              const isSelected = listType === this.dataListType;
+              return html` <btrix-button
+                variant=${isSelected ? "primary" : "neutral"}
+                ?raised=${isSelected}
+                aria-selected="${isSelected}"
+                href=${`${this.crawlsBaseUrl}?dataListType=${listType}`}
+                @click=${this.navLink}
+                >${label}</btrix-button
+              >`;
+            })}
           </div>
           <div
             class="sticky z-10 mb-3 top-2 p-4 bg-neutral-50 border rounded-lg"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -42,12 +42,12 @@ const sortableFields: Record<
   SortField,
   { label: string; defaultDirection?: SortDirection }
 > = {
-  started: {
-    label: msg("Date Started"),
-    defaultDirection: "desc",
-  },
   finished: {
     label: msg("Date Finished"),
+    defaultDirection: "desc",
+  },
+  started: {
+    label: msg("Date Started"),
     defaultDirection: "desc",
   },
   firstSeed: {
@@ -388,40 +388,7 @@ export class CrawlsList extends LiteElement {
           <div class="whitespace-nowrap text-neutral-500 mx-2">
             ${msg("Sort by:")}
           </div>
-          <div class="grow flex">
-            <sl-select
-              class="flex-1 md:w-[9.2rem]"
-              size="small"
-              pill
-              value=${this.orderBy.field}
-              @sl-change=${(e: Event) => {
-                const field = (e.target as HTMLSelectElement)
-                  .value as SortField;
-                this.orderBy = {
-                  field: field,
-                  direction:
-                    sortableFields[field].defaultDirection ||
-                    this.orderBy.direction,
-                };
-              }}
-            >
-              ${Object.entries(sortableFields).map(
-                ([value, { label }]) => html`
-                  <sl-option value=${value}>${label}</sl-option>
-                `
-              )}
-            </sl-select>
-            <sl-icon-button
-              name="arrow-down-up"
-              label=${msg("Reverse sort")}
-              @click=${() => {
-                this.orderBy = {
-                  ...this.orderBy,
-                  direction: this.orderBy.direction === "asc" ? "desc" : "asc",
-                };
-              }}
-            ></sl-icon-button>
-          </div>
+          <div class="grow flex">${this.renderSortControl()}</div>
         </div>
       </div>
 
@@ -439,6 +406,54 @@ export class CrawlsList extends LiteElement {
             </label>
           </div>`
         : ""}
+    `;
+  }
+
+  private renderSortControl() {
+    let options: any;
+    if (this.artifactType === "upload") {
+      options = html`
+        <sl-option value="finished">${msg("Date Uploaded")}</sl-option>
+      `;
+    } else if (this.artifactType === "crawl") {
+      options = Object.entries(sortableFields).map(
+        ([value, { label }]) => html`
+          <sl-option value=${value}>${label}</sl-option>
+        `
+      );
+    } else {
+      options = html`
+        <sl-option value="finished">${sortableFields.finished.label}</sl-option>
+        <sl-option value="started">${sortableFields.started.label}</sl-option>
+      `;
+    }
+    return html`
+      <sl-select
+        class="flex-1 md:w-[10rem]"
+        size="small"
+        pill
+        value=${this.orderBy.field}
+        @sl-change=${(e: Event) => {
+          const field = (e.target as HTMLSelectElement).value as SortField;
+          this.orderBy = {
+            field: field,
+            direction:
+              sortableFields[field].defaultDirection || this.orderBy.direction,
+          };
+        }}
+      >
+        ${options}
+      </sl-select>
+      <sl-icon-button
+        name="arrow-down-up"
+        label=${msg("Reverse sort")}
+        @click=${() => {
+          this.orderBy = {
+            ...this.orderBy,
+            direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+          };
+        }}
+      ></sl-icon-button>
     `;
   }
 
@@ -464,9 +479,7 @@ export class CrawlsList extends LiteElement {
       >
         <sl-input
           size="small"
-          placeholder=${msg(
-            "Filter by Workflow Name, Crawl Start URL, or Workflow ID"
-          )}
+          placeholder=${msg("Filter by Name, Crawl Start URL, or Workflow ID")}
           clearable
           value=${this.searchByValue}
           @sl-clear=${() => {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -257,7 +257,7 @@ export class CrawlsList extends LiteElement {
       {
         listType: "finished-crawls",
         icon: "gear-wide-connected",
-        label: msg("Finished Crawls"),
+        label: msg("Crawls"),
       },
     ];
 
@@ -283,7 +283,7 @@ export class CrawlsList extends LiteElement {
       <main>
         <header class="contents">
           <div class="flex w-full pb-3 mb-3 border-b">
-            <h1 class="text-xl font-semibold h-8">${msg("Archive Data")}</h1>
+            <h1 class="text-xl font-semibold h-8">${msg("Web Archives")}</h1>
           </div>
           <div class="flex gap-2 mb-3">
             ${listTypes.map(({ label, listType, icon }) => {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -580,7 +580,7 @@ export class CrawlsList extends LiteElement {
         `
       )}
       ${when(
-        crawl.type !== "upload",
+        crawl.type === "crawl",
         () => html`
           <sl-menu-item
             @click=${() =>
@@ -589,17 +589,16 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
             ${msg("Go to Workflow")}
           </sl-menu-item>
+          <sl-menu-item @click=${() => CopyButton.copyToClipboard(crawl.cid)}>
+            <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
+            ${msg("Copy Workflow ID")}
+          </sl-menu-item>
+          <sl-menu-item @click=${() => CopyButton.copyToClipboard(crawl.id)}>
+            <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
+            ${msg("Copy Crawl ID")}
+          </sl-menu-item>
         `
       )}
-
-      <sl-menu-item @click=${() => CopyButton.copyToClipboard(crawl.cid)}>
-        <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
-        ${msg("Copy Workflow ID")}
-      </sl-menu-item>
-      <sl-menu-item @click=${() => CopyButton.copyToClipboard(crawl.id)}>
-        <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
-        ${msg("Copy Crawl ID")}
-      </sl-menu-item>
       <sl-menu-item
         @click=${() => CopyButton.copyToClipboard(crawl.tags.join(", "))}
         ?disabled=${!crawl.tags.length}

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -611,7 +611,9 @@ export class CrawlsList extends LiteElement {
             @click=${() => this.deleteCrawl(crawl)}
           >
             <sl-icon name="trash" slot="prefix"></sl-icon>
-            ${crawl.type === "upload" ? msg("Delete Upload") : msg("Delete Crawl")}
+            ${crawl.type === "upload"
+              ? msg("Delete Upload")
+              : msg("Delete Crawl")}
           </sl-menu-item>
         `
       )}
@@ -664,7 +666,11 @@ export class CrawlsList extends LiteElement {
 
     return html`
       <div class="border-t border-b py-5">
-        <p class="text-center text-neutral-500">${this.dataListType === "uploads" ? msg("No uploads yet.") : msg("No crawls yet.")}</p>
+        <p class="text-center text-neutral-500">
+          ${this.dataListType === "uploads"
+            ? msg("No uploads yet.")
+            : msg("No crawls yet.")}
+        </p>
       </div>
     `;
   }
@@ -863,7 +869,8 @@ export class CrawlsList extends LiteElement {
   }
 
   private async deleteCrawl(crawl: Crawl) {
-    const typeName = crawl.type === "upload" ? "upload" : "crawl";
+    // TODO check if this makes translating entire string difficult:
+    const typeName = crawl.type === "upload" ? msg("upload") : msg("crawl");
 
     if (
       !window.confirm(
@@ -872,7 +879,7 @@ export class CrawlsList extends LiteElement {
     ) {
       return;
     }
-    
+
     let apiPath;
 
     switch (this.dataListType) {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -664,7 +664,7 @@ export class CrawlsList extends LiteElement {
 
     return html`
       <div class="border-t border-b py-5">
-        <p class="text-center text-neutral-500">${msg("No crawls yet.")}</p>
+        <p class="text-center text-neutral-500">${this.dataListType === "uploads" ? msg("No uploads yet.") : msg("No crawls yet.")}</p>
       </div>
     `;
   }
@@ -908,7 +908,7 @@ export class CrawlsList extends LiteElement {
         items: items.filter((c) => c.id !== crawl.id),
       };
       this.notify({
-        message: msg(`Successfully deleted ${typeName}`),
+        message: msg(str`Successfully deleted ${typeName}`),
         variant: "success",
         icon: "check2-circle",
       });
@@ -917,7 +917,7 @@ export class CrawlsList extends LiteElement {
       this.notify({
         message:
           (e.isApiError && e.message) ||
-          msg(`Sorry, couldn't run ${typeName} at this time.`),
+          msg(str`Sorry, couldn't run ${typeName} at this time.`),
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -244,17 +244,23 @@ export class CrawlsList extends LiteElement {
     }
 
     const hasCrawlItems = this.crawls.items.length;
-    const listTypes: { listType: DataListType; label: string }[] = [
+    const listTypes: {
+      listType: DataListType;
+      label: string;
+      icon?: string;
+    }[] = [
       {
         listType: "all",
         label: msg("All"),
       },
       {
         listType: "finished-crawls",
+        icon: "gear-wide-connected",
         label: msg("Finished Crawls"),
       },
       {
         listType: "uploads",
+        icon: "upload",
         label: msg("Uploads"),
       },
     ];
@@ -263,6 +269,7 @@ export class CrawlsList extends LiteElement {
     if (this.isAdminView) {
       listTypes.push({
         listType: "running-crawls",
+        icon: "gear-wide",
         label: msg("Running Crawls"),
       });
     }
@@ -274,7 +281,7 @@ export class CrawlsList extends LiteElement {
             <h1 class="text-xl font-semibold h-8">${msg("Archive Data")}</h1>
           </div>
           <div class="flex gap-2 mb-3">
-            ${listTypes.map(({ label, listType }) => {
+            ${listTypes.map(({ label, listType, icon }) => {
               const isSelected = listType === this.dataListType;
               return html` <btrix-button
                 variant=${isSelected ? "primary" : "neutral"}
@@ -282,8 +289,10 @@ export class CrawlsList extends LiteElement {
                 aria-selected="${isSelected}"
                 href=${`${this.crawlsBaseUrl}?dataListType=${listType}`}
                 @click=${this.navLink}
-                >${label}</btrix-button
-              >`;
+              >
+                ${icon ? html`<sl-icon name=${icon}></sl-icon>` : ""}
+                <span>${label}</span>
+              </btrix-button>`;
             })}
           </div>
           <div

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -242,9 +242,7 @@ export class CrawlsList extends LiteElement {
         <header class="contents">
           <div class="flex w-full h-8 mb-4">
             <h1 class="text-xl font-semibold">
-              ${this.isAdminView
-                ? msg("Running Crawls")
-                : msg("Finished Crawls")}
+              ${this.isAdminView ? msg("Running Crawls") : msg("Archive Data")}
             </h1>
           </div>
           <div
@@ -301,7 +299,7 @@ export class CrawlsList extends LiteElement {
             max-options-visible="1"
             placeholder=${this.isAdminView
               ? msg("All Active Crawls")
-              : msg("Finished Crawls")}
+              : msg("Archive Data")}
             @sl-change=${async (e: CustomEvent) => {
               const value = (e.target as SlSelect).value as CrawlState[];
               await this.updateComplete;

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -270,7 +270,7 @@ export class CrawlsList extends LiteElement {
       <main>
         <header class="contents">
           <div class="flex w-full pb-3 mb-3 border-b">
-            <h1 class="text-xl font-semibold h-8">${msg("Web Archives")}</h1>
+            <h1 class="text-xl font-semibold h-8">${msg("Archived Data")}</h1>
           </div>
           <div class="flex gap-2 mb-3">
             ${listTypes.map(({ label, artifactType, icon }) => {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -34,7 +34,7 @@ type SortField = "started" | "finished" | "firstSeed" | "fileSize";
 type SortDirection = "asc" | "desc";
 
 const ABORT_REASON_THROTTLE = "throttled";
-const INITIAL_PAGE_SIZE = 30;
+const INITIAL_PAGE_SIZE = 20;
 const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser.crawls";
 const POLL_INTERVAL_SECONDS = 10;
 const MIN_SEARCH_LENGTH = 2;

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -333,6 +333,19 @@ export class CrawlsList extends LiteElement {
   }
 
   private renderControls() {
+    let viewPlaceholder = "";
+    let viewOptions = [];
+    if (this.isAdminView) {
+      viewPlaceholder = msg("All Active Crawls");
+      viewOptions = activeCrawlStates;
+    } else {
+      viewOptions = finishedCrawlStates;
+      if (this.artifactType === "upload") {
+        viewPlaceholder = msg("All Uploaded");
+      } else {
+        viewPlaceholder = msg("All Finished");
+      }
+    }
     return html`
       <div
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-[minmax(0,100%)_fit-content(100%)_fit-content(100%)] gap-x-2 gap-y-2 items-center"
@@ -349,9 +362,7 @@ export class CrawlsList extends LiteElement {
             pill
             multiple
             max-options-visible="1"
-            placeholder=${this.isAdminView
-              ? msg("All Active Crawls")
-              : msg("Finished")}
+            placeholder=${viewPlaceholder}
             @sl-change=${async (e: CustomEvent) => {
               const value = (e.target as SlSelect).value as CrawlState[];
               await this.updateComplete;
@@ -361,9 +372,7 @@ export class CrawlsList extends LiteElement {
               };
             }}
           >
-            ${(this.isAdminView ? activeCrawlStates : finishedCrawlStates).map(
-              this.renderStatusMenuItem
-            )}
+            ${viewOptions.map(this.renderStatusMenuItem)}
           </sl-select>
         </div>
 
@@ -520,7 +529,10 @@ export class CrawlsList extends LiteElement {
     if (!this.crawls) return;
 
     return html`
-      <btrix-crawl-list baseUrl=${this.isAdminView ? "/crawls/crawl" : ""}>
+      <btrix-crawl-list
+        baseUrl=${this.isAdminView ? "/crawls/crawl" : ""}
+        artifactType=${ifDefined(this.artifactType || undefined)}
+      >
         ${this.crawls.items.map(this.renderCrawlItem)}
       </btrix-crawl-list>
 
@@ -783,6 +795,7 @@ export class CrawlsList extends LiteElement {
   ): Promise<Crawls> {
     const query = queryString.stringify(
       {
+        state: this.filterBy.state || null,
         name: this.filterBy.name,
         page: queryParams?.page || this.crawls?.page || 1,
         pageSize:

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -579,14 +579,19 @@ export class CrawlsList extends LiteElement {
           <sl-divider></sl-divider>
         `
       )}
+      ${when(
+        crawl.type !== "upload",
+        () => html`
+          <sl-menu-item
+            @click=${() =>
+              this.navTo(`/orgs/${crawl.oid}/workflows/crawl/${crawl.cid}`)}
+          >
+            <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
+            ${msg("Go to Workflow")}
+          </sl-menu-item>
+        `
+      )}
 
-      <sl-menu-item
-        @click=${() =>
-          this.navTo(`/orgs/${crawl.oid}/workflows/crawl/${crawl.cid}`)}
-      >
-        <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
-        ${msg("Go to Workflow")}
-      </sl-menu-item>
       <sl-menu-item @click=${() => CopyButton.copyToClipboard(crawl.cid)}>
         <sl-icon name="copy-code" library="app" slot="prefix"></sl-icon>
         ${msg("Copy Workflow ID")}

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -622,7 +622,7 @@ export class CrawlsList extends LiteElement {
             style="--sl-color-neutral-700: var(--danger)"
             @click=${() => this.deleteCrawl(crawl)}
           >
-            <sl-icon name="trash" slot="prefix"></sl-icon>
+            <sl-icon name="trash3" slot="prefix"></sl-icon>
             ${crawl.type === "upload"
               ? msg("Delete Upload")
               : msg("Delete Crawl")}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -252,6 +252,7 @@ export class Org extends LiteElement {
     return html`<btrix-crawls-list
       .authState=${this.authState!}
       userId=${this.userInfo!.id}
+      orgId=${this.orgId}
       ?isCrawler=${this.isCrawler}
       crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
       crawlsBaseUrl=${crawlsBaseUrl}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -6,6 +6,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import type { ViewState } from "../../utils/APIRouter";
 import type { AuthState } from "../../utils/AuthService";
 import type { CurrentUser } from "../../types/user";
+import type { Crawl } from "../../types/crawler";
 import type { OrgData } from "../../utils/orgs";
 import { isAdmin, isCrawler } from "../../utils/orgs";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -30,7 +31,6 @@ import type {
   UserRoleChangeEvent,
   OrgRemoveMemberEvent,
 } from "./settings";
-import type { DataListType } from "./crawls-list";
 
 export type OrgTab =
   | "crawls"
@@ -46,7 +46,7 @@ type Params = {
   browserId?: string;
   artifactId?: string;
   resourceId?: string;
-  dataListType?: DataListType;
+  artifactType?: Crawl["type"];
 };
 
 const defaultTab = "crawls";
@@ -246,7 +246,7 @@ export class Org extends LiteElement {
         crawlId=${this.params.crawlOrWorkflowId}
         crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
         crawlsBaseUrl=${crawlsBaseUrl}
-        crawlType=${this.params.dataListType === "uploads" ? "upload" : "crawl"}
+        artifactType=${this.params.artifactType || "crawl"}
         ?isCrawler=${this.isCrawler}
       ></btrix-crawl-detail>`;
     }
@@ -258,7 +258,7 @@ export class Org extends LiteElement {
       ?isCrawler=${this.isCrawler}
       crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
       crawlsBaseUrl=${crawlsBaseUrl}
-      dataListType=${ifDefined(this.params.dataListType)}
+      artifactType=${ifDefined(this.params.artifactType || undefined)}
       ?shouldFetch=${this.orgTab === "crawls" || this.orgTab === "artifacts"}
     ></btrix-crawls-list>`;
   }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -178,7 +178,7 @@ export class Org extends LiteElement {
           })}
           ${this.renderNavTab({
             tabName: "artifacts",
-            label: msg("Archive Data"),
+            label: msg("Web Archives"),
             path: "artifacts/crawls",
           })}
           ${this.renderNavTab({

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -175,11 +175,10 @@ export class Org extends LiteElement {
           })}
           ${this.renderNavTab({
             tabName: "artifacts",
-            label: msg("Finished Crawls"),
+            label: msg("Archive Data"),
             path: "artifacts/crawls",
           })}
-          ${
-            this.renderNavTab({
+          ${this.renderNavTab({
             tabName: "collections",
             label: msg("Collections"),
             path: "collections",

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -1,6 +1,7 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 import { when } from "lit/directives/when.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import type { ViewState } from "../../utils/APIRouter";
 import type { AuthState } from "../../utils/AuthService";
@@ -29,6 +30,7 @@ import type {
   UserRoleChangeEvent,
   OrgRemoveMemberEvent,
 } from "./settings";
+import type { DataListType } from "./crawls-list";
 
 export type OrgTab =
   | "crawls"
@@ -44,6 +46,7 @@ type Params = {
   browserId?: string;
   artifactId?: string;
   resourceId?: string;
+  dataListType?: DataListType;
 };
 
 const defaultTab = "crawls";
@@ -252,6 +255,7 @@ export class Org extends LiteElement {
       ?isCrawler=${this.isCrawler}
       crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
       crawlsBaseUrl=${crawlsBaseUrl}
+      dataListType=${ifDefined(this.params.dataListType)}
       ?shouldFetch=${this.orgTab === "crawls" || this.orgTab === "artifacts"}
     ></btrix-crawls-list>`;
   }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -178,7 +178,7 @@ export class Org extends LiteElement {
           })}
           ${this.renderNavTab({
             tabName: "artifacts",
-            label: msg("Web Archives"),
+            label: msg("Archived Data"),
             path: "artifacts/crawls",
           })}
           ${this.renderNavTab({

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -242,9 +242,11 @@ export class Org extends LiteElement {
     if (this.params.crawlOrWorkflowId) {
       return html` <btrix-crawl-detail
         .authState=${this.authState!}
+        orgId=${this.orgId}
         crawlId=${this.params.crawlOrWorkflowId}
         crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
         crawlsBaseUrl=${crawlsBaseUrl}
+        crawlType=${this.params.dataListType === "uploads" ? "upload" : "crawl"}
         ?isCrawler=${this.isCrawler}
       ></btrix-crawl-detail>`;
     }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -781,7 +781,7 @@ export class WorkflowDetail extends LiteElement {
               pill
               multiple
               max-options-visible="1"
-              placeholder=${msg("Web Archives")}
+              placeholder=${msg("Archived Data")}
               @sl-change=${async (e: CustomEvent) => {
                 const value = (e.target as SlSelect).value as CrawlState[];
                 await this.updateComplete;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -781,7 +781,7 @@ export class WorkflowDetail extends LiteElement {
               pill
               multiple
               max-options-visible="1"
-              placeholder=${msg("Archive Data")}
+              placeholder=${msg("Web Archives")}
               @sl-change=${async (e: CustomEvent) => {
                 const value = (e.target as SlSelect).value as CrawlState[];
                 await this.updateComplete;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -781,7 +781,7 @@ export class WorkflowDetail extends LiteElement {
               pill
               multiple
               max-options-visible="1"
-              placeholder=${msg("Finished Crawls")}
+              placeholder=${msg("Archive Data")}
               @sl-change=${async (e: CustomEvent) => {
                 const value = (e.target as SlSelect).value as CrawlState[];
                 await this.updateComplete;
@@ -926,11 +926,15 @@ export class WorkflowDetail extends LiteElement {
         break;
 
       case "waiting_capacity":
-        waitingMsg = msg("Crawl waiting for available resources before it can start...");
+        waitingMsg = msg(
+          "Crawl waiting for available resources before it can start..."
+        );
         break;
 
       case "waiting_org_limit":
-        waitingMsg = msg("Crawl waiting for others to finish, concurrent limit per Organization reached...");
+        waitingMsg = msg(
+          "Crawl waiting for others to finish, concurrent limit per Organization reached..."
+        );
         break;
     }
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -129,9 +129,9 @@ const theme = css`
   }
 
   /* Elevate select and buttons */
-  sl-select::part(control),
+  sl-select::part(combobox),
   sl-button:not([variant="text"])::part(base) {
-    box-shadow: var(--sl-shadow-small);
+    box-shadow: var(--sl-shadow-x-small);
   }
 
   /* Prevent horizontal scrollbar */

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -123,4 +123,5 @@ export type Crawl = CrawlConfig & {
   seedCount: number;
   stopping: boolean;
   collections: string[];
+  type: string;
 };

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -123,5 +123,5 @@ export type Crawl = CrawlConfig & {
   seedCount: number;
   stopping: boolean;
   collections: string[];
-  type: string;
+  type?: "crawl" | "upload" | null;
 };


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/933. This PR should be merged only after https://github.com/webrecorder/browsertrix-cloud/issues/934 and https://github.com/webrecorder/browsertrix-cloud/issues/929 are merged

<!-- Fixes #issue_number -->

### Changes
- Adds top-level "Archived Data" view, replacing "Finished Crawls" and moving it as "Crawls" into view
- Adds list for viewing all artifacts/data
- Adds list for viewing all uploaded crawls
- Updates crawl detail view to show upload details
- Edit upload metadata
- Delete uploads

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Web Archives | <img width="1121" alt="Screen Shot 2023-07-06 at 9 29 35 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/356368a1-e4d0-42ec-b657-e927a06797c3"> |
| Web Archives - Uploads | <img width="1114" alt="Screen Shot 2023-07-06 at 9 29 51 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/de65dc43-e5c2-48e3-8944-f975c7fc3e44"> |
| Upload detail | <img width="1117" alt="Screen Shot 2023-07-06 at 9 30 17 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/762533af-4126-4590-b283-128a7fee3cd9"> |




### Follow-ups

This PR doesn't contain any major URL changes, so the upload detail page is still called `crawl` and there may be other references to "crawl"s. URL changes will be handled in https://github.com/webrecorder/browsertrix-cloud/issues/935