### PR TITLE
Add /artifacts/upload/<id> path for uploads

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -222,10 +222,11 @@ export class CrawlListItem extends LitElement {
   renderRow() {
     const hash = this.crawl && isActive(this.crawl.state) ? "#watch" : "";
     const artifactType = this.crawl?.type || "crawl";
+    const typePath = this.crawl?.type === "upload" ? "upload" : "crawl";
     return html`<a
       class="item row"
       role="button"
-      href=${`${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/crawl`}/${
+      href=${`${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/${typePath}`}/${
         this.crawl?.id
       }?artifactType=${artifactType}${hash}`}
       @click=${async (e: MouseEvent) => {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
     "(/edit/:resourceId)",
     "(/crawls)",
     "(/crawl/:crawlOrWorkflowId)",
+    "(/upload/:crawlOrWorkflowId)",
     "(/artifact/:artifactId)",
     "(/profile(/:browserProfileId)(/browser/:browserId))",
     "(/members)",


### PR DESCRIPTION
partial work for #935
- add route for /artifacts/upload/<id> to be used for uploads
- link uploads to /artifacts/upload/<id> instead of /artifacts/crawl/<id>

This allows ArchiveWeb.page to deep link to point to valid URLs