### PR TITLE
Separate "run now" switch from scheduling options

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1449,7 +1449,6 @@ export class WorkflowDetail extends LiteElement {
         message: msg("Starting crawl."),
         variant: "success",
         icon: "check2-circle",
-        duration: 8000,
       });
     } catch (e: any) {
       let message = msg("Sorry, couldn't run crawl at this time.");

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1533,16 +1533,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
         )
       )}
       ${when(this.formState.scheduleType === "cron", this.renderScheduleCron)}
-      ${this.renderFormCol(html`<sl-checkbox
-        name="runNow"
-        ?checked=${this.formState.runNow}
-      >
-        ${msg("Run on Save")}
-      </sl-checkbox>`)}
-      ${this.renderHelpTextCol(
-        msg(`Start a crawl immediately upon saving workflow settings.`),
-        false
-      )}
     `;
   }
 

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -90,7 +90,7 @@ type FormState = {
   scale: WorkflowParams["scale"];
   blockAds: WorkflowParams["config"]["blockAds"];
   lang: WorkflowParams["config"]["lang"];
-  scheduleType: "now" | "date" | "cron" | "none";
+  scheduleType: "date" | "cron" | "none";
   scheduleFrequency: "daily" | "weekly" | "monthly" | "";
   scheduleDayOfMonth?: number;
   scheduleDayOfWeek?: number;
@@ -165,7 +165,7 @@ const getDefaultFormState = (): FormState => ({
   scale: 1,
   blockAds: true,
   lang: undefined,
-  scheduleType: "now",
+  scheduleType: "none",
   scheduleFrequency: "weekly",
   scheduleDayOfMonth: new Date().getDate(),
   scheduleDayOfWeek: new Date().getDay(),
@@ -300,7 +300,6 @@ export class CrawlConfigEditor extends LiteElement {
     FormState["scheduleType"],
     string
   > = {
-    now: msg("Run Immediately on Save"),
     date: msg("Run on a Specific Date & Time"),
     cron: msg("Run on a Recurring Basis"),
     none: msg("No Schedule"),
@@ -473,11 +472,7 @@ export class CrawlConfigEditor extends LiteElement {
         period: hours > 11 ? "PM" : "AM",
       };
     } else {
-      if (this.configId) {
-        formState.scheduleType = "none";
-      } else {
-        formState.scheduleType = "now";
-      }
+      formState.scheduleType = "none";
     }
 
     if (this.initialWorkflow.tags?.length) {
@@ -751,8 +746,7 @@ export class CrawlConfigEditor extends LiteElement {
                   ?disabled=${this.isSubmitting || this.formHasError}
                   ?loading=${this.isSubmitting}
                 >
-                  ${this.formState.scheduleType === "now" ||
-                  this.formState.runNow
+                  ${this.formState.runNow
                     ? msg("Save & Run Crawl")
                     : this.formState.scheduleType === "none"
                     ? msg("Save Workflow")
@@ -1512,12 +1506,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
             this.updateFormState({
               scheduleType: (e.target as SlRadio)
                 .value as FormState["scheduleType"],
-              runNow: (e.target as SlRadio).value === "now",
             })}
         >
-          <sl-radio value="now">${this.scheduleTypeLabels["now"]}</sl-radio>
-          <sl-radio value="cron">${this.scheduleTypeLabels["cron"]}</sl-radio>
           <sl-radio value="none">${this.scheduleTypeLabels["none"]}</sl-radio>
+          <sl-radio value="cron">${this.scheduleTypeLabels["cron"]}</sl-radio>
         </sl-radio-group>
       `)}
       ${this.renderHelpTextCol(
@@ -2154,7 +2146,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       description: this.formState.description,
       scale: this.formState.scale,
       profileid: this.formState.browserProfile?.id || "",
-      runNow: this.formState.runNow || this.formState.scheduleType === "now",
+      runNow: this.formState.runNow,
       schedule: this.formState.scheduleType === "cron" ? this.utcSchedule : "",
       crawlTimeout: this.formState.crawlTimeoutMinutes * 60,
       maxCrawlSize: this.formState.maxCrawlSizeGB * BYTES_PER_GB,

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -706,8 +706,13 @@ export class CrawlConfigEditor extends LiteElement {
     { isFirst = false, isLast = false } = {}
   ) {
     return html`
-      <div class="border rounded-lg flex flex-col h-full">
-        <div class="flex-1 p-6 grid grid-cols-5 gap-4">
+      <div class="flex flex-col h-full min-h-[21rem]">
+        <div
+          class="flex-1 p-6 grid grid-cols-5 gap-4 border rounded-lg ${!this
+            .configId && !isLast
+            ? "border-b-0 rounded-b-none"
+            : "mb-4"}"
+        >
           ${content}
           ${when(this.serverError, () =>
             this.renderErrorAlert(this.serverError!)
@@ -720,6 +725,37 @@ export class CrawlConfigEditor extends LiteElement {
   }
 
   private renderFooter({ isFirst = false, isLast = false }) {
+    if (this.configId) {
+      return html`
+        <footer
+          class="px-6 py-4 flex gap-2 items-center justify-end border rounded-lg"
+        >
+          <div class="mr-auto">${this.renderRunNowToggle()}</div>
+          <sl-button
+            type="submit"
+            size="small"
+            variant="primary"
+            ?disabled=${this.isSubmitting}
+            ?loading=${this.isSubmitting}
+          >
+            ${msg("Save Changes")}
+          </sl-button>
+        </footer>
+      `;
+    }
+
+    if (!this.configId) {
+      return html`
+        <footer
+          class="px-6 py-4 flex gap-2 items-center justify-end border ${isLast
+            ? "rounded-lg"
+            : "rounded-b-lg"}"
+        >
+          ${this.renderSteppedFooterButtons({ isFirst, isLast })}
+        </footer>
+      `;
+    }
+
     return html`
       <div class="px-6 py-4 border-t flex gap-2 items-center justify-end">
         ${when(

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -731,6 +731,9 @@ export class CrawlConfigEditor extends LiteElement {
           class="px-6 py-4 flex gap-2 items-center justify-end border rounded-lg"
         >
           <div class="mr-auto">${this.renderRunNowToggle()}</div>
+          <aside class="text-xs text-neutral-500">
+            ${msg("Changes in all sections will be saved")}
+          </aside>
           <sl-button
             type="submit"
             size="small"
@@ -738,7 +741,7 @@ export class CrawlConfigEditor extends LiteElement {
             ?disabled=${this.isSubmitting}
             ?loading=${this.isSubmitting}
           >
-            ${msg("Save Changes")}
+            ${msg("Save Workflow")}
           </sl-button>
         </footer>
       `;
@@ -2108,13 +2111,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
       if (crawlId && storageQuotaReached) {
         this.notify({
-          title: msg("Workflow saved."),
+          title: msg("Workflow saved without starting crawl."),
           message: msg(
-            "Could not start crawl with new workflow settings due to storage quota."
+            "Could not run crawl with new workflow settings due to storage quota."
           ),
           variant: "warning",
-          icon: "exclamation-triangle",
-          duration: 8000,
+          icon: "exclamation-circle",
+          duration: 12000,
         });
       } else {
         let message = msg("Workflow created.");
@@ -2138,12 +2141,24 @@ https://archiveweb.page/images/${"logo.svg"}`}
       );
     } catch (e: any) {
       if (e?.isApiError) {
-        const isConfigError = ({ loc }: any) =>
-          loc.some((v: string) => v === "config");
-        if (e.details && e.details.some(isConfigError)) {
-          this.serverError = this.formatConfigServerError(e.details);
+        if (e.details === "crawl_already_running") {
+          this.notify({
+            title: msg("Workflow saved without starting crawl."),
+            message: msg(
+              "Could not run crawl with new workflow settings due to already running crawl."
+            ),
+            variant: "warning",
+            icon: "exclamation-circle",
+            duration: 12000,
+          });
         } else {
-          this.serverError = e.message;
+          const isConfigError = ({ loc }: any) =>
+            loc.some((v: string) => v === "config");
+          if (Array.isArray(e.details) && e.details.some(isConfigError)) {
+            this.serverError = this.formatConfigServerError(e.details);
+          } else {
+            this.serverError = e.message;
+          }
         }
       } else {
         this.serverError = msg("Something unexpected went wrong");

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -643,34 +643,31 @@ export class CrawlConfigEditor extends LiteElement {
     const isActive = tabName === this.progressState.activeTab;
     const isConfirmSettings = tabName === "confirmSettings";
     const { error: isInvalid, completed } = this.progressState.tabs[tabName];
-    const iconProps = {
-      name: "circle",
-      library: "default",
-      class: "text-neutral-400",
-    };
-    if (isConfirmSettings) {
-      iconProps.name = "info-circle";
-      iconProps.class = "text-base";
-    } else {
-      if (isInvalid) {
-        iconProps.name = "exclamation-circle";
-        iconProps.class = "text-danger";
-      } else if (isActive) {
-        iconProps.name = "pencil-circle-dashed";
-        iconProps.library = "app";
-        iconProps.class = "text-base";
-      } else if (completed) {
-        iconProps.name = "check-circle";
-      }
-    }
+    let icon: TemplateResult = html``;
 
-    return html`
-      <btrix-tab
-        slot="nav"
-        name="newJobConfig-${tabName}"
-        class="whitespace-nowrap"
-        @click=${this.tabClickHandler(tabName)}
-      >
+    if (!this.configId) {
+      const iconProps = {
+        name: "circle",
+        library: "default",
+        class: "text-neutral-400",
+      };
+      if (isConfirmSettings) {
+        iconProps.name = "info-circle";
+        iconProps.class = "text-base";
+      } else {
+        if (isInvalid) {
+          iconProps.name = "exclamation-circle";
+          iconProps.class = "text-danger";
+        } else if (isActive) {
+          iconProps.name = "pencil-circle-dashed";
+          iconProps.library = "app";
+          iconProps.class = "text-base";
+        } else if (completed) {
+          iconProps.name = "check-circle";
+        }
+      }
+
+      icon = html`
         <sl-tooltip
           content=${msg("Form section contains errors")}
           ?disabled=${!isInvalid}
@@ -682,7 +679,22 @@ export class CrawlConfigEditor extends LiteElement {
             class="inline-block align-middle mr-1 text-base ${iconProps.class}"
           ></sl-icon>
         </sl-tooltip>
-        <span class="inline-block align-middle whitespace-normal">
+      `;
+    }
+
+    return html`
+      <btrix-tab
+        slot="nav"
+        name="newJobConfig-${tabName}"
+        class="whitespace-nowrap"
+        @click=${this.tabClickHandler(tabName)}
+      >
+        ${icon}
+        <span
+          class="inline-block align-middle whitespace-normal${this.configId
+            ? " ml-1"
+            : ""}"
+        >
           ${content}
         </span>
       </btrix-tab>
@@ -1974,6 +1986,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
       const nextTab = STEPS[STEPS.indexOf(activeTab!) + 1] as StepName;
       this.updateProgressState({
         activeTab: nextTab,
+        tabs: {
+          [activeTab]: {
+            completed: true,
+          },
+        },
       });
     }
   }

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -185,9 +185,6 @@ const getDefaultFormState = (): FormState => ({
   autoscrollBehavior: true,
 });
 const defaultProgressState = getDefaultProgressState();
-const orderedTabNames = STEPS.filter(
-  (stepName) => defaultProgressState.tabs[stepName as StepName]
-) as StepName[];
 
 function getLocalizedWeekDays() {
   const now = new Date();
@@ -551,6 +548,14 @@ export class CrawlConfigEditor extends LiteElement {
       crawlMetadata: msg("Metadata"),
       confirmSettings: msg("Review Settings"),
     };
+    let orderedTabNames = STEPS.filter(
+      (stepName) => defaultProgressState.tabs[stepName as StepName]
+    ) as StepName[];
+
+    if (this.configId) {
+      // Remove review tab
+      orderedTabNames = orderedTabNames.slice(0, -1);
+    }
 
     return html`
       <form
@@ -563,7 +568,11 @@ export class CrawlConfigEditor extends LiteElement {
       >
         <btrix-tab-list
           activePanel="newJobConfig-${this.progressState.activeTab}"
-          progressPanel="newJobConfig-${this.progressState.activeTab}"
+          progressPanel=${ifDefined(
+            this.configId
+              ? undefined
+              : `newJobConfig-${this.progressState.activeTab}`
+          )}
         >
           <header slot="header" class="flex justify-between items-baseline">
             <h3 class="font-semibold">


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1165

<!-- Fixes #issue_number -->

### Changes

- Removes "Run immediately" scheduling radio option
- Removes "Also run immediately" checkbox
- On new collections, moves "Run on Save" to final Review step
- On edit collection, adds "Run on Save" to each section
- Makes form navigation tabs in edit collections appear distinct and removes next/previous buttons and review step

### Manual testing

1. Log in and click "New Workflow"
2. Complete first step and go to "Scheduling" step. Verify radio button no longer shows "Run immediately" option or "Also run immediately" when "Run on Recurring Basis" is checked
3. Click "Review & Save". Verify "Run on Save" toggle is shown
4. Click "Save". Verify crawl runs.
5. Repeat 2-3
6. Toggle "Run on Save" off and save. Verify crawl does not run
7. Go into edit a workflow. Verify "Run on Save" is shown for each section in place of previous step button, and review step is removed
8. Repeat 4 and 6 for editing.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Collection - Review Settings | <img width="936" alt="Screenshot 2023-09-18 at 2 31 34 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/054705c5-c9ee-4f92-9a77-443944dc94d5"> |
| New Collection - Scheduling | <img width="935" alt="Screenshot 2023-09-18 at 2 31 28 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/bc77cf68-d873-43f9-a664-707dc36d3bff"> |
| Edit Collection - Scheduling | <img width="1141" alt="Screenshot 2023-09-19 at 3 20 31 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/e557b255-e832-4f92-95d4-f907a378098a"> |
| Edit Collection - Already running warning | <img width="437" alt="Screenshot 2023-09-19 at 3 28 19 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/38a5da3f-dffd-438f-9904-202d152ca30e"> |




### Follow-ups

While making these changes, I realized that it's unclear that clicking "Save" during editing will save all form sections. Per [Discord convo](https://discord.com/channels/895426029194207262/1011678975636013066/1153740760177455154), we may want to expand all form sections during edit or save only the current section. See https://github.com/webrecorder/browsertrix-cloud/issues/1204