### PR TITLE
fix: Right Align Copy Buttons & `<btrix-desc-list>` vertical `width: 100%`

### DIFF
--- a/frontend/src/components/desc-list.ts
+++ b/frontend/src/components/desc-list.ts
@@ -46,6 +46,10 @@ export class DescListItem extends LitElement {
       justify-content: var(--justify-item, initial);
       border-right: var(--border-right, 0px);
     }
+
+    .content {
+      width: var(--width-full, initial);
+    }
   `;
 
   @property({ type: String })
@@ -71,6 +75,7 @@ export class DescList extends LitElement {
     .vertical {
       grid-template-columns: 100%;
       gap: 1rem;
+      --width-full: 100%;
     }
 
     .horizontal {

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -218,19 +218,21 @@ export class CollectionDetail extends LiteElement {
         </p>
         <div class="flex items-center rounded border">
           <div class="text-base">
+            <sl-tooltip content="Open in New Tab">
+              <sl-icon-button
+                href=${publicReplayUrl}
+                name="box-arrow-up-right"
+                target="_blank"
+              >
+              </sl-icon-button>
+            </sl-tooltip>
+          </div>
+          <div class="flex-1 min-w-0 truncate">${publicReplayUrl}</div>
+          <div class="text-base">
             <btrix-copy-button
               .getValue=${() => publicReplayUrl}
               content=${msg("Copy Public URL")}
             ></btrix-copy-button>
-          </div>
-          <div class="flex-1 min-w-0 truncate">${publicReplayUrl}</div>
-          <div class="text-base">
-            <sl-icon-button
-              href=${publicReplayUrl}
-              name="box-arrow-up-right"
-              target="_blank"
-            >
-            </sl-icon-button>
           </div>
         </div>
       </section>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -121,7 +121,9 @@ export class CollectionDetail extends LiteElement {
         </sl-button>
         ${when(this.isCrawler, this.renderActions)}
       </header>
-      <div class="border rounded-lg py-2 mb-3">${this.renderInfoBar()}</div>
+      <div class="border rounded-lg py-2 px-4 mb-3">
+        ${this.renderInfoBar()}
+      </div>
       <div class="mb-3">${this.renderTabs()}</div>
 
       ${choose(

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -705,10 +705,14 @@ export class CrawlDetail extends LiteElement {
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Crawl ID")}>
           ${this.crawl
-            ? html`<btrix-copy-button
-                  value=${this.crawl.id}
-                ></btrix-copy-button>
-                <code title=${this.crawl.id}>${this.crawl.id}</code> `
+            ? html`
+                <div class="flex items-center gap-2">
+                  <code class="grow" title=${this.crawl.id}
+                    >${this.crawl.id}</code
+                  >
+                  <btrix-copy-button value=${this.crawl.id}></btrix-copy-button>
+                </div>
+              `
             : html`<sl-skeleton class="h-6"></sl-skeleton>`}
         </btrix-desc-list-item>
       </btrix-desc-list>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -319,7 +319,7 @@ export class WorkflowDetail extends LiteElement {
           </div>
         </header>
 
-        <section class="col-span-1 border rounded-lg py-2">
+        <section class="col-span-1 border rounded-lg py-2 px-4">
           ${this.renderDetails()}
         </section>
 


### PR DESCRIPTION
### Changes

#### Collection Share Menu
- All copy buttons on the collection share dialog are now on the right side
- Adds a tooltip to tell the user the button opens the link in a new tab

<img width="604" alt="Screenshot 2023-09-14 at 12 12 55 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/c76b8bd0-2084-456a-b012-3d84a6b9ce01">

### Archived Item Details
- Copy button is now right aligned
<img width="486" alt="Screenshot 2023-09-14 at 1 54 54 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/fa0741b7-91ad-4bb3-9100-08634297009d">


### App

The `<btrix-desc-list>` component is now set to `width: 100%;` when it is vertical to take up the entire width of the parent container instead of the component's content.  This should allow for easier placement of items within `<btrix-desc-list>` using flexbox in other places in the future?  Checked all the places where it's used for issues, LMK if this isn't an ideal solution?