### PR TITLE
Print crawl log to operator log (mostly for testing)

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -205,3 +205,11 @@ class K8sAPI:
                 self.api_client.set_default_header("Content-Type", content_type)
             else:
                 del self.api_client.default_headers["Content-Type"]
+
+    async def print_pod_logs(self, pod_names, container, lines=100):
+        """print pod logs"""
+        for pod in pod_names:
+            resp = await self.core_api.read_namespaced_pod_log(
+                pod, self.namespace, container=container, tail_lines=lines
+            )
+            print(resp)

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -212,4 +212,5 @@ class K8sAPI:
             resp = await self.core_api.read_namespaced_pod_log(
                 pod, self.namespace, container=container, tail_lines=lines
             )
+            print("============== LOGS FOR POD: {pod} ==============")
             print(resp)

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -212,5 +212,5 @@ class K8sAPI:
             resp = await self.core_api.read_namespaced_pod_log(
                 pod, self.namespace, container=container, tail_lines=lines
             )
-            print("============== LOGS FOR POD: {pod} ==============")
+            print(f"============== LOGS FOR POD: {pod} ==============")
             print(resp)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -698,6 +698,7 @@ class BtrixOperator(K8sAPI):
             )
 
             if state == "failed" and prev_state != "failed":
+                print("crawl failed: ", pod_names, stats)
                 asyncio.create_task(self.print_pod_logs(pod_names, "crawler"))
 
         # check for other statuses

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -144,8 +144,7 @@ def test_stop_crawl_partial(
         time.sleep(2)
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
         done = data.get("stats") and data.get("stats").get("done") > 0
-
-    print("crawl stats", data)
+        print("crawl stats", data)
 
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/stop",

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -145,6 +145,8 @@ def test_stop_crawl_partial(
         data = get_crawl(default_org_id, crawler_auth_headers, crawl_id)
         done = data.get("stats") and data.get("stats").get("done") > 0
 
+    print("crawl stats", data)
+
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/stop",
         headers=crawler_auth_headers,

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -43,6 +43,7 @@ data:
 
   FAST_RETRY_SECS: "{{ .Values.operator_fast_resync_secs | default 3 }}"
 
+  LOG_FAILED_CRAWL_LINES: "{{ .Values.log_failed_crawl_lines | default 0 }}"
 
 ---
 apiVersion: v1

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -30,3 +30,5 @@ max_pages_per_crawl: 4
 
 registration_enabled: "0"
 
+# log failed crawl pods to operator backend
+log_failed_crawl_lines: 200

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -111,6 +111,11 @@ job_memory: "70Mi"
 
 profile_browser_idle_seconds: 60
 
+# if set, print last 'log_failed_crawl_lines' of each failed
+# crawl pod to backend operator stdout
+# mostly intended for debugging / testing
+# log_failed_crawl_lines: 200
+
 
 # Nginx Image
 # =========================================


### PR DESCRIPTION
When a crawl fails, the operator can print the last few lines of the crawler pod to its own log.
Mostly intended for debugging failed crawls during testing.

Enabled via 'log_failed_crawl_lines' value setting, set to number of last lines to log from failed crawl.

Turned off by default, but enabled for tests to help track down failing tests.