### PR TITLE
ingress: minor tweaks to ingress to update to latest spec:

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   name: ingress-main
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress_class | default "nginx" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     # cors enabled via backend directly on allowed paths
@@ -23,6 +22,7 @@ metadata:
       proxy_set_header X-Forwarded-Proto {{ .Values.ingress.scheme | default "https" }};
 
 spec:
+  ingressClassName: {{ .Values.ingress_class | default "nginx" }}
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
@@ -35,7 +35,7 @@ spec:
     http:
       paths:
       - path: /(api/.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: browsertrix-cloud-backend
@@ -43,7 +43,7 @@ spec:
               number: 8000
 
       - path: /(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: browsertrix-cloud-frontend


### PR DESCRIPTION
- use pathType ImplementationSpecific for regexes
- use ingressClassName instead of annotation