### PR TITLE
remove default: similar to #952, remove default extraHops setting as …

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -58,7 +58,7 @@ class Seed(BaseModel):
     sitemap: Union[bool, HttpUrl, None]
     allowHash: Optional[bool]
     depth: Optional[int]
-    extraHops: Optional[int] = 0
+    extraHops: Optional[int]
 
 
 # ============================================================================


### PR DESCRIPTION
Similar to #952, remove another default from Seed object, as it prevents the config-wide extraHops setting from taking effect, as each seed gets a default extraHops of 0