### PR TITLE
Add menu item to remove crawl/upload from collection

### DIFF
--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -600,7 +600,15 @@ export class CollectionDetail extends LiteElement {
   private renderArchivedItem = (wc: Crawl | Upload) =>
     html`
       <btrix-crawl-list-item .crawl=${wc}>
-        <div slot="menuTrigger" role="none"></div>
+        <sl-menu slot="menu">
+          <sl-menu-item
+            style="--sl-color-neutral-700: var(--warning)"
+            @click=${() => console.log}
+          >
+            <sl-icon name="folder-minus" slot="prefix"></sl-icon>
+            ${msg("Remove from Collection")}
+          </sl-menu-item>
+        </sl-menu>
       </btrix-crawl-list-item>
     `;
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -20,7 +20,7 @@ import type { PageChangeEvent } from "../../components/pagination";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;
-const INITIAL_ITEMS_PAGE_SIZE = 10;
+const INITIAL_ITEMS_PAGE_SIZE = 20;
 const TABS = ["replay", "items"] as const;
 export type Tab = (typeof TABS)[number];
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -20,7 +20,7 @@ import type { PageChangeEvent } from "../../components/pagination";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;
-const INITIAL_ITEMS_PAGE_SIZE = 5;
+const INITIAL_ITEMS_PAGE_SIZE = 10;
 const TABS = ["replay", "items"] as const;
 export type Tab = (typeof TABS)[number];
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1102

<!-- Fixes #issue_number -->

### Changes

- Enables users to remove an item from a collection from the collection detail view.
- Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1102 by making use of the inactive menu trigger button.
- Updates collection items page size to match "Archived Items" page size (20 items per page)

### Manual testing

1. Log in and go to Collections
2. Click a collection with archived items
3. Click "Archived Items"
4. Click "..." action menu item next to an item. Verify menu opens with option to "Remove from Collection"
5. Click "Remove from Collection". Verify item is removed and toast notification is shown
6. Remove last item in page. Verify page is updates to last available page

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection Detail - Archived Items | <img width="398" alt="Screenshot 2023-08-25 at 11 17 57 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/f5b398e5-c120-43dd-b1c8-7c5ab3880fff"> |


<!-- ### Follow-ups -->
