### PR TITLE
Add event webhook notifications system to backend

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -85,6 +85,11 @@ class CollectionOps:
                 await update_collection_counts_and_tags(
                     self.collections, self.crawls, coll_id
                 )
+                asyncio.create_task(
+                    self.event_webhook_ops.create_added_to_collection_notification(
+                        crawl_ids, coll_id, org
+                    )
+                )
 
             return {"added": True, "id": coll_id, "name": name}
         except pymongo.errors.DuplicateKeyError:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -135,8 +135,8 @@ class CollectionOps:
         await update_collection_counts_and_tags(self.collections, self.crawls, coll_id)
 
         asyncio.create_task(
-            self.event_webhook_ops.create_added_removed_collection_notification(
-                crawl_ids, coll_id, org, added=True
+            self.event_webhook_ops.create_added_to_collection_notification(
+                crawl_ids, coll_id, org
             )
         )
 
@@ -159,8 +159,8 @@ class CollectionOps:
         await update_collection_counts_and_tags(self.collections, self.crawls, coll_id)
 
         asyncio.create_task(
-            self.event_webhook_ops.create_added_removed_collection_notification(
-                crawl_ids, coll_id, org, added=False
+            self.event_webhook_ops.create_removed_from_collection_notification(
+                crawl_ids, coll_id, org
             )
         )
 
@@ -281,7 +281,6 @@ class CollectionOps:
         names = [
             CollIdName(id=namedata["_id"], name=namedata["name"]) for namedata in names
         ]
-        print("names", names)
         return names
 
     async def get_collection_search_values(self, org: Organization):

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -55,7 +55,6 @@ class CrawlConfigOps:
         org_ops,
         crawl_manager,
         profiles,
-        event_webhook_ops,
     ):
         self.dbclient = dbclient
         self.crawls = mdb["crawls"]
@@ -66,7 +65,6 @@ class CrawlConfigOps:
         self.crawl_manager = crawl_manager
         self.profiles = profiles
         self.profiles.set_crawlconfigs(self)
-        self.event_webhook_ops = event_webhook_ops
         self.crawl_ops = None
         self.default_filename_template = os.environ["DEFAULT_CRAWL_FILENAME_TEMPLATE"]
 
@@ -180,12 +178,6 @@ class CrawlConfigOps:
 
     async def add_new_crawl(self, crawl_id: str, crawlconfig: CrawlConfig, user: User):
         """increments crawl count for this config and adds new crawl"""
-        asyncio.create_task(
-            self.event_webhook_ops.create_crawl_started_notification(
-                crawl_id, crawlconfig.oid
-            )
-        )
-
         inc = inc_crawl_count(self.crawl_configs, crawlconfig.id)
         add = self.crawl_ops.add_new_crawl(crawl_id, crawlconfig, user)
         await asyncio.gather(inc, add)
@@ -886,14 +878,11 @@ def init_crawl_config_api(
     org_ops,
     crawl_manager,
     profiles,
-    event_webhook_ops,
 ):
     """Init /crawlconfigs api routes"""
     # pylint: disable=invalid-name
 
-    ops = CrawlConfigOps(
-        dbclient, mdb, user_manager, org_ops, crawl_manager, profiles, event_webhook_ops
-    )
+    ops = CrawlConfigOps(dbclient, mdb, user_manager, org_ops, crawl_manager, profiles)
 
     router = ops.router
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -42,7 +42,9 @@ class CrawlOps(BaseCrawlOps):
     """Crawl Ops"""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods
-    def __init__(self, mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops):
+    def __init__(
+        self, mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops
+    ):
         super().__init__(mdb, users, crawl_configs, crawl_manager, colls)
         self.crawls = self.crawls
         self.crawl_configs = crawl_configs
@@ -625,12 +627,22 @@ async def recompute_crawl_file_count_and_size(crawls, crawl_id):
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, too-many-statements
 def init_crawls_api(
-    app, mdb, users, crawl_manager, crawl_config_ops, orgs, colls, user_dep, event_webhook_ops
+    app,
+    mdb,
+    users,
+    crawl_manager,
+    crawl_config_ops,
+    orgs,
+    colls,
+    user_dep,
+    event_webhook_ops,
 ):
     """API for crawl management, including crawl done callback"""
     # pylint: disable=invalid-name
 
-    ops = CrawlOps(mdb, users, crawl_manager, crawl_config_ops, orgs, colls, event_webhook_ops)
+    ops = CrawlOps(
+        mdb, users, crawl_manager, crawl_config_ops, orgs, colls, event_webhook_ops
+    )
 
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -42,15 +42,17 @@ class CrawlOps(BaseCrawlOps):
     """Crawl Ops"""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods
-    def __init__(self, mdb, users, crawl_manager, crawl_configs, orgs, colls):
+    def __init__(self, mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops):
         super().__init__(mdb, users, crawl_configs, crawl_manager, colls)
         self.crawls = self.crawls
         self.crawl_configs = crawl_configs
         self.user_manager = users
         self.orgs = orgs
+        self.event_webhook_ops = event_webhook_ops
 
         self.crawl_configs.set_crawl_ops(self)
         self.colls.set_crawl_ops(self)
+        self.event_webhook_ops.set_crawl_ops(self)
 
     async def init_index(self):
         """init index for crawls db collection"""
@@ -623,12 +625,12 @@ async def recompute_crawl_file_count_and_size(crawls, crawl_id):
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, too-many-statements
 def init_crawls_api(
-    app, mdb, users, crawl_manager, crawl_config_ops, orgs, colls, user_dep
+    app, mdb, users, crawl_manager, crawl_config_ops, orgs, colls, user_dep, event_webhook_ops
 ):
     """API for crawl management, including crawl done callback"""
     # pylint: disable=invalid-name
 
-    ops = CrawlOps(mdb, users, crawl_manager, crawl_config_ops, orgs, colls)
+    ops = CrawlOps(mdb, users, crawl_manager, crawl_config_ops, orgs, colls, event_webhook_ops)
 
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -75,6 +75,8 @@ def main():
 
     org_ops = init_orgs_api(app, mdb, user_manager, invites, current_active_user)
 
+    event_webhook_ops = init_event_webhooks_api(mdb, org_ops)
+
     user_manager.set_org_ops(org_ops)
 
     # pylint: disable=import-outside-toplevel
@@ -99,9 +101,8 @@ def main():
         org_ops,
         crawl_manager,
         profiles,
+        event_webhook_ops,
     )
-
-    event_webhook_ops = init_event_webhooks_api(mdb, org_ops)
 
     coll_ops = init_collections_api(app, mdb, org_ops, crawl_manager, event_webhook_ops)
 

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -101,7 +101,6 @@ def main():
         org_ops,
         crawl_manager,
         profiles,
-        event_webhook_ops,
     )
 
     coll_ops = init_collections_api(app, mdb, org_ops, crawl_manager, event_webhook_ops)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -25,6 +25,7 @@ from .crawlconfigs import init_crawl_config_api
 from .colls import init_collections_api
 from .crawls import init_crawls_api
 from .basecrawls import init_base_crawls_api
+from .webhooks import init_event_webhooks_api
 
 from .crawlmanager import CrawlManager
 from .utils import run_once_lock, register_exit_handler
@@ -41,7 +42,7 @@ db_inited = {"inited": False}
 
 
 # ============================================================================
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals, duplicate-code
 def main():
     """init browsertrix cloud api"""
 
@@ -100,7 +101,9 @@ def main():
         profiles,
     )
 
-    coll_ops = init_collections_api(app, mdb, org_ops, crawl_manager)
+    event_webhook_ops = init_event_webhooks_api(mdb, org_ops)
+
+    coll_ops = init_collections_api(app, mdb, org_ops, crawl_manager, event_webhook_ops)
 
     init_base_crawls_api(
         app,
@@ -122,6 +125,7 @@ def main():
         org_ops,
         coll_ops,
         current_active_user,
+        event_webhook_ops
     )
 
     init_uploads_api(
@@ -133,6 +137,7 @@ def main():
         org_ops,
         coll_ops,
         current_active_user,
+        event_webhook_ops,
     )
 
     crawl_config_ops.set_coll_ops(coll_ops)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -125,7 +125,7 @@ def main():
         org_ops,
         coll_ops,
         current_active_user,
-        event_webhook_ops
+        event_webhook_ops,
     )
 
     init_uploads_api(

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -38,6 +38,8 @@ def main():
 
     org_ops = OrgOps(mdb, invite_ops)
 
+    event_webhook_ops = EventWebhookOps(mdb, org_ops)
+
     user_manager.set_org_ops(org_ops)
 
     # pylint: disable=import-outside-toplevel
@@ -52,10 +54,14 @@ def main():
 
     profile_ops = ProfileOps(mdb, crawl_manager)
 
-    event_webhook_ops = EventWebhookOps(mdb, org_ops)
-
     crawl_config_ops = CrawlConfigOps(
-        dbclient, mdb, user_manager, org_ops, crawl_manager, profile_ops
+        dbclient,
+        mdb,
+        user_manager,
+        org_ops,
+        crawl_manager,
+        profile_ops,
+        event_webhook_ops,
     )
 
     coll_ops = CollectionOps(mdb, crawl_manager, org_ops, event_webhook_ops)

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -1,19 +1,65 @@
 """ entrypoint module for operator """
 
+import os
+import sys
 
 from fastapi import FastAPI
 
+from .crawlmanager import CrawlManager
+from .db import init_db
+from .emailsender import EmailSender
 from .operator import init_operator_webhook
-
 from .utils import register_exit_handler
+
+from .invites import InviteOps
+from .users import init_user_manager
+from .orgs import OrgOps
+from .crawlconfigs import CrawlConfigOps
+from .crawls import CrawlOps
+from .profiles import ProfileOps
+from .webhooks import EventWebhookOps
 
 app_root = FastAPI()
 
 
 # ============================================================================
+# pylint: disable=too-many-function-args, duplicate-code
 def main():
     """main init"""
-    init_operator_webhook(app_root)
+    email = EmailSender()
+    crawl_manager = None
+
+    dbclient, mdb = init_db()
+
+    invite_ops = InviteOps(mdb, email)
+
+    user_manager = init_user_manager(mdb, email, invite_ops)
+
+    org_ops = OrgOps(mdb, invite_ops)
+
+    user_manager.set_org_ops(org_ops)
+
+    # pylint: disable=import-outside-toplevel
+    if not os.environ.get("KUBERNETES_SERVICE_HOST"):
+        print(
+            "Sorry, the Browsertrix Cloud Backend must be run inside a Kubernetes environment.\
+             Kubernetes not detected (KUBERNETES_SERVICE_HOST is not set), Exiting"
+        )
+        sys.exit(1)
+
+    crawl_manager = CrawlManager()
+
+    profile_ops = ProfileOps(mdb, crawl_manager)
+
+    crawl_config_ops = CrawlConfigOps(
+        dbclient, mdb, user_manager, org_ops, crawl_manager, profile_ops
+    )
+
+    crawl_ops = CrawlOps(mdb, user_manager, crawl_manager, crawl_config_ops, org_ops)
+
+    event_webhook_ops = EventWebhookOps(mdb, org_ops, crawl_ops)
+
+    init_operator_webhook(app_root, mdb, event_webhook_ops)
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from .crawlmanager import CrawlManager
 from .db import init_db
 from .emailsender import EmailSender
-from .operator import init_operator_webhook
+from .operator import init_operator_api
 from .utils import register_exit_handler
 
 from .invites import InviteOps
@@ -70,7 +70,7 @@ def main():
         event_webhook_ops,
     )
 
-    init_operator_webhook(app_root, mdb, event_webhook_ops)
+    init_operator_api(app_root, mdb, event_webhook_ops)
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -61,7 +61,6 @@ def main():
         org_ops,
         crawl_manager,
         profile_ops,
-        event_webhook_ops,
     )
 
     coll_ops = CollectionOps(mdb, crawl_manager, org_ops, event_webhook_ops)

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -58,9 +58,9 @@ def main():
         dbclient, mdb, user_manager, org_ops, crawl_manager, profile_ops
     )
 
-    coll_ops = CollectionOps(mdb, crawl_manager, orgs, event_webhook_ops)
+    coll_ops = CollectionOps(mdb, crawl_manager, org_ops, event_webhook_ops)
 
-    crawl_ops = CrawlOps(
+    CrawlOps(
         mdb,
         user_manager,
         crawl_manager,

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -14,6 +14,7 @@ from .utils import register_exit_handler
 from .invites import InviteOps
 from .users import init_user_manager
 from .orgs import OrgOps
+from .colls import CollectionOps
 from .crawlconfigs import CrawlConfigOps
 from .crawls import CrawlOps
 from .profiles import ProfileOps
@@ -51,13 +52,23 @@ def main():
 
     profile_ops = ProfileOps(mdb, crawl_manager)
 
+    event_webhook_ops = EventWebhookOps(mdb, org_ops)
+
     crawl_config_ops = CrawlConfigOps(
         dbclient, mdb, user_manager, org_ops, crawl_manager, profile_ops
     )
 
-    crawl_ops = CrawlOps(mdb, user_manager, crawl_manager, crawl_config_ops, org_ops)
+    coll_ops = CollectionOps(mdb, crawl_manager, orgs, event_webhook_ops)
 
-    event_webhook_ops = EventWebhookOps(mdb, org_ops, crawl_ops)
+    crawl_ops = CrawlOps(
+        mdb,
+        user_manager,
+        crawl_manager,
+        crawl_config_ops,
+        org_ops,
+        coll_ops,
+        event_webhook_ops,
+    )
 
     init_operator_webhook(app_root, mdb, event_webhook_ops)
 

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -11,6 +11,7 @@ from .crawlconfigs import (
     inc_crawl_count,
 )
 from .crawls import add_new_crawl
+from .crawlmanager import CrawlManager
 from .emailsender import EmailSender
 from .invites import InviteOps
 from .users import init_user_manager
@@ -31,10 +32,12 @@ class ScheduledJob(K8sAPI):
         super().__init__()
         self.cid = os.environ["CID"]
 
-        _, mdb = init_db()
+        dbclient, mdb = init_db()
 
         self.crawls = mdb["crawls"]
         self.crawlconfigs = mdb["crawl_configs"]
+
+        email = EmailSender()
 
         invite_ops = InviteOps(mdb, email)
 

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -13,9 +13,14 @@ from .crawlconfigs import (
 from .crawls import add_new_crawl
 from .emailsender import EmailSender
 from .invites import InviteOps
+from .users import init_user_manager
 from .orgs import OrgOps
-from .utils import register_exit_handler
+from .colls import CollectionOps
+from .crawlconfigs import CrawlConfigOps
+from .crawls import CrawlOps
+from .profiles import ProfileOps
 from .webhooks import EventWebhookOps
+from .utils import register_exit_handler
 
 
 # ============================================================================
@@ -31,9 +36,41 @@ class ScheduledJob(K8sAPI):
         self.crawls = mdb["crawls"]
         self.crawlconfigs = mdb["crawl_configs"]
 
-        email = EmailSender()
         invite_ops = InviteOps(mdb, email)
+
+        user_manager = init_user_manager(mdb, email, invite_ops)
+
         org_ops = OrgOps(mdb, invite_ops)
+
+        event_webhook_ops = EventWebhookOps(mdb, org_ops)
+
+        user_manager.set_org_ops(org_ops)
+
+        crawl_manager = CrawlManager()
+
+        profile_ops = ProfileOps(mdb, crawl_manager)
+
+        crawl_config_ops = CrawlConfigOps(
+            dbclient,
+            mdb,
+            user_manager,
+            org_ops,
+            crawl_manager,
+            profile_ops,
+            event_webhook_ops,
+        )
+
+        coll_ops = CollectionOps(mdb, crawl_manager, org_ops, event_webhook_ops)
+
+        CrawlOps(
+            mdb,
+            user_manager,
+            crawl_manager,
+            crawl_config_ops,
+            org_ops,
+            coll_ops,
+            event_webhook_ops,
+        )
 
         self.event_webhook_ops = EventWebhookOps(mdb, org_ops)
 
@@ -63,6 +100,12 @@ class ScheduledJob(K8sAPI):
             self.cid, userid, oid, scale, crawl_timeout, manual=False
         )
 
+        asyncio.create_task(
+            self.event_webhook_ops.create_crawl_started_notification(
+                crawl_id, crawlconfig.oid, scheduled=True
+            )
+        )
+
         # db create
         await inc_crawl_count(self.crawlconfigs, crawlconfig.id)
         await add_new_crawl(
@@ -74,12 +117,6 @@ class ScheduledJob(K8sAPI):
             manual=False,
         )
         print("Crawl Created: " + crawl_id)
-
-        asyncio.create_task(
-            self.event_webhook_ops.create_crawl_started_notification(
-                crawl_id, crawlconfig.oid, scheduled=True
-            )
-        )
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -724,6 +724,7 @@ class OrgOut(BaseMongoModel):
     usage: Optional[Dict[str, int]]
     default: bool = False
 
+    webhooks: Optional[OrgWebhookUrls] = OrgWebhookUrls()
     quotas: Optional[OrgQuotas] = OrgQuotas()
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -882,7 +882,6 @@ class WebhookNotificationBody(BaseModel):
 
     # Store as str, not UUID, to make JSON-serializable
     orgId: str
-    event: str
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -894,7 +894,7 @@ class WebhookEventType(str, Enum):
 
 # ============================================================================
 class BaseCollectionItemBody(WebhookNotificationBody):
-    """Webhook notification POST body for when item is added to or removed from collection"""
+    """Webhook notification base POST body for collection changes"""
 
     collectionId: str
     itemIds: List[str]
@@ -902,11 +902,15 @@ class BaseCollectionItemBody(WebhookNotificationBody):
 
 # ============================================================================
 class CollectionItemAddedBody(BaseCollectionItemBody):
+    """Webhook notification POST body for collection additions"""
+
     event: str = Field(WebhookEventType.ADDED_TO_COLLECTION, const=True)
 
 
 # ============================================================================
 class CollectionItemRemovedBody(BaseCollectionItemBody):
+    """Webhook notification POST body for collection removals"""
+
     event: str = Field(WebhookEventType.REMOVED_FROM_COLLECTION, const=True)
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -883,7 +883,7 @@ class WebhookNotificationBody(BaseModel):
 class ArchivedItemCreatedBody(WebhookNotificationBody):
     """Webhook notification POST body for when archived item is created"""
 
-    crawlId: str
+    itemId: str
 
 
 # ============================================================================
@@ -891,7 +891,7 @@ class CollectionItemAddedRemovedBody(WebhookNotificationBody):
     """Webhook notification POST body for when item is added to or removed from collection"""
 
     collectionId: str
-    crawlIds: List[str]
+    itemIds: List[str]
     type: str = "added"
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -939,6 +939,7 @@ class CrawlFinishedBody(BaseArchivedItemBody):
     """Webhook notification POST body for when crawl finishes"""
 
     event: str = Field(WebhookEventType.CRAWL_FINISHED, const=True)
+    state: str
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum, IntEnum
 
 from typing import Optional, List, Dict, Union, Literal, Any
-from pydantic import BaseModel, UUID4, conint, Field, HttpUrl, EmailStr
+from pydantic import BaseModel, UUID4, conint, Field, HttpUrl, AnyHttpUrl, EmailStr
 from fastapi_users import models as fastapi_users_models
 
 from .db import BaseMongoModel
@@ -650,9 +650,9 @@ class Organization(BaseMongoModel):
 
     quotas: Optional[OrgQuotas] = OrgQuotas()
 
-    webhookUrls: Optional[OrgWebhookUrls]
+    webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
-    origin: Optional[HttpUrl]
+    origin: Optional[AnyHttpUrl]
 
     def is_owner(self, user):
         """Check if user is owner"""
@@ -723,8 +723,9 @@ class OrgOut(BaseMongoModel):
     users: Optional[Dict[str, Any]]
     usage: Optional[Dict[str, int]]
     default: bool = False
+    origin: Optional[AnyHttpUrl]
 
-    webhooks: Optional[OrgWebhookUrls] = OrgWebhookUrls()
+    webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
     quotas: Optional[OrgQuotas] = OrgQuotas()
 
 
@@ -882,14 +883,14 @@ class WebhookNotificationBody(BaseModel):
 class ArchivedItemCreatedBody(WebhookNotificationBody):
     """Webhook notification POST body for when archived item is created"""
 
-    crawlId: UUID4
+    crawlId: str
 
 
 # ============================================================================
 class CollectionItemAddedRemovedBody(WebhookNotificationBody):
     """Webhook notification POST body for when item is added to or removed from collection"""
 
-    collectionId: UUID4
+    collectionId: str
     crawlIds: List[str]
     type: str = "added"
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -770,12 +770,12 @@ class BtrixOperator(K8sAPI):
         if redis:
             await self.add_crawl_errors_to_db(redis, crawl_id)
 
-        await self.event_webhook_ops.create_crawl_finished_notification(crawl_id, state)
-
         if state in SUCCESSFUL_STATES:
             await add_successful_crawl_to_collections(
                 self.crawls, self.crawl_configs, self.collections, crawl_id, cid
             )
+
+        await self.event_webhook_ops.create_crawl_finished_notification(crawl_id, state)
 
     async def inc_crawl_complete_stats(self, crawl, finished):
         """Increment Crawl Stats"""

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -766,7 +766,7 @@ class BtrixOperator(K8sAPI):
                 self.crawls, self.crawl_configs, self.collections, crawl_id, cid
             )
 
-        await self.event_webhook_ops.create_item_created_notification(crawl_id)
+            await self.event_webhook_ops.create_item_created_notification(crawl_id)
 
     async def inc_crawl_complete_stats(self, crawl, finished):
         """Increment Crawl Stats"""

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -766,7 +766,7 @@ class BtrixOperator(K8sAPI):
                 self.crawls, self.crawl_configs, self.collections, crawl_id, cid
             )
 
-            await self.event_webhook_ops.create_item_created_notification(crawl_id)
+            await self.event_webhook_ops.create_crawl_finished_notification(crawl_id)
 
     async def inc_crawl_complete_stats(self, crawl, finished):
         """Increment Crawl Stats"""

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -220,7 +220,7 @@ class BtrixOperator(K8sAPI):
             scheduled = not manual
             asyncio.create_task(
                 self.event_webhook_ops.create_crawl_started_notification(
-                    crawl_id, oid, scheduled=scheduled
+                    crawl_id, uuid.UUID(oid), scheduled=scheduled
                 )
             )
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -761,12 +761,12 @@ class BtrixOperator(K8sAPI):
         if redis:
             await self.add_crawl_errors_to_db(redis, crawl_id)
 
+        await self.event_webhook_ops.create_crawl_finished_notification(crawl_id, state)
+
         if state in SUCCESSFUL_STATES:
             await add_successful_crawl_to_collections(
                 self.crawls, self.crawl_configs, self.collections, crawl_id, cid
             )
-
-            await self.event_webhook_ops.create_crawl_finished_notification(crawl_id)
 
     async def inc_crawl_complete_stats(self, crawl, finished):
         """Increment Crawl Stats"""

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -808,7 +808,7 @@ class BtrixOperator(K8sAPI):
 
 
 # ============================================================================
-def init_operator_webhook(app, mdb, event_webhook_ops):
+def init_operator_api(app, mdb, event_webhook_ops):
     """regsiters webhook handlers for metacontroller"""
 
     oper = BtrixOperator(mdb, event_webhook_ops)

--- a/backend/btrixcloud/templates/crawl_job.yaml
+++ b/backend/btrixcloud/templates/crawl_job.yaml
@@ -19,6 +19,7 @@ spec:
   oid: "{{ oid }}"
   scale: {{ scale }}
   maxCrawlSize: {{ max_crawl_size }}
+  manual: {{ manual }}
   ttlSecondsAfterFinished: 30
 
   {% if expire_time %}

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -241,11 +241,21 @@ class UploadFileReader(BufferedReader):
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, invalid-name
 def init_uploads_api(
-    app, mdb, users, crawl_manager, crawl_configs, orgs, colls, user_dep, event_webhook_ops
+    app,
+    mdb,
+    users,
+    crawl_manager,
+    crawl_configs,
+    orgs,
+    colls,
+    user_dep,
+    event_webhook_ops,
 ):
     """uploads api"""
 
-    ops = UploadOps(mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops)
+    ops = UploadOps(
+        mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops
+    )
 
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -6,13 +6,12 @@ import os
 import base64
 from urllib.parse import unquote
 
+import asyncio
 from io import BufferedReader
 from typing import Optional, List
 from fastapi import Depends, UploadFile, File
-
 from fastapi import HTTPException
 from pydantic import UUID4
-
 from starlette.requests import Request
 from pathvalidate import sanitize_filename
 
@@ -39,6 +38,15 @@ MIN_UPLOAD_PART_SIZE = 10000000
 # ============================================================================
 class UploadOps(BaseCrawlOps):
     """upload ops"""
+
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods, too-many-function-args
+    def __init__(
+        self, mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops
+    ):
+        super().__init__(mdb, users, crawl_configs, crawl_manager, colls)
+
+        self.orgs = orgs
+        self.event_webhook_ops = event_webhook_ops
 
     # pylint: disable=too-many-arguments, too-many-locals, duplicate-code, invalid-name
     async def upload_stream(
@@ -163,6 +171,11 @@ class UploadOps(BaseCrawlOps):
         await self.crawls.find_one_and_update(
             {"_id": crawl_id}, {"$set": uploaded.to_dict()}, upsert=True
         )
+
+        asyncio.create_task(
+            self.event_webhook_ops.create_item_created_notification(crawl_id)
+        )
+
         return {"id": crawl_id, "added": True}
 
     async def delete_uploads(
@@ -228,12 +241,11 @@ class UploadFileReader(BufferedReader):
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, invalid-name
 def init_uploads_api(
-    app, mdb, users, crawl_manager, crawl_configs, orgs, colls, user_dep
+    app, mdb, users, crawl_manager, crawl_configs, orgs, colls, user_dep, event_webhook_ops
 ):
     """uploads api"""
 
-    # ops = CrawlOps(mdb, users, crawl_manager, crawl_config_ops, orgs)
-    ops = UploadOps(mdb, users, crawl_configs, crawl_manager, colls)
+    ops = UploadOps(mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops)
 
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -173,7 +173,7 @@ class UploadOps(BaseCrawlOps):
         )
 
         asyncio.create_task(
-            self.event_webhook_ops.create_item_created_notification(crawl_id)
+            self.event_webhook_ops.create_upload_finished_notification(crawl_id)
         )
 
         return {"id": crawl_id, "added": True}

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -158,7 +158,7 @@ class EventWebhookOps:
 
         await self.send_notification(org, notification)
 
-        if crawl.collections:
+        if crawl.collectionIds:
             for coll_id in crawl.collectionIds:
                 await self.create_added_to_collection_notification(
                     crawl_ids=[crawl_id], coll_id=coll_id, org=org

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -120,7 +120,7 @@ class EventWebhookOps:
         # internally but duplicates the event name in the POST body
         body = notification.body.dict()
         body["event"] = notification.event
-        body["oid"] = notification.oid
+        body["orgId"] = str(notification.oid)
         body.pop("type", None)
 
         try:

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -164,10 +164,7 @@ class EventWebhookOps:
                     crawl_ids=[crawl_id], coll_id=coll_id, org=org
                 )
 
-    async def create_crawl_finished_notification(
-        self,
-        crawl_id: str,
-    ):
+    async def create_crawl_finished_notification(self, crawl_id: str, state: str):
         """Create webhook notification for finished crawl."""
         crawl_res = await self.crawls.find_one({"_id": crawl_id})
         org = await self.org_ops.get_org_by_id(crawl_res["oid"])
@@ -182,6 +179,7 @@ class EventWebhookOps:
             body=CrawlFinishedBody(
                 itemId=crawl_id,
                 orgId=str(org.id),
+                state=state,
             ),
         )
 

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -116,10 +116,11 @@ class EventWebhookOps:
                 return
             url = org.webhookUrls.removedFromCollectionUrl
 
-        # Add event name to body and remove type, which is useful internally
-        # but duplicates the event name in the POST body
+        # Add event name and oid to body and remove type, which is useful
+        # internally but duplicates the event name in the POST body
         body = notification.body.dict()
         body["event"] = notification.event
+        body["oid"] = notification.oid
         body.pop("type", None)
 
         try:

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -8,7 +8,7 @@ import uuid
 import aiohttp
 import backoff
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import UUID4
+from pydantic import UUID4, Union
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
@@ -168,7 +168,6 @@ class EventWebhookOps:
 
     async def _create_collection_items_modified_notification(
         self,
-        crawl_ids: List[str],
         coll_id: uuid.UUID,
         org: Organization,
         event: str,
@@ -206,7 +205,6 @@ class EventWebhookOps:
             return
 
         await self._create_collection_items_modified_notification(
-            crawl_ids,
             coll_id,
             org,
             event=WebhookEventType.ADDED_TO_COLLECTION,
@@ -228,7 +226,6 @@ class EventWebhookOps:
             return
 
         await self._create_collection_items_modified_notification(
-            crawl_ids,
             coll_id,
             org,
             event=WebhookEventType.REMOVED_FROM_COLLECTION,

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -208,6 +208,16 @@ class EventWebhookOps:
         self, crawl_id: str, oid: uuid.UUID, scheduled: bool = False
     ):
         """Create webhook notification for started crawl."""
+        # Check if already created this event
+        existing_notification = await self.webhooks.find_one(
+            {
+                "event": WebhookEventType.CRAWL_STARTED,
+                "body.itemId": crawl_id,
+            }
+        )
+        if existing_notification:
+            return
+
         org = await self.org_ops.get_org_by_id(oid)
 
         if not org.webhookUrls or not org.webhookUrls.crawlStarted:

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -1,0 +1,290 @@
+"""Webhook management"""
+
+import asyncio
+from datetime import datetime
+from typing import List
+import uuid
+
+import aiohttp
+import backoff
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import UUID4
+
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .models import (
+    WebhookEventType,
+    WebhookNotification,
+    ArchivedItemCreatedBody,
+    CollectionItemAddedRemovedBody,
+    PaginatedResponse,
+    Organization,
+)
+
+
+# ============================================================================
+class EventWebhookOps:
+    """Event webhook notification management"""
+
+    def __init__(self, mdb, org_ops):
+        self.webhooks = mdb["webhooks"]
+        self.colls = mdb["collections"]
+        self.crawls = mdb["crawls"]
+
+        self.org_ops = org_ops
+        self.crawl_ops = None
+
+        self.origin = None
+
+        self.router = APIRouter(
+            prefix="/webhooks",
+            tags=["webhooks"],
+            responses={404: {"description": "Not found"}},
+        )
+
+    def set_crawl_ops(self, ops):
+        """set crawl ops"""
+        self.crawl_ops = ops
+
+    async def list_notifications(
+        self,
+        org: Organization,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
+    ):
+        """List all webhook notifications"""
+        # Zero-index page for query
+        page = page - 1
+        skip = page_size * page
+
+        query = {"oid": org.id}
+
+        total = await self.webhooks.count_documents(query)
+
+        cursor = self.webhooks.find(query, skip=skip, limit=page_size)
+        results = await cursor.to_list(length=page_size)
+        notifications = [WebhookNotification.from_dict(res) for res in results]
+
+        return notifications, total
+
+    async def get_notification(self, org: Organization, notificationid: uuid.UUID):
+        """Get webhook notification by id and org"""
+        query = {"_id": notificationid, "oid": org.id}
+
+        res = await self.webhooks.find_one(query)
+        if not res:
+            raise HTTPException(status_code=404, detail="notification_not_found")
+
+        return WebhookNotification.from_dict(res)
+
+    @backoff.on_exception(backoff.expo, aiohttp.ClientError, max_tries=5, max_time=60)
+    async def send_notification(
+        self, org: Organization, notification: WebhookNotification
+    ):
+        """Send notification"""
+        if not org.webhookUrls:
+            print(
+                "Webhook URLs not configured - skipping sending notification",
+                flush=True,
+            )
+            return
+
+        # Get configured URL for this notification type
+        if notification.event == WebhookEventType.ARCHIVED_ITEM_CREATED:
+            if not org.webhookUrls.itemCreatedUrl:
+                print(
+                    "Webhook Item Created URL not configured, skipping",
+                    flush=True,
+                )
+                return
+            url = org.webhookUrls.itemCreatedUrl
+
+        elif notification.event == WebhookEventType.ADDED_TO_COLLECTION:
+            if not org.webhookUrls.addedToCollectionUrl:
+                print(
+                    "Webhook Item Added to Collection URL not configured, skipping",
+                    flush=True,
+                )
+                return
+            url = org.webhookUrls.addedToCollectionUrl
+
+        elif notification.event == WebhookEventType.REMOVED_FROM_COLLECTION:
+            if not org.webhookUrls.removedFromCollectionUrl:
+                print(
+                    "Webhook Item Removed from Collection URL not configured, skipping",
+                    flush=True,
+                )
+                return
+            url = org.webhookUrls.removedFromCollectionUrl
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(
+                    "POST",
+                    url,
+                    json=notification.body.to_dict(),
+                    raise_for_status=True,
+                ):
+                    await self.webhooks.find_one_and_update(
+                        {"_id": notification.id},
+                        {
+                            "$set": {
+                                "success": True,
+                                "lastAttempted": datetime.utcnow(),
+                            },
+                            "$inc": {"attempts": 1},
+                        },
+                    )
+
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(f"Webhook notification failed: {err}", flush=True)
+            await self.webhooks.find_one_and_update(
+                {"_id": notification.id},
+                {"$set": {"lastAttempted": datetime.utcnow()}, "$inc": {"attempts": 1}},
+            )
+
+    async def create_item_created_notification(self, crawl_id: str):
+        """Create webhook notification for item creation"""
+        crawl_res = await self.crawls.find_one({"_id": crawl_id})
+
+        org = await self.org_ops.get_org_by_id(crawl_res["oid"])
+
+        if not org.webhookUrls or not org.webhookUrls.itemCreatedUrl:
+            return
+
+        # Get full crawl with resources
+        crawl = await self.crawl_ops.get_crawl(crawl_id, org)
+        if not crawl:
+            print(f"Crawl {crawl_id} not found, skipping event webhook", flush=True)
+            return
+
+        notification = WebhookNotification(
+            id=uuid.uuid4(),
+            event=WebhookEventType.ARCHIVED_ITEM_CREATED,
+            oid=org.id,
+            body=ArchivedItemCreatedBody(
+                crawlId=crawl.id, downloadUrls=crawl.resources
+            ),
+            created=datetime.utcnow(),
+        )
+
+        await self.webhooks.insert_one(notification.to_dict())
+
+        await self.send_notification(org, notification)
+
+        if crawl.collections:
+            for coll_id in crawl.collections:
+                await self.create_added_removed_collection_notification(
+                    crawl_ids=[crawl_id], coll_id=coll_id, org=org
+                )
+
+    async def create_added_removed_collection_notification(
+        self,
+        crawl_ids: List[str],
+        coll_id: uuid.UUID,
+        org: Organization,
+        added: bool = True,
+    ):
+        """Create webhook notification for item added or removed from collection"""
+        if not org.webookUrls:
+            return
+
+        if added:
+            type_ = "added"
+            if not org.webhookUrls.addedToCollectionUrl:
+                return
+        else:
+            type_ = "removed"
+            if not org.webhookUrls.removedFromCollectionUrl:
+                return
+
+        event_type = WebhookEventType.ADDED_TO_COLLECTION
+        if not added:
+            event_type = WebhookEventType.REMOVED_FROM_COLLECTION
+
+        coll_download_url = f"/api/orgs/{org.id}/collections/{coll_id}/download"
+        if org.origin:
+            coll_download_url = (
+                f"{org.origin}/api/orgs/{org.id}/collections/{coll_id}/download"
+            )
+
+        notification = WebhookNotification(
+            id=uuid.uuid4(),
+            event=event_type,
+            oid=org.id,
+            body=CollectionItemAddedRemovedBody(
+                crawlIds=crawl_ids,
+                collectionId=coll_id,
+                type=type_,
+                downloadUrls=[coll_download_url],
+            ),
+            created=datetime.utcnow(),
+        )
+
+        await self.webhooks.insert_one(notification.to_dict())
+
+        await self.send_notification(org, notification)
+
+
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
+def init_event_webhooks_api(mdb, org_ops):
+    """init event webhooks system"""
+
+    ops = EventWebhookOps(mdb, org_ops)
+
+    router = ops.router
+
+    org_owner_dep = org_ops.org_owner_dep
+
+    @router.get("", response_model=PaginatedResponse)
+    async def list_notifications(
+        org: Organization = Depends(org_owner_dep),
+        pageSize: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
+    ):
+        notifications, total = await ops.list_notifications(
+            org, page_size=pageSize, page=page
+        )
+        return paginated_format(notifications, total, page, pageSize)
+
+    @router.get("/{notificationid}", response_model=WebhookNotification)
+    async def get_notification(
+        notificationid: UUID4,
+        org: Organization = Depends(org_owner_dep),
+    ):
+        return await ops.get_notification(org, notificationid)
+
+    @router.get("/{notificationid}/retry")
+    async def retry_notification(
+        notificationid: UUID4,
+        org: Organization = Depends(org_owner_dep),
+    ):
+        notification = await ops.get_notification(org, notificationid)
+        asyncio.create_task(ops.send_notification(org, notification))
+        return {"success": True}
+
+    # TODO: Add webhooks to OpenAPI documentation when we've updated FastAPI
+    # (requires FastAPI >= 0.99.0)
+
+    # @app.webhooks.post("archived-item-created")
+    # def archived_item_created(
+    #    body: ArchivedItemCreatedBody,
+    #    org: Organization = Depends(org_owner_dep)
+    # ):
+    #     """
+    #     When a new archived item is created, we will send a POST request with
+    #     the id for the item and download links for the item.
+    #     """
+
+    # @app.webhooks.post("added-to-collection")
+    # def added_to_collection(
+    #    body: CollectionItemAddedRemovedBody,
+    #    org: Organization = Depends(org_owner_dep)
+    # ):
+    #     """
+    #     When an archived item is added to a collection, we will send a POST
+    #     request with the ids of the archived item and collection and a
+    #     download link for the collection.
+    #     """
+
+    return ops

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -174,7 +174,7 @@ class EventWebhookOps:
             id=uuid.uuid4(),
             event=WebhookEventType.ARCHIVED_ITEM_CREATED,
             oid=org.id,
-            body=ArchivedItemCreatedBody(crawlId=crawl.id, downloadUrls=download_urls),
+            body=ArchivedItemCreatedBody(itemId=crawl.id, downloadUrls=download_urls),
             created=datetime.utcnow(),
         )
 
@@ -223,7 +223,7 @@ class EventWebhookOps:
             event=event_type,
             oid=org.id,
             body=CollectionItemAddedRemovedBody(
-                crawlIds=crawl_ids,
+                itemIds=crawl_ids,
                 collectionId=str(coll_id),
                 type=type_,
                 downloadUrls=[coll_download_url],

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -292,8 +292,19 @@ def init_event_webhooks_api(mdb, org_ops):
     #    org: Organization = Depends(org_owner_dep)
     # ):
     #     """
-    #     When an archived item is added to a collection, we will send a POST
-    #     request with the ids of the archived item and collection and a
+    #     When archived items are added to a collection, we will send a POST
+    #     request with the ids of the archived item(s) and collection and a
+    #     download link for the collection.
+    #     """
+
+    # @app.webhooks.post("removed-from-collection")
+    # def removed_from_collection(
+    #    body: CollectionItemAddedRemovedBody,
+    #    org: Organization = Depends(org_owner_dep)
+    # ):
+    #     """
+    #     When an archived items are removed from a collection, we will send a POST
+    #     request with the ids of the archived item(s) and collection and a
     #     download link for the collection.
     #     """
 

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -116,9 +116,11 @@ class EventWebhookOps:
                 return
             url = org.webhookUrls.removedFromCollectionUrl
 
-        # Add event name to body
+        # Add event name to body and remove type, which is useful internally
+        # but duplicates the event name in the POST body
         body = notification.body.dict()
         body["event"] = notification.event
+        body.pop("type", None)
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -2,13 +2,13 @@
 
 import asyncio
 from datetime import datetime
-from typing import List
+from typing import List, Union
 import uuid
 
 import aiohttp
 import backoff
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import UUID4, Union
+from pydantic import UUID4
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -208,6 +208,11 @@ class EventWebhookOps:
         self, crawl_id: str, oid: uuid.UUID, scheduled: bool = False
     ):
         """Create webhook notification for started crawl."""
+        org = await self.org_ops.get_org_by_id(oid)
+
+        if not org.webhookUrls or not org.webhookUrls.crawlStarted:
+            return
+
         # Check if already created this event
         existing_notification = await self.webhooks.find_one(
             {
@@ -216,11 +221,6 @@ class EventWebhookOps:
             }
         )
         if existing_notification:
-            return
-
-        org = await self.org_ops.get_org_by_id(oid)
-
-        if not org.webhookUrls or not org.webhookUrls.crawlStarted:
             return
 
         notification = WebhookNotification(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ python-multipart
 pathvalidate
 https://github.com/ikreymer/stream-zip/archive/refs/heads/stream-uncompress.zip
 boto3
+backoff>=2.2.1

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -303,22 +303,28 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
     data = r.json()
     if data.get("webhooks"):
         webhooks = data.get("webhooks")
-        assert webhooks.get("itemCreated") is None
+        assert webhooks.get("crawlStarted") is None
+        assert webhooks.get("crawlFinished") is None
+        assert webhooks.get("uploadFinished") is None
         assert webhooks.get("addedToCollection") is None
         assert webhooks.get("removedFromCollection") is None
 
     # Set URLs and verify
-    CREATED_URL = "https://example.com/created"
-    ADDED_URL = "https://example.com/added"
-    REMOVED_URL = "http://example.com/removed"
+    CRAWL_STARTED_URL = "https://example.com/crawl/started"
+    CRAWL_FINISHED_URL = "https://example.com/crawl/finished"
+    UPLOAD_FINISHED_URL = "https://example.com/crawl/finished"
+    COLL_ADDED_URL = "https://example.com/coll/added"
+    COLL_REMOVED_URL = "http://example.com/coll/removed"
 
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/event-webhook-urls",
         headers=admin_auth_headers,
         json={
-            "itemCreated": CREATED_URL,
-            "addedToCollection": ADDED_URL,
-            "removedFromCollection": REMOVED_URL,
+            "crawlStarted": CRAWL_STARTED_URL,
+            "crawlFinished": CRAWL_FINISHED_URL,
+            "uploadFinished": UPLOAD_FINISHED_URL,
+            "addedToCollection": COLL_ADDED_URL,
+            "removedFromCollection": COLL_REMOVED_URL,
         },
     )
     assert r.status_code == 200
@@ -331,9 +337,11 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
     assert r.status_code == 200
     data = r.json()
     urls = data["webhookUrls"]
-    assert urls["itemCreated"] == CREATED_URL
-    assert urls["addedToCollection"] == ADDED_URL
-    assert urls["removedFromCollection"] == REMOVED_URL
+    assert urls["crawlStarted"] == CRAWL_STARTED_URL
+    assert urls["crawlFinished"] == CRAWL_FINISHED_URL
+    assert urls["uploadFinished"] == UPLOAD_FINISHED_URL
+    assert urls["addedToCollection"] == COLL_ADDED_URL
+    assert urls["removedFromCollection"] == COLL_REMOVED_URL
 
 
 def test_update_event_webhook_urls_org_crawler(crawler_auth_headers, default_org_id):
@@ -341,7 +349,9 @@ def test_update_event_webhook_urls_org_crawler(crawler_auth_headers, default_org
         f"{API_PREFIX}/orgs/{default_org_id}/event-webhook-urls",
         headers=crawler_auth_headers,
         json={
-            "itemCreated": "https://example.com/created",
+            "crawlStarted": "https://example.com/crawlstarted",
+            "crawlFinished": "https://example.com/crawlfinished",
+            "uploadFinished": "https://example.com/uploadfinished",
             "addedToCollection": "https://example.com/added",
             "removedFromCollection": "https://example.com/removed",
         },

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -303,9 +303,9 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
     data = r.json()
     if data.get("webhooks"):
         webhooks = data.get("webhooks")
-        assert webhooks.get("itemCreatedUrl") is None
-        assert webhooks.get("addedToCollectionUrl") is None
-        assert webhooks.get("removedFromCollectionUrl") is None
+        assert webhooks.get("itemCreated") is None
+        assert webhooks.get("addedToCollection") is None
+        assert webhooks.get("removedFromCollection") is None
 
     # Set URLs and verify
     CREATED_URL = "https://example.com/created"
@@ -316,9 +316,9 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
         f"{API_PREFIX}/orgs/{default_org_id}/event-webhook-urls",
         headers=admin_auth_headers,
         json={
-            "itemCreatedUrl": CREATED_URL,
-            "addedToCollectionUrl": ADDED_URL,
-            "removedFromCollectionUrl": REMOVED_URL,
+            "itemCreated": CREATED_URL,
+            "addedToCollection": ADDED_URL,
+            "removedFromCollection": REMOVED_URL,
         },
     )
     assert r.status_code == 200
@@ -331,9 +331,9 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
     assert r.status_code == 200
     data = r.json()
     urls = data["webhookUrls"]
-    assert urls["itemCreatedUrl"] == CREATED_URL
-    assert urls["addedToCollectionUrl"] == ADDED_URL
-    assert urls["removedFromCollectionUrl"] == REMOVED_URL
+    assert urls["itemCreated"] == CREATED_URL
+    assert urls["addedToCollection"] == ADDED_URL
+    assert urls["removedFromCollection"] == REMOVED_URL
 
 
 def test_update_event_webhook_urls_org_crawler(crawler_auth_headers, default_org_id):
@@ -341,9 +341,9 @@ def test_update_event_webhook_urls_org_crawler(crawler_auth_headers, default_org
         f"{API_PREFIX}/orgs/{default_org_id}/event-webhook-urls",
         headers=crawler_auth_headers,
         json={
-            "itemCreatedUrl": "https://example.com/created",
-            "addedToCollectionUrl": "https://example.com/added",
-            "removedFromCollectionUrl": "https://example.com/removed",
+            "itemCreated": "https://example.com/created",
+            "addedToCollection": "https://example.com/added",
+            "removedFromCollection": "https://example.com/removed",
         },
     )
     assert r.status_code == 403

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -293,10 +293,10 @@ def test_delete_invite_by_email(admin_auth_headers, non_default_org_id):
     assert data["detail"] == "invite_not_found"
 
 
-def test_update_event_webhook_urls_org_admin(admin_auth_headers, non_default_org_id):
+def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id):
     # Verify no URLs are configured
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -313,7 +313,7 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, non_default_org
     REMOVED_URL = "http://example.com/removed"
 
     r = requests.post(
-        f"{API_PREFIX}/orgs/{non_default_org_id}/event-webhook-urls",
+        f"{API_PREFIX}/orgs/{default_org_id}/event-webhook-urls",
         headers=admin_auth_headers,
         json={
             "itemCreatedUrl": CREATED_URL,
@@ -325,7 +325,7 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, non_default_org
     assert r.json()["updated"]
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -495,7 +495,7 @@ def test_get_all_crawls_by_state(admin_auth_headers, default_org_id, admin_crawl
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 5
+    assert data["total"] >= 5
     items = data["items"]
     for item in items:
         assert item["state"] in ("complete", "partial_complete")

--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -7,10 +7,10 @@ from .conftest import API_PREFIX
 _webhook_event_id = None
 
 
-def test_list_webhook_events(admin_auth_headers, non_default_org_id):
+def test_list_webhook_events(admin_auth_headers, default_org_id):
     # Verify that webhook URLs have been set in previous tests
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -22,7 +22,7 @@ def test_list_webhook_events(admin_auth_headers, non_default_org_id):
 
     # Verify list endpoint works as expected
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks",
+        f"{API_PREFIX}/orgs/{default_org_id}/webhooks",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -43,9 +43,9 @@ def test_list_webhook_events(admin_auth_headers, non_default_org_id):
     assert _webhook_event_id
 
 
-def test_get_webhook_event(admin_auth_headers, non_default_org_id):
+def test_get_webhook_event(admin_auth_headers, default_org_id):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks/{_webhook_event_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/webhooks/{_webhook_event_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -60,10 +60,10 @@ def test_get_webhook_event(admin_auth_headers, non_default_org_id):
     assert item["lastAttempted"]
 
 
-def test_retry_webhook_event(admin_auth_headers, non_default_org_id):
+def test_retry_webhook_event(admin_auth_headers, default_org_id):
     # Expect to fail because we haven't set up URLs that accept webhooks
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks/{_webhook_event_id}/retry",
+        f"{API_PREFIX}/orgs/{default_org_id}/webhooks/{_webhook_event_id}/retry",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -74,7 +74,7 @@ def test_retry_webhook_event(admin_auth_headers, non_default_org_id):
 
     # Verify attempts have been increased
     r = requests.get(
-        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks/{_webhook_event_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/webhooks/{_webhook_event_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -50,14 +50,29 @@ def test_get_webhook_event(admin_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     item = r.json()
+
     assert item["id"]
-    assert item["event"]
     assert item["oid"]
-    assert item["body"]
     assert item["success"] is False
     assert item["attempts"] == 1
     assert item["created"]
     assert item["lastAttempted"]
+
+    body = item["body"]
+    assert body
+
+    event = item["event"]
+    assert event
+
+    if event == "archived-item-created":
+        assert len(body["downloadUrls"]) >= 1
+        assert body["itemId"]
+
+    elif event in ("added-to-collection", "removed-from-collection"):
+        assert len(body["downloadUrls"]) == 1
+        assert body["collectionId"]
+        assert len(body["itemIds"]) >= 1
+        assert body["type"] in ("added", "removed")
 
 
 def test_retry_webhook_event(admin_auth_headers, default_org_id):

--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -16,9 +16,9 @@ def test_list_webhook_events(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     urls = data["webhookUrls"]
-    assert urls["itemCreatedUrl"]
-    assert urls["addedToCollectionUrl"]
-    assert urls["removedFromCollectionUrl"]
+    assert urls["itemCreated"]
+    assert urls["addedToCollection"]
+    assert urls["removedFromCollection"]
 
     # Verify list endpoint works as expected
     r = requests.get(
@@ -64,15 +64,14 @@ def test_get_webhook_event(admin_auth_headers, default_org_id):
     event = item["event"]
     assert event
 
-    if event == "archived-item-created":
+    if event == "itemCreated":
         assert len(body["downloadUrls"]) >= 1
         assert body["itemId"]
 
-    elif event in ("added-to-collection", "removed-from-collection"):
+    elif event in ("addedToCollection", "removedFromCollection"):
         assert len(body["downloadUrls"]) == 1
         assert body["collectionId"]
         assert len(body["itemIds"]) >= 1
-        assert body["type"] in ("added", "removed")
 
 
 def test_retry_webhook_event(admin_auth_headers, default_org_id):

--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -1,0 +1,89 @@
+import time
+
+import requests
+
+from .conftest import API_PREFIX
+
+_webhook_event_id = None
+
+
+def test_list_webhook_events(admin_auth_headers, non_default_org_id):
+    # Verify that webhook URLs have been set in previous tests
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    urls = data["webhookUrls"]
+    assert urls["itemCreatedUrl"]
+    assert urls["addedToCollectionUrl"]
+    assert urls["removedFromCollectionUrl"]
+
+    # Verify list endpoint works as expected
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] > 0
+    for item in data["items"]:
+        assert item["id"]
+        assert item["event"]
+        assert item["oid"]
+        assert item["body"]
+        assert item["success"] is False
+        assert item["attempts"] == 1
+        assert item["created"]
+        assert item["lastAttempted"]
+
+    global _webhook_event_id
+    _webhook_event_id = data["items"][0]["id"]
+    assert _webhook_event_id
+
+
+def test_get_webhook_event(admin_auth_headers, non_default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks/{_webhook_event_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    item = r.json()
+    assert item["id"]
+    assert item["event"]
+    assert item["oid"]
+    assert item["body"]
+    assert item["success"] is False
+    assert item["attempts"] == 1
+    assert item["created"]
+    assert item["lastAttempted"]
+
+
+def test_retry_webhook_event(admin_auth_headers, non_default_org_id):
+    # Expect to fail because we haven't set up URLs that accept webhooks
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks/{_webhook_event_id}/retry",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+    # Give it some time to run
+    time.sleep(90)
+
+    # Verify attempts have been increased
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/webhooks/{_webhook_event_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    item = r.json()
+    assert item["id"]
+    assert item["event"]
+    assert item["oid"]
+    assert item["body"]
+    assert item["success"] is False
+    assert item["attempts"] == 2
+    assert item["created"]
+    assert item["lastAttempted"]

--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -16,7 +16,9 @@ def test_list_webhook_events(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     urls = data["webhookUrls"]
-    assert urls["itemCreated"]
+    assert urls["crawlStarted"]
+    assert urls["crawlFinished"]
+    assert urls["uploadFinished"]
     assert urls["addedToCollection"]
     assert urls["removedFromCollection"]
 
@@ -64,8 +66,12 @@ def test_get_webhook_event(admin_auth_headers, default_org_id):
     event = item["event"]
     assert event
 
-    if event == "itemCreated":
+    if event in ("crawlFinished", "uploadFinished"):
         assert len(body["downloadUrls"]) >= 1
+        assert body["itemId"]
+
+    elif event in ("crawlStarted"):
+        assert len(body["downloadUrls"]) == 0
         assert body["itemId"]
 
     elif event in ("addedToCollection", "removedFromCollection"):


### PR DESCRIPTION
Fixes #1041 

This PR introduces the backend API for event webhook notifications for the following events:

- Crawl started (including boolean indicating if crawl was scheduled)
- Crawl finished
- Upload finished
- Archived item added to collection
- Archived item removed from collection

Configuration of URLs is done via `/api/orgs/<oid>/event-webhook-urls`. If a URL is configured for a given event, a webhook notification is added to the database and then attempted to be sent (up to a total of 5 tries per overall attempt, with an increasing backoff between, implemented via use of the [backoff](https://github.com/litl/backoff) library, which supports async).

## Testing

Tested using a local instance exposed to the internet with [ngrok](https://ngrok.com/) and https://webhook.site, for creating a crawl, auto-adding crawls to collections, uploading a WACZ, and manually adding/removing items from collections.

In each case, the desired messages were successfully POSTed to webhook.site quickly after each event happened in the backend, and were logged in the database. I was also able to successfully retry a webhook notification via the API.

Backend tests have also been added for the LIST, GET, and retry API endpoints for webhook notifications.

## Sample notification POST bodies

### Crawl started

```json
{
  "downloadUrls": null,
  "orgId": "ac2fe747-1e72-4e02-9aac-35139baf4ded",
  "event": "crawlStarted",
  "itemId": "manual-20230831212544-777cd7d8-bf4",
  "scheduled": false
}
```

### Crawl finished

```json
{
  "downloadUrls": [
    "http://localhost:30870/data/ac2fe747-1e72-4e02-9aac-35139baf4ded/20230831212621089-777cd7d8-bf4-0.wacz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ADMIN%2F20230831%2F%2Fs3%2Faws4_request&X-Amz-Date=20230831T212629Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=f066944852359e54fa8a57658ae2406184e226284718f788ffd0219d6351a45c"
  ],
  "orgId": "ac2fe747-1e72-4e02-9aac-35139baf4ded",
  "event": "crawlFinished",
  "itemId": "manual-20230831212544-777cd7d8-bf4",
  "state": "canceled"
}
```

### Upload finished

```json
{
  "downloadUrls": [
    "http://localhost:30870/data/ac2fe747-1e72-4e02-9aac-35139baf4ded/uploads/upload-22f2834b-4ee2-4afa-8ff9-49cd171b8e78/specs-zqkv4mkr.wacz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ADMIN%2F20230831%2F%2Fs3%2Faws4_request&X-Amz-Date=20230831T212740Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=7d8256d42852a48f37aa5c0ad1813146f285f93f143724ee2872ca090b6aa543"
  ],
  "orgId": "ac2fe747-1e72-4e02-9aac-35139baf4ded",
  "event": "uploadFinished",
  "itemId": "upload-22f2834b-4ee2-4afa-8ff9-49cd171b8e78"
}
```

### Archived item(s) added to collection

```json
{
  "downloadUrls": [
    "http://localhost:30870/api/orgs/2569f151-b822-46b1-b4e1-fff5ca1958b7/collections/2938e855-5438-47c4-82a9-cfac44a1b17d/download"
  ],
  "orgId": "2569f151-b822-46b1-b4e1-fff5ca1958b7",
  "event": "addedToCollection",
  "collectionId": "2938e855-5438-47c4-82a9-cfac44a1b17d",
  "itemIds": [
    "manual-20230830161709-a7a099b1-a25"
  ]
}
```

**Note: the `downloadUrls` for collections will require headers, as they're an API route in the application rather than a presigned S3 URL like we use for archived item WACZs**

### Archived item(s) removed from collection

```json
{
  "downloadUrls": [
    "http://localhost:30870/api/orgs/2569f151-b822-46b1-b4e1-fff5ca1958b7/collections/2938e855-5438-47c4-82a9-cfac44a1b17d/download"
  ],
  "orgId": "2569f151-b822-46b1-b4e1-fff5ca1958b7",
  "event": "removedFromCollection",
  "collectionId": "2938e855-5438-47c4-82a9-cfac44a1b17d",
  "itemIds": [
    "manual-20230830161709-a7a099b1-a25"
  ]
}
```

## TODO

We still need to document the webhook notifications in our OpenAPI documentation. This is included in this PR but commented out because it's currently blocked by #1050 