### PR TITLE
Allow users to change display name and email

### DIFF
--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -311,12 +311,16 @@ export class AccountSettings extends LiteElement {
     const { password, newPassword } = serialize(form);
     let nextAuthState: Auth | null = null;
 
+    this.sectionSubmitting = "password";
+
     try {
       nextAuthState = await AuthService.login({
         email: this.authState.username,
         password: password as string,
       });
-    } catch {}
+    } catch {
+      form.reset();
+    }
 
     if (!nextAuthState) {
       this.notify({
@@ -324,10 +328,9 @@ export class AccountSettings extends LiteElement {
         variant: "danger",
         icon: "exclamation-octagon",
       });
+      this.sectionSubmitting = null;
       return;
     }
-
-    this.sectionSubmitting = "password";
 
     try {
       await this.apiFetch(`/users/me`, nextAuthState!, {

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -156,7 +156,6 @@ export class AccountSettings extends LiteElement {
               name="email"
               value=${this.userInfo.email}
               type="email"
-              minlength="2"
               aria-label=${msg("Email")}
             >
               <div slot="suffix">

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -338,6 +338,7 @@ export class AccountSettings extends LiteElement {
         }),
       });
 
+      form.reset();
       this.dispatchEvent(new CustomEvent("update-user-info"));
       this.notify({
         message: msg("Your password has been updated."),

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -1,6 +1,7 @@
 import { LitElement } from "lit";
 import { state, query, property } from "lit/decorators.js";
 import { msg, localized } from "@lit/localize";
+import type { SlInput } from "@shoelace-style/shoelace";
 
 import type { CurrentUser } from "../types/user";
 import LiteElement, { html } from "../utils/LiteElement";
@@ -18,6 +19,13 @@ class RequestVerify extends LitElement {
 
   @state()
   private requestSuccess: boolean = false;
+
+  willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("email")) {
+      this.isRequesting = false;
+      this.requestSuccess = false;
+    }
+  }
 
   createRenderRoot() {
     return this;
@@ -82,6 +90,9 @@ export class AccountSettings extends LiteElement {
   @property({ type: Object })
   userInfo?: CurrentUser;
 
+  @state()
+  sectionSubmitting: null | "name" | "email" | "password" = null;
+
   render() {
     if (!this.userInfo) return;
     return html`
@@ -89,48 +100,61 @@ export class AccountSettings extends LiteElement {
         <h1 class="text-xl font-semibold leading-8 mb-7">
           ${msg("Account Settings")}
         </h1>
-        <form class="border rounded mb-5">
+        <form class="border rounded mb-5" @submit=${this.onSubmitName}>
           <div class="p-4">
-            <h2 class="text-lg font-semibold leading-none mb-3">
+            <h2 class="text-lg font-semibold leading-none mb-4">
               ${msg("Display Name")}
             </h2>
-            <sl-input
-              name="displayName"
-              label=${msg(
+            <p class="mb-2">
+              ${msg(
                 "Enter your full name, or another name to display in the orgs you belong to."
               )}
+            </p>
+            <sl-input
+              name="displayName"
               value=${this.userInfo.name}
               maxlength="40"
               minlength="2"
+              required
+              aria-label=${msg("Display name")}
             ></sl-input>
           </div>
           <footer class="flex items-center justify-end border-t px-4 py-3">
-            <sl-button size="small" variant="primary">${msg("Save")}</sl-button>
+            <sl-button
+              type="submit"
+              size="small"
+              variant="primary"
+              ?loading=${this.sectionSubmitting === "name"}
+              >${msg("Save")}</sl-button
+            >
           </footer>
         </form>
         <form class="border rounded mb-5">
           <div class="p-4">
-            <h2 class="text-lg font-semibold leading-none mb-3">
+            <h2 class="text-lg font-semibold leading-none mb-4">
               ${msg("Email")}
             </h2>
+            <p class="mb-2">${msg("Update the email you use to log in.")}</p>
             <sl-input
               name="email"
-              label=${msg("Update the email you use to log in.")}
               value=${this.userInfo.email}
               type="email"
               minlength="2"
+              aria-label=${msg("Email")}
             ></sl-input>
           </div>
           <footer class="flex items-center justify-between border-t px-4 py-3">
             <btrix-request-verify
               email=${this.userInfo.email}
             ></btrix-request-verify>
-            <sl-button size="small" variant="primary">${msg("Save")}</sl-button>
+            <sl-button type="submit" size="small" variant="primary"
+              >${msg("Save")}</sl-button
+            >
           </footer>
         </form>
         <form class="border rounded mb-5">
           <div class="p-4">
-            <h2 class="text-lg font-semibold leading-none mb-3">
+            <h2 class="text-lg font-semibold leading-none mb-4">
               ${msg("Password")}
             </h2>
             <sl-input
@@ -150,10 +174,54 @@ export class AccountSettings extends LiteElement {
             ></sl-input>
           </div>
           <footer class="flex items-center justify-end border-t px-4 py-3">
-            <sl-button size="small" variant="primary">${msg("Save")}</sl-button>
+            <sl-button type="submit" size="small" variant="primary"
+              >${msg("Save")}</sl-button
+            >
           </footer>
         </form>
       </div>
     `;
+  }
+
+  private async onSubmitName(e: SubmitEvent) {
+    if (!this.userInfo) return;
+    const form = e.target as HTMLFormElement;
+    const input = form.querySelector("sl-input") as SlInput;
+    if (!input.checkValidity()) {
+      return;
+    }
+    e.preventDefault();
+    const newName = input.value.trim();
+
+    if (newName === this.userInfo.name) {
+      return;
+    }
+
+    this.sectionSubmitting = "name";
+
+    try {
+      await this.apiFetch(`/users/me`, this.authState!, {
+        method: "PATCH",
+        body: JSON.stringify({
+          email: this.userInfo.email,
+          name: newName,
+        }),
+      });
+
+      this.dispatchEvent(new CustomEvent("update-user-info"));
+      this.notify({
+        message: msg("Your name has been updated."),
+        variant: "success",
+        icon: "check2-circle",
+      });
+    } catch (e) {
+      this.notify({
+        message: msg("Sorry, couldn't update name at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+
+    this.sectionSubmitting = null;
   }
 }

--- a/frontend/src/components/account-settings.ts
+++ b/frontend/src/components/account-settings.ts
@@ -263,7 +263,7 @@ export class AccountSettings extends LiteElement {
       return;
     }
     e.preventDefault();
-    const newName = (serialize(form).name as string).trim();
+    const newName = (serialize(form).displayName as string).trim();
     if (newName === this.userInfo.name) {
       return;
     }

--- a/frontend/src/components/input/input.ts
+++ b/frontend/src/components/input/input.ts
@@ -43,6 +43,9 @@ export class Input extends LiteElement {
   @property()
   required?: any;
 
+  @property()
+  minlength?: number;
+
   @property({ type: Boolean })
   passwordToggle?: boolean;
 
@@ -65,6 +68,7 @@ export class Input extends LiteElement {
           autocomplete=${ifDefined(this.autocomplete)}
           placeholder=${ifDefined(this.placeholder)}
           value=${ifDefined(this.value)}
+          minlength=${ifDefined(this.minlength)}
           ?required=${Boolean(this.required)}
           @keydown=${this.handleKeyDown}
         />

--- a/frontend/src/components/sign-up-form.ts
+++ b/frontend/src/components/sign-up-form.ts
@@ -76,20 +76,6 @@ export class SignUpForm extends LiteElement {
         </div>
         <div class="mb-5">
           <btrix-input
-            id="password"
-            name="password"
-            type="password"
-            label="${msg("New password")}"
-            help-text=${msg("Must be between 8-64 characters")}
-            minlength="8"
-            autocomplete="new-password"
-            passwordToggle
-            required
-          >
-          </btrix-input>
-        </div>
-        <div class="mb-5">
-          <btrix-input
             id="name"
             name="name"
             label=${msg("Your name")}
@@ -97,12 +83,27 @@ export class SignUpForm extends LiteElement {
               desc: "Example user's name",
             })}
             autocomplete="nickname"
+            minlength="2"
           >
           </btrix-input>
           <p class="mt-2 text-sm text-gray-500">
-            <span class="text-gray-400">${msg("(optional)")}</span> ${msg(
-              "Your name will be visible to organization collaborators."
-            )}
+            ${msg("Your name will be visible to organization collaborators.")}
+          </p>
+        </div>
+        <div class="mb-5">
+          <btrix-input
+            id="password"
+            name="password"
+            type="password"
+            label="${msg("Password")}"
+            minlength="8"
+            autocomplete="new-password"
+            passwordToggle
+            required
+          >
+          </btrix-input>
+          <p class="mt-2 text-sm text-gray-500">
+            ${msg("Choose a strong password between 8-64 characters.")}
           </p>
         </div>
 
@@ -120,6 +121,7 @@ export class SignUpForm extends LiteElement {
   }
 
   private async onSubmit(event: SubmitEvent) {
+    const form = event.target as HTMLFormElement;
     event.preventDefault();
     event.stopPropagation();
     this.dispatchEvent(new CustomEvent("submit"));
@@ -127,7 +129,7 @@ export class SignUpForm extends LiteElement {
     this.serverError = undefined;
     this.isSubmitting = true;
 
-    const formData = new FormData(event.target as HTMLFormElement);
+    const formData = new FormData(form);
     const email = formData.get("email") as string;
     const password = formData.get("password") as string;
     const name = formData.get("name") as string;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -53,6 +53,7 @@ type UserSettings = {
  * @event logged-in
  * @event log-out
  * @event user-info-change
+ * @event update-user-info
  */
 @localized()
 export class App extends LiteElement {
@@ -653,6 +654,11 @@ export class App extends LiteElement {
           class="w-full max-w-screen-lg mx-auto p-2 md:py-8 box-border"
           @navigate="${this.onNavigateTo}"
           @logged-in=${this.onLoggedIn}
+          @update-user-info=${(e: CustomEvent) => {
+            e.stopPropagation();
+            this.updateUserInfo();
+          }}
+          @notify="${this.onNotify}"
           .authState="${this.authService.authState}"
           .userInfo="${this.userInfo}"
         ></btrix-account-settings>`;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/522

<!-- Fixes #issue_number -->

### Changes

- Refreshes account settings page styles
- Users can change their display name
- Users can change their email address, with verification status shown (note: backend does not automatically send new verification email)

### Manual testing

1. Log in and click app bar user dropdown -> Account Settings
2. Enter in a new display name and click "Save". Verify name saves as expected
3. Enter in a new email address and click "Save". Verify email saves as expected and verification status is updated
4. Click "Change Password". Verify password input receives focus
5. Enter in an incorrect current password. Verify form resets and does fails to save
6. Enter in correct current password and new password. Verify password saves as expected and form is hidden again.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Account Settings | <img width="666" alt="Screenshot 2023-10-10 at 4 32 13 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/955a3f99-6917-4cef-85ce-1bb241be5a5b"> |
| Account Settings - Email (unverified) | <img width="685" alt="Screenshot 2023-10-10 at 4 39 18 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/627bbc67-a513-4154-b3a9-7ad92764cc27"> |
| Account Settings - Password (expanded) | <img width="664" alt="Screenshot 2023-10-10 at 4 32 21 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/307c4d99-5dc8-450b-bcbd-664982b1fdf3"> |



### Follow-ups
Strong password requirements are not enforced, will be handled in https://github.com/webrecorder/browsertrix-cloud/issues/1233