### PR TITLE
Remove username lookups for crawls and workflows by storing usernames in db

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -121,11 +121,6 @@ class BaseCrawlOps:
         if crawl.type == "crawl":
             crawl = await self._resolve_crawl_refs(crawl, org)
 
-        user = await self.user_manager.get(crawl.userid)
-        if user:
-            # pylint: disable=invalid-name
-            crawl.userName = user.name
-
         crawl.storageQuotaReached = await self.orgs.storage_quota_reached(crawl.oid)
 
         return crawl
@@ -255,10 +250,6 @@ class BaseCrawlOps:
             crawl.profileName = await self.crawl_configs.profiles.get_profile_name(
                 crawl.profileid, org
             )
-
-        user = await self.user_manager.get(crawl.userid)
-        if user:
-            crawl.userName = user.name
 
         # if running, get stats directly from redis
         # more responsive, saves db update in operator
@@ -456,15 +447,6 @@ class BaseCrawlOps:
 
         aggregate.extend(
             [
-                {
-                    "$lookup": {
-                        "from": "users",
-                        "localField": "userid",
-                        "foreignField": "id",
-                        "as": "userName",
-                    },
-                },
-                {"$set": {"userName": {"$arrayElemAt": ["$userName.name", 0]}}},
                 {
                     "$facet": {
                         "items": [

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -129,6 +129,7 @@ class CrawlConfigOps:
 
         return profileid, profile_filename
 
+    # pylint: disable=invalid-name
     async def add_crawl_config(
         self,
         config: CrawlConfigIn,
@@ -136,14 +137,19 @@ class CrawlConfigOps:
         user: User,
     ):
         """Add new crawl config"""
-
         data = config.dict()
         data["oid"] = org.id
         data["createdBy"] = user.id
+        data["createdByName"] = user.name
         data["modifiedBy"] = user.id
+        data["modifiedByName"] = user.name
         data["_id"] = uuid.uuid4()
         data["created"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
         data["modified"] = data["created"]
+
+        if config.runNow:
+            data["lastStartedBy"] = user.id
+            data["lastStartedByName"] = user.name
 
         # Ensure page limit is below org maxPagesPerCall if set
         max_pages = await self.org_ops.get_max_pages_per_crawl(org.id)
@@ -181,12 +187,12 @@ class CrawlConfigOps:
         )
 
         if crawl_id and run_now:
-            await self.add_new_crawl(crawl_id, crawlconfig, user.id, manual=True)
+            await self.add_new_crawl(crawl_id, crawlconfig, user, manual=True)
 
         return result.inserted_id, crawl_id, quota_reached
 
     async def add_new_crawl(
-        self, crawl_id: str, crawlconfig: CrawlConfig, userid: uuid.UUID, manual: bool
+        self, crawl_id: str, crawlconfig: CrawlConfig, user: User, manual: bool
     ):
         """increments crawl count for this config and adds new crawl"""
 
@@ -194,9 +200,11 @@ class CrawlConfigOps:
 
         inc = self.inc_crawl_count(crawlconfig.id)
         add = self.crawl_ops.add_new_crawl(
-            crawl_id, crawlconfig, userid, started, manual
+            crawl_id, crawlconfig, user.id, started, manual
         )
-        info = self.set_config_current_crawl_info(crawlconfig.id, crawl_id, started)
+        info = self.set_config_current_crawl_info(
+            crawlconfig.id, crawl_id, started, user
+        )
 
         await asyncio.gather(inc, add, info)
 
@@ -286,6 +294,7 @@ class CrawlConfigOps:
         # set update query
         query = update.dict(exclude_unset=True)
         query["modifiedBy"] = user.id
+        query["modifiedByName"] = user.name
         query["modified"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
 
         query["profileid"], profile_filename = await self._lookup_profile(
@@ -410,43 +419,6 @@ class CrawlConfigOps:
         aggregate.extend(
             [
                 {
-                    "$lookup": {
-                        "from": "users",
-                        "localField": "createdBy",
-                        "foreignField": "id",
-                        "as": "userName",
-                    },
-                },
-                {"$set": {"createdByName": {"$arrayElemAt": ["$userName.name", 0]}}},
-                {
-                    "$lookup": {
-                        "from": "users",
-                        "localField": "lastStartedBy",
-                        "foreignField": "id",
-                        "as": "startedName",
-                    },
-                },
-                {
-                    "$set": {
-                        "lastStartedByName": {"$arrayElemAt": ["$startedName.name", 0]}
-                    }
-                },
-                {
-                    "$lookup": {
-                        "from": "users",
-                        "localField": "modifiedBy",
-                        "foreignField": "id",
-                        "as": "modifiedUserName",
-                    },
-                },
-                {
-                    "$set": {
-                        "modifiedByName": {
-                            "$arrayElemAt": ["$modifiedUserName.name", 0]
-                        }
-                    }
-                },
-                {
                     "$facet": {
                         "items": [
                             {"$skip": skip},
@@ -529,6 +501,8 @@ class CrawlConfigOps:
             update_query["lastCrawlId"] = str(last_crawl.get("_id"))
             update_query["lastCrawlStartTime"] = last_crawl.get("started")
             update_query["lastStartedBy"] = last_crawl.get("userid")
+            # TODO: Implement in crawls!
+            update_query["lastStartedByName"] = last_crawl.get("userName")
             update_query["lastCrawlTime"] = last_crawl_finished
             update_query["lastCrawlState"] = last_crawl.get("state")
             update_query["lastCrawlSize"] = sum(
@@ -577,22 +551,6 @@ class CrawlConfigOps:
             self._add_curr_crawl_stats(
                 crawlconfig, await self.get_running_crawl(crawlconfig)
             )
-
-        user = await self.user_manager.get(crawlconfig.createdBy)
-        # pylint: disable=invalid-name
-        if user:
-            crawlconfig.createdByName = user.name
-
-        modified_user = await self.user_manager.get(crawlconfig.modifiedBy)
-        # pylint: disable=invalid-name
-        if modified_user:
-            crawlconfig.modifiedByName = modified_user.name
-
-        if crawlconfig.lastStartedBy:
-            last_started_user = await self.user_manager.get(crawlconfig.lastStartedBy)
-            # pylint: disable=invalid-name
-            if last_started_user:
-                crawlconfig.lastStartedByName = last_started_user.name
 
         if crawlconfig.profileid:
             crawlconfig.profileName = await self.profiles.get_profile_name(
@@ -790,7 +748,7 @@ class CrawlConfigOps:
             crawl_id = await self.crawl_manager.create_crawl_job(
                 crawlconfig, userid=str(user.id)
             )
-            await self.add_new_crawl(crawl_id, crawlconfig, user.id, manual=True)
+            await self.add_new_crawl(crawl_id, crawlconfig, user, manual=True)
             return crawl_id
 
         except Exception as exc:
@@ -798,7 +756,7 @@ class CrawlConfigOps:
             raise HTTPException(status_code=500, detail=f"Error starting crawl: {exc}")
 
     async def set_config_current_crawl_info(
-        self, cid: uuid.UUID, crawl_id: str, crawl_start: datetime
+        self, cid: uuid.UUID, crawl_id: str, crawl_start: datetime, user: User
     ):
         """Set current crawl info in config when crawl begins"""
         result = await self.crawl_configs.find_one_and_update(
@@ -810,6 +768,8 @@ class CrawlConfigOps:
                     "lastCrawlTime": None,
                     "lastRun": crawl_start,
                     "isCrawlRunning": True,
+                    "lastStartedBy": user.id,
+                    "lastStartedByName": user.name,
                 }
             },
             return_document=pymongo.ReturnDocument.AFTER,
@@ -834,6 +794,7 @@ async def stats_recompute_all(crawl_configs, crawls, cid: uuid.UUID):
         "lastCrawlId": None,
         "lastCrawlStartTime": None,
         "lastStartedBy": None,
+        "lastStartedByName": None,
         "lastCrawlTime": None,
         "lastCrawlState": None,
         "lastCrawlSize": None,
@@ -858,6 +819,8 @@ async def stats_recompute_all(crawl_configs, crawls, cid: uuid.UUID):
         update_query["lastCrawlId"] = str(last_crawl.get("_id"))
         update_query["lastCrawlStartTime"] = last_crawl.get("started")
         update_query["lastStartedBy"] = last_crawl.get("userid")
+        # TODO: Implement in crawls!
+        update_query["lastStartedByName"] = last_crawl.get("userName")
         update_query["lastCrawlTime"] = last_crawl_finished
         update_query["lastCrawlState"] = last_crawl.get("state")
         update_query["lastCrawlSize"] = sum(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -501,7 +501,6 @@ class CrawlConfigOps:
             update_query["lastCrawlId"] = str(last_crawl.get("_id"))
             update_query["lastCrawlStartTime"] = last_crawl.get("started")
             update_query["lastStartedBy"] = last_crawl.get("userid")
-            # TODO: Implement in crawls!
             update_query["lastStartedByName"] = last_crawl.get("userName")
             update_query["lastCrawlTime"] = last_crawl_finished
             update_query["lastCrawlState"] = last_crawl.get("state")
@@ -819,7 +818,6 @@ async def stats_recompute_all(crawl_configs, crawls, cid: uuid.UUID):
         update_query["lastCrawlId"] = str(last_crawl.get("_id"))
         update_query["lastCrawlStartTime"] = last_crawl.get("started")
         update_query["lastStartedBy"] = last_crawl.get("userid")
-        # TODO: Implement in crawls!
         update_query["lastStartedByName"] = last_crawl.get("userName")
         update_query["lastCrawlTime"] = last_crawl_finished
         update_query["lastCrawlState"] = last_crawl.get("state")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -165,15 +165,6 @@ class CrawlOps(BaseCrawlOps):
         aggregate.extend(
             [
                 {
-                    "$lookup": {
-                        "from": "users",
-                        "localField": "userid",
-                        "foreignField": "id",
-                        "as": "userName",
-                    },
-                },
-                {"$set": {"userName": {"$arrayElemAt": ["$userName.name", 0]}}},
-                {
                     "$facet": {
                         "items": [
                             {"$skip": skip},
@@ -248,12 +239,19 @@ class CrawlOps(BaseCrawlOps):
         userid: uuid.UUID,
         started: str,
         manual: bool,
+        username: str = "",
     ):
         """initialize new crawl"""
+        if not username:
+            user = await self.user_manager.get(userid)
+            if user:
+                username = user.name
+
         crawl = Crawl(
             id=crawl_id,
             state="starting",
             userid=userid,
+            userName=username,
             oid=crawlconfig.oid,
             cid=crawlconfig.id,
             cid_rev=crawlconfig.rev,

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -15,7 +15,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0017"
+CURR_DB_VERSION = "0018"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0017_usernames.py
+++ b/backend/btrixcloud/migrations/migration_0017_usernames.py
@@ -1,0 +1,90 @@
+"""
+Migration 0017 - Store crawl and workflow userName directly in db
+"""
+from btrixcloud.migrations import BaseMigration
+
+from btrixcloud.emailsender import EmailSender
+from btrixcloud.invites import init_invites
+from btrixcloud.users import init_user_manager
+
+
+MIGRATION_VERSION = "0017"
+
+
+# pylint: disable=too-many-locals, invalid-name
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Store userName in db for crawls and workflows
+        """
+
+        mdb_configs = self.mdb["crawl_configs"]
+        mdb_crawls = self.mdb["crawls"]
+
+        email = EmailSender()
+        invites = init_invites(self.mdb, email)
+        user_manager = init_user_manager(self.mdb, email, invites)
+
+        crawls = [res async for res in mdb_crawls.find({})]
+        for crawl in crawls:
+            crawl_id = crawl["_id"]
+            if crawl.get("userName"):
+                continue
+            try:
+                user = await user_manager.get(crawl["userid"])
+                await mdb_crawls.find_one_and_update(
+                    {"_id": crawl_id},
+                    {"$set": {"userName": user.name}},
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update userName for crawl {crawl_id}: {err}", flush=True
+                )
+
+        configs = [res async for res in mdb_configs.find({})]
+        for config in configs:
+            cid = config["_id"]
+            if config.get("createdByName") and config.get("modifiedByName"):
+                continue
+            try:
+                created_by_name = ""
+                modified_by_name = ""
+                last_started_by_name = ""
+
+                created_user = await user_manager.get(config["createdBy"])
+                if created_user:
+                    created_by_name = created_user.name
+
+                modified_user = await user_manager.get(config["modifiedBy"])
+                if modified_user:
+                    modified_by_name = modified_user.name
+
+                last_started_by = config.get("lastStartedBy")
+                if last_started_by:
+                    last_started_user = await user_manager.get(last_started_by)
+                    if last_started_user:
+                        last_started_by_name = last_started_user.name
+
+                await mdb_configs.find_one_and_update(
+                    {"_id": cid},
+                    {
+                        "$set": {
+                            "createdByName": created_by_name,
+                            "modifiedByName": modified_by_name,
+                            "lastStartedByName": last_started_by_name,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update usernames for crawlconfig {cid}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/migrations/migration_0018_usernames.py
+++ b/backend/btrixcloud/migrations/migration_0018_usernames.py
@@ -1,5 +1,5 @@
 """
-Migration 0017 - Store crawl and workflow userName directly in db
+Migration 0018 - Store crawl and workflow userName directly in db
 """
 from btrixcloud.migrations import BaseMigration
 
@@ -8,7 +8,7 @@ from btrixcloud.invites import init_invites
 from btrixcloud.users import init_user_manager
 
 
-MIGRATION_VERSION = "0017"
+MIGRATION_VERSION = "0018"
 
 
 # pylint: disable=too-many-locals, invalid-name

--- a/backend/btrixcloud/migrations/migration_0018_usernames.py
+++ b/backend/btrixcloud/migrations/migration_0018_usernames.py
@@ -31,8 +31,7 @@ class Migration(BaseMigration):
         invites = init_invites(self.mdb, email)
         user_manager = init_user_manager(self.mdb, email, invites)
 
-        crawls = [res async for res in mdb_crawls.find({})]
-        for crawl in crawls:
+        async for crawl in mdb_crawls.find({}):
             crawl_id = crawl["_id"]
             if crawl.get("userName"):
                 continue
@@ -48,8 +47,7 @@ class Migration(BaseMigration):
                     f"Unable to update userName for crawl {crawl_id}: {err}", flush=True
                 )
 
-        configs = [res async for res in mdb_configs.find({})]
-        for config in configs:
+        async for config in mdb_configs.find({}):
             cid = config["_id"]
             if config.get("createdByName") and config.get("modifiedByName"):
                 continue

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -214,6 +214,7 @@ class CrawlConfigAdditional(BaseModel):
     isCrawlRunning: Optional[bool] = False
 
 
+
 # ============================================================================
 class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
     """Schedulable config"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -231,7 +231,7 @@ class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
 
 
 # ============================================================================
-class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
+class CrawlConfigOut(CrawlConfig):
     """Crawl Config Output"""
 
     lastCrawlStopping: Optional[bool] = False

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -221,6 +221,9 @@ class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
     id: UUID4
 
     config: RawCrawlConfig
+    createdByName: Optional[str]
+    modifiedByName: Optional[str]
+    lastStartedByName: Optional[str]
 
     def get_raw_config(self):
         """serialize config for browsertrix-crawler"""
@@ -232,13 +235,7 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     """Crawl Config Output"""
 
     lastCrawlStopping: Optional[bool] = False
-
     profileName: Optional[str]
-
-    createdByName: Optional[str]
-    modifiedByName: Optional[str]
-    lastStartedByName: Optional[str]
-
     firstSeed: Optional[str]
     seedCount: int = 0
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -231,13 +231,17 @@ class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
 
 
 # ============================================================================
-class CrawlConfigOut(CrawlConfig):
+class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     """Crawl Config Output"""
 
     lastCrawlStopping: Optional[bool] = False
     profileName: Optional[str]
     firstSeed: Optional[str]
     seedCount: int = 0
+
+    createdByName: Optional[str]
+    modifiedByName: Optional[str]
+    lastStartedByName: Optional[str]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -304,6 +304,7 @@ class BaseCrawl(BaseMongoModel):
     id: str
 
     userid: UUID4
+    userName: Optional[str]
     oid: UUID4
 
     started: datetime
@@ -346,9 +347,8 @@ class CrawlOut(BaseMongoModel):
     id: str
 
     userid: UUID4
-    oid: UUID4
-
     userName: Optional[str]
+    oid: UUID4
 
     name: Optional[str]
     description: Optional[str]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -214,7 +214,6 @@ class CrawlConfigAdditional(BaseModel):
     isCrawlRunning: Optional[bool] = False
 
 
-
 # ============================================================================
 class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
     """Schedulable config"""

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -161,6 +161,7 @@ class UploadOps(BaseCrawlOps):
             collectionIds=collection_uuids,
             tags=tags,
             userid=user.id,
+            userName=user.name,
             oid=org.id,
             files=files,
             state="complete",

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -14,6 +14,21 @@ _coll_id = None
 _admin_crawl_cid = None
 
 
+def test_crawl_config_usernames(
+    crawler_auth_headers, default_org_id, crawler_config_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{crawler_config_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["createdByName"]
+    assert data["modifiedByName"]
+    assert data["lastStartedByName"]
+
+
 def test_add_crawl_config(crawler_auth_headers, default_org_id, sample_crawl_data):
     # Create crawl config
     sample_crawl_data["schedule"] = "0 0 * * *"

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -218,6 +218,7 @@ def test_sort_crawls(
 
     last_created = None
     for crawl in items:
+        assert crawl["userName"]
         if last_created:
             assert crawl["started"] <= last_created
         last_created = crawl["started"]
@@ -232,6 +233,7 @@ def test_sort_crawls(
 
     last_created = None
     for crawl in items:
+        assert crawl["userName"]
         if last_created:
             assert crawl["started"] >= last_created
         last_created = crawl["started"]
@@ -246,6 +248,7 @@ def test_sort_crawls(
 
     last_finished = None
     for crawl in items:
+        assert crawl["userName"]
         if not crawl["finished"]:
             continue
         if last_finished:
@@ -262,6 +265,7 @@ def test_sort_crawls(
 
     last_finished = None
     for crawl in items:
+        assert crawl["userName"]
         if not crawl["finished"]:
             continue
         if last_finished:
@@ -278,6 +282,7 @@ def test_sort_crawls(
 
     last_size = None
     for crawl in items:
+        assert crawl["userName"]
         if last_size:
             assert crawl["fileSize"] <= last_size
         last_size = crawl["fileSize"]
@@ -292,6 +297,7 @@ def test_sort_crawls(
 
     last_size = None
     for crawl in items:
+        assert crawl["userName"]
         if last_size:
             assert crawl["fileSize"] >= last_size
         last_size = crawl["fileSize"]
@@ -306,6 +312,7 @@ def test_sort_crawls(
 
     last_first_seed = None
     for crawl in items:
+        assert crawl["userName"]
         if not crawl["firstSeed"]:
             continue
         if last_first_seed:
@@ -322,6 +329,7 @@ def test_sort_crawls(
 
     last_first_seed = None
     for crawl in items:
+        assert crawl["userName"]
         if not crawl["firstSeed"]:
             continue
         if last_first_seed:
@@ -351,7 +359,7 @@ def test_sort_crawl_configs(
     # Sort by created, descending (default)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=created",
-        headers=crawler_auth_headers,
+        headers=configer_auth_headers,
     )
     data = r.json()
     assert data["total"] == 8
@@ -359,84 +367,96 @@ def test_sort_crawl_configs(
     assert len(items) == 8
 
     last_created = None
-    for crawl in items:
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         if last_created:
-            assert crawl["created"] <= last_created
-        last_created = crawl["created"]
+            assert config["created"] <= last_created
+        last_created = config["created"]
 
     # Sort by created, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=created&sortDirection=1",
-        headers=crawler_auth_headers,
+        headers=configer_auth_headers,
     )
     data = r.json()
     items = data["items"]
 
     last_created = None
-    for crawl in items:
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         if last_created:
-            assert crawl["created"] >= last_created
-        last_created = crawl["created"]
+            assert config["created"] >= last_created
+        last_created = config["created"]
 
     # Sort by modified
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=modified",
-        headers=crawler_auth_headers,
+        headers=configer_auth_headers,
     )
     data = r.json()
     items = data["items"]
 
     last_modified = None
-    for crawl in items:
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         if last_modified:
-            assert crawl["modified"] <= last_modified
-        last_modified = crawl["modified"]
+            assert config["modified"] <= last_modified
+        last_modified = config["modified"]
 
     # Sort by modified, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=modified&sortDirection=1",
-        headers=crawler_auth_headers,
+        headers=configer_auth_headers,
     )
     data = r.json()
     items = data["items"]
 
     last_modified = None
-    for crawl in items:
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         if last_modified:
-            assert crawl["modified"] >= last_modified
-        last_modified = crawl["modified"]
+            assert config["modified"] >= last_modified
+        last_modified = config["modified"]
 
     # Sort by first seed
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=firstSeed",
-        headers=crawler_auth_headers,
+        headers=configer_auth_headers,
     )
     data = r.json()
     items = data["items"]
 
     last_first_seed = None
-    for crawl in items:
-        if not crawl["firstSeed"]:
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
+        if not config["firstSeed"]:
             continue
         if last_first_seed:
-            assert crawl["firstSeed"] <= last_first_seed
-        last_first_seed = crawl["firstSeed"]
+            assert config["firstSeed"] <= last_first_seed
+        last_first_seed = config["firstSeed"]
 
     # Sort by first seed, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=firstSeed&sortDirection=1",
-        headers=crawler_auth_headers,
+        headers=configer_auth_headers,
     )
     data = r.json()
     items = data["items"]
 
     last_first_seed = None
-    for crawl in items:
-        if not crawl["firstSeed"]:
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
+        if not config["firstSeed"]:
             continue
         if last_first_seed:
-            assert crawl["firstSeed"] >= last_first_seed
-        last_first_seed = crawl["firstSeed"]
+            assert config["firstSeed"] >= last_first_seed
+        last_first_seed = config["firstSeed"]
 
     # Sort by lastCrawlTime
     r = requests.get(
@@ -448,6 +468,8 @@ def test_sort_crawl_configs(
 
     last_crawl_time = None
     for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         config_last_time = config.get("lastCrawlTime")
         if not config_last_time:
             continue
@@ -465,6 +487,8 @@ def test_sort_crawl_configs(
 
     last_crawl_time = None
     for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         config_last_time = config.get("lastCrawlTime")
         if not config_last_time:
             continue
@@ -482,6 +506,8 @@ def test_sort_crawl_configs(
 
     last_crawl_time = None
     for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         config_last_time = config.get("lastCrawlStartTime")
         if not config_last_time:
             continue
@@ -499,6 +525,8 @@ def test_sort_crawl_configs(
 
     last_crawl_time = None
     for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         config_last_time = config.get("lastCrawlStartTime")
         if not config_last_time:
             continue
@@ -516,6 +544,8 @@ def test_sort_crawl_configs(
 
     last_updated_time = None
     for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         config_last_updated = config.get("lastRun")
         if not config_last_updated:
             continue
@@ -533,6 +563,8 @@ def test_sort_crawl_configs(
 
     last_updated_time = None
     for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
         config_last_updated = config.get("lastRun")
         if not config_last_updated:
             continue

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -359,7 +359,7 @@ def test_sort_crawl_configs(
     # Sort by created, descending (default)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=created",
-        headers=configer_auth_headers,
+        headers=crawler_auth_headers,
     )
     data = r.json()
     assert data["total"] == 8
@@ -377,7 +377,7 @@ def test_sort_crawl_configs(
     # Sort by created, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=created&sortDirection=1",
-        headers=configer_auth_headers,
+        headers=crawler_auth_headers,
     )
     data = r.json()
     items = data["items"]
@@ -393,7 +393,7 @@ def test_sort_crawl_configs(
     # Sort by modified
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=modified",
-        headers=configer_auth_headers,
+        headers=crawler_auth_headers,
     )
     data = r.json()
     items = data["items"]
@@ -409,7 +409,7 @@ def test_sort_crawl_configs(
     # Sort by modified, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=modified&sortDirection=1",
-        headers=configer_auth_headers,
+        headers=crawler_auth_headers,
     )
     data = r.json()
     items = data["items"]
@@ -425,7 +425,7 @@ def test_sort_crawl_configs(
     # Sort by first seed
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=firstSeed",
-        headers=configer_auth_headers,
+        headers=crawler_auth_headers,
     )
     data = r.json()
     items = data["items"]
@@ -443,7 +443,7 @@ def test_sort_crawl_configs(
     # Sort by first seed, ascending
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=firstSeed&sortDirection=1",
-        headers=configer_auth_headers,
+        headers=crawler_auth_headers,
     )
     data = r.json()
     items = data["items"]

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -82,6 +82,7 @@ def test_crawl_info(admin_auth_headers, default_org_id, admin_crawl_id):
     data = r.json()
     assert data["fileSize"] == wacz_size
     assert data["fileCount"] == 1
+    assert data["userName"]
 
 
 def test_crawls_include_seed_info(admin_auth_headers, default_org_id, admin_crawl_id):


### PR DESCRIPTION
Fixes #1186 

This PR includes a migration that has been tested locally on workflows, crawls, and uploads, including resetting `lastStartedByName` on workflows after deleting a crawl.