### PR TITLE
Allow org admins to update slug

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "pretty-ms": "^7.0.1",
     "query-string": "^8.1.0",
     "regex-colorize": "^0.0.3",
+    "slugify": "^1.6.6",
     "style-loader": "^3.3.0",
     "tailwindcss": "^3.2.7",
     "ts-loader": "^9.2.6",

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -554,30 +554,17 @@ export class Org extends LiteElement {
 
     return data;
   }
-
   private async onOrgInfoChange(e: OrgInfoChangeEvent) {
-    const { name, slug } = e.detail;
-
-    if (name) {
-      await this.updateOrgName(name);
-    }
-
-    if (slug) {
-      console.log("TODO update slug");
-    }
-  }
-
-  private async updateOrgName(newName: string) {
     this.isSavingOrgName = true;
 
     try {
       await this.apiFetch(`/orgs/${this.org!.id}/rename`, this.authState!, {
         method: "POST",
-        body: JSON.stringify({ name: newName }),
+        body: JSON.stringify(e.detail),
       });
 
       this.notify({
-        message: msg("Updated organization name."),
+        message: msg("Updated organization info."),
         variant: "success",
         icon: "check2-circle",
       });
@@ -589,13 +576,40 @@ export class Org extends LiteElement {
       this.notify({
         message: e.isApiError
           ? e.message
-          : msg("Sorry, couldn't update organization name at this time."),
+          : msg("Sorry, couldn't update organization info at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });
     }
 
     this.isSavingOrgName = false;
+  }
+
+  private async updateOrgSlug(newSlug: string) {
+    try {
+      await this.apiFetch(`/orgs/${this.org!.id}`, this.authState!, {
+        method: "PATCH",
+        body: JSON.stringify({ slug: newSlug }),
+      });
+
+      this.notify({
+        message: msg("Updated organization slug."),
+        variant: "success",
+        icon: "check2-circle",
+      });
+
+      this.dispatchEvent(
+        new CustomEvent("update-user-info", { bubbles: true })
+      );
+    } catch (e: any) {
+      this.notify({
+        message: e.isApiError
+          ? e.message
+          : msg("Sorry, couldn't update organization slug at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
   }
 
   private async onOrgRemoveMember(e: OrgRemoveMemberEvent) {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -31,7 +31,7 @@ import "./components/new-collection-dialog";
 import "./components/new-workflow-dialog";
 import type {
   Member,
-  OrgNameChangeEvent,
+  OrgInfoChangeEvent,
   UserRoleChangeEvent,
   OrgRemoveMemberEvent,
 } from "./settings";
@@ -536,7 +536,7 @@ export class Org extends LiteElement {
       activePanel=${activePanel}
       ?isAddingMember=${isAddingMember}
       ?isSavingOrgName=${this.isSavingOrgName}
-      @org-name-change=${this.onOrgNameChange}
+      @org-info-change=${this.onOrgInfoChange}
       @org-user-role-change=${this.onUserRoleChange}
       @org-remove-member=${this.onOrgRemoveMember}
     ></btrix-org-settings>`;
@@ -555,13 +555,25 @@ export class Org extends LiteElement {
     return data;
   }
 
-  private async onOrgNameChange(e: OrgNameChangeEvent) {
+  private async onOrgInfoChange(e: OrgInfoChangeEvent) {
+    const { name, slug } = e.detail;
+
+    if (name) {
+      await this.updateOrgName(name);
+    }
+
+    if (slug) {
+      console.log("TODO update slug");
+    }
+  }
+
+  private async updateOrgName(newName: string) {
     this.isSavingOrgName = true;
 
     try {
       await this.apiFetch(`/orgs/${this.org!.id}/rename`, this.authState!, {
         method: "POST",
-        body: JSON.stringify({ name: e.detail.value }),
+        body: JSON.stringify({ name: newName }),
       });
 
       this.notify({

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -104,7 +104,7 @@ export class Org extends LiteElement {
   private org?: OrgData | null;
 
   @state()
-  private isSavingOrgName = false;
+  private isSavingOrgInfo = false;
 
   get userOrg() {
     if (!this.userInfo) return null;
@@ -535,7 +535,7 @@ export class Org extends LiteElement {
       .orgId=${this.orgId}
       activePanel=${activePanel}
       ?isAddingMember=${isAddingMember}
-      ?isSavingOrgName=${this.isSavingOrgName}
+      ?isSavingOrgName=${this.isSavingOrgInfo}
       @org-info-change=${this.onOrgInfoChange}
       @org-user-role-change=${this.onUserRoleChange}
       @org-remove-member=${this.onOrgRemoveMember}
@@ -555,7 +555,7 @@ export class Org extends LiteElement {
     return data;
   }
   private async onOrgInfoChange(e: OrgInfoChangeEvent) {
-    this.isSavingOrgName = true;
+    this.isSavingOrgInfo = true;
 
     try {
       await this.apiFetch(`/orgs/${this.org!.id}/rename`, this.authState!, {
@@ -564,7 +564,7 @@ export class Org extends LiteElement {
       });
 
       this.notify({
-        message: msg("Updated organization info."),
+        message: msg("Updated organization."),
         variant: "success",
         icon: "check2-circle",
       });
@@ -576,40 +576,13 @@ export class Org extends LiteElement {
       this.notify({
         message: e.isApiError
           ? e.message
-          : msg("Sorry, couldn't update organization info at this time."),
+          : msg("Sorry, couldn't update organization at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });
     }
 
-    this.isSavingOrgName = false;
-  }
-
-  private async updateOrgSlug(newSlug: string) {
-    try {
-      await this.apiFetch(`/orgs/${this.org!.id}`, this.authState!, {
-        method: "PATCH",
-        body: JSON.stringify({ slug: newSlug }),
-      });
-
-      this.notify({
-        message: msg("Updated organization slug."),
-        variant: "success",
-        icon: "check2-circle",
-      });
-
-      this.dispatchEvent(
-        new CustomEvent("update-user-info", { bubbles: true })
-      );
-    } catch (e: any) {
-      this.notify({
-        message: e.isApiError
-          ? e.message
-          : msg("Sorry, couldn't update organization slug at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
-    }
+    this.isSavingOrgInfo = false;
   }
 
   private async onOrgRemoveMember(e: OrgRemoveMemberEvent) {

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -86,9 +86,9 @@ export class OrgSettings extends LiteElement {
   @state()
   private isSubmittingInvite = false;
 
-  private get tabLabels() {
+  private get tabLabels(): Record<Tab, string> {
     return {
-      information: msg("Information"),
+      information: msg("General"),
       members: msg("Members"),
     };
   }

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -205,7 +205,9 @@ export class OrgSettings extends LiteElement {
               required
               @sl-input=${(e: InputEvent) => {
                 const input = e.target as SlInput;
-                input.value = input.value.replace(/[/\\?%*:|"<>,\.\s]/, "-");
+                input.value = input.value
+                  .replace(/[/\\?#%*:|"<>,\.\s]/, "-")
+                  .replace(/--/, "-");
               }}
             >
             </sl-input>

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -26,7 +26,7 @@ export type Member = User & {
   name: string;
 };
 export type OrgInfoChangeEvent = CustomEvent<{
-  name?: string;
+  name: string;
   slug?: string;
 }>;
 export type UserRoleChangeEvent = CustomEvent<{
@@ -88,7 +88,7 @@ export class OrgSettings extends LiteElement {
 
   private get tabLabels() {
     return {
-      information: msg("Org Information"),
+      information: msg("Information"),
       members: msg("Members"),
     };
   }
@@ -205,9 +205,7 @@ export class OrgSettings extends LiteElement {
               required
               @sl-input=${(e: InputEvent) => {
                 const input = e.target as SlInput;
-                input.value = input.value
-                  .replace(/[/\\?%*:|"<>,\.\s]/, "-")
-                  .replace(/\s/, "-");
+                input.value = input.value.replace(/[/\\?%*:|"<>,\.\s]/, "-");
               }}
             >
             </sl-input>
@@ -444,13 +442,12 @@ export class OrgSettings extends LiteElement {
     if (!(await this.checkFormValidity(formEl))) return;
 
     const { orgName, orgSlug } = serialize(formEl);
-    const detail: any = {};
-    if (orgName !== this.org.name) {
-      detail.name = orgName;
-    }
+    const detail: any = { name: orgName };
+
     if (orgSlug !== this.org.slug) {
       detail.slug = orgSlug;
     }
+
     this.dispatchEvent(
       <OrgInfoChangeEvent>new CustomEvent("org-info-change", {
         detail,

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -202,7 +202,7 @@ export class OrgSettings extends LiteElement {
             <sl-input
               name="orgSlug"
               size="small"
-              label=${msg("Slug URL")}
+              label=${msg("Org ID")}
               placeholder="my-organization"
               autocomplete="off"
               value=${this.org.slug}

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -229,7 +229,7 @@ export class OrgSettings extends LiteElement {
               <sl-icon name="info-circle"></sl-icon>
             </div>
             <div class="mt-0.5 text-xs text-neutral-500">
-              ${msg("Org URL namespace in Browsertrix Cloud.")}
+              ${msg("Unique URL for this organization.")}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -175,6 +175,7 @@ export class OrgSettings extends LiteElement {
               name="orgName"
               size="small"
               label=${msg("Org Name")}
+              placeholder=${msg("My Organization")}
               autocomplete="off"
               value=${this.org.name}
               minlength="2"
@@ -198,6 +199,7 @@ export class OrgSettings extends LiteElement {
               name="orgSlug"
               size="small"
               label=${msg("Slug URL")}
+              placeholder="my-organization"
               autocomplete="off"
               value=${this.org.slug}
               minlength="2"
@@ -206,7 +208,7 @@ export class OrgSettings extends LiteElement {
               @sl-input=${(e: InputEvent) => {
                 const input = e.target as SlInput;
                 input.value = input.value
-                  .replace(/[/\\?#%*:|"<>,\.\s]/, "-")
+                  .replace(/[/\\!?#%*:|'"<>()\[\],\.\s]/, "-")
                   .replace(/--/, "-");
               }}
             >

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -11,6 +11,7 @@ export const AccessCode: Record<UserRole, number> = {
 export type OrgData = {
   id: string;
   name: string;
+  slug: string;
   quotas: Record<string, number>;
   bytesStored: number;
   users?: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6174,6 +6174,11 @@ slice-ansi@^5.0.0:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
 
+slugify@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
+  integrity sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==
+
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1259

<!-- Fixes #issue_number -->

### Changes

- Allows editing of org slugs (actual URL updates will be handled in https://github.com/webrecorder/browsertrix-cloud/issues/1258.)
- Converts user input to slug using [slugify](https://github.com/simov/slugify)
- Adds help text to org name and slug
- Renames tab from "information" to "general" settings

### Manual testing

1. Log in as org admin and go to "Org Settings"
2. Type in different org slug. Verify that help text updates with a valid slug.
3. Save changes. Verify slug saves as expected

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Org Settings - General | <img width="926" alt="Screenshot 2023-10-11 at 4 55 04 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/95c8f4ba-5c4b-4789-ac84-4d8c808c7519"> |