### PR TITLE
Show only running crawls in superadmin view

### DIFF
--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -1,16 +1,41 @@
 import { state, property } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
 import { msg, localized, str } from "@lit/localize";
+import type { SlSelect } from "@shoelace-style/shoelace";
 import queryString from "query-string";
 
+import type { PageChangeEvent } from "../components/pagination";
+import { CrawlStatus } from "../components/crawl-status";
 import type { AuthState } from "../utils/AuthService";
 import LiteElement, { html } from "../utils/LiteElement";
 import { needLogin } from "../utils/auth";
+import { activeCrawlStates, inactiveCrawlStates } from "../utils/crawler";
 import type { Crawl, CrawlState } from "../types/crawler";
 import type { APIPaginationQuery, APIPaginatedList } from "../types/api";
-import { ROUTES } from "../routes";
 import "./org/workflow-detail";
 import "./org/crawls-list";
 import { PropertyValueMap } from "lit";
+
+type SortField = "started" | "firstSeed" | "fileSize";
+type SortDirection = "asc" | "desc";
+const sortableFields: Record<
+  SortField,
+  { label: string; defaultDirection?: SortDirection }
+> = {
+  started: {
+    label: msg("Date Started"),
+    defaultDirection: "desc",
+  },
+  firstSeed: {
+    label: msg("Crawl Start URL"),
+    defaultDirection: "desc",
+  },
+  fileSize: {
+    label: msg("File Size"),
+    defaultDirection: "desc",
+  },
+};
+const ABORT_REASON_THROTTLE = "throttled";
 
 @needLogin
 @localized()
@@ -27,21 +52,46 @@ export class Crawls extends LiteElement {
   @state()
   private crawls?: APIPaginatedList;
 
-  willUpdate(changedProperties: Map<string, any>) {
+  @state()
+  private orderBy: {
+    field: SortField;
+    direction: SortDirection;
+  } = {
+    field: "started",
+    direction: sortableFields["started"].defaultDirection!,
+  };
+
+  @state()
+  private filterBy: Partial<Record<keyof Crawl, any>> = {
+    state: activeCrawlStates,
+  };
+
+  // Use to cancel requests
+  private getCrawlsController: AbortController | null = null;
+
+  protected willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("crawlId") && this.crawlId) {
       this.fetchWorkflowId();
+    } else {
+      if (
+        changedProperties.has("filterBy") ||
+        changedProperties.has("orderBy")
+      ) {
+        this.fetchCrawls();
+      }
     }
   }
 
-  protected firstUpdated(): void {
-    this.fetchCrawls();
+  disconnectedCallback(): void {
+    this.cancelInProgressGetCrawls();
+    super.disconnectedCallback();
   }
 
   render() {
     return html` <div
       class="w-full max-w-screen-lg mx-auto px-3 py-4 box-border"
     >
-      ${this.crawlId ? this.renderDetail() : this.renderList()}
+      ${this.crawlId ? this.renderDetail() : this.renderCrawls()}
     </div>`;
   }
 
@@ -59,7 +109,147 @@ export class Crawls extends LiteElement {
     `;
   }
 
-  private renderList() {
+  private renderCrawls() {
+    return html`
+      <main>
+        <header class="contents">
+          <div class="flex justify-between w-full pb-4 mb-3 border-b">
+            <h1 class="text-xl font-semibold h-8">
+              ${msg("All Running Crawls")}
+            </h1>
+          </div>
+          <div
+            class="sticky z-10 mb-3 top-2 p-4 bg-neutral-50 border rounded-lg"
+          >
+            ${this.renderControls()}
+          </div>
+        </header>
+
+        ${when(
+          this.crawls,
+          () => {
+            const { items, page, total, pageSize } = this.crawls!;
+            const hasCrawlItems = items.length;
+            return html`
+              <section>
+                ${hasCrawlItems
+                  ? this.renderCrawlList()
+                  : this.renderEmptyState()}
+              </section>
+              ${when(
+                hasCrawlItems || page > 1,
+                () => html`
+                  <footer class="mt-6 flex justify-center">
+                    <btrix-pagination
+                      page=${page}
+                      totalCount=${total}
+                      size=${pageSize}
+                      @page-change=${async (e: PageChangeEvent) => {
+                        await this.fetchCrawls({
+                          page: e.detail.page,
+                        });
+
+                        // Scroll to top of list
+                        // TODO once deep-linking is implemented, scroll to top of pushstate
+                        this.scrollIntoView({ behavior: "smooth" });
+                      }}
+                    ></btrix-pagination>
+                  </footer>
+                `
+              )}
+            `;
+          },
+          () => html`
+            <div class="w-full flex items-center justify-center my-12 text-2xl">
+              <sl-spinner></sl-spinner>
+            </div>
+          `
+        )}
+      </main>
+    `;
+  }
+
+  private renderControls() {
+    const viewPlaceholder = msg("Any Active Status");
+    const viewOptions = activeCrawlStates;
+    return html`
+      <div class="flex gap-2 items-center justify-end">
+        <div class="flex items-center">
+          <div class="text-neutral-500 mx-2">${msg("View:")}</div>
+          <sl-select
+            id="stateSelect"
+            class="flex-1 md:w-[14.5rem]"
+            size="small"
+            pill
+            multiple
+            max-options-visible="1"
+            placeholder=${viewPlaceholder}
+            @sl-change=${async (e: CustomEvent) => {
+              const value = (e.target as SlSelect).value as CrawlState[];
+              await this.updateComplete;
+              this.filterBy = {
+                ...this.filterBy,
+                state: value,
+              };
+            }}
+          >
+            ${viewOptions.map(this.renderStatusMenuItem)}
+          </sl-select>
+        </div>
+
+        <div class="flex items-center">
+          <div class="whitespace-nowrap text-neutral-500 mx-2">
+            ${msg("Sort by:")}
+          </div>
+          <div class="grow flex">${this.renderSortControl()}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSortControl() {
+    const options = Object.entries(sortableFields).map(
+      ([value, { label }]) => html`
+        <sl-option value=${value}>${label}</sl-option>
+      `
+    );
+    return html`
+      <sl-select
+        class="flex-1 md:w-[10rem]"
+        size="small"
+        pill
+        value=${this.orderBy.field}
+        @sl-change=${(e: Event) => {
+          const field = (e.target as HTMLSelectElement).value as SortField;
+          this.orderBy = {
+            field: field,
+            direction:
+              sortableFields[field].defaultDirection || this.orderBy.direction,
+          };
+        }}
+      >
+        ${options}
+      </sl-select>
+      <sl-icon-button
+        name="arrow-down-up"
+        label=${msg("Reverse sort")}
+        @click=${() => {
+          this.orderBy = {
+            ...this.orderBy,
+            direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+          };
+        }}
+      ></sl-icon-button>
+    `;
+  }
+
+  private renderStatusMenuItem = (state: CrawlState) => {
+    const { icon, label } = CrawlStatus.getContent(state);
+
+    return html`<sl-option value=${state}>${icon}${label}</sl-option>`;
+  };
+
+  private renderCrawlList() {
     if (!this.crawls) return;
 
     return html`
@@ -67,15 +257,26 @@ export class Crawls extends LiteElement {
         ${this.crawls.items.map(this.renderCrawlItem)}
       </btrix-crawl-list>
     `;
-    // return html`<btrix-crawls-list
-    //   .authState=${this.authState}
-    //   crawlsBaseUrl=${ROUTES.crawls}
-    //   crawlsAPIBaseUrl="/orgs/all/crawls"
-    //   artifactType="crawl"
-    //   isCrawler
-    //   isAdminView
-    //   shouldFetch
-    // ></btrix-crawls-list>`;
+  }
+
+  private renderEmptyState() {
+    if (this.crawls?.page && this.crawls?.page > 1) {
+      return html`
+        <div class="border-t border-b py-5">
+          <p class="text-center text-neutral-500">
+            ${msg("Could not find page.")}
+          </p>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="border-t border-b py-5">
+        <p class="text-center text-neutral-500">
+          ${msg("No matching crawls found.")}
+        </p>
+      </div>
+    `;
   }
 
   private renderCrawlItem = (crawl: Crawl) =>
@@ -108,35 +309,56 @@ export class Crawls extends LiteElement {
    * Fetch crawls and update internal state
    */
   private async fetchCrawls(params?: APIPaginationQuery): Promise<void> {
+    this.cancelInProgressGetCrawls();
     try {
-      this.crawls = await this.getCrawls({
-        ...params,
-      });
+      this.crawls = await this.getCrawls(params);
     } catch (e: any) {
-      this.notify({
-        message: msg("Sorry, couldn't retrieve crawls at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
+      if (e === ABORT_REASON_THROTTLE) {
+        console.debug("Fetch crawls aborted to throttle");
+      } else {
+        this.notify({
+          message: msg("Sorry, couldn't retrieve crawls at this time."),
+          variant: "danger",
+          icon: "exclamation-octagon",
+        });
+      }
     }
   }
+
+  private cancelInProgressGetCrawls() {
+    if (this.getCrawlsController) {
+      this.getCrawlsController.abort(ABORT_REASON_THROTTLE);
+      this.getCrawlsController = null;
+    }
+  }
+
   private async getCrawls(
     queryParams?: APIPaginationQuery & { state?: CrawlState[] }
   ): Promise<APIPaginatedList> {
     const query = queryString.stringify(
       {
+        ...this.filterBy,
         ...queryParams,
+        page: queryParams?.page || this.crawls?.page || 1,
+        pageSize: queryParams?.pageSize || this.crawls?.pageSize || 100,
+        sortBy: this.orderBy.field,
+        sortDirection: this.orderBy.direction === "desc" ? -1 : 1,
       },
       {
         arrayFormat: "comma",
       }
     );
 
+    this.getCrawlsController = new AbortController();
     const data = await this.apiFetch(
       `/orgs/all/crawls?${query}`,
-      this.authState!
+      this.authState!,
+      {
+        signal: this.getCrawlsController.signal,
+      }
     );
-    console.log(data);
+    this.getCrawlsController = null;
+
     return data;
   }
 

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -556,6 +556,7 @@ export class CrawlsList extends LiteElement {
 
     return html`
       <btrix-crawl-list
+        baseUrl=""
         artifactType=${ifDefined(this.artifactType || undefined)}
       >
         ${this.crawls.items.map(this.renderCrawlItem)}

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -781,12 +781,6 @@ export class CrawlsList extends LiteElement {
             state: this.filterBy.state || finishedCrawlStates,
           });
           break;
-        // case "crawl":
-        //   crawls = await this.getCrawls({
-        //     ...params,
-        //     state: this.filterBy.state || activeCrawlStates,
-        //   });
-        //   break;
         case "upload":
           crawls = await this.getUploads(params);
           break;


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1010

### Changes

Refactors superadmin running crawls page to use lower-level crawls list component, rather than re-using the org "archived data" component.

### Manual testing

1. Log in as superadmin
2. Start a crawl from an organization
3. Click "Running Crawls". Verify crawl is shown in view
4. Sort and filter crawls. Verify view updates as expected

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Running Crawls | <img width="1134" alt="Screenshot 2023-07-26 at 2 39 41 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/d1ace377-d4ce-4524-a290-41c98c1b890f"> |


<!-- ### Follow-ups -->
