### PR TITLE
API delete endpoint improvements

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -688,6 +688,13 @@ def init_base_crawls_api(
     @app.post("/orgs/{oid}/all-crawls/delete", tags=["all-crawls"])
     async def delete_crawls_all_types(
         delete_list: DeleteCrawlList,
+        user: User = Depends(user_dep),
         org: Organization = Depends(org_crawl_dep),
     ):
+        for crawl_id in delete_list.crawl_ids:
+            crawl_raw = await ops.get_crawl_raw(crawl_id, org)
+            crawl = BaseCrawl.from_dict(crawl_raw)
+            if (crawl.userid != user.id) and not org.is_owner(user):
+                raise HTTPException(status_code=403, detail="not_allowed")
+
         return await ops.delete_crawls_all_types(delete_list, org)

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -184,6 +184,69 @@ class BaseCrawlOps:
 
         return {"updated": True}
 
+    async def update_crawl_state(self, crawl_id: str, state: str):
+        """called only when job container is being stopped/canceled"""
+
+        data = {"state": state}
+        # if cancelation, set the finish time here
+        if state == "canceled":
+            data["finished"] = dt_now()
+
+        await self.crawls.find_one_and_update(
+            {
+                "_id": crawl_id,
+                "type": "crawl",
+                "state": {"$in": RUNNING_AND_STARTING_STATES},
+            },
+            {"$set": data},
+        )
+
+    async def shutdown_crawl(self, crawl_id: str, org: Organization, graceful: bool):
+        """stop or cancel specified crawl"""
+        crawl = await self.get_crawl_raw(crawl_id, org)
+        if crawl.get("type") != "crawl":
+            return
+
+        result = None
+        try:
+            result = await self.crawl_manager.shutdown_crawl(
+                crawl_id, org.id_str, graceful=graceful
+            )
+
+            if result.get("success"):
+                if graceful:
+                    await self.crawls.find_one_and_update(
+                        {"_id": crawl_id, "type": "crawl", "oid": org.id},
+                        {"$set": {"stopping": True}},
+                    )
+                return result
+
+        except Exception as exc:
+            # pylint: disable=raise-missing-from
+            # if reached here, probably crawl doesn't exist anymore
+            raise HTTPException(
+                status_code=404, detail=f"crawl_not_found, (details: {exc})"
+            )
+
+        # if job no longer running, canceling is considered success,
+        # but graceful stoppage is not possible, so would be a failure
+        if result.get("error") == "Not Found":
+            if not graceful:
+                await self.update_crawl_state(crawl_id, "canceled")
+                crawl = await self.get_crawl_raw(crawl_id, org)
+                if not await self.crawl_configs.stats_recompute_last(
+                    crawl["cid"], 0, -1
+                ):
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"crawl_config_not_found: {crawl['cid']}",
+                    )
+
+                return {"success": True}
+
+        # return whatever detail may be included in the response
+        raise HTTPException(status_code=400, detail=result)
+
     async def delete_crawls(
         self, org: Organization, delete_list: DeleteCrawlList, type_: str
     ):
@@ -692,9 +755,18 @@ def init_base_crawls_api(
         org: Organization = Depends(org_crawl_dep),
     ):
         for crawl_id in delete_list.crawl_ids:
-            crawl_raw = await ops.get_crawl_raw(crawl_id, org)
-            crawl = BaseCrawl.from_dict(crawl_raw)
-            if (crawl.userid != user.id) and not org.is_owner(user):
+            crawl = await ops.get_crawl_raw(crawl_id, org)
+
+            if (crawl.get("userid") != user.id) and not org.is_owner(user):
                 raise HTTPException(status_code=403, detail="not_allowed")
+
+            if (crawl.get("type") == "crawl") and not crawl.get("finished"):
+                try:
+                    await ops.shutdown_crawl(crawl_id, org, graceful=False)
+                except Exception as exc:
+                    # pylint: disable=raise-missing-from
+                    raise HTTPException(
+                        status_code=400, detail=f"Error Stopping Crawl: {exc}"
+                    )
 
         return await ops.delete_crawls_all_types(delete_list, org)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -700,7 +700,7 @@ def init_crawls_api(
         # - Crawler users can delete their own crawls
         # - Org owners can delete any crawls in org
         for crawl_id in delete_list.crawl_ids:
-            crawl_raw = await ops.get_crawl_raw(crawl_id, org)
+            crawl = await ops.get_crawl_raw(crawl_id, org)
             if (crawl.get("userid") != user.id) and not org.is_owner(user):
                 raise HTTPException(status_code=403, detail="not_allowed")
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -762,7 +762,7 @@ def init_crawls_api(
             crawl_raw = await ops.get_crawl_raw(crawl_id, org)
             crawl = Crawl.from_dict(crawl_raw)
             if (crawl.userid != user.id) and not org.is_owner(user):
-                raise HTTPException(status_code=403, detail="Not Allowed")
+                raise HTTPException(status_code=403, detail="not_allowed")
 
             if not crawl.finished:
                 try:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -701,18 +701,8 @@ def init_crawls_api(
         # - Org owners can delete any crawls in org
         for crawl_id in delete_list.crawl_ids:
             crawl_raw = await ops.get_crawl_raw(crawl_id, org)
-            crawl = Crawl.from_dict(crawl_raw)
-            if (crawl.userid != user.id) and not org.is_owner(user):
+            if (crawl.get("userid") != user.id) and not org.is_owner(user):
                 raise HTTPException(status_code=403, detail="not_allowed")
-
-            if not crawl.finished:
-                try:
-                    await ops.shutdown_crawl(crawl_id, org, graceful=False)
-                except Exception as exc:
-                    # pylint: disable=raise-missing-from
-                    raise HTTPException(
-                        status_code=400, detail=f"Error Stopping Crawl: {exc}"
-                    )
 
         return await ops.delete_crawls(org, delete_list)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -203,12 +203,16 @@ class CrawlOps(BaseCrawlOps):
         return crawls, total
 
     async def delete_crawls(
-        self, org: Organization, delete_list: DeleteCrawlList, type_="crawl"
+        self,
+        org: Organization,
+        delete_list: DeleteCrawlList,
+        type_="crawl",
+        user: Optional[User] = None,
     ):
         """Delete a list of crawls by id for given org"""
 
         count, cids_to_update, quota_reached = await super().delete_crawls(
-            org, delete_list, type_
+            org, delete_list, type_, user
         )
 
         if count < 1:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -700,7 +700,7 @@ def init_crawls_api(
         user: User = Depends(user_dep),
         org: Organization = Depends(org_crawl_dep),
     ):
-        return await ops.delete_crawls(org, delete_list, user)
+        return await ops.delete_crawls(org, delete_list, "crawl", user)
 
     @app.get(
         "/orgs/all/crawls/{crawl_id}/replay.json",

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -696,15 +696,7 @@ def init_crawls_api(
         user: User = Depends(user_dep),
         org: Organization = Depends(org_crawl_dep),
     ):
-        # Ensure user has appropriate permissions for all crawls in list:
-        # - Crawler users can delete their own crawls
-        # - Org owners can delete any crawls in org
-        for crawl_id in delete_list.crawl_ids:
-            crawl = await ops.get_crawl_raw(crawl_id, org)
-            if (crawl.get("userid") != user.id) and not org.is_owner(user):
-                raise HTTPException(status_code=403, detail="not_allowed")
-
-        return await ops.delete_crawls(org, delete_list)
+        return await ops.delete_crawls(org, delete_list, user)
 
     @app.get(
         "/orgs/all/crawls/{crawl_id}/replay.json",

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -263,7 +263,7 @@ def test_delete_crawls_crawler(
     )
     assert r.status_code == 403
     data = r.json()
-    assert data["detail"] == "Not Allowed"
+    assert data["detail"] == "not_allowed"
 
     # Test that crawler user can delete own crawl
     r = requests.post(

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -306,7 +306,7 @@ def test_delete_stream_upload(admin_auth_headers, crawler_auth_headers, default_
     # Verify non-admin user who didn't upload crawl can't delete it
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/delete",
-        headers=crawler__auth_headers,
+        headers=crawler_auth_headers,
         json={"crawl_ids": [upload_id]},
     )
     assert r.status_code == 403

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -1003,10 +1003,20 @@ ${this.crawl?.description}
         icon: "check2-circle",
       });
     } catch (e: any) {
+      let message = msg(
+        str`Sorry, couldn't delete archived item at this time.`
+      );
+      if (e.isApiError) {
+        if (e.details == "not_allowed") {
+          message = msg(
+            str`Only org owners can delete other users' archived items.`
+          );
+        } else if (e.message) {
+          message = e.message;
+        }
+      }
       this.notify({
-        message:
-          (e.isApiError && e.message) ||
-          msg("Sorry, couldn't run crawl at this time."),
+        message: message,
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -719,10 +719,20 @@ export class CrawlsList extends LiteElement {
       });
       this.fetchArchivedItems();
     } catch (e: any) {
+      let message = msg(
+        str`Sorry, couldn't delete archived item at this time.`
+      );
+      if (e.isApiError) {
+        if (e.details == "not_allowed") {
+          message = msg(
+            str`Only org owners can delete other users' archived items.`
+          );
+        } else if (e.message) {
+          message = e.message;
+        }
+      }
       this.notify({
-        message:
-          (e.isApiError && e.message) ||
-          msg(str`Sorry, couldn't delete archived item at this time.`),
+        message: message,
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1489,10 +1489,20 @@ export class WorkflowDetail extends LiteElement {
       });
       this.fetchCrawls();
     } catch (e: any) {
+      let message = msg(
+        str`Sorry, couldn't delete archived item at this time.`
+      );
+      if (e.isApiError) {
+        if (e.details == "not_allowed") {
+          message = msg(
+            str`Only org owners can delete other users' archived items.`
+          );
+        } else if (e.message) {
+          message = e.message;
+        }
+      }
       this.notify({
-        message:
-          (e.isApiError && e.message) ||
-          msg("Sorry, couldn't run crawl at this time."),
+        message: message,
         variant: "danger",
         icon: "exclamation-octagon",
       });


### PR DESCRIPTION
Fixes #1208 

- Applies user permissions check before deleting anything in all /delete endpoints
- Shuts down running crawls before deleting anything in /all-crawls/delete as well as /crawls/delete
- Splits delete_list.crawl_ids into crawls and upload lists at same time as checks in /all-crawls/delete
- Updates frontend notification message to `Only org owners can delete other users' archived items.` when a `crawler` user attempts to delete another users' archived items:

<img width="443" alt="Screen Shot 2023-09-29 at 4 33 47 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/3ae2b108-5e5c-4a0a-884b-394780b012d2">
