### PR TITLE
supports overriding the replayweb.page version without having to be r…

### DIFF
--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -44,6 +44,9 @@ spec:
             - name: NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE
               value: "1"
 
+            - name: RWP_BASE_URL
+              value: {{ .Values.rwp_base_url }}
+
             {{- if .Values.minio_local }}
             - name: LOCAL_MINIO_HOST
               value: "{{ .Values.minio_host }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,7 +72,7 @@ allow_dupe_invites: "0"
 invite_expire_seconds: 604800
 
 # base url for replayweb.page
-rwp_base_url: "https://replayweb.page/"
+rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.10/"
 
 superuser:
   # set this to enable a superuser admin

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,7 +72,7 @@ allow_dupe_invites: "0"
 invite_expire_seconds: 604800
 
 # base url for replayweb.page
-rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.10/"
+rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.11/"
 
 superuser:
   # set this to enable a superuser admin

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,4 @@
 # syntax=docker/dockerfile:1.4
-ARG RWP_BASE_URL=https://cdn.jsdelivr.net/npm/replaywebpage/
-
 FROM --platform=$BUILDPLATFORM docker.io/library/node:16 as build_deps
 
 WORKDIR /app
@@ -27,21 +25,16 @@ COPY --link src ./src/
 ARG GIT_COMMIT_HASH
 ARG GIT_BRANCH_NAME
 ARG VERSION
-ARG RWP_BASE_URL
 
 ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
     GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
-    VERSION=${VERSION} \
-    RWP_BASE_URL=${RWP_BASE_URL}
+    VERSION=${VERSION}
 
 # Prevent Docker image including node_modules to save space
 RUN yarn build && \
   rm -rf ./node_modules
 
 FROM docker.io/library/nginx:1.23.2
-
-ARG RWP_BASE_URL
-ENV RWP_BASE_URL=${RWP_BASE_URL}
 
 COPY --link --from=build_deps /app/dist /usr/share/nginx/html
 

--- a/frontend/config/dev-server.js
+++ b/frontend/config/dev-server.js
@@ -35,5 +35,10 @@ module.exports = {
       res.set("Content-Type", "application/javascript");
       res.send(`importScripts("${RWP_BASE_URL}sw.js")`);
     });
+
+    server.app.get("/replay/ui.js", (req, res) => {
+      res.set("Content-Type", "application/javascript");
+      res.redirect(307, RWP_BASE_URL + "ui.js");
+    });
   },
 };

--- a/frontend/config/dev-server.js
+++ b/frontend/config/dev-server.js
@@ -1,7 +1,7 @@
 const path = require("path");
 require(path.resolve(process.cwd(), "./webpack.config.js"));
 
-// for testing: for prod, the Dockerfile should have the official prod version used
+// for testing: for prod, using the version specified in Helm values.yaml
 const RWP_BASE_URL = process.env.RWP_BASE_URL || "https://replayweb.page/";
 
 if (!process.env.API_BASE_URL) {

--- a/frontend/config/dev-server.js
+++ b/frontend/config/dev-server.js
@@ -2,7 +2,8 @@ const path = require("path");
 require(path.resolve(process.cwd(), "./webpack.config.js"));
 
 // for testing: for prod, using the version specified in Helm values.yaml
-const RWP_BASE_URL = process.env.RWP_BASE_URL || "https://replayweb.page/";
+const RWP_BASE_URL =
+  process.env.RWP_BASE_URL || "https://cdn.jsdelivr.net/npm/replaywebpage/";
 
 if (!process.env.API_BASE_URL) {
   throw new Error(

--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -42,6 +42,11 @@ server {
       return 200 'importScripts("${RWP_BASE_URL}sw.js");';
     }
 
+    location /replay/ui.js {
+      add_header Content-Type application/javascript;
+      return 307 ${RWP_BASE_URL}ui.js;
+    }
+
     # used by docker only: k8s deployment handles /api directly via ingress
     location /api/ {
       proxy_pass http://${BACKEND_HOST}:8000;

--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -8,7 +8,7 @@
     />
     <title>Browsertrix Cloud</title>
     <base href="/" />
-    <script defer src="<%= rwp_base_url %>ui.js"></script>
+    <script defer src="/replay/ui.js"></script>
     <script
       src="https://browser.sentry-cdn.com/5.5.0/bundle.min.js"
       crossorigin="anonymous"

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -126,7 +126,6 @@ const main = {
     new HtmlWebpackPlugin({
       template: "src/index.ejs",
       templateParameters: {
-        rwp_base_url: RWP_BASE_URL,
         glitchtip_dsn: process.env.GLITCHTIP_DSN || "",
         environment: isDevServer ? "development" : "production",
         version,


### PR DESCRIPTION
…ebuild frontend image:

- ensures 'rwp_base_url' from helm chart is passed to nginx
- ensures both ui.js and sw.js are loaded based on nginx environment variable, not hard-coded
- ui.js loaded via redirect from new /replay/ui.js path now handled by nginx and devserver
- pin RWP to known working release in default values.yaml

Note: when running devserver, still defaulting to latest, as RWP_BASE_URL is set via:
https://github.com/webrecorder/browsertrix-cloud/blob/main/frontend/config/dev-server.js#L5

We could leave that as is, or try to put the RWP version somewhere the devserver can access, or it could try to read Helm values.yaml