### PR TITLE
Fix unsetting all collections via PATCH update

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -167,7 +167,7 @@ class BaseCrawlOps:
         # Update collections then unset from update_values
         # We handle these separately due to updates required for collection changes
         collection_ids = update_values.get("collectionIds")
-        if collection_ids:
+        if collection_ids is not None:
             await self._update_crawl_collections(crawl_id, org, collection_ids)
         update_values.pop("collectionIds", None)
 

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -810,6 +810,31 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
     assert data["name"] == UPDATED_NAME
     assert data["collectionIds"] == UPDATED_COLLECTION_IDS
 
+    # Submit patch request to set collections to empty list
+    UPDATED_COLLECTION_IDS = []
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        headers=admin_auth_headers,
+        json={
+            "collectionIds": UPDATED_COLLECTION_IDS,
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["updated"]
+
+    # Verify update was successful
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
+    assert data["description"] == UPDATED_DESC
+    assert data["name"] == UPDATED_NAME
+    assert data["collectionIds"] == []
+
 
 def test_delete_form_upload_from_all_crawls(admin_auth_headers, default_org_id):
     r = requests.post(


### PR DESCRIPTION
Follow-up to https://github.com/webrecorder/browsertrix-cloud/issues/1120
Related to https://github.com/webrecorder/browsertrix-cloud/issues/1070

Small fix to make sure we can unset all collections for a crawl.