### PR TITLE
Show storage meter even with no quota

### DIFF
--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -106,16 +106,16 @@ export class Meter extends LitElement {
     }
 
     .valueText {
-      display: inline-flex;
+      display: inline-block;
     }
 
-    .valueText.withSeparator:after {
+    .maxText.withSeparator:before {
       content: "/";
       padding: 0 0.3ch;
     }
 
     .maxText {
-      display: inline-block;
+      display: inline-flex;
     }
   `;
 
@@ -151,15 +151,17 @@ export class Meter extends LitElement {
         </sl-resize-observer>
         <div class="labels">
           <div class="label value" style="width:${barWidth}">
-            <span class="valueText withSeparator">
-              <slot name="valueLabel">${this.value}</slot>
+            <span class="valueText">
+              <slot name="valueLabel"></slot>
             </span>
           </div>
-          <div class="label max">
-            <span class="maxText">
-              <slot name="maxLabel">${this.max}</slot>
-            </span>
-          </div>
+          ${this.value >= this.max
+            ? ""
+            : html`<div class="label max">
+                <span class="maxText withSeparator">
+                  <slot name="maxLabel"></slot>
+                </span>
+              </div>`}
         </div>
       </div>
     `;
@@ -181,21 +183,22 @@ export class Meter extends LitElement {
     const remaining = Math.ceil(trackW - barWidth - pad);
 
     // Show compact value/max label when almost touching
-    const valueText = this.labels?.querySelector(".valueText");
-    if (this.maxText && this.maxText.clientWidth >= remaining) {
-      valueText?.classList.add("withSeparator");
+    if (this.maxText.clientWidth >= remaining) {
+      this.maxText.classList.add("withSeparator");
     } else {
-      valueText?.classList.remove("withSeparator");
+      this.maxText.classList.remove("withSeparator");
     }
   }
 
   private handleSlotchange() {
     if (!this.bars) return;
-    this.bars.forEach((el, i, arr) => {
-      if (i < arr.length - 1) {
-        el.style.cssText +=
-          "--border-right: 1px solid var(--sl-color-neutral-600)";
-      }
-    });
+    if (this.bars.length > 1) {
+      this.bars.forEach((el, i, arr) => {
+        if (i < arr.length - 1) {
+          el.style.cssText +=
+            "--border-right: 1px solid var(--sl-color-neutral-600)";
+        }
+      });
+    }
   }
 }

--- a/frontend/src/components/meter.ts
+++ b/frontend/src/components/meter.ts
@@ -50,7 +50,7 @@ export class Meter extends LitElement {
   min = 0;
 
   @property({ type: Number })
-  max = 100;
+  max?: number;
 
   @property({ type: Number })
   value = 0;
@@ -130,8 +130,9 @@ export class Meter extends LitElement {
 
   render() {
     // meter spec disallow values that exceed max
-    const boundedValue = Math.max(Math.min(this.value, this.max), this.min);
-    const barWidth = `${(boundedValue / this.max) * 100}%`;
+    const max = this.max ? Math.max(this.value, this.max) : this.value;
+    const boundedValue = Math.max(Math.min(this.value, max), this.min);
+    const barWidth = `${(boundedValue / max) * 100}%`;
     return html`
       <div
         class="meter"
@@ -139,14 +140,14 @@ export class Meter extends LitElement {
         aria-valuenow=${boundedValue}
         aria-valuetext=${ifDefined(this.valueText)}
         aria-valuemin=${this.min}
-        aria-valuemax=${this.max}
+        aria-valuemax=${max}
       >
         <sl-resize-observer @sl-resize=${this.onTrackResize}>
           <div class="track">
             <div class="valueBar" style="width:${barWidth}">
               <slot @slotchange=${this.handleSlotchange}></slot>
             </div>
-            ${this.value < this.max ? html`<slot name="available"></slot>` : ""}
+            ${this.value < max ? html`<slot name="available"></slot>` : ""}
           </div>
         </sl-resize-observer>
         <div class="labels">
@@ -155,13 +156,13 @@ export class Meter extends LitElement {
               <slot name="valueLabel"></slot>
             </span>
           </div>
-          ${this.value >= this.max
-            ? ""
-            : html`<div class="label max">
+          ${this.max
+            ? html`<div class="label max">
                 <span class="maxText withSeparator">
                   <slot name="maxLabel"></slot>
                 </span>
-              </div>`}
+              </div>`
+            : ""}
         </div>
       </div>
     `;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -299,16 +299,19 @@ export class Dashboard extends LiteElement {
               <div class="w-full h-full"></div>
             </sl-tooltip>
           </div>
-          <sl-format-bytes
-            slot="valueLabel"
-            value=${metrics.storageUsedBytes}
-            display="narrow"
-          ></sl-format-bytes>
-          <sl-format-bytes
-            slot="maxLabel"
-            value=${metrics.storageQuotaBytes}
-            display="narrow"
-          ></sl-format-bytes>
+          ${when(
+            hasQuota,
+            () => html`<sl-format-bytes
+                slot="valueLabel"
+                value=${metrics.storageUsedBytes}
+                display="narrow"
+              ></sl-format-bytes>
+              <sl-format-bytes
+                slot="maxLabel"
+                value=${metrics.storageQuotaBytes}
+                display="narrow"
+              ></sl-format-bytes>`
+          )}
         </btrix-meter>
       </div>
     `;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -208,11 +208,6 @@ export class Dashboard extends LiteElement {
 
   private renderStorageMeter(metrics: Metrics) {
     const hasQuota = Boolean(metrics.storageQuotaBytes);
-    // Account for usage that exceeds max
-    const maxBytes = Math.max(
-      metrics.storageUsedBytes,
-      hasQuota ? metrics.storageQuotaBytes : metrics.storageUsedBytes
-    );
     const isStorageFull =
       hasQuota && metrics.storageUsedBytes >= metrics.storageQuotaBytes;
     const renderBar = (value: number, label: string, color: string) => html`
@@ -246,7 +241,8 @@ export class Dashboard extends LiteElement {
             hasQuota
               ? html`
                   <sl-format-bytes
-                    value=${maxBytes - metrics.storageUsedBytes}
+                    value=${metrics.storageQuotaBytes -
+                    metrics.storageUsedBytes}
                   ></sl-format-bytes>
                   ${msg("Available")}
                 `
@@ -261,7 +257,7 @@ export class Dashboard extends LiteElement {
       <div class="mb-2">
         <btrix-meter
           value=${metrics.storageUsedBytes}
-          max=${maxBytes}
+          max=${ifDefined(metrics.storageQuotaBytes || undefined)}
           valueText=${msg("gigabyte")}
         >
           ${when(metrics.storageUsedCrawls, () =>


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix-cloud/issues/1198

<!-- Fixes #issue_number -->

### Changes

Displays how much storage items and browser profiles take up even when quota is not specified, per [Discord convo](https://discord.com/channels/895426029194207262/1011678975636013066/1156697490242949271).

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Dashboard | <img width="384" alt="Screenshot 2023-10-02 at 5 21 34 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/8fd4fbba-47a5-4684-bc2b-441f3d3f4905"> |


<!-- ### Follow-ups -->
