### PR TITLE
Fix too many request errors in UI

### DIFF
--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -308,7 +308,7 @@ export class Crawls extends LiteElement {
     try {
       this.crawls = await this.getCrawls(params);
     } catch (e: any) {
-      if (e === ABORT_REASON_THROTTLE) {
+      if (e.name === "AbortError") {
         console.debug("Fetch crawls aborted to throttle");
       } else {
         this.notify({

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -742,7 +742,7 @@ export class CollectionDetail extends LiteElement {
     try {
       this.archivedItems = await this.getArchivedItems(params);
     } catch (e: any) {
-      if (e === ABORT_REASON_THROTTLE) {
+      if (e.name === "AbortError") {
         console.debug("Fetch web captures aborted to throttle");
       } else {
         this.notify({

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -597,7 +597,7 @@ export class CrawlsList extends LiteElement {
     try {
       this.archivedItems = await this.getArchivedItems(params);
     } catch (e: any) {
-      if (e === ABORT_REASON_THROTTLE) {
+      if (e.name === "AbortError") {
         console.debug("Fetch archived items aborted to throttle");
       } else {
         this.notify({

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -160,18 +160,16 @@ export class WorkflowsList extends LiteElement {
       const workflows = await this.getWorkflows(params);
       this.workflows = workflows;
     } catch (e: any) {
-      if (e === ABORT_REASON_THROTTLE) {
+      if (e.isApiError) {
+        this.fetchErrorStatusCode = e.statusCode;
+      } else if (e.name === "AbortError") {
         console.debug("Fetch archived items aborted to throttle");
       } else {
-        if (e.isApiError) {
-          this.fetchErrorStatusCode = e.statusCode;
-        } else {
-          this.notify({
-            message: msg("Sorry, couldn't retrieve Workflows at this time."),
-            variant: "danger",
-            icon: "exclamation-octagon",
-          });
-        }
+        this.notify({
+          message: msg("Sorry, couldn't retrieve Workflows at this time."),
+          variant: "danger",
+          icon: "exclamation-octagon",
+        });
       }
     }
     this.isFetching = false;


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1129

<!-- Fixes #issue_number -->

### Changes

This bug appears to happen to Chrome due to Chromium not supporting a custom reason when aborting a `fetch()` request. Fixes issue by checking `Error` name instead, which should be consistently `AbortError` across browsers.

### Manual testing

Tested with both Chrome and Firefox.

1. Log in to an account with workflows
2. Open browser dev tools network tab. Throttle connection to slowest speed
3. Click quickly between "Scheduled" and "No Schedule". Verify that no toast errors are shown, and requests resolve as normal after some time.

### References
- [Related Stack Overflow question](https://stackoverflow.com/questions/75969669/abortsignal-timeout-in-fetch-request-always-responds-with-aborterror-but-not-t/75973817#75973817)
- [Chromium bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=1431754)