### PR TITLE
Fix frontend formatting pre-commit

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -112,10 +112,6 @@
       "no-unused-vars": "warn"
     }
   },
-  "prettier": {
-    "tabWidth": 2,
-    "useTabs": false
-  },
   "lint-staged": {
     "*.{ts,js}": [
       "prettier --write",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -117,8 +117,11 @@
     "useTabs": false
   },
   "lint-staged": {
-    "src/**/*.{ts,js}": "eslint --fix --quiet",
-    "src/*.{ts,js,html,css,json}": "prettier --write"
+    "*.{ts,js}": [
+      "prettier --write",
+      "eslint --fix --quiet"
+    ],
+    "*.{html,css,json}": "prettier --write"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
No issue created. Fixes formatting not running on certain files due to lint-staged configuration.

### Manual testing

1. Update a `.ts` file in `frontend` with formatting that should be updated. For example:
```ts
console.log('test')
    console.log('test')
```
3. Commit the changes. Verify the changes are formatted. With previous example:
```ts
console.log("test");
console.log("test");
```