### PR TITLE
Add --failOnFailedSeed checkbox to URL list workflows

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -103,6 +103,7 @@ class RawCrawlConfig(BaseModel):
     combineWARC: Optional[bool]
 
     useSitemap: Optional[bool] = False
+    failOnFailedSeed: Optional[bool] = False
 
     logging: Optional[str]
     behaviors: Optional[str] = "autoscroll,autoplay,autofetch,siteSpecific"

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -29,7 +29,7 @@ When enabled, the crawler will visit all the links it finds within each page def
 ??? example "Crawling tags & search queries with URL List crawls"
     This setting can be useful for crawling the content of specific tags or searh queries. Specify the tag or search query URL(s) in the _List of URLs_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
 
-### Stop Crawl on Failed URL
+### Fail Crawl on Failed URL
 
 `URL List`{ .badge-blue }
 

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -29,6 +29,12 @@ When enabled, the crawler will visit all the links it finds within each page def
 ??? example "Crawling tags & search queries with URL List crawls"
     This setting can be useful for crawling the content of specific tags or searh queries. Specify the tag or search query URL(s) in the _List of URLs_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
 
+### Stop Crawl On Failed URL
+
+`URL List`{ .badge-blue }
+
+When enabled, the crawler will stop crawling if any of the provided URLs are invalid or unsuccessfully crawled.
+
 ### Crawl Start URL
 
 `Seeded Crawl`{ .badge-orange }

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -29,11 +29,11 @@ When enabled, the crawler will visit all the links it finds within each page def
 ??? example "Crawling tags & search queries with URL List crawls"
     This setting can be useful for crawling the content of specific tags or searh queries. Specify the tag or search query URL(s) in the _List of URLs_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
 
-### Stop Crawl On Failed URL
+### Stop Crawl on Failed URL
 
 `URL List`{ .badge-blue }
 
-When enabled, the crawler will stop crawling if any of the provided URLs are invalid or unsuccessfully crawled.
+When enabled, the crawler will stop crawling if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Partial Complete".
 
 ### Crawl Start URL
 

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -33,7 +33,7 @@ When enabled, the crawler will visit all the links it finds within each page def
 
 `URL List`{ .badge-blue }
 
-When enabled, the crawler will stop crawling if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Partial Complete".
+When enabled, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Failed".
 
 ### Crawl Start URL
 

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -304,7 +304,7 @@ export class ConfigDetails extends LiteElement {
         Boolean(crawlConfig?.config.extraHops)
       )}
       ${this.renderSetting(
-        msg("Fail On Failed URL"),
+        msg("Stop Crawl On Failed URL"),
         Boolean(crawlConfig?.config.failOnFailedSeed)
       )}
     `;

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -303,6 +303,10 @@ export class ConfigDetails extends LiteElement {
         msg("Include Any Linked Page"),
         Boolean(crawlConfig?.config.extraHops)
       )}
+      ${this.renderSetting(
+        msg("Fail On Failed URL"),
+        Boolean(crawlConfig?.config.failOnFailedSeed)
+      )}
     `;
   };
 

--- a/frontend/src/components/config-details.ts
+++ b/frontend/src/components/config-details.ts
@@ -304,7 +304,7 @@ export class ConfigDetails extends LiteElement {
         Boolean(crawlConfig?.config.extraHops)
       )}
       ${this.renderSetting(
-        msg("Stop Crawl On Failed URL"),
+        msg("Fail Crawl On Failed URL"),
         Boolean(crawlConfig?.config.failOnFailedSeed)
       )}
     `;

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -994,7 +994,7 @@ https://example.com/path`}
         name="failOnFailedSeed"
         ?checked=${this.formState.failOnFailedSeed}
       >
-        ${msg("Stop Crawl On Failed URL")}
+        ${msg("Stop Crawl on Failed URL")}
       </sl-checkbox>`)}
       ${this.renderHelpTextCol(
         msg(

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -994,11 +994,11 @@ https://example.com/path`}
         name="failOnFailedSeed"
         ?checked=${this.formState.failOnFailedSeed}
       >
-        ${msg("Stop Crawl on Failed URL")}
+        ${msg("Fail Crawl on Failed URL")}
       </sl-checkbox>`)}
       ${this.renderHelpTextCol(
-        msg(
-          `If checked, the crawler will stop crawling if any of the provided URLs are invalid or unsuccessfully crawled.`
+msg(
+          `If checked, the crawler will immediately interrupt and fail the crawl if any of the provided URLs are invalid or unsuccessfully crawled.`
         ),
         false
       )}

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -997,9 +997,8 @@ https://example.com/path`}
         ${msg("Fail Crawl on Failed URL")}
       </sl-checkbox>`)}
       ${this.renderHelpTextCol(
-msg(
-          `If checked, the crawler will immediately interrupt and fail the crawl if any of the provided URLs are invalid or unsuccessfully crawled.`
-        ),
+        msg(
+          `If checked, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled.`
         false
       )}
       ${when(

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -999,7 +999,8 @@ https://example.com/path`}
       ${this.renderHelpTextCol(
         msg(
           `If checked, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled.`
-        false
+          ),
+          false
       )}
       ${when(
         this.formState.includeLinkedPages || this.jobType === "custom",

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -999,8 +999,8 @@ https://example.com/path`}
       ${this.renderHelpTextCol(
         msg(
           `If checked, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled.`
-          ),
-          false
+        ),
+        false
       )}
       ${when(
         this.formState.includeLinkedPages || this.jobType === "custom",

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -23,6 +23,7 @@ const defaultValue = {
     pageLoadTimeout: null,
     pageExtraDelay: null,
     useSitemap: false,
+    failOnFailedSeed: false,
   },
   tags: [],
   crawlTimeout: null,

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -30,6 +30,7 @@ export type SeedConfig = Pick<
   behaviors?: string | null;
   extraHops?: number | null;
   useSitemap: boolean;
+  failOnFailedSeed: boolean;
   depth?: number | null;
 };
 


### PR DESCRIPTION
Fixes #1180 

Screenshot of option as presented in UI:

<img width="938" alt="Screen Shot 2023-10-02 at 11 37 52 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/858549da-6b73-4d7a-a4ca-b9b07e868e5d">

Checkbox does not appear for seeded crawls.

Crawls that fail this way currently show as "Partial Complete", and the fatal message is clearly visible in the Error Logs.