### PR TITLE
improvements to redis pod:

### DIFF
--- a/backend/btrixcloud/templates/redis.yaml
+++ b/backend/btrixcloud/templates/redis.yaml
@@ -110,8 +110,21 @@ spec:
           memory: {{ redis_memory }}
 
       readinessProbe:
+        initialDelaySeconds: 10
+        timeoutSeconds: 5
         exec:
           command:
-            - redis-cli
-            - ping
+            - bash
+            - -c
+            - "res=$(redis-cli ping); [[ $res = 'PONG' ]]"
+
+      livenessProbe:
+        initialDelaySeconds: 10
+        timeoutSeconds: 5
+        exec:
+          command:
+            - bash
+            - -c
+            - "res=$(redis-cli ping); [[ $res = 'PONG' ]]"
+
 {% endif %}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -169,9 +169,9 @@ redis_pull_policy: "IfNotPresent"
 
 redis_url: "redis://local-redis.default:6379/1"
 
-redis_cpu: "5m"
+redis_cpu: "10m"
 
-redis_memory: "48Mi"
+redis_memory: "200Mi"
 
 redis_storage: "3Gi"
 


### PR DESCRIPTION
- add liveness check/fix readiness check - ensure 'redis-cli ping' actually returns 'PONG', as exit code is 0 even if errors will detect situations where redis is not available, such as due to to max clients being reached
- bump redis memory/cpu for now (until autoscaling/automatic adjustment is available)