### PR TITLE
Recalculate Organization.storedBytes in migration 0017

### DIFF
--- a/backend/btrixcloud/migrations/migration_0017_storage_by_type.py
+++ b/backend/btrixcloud/migrations/migration_0017_storage_by_type.py
@@ -54,11 +54,16 @@ class Migration(BaseMigration):
                 if profile_file:
                     bytes_stored_profiles += profile_file.get("size", 0)
 
+            org_total_bytes = (
+                bytes_stored_crawls + bytes_stored_uploads + bytes_stored_profiles
+            )
+
             try:
                 res = await mdb_orgs.find_one_and_update(
                     {"_id": oid},
                     {
                         "$set": {
+                            "bytesStored": org_total_bytes,
                             "bytesStoredCrawls": bytes_stored_crawls,
                             "bytesStoredUploads": bytes_stored_uploads,
                             "bytesStoredProfiles": bytes_stored_profiles,


### PR DESCRIPTION
On dev in the default organization, the `Organization.bytesStored` total was lower than it should be. This is likely due to how we use the dev server to test out unmerged branches, but in the interest of being careful we may as well have migration 0017 (re)set the org total based on the actual storage totals of crawl files, upload files, and profile browser files.