### PR TITLE
Increase wait to 30 seconds to ensure webhooks are sent

### DIFF
--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -222,7 +222,7 @@ def test_webhooks_sent(
     assert data["id"]
 
     # Wait to ensure async notifications are all sent
-    time.sleep(10)
+    time.sleep(30)
 
     # Send GET request to echo server to retrieve and verify POSTed data
     r = requests.get(ECHO_SERVER_URL)


### PR DESCRIPTION
Fixes #1172

I've re-run the CI a few times and haven't observed another failure yet.