### PR TITLE
Show running workflow error logs

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -520,7 +520,7 @@ class CrawlOps(BaseCrawlOps):
                 total = await redis.llen(f"{crawl_id}:e")
             except exceptions.ConnectionError:
                 # pylint: disable=raise-missing-from
-                raise HTTPException(status_code=503, detail="redis_connection_error")
+                raise HTTPException(status_code=503, detail="error_logs_not_available")
 
         parsed_errors = parse_jsonl_error_messages(errors)
         return parsed_errors, total

--- a/frontend/src/components/crawl-logs.ts
+++ b/frontend/src/components/crawl-logs.ts
@@ -84,6 +84,9 @@ export class CrawlLogs extends LitElement {
   @property({ type: Object })
   logs?: APIPaginatedList;
 
+  @property({ type: Boolean })
+  paginate = false;
+
   @state()
   private selectedLog:
     | (CrawlLog & {
@@ -145,14 +148,17 @@ export class CrawlLogs extends LitElement {
           `;
         })}
       </btrix-numbered-list>
-      <footer>
-        <btrix-pagination
-          page=${this.logs.page}
-          totalCount=${this.logs.total}
-          size=${this.logs.pageSize}
-        >
-        </btrix-pagination>
-      </footer>
+      ${this.paginate
+        ? html`<footer>
+            <btrix-pagination
+              page=${this.logs.page}
+              totalCount=${this.logs.total}
+              size=${this.logs.pageSize}
+            >
+            </btrix-pagination>
+          </footer>`
+        : ""}
+
       <btrix-dialog
         label=${msg("Log Details")}
         ?open=${this.selectedLog}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -816,6 +816,7 @@ ${this.crawl?.description}
             ? html`
                 <btrix-crawl-logs
                   .logs=${this.logs}
+                  paginate
                   @page-change=${async (e: PageChangeEvent) => {
                     await this.fetchCrawlLogs({
                       page: e.detail.page,

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -917,7 +917,7 @@ ${this.crawl?.description}
       return;
     }
     try {
-      this.logs = await this.getCrawlLogs(params);
+      this.logs = await this.getCrawlErrors(params);
     } catch {
       this.notify({
         message: msg("Sorry, couldn't retrieve crawl logs at this time."),
@@ -927,7 +927,7 @@ ${this.crawl?.description}
     }
   }
 
-  private async getCrawlLogs(
+  private async getCrawlErrors(
     params: Partial<APIPaginatedList>
   ): Promise<APIPaginatedList> {
     const page = params.page || this.logs?.page || 1;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -924,7 +924,7 @@ export class WorkflowDetail extends LiteElement {
 
       case "waiting_capacity":
         waitingMsg = msg(
-          "Crawl waiting for available resources before it can start..."
+          "Crawl waiting for available resources before it can continue..."
         );
         break;
 
@@ -1053,7 +1053,7 @@ export class WorkflowDetail extends LiteElement {
           () => html`<div class="mb-4">
             <btrix-alert variant="success" class="text-sm">
               ${msg(
-                html`Viewing logs for currently running crawl.
+                html`Viewing error logs for currently running crawl.
                   <a
                     href="${`${window.location.pathname}#watch`}"
                     class="underline hover:no-underline"
@@ -1082,7 +1082,9 @@ export class WorkflowDetail extends LiteElement {
                     class="border rounded-lg p-4 flex flex-col items-center justify-center"
                   >
                     <p class="text-center text-neutral-400">
-                      ${msg("No logs found for latest crawl.")}
+                      ${this.workflow?.lastCrawlState === "waiting_capacity"
+                        ? msg("Error logs currently not available.")
+                        : msg("No error logs found yet for latest crawl.")}
                     </p>
                   </div>
                 `,
@@ -1641,12 +1643,12 @@ export class WorkflowDetail extends LiteElement {
       this.logs = await this.getCrawlErrors(params);
     } catch (e: any) {
       if (e.isApiError && e.statusCode === 503) {
-        // TODO check for more specific error following
-        // https://github.com/webrecorder/browsertrix-cloud/issues/1238
-        console.info(e.message);
+        // do nothing, keep logs if previously loaded
       } else {
         this.notify({
-          message: msg("Sorry, couldn't retrieve crawl logs at this time."),
+          message: msg(
+            "Sorry, couldn't retrieve crawl error logs at this time."
+          ),
           variant: "danger",
           icon: "exclamation-octagon",
         });

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1666,12 +1666,18 @@ export class WorkflowDetail extends LiteElement {
   ): Promise<void> {
     try {
       this.logs = await this.getCrawlErrors(params);
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't retrieve crawl logs at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
+    } catch (e: any) {
+      if (e.isApiError && e.statusCode === 503) {
+        // TODO check for more specific error following
+        // https://github.com/webrecorder/browsertrix-cloud/issues/1238
+        console.info(e.message);
+      } else {
+        this.notify({
+          message: msg("Sorry, couldn't retrieve crawl logs at this time."),
+          variant: "danger",
+          icon: "exclamation-octagon",
+        });
+      }
     }
   }
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -466,14 +466,16 @@ export class WorkflowDetail extends LiteElement {
     if (this.activePanel === "logs") {
       const authToken = this.authState!.headers.Authorization.split(" ")[1];
       const isDownloadEnabled = Boolean(
-        this.logs && this.workflow?.lastCrawlId && !this.workflow.isCrawlRunning
+        this.logs?.total &&
+          this.workflow?.lastCrawlId &&
+          !this.workflow.isCrawlRunning
       );
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
         <sl-tooltip
           content=${msg(
             "Downloading will be enabled when this crawl is finished."
           )}
-          ?disabled=${isDownloadEnabled}
+          ?disabled=${!this.workflow?.isCrawlRunning}
         >
           <sl-button
             href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
@@ -1080,7 +1082,7 @@ export class WorkflowDetail extends LiteElement {
                     class="border rounded-lg p-4 flex flex-col items-center justify-center"
                   >
                     <p class="text-center text-neutral-400">
-                      ${msg("No logs found.")}
+                      ${msg("No logs found for latest crawl.")}
                     </p>
                   </div>
                 `,

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -131,7 +131,7 @@ export class WorkflowDetail extends LiteElement {
   private readonly tabLabels: Record<Tab, string> = {
     crawls: msg("Crawls"),
     watch: msg("Watch Crawl"),
-    logs: msg("Logs"),
+    logs: msg("Error Logs"),
     settings: msg("Workflow Settings"),
   };
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -465,16 +465,26 @@ export class WorkflowDetail extends LiteElement {
     }
     if (this.activePanel === "logs") {
       const authToken = this.authState!.headers.Authorization.split(" ")[1];
+      const isDownloadEnabled = Boolean(
+        this.logs && this.workflow?.lastCrawlId && !this.workflow.isCrawlRunning
+      );
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
-        <sl-button
-          href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
-          download=${`btrix-${this.lastCrawlId}-logs.txt`}
-          size="small"
-          ?disabled=${!this.logs?.total}
+        <sl-tooltip
+          content=${msg(
+            "Downloading will be enabled when this crawl is finished."
+          )}
+          ?disabled=${isDownloadEnabled}
         >
-          <sl-icon slot="prefix" name="download"></sl-icon>
-          ${msg("Download Logs")}
-        </sl-button>`;
+          <sl-button
+            href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
+            download=${`btrix-${this.lastCrawlId}-logs.txt`}
+            size="small"
+            ?disabled=${!isDownloadEnabled}
+          >
+            <sl-icon slot="prefix" name="download"></sl-icon>
+            ${msg("Download Logs")}
+          </sl-button>
+        </sl-tooltip>`;
     }
 
     return html`<h3>${this.tabLabels[this.activePanel]}</h3>`;
@@ -1110,7 +1120,7 @@ export class WorkflowDetail extends LiteElement {
 
   private renderCrawlErrors() {
     return html`
-      <sl-details summary="Toggle Me">
+      <sl-details>
         <h3
           slot="summary"
           class="leading-none text font-semibold flex items-center gap-2"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1187

<!-- Fixes #issue_number -->

### Changes

- Adds "Logs" tab to workflow detail
- Shows error logs in expandable section in "Watch" tab
- Show corresponding message (no logs yet or logs temporarily unavailable) when `/errors` returns 503

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail - Logs (never crawled) | <img width="920" alt="Screenshot 2023-09-27 at 2 27 03 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/5d201b5c-1546-4751-bd9f-24637d9ec371"> |
| Workflow Detail - Logs (no logs) | <img width="920" alt="Screenshot 2023-10-02 at 3 44 23 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/004be3fd-b0d6-4322-aa7b-0c94a07942b8"> |
| Workflow Detail - Logs (with logs) | <img width="930" alt="Screenshot 2023-09-27 at 2 32 55 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/a328e919-bd90-445d-987d-0aa1a3aadb4c"> |
| Workflow Detail - Logs (currently running) | <img width="924" alt="Screenshot 2023-09-27 at 2 41 14 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/15f993a8-2d40-4117-ae74-6265ad9174ae"> |
| Workflow Detail - Watch | <img width="932" alt="Screenshot 2023-09-27 at 2 51 31 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/170712a8-e62c-47a5-8c89-8470f9664883"> | 


<!-- ### Follow-ups -->
