### PR TITLE
Add totalSize to collections and make it sortable in list endpoint

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -182,7 +182,7 @@ class CollectionOps:
         aggregate = [{"$match": match_query}]
 
         if sort_by:
-            if sort_by not in ("modified", "name", "description"):
+            if sort_by not in ("modified", "name", "description", "totalSize"):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
@@ -267,6 +267,7 @@ async def update_collection_counts_and_tags(
     """Set current crawl info in config when crawl begins"""
     crawl_count = 0
     page_count = 0
+    total_size = 0
     tags = []
 
     cursor = crawls.find({"collections": collection_id})
@@ -275,6 +276,9 @@ async def update_collection_counts_and_tags(
         if crawl["state"] not in SUCCESSFUL_STATES:
             continue
         crawl_count += 1
+        files = crawl.get("files", [])
+        for file in files:
+            total_size += file.get("size", 0)
         if crawl.get("stats"):
             page_count += crawl.get("stats", {}).get("done", 0)
         if crawl.get("tags"):
@@ -288,6 +292,7 @@ async def update_collection_counts_and_tags(
             "$set": {
                 "crawlCount": crawl_count,
                 "pageCount": page_count,
+                "totalSize": total_size,
                 "tags": sorted_tags,
             }
         },

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -15,7 +15,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0009"
+CURR_DB_VERSION = "0010"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -1,0 +1,36 @@
+"""
+Migration 0010 - Precomputing collection total size
+"""
+from btrixcloud.colls import update_collection_counts_and_tags
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0010"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Recompute collection data to include totalSize.
+        """
+        # pylint: disable=duplicate-code
+        colls = self.mdb["collections"]
+        crawls = self.mdb["crawls"]
+
+        colls_to_update = [res async for res in colls.find({})]
+        if not colls_to_update:
+            return
+
+        for coll in colls_to_update:
+            coll_id = coll["_id"]
+            try:
+                await update_collection_counts_and_tags(colls, crawls, coll_id)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(f"Unable to update collection {coll_id}: {err}", flush=True)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -462,6 +462,7 @@ class Collection(BaseMongoModel):
 
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0
+    totalSize: Optional[int] = 0
 
     # Sorted by count, descending
     tags: Optional[List[str]] = []


### PR DESCRIPTION
Fixes #1000

- Adds `Collection.totalSize` that is updated each time a collection is updated (this is not incremental at this point, as computing tags by count requires looping through all the crawls anyway)
- Adds migration to precompute `totalSize` for existing collections