### PR TITLE
Tests: fix test get crawl loop

### DIFF
--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -10,7 +10,7 @@ crawl_id = None
 
 def get_crawl(org_id, auth_headers, crawl_id):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}",
+        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
         headers=auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -10,7 +10,7 @@ crawl_id = None
 
 def get_crawl(org_id, auth_headers, crawl_id):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
+        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}",
         headers=auth_headers,
     )
     assert r.status_code == 200
@@ -49,6 +49,7 @@ def test_cancel_crawl(default_org_id, crawler_auth_headers):
     data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     while data["state"] in ("running", "waiting_capacity"):
+        time.sleep(5)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] == "canceled"
@@ -88,6 +89,7 @@ def test_start_crawl_and_stop_immediately(
     assert r.json()["lastCrawlStopping"] == True
 
     while data["state"] in ("starting", "running", "waiting_capacity"):
+        time.sleep(5)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] in ("canceled", "partial_complete")
@@ -148,6 +150,7 @@ def test_stop_crawl_partial(
     assert r.json()["lastCrawlStopping"] == True
 
     while data["state"] == "running":
+        time.sleep(5)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
     assert data["state"] in ("partial_complete", "complete")

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -99,10 +99,9 @@ def run_crawl(org_id, headers):
 
 
 def get_crawl_status(org_id, crawl_id, headers):
-    while True:
-        r = requests.get(
-            f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
-            headers=headers,
-        )
-        data = r.json()
-        return data["state"]
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
+        headers=headers,
+    )
+    data = r.json()
+    return data["state"]


### PR DESCRIPTION
Fix tests that had a loop calling /replay.json endpoint without sleep, likely causing occasional failures..