### PR TITLE
Update frontend local dev guide

### DIFF
--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -72,7 +72,7 @@ If connecting to a local deployment cluster, set `API_BASE_URL` to:
 API_BASE_URL=http://localhost:30870
 ```
 
-??? info "Minikube (on Mac)"
+??? info "Port when using Minikube (on Mac)"
 
     When using Minikube on a Mac, the port will not be 30870. Instead, Minikube opens a tunnel to a random port,
     obtained by running `minikube service browsertrix-cloud-frontend --url` in a separate terminal.
@@ -100,7 +100,7 @@ To stop the development server type ++ctrl+c++ into your command line terminal.
 | `build-dev`        | bundles app and outputs it in `dist` directory                  |
 | `build`            | bundles app, optimized for production, and outputs it to `dist` |
 | `lint`             | find and fix auto-fixable javascript errors                     |
-| `format`           | formats js, html, and css files                                  |
+| `format`           | formats js, html, and css files                                 |
 | `localize:extract` | generate XLIFF file to be translated                            |
 | `localize:build`   | output a localized version of strings/templates                 |
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -1,21 +1,44 @@
-# Running the Frontend for UI Development
+# Developing the Frontend UI
 
-This guide explains how to run the Browsertrix Cloud frontend locally with [Yarn](https://classic.yarnpkg.com) against an existing backend instance.
+This guide explains how to run the Browsertrix Cloud frontend development server with [Yarn](https://classic.yarnpkg.com).
 
-This setup is ideal for rapid UI development that does not rely on any backend changes.
+Instead of rebuilding the entire frontend image to view your UI changes, you can use the included local development server to access the frontend from your browser. This setup is ideal for rapid UI development that does not rely on any backend changes.
 
 ## Requirements
 
-1. Browsertrix Cloud API backend already in a Kubernetes cluster (See: [Setup for Local Development](./local-dev-setup.md))
-2. Node v16 or greater with Yarn 1
+### 1. Browsertrix Cloud API backend already in a Kubernetes cluster
+
+The frontend development server requires an existing backend that has been deployed locally or is in production. See [Deploying Browsertrix Cloud](https://docs.browsertrix.cloud/deploy/).
+
+### 2. Node.js >=16 and Yarn 1
+
+To check if you already have Node.js installed, run the following command in your command line terminal:
+
+```sh
+node --version
+```
+
+You should see a version number like `v18.12.1`. If you see a command line error instead of a version number, or your version is less than 16, [install or upgrade Node.js](https://nodejs.org) before continuing.
+
+To check your Yarn installation:
+
+```sh
+yarn --version
+```
+
+You should see a version number like `1.22.19`. If you do not, [install or upgrade Yarn](https://classic.yarnpkg.com/en/docs/install).
 
 ## Quickstart
 
-Ensure the current working directory is set to the `/frontend` folder.
+Change your current working directory to `/frontend`:
 
 ```sh
 cd frontend
 ```
+
+!!! note
+
+    From this point on, all commands in this guide should be run from the `frontend` directory.
 
 Install dependencies:
 
@@ -29,13 +52,15 @@ Copy environment variables from the sample file:
 cp sample.env.local .env.local
 ```
 
-Update `API_BASE_URL` in `.env.local` to point to your dev backend base URL.
+Update `API_BASE_URL` in `.env.local` to point to your dev backend base URL. For example:
 
 ```
 API_BASE_URL=http://dev.example.com
 ```
 
-_Note:_ This setup assumes that your API endpoints are available under `/api`, which is the default configuration for the Browsertrix Cloud backend.
+!!! note
+
+    This setup assumes that your API endpoints are available under `/api`, which is the default configuration for the Browsertrix Cloud backend.
 
 If connecting to a local deployment cluster, set API_BASE_URL to:
 
@@ -50,7 +75,7 @@ API_BASE_URL=http://localhost:30870
 
     Set API_BASE_URL to provided URL instead, eg. `API_BASE_URL=http://127.0.0.1:<TUNNEL_PORT>`
 
-Start the dev server:
+Start the development server:
 
 ```sh
 yarn start
@@ -58,8 +83,7 @@ yarn start
 
 This will open `localhost:9870` in a new tab in your default browser.
 
-To develop against a local instance of the backend API,
-follow instructions for deploying to a local Docker instance. Update `API_BASE_URL` and then restart the dev server.
+Saving changes to files in `src` will automatically reload your browser window with the latest updates.
 
 ## Scripts
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -96,7 +96,7 @@ To stop the development server type <kbd>Ctrl</kbd> + <kbd>C</kbd> into your com
 | `build-dev`        | bundles app and outputs it in `dist` directory                  |
 | `build`            | bundles app, optimized for production, and outputs it to `dist` |
 | `lint`             | find and fix auto-fixable javascript errors                     |
-| `format`           | formats js, html and css files                                  |
+| `format`           | formats js, html, and css files                                  |
 | `localize:extract` | generate XLIFF file to be translated                            |
 | `localize:build`   | output a localized version of strings/templates                 |
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -6,7 +6,7 @@ This setup is ideal for rapid UI development that does not rely on any backend c
 
 ## Requirements
 
-1. rowsertrix Cloud API backend already in a Kubernetes cluster (See: [Setup for Local Development](./local-dev-setup.md))
+1. Browsertrix Cloud API backend already in a Kubernetes cluster (See: [Setup for Local Development](./local-dev-setup.md))
 2. Node v16 or greater with Yarn 1
 
 ## Quickstart
@@ -14,14 +14,13 @@ This setup is ideal for rapid UI development that does not rely on any backend c
 Ensure the current working directory is set to the `/frontend` folder.
 
 ```sh
-# From the repo root:
 cd frontend
 ```
 
 Install dependencies:
 
 ```sh
-yarn
+yarn install
 ```
 
 Copy environment variables from the sample file:
@@ -30,16 +29,18 @@ Copy environment variables from the sample file:
 cp sample.env.local .env.local
 ```
 
-Update `API_BASE_URL` in `.env.local` to point to your dev backend API. For example:
+Update `API_BASE_URL` in `.env.local` to point to your dev backend base URL.
 
 ```
-API_BASE_URL=http://dev.example.com/api
+API_BASE_URL=http://dev.example.com
 ```
+
+_Note:_ This setup assumes that your API endpoints are available under `/api`, which is the default configuration for the Browsertrix Cloud backend.
 
 If connecting to a local deployment cluster, set API_BASE_URL to:
 
 ```
-API_BASE_URL=http://localhost:30870/api
+API_BASE_URL=http://localhost:30870
 ```
 
 ??? info "Minikube (on Mac)"

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -30,7 +30,7 @@ You should see a version number like `1.22.19`. If you do not, [install or upgra
 
 ## Quickstart
 
-Change your current working directory to `/frontend`:
+From the command line, change your current working directory to `/frontend`:
 
 ```sh
 cd frontend
@@ -40,7 +40,7 @@ cd frontend
 
     From this point on, all commands in this guide should be run from the `frontend` directory.
 
-Install dependencies:
+Install UI dependencies:
 
 ```sh
 yarn install
@@ -52,7 +52,7 @@ Copy environment variables from the sample file:
 cp sample.env.local .env.local
 ```
 
-Update `API_BASE_URL` in `.env.local` to point to your dev backend base URL. For example:
+Update `API_BASE_URL` in `.env.local` to point to your backend API host. For example:
 
 ```
 API_BASE_URL=http://dev.example.com
@@ -62,7 +62,7 @@ API_BASE_URL=http://dev.example.com
 
     This setup assumes that your API endpoints are available under `/api`, which is the default configuration for the Browsertrix Cloud backend.
 
-If connecting to a local deployment cluster, set API_BASE_URL to:
+If connecting to a local deployment cluster, set `API_BASE_URL` to:
 
 ```
 API_BASE_URL=http://localhost:30870
@@ -75,7 +75,7 @@ API_BASE_URL=http://localhost:30870
 
     Set API_BASE_URL to provided URL instead, eg. `API_BASE_URL=http://127.0.0.1:<TUNNEL_PORT>`
 
-Start the development server:
+Start the frontend development server:
 
 ```sh
 yarn start
@@ -83,7 +83,9 @@ yarn start
 
 This will open `localhost:9870` in a new tab in your default browser.
 
-Saving changes to files in `src` will automatically reload your browser window with the latest updates.
+Saving changes to files in `src` will automatically reload your browser window with the latest UI updates.
+
+To stop the development server type <kbd>Ctrl</kbd> + <kbd>C</kbd> into your command line terminal.
 
 ## Scripts
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -10,7 +10,7 @@ Instead of rebuilding the entire frontend image to view your UI changes, you can
 
 The frontend development server requires an existing backend that has been deployed locally or is in production. See [Deploying Browsertrix Cloud](https://docs.browsertrix.cloud/deploy/).
 
-### 2. Node.js >=16 and Yarn 1
+### 2. Node.js ≥16 and Yarn 1
 
 To check if you already have Node.js installed, run the following command in your command line terminal:
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -85,7 +85,7 @@ This will open `localhost:9870` in a new tab in your default browser.
 
 Saving changes to files in `src` will automatically reload your browser window with the latest UI updates.
 
-To stop the development server type <kbd>Ctrl</kbd> + <kbd>C</kbd> into your command line terminal.
+To stop the development server type ++ctrl+c++ into your command line terminal.
 
 ## Scripts
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -1,19 +1,22 @@
-# Running the Frontend for Development
+# Running the Frontend for UI Development
 
-This guide explains how to deploy an instance of the Browsertrix Cloud frontend for development.
+This guide explains how to run the Browsertrix Cloud frontend locally with [Yarn](https://classic.yarnpkg.com) against an existing backend instance.
 
-This setup may be ideal for rapid development on the frontend, as it will allow running the frontend
-via `yarn` instead of the frontend image deployed in Kubernetes.
+This setup is ideal for rapid UI development that does not rely on any backend changes.
 
 ## Requirements
 
-This setup does require a Browsertrix Cloud API backend already in a Kubernetes cluster.
-
-Refer to [setup for local deployment](./local-dev-setup.md) for additional details on this setup.
+1. rowsertrix Cloud API backend already in a Kubernetes cluster (See: [Setup for Local Development](./local-dev-setup.md))
+2. Node v16 or greater with Yarn 1
 
 ## Quickstart
 
 Ensure the current working directory is set to the `/frontend` folder.
+
+```sh
+# From the repo root:
+cd frontend
+```
 
 Install dependencies:
 
@@ -45,8 +48,6 @@ API_BASE_URL=http://localhost:30870/api
     obtained by running `minikube service browsertrix-cloud-frontend --url` in a separate terminal.
 
     Set API_BASE_URL to provided URL instead, eg. `API_BASE_URL=http://127.0.0.1:<TUNNEL_PORT>`
-
-
 
 Start the dev server:
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -8,7 +8,7 @@ Instead of rebuilding the entire frontend image to view your UI changes, you can
 
 ### 1. Browsertrix Cloud API backend already in a Kubernetes cluster
 
-The frontend development server requires an existing backend that has been deployed locally or is in production. See [Deploying Browsertrix Cloud](https://docs.browsertrix.cloud/deploy/).
+The frontend development server requires an existing backend that has been deployed locally or is in production. See [Deploying Browsertrix Cloud](../../deploy/).
 
 ### 2. Node.js ≥16 and Yarn 1
 

--- a/docs/develop/frontend-dev.md
+++ b/docs/develop/frontend-dev.md
@@ -18,7 +18,11 @@ To check if you already have Node.js installed, run the following command in you
 node --version
 ```
 
-You should see a version number like `v18.12.1`. If you see a command line error instead of a version number, or your version is less than 16, [install or upgrade Node.js](https://nodejs.org) before continuing.
+You should see a version number like `v18.12.1`. If you see a command line error instead of a version number, [install Node.js](https://nodejs.org) before continuing.
+
+??? question "What if my other project requires a different version of Node.js?"
+
+    You can use [Node Version Manager](https://nodejs.org/en/download/package-manager#nvm) to install multiple Node.js versions and switch versions between projects.
 
 To check your Yarn installation:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,1 @@
+[Development guide](../docs/develop/frontend-dev.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.keys
   - def_list
   - attr_list
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1034

## Changes
- Clarifies use case for frontend development server
- Fixes incorrect sample API URLs
- Adds additional detail around requirements and quickstart
- Links back to docs from frontend README

## Manual testing

Run `mkdocs serve` and go to "Develop" -> "Developing the Frontend UI"