### PR TITLE
feat: Display waiting message while backend is initializing

### DIFF
--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -295,41 +295,11 @@ export class LogInPage extends LiteElement {
 
   private renderBackendInitializing() {
     return html`
-      <form @submit=${this.onSubmitLogIn} aria-describedby="formError">
         <div class="mb-5">
-          <btrix-input
-            id="email"
-            name="username"
-            label=${msg("Please wait while the backend is initializing")}
-            type="email"
-            autocomplete="username"
-            disabled="disabled"
-            required
-          >
-          </btrix-input>
+					<dialog id="backend-initializing" open> 
+						<p> Please wait while the backend initializes </p>
+					</dialog>
         </div>
-        <div class="mb-5">
-          <btrix-input
-            id="password"
-            name="password"
-            label=${msg("")}
-            type="password"
-            autocomplete="current-password"
-            passwordToggle
-            disabled="disabled"
-            required
-          >
-          </btrix-input>
-        </div>
-        <sl-button
-          class="w-full"
-          variant="primary"
-          ?loading=${this.formState.value === "signingIn"}
-          type="submit"
-          disabled="disabled"
-          >${msg("Log in")}</sl-button
-        >
-      </form>
     `;
   }
 
@@ -374,8 +344,10 @@ export class LogInPage extends LiteElement {
   }
 
   async checkBackendInitialized() {
-    const resp = await fetch("/api/healthz");
+    const resp = await fetch("/api/settings");
     if (resp.status === 200) {
+			const Dialog = <HTMLDialogElement>document.getElementById("backend-initializing");
+			Dialog.close()
       this.formStateService.send("BACKEND_INITIALIZED");
     } else {
       setTimeout(this.checkBackendInitialized, 5000);

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -191,16 +191,6 @@ export class LogInPage extends LiteElement {
           >${msg("Sign in with password")}</a
         >
       `;
-    } else if (this.formState.value === "backendInitializing") {
-      form = this.renderBackendInitializing();
-      link = html`
-        <a
-          class="text-sm text-gray-400 hover:text-gray-500"
-          href="/log-in"
-          @click=${this.navLink}
-          >${msg("Sign in with password")}</a
-        >
-      `;
     } else {
       form = this.renderLoginForm();
       link = html`
@@ -290,42 +280,15 @@ export class LogInPage extends LiteElement {
           class="w-full"
           variant="primary"
           ?loading=${this.formState.value === "signingIn"}
+          ?disabled=${this.formState.value === "backendInitializing"}
           type="submit"
           >${msg("Log in")}</sl-button
         >
-      </form>
-    `;
-  }
-
-  private renderBackendInitializing() {
-    return html`
-      <form @submit=${this.onSubmitLogIn} aria-describedby="formError">
-        <div class="mb-5">
-          <btrix-input
-            id="email"
-            name="username"
-            label=${msg("Email")}
-            type="email"
-            autocomplete="username"
-            required
-          >
-          </btrix-input>
-        </div>
-        <div class="mb-5">
-          <btrix-input
-            id="password"
-            name="password"
-            label=${msg("Password")}
-            type="password"
-            autocomplete="current-password"
-            passwordToggle
-            required
-          >
-          </btrix-input>
-          <dialog id="backend-initializing" open>
-            <p>Please wait while the backend initializes</p>
-          </dialog>
-        </div>
+        ${this.formState.value === "backendInitializing"
+          ? html`<p style="text-align:center;">
+              ${msg("Please wait while the backend initializes")}
+            </p>`
+          : ""}
       </form>
     `;
   }

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -165,7 +165,7 @@ export class LogInPage extends LiteElement {
 
   disconnectedCallback() {
     this.formStateService.stop();
-    window.clearTimeout(this.timeoutId);
+    window.clearTimeout(this.timerId);
     super.disconnectedCallback();
   }
 

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -346,7 +346,10 @@ export class LogInPage extends LiteElement {
       this.formStateService.send("BACKEND_INITIALIZED");
     } else {
       this.formStateService.send("BACKEND_NOT_INITIALIZED");
-      this.timerId = setTimeout(() => this.checkBackendInitialized(), 5000);
+      this.timerId = window.setTimeout(
+        () => this.checkBackendInitialized(),
+        5000
+      );
     }
   }
 

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -287,7 +287,7 @@ export class LogInPage extends LiteElement {
         ${this.formState.value === "backendInitializing"
           ? html` <div class="mt-3">
                
-              <btrix-alert variant="warning"
+              <btrix-alert variant="warning" class="text-center"
                 >${msg(
                   "Please wait while the backend initializes"
                 )}</btrix-alert

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -285,9 +285,14 @@ export class LogInPage extends LiteElement {
           >${msg("Log in")}</sl-button
         >
         ${this.formState.value === "backendInitializing"
-          ? html`<p style="text-align:center;">
-              ${msg("Please wait while the backend initializes")}
-            </p>`
+          ? html` <div class="mt-3">
+               
+              <btrix-alert variant="warning"
+                >${msg(
+                  "Please wait while the backend initializes"
+                )}</btrix-alert
+              >
+            </div>`
           : ""}
       </form>
     `;

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -288,7 +288,6 @@ export class LogInPage extends LiteElement {
         >
         ${this.formState.value === "backendInitializing"
           ? html` <div class="mt-3">
-               
               <btrix-alert variant="warning" class="text-center"
                 >${msg(
                   "Please wait while Browsertrix Cloud is initializing"

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -152,6 +152,7 @@ export class LogInPage extends LiteElement {
 
   @state()
   private formState = machine.initialState;
+  private timerId?: number;
 
   firstUpdated() {
     this.formStateService.subscribe((state) => {
@@ -164,6 +165,7 @@ export class LogInPage extends LiteElement {
 
   disconnectedCallback() {
     this.formStateService.stop();
+    window.clearTimeout(this.timeoutId);
     super.disconnectedCallback();
   }
 
@@ -289,7 +291,7 @@ export class LogInPage extends LiteElement {
                
               <btrix-alert variant="warning" class="text-center"
                 >${msg(
-                  "Please wait while the backend initializes"
+                  "Please wait while Browsertrix Cloud is initializing"
                 )}</btrix-alert
               >
             </div>`
@@ -344,7 +346,7 @@ export class LogInPage extends LiteElement {
       this.formStateService.send("BACKEND_INITIALIZED");
     } else {
       this.formStateService.send("BACKEND_NOT_INITIALIZED");
-      setTimeout(() => this.checkBackendInitialized(), 5000);
+      this.timerId = setTimeout(() => this.checkBackendInitialized(), 5000);
     }
   }
 


### PR DESCRIPTION
Resolves #794 

I added a `backendInitilizing` state to the state machine, and set that to be the initial state. Then in the `firstUpdated` function I added a call to  `checkBackendInitialized` which has a callback to itself (scary?). The rest is a render function that disables the inputs and displays "Please wait" message until the state transitions. 

Testing pending! 