### PR TITLE
Optimize Release Build on CI

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build Frontend
         uses: docker/build-push-action@v3
+        env:
+          HUSKY: 0
         with:
           context: frontend
           push: true

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -27,6 +27,8 @@ jobs:
             ${{ runner.os }}-btrix-frontend-build-
       - name: Install dependencies
         working-directory: frontend
+        env:
+          HUSKY: 0
         run: yarn install --frozen-lockfile
       - name: Unit tests
         working-directory: frontend

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,9 +66,6 @@ jobs:
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
 
-      - name: List Arch
-        run: docker inspect docker.io/webrecorder/frontend-yarn-build:latest | grep 'Architecture'
-
       -
         name: Build Frontend
         uses: docker/build-push-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
           cache-to: type=gha,scope=backend,mode=max
 
       -
-        name: Build Frontend Yarn Build
+        name: Build Frontend
         uses: docker/build-push-action@v4
         env:
           HUSKY: 0
@@ -56,7 +56,6 @@ jobs:
           context: frontend
           platforms: linux/amd64
           load: true
-          target: build_deps
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
@@ -65,24 +64,3 @@ jobs:
           tags: docker.io/webrecorder/frontend-yarn-build:latest
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
-
-      - name: Manual Build
-        run: docker build --platform linux/amd64,linux/arm64 --build-arg YARN_BUILD_DEPS=docker.io/webrecorder/frontend-yarn-build:latest -t webrecorder/browsertrix-frontend frontend
-
-      -
-        name: Build Frontend
-        uses: docker/build-push-action@v4
-        with:
-          context: frontend
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
-            GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
-            YARN_BUILD_DEPS=docker.io/webrecorder/frontend-yarn-build:latest
-
-          tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-frontend:${{ env.VERSION }}, webrecorder/browsertrix-frontend:latest
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: backend
           platforms: linux/amd64,linux/arm64
-          #push: true
+          push: true
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-backend:${{ env.VERSION }}, webrecorder/browsertrix-backend:latest
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
@@ -55,7 +55,7 @@ jobs:
         with:
           context: frontend
           platforms: linux/amd64
-          load: true
+          push: true
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,6 @@ jobs:
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
 
-          tags: docker.io/webrecorder/frontend-yarn-build:latest
+          tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-frontend:${{ env.VERSION }}, webrecorder/browsertrix-frontend:latest
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           HUSKY: 0
         with:
           context: frontend
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ env.VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,12 +29,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Free Disk space
-        shell: bash
-        run: |
-          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-
       -
         name: Set Env Vars
         run: |
@@ -44,7 +38,7 @@ jobs:
 
       -
         name: Build Backend
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: backend
           platforms: linux/amd64,linux/arm64
@@ -55,7 +49,7 @@ jobs:
 
       -
         name: Build Frontend Yarn Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         env:
           HUSKY: 0
         with:
@@ -71,6 +65,13 @@ jobs:
           tags: webrecorder/browsertrix-frontend-yarn-build:latest
           cache-from: type=gha,scope=frontend-yarn
           cache-to: type=gha,scope=frontend-yarn,mode=max
+
+      - name: List Images
+        run: docker images
+
+      - name: List Disk Space
+        run: df -h
+ 
       -
         name: Build Frontend
         uses: docker/build-push-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Browsertrix Cloud Release Build
 on:
   release:
     types: [published]
-  workflow_dispatch:
-
+  push:
+ 
 jobs:
   btrix-release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,15 +63,12 @@ jobs:
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
 
           tags: docker.io/webrecorder/frontend-yarn-build:latest
-          cache-from: type=gha,scope=frontend-yarn
-          cache-to: type=gha,scope=frontend-yarn,mode=max
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
 
-      - name: List Images
-        run: docker images
+      - name: List Arch
+        run: docker inspect docker.io/webrecorder/frontend-yarn-build:latest | grep 'Architecture'
 
-      - name: List Disk Space
-        run: df -h
- 
       -
         name: Build Frontend
         uses: docker/build-push-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: Browsertrix Cloud Release Build
 on:
   release:
     types: [published]
-  push:
  
 jobs:
   btrix-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: backend
           platforms: linux/amd64,linux/arm64
-          push: true
+          #push: true
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-backend:${{ env.VERSION }}, webrecorder/browsertrix-backend:latest
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
+        with:
+          driver: docker
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,8 @@ jobs:
       -
         name: Build Frontend Yarn Build
         uses: docker/build-push-action@v3
+        env:
+          HUSKY: 0
         with:
           context: frontend
           platforms: linux/amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
 
-          tags: webrecorder/browsertrix-frontend-yarn-build:latest
+          tags: docker.io/webrecorder/frontend-yarn-build:latest
           cache-from: type=gha,scope=frontend-yarn
           cache-to: type=gha,scope=frontend-yarn,mode=max
 
@@ -74,7 +74,7 @@ jobs:
  
       -
         name: Build Frontend
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: frontend
           platforms: linux/amd64,linux/arm64
@@ -83,7 +83,7 @@ jobs:
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
-            YARN_BUILD_DEPS=webrecorder/browsertrix-frontend-yarn-build:latest
+            YARN_BUILD_DEPS=docker.io/webrecorder/frontend-yarn-build:latest
 
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-frontend:${{ env.VERSION }}, webrecorder/browsertrix-frontend:latest
           cache-from: type=gha,scope=frontend

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,14 +21,19 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
+
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
 
       -
         name: Set Env Vars

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,9 @@ jobs:
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
 
+      - name: Manual Build
+        run: docker build --platform linux/amd64,linux/arm64 --build-arg YARN_BUILD_DEPS=docker.io/webrecorder/frontend-yarn-build:latest -t webrecorder/browsertrix-frontend frontend
+
       -
         name: Build Frontend
         uses: docker/build-push-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Browsertrix Cloud Release Build
 on:
   release:
     types: [published]
- 
+
 jobs:
   btrix-release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Browsertrix Cloud Release Build
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   btrix-release:
@@ -47,6 +48,22 @@ jobs:
           cache-to: type=gha,scope=backend,mode=max
 
       -
+        name: Build Frontend Yarn Build
+        uses: docker/build-push-action@v3
+        with:
+          context: frontend
+          platforms: linux/amd64
+          load: true
+          target: build_deps
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
+            GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
+
+          tags: webrecorder/browsertrix-frontend-yarn-build:latest
+          cache-from: type=gha,scope=frontend-yarn
+          cache-to: type=gha,scope=frontend-yarn,mode=max
+      -
         name: Build Frontend
         uses: docker/build-push-action@v3
         with:
@@ -57,6 +74,7 @@ jobs:
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
+            YARN_BUILD_DEPS=webrecorder/browsertrix-frontend-yarn-build:latest
 
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-frontend:${{ env.VERSION }}, webrecorder/browsertrix-frontend:latest
           cache-from: type=gha,scope=frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,8 +21,6 @@ COPY --link lit-localize.json \
 
 COPY --link src ./src/
 
-RUN yarn build
-
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all
 # subsequent RUN steps.
@@ -35,6 +33,10 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
     GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
     VERSION=${VERSION} \
     RWP_BASE_URL=${RWP_BASE_URL}
+
+# Prevent Docker image including node_modules to save space
+RUN yarn build && \
+  rm -rf ./node_modules
 
 FROM docker.io/library/nginx:1.23.2
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.4
 ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
+ARG YARN_BUILD_DEPS=build_deps
 
 FROM docker.io/library/node:16 as build_deps
 
@@ -9,8 +10,6 @@ COPY yarn.lock package.json ./
 # of including yarn cache in the build image
 RUN yarn --production --frozen-lockfile --network-timeout 1000000 && \
     yarn cache clean
-
-FROM build_deps as build
 
 COPY --link lit-localize.json \
     postcss.config.js \
@@ -22,6 +21,11 @@ COPY --link lit-localize.json \
     ./
 
 COPY --link src ./src/
+
+RUN yarn build
+
+ARG YARN_BUILD_DEPS
+FROM ${YARN_BUILD_DEPS} as build
 
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all
@@ -35,10 +39,6 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
     GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
     VERSION=${VERSION} \
     RWP_BASE_URL=${RWP_BASE_URL}
-
-# Prevent Docker caching node_modules
-RUN yarn build && \
-    rm -rf ./node_modules
 
 FROM docker.io/library/nginx:1.23.2
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,7 +25,7 @@ COPY --link src ./src/
 RUN yarn build
 
 ARG YARN_BUILD_DEPS
-FROM --platform=linux/amd64 ${YARN_BUILD_DEPS} as build
+FROM --platform=linux/amd64 "${YARN_BUILD_DEPS}" as build
 
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY yarn.lock package.json ./
 # Uses `yarn cache clean` to let Docker cache layer instead
 # of including yarn cache in the build image
-RUN yarn --production --frozen-lockfile --network-timeout 1000000 && \
+RUN yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000 && \
     yarn cache clean
 
 COPY --link lit-localize.json \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
-ARG YARN_BUILD_DEPS=build_deps
 
-FROM docker.io/library/node:16 as build_deps
+FROM --platform=$BUILDPLATFORM docker.io/library/node:16 as build_deps
 
 WORKDIR /app
 COPY yarn.lock package.json ./
@@ -24,9 +23,6 @@ COPY --link src ./src/
 
 RUN yarn build
 
-ARG YARN_BUILD_DEPS
-FROM --platform=linux/amd64 "${YARN_BUILD_DEPS}" as build
-
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all
 # subsequent RUN steps.
@@ -45,7 +41,7 @@ FROM docker.io/library/nginx:1.23.2
 ARG RWP_BASE_URL
 ENV RWP_BASE_URL=${RWP_BASE_URL}
 
-COPY --link --from=build /app/dist /usr/share/nginx/html
+COPY --link --from=build_deps /app/dist /usr/share/nginx/html
 
 #COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY --link ./frontend.conf.template /etc/nginx/templates/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,7 +25,7 @@ COPY --link src ./src/
 RUN yarn build
 
 ARG YARN_BUILD_DEPS
-FROM ${YARN_BUILD_DEPS} as build
+FROM --platform=linux/amd64 ${YARN_BUILD_DEPS} as build
 
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,20 +72,22 @@
     "localize:build": "lit-localize build"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4-fix.0",
     "@lit/localize-tools": "^0.6.9",
-    "@open-wc/testing": "^3.2.0",
-    "@playwright/test": "1.32.1",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/dev-server-rollup": "^0.3.21",
-    "@web/test-runner": "^0.13.22",
-    "@web/test-runner-playwright": "^0.8.8",
-    "chromium": "^3.0.3",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
     "sinon": "^12.0.1",
     "webpack-dev-server": "^4.3.0"
+  },
+  "optionalDependencies": {
+    "@esm-bundle/chai": "^4.3.4-fix.0",
+    "@open-wc/testing": "^3.2.0",
+    "@playwright/test": "1.32.1",
+    "@web/test-runner": "^0.13.22",
+    "@web/test-runner-playwright": "^0.8.8",
+    "chromium": "^3.0.3"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
Fix long build times for release by adding several optimizations:
- Always build yarn only on build platform with `--platform=$BUILDPLATFORM`
- Remove optional dependencies from build with --ignore-optional and move some devDependencies to be optional
- Disable husky precommit hook checks 