### PR TITLE
Require that all passwords are between 8 and 64 characters

### DIFF
--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -166,6 +166,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
             print(res, flush=True)
         except (DuplicateKeyError, UserAlreadyExists):
             print(f"User {email} already exists", flush=True)
+        # pylint: disable=raise-missing-from
         except InvalidPasswordException:
             raise HTTPException(status_code=422, detail="invalid_password")
 
@@ -200,6 +201,7 @@ class UserManager(BaseUserManager[UserCreate, UserDB]):
                     created_user, user_create, request=None
                 )
                 return created_user
+            # pylint: disable=raise-missing-from
             except InvalidPasswordException:
                 raise HTTPException(status_code=422, detail="invalid_password")
 

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -226,7 +226,7 @@ def test_send_and_accept_org_invite(
         json={
             "name": "accepted",
             "email": expected_stored_email,
-            "password": "testpw",
+            "password": "testingpassword",
             "inviteToken": token,
             "newOrg": False,
         },

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -1,6 +1,6 @@
 import requests
 
-from .conftest import API_PREFIX, CRAWLER_USERNAME
+from .conftest import API_PREFIX, CRAWLER_USERNAME, ADMIN_PW
 
 
 def test_create_super_user(admin_auth_headers):
@@ -42,3 +42,19 @@ def test_me_with_orgs(crawler_auth_headers, default_org_id):
     assert default_org["name"]
     assert default_org["default"]
     assert default_org["role"] == 20
+
+
+def test_add_user_to_org_invalid_password(admin_auth_headers, default_org_id):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/add-user",
+        json={
+            "email": "invalidpassword@example.com",
+            "password": "pw",
+            "name": "new-user 1",
+            "description": "test invalid password",
+            "role": 20,
+        },
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"] == "invalid_password"

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -310,7 +310,10 @@ export class AccountSettings extends LiteElement {
             id="newPassword"
             name="newPassword"
             type="password"
-            label="${msg("New password (8-64 characters)")}"
+            label="${msg("New password")}"
+            help-text=${msg("Must be between 8-64 characters")}
+            minlength="8"
+            maxlength="64"
             autocomplete="new-password"
             password-toggle
             required

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -313,7 +313,6 @@ export class AccountSettings extends LiteElement {
             label="${msg("New password")}"
             help-text=${msg("Must be between 8-64 characters")}
             minlength="8"
-            maxlength="64"
             autocomplete="new-password"
             password-toggle
             required

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -310,7 +310,7 @@ export class AccountSettings extends LiteElement {
             id="newPassword"
             name="newPassword"
             type="password"
-            label="${msg("New password")}"
+            label="${msg("New password (8-64 characters)")}"
             autocomplete="new-password"
             password-toggle
             required
@@ -351,8 +351,6 @@ export class AccountSettings extends LiteElement {
         email: this.authState.username,
         password: formData.get("password") as string,
       });
-
-      this.dispatchEvent(AuthService.createLoggedInEvent(nextAuthState));
     } catch (e: any) {
       console.debug(e);
     }
@@ -371,6 +369,7 @@ export class AccountSettings extends LiteElement {
 
     const params = {
       password: formData.get("newPassword"),
+      email: this.userInfo?.email,
     };
 
     try {
@@ -385,13 +384,17 @@ export class AccountSettings extends LiteElement {
           successMessage: "Successfully updated password",
         },
       });
+
+      this.dispatchEvent(AuthService.createLoggedInEvent(nextAuthState));
     } catch (e) {
       console.error(e);
 
       this.formStateService.send({
         type: "ERROR",
         detail: {
-          serverError: msg("Something went wrong changing password"),
+          serverError: msg(
+            "Something went wrong changing password. Verify that new password meets requirements (8-64 characters)."
+          ),
         },
       });
     }

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -82,7 +82,6 @@ export class SignUpForm extends LiteElement {
             label="${msg("New password")}"
             help-text=${msg("Must be between 8-64 characters")}
             minlength="8"
-            maxlength="64"
             autocomplete="new-password"
             passwordToggle
             required

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -79,7 +79,10 @@ export class SignUpForm extends LiteElement {
             id="password"
             name="password"
             type="password"
-            label=${msg("Create a password (8-64 characters)")}
+            label="${msg("New password")}"
+            help-text=${msg("Must be between 8-64 characters")}
+            minlength="8"
+            maxlength="64"
             autocomplete="new-password"
             passwordToggle
             required

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -79,7 +79,7 @@ export class SignUpForm extends LiteElement {
             id="password"
             name="password"
             type="password"
-            label=${msg("Create a password")}
+            label=${msg("Create a password (8-64 characters)")}
             autocomplete="new-password"
             passwordToggle
             required
@@ -172,9 +172,12 @@ export class SignUpForm extends LiteElement {
         const { detail } = await resp.json();
         if (detail === "REGISTER_USER_ALREADY_EXISTS") {
           shouldLogIn = true;
+        } else if (detail.code && detail.code === "REGISTER_INVALID_PASSWORD") {
+          this.serverError = msg(
+            "Invalid password. Must be between 8 and 64 characters"
+          );
         } else {
-          // TODO show validation details
-          this.serverError = msg("Invalid email address or password");
+          this.serverError = msg("Invalid email or password");
         }
         break;
       default:

--- a/frontend/src/pages/reset-password.ts
+++ b/frontend/src/pages/reset-password.ts
@@ -40,7 +40,6 @@ export class ResetPassword extends LiteElement {
                 label="${msg("New password")}"
                 help-text=${msg("Must be between 8-64 characters")}
                 minlength="8"
-                maxlength="64"
                 autocomplete="new-password"
                 passwordToggle
                 required

--- a/frontend/src/pages/reset-password.ts
+++ b/frontend/src/pages/reset-password.ts
@@ -37,7 +37,10 @@ export class ResetPassword extends LiteElement {
                 id="password"
                 name="password"
                 type="password"
-                label="${msg("New password (8-64 characters)")}"
+                label="${msg("New password")}"
+                help-text=${msg("Must be between 8-64 characters")}
+                minlength="8"
+                maxlength="64"
                 autocomplete="new-password"
                 passwordToggle
                 required

--- a/frontend/src/pages/reset-password.ts
+++ b/frontend/src/pages/reset-password.ts
@@ -37,7 +37,7 @@ export class ResetPassword extends LiteElement {
                 id="password"
                 name="password"
                 type="password"
-                label="${msg("New password")}"
+                label="${msg("New password (8-64 characters)")}"
                 autocomplete="new-password"
                 passwordToggle
                 required
@@ -95,17 +95,19 @@ export class ResetPassword extends LiteElement {
       case 400:
       case 422:
         const { detail } = await resp.json();
-
         if (detail === "RESET_PASSWORD_BAD_TOKEN") {
           // TODO password validation details
           this.serverError = msg(
             "Password reset email is not valid. Request a new password reset email"
           );
-        } else {
-          // TODO password validation details
-          this.serverError = msg("Invalid password");
+        } else if (
+          detail.code &&
+          detail.code === "RESET_PASSWORD_INVALID_PASSWORD"
+        ) {
+          this.serverError = msg(
+            "Invalid password. Must be between 8 and 64 characters"
+          );
         }
-
         break;
       default:
         this.serverError = msg("Something unexpected went wrong");


### PR DESCRIPTION
First steps for #1233 

Also fixes account settings password reset form to only trigger logged-in event after successful password change, and adds the missing email to the PATCH endpoint call, both of which were causing the password reset form to fail silently.

Password validation can be extended within the UserManager's validate_password method to add or modify requirements.

To test:
- Log in as admin user and attempt to change password to something shorter than 8 or longer than 64 characters, verify it fails with an error message
- Log in as admin user and attempt to change password to a password between 8-64 characters, verify it works successfully (log out and log back in to be sure)
- Invite a new user, go to the invitation link, and try to set a password shorter than 8 or longer than 64 characters, verify it fails with an error message
- Set a password between 8-64 characters from the user invite link, verify it works successfully (log out and log back in as new user to be sure)