### PR TITLE
feat: collections can be updated by base_crawls_api

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -131,7 +131,12 @@ class BaseCrawlOps:
         return res
 
     async def update_crawl(
-        self, crawl_id: str, org: Organization, update: UpdateCrawl, type_=None
+        self,
+        crawl_id: str,
+        org: Organization,
+        update: UpdateCrawl,
+        collections: Optional[list[str]] = None,
+        type_=None,
     ):
         """Update existing crawl (tags and notes only for now)"""
         update_values = update.dict(exclude_unset=True)
@@ -141,6 +146,8 @@ class BaseCrawlOps:
         query = {"_id": crawl_id, "oid": org.id}
         if type_:
             query["type"] = type_
+        if collections:
+            query["collections"] = collections
 
         # update in db
         result = await self.crawls.find_one_and_update(


### PR DESCRIPTION
The second half of #1070 

Allows for a crawl to optionally be updated with a collection or list of collections via the `base_crawls_api`. 

Still needs testing so opened as draft. 