### PR TITLE
fix(build): use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/frontend/00-browsertrix-nginx-init.sh
+++ b/frontend/00-browsertrix-nginx-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # remove old config
 rm /etc/nginx/conf.d/default.conf

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 CURR=$(dirname "${BASH_SOURCE[0]}")
 
 docker build -t ${REGISTRY}webrecorder/browsertrix-backend:latest $CURR/../backend/

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 CURR=$(dirname "${BASH_SOURCE[0]}")
 
 docker build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg --load -t ${REGISTRY}webrecorder/browsertrix-frontend:latest  $CURR/../frontend/

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version=`cat version.txt`
 jq ".version=\"$version\"" ./frontend/package.json > ./tmp-package.json


### PR DESCRIPTION
A more portable approach.
This is significant to me since I run NixOS which does not have a `/bin/bash`

I'm used to making PRs / getting reviews for _all_ changes, let me know if that isn't required