### PR TITLE
Backend: standardize search values, filters, and sorting for archived items

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -391,7 +391,7 @@ class BaseCrawlOps:
             aggregate.extend([{"$match": {"collections": {"$in": [collection_id]}}}])
 
         if sort_by:
-            if sort_by not in ("started", "finished", "fileSize", "fileCount"):
+            if sort_by not in ("started", "finished", "fileSize"):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -327,7 +327,7 @@ class BaseCrawlOps:
             {"$pull": {"collections": collection_id}},
         )
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches, invalid-name
     async def list_all_base_crawls(
         self,
         org: Optional[Organization] = None,
@@ -336,12 +336,14 @@ class BaseCrawlOps:
         description: str = None,
         collection_id: str = None,
         states: Optional[List[str]] = None,
+        first_seed: Optional[str] = None,
+        type_: Optional[str] = None,
+        cid: Optional[UUID4] = None,
         cls_type: Union[CrawlOut, CrawlOutWithResources] = CrawlOut,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: str = None,
         sort_direction: int = -1,
-        type_=None,
     ):
         """List crawls of all types from the db"""
         # Zero-index page for query
@@ -367,13 +369,24 @@ class BaseCrawlOps:
             # validated_states = [value for value in state if value in ALL_CRAWL_STATES]
             query["state"] = {"$in": states}
 
-        aggregate = [{"$match": query}, {"$unset": "errors"}]
+        if cid:
+            query["cid"] = cid
+
+        aggregate = [
+            {"$match": query},
+            {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
+            {"$set": {"firstSeed": "$firstSeedObject.url"}},
+            {"$unset": ["firstSeedObject", "errors"]},
+        ]
 
         if not resources:
             aggregate.extend([{"$unset": ["files"]}])
 
         if name:
             aggregate.extend([{"$match": {"name": name}}])
+
+        if first_seed:
+            aggregate.extend([{"$match": {"firstSeed": first_seed}}])
 
         if description:
             aggregate.extend([{"$match": {"description": description}}])
@@ -382,7 +395,7 @@ class BaseCrawlOps:
             aggregate.extend([{"$match": {"collections": {"$in": [collection_id]}}}])
 
         if sort_by:
-            if sort_by not in ("started", "finished"):
+            if sort_by not in ("started", "finished", "fileSize", "fileCount"):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
@@ -447,13 +460,41 @@ class BaseCrawlOps:
 
         return {"deleted": True}
 
+    async def get_search_values(self, org: Organization):
+        """List unique names, first seeds, and descriptions from all captures in org"""
+        names = await self.crawls.distinct("name", {"oid": org.id})
+        descriptions = await self.crawls.distinct("description", {"oid": org.id})
+        crawl_ids = await self.crawls.distinct("_id", {"oid": org.id})
+
+        # Remove empty strings
+        names = [name for name in names if name]
+        descriptions = [description for description in descriptions if description]
+
+        # Get first seeds
+        first_seeds = set()
+        cids = [
+            crawl.cid
+            async for crawl in self.crawls.find({"oid": org.id, "type": "crawl"})
+        ]
+        for cid in cids:
+            config = self.crawl_configs.get_crawl_config(cid, org)
+            first_seed = config["config"]["seeds"][0]["url"]
+            first_seeds.add(first_seed)
+
+        return {
+            "names": names,
+            "descriptions": descriptions,
+            "firstSeeds": list(first_seeds),
+            "crawlIds": crawl_ids,
+        }
+
 
 # ============================================================================
 def init_base_crawls_api(
     app, mdb, users, crawl_manager, crawl_config_ops, orgs, user_dep
 ):
     """base crawls api"""
-    # pylint: disable=invalid-name, duplicate-code, too-many-arguments
+    # pylint: disable=invalid-name, duplicate-code, too-many-arguments, too-many-locals
 
     ops = BaseCrawlOps(mdb, users, crawl_config_ops, crawl_manager)
 
@@ -472,12 +513,19 @@ def init_base_crawls_api(
         userid: Optional[UUID4] = None,
         name: Optional[str] = None,
         state: Optional[str] = None,
+        firstSeed: Optional[str] = None,
         description: Optional[str] = None,
         collectionId: Optional[UUID4] = None,
+        crawlType: Optional[str] = None,
+        cid: Optional[UUID4] = None,
         sortBy: Optional[str] = "finished",
         sortDirection: Optional[int] = -1,
     ):
         states = state.split(",") if state else None
+
+        if crawlType and crawlType not in ("crawl", "upload"):
+            raise HTTPException(status_code=400, detail="invalid_crawl_type")
+
         crawls, total = await ops.list_all_base_crawls(
             org,
             userid=userid,
@@ -485,6 +533,9 @@ def init_base_crawls_api(
             description=description,
             collection_id=collectionId,
             states=states,
+            first_seed=firstSeed,
+            type_=crawlType,
+            cid=cid,
             page_size=pageSize,
             page=page,
             sort_by=sortBy,
@@ -525,3 +576,9 @@ def init_base_crawls_api(
         org: Organization = Depends(org_crawl_dep),
     ):
         return await ops.delete_crawls_all_types(delete_list, org)
+
+    @app.get("/orgs/{oid}/all-crawls/search-values", tags=["all-crawls"])
+    async def get_all_crawls_search_values(
+        org: Organization = Depends(org_viewer_dep),
+    ):
+        return await ops.get_search_values(org)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -68,11 +68,19 @@ class CrawlOps(BaseCrawlOps):
         await self.crawls.create_index(
             [("type", pymongo.HASHED), ("state", pymongo.DESCENDING)]
         )
+        await self.crawls.create_index(
+            [("type", pymongo.HASHED), ("fileSize", pymongo.DESCENDING)]
+        )
+        await self.crawls.create_index(
+            [("type", pymongo.HASHED), ("fileCount", pymongo.DESCENDING)]
+        )
 
         await self.crawls.create_index([("finished", pymongo.DESCENDING)])
         await self.crawls.create_index([("oid", pymongo.HASHED)])
         await self.crawls.create_index([("cid", pymongo.HASHED)])
         await self.crawls.create_index([("state", pymongo.HASHED)])
+        await self.crawls.create_index([("fileSize", pymongo.DESCENDING)])
+        await self.crawls.create_index([("fileCount", pymongo.DESCENDING)])
 
     async def list_crawls(
         self,
@@ -154,7 +162,13 @@ class CrawlOps(BaseCrawlOps):
             aggregate.extend([{"$match": {"collections": {"$in": [collection_id]}}}])
 
         if sort_by:
-            if sort_by not in ("started", "finished", "fileSize", "firstSeed"):
+            if sort_by not in (
+                "started",
+                "finished",
+                "fileSize",
+                "firstSeed",
+                "fileCount",
+            ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -143,7 +143,6 @@ class CrawlOps(BaseCrawlOps):
                     "as": "crawlConfig",
                 },
             },
-            {"$set": {"name": {"$arrayElemAt": ["$crawlConfig.name", 0]}}},
         ]
 
         if not resources:
@@ -559,6 +558,7 @@ async def add_new_crawl(
         manual=manual,
         started=started,
         tags=crawlconfig.tags,
+        name=crawlconfig.name,
     )
 
     try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -71,16 +71,12 @@ class CrawlOps(BaseCrawlOps):
         await self.crawls.create_index(
             [("type", pymongo.HASHED), ("fileSize", pymongo.DESCENDING)]
         )
-        await self.crawls.create_index(
-            [("type", pymongo.HASHED), ("fileCount", pymongo.DESCENDING)]
-        )
 
         await self.crawls.create_index([("finished", pymongo.DESCENDING)])
         await self.crawls.create_index([("oid", pymongo.HASHED)])
         await self.crawls.create_index([("cid", pymongo.HASHED)])
         await self.crawls.create_index([("state", pymongo.HASHED)])
         await self.crawls.create_index([("fileSize", pymongo.DESCENDING)])
-        await self.crawls.create_index([("fileCount", pymongo.DESCENDING)])
 
     async def list_crawls(
         self,
@@ -166,7 +162,6 @@ class CrawlOps(BaseCrawlOps):
                 "finished",
                 "fileSize",
                 "firstSeed",
-                "fileCount",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -131,14 +131,6 @@ class CrawlOps(BaseCrawlOps):
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
             {"$unset": ["firstSeedObject", "errors"]},
-            {
-                "$lookup": {
-                    "from": "crawl_configs",
-                    "localField": "cid",
-                    "foreignField": "_id",
-                    "as": "crawlConfig",
-                },
-            },
         ]
 
         if not resources:

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -15,7 +15,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0012"
+CURR_DB_VERSION = "0013"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0013_crawl_name.py
+++ b/backend/btrixcloud/migrations/migration_0013_crawl_name.py
@@ -1,0 +1,42 @@
+"""
+Migration 0013 - Copy config name to crawls
+"""
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0013"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Copy crawl config names to associated crawls.
+        """
+        # pylint: disable=duplicate-code
+        crawls = self.mdb["crawls"]
+        crawl_configs = self.mdb["crawl_configs"]
+
+        configs = [res async for res in crawl_configs.find({"inactive": {"$ne": True}})]
+        if not configs:
+            return
+
+        for config in configs:
+            config_id = config["_id"]
+            try:
+                if not config.get("name"):
+                    continue
+                await crawls.update_many(
+                    {"cid": config_id}, {"$set": {"name": config.get("name")}}
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to set name for crawls from with config {config_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -368,6 +368,8 @@ class CrawlOutWithResources(CrawlOut):
 class UpdateCrawl(BaseModel):
     """Update crawl"""
 
+    name: Optional[str]
+    description: Optional[str]
     tags: Optional[List[str]] = []
     description: Optional[str]
 
@@ -440,8 +442,6 @@ class UploadedCrawl(BaseCrawl):
 # ============================================================================
 class UpdateUpload(UpdateCrawl):
     """Update modal that also includes name"""
-
-    name: Optional[str]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -296,6 +296,8 @@ class BaseCrawl(BaseMongoModel):
     started: datetime
     finished: Optional[datetime]
 
+    name: Optional[str]
+
     state: str
 
     stats: Optional[Dict[str, int]]
@@ -370,7 +372,7 @@ class UpdateCrawl(BaseModel):
 
     name: Optional[str]
     description: Optional[str]
-    tags: Optional[List[str]] = []
+    tags: Optional[List[str]]
     description: Optional[str]
 
 
@@ -435,7 +437,6 @@ class UploadedCrawl(BaseCrawl):
 
     type: str = Field("upload", const=True)
 
-    name: str
     tags: Optional[List[str]] = []
 
 

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -310,10 +310,10 @@ def init_uploads_api(app, mdb, users, crawl_manager, crawl_configs, orgs, user_d
         states = state.split(",") if state else None
 
         if name:
-            name = urllib.parse.unquote(name)
+            name = unquote(name)
 
         if description:
-            description = urllib.parse.unquote(description)
+            description = unquote(description)
 
         uploads, total = await ops.list_all_base_crawls(
             org,

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -299,6 +299,7 @@ def init_uploads_api(app, mdb, users, crawl_manager, crawl_configs, orgs, user_d
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
+        state: Optional[str] = None,
         userid: Optional[UUID4] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
@@ -306,9 +307,18 @@ def init_uploads_api(app, mdb, users, crawl_manager, crawl_configs, orgs, user_d
         sortBy: Optional[str] = "finished",
         sortDirection: Optional[int] = -1,
     ):
+        states = state.split(",") if state else None
+
+        if name:
+            name = urllib.parse.unquote(name)
+
+        if description:
+            description = urllib.parse.unquote(description)
+
         uploads, total = await ops.list_all_base_crawls(
             org,
             userid=userid,
+            states=states,
             name=name,
             description=description,
             page_size=pageSize,

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -119,6 +119,12 @@ def admin_config_id(admin_crawl_id):
 
 
 @pytest.fixture(scope="session")
+def admin_userid(admin_auth_headers):
+    r = requests.get(f"{API_PREFIX}/users/me", headers=crawler_auth_headers)
+    return r.json()["id"]
+
+
+@pytest.fixture(scope="session")
 def viewer_auth_headers(admin_auth_headers, default_org_id):
     requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/add-user",

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -18,6 +18,7 @@ CRAWLER_PW = "crawlerPASSWORD!"
 _admin_config_id = None
 _crawler_config_id = None
 _auto_add_config_id = None
+_all_crawls_config_id = None
 
 NON_DEFAULT_ORG_NAME = "Non-default org"
 
@@ -120,7 +121,7 @@ def admin_config_id(admin_crawl_id):
 
 @pytest.fixture(scope="session")
 def admin_userid(admin_auth_headers):
-    r = requests.get(f"{API_PREFIX}/users/me", headers=crawler_auth_headers)
+    r = requests.get(f"{API_PREFIX}/users/me", headers=admin_auth_headers)
     return r.json()["id"]
 
 
@@ -335,6 +336,54 @@ def auto_add_crawl_id(crawler_auth_headers, default_org_id, auto_add_collection_
 @pytest.fixture(scope="session")
 def auto_add_config_id(auto_add_crawl_id):
     return _auto_add_config_id
+
+
+@pytest.fixture(scope="session")
+def all_crawls_crawl_id(crawler_auth_headers, default_org_id):
+    # Start crawl.
+    crawl_data = {
+        "runNow": True,
+        "name": "All Crawls Test Crawl",
+        "description": "Lorem ipsum",
+        "config": {
+            "seeds": [{"url": "https://webrecorder.net/"}],
+        },
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
+        headers=crawler_auth_headers,
+        json=crawl_data,
+    )
+    data = r.json()
+
+    global _all_crawls_config_id
+    _all_crawls_config_id = data["id"]
+
+    crawl_id = data["run_now_job"]
+    # Wait for it to complete and then return crawl ID
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data["state"] == "complete":
+            break
+        time.sleep(5)
+
+    # Add description to crawl
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}",
+        headers=crawler_auth_headers,
+        json={"description": "Lorem ipsum"},
+    )
+    assert r.status_code == 200
+    return crawl_id
+
+
+@pytest.fixture(scope="session")
+def all_crawls_config_id(all_crawls_crawl_id):
+    return _all_crawls_config_id
 
 
 @pytest.fixture(scope="session")

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -191,10 +191,11 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     # Submit patch request to update tags and description
     UPDATED_TAGS = ["wr-test-1-updated", "wr-test-2-updated"]
     UPDATED_DESC = "Lorem ipsum test note."
+    UPDATED_NAME = "Updated crawl name"
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
         headers=admin_auth_headers,
-        json={"tags": UPDATED_TAGS, "description": UPDATED_DESC},
+        json={"tags": UPDATED_TAGS, "description": UPDATED_DESC, "name": UPDATED_NAME},
     )
     assert r.status_code == 200
     data = r.json()
@@ -209,6 +210,7 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     data = r.json()
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
     assert data["description"] == UPDATED_DESC
+    assert data["name"] == UPDATED_NAME
 
     # Verify deleting works as well
     r = requests.patch(

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -163,7 +163,12 @@ def test_stop_crawl_partial(
     )
     assert r.json()["lastCrawlStopping"] == True
 
-    while data["state"] == "running":
+    while data["state"] in (
+        "running",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
         time.sleep(5)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -48,7 +48,14 @@ def test_cancel_crawl(default_org_id, crawler_auth_headers):
 
     data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
-    while data["state"] in ("running", "waiting_capacity"):
+    while data["state"] in (
+        "starting",
+        "running",
+        "waiting_capacity",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
         time.sleep(5)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 
@@ -88,7 +95,14 @@ def test_start_crawl_and_stop_immediately(
     )
     assert r.json()["lastCrawlStopping"] == True
 
-    while data["state"] in ("starting", "running", "waiting_capacity"):
+    while data["state"] in (
+        "starting",
+        "running",
+        "waiting_capacity",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
         time.sleep(5)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
 

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -602,34 +602,6 @@ def test_sort_all_crawls(admin_auth_headers, default_org_id, admin_crawl_id):
             assert crawl["fileSize"] >= last_size
         last_size = crawl["fileSize"]
 
-    # Sort by fileCount
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=fileCount",
-        headers=admin_auth_headers,
-    )
-    data = r.json()
-    items = data["items"]
-
-    last_count = None
-    for crawl in items:
-        if last_count:
-            assert crawl["fileCount"] <= last_count
-        last_count = crawl["fileCount"]
-
-    # Sort by fileCount, ascending
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=fileCount&sortDirection=1",
-        headers=admin_auth_headers,
-    )
-    data = r.json()
-    items = data["items"]
-
-    last_count = None
-    for crawl in items:
-        if last_count:
-            assert crawl["fileCount"] >= last_count
-        last_count = crawl["fileCount"]
-
     # Invalid sort value
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=invalid",

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -647,7 +647,7 @@ def test_sort_all_crawls(admin_auth_headers, default_org_id, admin_crawl_id):
     assert r.json()["detail"] == "invalid_sort_direction"
 
 
-def test_all_crawls_search_values(admin_auth_headers, default_org_id, crawler_crawl_id):
+def test_all_crawls_search_values(admin_auth_headers, default_org_id):
     """Test that all-crawls search values return expected results"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values",
@@ -667,10 +667,7 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id, crawler_cr
 
     assert sorted(data["descriptions"]) == ["Lorem ipsum"]
     assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
-
     assert len(data["crawlIds"]) == 7
-    for id_ in (crawler_crawl_id, upload_id_2):
-        assert id_ in data["crawlIds"]
 
 
 def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id):

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -31,8 +31,11 @@ def test_run_two_only_one_concurrent(org_with_quotas, admin_auth_headers):
     ):
         time.sleep(2)
 
-    assert (
-        get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) == "running"
+    assert get_crawl_status(org_with_quotas, crawl_id_a, admin_auth_headers) in (
+        "running",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
     )
 
     while (
@@ -68,6 +71,10 @@ def test_cancel_and_run_other(org_with_quotas, admin_auth_headers):
     assert get_crawl_status(org_with_quotas, crawl_id_b, admin_auth_headers) in (
         "starting",
         "running",
+        "waiting_capacity",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
     )
 
     # cancel second crawl as well


### PR DESCRIPTION
Backend changes for #1025 
Fixes #1031 

This PR makes the following changes (we may want to copy this into the squash commit when merging):

- `all-crawls` list endpoint filters now conform to #1025 and URL decode values before passing them in
- `uploads` list endpoint now includes all `all-crawls` filters relevant to uploads
- An `all-crawls/search-values` endpoint is added to support searching across all archived item types
- Crawl configuration names are now copied to the crawl when the crawl is created, and crawl names and descriptions are now editable via the backend API (**note: this will require frontend changes as well to make them editable via the UI**)
- Migration added to copy existing config names for active configs into their associated crawls. This migration has been tested in a local deployment
- New statuses `generate-wacz`, `uploading-wacz`, and `pending-wait` are added when relevant to tests to ensure that they pass
- Tests coverage added for all new `all-crawls` endpoints, filters, and sort values