### PR TITLE
frontend build refactor

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build Frontend
         uses: docker/build-push-action@v3
+        env:
+          HUSKY: 0
         with:
           context: frontend
           push: true

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -38,12 +38,32 @@ jobs:
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
 
-      - name: Build Frontend
+      - name: Build Frontend dist
         uses: docker/build-push-action@v3
         env:
           HUSKY: 0
         with:
           context: frontend
+          file: frontend/builder.Dockerfile
+          load: true
+          platforms: linux/amd64
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
+            GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
+          tags: user/browsertrix-frontend-builder:test
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
+
+      - name: Copy Frontend dist
+        run: |
+          docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/dist && docker rm bc-frontend-builder-temp
+
+      - name: Build Frontend nginx
+        uses: docker/build-push-action@v3
+        with:
+          context: frontend
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ env.VERSION }}
@@ -51,8 +71,8 @@ jobs:
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
 
           tags: ${{ secrets.DO_REGISTRY_PATH }}/webrecorder/browsertrix-frontend:latest
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
+          # cache-from: type=gha,scope=frontend
+          # cache-to: type=gha,scope=frontend,mode=max
 
       - name: Get Kubeconfig
         env:

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -38,14 +38,12 @@ jobs:
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
 
-      -
-        name: Build Frontend Yarn Build
+      - name: Build Frontend Yarn Builder
         uses: docker/build-push-action@v3
         env:
           HUSKY: 0
         with:
           context: frontend
-          platforms: linux/amd64
           load: true
           file: frontend/builder.Dockerfile
           build-args: |
@@ -67,7 +65,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: frontend
-          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ env.VERSION }}

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -52,12 +52,12 @@ jobs:
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
           tags: user/browsertrix-frontend-builder:test
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
+          cache-from: type=gha,scope=frontend-builder
+          cache-to: type=gha,scope=frontend-builder,mode=max
 
       - name: Copy Frontend dist
         run: |
-          docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/dist && docker rm bc-frontend-builder-temp
+          docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/.dist && docker rm bc-frontend-builder-temp
 
       - name: Build Frontend nginx
         uses: docker/build-push-action@v3
@@ -71,8 +71,8 @@ jobs:
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
 
           tags: ${{ secrets.DO_REGISTRY_PATH }}/webrecorder/browsertrix-frontend:latest
-          # cache-from: type=gha,scope=frontend
-          # cache-to: type=gha,scope=frontend,mode=max
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
 
       - name: Get Kubeconfig
         env:

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -38,28 +38,32 @@ jobs:
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
 
-      - name: Build Frontend dist
+      -
+        name: Build Frontend Yarn Build
         uses: docker/build-push-action@v3
         env:
           HUSKY: 0
         with:
           context: frontend
-          file: frontend/builder.Dockerfile
-          load: true
           platforms: linux/amd64
+          load: true
+          file: frontend/builder.Dockerfile
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
+
           tags: user/browsertrix-frontend-builder:test
           cache-from: type=gha,scope=frontend-builder
           cache-to: type=gha,scope=frontend-builder,mode=max
 
-      - name: Copy Frontend dist
+      -
+        name: Copy Frontend dist
         run: |
           docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/.dist && docker rm bc-frontend-builder-temp
 
-      - name: Build Frontend nginx
+      -
+        name: Build Frontend
         uses: docker/build-push-action@v3
         with:
           context: frontend

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -27,6 +27,8 @@ jobs:
             ${{ runner.os }}-btrix-frontend-build-
       - name: Install dependencies
         working-directory: frontend
+        env:
+          HUSKY: 0
         run: yarn install --frozen-lockfile
       - name: Unit tests
         working-directory: frontend

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Browsertrix Cloud Release Build
 on:
   release:
     types: [published]
-  workflow_dispatch:
-
+  push:
+ 
 jobs:
   btrix-release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,15 +62,21 @@ jobs:
           context: frontend
           platforms: linux/amd64
           load: true
-          target: build_deps
+          file: frontend/builder.Dockerfile
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
 
-          tags: webrecorder/browsertrix-frontend-yarn-build:latest
-          cache-from: type=gha,scope=frontend-yarn
-          cache-to: type=gha,scope=frontend-yarn,mode=max
+          tags: user/browsertrix-frontend-builder:test
+          cache-from: type=gha,scope=frontend-builder
+          cache-to: type=gha,scope=frontend-builder,mode=max
+
+      -
+        name: Copy Frontend dist
+        run: |
+          docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/.dist && docker rm bc-frontend-builder-temp
+
       -
         name: Build Frontend
         uses: docker/build-push-action@v3
@@ -82,7 +88,6 @@ jobs:
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
-            YARN_BUILD_DEPS=webrecorder/browsertrix-frontend-yarn-build:latest
 
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-frontend:${{ env.VERSION }}, webrecorder/browsertrix-frontend:latest
           cache-from: type=gha,scope=frontend

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: backend
           platforms: linux/amd64,linux/arm64
-          push: true
+          #push: true
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-backend:${{ env.VERSION }}, webrecorder/browsertrix-backend:latest
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
+        with:
+          driver: docker
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,8 @@ jobs:
       -
         name: Build Frontend Yarn Build
         uses: docker/build-push-action@v3
+        env:
+          HUSKY: 0
         with:
           context: frontend
           platforms: linux/amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,14 +21,19 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
+
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android  # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
 
       -
         name: Set Env Vars

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           cache-to: type=gha,scope=backend,mode=max
 
       -
-        name: Build Frontend Yarn Build
+        name: Build Frontend Yarn Builder
         uses: docker/build-push-action@v3
         env:
           HUSKY: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Browsertrix Cloud Release Build
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   btrix-release:
@@ -47,6 +48,22 @@ jobs:
           cache-to: type=gha,scope=backend,mode=max
 
       -
+        name: Build Frontend Yarn Build
+        uses: docker/build-push-action@v3
+        with:
+          context: frontend
+          platforms: linux/amd64
+          load: true
+          target: build_deps
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
+            GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
+
+          tags: webrecorder/browsertrix-frontend-yarn-build:latest
+          cache-from: type=gha,scope=frontend-yarn
+          cache-to: type=gha,scope=frontend-yarn,mode=max
+      -
         name: Build Frontend
         uses: docker/build-push-action@v3
         with:
@@ -57,6 +74,7 @@ jobs:
             VERSION=${{ env.VERSION }}
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_BRANCH_NAME=${{ env.GIT_BRANCH_NAME }}
+            YARN_BUILD_DEPS=webrecorder/browsertrix-frontend-yarn-build:latest
 
           tags: ${{ env.REPO_PREFIX }}webrecorder/browsertrix-frontend:${{ env.VERSION }}, webrecorder/browsertrix-frontend:latest
           cache-from: type=gha,scope=frontend

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -349,6 +349,7 @@ class CrawlOut(BaseMongoModel):
     collections: Optional[List[UUID4]] = []
 
     # automated crawl fields
+    config: Optional[RawCrawlConfig]
     cid: Optional[UUID4]
     name: Optional[str]
     firstSeed: Optional[str]

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -16,6 +16,7 @@
 /tmp/
 
 # build
+/.dist/
 /dist/
 
 # dotenv

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.4
 ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
+ARG YARN_BUILD_DEPS=build_deps
 
 FROM docker.io/library/node:16 as build_deps
 
@@ -9,8 +10,6 @@ COPY yarn.lock package.json ./
 # of including yarn cache in the build image
 RUN yarn --production --frozen-lockfile --network-timeout 1000000 && \
     yarn cache clean
-
-FROM build_deps as build
 
 COPY --link lit-localize.json \
     postcss.config.js \
@@ -22,6 +21,11 @@ COPY --link lit-localize.json \
     ./
 
 COPY --link src ./src/
+
+RUN yarn build
+
+ARG YARN_BUILD_DEPS
+FROM ${YARN_BUILD_DEPS} as build
 
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all
@@ -35,10 +39,6 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
     GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
     VERSION=${VERSION} \
     RWP_BASE_URL=${RWP_BASE_URL}
-
-# Prevent Docker caching node_modules
-RUN yarn build && \
-    rm -rf ./node_modules
 
 FROM docker.io/library/nginx:1.23.2
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,8 +23,8 @@ COPY dist /usr/share/nginx/html
 # RUN ls /usr/share/nginx/html
 
 #COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY --link ./frontend.conf.template /etc/nginx/templates/
-COPY --link ./minio.conf /etc/nginx/includes/
+COPY ./frontend.conf.template /etc/nginx/templates/
+COPY ./minio.conf /etc/nginx/includes/
 
-ADD --link ./00-browsertrix-nginx-init.sh ./docker-entrypoint.d/
+ADD ./00-browsertrix-nginx-init.sh ./docker-entrypoint.d/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY yarn.lock package.json ./
 # Uses `yarn cache clean` to let Docker cache layer instead
 # of including yarn cache in the build image
-RUN yarn --production --frozen-lockfile --network-timeout 1000000 && \
+RUN yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000 && \
     yarn cache clean
 
 COPY --link lit-localize.json \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,51 +1,26 @@
 # syntax=docker/dockerfile:1.4
 ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
-ARG YARN_BUILD_DEPS=build_deps
-
-FROM docker.io/library/node:16 as build_deps
-
-WORKDIR /app
-COPY yarn.lock package.json ./
-# Uses `yarn cache clean` to let Docker cache layer instead
-# of including yarn cache in the build image
-RUN yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000 && \
-    yarn cache clean
-
-COPY --link lit-localize.json \
-    postcss.config.js \
-    tailwind.config.js \
-    tsconfig.json \
-    webpack.config.js \
-    webpack.prod.js \
-    index.d.ts \
-    ./
-
-COPY --link src ./src/
-
-RUN yarn build
-
-ARG YARN_BUILD_DEPS
-FROM --platform=linux/amd64 ${YARN_BUILD_DEPS} as build
-
-# Build variables used to show current app version
-# in the UI. Note that this will invalidate all
-# subsequent RUN steps.
-ARG GIT_COMMIT_HASH
-ARG GIT_BRANCH_NAME
-ARG VERSION
-ARG RWP_BASE_URL
-
-ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
-    GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
-    VERSION=${VERSION} \
-    RWP_BASE_URL=${RWP_BASE_URL}
 
 FROM docker.io/library/nginx:1.23.2
 
-ARG RWP_BASE_URL
-ENV RWP_BASE_URL=${RWP_BASE_URL}
+WORKDIR /app
+# COPY dist ./dist/
 
-COPY --link --from=build /app/dist /usr/share/nginx/html
+ARG GIT_COMMIT_HASH
+ARG GIT_BRANCH_NAME
+ARG VERSION
+
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
+  GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
+  VERSION=${VERSION} \
+  RWP_BASE_URL=${RWP_BASE_URL}
+
+RUN echo $GIT_COMMIT_HASH
+RUN echo $GIT_BRANCH_NAME
+RUN echo $VERSION
+
+COPY dist /usr/share/nginx/html
+RUN ls /usr/share/nginx/html
 
 #COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY --link ./frontend.conf.template /etc/nginx/templates/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,9 +3,6 @@ ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
 
 FROM docker.io/library/nginx:1.23.2
 
-WORKDIR /app
-# COPY dist ./dist/
-
 ARG GIT_COMMIT_HASH
 ARG GIT_BRANCH_NAME
 ARG VERSION
@@ -19,7 +16,7 @@ RUN echo $GIT_COMMIT_HASH
 RUN echo $GIT_BRANCH_NAME
 RUN echo $VERSION
 
-COPY dist /usr/share/nginx/html
+COPY .dist /usr/share/nginx/html
 # RUN ls /usr/share/nginx/html
 
 #COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,11 +17,10 @@ RUN echo $GIT_BRANCH_NAME
 RUN echo $VERSION
 
 COPY .dist /usr/share/nginx/html
-# RUN ls /usr/share/nginx/html
 
 #COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY ./frontend.conf.template /etc/nginx/templates/
-COPY ./minio.conf /etc/nginx/includes/
+COPY --link ./frontend.conf.template /etc/nginx/templates/
+COPY --link ./minio.conf /etc/nginx/includes/
 
-ADD ./00-browsertrix-nginx-init.sh ./docker-entrypoint.d/
+ADD --link ./00-browsertrix-nginx-init.sh ./docker-entrypoint.d/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ RUN echo $GIT_BRANCH_NAME
 RUN echo $VERSION
 
 COPY dist /usr/share/nginx/html
-RUN ls /usr/share/nginx/html
+# RUN ls /usr/share/nginx/html
 
 #COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY --link ./frontend.conf.template /etc/nginx/templates/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,7 +25,7 @@ COPY --link src ./src/
 RUN yarn build
 
 ARG YARN_BUILD_DEPS
-FROM ${YARN_BUILD_DEPS} as build
+FROM --platform=linux/amd64 ${YARN_BUILD_DEPS} as build
 
 # Build variables used to show current app version
 # in the UI. Note that this will invalidate all

--- a/frontend/builder.Dockerfile
+++ b/frontend/builder.Dockerfile
@@ -39,6 +39,10 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
   VERSION=${VERSION} \
   RWP_BASE_URL=${RWP_BASE_URL}
 
+RUN echo $GIT_COMMIT_HASH
+RUN echo $GIT_BRANCH_NAME
+RUN echo $VERSION
+
 # Prevent Docker caching node_modules
 RUN yarn build && \
   rm -rf ./node_modules

--- a/frontend/builder.Dockerfile
+++ b/frontend/builder.Dockerfile
@@ -43,6 +43,6 @@ RUN echo $GIT_COMMIT_HASH
 RUN echo $GIT_BRANCH_NAME
 RUN echo $VERSION
 
-# Prevent Docker caching node_modules
+# Prevent Docker image including node_modules to save space
 RUN yarn build && \
   rm -rf ./node_modules

--- a/frontend/builder.Dockerfile
+++ b/frontend/builder.Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.4
+ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
+
+FROM docker.io/library/node:16 as build_deps
+
+WORKDIR /app
+
+ENV HUSKY=0
+
+COPY yarn.lock package.json ./
+# Uses `yarn cache clean` to let Docker cache layer instead
+# of including yarn cache in the build image
+RUN yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000 && \
+  yarn cache clean
+
+FROM build_deps as build
+
+COPY --link lit-localize.json \
+  postcss.config.js \
+  tailwind.config.js \
+  tsconfig.json \
+  webpack.config.js \
+  webpack.prod.js \
+  index.d.ts \
+  ./
+
+COPY --link src ./src/
+
+# Build variables used to show current app version
+# in the UI. Note that this will invalidate all
+# subsequent RUN steps.
+ARG GIT_COMMIT_HASH
+ARG GIT_BRANCH_NAME
+ARG VERSION
+ARG RWP_BASE_URL
+
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
+  GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
+  VERSION=${VERSION} \
+  RWP_BASE_URL=${RWP_BASE_URL}
+
+# Prevent Docker caching node_modules
+RUN yarn build && \
+  rm -rf ./node_modules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,20 +72,22 @@
     "localize:build": "lit-localize build"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4-fix.0",
     "@lit/localize-tools": "^0.6.9",
-    "@open-wc/testing": "^3.2.0",
-    "@playwright/test": "1.32.1",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/dev-server-rollup": "^0.3.21",
-    "@web/test-runner": "^0.13.22",
-    "@web/test-runner-playwright": "^0.8.8",
-    "chromium": "^3.0.3",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
     "sinon": "^12.0.1",
     "webpack-dev-server": "^4.3.0"
+  },
+  "optionalDependencies": {
+    "@esm-bundle/chai": "^4.3.4-fix.0",
+    "@open-wc/testing": "^3.2.0",
+    "@playwright/test": "1.32.1",
+    "@web/test-runner": "^0.13.22",
+    "@web/test-runner-playwright": "^0.8.8",
+    "chromium": "^3.0.3"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -15,6 +15,7 @@
     ></script>
   </head>
   <body>
+    <!-- App -->
     <browsertrix-app
       version="v<%= version %>-<%= commitHash %>"
     ></browsertrix-app>

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -15,7 +15,6 @@
     ></script>
   </head>
   <body>
-    <!-- App -->
     <browsertrix-app
       version="v<%= version %>-<%= commitHash %>"
     ></browsertrix-app>

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -6,7 +6,7 @@ export GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 export RWP_BASE_URL="https://cdn.jsdelivr.net/npm/replaywebpage/"
 export VERSION=`cat version.txt`
 
-DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
+DOCKER_BUILDKIT=1 docker build \
     --build-arg GIT_COMMIT_HASH \
     --build-arg GIT_BRANCH_NAME \
     --build-arg --load \
@@ -15,7 +15,7 @@ DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
 
 docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/.dist && docker rm bc-frontend-builder-temp
 
-DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
+DOCKER_BUILDKIT=1 docker build \
     --build-arg GIT_COMMIT_HASH \
     --build-arg GIT_BRANCH_NAME \
     --build-arg --load \

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -3,8 +3,6 @@ CURR=$(dirname "${BASH_SOURCE[0]}")
 
 export GIT_COMMIT_HASH="$(git rev-parse --short HEAD)"
 export GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
-export RWP_BASE_URL="https://cdn.jsdelivr.net/npm/replaywebpage/"
-export VERSION=`cat version.txt`
 
 DOCKER_BUILDKIT=1 docker build \
     --build-arg GIT_COMMIT_HASH \

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 CURR=$(dirname "${BASH_SOURCE[0]}")
 
-DOCKER_BUILDKIT=1 docker build --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" --build-arg --load -t ${REGISTRY}webrecorder/browsertrix-frontend:latest  $CURR/../frontend/
+DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
+    --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" \
+    --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" \
+    --build-arg --load \
+    -t ${REGISTRY}webrecorder/browsertrix-frontend:latest  $CURR/../frontend/
 
 if [ -n "$REGISTRY" ]; then
     docker push ${REGISTRY}webrecorder/browsertrix-frontend

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,11 +1,25 @@
 #!/usr/bin/env bash
 CURR=$(dirname "${BASH_SOURCE[0]}")
 
+export GIT_COMMIT_HASH="$(git rev-parse --short HEAD)"
+export GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+export RWP_BASE_URL="https://cdn.jsdelivr.net/npm/replaywebpage/"
+export VERSION=`cat version.txt`
+
 DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
-    --build-arg GIT_COMMIT_HASH="$(git rev-parse --short HEAD)" \
-    --build-arg GIT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)" \
+    --build-arg GIT_COMMIT_HASH \
+    --build-arg GIT_BRANCH_NAME \
     --build-arg --load \
-    -t ${REGISTRY}webrecorder/browsertrix-frontend:latest  $CURR/../frontend/
+    --file frontend/builder.Dockerfile \
+    -t user/browsertrix-frontend-builder:test $CURR/../frontend/
+
+docker cp $(docker create --name bc-frontend-builder-temp user/browsertrix-frontend-builder:test):/app/dist ./frontend/.dist && docker rm bc-frontend-builder-temp
+
+DOCKER_BUILDKIT=1 docker build --progress=plain --no-cache \
+    --build-arg GIT_COMMIT_HASH \
+    --build-arg GIT_BRANCH_NAME \
+    --build-arg --load \
+    -t ${REGISTRY}webrecorder/browsertrix-frontend:latest $CURR/../frontend/
 
 if [ -n "$REGISTRY" ]; then
     docker push ${REGISTRY}webrecorder/browsertrix-frontend


### PR DESCRIPTION
## Changes
Separates frontend build image into 2:
1. Frontend dist builder image, which is built in native platform
2. Frontend final image, which is multiplatform, only contains nginx

The build steps are now as follows:
1. Build a local builder image using builder.Dockerfile that runs `yarn` install and `yarn build`.
2. Run local builder image as temporary container once, copy out `dist` to local filesystem, and remove container when done
3. Build final frontend image with `dist` in context

I updated `build-frontend.sh` to match the GH workflow. However, I'm unavailable to fully test this locally due to the issue [mentioned in Discord](https://discord.com/channels/895426029194207262/1138176787893997650/1138609815493558403), but was able to successfully run the release steps in `deploy-dev` to verify.

Example successful job: https://github.com/webrecorder/browsertrix-cloud/actions/runs/5803167901/job/15730769433