### PR TITLE
Paginate Workflows and refactor to use server-side queries

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -29,6 +29,17 @@ from .models import (
 )
 
 
+ALLOWED_SORT_KEYS = (
+    "created",
+    "modified",
+    "firstSeed",
+    "lastCrawlTime",
+    "lastCrawlStartTime",
+    "lastRun",
+    "name",
+)
+
+
 # ============================================================================
 class CrawlConfigOps:
     """Crawl Config Operations"""
@@ -324,14 +335,7 @@ class CrawlConfigOps:
             aggregate.extend([{"$match": {"firstSeed": first_seed}}])
 
         if sort_by:
-            if sort_by not in (
-                "created",
-                "modified",
-                "firstSeed",
-                "lastCrawlTime",
-                "lastCrawlStartTime",
-                "lastRun",
-            ):
+            if sort_by not in ALLOWED_SORT_KEYS:
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
@@ -340,12 +344,7 @@ class CrawlConfigOps:
 
             # Add modified as final sort key to give some order to workflows that
             # haven't been run yet.
-            if sort_by in (
-                "firstSeed",
-                "lastCrawlTime",
-                "lastCrawlStartTime",
-                "lastRun",
-            ):
+            if sort_by not in ("created", "modified"):
                 sort_query = {sort_by: sort_direction, "modified": sort_direction}
 
             aggregate.extend([{"$sort": sort_query}])

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -79,11 +79,15 @@ class CrawlConfigOps:
         )
 
         await self.crawl_configs.create_index(
-            [("oid", pymongo.ASCENDING), ("tags", pymongo.ASCENDING)]
+            [("oid", pymongo.HASHED), ("tags", pymongo.ASCENDING)]
         )
 
         await self.crawl_configs.create_index(
             [("lastRun", pymongo.DESCENDING), ("modified", pymongo.DESCENDING)]
+        )
+
+        await self.crawl_configs.create_index(
+            [("name", pymongo.ASCENDING), ("firstSeed", pymongo.ASCENDING)]
         )
 
         await self.config_revs.create_index([("cid", pymongo.HASHED)])
@@ -342,10 +346,14 @@ class CrawlConfigOps:
 
             sort_query = {sort_by: sort_direction}
 
-            # Add modified as final sort key to give some order to workflows that
-            # haven't been run yet.
-            if sort_by not in ("created", "modified"):
-                sort_query = {sort_by: sort_direction, "modified": sort_direction}
+            # add secondary sort keys:
+            # firstSeed for name
+            if sort_by == "name":
+                sort_query["firstSeed"] = sort_direction
+
+            # modified for last* fields in case crawl hasn't been run yet
+            elif sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
+                sort_query["modified"] = sort_direction
 
             aggregate.extend([{"$sort": sort_query}])
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -79,7 +79,7 @@ class CrawlConfigOps:
         )
 
         await self.crawl_configs.create_index(
-            [("oid", pymongo.HASHED), ("tags", pymongo.ASCENDING)]
+            [("oid", pymongo.ASCENDING), ("tags", pymongo.ASCENDING)]
         )
 
         await self.crawl_configs.create_index(

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -153,6 +153,9 @@ import("./collections-add").then(({ CollectionsAdd }) => {
 import("./code").then(({ Code }) => {
   customElements.define("btrix-code", Code);
 });
+import("./search-combobox").then(({ SearchCombobox }) => {
+  customElements.define("btrix-search-combobox", SearchCombobox);
+});
 
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/search-combobox.ts
+++ b/frontend/src/components/search-combobox.ts
@@ -1,0 +1,192 @@
+import { LitElement, html } from "lit";
+import { property, state, query } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import { when } from "lit/directives/when.js";
+import debounce from "lodash/fp/debounce";
+import Fuse from "fuse.js";
+import type { SlInput, SlMenuItem } from "@shoelace-style/shoelace";
+
+export type SelectEvent = CustomEvent<{
+  key: string | null;
+  value?: any;
+}>;
+type SearchResult = {
+  item: any;
+  matches: {
+    key: string;
+    value: string;
+  }[];
+};
+
+const MIN_SEARCH_LENGTH = 2;
+const MAX_SEARCH_RESULTS = 10;
+
+/**
+ * Fuzzy search through list of options
+ *
+ * @event on-select
+ * @event on-clear
+ */
+@localized()
+export class SearchCombobox extends LitElement {
+  @property({ type: Array })
+  searchOptions: any[] = [];
+
+  @property({ type: Array })
+  searchKeys: string[] = [];
+
+  @property({ type: Array })
+  keyLabels: { [key: string]: string } = {};
+
+  @property({ type: String })
+  selectedKey?: string;
+
+  @property({ type: String })
+  placeholder: string = msg("Start typing to search");
+
+  @state()
+  private searchByValue: string = "";
+
+  private get hasSearchStr() {
+    return this.searchByValue.length >= MIN_SEARCH_LENGTH;
+  }
+
+  @state()
+  private searchResultsOpen = false;
+
+  @query("sl-input")
+  private input!: SlInput;
+
+  private fuse = new Fuse([], {
+    keys: [],
+    shouldSort: false,
+    threshold: 0.2, // stricter; default is 0.6
+    includeMatches: true,
+  });
+
+  disconnectedCallback(): void {
+    this.onSearchInput.cancel();
+    super.disconnectedCallback();
+  }
+
+  protected willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.get("selectedKey") && !this.selectedKey) {
+      this.onSearchInput.cancel();
+      this.searchByValue = "";
+    }
+    if (changedProperties.has("searchKeys") && this.searchKeys) {
+      this.fuse = new Fuse([], {
+        ...(this.fuse as any).options,
+        keys: this.searchKeys,
+      });
+    }
+    if (
+      changedProperties.has("searchOptions") &&
+      Array.isArray(this.searchOptions)
+    ) {
+      this.fuse.setCollection(this.searchOptions as never[]);
+    }
+  }
+
+  render() {
+    return html`
+      <btrix-combobox
+        ?open=${this.searchResultsOpen}
+        @request-close=${() => {
+          this.searchResultsOpen = false;
+          this.searchByValue = "";
+        }}
+        @sl-select=${async (e: CustomEvent) => {
+          this.searchResultsOpen = false;
+          const item = e.detail.item as SlMenuItem;
+          const key = item.dataset["key"];
+          this.searchByValue = item.value;
+          await this.updateComplete;
+          this.dispatchEvent(
+            <SelectEvent>new CustomEvent("on-select", {
+              detail: {
+                key: key,
+                value: item.value,
+              },
+            })
+          );
+        }}
+      >
+        <sl-input
+          size="small"
+          placeholder=${this.placeholder}
+          clearable
+          value=${this.searchByValue}
+          @sl-clear=${() => {
+            this.searchResultsOpen = false;
+            this.onSearchInput.cancel();
+            this.dispatchEvent(new CustomEvent("on-clear"));
+          }}
+          @sl-input=${this.onSearchInput}
+        >
+          ${when(
+            this.selectedKey,
+            () =>
+              html`<sl-tag
+                slot="prefix"
+                size="small"
+                pill
+                style="margin-left: var(--sl-spacing-3x-small)"
+                >${this.keyLabels[this.selectedKey as string]}</sl-tag
+              >`,
+            () => html`<sl-icon name="search" slot="prefix"></sl-icon>`
+          )}
+        </sl-input>
+        ${this.renderSearchResults()}
+      </btrix-combobox>
+    `;
+  }
+
+  private renderSearchResults() {
+    if (!this.hasSearchStr) {
+      return html`
+        <sl-menu-item slot="menu-item" disabled
+          >${msg("Start typing to view filters.")}</sl-menu-item
+        >
+      `;
+    }
+
+    const searchResults = this.fuse
+      .search(this.searchByValue)
+      .slice(0, MAX_SEARCH_RESULTS) as any;
+    if (!searchResults.length) {
+      return html`
+        <sl-menu-item slot="menu-item" disabled
+          >${msg("No matching items found.")}</sl-menu-item
+        >
+      `;
+    }
+
+    return html`
+      ${searchResults.map(({ matches }: SearchResult) =>
+        matches.map(
+          ({ key, value }) => html`
+            <sl-menu-item slot="menu-item" data-key=${key} value=${value}>
+              <sl-tag slot="prefix" size="small" pill
+                >${this.keyLabels[key]}</sl-tag
+              >
+              ${value}
+            </sl-menu-item>
+          `
+        )
+      )}
+    `;
+  }
+
+  private onSearchInput = debounce(150)((e: any) => {
+    this.searchByValue = this.input.value?.trim();
+
+    if (this.searchResultsOpen === false && this.hasSearchStr) {
+      this.searchResultsOpen = true;
+    }
+
+    if (!this.searchByValue && this.selectedKey) {
+      this.dispatchEvent(new CustomEvent("on-clear"));
+    }
+  }) as any;
+}

--- a/frontend/src/components/search-combobox.ts
+++ b/frontend/src/components/search-combobox.ts
@@ -75,6 +75,7 @@ export class SearchCombobox extends LitElement {
       this.searchByValue = "";
     }
     if (changedProperties.has("searchKeys") && this.searchKeys) {
+      this.onSearchInput.cancel();
       this.fuse = new Fuse([], {
         ...(this.fuse as any).options,
         keys: this.searchKeys,
@@ -84,6 +85,7 @@ export class SearchCombobox extends LitElement {
       changedProperties.has("searchOptions") &&
       Array.isArray(this.searchOptions)
     ) {
+      this.onSearchInput.cancel();
       this.fuse.setCollection(this.searchOptions as never[]);
     }
   }
@@ -146,7 +148,7 @@ export class SearchCombobox extends LitElement {
     if (!this.hasSearchStr) {
       return html`
         <sl-menu-item slot="menu-item" disabled
-          >${msg("Start typing to view filters.")}</sl-menu-item
+          >${msg("Keep typing to search.")}</sl-menu-item
         >
       `;
     }
@@ -157,7 +159,7 @@ export class SearchCombobox extends LitElement {
     if (!searchResults.length) {
       return html`
         <sl-menu-item slot="menu-item" disabled
-          >${msg("No matching items found.")}</sl-menu-item
+          >${msg("No matches found.")}</sl-menu-item
         >
       `;
     }

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -275,7 +275,7 @@ export class WorkflowListItem extends LitElement {
             (workflow) =>
               html`
                 <sl-format-date
-                  date=${(workflow.lastRun || workflow.modified).toString()}
+                  date=${workflow.modified.toString()}
                   month="2-digit"
                   day="2-digit"
                   year="2-digit"
@@ -549,7 +549,7 @@ export class WorkflowList extends LitElement {
 
   render() {
     return html` <div class="listHeader row">
-        <div class="col">${msg("Workflow Name & Last Updated")}</div>
+        <div class="col">${msg("Name & Last Modified")}</div>
         <div class="col">${msg("Last Crawl Status")}</div>
         <div class="col">${msg("Total Size")}</div>
         <div class="col">${msg("Started By & Schedule")}</div>

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -27,6 +27,7 @@ import type { Crawl, Workflow } from "../types/crawler";
 import { srOnly, truncate, dropdown } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { humanizeNextDate, humanizeSchedule } from "../utils/cron";
+import { numberFormatter } from "../utils/number";
 
 const mediumBreakpointCss = css`30rem`;
 const largeBreakpointCss = css`60rem`;
@@ -225,8 +226,9 @@ export class WorkflowListItem extends LitElement {
   @state()
   private dropdownIsOpen?: boolean;
 
-  // TODO localize
-  private numberFormatter = new Intl.NumberFormat();
+  private numberFormatter = numberFormatter(undefined, {
+    notation: "compact",
+  });
 
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("dropdownIsOpen")) {
@@ -271,19 +273,23 @@ export class WorkflowListItem extends LitElement {
           ${this.safeRender(this.renderName)}
         </div>
         <div class="desc">
-          ${this.safeRender(
-            (workflow) =>
-              html`
-                <sl-format-date
-                  date=${workflow.modified.toString()}
-                  month="2-digit"
-                  day="2-digit"
-                  year="2-digit"
-                  hour="2-digit"
-                  minute="2-digit"
-                ></sl-format-date>
-              `
-          )}
+          ${this.safeRender((workflow) => {
+            if (workflow.schedule) {
+              return msg(
+                str`${humanizeSchedule(
+                  workflow.schedule,
+                  {
+                    length: "short",
+                  },
+                  numberFormatter
+                )}`
+              );
+            }
+            if (workflow.lastStartedByName) {
+              return msg(str`Manual run by ${workflow.lastStartedByName}`);
+            }
+            return msg("---");
+          })}
         </div>
       </div>
       <div class="col">
@@ -381,27 +387,33 @@ export class WorkflowListItem extends LitElement {
           ${this.safeRender((workflow) =>
             workflow.crawlCount === 1
               ? msg(str`${workflow.crawlCount} crawl`)
-              : msg(str`${(workflow.crawlCount ?? 0).toLocaleString()} crawls`)
+              : msg(
+                  str`${this.numberFormatter.format(
+                    workflow.crawlCount ?? 0
+                  )} crawls`
+                )
           )}
         </div>
       </div>
       <div class="col">
         <div class="detail truncate">
-          ${this.safeRender((workflow) =>
-            workflow.lastStartedByName
-              ? html`<span class="userName"
-                  >${workflow.lastStartedByName}</span
-                >`
-              : notSpecified
+          ${this.safeRender(
+            (workflow) =>
+              html`<span class="userName">${workflow.modifiedByName}</span>`
           )}
         </div>
         <div class="desc">
-          ${this.safeRender((workflow) =>
-            workflow.schedule
-              ? humanizeSchedule(workflow.schedule, {
-                  length: "short",
-                })
-              : msg("No Schedule")
+          ${this.safeRender(
+            (workflow) => html`
+              <sl-format-date
+                date=${workflow.modified.toString()}
+                month="2-digit"
+                day="2-digit"
+                year="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+              ></sl-format-date>
+            `
           )}
         </div>
       </div>
@@ -557,10 +569,10 @@ export class WorkflowList extends LitElement {
 
   render() {
     return html` <div class="listHeader row">
-        <div class="col">${msg("Name & Last Modified")}</div>
+        <div class="col">${msg("Name & Schedule")}</div>
         <div class="col">${msg("Latest Crawl")}</div>
         <div class="col">${msg("Total Size")}</div>
-        <div class="col">${msg("Started By & Schedule")}</div>
+        <div class="col">${msg("Last Modified")}</div>
         <div class="col action">
           <span class="srOnly">${msg("Actions")}</span>
         </div>

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -339,7 +339,7 @@ export class WorkflowListItem extends LitElement {
               workflow.lastCrawlSize
             ) {
               return html`<sl-format-bytes
-                  value=${workflow.totalSize}
+                  value=${+workflow.totalSize}
                   display="narrow"
                 ></sl-format-bytes>
                 <span class="currCrawlSize">
@@ -352,7 +352,7 @@ export class WorkflowListItem extends LitElement {
             }
             if (workflow.totalSize && workflow.lastCrawlSize) {
               return html`<sl-format-bytes
-                value=${workflow.totalSize}
+                value=${+workflow.totalSize}
                 display="narrow"
               ></sl-format-bytes>`;
             }
@@ -366,7 +366,7 @@ export class WorkflowListItem extends LitElement {
             }
             if (workflow.totalSize) {
               return html`<sl-format-bytes
-                value=${workflow.totalSize}
+                value=${+workflow.totalSize}
                 display="narrow"
               ></sl-format-bytes>`;
             }
@@ -522,7 +522,7 @@ export class WorkflowList extends LitElement {
       }
 
       .row {
-        display none;
+        display: none;
         font-size: var(--sl-font-size-x-small);
         color: var(--sl-color-neutral-600);
       }
@@ -553,7 +553,7 @@ export class WorkflowList extends LitElement {
 
   render() {
     return html` <div class="listHeader row">
-        <div class="col">${msg("Name & Last Updated")}</div>
+        <div class="col">${msg("Workflow Name & Last Updated")}</div>
         <div class="col">${msg("Last Crawl Status")}</div>
         <div class="col">${msg("Total Size")}</div>
         <div class="col">${msg("Started By & Schedule")}</div>

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -271,11 +271,11 @@ export class WorkflowListItem extends LitElement {
           ${this.safeRender(this.renderName)}
         </div>
         <div class="desc">
-          ${this.safeRender(() =>
-            this.workflow?.lastRun
+          ${this.safeRender((workflow) =>
+            workflow.lastRun
               ? html`
                   <sl-format-date
-                    date=${this.workflow?.lastRun.toString()}
+                    date=${workflow.lastRun.toString()}
                     month="2-digit"
                     day="2-digit"
                     year="2-digit"
@@ -283,7 +283,16 @@ export class WorkflowListItem extends LitElement {
                     minute="2-digit"
                   ></sl-format-date>
                 `
-              : ""
+              : html`
+                  <sl-format-date
+                    date=${(workflow.modified || workflow.created).toString()}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="2-digit"
+                    minute="2-digit"
+                  ></sl-format-date>
+                `
           )}
         </div>
       </div>

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -209,9 +209,6 @@ export class WorkflowListItem extends LitElement {
   @property({ type: Object })
   workflow?: Workflow;
 
-  @property({ type: Date })
-  lastUpdated?: Date;
-
   @query(".row")
   row!: HTMLElement;
 
@@ -275,10 +272,10 @@ export class WorkflowListItem extends LitElement {
         </div>
         <div class="desc">
           ${this.safeRender(() =>
-            this.lastUpdated
+            this.workflow?.lastRun
               ? html`
                   <sl-format-date
-                    date=${this.lastUpdated.toString()}
+                    date=${this.workflow?.lastRun.toString()}
                     month="2-digit"
                     day="2-digit"
                     year="2-digit"

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -271,28 +271,18 @@ export class WorkflowListItem extends LitElement {
           ${this.safeRender(this.renderName)}
         </div>
         <div class="desc">
-          ${this.safeRender((workflow) =>
-            workflow.lastRun
-              ? html`
-                  <sl-format-date
-                    date=${workflow.lastRun.toString()}
-                    month="2-digit"
-                    day="2-digit"
-                    year="2-digit"
-                    hour="2-digit"
-                    minute="2-digit"
-                  ></sl-format-date>
-                `
-              : html`
-                  <sl-format-date
-                    date=${workflow.modified.toString()}
-                    month="2-digit"
-                    day="2-digit"
-                    year="2-digit"
-                    hour="2-digit"
-                    minute="2-digit"
-                  ></sl-format-date>
-                `
+          ${this.safeRender(
+            (workflow) =>
+              html`
+                <sl-format-date
+                  date=${(workflow.lastRun || workflow.modified).toString()}
+                  month="2-digit"
+                  day="2-digit"
+                  year="2-digit"
+                  hour="2-digit"
+                  minute="2-digit"
+                ></sl-format-date>
+              `
           )}
         </div>
       </div>

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -43,7 +43,7 @@ const rowCss = css`
   }
   @media only screen and (min-width: ${largeBreakpointCss}) {
     .row {
-      grid-template-columns: 1fr 15rem 11rem 11rem 3rem;
+      grid-template-columns: 1fr 17rem 10rem 11rem 3rem;
     }
   }
 
@@ -301,13 +301,21 @@ export class WorkflowListItem extends LitElement {
         <div class="desc duration">
           ${this.safeRender((workflow) => {
             if (workflow.lastCrawlTime && workflow.lastCrawlStartTime) {
-              return msg(
-                str`Finished in ${RelativeDuration.humanize(
-                  new Date(`${workflow.lastCrawlTime}Z`).valueOf() -
-                    new Date(`${workflow.lastCrawlStartTime}Z`).valueOf(),
-                  { compact: true }
-                )}`
-              );
+              return html`<sl-format-date
+                  date=${workflow.lastRun.toString()}
+                  month="2-digit"
+                  day="2-digit"
+                  year="2-digit"
+                  hour="2-digit"
+                  minute="2-digit"
+                ></sl-format-date>
+                ${msg(
+                  str`in ${RelativeDuration.humanize(
+                    new Date(`${workflow.lastCrawlTime}Z`).valueOf() -
+                      new Date(`${workflow.lastCrawlStartTime}Z`).valueOf(),
+                    { compact: true }
+                  )}`
+                )}`;
             }
             if (workflow.lastCrawlStartTime) {
               const diff =
@@ -550,7 +558,7 @@ export class WorkflowList extends LitElement {
   render() {
     return html` <div class="listHeader row">
         <div class="col">${msg("Name & Last Modified")}</div>
-        <div class="col">${msg("Last Crawl Status")}</div>
+        <div class="col">${msg("Last Crawl Run")}</div>
         <div class="col">${msg("Total Size")}</div>
         <div class="col">${msg("Started By & Schedule")}</div>
         <div class="col action">

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -558,7 +558,7 @@ export class WorkflowList extends LitElement {
   render() {
     return html` <div class="listHeader row">
         <div class="col">${msg("Name & Last Modified")}</div>
-        <div class="col">${msg("Last Crawl Run")}</div>
+        <div class="col">${msg("Latest Crawl")}</div>
         <div class="col">${msg("Total Size")}</div>
         <div class="col">${msg("Started By & Schedule")}</div>
         <div class="col action">

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -285,7 +285,7 @@ export class WorkflowListItem extends LitElement {
                 `
               : html`
                   <sl-format-date
-                    date=${(workflow.modified || workflow.created).toString()}
+                    date=${workflow.modified.toString()}
                     month="2-digit"
                     day="2-digit"
                     year="2-digit"

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -247,15 +247,14 @@ export class CrawlsList extends LiteElement {
           this.archivedItems,
           () => {
             const { items, page, total, pageSize } = this.archivedItems!;
-            const hasCrawlItems = items.length;
             return html`
               <section>
-                ${hasCrawlItems
+                ${items.length
                   ? this.renderArchivedItemList()
                   : this.renderEmptyState()}
               </section>
               ${when(
-                hasCrawlItems || page > 1,
+                total > pageSize,
                 () => html`
                   <footer class="mt-6 flex justify-center">
                     <btrix-pagination
@@ -408,8 +407,10 @@ export class CrawlsList extends LiteElement {
         .keyLabels=${CrawlsList.FieldLabels}
         selectedKey=${ifDefined(this.selectedSearchFilterKey)}
         placeholder=${this.itemType === "upload"
-          ? msg("Search by name")
-          : msg("Search by name or Crawl Start URL")}
+          ? msg("Search all uploads by name")
+          : this.itemType === "crawl"
+          ? msg("Search all crawls by name or Crawl Start URL")
+          : msg("Search all items by name or Crawl Start URL")}
         @on-select=${(e: CustomEvent) => {
           const { key, value } = e.detail;
           this.filterBy = {

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -560,7 +560,7 @@ export class CrawlsList extends LiteElement {
                 }
               }}
             >
-              ${msg("Clear all filters")}
+              ${msg("Clear search and filters")}
             </button>
           </p>
         </div>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -134,7 +134,9 @@ export class WorkflowsList extends LiteElement {
       changedProperties.has("filterByScheduled") ||
       changedProperties.has("filterBy")
     ) {
-      this.fetchWorkflows();
+      this.fetchWorkflows({
+        page: changedProperties.has("orgId") ? 1 : undefined,
+      });
     }
     if (changedProperties.has("filterByCurrentUser")) {
       window.sessionStorage.setItem(

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -117,6 +117,7 @@ export class WorkflowsList extends LiteElement {
     }
     if (
       changedProperties.has("orgId") ||
+      changedProperties.has("orderBy") ||
       changedProperties.has("filterByCurrentUser") ||
       changedProperties.has("filterByScheduled") ||
       changedProperties.has("filterBy")

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -28,7 +28,7 @@ const sortableFields: Record<
   { label: string; defaultDirection?: SortDirection }
 > = {
   lastRun: {
-    label: msg("Last Updated"),
+    label: msg("Last Run"),
     defaultDirection: "desc",
   },
   firstSeed: {
@@ -36,11 +36,11 @@ const sortableFields: Record<
     defaultDirection: "asc",
   },
   name: {
-    label: msg("Workflow Name"),
+    label: msg("Name"),
     defaultDirection: "asc",
   },
   created: {
-    label: msg("Workflow Created"),
+    label: msg("Created"),
     defaultDirection: "desc",
   },
   modified: {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -28,7 +28,7 @@ const sortableFields: Record<
   { label: string; defaultDirection?: SortDirection }
 > = {
   lastRun: {
-    label: msg("Last Run"),
+    label: msg("Latest Crawl"),
     defaultDirection: "desc",
   },
   modified: {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -34,7 +34,7 @@ const sortableFields: Record<
     defaultDirection: "desc",
   },
   _name: {
-    label: msg("Name"),
+    label: msg("Workflow Name"),
     defaultDirection: "asc",
   },
 };
@@ -216,7 +216,7 @@ export class WorkflowsList extends LiteElement {
             class="w-full"
             slot="trigger"
             size="small"
-            placeholder=${msg("Search by Crawl Workflow name or Crawl URL")}
+            placeholder=${msg("Search by Workflow name or Crawl URL")}
             clearable
             ?disabled=${!this.workflows?.length}
             @sl-input=${this.onSearchInput}
@@ -346,7 +346,7 @@ export class WorkflowsList extends LiteElement {
     html`
       <btrix-workflow-list-item
         .workflow=${workflow}
-        lastUpdated=${this.workflowLastUpdated(workflow)}
+        .lastUpdated=${this.workflowLastUpdated(workflow)}
       >
         <sl-menu slot="menu">${this.renderMenuItems(workflow)}</sl-menu>
       </btrix-workflow-list-item>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -35,12 +35,12 @@ const sortableFields: Record<
     label: msg("Last Modified"),
     defaultDirection: "desc",
   },
-  firstSeed: {
-    label: msg("Crawl Start URL"),
-    defaultDirection: "asc",
-  },
   name: {
     label: msg("Name"),
+    defaultDirection: "asc",
+  },
+  firstSeed: {
+    label: msg("Crawl Start URL"),
     defaultDirection: "asc",
   },
   created: {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -194,7 +194,7 @@ export class WorkflowsList extends LiteElement {
     return html`
       <header class="contents">
         <div class="flex justify-between w-full h-8 mb-4">
-          <h1 class="text-xl font-semibold">${msg("Crawling")}</h1>
+          <h1 class="text-xl font-semibold">${msg("Crawl Workflows")}</h1>
           ${when(
             this.isCrawler,
             () => html`
@@ -205,7 +205,7 @@ export class WorkflowsList extends LiteElement {
                 @click=${this.navLink}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("New Crawl Workflow")}
+                ${msg("New Workflow")}
               </sl-button>
             `
           )}

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -14,7 +14,7 @@ import type { APIPaginatedList, APIPaginationQuery } from "../../types/api";
 import type { PageChangeEvent } from "../../components/pagination";
 
 type SearchFields = "name" | "firstSeed";
-type SortField = "lastRun" | "name";
+type SortField = "lastRun" | "name" | "firstSeed" | "created" | "modified";
 type SortDirection = "asc" | "desc";
 
 const FILTER_BY_CURRENT_USER_STORAGE_KEY =
@@ -31,9 +31,21 @@ const sortableFields: Record<
     label: msg("Last Updated"),
     defaultDirection: "desc",
   },
+  firstSeed: {
+    label: msg("Crawl Start URL"),
+    defaultDirection: "asc",
+  },
   name: {
     label: msg("Workflow Name"),
     defaultDirection: "asc",
+  },
+  created: {
+    label: msg("Workflow Created"),
+    defaultDirection: "desc",
+  },
+  modified: {
+    label: msg("Workflow Edited"),
+    defaultDirection: "desc",
   },
 };
 

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -31,6 +31,10 @@ const sortableFields: Record<
     label: msg("Last Run"),
     defaultDirection: "desc",
   },
+  modified: {
+    label: msg("Last Modified"),
+    defaultDirection: "desc",
+  },
   firstSeed: {
     label: msg("Crawl Start URL"),
     defaultDirection: "asc",
@@ -41,10 +45,6 @@ const sortableFields: Record<
   },
   created: {
     label: msg("Created"),
-    defaultDirection: "desc",
-  },
-  modified: {
-    label: msg("Workflow Edited"),
     defaultDirection: "desc",
   },
 };

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -71,6 +71,7 @@ export type Workflow = CrawlConfig & {
   lastCrawlSize: number | null;
   lastStartedByName: string | null;
   lastCrawlStopping: boolean | null;
+  lastRun: string;
   totalSize: string | null;
   inactive: boolean;
   firstSeed: string;

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -1,6 +1,8 @@
 import { parseCron } from "@cheap-glitch/mi-cron";
 import { msg, str } from "@lit/localize";
 
+import * as numberUtils from "./number";
+
 export const getNextDate = parseCron.nextDate;
 
 export type ScheduleInterval = "daily" | "weekly" | "monthly";
@@ -60,7 +62,8 @@ export function humanizeNextDate(
  **/
 export function humanizeSchedule(
   schedule: string,
-  options: { length?: "short" } = {}
+  options: { length?: "short" } = {},
+  numberFormatter: any = numberUtils.numberFormatter
 ): string {
   const interval = getScheduleInterval(schedule);
   const parsed = parseCron(schedule);
@@ -77,21 +80,27 @@ export function humanizeSchedule(
   let intervalMsg: any = "";
 
   if (options.length === "short") {
-    const formattedTime = nextDate.toLocaleString(undefined, {
-      minute: "numeric",
-      hour: "numeric",
-    });
-
     switch (interval) {
-      case "daily":
-        intervalMsg = msg(str`${formattedTime} every day`);
+      case "daily": {
+        const formattedTime = nextDate.toLocaleString(undefined, {
+          minute: "numeric",
+          hour: "numeric",
+        });
+        intervalMsg = msg(str`${formattedTime} daily`);
         break;
+      }
       case "weekly":
         intervalMsg = msg(str`Every ${formattedWeekDay}`);
         break;
-      case "monthly":
-        intervalMsg = msg(str`Day ${days[0]} of every month`);
+      case "monthly": {
+        const { format } = numberFormatter();
+        intervalMsg = msg(
+          str`Monthly on the ${format(days[0], { ordinal: true })}`
+        );
+
         break;
+      }
+
       default:
         break;
     }

--- a/frontend/src/utils/css.ts
+++ b/frontend/src/utils/css.ts
@@ -77,6 +77,8 @@ export const truncate = css`
     overflow: clip visible;
     text-overflow: ellipsis;
     white-space: nowrap;
+    /* Fix for if flex item: */
+    min-width: 0;
   }
 `;
 

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -1,0 +1,32 @@
+/**
+ * Internationalized number formatter
+ * Usage:
+ * ```ts
+ * const formatter = numberFormatter()
+ * formatter.format(10000); // 10,000
+ * formatter.format(10, { ordinal: true }); // 10th
+ * ```
+ **/
+export function numberFormatter(locales?: any, opts?: any) {
+  const numFormat = new Intl.NumberFormat(locales, opts);
+  const pluralRules = new Intl.PluralRules("en", { type: "ordinal" });
+
+  const suffixes = new Map([
+    ["one", "st"],
+    ["two", "nd"],
+    ["few", "rd"],
+    ["other", "th"],
+  ]);
+
+  const format = (n: number, opts: { ordinal?: boolean } = {}) => {
+    if (opts.ordinal) {
+      const rule = pluralRules.select(n);
+      const suffix = suffixes.get(rule);
+      return `${numFormat.format(n)}${suffix}`;
+    }
+
+    return numFormat.format(n);
+  };
+
+  return { format };
+}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/859

<!-- Fixes #issue_number -->

### Changes

- Paginates Crawl Workflows when there are more than 10 workflows
- Refactors workflow search and crawl search to use the same component
- Adds sort by first seed, workflow creation date, and workflow modified date
- Separates "last run" date from "modified" date

### Manual testing

1. Log in as a superadmin user and click an org with >10 workflows
2. Click pagination controls. Verify list paginates as expected
3. Enter text into search field. Verify search functions the same as searching for crawls in "Archived Items"
4. Sort by options and reverse sort. Verify list is ordered as expected


### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawling | **Pagination:**<br/><img width="304" alt="Screenshot 2023-08-21 at 4 09 35 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/2b0bb836-09d5-4b3b-aa07-bad90c972cbc"><br/><br/>**Search values:**<br/><img width="726" alt="Screenshot 2023-08-21 at 4 15 47 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/f7966bca-5036-47d0-932d-ca40cd930194"><br/><br/>**Headers & Row**:<br /><img width="1109" alt="Screenshot 2023-08-22 at 11 02 12 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/a30832f7-ccac-43ab-a0b5-277fdecbe929"> |



<!-- ### Follow-ups -->
