### PR TITLE
Standardize archived item filtering, sorting and labels

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -466,7 +466,6 @@ class BaseCrawlOps:
 
         names = await self.crawls.distinct("name", match_query)
         descriptions = await self.crawls.distinct("description", match_query)
-        crawl_ids = await self.crawls.distinct("_id", match_query)
         cids = (
             await self.crawls.distinct("cid", match_query)
             if not type_ or type_ == "crawl"
@@ -489,7 +488,6 @@ class BaseCrawlOps:
             "names": names,
             "descriptions": descriptions,
             "firstSeeds": list(first_seeds),
-            "crawlIds": list(crawl_ids),
         }
 
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -467,7 +467,7 @@ class BaseCrawlOps:
         names = await self.crawls.distinct("name", match_query)
         descriptions = await self.crawls.distinct("description", match_query)
         crawl_ids = await self.crawls.distinct("_id", match_query)
-        cids = await self.crawls.distinct("cid", match_query)
+        cids = await self.crawls.distinct("cid", match_query) if not type_ or type_ == "crawl" else []
 
         # Remove empty strings
         names = [name for name in names if name]

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -467,7 +467,11 @@ class BaseCrawlOps:
         names = await self.crawls.distinct("name", match_query)
         descriptions = await self.crawls.distinct("description", match_query)
         crawl_ids = await self.crawls.distinct("_id", match_query)
-        cids = await self.crawls.distinct("cid", match_query) if not type_ or type_ == "crawl" else []
+        cids = (
+            await self.crawls.distinct("cid", match_query)
+            if not type_ or type_ == "crawl"
+            else []
+        )
 
         # Remove empty strings
         names = [name for name in names if name]

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -474,14 +474,12 @@ class BaseCrawlOps:
         descriptions = [description for description in descriptions if description]
 
         first_seeds = set()
-
-        if type_ == "crawl":
-            for cid in cids:
-                if not cid:
-                    continue
-                config = await self.crawl_configs.get_crawl_config(cid, org)
-                first_seed = config.config.seeds[0]
-                first_seeds.add(first_seed.url)
+        for cid in cids:
+            if not cid:
+                continue
+            config = await self.crawl_configs.get_crawl_config(cid, org)
+            first_seed = config.config.seeds[0]
+            first_seeds.add(first_seed.url)
 
         return {
             "names": names,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -624,7 +624,6 @@ class CrawlConfigOps:
         names = await self.crawl_configs.distinct("name", {"oid": org.id})
         descriptions = await self.crawl_configs.distinct("description", {"oid": org.id})
         workflow_ids = await self.crawl_configs.distinct("_id", {"oid": org.id})
-        crawl_ids = await self.crawl_ops.crawls.distinct("_id", {"oid": org.id})
 
         # Remove empty strings
         names = [name for name in names if name]
@@ -641,7 +640,6 @@ class CrawlConfigOps:
             "descriptions": descriptions,
             "firstSeeds": list(first_seeds),
             "workflowIds": workflow_ids,
-            "crawlIds": crawl_ids,
         }
 
     async def run_now(self, cid: str, org: Organization, user: User):

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -684,7 +684,7 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
 
     # Test invalid filter
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values?crawlType=upload",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values?crawlType=invalid",
         headers=admin_auth_headers,
     )
     assert r.status_code == 400

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -625,6 +625,7 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values",
         headers=admin_auth_headers,
     )
+    assert r.status_code == 200
     data = r.json()
 
     assert len(data["names"]) == 5
@@ -640,6 +641,54 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
     assert sorted(data["descriptions"]) == ["Lorem ipsum"]
     assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
     assert len(data["crawlIds"]) == 7
+
+    # Test filtering by crawls
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values?crawlType=crawl",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert len(data["names"]) == 2
+    expected_names = [
+        "Crawler User Test Crawl",
+        "All Crawls Test Crawl",
+    ]
+    for expected_name in expected_names:
+        assert expected_name in data["names"]
+
+    assert sorted(data["descriptions"]) == ["Lorem ipsum"]
+    assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
+    assert len(data["crawlIds"]) == 4
+
+    # Test filtering by uploads
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values?crawlType=upload",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert len(data["names"]) == 3
+    expected_names = [
+        "My Upload Updated",
+        "test2.wacz",
+    ]
+    for expected_name in expected_names:
+        assert expected_name in data["names"]
+
+    assert sorted(data["descriptions"]) == []
+    assert sorted(data["firstSeeds"]) == []
+    assert len(data["crawlIds"]) == 3
+
+    # Test invalid filter
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values?crawlType=upload",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "invalid_crawl_type"
 
 
 def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id):

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -640,7 +640,6 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
 
     assert sorted(data["descriptions"]) == ["Lorem ipsum"]
     assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
-    assert len(data["crawlIds"]) == 7
 
     # Test filtering by crawls
     r = requests.get(
@@ -660,7 +659,6 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
 
     assert sorted(data["descriptions"]) == ["Lorem ipsum"]
     assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
-    assert len(data["crawlIds"]) == 4
 
     # Test filtering by uploads
     r = requests.get(
@@ -680,7 +678,6 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
 
     assert sorted(data["descriptions"]) == []
     assert sorted(data["firstSeeds"]) == []
-    assert len(data["crawlIds"]) == 3
 
     # Test invalid filter
     r = requests.get(

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -344,36 +344,33 @@ export class CrawlListItem extends LitElement {
         </div>
       </div>
       <div class="col action">
-        <slot name="menuTrigger">
-          <btrix-button
-            class="dropdownTrigger"
-            label=${msg("Actions")}
-            icon
-            @click=${(e: MouseEvent) => {
-              // Prevent anchor link default behavior
-              e.preventDefault();
-              // Stop prop to anchor link
-              e.stopPropagation();
-              this.dropdownIsOpen = !this.dropdownIsOpen;
-            }}
-            @focusout=${(e: FocusEvent) => {
-              const relatedTarget = e.relatedTarget as HTMLElement;
-              if (relatedTarget) {
-                if (this.menuArr[0]?.contains(relatedTarget)) {
-                  // Keep dropdown open if moving to menu selection
-                  return;
-                }
-                if (this.row?.isEqualNode(relatedTarget)) {
-                  // Handle with click event
-                  return;
-                }
+        <sl-icon-button
+          class="dropdownTrigger"
+          label=${msg("Actions")}
+          name="three-dots-vertical"
+          @click=${(e: MouseEvent) => {
+            // Prevent anchor link default behavior
+            e.preventDefault();
+            // Stop prop to anchor link
+            e.stopPropagation();
+            this.dropdownIsOpen = !this.dropdownIsOpen;
+          }}
+          @focusout=${(e: FocusEvent) => {
+            const relatedTarget = e.relatedTarget as HTMLElement;
+            if (relatedTarget) {
+              if (this.menuArr[0]?.contains(relatedTarget)) {
+                // Keep dropdown open if moving to menu selection
+                return;
               }
-              this.dropdownIsOpen = false;
-            }}
-          >
-            <sl-icon name="three-dots-vertical"></sl-icon>
-          </btrix-button>
-        </slot>
+              if (this.row?.isEqualNode(relatedTarget)) {
+                // Handle with click event
+                return;
+              }
+            }
+            this.dropdownIsOpen = false;
+          }}
+        >
+        </sl-icon-button>
       </div>
     </a>`;
   }

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -500,7 +500,7 @@ export class CrawlsList extends LiteElement {
     if (!this.hasSearchStr) {
       return html`
         <sl-menu-item slot="menu-item" disabled
-          >${msg("Start typing to view crawl filters.")}</sl-menu-item
+          >${msg("Start typing to view filters.")}</sl-menu-item
         >
       `;
     }

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -634,9 +634,7 @@ export class CrawlsList extends LiteElement {
             @click=${() => this.deleteItem(item)}
           >
             <sl-icon name="trash3" slot="prefix"></sl-icon>
-            ${item.type === "upload"
-              ? msg("Delete Upload")
-              : msg("Delete Crawl")}
+            ${msg("Delete Item")}
           </sl-menu-item>
         `
       )}
@@ -816,13 +814,8 @@ export class CrawlsList extends LiteElement {
   }
 
   private async deleteItem(item: Crawl) {
-    // TODO check if this makes translating entire string difficult:
-    const typeName = item.type === "upload" ? msg("upload") : msg("crawl");
-
     if (
-      !window.confirm(
-        msg(str`Are you sure you want to delete ${typeName} of ${item.name}?`)
-      )
+      !window.confirm(msg(str`Are you sure you want to delete ${item.name}?`))
     ) {
       return;
     }
@@ -859,7 +852,7 @@ export class CrawlsList extends LiteElement {
         items: items.filter((c) => c.id !== item.id),
       };
       this.notify({
-        message: msg(str`Successfully deleted ${typeName}`),
+        message: msg(str`Successfully deleted archived item.`),
         variant: "success",
         icon: "check2-circle",
       });
@@ -868,7 +861,7 @@ export class CrawlsList extends LiteElement {
       this.notify({
         message:
           (e.isApiError && e.message) ||
-          msg(str`Sorry, couldn't run ${typeName} at this time.`),
+          msg(str`Sorry, couldn't delete archived item at this time.`),
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -509,7 +509,7 @@ export class CrawlsList extends LiteElement {
     if (!searchResults.length) {
       return html`
         <sl-menu-item slot="menu-item" disabled
-          >${msg("No matching crawls found.")}</sl-menu-item
+          >${msg("No matching items found.")}</sl-menu-item
         >
       `;
     }
@@ -654,7 +654,7 @@ export class CrawlsList extends LiteElement {
         <div class="border rounded-lg bg-neutral-50 p-4">
           <p class="text-center">
             <span class="text-neutral-400"
-              >${msg("No matching crawls found.")}</span
+              >${msg("No matching items found.")}</span
             >
             <button
               class="text-neutral-500 font-medium underline hover:no-underline"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -463,7 +463,9 @@ export class CrawlsList extends LiteElement {
       >
         <sl-input
           size="small"
-          placeholder=${msg("Search by name")}
+          placeholder=${this.artifactType === "upload"
+            ? msg("Search by name")
+            : msg("Search by name or Crawl Start URL")}
           clearable
           value=${this.searchByValue}
           @sl-clear=${() => {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -245,7 +245,7 @@ export class CrawlsList extends LiteElement {
             <h1
               class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
             >
-              ${msg("All Archived Data")}
+              ${msg("All Archived Items")}
             </h1>
             ${when(
               this.isCrawler,

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -722,7 +722,7 @@ export class CrawlsList extends LiteElement {
 
     this.cancelInProgressGetCrawls();
     try {
-      this.crawls = await this.getArchivedItems(this.artifactType, params);
+      this.crawls = await this.getArchivedItems(params);
     } catch (e: any) {
       if (e === ABORT_REASON_THROTTLE) {
         console.debug("Fetch archived items aborted to throttle");
@@ -744,7 +744,6 @@ export class CrawlsList extends LiteElement {
   }
 
   private async getArchivedItems(
-    artifactType: Crawl["type"],
     queryParams?: APIPaginationQuery & { state?: CrawlState[] }
   ): Promise<Crawls> {
     const query = queryString.stringify(
@@ -759,7 +758,7 @@ export class CrawlsList extends LiteElement {
         userid: this.filterByCurrentUser ? this.userId : undefined,
         sortBy: this.orderBy.field,
         sortDirection: this.orderBy.direction === "desc" ? -1 : 1,
-        crawlType: artifactType,
+        crawlType: this.artifactType,
       },
       {
         arrayFormat: "comma",
@@ -818,13 +817,16 @@ export class CrawlsList extends LiteElement {
       .split("/orgs/")[1]
       .split("/")[0];
     try {
+      const query = queryString.stringify({
+        crawlType: this.artifactType,
+      });
       const data: {
         crawlIds: string[];
         names: string[];
         descriptions: string[];
         firstSeeds: string[];
       } = await this.apiFetch(
-        `/orgs/${oid}/all-crawls/search-values`,
+        `/orgs/${oid}/all-crawls/search-values?${query}`,
         this.authState!
       );
 

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -255,7 +255,7 @@ export class CrawlsList extends LiteElement {
                   @click=${() => (this.isUploadingArchive = true)}
                 >
                   <sl-icon slot="prefix" name="upload"></sl-icon>
-                  ${msg("Upload Archive")}
+                  ${msg("Upload WACZ")}
                 </sl-button>
               `
             )}

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -23,7 +23,7 @@ import { isActive, activeCrawlStates } from "../../utils/crawler";
 type Crawls = APIPaginatedList & {
   items: Crawl[];
 };
-type SearchFields = "name" | "firstSeed" | "cid";
+type SearchFields = "name" | "firstSeed";
 type SearchResult = {
   item: {
     key: SearchFields;
@@ -76,7 +76,6 @@ export class CrawlsList extends LiteElement {
   static FieldLabels: Record<SearchFields, string> = {
     name: msg("Name"),
     firstSeed: msg("Crawl Start URL"),
-    cid: msg("Workflow ID"),
   };
 
   @property({ type: Object })
@@ -486,13 +485,13 @@ export class CrawlsList extends LiteElement {
       >
         <sl-input
           size="small"
-          placeholder=${msg("Filter by Name, Crawl Start URL, or Workflow ID")}
+          placeholder=${msg("Filter by Name or Crawl Start URL")}
           clearable
           value=${this.searchByValue}
           @sl-clear=${() => {
             this.searchResultsOpen = false;
             this.onSearchInput.cancel();
-            const { name, firstSeed, cid, ...otherFilters } = this.filterBy;
+            const { name, firstSeed, ...otherFilters } = this.filterBy;
             this.filterBy = otherFilters;
           }}
           @sl-input=${this.onSearchInput}
@@ -884,8 +883,13 @@ export class CrawlsList extends LiteElement {
       .split("/orgs/")[1]
       .split("/")[0];
     try {
-      const { names, firstSeeds, workflowIds } = await this.apiFetch(
-        `/orgs/${oid}/crawlconfigs/search-values`,
+      const data: {
+        crawlIds: string[];
+        names: string[];
+        descriptions: string[];
+        firstSeeds: string[];
+      } = await this.apiFetch(
+        `/orgs/${oid}/all-crawls/search-values`,
         this.authState!
       );
 
@@ -897,9 +901,8 @@ export class CrawlsList extends LiteElement {
           value,
         });
       this.fuse.setCollection([
-        ...names.map(toSearchItem("name")),
-        ...firstSeeds.map(toSearchItem("firstSeed")),
-        ...workflowIds.map(toSearchItem("cid")),
+        ...data.names.map(toSearchItem("name")),
+        ...data.firstSeeds.map(toSearchItem("firstSeed")),
       ] as any);
     } catch (e) {
       console.debug(e);

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -876,29 +876,6 @@ export class CrawlsList extends LiteElement {
 
     return data;
   }
-
-  /**
-   * Create a new template using existing template data
-   */
-  private async duplicateConfig(crawl: Crawl, workflow: Workflow) {
-    const workflowParams: WorkflowParams = {
-      ...workflow,
-      name: msg(str`${workflow.name} Copy`),
-    };
-
-    this.navTo(
-      `/orgs/${crawl.oid}/workflows?new&jobType=${workflowParams.jobType}`,
-      {
-        workflow: workflowParams,
-      }
-    );
-
-    this.notify({
-      message: msg(str`Copied Workflow to new template.`),
-      variant: "success",
-      icon: "check2-circle",
-    });
-  }
 }
 
 customElements.define("btrix-crawls-list", CrawlsList);

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -179,7 +179,7 @@ export class Org extends LiteElement {
           })}
           ${this.renderNavTab({
             tabName: "artifacts",
-            label: msg("All Archived Data"),
+            label: msg("All Archived Items"),
             path: "artifacts/crawls",
           })}
           ${this.renderNavTab({

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1662,7 +1662,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       )}
       ${this.renderHelpTextCol(
         msg(`Create or assign this crawl (and its outputs) to one or more tags
-        to help organize your archived data.`)
+        to help organize your archived items.`)
       )}
       ${this.renderFormCol(
         html`


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1025

<!-- Fixes #issue_number -->

### Changes

- Renames list view to "All Archived Items"
- Refactors fetches to use single `all-crawls` endpoints
- Removes search by config ID for more search parity with uploads
- Adds sort by size
- Refactors property and method names to replace `crawl*`
- Replaces remaining references to "crawl" in copy with "item"'

The view/status filter needs some re-thinking, since uploads cannot be partially complete or timed out. Maybe the "All"/"Crawls"/"Uploads" can be moved into the filter control area, and choosing one of the types reveals more filters in a more predictable way.

### Manual testing

1. Log in and click "All Archived Items"
2. Sort by Size. Verify both crawls and uploads are sorted
3. Type some text into search bar. Verify both crawls and uploads are shown in results
4. Click a search result. Verify list is filtered as expected
5. Repeat 2-4 for Crawls and Uploads to test against regressions

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| All Archived Items | <img width="1138" alt="Screen Shot 2023-08-09 at 2 02 49 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/de160047-c9f2-4234-8da9-2279890f7e9c"> |


<!-- ### Follow-ups -->

