### PR TITLE
Reset crawl state to running when any crawlers are running (after post-process states)

### DIFF
--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -822,11 +822,11 @@ class BtrixOperator(K8sAPI):
         # check for other statuses
         else:
             new_status = None
-            if status_count.get("running") > 0:
+            if status_count.get("running"):
                 if status.state in ("generate-wacz", "uploading-wacz", "pending-wacz"):
                     new_status = "running"
 
-            if status_count.get("generate-wacz"):
+            elif status_count.get("generate-wacz"):
                 new_status = "generate-wacz"
             elif status_count.get("uploading-wacz"):
                 new_status = "uploading-wacz"

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -822,10 +822,14 @@ class BtrixOperator(K8sAPI):
         # check for other statuses
         else:
             new_status = None
-            if status_count.get("uploading-wacz"):
-                new_status = "uploading-wacz"
-            elif status_count.get("generate-wacz"):
+            if status_count.get("running") > 0:
+                if status.state in ("generate-wacz", "uploading-wacz", "pending-wacz"):
+                    new_status = "running"
+
+            if status_count.get("generate-wacz"):
                 new_status = "generate-wacz"
+            elif status_count.get("uploading-wacz"):
+                new_status = "uploading-wacz"
             elif status_count.get("pending-wait"):
                 new_status = "pending-wait"
             if new_status:


### PR DESCRIPTION
Fixes #1178 

When any of the crawler are `running` after entering `generate-wacz`, `uploading-wacz`, `pending-wait`, ensure the state is reset back to running (to allow watch windows to be shown).

For multiple crawler instance always show the 'earliest state' for consistency.

For example, if one instance is `running` and another is `uploading-wacz`, show state as `running` to ensure watch windows are shown. Similarily, if one instance is `generate-wacz` and another is `uploading-wacz`, show `generate-wacz` (generate-wacz happens before uploading-wacz, and `running` happens before `generate-wacz`)

This is a bit tricky to test, especially with small crawlers.

One way to test:
1) set `crawler_session_time_limit_seconds: 60` in local.yaml
2) modify a local browsertrix-crawler to `await sleep(30)` after uploading to simulate a long upload time that may happen with larger crawls.
```
       await this.storage.uploadCollWACZ(waczPath, targetFilename, isFinished);
+      await sleep(60);
```
3) Observe that the state switches to 'Uploading WACZ' and then back to 'Running' after upload is done and crawl has restarted.