### PR TITLE
chart: move minio credentials to separate secret

### DIFF
--- a/chart/templates/minio.yaml
+++ b/chart/templates/minio.yaml
@@ -1,4 +1,19 @@
 {{- if .Values.minio_local }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: minio-auth
+  namespace: {{ .Release.Namespace }}
+
+type: Opaque
+stringData:
+ {{- with (first .Values.storages) }}
+  MINIO_ROOT_USER: "{{ .access_key }}"
+  MINIO_ROOT_PASSWORD: "{{ .secret_key }}"
+
+  MC_HOST: "{{ $.Values.minio_scheme }}://{{ .access_key }}:{{ .secret_key }}@{{ $.Values.minio_host }}"
+{{- end }}
 
 ---
 kind: PersistentVolumeClaim
@@ -81,7 +96,7 @@ spec:
           args: ["server", "/data", "--console-address", ":9001"]
           envFrom:
             - secretRef:
-                name: auth-secrets
+                name: minio-auth
 
           volumeMounts:
             - name: data-minio

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -9,15 +9,6 @@ type: Opaque
 stringData:
   PASSWORD_SECRET: "{{ .Values.backend_password_secret }}"
 
-{{- if .Values.minio_local }}
-{{- with (first .Values.storages) }}
-  MINIO_ROOT_USER: "{{ .access_key }}"
-  MINIO_ROOT_PASSWORD: "{{ .secret_key }}"
-
-  MC_HOST: "{{ $.Values.minio_scheme }}://{{ .access_key }}:{{ .secret_key }}@{{ $.Values.minio_host }}"
-{{- end }}
-{{- end }}
-
   EMAIL_SMTP_PORT: "{{ .Values.email.smtp_port }}"
   EMAIL_SMTP_HOST: "{{ .Values.email.smtp_host }}"
   EMAIL_SENDER: "{{ .Values.email.sender_email }}"


### PR DESCRIPTION
Part of recommendation of #490, split the minio secret into its own file so that its used only with minio.