### PR TITLE
List web captures in Collection

### DIFF
--- a/frontend/src/components/button.ts
+++ b/frontend/src/components/button.ts
@@ -129,6 +129,7 @@ export class Button extends LitElement {
         raised: this.raised,
       })}
       ?disabled=${this.disabled}
+      href=${ifDefined(this.href)}
       aria-label=${ifDefined(this.label)}
       @click=${this.handleClick}
     >

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -226,9 +226,8 @@ export class CrawlListItem extends LitElement {
     return html`<a
       class="item row"
       role="button"
-      href="${this.baseUrl || `/orgs/${this.crawl?.oid}/artifacts/${typePath}`}/${
-        this.crawl?.id
-      }"
+      href="${this.baseUrl ||
+      `/orgs/${this.crawl?.oid}/artifacts/${typePath}`}/${this.crawl?.id}"
       @click=${async (e: MouseEvent) => {
         e.preventDefault();
         await this.updateComplete;
@@ -521,15 +520,9 @@ export class CrawlList extends LitElement {
         <div class="col">
           <slot name="idCol">${msg("Name")}</slot>
         </div>
-        <div class="col">
-          ${this.artifactType === "upload" ? msg("Uploaded") : msg("Finished")}
-        </div>
+        <div class="col">${msg("Finished")}</div>
         <div class="col">${msg("Size")}</div>
-        <div class="col">
-          ${this.artifactType === "upload"
-            ? msg("Uploaded By")
-            : msg("Started By")}
-        </div>
+        <div class="col">${msg("Initiated By")}</div>
         <div class="col action">
           <span class="srOnly">${msg("Actions")}</span>
         </div>

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -520,7 +520,7 @@ export class CrawlList extends LitElement {
         <div class="col">
           <slot name="idCol">${msg("Name")}</slot>
         </div>
-        <div class="col">${msg("Created At")}</div>
+        <div class="col">${msg("Date Created")}</div>
         <div class="col">${msg("Size")}</div>
         <div class="col">${msg("Created By")}</div>
         <div class="col action">

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -520,9 +520,9 @@ export class CrawlList extends LitElement {
         <div class="col">
           <slot name="idCol">${msg("Name")}</slot>
         </div>
-        <div class="col">${msg("Finished")}</div>
+        <div class="col">${msg("Created At")}</div>
         <div class="col">${msg("Size")}</div>
-        <div class="col">${msg("Initiated By")}</div>
+        <div class="col">${msg("Created By")}</div>
         <div class="col action">
           <span class="srOnly">${msg("Actions")}</span>
         </div>

--- a/frontend/src/components/not-found.ts
+++ b/frontend/src/components/not-found.ts
@@ -8,7 +8,9 @@ export class NotFound extends LitElement {
   }
   render() {
     return html`
-      <div class="text-xl text-gray-400">${msg("Page not found")}</div>
+      <div class="text-xl text-gray-400 text-center">
+        ${msg("Page not found")}
+      </div>
     `;
   }
 }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -20,22 +20,14 @@ import type { PageChangeEvent } from "../../components/pagination";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;
 const TABS = ["replay", "web-captures"] as const;
 export type Tab = (typeof TABS)[number];
-type SortField = "started" | "firstSeed" | "fileSize";
+type SortField = "finished";
 type SortDirection = "asc" | "desc";
 const sortableFields: Record<
   SortField,
   { label: string; defaultDirection?: SortDirection }
 > = {
-  started: {
-    label: msg("Date Started"),
-    defaultDirection: "desc",
-  },
-  firstSeed: {
-    label: msg("Crawl Start URL"),
-    defaultDirection: "desc",
-  },
-  fileSize: {
-    label: msg("File Size"),
+  finished: {
+    label: msg("Date Finished"),
     defaultDirection: "desc",
   },
 };
@@ -75,8 +67,8 @@ export class CollectionDetail extends LiteElement {
     field: SortField;
     direction: SortDirection;
   } = {
-    field: "started",
-    direction: sortableFields["started"].defaultDirection!,
+    field: "finished",
+    direction: sortableFields["finished"].defaultDirection!,
   };
 
   @state()

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -51,7 +51,7 @@ export class CollectionDetail extends LiteElement {
 
   render() {
     return html`${this.renderHeader()}
-      <header class="md:flex justify-between items-end pb-3 border-b">
+      <header class="md:flex justify-between items-end pb-3 mb-3 border-b">
         <h2
           class="flex-1 min-w-0 text-xl font-semibold leading-10 truncate mr-2"
         >
@@ -59,6 +59,7 @@ export class CollectionDetail extends LiteElement {
         </h2>
         ${when(this.isCrawler, this.renderActions)}
       </header>
+      ${this.renderTabs()}
       <div class="my-7">${this.renderDescription()}</div>
       ${when(
         this.collection?.resources.length,
@@ -108,6 +109,32 @@ export class CollectionDetail extends LiteElement {
       </a>
     </nav>
   `;
+
+  private renderTabs = () => {
+    const isReplay = false;
+    return html`
+      <nav class="flex gap-2 mb-3">
+        <btrix-button
+          variant=${isReplay ? "primary" : "neutral"}
+          ?raised=${isReplay}
+          aria-selected="${isReplay}"
+          @click=${this.navLink}
+        >
+          <sl-icon name="link-replay" library="app"></sl-icon>
+          <span>${msg("Replay")}</span>
+        </btrix-button>
+        <btrix-button
+          variant=${isReplay ? "neutral" : "primary"}
+          ?raised=${!isReplay}
+          aria-selected="${!isReplay}"
+          @click=${this.navLink}
+        >
+          <sl-icon name="list-ul"></sl-icon>
+          <span>${msg("Selected Web Captures")}</span>
+        </btrix-button>
+      </nav>
+    `;
+  };
 
   private renderActions = () => {
     const authToken = this.authState!.headers.Authorization.split(" ")[1];

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -9,6 +9,8 @@ import type { Collection } from "../../types/collection";
 import type { IntersectEvent } from "../../components/observable";
 
 const DESCRIPTION_MAX_HEIGHT_PX = 200;
+const TABS = ["replay", "web-captures"] as const;
+export type Tab = (typeof TABS)[number];
 
 @localized()
 export class CollectionDetail extends LiteElement {
@@ -20,6 +22,9 @@ export class CollectionDetail extends LiteElement {
 
   @property({ type: String })
   collectionId!: string;
+
+  @property({ type: String })
+  resourceTab?: Tab = TABS[0];
 
   @property({ type: Boolean })
   isCrawler?: boolean;
@@ -35,6 +40,17 @@ export class CollectionDetail extends LiteElement {
 
   @state()
   private isDescriptionExpanded = false;
+
+  private readonly tabLabels: Record<Tab, { icon: any; text: string }> = {
+    replay: {
+      icon: { name: "link-replay", library: "app" },
+      text: msg("Replay"),
+    },
+    "web-captures": {
+      icon: { name: "list-ul", library: "default" },
+      text: msg("Included Web Captures"),
+    },
+  };
 
   protected async willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("orgId")) {
@@ -111,27 +127,26 @@ export class CollectionDetail extends LiteElement {
   `;
 
   private renderTabs = () => {
-    const isReplay = false;
     return html`
       <nav class="flex gap-2 mb-3">
-        <btrix-button
-          variant=${isReplay ? "primary" : "neutral"}
-          ?raised=${isReplay}
-          aria-selected="${isReplay}"
-          @click=${this.navLink}
-        >
-          <sl-icon name="link-replay" library="app"></sl-icon>
-          <span>${msg("Replay")}</span>
-        </btrix-button>
-        <btrix-button
-          variant=${isReplay ? "neutral" : "primary"}
-          ?raised=${!isReplay}
-          aria-selected="${!isReplay}"
-          @click=${this.navLink}
-        >
-          <sl-icon name="list-ul"></sl-icon>
-          <span>${msg("Selected Web Captures")}</span>
-        </btrix-button>
+        ${TABS.map((tabName) => {
+          const isSelected = tabName === this.resourceTab;
+          return html`
+            <btrix-button
+              variant=${isSelected ? "primary" : "neutral"}
+              ?raised=${isSelected}
+              aria-selected="${isSelected}"
+              href=${`/orgs/${this.orgId}/collections/view/${this.collectionId}/${tabName}`}
+              @click=${this.navLink}
+            >
+              <sl-icon
+                name=${this.tabLabels[tabName].icon.name}
+                library=${this.tabLabels[tabName].icon.library}
+              ></sl-icon>
+              ${this.tabLabels[tabName].text}</btrix-button
+            >
+          `;
+        })}
       </nav>
     `;
   };

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -7,7 +7,6 @@ import queryString from "query-string";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
-import { inactiveCrawlStates } from "../../utils/crawler";
 import type { Collection } from "../../types/collection";
 import type {
   APIPaginatedList,
@@ -17,21 +16,10 @@ import type {
 import type { Crawl, CrawlState, Upload } from "../../types/crawler";
 import type { PageChangeEvent } from "../../components/pagination";
 
+const ABORT_REASON_THROTTLE = "throttled";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;
 const TABS = ["replay", "web-captures"] as const;
 export type Tab = (typeof TABS)[number];
-type SortField = "finished";
-type SortDirection = "asc" | "desc";
-const sortableFields: Record<
-  SortField,
-  { label: string; defaultDirection?: SortDirection }
-> = {
-  finished: {
-    label: msg("Date Finished"),
-    defaultDirection: "desc",
-  },
-};
-const ABORT_REASON_THROTTLE = "throttled";
 
 @localized()
 export class CollectionDetail extends LiteElement {
@@ -61,20 +49,6 @@ export class CollectionDetail extends LiteElement {
 
   @state()
   private isDescriptionExpanded = false;
-
-  @state()
-  private orderBy: {
-    field: SortField;
-    direction: SortDirection;
-  } = {
-    field: "finished",
-    direction: sortableFields["finished"].defaultDirection!,
-  };
-
-  @state()
-  private filterBy: Partial<Record<keyof Crawl, any>> = {
-    state: inactiveCrawlStates,
-  };
 
   // Use to cancel requests
   private getWebCapturesController: AbortController | null = null;

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -116,15 +116,16 @@ export class CollectionDetail extends LiteElement {
 
   render() {
     return html`${this.renderHeader()}
-      <header class="md:flex justify-between items-end pb-3 mb-3 border-b">
-        <h2
-          class="flex-1 min-w-0 text-xl font-semibold leading-10 truncate mr-2"
+      <header class="md:flex items-center gap-2 pb-3 mb-3 border-b">
+        <h1
+          class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
         >
-          ${this.collection?.name || html`<sl-skeleton></sl-skeleton>`}
-        </h2>
+          ${this.collection?.name ||
+          html`<sl-skeleton class="w-96"></sl-skeleton>`}
+        </h1>
         ${when(this.isCrawler, this.renderActions)}
       </header>
-      <div class="mb-5">${this.renderTabs()}</div>
+      <div class="mb-3">${this.renderTabs()}</div>
 
       ${choose(
         this.resourceTab,
@@ -165,7 +166,7 @@ export class CollectionDetail extends LiteElement {
   }
 
   private renderHeader = () => html`
-    <nav class="mb-5">
+    <nav class="mb-7">
       <a
         class="text-gray-600 hover:text-gray-800 text-sm font-medium"
         href=${`/orgs/${this.orgId}/collections`}
@@ -252,9 +253,9 @@ export class CollectionDetail extends LiteElement {
     return html`
       <section>
         <header class="flex items-center justify-between">
-          <h3 class="text-lg font-semibold leading-none h-8 min-h-fit mb-1">
+          <h2 class="text-lg font-semibold leading-none h-8 min-h-fit mb-1">
             ${msg("Description")}
-          </h3>
+          </h2>
           ${when(
             this.isCrawler,
             () =>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -370,7 +370,7 @@ export class CollectionsList extends LiteElement {
             <div class="col-span-1 text-xs pl-3">${msg("Collection Name")}</div>
             <div class="col-span-1 text-xs">${msg("Top 3 Tags")}</div>
             <div class="col-span-1 text-xs">${msg("Last Updated")}</div>
-            <div class="col-span-1 text-xs">${msg("Total Crawls")}</div>
+            <div class="col-span-1 text-xs">${msg("Web Captures")}</div>
             <div class="col-span-2 text-xs">${msg("Total Pages")}</div>
           </div>
         </header>
@@ -474,8 +474,10 @@ export class CollectionsList extends LiteElement {
             class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"
           >
             ${col.crawlCount === 1
-              ? msg("1 crawl")
-              : msg(str`${this.numberFormatter.format(col.crawlCount)} crawls`)}
+              ? msg("1 capture")
+              : msg(
+                  str`${this.numberFormatter.format(col.crawlCount)} captures`
+                )}
           </div>
           <div
             class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -447,6 +447,7 @@ export class CollectionsList extends LiteElement {
             <a
               href=${`/orgs/${this.orgId}/collections/view/${col.id}`}
               class="block text-primary hover:text-indigo-500"
+              @click=${this.navLink}
             >
               ${col.name}
             </a>

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -40,7 +40,7 @@ export class CollectionsNew extends LiteElement {
   }
 
   private renderHeader = () => html`
-    <nav class="mb-5">
+    <nav class="mb-7">
       <a
         class="text-gray-600 hover:text-gray-800 text-sm font-medium"
         href=${`/orgs/${this.orgId}/collections`}
@@ -69,9 +69,7 @@ export class CollectionsNew extends LiteElement {
       );
 
       this.notify({
-        message: msg(
-          str`Successfully created "${data.name}" Collection.`
-        ),
+        message: msg(str`Successfully created "${data.name}" Collection.`),
         variant: "success",
         icon: "check2-circle",
         duration: 8000,

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -230,25 +230,32 @@ export class CrawlDetail extends LiteElement {
 
     // TODO abstract into breadcrumbs
     const isWorkflowArtifact = this.crawlsBaseUrl.includes("/workflows/");
+    const isCollectionArtifact = this.crawlsBaseUrl.includes("/collections/");
+
+    let label = msg("Back to All Crawls");
+    if (isWorkflowArtifact) {
+      label = msg("Back to Crawl Workflow");
+    } else if (isCollectionArtifact) {
+      label = msg("Back to Collection");
+    } else if (this.crawl?.type === "upload") {
+      label = msg("Back to All Uploads");
+    }
 
     return html`
       <div class="mb-7">
         <a
           class="text-neutral-500 hover:text-neutral-600 text-sm font-medium"
-          href="${this.crawlsBaseUrl}?artifactType=${this.crawl?.type}"
+          href="${this.crawlsBaseUrl}${isWorkflowArtifact ||
+          isCollectionArtifact
+            ? ""
+            : `?artifactType=${this.crawl?.type}`}"
           @click=${this.navLink}
         >
           <sl-icon
             name="arrow-left"
             class="inline-block align-middle"
           ></sl-icon>
-          <span class="inline-block align-middle"
-            >${isWorkflowArtifact
-              ? msg("Back to Crawl Workflow")
-              : this.crawl?.type === "upload"
-              ? msg("Back to All Uploads")
-              : msg("Back to All Crawls")}</span
-          >
+          <span class="inline-block align-middle">${label}</span>
         </a>
       </div>
 

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -261,8 +261,6 @@ export class CrawlDetail extends LiteElement {
 
       <div class="mb-4">${this.renderHeader()}</div>
 
-      <hr class="mb-4" />
-
       <main>
         <section class="grid grid-cols-6 gap-4">
           <div class="col-span-6 md:col-span-1">${this.renderNav()}</div>
@@ -391,8 +389,10 @@ export class CrawlDetail extends LiteElement {
 
   private renderHeader() {
     return html`
-      <header class="md:flex justify-between items-end">
-        <h1 class="text-xl font-semibold mb-4 md:mb-0 md:mr-2">
+      <header class="md:flex items-center gap-2 pb-3 mb-3 border-b">
+        <h1
+          class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
+        >
           ${this.renderName()}
         </h1>
         <div

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -249,8 +249,10 @@ export class CrawlsList extends LiteElement {
     return html`
       <main>
         <header class="contents">
-          <div class="flex justify-between w-full pb-4 mb-3 border-b">
-            <h1 class="text-xl font-semibold h-8">
+          <div class="md:flex items-center gap-2 pb-3 mb-3 border-b">
+            <h1
+              class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
+            >
               ${msg("All Archived Data")}
             </h1>
             ${when(

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -238,7 +238,9 @@ export class Org extends LiteElement {
     const crawlsAPIBaseUrl = `/orgs/${this.orgId}/crawls`;
     const crawlsBaseUrl = `/orgs/${this.orgId}/artifacts/crawls`;
 
-    const artifactType = this.orgPath.includes("/artifacts/upload") ? "upload" : "crawl";
+    const artifactType = this.orgPath.includes("/artifacts/upload")
+      ? "upload"
+      : "crawl";
 
     if (this.params.crawlOrWorkflowId) {
       return html` <btrix-crawl-detail
@@ -345,34 +347,28 @@ export class Org extends LiteElement {
   private renderCollections() {
     if (this.params.resourceId) {
       if (this.orgPath.includes(`/edit/${this.params.resourceId}`)) {
-        return html`<div class="lg:px-5">
-          <btrix-collection-edit
-            .authState=${this.authState!}
-            orgId=${this.orgId!}
-            collectionId=${this.params.resourceId}
-            ?isCrawler=${this.isCrawler}
-          ></btrix-collection-edit>
-        </div>`;
-      }
-
-      return html`<div class="lg:px-5">
-        <btrix-collection-detail
+        return html`<btrix-collection-edit
           .authState=${this.authState!}
           orgId=${this.orgId!}
           collectionId=${this.params.resourceId}
           ?isCrawler=${this.isCrawler}
-        ></btrix-collection-detail>
-      </div>`;
+        ></btrix-collection-edit>`;
+      }
+
+      return html`<btrix-collection-detail
+        .authState=${this.authState!}
+        orgId=${this.orgId!}
+        collectionId=${this.params.resourceId}
+        ?isCrawler=${this.isCrawler}
+      ></btrix-collection-detail>`;
     }
 
     if (this.orgPath.endsWith("/new")) {
-      return html`<div class="lg:px-5">
-        <btrix-collections-new
-          .authState=${this.authState!}
-          orgId=${this.orgId!}
-          ?isCrawler=${this.isCrawler}
-        ></btrix-collections-new>
-      </div>`;
+      return html`<btrix-collections-new
+        .authState=${this.authState!}
+        orgId=${this.orgId!}
+        ?isCrawler=${this.isCrawler}
+      ></btrix-collections-new>`;
     }
 
     return html`<btrix-collections-list

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -30,6 +30,7 @@ import type {
   UserRoleChangeEvent,
   OrgRemoveMemberEvent,
 } from "./settings";
+import type { Tab as CollectionTab } from "./collection-detail";
 
 export type OrgTab =
   | "crawls"
@@ -45,6 +46,7 @@ type Params = {
   browserId?: string;
   artifactId?: string;
   resourceId?: string;
+  resourceTab?: string;
   artifactType?: Crawl["type"];
 };
 
@@ -359,6 +361,7 @@ export class Org extends LiteElement {
         .authState=${this.authState!}
         orgId=${this.orgId!}
         collectionId=${this.params.resourceId}
+        resourceTab=${(this.params.resourceTab as CollectionTab) || "replay"}
         ?isCrawler=${this.isCrawler}
       ></btrix-collection-detail>`;
     }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -357,6 +357,20 @@ export class Org extends LiteElement {
         ></btrix-collection-edit>`;
       }
 
+      if (this.params.artifactId) {
+        const crawlsAPIBaseUrl = `/orgs/${this.orgId}/crawls`;
+        // TODO abstract into breadcrumbs
+        const crawlsBaseUrl = `/orgs/${this.orgId}/collections/view/${this.params.resourceId}/web-captures`;
+
+        return html` <btrix-crawl-detail
+          .authState=${this.authState!}
+          crawlId=${this.params.artifactId}
+          crawlsAPIBaseUrl=${crawlsAPIBaseUrl}
+          crawlsBaseUrl=${crawlsBaseUrl}
+          ?isCrawler=${this.isCrawler}
+        ></btrix-crawl-detail>`;
+      }
+
       return html`<btrix-collection-detail
         .authState=${this.authState!}
         orgId=${this.orgId!}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -14,7 +14,7 @@ export const ROUTES = {
     "/orgs/:orgId/:orgTab",
     // Optional segments:
     "(/new)",
-    "(/view/:resourceId)",
+    "(/view/:resourceId(/:resourceTab))",
     "(/edit/:resourceId)",
     "(/crawls)",
     "(/crawl/:crawlOrWorkflowId)",


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1023

<!-- Fixes #issue_number -->

### Changes

- Adds tab for "Web Captures" in Collection detail view
- Move Collection description under Replay section
- Fixes app reloading when clicking into a Collection
- Standardizes Web Capture list headers from "Finished -> "Created Date" (see parent ticket for task on standardizing search/filter/sort)

### Manual testing

1. Log in
2. Click "Collections". Verify list shows number of "Web Captures" not "Crawls"
3. Click a Collection. Verify that "Replay" tab is highlighted and replay window is rendered, with description below.
4. Click "Web Captures". Verify all web captures (crawls and uploads) in the collection are loaded
5. Click a web capture. Verify that back button is labeled "Back to Collection" and clicking it takes you back to the collection web captures page

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection List | <img width="1135" alt="Screenshot 2023-07-31 at 4 24 58 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/b7a463f1-028e-4044-b46d-c9262e759b0a"> |
| Collection Detail - Web Captures | <img width="1136" alt="Screenshot 2023-07-31 at 3 55 52 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/aabbef53-c9fc-4875-b52a-d3e0a6b85e98"> |
| Web Capture Detail | **"Back" link:**<br /><img width="1128" alt="Screenshot 2023-07-31 at 3 48 18 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/c0b6c923-5e79-40e8-b794-eb636e487ff4"> |
| Collection Detail - Web Captures (no web captures included) | <img width="1140" alt="Screenshot 2023-07-31 at 3 52 06 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/b12a432a-6d3e-4307-96cd-6bd5a3c76cea"> |


<!-- ### Follow-ups -->
