### PR TITLE
Add button to download error logs

### DIFF
--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -186,7 +186,9 @@ export class CrawlDetail extends LiteElement {
                   download=${`btrix-${this.crawlId}-logs.txt`}
                   size="small"
                   variant="primary"
-                  >${msg("Download Logs")}</sl-button
+                >
+                  <sl-icon slot="prefix" name="download"></sl-icon>
+                  ${msg("Download Logs")}</sl-button
                 >`
             )}
           `,

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -178,13 +178,17 @@ export class CrawlDetail extends LiteElement {
         sectionContent = this.renderPanel(
           html`
             ${this.renderTitle(msg("Error Logs"))}
-            <sl-button
-              href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/logs?auth_bearer=${authToken}`}
-              download=${`btrix-${this.crawlId}-logs.txt`}
-              size="small"
-              variant="primary"
-              >${msg("Download Logs")}</sl-button
-            >
+            ${when(
+              this.logs?.total,
+              () =>
+                html`<sl-button
+                  href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/logs?auth_bearer=${authToken}`}
+                  download=${`btrix-${this.crawlId}-logs.txt`}
+                  size="small"
+                  variant="primary"
+                  >${msg("Download Logs")}</sl-button
+                >`
+            )}
           `,
           this.renderLogs()
         );

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -157,6 +157,7 @@ export class CrawlDetail extends LiteElement {
   }
 
   render() {
+    const authToken = this.authState!.headers.Authorization.split(" ")[1];
     let sectionContent: string | TemplateResult = "";
 
     switch (this.sectionName) {
@@ -174,7 +175,19 @@ export class CrawlDetail extends LiteElement {
         );
         break;
       case "logs":
-        sectionContent = this.renderPanel(msg("Error Logs"), this.renderLogs());
+        sectionContent = this.renderPanel(
+          html`
+            ${this.renderTitle(msg("Error Logs"))}
+            <sl-button
+              href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/logs?auth_bearer=${authToken}`}
+              download=${`btrix-${this.crawlId}-logs.txt`}
+              size="small"
+              variant="primary"
+              >${msg("Download Logs")}</sl-button
+            >
+          `,
+          this.renderLogs()
+        );
         break;
       case "config":
         sectionContent = this.renderPanel(
@@ -200,7 +213,7 @@ export class CrawlDetail extends LiteElement {
             <div class="col-span-1 flex flex-col">
               ${this.renderPanel(
                 html`
-                  ${msg("Metadata")}
+                  ${this.renderTitle(msg("Metadata"))}
                   ${when(
                     this.isCrawler,
                     () => html`
@@ -510,14 +523,22 @@ export class CrawlDetail extends LiteElement {
     `;
   }
 
-  private renderPanel(title: any, content: any, classes: any = {}) {
+  private renderTitle(title: string) {
+    return html`<h2 class="text-lg font-semibold">${title}</h2>`;
+  }
+
+  private renderPanel(
+    heading: string | TemplateResult,
+    content: any,
+    classes: any = {}
+  ) {
+    const headingIsTitle = typeof heading === "string";
     return html`
-      <h2
-        id="exclusions"
-        class="flex-0 flex items-center justify-between text-lg font-semibold leading-none h-8 min-h-fit mb-2"
+      <header
+        class="flex-0 flex items-center justify-between leading-none h-8 min-h-fit mb-2"
       >
-        ${title}
-      </h2>
+        ${headingIsTitle ? this.renderTitle(heading) : heading}
+      </header>
       <div
         class=${classMap({
           "flex-1": true,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1072

<!-- Fixes #issue_number -->

### Changes

Adds download button in Crawl detail "Error Logs" view. The logs are downloaded with filename `btrix-<crawl id>-logs.txt`.

### Manual testing

1. Log in and go to "Archived Items"
2. Click a crawl with logs
3. Click "Error Logs"
4. Click "Download Logs" button. Verify logs are downloaded with the correct filename

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl Detail - Error Logs | <img width="1136" alt="Screenshot 2023-08-15 at 3 29 34 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/8af0ab03-ecd9-451d-91f1-eb77ce2e7a77"> |


<!-- ### Follow-ups -->
