### PR TITLE
chart: always pull latest crawler image - since default image is poin…

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -177,7 +177,7 @@ redis_limits_memory: "64Mi"
 # =========================================
 
 crawler_image: "webrecorder/browsertrix-crawler:latest"
-crawler_pull_policy: "IfNotPresent"
+crawler_pull_policy: "Always"
 
 crawler_namespace: "crawlers"
 


### PR DESCRIPTION
…ting to webrecorder/browsertrix-crawler:latest, makes sense to always pull latest

Seems like the best approach for default settings, we want users to always have the latest