### PR TITLE
exclusion regex: show unmodified regex string, avoid dropping the '\'…

### DIFF
--- a/frontend/src/components/queue-exclusion-table.ts
+++ b/frontend/src/components/queue-exclusion-table.ts
@@ -112,10 +112,11 @@ export class QueueExclusionTable extends LiteElement {
     this.results = this.exclusions
       .slice((this.page - 1) * this.pageSize, this.page * this.pageSize)
       .map((str: any) => {
-        const unescaped = str.replace(/\\/g, "");
         return {
-          type: regexEscape(unescaped) === str ? "text" : "regex",
-          value: unescaped,
+          // if escaped version of string, with '\' removed matches string, then consider it
+          // to be matching text, otherwise, regex
+          type: regexEscape(str.replace(/\\/g, "")) === str ? "text" : "regex",
+          value: str,
         };
       });
   }


### PR DESCRIPTION
… when displaying escaped regexes

When a regex had `\.`, the UI would drop the `\` and display `.` only. This should fix that.

1. Create a new crawl workflow with `\.` as exclusion regex
2. Start a crawl
3. Verify exclusions list shows regex as `\.` not `.`