### PR TITLE
fix: only use db_create when the db is created

### DIFF
--- a/ansible/playbooks/do_setup.yml
+++ b/ansible/playbooks/do_setup.yml
@@ -41,13 +41,13 @@
 
     - name: d_ocean | db | set db url
       ansible.builtin.set_fact:
-        db_url:  "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') }}" 
+        db_url:  "{{ db_create.stdout if db_create.changed == true else db_check.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') }}" 
       vars:
         name_query: '[?name==`{{db_name}}`]'
 
     - name: d_ocean | db | set db id
       ansible.builtin.set_fact:
-        db_uuid: "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].id')}}"
+        db_uuid: "{{ db_create.stdout if db_create.changed == true else db_check.stdout | from_json | json_query(name_query) | json_query('[0].id')}}"
       vars:
         name_query: '[?name==`{{db_name}}`]'
 


### PR DESCRIPTION
Made a mistake in my last PR, my apologies. I realized a bit late and rediscovered this on further testing. We want to use db_create only when the db is created (meaning the result of the db creation script should have run, which means changed=true)