### PR TITLE
Show details in crawl error log

### DIFF
--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -68,6 +68,16 @@ export class CrawlLogs extends LitElement {
       a:hover {
         text-decoration: none;
       }
+
+      pre {
+        white-space: pre-wrap;
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-font-size-x-small);
+        margin: 0;
+        padding: var(--sl-spacing-small);
+        border: 1px solid var(--sl-panel-border-color);
+        border-radius: var(--sl-border-radius-medium);
+      }
     `,
   ];
 
@@ -79,6 +89,7 @@ export class CrawlLogs extends LitElement {
 
   render() {
     if (!this.logs) return;
+    console.log(this.selectedLog);
     return html`<btrix-numbered-list>
         <btrix-numbered-list-header slot="header">
           <div class="row">
@@ -130,6 +141,41 @@ export class CrawlLogs extends LitElement {
           size=${this.logs.pageSize}
         >
         </btrix-pagination>
-      </footer> `;
+      </footer>
+      <btrix-dialog
+        label=${msg("Log Details")}
+        ?open=${this.selectedLog}
+        style="--width: 40rem"
+        @sl-after-hide=${() => (this.selectedLog = null)}
+        >${this.renderLogDetails()}</btrix-dialog
+      > `;
+  }
+
+  private renderLogDetails() {
+    if (!this.selectedLog) return;
+    const { details } = this.selectedLog;
+
+    return html`
+      <btrix-desc-list>
+        ${Object.entries(details).map(
+          ([key, value]) => html`
+            <btrix-desc-list-item label=${key}>
+              ${key === "stack" ||
+              (typeof value !== "string" && typeof value !== "number")
+                ? this.renderPre(value)
+                : value ?? "--"}
+            </btrix-desc-list-item>
+          `
+        )}
+      </btrix-desc-list>
+    `;
+  }
+
+  private renderPre(value: any) {
+    let str = value;
+    if (typeof value !== "string") {
+      str = JSON.stringify(value, null, 2);
+    }
+    return html`<pre><code>${str}</code></pre>`;
   }
 }

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -25,9 +25,8 @@ export class CrawlLogs extends LitElement {
 
       .row {
         display: grid;
-        grid-template-columns: 9rem 4rem 14rem 1fr;
+        grid-template-columns: 9rem 4rem 15rem 1fr;
         line-height: 1.3;
-        max-width: 800px;
       }
 
       .cell {
@@ -61,11 +60,22 @@ export class CrawlLogs extends LitElement {
         overflow: hidden;
         white-space: nowrap;
       }
+
+      a {
+        color: inherit;
+      }
+
+      a:hover {
+        text-decoration: none;
+      }
     `,
   ];
 
   @property({ type: Object })
   logs?: APIPaginatedList;
+
+  @state()
+  private selectedLog: CrawlLog | null = null;
 
   render() {
     if (!this.logs) return;
@@ -80,7 +90,11 @@ export class CrawlLogs extends LitElement {
         </btrix-numbered-list-header>
         ${this.logs.items.map(
           (log: CrawlLog, idx) => html`
-            <btrix-numbered-list-item>
+            <btrix-numbered-list-item
+              hoverable
+              @click=${() => (this.selectedLog = log)}
+            >
+              <div slot="marker">${idx + 1}.</div>
               <div class="row">
                 <div>
                   <sl-format-date

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -87,9 +87,11 @@ export class CrawlLogs extends LitElement {
   @state()
   private selectedLog: CrawlLog | null = null;
 
+  @state()
+  private selectedLogIndex: number | null = null;
+
   render() {
     if (!this.logs) return;
-    console.log(this.selectedLog);
     return html`<btrix-numbered-list>
         <btrix-numbered-list-header slot="header">
           <div class="row">
@@ -99,11 +101,17 @@ export class CrawlLogs extends LitElement {
             <div class="cell">${msg("Page URL")}</div>
           </div>
         </btrix-numbered-list-header>
-        ${this.logs.items.map(
-          (log: CrawlLog, idx) => html`
+        ${this.logs.items.map((log: CrawlLog, idx) => {
+          const selected = this.selectedLogIndex === idx;
+          return html`
             <btrix-numbered-list-item
               hoverable
-              @click=${() => (this.selectedLog = log)}
+              ?selected=${selected}
+              aria-selected="${selected}"
+              @click=${() => {
+                this.selectedLog = log;
+                this.selectedLogIndex = idx;
+              }}
             >
               <div slot="marker">${idx + 1}.</div>
               <div class="row">
@@ -131,8 +139,8 @@ export class CrawlLogs extends LitElement {
                 </div>
               </div>
             </btrix-numbered-list-item>
-          `
-        )}
+          `;
+        })}
       </btrix-numbered-list>
       <footer>
         <btrix-pagination
@@ -157,9 +165,12 @@ export class CrawlLogs extends LitElement {
 
     return html`
       <btrix-desc-list>
+        <btrix-desc-list-item label=${msg("Timestamp").toUpperCase()}>
+          ${this.selectedLog.timestamp}
+        </btrix-desc-list-item>
         ${Object.entries(details).map(
           ([key, value]) => html`
-            <btrix-desc-list-item label=${key}>
+            <btrix-desc-list-item label=${key.toUpperCase()}>
               ${key === "stack" ||
               (typeof value !== "string" && typeof value !== "number")
                 ? this.renderPre(value)

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -85,10 +85,11 @@ export class CrawlLogs extends LitElement {
   logs?: APIPaginatedList;
 
   @state()
-  private selectedLog: CrawlLog | null = null;
-
-  @state()
-  private selectedLogIndex: number | null = null;
+  private selectedLog:
+    | (CrawlLog & {
+        index: number;
+      })
+    | null = null;
 
   render() {
     if (!this.logs) return;
@@ -102,15 +103,17 @@ export class CrawlLogs extends LitElement {
           </div>
         </btrix-numbered-list-header>
         ${this.logs.items.map((log: CrawlLog, idx) => {
-          const selected = this.selectedLogIndex === idx;
+          const selected = this.selectedLog?.index === idx;
           return html`
             <btrix-numbered-list-item
               hoverable
               ?selected=${selected}
               aria-selected="${selected}"
               @click=${() => {
-                this.selectedLog = log;
-                this.selectedLogIndex = idx;
+                this.selectedLog = {
+                  index: idx,
+                  ...log,
+                };
               }}
             >
               <div slot="marker">${idx + 1}.</div>
@@ -162,7 +165,6 @@ export class CrawlLogs extends LitElement {
   private renderLogDetails() {
     if (!this.selectedLog) return;
     const { details } = this.selectedLog;
-
     return html`
       <btrix-desc-list>
         <btrix-desc-list-item label=${msg("Timestamp").toUpperCase()}>

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -25,6 +25,9 @@ export class NumberedListItem extends LitElement {
   isEven: boolean = false;
 
   @property({ type: Boolean })
+  selected: boolean = false;
+
+  @property({ type: Boolean })
   hoverable: boolean = false;
 
   static styles = css`
@@ -75,6 +78,11 @@ export class NumberedListItem extends LitElement {
       cursor: pointer;
     }
 
+    .item.selected .content {
+      background-color: var(--sl-color-blue-400);
+      color: var(--sl-color-neutral-0);
+    }
+
     .item.hoverable:hover .content {
       background-color: var(--sl-color-blue-500);
       color: var(--sl-color-neutral-0);
@@ -89,6 +97,7 @@ export class NumberedListItem extends LitElement {
           first: this.isFirst,
           last: this.isLast,
           even: this.isEven,
+          selected: this.selected,
           hoverable: this.hoverable,
         })}
       >

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -78,11 +78,7 @@ export class NumberedListItem extends LitElement {
       cursor: pointer;
     }
 
-    .item.selected .content {
-      background-color: var(--sl-color-blue-400);
-      color: var(--sl-color-neutral-0);
-    }
-
+    .item.selected .content,
     .item.hoverable:hover .content {
       background-color: var(--sl-color-blue-500);
       color: var(--sl-color-neutral-0);

--- a/frontend/src/components/numbered-list.ts
+++ b/frontend/src/components/numbered-list.ts
@@ -24,6 +24,9 @@ export class NumberedListItem extends LitElement {
   @property({ type: Boolean })
   isEven: boolean = false;
 
+  @property({ type: Boolean })
+  hoverable: boolean = false;
+
   static styles = css`
     :host,
     .item {
@@ -65,7 +68,16 @@ export class NumberedListItem extends LitElement {
     }
 
     .item.even .content {
-      background-color: var(--sl-color-neutral-50); */
+      background-color: var(--sl-color-neutral-50);
+    }
+
+    .item.hoverable {
+      cursor: pointer;
+    }
+
+    .item.hoverable:hover .content {
+      background-color: var(--sl-color-blue-500);
+      color: var(--sl-color-neutral-0);
     }
   `;
 
@@ -77,6 +89,7 @@ export class NumberedListItem extends LitElement {
           first: this.isFirst,
           last: this.isLast,
           even: this.isEven,
+          hoverable: this.hoverable,
         })}
       >
         <div class="marker"><slot name="marker"></slot></div>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1069

<!-- Fixes #issue_number -->

### Changes

Shows crawl error log details in a dialog. Since the detail object does not always follow a specific format, this iteration uses the detail key in uppercase as the label.

### Manual testing

1. Log in and go to "Archived Items"
2. Click into a crawl
3. Click "Errors Logs"
4. Click on a log. Verify a modal with details are shown

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl Detail - Error Logs - detail modal | <img width="657" alt="Screenshot 2023-08-15 at 2 58 53 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/438918b5-46ff-452a-b2bb-fa69fe63cd6e"> |


<!-- ### Follow-ups -->
