### PR TITLE
Add MkDocs YAML schema to vscode settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "yaml.schemas": {
+      "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
+    },
+    "yaml.customTags": [ 
+      "!ENV scalar",
+      "!ENV sequence",
+      "tag:yaml.org,2002:python/name:materialx.emoji.to_svg",
+      "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
+      "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
+    ]
+  }
+  

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,12 @@
 {
-    "yaml.schemas": {
-      "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
-    },
-    "yaml.customTags": [ 
-      "!ENV scalar",
-      "!ENV sequence",
-      "tag:yaml.org,2002:python/name:materialx.emoji.to_svg",
-      "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
-      "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
-    ]
-  }
-  
+  "yaml.schemas": {
+    "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
+  },
+  "yaml.customTags": [ 
+    "!ENV scalar",
+    "!ENV sequence",
+    "tag:yaml.org,2002:python/name:materialx.emoji.to_svg",
+    "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
+    "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ theme:
     - navigation.tabs.sticky
     - navigation.instant
     - navigation.tracking
-    - navigation-indexes
+    - navigation.indexes
     - navigation.footer
     - content.code.copy
     - content.action.edit


### PR DESCRIPTION
### Context

Adds [config validation for editing the MkDocs config file](https://squidfunk.github.io/mkdocs-material/creating-your-site/?h=yaml#minimal-configuration) in VSCode.

### Testing

1. Install [yaml language support](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) if you don't have it already.
2. Attempt to make a change to `mkdocs.yml`, verify that suggestions pop up and that the "Material for MkDocs" schema is loaded
<img width="585" alt="Screenshot 2023-08-14 at 7 45 39 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/1d698d66-7191-4bd7-bca4-95b748548ea9">

### Reasons why we might not want this

Some folks don't use VSCode?  Maybe this is an extra thing we have to support that is of dubious usefulness?  Generally I like settings that reduce human error, is this one worth it?  ¯\\\_(ツ)_/¯ 