### PR TITLE
Collections list and detail published state enhancements

### DIFF
--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -245,6 +245,9 @@ export class CollectionDetail extends LiteElement {
           <a
             href=${`/api/orgs/${this.orgId}/collections/${this.collectionId}/download?auth_bearer=${authToken}`}
             class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
+            @click=${(e: MouseEvent) => {
+              (e.target as HTMLAnchorElement).closest("sl-dropdown")?.hide();
+            }}
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>
             ${msg("Download Collection")}

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -61,14 +61,19 @@ export class CollectionDetail extends LiteElement {
           ${this.collection?.name || html`<sl-skeleton></sl-skeleton>`}
         </h2>
         <div>
-          ${when(this.collection?.publishedUrl, () => html`
-            <sl-button size="small" class="p-2 mb-2"
-            @click=${() => this.showPublishedInfo = true}
-            >
-            <sl-icon name="code-slash"></sl-icon>
-            View Embed Code
-            </sl-button>
-          `)}
+          ${when(
+            this.collection?.publishedUrl,
+            () => html`
+              <sl-button
+                size="small"
+                class="p-2 mb-2"
+                @click=${() => (this.showPublishedInfo = true)}
+              >
+                <sl-icon name="code-slash"></sl-icon>
+                View Embed Code
+              </sl-button>
+            `
+          )}
           ${when(this.isCrawler, this.renderActions)}
         </div>
       </header>
@@ -105,8 +110,7 @@ export class CollectionDetail extends LiteElement {
           >
         </div>
       </btrix-dialog>
-      ${when(this.showPublishedInfo, this.renderPublishedInfo)}
-      `;
+      ${when(this.showPublishedInfo, this.renderPublishedInfo)} `;
   }
 
   private renderPublishedInfo = () => {
@@ -114,7 +118,8 @@ export class CollectionDetail extends LiteElement {
       return;
     }
 
-    const fullUrl = new URL(this.collection?.publishedUrl, window.location.href).href;
+    const fullUrl = new URL(this.collection?.publishedUrl, window.location.href)
+      .href;
 
     return html`
   <sl-dialog
@@ -133,7 +138,7 @@ export class CollectionDetail extends LiteElement {
         </code></p>
         <p>See <a class="text-primary" href="https://replayweb.page/docs/embedding"> our embedding guide for more details.</a></p>
       </p>
-  </sl-dialog>`
+  </sl-dialog>`;
   };
 
   private renderHeader = () => html`
@@ -152,45 +157,56 @@ export class CollectionDetail extends LiteElement {
   `;
 
   private renderActions = () => {
+    // FIXME replace auth token post-workshop
+    const authToken = this.authState!.headers.Authorization.split(" ")[1];
     return html`
       <sl-dropdown distance="4">
         <sl-button slot="trigger" size="small" caret
           >${msg("Actions")}</sl-button
         >
         <sl-menu>
-          ${!this.collection?.publishedUrl ? html`
-            <sl-menu-item
-            style="--sl-color-neutral-700: var(--success)"
-            @click=${this.onPublish}
-            >
-              <sl-icon name="journal-plus" slot="prefix"></sl-icon>
-              ${msg("Publish Collection")}
-            </sl-menu-item>
-            
-            ` : html`
-            <sl-menu-item
-              style="--sl-color-neutral-700: var(--success)"
-            >
-            <sl-icon name="box-arrow-up-left" slot="prefix"></sl-icon>
-            <a target="_blank" slot="prefix" href="https://replayweb.page?source=${new URL(this.collection?.publishedUrl || "", window.location.href).href}">
-            Go to Public View
-            </a>
-            </sl-menu-item>
-            <sl-menu-item
-            style="--sl-color-neutral-700: var(--warning)"
-            @click=${this.onUnpublish}
-            >
-              <sl-icon name="journal-x" slot="prefix"></sl-icon>
-              ${msg("Unpublish Collection")}
-            </sl-menu-item>
-            `}
+          ${!this.collection?.publishedUrl
+            ? html`
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--success)"
+                  @click=${this.onPublish}
+                >
+                  <sl-icon name="journal-plus" slot="prefix"></sl-icon>
+                  ${msg("Publish Collection")}
+                </sl-menu-item>
+              `
+            : html`
+                <sl-menu-item style="--sl-color-neutral-700: var(--success)">
+                  <sl-icon name="box-arrow-up-left" slot="prefix"></sl-icon>
+                  <a
+                    target="_blank"
+                    slot="prefix"
+                    href="https://replayweb.page?source=${new URL(
+                      this.collection?.publishedUrl || "",
+                      window.location.href
+                    ).href}"
+                  >
+                    Go to Public View
+                  </a>
+                </sl-menu-item>
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--warning)"
+                  @click=${this.onUnpublish}
+                >
+                  <sl-icon name="journal-x" slot="prefix"></sl-icon>
+                  ${msg("Unpublish Collection")}
+                </sl-menu-item>
+              `}
           <sl-divider></sl-divider>
-          <sl-menu-item
-          @click=${this.onDownload}
+          <!-- Shoelace doesn't allow "href" on menu items,
+              see https://github.com/shoelace-style/shoelace/issues/1351 -->
+          <a
+            href=${`/api/orgs/${this.orgId}/collections/${this.collectionId}/download?auth_bearer=${authToken}`}
+            class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>
             ${msg("Download Collection")}
-          </sl-menu-item>
+          </a>
           <sl-divider></sl-divider>
           <sl-menu-item
             @click=${() =>
@@ -393,24 +409,6 @@ export class CollectionDetail extends LiteElement {
     return data;
   }
 
-  private async onDownload() {
-    const resp = await fetch(
-      `/api/orgs/${this.orgId}/collections/${this.collectionId}/download`,
-      {
-        headers: {...this.authState!.headers}
-      }
-    );
-    const blob = await resp.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    document.body.appendChild(a);
-    a.setAttribute("display", "none");
-    a.href = objectUrl;
-    a.setAttribute("download", this.collection?.name + ".wacz");
-    a.click();
-    window.URL.revokeObjectURL(objectUrl);
-  }
-
   private async onPublish() {
     const data = await this.apiFetch(
       `/orgs/${this.orgId}/collections/${this.collectionId}/publish`,
@@ -421,7 +419,7 @@ export class CollectionDetail extends LiteElement {
     );
     const { published, url } = data;
     if (this.collection && url && published) {
-      this.collection = {...this.collection, publishedUrl: url};
+      this.collection = { ...this.collection, publishedUrl: url };
     }
   }
 
@@ -434,7 +432,7 @@ export class CollectionDetail extends LiteElement {
       }
     );
     if (this.collection && data?.published === false) {
-      this.collection = {...this.collection, publishedUrl: undefined};
+      this.collection = { ...this.collection, publishedUrl: undefined };
     }
   }
 }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -110,7 +110,7 @@ export class CollectionDetail extends LiteElement {
           >
         </div>
       </btrix-dialog>
-      ${when(this.showPublishedInfo, this.renderPublishedInfo)} `;
+      ${this.renderPublishedInfo()}`;
   }
 
   private renderPublishedInfo = () => {
@@ -120,25 +120,67 @@ export class CollectionDetail extends LiteElement {
 
     const fullUrl = new URL(this.collection?.publishedUrl, window.location.href)
       .href;
+    const embedCode = `<replay-web-page src="${fullUrl}"></replay-web-page>`;
+    const importCode = `importScripts("https://replayweb.page/sw.js");`;
 
-    return html`
-  <sl-dialog
-     label=${msg(str`${this.collection?.name} Embedding Info`)}
-     ?open=${this.showPublishedInfo}
-     @sl-request-close=${() => (this.showPublishedInfo = false)}
-  >
-      <p class="text-left">
-        Embed this published collection in other site using the following embed code and ReplayWeb.page:
-        <p class="py-4"><code class="bg-slate-100 py-0 my-8">
-        &lt;replay-web-page src="${fullUrl}"&gt;&lt;/replay-web-page&gt;
-        </code></p>
-        <p class="py-4">Add the following to ./replay/sw.js</p>
-        <p><code class="bg-slate-100 py-0 my-8">
-        importScripts("https://replayweb.page/sw.js");
-        </code></p>
-        <p>See <a class="text-primary" href="https://replayweb.page/docs/embedding"> our embedding guide for more details.</a></p>
-      </p>
-  </sl-dialog>`;
+    return html` <btrix-dialog
+      label=${msg(str`Embed Code for “${this.collection?.name}”`)}
+      ?open=${this.showPublishedInfo}
+      @sl-request-close=${() => (this.showPublishedInfo = false)}
+    >
+      <div class="text-left">
+        <p class="mb-5">
+          ${msg(
+            html`Embed this collection in other site using these
+              <strong class="font-medium">ReplayWeb.page</strong> code snippets.`
+          )}
+        </p>
+        <p class="mb-3">
+          ${msg(html`Add the following embed code to your HTML page:`)}
+        </p>
+        <div class="relative">
+          <pre
+            class="whitespace-pre-wrap mb-5 rounded p-4 bg-slate-50 text-slate-600 text-[0.9em]"
+          ><code>${embedCode}</code></pre>
+          <div class="absolute top-0 right-0">
+            <btrix-copy-button
+              .getValue=${() => embedCode}
+              content=${msg("Copy Embed Code")}
+            ></btrix-copy-button>
+          </div>
+        </div>
+        <p class="mb-3">
+          ${msg(
+            html`Add the following JavaScript to
+              <code class="text-[0.9em]">./replay/sw.js</code>:`
+          )}
+        </p>
+        <div class="relative">
+          <pre
+            class="whitespace-pre-wrap mb-5 rounded p-4 bg-slate-50 text-slate-600 text-[0.9em]"
+          ><code>${importCode}</code></pre>
+          <div class="absolute top-0 right-0">
+            <btrix-copy-button
+              .getValue=${() => importCode}
+              content=${msg("Copy JS")}
+            ></btrix-copy-button>
+          </div>
+        </div>
+        <p>
+          ${msg(
+            html`See
+              <a
+                class="text-primary"
+                href="https://replayweb.page/docs/embedding"
+                target="_blank"
+              >
+                our embedding guide</a
+              >
+              for more details.`
+          )}
+        </p>
+      </div>
+    </btrix-dialog>`;
   };
 
   private renderHeader = () => html`

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -120,7 +120,7 @@ export class CollectionDetail extends LiteElement {
 
     const fullUrl = new URL(this.collection?.publishedUrl, window.location.href)
       .href;
-    const embedCode = `<replay-web-page src="${fullUrl}"></replay-web-page>`;
+    const embedCode = `<replay-web-page source="${fullUrl}"></replay-web-page>`;
     const importCode = `importScripts("https://replayweb.page/sw.js");`;
 
     return html` <btrix-dialog

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -131,7 +131,7 @@ export class CollectionDetail extends LiteElement {
       <div class="text-left">
         <p class="mb-5">
           ${msg(
-            html`Embed this collection in other site using these
+            html`Embed this collection in another site using these
               <strong class="font-medium">ReplayWeb.page</strong> code snippets.`
           )}
         </p>

--- a/frontend/src/pages/org/collection-edit.ts
+++ b/frontend/src/pages/org/collection-edit.ts
@@ -95,10 +95,10 @@ export class CollectionEdit extends LiteElement {
         await this.saveMetadata({ name, description });
       }
 
+      this.navTo(`/orgs/${this.orgId}/collections/view/${this.collectionId}`);
       this.notify({
         message: msg(
-          html`Successfully updated
-            <strong>${name}</strong> Collection.`
+          html`Successfully updated <strong>${name}</strong> Collection.`
         ),
         variant: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -540,6 +540,7 @@ export class CollectionsList extends LiteElement {
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
             @click=${() => this.confirmDelete(col)}
+            ?disabled=${Boolean(col.publishedUrl)}
           >
             <sl-icon name="trash3" slot="prefix"></sl-icon>
             ${msg("Delete Collection")}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -438,29 +438,18 @@ export class CollectionsList extends LiteElement {
   };
 
   private renderItem = (col: Collection) =>
-    html`<li class="mb-2 last:mb-0">
-      <a
-        href=${`/orgs/${this.orgId}/collections/view/${col.id}`}
-        class="block border rounded shadow-sm leading-none hover:bg-neutral-50"
-        @click=${(e: MouseEvent) => {
-          if (
-            (
-              (e.currentTarget as HTMLElement)?.querySelector(
-                ".actionsCol"
-              ) as HTMLElement
-            ).contains(e.target as HTMLElement)
-          ) {
-            e.preventDefault();
-          } else {
-            this.navLink(e);
-          }
-        }}
-      >
+    html`<li class="group mb-2 last:mb-0">
+      <div class="block border rounded leading-none group-hover:bg-neutral-50">
         <div
           class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[1fr_16ch_repeat(3,10ch)_2.5rem] gap-3 lg:h-10 items-center"
         >
           <div class="col-span-1 md:pl-3 truncate font-semibold">
-            ${col.name}
+            <a
+              href=${`/orgs/${this.orgId}/collections/view/${col.id}`}
+              class="block text-primary hover:text-indigo-500"
+            >
+              ${col.name}
+            </a>
           </div>
           <div class="col-span-1 text-xs text-neutral-500 font-monostyle">
             <sl-format-date
@@ -519,10 +508,12 @@ export class CollectionsList extends LiteElement {
             ${this.isCrawler ? this.renderActions(col) : ""}
           </div>
         </div>
-      </a>
+      </div>
     </li>`;
 
   private renderActions = (col: Collection) => {
+    // FIXME replace auth token post-workshop
+    const authToken = this.authState!.headers.Authorization.split(" ")[1];
     return html`
       <sl-dropdown distance="4">
         <btrix-button class="p-2" slot="trigger" label=${msg("Actions")} icon>
@@ -536,6 +527,19 @@ export class CollectionsList extends LiteElement {
             <sl-icon name="gear" slot="prefix"></sl-icon>
             ${msg("Edit Collection")}
           </sl-menu-item>
+          <!-- Shoelace doesn't allow "href" on menu items,
+              see https://github.com/shoelace-style/shoelace/issues/1351 -->
+          <a
+            href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
+            class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
+            @click=${(e: MouseEvent) => {
+              console.log("click?");
+            }}
+          >
+            <sl-icon name="cloud-download" slot="prefix"></sl-icon>
+            ${msg("Download Collection")}
+          </a>
+          <sl-divider></sl-divider>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
             @click=${() => this.confirmDelete(col)}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -438,8 +438,8 @@ export class CollectionsList extends LiteElement {
   };
 
   private renderItem = (col: Collection) =>
-    html`<li class="group mb-2 last:mb-0">
-      <div class="block border rounded leading-none group-hover:bg-neutral-50">
+    html`<li class="mb-2 last:mb-0">
+      <div class="block border rounded leading-none">
         <div
           class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[1fr_16ch_repeat(3,10ch)_2.5rem] gap-3 lg:h-10 items-center"
         >
@@ -532,9 +532,6 @@ export class CollectionsList extends LiteElement {
           <a
             href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
             class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
-            @click=${(e: MouseEvent) => {
-              console.log("click?");
-            }}
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>
             ${msg("Download Collection")}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -365,13 +365,13 @@ export class CollectionsList extends LiteElement {
       return html`
         <header class="py-2 text-neutral-600 leading-none">
           <div
-            class="hidden md:grid md:grid-cols-[repeat(2,1fr)_16ch_repeat(2,10ch)_2.5rem] gap-3"
+            class="hidden md:grid md:grid-cols-[1fr_16ch_repeat(3,10ch)_2.5rem] gap-3"
           >
             <div class="col-span-1 text-xs pl-3">${msg("Collection Name")}</div>
-            <div class="col-span-1 text-xs">${msg("Top 3 Tags")}</div>
             <div class="col-span-1 text-xs">${msg("Last Updated")}</div>
             <div class="col-span-1 text-xs">${msg("Total Crawls")}</div>
-            <div class="col-span-2 text-xs">${msg("Total Pages")}</div>
+            <div class="col-span-1 text-xs">${msg("Total Pages")}</div>
+            <div class="col-span-2 text-xs">${msg("Public View")}</div>
           </div>
         </header>
         <ul class="contents">
@@ -457,18 +457,10 @@ export class CollectionsList extends LiteElement {
         }}
       >
         <div
-          class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[repeat(2,1fr)_16ch_repeat(2,10ch)_2.5rem] gap-3 lg:h-10 items-center"
+          class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[1fr_16ch_repeat(3,10ch)_2.5rem] gap-3 lg:h-10 items-center"
         >
           <div class="col-span-1 md:pl-3 truncate font-semibold">
             ${col.name}
-          </div>
-          <div class="col-span-1 order-last md:order-none truncate">
-            ${col.tags
-              .slice(0, 3)
-              .map(
-                (tag) =>
-                  html`<btrix-tag class="mr-1" size="small">${tag}</btrix-tag>`
-              )}
           </div>
           <div class="col-span-1 text-xs text-neutral-500 font-monostyle">
             <sl-format-date
@@ -493,6 +485,33 @@ export class CollectionsList extends LiteElement {
             ${col.pageCount === 1
               ? msg("1 page")
               : msg(str`${this.numberFormatter.format(col.pageCount)} pages`)}
+          </div>
+          <div
+            class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"
+          >
+            ${col.publishedUrl
+              ? html`
+                  <a
+                    class="text-primary hover:text-indigo-500"
+                    href="https://replayweb.page?source=${new URL(
+                      col.publishedUrl
+                    ).href}"
+                    target="_blank"
+                    rel="noopener noreferrer nofollow"
+                    @click=${(e: MouseEvent) => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    <sl-icon
+                      class="inline-block align-middle"
+                      name="link-45deg"
+                    ></sl-icon>
+                    <span class="inline-block align-middle"
+                      >${msg("View")}</span
+                    >
+                  </a>
+                `
+              : html`<span role="presentation">--</span>`}
           </div>
           <div
             class="actionsCol absolute top-0 right-0 md:relative col-span-1 flex items-center justify-center"

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -532,6 +532,9 @@ export class CollectionsList extends LiteElement {
           <a
             href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
             class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
+            @click=${(e: MouseEvent) => {
+              (e.target as HTMLAnchorElement).closest("sl-dropdown")?.hide();
+            }}
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>
             ${msg("Download Collection")}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/972

### Changes
- Hides top 3 tags which aren't currently working
- Link to published/public view in list
  - This required changing the collection list item from `<a>` to `<div>` and making just the name linked as to not nest interactive elements.
- Add "Download" menu item to list
- Disable delete button for published collections
- Improve download performance in detail view
- Redirect on collection save to detail view
- Style “view embed code” modal

FYI some formatting changes made it in.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collections List | <img width="1112" alt="Screen Shot 2023-07-10 at 3 28 59 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/d6209898-e80b-4007-952c-9193dc228023"> |
| Collections List - Action menu | <img width="232" alt="Screen Shot 2023-07-10 at 3 16 10 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/036293fb-7969-41bc-b0f1-b40e2d81ea67"> |
| Collections Detail - Embed code modal | <img width="514" alt="Screen Shot 2023-07-10 at 3 10 29 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/81a626a7-8275-4a8a-9d64-0baf30e6be2d"> |

<!-- ### Follow-ups -->
