### PR TITLE
migration improvements:

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -151,7 +151,8 @@ async def await_db_and_migrations(mdb, db_inited):
     while await base_migration.migrate_up_needed():
         version = await base_migration.get_db_version()
         print(
-            f"Waiting for migrations to finish, DB at {version}, latest {CURR_DB_VERSION}"
+            f"Waiting for migrations to finish, DB at {version}, latest {CURR_DB_VERSION}",
+            flush=True,
         )
 
         await asyncio.sleep(5)

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -148,7 +148,7 @@ async def await_db_and_migrations(mdb, db_inited):
     print("Database setup started", flush=True)
 
     base_migration = BaseMigration(mdb, CURR_DB_VERSION)
-    while await base_migration.migrate_up_needed():
+    while await base_migration.migrate_up_needed(ignore_rerun=True):
         version = await base_migration.get_db_version()
         print(
             f"Waiting for migrations to finish, DB at {version}, latest {CURR_DB_VERSION}",

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
 
-from .db import init_db, ping_db, update_and_prepare_db
+from .db import init_db, await_db_and_migrations, update_and_prepare_db
 
 from .emailsender import EmailSender
 from .invites import init_invites
@@ -157,7 +157,7 @@ def main():
             )
         )
     else:
-        asyncio.create_task(ping_db(mdb, db_inited))
+        asyncio.create_task(await_db_and_migrations(mdb, db_inited))
 
     app.include_router(org_ops.router)
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
 
   IDLE_TIMEOUT: "{{ .Values.profile_browser_idle_seconds | default 60 }}"
 
-  RERUN_LAST_MIGRATION: "{{ .Values.rerun_last_migration }}"
+  RERUN_FROM_MIGRATION: "{{ .Values.rerun_from_migration }}"
 
   PRESIGN_DURATION_MINUTES: "{{ .Values.storage_presign_duration_minutes | default 60 }}"
 


### PR DESCRIPTION
- fixes #1227 
- avoid starting some workers while migration is still running
- ensure workers that aren't performing migration await for migration to complete
- backend will not be valid until migration is run