### PR TITLE
Add org metrics API endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     - id: mypy
       name: mypy
       entry: cd backend && mypy
+      language: python
       args: ["btrixcloud/"]
 - repo: local
   hooks:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -16,7 +16,7 @@ from .db import BaseMongoModel
 MAX_CRAWL_SCALE = int(os.environ.get("MAX_CRAWL_SCALE", 3))
 
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-lines
 # ============================================================================
 
 ### MAIN USER MODEL ###

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -740,6 +740,26 @@ class OrgOut(BaseMongoModel):
 
 
 # ============================================================================
+class OrgMetrics(BaseModel):
+    """Organization API metrics model"""
+
+    storageUsedBytes: int
+    storageUsedGB: float
+    storageQuota: int
+    storageQuotaGB: float
+    archivedItemCount: int
+    crawlCount: int
+    uploadCount: int
+    pageCount: int
+    profileCount: int
+    workflowsRunningCount: int
+    maxConcurrentCrawls: int
+    workflowsQueuedCount: int
+    collectionsCount: int
+    publicCollectionsCount: int
+
+
+# ============================================================================
 
 ### PAGINATION ###
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -745,7 +745,7 @@ class OrgMetrics(BaseModel):
 
     storageUsedBytes: int
     storageUsedGB: float
-    storageQuota: int
+    storageQuotaBytes: int
     storageQuotaGB: float
     archivedItemCount: int
     crawlCount: int

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -374,7 +374,7 @@ class OrgOps:
         return {
             "storageUsedBytes": org.bytesStored,
             "storageUsedGB": round((org.bytesStored / BYTES_IN_GB), 2),
-            "storageQuota": storage_quota,
+            "storageQuotaBytes": storage_quota,
             "storageQuotaGB": storage_quota_gb,
             "archivedItemCount": archived_item_count,
             "crawlCount": crawl_count,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -341,6 +341,8 @@ class OrgOps:
         if storage_quota:
             storage_quota_gb = round(storage_quota / BYTES_IN_GB)
 
+        max_concurrent_crawls = await self.get_max_concurrent_crawls(org.id)
+
         archived_item_count = 0
         crawl_count = 0
         upload_count = 0
@@ -382,7 +384,7 @@ class OrgOps:
             "pageCount": page_count,
             "profileCount": profile_count,
             "workflowsRunningCount": workflows_running_count,
-            "maxConcurrentCrawls": org.quotas.maxConcurrentCrawls,
+            "maxConcurrentCrawls": max_concurrent_crawls,
             "workflowsQueuedCount": workflows_queued_count,
             "collectionsCount": collections_count,
             "publicCollectionsCount": public_collections_count,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -343,6 +343,8 @@ class OrgOps:
 
         max_concurrent_crawls = await self.get_max_concurrent_crawls(org.id)
 
+        # Calculate these counts in loop to avoid having db iterate through
+        # archived items several times.
         archived_item_count = 0
         crawl_count = 0
         upload_count = 0

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -354,9 +354,10 @@ class OrgOps:
             if item["state"] not in SUCCESSFUL_STATES:
                 continue
             archived_item_count += 1
-            if item["type"] == "crawl":
+            type_ = item.get("type")
+            if type_ == "crawl":
                 crawl_count += 1
-            if item["type"] == "upload":
+            if type_ == "upload":
                 upload_count += 1
             if item.get("stats"):
                 page_count += item.get("stats", {}).get("done", 0)

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -335,7 +335,7 @@ class OrgOps:
 
     async def get_org_metrics(self, org: Organization):
         """Calculate and return org metrics"""
-        # pylint: ignore=too-many-locals
+        # pylint: disable=too-many-locals
         storage_quota_gb = 0
         storage_quota = await self.get_org_storage_quota(org.id)
         if storage_quota:

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -358,3 +358,27 @@ def test_update_event_webhook_urls_org_crawler(crawler_auth_headers, default_org
     )
     assert r.status_code == 403
     assert r.json()["detail"] == "User does not have permission to perform this action"
+
+
+def test_org_metrics(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/metrics",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["storageUsedBytes"] > 0
+    assert data["storageUsedGB"] > 0
+    assert data["storageQuotaBytes"] >= 0
+    assert data["storageQuotaGB"] >= 0
+    assert data["archivedItemCount"] > 0
+    assert data["crawlCount"] > 0
+    assert data["uploadCount"] >= 0
+    assert data["archivedItemCount"] == data["crawlCount"] + data["uploadCount"]
+    assert data["pageCount"] > 0
+    assert data["profileCount"] >= 0
+    assert data["workflowsRunningCount"] >= 0
+    assert data["workflowsQueuedCount"] >= 0
+    assert data["collectionsCount"] > 0
+    assert data["publicCollectionsCount"] >= 0


### PR DESCRIPTION
Fixes #1192 

We may want to precompute the archived item, upload, crawl, and page counts in a future pass to make this endpoint faster.