### PR TITLE
"Add new" dialog for all resources

### DIFF
--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -552,9 +552,12 @@ export class CollectionEditor extends LiteElement {
             ></btrix-markdown-editor>
           </fieldset>
           <label>
-            <sl-switch name="isPublic" ?checked=${this.metadataValues?.isPublic}
-              >Publicly Accessible</sl-switch
+            <sl-switch
+              name="isPublic"
+              ?checked=${this.metadataValues?.isPublic}
             >
+              ${msg("Publicly Accessible")}
+            </sl-switch>
           </label>
         </div>
         <footer class="border-t px-6 py-4 flex gap-2 justify-end">

--- a/frontend/src/pages/org/collection-editor.ts
+++ b/frontend/src/pages/org/collection-editor.ts
@@ -36,7 +36,7 @@ import type { Collection } from "../../types/collection";
 import type { Crawl, CrawlState, Upload, Workflow } from "../../types/crawler";
 import type { PageChangeEvent } from "../../components/pagination";
 
-const TABS = ["metadata", "crawls", "uploads"] as const;
+const TABS = ["crawls", "uploads", "metadata"] as const;
 type Tab = (typeof TABS)[number];
 type SearchFields = "name" | "firstSeed";
 type SearchResult = {
@@ -111,7 +111,7 @@ export class CollectionEditor extends LiteElement {
   collectionId?: string;
 
   @property({ type: Object })
-  metadataValues?: Collection;
+  metadataValues?: Partial<Collection>;
 
   @property({ type: Boolean })
   isSubmitting = false;
@@ -226,16 +226,6 @@ export class CollectionEditor extends LiteElement {
   };
 
   protected async willUpdate(changedProperties: Map<string, any>) {
-    if (
-      changedProperties.has("activeTab") &&
-      !changedProperties.get("activeTab") &&
-      this.activeTab
-    ) {
-      // First tab load
-      if (this.activeTab !== "metadata" && !this.collectionId) {
-        this.goToTab("metadata");
-      }
-    }
     if (changedProperties.has("orgId") && this.orgId) {
       this.fetchSearchValues();
     }
@@ -419,15 +409,6 @@ export class CollectionEditor extends LiteElement {
               <sl-button
                 type="button"
                 size="small"
-                class="mr-auto"
-                @click=${() => this.goToTab("metadata")}
-              >
-                <sl-icon slot="prefix" name="chevron-left"></sl-icon>
-                ${msg("Previous Step")}
-              </sl-button>
-              <sl-button
-                type="button"
-                size="small"
                 @click=${() => this.goToTab("uploads")}
               >
                 <sl-icon slot="suffix" name="chevron-right"></sl-icon>
@@ -514,6 +495,14 @@ export class CollectionEditor extends LiteElement {
                 <sl-icon slot="prefix" name="chevron-left"></sl-icon>
                 ${msg("Previous Step")}
               </sl-button>
+              <sl-button
+                type="button"
+                size="small"
+                @click=${() => this.goToTab("metadata")}
+              >
+                <sl-icon slot="suffix" name="chevron-right"></sl-icon>
+                ${msg("Add Metadata")}
+              </sl-button>
             `
           )}
           <sl-button
@@ -574,25 +563,19 @@ export class CollectionEditor extends LiteElement {
             () => html`
               <sl-button
                 type="button"
+                class="mr-auto"
                 size="small"
-                variant="primary"
-                @click=${async () => {
-                  await this.nameInput;
-                  const isValid = this.nameInput!.reportValidity();
-                  if (isValid) {
-                    this.goToTab("crawls");
-                  }
-                }}
+                @click=${() => this.goToTab("uploads")}
               >
-                <sl-icon slot="suffix" name="chevron-right"></sl-icon>
-                ${msg("Select Items")}
+                <sl-icon slot="prefix" name="chevron-left"></sl-icon>
+                ${msg("Previous Step")}
               </sl-button>
             `
           )}
           <sl-button
             type="submit"
             size="small"
-            variant=${this.collectionId ? "primary" : "default"}
+            variant="primary"
             ?disabled=${this.isSubmitting ||
             Object.values(this.workflowIsLoading).some(
               (isLoading) => isLoading === true
@@ -601,9 +584,7 @@ export class CollectionEditor extends LiteElement {
           >
             ${this.collectionId
               ? msg("Save Metadata")
-              : this.hasItemSelection
-              ? msg("Create Collection")
-              : msg("Create Collection without Items")}
+              : msg("Create Collection")}
           </sl-button>
         </footer>
       </section>
@@ -1367,7 +1348,7 @@ export class CollectionEditor extends LiteElement {
   }
 
   private getActivePanelFromHash = () => {
-    const hashValue = window.location.hash.slice(1);
+    const hashValue = window.location.hash.slice(1).split("?")[0];
     if (TABS.includes(hashValue as any)) {
       this.activeTab = hashValue as Tab;
     } else {

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -225,12 +225,17 @@ export class CollectionsList extends LiteElement {
           </p>
           <div>
             <sl-button
-              href=${`/orgs/${this.orgId}/collections/new`}
               variant="primary"
-              @click=${this.navLink}
+              @click=${() => {
+                this.dispatchEvent(
+                  <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                    detail: "collection",
+                  })
+                );
+              }}
             >
               <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              ${msg("Create Collection")}
+              ${msg("Create a New Collection")}
             </sl-button>
           </div>
         `,
@@ -435,12 +440,17 @@ export class CollectionsList extends LiteElement {
             </p>
             <div>
               <sl-button
-                href=${`/orgs/${this.orgId}/collections/new`}
                 variant="primary"
-                @click=${this.navLink}
+                @click=${() => {
+                  this.dispatchEvent(
+                    <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                      detail: "collection",
+                    })
+                  );
+                }}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("Create Collection")}
+                ${msg("Create a New Collection")}
               </sl-button>
             </div>
           `,

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -16,6 +16,7 @@ import type {
   CollectionSearchValues,
 } from "../../types/collection";
 import noCollectionsImg from "../../assets/images/no-collections-found.webp";
+import type { SelectNewDialogEvent } from "./index";
 
 type Collections = APIPaginatedList & {
   items: Collection[];
@@ -132,10 +133,15 @@ export class CollectionsList extends LiteElement {
             this.isCrawler,
             () => html`
               <sl-button
-                href=${`/orgs/${this.orgId}/collections/new`}
                 variant="primary"
                 size="small"
-                @click=${this.navLink}
+                @click=${() => {
+                  this.dispatchEvent(
+                    <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                      detail: "collection",
+                    })
+                  );
+                }}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                 ${msg("New Collection")}

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -18,6 +18,9 @@ export class CollectionsNew extends LiteElement {
   @property({ type: Boolean })
   isCrawler?: boolean;
 
+  @property({ type: String })
+  name?: string;
+
   @state()
   private collection?: Collection;
 
@@ -29,10 +32,15 @@ export class CollectionsNew extends LiteElement {
 
   render() {
     return html`${this.renderHeader()}
-      <h2 class="text-xl font-semibold mb-6">${msg("New Collection")}</h2>
+      <h2 class="text-xl font-semibold mb-6">
+        ${msg("New Collection")}${this.name ? html` &mdash; ${this.name}` : ""}
+      </h2>
       <btrix-collection-editor
         .authState=${this.authState}
         orgId=${this.orgId}
+        .metadataValues=${{
+          name: this.name || "",
+        }}
         ?isSubmitting=${this.isSubmitting}
         ?isCrawler=${this.isCrawler}
         @on-submit=${this.onSubmit}

--- a/frontend/src/pages/org/components/new-browser-profile-dialog.ts
+++ b/frontend/src/pages/org/components/new-browser-profile-dialog.ts
@@ -25,7 +25,7 @@ export class NewBrowserProfileDialog extends LiteElement {
 
   render() {
     return html` <btrix-dialog
-      label=${msg(str`New Browser Profile`)}
+      label=${msg(str`Create a New Browser Profile`)}
       ?open=${this.open}
       @sl-initial-focus=${async (e: CustomEvent) => {
         const nameInput = (await this.form).querySelector(

--- a/frontend/src/pages/org/components/new-collection-dialog.ts
+++ b/frontend/src/pages/org/components/new-collection-dialog.ts
@@ -62,6 +62,9 @@ export class NewCollectionDialog extends LiteElement {
             maxlength=${4000}
           ></btrix-markdown-editor>
         </fieldset>
+        <label>
+          <sl-switch name="isPublic"> ${msg("Publicly Accessible")} </sl-switch>
+        </label>
         <input class="invisible h-0 w-0" type="submit" />
       </form>
       <div slot="footer" class="flex gap-3 items-center justify-end">
@@ -116,7 +119,7 @@ export class NewCollectionDialog extends LiteElement {
       return;
     }
 
-    const { name, description } = serialize(form);
+    const { name, description, isPublic } = serialize(form);
     this.isSubmitting = true;
     try {
       const data = await this.apiFetch(
@@ -127,6 +130,7 @@ export class NewCollectionDialog extends LiteElement {
           body: JSON.stringify({
             name,
             description,
+            public: Boolean(isPublic),
           }),
         }
       );

--- a/frontend/src/pages/org/components/new-collection-dialog.ts
+++ b/frontend/src/pages/org/components/new-collection-dialog.ts
@@ -63,7 +63,19 @@ export class NewCollectionDialog extends LiteElement {
           ></btrix-markdown-editor>
         </fieldset>
         <label>
-          <sl-switch name="isPublic"> ${msg("Publicly Accessible")} </sl-switch>
+          <sl-switch name="isPublic">${msg("Publicly Accessible")}</sl-switch>
+          <sl-tooltip
+            content=${msg(
+              "Enable public access to make Collections shareable. Only people with the shared link can view your Collection."
+            )}
+            hoist
+            @sl-hide=${this.stopProp}
+            @sl-after-hide=${this.stopProp}
+            ><sl-icon
+              class="ml-1 inline-block align-middle text-slate-500"
+              name="info-circle"
+            ></sl-icon
+          ></sl-tooltip>
         </label>
         <input class="invisible h-0 w-0" type="submit" />
       </form>
@@ -153,6 +165,13 @@ export class NewCollectionDialog extends LiteElement {
     }
 
     this.isSubmitting = false;
+  }
+
+  /**
+   * https://github.com/shoelace-style/shoelace/issues/170
+   */
+  private stopProp(e: CustomEvent) {
+    e.stopPropagation();
   }
 }
 customElements.define("btrix-new-collection-dialog", NewCollectionDialog);

--- a/frontend/src/pages/org/components/new-collection-dialog.ts
+++ b/frontend/src/pages/org/components/new-collection-dialog.ts
@@ -29,7 +29,7 @@ export class NewCollectionDialog extends LiteElement {
 
   render() {
     return html` <btrix-dialog
-      label=${msg(str`New Collection`)}
+      label=${msg(str`Create a New Collection`)}
       ?open=${this.open}
       @sl-initial-focus=${async (e: CustomEvent) => {
         const nameInput = (await this.form).querySelector(

--- a/frontend/src/pages/org/components/new-collection-dialog.ts
+++ b/frontend/src/pages/org/components/new-collection-dialog.ts
@@ -1,0 +1,117 @@
+import { state, property, queryAsync } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+import type { SlInput } from "@shoelace-style/shoelace";
+import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
+
+import { maxLengthValidator } from "../../../utils/form";
+import type { AuthState } from "../../../utils/AuthService";
+import LiteElement, { html } from "../../../utils/LiteElement";
+import type { Dialog } from "../../../components/dialog";
+
+@localized()
+export class NewCollectionDialog extends LiteElement {
+  @property({ type: Object })
+  authState!: AuthState;
+
+  @property({ type: String })
+  orgId!: string;
+
+  @property({ type: Boolean })
+  open = false;
+
+  @state()
+  private isSubmitting = false;
+
+  @queryAsync("#collectionForm")
+  private form!: Promise<HTMLFormElement>;
+
+  private validateNameMax = maxLengthValidator(50);
+
+  render() {
+    return html` <btrix-dialog
+      label=${msg(str`New Collection`)}
+      ?open=${this.open}
+      @sl-initial-focus=${async (e: CustomEvent) => {
+        const nameInput = (await this.form).querySelector(
+          'sl-input[name="name"]'
+        ) as SlInput;
+        if (nameInput) {
+          e.preventDefault();
+          nameInput.focus();
+        }
+      }}
+    >
+      <form id="collectionForm" @reset=${this.onReset} @submit=${this.onSubmit}>
+        <p class="text-neutral-500 max-w-prose mb-5">
+          ${msg(
+            "Choose a unique name for your collection. You can change it before saving the collection."
+          )}
+        </p>
+        <sl-input
+          class="with-max-help-text"
+          name="name"
+          label=${msg("Collection Name")}
+          placeholder=${msg("My Collection")}
+          autocomplete="off"
+          required
+          help-text=${this.validateNameMax.helpText}
+          @sl-input=${this.validateNameMax.validate}
+        ></sl-input>
+
+        <input class="invisible h-0 w-0" type="submit" />
+      </form>
+      <div slot="footer" class="flex justify-between">
+        <sl-button
+          size="small"
+          @click=${async () => {
+            // Using reset method instead of type="reset" fixes
+            // incorrect getRootNode in Chrome
+            (await this.form).reset();
+          }}
+          >${msg("Cancel")}</sl-button
+        >
+        <sl-button
+          variant="primary"
+          size="small"
+          ?loading=${this.isSubmitting}
+          ?disabled=${this.isSubmitting}
+          @click=${async () => {
+            // Using submit method instead of type="submit" fixes
+            // incorrect getRootNode in Chrome
+            const form = await this.form;
+            const submitInput = form.querySelector(
+              'input[type="submit"]'
+            ) as HTMLInputElement;
+            form.requestSubmit(submitInput);
+          }}
+          >${msg("Continue")}</sl-button
+        >
+      </div>
+    </btrix-dialog>`;
+  }
+
+  private async hideDialog() {
+    ((await this.form).closest("btrix-dialog") as Dialog).hide();
+  }
+
+  private onReset() {
+    this.hideDialog();
+  }
+
+  private async onSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const form = event.target as HTMLFormElement;
+    const nameInput = form.querySelector('sl-input[name="name"]') as SlInput;
+    if (!nameInput.checkValidity()) {
+      return;
+    }
+
+    const { name } = serialize(form);
+
+    this.hideDialog();
+    this.navTo(`/orgs/${this.orgId}/collections/new?name=${name}#crawls`);
+  }
+}
+customElements.define("btrix-new-collection-dialog", NewCollectionDialog);

--- a/frontend/src/pages/org/components/new-collection-dialog.ts
+++ b/frontend/src/pages/org/components/new-collection-dialog.ts
@@ -130,7 +130,7 @@ export class NewCollectionDialog extends LiteElement {
           body: JSON.stringify({
             name,
             description,
-            public: Boolean(isPublic),
+            isPublic: Boolean(isPublic),
           }),
         }
       );

--- a/frontend/src/pages/org/components/new-collection-dialog.ts
+++ b/frontend/src/pages/org/components/new-collection-dialog.ts
@@ -62,9 +62,6 @@ export class NewCollectionDialog extends LiteElement {
             maxlength=${4000}
           ></btrix-markdown-editor>
         </fieldset>
-        <label>
-          <sl-switch name="isPublic"> ${msg("Publicly Accessible")} </sl-switch>
-        </label>
         <input class="invisible h-0 w-0" type="submit" />
       </form>
       <div slot="footer" class="flex gap-3 items-center justify-end">
@@ -119,7 +116,7 @@ export class NewCollectionDialog extends LiteElement {
       return;
     }
 
-    const { name, description, isPublic } = serialize(form);
+    const { name, description } = serialize(form);
     this.isSubmitting = true;
     try {
       const data = await this.apiFetch(
@@ -130,7 +127,6 @@ export class NewCollectionDialog extends LiteElement {
           body: JSON.stringify({
             name,
             description,
-            public: Boolean(isPublic),
           }),
         }
       );

--- a/frontend/src/pages/org/components/new-workflow-dialog.ts
+++ b/frontend/src/pages/org/components/new-workflow-dialog.ts
@@ -67,7 +67,7 @@ export class NewWorkflowDialog extends LitElement {
   render() {
     return html`
       <btrix-dialog
-        label=${msg("New Crawl Workflow")}
+        label=${msg("Create a New Crawl Workflow")}
         ?open=${this.open}
         style="--width: 50rem"
       >

--- a/frontend/src/pages/org/components/new-workflow-dialog.ts
+++ b/frontend/src/pages/org/components/new-workflow-dialog.ts
@@ -1,0 +1,127 @@
+import { LitElement, html, css } from "lit";
+import { state, property } from "lit/decorators.js";
+import { msg, localized, str } from "@lit/localize";
+
+import seededCrawlSvg from "../../../assets/images/new-crawl-config_Seeded-Crawl.svg";
+import urlListSvg from "../../../assets/images/new-crawl-config_URL-List.svg";
+
+export type SelectJobTypeEvent = CustomEvent<"url-list" | "seed-crawl">;
+
+/**
+ * @event select-job-type SelectJobTypeEvent
+ */
+@localized()
+export class NewWorkflowDialog extends LitElement {
+  static styles = css`
+    .title,
+    .container {
+      margin: var(--sl-spacing-large);
+    }
+
+    .container {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .heading {
+      font-size: var(--sl-font-size-large);
+      font-weight: var(--sl-font-weight-semibold);
+      margin-top: 0;
+      margin-bottom: var(--sl-spacing-small);
+      line-height: 1;
+    }
+
+    .description {
+      color: var(--sl-color-neutral-500);
+      margin: 0;
+      max-width: 23em;
+    }
+
+    .jobTypeButton {
+      display: block;
+    }
+
+    figure {
+      margin: 0;
+      padding: 0;
+    }
+
+    .jobTypeButton:hover .jobTypeImg {
+      transform: scale(1.05);
+    }
+
+    .jobTypeImg {
+      transition-property: transform;
+      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+      transition-duration: 150ms;
+      margin-bottom: var(--sl-spacing-small);
+    }
+  `;
+
+  @property({ type: String })
+  orgId!: string;
+
+  @property({ type: Boolean })
+  open = false;
+
+  render() {
+    return html`
+      <btrix-dialog
+        label=${msg("New Crawl Workflow")}
+        ?open=${this.open}
+        style="--width: 50rem"
+      >
+        <h3 class="title heading">${msg("Choose Crawl Type")}</h3>
+        <div class="container">
+          <div
+            role="button"
+            class="jobTypeButton"
+            @click=${() => {
+              this.dispatchEvent(
+                <SelectJobTypeEvent>new CustomEvent("select-job-type", {
+                  detail: "url-list",
+                })
+              );
+            }}
+          >
+            <figure>
+              <img class="jobTypeImg" src=${urlListSvg} />
+              <figcaption>
+                <div class="heading">${msg("URL List")}</div>
+                <p class="description">
+                  ${msg(
+                    "The crawler visits every URL specified in a list, and optionally every URL linked on those pages."
+                  )}
+                </p>
+              </figcaption>
+            </figure>
+          </div>
+          <div
+            role="button"
+            class="jobTypeButton"
+            @click=${() => {
+              this.dispatchEvent(
+                <SelectJobTypeEvent>new CustomEvent("select-job-type", {
+                  detail: "seed-crawl",
+                })
+              );
+            }}
+          >
+            <figure>
+              <img class="jobTypeImg" src=${seededCrawlSvg} />
+              <figcaption>
+                <div class="heading">${msg("Seeded Crawl")}</div>
+                <p class="description">
+                  ${msg(
+                    "The crawler automatically discovers and archives pages starting from a single seed URL."
+                  )}
+                </p>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </btrix-dialog>
+    `;
+  }
+}
+customElements.define("btrix-new-workflow-dialog", NewWorkflowDialog);

--- a/frontend/src/pages/org/components/new-workflow-dialog.ts
+++ b/frontend/src/pages/org/components/new-workflow-dialog.ts
@@ -15,12 +15,14 @@ export class NewWorkflowDialog extends LitElement {
   static styles = css`
     .title,
     .container {
-      margin: var(--sl-spacing-large);
+      margin: var(--sl-spacing-large) 0;
     }
 
     .container {
       display: flex;
-      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: var(--sl-spacing-4x-large);
+      justify-content: center;
     }
 
     .heading {
@@ -34,11 +36,11 @@ export class NewWorkflowDialog extends LitElement {
     .description {
       color: var(--sl-color-neutral-500);
       margin: 0;
-      max-width: 23em;
     }
 
     .jobTypeButton {
       display: block;
+      width: min-content;
     }
 
     figure {
@@ -69,7 +71,7 @@ export class NewWorkflowDialog extends LitElement {
       <btrix-dialog
         label=${msg("Create a New Crawl Workflow")}
         ?open=${this.open}
-        style="--width: 50rem"
+        style="--width: 46rem"
       >
         <h3 class="title heading">${msg("Choose Crawl Type")}</h3>
         <div class="container">

--- a/frontend/src/pages/org/components/new-workflow-dialog.ts
+++ b/frontend/src/pages/org/components/new-workflow-dialog.ts
@@ -41,6 +41,7 @@ export class NewWorkflowDialog extends LitElement {
     .jobTypeButton {
       display: block;
       width: min-content;
+      cursor: pointer;
     }
 
     figure {

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -54,55 +54,53 @@ export class Dashboard extends LiteElement {
       this.metrics.storageUsedBytes >= this.metrics.storageQuotaBytes;
 
     return html`<header
-        class="flex items-center justify-between gap-2 pb-3 mb-7 border-b"
+        class="flex items-center justify-end gap-2 pb-3 mb-7 border-b"
       >
-        <h1 class="min-w-0 text-xl font-semibold leading-8">
+        <h1 class="min-w-0 text-xl font-semibold leading-8 mr-auto">
           ${this.org?.name}
         </h1>
-        <div>
-          <sl-icon-button
-            href=${`/orgs/${this.orgId}/settings`}
-            class="text-lg"
-            name="gear"
-            label="Edit org settings"
-            @click=${this.navLink}
-          ></sl-icon-button>
-          <sl-dropdown
-            distance="4"
-            placement="bottom-end"
-            @sl-select=${(e: SlSelectEvent) => {
-              this.dispatchEvent(
-                <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
-                  detail: e.detail.item.value,
-                })
-              );
-            }}
-          >
-            <sl-button slot="trigger" size="small" caret>
-              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              ${msg("Add New...")}
-            </sl-button>
-            <sl-menu>
-              <sl-menu-item value="workflow"
-                >${msg("Crawl Workflow")}</sl-menu-item
-              >
-              <sl-menu-item
-                value="upload"
-                ?disabled=${!this.metrics || quotaReached}
-                >${msg("Upload")}</sl-menu-item
-              >
-              <sl-menu-item value="collection">
-                ${msg("Collection")}
-              </sl-menu-item>
-              <sl-menu-item
-                value="browser-profile"
-                ?disabled=${!this.metrics || quotaReached}
-              >
-                ${msg("Browser Profile")}
-              </sl-menu-item>
-            </sl-menu>
-          </sl-dropdown>
-        </div>
+        <sl-dropdown
+          distance="4"
+          placement="bottom-end"
+          @sl-select=${(e: SlSelectEvent) => {
+            this.dispatchEvent(
+              <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                detail: e.detail.item.value,
+              })
+            );
+          }}
+        >
+          <sl-button slot="trigger" size="small" caret>
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            ${msg("Add New...")}
+          </sl-button>
+          <sl-menu>
+            <sl-menu-item value="workflow"
+              >${msg("Crawl Workflow")}</sl-menu-item
+            >
+            <sl-menu-item
+              value="upload"
+              ?disabled=${!this.metrics || quotaReached}
+              >${msg("Upload")}</sl-menu-item
+            >
+            <sl-menu-item value="collection">
+              ${msg("Collection")}
+            </sl-menu-item>
+            <sl-menu-item
+              value="browser-profile"
+              ?disabled=${!this.metrics || quotaReached}
+            >
+              ${msg("Browser Profile")}
+            </sl-menu-item>
+          </sl-menu>
+        </sl-dropdown>
+        <sl-icon-button
+          href=${`/orgs/${this.orgId}/settings`}
+          class="text-lg"
+          name="gear"
+          label="Edit org settings"
+          @click=${this.navLink}
+        ></sl-icon-button>
       </header>
       <main>
         <div class="flex flex-col md:flex-row gap-6">

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -48,6 +48,11 @@ export class Dashboard extends LiteElement {
   }
 
   render() {
+    const quotaReached =
+      this.metrics &&
+      this.metrics.storageQuotaBytes > 0 &&
+      this.metrics.storageUsedBytes >= this.metrics.storageQuotaBytes;
+
     return html`<header
         class="flex items-center justify-between gap-2 pb-3 mb-7 border-b"
       >
@@ -73,7 +78,7 @@ export class Dashboard extends LiteElement {
               );
             }}
           >
-            <sl-button slot="trigger" variant="primary" size="small" caret>
+            <sl-button slot="trigger" size="small" caret>
               <sl-icon slot="prefix" name="plus-lg"></sl-icon>
               ${msg("Add New...")}
             </sl-button>
@@ -81,11 +86,18 @@ export class Dashboard extends LiteElement {
               <sl-menu-item value="workflow"
                 >${msg("Crawl Workflow")}</sl-menu-item
               >
-              <sl-menu-item value="upload">${msg("Upload")}</sl-menu-item>
+              <sl-menu-item
+                value="upload"
+                ?disabled=${!this.metrics || quotaReached}
+                >${msg("Upload")}</sl-menu-item
+              >
               <sl-menu-item value="collection">
                 ${msg("Collection")}
               </sl-menu-item>
-              <sl-menu-item value="browser-profile">
+              <sl-menu-item
+                value="browser-profile"
+                ?disabled=${!this.metrics || quotaReached}
+              >
                 ${msg("Browser Profile")}
               </sl-menu-item>
             </sl-menu>
@@ -129,37 +141,7 @@ export class Dashboard extends LiteElement {
                   iconProps: { name: "window-fullscreen" },
                 })}
               </dl>
-            `,
-            (metrics) => html`<footer class="mt-4 flex justify-end">
-              <sl-dropdown
-                distance="4"
-                placement="bottom-end"
-                @sl-select=${(e: SlSelectEvent) => {
-                  this.dispatchEvent(
-                    <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
-                      detail: e.detail.item.value,
-                    })
-                  );
-                }}
-              >
-                <sl-button
-                  slot="trigger"
-                  size="small"
-                  caret
-                  ?disabled=${metrics.storageQuotaBytes > 0 &&
-                  metrics.storageUsedBytes >= metrics.storageQuotaBytes}
-                >
-                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                  ${msg("Add New...")}
-                </sl-button>
-                <sl-menu>
-                  <sl-menu-item value="browser-profile">
-                    ${msg("Browser Profile")}
-                  </sl-menu-item>
-                  <sl-menu-item value="upload">${msg("Upload")}</sl-menu-item>
-                </sl-menu>
-              </sl-dropdown>
-            </footer> `
+            `
           )}
           ${this.renderCard(
             msg("Crawling"),
@@ -184,19 +166,6 @@ export class Dashboard extends LiteElement {
                   iconProps: { name: "file-richtext-fill" },
                 })}
               </dl>
-            `,
-            (metrics) => html`
-              <footer class="mt-4 flex justify-end">
-                <sl-button
-                  href=${`/orgs/${this.orgId}/workflows?new&jobType=`}
-                  size="small"
-                  @click=${this.navLink}
-                >
-                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
-                    "New Workflow"
-                  )}
-                </sl-button>
-              </footer>
             `
           )}
           ${this.renderCard(
@@ -216,19 +185,6 @@ export class Dashboard extends LiteElement {
                   iconProps: { name: "people-fill" },
                 })}
               </dl>
-            `,
-            (metrics) => html`
-              <footer class="mt-4 flex justify-end">
-                <sl-button
-                  href=${`/orgs/${this.orgId}/collections/new`}
-                  size="small"
-                  @click=${this.navLink}
-                >
-                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>${msg(
-                    "New Collection"
-                  )}
-                </sl-button>
-              </footer>
             `
           )}
         </div>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -79,7 +79,7 @@ export class Dashboard extends LiteElement {
         >
           <sl-button slot="trigger" size="small" caret>
             <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-            ${msg("Add New...")}
+            ${msg("Create New...")}
           </sl-button>
           <sl-menu>
             <sl-menu-item value="workflow"

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -62,6 +62,34 @@ export class Dashboard extends LiteElement {
             label="Edit org settings"
             @click=${this.navLink}
           ></sl-icon-button>
+          <sl-dropdown
+            distance="4"
+            placement="bottom-end"
+            @sl-select=${(e: SlSelectEvent) => {
+              this.dispatchEvent(
+                <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                  detail: e.detail.item.value,
+                })
+              );
+            }}
+          >
+            <sl-button slot="trigger" variant="primary" size="small" caret>
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              ${msg("Add New...")}
+            </sl-button>
+            <sl-menu>
+              <sl-menu-item value="workflow"
+                >${msg("Crawl Workflow")}</sl-menu-item
+              >
+              <sl-menu-item value="upload">${msg("Upload")}</sl-menu-item>
+              <sl-menu-item value="collection">
+                ${msg("Collection")}
+              </sl-menu-item>
+              <sl-menu-item value="browser-profile">
+                ${msg("Browser Profile")}
+              </sl-menu-item>
+            </sl-menu>
+          </sl-dropdown>
         </div>
       </header>
       <main>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -59,6 +59,13 @@ export class Dashboard extends LiteElement {
         <h1 class="min-w-0 text-xl font-semibold leading-8 mr-auto">
           ${this.org?.name}
         </h1>
+        <sl-icon-button
+          href=${`/orgs/${this.orgId}/settings`}
+          class="text-lg"
+          name="gear"
+          label="Edit org settings"
+          @click=${this.navLink}
+        ></sl-icon-button>
         <sl-dropdown
           distance="4"
           placement="bottom-end"
@@ -94,13 +101,6 @@ export class Dashboard extends LiteElement {
             </sl-menu-item>
           </sl-menu>
         </sl-dropdown>
-        <sl-icon-button
-          href=${`/orgs/${this.orgId}/settings`}
-          class="text-lg"
-          name="gear"
-          label="Edit org settings"
-          @click=${this.navLink}
-        ></sl-icon-button>
       </header>
       <main>
         <div class="flex flex-col md:flex-row gap-6">

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -419,7 +419,8 @@ export class Org extends LiteElement {
 
   private renderWorkflows() {
     const isEditing = this.params.hasOwnProperty("edit");
-    const isNewResourceTab = this.params.hasOwnProperty("new");
+    const isNewResourceTab =
+      this.params.hasOwnProperty("new") && this.params.jobType;
     const workflowId = this.params.workflowId;
 
     if (workflowId) {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -218,7 +218,7 @@ export class Org extends LiteElement {
             <strong>${msg("Your org has reached its storage limit")}</strong
             ><br />
             ${msg(
-              "To run crawls again, delete unneeded archived items and unused browser profiles to free up space, or contact us to upgrade your storage plan."
+              "To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact us to upgrade your storage plan."
             )}
           </sl-alert>
         </div>

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -27,6 +27,8 @@ import "./settings";
 import "./dashboard";
 import "./components/file-uploader";
 import "./components/new-browser-profile-dialog";
+import "./components/new-collection-dialog";
+import "./components/new-workflow-dialog";
 import type {
   Member,
   OrgNameChangeEvent,
@@ -334,6 +336,21 @@ export class Org extends LiteElement {
           ?open=${this.openDialogName === "browser-profile"}
         >
         </btrix-new-browser-profile-dialog>
+        <btrix-new-workflow-dialog
+          orgId=${this.orgId}
+          ?open=${this.openDialogName === "workflow"}
+          @select-job-type=${(e: SelectJobTypeEvent) => {
+            this.openDialogName = undefined;
+            this.navTo(`/orgs/${this.orgId}/workflows?new&jobType=${e.detail}`);
+          }}
+        >
+        </btrix-new-workflow-dialog>
+        <btrix-new-collection-dialog
+          .authState=${this.authState}
+          orgId=${this.orgId}
+          ?open=${this.openDialogName === "collection"}
+        >
+        </btrix-new-collection-dialog>
       </div>
     `;
   }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -34,6 +34,7 @@ import type {
   OrgRemoveMemberEvent,
 } from "./settings";
 import type { Tab as CollectionTab } from "./collection-detail";
+import type { SelectJobTypeEvent } from "./components/new-workflow-dialog";
 
 export type SelectNewDialogEvent = CustomEvent<
   "workflow" | "collection" | "browser-profile" | "upload"

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -38,9 +38,8 @@ import type {
 import type { Tab as CollectionTab } from "./collection-detail";
 import type { SelectJobTypeEvent } from "./components/new-workflow-dialog";
 
-export type SelectNewDialogEvent = CustomEvent<
-  "workflow" | "collection" | "browser-profile" | "upload"
->;
+type ResourceName = "workflow" | "collection" | "browser-profile" | "upload";
+export type SelectNewDialogEvent = CustomEvent<ResourceName>;
 export type OrgTab =
   | "home"
   | "crawls"
@@ -59,7 +58,7 @@ type Params = {
   collectionTab?: string;
   itemType?: Crawl["type"];
   jobType?: JobType;
-  name: string;
+  new?: ResourceName;
 };
 const defaultTab = "home";
 
@@ -102,7 +101,7 @@ export class Org extends LiteElement {
     | "upload";
 
   @state()
-  private isDialogVisible = false;
+  private isCreateDialogVisible = false;
 
   @state()
   private org?: OrgData | null;
@@ -305,7 +304,7 @@ export class Org extends LiteElement {
     if (!this.authState || !this.orgId || !this.isCrawler) {
       return;
     }
-    if (!this.isDialogVisible) {
+    if (!this.isCreateDialogVisible) {
       return;
     }
     return html`
@@ -316,7 +315,7 @@ export class Org extends LiteElement {
         }}
         @sl-after-hide=${(e: CustomEvent) => {
           e.stopPropagation();
-          this.isDialogVisible = false;
+          this.isCreateDialogVisible = false;
         }}
       >
         <btrix-file-uploader
@@ -487,15 +486,6 @@ export class Org extends LiteElement {
       ></btrix-collection-detail>`;
     }
 
-    if (this.orgPath.includes("/new")) {
-      return html`<btrix-collections-new
-        .authState=${this.authState!}
-        orgId=${this.orgId!}
-        ?isCrawler=${this.isCrawler}
-        name=${this.params.name}
-      ></btrix-collections-new>`;
-    }
-
     return html`<btrix-collections-list
       .authState=${this.authState!}
       orgId=${this.orgId!}
@@ -526,7 +516,7 @@ export class Org extends LiteElement {
 
   private async onSelectNewDialog(e: SelectNewDialogEvent) {
     e.stopPropagation();
-    this.isDialogVisible = true;
+    this.isCreateDialogVisible = true;
     await this.updateComplete;
     this.openDialogName = e.detail;
   }

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -335,6 +335,9 @@ export class CrawlConfigEditor extends LiteElement {
   }
 
   async willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("jobType") && this.jobType) {
+      this.initializeEditor();
+    }
     if (changedProperties.has("authState") && this.authState) {
       await this.fetchAPIDefaults();
       if (this.orgId) {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -12,6 +12,7 @@ import { CopyButton } from "../../components/copy-button";
 import { SlCheckbox } from "@shoelace-style/shoelace";
 import type { APIPaginatedList, APIPaginationQuery } from "../../types/api";
 import type { PageChangeEvent } from "../../components/pagination";
+import type { SelectNewDialogEvent } from "./index";
 
 type SearchFields = "name" | "firstSeed";
 type SortField = "lastRun" | "name" | "firstSeed" | "created" | "modified";
@@ -202,10 +203,15 @@ export class WorkflowsList extends LiteElement {
             this.isCrawler,
             () => html`
               <sl-button
-                href=${`/orgs/${this.orgId}/workflows?new&jobType=`}
                 variant="primary"
                 size="small"
-                @click=${this.navLink}
+                @click=${() => {
+                  this.dispatchEvent(
+                    <SelectNewDialogEvent>new CustomEvent("select-new-dialog", {
+                      detail: "workflow",
+                    })
+                  );
+                }}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                 ${msg("New Workflow")}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1197

<!-- Fixes #issue_number -->

### Changes
- Replaces individual "New" buttons in home page with dropdown button in header
- Refactors required step of new workflow and new collection into dialog

### Manual testing

1. Log in. Verify "Add New..." dropdown button is in home dashboard header
2. Click "Add New..." > "Crawl Workflow" > Crawl type. Verify you're taken to the correct form.
3. Click "Start Over". Verify crawl type dialog is shown
4. Go to Crawling page and click "New Workflow". Verify dialog is shown as expected
5. Go to home page
6. Click "Add New..." > "Collection". Verify dialog is shown
7. Enter name and click "Create Collection". Verify you're taken to the crawl selection form.
8. Go to Collections page and click "New Collection". Verify dialog is shown as expected

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Home | <img width="1132" alt="Screenshot 2023-09-25 at 2 26 15 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/257ca4f0-f8ac-4dde-92ce-de718bef652d"> |
| Home | <img width="191" alt="Screenshot 2023-09-25 at 2 26 19 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/2781134a-6157-4e4a-93ec-be13d7baad75"> |
| Home/Crawling - New Workflow dialog | <img width="765" alt="Screenshot 2023-09-25 at 2 26 26 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/628ada46-14a1-4771-a57f-314f0c60231f"> |
| Home/Collections - New Collection dialog | <img width="752" alt="Screenshot 2023-09-25 at 2 44 37 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/f3549bd6-edef-4cbe-b065-893342d4a50b"> |


<!-- ### Follow-ups -->
