### PR TITLE
Track pod resource usage, detect OOM crashes, handle auto-scaling

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --k3s-arg "--disable=traefik --disable=servicelb"
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -68,11 +68,6 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 3.10.2
-
-      - name: Install Additional Helm Dependencies
-        run: |
-          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-          helm upgrade --install metrics-server metrics-server/metrics-server
 
       - name: Start Cluster with Helm
         run: |

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--disable=traefik@server:* --disable=servicelb@server:*"
+            --k3s-arg "--disable=traefik,servicelb@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -69,6 +69,11 @@ jobs:
         with:
           version: 3.10.2
 
+      - name: Install Additional Helm Dependencies
+        run: |
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm upgrade --install metrics-server metrics-server/metrics-server
+
       - name: Start Cluster with Helm
         run: |
           helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml btrix ./chart/

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--disable=traefik --disable=servicelb"
+            --k3s-arg "--disable=traefik@server:* --disable=servicelb@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -60,6 +60,11 @@ jobs:
         with:
           version: 3.10.2
 
+      - name: Install Additional Helm Dependencies
+        run: |
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm upgrade --install metrics-server metrics-server/metrics-server
+
       - name: Start Cluster with Helm
         run: |
           helm upgrade --install -f ./chart/values.yaml -f ./chart/test/test.yaml --set invite_expire_seconds=10 --set max_pages_per_crawl=10 btrix ./chart/

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -17,7 +17,7 @@ jobs:
             -p "30870:30870@agent:0:direct"
             --agents 1
             --no-lb
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --k3s-arg "--disable=traefik,servicelb@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,11 +59,6 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 3.10.2
-
-      - name: Install Additional Helm Dependencies
-        run: |
-          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-          helm upgrade --install metrics-server metrics-server/metrics-server
 
       - name: Start Cluster with Helm
         run: |

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -2,8 +2,8 @@ name: Cluster Run (MicroK8s)
 
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
     paths:
       - 'backend/**'
       - 'chart/**'

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -2,8 +2,8 @@ name: Cluster Run (MicroK8s)
 
 on:
   push:
-    branches:
-      - main
+    #branches:
+    #  - main
     paths:
       - 'backend/**'
       - 'chart/**'

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -340,7 +340,7 @@ class BaseCrawlOps:
         if crawl.state in RUNNING_STATES:
             try:
                 async with self.get_redis(crawl.id) as redis:
-                    crawl.stats = await get_redis_crawl_stats(redis, crawl.id)
+                    crawl.stats, _ = await get_redis_crawl_stats(redis, crawl.id)
             # redis not available, ignore
             except exceptions.ConnectionError:
                 pass

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -516,6 +516,11 @@ class CrawlOps(BaseCrawlOps):
 
         return await self.crawls.find_one_and_update(query, {"$set": kwargs})
 
+    async def update_running_crawl_stats(self, crawl_id, stats):
+        """update running crawl stats"""
+        query = {"_id": crawl_id, "type": "crawl", "state": "running"}
+        return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
+
     async def get_crawl_state(self, crawl_id):
         """return current crawl state of a crawl"""
         res = await self.crawls.find_one(

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -233,3 +233,22 @@ class K8sAPI:
             # pylint: disable=bare-except
             except:
                 print("Logs Not Found")
+
+    async def is_pod_metrics_available(self):
+        """return true/false if metrics server api is available by
+        attempting list operation. if operation succeeds, then
+        metrics are available, otherwise not available
+        """
+        try:
+            await self.custom_api.list_namespaced_custom_object(
+                group="metrics.k8s.io",
+                version="v1beta1",
+                namespace=self.namespace,
+                plural="pods",
+                limit=1,
+            )
+            return True
+        # pylint: disable=broad-exception-caught
+        except Exception as exc:
+            print(exc)
+            return False

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -75,7 +75,7 @@ def main():
         event_webhook_ops,
     )
 
-    init_operator_api(
+    return init_operator_api(
         app_root, crawl_config_ops, crawl_ops, org_ops, coll_ops, event_webhook_ops
     )
 
@@ -85,4 +85,5 @@ def main():
 async def startup():
     """init on startup"""
     register_exit_handler()
-    main()
+    oper = main()
+    await oper.async_init()

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1001,6 +1001,8 @@ class BtrixOperator(K8sAPI):
         status.size = stats["size"]
         status.sizeHuman = humanize.naturalsize(status.size)
 
+        await self.crawl_ops.update_running_crawl_stats(crawl.id, stats)
+
         for key, value in sizes.items():
             value = int(value)
             if value > 0:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -995,6 +995,9 @@ class BtrixOperator(K8sAPI):
         results = await redis.hgetall(f"{crawl.id}:status")
         stats, sizes = await get_redis_crawl_stats(redis, crawl.id)
 
+        # need to add size of previously completed WACZ files as well!
+        stats["size"] += status.filesAddedSize
+
         # update status
         status.pagesDone = stats["done"]
         status.pagesFound = stats["found"]

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -40,8 +40,12 @@ from .models import CrawlFile, CrawlCompleteIn
 CMAP = "ConfigMap.v1"
 PVC = "PersistentVolumeClaim.v1"
 POD = "Pod.v1"
-CJS = "CrawlJob.btrix.cloud/v1"
-METRICS = "PodMetrics.metrics.k8s.io/v1beta1"
+
+BTRIX_API = "btrix.cloud/v1"
+CJS = f"CrawlJob.{BTRIX_API}"
+
+METRICS_API = "metrics.k8s.io/v1beta1"
+METRICS = f"PodMetrics.{METRICS_API}"
 
 DEFAULT_TTL = 30
 
@@ -590,13 +594,13 @@ class BtrixOperator(K8sAPI):
                     "labelSelector": {"matchLabels": {"btrix.crawlconfig": cid}},
                 },
                 {
-                    "apiVersion": "btrix.cloud/v1",
+                    "apiVersion": BTRIX_API,
                     "resource": "crawljobs",
                     "labelSelector": {"matchLabels": {"oid": oid}},
                 },
                 # enable for podmetrics
                 {
-                    "apiVersion": "metrics.k8s.io/v1beta1",
+                    "apiVersion": METRICS_API,
                     "resource": "pods",
                     "labelSelector": {"matchLabels": {"crawl": crawl_id}},
                 },

--- a/backend/btrixcloud/templates/crawler.yaml
+++ b/backend/btrixcloud/templates/crawler.yaml
@@ -28,7 +28,7 @@ spec:
 # -------
 # CRAWLER
 # -------
-{% if not force_restart %}
+{% if not do_restart %}
 ---
 apiVersion: v1
 kind: Pod
@@ -151,11 +151,11 @@ spec:
 
       resources:
         limits:
-          memory: "{{ crawler_memory }}"
+          memory: "{{ memory }}"
 
         requests:
-          cpu: "{{ crawler_cpu }}"
-          memory: "{{ crawler_memory }}"
+          cpu: "{{ cpu }}"
+          memory: "{{ memory }}"
 
       {% if crawler_liveness_port and crawler_liveness_port != '0' %}
       livenessProbe:

--- a/backend/btrixcloud/templates/redis.yaml
+++ b/backend/btrixcloud/templates/redis.yaml
@@ -26,7 +26,7 @@ spec:
 # --------
 # REDIS
 # --------
-{% if init_redis and not do_restart %}
+{% if init_redis %}
 ---
 apiVersion: v1
 kind: Pod

--- a/backend/btrixcloud/templates/redis.yaml
+++ b/backend/btrixcloud/templates/redis.yaml
@@ -26,7 +26,7 @@ spec:
 # --------
 # REDIS
 # --------
-{% if init_redis %}
+{% if init_redis and not do_restart %}
 ---
 apiVersion: v1
 kind: Pod
@@ -103,11 +103,11 @@ spec:
 
       resources:
         limits:
-          memory: {{ redis_memory }}
+          memory: {{ memory }}
 
         requests:
-          cpu: {{ redis_cpu }}
-          memory: {{ redis_memory }}
+          cpu: {{ cpu }}
+          memory: {{ memory }}
 
       readinessProbe:
         initialDelaySeconds: 10

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -48,11 +48,11 @@ async def get_redis_crawl_stats(redis, crawl_id):
         pages_done = await redis.llen(f"{crawl_id}:d")
 
     pages_found = await redis.scard(f"{crawl_id}:s")
-    archive_size = await redis.hvals(f"{crawl_id}:size")
-    archive_size = sum(int(x) for x in archive_size)
+    sizes = await redis.hgetall(f"{crawl_id}:size")
+    archive_size = sum(int(x) for x in sizes.values())
 
     stats = {"found": pages_found, "done": pages_done, "size": archive_size}
-    return stats
+    return stats, sizes
 
 
 def run_once_lock(name):

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -53,7 +53,7 @@ metadata:
 
 data:
   CRAWL_ARGS: >-
-    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --userAgentSuffix {{ .Values.user_agent_suffix | quote }} --userAgent {{ .Values.user_agent | quote }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis {{ .Values.crawler_extra_args }} --restartsOnError
+    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --userAgentSuffix {{ .Values.user_agent_suffix | quote }} --userAgent {{ .Values.user_agent | quote }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --restartsOnError --headless {{ .Values.crawler_extra_args }}
 
 ---
 apiVersion: v1

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -17,17 +17,9 @@ rules:
   resources: ["crawljobs", "profilejobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: cronjob-manage
-rules:
-- apiGroups: ["batch"]
-  resources: ["cronjobs"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
-
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["list"]
 
 ---
 kind: RoleBinding
@@ -48,24 +40,3 @@ roleRef:
   kind: Role
   name: crawler-run
   apiGroup: rbac.authorization.k8s.io
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cronjob-role
-  namespace: {{ .Release.Namespace }}
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: {{ .Release.Namespace }}
-
-- kind: User
-  name: system:anonymous
-  namespace: {{ .Release.Namespace }}
-
-roleRef:
-  kind: Role
-  name: cronjob-manage
-  apiGroup: rbac.authorization.k8s.io
-

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -206,9 +206,9 @@ crawler_browser_instances: 2
 
 # this value is added to crawler_cpu_base, for each additional browser
 # crawler_cpu = crawler_cpu_base + crawler_pu_per_extra_browser * (crawler_browser_instances - 1)
-crawler_extra_cpu_per_browser: 300m
+crawler_extra_cpu_per_browser: 600m
 
-crawler_extra_memory_per_browser: 256Mi
+crawler_extra_memory_per_browser: 768Mi
 
 # if not set, defaults to the following, but can be overridden directly:
 # crawler_cpu = crawler_cpu_base + crawler_cpu_per_extra_browser * (crawler_browser_instances - 1)


### PR DESCRIPTION
This PR adds tracking of pod allocated resources, actual usage and percentage (for memory, cpu and disk).
It alos adds detection of OOMs to the PodStatus
It allows for auto-scaling pods based on these values, and responding and detecting crashes.

~~It does add a dependence on metric server being available, and the tests have been updated to install metrics-server for k3s~~

Checks if metrics server is available, and uses cpu/memory settings from metrics server, otherwise attempts to get memory usage estimate directly from Redis.

Initial auto-scaling only handles Redis, and adjusts memory by 20% if over 90% is used or an OOM has been reached.

Additional cleanup: Cleans up roles to allow checking pod metrics, removes unused role settings (for cronjobs)