### PR TITLE
Add and enforce org maxPagesPerCrawl quota

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -119,6 +119,11 @@ class CrawlConfigOps:
         data["created"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
         data["modified"] = data["created"]
 
+        # Ensure page limit is below org maxPagesPerCall if set
+        max_pages = await self.org_ops.get_max_pages_per_crawl(org)
+        if max_pages > 0:
+            data["config"]["limit"] = max_pages
+
         data["profileid"], profile_filename = await self._lookup_profile(
             config.profileid, org
         )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -607,6 +607,7 @@ class OrgQuotas(BaseModel):
     """Organization quotas (settable by superadmin)"""
 
     maxConcurrentCrawls: Optional[int] = 0
+    maxPagesPerCrawl: Optional[int] = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -239,6 +239,10 @@ class OrgOps:
                 org_owners.append(key)
         return org_owners
 
+    async def get_max_pages_per_crawl(self, org: Organization):
+        """Return org-specific max pages per crawl setting or 0."""
+        return await get_max_pages_per_crawl(self.orgs, org.id)
+
 
 # ============================================================================
 async def inc_org_stats(orgs, oid, duration):
@@ -255,6 +259,16 @@ async def get_max_concurrent_crawls(orgs, oid):
     if org:
         org = Organization.from_dict(org)
         return org.quotas.maxConcurrentCrawls
+    return 0
+
+
+# ============================================================================
+async def get_max_pages_per_crawl(orgs, oid):
+    """return max allowed concurrent crawls, if any"""
+    org = await orgs.find_one({"_id": oid})
+    if org:
+        org = Organization.from_dict(org)
+        return org.quotas.maxPagesPerCrawl
     return 0
 
 

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -50,9 +50,13 @@ export class OrgsList extends LiteElement {
         @sl-request-close=${() => (this.currOrg = null)}
       >
         ${Object.entries(this.currOrg.quotas).map(([key, value]) => {
+          const label =
+            key === "maxConcurrentCrawls"
+              ? "Max Concurrent Crawls"
+              : "Max Pages Per Crawl";
           return html` <sl-input
             name=${key}
-            label=${msg("Max Concurrent Crawls")}
+            label=${msg(label)}
             value=${value}
             type="number"
             @sl-input="${this.onUpdateQuota}"

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -54,9 +54,10 @@ export class OrgsList extends LiteElement {
             key === "maxConcurrentCrawls"
               ? "Max Concurrent Crawls"
               : "Max Pages Per Crawl";
+          const localizedLabel = msg(str`${label}`);
           return html` <sl-input
             name=${key}
-            label=${msg(label)}
+            label=${localizedLabel}
             value=${value}
             type="number"
             @sl-input="${this.onUpdateQuota}"

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -52,12 +52,11 @@ export class OrgsList extends LiteElement {
         ${Object.entries(this.currOrg.quotas).map(([key, value]) => {
           const label =
             key === "maxConcurrentCrawls"
-              ? "Max Concurrent Crawls"
-              : "Max Pages Per Crawl";
-          const localizedLabel = msg(str`${label}`);
+              ? msg("Max Concurrent Crawls")
+              : msg("Max Pages Per Crawl");
           return html` <sl-input
             name=${key}
-            label=${localizedLabel}
+            label=${label}
             value=${value}
             type="number"
             @sl-input="${this.onUpdateQuota}"


### PR DESCRIPTION
Fixes #1040 

- Add `maxPagesPerCrawl` org quota to backend and enforce in new crawlconfigs
- Add `maxPagesPerCrawl` to frontend org quotas
- Enforce `maxPagesPerCrawl` org quota in frontend workflow editor

Screenshot of frontend org quotas:

<img width="513" alt="Screen Shot 2023-08-03 at 1 14 30 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/b3e5b7f0-9442-49e4-a925-44a7d40ac21a">

