### PR TITLE
Add operator logs to nightly tests

### DIFF
--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -78,6 +78,10 @@ jobs:
       - name: Run Tests
         run: pytest -vv ./backend/test_nightly/*.py
 
-      - name: Print Backend Logs
+      - name: Print Backend Logs (API)
         if: ${{ failure() }}
-        run: kubectl logs svc/browsertrix-cloud-backend
+        run: kubectl logs svc/browsertrix-cloud-backend -c api
+
+      - name: Print Backend Logs (Operator)
+        if: ${{ failure() }}
+        run: kubectl logs svc/browsertrix-cloud-backend -c op


### PR DESCRIPTION
The nightly tests currently don't print the operator logs, which makes it difficult to determine why tests are failing now that the operator prints out the last 200 lines of the crawler log on failures.