### PR TITLE
Improved type checking for backend with mypy

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Backend Lint Check
+name: Backend Lint + Type Check
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
           cd backend/
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install -U black pylint
+          pip install -U black pylint mypy
 
       - name: Style Check
         run: |
@@ -35,3 +35,8 @@ jobs:
         run: |
           cd backend/
           pylint btrixcloud/
+
+      - name: Type Check
+        run: |
+          cd backend/
+          mypy --install-types --non-interactive btrixcloud/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
       args: ["btrixcloud/"]
 - repo: local
   hooks:
+    - id: mypy
+      name: mypy
+      entry: cd backend && mypy
+      args: ["btrixcloud/"]
+- repo: local
+  hooks:
     - id: husky-run-pre-commit
       name: husky
       language: system

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -64,7 +64,7 @@ class CollectionOps:
         oid: uuid.UUID,
         name: str,
         crawl_ids: Optional[List[str]],
-        description: str = None,
+        description: Optional[str] = None,
     ):
         """Add new collection"""
         crawl_ids = crawl_ids if crawl_ids else []
@@ -174,7 +174,7 @@ class CollectionOps:
         self, coll_id: uuid.UUID, org: Organization, resources=False, public_only=False
     ):
         """Get collection by id"""
-        query = {"_id": coll_id}
+        query: dict[str, object] = {"_id": coll_id}
         if public_only:
             query["isPublic"] = True
 
@@ -193,7 +193,7 @@ class CollectionOps:
         oid: uuid.UUID,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: str = None,
+        sort_by: Optional[str] = None,
         sort_direction: int = 1,
         name: Optional[str] = None,
         name_prefix: Optional[str] = None,
@@ -204,7 +204,7 @@ class CollectionOps:
         page = page - 1
         skip = page * page_size
 
-        match_query = {"oid": oid}
+        match_query: dict[str, object] = {"oid": oid}
 
         if name:
             match_query["name"] = name
@@ -398,7 +398,7 @@ def init_collections_api(app, mdb, orgs, crawl_manager, event_webhook_ops):
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: str = None,
+        sortBy: Optional[str] = None,
         sortDirection: int = 1,
         name: Optional[str] = None,
         namePrefix: Optional[str] = None,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -329,11 +329,11 @@ class CrawlConfigOps:
         org: Organization,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        created_by: uuid.UUID = None,
-        modified_by: uuid.UUID = None,
-        first_seed: str = None,
-        name: str = None,
-        description: str = None,
+        created_by: Optional[uuid.UUID] = None,
+        modified_by: Optional[uuid.UUID] = None,
+        first_seed: str = "",
+        name: str = "",
+        description: str = "",
         tags: Optional[List[str]] = None,
         schedule: Optional[bool] = None,
         sort_by: str = "lastRun",
@@ -497,7 +497,7 @@ class CrawlConfigOps:
 
     async def stats_recompute_last(self, cid: uuid.UUID, size: int, inc_crawls=1):
         """recompute stats by incrementing size counter and number of crawls"""
-        update_query = {
+        update_query: dict[str, object] = {
             "lastCrawlId": None,
             "lastCrawlStartTime": None,
             "lastStartedBy": None,
@@ -599,7 +599,7 @@ class CrawlConfigOps:
         config_cls=CrawlConfig,
     ):
         """Get crawl config by id"""
-        query = {"_id": cid}
+        query: dict[str, object] = {"_id": cid}
         if oid:
             query["oid"] = oid
         if active_only:
@@ -800,7 +800,7 @@ async def stats_recompute_all(crawl_configs, crawls, cid: uuid.UUID):
     Should only be called when a crawl completes from operator or on migration
     when no crawls are running.
     """
-    update_query = {
+    update_query: dict[str, object] = {
         "crawlCount": 0,
         "crawlSuccessfulCount": 0,
         "totalSize": 0,
@@ -890,7 +890,7 @@ def init_crawl_config_api(
         description: Optional[str] = None,
         tag: Union[List[str], None] = Query(default=None),
         schedule: Optional[bool] = None,
-        sortBy: str = None,
+        sortBy: str = "",
         sortDirection: int = -1,
     ):
         # pylint: disable=duplicate-code

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -83,18 +83,18 @@ class CrawlOps(BaseCrawlOps):
     async def list_crawls(
         self,
         org: Optional[Organization] = None,
-        cid: uuid.UUID = None,
-        userid: uuid.UUID = None,
-        crawl_id: str = None,
+        cid: Optional[uuid.UUID] = None,
+        userid: Optional[uuid.UUID] = None,
+        crawl_id: str = "",
         running_only=False,
         state: Optional[List[str]] = None,
-        first_seed: str = None,
-        name: str = None,
-        description: str = None,
-        collection_id: uuid.UUID = None,
+        first_seed: str = "",
+        name: str = "",
+        description: str = "",
+        collection_id: Optional[uuid.UUID] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: str = None,
+        sort_by: str = "",
         sort_direction: int = -1,
         resources: bool = False,
     ):
@@ -106,7 +106,7 @@ class CrawlOps(BaseCrawlOps):
 
         oid = org.id if org else None
 
-        query = {"type": {"$in": ["crawl", None]}}
+        query: dict[str, object] = {"type": {"$in": ["crawl", None]}}
         if oid:
             query["oid"] = oid
 
@@ -651,8 +651,9 @@ def init_crawls_api(
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
+        states = []
         if state:
-            state = state.split(",")
+            states = state.split(",")
 
         if firstSeed:
             firstSeed = urllib.parse.unquote(firstSeed)
@@ -668,7 +669,7 @@ def init_crawls_api(
             userid=userid,
             cid=cid,
             running_only=runningOnly,
-            state=state,
+            state=states,
             first_seed=firstSeed,
             name=name,
             description=description,
@@ -696,8 +697,9 @@ def init_crawls_api(
         sortDirection: Optional[int] = -1,
     ):
         # pylint: disable=duplicate-code
+        states = []
         if state:
-            state = state.split(",")
+            states = state.split(",")
 
         if firstSeed:
             firstSeed = urllib.parse.unquote(firstSeed)
@@ -713,7 +715,7 @@ def init_crawls_api(
             userid=userid,
             cid=cid,
             running_only=False,
-            state=state,
+            state=states,
             first_seed=firstSeed,
             name=name,
             description=description,

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -6,7 +6,7 @@ import os
 import urllib
 import asyncio
 
-from typing import Optional
+from typing import Optional, Union
 
 import motor.motor_asyncio
 from pydantic import BaseModel, UUID4
@@ -170,7 +170,7 @@ async def create_indexes(org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_
 class BaseMongoModel(BaseModel):
     """Base pydantic model that is also a mongo doc"""
 
-    id: Optional[UUID4]
+    id: Optional[Union[UUID4, str]]
 
     @property
     def id_str(self):

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -94,9 +94,9 @@ class InviteOps:
         """remove invite from invite list"""
         await self.invites.delete_one({"_id": invite_token})
 
-    async def remove_invite_by_email(self, email: str, oid: str = None):
+    async def remove_invite_by_email(self, email: str, oid: Optional[uuid.UUID] = None):
         """remove invite from invite list by email"""
-        query = {"email": email}
+        query: dict[str, object] = {"email": email}
         if oid:
             query["oid"] = oid
         # Use delete_many rather than delete_one to clean up any duplicate
@@ -119,7 +119,7 @@ class InviteOps:
         user_manager,
         org=None,
         allow_existing=False,
-        headers: dict = None,
+        headers: Optional[dict] = None,
     ):
         """Invite user to org (if not specified, to default org).
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -494,7 +494,7 @@ class BtrixOperator(K8sAPI):
         if len(data.related[CJS]) <= max_crawls:
             return True
 
-        name = data.parent.get("metadata").get("name")
+        name = data.parent.get("metadata", {}).get("name")
 
         # def metadata_key(val):
         #    return val.get("metadata").get("creationTimestamp")

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -7,7 +7,7 @@ import urllib.parse
 import uuid
 from datetime import datetime
 
-from typing import Union
+from typing import Union, Optional
 
 from pymongo import ReturnDocument
 from pymongo.errors import AutoReconnect, DuplicateKeyError
@@ -128,6 +128,7 @@ class OrgOps:
         self, oid: uuid.UUID, user: User, role: UserRole = UserRole.VIEWER
     ):
         """Get an org for user by unique id"""
+        query: dict[str, object]
         if user.is_superuser:
             query = {"_id": oid}
         else:
@@ -236,10 +237,10 @@ class OrgOps:
         return True
 
     async def add_user_to_org(
-        self, org: Organization, userid: uuid.UUID, role: UserRole = UserRole.OWNER
+        self, org: Organization, userid: uuid.UUID, role: Optional[UserRole] = None
     ):
         """Add user to organization with specified role"""
-        org.users[str(userid)] = role
+        org.users[str(userid)] = role or UserRole.OWNER
         await self.update(org)
 
     async def get_org_owners(self, org: Organization):
@@ -328,7 +329,7 @@ class OrgOps:
 
 # ============================================================================
 # pylint: disable=too-many-statements
-def init_orgs_api(app, mdb, user_manager, invites, user_dep: User):
+def init_orgs_api(app, mdb, user_manager, invites, user_dep):
     """Init organizations api router for /orgs"""
     # pylint: disable=too-many-locals,invalid-name
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -20,7 +20,8 @@ from .models import (
     UrlIn,
     ProfileLaunchBrowserIn,
     BrowserId,
-    ProfileCreateUpdate,
+    ProfileCreate,
+    ProfileUpdate,
     Organization,
     User,
     PaginatedResponse,
@@ -136,9 +137,9 @@ class ProfileOps:
 
     async def commit_to_profile(
         self,
-        browser_commit: ProfileCreateUpdate,
+        browser_commit: ProfileCreate,
         metadata: dict,
-        profileid: uuid.UUID = None,
+        profileid: Optional[uuid.UUID] = None,
     ):
         """commit profile and shutdown profile browser"""
         if not profileid:
@@ -200,9 +201,7 @@ class ProfileOps:
             "storageQuotaReached": quota_reached,
         }
 
-    async def update_profile_metadata(
-        self, profileid: UUID4, update: ProfileCreateUpdate
-    ):
+    async def update_profile_metadata(self, profileid: UUID4, update: ProfileUpdate):
         """Update name and description metadata only on existing profile"""
         query = {"name": update.name}
         if update.description is not None:
@@ -243,7 +242,7 @@ class ProfileOps:
         self, profileid: uuid.UUID, org: Optional[Organization] = None
     ):
         """get profile by id and org"""
-        query = {"_id": profileid}
+        query: dict[str, object] = {"_id": profileid}
         if org:
             query["oid"] = org.id
 
@@ -304,7 +303,7 @@ class ProfileOps:
         if len(profile.crawlconfigs) > 0:
             return {"error": "in_use", "crawlconfigs": profile.crawlconfigs}
 
-        query = {"_id": profileid}
+        query: dict[str, object] = {"_id": profileid}
         if org:
             query["oid"] = org.id
 
@@ -384,7 +383,7 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
 
     @router.post("")
     async def commit_browser_to_new(
-        browser_commit: ProfileCreateUpdate,
+        browser_commit: ProfileCreate,
         org: Organization = Depends(org_crawl_dep),
     ):
         metadata = await browser_get_metadata(browser_commit.browserid, org)
@@ -393,7 +392,7 @@ def init_profiles_api(mdb, crawl_manager, org_ops, user_dep):
 
     @router.patch("/{profileid}")
     async def commit_browser_to_existing(
-        browser_commit: ProfileCreateUpdate,
+        browser_commit: ProfileUpdate,
         profileid: UUID4,
         org: Organization = Depends(org_crawl_dep),
     ):

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -269,8 +269,8 @@ def init_uploads_api(
     @app.put("/orgs/{oid}/uploads/formdata", tags=["uploads"])
     async def upload_formdata(
         uploads: List[UploadFile] = File(...),
-        name: Optional[str] = "",
-        description: Optional[str] = "",
+        name: str = "",
+        description: str = "",
         collections: Optional[str] = "",
         tags: Optional[str] = "",
         org: Organization = Depends(org_crawl_dep),
@@ -294,8 +294,8 @@ def init_uploads_api(
     async def upload_stream(
         request: Request,
         filename: str,
-        name: Optional[str] = "",
-        description: Optional[str] = "",
+        name: str = "",
+        description: str = "",
         collections: Optional[str] = "",
         tags: Optional[str] = "",
         replaceId: Optional[str] = "",

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -276,14 +276,14 @@ class OA2BearerOrQuery(OAuth2PasswordBearer):
     """Override bearer check to also test query"""
 
     async def __call__(
-        self, request: Request = None, websocket: WebSocket = None
+        self, request: Request = None, websocket: WebSocket = None  # type: ignore
     ) -> Optional[str]:
         param = None
         exc = None
         # use websocket as request if no request
-        request = request or websocket
+        request = request or websocket  # type: ignore
         try:
-            param = await super().__call__(request)
+            param = await super().__call__(request)  # type: ignore
             if param:
                 return param
 
@@ -291,7 +291,8 @@ class OA2BearerOrQuery(OAuth2PasswordBearer):
         except Exception as super_exc:
             exc = super_exc
 
-        param = request.query_params.get("auth_bearer")
+        if request:
+            param = request.query_params.get("auth_bearer")
 
         if param:
             return param
@@ -411,7 +412,7 @@ def init_users_api(app, user_manager):
 
     @users_router.get("/me/invite/{token}", tags=["invites"])
     async def get_existing_user_invite_info(
-        token: str, user: User = Depends(current_active_user)
+        token: str, user: UserDB = Depends(current_active_user)
     ):
         try:
             invite = user.invites[token]

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -66,7 +66,7 @@ class EventWebhookOps:
         page = page - 1
         skip = page_size * page
 
-        query = {"oid": org.id}
+        query: dict[str, object] = {"oid": org.id}
 
         if success in (True, False):
             query["success"] = success
@@ -198,7 +198,7 @@ class EventWebhookOps:
 
         notification = WebhookNotification(
             id=uuid.uuid4(),
-            event=event,
+            event=WebhookEventType(event),
             oid=org.id,
             body=body,
             created=datetime.utcnow(),
@@ -303,7 +303,7 @@ class EventWebhookOps:
 
         notification = WebhookNotification(
             id=uuid.uuid4(),
-            event=event,
+            event=WebhookEventType(event),
             oid=org.id,
             body=body,
             created=datetime.utcnow(),

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -198,7 +198,7 @@ class EventWebhookOps:
 
         notification = WebhookNotification(
             id=uuid.uuid4(),
-            event=WebhookEventType(event),
+            event=event,
             oid=org.id,
             body=body,
             created=datetime.utcnow(),
@@ -303,7 +303,7 @@ class EventWebhookOps:
 
         notification = WebhookNotification(
             id=uuid.uuid4(),
-            event=WebhookEventType(event),
+            event=event,
             oid=org.id,
             body=body,
             created=datetime.utcnow(),

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+plugins = pydantic.mypy
+ignore_missing_imports = True


### PR DESCRIPTION
This PR adds includes a pass with [mypy](https://mypy-lang.org/) static type checker to fix any type issues, and also enables it to run via CI.
Hopefully will help us reduce backend type issues more quickly. (Of course, only applicable where we use types).

For example, we do have a lot of untyped mongo queries which are just set as `query: dict[str, object]`.
I suppose if we wanted to be more strict, could define these as well (probably at a later time).