### PR TITLE
Enable saving individual collection form sections

### DIFF
--- a/frontend/src/pages/org/collection-edit.ts
+++ b/frontend/src/pages/org/collection-edit.ts
@@ -106,16 +106,19 @@ export class CollectionEdit extends LiteElement {
         ),
         variant: "success",
         icon: "check2-circle",
-        duration: 8000,
       });
     } catch (e: any) {
       if (e?.isApiError) {
-        this.serverError = e?.message;
+        this.serverError = e?.message as string;
       } else {
         this.serverError = msg("Something unexpected went wrong");
       }
 
-      console.log(this.serverError);
+      this.notify({
+        message: this.serverError,
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
     }
 
     this.isSubmitting = false;

--- a/frontend/src/pages/org/collection-edit.ts
+++ b/frontend/src/pages/org/collection-edit.ts
@@ -87,7 +87,7 @@ export class CollectionEdit extends LiteElement {
       e.detail.values;
 
     try {
-      if (oldCrawlIds && oldCrawlIds) {
+      if (crawlIds && oldCrawlIds) {
         await this.saveCrawlSelection({
           crawlIds,
           oldCrawlIds,
@@ -96,11 +96,10 @@ export class CollectionEdit extends LiteElement {
         await this.saveMetadata({
           name,
           description,
-          isPublic: isPublic === "on",
+          isPublic,
         });
       }
 
-      this.navTo(`/orgs/${this.orgId}/collections/view/${this.collectionId}`);
       this.notify({
         message: msg(
           html`Successfully updated <strong>${name}</strong> Collection.`

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -663,7 +663,7 @@ export class CollectionEditor extends LiteElement {
         aria-controls=${selectedCrawlIds.join(" ")}
         @on-change=${(e: CheckboxChangeEvent) => {
           if (e.detail.checked || !allChecked) {
-            this.selectItemss(crawls, "crawl");
+            this.selectItems(crawls, "crawl");
           } else {
             this.deselectItems(crawls, "crawl");
           }
@@ -1104,7 +1104,7 @@ export class CollectionEditor extends LiteElement {
               ...(this.collectionUploads || []),
               ...[upload],
             ] as any) as any;
-            this.selectItemss([upload], "upload");
+            this.selectItems([upload], "upload");
           } else {
             this.deselectItems([upload], "upload");
           }
@@ -1183,7 +1183,7 @@ export class CollectionEditor extends LiteElement {
     </div>
   `;
 
-  private selectItemss(items: (Crawl | Upload)[], itemType: Crawl["type"]) {
+  private selectItems(items: (Crawl | Upload)[], itemType: Crawl["type"]) {
     const allItems = items.reduce(
       (acc: any, item) => ({
         ...acc,
@@ -1209,7 +1209,7 @@ export class CollectionEditor extends LiteElement {
 
   private async selectWorkflow(workflowId: string) {
     const crawls = await this.fetchWorkflowCrawls(workflowId);
-    this.selectItemss(crawls, "crawl");
+    this.selectItems(crawls, "crawl");
   }
 
   private checkboxGroupUpdated = async (el: any) => {

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -216,6 +216,16 @@ export class CollectionEditor extends LiteElement {
   };
 
   protected async willUpdate(changedProperties: Map<string, any>) {
+    if (
+      changedProperties.has("activeTab") &&
+      !changedProperties.get("activeTab") &&
+      this.activeTab
+    ) {
+      // First tab load
+      if (this.activeTab !== "metadata" && !this.collectionId) {
+        this.goToTab("metadata");
+      }
+    }
     if (changedProperties.has("orgId") && this.orgId) {
       this.fetchSearchValues();
     }
@@ -1274,9 +1284,9 @@ export class CollectionEditor extends LiteElement {
     await this.updateComplete;
 
     const form = event.target as HTMLFormElement;
-    if (form.querySelector("[data-invalid]")) {
-      return;
-    }
+    // if (form.querySelector("[data-invalid]")) {
+    //   return;
+    // }
 
     const formValues = serialize(form) as FormValues;
     let values: any = {};

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -87,6 +87,11 @@ export type CollectionSubmitEvent = CustomEvent<{
     isPublic: boolean;
   };
 }>;
+type FormValues = {
+  name: string;
+  description: string;
+  isPublic?: string;
+};
 
 /**
  * @event on-submit
@@ -1279,9 +1284,30 @@ export class CollectionEditor extends LiteElement {
       return;
     }
 
-    const formValues = serialize(form);
-    const values: any = {};
+    const formValues = serialize(form) as FormValues;
+    let values: any = {};
 
+    if (this.collectionId) {
+      values = this.getEditedValues(formValues);
+    } else {
+      values.name = formValues.name;
+      values.description = formValues.description;
+      values.isPublic = Boolean(formValues.isPublic);
+      values.crawlIds = [
+        ...Object.keys(this.selectedCrawls),
+        Object.keys(this.selectedUploads),
+      ];
+    }
+
+    this.dispatchEvent(
+      <CollectionSubmitEvent>new CustomEvent("on-submit", {
+        detail: { values },
+      })
+    );
+  }
+
+  private getEditedValues(formValues: FormValues) {
+    const values: any = {};
     switch (this.activeTab) {
       case "metadata": {
         values.name = formValues.name;
@@ -1307,11 +1333,7 @@ export class CollectionEditor extends LiteElement {
         break;
     }
 
-    this.dispatchEvent(
-      <CollectionSubmitEvent>new CustomEvent("on-submit", {
-        detail: { values },
-      })
-    );
+    return values;
   }
 
   private getActivePanelFromHash = () => {

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -1289,7 +1289,7 @@ export class CollectionEditor extends LiteElement {
       values.isPublic = Boolean(formValues.isPublic);
       values.crawlIds = [
         ...Object.keys(this.selectedCrawls),
-        Object.keys(this.selectedUploads),
+        ...Object.keys(this.selectedUploads),
       ];
     }
 

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -417,29 +417,9 @@ export class CollectionEditor extends LiteElement {
                 <sl-icon slot="prefix" name="chevron-left"></sl-icon>
                 ${msg("Previous Step")}
               </sl-button>
-            `
-          )}
-          <sl-button
-            type="submit"
-            size="small"
-            variant=${this.collectionId ? "primary" : "default"}
-            ?disabled=${this.isSubmitting ||
-            Object.values(this.workflowIsLoading).some(
-              (isLoading) => isLoading === true
-            )}
-            ?loading=${this.isSubmitting}
-          >
-            ${this.collectionId
-              ? msg("Save Crawl Selection")
-              : msg("Save Collection")}
-          </sl-button>
-          ${when(
-            !this.collectionId,
-            () => html`
               <sl-button
                 type="button"
                 size="small"
-                variant="primary"
                 @click=${() => this.goToTab("uploads")}
               >
                 <sl-icon slot="suffix" name="chevron-right"></sl-icon>
@@ -447,6 +427,18 @@ export class CollectionEditor extends LiteElement {
               </sl-button>
             `
           )}
+          <sl-button
+            type="submit"
+            size="small"
+            variant="primary"
+            ?disabled=${this.isSubmitting ||
+            Object.values(this.workflowIsLoading).some(
+              (isLoading) => isLoading === true
+            )}
+            ?loading=${this.isSubmitting}
+          >
+            ${this.collectionId ? msg("Save Crawls") : msg("Create Collection")}
+          </sl-button>
         </footer>
       </section>
     `;
@@ -523,8 +515,8 @@ export class CollectionEditor extends LiteElement {
             ?loading=${this.isSubmitting}
           >
             ${this.collectionId
-              ? msg("Save Upload Selection")
-              : msg("Save Collection")}
+              ? msg("Save Uploads")
+              : msg("Create Collection")}
           </sl-button>
         </footer>
       </section>
@@ -563,20 +555,6 @@ export class CollectionEditor extends LiteElement {
           </label>
         </div>
         <footer class="border-t px-6 py-4 flex gap-2 justify-end">
-          <sl-button
-            type="submit"
-            size="small"
-            variant=${this.collectionId ? "primary" : "default"}
-            ?disabled=${this.isSubmitting ||
-            Object.values(this.workflowIsLoading).some(
-              (isLoading) => isLoading === true
-            )}
-            ?loading=${this.isSubmitting}
-          >
-            ${this.collectionId
-              ? msg("Save Metadata")
-              : msg("Save Collection without Items")}
-          </sl-button>
           ${when(
             !this.collectionId,
             () => html`
@@ -597,6 +575,20 @@ export class CollectionEditor extends LiteElement {
               </sl-button>
             `
           )}
+          <sl-button
+            type="submit"
+            size="small"
+            variant=${this.collectionId ? "primary" : "default"}
+            ?disabled=${this.isSubmitting ||
+            Object.values(this.workflowIsLoading).some(
+              (isLoading) => isLoading === true
+            )}
+            ?loading=${this.isSubmitting}
+          >
+            ${this.collectionId
+              ? msg("Save Metadata")
+              : msg("Create Collection without Items")}
+          </sl-button>
         </footer>
       </section>
     `;

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -1189,13 +1189,7 @@ export class CollectionEditor extends LiteElement {
   `;
 
   private selectItems(items: (Crawl | Upload)[], itemType: Crawl["type"]) {
-    const allItems = items.reduce(
-      (acc: any, item) => ({
-        ...acc,
-        [item.id]: item,
-      }),
-      {}
-    );
+    const allItems = keyBy("id")(items);
     if (itemType === "upload") {
       this.selectedUploads = mergeDeep(this.selectedUploads, allItems);
     } else {
@@ -1445,16 +1439,11 @@ export class CollectionEditor extends LiteElement {
       const uploads =
         uploadsRes.status === "fulfilled" ? uploadsRes.value.items : [];
 
-      const keyByid = (items: (Crawl | Upload)[]) =>
-        items.reduce(
-          (acc: any, item) => ({
-            ...acc,
-            [item.id]: item,
-          }),
-          {}
-        );
-      this.selectedCrawls = mergeDeep(this.selectedCrawls, keyByid(crawls));
-      this.selectedUploads = mergeDeep(this.selectedUploads, keyByid(uploads));
+      this.selectedCrawls = mergeDeep(this.selectedCrawls, keyBy("id")(crawls));
+      this.selectedUploads = mergeDeep(
+        this.selectedUploads,
+        keyBy("id")(uploads)
+      );
 
       // TODO remove omit once API removes errors
       this.collectionCrawls = crawls.map(omit("errors")) as Crawl[];

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -36,7 +36,7 @@ import type { Collection } from "../../types/collection";
 import type { Crawl, CrawlState, Upload, Workflow } from "../../types/crawler";
 import type { PageChangeEvent } from "../../components/pagination";
 
-const TABS = ["crawls", "uploads", "metadata"] as const;
+const TABS = ["metadata", "crawls", "uploads"] as const;
 type Tab = (typeof TABS)[number];
 type SearchFields = "name" | "firstSeed";
 type SearchResult = {

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -187,6 +187,13 @@ export class CollectionEditor extends LiteElement {
     return this.searchByValue.length >= MIN_SEARCH_LENGTH;
   }
 
+  private get hasItemSelection() {
+    return Boolean(
+      Object.keys(this.selectedCrawls).length ||
+        Object.keys(this.selectedUploads).length
+    );
+  }
+
   private get selectedSearchFilterKey() {
     return Object.keys(this.fieldLabels).find((key) =>
       Boolean((this.filterWorkflowsBy as any)[key])
@@ -437,7 +444,11 @@ export class CollectionEditor extends LiteElement {
             )}
             ?loading=${this.isSubmitting}
           >
-            ${this.collectionId ? msg("Save Crawls") : msg("Create Collection")}
+            ${this.collectionId
+              ? msg("Save Crawls")
+              : this.hasItemSelection
+              ? msg("Create Collection")
+              : msg("Create Collection without Items")}
           </sl-button>
         </footer>
       </section>
@@ -516,7 +527,9 @@ export class CollectionEditor extends LiteElement {
           >
             ${this.collectionId
               ? msg("Save Uploads")
-              : msg("Create Collection")}
+              : this.hasItemSelection
+              ? msg("Create Collection")
+              : msg("Create Collection without Items")}
           </sl-button>
         </footer>
       </section>
@@ -587,6 +600,8 @@ export class CollectionEditor extends LiteElement {
           >
             ${this.collectionId
               ? msg("Save Metadata")
+              : this.hasItemSelection
+              ? msg("Create Collection")
               : msg("Create Collection without Items")}
           </sl-button>
         </footer>

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -348,6 +348,7 @@ export class CollectionEditor extends LiteElement {
           <div class="border rounded-lg py-2 flex-1">
             ${guard(
               [
+                this.activeTab === "crawls",
                 this.isCrawler,
                 this.collectionCrawls,
                 this.selectedCrawls,
@@ -610,6 +611,12 @@ export class CollectionEditor extends LiteElement {
   };
 
   private renderCollectionWorkflowList = () => {
+    if (this.activeTab !== "crawls") {
+      // Prevent rendering workflow list when tab isn't visible
+      // in order to accurately calculate visible item size
+      return;
+    }
+
     if (this.collectionId && !this.collectionCrawls) {
       return this.renderLoading();
     }

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -77,18 +77,21 @@ export class CollectionsNew extends LiteElement {
         message: msg(str`Successfully created "${data.name}" Collection.`),
         variant: "success",
         icon: "check2-circle",
-        duration: 8000,
       });
 
       this.navTo(`/orgs/${this.orgId}/collections/view/${data.id}`);
     } catch (e: any) {
       if (e?.isApiError) {
-        this.serverError = e?.message;
+        this.serverError = e?.message as string;
       } else {
         this.serverError = msg("Something unexpected went wrong");
       }
 
-      console.log(this.serverError);
+      this.notify({
+        message: this.serverError,
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
     }
 
     this.isSubmitting = false;

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -56,7 +56,6 @@ export class CollectionsNew extends LiteElement {
 
   private async onSubmit(e: CollectionSubmitEvent) {
     this.isSubmitting = true;
-    console.log("submit", e.detail.values);
 
     try {
       const { name, description, crawlIds, isPublic } = e.detail.values;
@@ -69,7 +68,7 @@ export class CollectionsNew extends LiteElement {
             name,
             description,
             crawlIds,
-            public: isPublic === "on",
+            public: isPublic,
           }),
         }
       );
@@ -81,7 +80,7 @@ export class CollectionsNew extends LiteElement {
         duration: 8000,
       });
 
-      this.navTo(`/orgs/${this.orgId}/collections`);
+      this.navTo(`/orgs/${this.orgId}/collections/view/${data.id}`);
     } catch (e: any) {
       if (e?.isApiError) {
         this.serverError = e?.message;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1163

<!-- Fixes #issue_number -->

### Changes

- Moves metadata tab to first position
- Adds save button to each section, stays in edit view on saving
- Validates name exists before moving to next section or saving
- Changes save button text to "Create Collection without Items" if crawl/uploads aren't selected in new collection
- Fix server error not showing in UI

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit Collection - Metadata | <img width="1116" alt="Screenshot 2023-09-12 at 12 54 48 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/6a74ad34-4167-44c3-99bc-68d1f176bdcc"> |
| Edit Collection - Crawls | <img width="1127" alt="Screenshot 2023-09-12 at 12 54 53 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/b681dd76-ed85-408c-9f4d-d171566436b1"> |
| Edit Collection - Uploads | <img width="1138" alt="Screenshot 2023-09-12 at 12 54 59 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/a20f7415-b9c0-43c6-9820-aa7c752429e4"> |
| New Collection - Metadata (without crawls or uploads) | <img width="1131" alt="Screenshot 2023-09-12 at 12 55 12 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/10686a73-907a-4ed4-b602-d20b706eb152"> |
| New Collection - Crawls | <img width="1129" alt="Screenshot 2023-09-12 at 12 55 25 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/abd9356b-5a13-4519-84d6-8bbad6e096b9"> |
| New Collection - Uploads | <img width="1133" alt="Screenshot 2023-09-12 at 12 55 32 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/1889de91-326f-4651-afe5-5f21354df435"> |



<!-- ### Follow-ups -->
