### PR TITLE
fix redis connection leaks + exclusions error: (fixes #1065)

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -68,11 +68,9 @@ class K8sAPI:
     async def get_redis_client(self, redis_url):
         """return redis client with correct params for one-time use"""
         # manual settings until redis 5.0.0 is released
-        pool = ConnectionPool.from_url(redis_url)
+        pool = ConnectionPool.from_url(redis_url, decode_responses=True)
         redis = Redis(
             connection_pool=pool,
-            single_connection_client=True,
-            encoding="utf-8",
             decode_responses=True,
         )
         redis.auto_close_connection_pool = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ loguru
 aiofiles
 kubernetes-asyncio==22.6.5
 aiobotocore
-redis>=4.2.0rc1
+redis>=5.0.0rc2
 pyyaml
 jinja2
 humanize


### PR DESCRIPTION
- use contextmanager for accessing redis to ensure redis.close() is always called
- add get_redis_client() to k8sapi to ensure unified place to get redis client
- use connectionpool.from_url() until redis 5.0.0 is released to ensure auto close and single client settings are applied
- also: catch invalid regex passed to re.compile() in queue regex check, return 400 instead of 500 for invalid regex
- redis requirements: bump to 5.0.0rc2