### PR TITLE
Remove config from list endpoints to speed up responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     - id: mypy
       name: mypy
       entry: cd backend && mypy
+      language: python
       args: ["btrixcloud/"]
 - repo: local
   hooks:

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -419,7 +419,7 @@ class BaseCrawlOps:
             {"$match": query},
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
-            {"$unset": ["firstSeedObject", "errors"]},
+            {"$unset": ["firstSeedObject", "errors", "config"]},
         ]
 
         if not resources:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -131,7 +131,7 @@ class CrawlOps(BaseCrawlOps):
             {"$match": query},
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
-            {"$unset": ["firstSeedObject", "errors"]},
+            {"$unset": ["firstSeedObject", "errors", "config"]},
         ]
 
         if not resources:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -16,7 +16,7 @@ from .db import BaseMongoModel
 MAX_CRAWL_SCALE = int(os.environ.get("MAX_CRAWL_SCALE", 3))
 
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-lines
 # ============================================================================
 
 ### MAIN USER MODEL ###

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -221,8 +221,59 @@ class CrawlConfig(CrawlConfigCore):
 
 
 # ============================================================================
-class CrawlConfigOut(CrawlConfig):
+class CrawlConfigOut(BaseMongoModel):
     """Crawl Config Output"""
+
+    config: Optional[RawCrawlConfig]
+
+    schedule: Optional[str] = ""
+
+    jobType: Optional[JobType] = JobType.CUSTOM
+    config: RawCrawlConfig
+
+    tags: Optional[List[str]] = []
+
+    crawlTimeout: Optional[int] = 0
+    maxCrawlSize: Optional[int] = 0
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1  # type: ignore
+
+    oid: UUID4
+
+    profileid: Optional[UUID4]
+
+    id: UUID4
+
+    name: Optional[str]
+    description: Optional[str]
+
+    created: datetime
+    createdBy: Optional[UUID4]
+
+    modified: Optional[datetime]
+    modifiedBy: Optional[UUID4]
+
+    autoAddCollections: Optional[List[UUID4]] = []
+
+    inactive: Optional[bool] = False
+
+    rev: int = 0
+
+    crawlAttemptCount: Optional[int] = 0
+    crawlCount: Optional[int] = 0
+    crawlSuccessfulCount: Optional[int] = 0
+
+    totalSize: Optional[int] = 0
+
+    lastCrawlId: Optional[str]
+    lastCrawlStartTime: Optional[datetime]
+    lastStartedBy: Optional[UUID4]
+    lastCrawlTime: Optional[datetime]
+    lastCrawlState: Optional[str]
+    lastCrawlSize: Optional[int]
+
+    lastRun: Optional[datetime]
+
+    isCrawlRunning: Optional[bool] = False
 
     lastCrawlStopping: Optional[bool] = False
 
@@ -234,8 +285,6 @@ class CrawlConfigOut(CrawlConfig):
 
     firstSeed: Optional[str]
     seedCount: int = 0
-
-    config: Optional[RawCrawlConfig]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -233,6 +233,9 @@ class CrawlConfigOut(CrawlConfig):
     lastStartedByName: Optional[str]
 
     firstSeed: Optional[str]
+    seedCount: int = 0
+
+    config: Optional[RawCrawlConfig]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -229,7 +229,6 @@ class CrawlConfigOut(BaseMongoModel):
     schedule: Optional[str] = ""
 
     jobType: Optional[JobType] = JobType.CUSTOM
-    config: RawCrawlConfig
 
     tags: Optional[List[str]] = []
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -164,7 +164,7 @@ class CrawlConfigCore(BaseMongoModel):
     schedule: Optional[str] = ""
 
     jobType: Optional[JobType] = JobType.CUSTOM
-    config: RawCrawlConfig
+    config: Optional[RawCrawlConfig]
 
     tags: Optional[List[str]] = []
 
@@ -178,10 +178,8 @@ class CrawlConfigCore(BaseMongoModel):
 
 
 # ============================================================================
-class CrawlConfig(CrawlConfigCore):
-    """Schedulable config"""
-
-    id: UUID4
+class CrawlConfigAdditional(BaseModel):
+    """Additional fields shared by CrawlConfig and CrawlConfigOut."""
 
     name: Optional[str]
     description: Optional[str]
@@ -214,6 +212,15 @@ class CrawlConfig(CrawlConfigCore):
     lastRun: Optional[datetime]
 
     isCrawlRunning: Optional[bool] = False
+
+
+# ============================================================================
+class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
+    """Schedulable config"""
+
+    id: UUID4
+
+    config: RawCrawlConfig
 
     def get_raw_config(self):
         """serialize config for browsertrix-crawler"""
@@ -221,58 +228,8 @@ class CrawlConfig(CrawlConfigCore):
 
 
 # ============================================================================
-class CrawlConfigOut(BaseMongoModel):
+class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     """Crawl Config Output"""
-
-    config: Optional[RawCrawlConfig]
-
-    schedule: Optional[str] = ""
-
-    jobType: Optional[JobType] = JobType.CUSTOM
-
-    tags: Optional[List[str]] = []
-
-    crawlTimeout: Optional[int] = 0
-    maxCrawlSize: Optional[int] = 0
-    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = 1  # type: ignore
-
-    oid: UUID4
-
-    profileid: Optional[UUID4]
-
-    id: UUID4
-
-    name: Optional[str]
-    description: Optional[str]
-
-    created: datetime
-    createdBy: Optional[UUID4]
-
-    modified: Optional[datetime]
-    modifiedBy: Optional[UUID4]
-
-    autoAddCollections: Optional[List[UUID4]] = []
-
-    inactive: Optional[bool] = False
-
-    rev: int = 0
-
-    crawlAttemptCount: Optional[int] = 0
-    crawlCount: Optional[int] = 0
-    crawlSuccessfulCount: Optional[int] = 0
-
-    totalSize: Optional[int] = 0
-
-    lastCrawlId: Optional[str]
-    lastCrawlStartTime: Optional[datetime]
-    lastStartedBy: Optional[UUID4]
-    lastCrawlTime: Optional[datetime]
-    lastCrawlState: Optional[str]
-    lastCrawlSize: Optional[int]
-
-    lastRun: Optional[datetime]
-
-    isCrawlRunning: Optional[bool] = False
 
     lastCrawlStopping: Optional[bool] = False
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -429,6 +429,8 @@ class Crawl(BaseCrawl, CrawlConfigCore):
 
     cid: UUID4
 
+    config: RawCrawlConfig
+
     cid_rev: int = 0
 
     # schedule: Optional[str]

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -267,6 +267,10 @@ def test_workflow_total_size_and_last_crawl_stats(
     assert data["total"] > 0
     items = data["items"]
     for workflow in items:
+        assert workflow.get("config") is None
+        assert workflow["seedCount"]
+        assert workflow["firstSeed"]
+
         last_crawl_id = workflow.get("lastCrawlId")
         if last_crawl_id and last_crawl_id in (admin_crawl_id, crawler_crawl_id):
             assert workflow["totalSize"] > 0

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -23,7 +23,7 @@ import { msg, localized, str } from "@lit/localize";
 import type { SlIconButton, SlMenu } from "@shoelace-style/shoelace";
 
 import { RelativeDuration } from "./relative-duration";
-import type { Crawl, Workflow } from "../types/crawler";
+import type { Crawl, ListWorkflow } from "../types/crawler";
 import { srOnly, truncate, dropdown } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { humanizeNextDate, humanizeSchedule } from "../utils/cron";
@@ -208,7 +208,7 @@ export class WorkflowListItem extends LitElement {
   ];
 
   @property({ type: Object })
-  workflow?: Workflow;
+  workflow?: ListWorkflow;
 
   @query(".row")
   row!: HTMLElement;
@@ -470,7 +470,7 @@ export class WorkflowListItem extends LitElement {
     </div> `;
   }
 
-  private safeRender(render: (workflow: Workflow) => any) {
+  private safeRender(render: (workflow: ListWorkflow) => any) {
     if (!this.workflow) {
       return html`<sl-skeleton></sl-skeleton>`;
     }
@@ -478,12 +478,12 @@ export class WorkflowListItem extends LitElement {
   }
 
   // TODO consolidate collections/workflow name
-  private renderName(workflow: Workflow) {
+  private renderName(workflow: ListWorkflow) {
     if (workflow.name)
       return html`<span class="truncate">${workflow.name}</span>`;
     if (!workflow.firstSeed)
       return html`<span class="truncate">${workflow.id}</span>`;
-    const remainder = workflow.config.seeds.length - 1;
+    const remainder = workflow.seedCount - 1;
     let nameSuffix: any = "";
     if (remainder) {
       if (remainder === 1) {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -80,43 +80,7 @@ export type Workflow = CrawlConfig & {
   autoAddCollections: string[];
 };
 
-export type ListWorkflow = {
-  id: string;
-  jobType?: JobType;
-  name: string;
-  description: string | null;
-  schedule: string;
-  scale: number;
-  profileid: string | null;
-  tags: string[];
-  crawlTimeout: number | null;
-  maxCrawlSize: number | null;
-  oid: string;
-  profileName: string | null;
-  createdBy: string; // User ID
-  createdByName: string | null; // User full name
-  created: string; // Date string
-  modifiedBy: string; // User ID
-  modifiedByName: string | null; // User full name
-  modified: string; // Date string
-  crawlCount: number;
-  crawlAttemptCount: number;
-  crawlSuccessfulCount: number;
-  lastCrawlId: string | null; // last finished or current crawl
-  lastCrawlStartTime: string | null;
-  lastCrawlTime: string | null; // when last crawl finished
-  lastCrawlState: CrawlState;
-  lastCrawlSize: number | null;
-  lastStartedByName: string | null;
-  lastCrawlStopping: boolean | null;
-  lastRun: string;
-  totalSize: string | null;
-  inactive: boolean;
-  firstSeed: string;
-  isCrawlRunning: boolean | null;
-  autoAddCollections: string[];
-  seedCount: number;
-};
+export type ListWorkflow = Omit<Workflow, "config">;
 
 export type Profile = {
   id: string;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -80,6 +80,44 @@ export type Workflow = CrawlConfig & {
   autoAddCollections: string[];
 };
 
+export type ListWorkflow = {
+  id: string;
+  jobType?: JobType;
+  name: string;
+  description: string | null;
+  schedule: string;
+  scale: number;
+  profileid: string | null;
+  tags: string[];
+  crawlTimeout: number | null;
+  maxCrawlSize: number | null;
+  oid: string;
+  profileName: string | null;
+  createdBy: string; // User ID
+  createdByName: string | null; // User full name
+  created: string; // Date string
+  modifiedBy: string; // User ID
+  modifiedByName: string | null; // User full name
+  modified: string; // Date string
+  crawlCount: number;
+  crawlAttemptCount: number;
+  crawlSuccessfulCount: number;
+  lastCrawlId: string | null; // last finished or current crawl
+  lastCrawlStartTime: string | null;
+  lastCrawlTime: string | null; // when last crawl finished
+  lastCrawlState: CrawlState;
+  lastCrawlSize: number | null;
+  lastStartedByName: string | null;
+  lastCrawlStopping: boolean | null;
+  lastRun: string;
+  totalSize: string | null;
+  inactive: boolean;
+  firstSeed: string;
+  isCrawlRunning: boolean | null;
+  autoAddCollections: string[];
+  seedCount: number;
+};
+
 export type Profile = {
   id: string;
   name: string;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -78,11 +78,10 @@ export type Workflow = CrawlConfig & {
   firstSeed: string;
   isCrawlRunning: boolean | null;
   autoAddCollections: string[];
-};
-
-export type ListWorkflow = Omit<Workflow, "config"> & {
   seedCount: number;
 };
+
+export type ListWorkflow = Omit<Workflow, "config">;
 
 export type Profile = {
   id: string;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -80,7 +80,9 @@ export type Workflow = CrawlConfig & {
   autoAddCollections: string[];
 };
 
-export type ListWorkflow = Omit<Workflow, "config">;
+export type ListWorkflow = Omit<Workflow, "config"> & {
+  seedCount: number;
+};
 
 export type Profile = {
   id: string;


### PR DESCRIPTION
Fixes #1185 

This PR removes the `config` from `crawlconfigs/`, `all-crawls/`, and `crawls/` list endpoints to avoid slowdowns related to long lists of seeds.

`CrawlConfigOut` now contains a `seedCount` used in the frontend. This is also included in the GET response for a single workflow in anticipation of #1190. We may want to move the seed count into the database at that point, but for now using `$size` is pretty performant.

Frontend changes have been made as necessary.