### PR TITLE
Fix crawl scope help text

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -954,7 +954,8 @@ https://example.com/path`}
     }
     const exampleHost = exampleUrl.host;
     const exampleProtocol = exampleUrl.protocol;
-    const examplePathname = exampleUrl.pathname.replace(/\/$/, "");
+    const examplePathname = exampleUrl.pathname;
+    const examplePathnameNoTrailing = examplePathname.replace(/\/$/, "");
     const exampleDomain = `${exampleProtocol}//${exampleHost}`;
 
     let helpText: TemplateResult | string;
@@ -966,7 +967,10 @@ https://example.com/path`}
             <span class="text-blue-500 break-word break-word"
               >${exampleDomain}</span
             ><span class="text-blue-500 font-medium break-word"
-              >/path/page-2</span
+              >${examplePathnameNoTrailing.slice(
+                0,
+                examplePathnameNoTrailing.lastIndexOf("/")
+              )}/</span
             >`
         );
         break;

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1031,6 +1031,12 @@ https://example.com/path`}
           @sl-input=${async (e: Event) => {
             const inputEl = e.target as SlInput;
             await inputEl.updateComplete;
+            this.updateFormState(
+              {
+                primarySeedUrl: inputEl.value,
+              },
+              true
+            );
             if (!inputEl.checkValidity() && validURL(inputEl.value)) {
               inputEl.setCustomValidity("");
               inputEl.helpText = "";

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -955,7 +955,6 @@ https://example.com/path`}
     const exampleHost = exampleUrl.host;
     const exampleProtocol = exampleUrl.protocol;
     const examplePathname = exampleUrl.pathname;
-    const examplePathnameNoTrailing = examplePathname.replace(/\/$/, "");
     const exampleDomain = `${exampleProtocol}//${exampleHost}`;
 
     let helpText: TemplateResult | string;
@@ -967,9 +966,9 @@ https://example.com/path`}
             <span class="text-blue-500 break-word break-word"
               >${exampleDomain}</span
             ><span class="text-blue-500 font-medium break-word"
-              >${examplePathnameNoTrailing.slice(
+              >${examplePathname.slice(
                 0,
-                examplePathnameNoTrailing.lastIndexOf("/")
+                examplePathname.lastIndexOf("/")
               )}/</span
             >`
         );


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1164

### Changes

- Updates help text with correct example when entering in a crawl start URL
- Prevents trailing slash from being removed from custom scope type example

### Manual testing

1. Login and go to New Workflow
2. Enter in a Crawl Start URL. Verify that blue example URL updates according to [scope rules](https://github.com/webrecorder/browsertrix-crawler#crawl-scope----configuring-pages-included-or-excluded-from-a-crawl)

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Workflow - Scope | <img width="525" alt="Screenshot 2023-09-12 at 2 38 53 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/a3c441a6-e162-4348-a562-5fb94dc34bcf"> |
| Edit Workflow - Scope | <img width="522" alt="Screenshot 2023-09-12 at 2 39 16 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/be4ffd87-2592-40f9-9233-41865ffd896a"> |



<!-- ### Follow-ups -->
