### PR TITLE
Add proxy settings for crawler and profilebrowser

### DIFF
--- a/backend/btrixcloud/templates/crawler.yaml
+++ b/backend/btrixcloud/templates/crawler.yaml
@@ -138,6 +138,15 @@ spec:
             - name: STORE_USER
               value: "{{ userid }}"
 
+        {% if crawler_socks_proxy_host %}
+            - name: SOCKS_HOST
+              value: "{{ crawler_socks_proxy_host }}"
+          {% if crawler_socks_proxy_port %}
+            - name: SOCKS_PORT
+              value: "{{ crawler_socks_proxy_port }}"
+          {% endif %}
+        {% endif %}
+
           resources:
             limits:
               cpu: {{ crawler_limits_cpu }}
@@ -166,7 +175,7 @@ metadata:
   labels:
     crawl: {{ id }}
     role: crawler
- 
+
 spec:
   clusterIP: None
   selector:

--- a/backend/btrixcloud/templates/profilebrowser.yaml
+++ b/backend/btrixcloud/templates/profilebrowser.yaml
@@ -78,6 +78,10 @@ spec:
             - name: VNC_PASS
               value: {{ vnc_password }}
 
+          {% if crawler_socks_proxy_host %}
+            - name: CHROME_FLAGS
+              value: "--proxy-server=socks5://{{ crawler_socks_proxy_host }}:{{ crawler_socks_proxy_port | default('9050') }}"
+          {% endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -117,6 +117,9 @@ data:
 
     crawler_liveness_port: "{{ .Values.crawler_liveness_port | default 0 }}"
 
+    crawler_socks_proxy_host: "{{ .Values.crawler_socks_proxy_host }}"
+    crawler_socks_proxy_port: "{{ .Values.crawler_socks_proxy_port }}"
+
     crawler_node_type: "{{ .Values.crawler_node_type }}"
     redis_node_type: "{{ .Values.redis_node_type }}"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -202,6 +202,10 @@ crawler_session_time_limit_seconds: 18000
 
 crawler_liveness_port: 6065
 
+# optional: use socks5 proxy for crawler and profilebrowser
+# crawler_socks_proxy_host: 192.0.2.1
+# crawler_socks_proxy_port: 9050
+
 # time to wait for graceful stop
 grace_period: 1000
 


### PR DESCRIPTION
Hi :wave: 
I have to set up browsertrix-cloud in a municipal IT infrastructure, where I likely won't get direct access to the internet. With these settings I can run crawls and create browser profiles with their traffic running through my local proxy.