### PR TITLE
chart resources: adjust backend memory to 350Mi, as 200Mi was too low

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,7 +101,7 @@ backend_workers: 2
 
 backend_cpu: "25m"
 
-backend_memory: "200Mi"
+backend_memory: "350Mi"
 
 # port for operator service
 opPort: 8756


### PR DESCRIPTION
microk8s tests were failing due to memory being set too low, adjust to 350Mi