### PR TITLE
Frontend more upload path fixes

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -226,9 +226,9 @@ export class CrawlListItem extends LitElement {
     return html`<a
       class="item row"
       role="button"
-      href=${`${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/${typePath}`}/${
+      href="${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/${typePath}`}/${
         this.crawl?.id
-      }?artifactType=${artifactType}${hash}`}
+      }"
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -235,7 +235,7 @@ export class CrawlDetail extends LiteElement {
       <div class="mb-7">
         <a
           class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
-          href=${this.crawlsBaseUrl}
+          href="${this.crawlsBaseUrl}?artifactType=${this.crawl?.type}"
           @click=${this.navLink}
         >
           <sl-icon
@@ -245,7 +245,9 @@ export class CrawlDetail extends LiteElement {
           <span class="inline-block align-middle"
             >${isWorkflowArtifact
               ? msg("Back to Crawl Workflow")
-              : msg("Back to Archived Data")}</span
+              : (this.crawl?.type === "upload" ?
+                 msg("Back to All Uploads") : msg("Back to All Crawls"))
+              }</span
           >
         </a>
       </div>

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -579,7 +579,7 @@ export class CrawlsList extends LiteElement {
             () => html`
               <sl-menu-item
                 @click=${() =>
-                  this.navTo(`/orgs/${crawl.oid}/artifacts/crawl/${crawl.id}`)}
+                  this.navTo(`/orgs/${crawl.oid}/artifacts/${crawl.type === "upload" ? "upload" : "crawl"}/${crawl.id}`)}
               >
                 ${msg("View Crawl Details")}
               </sl-menu-item>

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -270,7 +270,7 @@ export class CrawlsList extends LiteElement {
       <main>
         <header class="contents">
           <div class="flex w-full pb-3 mb-3 border-b">
-            <h1 class="text-xl font-semibold h-8">${msg("Archived Data")}</h1>
+            <h1 class="text-xl font-semibold h-8">${msg("All Archived Data")}</h1>
           </div>
           <div class="flex gap-2 mb-3">
             ${listTypes.map(({ label, artifactType, icon }) => {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -239,6 +239,8 @@ export class Org extends LiteElement {
     const crawlsAPIBaseUrl = `/orgs/${this.orgId}/crawls`;
     const crawlsBaseUrl = `/orgs/${this.orgId}/artifacts/crawls`;
 
+    const artifactType = this.orgPath.includes("/artifacts/upload") ? "upload" : "crawl";
+
     if (this.params.crawlOrWorkflowId) {
       return html` <btrix-crawl-detail
         .authState=${this.authState!}
@@ -246,7 +248,7 @@ export class Org extends LiteElement {
         crawlId=${this.params.crawlOrWorkflowId}
         crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
         crawlsBaseUrl=${crawlsBaseUrl}
-        artifactType=${this.params.artifactType || "crawl"}
+        artifactType=${artifactType || "crawl"}
         ?isCrawler=${this.isCrawler}
       ></btrix-crawl-detail>`;
     }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -178,7 +178,7 @@ export class Org extends LiteElement {
           })}
           ${this.renderNavTab({
             tabName: "artifacts",
-            label: msg("Archived Data"),
+            label: msg("All Archived Data"),
             path: "artifacts/crawls",
           })}
           ${this.renderNavTab({

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -781,7 +781,7 @@ export class WorkflowDetail extends LiteElement {
               pill
               multiple
               max-options-visible="1"
-              placeholder=${msg("Archived Data")}
+              placeholder=${msg("All Crawls")}
               @sl-change=${async (e: CustomEvent) => {
                 const value = (e.target as SlSelect).value as CrawlState[];
                 await this.updateComplete;


### PR DESCRIPTION
Additional fixes for #935 + naming tweaks
   - don't use ?artifactType for detail pages, ensure correct artifact selected based on path without query
   - from uploads detail, return to 'All Uploads' with filter
   - from crawls detail, return to 'All Crawls' with filter
   - rename general to 'All Archived Data'