### PR TITLE
Execution Time System Refactor

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -799,15 +799,6 @@ class CrawlConfigOps:
         except Exception:
             return [], 0
 
-    async def inc_execution_seconds(self, cid: uuid.UUID, execution_seconds: int):
-        """add crawl execution seconds to workflow"""
-        await self.crawl_configs.find_one_and_update(
-            {"_id": cid},
-            {
-                "$inc": {"executionSeconds": execution_seconds},
-            },
-        )
-
 
 # ============================================================================
 # pylint: disable=too-many-locals

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -565,20 +565,6 @@ class CrawlOps(BaseCrawlOps):
         except Exception:
             return [], 0
 
-    async def inc_execution_seconds(
-        self, crawl_id: str, oid: uuid.UUID, execution_seconds: int
-    ):
-        """add execution seconds to crawl, workflow, and org"""
-        await self.crawls.find_one_and_update(
-            {"_id": crawl_id},
-            {
-                "$inc": {"executionSeconds": execution_seconds},
-            },
-        )
-        crawl = await self.get_crawl_raw(crawl_id)
-        await self.crawl_configs.inc_execution_seconds(crawl["cid"], execution_seconds)
-        await self.orgs.inc_execution_seconds(oid, execution_seconds)
-
 
 # ============================================================================
 async def recompute_crawl_file_count_and_size(crawls, crawl_id):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -177,8 +177,6 @@ class CrawlConfigCore(BaseMongoModel):
 
     profileid: Optional[UUID4]
 
-    executionSeconds: int = 0
-
 
 # ============================================================================
 class CrawlConfigAdditional(BaseModel):
@@ -387,8 +385,6 @@ class CrawlOut(BaseMongoModel):
     cid_rev: Optional[int]
 
     storageQuotaReached: Optional[bool]
-
-    executionSeconds: int = 0
 
 
 # ============================================================================
@@ -670,8 +666,7 @@ class Organization(BaseMongoModel):
     storage: Union[S3Storage, DefaultStorage]
 
     usage: Dict[str, int] = {}
-
-    executionSeconds: Dict[str, int] = {}
+    crawlExecSeconds: Dict[str, int] = {}
 
     bytesStored: int = 0
     bytesStoredCrawls: int = 0
@@ -719,9 +714,7 @@ class Organization(BaseMongoModel):
 
         if not self.is_crawler(user):
             exclude.add("usage")
-
-        if not self.is_crawler(user):
-            exclude.add("executionSeconds")
+            exclude.add("crawlExecSeconds")
 
         result = self.to_dict(
             exclude_unset=True,
@@ -756,7 +749,7 @@ class OrgOut(BaseMongoModel):
     name: str
     users: Optional[Dict[str, Any]]
     usage: Optional[Dict[str, int]]
-    executionSeconds: Optional[Dict[str, int]]
+    crawlExecSeconds: Optional[Dict[str, int]]
     default: bool = False
     bytesStored: int
     bytesStoredCrawls: int

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -320,12 +320,13 @@ class OrgOps:
             {"_id": org.id}, {"$set": {"origin": origin}}
         )
 
-    async def inc_org_stats(self, oid, duration):
+    async def inc_org_time_stats(self, oid, duration, is_exec_time=False):
         """inc crawl duration stats for org oid"""
         # init org crawl stats
+        key = "crawlExecSeconds" if is_exec_time else "usage"
         yymm = datetime.utcnow().strftime("%Y-%m")
         await self.orgs.find_one_and_update(
-            {"_id": oid}, {"$inc": {f"usage.{yymm}": duration}}
+            {"_id": oid}, {"$inc": {f"{key}.{yymm}": duration}}
         )
 
     async def get_max_concurrent_crawls(self, oid):
@@ -390,13 +391,6 @@ class OrgOps:
             "collectionsCount": collections_count,
             "publicCollectionsCount": public_collections_count,
         }
-
-    async def inc_execution_seconds(self, oid: uuid.UUID, execution_seconds: int):
-        """add execution seconds to org, tracked by month"""
-        yymm = datetime.utcnow().strftime("%Y-%m")
-        await self.orgs.find_one_and_update(
-            {"_id": oid}, {"$inc": {f"executionSeconds.{yymm}": execution_seconds}}
-        )
 
 
 # ============================================================================

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -28,20 +28,6 @@ def to_k8s_date(dt_val):
     return dt_val.isoformat("T") + "Z"
 
 
-def from_timestamp_str(string) -> Optional[datetime]:
-    """convert iso date string with or without milliseconds to datetime"""
-    dt_instance: Optional[datetime] = None
-    datetime_format = "%Y-%m-%dT%H:%M:%S.%fZ"
-    datetime_format_no_ms = "%Y-%m-%dT%H:%M:%SZ"
-    for dt_format in (datetime_format, datetime_format_no_ms):
-        try:
-            dt_instance = datetime.strptime(string, dt_format)
-            break
-        except ValueError:
-            pass
-    return dt_instance
-
-
 def dt_now():
     """get current ts"""
     return datetime.utcnow().replace(microsecond=0, tzinfo=None)


### PR DESCRIPTION
Addendum to #1235, implements approach mentioned in 
https://github.com/webrecorder/browsertrix-cloud/pull/1218#issuecomment-1747988456

- Operator checks for remaining `<crawl_id>:start:<instanceid>` keys on pod crash or crawl end,
and adds difference between current time and start times to execution time.
- Execution time added to 'crawlExecSeconds` in db
- Depends on webrecorder/browsertrix-crawler#405 in the crawler