### PR TITLE
feat: add SMTP {port, use_tls} config

### DIFF
--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -39,9 +39,9 @@ class EmailSender:
         context = ssl.create_default_context()
         with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
             if self.smtp_use_tls:
-                server.ehlo()  # Can be omitted
+                server.ehlo()
                 server.starttls(context=context)
-            server.ehlo()  # Can be omitted
+            server.ehlo()
             if self.password is not None:
                 server.login(self.sender, self.password)
             server.send_message(msg)

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -23,6 +23,7 @@ stringData:
   EMAIL_SENDER: "{{ .Values.email.sender_email }}"
   EMAIL_REPLY_TO: "{{ .Values.email.reply_to }}"
   EMAIL_PASSWORD: "{{ .Values.email.password }}"
+  EMAIL_SMTP_USE_TLS: "{{ .Values.email.use_tls }}"
 
   SUPERUSER_EMAIL: "{{ .Values.superuser.email }}"
   SUPERUSER_PASSWORD: "{{ .Values.superuser.password }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -255,6 +255,7 @@ email:
   sender_email: example@example.com
   password: password
   reply_to_email: example@example.com
+  use_tls: True
 
 
 # Deployment options


### PR DESCRIPTION
Resolves #1136 

We already had infrastructure in place to configure ports through the helm chart, but it wasn't plugged into the backend. 

I have yet to test this against a local mail server that doesn't require tls / login 

Also check that If `password` is None and then don't attempt to log in