### PR TITLE
Fix: Make Collections Public on Creation

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -62,23 +62,20 @@ class CollectionOps:
     async def add_collection(
         self,
         oid: uuid.UUID,
-        name: str,
-        crawl_ids: Optional[List[str]],
-        description: Optional[str] = None,
-        is_public: Optional[bool] = False,
+        coll: CollIn
     ):
         """Add new collection"""
-        crawl_ids = crawl_ids if crawl_ids else []
+        crawl_ids = coll.crawl_ids if coll.crawl_ids else []
         coll_id = uuid.uuid4()
         modified = datetime.utcnow().replace(microsecond=0, tzinfo=None)
 
         coll = Collection(
-            id=coll_id,
+            id=coll.coll_id,
             oid=oid,
-            name=name,
-            description=description,
+            name=coll.name,
+            description=coll.description,
             modified=modified,
-            isPublic=is_public,
+            isPublic=coll.is_public,
         )
         try:
             await self.collections.insert_one(coll.to_dict())
@@ -389,10 +386,7 @@ def init_collections_api(app, mdb, orgs, crawl_manager, event_webhook_ops):
     ):
         return await colls.add_collection(
             org.id,
-            new_coll.name,
-            new_coll.crawlIds,
-            new_coll.description,
-            new_coll.isPublic,
+            new_coll
         )
 
     @app.get(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -392,7 +392,7 @@ def init_collections_api(app, mdb, orgs, crawl_manager, event_webhook_ops):
             new_coll.name,
             new_coll.crawlIds,
             new_coll.description,
-            new_coll.isPublic,
+            new_coll.public,
         )
 
     @app.get(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -65,6 +65,7 @@ class CollectionOps:
         name: str,
         crawl_ids: Optional[List[str]],
         description: Optional[str] = None,
+        isPublic: Optional[bool] = False,
     ):
         """Add new collection"""
         crawl_ids = crawl_ids if crawl_ids else []
@@ -77,6 +78,7 @@ class CollectionOps:
             name=name,
             description=description,
             modified=modified,
+            isPublic=isPublic,
         )
         try:
             await self.collections.insert_one(coll.to_dict())
@@ -386,7 +388,11 @@ def init_collections_api(app, mdb, orgs, crawl_manager, event_webhook_ops):
         new_coll: CollIn, org: Organization = Depends(org_crawl_dep)
     ):
         return await colls.add_collection(
-            org.id, new_coll.name, new_coll.crawlIds, new_coll.description
+            org.id,
+            new_coll.name,
+            new_coll.crawlIds,
+            new_coll.description,
+            new_coll.isPublic,
         )
 
     @app.get(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -392,7 +392,7 @@ def init_collections_api(app, mdb, orgs, crawl_manager, event_webhook_ops):
             new_coll.name,
             new_coll.crawlIds,
             new_coll.description,
-            new_coll.public,
+            new_coll.isPublic,
         )
 
     @app.get(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -65,7 +65,7 @@ class CollectionOps:
         name: str,
         crawl_ids: Optional[List[str]],
         description: Optional[str] = None,
-        isPublic: Optional[bool] = False,
+        is_public: Optional[bool] = False,
     ):
         """Add new collection"""
         crawl_ids = crawl_ids if crawl_ids else []
@@ -78,7 +78,7 @@ class CollectionOps:
             name=name,
             description=description,
             modified=modified,
-            isPublic=isPublic,
+            isPublic=is_public,
         )
         try:
             await self.collections.insert_one(coll.to_dict())

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -506,7 +506,7 @@ class CollIn(BaseModel):
     description: Optional[str]
     crawlIds: Optional[List[str]] = []
 
-    isPublic: Optional[bool] = False
+    public: Optional[bool] = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -506,7 +506,7 @@ class CollIn(BaseModel):
     description: Optional[str]
     crawlIds: Optional[List[str]] = []
 
-    public: Optional[bool] = False
+    isPublic: Optional[bool] = False
 
 
 # ============================================================================

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -562,9 +562,15 @@ def test_filter_sort_collections(
     assert data["total"] == 3
 
     items = data["items"]
-    assert items[0]["name"] == SECOND_COLLECTION_NAME or items[0]["name"] == PUBLIC_COLLECTION_NAME
+    assert (
+        items[0]["name"] == SECOND_COLLECTION_NAME
+        or items[0]["name"] == PUBLIC_COLLECTION_NAME
+    )
     assert items[0].get("description") is None
-    assert items[1]["name"] == PUBLIC_COLLECTION_NAME or items[1]["name"] == SECOND_COLLECTION_NAME
+    assert (
+        items[1]["name"] == PUBLIC_COLLECTION_NAME
+        or items[1]["name"] == SECOND_COLLECTION_NAME
+    )
     assert items[1]["name"] != items[0]["name"]
     assert items[1].get("description") is None
     assert items[2]["name"] == UPDATED_NAME
@@ -582,9 +588,15 @@ def test_filter_sort_collections(
     items = data["items"]
     assert items[0]["name"] == UPDATED_NAME
     assert items[0]["description"] == DESCRIPTION
-    assert items[1]["name"] == SECOND_COLLECTION_NAME or items[1]["name"] == PUBLIC_COLLECTION_NAME
+    assert (
+        items[1]["name"] == SECOND_COLLECTION_NAME
+        or items[1]["name"] == PUBLIC_COLLECTION_NAME
+    )
     assert items[1].get("description") is None
-    assert items[2]["name"] == PUBLIC_COLLECTION_NAME or items[2]["name"] == SECOND_COLLECTION_NAME
+    assert (
+        items[2]["name"] == PUBLIC_COLLECTION_NAME
+        or items[2]["name"] == SECOND_COLLECTION_NAME
+    )
     assert items[1]["name"] != items[2]["name"]
     assert items[2].get("description") is None
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -8,6 +8,7 @@ from .conftest import API_PREFIX
 from .utils import read_in_chunks
 
 COLLECTION_NAME = "Test collection"
+PUBLIC_COLLECTION_NAME = "Public Test collection"
 UPDATED_NAME = "Updated tést cöllection"
 SECOND_COLLECTION_NAME = "second-collection"
 DESCRIPTION = "Test description"
@@ -46,6 +47,31 @@ def test_create_collection(
     )
     assert _coll_id in r.json()["collectionIds"]
     assert r.json()["collections"] == [{"name": COLLECTION_NAME, "id": _coll_id}]
+
+
+def test_create_public_collection(crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=crawler_auth_headers,
+        json={
+            "crawlIds": [crawler_crawl_id],
+            "name": PUBLIC_COLLECTION_NAME,
+            "isPublic": True,
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["added"]
+    assert data["name"] == PUBLIC_COLLECTION_NAME
+
+    _public_coll_id = data["id"]
+
+    # Verify that it is public
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.json()["isPubilc"] == True
 
 
 def test_create_collection_taken_name(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1,3 +1,4 @@
+from pickle import PickleBuffer
 import requests
 import os
 
@@ -49,7 +50,9 @@ def test_create_collection(
     assert r.json()["collections"] == [{"name": COLLECTION_NAME, "id": _coll_id}]
 
 
-def test_create_public_collection(crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id):
+def test_create_public_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=crawler_auth_headers,
@@ -411,10 +414,10 @@ def test_list_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
-    assert len(items) == 2
+    assert len(items) == 3
 
     first_coll = [coll for coll in items if coll["name"] == UPDATED_NAME][0]
     assert first_coll["id"]
@@ -529,11 +532,12 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
-    assert items[0]["name"] == SECOND_COLLECTION_NAME
-    assert items[1]["name"] == UPDATED_NAME
+    assert items[0]["name"] == PUBLIC_COLLECTION_NAME
+    assert items[1]["name"] == SECOND_COLLECTION_NAME
+    assert items[2]["name"] == UPDATED_NAME
 
     # Test sorting by name, descending
     r = requests.get(
@@ -542,11 +546,12 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
     assert items[0]["name"] == UPDATED_NAME
     assert items[1]["name"] == SECOND_COLLECTION_NAME
+    assert items[2]["name"] == PUBLIC_COLLECTION_NAME
 
     # Test sorting by description, ascending (default)
     r = requests.get(
@@ -555,13 +560,16 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
-    assert items[0]["name"] == SECOND_COLLECTION_NAME
+    assert items[0]["name"] == SECOND_COLLECTION_NAME or items[0]["name"] == PUBLIC_COLLECTION_NAME
     assert items[0].get("description") is None
-    assert items[1]["name"] == UPDATED_NAME
-    assert items[1]["description"] == DESCRIPTION
+    assert items[1]["name"] == PUBLIC_COLLECTION_NAME or items[1]["name"] == SECOND_COLLECTION_NAME
+    assert items[1]["name"] != items[0]["name"]
+    assert items[1].get("description") is None
+    assert items[2]["name"] == UPDATED_NAME
+    assert items[2]["description"] == DESCRIPTION
 
     # Test sorting by description, descending
     r = requests.get(
@@ -570,13 +578,16 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
     assert items[0]["name"] == UPDATED_NAME
     assert items[0]["description"] == DESCRIPTION
-    assert items[1]["name"] == SECOND_COLLECTION_NAME
+    assert items[1]["name"] == SECOND_COLLECTION_NAME or items[1]["name"] == PUBLIC_COLLECTION_NAME
     assert items[1].get("description") is None
+    assert items[2]["name"] == PUBLIC_COLLECTION_NAME or items[2]["name"] == SECOND_COLLECTION_NAME
+    assert items[1]["name"] != items[2]["name"]
+    assert items[2].get("description") is None
 
     # Test sorting by modified, ascending
     r = requests.get(
@@ -585,7 +596,7 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
     assert items[0]["modified"] <= items[1]["modified"]
@@ -597,7 +608,7 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
     assert items[0]["modified"] >= items[1]["modified"]
@@ -609,7 +620,7 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
     assert items[0]["totalSize"] <= items[1]["totalSize"]
@@ -621,7 +632,7 @@ def test_filter_sort_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
 
     items = data["items"]
     assert items[0]["totalSize"] >= items[1]["totalSize"]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -71,7 +71,7 @@ def test_create_public_collection(crawler_auth_headers, default_org_id, crawler_
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
         headers=crawler_auth_headers,
     )
-    assert r.json()["isPubilc"] == True
+    assert r.json()["isPublic"]
 
 
 def test_create_collection_taken_name(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1,4 +1,3 @@
-from pickle import PickleBuffer
 import requests
 import os
 

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -68,7 +68,7 @@ export class CollectionsNew extends LiteElement {
             name,
             description,
             crawlIds,
-            isPublic: isPublic,
+            isPublic,
           }),
         }
       );

--- a/frontend/src/pages/org/collections-new.ts
+++ b/frontend/src/pages/org/collections-new.ts
@@ -68,7 +68,7 @@ export class CollectionsNew extends LiteElement {
             name,
             description,
             crawlIds,
-            public: isPublic,
+            isPublic: isPublic,
           }),
         }
       );


### PR DESCRIPTION
Resolves #1212 

- fix: #1212 Add isPublic to Add Collection endpoint
- fix: frontend sends `public` not `isPublic`

The model was previously wrong, so I updated it, but I get the sense that the frontend should actually use `isPublic` instead of `public`. For example, the PATCH endpoint currently does ensure that a collection will be public if set so through the use of the `isPublic` variable on the request.

Tested locally and creation leads to a new publically accessible collection. 
