### PR TITLE
dev: Adds GitHub feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,6 +5,6 @@ contact_links:
   - name: Get help on our forum
     url: https://forum.webrecorder.net/
     about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!
-  # - name: Check out the docs
-  #   url: https://docs.browsertrix.cloud
-  #   about: Solutions to common questions may be available in the documentation!
+  - name: Check out the docs
+    url: https://docs.browsertrix.cloud
+    about: Solutions to common questions may be available in the documentation!

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -1,0 +1,42 @@
+name: Feature / Change Request
+description: If new things should be added or something that is working as intended should be changed, please file this type of issue!
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  # Context
+  - type: textarea
+    attributes:
+      label: Context
+      description: Describe any prior information that we are taking into account to inform this future development.
+      placeholder: "Now that x is done we should do y to accomplish z."
+    validations:
+      required: true
+  # User story sentence
+  - type: textarea
+    attributes:
+      label: User Story Sentence
+      placeholder: "As a user, I want to be able to ____ so that I can ____"
+    validations:
+      required: true
+  # Requirements
+  - type: textarea
+    attributes:
+      label: Requirements
+      description: List the outcomes of the feature being implemented without design or implementation details.
+      placeholder: |
+        1. Item metadata should show links to the collections that the item belongs to.
+        2. Items can be added or removed from collections when editing an item.
+    validations:
+      required: true
+  # Todo
+  - type: textarea
+    attributes:
+      label: Todo
+      description: Any other linked issues / tasks to complete to implement this feature (leave blank if unknown).
+      placeholder: |
+        - [ ] Mockups: 
+        - [ ] Design: 
+        - [ ] UI: 
+        - [ ] API: 
+    validations:
+      required: false


### PR DESCRIPTION
### Context

A while ago we made a bug issue template but I was somewhat against making a feature issue template.  At that time I didn't want to _encourage_ outside feature requests — but realistically people will file blank issues anyways, and then we'll just get bad feature requests. 🙃 

In any case, now that _we_ have settled into a good pattern for feature issues, I think it's time to make it official!  Hopefully this will lead to more consistently defined feature issues and better communication — from outside contributors and internally!

... Also it will notably force _me_ to adhere to some more consistent best practices 🙂 

### Changes
- Adds feature request issue template
- Enables the documentation link now that we have more documentation available!

### Testing

GitHub has no good way of previewing these graphically.  YAML is valid according to [yamllint.com](https://www.yamllint.com/).  Please read through the config and note any sections that should be changed / expanded upon :)