### PR TITLE
helm chart tweaks:

### DIFF
--- a/backend/btrixcloud/templates/crawler.yaml
+++ b/backend/btrixcloud/templates/crawler.yaml
@@ -19,7 +19,7 @@ spec:
 
   serviceName: crawl-{{ id }}
   replicas: {{ scale }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
 
   # not yet supported
   #persistentVolumeClaimRetentionPolicy:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress_class | default "nginx" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    # cors enabled via backend directly on allowed paths
+    #nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,7 +101,7 @@ backend_workers: 2
 
 backend_cpu: "25m"
 
-backend_memory: "384Mi"
+backend_memory: "200Mi"
 
 # port for operator service
 opPort: 8756
@@ -187,7 +187,7 @@ crawler_browser_instances: 2
 crawler_cpu_per_browser: 650
 
 # this value is an integer in 'Mi' (Megabyte) units, multiplied by 'crawler_browser_instances'
-crawler_memory_per_browser: 768
+crawler_memory_per_browser: 675
 
 # minimum size allocated to each crawler
 # should be at least double crawl session size to ensure space for WACZ


### PR DESCRIPTION
- lower mem requirements for backend and crawler to be closer to pre 1.6.0
- disable cors in ingress to pass through cors headers from backend
- set crawler statefulset to init in ordered rather than parallel for better handling of multiple crawls