### PR TITLE
New org home page dashboard

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -140,9 +140,6 @@ import("./markdown-editor").then(({ MarkdownEditor }) => {
 import("./markdown-viewer").then(({ MarkdownViewer }) => {
   customElements.define("btrix-markdown-viewer", MarkdownViewer);
 });
-import("./file-uploader").then(({ FileUploader }) => {
-  customElements.define("btrix-file-uploader", FileUploader);
-});
 import("./file-list").then(({ FileList, FileListItem }) => {
   customElements.define("btrix-file-list", FileList);
   customElements.define("btrix-file-list-item", FileListItem);
@@ -156,7 +153,6 @@ import("./code").then(({ Code }) => {
 import("./search-combobox").then(({ SearchCombobox }) => {
   customElements.define("btrix-search-combobox", SearchCombobox);
 });
-
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);
 customElements.define("btrix-time-input", TimeInput);

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -161,7 +161,7 @@ export class OrgsList extends LiteElement {
   }
 
   private makeOnOrgClick(org: OrgData): Function {
-    const navigate = () => this.navTo(`/orgs/${org.id}/workflows/crawls`);
+    const navigate = () => this.navTo(`/orgs/${org.id}`);
 
     if (typeof window.getSelection !== undefined) {
       return () => {

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -6,7 +6,6 @@ import type { OrgData } from "../utils/orgs";
 import LiteElement, { html } from "../utils/LiteElement";
 
 import { isAdmin } from "../utils/orgs";
-import { DASHBOARD_ROUTE } from "../routes";
 import { SlInput } from "@shoelace-style/shoelace";
 
 @localized()

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -19,7 +19,7 @@ import type { CurrentUser, UserOrg } from "./types/user";
 import type { AuthStorageEventData } from "./utils/AuthService";
 import type { OrgData } from "./utils/orgs";
 import theme from "./theme";
-import { ROUTES, DASHBOARD_ROUTE } from "./routes";
+import { ROUTES } from "./routes";
 import "./shoelace";
 import "./components";
 import "./pages";
@@ -128,7 +128,7 @@ export class App extends LiteElement {
         window.location.pathname === "/reset-password")
     ) {
       // Redirect to logged in home page
-      this.viewState = this.router.match(DASHBOARD_ROUTE);
+      this.viewState = this.router.match(ROUTES.home);
       window.history.replaceState(this.viewState, "", this.viewState.pathname);
     } else {
       this.viewState = this.router.match(
@@ -217,7 +217,7 @@ export class App extends LiteElement {
 
     if (newViewPath === "/log-in" && this.authService.authState) {
       // Redirect to logged in home page
-      this.viewState = this.router.match(DASHBOARD_ROUTE);
+      this.viewState = this.router.match(ROUTES.home);
     } else {
       this.viewState = this.router.match(newViewPath);
     }
@@ -794,7 +794,7 @@ export class App extends LiteElement {
     });
 
     if (!detail.api) {
-      this.navigate(detail.redirectUrl || DASHBOARD_ROUTE);
+      this.navigate(detail.redirectUrl || ROUTES.home);
     }
 
     if (detail.firstLogin) {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -264,7 +264,7 @@ export class App extends LiteElement {
     const isAdmin = this.userInfo?.isAdmin;
     let homeHref = "/";
     if (!isAdmin && this.selectedOrgId) {
-      homeHref = `/orgs/${this.selectedOrgId}/workflows/crawls`;
+      homeHref = `/orgs/${this.selectedOrgId}`;
     }
 
     return html`
@@ -392,7 +392,7 @@ export class App extends LiteElement {
           @sl-select=${(e: CustomEvent) => {
             const { value } = e.detail.item;
             if (value) {
-              this.navigate(`/orgs/${value}/workflows/crawls`);
+              this.navigate(`/orgs/${value}`);
               if (this.userInfo) {
                 this.persistUserSettings(this.userInfo.id, { orgId: value });
               }
@@ -624,10 +624,11 @@ export class App extends LiteElement {
       case "org": {
         const orgId = this.viewState.params.orgId;
         const orgPath = this.viewState.pathname;
-        const orgTab = window.location.pathname
-          .slice(window.location.pathname.indexOf(orgId) + orgId.length)
-          .replace(/^\//, "")
-          .split("/")[0];
+        const orgTab =
+          window.location.pathname
+            .slice(window.location.pathname.indexOf(orgId) + orgId.length)
+            .replace(/(^\/|\/$)/, "")
+            .split("/")[0] || "home";
         return html`<btrix-org
           class="w-full"
           @navigate=${this.onNavigateTo}

--- a/frontend/src/pages/accept-invite.ts
+++ b/frontend/src/pages/accept-invite.ts
@@ -3,7 +3,7 @@ import { msg, str, localized } from "@lit/localize";
 
 import LiteElement, { html } from "../utils/LiteElement";
 import type { AuthState } from "../utils/AuthService";
-import { DASHBOARD_ROUTE } from "../routes";
+import { ROUTES } from "../routes";
 
 @localized()
 export class AcceptInvite extends LiteElement {
@@ -158,7 +158,7 @@ export class AcceptInvite extends LiteElement {
         icon: "check2-circle",
       });
 
-      this.navTo(DASHBOARD_ROUTE);
+      this.navTo(ROUTES.home);
     } catch (err: any) {
       if (err.isApiError && err.message === "Invalid Invite Code") {
         this.serverError = msg("This invitation is not valid");
@@ -175,6 +175,6 @@ export class AcceptInvite extends LiteElement {
       icon: "info-circle",
     });
 
-    this.navTo(DASHBOARD_ROUTE);
+    this.navTo(ROUTES.home);
   }
 }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -48,7 +48,7 @@ export class Home extends LiteElement {
 
   willUpdate(changedProperties: Map<string, any>) {
     if (changedProperties.has("orgId") && this.orgId) {
-      this.navTo(`/orgs/${this.orgId}/workflows/crawls`);
+      this.navTo(`/orgs/${this.orgId}`);
     } else if (changedProperties.has("authState") && this.authState) {
       this.fetchOrgs();
     }

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -6,7 +6,7 @@ import type { ViewState } from "../utils/APIRouter";
 import LiteElement, { html } from "../utils/LiteElement";
 import type { LoggedInEventDetail } from "../utils/AuthService";
 import AuthService from "../utils/AuthService";
-import { DASHBOARD_ROUTE } from "../routes";
+import { ROUTES } from "../routes";
 
 type FormContext = {
   successMessage?: string;
@@ -146,7 +146,7 @@ export class LogInPage extends LiteElement {
   viewState!: ViewState;
 
   @property({ type: String })
-  redirectUrl: string = DASHBOARD_ROUTE;
+  redirectUrl: string = ROUTES.home;
 
   private formStateService = interpret(machine);
 

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -126,8 +126,8 @@ export class CollectionsList extends LiteElement {
   render() {
     return html`
       <header class="contents">
-        <div class="flex justify-between w-full h-8 mb-4">
-          <h1 class="text-xl font-semibold">${msg("Collections")}</h1>
+        <div class="flex justify-between w-full mb-4">
+          <h1 class="text-xl font-semibold leading-8">${msg("Collections")}</h1>
           ${when(
             this.isCrawler,
             () => html`
@@ -138,7 +138,7 @@ export class CollectionsList extends LiteElement {
                 @click=${this.navLink}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("Create Collection")}
+                ${msg("New Collection")}
               </sl-button>
             `
           )}

--- a/frontend/src/pages/org/components/file-uploader.ts
+++ b/frontend/src/pages/org/components/file-uploader.ts
@@ -7,12 +7,16 @@ import queryString from "query-string";
 import throttle from "lodash/fp/throttle";
 import type { SlButton } from "@shoelace-style/shoelace";
 
-import type { Tags, TagInputEvent, TagsChangeEvent } from "./tag-input";
-import type { AuthState } from "../utils/AuthService";
-import LiteElement, { html } from "../utils/LiteElement";
-import { APIError } from "../utils/api";
-import { maxLengthValidator } from "../utils/form";
-import type { FileRemoveEvent } from "./file-list";
+import type {
+  Tags,
+  TagInputEvent,
+  TagsChangeEvent,
+} from "../../../components/tag-input";
+import type { AuthState } from "../../../utils/AuthService";
+import LiteElement, { html } from "../../../utils/LiteElement";
+import { APIError } from "../../../utils/api";
+import { maxLengthValidator } from "../../../utils/form";
+import type { FileRemoveEvent } from "../../../components/file-list";
 
 export type FileUploaderRequestCloseEvent = CustomEvent<{}>;
 export type FileUploaderUploadStartEvent = CustomEvent<{
@@ -533,3 +537,4 @@ export class FileUploader extends LiteElement {
     return !formEl.querySelector("[data-invalid]");
   }
 }
+customElements.define("btrix-file-uploader", FileUploader);

--- a/frontend/src/pages/org/components/new-browser-profile-dialog.ts
+++ b/frontend/src/pages/org/components/new-browser-profile-dialog.ts
@@ -1,0 +1,182 @@
+import { state, property, queryAsync } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import type { SlInput } from "@shoelace-style/shoelace";
+
+import type { AuthState } from "../../../utils/AuthService";
+import LiteElement, { html } from "../../../utils/LiteElement";
+import type { Dialog } from "../../../components/dialog";
+
+@localized()
+export class NewBrowserProfileDialog extends LiteElement {
+  @property({ type: Object })
+  authState!: AuthState;
+
+  @property({ type: String })
+  orgId!: string;
+
+  @property({ type: Boolean })
+  open = false;
+
+  @state()
+  private isSubmitting = false;
+
+  @queryAsync("#browserProfileForm")
+  private form!: Promise<HTMLFormElement>;
+
+  render() {
+    return html` <btrix-dialog
+      label=${msg(str`New Browser Profile`)}
+      ?open=${this.open}
+      @sl-initial-focus=${async (e: CustomEvent) => {
+        const nameInput = (await this.form).querySelector(
+          'sl-input[name="url"]'
+        ) as SlInput;
+        if (nameInput) {
+          e.preventDefault();
+          nameInput.focus();
+        }
+      }}
+    >
+      <form
+        id="browserProfileForm"
+        @reset=${this.onReset}
+        @submit=${this.onSubmit}
+      >
+        <div class="grid gap-5">
+          <div>
+            <label
+              id="startingUrlLabel"
+              class="text-sm leading-normal"
+              style="margin-bottom: var(--sl-spacing-3x-small)"
+              >${msg("Starting URL")}
+            </label>
+
+            <div class="flex">
+              <sl-select
+                class="grow-0 mr-1"
+                name="urlPrefix"
+                value="https://"
+                hoist
+                @sl-hide=${this.stopProp}
+                @sl-after-hide=${this.stopProp}
+              >
+                <sl-option value="http://">http://</sl-option>
+                <sl-option value="https://">https://</sl-option>
+              </sl-select>
+              <sl-input
+                class="grow"
+                name="url"
+                placeholder=${msg("example.com")}
+                autocomplete="off"
+                aria-labelledby="startingUrlLabel"
+                required
+              >
+              </sl-input>
+            </div>
+          </div>
+        </div>
+        <input class="invisible h-0 w-0" type="submit" />
+      </form>
+      <div slot="footer" class="flex justify-between">
+        <sl-button
+          size="small"
+          @click=${async () => {
+            // Using reset method instead of type="reset" fixes
+            // incorrect getRootNode in Chrome
+            (await this.form).reset();
+          }}
+          >${msg("Cancel")}</sl-button
+        >
+        <sl-button
+          variant="primary"
+          size="small"
+          ?loading=${this.isSubmitting}
+          ?disabled=${this.isSubmitting}
+          @click=${async () => {
+            // Using submit method instead of type="submit" fixes
+            // incorrect getRootNode in Chrome
+            const form = await this.form;
+            const submitInput = form.querySelector(
+              'input[type="submit"]'
+            ) as HTMLInputElement;
+            form.requestSubmit(submitInput);
+          }}
+          >${msg("Start Profile Creator")}</sl-button
+        >
+      </div>
+    </btrix-dialog>`;
+  }
+
+  private async hideDialog() {
+    ((await this.form).closest("btrix-dialog") as Dialog).hide();
+  }
+
+  private onReset() {
+    this.hideDialog();
+  }
+
+  private async onSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    this.isSubmitting = true;
+
+    const formData = new FormData(event.target as HTMLFormElement);
+    const url = formData.get("url") as string;
+
+    try {
+      const data = await this.createBrowser({
+        url: `${formData.get("urlPrefix")}${url.substring(
+          url.indexOf(",") + 1
+        )}`,
+      });
+
+      this.notify({
+        message: msg("Starting up browser for profile creation."),
+        variant: "success",
+        icon: "check2-circle",
+      });
+      await this.hideDialog();
+      this.navTo(
+        `/orgs/${this.orgId}/browser-profiles/profile/browser/${
+          data.browserid
+        }?name=${window.encodeURIComponent(
+          "My Profile"
+        )}&description=&profileId=`
+      );
+    } catch (e: any) {
+      this.notify({
+        message: msg("Sorry, couldn't create browser profile at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+    this.isSubmitting = false;
+  }
+
+  private createBrowser({ url }: { url: string }) {
+    const params = {
+      url,
+    };
+
+    return this.apiFetch(
+      `/orgs/${this.orgId}/profiles/browser`,
+      this.authState!,
+      {
+        method: "POST",
+        body: JSON.stringify(params),
+      }
+    );
+  }
+
+  /**
+   * Stop propgation of sl-select events.
+   * Prevents bug where sl-dialog closes when dropdown closes
+   * https://github.com/shoelace-style/shoelace/issues/170
+   */
+  private stopProp(e: CustomEvent) {
+    e.stopPropagation();
+  }
+}
+customElements.define(
+  "btrix-new-browser-profile-dialog",
+  NewBrowserProfileDialog
+);

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -75,13 +75,6 @@ export class CrawlsList extends LiteElement {
   @property({ type: String })
   itemType: Crawl["type"] = null;
 
-  /**
-   * Fetch & refetch data when needed,
-   * e.g. when component is visible
-   **/
-  @property({ type: Boolean })
-  shouldFetch?: boolean;
-
   @state()
   private archivedItems?: Crawls;
 
@@ -136,29 +129,24 @@ export class CrawlsList extends LiteElement {
 
   protected willUpdate(changedProperties: Map<string, any>) {
     if (
-      changedProperties.has("shouldFetch") ||
       changedProperties.has("filterByCurrentUser") ||
       changedProperties.has("filterBy") ||
       changedProperties.has("orderBy") ||
       changedProperties.has("itemType")
     ) {
-      if (this.shouldFetch) {
-        if (changedProperties.has("itemType")) {
-          this.filterBy = {};
-          this.orderBy = {
-            field: "finished",
-            direction: sortableFields["finished"].defaultDirection!,
-          };
-          this.archivedItems = undefined;
-        }
-
-        this.fetchArchivedItems({
-          page: 1,
-          pageSize: INITIAL_PAGE_SIZE,
-        });
-      } else {
-        this.cancelInProgressGetArchivedItems();
+      if (changedProperties.has("itemType")) {
+        this.filterBy = {};
+        this.orderBy = {
+          field: "finished",
+          direction: sortableFields["finished"].defaultDirection!,
+        };
+        this.archivedItems = undefined;
       }
+
+      this.fetchArchivedItems({
+        page: 1,
+        pageSize: INITIAL_PAGE_SIZE,
+      });
 
       if (changedProperties.has("filterByCurrentUser")) {
         window.sessionStorage.setItem(
@@ -598,8 +586,6 @@ export class CrawlsList extends LiteElement {
    * Fetch archived items and update internal state
    */
   private async fetchArchivedItems(params?: APIPaginationQuery): Promise<void> {
-    if (!this.shouldFetch) return;
-
     this.cancelInProgressGetArchivedItems();
     try {
       this.archivedItems = await this.getArchivedItems(params);

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -203,10 +203,8 @@ export class CrawlsList extends LiteElement {
     return html`
       <main>
         <header class="contents">
-          <div class="md:flex items-center gap-2 pb-3 mb-3 border-b">
-            <h1
-              class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
-            >
+          <div class="flex justify-between gap-2 pb-3 mb-3 border-b">
+            <h1 class="text-xl font-semibold leading-8 mb-2 md:mb-0">
               ${msg("Archived Items")}
             </h1>
             ${when(

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,9 +1,11 @@
 import type { TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
+import type { SlSelectEvent } from "@shoelace-style/shoelace";
 
 import LiteElement, { html } from "../../utils/LiteElement";
 import type { OrgData } from "../../utils/orgs";
+import type { SelectNewDialogEvent } from "./index";
 
 @localized()
 export class Dashboard extends LiteElement {
@@ -53,7 +55,31 @@ export class Dashboard extends LiteElement {
                   icon: "file-richtext-fill",
                 })}
               </dl>
-            `
+            `,
+            html`<footer class="mt-4 flex justify-end">
+              <sl-dropdown
+                distance="4"
+                placement="bottom-end"
+                @sl-select=${(e: SlSelectEvent) => {
+                  this.dispatchEvent(
+                    <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                      detail: e.detail.item.value,
+                    })
+                  );
+                }}
+              >
+                <sl-button slot="trigger" size="small" caret>
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  ${msg("Add New...")}
+                </sl-button>
+                <sl-menu>
+                  <sl-menu-item value="browser-profile">
+                    ${msg("Browser Profile")}
+                  </sl-menu-item>
+                  <sl-menu-item value="upload">${msg("Upload")}</sl-menu-item>
+                </sl-menu>
+              </sl-dropdown>
+            </footer> `
           )}
           ${this.renderCard(
             msg("Crawling"),
@@ -74,7 +100,7 @@ export class Dashboard extends LiteElement {
               </dl>
             `,
             html`
-              <footer class="text-right">
+              <footer class="mt-4 flex justify-end">
                 <sl-button
                   href=${`/orgs/${this.orgId}/workflows?new&jobType=`}
                   size="small"
@@ -100,7 +126,7 @@ export class Dashboard extends LiteElement {
               </dl>
             `,
             html`
-              <footer class="text-right">
+              <footer class="mt-4 flex justify-end">
                 <sl-button
                   href=${`/orgs/${this.orgId}/collections/new`}
                   size="small"

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,0 +1,23 @@
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+
+import LiteElement, { html } from "../../utils/LiteElement";
+import type { OrgData } from "../../utils/orgs";
+
+@localized()
+export class Dashboard extends LiteElement {
+  @property({ type: Object })
+  org: OrgData | null = null;
+
+  render() {
+    return html`<header class="md:flex items-center gap-2 pb-3 mb-3 border-b">
+        <h1
+          class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
+        >
+          ${this.org?.name}
+        </h1>
+      </header>
+      <main>TODO</main> `;
+  }
+}
+customElements.define("btrix-dashboard", Dashboard);

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,3 +1,4 @@
+import type { TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
 
@@ -10,14 +11,135 @@ export class Dashboard extends LiteElement {
   org: OrgData | null = null;
 
   render() {
-    return html`<header class="md:flex items-center gap-2 pb-3 mb-3 border-b">
-        <h1
-          class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate mb-2 md:mb-0"
-        >
+    return html`<header class="md:flex items-center gap-2 pb-3 mb-7 border-b">
+        <h1 class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate">
           ${this.org?.name}
         </h1>
       </header>
-      <main>TODO</main> `;
+      <main>
+        <div class="flex flex-col md:flex-row gap-6">
+          ${this.renderCard(
+            msg("Storage"),
+            html`
+              <div class="font-semibold mb-3">
+                <sl-format-bytes value=${0}></sl-format-bytes> ${msg("Used")}
+              </div>
+              <dl>
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Crawl"),
+                  pluralLabel: msg("Crawls"),
+                  icon: "gear-wide-connected",
+                })}
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Upload"),
+                  pluralLabel: msg("Uploads"),
+                  icon: "upload",
+                })}
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Browser Profile"),
+                  pluralLabel: msg("Browser Profiles"),
+                  icon: "window-fullscreen",
+                })}
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Total Page"),
+                  pluralLabel: msg("Total Pages"),
+                  icon: "file-richtext-fill",
+                })}
+              </dl>
+            `
+          )}
+          ${this.renderCard(
+            msg("Crawling"),
+            html`
+              <dl>
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Crawl Running"),
+                  pluralLabel: msg("Crawls Running"),
+                  icon: "record-fill",
+                })}
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Crawl Workflow Waiting"),
+                  pluralLabel: msg("Crawl Workflows Waiting"),
+                  icon: "hourglass-split",
+                })}
+              </dl>
+            `,
+            html`
+              <footer class="text-right">
+                <sl-button>
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
+                    "New Workflow"
+                  )}
+                </sl-button>
+              </footer>
+            `
+          )}
+          ${this.renderCard(
+            msg("Collections"),
+            html`
+              <dl>
+                ${this.renderStat({
+                  value: 0,
+                  singleLabel: msg("Collection"),
+                  pluralLabel: msg("Collections"),
+                  icon: "collection-fill",
+                })}
+              </dl>
+            `,
+            html`
+              <footer class="text-right">
+                <sl-button>
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
+                    "New Collection"
+                  )}
+                </sl-button>
+              </footer>
+            `
+          )}
+        </div>
+      </main> `;
+  }
+
+  private renderCard(
+    title: string,
+    content: TemplateResult,
+    footer?: TemplateResult
+  ) {
+    return html`
+      <section class="flex-1 flex flex-col border rounded p-4">
+        <h2 class="text-lg font-semibold leading-none border-b pb-3 mb-3">
+          ${title}
+        </h2>
+        <div class="flex-1">${content}</div>
+        ${footer}
+      </section>
+    `;
+  }
+
+  private renderStat(stat: {
+    value: number;
+    singleLabel: string;
+    pluralLabel: string;
+    icon: string;
+  }) {
+    return html`
+      <div class="flex items-center mb-2 last:mb-0">
+        <sl-icon
+          class="text-base text-neutral-500 mr-2"
+          name=${stat.icon}
+        ></sl-icon>
+        <dt class="order-last">
+          ${stat.value === 1 ? stat.singleLabel : stat.pluralLabel}
+        </dt>
+        <dd class="mr-1">${stat.value.toLocaleString()}</dd>
+      </div>
+    `;
   }
 }
 customElements.define("btrix-dashboard", Dashboard);

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,5 +1,6 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
 import { msg, localized, str } from "@lit/localize";
 import type { SlSelectEvent } from "@shoelace-style/shoelace";
 
@@ -199,17 +200,22 @@ export class Dashboard extends LiteElement {
     renderContent: (metric: Metrics) => TemplateResult,
     renderFooter?: (metric: Metrics) => TemplateResult
   ) {
-    if (!this.metrics) {
-      return html`todo`;
-    }
-
     return html`
-      <section class="flex-1 flex flex-col border rounded p-4">
+      <section
+        class="flex-1 flex flex-col border rounded p-4 transition-opacity delay-75 ${this
+          .metrics
+          ? "opacity-100"
+          : "opacity-0"}"
+      >
         <h2 class="text-lg font-semibold leading-none border-b pb-3 mb-3">
           ${title}
         </h2>
-        <div class="flex-1">${renderContent(this.metrics)}</div>
-        ${renderFooter ? renderFooter(this.metrics) : ""}
+        <div class="flex-1">
+          ${when(this.metrics, () => renderContent(this.metrics!))}
+        </div>
+        ${when(renderFooter && this.metrics, () =>
+          renderFooter!(this.metrics!)
+        )}
       </section>
     `;
   }

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -183,8 +183,8 @@ export class Dashboard extends LiteElement {
                 })}
                 ${this.renderStat({
                   value: metrics.publicCollectionsCount,
-                  singleLabel: msg("Public Collection"),
-                  pluralLabel: msg("Public Collections"),
+                  singleLabel: msg("Shareable Collection"),
+                  pluralLabel: msg("Shareable Collections"),
                   iconProps: { name: "people-fill" },
                 })}
               </dl>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -7,6 +7,9 @@ import type { OrgData } from "../../utils/orgs";
 
 @localized()
 export class Dashboard extends LiteElement {
+  @property({ type: String })
+  orgId!: string;
+
   @property({ type: Object })
   org: OrgData | null = null;
 
@@ -72,7 +75,11 @@ export class Dashboard extends LiteElement {
             `,
             html`
               <footer class="text-right">
-                <sl-button size="small">
+                <sl-button
+                  href=${`/orgs/${this.orgId}/workflows?new&jobType=`}
+                  size="small"
+                  @click=${this.navLink}
+                >
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
                     "New Workflow"
                   )}
@@ -94,7 +101,11 @@ export class Dashboard extends LiteElement {
             `,
             html`
               <footer class="text-right">
-                <sl-button size="small">
+                <sl-button
+                  href=${`/orgs/${this.orgId}/collections/new`}
+                  size="small"
+                  @click=${this.navLink}
+                >
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
                     "New Collection"
                   )}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -47,10 +47,21 @@ export class Dashboard extends LiteElement {
   }
 
   render() {
-    return html`<header class="flex justify-between gap-2 pb-3 mb-7 border-b">
+    return html`<header
+        class="flex items-center justify-between gap-2 pb-3 mb-7 border-b"
+      >
         <h1 class="min-w-0 text-xl font-semibold leading-8">
           ${this.org?.name}
         </h1>
+        <div>
+          <sl-icon-button
+            href=${`/orgs/${this.orgId}/settings`}
+            class="text-lg"
+            name="gear"
+            label="Edit org settings"
+            @click=${this.navLink}
+          ></sl-icon-button>
+        </div>
       </header>
       <main>
         <div class="flex flex-col md:flex-row gap-6">

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -11,8 +11,8 @@ export class Dashboard extends LiteElement {
   org: OrgData | null = null;
 
   render() {
-    return html`<header class="md:flex items-center gap-2 pb-3 mb-7 border-b">
-        <h1 class="flex-1 min-w-0 text-xl font-semibold leading-7 truncate">
+    return html`<header class="flex justify-between gap-2 pb-3 mb-7 border-b">
+        <h1 class="min-w-0 text-xl font-semibold leading-8">
           ${this.org?.name}
         </h1>
       </header>
@@ -72,7 +72,7 @@ export class Dashboard extends LiteElement {
             `,
             html`
               <footer class="text-right">
-                <sl-button>
+                <sl-button size="small">
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
                     "New Workflow"
                   )}
@@ -94,7 +94,7 @@ export class Dashboard extends LiteElement {
             `,
             html`
               <footer class="text-right">
-                <sl-button>
+                <sl-button size="small">
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
                     "New Collection"
                   )}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,6 +1,7 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { state, property } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { msg, localized, str } from "@lit/localize";
 import type { SlSelectEvent } from "@shoelace-style/shoelace";
 
@@ -79,25 +80,25 @@ export class Dashboard extends LiteElement {
                   value: metrics.archivedItemCount,
                   singleLabel: msg("Archived Item"),
                   pluralLabel: msg("Archived Items"),
-                  icon: "file-zip-fill",
+                  iconProps: { name: "file-zip-fill" },
                 })}
                 ${this.renderStat({
                   value: metrics.crawlCount,
                   singleLabel: msg("Crawl"),
                   pluralLabel: msg("Crawls"),
-                  icon: "gear-wide-connected",
+                  iconProps: { name: "gear-wide-connected" },
                 })}
                 ${this.renderStat({
                   value: metrics.uploadCount,
                   singleLabel: msg("Upload"),
                   pluralLabel: msg("Uploads"),
-                  icon: "upload",
+                  iconProps: { name: "upload" },
                 })}
                 ${this.renderStat({
                   value: metrics.profileCount,
                   singleLabel: msg("Browser Profile"),
                   pluralLabel: msg("Browser Profiles"),
-                  icon: "window-fullscreen",
+                  iconProps: { name: "window-fullscreen" },
                 })}
               </dl>
             `,
@@ -140,19 +141,19 @@ export class Dashboard extends LiteElement {
                   value: metrics.workflowsRunningCount,
                   singleLabel: msg("Crawl Running"),
                   pluralLabel: msg("Crawls Running"),
-                  icon: "record-fill",
+                  iconProps: { name: "dot", library: "app" },
                 })}
                 ${this.renderStat({
                   value: metrics.workflowsQueuedCount,
                   singleLabel: msg("Crawl Workflow Waiting"),
                   pluralLabel: msg("Crawl Workflows Waiting"),
-                  icon: "hourglass-split",
+                  iconProps: { name: "hourglass-split" },
                 })}
                 ${this.renderStat({
                   value: metrics.pageCount,
                   singleLabel: msg("Page Crawled"),
                   pluralLabel: msg("Pages Crawled"),
-                  icon: "file-richtext-fill",
+                  iconProps: { name: "file-richtext-fill" },
                 })}
               </dl>
             `,
@@ -178,13 +179,13 @@ export class Dashboard extends LiteElement {
                   value: metrics.collectionsCount,
                   singleLabel: msg("Collection Total"),
                   pluralLabel: msg("Collections Total"),
-                  icon: "collection-fill",
+                  iconProps: { name: "collection-fill" },
                 })}
                 ${this.renderStat({
                   value: metrics.publicCollectionsCount,
                   singleLabel: msg("Public Collection"),
                   pluralLabel: msg("Public Collections"),
-                  icon: "people-fill",
+                  iconProps: { name: "people-fill" },
                 })}
               </dl>
             `,
@@ -235,13 +236,14 @@ export class Dashboard extends LiteElement {
     value: number;
     singleLabel: string;
     pluralLabel: string;
-    icon: string;
+    iconProps: { name: string; library?: string };
   }) {
     return html`
       <div class="flex items-center mb-2 last:mb-0">
         <sl-icon
           class="text-base text-neutral-500 mr-2"
-          name=${stat.icon}
+          name=${stat.iconProps.name}
+          library=${ifDefined(stat.iconProps.library)}
         ></sl-icon>
         <dt class="order-last">
           ${stat.value === 1 ? stat.singleLabel : stat.pluralLabel}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -173,7 +173,7 @@ export class Org extends LiteElement {
       ${this.renderStorageAlert()} ${this.renderOrgNavBar()}
       <main>
         <div
-          class="w-full max-w-screen-lg mx-auto px-3 box-border py-5"
+          class="w-full max-w-screen-lg mx-auto px-3 box-border py-7"
           aria-labelledby="${this.orgTab}-tab"
         >
           ${tabPanelContent}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -138,6 +138,8 @@ export class Org extends LiteElement {
 
     let tabPanelContent = "" as any;
 
+    console.log(this.orgTab);
+
     switch (this.orgTab) {
       case "items":
         tabPanelContent = this.renderArchive();

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -284,7 +284,9 @@ export class Org extends LiteElement {
   }
 
   private renderDashboard() {
-    return html` <btrix-dashboard .org=${this.org}></btrix-dashboard> `;
+    return html`
+      <btrix-dashboard orgId=${this.orgId} .org=${this.org}></btrix-dashboard>
+    `;
   }
 
   private renderArchive() {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -340,6 +340,7 @@ export class Org extends LiteElement {
   private renderDashboard() {
     return html`
       <btrix-dashboard
+        .authState=${this.authState!}
         orgId=${this.orgId}
         .org=${this.org || null}
         @select-new-dialog=${this.onSelectNewDialog}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -24,6 +24,7 @@ import "./browser-profiles-detail";
 import "./browser-profiles-list";
 import "./browser-profiles-new";
 import "./settings";
+import "./dashboard";
 import type {
   Member,
   OrgNameChangeEvent,
@@ -33,6 +34,7 @@ import type {
 import type { Tab as CollectionTab } from "./collection-detail";
 
 export type OrgTab =
+  | "home"
   | "crawls"
   | "workflows"
   | "items"
@@ -49,7 +51,7 @@ type Params = {
   collectionTab?: string;
   itemType?: Crawl["type"];
 };
-const defaultTab = "workflows";
+const defaultTab = "home";
 
 @needLogin
 @localized()
@@ -138,9 +140,10 @@ export class Org extends LiteElement {
 
     let tabPanelContent = "" as any;
 
-    console.log(this.orgTab);
-
     switch (this.orgTab) {
+      case "home":
+        tabPanelContent = this.renderDashboard();
+        break;
       case "items":
         tabPanelContent = this.renderArchive();
         break;
@@ -210,6 +213,11 @@ export class Org extends LiteElement {
       <div class="w-full max-w-screen-lg mx-auto px-3 box-border">
         <nav class="-ml-3 flex items-end overflow-x-auto">
           ${this.renderNavTab({
+            tabName: "home",
+            label: msg("Overview"),
+            path: "",
+          })}
+          ${this.renderNavTab({
             tabName: "workflows",
             label: msg("Crawling"),
             path: "workflows/crawls",
@@ -228,12 +236,14 @@ export class Org extends LiteElement {
             this.renderNavTab({
               tabName: "browser-profiles",
               label: msg("Browser Profiles"),
+              path: "browser-profiles",
             })
           )}
           ${when(this.isAdmin || this.userInfo?.isAdmin, () =>
             this.renderNavTab({
               tabName: "settings",
               label: msg("Org Settings"),
+              path: "settings",
             })
           )}
         </nav>
@@ -250,7 +260,7 @@ export class Org extends LiteElement {
   }: {
     tabName: OrgTab;
     label: string;
-    path?: string;
+    path: string;
   }) {
     const isActive = this.orgTab === tabName;
 
@@ -258,7 +268,7 @@ export class Org extends LiteElement {
       <a
         id="${tabName}-tab"
         class="block flex-shrink-0 px-3 hover:bg-neutral-50 rounded-t transition-colors"
-        href=${`/orgs/${this.orgId}/${path || tabName}`}
+        href=${`/orgs/${this.orgId}${path ? `/${path}` : ""}`}
         aria-selected=${isActive}
         @click=${this.navLink}
       >
@@ -271,6 +281,10 @@ export class Org extends LiteElement {
         </div>
       </a>
     `;
+  }
+
+  private renderDashboard() {
+    return html` <btrix-dashboard .org=${this.org}></btrix-dashboard> `;
   }
 
   private renderArchive() {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -22,7 +22,6 @@ import { humanizeSchedule, humanizeNextDate } from "../../utils/cron";
 import { APIPaginatedList } from "../../types/api";
 import { inactiveCrawlStates, isActive } from "../../utils/crawler";
 import { SlSelect } from "@shoelace-style/shoelace";
-import { DASHBOARD_ROUTE } from "../../routes";
 
 const SECTIONS = ["crawls", "watch", "settings"] as const;
 type Tab = (typeof SECTIONS)[number];

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -194,8 +194,10 @@ export class WorkflowsList extends LiteElement {
   render() {
     return html`
       <header class="contents">
-        <div class="flex justify-between w-full h-8 mb-4">
-          <h1 class="text-xl font-semibold">${msg("Crawl Workflows")}</h1>
+        <div class="flex justify-between w-full mb-4">
+          <h1 class="text-xl font-semibold leading-8">
+            ${msg("Crawl Workflows")}
+          </h1>
           ${when(
             this.isCrawler,
             () => html`

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -26,5 +26,3 @@ export const ROUTES = {
   // Redirect for https://github.com/webrecorder/browsertrix-cloud/issues/935
   awpUploadRedirect: "/orgs/:orgId/artifacts/upload/:uploadId",
 } as const;
-
-export const DASHBOARD_ROUTE = "/";

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,4 +1,3 @@
-import { DASHBOARD_ROUTE } from "../routes";
 import LiteElement from "../utils/LiteElement";
 import type { AuthState } from "../utils/AuthService";
 import type { CurrentUser } from "../types/user";


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1188

<!-- Fixes #issue_number -->

### Changes

- New org overview page view
- Updates org home page to new view
- Refactors browser profile "new" dialog to use `<btrix-dialog>`

**Differences from mockups**:
- Moved "Total Pages" to "Pages Crawled" since only crawled pages are included
- Added "Archived Items" total (@Shrinks99: Feel free to suggest alternative icon)
- Added "Add New..." dropdown to "Storage". We can move the "Add New" shortcut to the header in this follow up: https://github.com/webrecorder/browsertrix-cloud/pull/1202

### Manual testing

1. Log in. Verify new home view is shown with the correct metrics
2. Click any nav and then "Browsertrix Cloud". Verify you're taken to new home view
3. Complete each "Add New" and "New" flow. Verify new resources are created as expected
4. Regression test Browser Profiles -> "New Browser Profile"
5. Log out and log in as super admin
6. Click org. Verify new home view is shown
7. Switch orgs. Verify you're taken to org's overview
8. Go to an org with quota reached (e.g. "Org with Limits" on dev.) Verify "Add New..." button is disabled

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Home | <img width="1132" alt="Screenshot 2023-09-19 at 4 14 12 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/7aabe4fb-6adb-4f4d-a3bd-469e1ef151fe"> |
| Home - Storage "Add New..." dropdown | <img width="186" alt="Screenshot 2023-09-19 at 4 14 28 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/7accc0be-b473-474d-8cb5-6db0ab79c596"> |
| Home - Adding new browser profile | <img width="1147" alt="Screenshot 2023-09-19 at 4 14 39 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/fec0329a-dbd3-4efa-b311-af4f4a0c2c00"> |



<!-- ### Follow-ups -->
