### PR TITLE
fix: mongodb uri password not accessible on second API call

### DIFF
--- a/ansible/playbooks/do_setup.yml
+++ b/ansible/playbooks/do_setup.yml
@@ -39,17 +39,32 @@
       vars:
         name_query: '[?name==`{{db_name}}`]'
 
-    - name: d_ocean | db | set db url
+    - name: d_ocean | db | set db id
       ansible.builtin.set_fact:
-        db_url:  "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') }}" 
+        db_uuid: "{{ db_create.stdout if db_create.changed == true else db_check.stdout | from_json | json_query(name_query) | json_query('[0].id')}}"
       vars:
         name_query: '[?name==`{{db_name}}`]'
 
-    - name: d_ocean | db | set db id
+    - name: d_ocean | db | reset db user password
+      ansible.builtin.command: doctl databases user reset {{ db_uuid }} doadmin -o json
+      register: db_user
+      when: db_create.changed == false 
+
+    - name: d_ocean | db | set db config
       ansible.builtin.set_fact:
-        db_uuid: "{{ db_create.stdout if db_create.changed == false else db_check.stdout | from_json | json_query(name_query) | json_query('[0].id')}}"
+        db_url: "{{ db_create.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') }}" 
+      when: db_create.changed == true 
       vars:
         name_query: '[?name==`{{db_name}}`]'
+
+    - name: d_ocean | db | set db config 
+      ansible.builtin.set_fact:
+        db_url: "{{ db_check.stdout | from_json | json_query(name_query) | json_query('[0].private_connection.uri') | replace(old, new)}}" 
+      when: db_create.changed == false 
+      vars:
+        name_query: '[?name==`{{ db_name }}`]'
+        old: ":@"
+        new: ":{{ db_user.stdout | from_json | json_query('[0].password') }}@"
 
   # Storage (Space)
   # ===========================================


### PR DESCRIPTION
This adds a little bit of complexity in making sure that mongodb is configured idempotently. 

The flow is this:
- check for the db's existence
- if it doesnt exist
  - create a database
  - use the return value of the api call to get the private connection uri
- if it does exist
  - reset the password for the doadmin user
  - get the uri from the original `doctl db ls` call 
  - in the private connection uri replace `:@` (where the password should go) with `:{{ db_user_password }}@` which we get from reseting the user 