### PR TITLE
Implement sync streaming for finished crawl logs

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -17,7 +17,7 @@ import pymongo
 
 from .crawlconfigs import set_config_current_crawl_info
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .storages import sync_get_wacz_logs
+from .storages import sync_stream_wacz_logs
 from .utils import dt_now, parse_jsonl_error_messages
 from .basecrawls import BaseCrawlOps
 from .models import (
@@ -933,7 +933,7 @@ def init_crawls_api(
         # If crawl is finished, stream logs from WACZ files
         if crawl.finished:
             wacz_files = await ops.get_wacz_files(crawl_id, org)
-            resp = await sync_get_wacz_logs(
+            resp = await sync_stream_wacz_logs(
                 org, wacz_files, log_levels, contexts, crawl_manager
             )
             return StreamingResponse(resp)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -349,7 +349,7 @@ def _parse_json(line):
 
 # ============================================================================
 def _sync_get_logs(wacz_files, log_levels, contexts, client, bucket, key):
-    """generate streaming zip as sync"""
+    """Generate filtered stream of logs from specified WACZs sorted by timestamp"""
 
     # pylint: disable=too-many-function-args
     def stream_log_bytes_as_line_dicts(stream_generator):

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -399,9 +399,7 @@ def _sync_get_logs(wacz_files, log_levels, contexts, client, bucket, key):
             log_stream = sync_get_log_stream(
                 client, bucket, wacz_key, log_zipinfo, cd_start
             )
-            wacz_log_streams.extend(
-                stream_log_bytes_as_line_dicts(log_stream, log_levels, contexts)
-            )
+            wacz_log_streams.extend(stream_log_bytes_as_line_dicts(log_stream))
 
         log_generators.append(wacz_log_streams)
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -367,7 +367,7 @@ def _sync_get_logs(wacz_files, log_levels, contexts, client, bucket, key):
                     if json_dict:
                         yield json_dict
         except StopIteration:
-            json_dict = _parse_json(line)
+            json_dict = _parse_json(last_line)
             if json_dict:
                 yield json_dict
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -323,8 +323,8 @@ async def delete_file(org, filename, crawl_manager, def_storage_name="default"):
 
 
 # ============================================================================
-async def sync_get_wacz_logs(org, wacz_files, log_levels, contexts, crawl_manager):
-    """Return generator of log lines from WACZ"""
+async def sync_stream_wacz_logs(org, wacz_files, log_levels, contexts, crawl_manager):
+    """Return filtered stream of logs from specified WACZs sorted by timestamp"""
     client, bucket, key, _ = await get_sync_client(org, crawl_manager)
 
     loop = asyncio.get_event_loop()

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -363,13 +363,16 @@ def _sync_get_logs(wacz_files, log_levels, contexts, client, bucket, key):
                 chunk_by_line = chunk.split("\n")
                 last_line = chunk_by_line.pop()
                 for line in chunk_by_line:
+                    if not line:
+                        continue
                     json_dict = _parse_json(line)
                     if json_dict:
                         yield json_dict
         except StopIteration:
-            json_dict = _parse_json(last_line)
-            if json_dict:
-                yield json_dict
+            if last_line:
+                json_dict = _parse_json(last_line)
+                if json_dict:
+                    yield json_dict
 
     def stream_json_lines(iterator, log_levels, contexts):
         """Yield parsed JSON dicts as JSON-lines bytes after filtering as necessary"""

--- a/backend/btrixcloud/zip.py
+++ b/backend/btrixcloud/zip.py
@@ -18,6 +18,8 @@ ZIP64_EOCD_LOCATOR_SIZE = 20
 
 MAX_STANDARD_ZIP_SIZE = 4_294_967_295
 
+CHUNK_SIZE = 1024 * 256
+
 
 # ============================================================================
 async def extract_and_parse_log_file(client, bucket, key, log_zipinfo, cd_start):
@@ -64,6 +66,31 @@ async def extract_and_parse_log_file(client, bucket, key, log_zipinfo, cd_start)
     return parsed_log_lines
 
 
+def sync_get_log_stream(client, bucket, key, log_zipinfo, cd_start):
+    """Return uncompressed byte stream of log file in WACZ"""
+    # pylint: disable=too-many-locals
+    file_head = sync_fetch(
+        client, bucket, key, cd_start + log_zipinfo.header_offset + 26, 4
+    )
+    name_len = parse_little_endian_to_int(file_head[0:2])
+    extra_len = parse_little_endian_to_int(file_head[2:4])
+
+    content = sync_fetch_stream(
+        client,
+        bucket,
+        key,
+        cd_start + log_zipinfo.header_offset + 30 + name_len + extra_len,
+        log_zipinfo.compress_size,
+    )
+
+    if log_zipinfo.compress_type == zipfile.ZIP_DEFLATED:
+        uncompressed_content = zlib.decompressobj(-zlib.MAX_WBITS).decompress(content)
+    else:
+        uncompressed_content = content
+
+    return uncompressed_content
+
+
 async def get_zip_file(client, bucket, key):
     """Fetch enough of the WACZ file be able to read the zip filelist"""
     file_size = await get_file_size(client, bucket, key)
@@ -106,9 +133,53 @@ async def get_zip_file(client, bucket, key):
     )
 
 
+def sync_get_zip_file(client, bucket, key):
+    """Fetch enough of the WACZ file be able to read the zip filelist"""
+    file_size = sync_get_file_size(client, bucket, key)
+    eocd_record = sync_fetch(
+        client, bucket, key, file_size - EOCD_RECORD_SIZE, EOCD_RECORD_SIZE
+    )
+
+    if file_size <= MAX_STANDARD_ZIP_SIZE:
+        cd_start, cd_size = get_central_directory_metadata_from_eocd(eocd_record)
+        central_directory = sync_fetch(client, bucket, key, cd_start, cd_size)
+        with zipfile.ZipFile(io.BytesIO(central_directory + eocd_record)) as zip_file:
+            return (cd_start, zip_file)
+
+    zip64_eocd_record = sync_fetch(
+        client,
+        bucket,
+        key,
+        file_size
+        - (EOCD_RECORD_SIZE + ZIP64_EOCD_LOCATOR_SIZE + ZIP64_EOCD_RECORD_SIZE),
+        ZIP64_EOCD_RECORD_SIZE,
+    )
+    zip64_eocd_locator = sync_fetch(
+        client,
+        bucket,
+        key,
+        file_size - (EOCD_RECORD_SIZE + ZIP64_EOCD_LOCATOR_SIZE),
+        ZIP64_EOCD_LOCATOR_SIZE,
+    )
+    cd_start, cd_size = get_central_directory_metadata_from_eocd64(zip64_eocd_record)
+    central_directory = sync_fetch(client, bucket, key, cd_start, cd_size)
+    with zipfile.ZipFile(
+        io.BytesIO(
+            central_directory + zip64_eocd_record + zip64_eocd_locator + eocd_record
+        )
+    ) as zip_file:
+        return (cd_start, zip_file)
+
+
 async def get_file_size(client, bucket, key):
     """Get WACZ file size from HEAD request"""
     head_response = await client.head_object(Bucket=bucket, Key=key)
+    return head_response["ContentLength"]
+
+
+def sync_get_file_size(client, bucket, key):
+    """Get WACZ file size from HEAD request"""
+    head_response = client.head_object(Bucket=bucket, Key=key)
     return head_response["ContentLength"]
 
 
@@ -119,6 +190,20 @@ async def fetch(client, bucket, key, start, length):
         Bucket=bucket, Key=key, Range=f"bytes={start}-{end}"
     )
     return await response["Body"].read()
+
+
+def sync_fetch(client, bucket, key, start, length):
+    """Fetch a byte range from a file in object storage"""
+    end = start + length - 1
+    response = client.get_object(Bucket=bucket, Key=key, Range=f"bytes={start}-{end}")
+    return response["Body"].read()
+
+
+def sync_fetch_stream(client, bucket, key, start, length):
+    """Fetch a byte range from a file in object storage as a stream"""
+    end = start + length - 1
+    response = client.get_object(Bucket=bucket, Key=key, Range=f"bytes={start}-{end}")
+    return response["Body"].iter_chunks(chunk_size=CHUNK_SIZE)
 
 
 def get_central_directory_metadata_from_eocd(eocd):

--- a/backend/btrixcloud/zip.py
+++ b/backend/btrixcloud/zip.py
@@ -2,13 +2,9 @@
 Methods for interacting with zip/WACZ files
 """
 import io
-import json
-import os
 import struct
 import zipfile
 import zlib
-
-from fastapi import HTTPException
 
 
 # ============================================================================


### PR DESCRIPTION
Connected to #669 

This PR converts log streaming after a crawl has finished to a proper (sync) stream which no longer reads the entire log files into memory.

There may be room for further optimization - calling the endpoint against a large crawl on dev with 3 WACZ files, some of which have multiple log files, I got a combined stream of ~19k lines, which were sorted until ~line 16,800, presumably because one of the log streams was opened much later than the others.

Verified on dev that the entire log files are no longer being read into memory and the endpoint is not causing any significant increase in RAM usage.