### PR TITLE
Fix: Stream log downloading from WACZ

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -390,7 +390,7 @@ def _sync_get_logs(
         wacz_files: List[CrawlFile],
     ) -> List[List[CrawlFile]]:
         """Place wacz_files into their own list based on instance number"""
-        wacz_files = sorted(wacz_files, key=lambda file: file.filename)
+        wacz_files.sort(key=lambda file: file.filename)
         waczs_groups: Dict[str, List[CrawlFile]] = {}
         for file in wacz_files:
             instance_number = file.filename[
@@ -417,6 +417,7 @@ def _sync_get_logs(
                 for f in zip_file.filelist
                 if f.filename.startswith("logs/") and not f.is_dir()
             ]
+            log_files.sort(key=lambda log_zipinfo: log_zipinfo.filename)
 
             for log_zipinfo in log_files:
                 wacz_log_streams.append(

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -18,7 +18,7 @@ from stream_zip import stream_zip, NO_COMPRESSION_64
 import aiobotocore.session
 import boto3
 
-from .models import Organization, DefaultStorage, S3Storage, User
+from .models import CrawlFile, Organization, DefaultStorage, S3Storage, User
 from .zip import (
     sync_get_zip_file,
     sync_get_log_stream,
@@ -350,7 +350,7 @@ def _parse_json(line):
 
 # ============================================================================
 def _sync_get_logs(
-    wacz_files,
+    wacz_files: List[CrawlFile],
     log_levels: List[str],
     contexts: List[str],
     client,
@@ -386,7 +386,7 @@ def _sync_get_logs(
             json_str = json.dumps(line_dict, ensure_ascii=False) + "\n"
             yield json_str.encode("utf-8")
 
-    def organize_based_on_instance_number(wacz_files):
+    def organize_based_on_instance_number(wacz_files: List[CrawlFile]) -> List[List[CrawlFile]]:
         """Place wacz_files into their own list based on instance number"""
         waczs_groups = {}
         for file in wacz_files:

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -1,7 +1,7 @@
 """
 Storage API
 """
-from typing import Optional, Union, Iterator, Iterable, List
+from typing import Optional, Union, Iterator, Iterable, List, Dict
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
 
@@ -386,9 +386,12 @@ def _sync_get_logs(
             json_str = json.dumps(line_dict, ensure_ascii=False) + "\n"
             yield json_str.encode("utf-8")
 
-    def organize_based_on_instance_number(wacz_files: List[CrawlFile]) -> List[List[CrawlFile]]:
+    def organize_based_on_instance_number(
+        wacz_files: List[CrawlFile],
+    ) -> List[List[CrawlFile]]:
         """Place wacz_files into their own list based on instance number"""
-        waczs_groups = {}
+        wacz_files = sorted(wacz_files, key=lambda file: file.filename)
+        waczs_groups: Dict[str, List[CrawlFile]] = {}
         for file in wacz_files:
             instance_number = file.filename[
                 file.filename.rfind("-") + 1 : file.filename.rfind(".")

--- a/backend/btrixcloud/zip.py
+++ b/backend/btrixcloud/zip.py
@@ -40,7 +40,21 @@ def sync_get_log_stream(client, bucket, key, log_zipinfo, cd_start):
     else:
         uncompressed_content = content
 
-    return uncompressed_content
+    return sync_iter_lines(uncompressed_content)
+
+
+def sync_iter_lines(chunk_iter, keepends=True):
+    """
+    Iter by lines, adapted from botocore
+    """
+    pending = b""
+    for chunk in chunk_iter:
+        lines = (pending + chunk).splitlines(True)
+        for line in lines[:-1]:
+            yield line.splitlines(keepends)[0]
+        pending = lines[-1]
+    if pending:
+        yield pending.splitlines(keepends)[0]
 
 
 async def get_zip_file(client, bucket, key):


### PR DESCRIPTION
Resolves #669, though further testing is necessary (file close on complete?)
Currently deployed to dev, tested locally as well. I was able to download the logs from this [crawl](https://dev.browsertrix.cloud/orgs/44bf96c1-6007-4521-9313-4e927cd9862a/items/crawl/manual-20230921161602-5f581423-781#logs) 

~~The big caveat to this is that logs from multiple WACZs may no longer be sorted. Previously we were using `heapq.merge` but we can't do that anymore because there is no comparison operator between `generators`. We could implement our own, but currently decided that is out of scope.~~
We now sort logs even between multi-WACZ Crawls, and are a little smarter about when to use `heapq.merge` and when to use `itertools.chain`! 


Previously we were using `array.extend` which iterates through the generators leaving us with OOM issues. Now instead we `itertools.chain` the `generators` but we still need to iterate through each of them. 
