### PR TITLE
backend: crawlout: include raw crawnconfig in api details, fixes #1030

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -349,6 +349,7 @@ class CrawlOut(BaseMongoModel):
     collections: Optional[List[UUID4]] = []
 
     # automated crawl fields
+    config: Optional[RawCrawlConfig]
     cid: Optional[UUID4]
     name: Optional[str]
     firstSeed: Optional[str]


### PR DESCRIPTION
The raw crawlconfig was previously missing, resulting in it not being include din the API returns. Fixes #1030