### PR TITLE
feat: configure mongodb firewall

### DIFF
--- a/ansible/playbooks/do_setup.yml
+++ b/ansible/playbooks/do_setup.yml
@@ -162,6 +162,16 @@
       ansible.builtin.set_fact:
         lb_id: "{{ lb_id_result.stdout | from_json | json_query('load_balancers[0].id') }}"
 
+  # FIREWALL
+  # ===========================================
+    - name: d_ocean | db | get db firewall list
+      ansible.builtin.command: doctl db firewalls list {{ db_uuid }} -o json
+      register: db_firewalls
+
+    - name: d_ocean | db | configure firewall for mongoDB
+      ansible.builtin.command: doctl db firewalls append {{ db_uuid }} --rule k8s:{{ my_cluster.data.id }}
+      when: "db_firewalls.stdout == []"
+
   # DNS
   # ===========================================
     - name: d_ocean | dns | grab loadbalancer ip using doctl


### PR DESCRIPTION
Configure firewall for mongoDB if it doesn't exist. This one still makes the assumption that if there is any firewall config we don't touch it, but that seems kind of reasonable to me. We primarily want to ensure that the db isn't publicly accessible. 