### PR TITLE
Allow users to add uploads to collections

### DIFF
--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -125,3 +125,5 @@ export type Crawl = CrawlConfig & {
   collections: string[];
   type?: "crawl" | "upload" | null;
 };
+
+export type Upload = Crawl & { type: "upload" };

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -126,4 +126,15 @@ export type Crawl = CrawlConfig & {
   type?: "crawl" | "upload" | null;
 };
 
-export type Upload = Crawl & { type: "upload" };
+export type Upload = Omit<
+  Crawl,
+  | "cid"
+  | "stats"
+  | "schedule"
+  | "manual"
+  | "stopping"
+  | "firstSeed"
+  | "seedCount"
+> & {
+  type: "upload";
+};


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/936

<!-- Fixes #issue_number -->

### Changes

Initial implementation of collection upload picker for new and existing collections.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Collection - Select Uploads | **Empty state**:<br/><img width="920" alt="Screen Shot 2023-07-08 at 9 11 43 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/c6292910-4d56-4fe5-9436-fdd02eafd49b"> |
| Edit Collection - Select Uploads | <img width="1077" alt="Screen Shot 2023-07-08 at 10 02 32 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/30409429-6b40-4f41-b6d5-0bab607a1970"> |



### Follow-ups

This is a quick-and-dirty implementation and isn't the most ideal UI, maybe drag-over, or integration with "Select Crawls" for the next release? Once upload UI is added to browsertrix cloud, we should link to it in the empty state and/or allow direct upload into a collection.