### PR TITLE
Show org storage quotas in dashboard

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -153,8 +153,9 @@ import("./code").then(({ Code }) => {
 import("./search-combobox").then(({ SearchCombobox }) => {
   customElements.define("btrix-search-combobox", SearchCombobox);
 });
-import("./meter").then(({ Meter }) => {
+import("./meter").then(({ Meter, MeterBar }) => {
   customElements.define("btrix-meter", Meter);
+  customElements.define("btrix-meter-bar", MeterBar);
 });
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -153,6 +153,9 @@ import("./code").then(({ Code }) => {
 import("./search-combobox").then(({ SearchCombobox }) => {
   customElements.define("btrix-search-combobox", SearchCombobox);
 });
+import("./meter").then(({ Meter }) => {
+  customElements.define("btrix-meter", Meter);
+});
 customElements.define("btrix-alert", Alert);
 customElements.define("btrix-input", Input);
 customElements.define("btrix-time-input", TimeInput);

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -32,7 +32,7 @@ export class MeterBar extends LitElement {
  *
  * Usage example:
  * ```ts
- * <btrix-meter max="50" value="40" low="10" high="49"></btrix-meter>
+ * <btrix-meter max="50" value="40" low="10"></btrix-meter>
  * ```
  */
 export class Meter extends LitElement {
@@ -47,9 +47,6 @@ export class Meter extends LitElement {
 
   @property({ type: Array })
   subValues?: number[];
-
-  @property({ type: Number })
-  high?: number;
 
   @property({ type: String })
   valueText?: string;
@@ -121,6 +118,7 @@ export class Meter extends LitElement {
   }
 
   render() {
+    // meter spec disallow values that exceed max
     const boundedValue = Math.max(Math.min(this.value, this.max), this.min);
     const barWidth = `${(boundedValue / this.max) * 100}%`;
     return html`

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -16,10 +16,14 @@ export class MeterBar extends LitElement {
     .bar {
       height: 1rem;
       background-color: var(--background-color, var(--sl-color-blue-500));
+      min-width: 4px;
     }
   `;
 
   render() {
+    if (this.value <= 0) {
+      return;
+    }
     return html`<sl-tooltip>
       <div slot="content"><slot></slot></div>
       <div class="bar" style="width:${this.value}%"></div>
@@ -50,12 +54,6 @@ export class Meter extends LitElement {
 
   @property({ type: String })
   valueText?: string;
-
-  @property({ type: String })
-  valueLabel?: string;
-
-  @property({ type: String })
-  maxLabel?: string;
 
   @query(".valueBar")
   private valueBar?: HTMLElement;
@@ -101,9 +99,13 @@ export class Meter extends LitElement {
       flex-grow: 1;
     }
 
+    .valueText {
+      display: inline-flex;
+    }
+
     .valueText.withSeparator:after {
       content: "/";
-      padding: 0 0.5ch;
+      padding: 0 0.3ch;
     }
 
     .maxText {
@@ -135,16 +137,19 @@ export class Meter extends LitElement {
             <div class="valueBar" style="width:${barWidth}">
               <slot></slot>
             </div>
+            <slot name="available"></slot>
           </div>
         </sl-resize-observer>
         <div class="labels">
           <div class="label value" style="width:${barWidth}">
-            <span class="valueText withSeparator"
-              >${this.valueLabel || this.value}</span
-            >
+            <span class="valueText withSeparator">
+              <slot name="valueLabel">${this.value}</slot>
+            </span>
           </div>
           <div class="label max">
-            <span class="maxText">${this.maxLabel || this.max}</span>
+            <span class="maxText">
+              <slot name="maxLabel">${this.max}</slot>
+            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -1,5 +1,10 @@
 import { LitElement, html, css, PropertyValues } from "lit";
-import { property, query, state } from "lit/decorators.js";
+import {
+  property,
+  query,
+  queryAssignedElements,
+  state,
+} from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import debounce from "lodash/fp/debounce";
 
@@ -17,6 +22,7 @@ export class MeterBar extends LitElement {
       height: 1rem;
       background-color: var(--background-color, var(--sl-color-blue-500));
       min-width: 4px;
+      border-right: var(--border-right, 0);
     }
   `;
 
@@ -113,6 +119,9 @@ export class Meter extends LitElement {
     }
   `;
 
+  @queryAssignedElements({ selector: "btrix-meter-bar" })
+  bars?: Array<HTMLElement>;
+
   updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("value") || changedProperties.has("max")) {
       this.repositionLabels();
@@ -135,7 +144,7 @@ export class Meter extends LitElement {
         <sl-resize-observer @sl-resize=${this.onTrackResize}>
           <div class="track">
             <div class="valueBar" style="width:${barWidth}">
-              <slot></slot>
+              <slot @slotchange=${this.handleSlotchange}></slot>
             </div>
             <slot name="available"></slot>
           </div>
@@ -178,5 +187,15 @@ export class Meter extends LitElement {
     } else {
       valueText?.classList.remove("withSeparator");
     }
+  }
+
+  private handleSlotchange() {
+    if (!this.bars) return;
+    this.bars.forEach((el, i, arr) => {
+      if (i < arr.length - 1) {
+        el.style.cssText +=
+          "--border-right: 1px solid var(--sl-color-neutral-600)";
+      }
+    });
   }
 }

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -87,6 +87,10 @@ export class Meter extends LitElement {
     }
   `;
 
+  firstUpdated() {
+    this.repositionLabels();
+  }
+
   render() {
     const barWidth = `${Math.min(100, (this.value / this.max) * 100)}%`;
     return html`
@@ -129,9 +133,16 @@ export class Meter extends LitElement {
     const { entries } = e.detail;
     const entry = entries[0];
     const trackWidth = entry.contentBoxSize[0].inlineSize;
-    const barWidth = entry.target.querySelector(".bar").clientWidth;
+    this.repositionLabels(trackWidth);
+  }
+
+  private repositionLabels(trackWidth?: number) {
+    if (!this.bar) return;
+    const trackW = trackWidth || this.bar.closest(".track")?.clientWidth;
+    if (!trackW) return;
+    const barWidth = this.bar.clientWidth;
     const pad = 8;
-    const remaining = Math.ceil(trackWidth - barWidth - pad);
+    const remaining = Math.ceil(trackW - barWidth - pad);
 
     // Show compact value/max label when almost touching
     this.showCompactLabels = Boolean(

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -146,7 +146,7 @@ export class Meter extends LitElement {
             <div class="valueBar" style="width:${barWidth}">
               <slot @slotchange=${this.handleSlotchange}></slot>
             </div>
-            <slot name="available"></slot>
+            ${this.value < this.max ? html`<slot name="available"></slot>` : ""}
           </div>
         </sl-resize-observer>
         <div class="labels">

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -1,0 +1,80 @@
+import { LitElement, html, css } from "lit";
+import { property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+/**
+ * Show scalar value within a range
+ *
+ * Usage example:
+ * ```ts
+ * <btrix-meter max="50" value="40" low="10" high="49"></btrix-meter>
+ * ```
+ */
+export class Meter extends LitElement {
+  @property({ type: Number })
+  max = 1;
+
+  @property({ type: Number })
+  value = 0;
+
+  @property({ type: Number })
+  min?: number;
+
+  @property({ type: Number })
+  high?: number;
+
+  static styles = css`
+    meter {
+      display: block;
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
+      width: 100%;
+      height: 1rem;
+      border-radius: var(--sl-border-radius-medium);
+    }
+
+    meter,
+    meter::-webkit-meter-bar {
+      background: none;
+      background-color: var(--sl-color-neutral-100);
+      box-shadow: inset 0px 1px 1px 0px rgba(0, 0, 0, 0.25);
+    }
+
+    meter::-moz-meter-bar {
+      background: none;
+      background-color: var(--sl-color-blue-500);
+      border-radius: var(--sl-border-radius-medium);
+    }
+    .value-bar {
+      height: 1rem;
+      background-color: var(--sl-color-blue-500);
+      border-radius: var(--sl-border-radius-medium);
+    }
+
+    meter.danger .value-bar {
+      background-color: var(--sl-color-red-500);
+    }
+    meter.danger::-moz-meter-bar {
+      background-color: var(--sl-color-red-500);
+    }
+  `;
+
+  render() {
+    return html`
+      <style></style>
+      <meter
+        class="${this.value >= (this.high || this.max) ? "danger" : ""}"
+        value=${this.value}
+        max=${this.max}
+        min=${ifDefined(this.min)}
+        high=${ifDefined(this.high)}
+      >
+        <div
+          class="value-bar"
+          style="width:${Math.min(100, (this.value / this.max) * 100)}%"
+        ></div>
+      </meter>
+    `;
+  }
+}

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -15,7 +15,7 @@ export class Meter extends LitElement {
   @property({ type: Number })
   min = 0;
   @property({ type: Number })
-  max = 1;
+  max = 100;
 
   @property({ type: Number })
   value = 0;
@@ -100,12 +100,13 @@ export class Meter extends LitElement {
   }
 
   render() {
-    const barWidth = `${Math.min(100, (this.value / this.max) * 100)}%`;
+    const boundedValue = Math.max(Math.min(this.value, this.max), this.min);
+    const barWidth = `${(boundedValue / this.max) * 100}%`;
     return html`
       <div
         class="meter"
-        role="${"meter" as any}"
-        aria-valuenow=${this.value}
+        role="meter"
+        aria-valuenow=${boundedValue}
         aria-valuetext=${ifDefined(this.valueText)}
         aria-valuemin=${this.min}
         aria-valuemax=${this.max}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -52,9 +52,9 @@ export class Dashboard extends LiteElement {
 
   private readonly colors = {
     default: "neutral",
-    crawls: "sky",
-    uploads: "lime",
-    browserProfiles: "fuchsia",
+    crawls: "green",
+    uploads: "sky",
+    browserProfiles: "indigo",
   };
 
   willUpdate(changedProperties: PropertyValues<this>) {
@@ -251,6 +251,20 @@ export class Dashboard extends LiteElement {
       metrics.storageQuotaBytes
     );
     const isStorageFull = metrics.storageUsedBytes >= metrics.storageQuotaBytes;
+    const renderBar = (value: number, color: string) => html`
+      <btrix-meter-bar
+        value=${(value / metrics.storageUsedBytes) * 100}
+        style="--background-color:var(--sl-color-${color}-400)"
+      >
+        <div class="text-center">
+          <div>${msg("Uploads")}</div>
+          <div class="text-xs opacity-80">
+            <sl-format-bytes value=${value} display="narrow"></sl-format-bytes>
+            | ${this.renderPercentage(value / metrics.storageUsedBytes)}
+          </div>
+        </div>
+      </btrix-meter-bar>
+    `;
     return html`
       <div class="font-semibold mb-1">
         ${when(
@@ -278,66 +292,15 @@ export class Dashboard extends LiteElement {
           max=${maxBytes}
           valueText=${msg("gigabyte")}
         >
-          <btrix-meter-bar
-            value=${(metrics.storageUsedCrawls / metrics.storageUsedBytes) *
-            100}
-            style="--background-color:var(--sl-color-${this.colors.crawls}-400)"
-          >
-            <div class="text-center">
-              <div>${msg("Crawls")}</div>
-              <div class="text-xs opacity-80">
-                <sl-format-bytes
-                  value=${metrics.storageUsedCrawls}
-                  display="narrow"
-                ></sl-format-bytes>
-                |
-                ${this.renderPercentage(
-                  metrics.storageUsedCrawls / metrics.storageUsedBytes
-                )}
-              </div>
-            </div>
-          </btrix-meter-bar>
-          <btrix-meter-bar
-            value=${(metrics.storageUsedUploads / metrics.storageUsedBytes) *
-            100}
-            style="--background-color:var(--sl-color-${this.colors
-              .uploads}-400)"
-          >
-            <div class="text-center">
-              <div>${msg("Uploads")}</div>
-              <div class="text-xs opacity-80">
-                <sl-format-bytes
-                  value=${metrics.storageUsedUploads}
-                  display="narrow"
-                ></sl-format-bytes>
-                |
-                ${this.renderPercentage(
-                  metrics.storageUsedUploads / metrics.storageUsedBytes
-                )}
-              </div>
-            </div>
-          </btrix-meter-bar>
-          <btrix-meter-bar
-            value=${(metrics.storageUsedProfiles / metrics.storageUsedBytes) *
-            100}
-            style="--background-color:var(--sl-color-${this.colors
-              .browserProfiles}-400)"
-          >
-            <div class="text-center">
-              <div>${msg("Browser Profiles")}</div>
-              <div class="text-xs opacity-80">
-                <sl-format-bytes
-                  value=${metrics.storageUsedProfiles}
-                  display="narrow"
-                ></sl-format-bytes>
-                |
-                ${this.renderPercentage(
-                  metrics.storageUsedProfiles / metrics.storageUsedBytes
-                )}
-              </div>
-            </div>
-          </btrix-meter-bar>
-
+          ${when(metrics.storageUsedCrawls, () =>
+            renderBar(metrics.storageUsedCrawls, this.colors.crawls)
+          )}
+          ${when(metrics.storageUsedUploads, () =>
+            renderBar(metrics.storageUsedUploads, this.colors.uploads)
+          )}
+          ${when(metrics.storageUsedProfiles, () =>
+            renderBar(metrics.storageUsedProfiles, this.colors.browserProfiles)
+          )}
           <div slot="available" class="flex-1">
             <sl-tooltip>
               <div slot="content" class="text-xs opacity-80">

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -43,13 +43,6 @@ export class Dashboard extends LiteElement {
   @state()
   private metrics?: Metrics;
 
-  private gbFormatter = Intl.NumberFormat("en", {
-    notation: "compact",
-    style: "unit",
-    unit: "gigabyte",
-    unitDisplay: "narrow",
-  });
-
   private readonly colors = {
     default: "neutral",
     crawls: "green",
@@ -93,9 +86,10 @@ export class Dashboard extends LiteElement {
                   !metrics.storageQuotaBytes,
                   () => html`
                     ${this.renderStat({
-                      value: this.gbFormatter.format(
-                        (metrics.storageUsedBytes ?? 0) / BYTES_PER_GB
-                      ),
+                      value: html`<sl-format-bytes
+                        value=${metrics.storageUsedBytes ?? 0}
+                        display="narrow"
+                      ></sl-format-bytes>`,
                       singleLabel: msg("of Data Stored"),
                       pluralLabel: msg("of Data Stored"),
                       iconProps: { name: "database" },
@@ -370,7 +364,7 @@ export class Dashboard extends LiteElement {
   }
 
   private renderStat(stat: {
-    value: number | string;
+    value: number | string | TemplateResult;
     singleLabel: string;
     pluralLabel: string;
     iconProps: { name: string; library?: string; color?: string };

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -80,66 +80,7 @@ export class Dashboard extends LiteElement {
             (metrics) => html`
               ${when(
                 metrics.storageQuotaBytes,
-                () => html`
-                  <div class="font-semibold mb-1">
-                    ${msg(
-                      str`${Math.round(
-                        (metrics.storageUsedBytes / metrics.storageQuotaBytes) *
-                          100
-                      )}% used`
-                    )}
-                  </div>
-                  <div class="mb-2">
-                    <btrix-meter
-                      value=${metrics.storageUsedBytes}
-                      max=${metrics.storageQuotaBytes}
-                      high=${metrics.storageQuotaBytes}
-                      valueText=${msg("gigabyte")}
-                      valueLabel=${this.bytesLabel(metrics.storageUsedBytes)}
-                      maxLabel=${this.bytesLabel(metrics.storageUsedBytes)}
-                    >
-                      <btrix-meter-bar
-                        value=${(metrics.storageUsedCrawls /
-                          metrics.storageUsedBytes) *
-                        100}
-                        style="--background-color:var(--sl-color-sky-400)"
-                      >
-                        <div class="text-center">
-                          <div>${msg("Crawls")}</div>
-                          <div class="text-xs opacity-80">
-                            ${this.bytesLabel(metrics.storageUsedCrawls)}
-                          </div>
-                        </div>
-                      </btrix-meter-bar>
-                      <btrix-meter-bar
-                        value=${(metrics.storageUsedUploads /
-                          metrics.storageUsedBytes) *
-                        100}
-                        style="--background-color:var(--sl-color-lime-400)"
-                      >
-                        <div class="text-center">
-                          <div>${msg("Uploads")}</div>
-                          <div class="text-xs opacity-80">
-                            ${this.bytesLabel(metrics.storageUsedUploads)}
-                          </div>
-                        </div>
-                      </btrix-meter-bar>
-                      <btrix-meter-bar
-                        value=${(metrics.storageUsedProfiles /
-                          metrics.storageUsedBytes) *
-                        100}
-                        style="--background-color:var(--sl-color-fuchsia-400)"
-                      >
-                        <div class="text-center">
-                          <div>${msg("Browser Profiles")}</div>
-                          <div class="text-xs opacity-80">
-                            ${this.bytesLabel(metrics.storageUsedProfiles)}
-                          </div>
-                        </div>
-                      </btrix-meter-bar>
-                    </btrix-meter>
-                  </div>
-                `,
+                () => this.renderStorageMeter(metrics),
                 () => html`
                   <div class="font-semibold mb-3">
                     <sl-format-bytes
@@ -279,6 +220,69 @@ export class Dashboard extends LiteElement {
           )}
         </div>
       </main> `;
+  }
+
+  private renderStorageMeter(metrics: Metrics) {
+    // Account for usage that exceeds max
+    const maxBytes = Math.max(
+      metrics.storageUsedBytes,
+      metrics.storageQuotaBytes
+    );
+    return html`
+      <div class="font-semibold mb-1">
+        ${msg(
+          str`${Math.round(
+            (metrics.storageUsedBytes / metrics.storageQuotaBytes) * 100
+          )}% used`
+        )}
+      </div>
+      <div class="mb-2">
+        <btrix-meter
+          value=${metrics.storageUsedBytes}
+          max=${maxBytes}
+          valueText=${msg("gigabyte")}
+          valueLabel=${this.bytesLabel(metrics.storageUsedBytes)}
+          maxLabel=${this.bytesLabel(metrics.storageQuotaBytes)}
+        >
+          <btrix-meter-bar
+            value=${(metrics.storageUsedCrawls / metrics.storageUsedBytes) *
+            100}
+            style="--background-color:var(--sl-color-sky-400)"
+          >
+            <div class="text-center">
+              <div>${msg("Crawls")}</div>
+              <div class="text-xs opacity-80">
+                ${this.bytesLabel(metrics.storageUsedCrawls)}
+              </div>
+            </div>
+          </btrix-meter-bar>
+          <btrix-meter-bar
+            value=${(metrics.storageUsedUploads / metrics.storageUsedBytes) *
+            100}
+            style="--background-color:var(--sl-color-lime-400)"
+          >
+            <div class="text-center">
+              <div>${msg("Uploads")}</div>
+              <div class="text-xs opacity-80">
+                ${this.bytesLabel(metrics.storageUsedUploads)}
+              </div>
+            </div>
+          </btrix-meter-bar>
+          <btrix-meter-bar
+            value=${(metrics.storageUsedProfiles / metrics.storageUsedBytes) *
+            100}
+            style="--background-color:var(--sl-color-fuchsia-400)"
+          >
+            <div class="text-center">
+              <div>${msg("Browser Profiles")}</div>
+              <div class="text-xs opacity-80">
+                ${this.bytesLabel(metrics.storageUsedProfiles)}
+              </div>
+            </div>
+          </btrix-meter-bar>
+        </btrix-meter>
+      </div>
+    `;
   }
 
   private renderCard(

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -50,6 +50,13 @@ export class Dashboard extends LiteElement {
     unitDisplay: "narrow",
   });
 
+  private readonly colors = {
+    default: "neutral",
+    crawls: "sky",
+    uploads: "lime",
+    browserProfiles: "fuchsia",
+  };
+
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("orgId")) {
       this.fetchMetrics();
@@ -101,19 +108,25 @@ export class Dashboard extends LiteElement {
                   value: metrics.crawlCount,
                   singleLabel: msg("Crawl"),
                   pluralLabel: msg("Crawls"),
-                  iconProps: { name: "gear-wide-connected" },
+                  iconProps: {
+                    name: "gear-wide-connected",
+                    color: this.colors.crawls,
+                  },
                 })}
                 ${this.renderStat({
                   value: metrics.uploadCount,
                   singleLabel: msg("Upload"),
                   pluralLabel: msg("Uploads"),
-                  iconProps: { name: "upload" },
+                  iconProps: { name: "upload", color: this.colors.uploads },
                 })}
                 ${this.renderStat({
                   value: metrics.profileCount,
                   singleLabel: msg("Browser Profile"),
                   pluralLabel: msg("Browser Profiles"),
-                  iconProps: { name: "window-fullscreen" },
+                  iconProps: {
+                    name: "window-fullscreen",
+                    color: this.colors.browserProfiles,
+                  },
                 })}
               </dl>
             `,
@@ -156,13 +169,17 @@ export class Dashboard extends LiteElement {
                   value: metrics.workflowsRunningCount,
                   singleLabel: msg("Crawl Running"),
                   pluralLabel: msg("Crawls Running"),
-                  iconProps: { name: "dot", library: "app" },
+                  iconProps: {
+                    name: "dot",
+                    library: "app",
+                    color: metrics.workflowsRunningCount ? "green" : "neutral",
+                  },
                 })}
                 ${this.renderStat({
                   value: metrics.workflowsQueuedCount,
                   singleLabel: msg("Crawl Workflow Waiting"),
                   pluralLabel: msg("Crawl Workflows Waiting"),
-                  iconProps: { name: "hourglass-split" },
+                  iconProps: { name: "hourglass-split", color: "purple" },
                 })}
                 ${this.renderStat({
                   value: metrics.pageCount,
@@ -200,7 +217,7 @@ export class Dashboard extends LiteElement {
                   value: metrics.publicCollectionsCount,
                   singleLabel: msg("Shareable Collection"),
                   pluralLabel: msg("Shareable Collections"),
-                  iconProps: { name: "people-fill" },
+                  iconProps: { name: "people-fill", color: "emerald" },
                 })}
               </dl>
             `,
@@ -247,7 +264,7 @@ export class Dashboard extends LiteElement {
           <btrix-meter-bar
             value=${(metrics.storageUsedCrawls / metrics.storageUsedBytes) *
             100}
-            style="--background-color:var(--sl-color-sky-400)"
+            style="--background-color:var(--sl-color-${this.colors.crawls}-400)"
           >
             <div class="text-center">
               <div>${msg("Crawls")}</div>
@@ -259,7 +276,8 @@ export class Dashboard extends LiteElement {
           <btrix-meter-bar
             value=${(metrics.storageUsedUploads / metrics.storageUsedBytes) *
             100}
-            style="--background-color:var(--sl-color-lime-400)"
+            style="--background-color:var(--sl-color-${this.colors
+              .uploads}-400)"
           >
             <div class="text-center">
               <div>${msg("Uploads")}</div>
@@ -271,7 +289,8 @@ export class Dashboard extends LiteElement {
           <btrix-meter-bar
             value=${(metrics.storageUsedProfiles / metrics.storageUsedBytes) *
             100}
-            style="--background-color:var(--sl-color-fuchsia-400)"
+            style="--background-color:var(--sl-color-${this.colors
+              .browserProfiles}-400)"
           >
             <div class="text-center">
               <div>${msg("Browser Profiles")}</div>
@@ -314,7 +333,7 @@ export class Dashboard extends LiteElement {
     value: number;
     singleLabel: string;
     pluralLabel: string;
-    iconProps: { name: string; library?: string };
+    iconProps: { name: string; library?: string; color?: string };
   }) {
     return html`
       <div class="flex items-center mb-2 last:mb-0">
@@ -322,6 +341,8 @@ export class Dashboard extends LiteElement {
           class="text-base text-neutral-500 mr-2"
           name=${stat.iconProps.name}
           library=${ifDefined(stat.iconProps.library)}
+          style="color:var(--sl-color-${stat.iconProps.color ||
+          this.colors.default}-500)"
         ></sl-icon>
         <dt class="order-last">
           ${stat.value === 1 ? stat.singleLabel : stat.pluralLabel}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -92,7 +92,7 @@ export class Dashboard extends LiteElement {
                       ></sl-format-bytes>`,
                       singleLabel: msg("of Data Stored"),
                       pluralLabel: msg("of Data Stored"),
-                      iconProps: { name: "database" },
+                      iconProps: { name: "device-hdd-fill" },
                     })}
                     <sl-divider
                       style="--spacing:var(--sl-spacing-small)"

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -89,6 +89,22 @@ export class Dashboard extends LiteElement {
                 this.renderStorageMeter(metrics)
               )}
               <dl>
+                ${when(
+                  !metrics.storageQuotaBytes,
+                  () => html`
+                    ${this.renderStat({
+                      value: this.gbFormatter.format(
+                        (metrics.storageUsedBytes ?? 0) / BYTES_PER_GB
+                      ),
+                      singleLabel: msg("of Data Stored"),
+                      pluralLabel: msg("of Data Stored"),
+                      iconProps: { name: "database" },
+                    })}
+                    <sl-divider
+                      style="--spacing:var(--sl-spacing-small)"
+                    ></sl-divider>
+                  `
+                )}
                 ${this.renderStat({
                   value: metrics.crawlCount,
                   singleLabel: msg("Crawl"),
@@ -113,26 +129,15 @@ export class Dashboard extends LiteElement {
                     color: this.colors.browserProfiles,
                   },
                 })}
-                <sl-divider></sl-divider>
+                <sl-divider
+                  style="--spacing:var(--sl-spacing-small)"
+                ></sl-divider>
                 ${this.renderStat({
                   value: metrics.archivedItemCount,
                   singleLabel: msg("Archived Item"),
                   pluralLabel: msg("Archived Items"),
                   iconProps: { name: "file-zip-fill" },
                 })}
-                ${when(
-                  !metrics.storageQuotaBytes,
-                  () => html`
-                    ${this.renderStat({
-                      value: this.gbFormatter.format(
-                        (metrics.storageUsedBytes ?? 0) / BYTES_PER_GB
-                      ),
-                      singleLabel: msg("of Data Stored"),
-                      pluralLabel: msg("of Data Stored"),
-                      iconProps: { name: "database" },
-                    })}
-                  `
-                )}
               </dl>
             `,
             (metrics) => html`<footer class="mt-4 flex justify-end">
@@ -251,13 +256,13 @@ export class Dashboard extends LiteElement {
       metrics.storageQuotaBytes
     );
     const isStorageFull = metrics.storageUsedBytes >= metrics.storageQuotaBytes;
-    const renderBar = (value: number, color: string) => html`
+    const renderBar = (value: number, label: string, color: string) => html`
       <btrix-meter-bar
         value=${(value / metrics.storageUsedBytes) * 100}
         style="--background-color:var(--sl-color-${color}-400)"
       >
         <div class="text-center">
-          <div>${msg("Uploads")}</div>
+          <div>${label}</div>
           <div class="text-xs opacity-80">
             <sl-format-bytes value=${value} display="narrow"></sl-format-bytes>
             | ${this.renderPercentage(value / metrics.storageUsedBytes)}
@@ -293,13 +298,25 @@ export class Dashboard extends LiteElement {
           valueText=${msg("gigabyte")}
         >
           ${when(metrics.storageUsedCrawls, () =>
-            renderBar(metrics.storageUsedCrawls, this.colors.crawls)
+            renderBar(
+              metrics.storageUsedCrawls,
+              msg("Crawls"),
+              this.colors.crawls
+            )
           )}
           ${when(metrics.storageUsedUploads, () =>
-            renderBar(metrics.storageUsedUploads, this.colors.uploads)
+            renderBar(
+              metrics.storageUsedUploads,
+              msg("Uploads"),
+              this.colors.uploads
+            )
           )}
           ${when(metrics.storageUsedProfiles, () =>
-            renderBar(metrics.storageUsedProfiles, this.colors.browserProfiles)
+            renderBar(
+              metrics.storageUsedProfiles,
+              msg("Profiles"),
+              this.colors.browserProfiles
+            )
           )}
           <div slot="available" class="flex-1">
             <sl-tooltip>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -369,19 +369,22 @@ export class Dashboard extends LiteElement {
     pluralLabel: string;
     iconProps: { name: string; library?: string; color?: string };
   }) {
+    const { value, iconProps } = stat;
     return html`
       <div class="flex items-center mb-2 last:mb-0">
         <sl-icon
           class="text-base text-neutral-500 mr-2"
-          name=${stat.iconProps.name}
-          library=${ifDefined(stat.iconProps.library)}
-          style="color:var(--sl-color-${stat.iconProps.color ||
+          name=${iconProps.name}
+          library=${ifDefined(iconProps.library)}
+          style="color:var(--sl-color-${iconProps.color ||
           this.colors.default}-500)"
         ></sl-icon>
         <dt class="order-last">
-          ${stat.value === 1 ? stat.singleLabel : stat.pluralLabel}
+          ${value === 1 ? stat.singleLabel : stat.pluralLabel}
         </dt>
-        <dd class="mr-1">${stat.value.toLocaleString()}</dd>
+        <dd class="mr-1">
+          ${typeof value === "number" ? value.toLocaleString() : value}
+        </dd>
       </div>
     `;
   }

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -95,13 +95,49 @@ export class Dashboard extends LiteElement {
                       max=${metrics.storageQuotaBytes}
                       high=${metrics.storageQuotaBytes}
                       valueText=${msg("gigabyte")}
-                      valueLabel=${this.gbFormatter.format(
-                        metrics.storageUsedBytes / BYTES_PER_GB
-                      )}
-                      maxLabel=${this.gbFormatter.format(
-                        metrics.storageQuotaBytes / BYTES_PER_GB
-                      )}
-                    ></btrix-meter>
+                      valueLabel=${this.bytesLabel(metrics.storageUsedBytes)}
+                      maxLabel=${this.bytesLabel(metrics.storageUsedBytes)}
+                    >
+                      <btrix-meter-bar
+                        value=${(metrics.storageUsedCrawls /
+                          metrics.storageUsedBytes) *
+                        100}
+                        style="--background-color:var(--sl-color-sky-400)"
+                      >
+                        <div class="text-center">
+                          <div>${msg("Crawls")}</div>
+                          <div class="text-xs opacity-80">
+                            ${this.bytesLabel(metrics.storageUsedCrawls)}
+                          </div>
+                        </div>
+                      </btrix-meter-bar>
+                      <btrix-meter-bar
+                        value=${(metrics.storageUsedUploads /
+                          metrics.storageUsedBytes) *
+                        100}
+                        style="--background-color:var(--sl-color-lime-400)"
+                      >
+                        <div class="text-center">
+                          <div>${msg("Uploads")}</div>
+                          <div class="text-xs opacity-80">
+                            ${this.bytesLabel(metrics.storageUsedUploads)}
+                          </div>
+                        </div>
+                      </btrix-meter-bar>
+                      <btrix-meter-bar
+                        value=${(metrics.storageUsedProfiles /
+                          metrics.storageUsedBytes) *
+                        100}
+                        style="--background-color:var(--sl-color-fuchsia-400)"
+                      >
+                        <div class="text-center">
+                          <div>${msg("Browser Profiles")}</div>
+                          <div class="text-xs opacity-80">
+                            ${this.bytesLabel(metrics.storageUsedProfiles)}
+                          </div>
+                        </div>
+                      </btrix-meter-bar>
+                    </btrix-meter>
                   </div>
                 `,
                 () => html`
@@ -291,12 +327,21 @@ export class Dashboard extends LiteElement {
     `;
   }
 
+  private bytesLabel(n: number) {
+    return this.gbFormatter.format(n / BYTES_PER_GB);
+  }
+
   private async fetchMetrics() {
     try {
       const data = await this.apiFetch(
         `/orgs/${this.orgId}/metrics`,
         this.authState!
       );
+
+      // TODO remove after testing
+      data.storageUsedCrawls = data.storageUsedBytes * 0.25;
+      data.storageUsedUploads = data.storageUsedBytes * 0.25;
+      data.storageUsedProfiles = data.storageUsedBytes * 0.5;
 
       this.metrics = data;
     } catch (e: any) {

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -314,13 +314,16 @@ export class Dashboard extends LiteElement {
           )}
           <div slot="available" class="flex-1">
             <sl-tooltip>
-              <div slot="content" class="text-xs opacity-80">
-                ${this.renderPercentage(
-                  (metrics.storageQuotaBytes - metrics.storageUsedBytes) /
-                    metrics.storageQuotaBytes
-                )}
+              <div slot="content">
+                <div>${msg("Available")}</div>
+                <div class="text-xs opacity-80">
+                  ${this.renderPercentage(
+                    (metrics.storageQuotaBytes - metrics.storageUsedBytes) /
+                      metrics.storageQuotaBytes
+                  )}
+                </div>
               </div>
-              <div class="w-full h-full" role="none"></div>
+              <div class="w-full h-full"></div>
             </sl-tooltip>
           </div>
           <sl-format-bytes

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -99,12 +99,6 @@ export class Dashboard extends LiteElement {
               )}
               <dl>
                 ${this.renderStat({
-                  value: metrics.archivedItemCount,
-                  singleLabel: msg("Archived Item"),
-                  pluralLabel: msg("Archived Items"),
-                  iconProps: { name: "file-zip-fill" },
-                })}
-                ${this.renderStat({
                   value: metrics.crawlCount,
                   singleLabel: msg("Crawl"),
                   pluralLabel: msg("Crawls"),
@@ -127,6 +121,13 @@ export class Dashboard extends LiteElement {
                     name: "window-fullscreen",
                     color: this.colors.browserProfiles,
                   },
+                })}
+                <sl-divider></sl-divider>
+                ${this.renderStat({
+                  value: metrics.archivedItemCount,
+                  singleLabel: msg("Archived Item"),
+                  pluralLabel: msg("Archived Items"),
+                  iconProps: { name: "file-zip-fill" },
                 })}
               </dl>
             `,

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -41,6 +41,13 @@ export class Dashboard extends LiteElement {
   @state()
   private metrics?: Metrics;
 
+  private gbFormatter = Intl.NumberFormat("en", {
+    notation: "compact",
+    style: "unit",
+    unit: "gigabyte",
+    unitDisplay: "narrow",
+  });
+
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("orgId")) {
       this.fetchMetrics();
@@ -69,12 +76,41 @@ export class Dashboard extends LiteElement {
           ${this.renderCard(
             msg("Storage"),
             (metrics) => html`
-              <div class="font-semibold mb-3">
-                <sl-format-bytes
-                  value=${metrics.storageUsedBytes ?? 0}
-                ></sl-format-bytes>
-                ${msg("Used")}
-              </div>
+              ${when(
+                metrics.storageQuotaBytes,
+                () => html`
+                  <div class="font-semibold mb-1">
+                    ${msg(
+                      str`${Math.round(
+                        (metrics.storageUsedBytes / metrics.storageQuotaBytes) *
+                          100
+                      )}% used`
+                    )}
+                  </div>
+                  <div class="mb-2">
+                    <btrix-meter
+                      value=${metrics.storageUsedBytes}
+                      max=${metrics.storageQuotaBytes}
+                      high=${metrics.storageQuotaBytes}
+                      valueText=${msg("gigabyte")}
+                      valueLabel=${this.gbFormatter.format(
+                        metrics.storageUsedGB
+                      )}
+                      maxLabel=${this.gbFormatter.format(
+                        metrics.storageQuotaGB
+                      )}
+                    ></btrix-meter>
+                  </div>
+                `,
+                () => html`
+                  <div class="font-semibold mb-3">
+                    <sl-format-bytes
+                      value=${metrics.storageUsedBytes ?? 0}
+                    ></sl-format-bytes>
+                    ${msg("Used")}
+                  </div>
+                `
+              )}
               <dl>
                 ${this.renderStat({
                   value: metrics.archivedItemCount,

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -12,9 +12,10 @@ import type { SelectNewDialogEvent } from "./index";
 
 type Metrics = {
   storageUsedBytes: number;
-  storageUsedGB: number;
+  storageUsedCrawls: number;
+  storageUsedUploads: number;
+  storageUsedProfiles: number;
   storageQuotaBytes: number;
-  storageQuotaGB: number;
   archivedItemCount: number;
   crawlCount: number;
   uploadCount: number;
@@ -26,6 +27,7 @@ type Metrics = {
   collectionsCount: number;
   publicCollectionsCount: number;
 };
+const BYTES_PER_GB = 1e9;
 
 @localized()
 export class Dashboard extends LiteElement {
@@ -94,10 +96,10 @@ export class Dashboard extends LiteElement {
                       high=${metrics.storageQuotaBytes}
                       valueText=${msg("gigabyte")}
                       valueLabel=${this.gbFormatter.format(
-                        metrics.storageUsedGB
+                        metrics.storageUsedBytes / BYTES_PER_GB
                       )}
                       maxLabel=${this.gbFormatter.format(
-                        metrics.storageQuotaGB
+                        metrics.storageQuotaBytes / BYTES_PER_GB
                       )}
                     ></btrix-meter>
                   </div>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -280,7 +280,7 @@ export class Dashboard extends LiteElement {
                 class="text-danger"
                 name="exclamation-triangle"
               ></sl-icon>
-              <span>${msg("Storage Full")}</span>
+              <span>${msg("Storage is Full")}</span>
             </div>
           `,
           () => html`


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1198

<!-- Fixes #issue_number -->

### Changes

- Displays storage quota in subdivided meter
- Updates icon colors
- Adds new `<btrix-meter>` component

### Manual testing

1. Log in as superadmin
2. Go to org without quotas. Verify metrics are shown with additional "Data Stored" stat
3. Go to org with quota. Verify meter is shown with hoverable value bars for each storage category

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Dashboard - No quota | <img width="365" alt="Screenshot 2023-09-25 at 2 11 24 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/33dc1492-c657-4a25-92ff-ab107d8eed62"> |
| Dashboard - Quota reached | <img width="369" alt="Screenshot 2023-09-25 at 2 12 06 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/13952a16-95e4-4e10-a814-5e249c1d1736"> |
| Dashboard - Storage available | <img width="371" alt="Screenshot 2023-09-25 at 2 11 32 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/3c05333d-8bbd-498b-ba5e-5605d2b5ad55"> |
| Dashboard - Storage available | **Subcategory tooltip:**<br /><img width="450" alt="Screenshot 2023-09-25 at 2 02 43 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/c0f9c15c-4091-453b-b55b-87daa9733d74"><br /><br />**Subcategory tooltip w/ less than 1%:**<br /><img width="437" alt="Screenshot 2023-09-25 at 2 02 50 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/af6bd85d-6895-4bcf-88e3-ef33d724ffea"><br /><br />**Available space tooltip:**<br /><img width="444" alt="Screenshot 2023-09-25 at 2 02 54 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/0d2a255b-159e-4639-ae11-2ad49f266542"> |



<!-- ### Follow-ups -->
