### PR TITLE
Display actions in watch crawl tab after workflow crawl completes

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -428,7 +428,7 @@ export class WorkflowDetail extends LiteElement {
           this.getWorkflowPromise?.then(
             () => html`
               ${when(this.activePanel === "watch", () =>
-                this.lastCrawlId
+                this.workflow?.isCrawlRunning
                   ? html` <div class="border rounded-lg py-2 mb-5 h-14">
                         ${this.renderCurrentCrawl()}
                       </div>


### PR DESCRIPTION
Fixes #942 

This functionality was already implemented but a bug was preventing it from displaying the links.

### Before

![image](https://github.com/webrecorder/browsertrix-cloud/assets/6758804/c6ef3a69-7892-4a71-b75c-a04cdaa20182)


### After

![image](https://github.com/webrecorder/browsertrix-cloud/assets/6758804/9af08d96-2cca-46e0-9418-5ffa979bede6)
