### PR TITLE
fix: Terminology unification "crawls" & "archive data" → "items"

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -296,7 +296,7 @@ export class ConfigDetails extends LiteElement {
                     html`<sl-tag class="mt-1 mr-2" variant="neutral">
                       ${coll.name}
                       <span class="pl-1 font-monostyle text-xs">
-                        (${msg(str`${coll.crawlCount} Crawls`)})
+                        (${msg(str`${coll.crawlCount} items`)})
                       </span>
                     </sl-tag>`
                 )

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -1055,7 +1055,7 @@ export class CollectionEditor extends LiteElement {
         class="flex flex-col items-center justify-center text-center p-4 my-12"
       >
         <p class="text-neutral-400 text-center max-w-[24em]">
-          ${msg("Your organization hasn't uploaded any archived items.")}
+          ${msg("Your organization doesn't have any uploads.")}
         </p>
       </div>`;
     }

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -1055,7 +1055,7 @@ export class CollectionEditor extends LiteElement {
         class="flex flex-col items-center justify-center text-center p-4 my-12"
       >
         <p class="text-neutral-400 text-center max-w-[24em]">
-          ${msg("Your organization doesn't have any uploaded Archive Data.")}
+          ${msg("Your organization hasn't uploaded any archived items.")}
         </p>
       </div>`;
     }


### PR DESCRIPTION
Fixes old terms used in two places.

Leaving "crawls" in the collection-add component to be fixed as a part of #1085.