### PR TITLE
fix: node size c-4 doesn't exist on DO

### DIFF
--- a/ansible/group_vars/do/main.yml
+++ b/ansible/group_vars/do/main.yml
@@ -2,7 +2,7 @@
 project_name: "default"
 
 main_node_size: "s-1vcpu-2gb"
-crawl_node_size: "c-4"
+crawl_node_size: "s-1vcpu-2gb"
 droplet_region: "sfo3"
 
 node_pools:


### PR DESCRIPTION
Use the same size as main_nodes but keep the config option in case we want to size them differently. 