### PR TITLE
Streaming Download for Collections

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -177,8 +177,7 @@ class BaseCrawlOps:
         size = 0
         for file_ in crawl.files:
             size += file_.size
-            status_code = await delete_crawl_file_object(org, file_, self.crawl_manager)
-            if status_code != 204:
+            if not await delete_crawl_file_object(org, file_, self.crawl_manager):
                 raise HTTPException(status_code=400, detail="file_deletion_error")
 
         return size

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -5,11 +5,22 @@ from typing import Union
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
 
+import asyncio
+import json
+
+from datetime import datetime
+
 from fastapi import Depends, HTTPException
-from aiobotocore.session import get_session
+from stream_zip import stream_zip, NO_COMPRESSION_64
+
+import aiobotocore.session
+import boto3
 
 from .models import Organization, DefaultStorage, S3Storage, User
 from .zip import get_zip_file, extract_and_parse_log_file
+
+
+CHUNK_SIZE = 1024 * 256
 
 
 # ============================================================================
@@ -65,7 +76,7 @@ async def get_s3_client(storage, use_access=False):
 
     endpoint_url = parts.scheme + "://" + parts.netloc
 
-    session = get_session()
+    session = aiobotocore.session.get_session()
 
     async with session.create_client(
         "s3",
@@ -75,6 +86,34 @@ async def get_s3_client(storage, use_access=False):
         aws_secret_access_key=storage.secret_key,
     ) as client:
         yield client, bucket, key
+
+
+# ============================================================================
+def get_sync_s3_client(storage, use_access=False):
+    """context manager for s3 client"""
+    endpoint_url = storage.endpoint_url
+
+    if not endpoint_url.endswith("/"):
+        endpoint_url += "/"
+
+    parts = urlsplit(endpoint_url)
+    bucket, key = parts.path[1:].split("/", 1)
+
+    endpoint_url = parts.scheme + "://" + parts.netloc
+
+    client = boto3.client(
+        "s3",
+        region_name=storage.region,
+        endpoint_url=endpoint_url,
+        aws_access_key_id=storage.access_key,
+        aws_secret_access_key=storage.secret_key,
+    )
+
+    public_endpoint_url = (
+        storage.endpoint_url if not use_access else storage.access_endpoint_url
+    )
+
+    return client, bucket, key, public_endpoint_url
 
 
 # ============================================================================
@@ -106,6 +145,22 @@ async def do_upload_single(org, filename, data, crawl_manager, storage_name="def
         key += filename
 
         return await client.put_object(Bucket=bucket, Key=key, Body=data)
+
+
+# ============================================================================
+async def get_sync_client(org, crawl_manager, storage_name="default", use_access=False):
+    """get sync client"""
+    s3storage = None
+
+    if org.storage.type == "s3":
+        s3storage = org.storage
+    else:
+        s3storage = await crawl_manager.get_default_storage(storage_name)
+
+    if not s3storage:
+        raise TypeError("No Default Storage Found, Invalid Storage Type")
+
+    return get_sync_s3_client(s3storage, use_access=use_access)
 
 
 # ============================================================================
@@ -232,10 +287,18 @@ async def get_presigned_url(org, crawlfile, crawl_manager, duration=3600):
 # ============================================================================
 async def delete_crawl_file_object(org, crawlfile, crawl_manager):
     """delete crawl file from storage."""
+    return await delete_file(
+        org, crawlfile.filename, crawl_manager, crawlfile.def_storage_name
+    )
+
+
+# ============================================================================
+async def delete_file(org, filename, crawl_manager, def_storage_name="default"):
+    """delete specified file from storage"""
     status_code = None
 
-    if crawlfile.def_storage_name:
-        s3storage = await crawl_manager.get_default_storage(crawlfile.def_storage_name)
+    if def_storage_name:
+        s3storage = await crawl_manager.get_default_storage(def_storage_name)
 
     elif org.storage.type == "s3":
         s3storage = org.storage
@@ -248,11 +311,11 @@ async def delete_crawl_file_object(org, crawlfile, crawl_manager):
         bucket,
         key,
     ):
-        key += crawlfile.filename
+        key += filename
         response = await client.delete_object(Bucket=bucket, Key=key)
         status_code = response["ResponseMetadata"]["HTTPStatusCode"]
 
-    return status_code
+    return status_code == 204
 
 
 # ============================================================================
@@ -289,3 +352,55 @@ async def get_wacz_logs(org, crawlfile, crawl_manager):
             combined_log_lines.extend(parsed_log_lines)
 
         return combined_log_lines
+
+
+# ============================================================================
+def _sync_dl(all_files, client, bucket, key):
+    """generate streaming zip as sync"""
+    for file_ in all_files:
+        file_.path = file_.name
+
+    datapackage = {
+        "profile": "multi-wacz-package",
+        "resources": [file_.dict() for file_ in all_files],
+    }
+    datapackage = json.dumps(datapackage).encode("utf-8")
+
+    def get_file(name):
+        response = client.get_object(Bucket=bucket, Key=key + name)
+        return response["Body"].iter_chunks(chunk_size=CHUNK_SIZE)
+
+    def member_files():
+        modified_at = datetime(year=1980, month=1, day=1)
+        perms = 0o664
+        for file_ in all_files:
+            yield (
+                file_.name,
+                modified_at,
+                perms,
+                NO_COMPRESSION_64,
+                get_file(file_.name),
+            )
+
+        yield (
+            "datapackage.json",
+            modified_at,
+            perms,
+            NO_COMPRESSION_64,
+            (datapackage,),
+        )
+
+    return stream_zip(member_files(), chunk_size=CHUNK_SIZE)
+
+
+# ============================================================================
+async def download_streaming_wacz(org, crawl_manager, files):
+    """return an iter for downloading a stream nested wacz file
+    from list of files"""
+    client, bucket, key, _ = await get_sync_client(org, crawl_manager)
+
+    loop = asyncio.get_event_loop()
+
+    resp = await loop.run_in_executor(None, _sync_dl, files, client, bucket, key)
+
+    return resp

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,5 @@ jinja2
 humanize
 python-multipart
 pathvalidate
+https://github.com/ikreymer/stream-zip/archive/refs/heads/stream-uncompress.zip
+boto3

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -110,6 +110,8 @@ export class CollectionDetail extends LiteElement {
   `;
 
   private renderActions = () => {
+    const authToken = this.authState!.headers.Authorization.split(" ")[1];
+
     return html`
       <sl-dropdown distance="4">
         <sl-button slot="trigger" size="small" caret
@@ -125,6 +127,20 @@ export class CollectionDetail extends LiteElement {
             <sl-icon name="gear" slot="prefix"></sl-icon>
             ${msg("Edit Collection")}
           </sl-menu-item>
+          <sl-divider></sl-divider>
+          <!-- Shoelace doesn't allow "href" on menu items,
+              see https://github.com/shoelace-style/shoelace/issues/1351 -->
+          <a
+            href=${`/api/orgs/${this.orgId}/collections/${this.collectionId}/download?auth_bearer=${authToken}`}
+            class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
+            @click=${(e: MouseEvent) => {
+              (e.target as HTMLAnchorElement).closest("sl-dropdown")?.hide();
+            }}
+          >
+            <sl-icon name="cloud-download" slot="prefix"></sl-icon>
+            ${msg("Download Collection")}
+          </a>
+          <sl-divider></sl-divider>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
             @click=${this.confirmDelete}

--- a/frontend/src/pages/org/collection-edit.ts
+++ b/frontend/src/pages/org/collection-edit.ts
@@ -95,10 +95,10 @@ export class CollectionEdit extends LiteElement {
         await this.saveMetadata({ name, description });
       }
 
+      this.navTo(`/orgs/${this.orgId}/collections/view/${this.collectionId}`);
       this.notify({
         message: msg(
-          html`Successfully updated
-            <strong>${name}</strong> Collection.`
+          html`Successfully updated <strong>${name}</strong> Collection.`
         ),
         variant: "success",
         icon: "check2-circle",

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -504,6 +504,8 @@ export class CollectionsList extends LiteElement {
     </li>`;
 
   private renderActions = (col: Collection) => {
+    const authToken = this.authState!.headers.Authorization.split(" ")[1];
+
     return html`
       <sl-dropdown distance="4">
         <btrix-button class="p-2" slot="trigger" label=${msg("Actions")} icon>
@@ -517,6 +519,19 @@ export class CollectionsList extends LiteElement {
             <sl-icon name="gear" slot="prefix"></sl-icon>
             ${msg("Edit Collection")}
           </sl-menu-item>
+          <!-- Shoelace doesn't allow "href" on menu items,
+          see https://github.com/shoelace-style/shoelace/issues/1351 -->
+          <a
+            href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
+            class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
+            @click=${(e: MouseEvent) => {
+              (e.target as HTMLAnchorElement).closest("sl-dropdown")?.hide();
+            }}
+          >
+            <sl-icon name="cloud-download" slot="prefix"></sl-icon>
+            ${msg("Download Collection")}
+          </a>
+          <sl-divider></sl-divider>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
             @click=${() => this.confirmDelete(col)}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -519,8 +519,9 @@ export class CollectionsList extends LiteElement {
             <sl-icon name="gear" slot="prefix"></sl-icon>
             ${msg("Edit Collection")}
           </sl-menu-item>
+          <sl-divider></sl-divider>
           <!-- Shoelace doesn't allow "href" on menu items,
-          see https://github.com/shoelace-style/shoelace/issues/1351 -->
+              see https://github.com/shoelace-style/shoelace/issues/1351 -->
           <a
             href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
             class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -439,28 +439,17 @@ export class CollectionsList extends LiteElement {
 
   private renderItem = (col: Collection) =>
     html`<li class="mb-2 last:mb-0">
-      <a
-        href=${`/orgs/${this.orgId}/collections/view/${col.id}`}
-        class="block border rounded shadow-sm leading-none hover:bg-neutral-50"
-        @click=${(e: MouseEvent) => {
-          if (
-            (
-              (e.currentTarget as HTMLElement)?.querySelector(
-                ".actionsCol"
-              ) as HTMLElement
-            ).contains(e.target as HTMLElement)
-          ) {
-            e.preventDefault();
-          } else {
-            this.navLink(e);
-          }
-        }}
-      >
+      <div class="block border rounded leading-none">
         <div
           class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[repeat(2,1fr)_16ch_repeat(2,10ch)_2.5rem] gap-3 lg:h-10 items-center"
         >
           <div class="col-span-1 md:pl-3 truncate font-semibold">
-            ${col.name}
+            <a
+              href=${`/orgs/${this.orgId}/collections/view/${col.id}`}
+              class="block text-primary hover:text-indigo-500"
+            >
+              ${col.name}
+            </a>
           </div>
           <div class="col-span-1 order-last md:order-none truncate">
             ${col.tags
@@ -500,7 +489,7 @@ export class CollectionsList extends LiteElement {
             ${this.isCrawler ? this.renderActions(col) : ""}
           </div>
         </div>
-      </a>
+      </div>
     </li>`;
 
   private renderActions = (col: Collection) => {
@@ -525,6 +514,7 @@ export class CollectionsList extends LiteElement {
           <a
             href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
             class="px-6 py-[0.6rem] flex gap-2 items-center whitespace-nowrap hover:bg-neutral-100"
+            download
             @click=${(e: MouseEvent) => {
               (e.target as HTMLAnchorElement).closest("sl-dropdown")?.hide();
             }}

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -14,4 +14,4 @@ export type CollectionList = Collection[];
 
 export type CollectionSearchValues = {
   names: string[];
-}
+};


### PR DESCRIPTION
Support for streaming download of collections as a single WACZ file, fixes #927 
(Split from #994)
Includes:
- New streaming download endpoint: /orgs/{oid}/collections/{coll_id}/download
- Download Collection menu item on collection detail and collection list views
- Also: simplified delete_file() method for deletion on the backend