### PR TITLE
load handling: only launch redis pods if crawler pods successfully loaded.

### DIFF
--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -304,6 +304,9 @@ class BtrixOperator(K8sAPI):
             if finished:
                 status.finished = to_k8s_date(finished)
 
+            if new_state != state:
+                print(f"state mismatch, actual state {new_state}, requested {state}")
+
         if status.state != state:
             print(
                 f"Not setting state: {status.state} -> {state}, {crawl_id} not allowed"

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -469,7 +469,7 @@ class BtrixOperator(K8sAPI):
         """sync crawl state for running crawl"""
         # check if at least one pod started running
         if not await self.check_if_pods_running(pods):
-            if self.should_mark_waiting(crawl):
+            if self.should_mark_waiting(status.state, crawl.started):
                 await self.set_state(
                     "waiting_capacity",
                     status,
@@ -548,13 +548,13 @@ class BtrixOperator(K8sAPI):
 
         return False
 
-    def should_mark_waiting(self, crawl):
+    def should_mark_waiting(self, state, started):
         """Should the crawl be marked as waiting for capacity?"""
-        if crawl.status == "running":
+        if state == "running":
             return True
 
-        if crawl.status == "starting":
-            started = from_k8s_date(crawl.started)
+        if state == "starting":
+            started = from_k8s_date(started)
             return (datetime.utcnow() - started).total_seconds() > STARTING_TIME_SECS
 
         return False

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -508,6 +508,16 @@ class BtrixOperator(K8sAPI):
                 if pod["status"]["phase"] == "Running":
                     return True
 
+                # consider 'ContainerCreating' as running
+                if pod["status"]["phase"] == "Pending":
+                    if (
+                        pod["status"]["containerStatuses"][0]["state"]["waiting"][
+                            "reason"
+                        ]
+                        == "ContainerCreating"
+                    ):
+                        return True
+
                 print("non-running pod status", pod["status"], flush=True)
 
         # pylint: disable=bare-except

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -298,14 +298,14 @@ class BtrixOperator(K8sAPI):
                 return True
 
             # get actual crawl state
-            new_state, finished = await get_crawl_state(self.crawls, crawl_id)
-            if new_state:
-                status.state = new_state
+            actual_state, finished = await get_crawl_state(self.crawls, crawl_id)
+            if actual_state:
+                status.state = actual_state
             if finished:
                 status.finished = to_k8s_date(finished)
 
-            if new_state != state:
-                print(f"state mismatch, actual state {new_state}, requested {state}")
+            if actual_state != state:
+                print(f"state mismatch, actual state {actual_state}, requested {state}")
 
         if status.state != state:
             print(

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -548,7 +548,7 @@ class BtrixOperator(K8sAPI):
 
         return False
 
-    async def should_mark_waiting(self, crawl):
+    def should_mark_waiting(self, crawl):
         """Should the crawl be marked as waiting for capacity?"""
         if crawl.status == "running":
             return True

--- a/backend/btrixcloud/templates/redis.yaml
+++ b/backend/btrixcloud/templates/redis.yaml
@@ -18,7 +18,7 @@ spec:
       role: redis
 
   serviceName: redis-{{ id }}
-  replicas: 1
+  replicas: {{ redis_scale }}
   podManagementPolicy: Parallel
 
   # not yet supported

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -64,6 +64,8 @@ data:
 
   PRESIGN_DURATION_MINUTES: "{{ .Values.storage_presign_duration_minutes | default 60 }}"
 
+  FAST_RETRY_SECS: "{{ .Values.operator_fast_resync_secs | default 3 }}"
+
 
 ---
 apiVersion: v1


### PR DESCRIPTION
~~When crawler pods are stuck in pending (eg. waiting for additional resources), scale down Redis StatefulSet to 0 to avoid using up resources for an unused redis instance.~~

Modified slightly to not launch redis pods until needed:
- waits for crawler pod to be available before starting redis pods, to avoid situation where many crawler pods are in pending mode, but redis pods are still running.
- redis statefulset starts at scale of 0
- once crawler pod becomes available, redis sts is scaled to 1 (via initRedis=true status)
- can happen during 'starting' state or 'waiting_capacity' state
- set to 'running' state only after redis and at least one crawler pod is available
- if no crawler pods available after running, or, if stuck in starting for >60 seconds, switch to 'waiting_capacity' state
- when entering 'waiting_capacity', also scale down redis to 0, wait for crawler pod to become available, then scale up redis to 1, and get back to 'running'

 Fixes #1006 