### PR TITLE
Use base10 for sizes in frontend

### DIFF
--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -96,34 +96,13 @@ export class ConfigDetails extends LiteElement {
       }
     };
 
-    const renderSize = (valueBytes?: number | null, fallbackValue?: number) => {
-      const bytesPerGB = 1e9;
-
+    const renderSize = (valueBytes?: number | null) => {
       // Eventually we will want to set this to the selected locale
-      const formatter = new Intl.NumberFormat(undefined, {
-        style: "unit",
-        unit: "gigabyte",
-        unitDisplay: "narrow",
-      });
-
       if (valueBytes) {
-        const sizeGB = Math.floor(valueBytes / bytesPerGB);
-        return formatter.format(sizeGB);
-      }
-
-      if (typeof fallbackValue === "number") {
-        let value = "";
-        if (fallbackValue === Infinity) {
-          value = msg("Unlimited");
-        } else if (fallbackValue === 0) {
-          value = formatter.format(0);
-        } else {
-          const sizeGB = Math.floor(fallbackValue / bytesPerGB);
-          value = formatter.format(sizeGB);
-        }
-        return html`<span class="text-neutral-400"
-          >${value} ${msg("(default)")}</span
-        >`;
+        return html`<sl-format-bytes
+          value=${valueBytes}
+          display="narrow"
+        ></sl-format-bytes>`;
       }
 
       return html`<span class="text-neutral-400"
@@ -205,7 +184,7 @@ export class ConfigDetails extends LiteElement {
           )}
           ${this.renderSetting(
             msg("Crawl Size Limit"),
-            renderSize(crawlConfig?.maxCrawlSize, Infinity)
+            renderSize(crawlConfig?.maxCrawlSize)
           )}
           ${this.renderSetting(msg("Crawler Instances"), crawlConfig?.scale)}
         </btrix-desc-list>

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -95,7 +95,6 @@ export class ConfigDetails extends LiteElement {
         >`;
       }
     };
-
     const renderSize = (valueBytes?: number | null) => {
       // Eventually we will want to set this to the selected locale
       if (valueBytes) {

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -97,7 +97,7 @@ export class ConfigDetails extends LiteElement {
     };
 
     const renderSize = (valueBytes?: number | null, fallbackValue?: number) => {
-      const bytesPerGB = 1073741824;
+      const bytesPerGB = 1e9;
 
       // Eventually we will want to set this to the selected locale
       const formatter = new Intl.NumberFormat(undefined, {

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -215,7 +215,7 @@ const DEFAULT_BEHAVIORS = [
   "autofetch",
   "siteSpecific",
 ];
-const BYTES_PER_GB = 1073741824;
+const BYTES_PER_GB = 1e9;
 
 @localized()
 export class CrawlConfigEditor extends LiteElement {


### PR DESCRIPTION
Fixes #1125 

Related to https://github.com/webrecorder/browsertrix-cloud/pull/1106

This PR replaces the two instances in the frontend where we were currently using base2 GiB with base10. I took a look around the code base and didn't notice any others.