### PR TITLE
feat(microk8s): configure passwords through ansible

### DIFF
--- a/ansible/group_vars/microk8s/btrix_values.j2
+++ b/ansible/group_vars/microk8s/btrix_values.j2
@@ -2,7 +2,13 @@ ingress_class: "public"
 
 mongo_auth:
   username: root
-  password: example
+  password: "{{ mongo_password | default('PASSWORD!') }}"
+
+superuser:
+  email: "{{ superuser_email }}"
+  password: "{{ superuser_password }}"
+
+default_org: "{{ browsertrix_default_org }}"
 
 ingress:
   host: "{{ domain }}"

--- a/ansible/group_vars/microk8s/main.yml
+++ b/ansible/group_vars/microk8s/main.yml
@@ -35,3 +35,5 @@ superuser_password: "{{ browsertrix_superuser_password | default('PASSW0RD!') }}
 browsertrix_default_org: "{{ default_org | default('My Organization') }}"
 
 mongo_password: "{{ browsertrix_mongo_password | default('PASSWORD!') }}"
+
+enable_signing: true

--- a/ansible/group_vars/microk8s/main.yml
+++ b/ansible/group_vars/microk8s/main.yml
@@ -36,4 +36,7 @@ browsertrix_default_org: "{{ default_org | default('My Organization') }}"
 
 mongo_password: "{{ browsertrix_mongo_password | default('PASSWORD!') }}"
 
-enable_signing: true
+enable_signing: false
+cert_email: "dev@browsertrix.cloud"
+signing_domain: 
+signing_authtoken:

--- a/ansible/group_vars/microk8s/main.yml
+++ b/ansible/group_vars/microk8s/main.yml
@@ -28,3 +28,10 @@ microk8s_plugins:
   registry: true         # Private image registry exposed on localhost:32000
   storage: true          # Storage class; allocates storage from host
   cert-manager: true     # Cert manager
+
+# Configuration for Containers
+superuser_email: "{{ browsertrix_superuser_email | default('admin@example.com') }}"
+superuser_password: "{{ browsertrix_superuser_password | default('PASSW0RD!') }}"
+browsertrix_default_org: "{{ default_org | default('My Organization') }}"
+
+mongo_password: "{{ browsertrix_mongo_password | default('PASSWORD!') }}"

--- a/docs/deploy/ansible/microk8s.md
+++ b/docs/deploy/ansible/microk8s.md
@@ -30,6 +30,13 @@ cd browsertrix-cloud
 ```zsh
 ansible-playbook -i inventory/hosts playbooks/install_microk8s.yml -e host_ip="1.2.3.4" -e domain_name="yourdomain.com" -e your_user="your_vps_admin_user"
 ```
+You may optionally also pass in:
+- `browsertrix_superuser_email`
+- `browsertrix_superuser_password`
+- `browsertrix_mongo_password`
+- `default_org`
+
+If left empty they will be configured with the defaults
 
 #### Upgrading
 


### PR DESCRIPTION
Implements #777, but in a more flexible and simpler way (imo) 

We set ansible vars containing passwords or defaults, that then get templated into helm values, which then get deployed into helm. The template already existed, so I added a couple more things to it. 

Draft because untested as yet. 