### PR TITLE
null check: check before accessing config in 'get_all_crawl_search_values'

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -519,6 +519,8 @@ class BaseCrawlOps:
             if not cid:
                 continue
             config = await self.crawl_configs.get_crawl_config(cid, org)
+            if not config:
+                continue
             first_seed = config.config.seeds[0]
             first_seeds.add(first_seed.url)
 


### PR DESCRIPTION
Found an example in beta where this was null, adding as a sanity check.