### PR TITLE
Unset default scopeType for seeds so they inherit parent scopeType by…

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -51,7 +51,7 @@ class Seed(BaseModel):
     """Crawl seed"""
 
     url: HttpUrl
-    scopeType: Optional[ScopeType] = ScopeType.PREFIX
+    scopeType: Optional[ScopeType]
 
     include: Union[str, List[str], None]
     exclude: Union[str, List[str], None]


### PR DESCRIPTION
… default

Fixes #951 

By removing the Seed scopetype default to "prefix", seeds no longer need to have a `scopeType` explicitly set in the POST API endpoint to create a new crawlconfig, and will default to the parent scopeType in the crawler. 