### PR TITLE
Support for Publicly Shareable Collections 

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -465,6 +465,8 @@ class Collection(BaseMongoModel):
     # Sorted by count, descending
     tags: Optional[List[str]] = []
 
+    isPublic: Optional[bool] = False
+
 
 # ============================================================================
 class CollIn(BaseModel):
@@ -473,6 +475,8 @@ class CollIn(BaseModel):
     name: str = Field(..., min_length=1)
     description: Optional[str]
     crawlIds: Optional[List[str]] = []
+
+    isPublic: Optional[bool] = False
 
 
 # ============================================================================
@@ -488,6 +492,7 @@ class UpdateColl(BaseModel):
 
     name: Optional[str]
     description: Optional[str]
+    isPublic: Optional[bool]
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -45,6 +45,7 @@ class OrgOps:
         self.org_viewer_dep = None
         self.org_crawl_dep = None
         self.org_owner_dep = None
+        self.org_public = None
 
         self.invites = invites
 
@@ -300,6 +301,13 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
 
         return org
 
+    async def org_public(oid: str):
+        org = await ops.get_org_by_id(uuid.UUID(oid))
+        if not org:
+            raise HTTPException(status_code=404, detail="org_not_found")
+
+        return org
+
     router = APIRouter(
         prefix="/orgs/{oid}",
         dependencies=[Depends(org_dep)],
@@ -310,6 +318,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
     ops.org_viewer_dep = org_dep
     ops.org_crawl_dep = org_crawl_dep
     ops.org_owner_dep = org_owner_dep
+    ops.org_public = org_public
 
     @app.get("/orgs", tags=["organizations"], response_model=PaginatedResponse)
     async def get_orgs(

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -402,7 +402,6 @@ def init_users_api(app, user_manager):
                 }
                 for org in user_orgs
             ]
-        print(f"user info with orgs: {user_info}", flush=True)
         return user_info
 
     @users_router.get("/invite/{token}", tags=["invites"])

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -86,31 +86,28 @@ export class CollectionDetail extends LiteElement {
   render() {
     return html`${this.renderHeader()}
       <header class="md:flex items-center gap-2 pb-3 mb-3 border-b">
-        <h1
-          class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
-        >
+        <div class="flex items-center gap-2 w-full mb-2 md:mb-0">
           ${when(
             this.collection?.isPublic,
             () => html`
-              <sl-icon
-                style="font-size: 16px; color: var(--sl-color-success-600)"
-                name="globe2"
-                slot="prefix"
-                title="${msg("Publicly Accessible")}"
-              ></sl-icon>
+              <sl-tooltip content=${msg("Publicly Accessible")}>
+                <sl-icon
+                  style="font-size: 16px; color: var(--sl-color-success-600)"
+                  name="globe2"
+                  label="${msg("Publicly Accessible")}"
+                ></sl-icon>
+              </sl-tooltip>
             `
           )}
-          ${this.collection?.name ||
-          html`<sl-skeleton class="w-96"></sl-skeleton>`}
-        </h1>
+          <h1 class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate">
+            ${this.collection?.name ||
+            html`<sl-skeleton class="w-96"></sl-skeleton>`}
+          </h1>
+        </div>
         ${when(
           this.collection?.isPublic,
           () => html`
-            <sl-button
-              size="small"
-              class="p-2"
-              @click=${() => (this.showEmbedInfo = true)}
-            >
+            <sl-button size="small" @click=${() => (this.showEmbedInfo = true)}>
               <sl-icon name="code-slash"></sl-icon>
               View Embed Code
             </sl-button>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -320,7 +320,7 @@ export class CollectionDetail extends LiteElement {
                   </a>
                 </sl-menu-item>
                 <sl-menu-item @click=${() => this.onTogglePublic(false)}>
-                  <sl-icon name="eye-slash-fill" slot="prefix"></sl-icon>
+                  <sl-icon name="eye-slash" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>
               `}

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -319,7 +319,10 @@ export class CollectionDetail extends LiteElement {
                     Go to Public View
                   </a>
                 </sl-menu-item>
-                <sl-menu-item @click=${() => this.onTogglePublic(false)}>
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--warning)"
+                  @click=${() => this.onTogglePublic(false)}
+                >
                   <sl-icon name="eye-slash-fill" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -93,18 +93,17 @@ export class CollectionDetail extends LiteElement {
     return html`${this.renderHeader()}
       <header class="md:flex items-center gap-2 pb-3">
         <div class="flex items-center gap-2 w-full mb-2 md:mb-0">
-          ${when(
-            this.collection?.isPublic,
-            () => html`
-              <sl-tooltip content=${msg("Publicly Accessible")}>
-                <sl-icon
-                  style="font-size: 16px; color: var(--sl-color-success-600)"
-                  name="globe2"
-                  label="${msg("Publicly Accessible")}"
-                ></sl-icon>
-              </sl-tooltip>
-            `
-          )}
+          ${this.collection?.isPublic
+            ? html`
+                <sl-tooltip content=${msg("Shareable")}>
+                  <sl-icon class="text-lg" name="people-fill"></sl-icon>
+                </sl-tooltip>
+              `
+            : html`
+                <sl-tooltip content=${msg("Private")}>
+                  <sl-icon class="text-lg" name="eye-slash"></sl-icon>
+                </sl-tooltip>
+              `}
           <h1
             class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
           >
@@ -305,13 +304,13 @@ export class CollectionDetail extends LiteElement {
                   style="--sl-color-neutral-700: var(--success)"
                   @click=${() => this.onTogglePublic(true)}
                 >
-                  <sl-icon name="globe2" slot="prefix"></sl-icon>
-                  ${msg("Make Public")}
+                  <sl-icon name="people-fill" slot="prefix"></sl-icon>
+                  ${msg("Make Shareable")}
                 </sl-menu-item>
               `
             : html`
                 <sl-menu-item style="--sl-color-neutral-700: var(--success)">
-                  <sl-icon name="box-arrow-up-left" slot="prefix"></sl-icon>
+                  <sl-icon name="box-arrow-up-right" slot="prefix"></sl-icon>
                   <a
                     target="_blank"
                     slot="prefix"
@@ -320,10 +319,7 @@ export class CollectionDetail extends LiteElement {
                     Go to Public View
                   </a>
                 </sl-menu-item>
-                <sl-menu-item
-                  style="--sl-color-neutral-700: var(--warning)"
-                  @click=${() => this.onTogglePublic(false)}
-                >
+                <sl-menu-item @click=${() => this.onTogglePublic(false)}>
                   <sl-icon name="eye-slash" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -101,7 +101,7 @@ export class CollectionDetail extends LiteElement {
               `
             : html`
                 <sl-tooltip content=${msg("Private")}>
-                  <sl-icon class="text-lg" name="eye-slash"></sl-icon>
+                  <sl-icon class="text-lg" name="eye-slash-fill"></sl-icon>
                 </sl-tooltip>
               `}
           <h1
@@ -320,7 +320,7 @@ export class CollectionDetail extends LiteElement {
                   </a>
                 </sl-menu-item>
                 <sl-menu-item @click=${() => this.onTogglePublic(false)}>
-                  <sl-icon name="eye-slash" slot="prefix"></sl-icon>
+                  <sl-icon name="eye-slash-fill" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>
               `}

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -50,6 +50,9 @@ export class CollectionDetail extends LiteElement {
   @state()
   private isDescriptionExpanded = false;
 
+  @state()
+  private showEmbedInfo = false;
+
   // Use to cancel requests
   private getWebCapturesController: AbortController | null = null;
 
@@ -86,9 +89,33 @@ export class CollectionDetail extends LiteElement {
         <h1
           class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
         >
+          ${when(
+            this.collection?.isPublic,
+            () => html`
+              <sl-icon
+                style="font-size: 16px; color: var(--sl-color-success-600)"
+                name="globe2"
+                slot="prefix"
+                title="${msg("Publicly Accessible")}"
+              ></sl-icon>
+            `
+          )}
           ${this.collection?.name ||
           html`<sl-skeleton class="w-96"></sl-skeleton>`}
         </h1>
+        ${when(
+          this.collection?.isPublic,
+          () => html`
+            <sl-button
+              size="small"
+              class="p-2"
+              @click=${() => (this.showEmbedInfo = true)}
+            >
+              <sl-icon name="code-slash"></sl-icon>
+              View Embed Code
+            </sl-button>
+          `
+        )}
         ${when(this.isCrawler, this.renderActions)}
       </header>
       <div class="mb-3">${this.renderTabs()}</div>
@@ -128,8 +155,84 @@ export class CollectionDetail extends LiteElement {
             >Delete Collection</sl-button
           >
         </div>
-      </btrix-dialog>`;
+      </btrix-dialog>
+      ${this.renderShareInfo()}`;
   }
+
+  private getPublicReplayURL() {
+    return new URL(
+      `/api/orgs/${this.orgId}/collections/${this.collectionId}/public/replay.json`,
+      window.location.href
+    ).href;
+  }
+
+  private renderShareInfo = () => {
+    if (!this.collection?.isPublic) {
+      return;
+    }
+
+    const embedCode = `<replay-web-page source="${this.getPublicReplayURL()}"></replay-web-page>`;
+    const importCode = `importScripts("https://replayweb.page/sw.js");`;
+
+    return html` <btrix-dialog
+      label=${msg(str`Embed Code for “${this.collection?.name}”`)}
+      ?open=${this.showEmbedInfo}
+      @sl-request-close=${() => (this.showEmbedInfo = false)}
+    >
+      <div class="text-left">
+        <p class="mb-5">
+          ${msg(
+            html`Embed this collection in another site using these
+              <strong class="font-medium">ReplayWeb.page</strong> code snippets.`
+          )}
+        </p>
+        <p class="mb-3">
+          ${msg(html`Add the following embed code to your HTML page:`)}
+        </p>
+        <div class="relative">
+          <pre
+            class="whitespace-pre-wrap mb-5 rounded p-4 bg-slate-50 text-slate-600 text-[0.9em]"
+          ><code>${embedCode}</code></pre>
+          <div class="absolute top-0 right-0">
+            <btrix-copy-button
+              .getValue=${() => embedCode}
+              content=${msg("Copy Embed Code")}
+            ></btrix-copy-button>
+          </div>
+        </div>
+        <p class="mb-3">
+          ${msg(
+            html`Add the following JavaScript to
+              <code class="text-[0.9em]">./replay/sw.js</code>:`
+          )}
+        </p>
+        <div class="relative">
+          <pre
+            class="whitespace-pre-wrap mb-5 rounded p-4 bg-slate-50 text-slate-600 text-[0.9em]"
+          ><code>${importCode}</code></pre>
+          <div class="absolute top-0 right-0">
+            <btrix-copy-button
+              .getValue=${() => importCode}
+              content=${msg("Copy JS")}
+            ></btrix-copy-button>
+          </div>
+        </div>
+        <p>
+          ${msg(
+            html`See
+              <a
+                class="text-primary"
+                href="https://replayweb.page/docs/embedding"
+                target="_blank"
+              >
+                our embedding guide</a
+              >
+              for more details.`
+          )}
+        </p>
+      </div>
+    </btrix-dialog>`;
+  };
 
   private renderHeader = () => html`
     <nav class="mb-7">
@@ -190,6 +293,35 @@ export class CollectionDetail extends LiteElement {
             ${msg("Edit Collection")}
           </sl-menu-item>
           <sl-divider></sl-divider>
+          ${!this.collection?.isPublic
+            ? html`
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--success)"
+                  @click=${() => this.onTogglePublic(true)}
+                >
+                  <sl-icon name="globe2" slot="prefix"></sl-icon>
+                  ${msg("Make Public")}
+                </sl-menu-item>
+              `
+            : html`
+                <sl-menu-item style="--sl-color-neutral-700: var(--success)">
+                  <sl-icon name="box-arrow-up-left" slot="prefix"></sl-icon>
+                  <a
+                    target="_blank"
+                    slot="prefix"
+                    href="https://replayweb.page?source=${this.getPublicReplayURL()}"
+                  >
+                    Go to Public View
+                  </a>
+                </sl-menu-item>
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--warning)"
+                  @click=${() => this.onTogglePublic(false)}
+                >
+                  <sl-icon name="eye-slash" slot="prefix"></sl-icon>
+                  ${msg("Make Private")}
+                </sl-menu-item>
+              `}
           <!-- Shoelace doesn't allow "href" on menu items,
               see https://github.com/shoelace-style/shoelace/issues/1351 -->
           <a
@@ -420,6 +552,21 @@ export class CollectionDetail extends LiteElement {
       });
     }
   };
+
+  private async onTogglePublic(isPublic: boolean) {
+    const res = await this.apiFetch(
+      `/orgs/${this.orgId}/collections/${this.collectionId}`,
+      this.authState!,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ isPublic }),
+      }
+    );
+
+    if (res.updated && this.collection) {
+      this.collection = { ...this.collection, isPublic };
+    }
+  }
 
   private confirmDelete = () => {
     this.openDialogName = "delete";

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -104,9 +104,7 @@ export class CollectionDetail extends LiteElement {
                   <sl-icon class="text-lg" name="eye-slash-fill"></sl-icon>
                 </sl-tooltip>
               `}
-          <h1
-            class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
-          >
+          <h1 class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate">
             ${this.collection?.name ||
             html`<sl-skeleton class="w-96"></sl-skeleton>`}
           </h1>

--- a/frontend/src/pages/org/collection-edit.ts
+++ b/frontend/src/pages/org/collection-edit.ts
@@ -83,7 +83,8 @@ export class CollectionEdit extends LiteElement {
 
   private async onSubmit(e: CollectionSubmitEvent) {
     this.isSubmitting = true;
-    const { name, description, crawlIds, oldCrawlIds } = e.detail.values;
+    const { name, description, crawlIds, oldCrawlIds, isPublic } =
+      e.detail.values;
 
     try {
       if (oldCrawlIds && oldCrawlIds) {
@@ -92,7 +93,11 @@ export class CollectionEdit extends LiteElement {
           oldCrawlIds,
         });
       } else {
-        await this.saveMetadata({ name, description });
+        await this.saveMetadata({
+          name,
+          description,
+          isPublic: isPublic === "on",
+        });
       }
 
       this.navTo(`/orgs/${this.orgId}/collections/view/${this.collectionId}`);
@@ -117,7 +122,11 @@ export class CollectionEdit extends LiteElement {
     this.isSubmitting = false;
   }
 
-  private saveMetadata(values: { name: string; description: string | null }) {
+  private saveMetadata(values: {
+    name: string;
+    description: string | null;
+    isPublic: boolean;
+  }) {
     return this.apiFetch(
       `/orgs/${this.orgId}/collections/${this.collectionId}`,
       this.authState!,

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -515,7 +515,7 @@ export class CollectionEditor extends LiteElement {
           </fieldset>
           <label>
             <sl-switch name="isPublic" ?checked=${this.metadataValues?.isPublic}
-              >Publishable to IPFS</sl-switch
+              >Publicly Accessible</sl-switch
             >
           </label>
         </div>

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -84,6 +84,7 @@ export type CollectionSubmitEvent = CustomEvent<{
     description: string | null;
     crawlIds: string[];
     oldCrawlIds?: string[];
+    isPublic: string | null;
   };
 }>;
 
@@ -512,6 +513,11 @@ export class CollectionEditor extends LiteElement {
               maxlength=${4000}
             ></btrix-markdown-editor>
           </fieldset>
+          <label>
+            <sl-switch name="isPublic" ?checked=${this.metadataValues?.isPublic}
+              >Publishable to IPFS</sl-switch
+            >
+          </label>
         </div>
         <footer class="border-t px-6 py-4 flex justify-between">
           ${when(

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -466,7 +466,7 @@ export class CollectionsList extends LiteElement {
                 : html`
                     <sl-icon
                       style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
-                      name="eye-slash"
+                      name="eye-slash-fill"
                       slot="prefix"
                       title="${msg("Private")}"
                     ></sl-icon>
@@ -564,7 +564,7 @@ export class CollectionsList extends LiteElement {
                   </a>
                 </sl-menu-item>
                 <sl-menu-item @click=${() => this.onTogglePublic(col, false)}>
-                  <sl-icon name="eye-slash" slot="prefix"></sl-icon>
+                  <sl-icon name="eye-slash-fill" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>
               `}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -456,20 +456,20 @@ export class CollectionsList extends LiteElement {
             >
               ${col?.isPublic
                 ? html`
-                    <sl-icon
-                      style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
-                      name="people-fill"
-                      slot="prefix"
-                      title="${msg("Shareable")}"
-                    ></sl-icon>
+                    <sl-tooltip content=${msg("Shareable")}>
+                      <sl-icon
+                        style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
+                        name="people-fill"
+                      ></sl-icon>
+                    </sl-tooltip>
                   `
                 : html`
-                    <sl-icon
-                      style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
-                      name="eye-slash-fill"
-                      slot="prefix"
-                      title="${msg("Private")}"
-                    ></sl-icon>
+                    <sl-tooltip content=${msg("Private")}>
+                      <sl-icon
+                        style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
+                        name="eye-slash-fill"
+                      ></sl-icon>
+                    </sl-tooltip>
                   `}
               ${col.name}
             </a>
@@ -563,7 +563,10 @@ export class CollectionsList extends LiteElement {
                     Go to Shared View
                   </a>
                 </sl-menu-item>
-                <sl-menu-item @click=${() => this.onTogglePublic(col, false)}>
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--warning)"
+                  @click=${() => this.onTogglePublic(col, false)}
+                >
                   <sl-icon name="eye-slash-fill" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -454,6 +454,23 @@ export class CollectionsList extends LiteElement {
               class="block text-primary hover:text-indigo-500"
               @click=${this.navLink}
             >
+              ${col?.isPublic
+                ? html`
+                    <sl-icon
+                      style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
+                      name="people-fill"
+                      slot="prefix"
+                      title="${msg("Shareable")}"
+                    ></sl-icon>
+                  `
+                : html`
+                    <sl-icon
+                      style="margin-right: 4px; vertical-align: bottom; font-size: 14px;"
+                      name="eye-slash"
+                      slot="prefix"
+                      title="${msg("Private")}"
+                    ></sl-icon>
+                  `}
               ${col.name}
             </a>
           </div>
@@ -523,6 +540,34 @@ export class CollectionsList extends LiteElement {
             ${msg("Edit Collection")}
           </sl-menu-item>
           <sl-divider></sl-divider>
+          ${!col?.isPublic
+            ? html`
+                <sl-menu-item
+                  style="--sl-color-neutral-700: var(--success)"
+                  @click=${() => this.onTogglePublic(col, true)}
+                >
+                  <sl-icon name="people-fill" slot="prefix"></sl-icon>
+                  ${msg("Make Shareable")}
+                </sl-menu-item>
+              `
+            : html`
+                <sl-menu-item style="--sl-color-neutral-700: var(--success)">
+                  <sl-icon name="box-arrow-up-right" slot="prefix"></sl-icon>
+                  <a
+                    target="_blank"
+                    slot="prefix"
+                    href="https://replayweb.page?source=${this.getPublicReplayURL(
+                      col
+                    )}"
+                  >
+                    Go to Shared View
+                  </a>
+                </sl-menu-item>
+                <sl-menu-item @click=${() => this.onTogglePublic(col, false)}>
+                  <sl-icon name="eye-slash" slot="prefix"></sl-icon>
+                  ${msg("Make Private")}
+                </sl-menu-item>
+              `}
           <!-- Shoelace doesn't allow "href" on menu items,
               see https://github.com/shoelace-style/shoelace/issues/1351 -->
           <a
@@ -571,6 +616,26 @@ export class CollectionsList extends LiteElement {
       };
     }
   }) as any;
+
+  private async onTogglePublic(coll: Collection, isPublic: boolean) {
+    const res = await this.apiFetch(
+      `/orgs/${this.orgId}/collections/${coll.id}`,
+      this.authState!,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ isPublic }),
+      }
+    );
+
+    this.fetchCollections();
+  }
+
+  private getPublicReplayURL(col: Collection) {
+    return new URL(
+      `/api/orgs/${this.orgId}/collections/${col.id}/public/replay.json`,
+      window.location.href
+    ).href;
+  }
 
   private confirmDelete = (collection: Collection) => {
     this.collectionToDelete = collection;

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -564,7 +564,7 @@ export class CollectionsList extends LiteElement {
                   </a>
                 </sl-menu-item>
                 <sl-menu-item @click=${() => this.onTogglePublic(col, false)}>
-                  <sl-icon name="eye-slash-fill" slot="prefix"></sl-icon>
+                  <sl-icon name="eye-slash" slot="prefix"></sl-icon>
                   ${msg("Make Private")}
                 </sl-menu-item>
               `}

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -59,12 +59,18 @@ export class CollectionsNew extends LiteElement {
     console.log("submit", e.detail.values);
 
     try {
+      const { name, description, crawlIds, isPublic } = e.detail.values;
       const data = await this.apiFetch(
         `/orgs/${this.orgId}/collections`,
         this.authState!,
         {
           method: "POST",
-          body: JSON.stringify(e.detail.values),
+          body: JSON.stringify({
+            name,
+            description,
+            crawlIds,
+            public: isPublic === "on",
+          }),
         }
       );
 

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -9,6 +9,7 @@ export type Collection = {
   totalSize: number;
   tags: string[];
   resources: string[];
+  isPublic: boolean;
 };
 
 export type CollectionList = Collection[];


### PR DESCRIPTION
This PR adds a 'isPublic' toggle to collections. Public collections are accessible via a new 
`/api/orgs/<orgid>/collections/<coll_id>/public/replay.json` endpoint which is accessible without login and has CORS for any origin.

The PR borrows from previous work in #926 and #994. Closes #985, focusing on just public collections.

UI Changes:

Private collection options:
<img width="1552" alt="Screen Shot 2023-08-02 at 9 46 30 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/f9f9d4cb-7b15-4470-92a0-bc604fa6f7b1">

Public collection options: 
'Go to Public View' opens in ReplayWeb.page
<img width="1552" alt="Screen Shot 2023-08-02 at 9 46 45 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/2a903778-63bf-4d9a-92f5-19c8cebcd10b">

View Embed (from #994):
<img width="1552" alt="Screen Shot 2023-08-02 at 9 49 28 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/b918d863-4da5-4dc6-9bd8-b68f00e211b8">

Also 'Publicly Accessible' switch on metadata screen:
<img width="1552" alt="Screen Shot 2023-08-02 at 9 51 12 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/14074160-c318-49ab-83c9-15f0920dec87">

Collections view with icons (final):
<img width="1207" alt="Screen Shot 2023-08-03 at 7 10 03 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/600a86c7-bcc4-4169-bf9e-f93878b52d60">


Still needed (on RWP):
- Ensure standalone RWP automatically updates when new crawls are added
- Additional RWP improvements for (thumbnails, etc..)
