### PR TITLE
Rework models and crawl responses

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -19,8 +19,9 @@ from .models import (
     UpdateCrawl,
     DeleteCrawlList,
     Organization,
+    PaginatedResponse,
 )
-from .pagination import PaginatedResponseModel, paginated_format, DEFAULT_PAGE_SIZE
+from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .storages import get_presigned_url, delete_crawl_file_object
 from .users import User
 from .utils import dt_now, get_redis_crawl_stats
@@ -461,7 +462,7 @@ def init_base_crawls_api(
     @app.get(
         "/orgs/{oid}/all-crawls",
         tags=["all-crawls"],
-        response_model=PaginatedResponseModel,
+        response_model=PaginatedResponse,
     )
     async def list_all_base_crawls(
         org: Organization = Depends(org_viewer_dep),

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -20,10 +20,10 @@ from .models import (
     DeleteCrawlList,
     Organization,
     PaginatedResponse,
+    User,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .storages import get_presigned_url, delete_crawl_file_object
-from .users import User
 from .utils import dt_now, get_redis_crawl_stats
 
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -97,7 +97,9 @@ class BaseCrawlOps:
         res = await self.get_crawl_raw(crawlid, org, type_)
 
         if cls_type == CrawlOutWithResources:
-            res["resources"] = await self._files_to_resources(res.get("files"), org, crawlid)
+            res["resources"] = await self._files_to_resources(
+                res.get("files"), org, crawlid
+            )
 
         del res["files"]
         del res["errors"]

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -18,8 +18,8 @@ from .models import (
     CrawlOutWithResources,
     UpdateCrawl,
     DeleteCrawlList,
+    Organization,
 )
-from .orgs import Organization
 from .pagination import PaginatedResponseModel, paginated_format, DEFAULT_PAGE_SIZE
 from .storages import get_presigned_url, delete_crawl_file_object
 from .users import User

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -10,7 +10,6 @@ import pymongo
 from fastapi import Depends, HTTPException
 
 from .basecrawls import SUCCESSFUL_STATES
-from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
     Collection,
@@ -19,6 +18,7 @@ from .models import (
     UpdateColl,
     AddRemoveCrawlList,
     CrawlOutWithResources,
+    Organization,
 )
 
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -15,7 +15,7 @@ from .basecrawls import SUCCESSFUL_STATES
 from .db import BaseMongoModel
 from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .models import BaseCrawlOutWithResources, CrawlFileOut
+from .models import CrawlOutWithResources, CrawlFileOut
 
 
 # ============================================================================
@@ -275,7 +275,7 @@ class CollectionOps:
             collection_id=coll_id,
             states=SUCCESSFUL_STATES,
             page_size=10_000,
-            cls_type=BaseCrawlOutWithResources,
+            cls_type=CrawlOutWithResources,
         )
 
         for crawl in crawls:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -19,6 +19,7 @@ from .models import (
     AddRemoveCrawlList,
     CrawlOutWithResources,
     Organization,
+    PaginatedResponse,
 )
 
 
@@ -339,6 +340,7 @@ def init_collections_api(app, mdb, crawls, orgs, crawl_manager):
     @app.get(
         "/orgs/{oid}/collections",
         tags=["collections"],
+        response_model=PaginatedResponse,
     )
     async def list_collection_all(
         org: Organization = Depends(org_viewer_dep),

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -11,10 +11,11 @@ from fastapi import Depends, HTTPException
 
 from pydantic import BaseModel, UUID4, Field
 
-from .basecrawls import BaseCrawlOutWithResources, CrawlFileOut, SUCCESSFUL_STATES
+from .basecrawls import SUCCESSFUL_STATES
 from .db import BaseMongoModel
 from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .models import BaseCrawlOutWithResources, CrawlFileOut
 
 
 # ============================================================================

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -9,60 +9,17 @@ from typing import Optional, List
 import pymongo
 from fastapi import Depends, HTTPException
 
-from pydantic import BaseModel, UUID4, Field
-
 from .basecrawls import SUCCESSFUL_STATES
-from .db import BaseMongoModel
 from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .models import CrawlOutWithResources, CrawlFileOut
-
-
-# ============================================================================
-class Collection(BaseMongoModel):
-    """Org collection structure"""
-
-    name: str = Field(..., min_length=1)
-    oid: UUID4
-    description: Optional[str]
-    modified: Optional[datetime]
-
-    crawlCount: Optional[int] = 0
-    pageCount: Optional[int] = 0
-
-    # Sorted by count, descending
-    tags: Optional[List[str]] = []
-
-
-# ============================================================================
-class CollIn(BaseModel):
-    """Collection Passed in By User"""
-
-    name: str = Field(..., min_length=1)
-    description: Optional[str]
-    crawlIds: Optional[List[str]] = []
-
-
-# ============================================================================
-class CollOut(Collection):
-    """Collection output model with annotations."""
-
-    resources: Optional[List[CrawlFileOut]] = []
-
-
-# ============================================================================
-class UpdateColl(BaseModel):
-    """Update collection"""
-
-    name: Optional[str]
-    description: Optional[str]
-
-
-# ============================================================================
-class AddRemoveCrawlList(BaseModel):
-    """Update crawl config name, crawl schedule, or tags"""
-
-    crawlIds: Optional[List[str]] = []
+from .models import (
+    Collection,
+    CollIn,
+    CollOut,
+    UpdateColl,
+    AddRemoveCrawlList,
+    CrawlOutWithResources,
+)
 
 
 # ============================================================================

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -11,8 +11,7 @@ from fastapi import Depends, HTTPException
 
 from pydantic import BaseModel, UUID4, Field
 
-from .basecrawls import BaseCrawlOutWithResources
-from .crawls import CrawlFileOut, SUCCESSFUL_STATES
+from .basecrawls import BaseCrawlOutWithResources, CrawlFileOut, SUCCESSFUL_STATES
 from .db import BaseMongoModel
 from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -33,6 +33,8 @@ from .models import (
 class CrawlConfigOps:
     """Crawl Config Operations"""
 
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods
+
     def __init__(self, dbclient, mdb, user_manager, org_ops, crawl_manager, profiles):
         self.dbclient = dbclient
         self.crawls = mdb["crawls"]

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -15,7 +15,6 @@ import pymongo
 from pydantic import UUID4
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from .users import User
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
     CrawlConfigIn,
@@ -25,6 +24,7 @@ from .models import (
     CrawlConfigIdNameOut,
     UpdateCrawlConfig,
     Organization,
+    User,
 )
 
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -25,6 +25,7 @@ from .models import (
     UpdateCrawlConfig,
     Organization,
     User,
+    PaginatedResponse,
 )
 
 
@@ -858,7 +859,7 @@ def init_crawl_config_api(
     org_crawl_dep = org_ops.org_crawl_dep
     org_viewer_dep = org_ops.org_viewer_dep
 
-    @router.get("")
+    @router.get("", response_model=PaginatedResponse)
     async def get_crawl_configs(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -16,7 +16,6 @@ from pydantic import UUID4
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from .users import User
-from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
     CrawlConfigIn,
@@ -25,6 +24,7 @@ from .models import (
     CrawlConfigOut,
     CrawlConfigIdNameOut,
     UpdateCrawlConfig,
+    Organization,
 )
 
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -8,10 +8,8 @@ import base64
 
 from datetime import timedelta
 
-from .orgs import S3Storage
-
 from .k8sapi import K8sAPI
-
+from .models import S3Storage
 from .utils import dt_now, to_k8s_date
 
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -32,8 +32,7 @@ from .models import (
     CrawlScale,
     Crawl,
     CrawlOut,
-    ListCrawlOut,
-    ListCrawlOutWithResources,
+    CrawlOutWithResources,
 )
 from .basecrawls import RUNNING_AND_STARTING_STATES, ALL_CRAWL_STATES
 
@@ -200,9 +199,9 @@ class CrawlOps(BaseCrawlOps):
         except (IndexError, ValueError):
             total = 0
 
-        cls = ListCrawlOut
+        cls = CrawlOut
         if resources:
-            cls = ListCrawlOutWithResources
+            cls = CrawlOutWithResources
 
         crawls = []
         for result in items:
@@ -229,7 +228,7 @@ class CrawlOps(BaseCrawlOps):
 
         del res["errors"]
 
-        crawl = CrawlOut.from_dict(res)
+        crawl = CrawlOutWithResources.from_dict(res)
 
         return await self._resolve_crawl_refs(crawl, org)
 
@@ -770,7 +769,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
     @app.get(
         "/orgs/all/crawls/{crawl_id}/replay.json",
         tags=["crawls"],
-        response_model=CrawlOut,
+        response_model=CrawlOutWithResources,
     )
     async def get_crawl_admin(crawl_id, user: User = Depends(user_dep)):
         if not user.is_superuser:
@@ -781,7 +780,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/replay.json",
         tags=["crawls"],
-        response_model=CrawlOut,
+        response_model=CrawlOutWithResources,
     )
     async def get_crawl(crawl_id, org: Organization = Depends(org_viewer_dep)):
         return await ops.get_crawl(crawl_id, org)
@@ -789,7 +788,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
     @app.get(
         "/orgs/all/crawls/{crawl_id}",
         tags=["crawls"],
-        response_model=ListCrawlOut,
+        response_model=CrawlOut,
     )
     async def list_single_crawl_admin(crawl_id, user: User = Depends(user_dep)):
         if not user.is_superuser:
@@ -804,7 +803,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}",
         tags=["crawls"],
-        response_model=ListCrawlOut,
+        response_model=CrawlOut,
     )
     async def list_single_crawl(crawl_id, org: Organization = Depends(org_viewer_dep)):
         crawls, _ = await ops.list_crawls(org, crawl_id=crawl_id)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -17,7 +17,6 @@ from redis import asyncio as exceptions
 import pymongo
 
 from .crawlconfigs import set_config_current_crawl_info
-from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .storages import get_wacz_logs
 from .users import User
@@ -33,6 +32,7 @@ from .models import (
     Crawl,
     CrawlOut,
     CrawlOutWithResources,
+    Organization,
 )
 from .basecrawls import RUNNING_AND_STARTING_STATES, ALL_CRAWL_STATES
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -19,7 +19,6 @@ import pymongo
 from .crawlconfigs import set_config_current_crawl_info
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .storages import get_wacz_logs
-from .users import User
 from .utils import dt_now, parse_jsonl_error_messages
 from .basecrawls import BaseCrawlOps
 from .models import (
@@ -33,6 +32,7 @@ from .models import (
     CrawlOut,
     CrawlOutWithResources,
     Organization,
+    User,
 )
 from .basecrawls import RUNNING_AND_STARTING_STATES, ALL_CRAWL_STATES
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -207,8 +207,9 @@ class CrawlOps(BaseCrawlOps):
         crawls = []
         for result in items:
             crawl = cls.from_dict(result)
+            files = result.get("files") if resources else None
             crawl = await self._resolve_crawl_refs(
-                crawl, org, add_first_seed=False, resources=resources
+                crawl, org, add_first_seed=False, files=files
             )
             crawls.append(crawl)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -33,6 +33,7 @@ from .models import (
     CrawlOutWithResources,
     Organization,
     User,
+    PaginatedResponse,
 )
 from .basecrawls import RUNNING_AND_STARTING_STATES, ALL_CRAWL_STATES
 
@@ -677,7 +678,7 @@ def init_crawls_api(app, mdb, users, crawl_manager, crawl_config_ops, orgs, user
         )
         return paginated_format(crawls, total, page, pageSize)
 
-    @app.get("/orgs/{oid}/crawls", tags=["crawls"])
+    @app.get("/orgs/{oid}/crawls", tags=["crawls"], response_model=PaginatedResponse)
     async def list_crawls(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -1,7 +1,6 @@
 """ Invite system management """
 
 from datetime import datetime
-from enum import IntEnum
 from typing import Optional
 import os
 import urllib.parse
@@ -9,55 +8,10 @@ import time
 import uuid
 
 from pymongo.errors import AutoReconnect
-from pydantic import BaseModel, UUID4
 from fastapi import HTTPException
 
-from .db import BaseMongoModel
 from .pagination import DEFAULT_PAGE_SIZE
-
-
-# ============================================================================
-class UserRole(IntEnum):
-    """User role"""
-
-    VIEWER = 10
-    CRAWLER = 20
-    OWNER = 40
-    SUPERADMIN = 100
-
-
-# ============================================================================
-class InvitePending(BaseMongoModel):
-    """An invite for a new user, with an email and invite token as id"""
-
-    created: datetime
-    inviterEmail: str
-    oid: Optional[UUID4]
-    role: Optional[UserRole] = UserRole.VIEWER
-    email: Optional[str]
-
-
-# ============================================================================
-class InviteRequest(BaseModel):
-    """Request to invite another user"""
-
-    email: str
-
-
-# ============================================================================
-class InviteToOrgRequest(InviteRequest):
-    """Request to invite another user to an organization"""
-
-    role: UserRole
-
-
-# ============================================================================
-class AddToOrgRequest(InviteRequest):
-    """Request to add a new user to an organization directly"""
-
-    role: UserRole
-    password: str
-    name: str
+from .models import UserRole, InvitePending, InviteRequest
 
 
 # ============================================================================

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -88,14 +88,6 @@ def main():
 
     init_storages_api(org_ops, crawl_manager, current_active_user)
 
-    init_uploads_api(
-        app, mdb, user_manager, crawl_manager, org_ops, current_active_user
-    )
-
-    init_base_crawls_api(
-        app, mdb, user_manager, crawl_manager, org_ops, current_active_user
-    )
-
     profiles = init_profiles_api(mdb, crawl_manager, org_ops, current_active_user)
 
     crawl_config_ops = init_crawl_config_api(
@@ -108,7 +100,27 @@ def main():
         profiles,
     )
 
+    init_base_crawls_api(
+        app,
+        mdb,
+        user_manager,
+        crawl_manager,
+        crawl_config_ops,
+        org_ops,
+        current_active_user,
+    )
+
     crawls = init_crawls_api(
+        app,
+        mdb,
+        user_manager,
+        crawl_manager,
+        crawl_config_ops,
+        org_ops,
+        current_active_user,
+    )
+
+    init_uploads_api(
         app,
         mdb,
         user_manager,

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -3,8 +3,7 @@ Migration 0003 - Mutable crawl configs and crawl revision history
 """
 from datetime import datetime
 
-from btrixcloud.crawlconfigs import CrawlConfig
-from btrixcloud.crawls import Crawl
+from btrixcloud.models import Crawl, CrawlConfig
 from btrixcloud.migrations import BaseMigration, MigrationError
 
 

--- a/backend/btrixcloud/migrations/migration_0004_config_seeds.py
+++ b/backend/btrixcloud/migrations/migration_0004_config_seeds.py
@@ -3,8 +3,7 @@ Migration 0004 - Ensuring all config.seeds are Seeds not HttpUrls
 """
 from pydantic import HttpUrl
 
-from btrixcloud.crawlconfigs import CrawlConfig, ScopeType, Seed
-from btrixcloud.crawls import Crawl
+from btrixcloud.models import Crawl, CrawlConfig, ScopeType, Seed
 from btrixcloud.migrations import BaseMigration
 
 

--- a/backend/btrixcloud/migrations/migration_0005_operator_scheduled_jobs.py
+++ b/backend/btrixcloud/migrations/migration_0005_operator_scheduled_jobs.py
@@ -1,7 +1,7 @@
 """
 Migration 0005 - Updating scheduled cron jobs after Operator changes
 """
-from btrixcloud.crawlconfigs import CrawlConfig, UpdateCrawlConfig
+from btrixcloud.models import CrawlConfig, UpdateCrawlConfig
 from btrixcloud.crawlmanager import CrawlManager
 from btrixcloud.migrations import BaseMigration
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -16,7 +16,7 @@ from .orgs import MAX_CRAWL_SCALE
 
 # ============================================================================
 
-### CONFIGS ###
+### CRAWL CONFIGS ###
 
 
 # ============================================================================
@@ -297,8 +297,8 @@ class BaseCrawl(BaseMongoModel):
 
 
 # ============================================================================
-class BaseCrawlOut(BaseMongoModel):
-    """Base crawl output model"""
+class CrawlOut(BaseMongoModel):
+    """Crawl output model, shared across all crawl types"""
 
     # pylint: disable=duplicate-code
 
@@ -339,12 +339,16 @@ class BaseCrawlOut(BaseMongoModel):
     firstSeed: Optional[str]
     seedCount: Optional[int]
     profileName: Optional[str]
+    stopping: Optional[bool]
+    manual: Optional[bool]
+    cid_rev: Optional[int]
 
 
 # ============================================================================
-class BaseCrawlOutWithResources(BaseCrawlOut):
-    """includes resources"""
+class CrawlOutWithResources(CrawlOut):
+    """Crawl output model including resources"""
 
+    files: Optional[List[CrawlFile]] = []
     resources: Optional[List[CrawlFileOut]] = []
 
 
@@ -365,7 +369,7 @@ class DeleteCrawlList(BaseModel):
 
 # ============================================================================
 
-### CRAWLS ###
+### AUTOMATED CRAWLS ###
 
 
 # ============================================================================
@@ -392,69 +396,6 @@ class Crawl(BaseCrawl, CrawlConfigCore):
 
 
 # ============================================================================
-class CrawlOut(Crawl):
-    """Output for single crawl, with additional fields"""
-
-    userName: Optional[str]
-    name: Optional[str]
-    description: Optional[str]
-    profileName: Optional[str]
-    resources: Optional[List[CrawlFileOut]] = []
-    firstSeed: Optional[str]
-    seedCount: Optional[int] = 0
-    errors: Optional[List[str]]
-
-
-# ============================================================================
-class ListCrawlOut(BaseMongoModel):
-    """Crawl output model for list view"""
-
-    # pylint: disable=duplicate-code
-
-    id: str
-
-    userid: UUID4
-    userName: Optional[str]
-
-    oid: UUID4
-    cid: UUID4
-    name: Optional[str]
-    description: Optional[str]
-
-    manual: Optional[bool]
-
-    started: datetime
-    finished: Optional[datetime]
-
-    state: str
-
-    stats: Optional[Dict[str, int]]
-
-    fileSize: int = 0
-    fileCount: int = 0
-
-    tags: Optional[List[str]] = []
-
-    notes: Optional[str]
-
-    firstSeed: Optional[str]
-    seedCount: Optional[int] = 0
-    errors: Optional[List[str]]
-
-    stopping: Optional[bool] = False
-
-    collections: Optional[List[UUID4]] = []
-
-
-# ============================================================================
-class ListCrawlOutWithResources(ListCrawlOut):
-    """Crawl output model used internally with files and resources."""
-
-    files: Optional[List[CrawlFile]] = []
-    resources: Optional[List[CrawlFileOut]] = []
-
-
-# ============================================================================
 class CrawlCompleteIn(BaseModel):
     """Completed Crawl Webhook POST message"""
 
@@ -467,3 +408,24 @@ class CrawlCompleteIn(BaseModel):
     hash: str
 
     completed: Optional[bool] = True
+
+
+# ============================================================================
+
+### UPLOADED CRAWLS ###
+
+
+# ============================================================================
+class UploadedCrawl(BaseCrawl):
+    """Store State of a Crawl Upload"""
+
+    type: str = Field("upload", const=True)
+
+    name: str
+
+
+# ============================================================================
+class UpdateUpload(UpdateCrawl):
+    """Update modal that also includes name"""
+
+    name: Optional[str]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -364,7 +364,6 @@ class CrawlOut(BaseMongoModel):
 class CrawlOutWithResources(CrawlOut):
     """Crawl output model including resources"""
 
-    files: Optional[List[CrawlFile]] = []
     resources: Optional[List[CrawlFileOut]] = []
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -15,6 +15,72 @@ from .orgs import MAX_CRAWL_SCALE
 
 # pylint: disable=invalid-name
 
+
+# ============================================================================
+
+### USERS ###
+
+
+# ============================================================================
+class User(fastapi_users_models.BaseUser):
+    """
+    Base User Model
+    """
+
+    name: Optional[str] = ""
+
+
+# ============================================================================
+# use custom model as model.BaseUserCreate includes is_* field
+class UserCreateIn(fastapi_users_models.CreateUpdateDictModel):
+    """
+    User Creation Model exposed to API
+    """
+
+    email: EmailStr
+    password: str
+
+    name: Optional[str] = ""
+
+    inviteToken: Optional[UUID4]
+
+    newOrg: bool
+    newOrgName: Optional[str] = ""
+
+
+# ============================================================================
+class UserCreate(fastapi_users_models.BaseUserCreate):
+    """
+    User Creation Model
+    """
+
+    name: Optional[str] = ""
+
+    inviteToken: Optional[UUID4]
+
+    newOrg: bool
+    newOrgName: Optional[str] = ""
+
+
+# ============================================================================
+class UserUpdate(User, fastapi_users_models.CreateUpdateDictModel):
+    """
+    User Update Model
+    """
+
+    password: Optional[str]
+    email: Optional[EmailStr]
+
+
+# ============================================================================
+class UserDB(User, fastapi_users_models.BaseUserDB):
+    """
+    User in DB Model
+    """
+
+    invites: Dict[str, InvitePending] = {}
+
+
 # ============================================================================
 
 ### CRAWL CONFIGS ###
@@ -759,68 +825,3 @@ class ProfileCreateUpdate(BaseModel):
     browserid: Optional[str]
     name: str
     description: Optional[str] = ""
-
-
-# ============================================================================
-
-### USERS ###
-
-
-# ============================================================================
-class User(fastapi_users_models.BaseUser):
-    """
-    Base User Model
-    """
-
-    name: Optional[str] = ""
-
-
-# ============================================================================
-# use custom model as model.BaseUserCreate includes is_* field
-class UserCreateIn(fastapi_users_models.CreateUpdateDictModel):
-    """
-    User Creation Model exposed to API
-    """
-
-    email: EmailStr
-    password: str
-
-    name: Optional[str] = ""
-
-    inviteToken: Optional[UUID4]
-
-    newOrg: bool
-    newOrgName: Optional[str] = ""
-
-
-# ============================================================================
-class UserCreate(fastapi_users_models.BaseUserCreate):
-    """
-    User Creation Model
-    """
-
-    name: Optional[str] = ""
-
-    inviteToken: Optional[UUID4]
-
-    newOrg: bool
-    newOrgName: Optional[str] = ""
-
-
-# ============================================================================
-class UserUpdate(User, fastapi_users_models.CreateUpdateDictModel):
-    """
-    User Update Model
-    """
-
-    password: Optional[str]
-    email: Optional[EmailStr]
-
-
-# ============================================================================
-class UserDB(User, fastapi_users_models.BaseUserDB):
-    """
-    User in DB Model
-    """
-
-    invites: Dict[str, InvitePending] = {}

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -676,3 +676,18 @@ class OrgOut(BaseMongoModel):
     default: bool = False
 
     quotas: Optional[OrgQuotas] = OrgQuotas()
+
+
+# ============================================================================
+
+### PAGINATION ###
+
+
+# ============================================================================
+class PaginatedResponse(BaseModel):
+    """Paginated response model"""
+
+    items: List[Any]
+    total: int
+    page: int
+    pageSize: int

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -18,7 +18,7 @@ from .orgs import MAX_CRAWL_SCALE
 
 # ============================================================================
 
-### USERS ###
+### MAIN USER MODEL ###
 
 
 # ============================================================================
@@ -28,57 +28,6 @@ class User(fastapi_users_models.BaseUser):
     """
 
     name: Optional[str] = ""
-
-
-# ============================================================================
-# use custom model as model.BaseUserCreate includes is_* field
-class UserCreateIn(fastapi_users_models.CreateUpdateDictModel):
-    """
-    User Creation Model exposed to API
-    """
-
-    email: EmailStr
-    password: str
-
-    name: Optional[str] = ""
-
-    inviteToken: Optional[UUID4]
-
-    newOrg: bool
-    newOrgName: Optional[str] = ""
-
-
-# ============================================================================
-class UserCreate(fastapi_users_models.BaseUserCreate):
-    """
-    User Creation Model
-    """
-
-    name: Optional[str] = ""
-
-    inviteToken: Optional[UUID4]
-
-    newOrg: bool
-    newOrgName: Optional[str] = ""
-
-
-# ============================================================================
-class UserUpdate(User, fastapi_users_models.CreateUpdateDictModel):
-    """
-    User Update Model
-    """
-
-    password: Optional[str]
-    email: Optional[EmailStr]
-
-
-# ============================================================================
-class UserDB(User, fastapi_users_models.BaseUserDB):
-    """
-    User in DB Model
-    """
-
-    invites: Dict[str, InvitePending] = {}
 
 
 # ============================================================================
@@ -825,3 +774,59 @@ class ProfileCreateUpdate(BaseModel):
     browserid: Optional[str]
     name: str
     description: Optional[str] = ""
+
+
+# ============================================================================
+
+### PROFILES ###
+
+
+# ============================================================================
+# use custom model as model.BaseUserCreate includes is_* field
+class UserCreateIn(fastapi_users_models.CreateUpdateDictModel):
+    """
+    User Creation Model exposed to API
+    """
+
+    email: EmailStr
+    password: str
+
+    name: Optional[str] = ""
+
+    inviteToken: Optional[UUID4]
+
+    newOrg: bool
+    newOrgName: Optional[str] = ""
+
+
+# ============================================================================
+class UserCreate(fastapi_users_models.BaseUserCreate):
+    """
+    User Creation Model
+    """
+
+    name: Optional[str] = ""
+
+    inviteToken: Optional[UUID4]
+
+    newOrg: bool
+    newOrgName: Optional[str] = ""
+
+
+# ============================================================================
+class UserUpdate(User, fastapi_users_models.CreateUpdateDictModel):
+    """
+    User Update Model
+    """
+
+    password: Optional[str]
+    email: Optional[EmailStr]
+
+
+# ============================================================================
+class UserDB(User, fastapi_users_models.BaseUserDB):
+    """
+    User in DB Model
+    """
+
+    invites: Dict[str, InvitePending] = {}

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1,0 +1,469 @@
+"""
+Crawl-related models and types
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from typing import Optional, List, Dict, Union
+from pydantic import BaseModel, UUID4, conint, Field, HttpUrl
+
+from .db import BaseMongoModel
+from .orgs import MAX_CRAWL_SCALE
+
+
+# pylint: disable=invalid-name
+
+# ============================================================================
+
+### CONFIGS ###
+
+
+# ============================================================================
+class JobType(str, Enum):
+    """Job Types"""
+
+    URL_LIST = "url-list"
+    SEED_CRAWL = "seed-crawl"
+    CUSTOM = "custom"
+
+
+# ============================================================================
+class ScopeType(str, Enum):
+    """Crawl scope type"""
+
+    PAGE = "page"
+    PAGE_SPA = "page-spa"
+    PREFIX = "prefix"
+    HOST = "host"
+    DOMAIN = "domain"
+    ANY = "any"
+    CUSTOM = "custom"
+
+
+# ============================================================================
+class Seed(BaseModel):
+    """Crawl seed"""
+
+    url: HttpUrl
+    scopeType: Optional[ScopeType]
+
+    include: Union[str, List[str], None]
+    exclude: Union[str, List[str], None]
+    sitemap: Union[bool, HttpUrl, None]
+    allowHash: Optional[bool]
+    depth: Optional[int]
+    extraHops: Optional[int]
+
+
+# ============================================================================
+class RawCrawlConfig(BaseModel):
+    """Base Crawl Config"""
+
+    seeds: List[Seed]
+
+    scopeType: Optional[ScopeType] = ScopeType.PREFIX
+
+    include: Union[str, List[str], None] = None
+    exclude: Union[str, List[str], None] = None
+
+    depth: Optional[int] = -1
+    limit: Optional[int] = 0
+    extraHops: Optional[int] = 0
+
+    lang: Optional[str]
+    blockAds: Optional[bool] = False
+
+    behaviorTimeout: Optional[int]
+    pageLoadTimeout: Optional[int]
+    pageExtraDelay: Optional[int] = 0
+
+    workers: Optional[int]
+
+    headless: Optional[bool]
+
+    generateWACZ: Optional[bool]
+    combineWARC: Optional[bool]
+
+    useSitemap: Optional[bool] = False
+
+    logging: Optional[str]
+    behaviors: Optional[str] = "autoscroll,autoplay,autofetch,siteSpecific"
+
+
+# ============================================================================
+class CrawlConfigIn(BaseModel):
+    """CrawlConfig input model, submitted via API"""
+
+    schedule: Optional[str] = ""
+    runNow: Optional[bool] = False
+
+    config: RawCrawlConfig
+
+    name: str
+
+    description: Optional[str]
+
+    jobType: Optional[JobType] = JobType.CUSTOM
+
+    profileid: Optional[str]
+
+    autoAddCollections: Optional[List[UUID4]] = []
+    tags: Optional[List[str]] = []
+
+    crawlTimeout: Optional[int] = 0
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
+
+    crawlFilenameTemplate: Optional[str]
+
+
+# ============================================================================
+class ConfigRevision(BaseMongoModel):
+    """Crawl Config Revision"""
+
+    cid: UUID4
+
+    schedule: Optional[str] = ""
+
+    config: RawCrawlConfig
+
+    profileid: Optional[UUID4]
+
+    crawlTimeout: Optional[int] = 0
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
+
+    modified: datetime
+    modifiedBy: Optional[UUID4]
+
+    rev: int = 0
+
+
+# ============================================================================
+class CrawlConfigCore(BaseMongoModel):
+    """Core data shared between crawls and crawlconfigs"""
+
+    schedule: Optional[str] = ""
+
+    jobType: Optional[JobType] = JobType.CUSTOM
+    config: RawCrawlConfig
+
+    tags: Optional[List[str]] = []
+
+    crawlTimeout: Optional[int] = 0
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1
+
+    oid: UUID4
+
+    profileid: Optional[UUID4]
+
+
+# ============================================================================
+class CrawlConfig(CrawlConfigCore):
+    """Schedulable config"""
+
+    name: Optional[str]
+    description: Optional[str]
+
+    created: datetime
+    createdBy: Optional[UUID4]
+
+    modified: Optional[datetime]
+    modifiedBy: Optional[UUID4]
+
+    autoAddCollections: Optional[List[UUID4]] = []
+
+    inactive: Optional[bool] = False
+
+    rev: int = 0
+
+    crawlAttemptCount: Optional[int] = 0
+    crawlCount: Optional[int] = 0
+    crawlSuccessfulCount: Optional[int] = 0
+
+    totalSize: Optional[int] = 0
+
+    lastCrawlId: Optional[str]
+    lastCrawlStartTime: Optional[datetime]
+    lastStartedBy: Optional[UUID4]
+    lastCrawlTime: Optional[datetime]
+    lastCrawlState: Optional[str]
+    lastCrawlSize: Optional[int]
+
+    lastRun: Optional[datetime]
+
+    isCrawlRunning: Optional[bool] = False
+
+    def get_raw_config(self):
+        """serialize config for browsertrix-crawler"""
+        return self.config.dict(exclude_unset=True, exclude_none=True)
+
+
+# ============================================================================
+class CrawlConfigOut(CrawlConfig):
+    """Crawl Config Output"""
+
+    lastCrawlStopping: Optional[bool] = False
+
+    profileName: Optional[str]
+
+    createdByName: Optional[str]
+    modifiedByName: Optional[str]
+    lastStartedByName: Optional[str]
+
+    firstSeed: Optional[str]
+
+
+# ============================================================================
+class CrawlConfigIdNameOut(BaseMongoModel):
+    """Crawl Config id and name output only"""
+
+    name: str
+
+
+# ============================================================================
+class UpdateCrawlConfig(BaseModel):
+    """Update crawl config name, crawl schedule, or tags"""
+
+    # metadata: not revision tracked
+    name: Optional[str]
+    tags: Optional[List[str]]
+    description: Optional[str]
+    autoAddCollections: Optional[List[UUID4]]
+
+    # crawl data: revision tracked
+    schedule: Optional[str]
+    profileid: Optional[str]
+    crawlTimeout: Optional[int]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
+    crawlFilenameTemplate: Optional[str]
+    config: Optional[RawCrawlConfig]
+
+
+# ============================================================================
+
+### BASE CRAWLS ###
+
+
+# ============================================================================
+class CrawlFile(BaseModel):
+    """file from a crawl"""
+
+    filename: str
+    hash: str
+    size: int
+    def_storage_name: Optional[str]
+
+    presignedUrl: Optional[str]
+    expireAt: Optional[datetime]
+
+
+# ============================================================================
+class CrawlFileOut(BaseModel):
+    """output for file from a crawl (conformance to Data Resource Spec)"""
+
+    name: str
+    path: str
+    hash: str
+    size: int
+    crawlId: Optional[str]
+
+
+# ============================================================================
+class BaseCrawl(BaseMongoModel):
+    """Base Crawl object (representing crawls, uploads and manual sessions)"""
+
+    id: str
+
+    userid: UUID4
+    oid: UUID4
+
+    started: datetime
+    finished: Optional[datetime]
+
+    state: str
+
+    stats: Optional[Dict[str, int]]
+
+    files: Optional[List[CrawlFile]] = []
+
+    notes: Optional[str]
+
+    errors: Optional[List[str]] = []
+
+    collections: Optional[List[UUID4]] = []
+
+    fileSize: int = 0
+    fileCount: int = 0
+
+
+# ============================================================================
+class BaseCrawlOut(BaseMongoModel):
+    """Base crawl output model"""
+
+    # pylint: disable=duplicate-code
+
+    type: Optional[str]
+
+    id: str
+
+    userid: UUID4
+    oid: UUID4
+
+    userName: Optional[str]
+
+    name: Optional[str]
+    description: Optional[str]
+
+    started: datetime
+    finished: Optional[datetime]
+
+    state: str
+
+    stats: Optional[Dict[str, int]]
+
+    fileSize: int = 0
+    fileCount: int = 0
+
+    tags: Optional[List[str]] = []
+
+    notes: Optional[str]
+
+    errors: Optional[List[str]]
+
+    collections: Optional[List[UUID4]] = []
+
+    # automated crawl fields
+    cid: Optional[UUID4]
+    name: Optional[str]
+    description: Optional[str]
+    firstSeed: Optional[str]
+    seedCount: Optional[int]
+    profileName: Optional[str]
+
+
+# ============================================================================
+class BaseCrawlOutWithResources(BaseCrawlOut):
+    """includes resources"""
+
+    resources: Optional[List[CrawlFileOut]] = []
+
+
+# ============================================================================
+class UpdateCrawl(BaseModel):
+    """Update crawl"""
+
+    tags: Optional[List[str]] = []
+    notes: Optional[str]
+
+
+# ============================================================================
+class DeleteCrawlList(BaseModel):
+    """delete crawl list POST body"""
+
+    crawl_ids: List[str]
+
+
+# ============================================================================
+
+### CRAWLS ###
+
+
+# ============================================================================
+class CrawlScale(BaseModel):
+    """scale the crawl to N parallel containers"""
+
+    scale: conint(ge=1, le=MAX_CRAWL_SCALE) = 1
+
+
+# ============================================================================
+class Crawl(BaseCrawl, CrawlConfigCore):
+    """Store State of a Crawl (Finished or Running)"""
+
+    type: str = Field("crawl", const=True)
+
+    cid: UUID4
+
+    cid_rev: int = 0
+
+    # schedule: Optional[str]
+    manual: Optional[bool]
+
+    stopping: Optional[bool] = False
+
+
+# ============================================================================
+class CrawlOut(Crawl):
+    """Output for single crawl, with additional fields"""
+
+    userName: Optional[str]
+    name: Optional[str]
+    description: Optional[str]
+    profileName: Optional[str]
+    resources: Optional[List[CrawlFileOut]] = []
+    firstSeed: Optional[str]
+    seedCount: Optional[int] = 0
+    errors: Optional[List[str]]
+
+
+# ============================================================================
+class ListCrawlOut(BaseMongoModel):
+    """Crawl output model for list view"""
+
+    # pylint: disable=duplicate-code
+
+    id: str
+
+    userid: UUID4
+    userName: Optional[str]
+
+    oid: UUID4
+    cid: UUID4
+    name: Optional[str]
+    description: Optional[str]
+
+    manual: Optional[bool]
+
+    started: datetime
+    finished: Optional[datetime]
+
+    state: str
+
+    stats: Optional[Dict[str, int]]
+
+    fileSize: int = 0
+    fileCount: int = 0
+
+    tags: Optional[List[str]] = []
+
+    notes: Optional[str]
+
+    firstSeed: Optional[str]
+    seedCount: Optional[int] = 0
+    errors: Optional[List[str]]
+
+    stopping: Optional[bool] = False
+
+    collections: Optional[List[UUID4]] = []
+
+
+# ============================================================================
+class ListCrawlOutWithResources(ListCrawlOut):
+    """Crawl output model used internally with files and resources."""
+
+    files: Optional[List[CrawlFile]] = []
+    resources: Optional[List[CrawlFileOut]] = []
+
+
+# ============================================================================
+class CrawlCompleteIn(BaseModel):
+    """Completed Crawl Webhook POST message"""
+
+    id: str
+
+    user: str
+
+    filename: str
+    size: int
+    hash: str
+
+    completed: Optional[bool] = True

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -429,3 +429,55 @@ class UpdateUpload(UpdateCrawl):
     """Update modal that also includes name"""
 
     name: Optional[str]
+
+
+# ============================================================================
+
+### COLLECTIONS ###
+
+
+# ============================================================================
+class Collection(BaseMongoModel):
+    """Org collection structure"""
+
+    name: str = Field(..., min_length=1)
+    oid: UUID4
+    description: Optional[str]
+    modified: Optional[datetime]
+
+    crawlCount: Optional[int] = 0
+    pageCount: Optional[int] = 0
+
+    # Sorted by count, descending
+    tags: Optional[List[str]] = []
+
+
+# ============================================================================
+class CollIn(BaseModel):
+    """Collection Passed in By User"""
+
+    name: str = Field(..., min_length=1)
+    description: Optional[str]
+    crawlIds: Optional[List[str]] = []
+
+
+# ============================================================================
+class CollOut(Collection):
+    """Collection output model with annotations."""
+
+    resources: Optional[List[CrawlFileOut]] = []
+
+
+# ============================================================================
+class UpdateColl(BaseModel):
+    """Update collection"""
+
+    name: Optional[str]
+    description: Optional[str]
+
+
+# ============================================================================
+class AddRemoveCrawlList(BaseModel):
+    """Collections to add or remove from collection"""
+
+    crawlIds: Optional[List[str]] = []

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -5,7 +5,7 @@ Crawl-related models and types
 from datetime import datetime
 from enum import Enum, IntEnum
 
-from typing import Optional, List, Dict, Union
+from typing import Optional, List, Dict, Union, Literal, Any
 from pydantic import BaseModel, UUID4, conint, Field, HttpUrl
 
 from .db import BaseMongoModel
@@ -530,3 +530,149 @@ class AddToOrgRequest(InviteRequest):
     role: UserRole
     password: str
     name: str
+
+
+# ============================================================================
+
+### ORGS ###
+
+
+# ============================================================================
+class UpdateRole(InviteToOrgRequest):
+    """Update existing role for user"""
+
+
+# ============================================================================
+class RemoveFromOrg(InviteRequest):
+    """Remove this user from org"""
+
+
+# ============================================================================
+class RemovePendingInvite(InviteRequest):
+    """Delete pending invite to org by email"""
+
+
+# ============================================================================
+class RenameOrg(BaseModel):
+    """Request to invite another user"""
+
+    name: str
+
+
+# ============================================================================
+class DefaultStorage(BaseModel):
+    """Storage reference"""
+
+    type: Literal["default"] = "default"
+    name: str
+    path: str = ""
+
+
+# ============================================================================
+class S3Storage(BaseModel):
+    """S3 Storage Model"""
+
+    type: Literal["s3"] = "s3"
+
+    endpoint_url: str
+    access_key: str
+    secret_key: str
+    access_endpoint_url: Optional[str]
+    region: Optional[str] = ""
+    use_access_for_presign: Optional[bool] = True
+
+
+# ============================================================================
+class OrgQuotas(BaseModel):
+    """Organization quotas (settable by superadmin)"""
+
+    maxConcurrentCrawls: Optional[int] = 0
+
+
+# ============================================================================
+class Organization(BaseMongoModel):
+    """Organization Base Model"""
+
+    name: str
+
+    users: Dict[str, UserRole]
+
+    storage: Union[S3Storage, DefaultStorage]
+
+    usage: Dict[str, int] = {}
+
+    default: bool = False
+
+    quotas: Optional[OrgQuotas] = OrgQuotas()
+
+    def is_owner(self, user):
+        """Check if user is owner"""
+        return self._is_auth(user, UserRole.OWNER)
+
+    def is_crawler(self, user):
+        """Check if user can crawl (write)"""
+        return self._is_auth(user, UserRole.CRAWLER)
+
+    def is_viewer(self, user):
+        """Check if user can view (read)"""
+        return self._is_auth(user, UserRole.VIEWER)
+
+    def _is_auth(self, user, value):
+        """Check if user has at least specified permission level"""
+        if user.is_superuser:
+            return True
+
+        res = self.users.get(str(user.id))
+        if not res:
+            return False
+
+        return res >= value
+
+    async def serialize_for_user(self, user: User, user_manager):
+        """Serialize result based on current user access"""
+
+        exclude = {"storage"}
+
+        if not self.is_owner(user):
+            exclude.add("users")
+
+        if not self.is_crawler(user):
+            exclude.add("usage")
+
+        result = self.to_dict(
+            exclude_unset=True,
+            exclude_defaults=True,
+            exclude_none=True,
+            exclude=exclude,
+        )
+
+        if self.is_owner(user):
+            keys = list(result["users"].keys())
+            user_list = await user_manager.get_user_names_by_ids(keys)
+
+            for org_user in user_list:
+                id_ = str(org_user["id"])
+                role = result["users"].get(id_)
+                if not role:
+                    continue
+
+                result["users"][id_] = {
+                    "role": role,
+                    "name": org_user.get("name", ""),
+                    "email": org_user.get("email", ""),
+                }
+
+        return OrgOut.from_dict(result)
+
+
+# ============================================================================
+class OrgOut(BaseMongoModel):
+    """Organization API output model"""
+
+    id: UUID4
+    name: str
+    users: Optional[Dict[str, Any]]
+    usage: Optional[Dict[str, int]]
+    default: bool = False
+
+    quotas: Optional[OrgQuotas] = OrgQuotas()

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -3,7 +3,7 @@ Crawl-related models and types
 """
 
 from datetime import datetime
-from enum import Enum
+from enum import Enum, IntEnum
 
 from typing import Optional, List, Dict, Union
 from pydantic import BaseModel, UUID4, conint, Field, HttpUrl
@@ -481,3 +481,52 @@ class AddRemoveCrawlList(BaseModel):
     """Collections to add or remove from collection"""
 
     crawlIds: Optional[List[str]] = []
+
+
+# ============================================================================
+
+### INVITES ###
+
+
+# ============================================================================
+class UserRole(IntEnum):
+    """User role"""
+
+    VIEWER = 10
+    CRAWLER = 20
+    OWNER = 40
+    SUPERADMIN = 100
+
+
+# ============================================================================
+class InvitePending(BaseMongoModel):
+    """An invite for a new user, with an email and invite token as id"""
+
+    created: datetime
+    inviterEmail: str
+    oid: Optional[UUID4]
+    role: Optional[UserRole] = UserRole.VIEWER
+    email: Optional[str]
+
+
+# ============================================================================
+class InviteRequest(BaseModel):
+    """Request to invite another user"""
+
+    email: str
+
+
+# ============================================================================
+class InviteToOrgRequest(InviteRequest):
+    """Request to invite another user to an organization"""
+
+    role: UserRole
+
+
+# ============================================================================
+class AddToOrgRequest(InviteRequest):
+    """Request to add a new user to an organization directly"""
+
+    role: UserRole
+    password: str
+    name: str

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -691,3 +691,70 @@ class PaginatedResponse(BaseModel):
     total: int
     page: int
     pageSize: int
+
+
+# ============================================================================
+
+### PROFILES ###
+
+
+# ============================================================================
+class ProfileFile(BaseModel):
+    """file from a crawl"""
+
+    filename: str
+    hash: str
+    size: int
+
+
+# ============================================================================
+class Profile(BaseMongoModel):
+    """Browser profile"""
+
+    name: str
+    description: Optional[str] = ""
+
+    userid: UUID4
+    oid: UUID4
+
+    origins: List[str]
+    resource: Optional[ProfileFile]
+
+    created: Optional[datetime]
+
+
+# ============================================================================
+class ProfileWithCrawlConfigs(Profile):
+    """Profile with list of crawlconfigs using this profile"""
+
+    crawlconfigs: List[CrawlConfigIdNameOut] = []
+
+
+# ============================================================================
+class UrlIn(BaseModel):
+    """Request to set url"""
+
+    url: HttpUrl
+
+
+# ============================================================================
+class ProfileLaunchBrowserIn(UrlIn):
+    """Request to launch new browser for creating profile"""
+
+    profileId: Optional[UUID4]
+
+
+# ============================================================================
+class BrowserId(BaseModel):
+    """Profile id on newly created profile"""
+
+    browserid: str
+
+
+# ============================================================================
+class ProfileCreateUpdate(BaseModel):
+    """Profile metadata for committing current browser to profile"""
+
+    browserid: Optional[str]
+    name: str
+    description: Optional[str] = ""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from enum import Enum, IntEnum
 
 from typing import Optional, List, Dict, Union, Literal, Any
-from pydantic import BaseModel, UUID4, conint, Field, HttpUrl
+from pydantic import BaseModel, UUID4, conint, Field, HttpUrl, EmailStr
+from fastapi_users import models as fastapi_users_models
 
 from .db import BaseMongoModel
 from .orgs import MAX_CRAWL_SCALE
@@ -758,3 +759,68 @@ class ProfileCreateUpdate(BaseModel):
     browserid: Optional[str]
     name: str
     description: Optional[str] = ""
+
+
+# ============================================================================
+
+### USERS ###
+
+
+# ============================================================================
+class User(fastapi_users_models.BaseUser):
+    """
+    Base User Model
+    """
+
+    name: Optional[str] = ""
+
+
+# ============================================================================
+# use custom model as model.BaseUserCreate includes is_* field
+class UserCreateIn(fastapi_users_models.CreateUpdateDictModel):
+    """
+    User Creation Model exposed to API
+    """
+
+    email: EmailStr
+    password: str
+
+    name: Optional[str] = ""
+
+    inviteToken: Optional[UUID4]
+
+    newOrg: bool
+    newOrgName: Optional[str] = ""
+
+
+# ============================================================================
+class UserCreate(fastapi_users_models.BaseUserCreate):
+    """
+    User Creation Model
+    """
+
+    name: Optional[str] = ""
+
+    inviteToken: Optional[UUID4]
+
+    newOrg: bool
+    newOrgName: Optional[str] = ""
+
+
+# ============================================================================
+class UserUpdate(User, fastapi_users_models.CreateUpdateDictModel):
+    """
+    User Update Model
+    """
+
+    password: Optional[str]
+    email: Optional[EmailStr]
+
+
+# ============================================================================
+class UserDB(User, fastapi_users_models.BaseUserDB):
+    """
+    User in DB Model
+    """
+
+    invites: Dict[str, InvitePending] = {}

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -10,12 +10,12 @@ from pydantic import BaseModel, UUID4, conint, Field, HttpUrl, EmailStr
 from fastapi_users import models as fastapi_users_models
 
 from .db import BaseMongoModel
-from .orgs import MAX_CRAWL_SCALE
+
+# crawl scale for constraint
+MAX_CRAWL_SCALE = 3
 
 
 # pylint: disable=invalid-name
-
-
 # ============================================================================
 
 ### MAIN USER MODEL ###

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -28,13 +28,12 @@ from .basecrawls import NON_RUNNING_STATES, SUCCESSFUL_STATES
 from .colls import add_successful_crawl_to_collections
 from .crawlconfigs import stats_recompute_last
 from .crawls import (
-    CrawlFile,
-    CrawlCompleteIn,
     add_crawl_file,
     update_crawl_state_if_allowed,
     get_crawl_state,
     add_crawl_errors,
 )
+from .models import CrawlFile, CrawlCompleteIn
 
 
 STS = "StatefulSet.apps/v1"

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -24,6 +24,7 @@ from .k8sapi import K8sAPI
 
 from .db import init_db
 from .orgs import inc_org_stats, get_max_concurrent_crawls
+from .basecrawls import NON_RUNNING_STATES, SUCCESSFUL_STATES
 from .colls import add_successful_crawl_to_collections
 from .crawlconfigs import stats_recompute_last
 from .crawls import (
@@ -33,8 +34,6 @@ from .crawls import (
     update_crawl_state_if_allowed,
     get_crawl_state,
     add_crawl_errors,
-    NON_RUNNING_STATES,
-    SUCCESSFUL_STATES,
 )
 
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -26,11 +26,10 @@ from .models import (
     InviteToOrgRequest,
     UserRole,
     User,
+    MAX_CRAWL_SCALE,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
-# crawl scale for constraint
-MAX_CRAWL_SCALE = 3
 
 DEFAULT_ORG = os.environ.get("DEFAULT_ORG", "My Organization")
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -17,7 +17,7 @@ from .db import BaseMongoModel
 
 from .users import User
 
-from .invites import (
+from .models import (
     AddToOrgRequest,
     InvitePending,
     InviteRequest,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -12,8 +12,6 @@ from typing import Union
 from pymongo.errors import AutoReconnect, DuplicateKeyError
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from .users import User
-
 from .models import (
     Organization,
     DefaultStorage,
@@ -27,8 +25,8 @@ from .models import (
     InvitePending,
     InviteToOrgRequest,
     UserRole,
+    User,
 )
-
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
 # crawl scale for constraint

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -7,20 +7,24 @@ import urllib.parse
 import uuid
 from datetime import datetime
 
-from typing import Dict, Union, Literal, Optional, Any
+from typing import Union
 
-from pydantic import BaseModel, UUID4
 from pymongo.errors import AutoReconnect, DuplicateKeyError
 from fastapi import APIRouter, Depends, HTTPException, Request
-
-from .db import BaseMongoModel
 
 from .users import User
 
 from .models import (
+    Organization,
+    DefaultStorage,
+    S3Storage,
+    OrgQuotas,
+    RenameOrg,
+    UpdateRole,
+    RemovePendingInvite,
+    RemoveFromOrg,
     AddToOrgRequest,
     InvitePending,
-    InviteRequest,
     InviteToOrgRequest,
     UserRole,
 )
@@ -31,147 +35,6 @@ from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 MAX_CRAWL_SCALE = 3
 
 DEFAULT_ORG = os.environ.get("DEFAULT_ORG", "My Organization")
-
-
-# ============================================================================
-class UpdateRole(InviteToOrgRequest):
-    """Update existing role for user"""
-
-
-# ============================================================================
-class RemoveFromOrg(InviteRequest):
-    """Remove this user from org"""
-
-
-# ============================================================================
-class RemovePendingInvite(InviteRequest):
-    """Delete pending invite to org by email"""
-
-
-# ============================================================================
-class RenameOrg(BaseModel):
-    """Request to invite another user"""
-
-    name: str
-
-
-# ============================================================================
-class DefaultStorage(BaseModel):
-    """Storage reference"""
-
-    type: Literal["default"] = "default"
-    name: str
-    path: str = ""
-
-
-# ============================================================================
-class S3Storage(BaseModel):
-    """S3 Storage Model"""
-
-    type: Literal["s3"] = "s3"
-
-    endpoint_url: str
-    access_key: str
-    secret_key: str
-    access_endpoint_url: Optional[str]
-    region: Optional[str] = ""
-    use_access_for_presign: Optional[bool] = True
-
-
-# ============================================================================
-class OrgQuotas(BaseModel):
-    """Organization quotas (settable by superadmin)"""
-
-    maxConcurrentCrawls: Optional[int] = 0
-
-
-# ============================================================================
-class Organization(BaseMongoModel):
-    """Organization Base Model"""
-
-    name: str
-
-    users: Dict[str, UserRole]
-
-    storage: Union[S3Storage, DefaultStorage]
-
-    usage: Dict[str, int] = {}
-
-    default: bool = False
-
-    quotas: Optional[OrgQuotas] = OrgQuotas()
-
-    def is_owner(self, user):
-        """Check if user is owner"""
-        return self._is_auth(user, UserRole.OWNER)
-
-    def is_crawler(self, user):
-        """Check if user can crawl (write)"""
-        return self._is_auth(user, UserRole.CRAWLER)
-
-    def is_viewer(self, user):
-        """Check if user can view (read)"""
-        return self._is_auth(user, UserRole.VIEWER)
-
-    def _is_auth(self, user, value):
-        """Check if user has at least specified permission level"""
-        if user.is_superuser:
-            return True
-
-        res = self.users.get(str(user.id))
-        if not res:
-            return False
-
-        return res >= value
-
-    async def serialize_for_user(self, user: User, user_manager):
-        """Serialize result based on current user access"""
-
-        exclude = {"storage"}
-
-        if not self.is_owner(user):
-            exclude.add("users")
-
-        if not self.is_crawler(user):
-            exclude.add("usage")
-
-        result = self.to_dict(
-            exclude_unset=True,
-            exclude_defaults=True,
-            exclude_none=True,
-            exclude=exclude,
-        )
-
-        if self.is_owner(user):
-            keys = list(result["users"].keys())
-            user_list = await user_manager.get_user_names_by_ids(keys)
-
-            for org_user in user_list:
-                id_ = str(org_user["id"])
-                role = result["users"].get(id_)
-                if not role:
-                    continue
-
-                result["users"][id_] = {
-                    "role": role,
-                    "name": org_user.get("name", ""),
-                    "email": org_user.get("email", ""),
-                }
-
-        return OrgOut.from_dict(result)
-
-
-# ============================================================================
-class OrgOut(BaseMongoModel):
-    """Organization API output model"""
-
-    id: UUID4
-    name: str
-    users: Optional[Dict[str, Any]]
-    usage: Optional[Dict[str, int]]
-    default: bool = False
-
-    quotas: Optional[OrgQuotas] = OrgQuotas()
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -26,7 +26,6 @@ from .models import (
     InviteToOrgRequest,
     UserRole,
     User,
-    MAX_CRAWL_SCALE,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -26,6 +26,7 @@ from .models import (
     InviteToOrgRequest,
     UserRole,
     User,
+    PaginatedResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
@@ -310,7 +311,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
     ops.org_crawl_dep = org_crawl_dep
     ops.org_owner_dep = org_owner_dep
 
-    @app.get("/orgs", tags=["organizations"])
+    @app.get("/orgs", tags=["organizations"], response_model=PaginatedResponse)
     async def get_orgs(
         user: User = Depends(user_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 DEFAULT_PAGE_SIZE = 1_000
 
+
 # ============================================================================
 def paginated_format(
     items: Optional[List[Any]],

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -6,17 +6,6 @@ from pydantic import BaseModel
 
 DEFAULT_PAGE_SIZE = 1_000
 
-
-# ============================================================================
-class PaginatedResponseModel(BaseModel):
-    """Paginated response model"""
-
-    items: List[Any]
-    total: int
-    page: int
-    pageSize: int
-
-
 # ============================================================================
 def paginated_format(
     items: Optional[List[Any]],

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -1,8 +1,6 @@
 """API pagination"""
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
-
 
 DEFAULT_PAGE_SIZE = 1_000
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -11,12 +11,11 @@ from fastapi import APIRouter, Depends, Request, HTTPException
 from pydantic import BaseModel, UUID4, HttpUrl
 import aiohttp
 
-from .orgs import Organization
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .users import User
 
 from .db import BaseMongoModel
-from .models import CrawlConfigIdNameOut
+from .models import CrawlConfigIdNameOut, Organization
 
 
 BROWSER_EXPIRE = 300

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -1,86 +1,32 @@
 """ Profile Management """
 
-from typing import Optional, List
+from typing import Optional
 from datetime import datetime
 import uuid
 import os
 
 from urllib.parse import urlencode
 
+from pydantic import UUID4
 from fastapi import APIRouter, Depends, Request, HTTPException
-from pydantic import BaseModel, UUID4, HttpUrl
 import aiohttp
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .users import User
 
-from .db import BaseMongoModel
-from .models import CrawlConfigIdNameOut, Organization
+from .models import (
+    Profile,
+    ProfileWithCrawlConfigs,
+    ProfileFile,
+    UrlIn,
+    ProfileLaunchBrowserIn,
+    BrowserId,
+    ProfileCreateUpdate,
+    Organization,
+)
 
 
 BROWSER_EXPIRE = 300
-
-
-# ============================================================================
-class ProfileFile(BaseModel):
-    """file from a crawl"""
-
-    filename: str
-    hash: str
-    size: int
-
-
-# ============================================================================
-class Profile(BaseMongoModel):
-    """Browser profile"""
-
-    name: str
-    description: Optional[str] = ""
-
-    userid: UUID4
-    oid: UUID4
-
-    origins: List[str]
-    resource: Optional[ProfileFile]
-
-    created: Optional[datetime]
-
-
-# ============================================================================
-class ProfileWithCrawlConfigs(Profile):
-    """Profile with list of crawlconfigs using this profile"""
-
-    crawlconfigs: List[CrawlConfigIdNameOut] = []
-
-
-# ============================================================================
-class UrlIn(BaseModel):
-    """Request to set url"""
-
-    url: HttpUrl
-
-
-# ============================================================================
-class ProfileLaunchBrowserIn(UrlIn):
-    """Request to launch new browser for creating profile"""
-
-    profileId: Optional[UUID4]
-
-
-# ============================================================================
-class BrowserId(BaseModel):
-    """Profile id on newly created profile"""
-
-    browserid: str
-
-
-# ============================================================================
-class ProfileCreateUpdate(BaseModel):
-    """Profile metadata for committing current browser to profile"""
-
-    browserid: Optional[str]
-    name: str
-    description: Optional[str] = ""
 
 
 # ============================================================================

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -22,6 +22,7 @@ from .models import (
     ProfileCreateUpdate,
     Organization,
     User,
+    PaginatedResponse,
 )
 
 
@@ -355,7 +356,7 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
         await browser_get_metadata(browserid, org)
         return browserid
 
-    @router.get("")
+    @router.get("", response_model=PaginatedResponse)
     async def list_profiles(
         org: Organization = Depends(org_crawl_dep),
         userid: Optional[UUID4] = None,

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -12,8 +12,6 @@ from fastapi import APIRouter, Depends, Request, HTTPException
 import aiohttp
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .users import User
-
 from .models import (
     Profile,
     ProfileWithCrawlConfigs,
@@ -23,6 +21,7 @@ from .models import (
     BrowserId,
     ProfileCreateUpdate,
     Organization,
+    User,
 )
 
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -16,7 +16,7 @@ from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .users import User
 
 from .db import BaseMongoModel
-from .crawlconfigs import CrawlConfigIdNameOut
+from .models import CrawlConfigIdNameOut
 
 
 BROWSER_EXPIRE = 300

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -8,8 +8,7 @@ from contextlib import asynccontextmanager
 from fastapi import Depends, HTTPException
 from aiobotocore.session import get_session
 
-from .models import Organization, DefaultStorage, S3Storage
-from .users import User
+from .models import Organization, DefaultStorage, S3Storage, User
 from .zip import get_zip_file, extract_and_parse_log_file
 
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 from fastapi import Depends, HTTPException
 from aiobotocore.session import get_session
 
-from .orgs import Organization, DefaultStorage, S3Storage
+from .models import Organization, DefaultStorage, S3Storage
 from .users import User
 from .zip import get_zip_file, extract_and_parse_log_file
 

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -15,11 +15,11 @@ from pydantic import Field, UUID4
 from starlette.requests import Request
 from pathvalidate import sanitize_filename
 
-from .basecrawls import (
+from .basecrawls import BaseCrawlOps
+from .models import (
     BaseCrawl,
     BaseCrawlOut,
     BaseCrawlOutWithResources,
-    BaseCrawlOps,
     CrawlFile,
     UpdateCrawl,
     DeleteCrawlList,

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -25,8 +25,8 @@ from .models import (
     UpdateUpload,
     Organization,
     PaginatedResponse,
+    User,
 )
-from .users import User
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .storages import do_upload_single, do_upload_multipart
 from .utils import dt_now

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -24,9 +24,10 @@ from .models import (
     UploadedCrawl,
     UpdateUpload,
     Organization,
+    PaginatedResponse,
 )
 from .users import User
-from .pagination import PaginatedResponseModel, paginated_format, DEFAULT_PAGE_SIZE
+from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .storages import do_upload_single, do_upload_multipart
 from .utils import dt_now
 
@@ -242,9 +243,7 @@ def init_uploads_api(app, mdb, users, crawl_manager, crawl_configs, orgs, user_d
             request.stream(), filename, name, notes, org, user, replaceId
         )
 
-    @app.get(
-        "/orgs/{oid}/uploads", tags=["uploads"], response_model=PaginatedResponseModel
-    )
+    @app.get("/orgs/{oid}/uploads", tags=["uploads"], response_model=PaginatedResponse)
     async def list_uploads(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -235,11 +235,11 @@ class UploadFileReader(BufferedReader):
 
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, invalid-name
-def init_uploads_api(app, mdb, users, crawl_manager, orgs, user_dep):
+def init_uploads_api(app, mdb, users, crawl_manager, crawl_configs, orgs, user_dep):
     """uploads api"""
 
     # ops = CrawlOps(mdb, users, crawl_manager, crawl_config_ops, orgs)
-    ops = UploadOps(mdb, users, crawl_manager)
+    ops = UploadOps(mdb, users, crawl_configs, crawl_manager)
 
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -23,9 +23,9 @@ from .models import (
     DeleteCrawlList,
     UploadedCrawl,
     UpdateUpload,
+    Organization,
 )
 from .users import User
-from .orgs import Organization
 from .pagination import PaginatedResponseModel, paginated_format, DEFAULT_PAGE_SIZE
 from .storages import do_upload_single, do_upload_multipart
 from .utils import dt_now

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -25,7 +25,15 @@ from fastapi_users.authentication import (
 )
 from fastapi_users.db import MongoDBUserDatabase
 
-from .models import User, UserCreateIn, UserCreate, UserUpdate, UserDB, UserRole
+from .models import (
+    User,
+    UserCreateIn,
+    UserCreate,
+    UserUpdate,
+    UserDB,
+    UserRole,
+    PaginatedResponse,
+)
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
 
@@ -414,7 +422,7 @@ def init_users_api(app, user_manager):
 
         return await user_manager.format_invite(invite)
 
-    @users_router.get("/invites", tags=["invites"])
+    @users_router.get("/invites", tags=["invites"], response_model=PaginatedResponse)
     async def get_pending_invites(
         user: User = Depends(current_active_user),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -6,9 +6,9 @@ import os
 import uuid
 import asyncio
 
-from typing import Dict, Optional
+from typing import Optional
 
-from pydantic import EmailStr, UUID4
+from pydantic import UUID4
 import passlib.pwd
 
 from fastapi import Request, Response, HTTPException, Depends, WebSocket
@@ -16,7 +16,7 @@ from fastapi.security import OAuth2PasswordBearer
 
 from pymongo.errors import DuplicateKeyError
 
-from fastapi_users import FastAPIUsers, models, BaseUserManager
+from fastapi_users import FastAPIUsers, BaseUserManager
 from fastapi_users.manager import UserAlreadyExists
 from fastapi_users.authentication import (
     AuthenticationBackend,
@@ -25,7 +25,7 @@ from fastapi_users.authentication import (
 )
 from fastapi_users.db import MongoDBUserDatabase
 
-from .invites import InvitePending, UserRole
+from .models import User, UserCreateIn, UserCreate, UserUpdate, UserDB, UserRole
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
 
@@ -33,66 +33,6 @@ from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", uuid.uuid4().hex)
 
 JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME_MINUTES", 60)) * 60
-
-
-# ============================================================================
-class User(models.BaseUser):
-    """
-    Base User Model
-    """
-
-    name: Optional[str] = ""
-
-
-# ============================================================================
-# use custom model as model.BaseUserCreate includes is_* field
-class UserCreateIn(models.CreateUpdateDictModel):
-    """
-    User Creation Model exposed to API
-    """
-
-    email: EmailStr
-    password: str
-
-    name: Optional[str] = ""
-
-    inviteToken: Optional[UUID4]
-
-    newOrg: bool
-    newOrgName: Optional[str] = ""
-
-
-# ============================================================================
-class UserCreate(models.BaseUserCreate):
-    """
-    User Creation Model
-    """
-
-    name: Optional[str] = ""
-
-    inviteToken: Optional[UUID4]
-
-    newOrg: bool
-    newOrgName: Optional[str] = ""
-
-
-# ============================================================================
-class UserUpdate(User, models.CreateUpdateDictModel):
-    """
-    User Update Model
-    """
-
-    password: Optional[str]
-    email: Optional[EmailStr]
-
-
-# ============================================================================
-class UserDB(User, models.BaseUserDB):
-    """
-    User in DB Model
-    """
-
-    invites: Dict[str, InvitePending] = {}
 
 
 # ============================================================================
@@ -360,6 +300,7 @@ class BearerOrQueryTransport(BearerTransport):
 
     scheme: OA2BearerOrQuery
 
+    # pylint: disable=invalid-name
     def __init__(self, tokenUrl: str):
         # pylint: disable=super-init-not-called
         self.scheme = OA2BearerOrQuery(tokenUrl, auto_error=False)

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -52,7 +52,7 @@ def test_list_stream_upload(admin_auth_headers, default_org_id):
 
 def test_get_stream_upload(admin_auth_headers, default_org_id):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}/replay.json",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -46,7 +46,7 @@ def test_list_stream_upload(admin_auth_headers, default_org_id):
     assert found
     assert found["name"] == "My Upload"
     assert found["notes"] == "Testing\nData"
-    assert "files" not in found or found["files"] == []
+    assert "files" not in found
     assert "resources" not in found
 
 
@@ -57,7 +57,7 @@ def test_get_stream_upload(admin_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     result = r.json()
-    assert "files" not in result or result["files"] == []
+    assert "files" not in result
     upload_dl_path = result["resources"][0]["path"]
     assert "test-" in result["resources"][0]["name"]
     assert result["resources"][0]["name"].endswith(".wacz")
@@ -120,8 +120,8 @@ def test_list_uploads(admin_auth_headers, default_org_id):
     assert found
     assert found["name"] == "test2.wacz"
 
-    assert "files" not in found or found["files"] == []
-    assert "resources" not in found
+    assert "files" not in res
+    assert "resources" not in res
 
 
 def test_collection_uploads(admin_auth_headers, default_org_id):
@@ -185,8 +185,8 @@ def test_get_upload_replay_json(admin_auth_headers, default_org_id):
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data or data.get("files") == []
-    assert "errors" not in data or data.get("errors") in (None, [])
+    assert data["errors"] == None
+    assert "files" not in data
 
 
 def test_get_upload_replay_json_admin(admin_auth_headers, default_org_id):
@@ -204,8 +204,8 @@ def test_get_upload_replay_json_admin(admin_auth_headers, default_org_id):
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data or data.get("files") == []
-    assert "errors" not in data or data.get("errors") in (None, [])
+    assert data["errors"] == None
+    assert "files" not in data
 
 
 def test_replace_upload(admin_auth_headers, default_org_id):
@@ -323,7 +323,7 @@ def test_verify_from_upload_resource_count(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     result = r.json()
 
-    assert "files" not in result or result["files"] == []
+    assert "files" not in result
     assert len(result["resources"]) == 3
 
     r = requests.get(
@@ -378,7 +378,7 @@ def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id):
 
     assert data["name"] == "test2.wacz"
 
-    assert "files" not in data or data["files"] == []
+    assert "files" not in data
     assert data["resources"]
 
 
@@ -397,8 +397,8 @@ def test_get_upload_replay_json_from_all_crawls(admin_auth_headers, default_org_
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data or data.get("files") == []
-    assert "errors" not in data or data.get("errors") in (None, [])
+    assert data["errors"] == None
+    assert "files" not in data
 
 
 def test_get_upload_replay_json_admin_from_all_crawls(
@@ -418,8 +418,8 @@ def test_get_upload_replay_json_admin_from_all_crawls(
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data or data.get("files") == []
-    assert "errors" not in data or data.get("errors") in (None, [])
+    assert data["errors"] == None
+    assert "files" not in data
 
 
 def test_delete_form_upload_from_all_crawls(admin_auth_headers, default_org_id):

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -46,7 +46,7 @@ def test_list_stream_upload(admin_auth_headers, default_org_id):
     assert found
     assert found["name"] == "My Upload"
     assert found["notes"] == "Testing\nData"
-    assert "files" not in found
+    assert "files" not in found or found["files"] == []
     assert "resources" not in found
 
 
@@ -57,7 +57,7 @@ def test_get_stream_upload(admin_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     result = r.json()
-    assert "files" not in result
+    assert "files" not in result or result["files"] == []
     upload_dl_path = result["resources"][0]["path"]
     assert "test-" in result["resources"][0]["name"]
     assert result["resources"][0]["name"].endswith(".wacz")
@@ -120,8 +120,8 @@ def test_list_uploads(admin_auth_headers, default_org_id):
     assert found
     assert found["name"] == "test2.wacz"
 
-    assert "files" not in res
-    assert "resources" not in res
+    assert "files" not in found or found["files"] == []
+    assert "resources" not in found
 
 
 def test_collection_uploads(admin_auth_headers, default_org_id):
@@ -185,8 +185,8 @@ def test_get_upload_replay_json(admin_auth_headers, default_org_id):
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data
-    assert "errors" not in data or data.get("errors") is None
+    assert "files" not in data or data.get("files") == []
+    assert "errors" not in data or data.get("errors") in (None, [])
 
 
 def test_get_upload_replay_json_admin(admin_auth_headers, default_org_id):
@@ -204,8 +204,8 @@ def test_get_upload_replay_json_admin(admin_auth_headers, default_org_id):
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data
-    assert "errors" not in data or data.get("errors") is None
+    assert "files" not in data or data.get("files") == []
+    assert "errors" not in data or data.get("errors") in (None, [])
 
 
 def test_replace_upload(admin_auth_headers, default_org_id):
@@ -227,7 +227,7 @@ def do_upload_replace(admin_auth_headers, default_org_id, upload_id):
     actual_id = r.json()["id"]
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/uploads/{actual_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/uploads/{actual_id}/replay.json",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -317,13 +317,13 @@ def test_delete_stream_upload_2(admin_auth_headers, default_org_id):
 
 def test_verify_from_upload_resource_count(admin_auth_headers, default_org_id):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id_2}",
+        f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id_2}/replay.json",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
     result = r.json()
 
-    assert "files" not in result
+    assert "files" not in result or result["files"] == []
     assert len(result["resources"]) == 3
 
     r = requests.get(
@@ -378,7 +378,7 @@ def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id):
 
     assert data["name"] == "test2.wacz"
 
-    assert "files" not in data
+    assert "files" not in data or data["files"] == []
     assert data["resources"]
 
 
@@ -397,8 +397,8 @@ def test_get_upload_replay_json_from_all_crawls(admin_auth_headers, default_org_
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data
-    assert "errors" not in data or data.get("errors") is None
+    assert "files" not in data or data.get("files") == []
+    assert "errors" not in data or data.get("errors") in (None, [])
 
 
 def test_get_upload_replay_json_admin_from_all_crawls(
@@ -418,8 +418,8 @@ def test_get_upload_replay_json_admin_from_all_crawls(
     assert data["resources"][0]["path"]
     assert data["resources"][0]["size"]
     assert data["resources"][0]["hash"]
-    assert "files" not in data
-    assert "errors" not in data or data.get("errors") is None
+    assert "files" not in data or data.get("files") == []
+    assert "errors" not in data or data.get("errors") in (None, [])
 
 
 def test_delete_form_upload_from_all_crawls(admin_auth_headers, default_org_id):

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -315,7 +315,6 @@ def test_delete_stream_upload_2(admin_auth_headers, default_org_id):
     assert r.json()["deleted"] == True
 
 
-
 def test_verify_from_upload_resource_count(admin_auth_headers, default_org_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id_2}",
@@ -354,6 +353,12 @@ def test_list_all_crawls(admin_auth_headers, default_org_id):
 
     for item in items:
         assert item["type"] in ("crawl", "upload")
+
+        if item["type"] == "crawl":
+            assert item["firstSeed"]
+            assert item["seedCount"]
+            assert item.get("name") or item.get("name") == ""
+
         assert item["id"]
         assert item["userid"]
         assert item["oid"] == default_org_id

--- a/chart/templates/mongo.yaml
+++ b/chart/templates/mongo.yaml
@@ -102,18 +102,18 @@ spec:
               memory: {{ .Values.mongo_requests_memory }}
 
           # should work with 6.0.x with longer timeout
-          # readinessProbe:
-          #   timeoutSeconds: 20
-          #   periodSeconds: 40
-          #   initialDelaySeconds: 5
-          #   successThreshold: 1
-          #   failureThreshold: 5
-          #   exec:
-          #     command:
-          #       - mongosh
-          #       - --eval
-          #       - db.adminCommand('ping')
-          #       - --quiet
+          readinessProbe:
+            timeoutSeconds: 20
+            periodSeconds: 40
+            initialDelaySeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - db.adminCommand('ping')
+                - --quiet
 
 ---
 apiVersion: v1

--- a/chart/templates/mongo.yaml
+++ b/chart/templates/mongo.yaml
@@ -102,18 +102,18 @@ spec:
               memory: {{ .Values.mongo_requests_memory }}
 
           # should work with 6.0.x with longer timeout
-          readinessProbe:
-            timeoutSeconds: 20
-            periodSeconds: 40
-            initialDelaySeconds: 5
-            successThreshold: 1
-            failureThreshold: 5
-            exec:
-              command:
-                - mongosh
-                - --eval
-                - db.adminCommand('ping')
-                - --quiet
+          # readinessProbe:
+          #   timeoutSeconds: 20
+          #   periodSeconds: 40
+          #   initialDelaySeconds: 5
+          #   successThreshold: 1
+          #   failureThreshold: 5
+          #   exec:
+          #     command:
+          #       - mongosh
+          #       - --eval
+          #       - db.adminCommand('ping')
+          #       - --quiet
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Fixes #981 

The following fields are now added in the GET /all-crawl endpoints (single crawl and list) for automated crawls only:

- cid
- name
- description
- firstSeed
- seedCount
- profileName

This provides sufficient data for the frontend's All Archived Data tab to be consistent between All and Crawls.

Since it's not possible to add additional aggregation stages within a `cond` in mongo, these fields are added by annotating the items after the aggregation completes in the list endpoint.

In the process of getting there:
- All pydantic models have been moved to a new `models.py` module, and de-duplicated in some cases (there may be more room here to continue on that front, but I didn't want the scope to get too out of control).
- The `PaginatedResponse` model has been added as the response_model for all list GET endpoints
- Some of the get_<resource> methods that return a single resource were reworked to optionally include or exclude resources
- Removed `files` from crawl output model: only return `resources` which conform with frictionless data format and include presigned URLs.