### PR TITLE
Collections: poll collection until publication job is finished

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -252,8 +252,7 @@ class BaseCrawlOps:
         size = 0
         for file_ in crawl.files:
             size += file_.size
-            status_code = await delete_crawl_file_object(org, file_, self.crawl_manager)
-            if status_code != 204:
+            if not await delete_crawl_file_object(org, file_, self.crawl_manager):
                 raise HTTPException(status_code=400, detail="file_deletion_error")
 
         return size

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -40,7 +40,7 @@ class Collection(BaseMongoModel):
     tags: Optional[List[str]] = []
 
     publishedUrl: Optional[str] = ""
-    publishing: Optional[str] = False
+    publishing: Optional[bool] = False
     # published: Optional[bool] = False
 
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -368,7 +368,7 @@ class CollectionOps:
         )
 
         await self.update_collection(
-            coll_id, org, UpdateColl(publishedUrl=published_url)
+            coll.id, org, UpdateColl(publishedUrl=published_url)
         )
 
     async def unpublish_collection(self, coll_id: uuid.UUID, org: Organization):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -393,7 +393,7 @@ class CollectionOps:
         await delete_crawl_file_object(org, crawl_file, self.crawl_manager)
 
         await self.update_collection(
-            coll_id, org, UpdateColl(publishedUrl="", published=False)
+            coll_id, org, UpdateColl(publishedUrl="", published=False, publishing=False)
         )
 
         return {"published": False}

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -341,7 +341,9 @@ class CollectionOps:
             org, self.crawl_manager, use_full=True
         )
 
-        await self.update_collection(coll.id, org, UpdateColl(publishing=True))
+        await self.update_collection(
+            coll.id, org, UpdateColl(publishedUrl="", publishing=True)
+        )
 
         published_url = endpoint_url + path
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -357,7 +357,6 @@ class CollectionOps:
         self, loop, coll: CollOut, org: Organization, path: str, client, bucket, key
     ):
         """Task to run in background to finish publishing and update model"""
-        print("Started publication finish task", flush=True)
         await loop.run_in_executor(
             None, self.sync_publish, coll.resources, client, bucket, key, path
         )

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -40,6 +40,7 @@ class Collection(BaseMongoModel):
     tags: Optional[List[str]] = []
 
     publishedUrl: Optional[str] = ""
+    publishing: Optional[str] = False
     # published: Optional[bool] = False
 
 
@@ -66,7 +67,8 @@ class UpdateColl(BaseModel):
     name: Optional[str]
     description: Optional[str]
     publishedUrl: Optional[str]
-    published: Optional[bool]
+    publishing: Optional[bool]
+    # published: Optional[bool]
 
 
 # ============================================================================
@@ -339,6 +341,8 @@ class CollectionOps:
             org, self.crawl_manager, use_full=True
         )
 
+        await self.update_collection(coll.id, org, UpdateColl(publishing=True))
+
         published_url = endpoint_url + path
 
         loop = asyncio.get_event_loop()
@@ -368,7 +372,7 @@ class CollectionOps:
         )
 
         await self.update_collection(
-            coll.id, org, UpdateColl(publishedUrl=published_url)
+            coll.id, org, UpdateColl(publishedUrl=published_url, publishing=False)
         )
 
     async def unpublish_collection(self, coll_id: uuid.UUID, org: Organization):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -498,7 +498,7 @@ class CollectionOps:
 
         def get_file(name):
             response = client.get_object(Bucket=bucket, Key=key + name)
-            return response["Body"].iter_chunks(chunk_size=256*1024)
+            return response["Body"].iter_chunks(chunk_size=256 * 1024)
 
         def member_files():
             modified_at = datetime.now()
@@ -583,9 +583,7 @@ def to_file_like_obj(iterable):
             """read interface for file-like obj"""
             print("size read", size, flush=True)
 
-            return b"".join(
-                up_to_iter(size)
-            )
+            return b"".join(up_to_iter(size))
 
     return FileLikeObj()
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -455,12 +455,14 @@ class CollectionOps:
             wacz_stream = self.sync_dl(all_files, client, bucket, key)
             wacz_stream = to_file_like_obj(wacz_stream)
 
-            GB = 1024 ** 3
-            config = TransferConfig(multipart_threshold=5*GB)
+            config = TransferConfig(multipart_threshold=5 * 1024**3)
 
             client.upload_fileobj(
-                Fileobj=wacz_stream, Bucket=bucket, Key=path, Callback=counter.update
-                Config=config
+                Fileobj=wacz_stream,
+                Bucket=bucket,
+                Key=path,
+                Callback=counter.update,
+                Config=config,
             )
 
             print("Published To: " + path, flush=True)
@@ -522,6 +524,7 @@ class CollectionOps:
 
 
 # ============================================================================
+# pylint: disable=too-few-public-methods
 class UploadCounter:
     """UploadCounter"""
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -5,7 +5,18 @@ from typing import Union
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
 
+import asyncio
+import json
+import queue
+import time
+
+from datetime import datetime
+
 from fastapi import Depends, HTTPException
+from stream_zip import stream_zip, NO_COMPRESSION_64
+
+from boto3.s3.transfer import TransferConfig
+
 
 import aiobotocore.session
 import botocore.session
@@ -14,6 +25,9 @@ import boto3
 from .orgs import Organization, DefaultStorage, S3Storage
 from .users import User
 from .zip import get_zip_file, extract_and_parse_log_file
+
+
+CHUNK_SIZE = 1024 * 256
 
 
 # ============================================================================
@@ -305,10 +319,18 @@ async def get_presigned_url(org, crawlfile, crawl_manager, duration=3600):
 # ============================================================================
 async def delete_crawl_file_object(org, crawlfile, crawl_manager):
     """delete crawl file from storage."""
+    return await delete_file(
+        org, crawlfile.filename, crawl_manager, crawlfile.def_storage_name
+    )
+
+
+# ============================================================================
+async def delete_file(org, filename, crawl_manager, def_storage_name="default"):
+    """delete specified file from storage"""
     status_code = None
 
-    if crawlfile.def_storage_name:
-        s3storage = await crawl_manager.get_default_storage(crawlfile.def_storage_name)
+    if def_storage_name:
+        s3storage = await crawl_manager.get_default_storage(def_storage_name)
 
     elif org.storage.type == "s3":
         s3storage = org.storage
@@ -321,11 +343,11 @@ async def delete_crawl_file_object(org, crawlfile, crawl_manager):
         bucket,
         key,
     ):
-        key += crawlfile.filename
+        key += filename
         response = await client.delete_object(Bucket=bucket, Key=key)
         status_code = response["ResponseMetadata"]["HTTPStatusCode"]
 
-    return status_code
+    return status_code == 204
 
 
 # ============================================================================
@@ -364,6 +386,7 @@ async def get_wacz_logs(org, crawlfile, crawl_manager):
         return combined_log_lines
 
 
+# ============================================================================
 def get_public_policy(bucket_path):
     """return public policy for /public paths"""
     return {
@@ -378,3 +401,223 @@ def get_public_policy(bucket_path):
             }
         ],
     }
+
+
+# ============================================================================
+def _sync_dl(all_files, client, bucket, key):
+    """generate streaming zip as sync"""
+    for file_ in all_files:
+        file_.path = file_.name
+
+    datapackage = {
+        "profile": "multi-wacz-package",
+        "resources": [file_.dict() for file_ in all_files],
+    }
+    datapackage = json.dumps(datapackage).encode("utf-8")
+
+    def get_file(name):
+        response = client.get_object(Bucket=bucket, Key=key + name)
+        return response["Body"].iter_chunks(chunk_size=CHUNK_SIZE)
+
+    def member_files():
+        modified_at = datetime(year=1980, month=1, day=1)
+        perms = 0o664
+        for file_ in all_files:
+            yield (
+                file_.name,
+                modified_at,
+                perms,
+                NO_COMPRESSION_64,
+                get_file(file_.name),
+            )
+
+        yield (
+            "datapackage.json",
+            modified_at,
+            perms,
+            NO_COMPRESSION_64,
+            (datapackage,),
+        )
+
+    return stream_zip(member_files(), chunk_size=CHUNK_SIZE)
+
+
+# ============================================================================
+async def download_streaming_wacz(org, crawl_manager, files):
+    """return an iter for downloading a stream nested wacz file
+    from list of files"""
+    client, bucket, key, _ = await get_sync_client(org, crawl_manager)
+
+    loop = asyncio.get_event_loop()
+
+    resp = await loop.run_in_executor(None, _sync_dl, files, client, bucket, key)
+
+    return resp
+
+
+# ============================================================================
+async def upload_streaming_wacz(
+    target_path, org, crawl_manager, files, update_published_callback
+):
+    """perform a streaming upload of a wacz file for the specified collection"""
+
+    client, bucket, key, endpoint_url = await get_sync_client(
+        org, crawl_manager, use_full=True
+    )
+
+    # set published url to empty / publishing
+    await update_published_callback("")
+
+    loop = asyncio.get_event_loop()
+
+    msgq = queue.Queue()
+
+    total_size = 0
+    for file_ in files:
+        total_size += file_.size
+
+    uploading = True
+
+    async def process_q(msgq, total_size, update_published_callback):
+        """update upload size in db"""
+
+        while uploading:
+            try:
+                new_value = msgq.get_nowait()
+                if new_value == -1:
+                    break
+
+                percent = 100 * new_value / total_size
+
+                await update_published_callback("", percent)
+
+            except queue.Empty:
+                await asyncio.sleep(3)
+
+    async def finish_task(published_url):
+        if not await loop.run_in_executor(
+            None,
+            _sync_publish,
+            files,
+            client,
+            bucket,
+            key,
+            target_path,
+            msgq,
+        ):
+            # publishing failed
+            published_url = ""
+
+        nonlocal uploading
+        uploading = False
+
+        await update_published_callback(published_url)
+
+    asyncio.create_task(process_q(msgq, total_size, update_published_callback))
+
+    published_url = endpoint_url + target_path
+    asyncio.create_task(finish_task(published_url))
+
+    return {"publishing": True}
+
+
+# ============================================================================
+def _sync_publish(all_files, client, bucket, key, target_path, msgq):
+    """publish collection to public s3 path"""
+
+    counter = UploadCounter(msgq)
+    try:
+        target_path = key + target_path
+
+        wacz_stream = _sync_dl(all_files, client, bucket, key)
+        wacz_stream = to_file_like_obj(wacz_stream)
+
+        # set part size to 5MB
+        config = TransferConfig(multipart_threshold=5 * 1024**2)
+
+        client.upload_fileobj(
+            Fileobj=wacz_stream,
+            Bucket=bucket,
+            Key=target_path,
+            Callback=counter.update,
+            Config=config,
+        )
+
+        bucket_path = bucket + "/" + key.rstrip("/") if key else bucket
+
+        policy = json.dumps(get_public_policy(bucket_path))
+
+        client.put_bucket_policy(Bucket=bucket, Policy=policy)
+
+        # indicate we're done with this q
+        msgq.put(-1)
+
+        return True
+
+    # pylint: disable=broad-exception-caught
+    except Exception:
+        return False
+
+
+# ============================================================================
+# pylint: disable=too-few-public-methods
+class UploadCounter:
+    """UploadCounter"""
+
+    def __init__(self, msgq):
+        self.counter = 0
+        self.msgq = msgq
+        self.last_update = 0
+
+    def update(self, num):
+        """upload callback"""
+        self.counter += num
+        update_time = time.time()
+        if (update_time - self.last_update) > 1:
+            self.last_update = update_time
+            self.msgq.put(self.counter)
+
+
+# ============================================================================
+def to_file_like_obj(iterable):
+    """iter to file like obj"""
+    chunk = b""
+    offset = 0
+    # pylint: disable=invalid-name
+    it = iter(iterable)
+
+    def up_to_iter(size):
+        nonlocal chunk, offset
+
+        # if no size, yield exactly one chunk
+        if not size or size < 0:
+            try:
+                chunk = next(it)
+                yield chunk
+            except StopIteration:
+                pass
+
+            return
+
+        while size:
+            if offset == len(chunk):
+                try:
+                    chunk = next(it)
+                except StopIteration:
+                    break
+                else:
+                    offset = 0
+            to_yield = min(size, len(chunk) - offset)
+            offset = offset + to_yield
+            size -= to_yield
+            yield chunk[offset - to_yield : offset]
+
+    # pylint: disable=too-few-public-methods
+    class FileLikeObj:
+        """file-like obj wrapper for upload"""
+
+        def read(self, size=-1):
+            """read interface for file-like obj"""
+            return b"".join(up_to_iter(size))
+
+    return FileLikeObj()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,5 +11,5 @@ jinja2
 humanize
 python-multipart
 pathvalidate
-stream-zip
+https://github.com/ikreymer/stream-zip/archive/refs/heads/stream-uncompress.zip
 boto3

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -102,8 +102,8 @@ backend_workers: 2
 backend_requests_cpu: "10m"
 backend_limits_cpu: "768m"
 
-backend_requests_memory: "100Mi"
-backend_limits_memory: "512Mi"
+backend_requests_memory: "1024Mi"
+backend_limits_memory: "1024Mi"
 
 # port for operator service
 opPort: 8756

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -102,8 +102,8 @@ backend_workers: 2
 backend_requests_cpu: "10m"
 backend_limits_cpu: "768m"
 
-backend_requests_memory: "1024Mi"
-backend_limits_memory: "1024Mi"
+backend_requests_memory: "100Mi"
+backend_limits_memory: "512Mi"
 
 # port for operator service
 opPort: 8756

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -442,7 +442,7 @@ export class CollectionDetail extends LiteElement {
         `/orgs/${this.orgId}/collections/${this.collectionId}`,
         this.authState!
       );
-      if (data.publishedUrl.length > 0) {
+      if (data.publishedUrl?.length > 0) {
         this.isLoading = false;
         this.collection = data;
         return;

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -218,13 +218,17 @@ export class CollectionDetail extends LiteElement {
   private renderActions = () => {
     // FIXME replace auth token post-workshop
     const authToken = this.authState!.headers.Authorization.split(" ")[1];
+
+    const fullUrl = this.collection?.publishedUrl ? new URL(this.collection?.publishedUrl, window.location.href)
+    .href : "";
+
     return html`
       <sl-dropdown distance="4">
         <sl-button slot="trigger" size="small" caret
           >${msg("Actions")}</sl-button
         >
         <sl-menu>
-          ${!this.collection?.publishedUrl
+          ${!fullUrl
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -240,10 +244,7 @@ export class CollectionDetail extends LiteElement {
                   <a
                     target="_blank"
                     slot="prefix"
-                    href="https://replayweb.page?source=${new URL(
-                      this.collection?.publishedUrl || "",
-                      window.location.href
-                    ).href}"
+                    href="https://replayweb.page?source=${fullUrl}"
                   >
                     Go to Public View
                   </a>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -41,6 +41,9 @@ export class CollectionDetail extends LiteElement {
   @state()
   private showPublishedInfo = false;
 
+  @state()
+  private pPercent = 0;
+
   protected async willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("orgId")) {
       this.collection = undefined;
@@ -67,7 +70,10 @@ export class CollectionDetail extends LiteElement {
         </h2>
         ${when(this.collection?.publishing && !this.collection?.publishedUrl, () => html`
           <div class="flex items-center justify-center mr-2 p-2">
-            <div class="mr-1">${msg(str`Publishing in progress`)}</div>
+            <div class="flex flex-col mr-1">
+              <span>${msg(str`Publishing in progress`)}</span>
+              <sl-progress-bar value="${this.pPercent}" style="--height: 6px;"></sl-progress-bar>
+            </div>
             <sl-spinner></sl-spinner>
           </div>
         `)}
@@ -222,7 +228,6 @@ export class CollectionDetail extends LiteElement {
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
-                  ?disabled=${this.collection?.publishing && !this.collection?.publishedUrl}
                   @click=${this.onPublish}
                 >
                   <sl-icon name="journal-plus" slot="prefix"></sl-icon>
@@ -490,6 +495,7 @@ export class CollectionDetail extends LiteElement {
         `/orgs/${this.orgId}/collections/${this.collectionId}`,
         this.authState!
       );
+      this.pPercent = Number(data.pPercent);
       if (!data.publishing && data.publishedUrl && data.publishedUrl?.length > 0) {
         this.collection = data;
         return;

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -72,7 +72,7 @@ export class CollectionDetail extends LiteElement {
           </div>
         `)}
         <div>
-          ${when(this.collection?.published, () => html`
+          ${when(this.collection?.publishedUrl, () => html`
             <sl-button size="small" class="p-2 mb-2"
             @click=${() => this.showPublishedInfo = true}
             >
@@ -122,7 +122,7 @@ export class CollectionDetail extends LiteElement {
   }
 
   private renderPublishedInfo = () => {
-    if (!this.collection?.published || !this.collection?.publishedUrl) {
+    if (!this.collection?.publishedUrl) {
       return;
     }
 
@@ -170,7 +170,7 @@ export class CollectionDetail extends LiteElement {
           >${msg("Actions")}</sl-button
         >
         <sl-menu>
-          ${!this.collection?.published ? html`
+          ${!this.collection?.publishedUrl ? html`
             <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
             ?disabled=${this.isLoading}
@@ -432,11 +432,11 @@ export class CollectionDetail extends LiteElement {
         method: "POST",
       }
     );
-    const { url, published } = data;
+    const { url } = data;
     if (this.collection && url) {
-      this.collection = {...this.collection, publishedUrl: url, published: published};
+      this.collection = {...this.collection, publishedUrl: url};
     }
-    if (!this.collection?.published) {
+    if (!this.collection?.publishedUrl) {
       this.isLoading = true;
       await this.waitForCollectionPublished();
     }
@@ -448,7 +448,7 @@ export class CollectionDetail extends LiteElement {
         `/orgs/${this.orgId}/collections/${this.collectionId}`,
         this.authState!
       );
-      if (data.published === true) {
+      if (data.publishedUrl.length > 0) {
         this.isLoading = false;
         this.collection = data;
         return;
@@ -479,7 +479,7 @@ export class CollectionDetail extends LiteElement {
       }
     );
     if (this.collection && data?.published === false) {
-      this.collection = {...this.collection, publishedUrl: undefined, published: false};
+      this.collection = {...this.collection, publishedUrl: undefined};
     }
   }
 }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -432,8 +432,9 @@ export class CollectionDetail extends LiteElement {
         method: "POST",
       }
     );
-    if (this.collection) {
-      this.collection.publishing = true;
+    const { publishing } = data;
+    if (this.collection && publishing) {
+      this.collection = {...this.collection, publishing: publishing};
     }
     await this.waitForCollectionPublished();
   }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -66,7 +66,7 @@ export class CollectionDetail extends LiteElement {
           ${this.collection?.name || html`<sl-skeleton></sl-skeleton>`}
         </h2>
         ${when(this.isLoading, () => html`
-          <div class="flex justify-center mr-2 p-2">
+          <div class="flex items-center justify-center mr-2 p-2">
             <div class="mr-1">${msg(str`Publishing in progress`)}</div>
             <sl-spinner></sl-spinner>
           </div>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -108,7 +108,6 @@ export class CollectionDetail extends LiteElement {
           <sl-button
             size="small"
             variant="primary"
-            ?disabled=${this.collection?.publishing === true}
             @click=${async () => {
               await this.deleteCollection();
               this.openDialogName = undefined;
@@ -216,6 +215,7 @@ export class CollectionDetail extends LiteElement {
           </sl-menu-item>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
+            ?disabled=${this.collection?.publishing === true}
             @click=${this.confirmDelete}
           >
             <sl-icon name="trash3" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -46,7 +46,7 @@ export class CollectionDetail extends LiteElement {
       this.collection = undefined;
       this.fetchCollection();
     }
-    if (this.collection && this.collection.publishing) {
+    if (this.collection && (this.collection.publishing === true || !this.collection.publishedUrl)) {
       await this.waitForCollectionPublished();
     }
   }
@@ -65,7 +65,7 @@ export class CollectionDetail extends LiteElement {
         >
           ${this.collection?.name || html`<sl-skeleton></sl-skeleton>`}
         </h2>
-        ${when(this.collection?.publishing, () => html`
+        ${when(this.collection?.publishing && !this.collection?.publishedUrl, () => html`
           <div class="flex items-center justify-center mr-2 p-2">
             <div class="mr-1">${msg(str`Publishing in progress`)}</div>
             <sl-spinner></sl-spinner>
@@ -108,7 +108,7 @@ export class CollectionDetail extends LiteElement {
           <sl-button
             size="small"
             variant="primary"
-            ?disabled=${this.collection?.publishing}
+            ?disabled=${this.collection?.publishing === true}
             @click=${async () => {
               await this.deleteCollection();
               this.openDialogName = undefined;
@@ -173,7 +173,7 @@ export class CollectionDetail extends LiteElement {
           ${!this.collection?.publishedUrl ? html`
             <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
-            ?disabled=${this.collection?.publishing}
+            ?disabled=${this.collection?.publishing && !this.collection?.publishedUrl}
             @click=${this.onPublish}
             >
               <sl-icon name="journal-plus" slot="prefix"></sl-icon>
@@ -445,7 +445,7 @@ export class CollectionDetail extends LiteElement {
         `/orgs/${this.orgId}/collections/${this.collectionId}`,
         this.authState!
       );
-      if (data.publishedUrl && data.publishedUrl?.length > 0) {
+      if (!data.publishing && data.publishedUrl && data.publishedUrl?.length > 0) {
         this.collection = data;
         return;
       }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -442,7 +442,7 @@ export class CollectionDetail extends LiteElement {
         `/orgs/${this.orgId}/collections/${this.collectionId}`,
         this.authState!
       );
-      if (data.publishedUrl?.length > 0) {
+      if (data.publishedUrl && data.publishedUrl?.length > 0) {
         this.isLoading = false;
         this.collection = data;
         return;

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -432,14 +432,8 @@ export class CollectionDetail extends LiteElement {
         method: "POST",
       }
     );
-    const { url } = data;
-    if (this.collection && url) {
-      this.collection = {...this.collection, publishedUrl: url};
-    }
-    if (!this.collection?.publishedUrl) {
-      this.isLoading = true;
-      await this.waitForCollectionPublished();
-    }
+    this.isLoading = true;
+    await this.waitForCollectionPublished();
   }
 
   private async waitForCollectionPublished() {

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -483,7 +483,7 @@ export class CollectionsList extends LiteElement {
                   <a
                     class="text-primary hover:text-indigo-500"
                     href="https://replayweb.page?source=${new URL(
-                      col.publishedUrl
+                      col.publishedUrl, window.location.href
                     ).href}"
                     target="_blank"
                     rel="noopener noreferrer nofollow"

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -46,6 +46,9 @@ import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/menu-label/menu-label"
 );
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/progress-bar/progress-bar.js"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/relative-time/relative-time"
 );
 import(

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -10,7 +10,7 @@ export type Collection = {
   resources: string[];
   publishedUrl?: string;
   publishing?: boolean;
-  //published?: boolean;
+  pPercent?: number;
 };
 
 export type CollectionList = Collection[];

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -9,6 +9,7 @@ export type Collection = {
   tags: string[];
   resources: string[];
   publishedUrl?: string;
+  published?: boolean;
 };
 
 export type CollectionList = Collection[];

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -10,7 +10,7 @@ export type Collection = {
   resources: string[];
   publishedUrl?: string;
   publishing?: boolean;
-  published?: boolean;
+  //published?: boolean;
 };
 
 export type CollectionList = Collection[];

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -9,6 +9,7 @@ export type Collection = {
   tags: string[];
   resources: string[];
   publishedUrl?: string;
+  publishing?: boolean;
   published?: boolean;
 };
 


### PR DESCRIPTION
Initial implementation of #973 

Updated screenshot of status indicator:

![image](https://github.com/webrecorder/browsertrix-cloud/assets/6758804/8d61c784-685b-40a0-9a01-2da73825dfdb)

Ideally we'd want to use the sync upload callback to load a progress bar, but that will require some additional refactoring. Progress on this has been slower than expected because every time I try to publish a large collection my dev environment breaks (I think running out of memory due to the way the download stream is currently implemented).
