### PR TITLE
fix(build): build frontend was missing required env vars for older versions of Docker

### DIFF
--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 CURR=$(dirname "${BASH_SOURCE[0]}")
 
-docker build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg --load -t ${REGISTRY}webrecorder/browsertrix-frontend:latest  $CURR/../frontend/
+DOCKER_BUILDKIT=1 docker build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg --load -t ${REGISTRY}webrecorder/browsertrix-frontend:latest  $CURR/../frontend/
 
 if [ -n "$REGISTRY" ]; then
     docker push ${REGISTRY}webrecorder/browsertrix-frontend


### PR DESCRIPTION
Apparently my version of docker is quite old, but this is the difference between with / without the var: 

![image](https://github.com/webrecorder/browsertrix-cloud/assets/22575913/ef9de6ec-4676-4f71-8fdf-70d64cd26a60)


[BuildKit](https://docs.docker.com/build/buildkit/) docs mention this is the default from >= 23 which isn't the version I'm running:
`Docker version 20.10.21, build v20.10.21`

Feel free to tell me to update instead of adding this, I guess it keeps our build process compatible with older versions of Docker?