### PR TITLE
Passthrough x-forwarded-proto header in frontend nginx

### DIFF
--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -9,6 +9,12 @@ server {
     }
 }
 
+# if behind proxy passthrough X-Forwarded-Proto header
+map $http_x_forwarded_proto $ingress_proto {
+    ""       $scheme;
+    default  $http_x_forwarded_proto;
+}
+
 
 server {
     listen 80 default_server;
@@ -51,7 +57,7 @@ server {
     location /api/ {
       proxy_pass http://${BACKEND_HOST}:8000;
       proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $ingress_proto;
     }
 
     location ~* /watch/([^/]+)/([^/]+)/([^/]+)/ws {
@@ -125,4 +131,3 @@ server {
 
     include ./includes/*.conf;
 }
-


### PR DESCRIPTION
When not using a kubernetes ingress but a reverse proxy in front of the frontend nginx with `local_service_port`, the frontend nginx would force the x-forwarded-proto header to http. This would break browser profile creation when using browsertrix over https. This change only sets x-forwarded-proto when the incoming request doesn't have it.

Supersedes this PR https://github.com/webrecorder/browsertrix-cloud/pull/1183/