### PR TITLE
fix 'lastRun' sort:

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -255,12 +255,8 @@ class CrawlOps(BaseCrawlOps):
 
     async def add_new_crawl(self, crawl_id: str, crawlconfig: CrawlConfig, user: User):
         """initialize new crawl"""
-        new_crawl = await add_new_crawl(self.crawls, crawl_id, crawlconfig, user.id)
-        return await set_config_current_crawl_info(
-            self.crawl_configs.crawl_configs,
-            crawlconfig.id,
-            new_crawl["id"],
-            new_crawl["started"],
+        return await add_new_crawl(
+            self.crawls, self.crawl_configs, crawl_id, crawlconfig, user.id
         )
 
     async def update_crawl_scale(
@@ -532,8 +528,14 @@ class CrawlOps(BaseCrawlOps):
 
 
 # ============================================================================
+# pylint: disable=too-many-arguments
 async def add_new_crawl(
-    crawls, crawl_id: str, crawlconfig: CrawlConfig, userid: UUID4, manual=True
+    crawls,
+    crawlconfigs,
+    crawl_id: str,
+    crawlconfig: CrawlConfig,
+    userid: UUID4,
+    manual=True,
 ):
     """initialize new crawl"""
     started = dt_now()
@@ -559,7 +561,14 @@ async def add_new_crawl(
 
     try:
         result = await crawls.insert_one(crawl.to_dict())
-        return {"id": str(result.inserted_id), "started": str(started)}
+
+        return await set_config_current_crawl_info(
+            crawlconfigs,
+            crawlconfig.id,
+            result.inserted_id,
+            started,
+        )
+
     except pymongo.errors.DuplicateKeyError:
         # print(f"Crawl Already Added: {crawl.id} - {crawl.state}")
         return False

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -256,7 +256,11 @@ class CrawlOps(BaseCrawlOps):
     async def add_new_crawl(self, crawl_id: str, crawlconfig: CrawlConfig, user: User):
         """initialize new crawl"""
         return await add_new_crawl(
-            self.crawls, self.crawl_configs, crawl_id, crawlconfig, user.id
+            self.crawls,
+            self.crawl_configs.crawl_configs,
+            crawl_id,
+            crawlconfig,
+            user.id,
         )
 
     async def update_crawl_scale(

--- a/backend/btrixcloud/main_scheduled_job.py
+++ b/backend/btrixcloud/main_scheduled_job.py
@@ -9,7 +9,6 @@ from .db import init_db
 from .crawlconfigs import (
     get_crawl_config,
     inc_crawl_count,
-    set_config_current_crawl_info,
 )
 from .crawls import add_new_crawl
 from .utils import register_exit_handler
@@ -55,17 +54,14 @@ class ScheduledJob(K8sAPI):
 
         # db create
         await inc_crawl_count(self.crawlconfigs, crawlconfig.id)
-        new_crawl = await add_new_crawl(
-            self.crawls, crawl_id, crawlconfig, uuid.UUID(userid), manual=False
+        await add_new_crawl(
+            self.crawls,
+            self.crawlconfigs,
+            crawl_id,
+            crawlconfig,
+            uuid.UUID(userid),
+            manual=False,
         )
-        # pylint: disable=duplicate-code
-        await set_config_current_crawl_info(
-            self.crawlconfigs.crawl_configs,
-            crawlconfig.id,
-            new_crawl["id"],
-            new_crawl["started"],
-        )
-
         print("Crawl Created: " + crawl_id)
 
 


### PR DESCRIPTION
- don't cast 'started' value to string when setting as starting crawl time (regression from #937)
- caused incorrect sorting as finished crawl time was a datetime, while starting crawl time was a string
- move updated config crawl info in one place, simplify to avoid returning started time altogether, just set directly
- fixes #1108