### PR TITLE
Add support for collectionIds to archived item PATCH endpoints

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -629,6 +629,12 @@ def init_base_crawls_api(
     async def get_crawl(crawl_id, org: Organization = Depends(org_viewer_dep)):
         return await ops.get_crawl(crawl_id, org)
 
+    @app.patch("/orgs/{oid}/all-crawls/{crawl_id}", tags=["all-crawls"])
+    async def update_crawl(
+        update: UpdateCrawl, crawl_id: str, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await ops.update_crawl(crawl_id, org, update)
+
     @app.post("/orgs/{oid}/all-crawls/delete", tags=["all-crawls"])
     async def delete_crawls_all_types(
         delete_list: DeleteCrawlList,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -166,7 +166,7 @@ class BaseCrawlOps:
 
         # Update collections then unset from update_values
         # We handle these separately due to updates required for collection changes
-        collection_ids = update_values.get("collectionIds", [])
+        collection_ids = update_values.get("collectionIds")
         if collection_ids:
             await self._update_crawl_collections(crawl_id, org, collection_ids)
         update_values.pop("collectionIds", None)

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -169,7 +169,7 @@ class BaseCrawlOps:
         collection_ids = update_values.get("collectionIds", [])
         if collection_ids:
             await self._update_crawl_collections(crawl_id, org, collection_ids)
-            update_values.pop("collectionIds", None)
+        update_values.pop("collectionIds", None)
 
         query = {"_id": crawl_id, "oid": org.id}
         if type_:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -388,6 +388,7 @@ class UpdateCrawl(BaseModel):
     description: Optional[str]
     tags: Optional[List[str]]
     description: Optional[str]
+    collectionIds: Optional[List[UUID4]]
 
 
 # ============================================================================

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -179,7 +179,11 @@ def test_verify_wacz():
     assert len(pages.strip().split("\n")) == 4
 
 
-def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
+def test_update_crawl(
+    admin_auth_headers,
+    default_org_id,
+    admin_crawl_id,
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
         headers=admin_auth_headers,
@@ -187,15 +191,30 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     assert r.status_code == 200
     data = r.json()
     assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
+    assert len(data["collectionIds"]) == 1
 
-    # Submit patch request to update tags and description
+    # Make new collection
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=admin_auth_headers,
+        json={"name": "Crawl Update Test Collection"},
+    )
+    new_coll_id = r.json()["id"]
+
+    # Submit patch request
     UPDATED_TAGS = ["wr-test-1-updated", "wr-test-2-updated"]
     UPDATED_DESC = "Lorem ipsum test note."
     UPDATED_NAME = "Updated crawl name"
+    UPDATED_COLLECTION_IDS = [new_coll_id]
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
         headers=admin_auth_headers,
-        json={"tags": UPDATED_TAGS, "description": UPDATED_DESC, "name": UPDATED_NAME},
+        json={
+            "tags": UPDATED_TAGS,
+            "description": UPDATED_DESC,
+            "name": UPDATED_NAME,
+            "collectionIds": UPDATED_COLLECTION_IDS,
+        },
     )
     assert r.status_code == 200
     data = r.json()
@@ -211,6 +230,7 @@ def test_update_crawl(admin_auth_headers, default_org_id, admin_crawl_id):
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
     assert data["description"] == UPDATED_DESC
     assert data["name"] == UPDATED_NAME
+    assert data["collectionIds"] == UPDATED_COLLECTION_IDS
 
     # Verify deleting works as well
     r = requests.patch(

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -258,15 +258,30 @@ def test_update_upload_metadata(admin_auth_headers, default_org_id):
     assert data["name"] == "My Upload Updated"
     assert not data["tags"]
     assert not data["description"]
+    assert len(data["collectionIds"]) == 1
+
+    # Make new collection
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=admin_auth_headers,
+        json={"name": "Patch Update Test Collection"},
+    )
+    new_coll_id = r.json()["id"]
 
     # Submit patch request to update name, tags, and description
     UPDATED_NAME = "New Upload Name"
     UPDATED_TAGS = ["wr-test-1-updated", "wr-test-2-updated"]
     UPDATED_DESC = "Lorem ipsum test note."
+    UPDATED_COLLECTION_IDS = [new_coll_id]
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}",
         headers=admin_auth_headers,
-        json={"tags": UPDATED_TAGS, "description": UPDATED_DESC, "name": UPDATED_NAME},
+        json={
+            "tags": UPDATED_TAGS,
+            "description": UPDATED_DESC,
+            "name": UPDATED_NAME,
+            "collectionIds": UPDATED_COLLECTION_IDS,
+        },
     )
     assert r.status_code == 200
     data = r.json()
@@ -282,6 +297,7 @@ def test_update_upload_metadata(admin_auth_headers, default_org_id):
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
     assert data["description"] == UPDATED_DESC
     assert data["name"] == UPDATED_NAME
+    assert data["collectionIds"] == UPDATED_COLLECTION_IDS
 
 
 def test_delete_stream_upload(admin_auth_headers, default_org_id):

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -767,8 +767,8 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     assert data["name"] == "My Upload Updated"
-    assert sorted(data["tags"]) == ["wr-test-1-updated", "wr-test-2-updated"]
-    assert data["description"] == "Lorem ipsum test note."
+    assert not data["tags"]
+    assert not data["description"]
     assert len(data["collectionIds"]) == 1
 
     # Make new collection

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -759,6 +759,58 @@ def test_get_upload_replay_json_admin_from_all_crawls(
     assert "files" not in data
 
 
+def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["name"] == "New Upload Name"
+    assert sorted(data["tags"]) == ["wr-test-1-updated", "wr-test-2-updated"]
+    assert data["description"] == "Lorem ipsum test note."
+    assert len(data["collectionIds"]) == 1
+
+    # Make new collection
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=admin_auth_headers,
+        json={"name": "Patch Update Test Collection 2"},
+    )
+    new_coll_id = r.json()["id"]
+
+    # Submit patch request to update name, tags, and description
+    UPDATED_NAME = "New Upload Name 2"
+    UPDATED_TAGS = ["wr-test-1-updated-again", "wr-test-2-updated-again"]
+    UPDATED_DESC = "Lorem ipsum test note 2."
+    UPDATED_COLLECTION_IDS = [new_coll_id]
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        headers=admin_auth_headers,
+        json={
+            "tags": UPDATED_TAGS,
+            "description": UPDATED_DESC,
+            "name": UPDATED_NAME,
+            "collectionIds": UPDATED_COLLECTION_IDS,
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["updated"]
+
+    # Verify update was successful
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
+    assert data["description"] == UPDATED_DESC
+    assert data["name"] == UPDATED_NAME
+    assert data["collectionIds"] == UPDATED_COLLECTION_IDS
+
+
 def test_delete_form_upload_from_all_crawls(admin_auth_headers, default_org_id):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/delete",

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -766,7 +766,7 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["name"] == "New Upload Name"
+    assert data["name"] == "My Upload Updated"
     assert sorted(data["tags"]) == ["wr-test-1-updated", "wr-test-2-updated"]
     assert data["description"] == "Lorem ipsum test note."
     assert len(data["collectionIds"]) == 1


### PR DESCRIPTION
Fixes #1120 
Related to https://github.com/webrecorder/browsertrix-cloud/issues/1070

Also adds `PATCH /orgs/<oid>/all-crawls/update` API endpoint that should work for any type of archived item.