### PR TITLE
dev: GitHub Issue form update: updates "user story" title

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,8 @@
 blank_issues_enabled: true
 
 contact_links:
+  - name: Report a security vulnerability
+    about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
   - name: Get help on our forum
     url: https://forum.webrecorder.net/
     about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -22,9 +22,11 @@ body:
   - type: textarea
     attributes:
       label: Requirements
-      description: List the outcomes of the feature being implemented without design or implementation details.
-      placeholder: |
+      description: |
         Webrecorder team only! :)
+        
+        List the outcomes of the feature being implemented without design or implementation details.
+      placeholder: |
         1. Item metadata should show links to the collections that the item belongs to.
         2. Items can be added or removed from collections when editing an item.
     validations:

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -38,6 +38,7 @@ body:
       label: Todo
       description: |
         Webrecorder team only! :)
+        
         Any other linked issues / tasks to complete to implement this feature (leave blank if unknown).
       placeholder: |
         - [ ] Mockups: 

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -35,9 +35,10 @@ body:
   - type: textarea
     attributes:
       label: Todo
-      description: Any other linked issues / tasks to complete to implement this feature (leave blank if unknown).
-      placeholder: |
+      description: |
         Webrecorder team only! :)
+        Any other linked issues / tasks to complete to implement this feature (leave blank if unknown).
+      placeholder: |
         - [ ] Mockups: 
         - [ ] Design: 
         - [ ] UI: 

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Requirements
       description: |
-        Webrecorder team only! :)
+        Intended primarily for use by Webrecorder team, leave blank if unknown.
         
         List the outcomes of the feature being implemented without design or implementation details.
       placeholder: |
@@ -37,9 +37,9 @@ body:
     attributes:
       label: Todo
       description: |
-        Webrecorder team only! :)
-        
-        Any other linked issues / tasks to complete to implement this feature (leave blank if unknown).
+        Intended primarily for use by Webrecorder team, leave blank if unknown.
+
+        Any other linked issues / tasks to complete to implement this feature.
       placeholder: |
         - [ ] Mockups: 
         - [ ] Design: 

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -15,6 +15,7 @@ body:
   - type: textarea
     attributes:
       label: What change would you like to see?
+      description: Describe the solution you'd like. If relevant, include ways in which you've tried to solve the issue with the current version.
       placeholder: "As a user, I want to be able to ____ so that I can ____"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -14,7 +14,7 @@ body:
   # User story sentence
   - type: textarea
     attributes:
-      label: User Story Sentence
+      label: What change would you like to see?
       placeholder: "As a user, I want to be able to ____ so that I can ____"
     validations:
       required: true
@@ -24,16 +24,18 @@ body:
       label: Requirements
       description: List the outcomes of the feature being implemented without design or implementation details.
       placeholder: |
+        Webrecorder team only! :)
         1. Item metadata should show links to the collections that the item belongs to.
         2. Items can be added or removed from collections when editing an item.
     validations:
-      required: true
+      required: false
   # Todo
   - type: textarea
     attributes:
       label: Todo
       description: Any other linked issues / tasks to complete to implement this feature (leave blank if unknown).
       placeholder: |
+        Webrecorder team only! :)
         - [ ] Mockups: 
         - [ ] Design: 
         - [ ] UI: 


### PR DESCRIPTION
- User story title should be friendlier to those who don't know what a "user story" is!
- Clarifies sections that shouldn't be edited by users in the preview text
- Adds information about reporting security issues

### Caveats
- [x] Should only be closed once security@webrecorder.org is a thing.