### PR TITLE
Refactor / Cleanup: move ops functions back into classes

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -235,7 +235,7 @@ class BaseCrawlOps:
         """Resolve running crawl data"""
         # pylint: disable=too-many-branches
         config = await self.crawl_configs.get_crawl_config(
-            crawl.cid, org, active_only=False
+            crawl.cid, org.id, active_only=False
         )
         if config and config.config.seeds:
             if add_first_seed:
@@ -524,7 +524,7 @@ class BaseCrawlOps:
         for cid in cids:
             if not cid:
                 continue
-            config = await self.crawl_configs.get_crawl_config(cid, org)
+            config = await self.crawl_configs.get_crawl_config(cid, org.id)
             if not config:
                 continue
             first_seed = config.config.seeds[0]

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -234,7 +234,7 @@ class BaseCrawlOps:
         """Resolve running crawl data"""
         # pylint: disable=too-many-branches
         config = await self.crawl_configs.get_crawl_config(
-            crawl.cid, org.id, active_only=False
+            crawl.cid, org.id if org else None, active_only=False
         )
         if config and config.config.seeds:
             if add_first_seed:

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -24,7 +24,6 @@ from .models import (
     PaginatedResponse,
     User,
 )
-from .orgs import inc_org_bytes_stored, storage_quota_reached
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .storages import get_presigned_url, delete_crawl_file_object
 from .utils import dt_now, get_redis_crawl_stats
@@ -53,12 +52,12 @@ class BaseCrawlOps:
 
     # pylint: disable=duplicate-code, too-many-arguments, too-many-locals
 
-    def __init__(self, mdb, users, crawl_configs, crawl_manager, colls):
+    def __init__(self, mdb, users, orgs, crawl_configs, crawl_manager, colls):
         self.crawls = mdb["crawls"]
-        self.orgs_db = mdb["organizations"]
         self.crawl_configs = crawl_configs
         self.crawl_manager = crawl_manager
         self.user_manager = users
+        self.orgs = orgs
         self.colls = colls
 
         self.presign_duration_seconds = (
@@ -210,7 +209,7 @@ class BaseCrawlOps:
 
         res = await self.crawls.delete_many(query)
 
-        quota_reached = await inc_org_bytes_stored(self.orgs_db, org.id, -size)
+        quota_reached = await self.orgs.inc_org_bytes_stored(org.id, -size)
 
         return res.deleted_count, size, cids_to_update, quota_reached
 
@@ -544,7 +543,7 @@ def init_base_crawls_api(
     """base crawls api"""
     # pylint: disable=invalid-name, duplicate-code, too-many-arguments, too-many-locals
 
-    ops = BaseCrawlOps(mdb, users, crawl_config_ops, crawl_manager, colls)
+    ops = BaseCrawlOps(mdb, users, orgs, crawl_config_ops, crawl_manager, colls)
 
     org_viewer_dep = orgs.org_viewer_dep
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -126,7 +126,7 @@ class BaseCrawlOps:
             # pylint: disable=invalid-name
             crawl.userName = user.name
 
-        crawl.storageQuotaReached = await storage_quota_reached(self.orgs_db, crawl.oid)
+        crawl.storageQuotaReached = await self.orgs.storage_quota_reached(crawl.oid)
 
         return crawl
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -166,7 +166,7 @@ class CrawlConfigOps:
         )
 
         run_now = config.runNow
-        quota_reached = await self.org_ops.storage_quota_reached(org)
+        quota_reached = await self.org_ops.storage_quota_reached(org.id)
 
         if quota_reached:
             run_now = False
@@ -756,7 +756,7 @@ class CrawlConfigOps:
                 detail=f"crawl-config-{cid} missing, can not start crawl",
             )
 
-        if await self.org_ops.storage_quota_reached(org):
+        if await self.org_ops.storage_quota_reached(org.id):
             raise HTTPException(status_code=403, detail="storage_quota_reached")
 
         try:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -981,7 +981,7 @@ def init_crawl_config_api(
 
     @router.delete("/{cid}")
     async def make_inactive(cid: str, org: Organization = Depends(org_crawl_dep)):
-        crawlconfig = await ops.get_crawl_config(uuid.UUID(cid), org)
+        crawlconfig = await ops.get_crawl_config(uuid.UUID(cid), org.id)
 
         if not crawlconfig:
             raise HTTPException(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -146,7 +146,7 @@ class CrawlConfigOps:
         data["modified"] = data["created"]
 
         # Ensure page limit is below org maxPagesPerCall if set
-        max_pages = await self.org_ops.get_max_pages_per_crawl(org)
+        max_pages = await self.org_ops.get_max_pages_per_crawl(org.id)
         if max_pages > 0:
             data["config"]["limit"] = max_pages
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -575,7 +575,7 @@ class CrawlOps(BaseCrawlOps):
         return res.get("state"), res.get("finished")
 
     async def add_crawl_errors(self, crawl_id, errors):
-        """add crawl errors from redis to mmongodb errors field"""
+        """add crawl errors from redis to mongodb errors field"""
         await self.crawls.find_one_and_update(
             {"_id": crawl_id}, {"$push": {"errors": {"$each": errors}}}
         )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -44,11 +44,10 @@ class CrawlOps(BaseCrawlOps):
     def __init__(
         self, mdb, users, crawl_manager, crawl_configs, orgs, colls, event_webhook_ops
     ):
-        super().__init__(mdb, users, crawl_configs, crawl_manager, colls)
+        super().__init__(mdb, users, orgs, crawl_configs, crawl_manager, colls)
         self.crawls = self.crawls
         self.crawl_configs = crawl_configs
         self.user_manager = users
-        self.orgs = orgs
         self.event_webhook_ops = event_webhook_ops
 
         self.crawl_configs.set_crawl_ops(self)

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -75,7 +75,9 @@ def main():
         event_webhook_ops,
     )
 
-    init_operator_api(app_root, mdb, crawl_config_ops, coll_ops, event_webhook_ops)
+    init_operator_api(
+        app_root, mdb, crawl_config_ops, org_ops, coll_ops, event_webhook_ops
+    )
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -75,7 +75,7 @@ def main():
         event_webhook_ops,
     )
 
-    init_operator_api(app_root, mdb, event_webhook_ops)
+    init_operator_api(app_root, mdb, crawl_config_ops, event_webhook_ops)
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -5,7 +5,7 @@ import sys
 
 from fastapi import FastAPI
 
-from .crawlmanager import CrawlManager
+# from .crawlmanager import CrawlManager
 from .db import init_db
 from .emailsender import EmailSender
 from .operator import init_operator_api
@@ -50,9 +50,10 @@ def main():
         )
         sys.exit(1)
 
-    crawl_manager = CrawlManager()
+    # don't init here, just use none
+    # crawl_manager = CrawlManager()
 
-    profile_ops = ProfileOps(mdb, crawl_manager)
+    profile_ops = ProfileOps(mdb, org_ops, crawl_manager)
 
     crawl_config_ops = CrawlConfigOps(
         dbclient,

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -75,7 +75,7 @@ def main():
         event_webhook_ops,
     )
 
-    init_operator_api(app_root, mdb, crawl_config_ops, event_webhook_ops)
+    init_operator_api(app_root, mdb, crawl_config_ops, coll_ops, event_webhook_ops)
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -5,7 +5,7 @@ import sys
 
 from fastapi import FastAPI
 
-# from .crawlmanager import CrawlManager
+from .crawlmanager import CrawlManager
 from .db import init_db
 from .emailsender import EmailSender
 from .operator import init_operator_api
@@ -50,8 +50,7 @@ def main():
         )
         sys.exit(1)
 
-    # don't init here, just use none
-    # crawl_manager = CrawlManager()
+    crawl_manager = CrawlManager()
 
     profile_ops = ProfileOps(mdb, org_ops, crawl_manager)
 

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -76,7 +76,7 @@ def main():
     )
 
     init_operator_api(
-        app_root, mdb, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
+        app_root, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
     )
 
 

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -65,7 +65,7 @@ def main():
 
     coll_ops = CollectionOps(mdb, crawl_manager, org_ops, event_webhook_ops)
 
-    CrawlOps(
+    crawl_ops = CrawlOps(
         mdb,
         user_manager,
         crawl_manager,
@@ -76,7 +76,7 @@ def main():
     )
 
     init_operator_api(
-        app_root, mdb, crawl_config_ops, org_ops, coll_ops, event_webhook_ops
+        app_root, mdb, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
     )
 
 

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -20,8 +20,6 @@ class Migration(BaseMigration):
         Recompute collection data to include totalSize.
         """
         # pylint: disable=duplicate-code
-        # colls = self.mdb["collections"]
-        # crawls = self.mdb["crawls"]
         coll_ops = CollectionOps(self.mdb, None, None, None)
 
         colls_to_update = [res async for res in coll_ops.collections.find({})]

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -1,7 +1,7 @@
 """
 Migration 0010 - Precomputing collection total size
 """
-from btrixcloud.colls import update_collection_counts_and_tags
+from btrixcloud.colls import CollectionOps
 from btrixcloud.migrations import BaseMigration
 
 
@@ -20,17 +20,18 @@ class Migration(BaseMigration):
         Recompute collection data to include totalSize.
         """
         # pylint: disable=duplicate-code
-        colls = self.mdb["collections"]
-        crawls = self.mdb["crawls"]
+        # colls = self.mdb["collections"]
+        # crawls = self.mdb["crawls"]
+        coll_ops = CollectionOps(self.mdb, None, None, None)
 
-        colls_to_update = [res async for res in colls.find({})]
+        colls_to_update = [res async for res in coll_ops.collections.find({})]
         if not colls_to_update:
             return
 
         for coll in colls_to_update:
             coll_id = coll["_id"]
             try:
-                await update_collection_counts_and_tags(colls, crawls, coll_id)
+                await coll_ops.update_collection_counts_and_tags(coll_id)
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(f"Unable to update collection {coll_id}: {err}", flush=True)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1011,7 +1011,9 @@ class BtrixOperator(K8sAPI):
 
         if not actual_state:
             # pylint: disable=duplicate-code
-            crawlconfig = await self.crawl_config_ops.get_crawl_config(uuid.UUID(cid))
+            crawlconfig = await self.crawl_config_ops.get_crawl_config(
+                uuid.UUID(cid), uuid.UUID(oid)
+            )
             if not crawlconfig:
                 print(
                     f"warn: no crawlconfig {cid}. skipping scheduled job. old cronjob left over?"

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -26,8 +26,6 @@ from .utils import (
 )
 from .k8sapi import K8sAPI
 
-from .orgs import storage_quota_reached
-
 from .basecrawls import (
     NON_RUNNING_STATES,
     RUNNING_STATES,
@@ -128,7 +126,7 @@ class BtrixOperator(K8sAPI):
     """BtrixOperator Handler"""
 
     def __init__(
-        self, mdb, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
+        self, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
     ):
         super().__init__()
 
@@ -139,8 +137,6 @@ class BtrixOperator(K8sAPI):
         self.event_webhook_ops = event_webhook_ops
 
         self.config_file = "/config/config.yaml"
-
-        self.orgs = mdb["organizations"]
 
         self.done_key = "crawls-done"
 
@@ -280,7 +276,7 @@ class BtrixOperator(K8sAPI):
             if (
                 not pods
                 and not data.children[PVC]
-                and await storage_quota_reached(self.orgs, crawl.oid)
+                and await self.org_ops.storage_quota_reached(crawl.oid)
             ):
                 await self.mark_finished(
                     crawl.id, crawl.cid, crawl.oid, status, "skipped_quota_reached"
@@ -1035,12 +1031,12 @@ class BtrixOperator(K8sAPI):
 
 # ============================================================================
 def init_operator_api(
-    app, mdb, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
+    app, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
 ):
     """regsiters webhook handlers for metacontroller"""
 
     oper = BtrixOperator(
-        mdb, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
+        crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
     )
 
     @app.post("/op/crawls/sync")

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -250,9 +250,13 @@ class OrgOps:
                 org_owners.append(key)
         return org_owners
 
-    async def get_max_pages_per_crawl(self, org: Organization):
+    async def get_max_pages_per_crawl(self, oid: uuid.UUID):
         """Return org-specific max pages per crawl setting or 0."""
-        return await get_max_pages_per_crawl(self.orgs, org.id)
+        org = await self.orgs.find_one({"_id": oid})
+        if org:
+            org = Organization.from_dict(org)
+            return org.quotas.maxPagesPerCrawl
+        return 0
 
     async def inc_bytes_stored(self, org: Organization, size: int):
         """Increase org bytesStored count (pass negative value to subtract)."""
@@ -323,16 +327,6 @@ async def storage_quota_reached(orgs, oid: uuid.UUID):
         return True
 
     return False
-
-
-# ============================================================================
-async def get_max_pages_per_crawl(orgs, oid):
-    """return max allowed concurrent crawls, if any"""
-    org = await orgs.find_one({"_id": oid})
-    if org:
-        org = Organization.from_dict(org)
-        return org.quotas.maxPagesPerCrawl
-    return 0
 
 
 # ============================================================================


### PR DESCRIPTION
Remove many standalone functions in *ops files and merge them with existing Ops classes.
Previously, these were added because the operator didn't have access to the classes, with latest updates, that is no longer the case, so can avoid duplication by using the classes for most functions.
Updated to pass ops classes to operator as needed.