### PR TITLE
operator: ensure finished is always set

### DIFF
--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -629,6 +629,9 @@ class BtrixOperator(K8sAPI):
             state, status, crawl_id, allowed_from=allowed_from, **kwargs
         ):
             print("already finished, ignoring mark_finished")
+            if not status.finished:
+                status.finished = to_k8s_date(finished)
+
             return status
 
         status.finished = to_k8s_date(finished)


### PR DESCRIPTION
In case the `.finished` value is somehow not set while crawl has already been complete, ensure that it is set so the crawl can be removed by operator.