### PR TITLE
Compute execution time in operator

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --k3s-arg "--disable=traefik --disable=servicelb"
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -68,11 +68,6 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 3.10.2
-
-      - name: Install Additional Helm Dependencies
-        run: |
-          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-          helm upgrade --install metrics-server metrics-server/metrics-server
 
       - name: Start Cluster with Helm
         run: |

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--disable=traefik@server:* --disable=servicelb@server:*"
+            --k3s-arg "--disable=traefik,servicelb@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -69,6 +69,11 @@ jobs:
         with:
           version: 3.10.2
 
+      - name: Install Additional Helm Dependencies
+        run: |
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm upgrade --install metrics-server metrics-server/metrics-server
+
       - name: Start Cluster with Helm
         run: |
           helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml btrix ./chart/

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--disable=traefik --disable=servicelb"
+            --k3s-arg "--disable=traefik@server:* --disable=servicelb@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -60,6 +60,11 @@ jobs:
         with:
           version: 3.10.2
 
+      - name: Install Additional Helm Dependencies
+        run: |
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm upgrade --install metrics-server metrics-server/metrics-server
+
       - name: Start Cluster with Helm
         run: |
           helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml --set invite_expire_seconds=10 --set max_pages_per_crawl=10 btrix ./chart/

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -17,7 +17,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --k3s-arg "--disable=traefik,servicelb@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,11 +59,6 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 3.10.2
-
-      - name: Install Additional Helm Dependencies
-        run: |
-          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-          helm upgrade --install metrics-server metrics-server/metrics-server
 
       - name: Start Cluster with Helm
         run: |

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -2,8 +2,8 @@ name: Cluster Run (MicroK8s)
 
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
     paths:
       - 'backend/**'
       - 'chart/**'

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -2,8 +2,8 @@ name: Cluster Run (MicroK8s)
 
 on:
   push:
-    branches:
-      - main
+    #branches:
+    #  - main
     paths:
       - 'backend/**'
       - 'chart/**'

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -340,7 +340,7 @@ class BaseCrawlOps:
         if crawl.state in RUNNING_STATES:
             try:
                 async with self.get_redis(crawl.id) as redis:
-                    crawl.stats = await get_redis_crawl_stats(redis, crawl.id)
+                    crawl.stats, _ = await get_redis_crawl_stats(redis, crawl.id)
             # redis not available, ignore
             except exceptions.ConnectionError:
                 pass

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -799,6 +799,15 @@ class CrawlConfigOps:
         except Exception:
             return [], 0
 
+    async def add_execution_seconds(self, cid: uuid.UUID, execution_seconds: int):
+        """add crawl execution seconds to workflow"""
+        await self.crawl_configs.find_one_and_update(
+            {"_id": cid},
+            {
+                "$inc": {"executionSeconds": execution_seconds},
+            },
+        )
+
 
 # ============================================================================
 # pylint: disable=too-many-locals

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -799,7 +799,7 @@ class CrawlConfigOps:
         except Exception:
             return [], 0
 
-    async def add_execution_seconds(self, cid: uuid.UUID, execution_seconds: int):
+    async def inc_execution_seconds(self, cid: uuid.UUID, execution_seconds: int):
         """add crawl execution seconds to workflow"""
         await self.crawl_configs.find_one_and_update(
             {"_id": cid},

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -565,14 +565,14 @@ class CrawlOps(BaseCrawlOps):
         except Exception:
             return [], 0
 
-    async def add_execution_seconds(
+    async def inc_execution_seconds(
         self, crawl_id: str, oid: uuid.UUID, execution_seconds: int
     ):
         """add execution seconds to crawl, workflow, and org"""
         await self.crawls.find_one_and_update(
             {"_id": crawl_id},
             {
-                "$set": {"executionSeconds": execution_seconds},
+                "$inc": {"executionSeconds": execution_seconds},
             },
         )
         crawl = await self.get_crawl_raw(crawl_id)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -572,12 +572,12 @@ class CrawlOps(BaseCrawlOps):
         await self.crawls.find_one_and_update(
             {"_id": crawl_id},
             {
-                "$inc": {"executionSeconds": execution_seconds},
+                "$set": {"executionSeconds": execution_seconds},
             },
         )
         crawl = await self.get_crawl_raw(crawl_id)
-        await self.crawl_configs.add_execution_seconds(crawl["cid"], execution_seconds)
-        await self.orgs.add_execution_seconds(oid, execution_seconds)
+        await self.crawl_configs.inc_execution_seconds(crawl["cid"], execution_seconds)
+        await self.orgs.inc_execution_seconds(oid, execution_seconds)
 
 
 # ============================================================================

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -565,6 +565,20 @@ class CrawlOps(BaseCrawlOps):
         except Exception:
             return [], 0
 
+    async def add_execution_seconds(
+        self, crawl_id: str, oid: uuid.UUID, execution_seconds: int
+    ):
+        """add execution seconds to crawl, workflow, and org"""
+        await self.crawls.find_one_and_update(
+            {"_id": crawl_id},
+            {
+                "$inc": {"executionSeconds": execution_seconds},
+            },
+        )
+        crawl = await self.get_crawl_raw(crawl_id)
+        await self.crawl_configs.add_execution_seconds(crawl["cid"], execution_seconds)
+        await self.orgs.add_execution_seconds(oid, execution_seconds)
+
 
 # ============================================================================
 async def recompute_crawl_file_count_and_size(crawls, crawl_id):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -516,6 +516,11 @@ class CrawlOps(BaseCrawlOps):
 
         return await self.crawls.find_one_and_update(query, {"$set": kwargs})
 
+    async def update_running_crawl_stats(self, crawl_id, stats):
+        """update running crawl stats"""
+        query = {"_id": crawl_id, "type": "crawl", "state": "running"}
+        return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
+
     async def get_crawl_state(self, crawl_id):
         """return current crawl state of a crawl"""
         res = await self.crawls.find_one(

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -233,3 +233,22 @@ class K8sAPI:
             # pylint: disable=bare-except
             except:
                 print("Logs Not Found")
+
+    async def is_pod_metrics_available(self):
+        """return true/false if metrics server api is available by
+        attempting list operation. if operation succeeds, then
+        metrics are available, otherwise not available
+        """
+        try:
+            await self.custom_api.list_namespaced_custom_object(
+                group="metrics.k8s.io",
+                version="v1beta1",
+                namespace=self.namespace,
+                plural="pods",
+                limit=1,
+            )
+            return True
+        # pylint: disable=broad-exception-caught
+        except Exception as exc:
+            print(exc)
+            return False

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -75,7 +75,7 @@ def main():
         event_webhook_ops,
     )
 
-    init_operator_api(
+    return init_operator_api(
         app_root, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
     )
 
@@ -85,4 +85,5 @@ def main():
 async def startup():
     """init on startup"""
     register_exit_handler()
-    main()
+    oper = main()
+    await oper.async_init()

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -177,6 +177,8 @@ class CrawlConfigCore(BaseMongoModel):
 
     profileid: Optional[UUID4]
 
+    executionSeconds: int = 0
+
 
 # ============================================================================
 class CrawlConfigAdditional(BaseModel):
@@ -385,6 +387,8 @@ class CrawlOut(BaseMongoModel):
     cid_rev: Optional[int]
 
     storageQuotaReached: Optional[bool]
+
+    executionSeconds: int = 0
 
 
 # ============================================================================
@@ -667,6 +671,8 @@ class Organization(BaseMongoModel):
 
     usage: Dict[str, int] = {}
 
+    executionSeconds: Dict[str, int] = {}
+
     bytesStored: int = 0
     bytesStoredCrawls: int = 0
     bytesStoredUploads: int = 0
@@ -714,6 +720,9 @@ class Organization(BaseMongoModel):
         if not self.is_crawler(user):
             exclude.add("usage")
 
+        if not self.is_crawler(user):
+            exclude.add("executionSeconds")
+
         result = self.to_dict(
             exclude_unset=True,
             exclude_none=True,
@@ -747,6 +756,7 @@ class OrgOut(BaseMongoModel):
     name: str
     users: Optional[Dict[str, Any]]
     usage: Optional[Dict[str, int]]
+    executionSeconds: Optional[Dict[str, int]]
     default: bool = False
     bytesStored: int
     bytesStoredCrawls: int

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1001,6 +1001,8 @@ class BtrixOperator(K8sAPI):
         status.size = stats["size"]
         status.sizeHuman = humanize.naturalsize(status.size)
 
+        await self.crawl_ops.update_running_crawl_stats(crawl.id, stats)
+
         for key, value in sizes.items():
             value = int(value)
             if value > 0:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1189,19 +1189,19 @@ class BtrixOperator(K8sAPI):
                 start_times = await redis.lrange(f"{crawl_id}:start:{name}", 0, -1)
                 end_times = await redis.lrange(f"{crawl_id}:end:{name}", 0, -1)
 
-                # Add current time as last end time if it was never set
-                if len(end_times) - len(start_times) == 1:
-                    end_times.append(datetime.strftime(datetime.now(), DATETIME_FORMAT))
+                for time_idx, start_time_str in enumerate(start_times):
+                    start_time = datetime.strptime(start_time_str, DATETIME_FORMAT)
 
-                if len(start_times) != len(end_times):
-                    # TODO: Handle this exception state
-                    print(
-                        "Warning: Start and end times array lengths differ", flush=True
-                    )
-
-                for time_idx, start_time in enumerate(start_times):
-                    start_time = datetime.strptime(start_time, DATETIME_FORMAT)
-                    end_time = datetime.strptime(end_times[time_idx], DATETIME_FORMAT)
+                    try:
+                        end_time = datetime.strptime(
+                            end_times[time_idx], DATETIME_FORMAT
+                        )
+                    except IndexError:
+                        print(
+                            f"Start time {start_time_str} has no corresponding end time, using current time",
+                            flush=True,
+                        )
+                        end_time = datetime.now()
 
                     duration = end_time - start_time
                     seconds = duration.total_seconds()

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1140,7 +1140,7 @@ class BtrixOperator(K8sAPI):
 
         asyncio.create_task(
             self.do_crawl_finished_tasks(
-                crawl_id, cid, oid, status.filesAddedSize, state
+                crawl_id, cid, oid, status.filesAddedSize, state, crawl
             )
         )
 
@@ -1148,10 +1148,10 @@ class BtrixOperator(K8sAPI):
 
     # pylint: disable=too-many-arguments
     async def do_crawl_finished_tasks(
-        self, crawl_id, cid, oid, files_added_size, state
+        self, crawl_id, cid, oid, files_added_size, state, crawl
     ):
         """Run tasks after crawl completes in asyncio.task coroutine."""
-        await self.compute_execution_time(crawl_id, oid)
+        await self.compute_execution_time(crawl_id, oid, crawl)
 
         await self.crawl_config_ops.stats_recompute_last(cid, files_added_size, 1)
 
@@ -1167,7 +1167,7 @@ class BtrixOperator(K8sAPI):
         # finally, delete job
         await self.delete_crawl_job(crawl_id)
 
-    async def compute_execution_time(self, crawl_id, oid):
+    async def compute_execution_time(self, crawl_id, oid, crawl=None):
         """Compute execution time for crawl from start and end times in redis"""
         # pylint: disable=invalid-name
         DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -995,6 +995,9 @@ class BtrixOperator(K8sAPI):
         results = await redis.hgetall(f"{crawl.id}:status")
         stats, sizes = await get_redis_crawl_stats(redis, crawl.id)
 
+        # need to add size of previously completed WACZ files as well!
+        stats["size"] += status.filesAddedSize
+
         # update status
         status.pagesDone = stats["done"]
         status.pagesFound = stats["found"]

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1242,9 +1242,7 @@ class BtrixOperator(K8sAPI):
                     # Round up to nearest int
                     execution_secs += math.ceil(seconds)
 
-            print(
-                f"Adding {executation_secs} total execution seconds to db", flush=True
-            )
+            print(f"Adding {execution_secs} total execution seconds to db", flush=True)
             await self.crawl_ops.add_execution_seconds(crawl_id, oid, execution_secs)
 
         # pylint: disable=broad-exception-caught

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -40,8 +40,12 @@ from .models import CrawlFile, CrawlCompleteIn
 CMAP = "ConfigMap.v1"
 PVC = "PersistentVolumeClaim.v1"
 POD = "Pod.v1"
-CJS = "CrawlJob.btrix.cloud/v1"
-METRICS = "PodMetrics.metrics.k8s.io/v1beta1"
+
+BTRIX_API = "btrix.cloud/v1"
+CJS = f"CrawlJob.{BTRIX_API}"
+
+METRICS_API = "metrics.k8s.io/v1beta1"
+METRICS = f"PodMetrics.{METRICS_API}"
 
 DEFAULT_TTL = 30
 
@@ -590,13 +594,13 @@ class BtrixOperator(K8sAPI):
                     "labelSelector": {"matchLabels": {"btrix.crawlconfig": cid}},
                 },
                 {
-                    "apiVersion": "btrix.cloud/v1",
+                    "apiVersion": BTRIX_API,
                     "resource": "crawljobs",
                     "labelSelector": {"matchLabels": {"oid": oid}},
                 },
                 # enable for podmetrics
                 {
-                    "apiVersion": "metrics.k8s.io/v1beta1",
+                    "apiVersion": METRICS_API,
                     "resource": "pods",
                     "labelSelector": {"matchLabels": {"crawl": crawl_id}},
                 },

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1111,8 +1111,6 @@ class BtrixOperator(K8sAPI):
         if crawl and state in SUCCESSFUL_STATES:
             await self.inc_crawl_complete_stats(crawl, finished)
 
-        await self.compute_execution_time(crawl_id, oid, crawl)
-
         asyncio.create_task(
             self.do_crawl_finished_tasks(
                 crawl_id, cid, oid, status.filesAddedSize, state
@@ -1126,6 +1124,8 @@ class BtrixOperator(K8sAPI):
         self, crawl_id, cid, oid, files_added_size, state
     ):
         """Run tasks after crawl completes in asyncio.task coroutine."""
+        await self.compute_execution_time(crawl_id, oid, crawl)
+
         await self.crawl_config_ops.stats_recompute_last(cid, files_added_size, 1)
 
         if state in SUCCESSFUL_STATES and oid:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -894,7 +894,8 @@ class BtrixOperator(K8sAPI):
                         crash_time = terminated.get("finishedAt")
                         pod_status = status.podStatus[name]
                         pod_status.isNewCrash = pod_status.crashTime != crash_time
-                        pod_status.restartCount += 1
+                        if pod_status.isNewCrash:
+                            pod_status.restartCount += 1
                         print(
                             f"pod {name} isNewCrash: {pod_status.isNewCrash}",
                             flush=True,
@@ -1254,7 +1255,7 @@ class BtrixOperator(K8sAPI):
                 f"Adding {execution_secs} (rounded up from {execution_time}) total execution seconds to db",
                 flush=True,
             )
-            await self.crawl_ops.add_execution_seconds(crawl_id, oid, execution_secs)
+            await self.crawl_ops.inc_execution_seconds(crawl_id, oid, execution_secs)
 
         # pylint: disable=broad-exception-caught
         except Exception as err:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1199,7 +1199,11 @@ class BtrixOperator(K8sAPI):
                 start_times = await redis.lrange(f"{crawl_id}:start:{name}", 0, -1)
                 end_times = await redis.lrange(f"{crawl_id}:end:{name}", 0, -1)
 
-                if not len(start_times) == len(end_times):
+                # Add current time as last end time if it was never set
+                if len(end_times) - len(start_times) == 1:
+                    end_times.append(datetime.strftime(datetime.now(), DATETIME_FORMAT))
+
+                if len(start_times) != len(end_times):
                     # TODO: Handle this exception state
                     print(
                         f"Warning: Start and end times array lengths differ", flush=True

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -391,6 +391,13 @@ class OrgOps:
             "publicCollectionsCount": public_collections_count,
         }
 
+    async def add_execution_seconds(self, oid: uuid.UUID, execution_seconds: int):
+        """add execution seconds to org, tracked by month"""
+        yymm = datetime.utcnow().strftime("%Y-%m")
+        await self.orgs.find_one_and_update(
+            {"_id": oid}, {"$inc": {f"executionSeconds.{yymm}": execution_seconds}}
+        )
+
 
 # ============================================================================
 # pylint: disable=too-many-statements

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -391,7 +391,7 @@ class OrgOps:
             "publicCollectionsCount": public_collections_count,
         }
 
-    async def add_execution_seconds(self, oid: uuid.UUID, execution_seconds: int):
+    async def inc_execution_seconds(self, oid: uuid.UUID, execution_seconds: int):
         """add execution seconds to org, tracked by month"""
         yymm = datetime.utcnow().strftime("%Y-%m")
         await self.orgs.find_one_and_update(

--- a/backend/btrixcloud/templates/crawler.yaml
+++ b/backend/btrixcloud/templates/crawler.yaml
@@ -28,7 +28,7 @@ spec:
 # -------
 # CRAWLER
 # -------
-{% if not force_restart %}
+{% if not do_restart %}
 ---
 apiVersion: v1
 kind: Pod
@@ -151,11 +151,11 @@ spec:
 
       resources:
         limits:
-          memory: "{{ crawler_memory }}"
+          memory: "{{ memory }}"
 
         requests:
-          cpu: "{{ crawler_cpu }}"
-          memory: "{{ crawler_memory }}"
+          cpu: "{{ cpu }}"
+          memory: "{{ memory }}"
 
       {% if crawler_liveness_port and crawler_liveness_port != '0' %}
       livenessProbe:

--- a/backend/btrixcloud/templates/redis.yaml
+++ b/backend/btrixcloud/templates/redis.yaml
@@ -26,7 +26,7 @@ spec:
 # --------
 # REDIS
 # --------
-{% if init_redis and not do_restart %}
+{% if init_redis %}
 ---
 apiVersion: v1
 kind: Pod

--- a/backend/btrixcloud/templates/redis.yaml
+++ b/backend/btrixcloud/templates/redis.yaml
@@ -26,7 +26,7 @@ spec:
 # --------
 # REDIS
 # --------
-{% if init_redis %}
+{% if init_redis and not do_restart %}
 ---
 apiVersion: v1
 kind: Pod
@@ -103,11 +103,11 @@ spec:
 
       resources:
         limits:
-          memory: {{ redis_memory }}
+          memory: {{ memory }}
 
         requests:
-          cpu: {{ redis_cpu }}
-          memory: {{ redis_memory }}
+          cpu: {{ cpu }}
+          memory: {{ memory }}
 
       readinessProbe:
         initialDelaySeconds: 10

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -28,6 +28,17 @@ def to_k8s_date(dt_val):
     return dt_val.isoformat("T") + "Z"
 
 
+def from_timestamp_str(string):
+    """convert iso date string with or without milliseconds to datetime"""
+    DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+    DATETIME_FORMAT_NO_MS = "%Y-%m-%dT%H:%M:%SZ"
+    for dt_format in (DATETIME_FORMAT, DATETIME_FORMAT_NO_MS):
+        try:
+            return datetime.strptime(string, dt_format)
+        except ValueError:
+            pass
+
+
 def dt_now():
     """get current ts"""
     return datetime.utcnow().replace(microsecond=0, tzinfo=None)

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -48,11 +48,11 @@ async def get_redis_crawl_stats(redis, crawl_id):
         pages_done = await redis.llen(f"{crawl_id}:d")
 
     pages_found = await redis.scard(f"{crawl_id}:s")
-    archive_size = await redis.hvals(f"{crawl_id}:size")
-    archive_size = sum(int(x) for x in archive_size)
+    sizes = await redis.hgetall(f"{crawl_id}:size")
+    archive_size = sum(int(x) for x in sizes.values())
 
     stats = {"found": pages_found, "done": pages_done, "size": archive_size}
-    return stats
+    return stats, sizes
 
 
 def run_once_lock(name):

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -9,7 +9,6 @@ import signal
 import atexit
 
 from datetime import datetime
-from typing import Optional
 
 from redis import asyncio as exceptions
 
@@ -29,7 +28,7 @@ def to_k8s_date(dt_val):
     return dt_val.isoformat("T") + "Z"
 
 
-def from_timestamp_str(string):
+def from_timestamp_str(string) -> Optional[datetime]:
     """convert iso date string with or without milliseconds to datetime"""
     dt_instance: Optional[datetime] = None
     datetime_format = "%Y-%m-%dT%H:%M:%S.%fZ"

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -9,6 +9,7 @@ import signal
 import atexit
 
 from datetime import datetime
+from typing import Optional
 
 from redis import asyncio as exceptions
 
@@ -30,16 +31,16 @@ def to_k8s_date(dt_val):
 
 def from_timestamp_str(string):
     """convert iso date string with or without milliseconds to datetime"""
-    dt: Optional[datetime] = None
+    dt_instance: Optional[datetime] = None
     datetime_format = "%Y-%m-%dT%H:%M:%S.%fZ"
     datetime_format_no_ms = "%Y-%m-%dT%H:%M:%SZ"
     for dt_format in (datetime_format, datetime_format_no_ms):
         try:
-            dt = datetime.strptime(string, dt_format)
+            dt_instance = datetime.strptime(string, dt_format)
             break
         except ValueError:
             pass
-    return dt
+    return dt_instance
 
 
 def dt_now():

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -30,13 +30,16 @@ def to_k8s_date(dt_val):
 
 def from_timestamp_str(string):
     """convert iso date string with or without milliseconds to datetime"""
-    DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-    DATETIME_FORMAT_NO_MS = "%Y-%m-%dT%H:%M:%SZ"
-    for dt_format in (DATETIME_FORMAT, DATETIME_FORMAT_NO_MS):
+    dt: Optional[datetime] = None
+    datetime_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+    datetime_format_no_ms = "%Y-%m-%dT%H:%M:%SZ"
+    for dt_format in (datetime_format, datetime_format_no_ms):
         try:
-            return datetime.strptime(string, dt_format)
+            dt = datetime.strptime(string, dt_format)
+            break
         except ValueError:
             pass
+    return dt
 
 
 def dt_now():

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -53,7 +53,7 @@ metadata:
 
 data:
   CRAWL_ARGS: >-
-    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --userAgentSuffix {{ .Values.user_agent_suffix | quote }} --userAgent {{ .Values.user_agent | quote }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis {{ .Values.crawler_extra_args }} --restartsOnError
+    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --userAgentSuffix {{ .Values.user_agent_suffix | quote }} --userAgent {{ .Values.user_agent | quote }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --restartsOnError --headless {{ .Values.crawler_extra_args }}
 
 ---
 apiVersion: v1

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -17,17 +17,9 @@ rules:
   resources: ["crawljobs", "profilejobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: cronjob-manage
-rules:
-- apiGroups: ["batch"]
-  resources: ["cronjobs"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
-
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["list"]
 
 ---
 kind: RoleBinding
@@ -48,24 +40,3 @@ roleRef:
   kind: Role
   name: crawler-run
   apiGroup: rbac.authorization.k8s.io
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cronjob-role
-  namespace: {{ .Release.Namespace }}
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: {{ .Release.Namespace }}
-
-- kind: User
-  name: system:anonymous
-  namespace: {{ .Release.Namespace }}
-
-roleRef:
-  kind: Role
-  name: cronjob-manage
-  apiGroup: rbac.authorization.k8s.io
-

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -206,9 +206,9 @@ crawler_browser_instances: 2
 
 # this value is added to crawler_cpu_base, for each additional browser
 # crawler_cpu = crawler_cpu_base + crawler_pu_per_extra_browser * (crawler_browser_instances - 1)
-crawler_extra_cpu_per_browser: 300m
+crawler_extra_cpu_per_browser: 600m
 
-crawler_extra_memory_per_browser: 256Mi
+crawler_extra_memory_per_browser: 768Mi
 
 # if not set, defaults to the following, but can be overridden directly:
 # crawler_cpu = crawler_cpu_base + crawler_cpu_per_extra_browser * (crawler_browser_instances - 1)


### PR DESCRIPTION
Fixes #1176 

For successful crawl, get number of execution seconds and add to crawl (set value), workflow (cumulative of all crawls in workflow), and org (by month, similar to usage).

Execution times are stored in seconds so that we can convert to minutes on an as-needed basis as accurately as possible.

In case of a crawler crash or restart, capture the restart time in the operator and set an end time in Redis for the affected crawler pod if needed (a check is built-in to account for if the crawler has set a new start time since the restart).

Still testing, so kept as draft for now.

Requires crawler changes from: https://github.com/webrecorder/browsertrix-crawler/pull/397