### PR TITLE
follow-up to #1066: update redis to 5.0.0 which includes full fix for…

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -13,8 +13,7 @@ from kubernetes_asyncio.client.api import custom_objects_api
 from kubernetes_asyncio.utils import create_from_dict
 from kubernetes_asyncio.client.exceptions import ApiException
 
-from redis.asyncio import Redis
-from redis.asyncio.connection import ConnectionPool
+from redis import asyncio as aioredis
 
 from fastapi.templating import Jinja2Templates
 from .utils import get_templates_dir, dt_now, to_k8s_date
@@ -67,14 +66,9 @@ class K8sAPI:
 
     async def get_redis_client(self, redis_url):
         """return redis client with correct params for one-time use"""
-        # manual settings until redis 5.0.0 is released
-        pool = ConnectionPool.from_url(redis_url, decode_responses=True)
-        redis = Redis(
-            connection_pool=pool,
-            decode_responses=True,
+        return aioredis.from_url(
+            redis_url, decode_responses=True, auto_close_connection_pool=True
         )
-        redis.auto_close_connection_pool = True
-        return redis
 
     # pylint: disable=too-many-arguments
     async def new_crawl_job(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ loguru
 aiofiles
 kubernetes-asyncio==22.6.5
 aiobotocore
-redis>=5.0.0rc2
+redis>=5.0.0
 pyyaml
 jinja2
 humanize


### PR DESCRIPTION
… connection leak in from_url(),

remove previous workaround