### PR TITLE
Add info bar to Collection detail view

### DIFF
--- a/frontend/src/components/desc-list.ts
+++ b/frontend/src/components/desc-list.ts
@@ -15,10 +15,15 @@
  * ```
  */
 import { LitElement, html, css } from "lit";
-import { property } from "lit/decorators.js";
+import { property, queryAssignedElements } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 
 export class DescListItem extends LitElement {
   static styles = css`
+    :host {
+      display: contents;
+    }
+
     dt {
       color: var(--sl-color-neutral-500);
       font-size: var(--sl-font-size-x-small);
@@ -35,15 +40,23 @@ export class DescListItem extends LitElement {
       font-variation-settings: var(--font-monostyle-variation);
       line-height: 1rem;
     }
+
+    .item {
+      display: flex;
+      justify-content: var(--justify-item, initial);
+      border-right: var(--border-right, 0px);
+    }
   `;
 
   @property({ type: String })
   label: string = "";
 
   render() {
-    return html`<div>
-      <dt>${this.label}</dt>
-      <dd><slot></slot></dd>
+    return html`<div class="item">
+      <div class="content">
+        <dt>${this.label}</dt>
+        <dd><slot></slot></dd>
+      </div>
     </div>`;
   }
 }
@@ -52,13 +65,46 @@ export class DescList extends LitElement {
   static styles = css`
     dl {
       display: grid;
-      grid-template-columns: 100%;
-      grid-gap: 1rem;
       margin: 0;
+    }
+
+    .vertical {
+      grid-template-columns: 100%;
+      gap: 1rem;
+    }
+
+    .horizontal {
+      grid-auto-flow: column;
     }
   `;
 
+  @property({ type: Boolean })
+  horizontal = false;
+
   render() {
-    return html`<dl><slot></slot></dl>`;
+    return html`<dl
+      class=${classMap({
+        vertical: !this.horizontal,
+        horizontal: this.horizontal,
+      })}
+    >
+      <slot @slotchange=${this.handleSlotchange}></slot>
+    </dl>`;
+  }
+
+  @queryAssignedElements({ selector: "btrix-desc-list-item" })
+  private listItems!: Array<HTMLElement>;
+
+  private handleSlotchange() {
+    if (this.horizontal) {
+      // Style children
+      this.listItems.map((el, i, arr) => {
+        let style = "--justify-item: center;";
+        if (i < arr.length - 1) {
+          style = `${style} --border-right: 1px solid var(--sl-panel-border-color);`;
+        }
+        el.setAttribute("style", style);
+      });
+    }
   }
 }

--- a/frontend/src/components/desc-list.ts
+++ b/frontend/src/components/desc-list.ts
@@ -33,7 +33,7 @@ export class DescListItem extends LitElement {
 
     dd {
       margin: 0;
-      padding: 0;
+      padding: 0 0 var(--sl-spacing-2x-small);
       color: var(--sl-color-neutral-700);
       font-size: var(--sl-font-size-medium);
       font-family: var(--font-monostyle-family);

--- a/frontend/src/components/desc-list.ts
+++ b/frontend/src/components/desc-list.ts
@@ -15,7 +15,7 @@
  * ```
  */
 import { LitElement, html, css } from "lit";
-import { property, queryAssignedElements } from "lit/decorators.js";
+import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
 export class DescListItem extends LitElement {
@@ -74,7 +74,15 @@ export class DescList extends LitElement {
     }
 
     .horizontal {
+      --justify-item: center;
+      --border-right: 1px solid var(--sl-panel-border-color);
       grid-auto-flow: column;
+    }
+
+    /* Although this only applies to .horizontal, apply to any last child
+    since we can't do complex selectors with ::slotted */
+    ::slotted(*:last-of-type) {
+      --border-right: 0px;
     }
   `;
 
@@ -88,23 +96,7 @@ export class DescList extends LitElement {
         horizontal: this.horizontal,
       })}
     >
-      <slot @slotchange=${this.handleSlotchange}></slot>
+      <slot></slot>
     </dl>`;
-  }
-
-  @queryAssignedElements({ selector: "btrix-desc-list-item" })
-  private listItems!: Array<HTMLElement>;
-
-  private handleSlotchange() {
-    if (this.horizontal) {
-      // Style children
-      this.listItems.map((el, i, arr) => {
-        let style = "--justify-item: center;";
-        if (i < arr.length - 1) {
-          style = `${style} --border-right: 1px solid var(--sl-panel-border-color);`;
-        }
-        el.setAttribute("style", style);
-      });
-    }
   }
 }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -19,7 +19,7 @@ import type { PageChangeEvent } from "../../components/pagination";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;
-const TABS = ["replay", "web-captures"] as const;
+const TABS = ["replay", "items"] as const;
 export type Tab = (typeof TABS)[number];
 
 @localized()
@@ -64,9 +64,9 @@ export class CollectionDetail extends LiteElement {
       icon: { name: "link-replay", library: "app" },
       text: msg("Replay"),
     },
-    "web-captures": {
+    items: {
       icon: { name: "list-ul", library: "default" },
-      text: msg("Web Captures"),
+      text: msg("Archived Items"),
     },
   };
 
@@ -104,7 +104,7 @@ export class CollectionDetail extends LiteElement {
         this.resourceTab,
         [
           ["replay", this.renderOverview],
-          ["web-captures", this.renderWebCaptures],
+          ["items", this.renderWebCaptures],
         ],
 
         () => html`<btrix-not-found></btrix-not-found>`

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -369,14 +369,14 @@ export class CollectionsList extends LiteElement {
       return html`
         <header class="py-2 text-neutral-600 leading-none">
           <div
-            class="hidden md:grid md:grid-cols-[repeat(2,1fr)_16ch_repeat(3,10ch)_2.5rem] gap-3"
+            class="hidden md:grid md:grid-cols-[repeat(2,1fr)_repeat(3,12ch)_16ch_2.5rem] gap-3"
           >
             <div class="col-span-1 text-xs pl-3">${msg("Collection Name")}</div>
             <div class="col-span-1 text-xs">${msg("Top 3 Tags")}</div>
-            <div class="col-span-1 text-xs">${msg("Last Updated")}</div>
-            <div class="col-span-1 text-xs">${msg("Size")}</div>
-            <div class="col-span-1 text-xs">${msg("Web Captures")}</div>
-            <div class="col-span-2 text-xs">${msg("Total Pages")}</div>
+            <div class="col-span-1 text-xs">${msg("Archived Items")}</div>
+            <div class="col-span-1 text-xs">${msg("Total Size")}</div>
+            <div class="col-span-1 text-xs">${msg("Total Pages")}</div>
+            <div class="col-span-2 text-xs">${msg("Last Updated")}</div>
           </div>
         </header>
         <ul class="contents">
@@ -446,7 +446,7 @@ export class CollectionsList extends LiteElement {
     html`<li class="mb-2 last:mb-0">
       <div class="block border rounded leading-none">
         <div
-          class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[repeat(2,1fr)_16ch_repeat(3,10ch)_2.5rem] gap-3 lg:h-10 items-center"
+          class="relative p-3 md:p-0 grid grid-cols-1 md:grid-cols-[repeat(2,1fr)_repeat(3,12ch)_16ch_2.5rem] gap-3 lg:h-10 items-center"
         >
           <div class="col-span-1 md:pl-3 truncate font-semibold">
             <a
@@ -465,15 +465,12 @@ export class CollectionsList extends LiteElement {
                   html`<btrix-tag class="mr-1" size="small">${tag}</btrix-tag>`
               )}
           </div>
-          <div class="col-span-1 text-xs text-neutral-500 font-monostyle">
-            <sl-format-date
-              date=${`${col.modified}Z`}
-              month="2-digit"
-              day="2-digit"
-              year="2-digit"
-              hour="2-digit"
-              minute="2-digit"
-            ></sl-format-date>
+          <div
+            class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"
+          >
+            ${col.crawlCount === 1
+              ? msg("1 item")
+              : msg(str`${this.numberFormatter.format(col.crawlCount)} items`)}
           </div>
           <div
             class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"
@@ -486,18 +483,19 @@ export class CollectionsList extends LiteElement {
           <div
             class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"
           >
-            ${col.crawlCount === 1
-              ? msg("1 capture")
-              : msg(
-                  str`${this.numberFormatter.format(col.crawlCount)} captures`
-                )}
-          </div>
-          <div
-            class="col-span-1 truncate text-xs text-neutral-500 font-monostyle"
-          >
             ${col.pageCount === 1
               ? msg("1 page")
               : msg(str`${this.numberFormatter.format(col.pageCount)} pages`)}
+          </div>
+          <div class="col-span-1 text-xs text-neutral-500 font-monostyle">
+            <sl-format-date
+              date=${`${col.modified}Z`}
+              month="2-digit"
+              day="2-digit"
+              year="2-digit"
+              hour="2-digit"
+              minute="2-digit"
+            ></sl-format-date>
           </div>
           <div
             class="actionsCol absolute top-0 right-0 md:relative col-span-1 flex items-center justify-center"

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -306,7 +306,7 @@ export class WorkflowDetail extends LiteElement {
           </div>
         </header>
 
-        <section class="col-span-1 border rounded-lg py-2 h-14">
+        <section class="col-span-1 border rounded-lg py-2">
           ${this.renderDetails()}
         </section>
 
@@ -683,7 +683,7 @@ export class WorkflowDetail extends LiteElement {
 
   private renderDetails() {
     return html`
-      <dl class="h-14 px-3 md:px-0 md:flex justify-evenly">
+      <btrix-desc-list horizontal>
         ${this.renderDetailItem(
           msg("Status"),
           () => html`
@@ -711,26 +711,20 @@ export class WorkflowDetail extends LiteElement {
               `
             : html`<span class="text-neutral-400">${msg("No Schedule")}</span>`
         )}
-        ${this.renderDetailItem(
-          msg("Created By"),
-          () =>
-            msg(
-              str`${
-                this.workflow!.createdByName
-              } on ${this.dateFormatter.format(
-                new Date(`${this.workflow!.created}Z`)
-              )}`
-            ),
-          true
+        ${this.renderDetailItem(msg("Created By"), () =>
+          msg(
+            str`${this.workflow!.createdByName} on ${this.dateFormatter.format(
+              new Date(`${this.workflow!.created}Z`)
+            )}`
+          )
         )}
-      </dl>
+      </btrix-desc-list>
     `;
   }
 
   private renderDetailItem(
     label: string | TemplateResult,
-    renderContent: () => any,
-    isLast = false
+    renderContent: () => any
   ) {
     return html`
       <btrix-desc-list-item label=${label}>
@@ -740,7 +734,6 @@ export class WorkflowDetail extends LiteElement {
           () => html`<sl-skeleton class="w-full"></sl-skeleton>`
         )}
       </btrix-desc-list-item>
-      ${when(!isLast, () => html`<hr class="flex-0 border-l w-0 h-10" />`)}
     `;
   }
 
@@ -878,7 +871,7 @@ export class WorkflowDetail extends LiteElement {
     const skeleton = html`<sl-skeleton class="w-full"></sl-skeleton>`;
 
     return html`
-      <dl class="px-3 md:px-0 md:flex justify-evenly">
+      <btrix-desc-list horizontal>
         ${this.renderDetailItem(msg("Pages Crawled"), () =>
           this.lastCrawlStats
             ? msg(
@@ -906,12 +899,10 @@ export class WorkflowDetail extends LiteElement {
               ></sl-format-bytes>`
             : skeleton
         )}
-        ${this.renderDetailItem(
-          msg("Crawler Instances"),
-          () => (this.workflow ? this.workflow.scale : skeleton),
-          true
+        ${this.renderDetailItem(msg("Crawler Instances"), () =>
+          this.workflow ? this.workflow.scale : skeleton
         )}
-      </dl>
+      </btrix-desc-list>
     `;
   };
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1014

<!-- Fixes #issue_number -->

### Changes

- Adds Collection info bar to detail view
- Update "Web Captures" -> "Archived Items"
- Updates Collection list columns to match
- Refactors `btrix-desc-list` and usage in `workflow-details` to reuse horizontal info bar component

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection Detail | <img width="1141" alt="Screenshot 2023-08-01 at 11 42 19 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/8c4d0cd7-3812-4444-977a-e6e9504b9798"> |


<!-- ### Follow-ups -->
