### PR TITLE
fix: don't break when unable to parse yaml file

### DIFF
--- a/scripts/check_passwords.py
+++ b/scripts/check_passwords.py
@@ -1,6 +1,7 @@
 "A small dirty script to check that none of the password config options have been set to real passwords"
 from collections.abc import Generator
 import yaml
+from yaml.scanner import ScannerError
 import sys
 
 
@@ -33,15 +34,19 @@ WE_DUN_GOOFED: bool = False
 changed_files = sys.argv[1:] # Ignore filename of this script
 for file in changed_files:
     with open(file, 'r') as f:
-        yml = yaml.safe_load(f)
-        gen = key_finder(yml)
-        for password_keys in gen:
-            if password_keys[-1] not in ALLOWED_PASSWORDS:
-                if len(password_keys) == 2:
-                    print(f"top level key '{password_keys[0]}' in {file} contains a real password!")
-                else:
-                    print(f"top level key '{password_keys[0]}' with subkey '{password_keys[1]}' in {file} contains a real password!")
-                WE_DUN_GOOFED = True
+        try:
+            yml = yaml.safe_load(f)
+            gen = key_finder(yml)
+            for password_keys in gen:
+                if password_keys[-1] not in ALLOWED_PASSWORDS:
+                    if len(password_keys) == 2:
+                        print(f"top level key '{password_keys[0]}' in {file} contains a real password!")
+                    else:
+                        print(f"top level key '{password_keys[0]}' with subkey '{password_keys[1]}' in {file} contains a real password!")
+                    WE_DUN_GOOFED = True
+        except ScannerError:
+            print(f"Couldn't parse yaml file for: {file}")
+            pass
 
 if WE_DUN_GOOFED:
     exit(1)


### PR DESCRIPTION
We have some templates that aren't technically valid yaml files that still can get changed. If we can't parse the yml file, just continue while letting the user know. 