### PR TITLE
fix: pass ansible-lint in DO playbook

### DIFF
--- a/ansible/lint-cfg.yml
+++ b/ansible/lint-cfg.yml
@@ -1,0 +1,121 @@
+---
+# .ansible-lint
+
+profile: production # min, basic, moderate,safety, shared, production
+
+# Allows dumping of results in SARIF format
+# sarif_file: result.sarif
+
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option are parsed relative to the CWD of execution.
+exclude_paths:
+  - .cache/ # implicit unless exclude_paths is defined in config
+  - test/fixtures/formatting-before/
+  - test/fixtures/formatting-prettier/
+# parseable: true
+# quiet: true
+# strict: true
+# verbosity: 1
+
+# Mock modules or roles in order to pass ansible-playbook --syntax-check
+mock_modules:
+  - zuul_return
+  # note the foo.bar is invalid as being neither a module or a collection
+  - fake_namespace.fake_collection.fake_module
+  - fake_namespace.fake_collection.fake_module.fake_submodule
+mock_roles:
+  - mocked_role
+  - author.role_name # old standalone galaxy role
+  - fake_namespace.fake_collection.fake_role # role within a collection
+
+# Enable checking of loop variable prefixes in roles
+loop_var_prefix: "^(__|{role}_)"
+
+# Enforce variable names to follow pattern below, in addition to Ansible own
+# requirements, like avoiding python identifiers. To disable add `var-naming`
+# to skip_list.
+var_naming_pattern: "^[a-z_][a-z0-9_]*$"
+
+use_default_rules: true
+# Load custom rules from this specific folder
+# rulesdir:
+#   - ./rule/directory/
+
+# Ansible-lint is able to recognize and load skip rules stored inside
+# `.ansible-lint-ignore` (or `.config/ansible-lint-ignore.txt`) files.
+# To skip a rule just enter filename and tag, like "playbook.yml package-latest"
+# on a new line.
+# Optionally you can add comments after the tag, prefixed by "#". We discourage
+# the use of skip_list below because that will hide violations from the output.
+# When putting ignores inside the ignore file, they are marked as ignored, but
+# still visible, making it easier to address later.
+skip_list:
+  - skip_this_tag
+  - name[casing]
+  - yaml[line-length]
+
+# Ansible-lint does not automatically load rules that have the 'opt-in' tag.
+# You must enable opt-in rules by listing each rule 'id' below.
+enable_list:
+  - args
+  - empty-string-compare # opt-in
+  - no-log-password # opt-in
+  - no-same-owner # opt-in
+  - name[prefix] # opt-in
+  # add yaml here if you want to avoid ignoring yaml checks when yamllint is missing
+# Report only a subset of tags and fully ignore any others
+# tags:
+#   - 
+
+# Ansible-lint does not fail on warnings from the rules or tags listed below
+warn_list:
+  - skip_this_tag
+  - experimental # experimental is included in the implicit list
+  # - role-name
+  # - yaml[document-start]  # you can also use sub-rule matches
+
+# Some rules can transform files to fix (or make it easier to fix) identified
+# errors. `ansible-lint --write` will reformat YAML files and run these transforms.
+# By default it will run all transforms (effectively `write_list: ["all"]`).
+# You can disable running transforms by setting `write_list: ["none"]`.
+# Or only enable a subset of rule transforms by listing rules/tags here.
+# write_list:
+#   - all
+
+# Offline mode disables installation of requirements.yml and schema refreshing
+offline: true
+
+# Define required Ansible's variables to satisfy syntax check
+extra_vars:
+  foo: bar
+  multiline_string_variable: |
+    line1
+    line2
+  complex_variable: ":{;\t$()"
+
+# Uncomment to enforce action validation with tasks, usually is not
+# needed as Ansible syntax check also covers it.
+# skip_action_validation: false
+
+# List of additional kind:pattern to be added at the top of the default
+# match list, first match determines the file kind.
+kinds:
+  # - playbook: "**/examples/*.{yml,yaml}"
+  # - galaxy: "**/folder/galaxy.yml"
+  # - tasks: "**/tasks/*.yml"
+  # - vars: "**/vars/*.yml"
+  # - meta: "**/meta/main.yml"
+  - yaml: "**/*.yaml-too"
+
+# List of additional collections to allow in only-builtins rule.
+# only_builtins_allow_collections:
+#   - example_ns.example_collection
+
+# List of additions modules to allow in only-builtins rule.
+# only_builtins_allow_modules:
+#   - example_module
+
+# Allow setting custom prefix for name[prefix] rule
+task_name_prefix: "{stem} | "
+

--- a/ansible/playbooks/do_setup.yml
+++ b/ansible/playbooks/do_setup.yml
@@ -36,20 +36,21 @@
       poll: 60
       register: db_create
       when: "db_check.stdout | from_json | json_query(name_query) | length < 1"
+      changed_when: true
       vars:
-        name_query: '[?name==`{{db_name}}`]'
+        name_query: '[?name==`{{ db_name }}`]'
 
     - name: d_ocean | db | set db url
       ansible.builtin.set_fact:
-        db_url:  "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') }}" 
+        db_url: "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') }}"
       vars:
-        name_query: '[?name==`{{db_name}}`]'
+        name_query: '[?name==`{{ db_name }}`]'
 
     - name: d_ocean | db | set db id
       ansible.builtin.set_fact:
-        db_uuid: "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].id')}}"
+        db_uuid: "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].id') }}"
       vars:
-        name_query: '[?name==`{{db_name}}`]'
+        name_query: '[?name==`{{ db_name }}`]'
 
   # Storage (Space)
   # ===========================================
@@ -70,7 +71,7 @@
         bucket_endpoint_url: "{{ db_space_result.data.space.endpoint_url }}/{{ db_space_result.data.space.name }}/{{ bucket_path }}/"
 
     - name: d_ocean | space | set bucket cors
-      community.aws.aws_s3_cors:
+      community.aws.s3_cors:
         name: "{{ bucket_name }}"
         aws_access_key: "{{ lookup('env', 'DO_AWS_ACCESS_KEY') }}"
         aws_secret_key: "{{ lookup('env', 'DO_AWS_SECRET_KEY') }}"
@@ -98,11 +99,11 @@
       failed_when: false
       register: cluster_check
 
-    - name: d_ocean | k8s | create a kubernetes cluster in {{ droplet_region }}
+    - name: d_ocean | k8s | create a  kubernetes cluster in {{ droplet_region }}
       # skip_ansible_lint
       ansible.builtin.command: >-
         doctl kubernetes cluster create {{ k8s_name }} --1-clicks ingress-nginx,cert-manager --node-pool
-        "{{ node_pools | select('match','name=*') | list |join(',') }}"
+        "{{ node_pools | select('match', 'name=*') | list | join(',') }}"
         --region={{ droplet_region }}
 
       async: 1800
@@ -119,9 +120,9 @@
     - name: d_ocean | k8s | create a admin node pool in the cluster {{ k8s_name }}
       # skip_ansible_lint
       ansible.builtin.command: >-
-        doctl kubernetes cluster node-pool create {{ k8s_name }} 
-          --name {{ admin_node_pool.name }}   --size {{ admin_node_pool.size }} 
-          --label {{ admin_node_pool.label }} --count {{ admin_node_pool.count }} 
+        doctl kubernetes cluster node-pool create {{ k8s_name }}
+          --name {{ admin_node_pool.name }}   --size {{ admin_node_pool.size }}
+          --label {{ admin_node_pool.label }} --count {{ admin_node_pool.count }}
 
       async: 1800
       poll: 60
@@ -171,10 +172,12 @@
     - name: d_ocean | db | get db firewall list
       ansible.builtin.command: doctl db firewalls list {{ db_uuid }} -o json
       register: db_firewalls
+      changed_when: true
 
     - name: d_ocean | db | configure firewall for mongoDB
       ansible.builtin.command: doctl db firewalls append {{ db_uuid }} --rule k8s:{{ my_cluster.data.id }}
       when: "db_firewalls.stdout == []"
+      changed_when: true # if it runs, it's changed
 
   # DNS
   # ===========================================
@@ -200,20 +203,29 @@
 
   # Signing + DNS
   # ===========================================
-    - name: d_coean | signing | set signing domain + authtoken
+    - name: d_ocean | signing | set signing domain + authtoken
       ansible.builtin.set_fact:
         full_signing_domain: "{{ signing_host }}.{{ full_domain }}"
         signing_subdomain: "{{ signing_host + '.' + subdomain if subdomain else signing_host }}"
         signing_authtoken: "{{ 99999999 | random | to_uuid }}"
 
       when: enable_signing
+      changed_when: true
+
+    - name: d_ocean | signing | check signing record exists
+      ansible.builtin.command: doctl compute domain records ls {{ domain }} -o json
+      register: check_domain
+      changed_when: true
 
     - name: d_ocean | signing | register the dns for signing subdomain
       ansible.builtin.command: >-
           doctl compute domain records create --record-type A --record-name "{{ signing_subdomain }}" --record-data "{{ lb_ip }}" "{{ domain }}"
 
       register: signing_dns_result
-      when: enable_signing
+      when: "check_domain.stdout | from_json | json_query(name_query) | length < 1"
+      changed_when: true # if it ran, it changed
+      vars:
+        name_query: '[?name==`{{ signing_subdomain }}`]'
 
 
   # Registry
@@ -222,20 +234,24 @@
       ansible.builtin.command: doctl registry get --format Endpoint
       register: do_registry_result
       when: use_do_registry
+      changed_when: true
       failed_when: do_registry_result.stdout_lines | length < 2
 
     - name: d_ocean | registry | store registry endpoint
       ansible.builtin.set_fact:
         registry_endpoint: "{{ do_registry_result.stdout_lines[1] }}"
       when: use_do_registry
+      changed_when: true
 
     - name: d_ocean | registry | configure kubectl
-      ansible.builtin.shell: doctl k8s cluster kubeconfig save {{ my_cluster.data.id }}
+      ansible.builtin.command: doctl k8s cluster kubeconfig save {{ my_cluster.data.id }}
       when: configure_kubectl
+      changed_when: true
 
     - name: d_ocean | registry | add to new k8s cluster
       ansible.builtin.shell: set -o pipefail && doctl registry kubernetes-manifest | kubectl apply -f -
       when: use_do_registry
+      changed_when: true
 
   # Addons
   # ===========================================

--- a/ansible/playbooks/do_setup.yml
+++ b/ansible/playbooks/do_setup.yml
@@ -71,7 +71,8 @@
         bucket_endpoint_url: "{{ db_space_result.data.space.endpoint_url }}/{{ db_space_result.data.space.name }}/{{ bucket_path }}/"
 
     - name: d_ocean | space | set bucket cors
-      community.aws.s3_cors:
+      # skip_ansible_lint
+      community.aws.aws_s3_cors:
         name: "{{ bucket_name }}"
         aws_access_key: "{{ lookup('env', 'DO_AWS_ACCESS_KEY') }}"
         aws_secret_key: "{{ lookup('env', 'DO_AWS_SECRET_KEY') }}"


### PR DESCRIPTION
A mostly default ansible-lint config file (we skip `jinja[naming]` since none of our names are compliant and who really cares about that anyway)

Mostly white space and `changed_when=true` changes so ansible-lint is happy. Biggest change is making signing records idempotent, previously it would always add a new record. In hind sight I should've made that a different PR. 

Github action in follow up PR. 