### PR TITLE
Prevent user from logging in after 5 consecutive failed login attempts until pw is reset

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -209,7 +209,7 @@ def init_jwt_auth(user_manager):
                 f"Password reset email sent after too many attempts for {login_email}",
                 flush=True,
             )
-            await user_manager.set_failed_logins(attempted_user, 0)
+            await user_manager.reset_failed_logins(attempted_user)
             raise HTTPException(
                 status_code=429,
                 detail="too_many_login_attempts",
@@ -230,7 +230,7 @@ def init_jwt_auth(user_manager):
         #        detail="login_user_not_verified",
         #    )
 
-        await user_manager.set_failed_logins(attempted_user, 0)
+        await user_manager.reset_failed_logins(attempted_user)
         return get_bearer_response(user)
 
     @auth_jwt_router.post("/refresh", response_model=BearerResponse)

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -215,10 +215,6 @@ def init_jwt_auth(user_manager):
                 detail="too_many_login_attempts",
             )
 
-        # If user is locked, aways return 429 to prevent someone from continuing
-        # to get feedback on whether login credentials are invalid
-        if attempted_user.locked:
-            raise HTTPException(status_code=429, detail="too_many_login_attempts")
         if not user:
             raise HTTPException(
                 status_code=400,

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -2,6 +2,7 @@
 
 import os
 import uuid
+import asyncio
 from datetime import datetime, timedelta
 from typing import Optional, Tuple, List
 from passlib import pwd
@@ -172,53 +173,62 @@ def init_jwt_auth(user_manager):
     @auth_jwt_router.post("/login", response_model=BearerResponse)
     async def login(
         credentials: OAuth2PasswordRequestForm = Depends(),
-    ):
+    ) -> BearerResponse:
         """Prevent brute force password attacks.
 
         After 5 or more consecutive failed login attempts for the same user,
         lock the user account and send an email to reset their password.
         On successful login when user is not already locked, reset count to 0.
         """
-        user = await user_manager.authenticate(
-            credentials.username, credentials.password
-        )
-
         login_email = credentials.username
 
-        if user is None:
-            print(f"Failed login attempt for {login_email}", flush=True)
-            await user_manager.inc_failed_logins(login_email)
-
         failed_count = await user_manager.get_failed_logins_count(login_email)
+
         if failed_count > 0:
             print(
                 f"Consecutive failed login count for {login_email}: {failed_count}",
                 flush=True,
             )
+
+        # first, check if failed count exceeds max failed logins
+        # if so, don't try logging in
         if failed_count >= MAX_FAILED_LOGINS:
-            attempted_user = await user_manager.get_by_email(login_email)
-            if attempted_user:
-                await user_manager.forgot_password(attempted_user)
-                print(
-                    f"Password reset email sent after too many attempts for {login_email}",
-                    flush=True,
-                )
+            # only send reset email on first failure to avoid spamming user
+            if failed_count == MAX_FAILED_LOGINS:
+                # do this async to avoid hinting at any delay if user exists
+                async def send_reset_if_needed():
+                    attempted_user = await user_manager.get_by_email(login_email)
+                    if attempted_user:
+                        await user_manager.forgot_password(attempted_user)
+                        print(
+                            f"Password reset email sent after too many attempts for {login_email}",
+                            flush=True,
+                        )
+
+                asyncio.create_task(send_reset_if_needed())
+
+            # any further attempt is a failure, increment to track further attempts
+            # and avoid sending email again
+            await user_manager.inc_failed_logins(login_email)
+
             raise HTTPException(
                 status_code=429,
                 detail="too_many_login_attempts",
             )
 
+        # attempt login
+        user = await user_manager.authenticate(login_email, credentials.password)
+
         if not user:
+            print(f"Failed login attempt for {login_email}", flush=True)
+            await user_manager.inc_failed_logins(login_email)
+
             raise HTTPException(
                 status_code=400,
                 detail="login_bad_credentials",
             )
-        # if requires_verification and not user.is_verified:
-        #    raise HTTPException(
-        #        status_code=400,
-        #        detail="login_user_not_verified",
-        #    )
 
+        # successfully logged in, reset failed logins, return user
         await user_manager.reset_failed_logins(login_email)
         return get_bearer_response(user)
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -89,12 +89,9 @@ class User(BaseModel):
     hashed_password: str
 
     # Consecutive failed logins, reset to 0 on successful login.
+    # On failed_logins >= 5, user is unable to log in until they
+    # reset their password.
     failed_logins: Optional[int] = 0
-
-    # If user is logged, they are unable to log in until they reset their
-    # password from the /forgot-password email or /users/me/password-change.
-    # This is to prevent brute force cracking of passwords via /login.
-    locked: Optional[bool] = False
 
     def dict(self, *a, **kw):
         """ensure invites / hashed_password never serialize, just in case"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -102,7 +102,7 @@ class FailedLogin(BaseMongoModel):
     Failed login model
     """
 
-    created: datetime = datetime.now()
+    attempted: datetime = datetime.now()
     email: str
 
     # Consecutive failed logins, reset to 0 on successful login or after

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -88,17 +88,28 @@ class User(BaseModel):
     invites: Dict[str, InvitePending] = {}
     hashed_password: str
 
-    # Consecutive failed logins, reset to 0 on successful login.
-    # On failed_logins >= 5, user is unable to log in until they
-    # reset their password.
-    failed_logins: Optional[int] = 0
-
     def dict(self, *a, **kw):
         """ensure invites / hashed_password never serialize, just in case"""
         exclude = kw.get("exclude") or set()
         exclude.add("invites")
         exclude.add("hashed_password")
         return super().dict(*a, **kw)
+
+
+# ============================================================================
+class FailedLogin(BaseMongoModel):
+    """
+    Failed login model
+    """
+
+    created: datetime = datetime.now()
+    email: str
+
+    # Consecutive failed logins, reset to 0 on successful login or after
+    # password is reset. On failed_logins >= 5 within the hour before this
+    # object is deleted, the user is unable to log in until they reset their
+    # password.
+    count: int = 1
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -88,6 +88,14 @@ class User(BaseModel):
     invites: Dict[str, InvitePending] = {}
     hashed_password: str
 
+    # Consecutive failed logins, reset to 0 on successful login.
+    failed_logins: Optional[int] = 0
+
+    # If user is logged, they are unable to log in until they reset their
+    # password from the /forgot-password email or /users/me/password-change.
+    # This is to prevent brute force cracking of passwords via /login.
+    locked: Optional[bool] = False
+
     def dict(self, *a, **kw):
         """ensure invites / hashed_password never serialize, just in case"""
         exclude = kw.get("exclude") or set()

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -79,7 +79,7 @@ class UserManager:
         await self.users.create_index("id", unique=True)
         await self.users.create_index("email", unique=True)
         # Expire failed logins object after one hour
-        await self.failed_logins.create_index("created", expireAfterSeconds=3600)
+        await self.failed_logins.create_index("attempted", expireAfterSeconds=3600)
 
     async def register(
         self, user: UserCreateIn, request: Optional[Request] = None
@@ -548,7 +548,8 @@ class UserManager:
         await self.failed_logins.find_one_and_update(
             {"email": email},
             {
-                "$setOnInsert": failed_login.to_dict(exclude={"count"}),
+                "$setOnInsert": failed_login.to_dict(exclude={"count", "attempted"}),
+                "$set": {"attempted": failed_login.dict(include={"attempted"})},
                 "$inc": {"count": 1},
             },
             upsert=True,

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -434,11 +434,6 @@ class UserManager:
             user.email, token, request and request.headers
         )
 
-        # Lock user until password is reset
-        await self.users.find_one_and_update(
-            {"id": user.id}, {"$set": {"locked": True}}
-        )
-
     async def reset_password(self, token: str, password: str) -> None:
         """reset password to new password given reset token"""
         try:
@@ -522,8 +517,9 @@ class UserManager:
         user.hashed_password = hashed_password
         await self.users.find_one_and_update(
             {"id": user.id},
-            {"$set": {"hashed_password": hashed_password, "locked": False}},
+            {"$set": {"hashed_password": hashed_password}},
         )
+        await self.reset_failed_logins(user)
 
     async def reset_failed_logins(self, user: User) -> None:
         """Reset consecutive failed login attempts for user to 0"""

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -525,16 +525,17 @@ class UserManager:
             {"$set": {"hashed_password": hashed_password, "locked": False}},
         )
 
-    async def set_failed_logins(self, user: User, count: int) -> None:
-        """Set consecutive failed login attempts for user"""
+    async def reset_failed_logins(self, user: User) -> None:
+        """Reset consecutive failed login attempts for user to 0"""
         await self.users.find_one_and_update(
-            {"id": user.id}, {"$set": {"failed_logins": count}}
+            {"id": user.id}, {"$set": {"failed_logins": 0}}
         )
 
     async def inc_failed_logins(self, user: User) -> None:
         """Inc consecutive failed login attempts for user by 1"""
-        count = await self.get_failed_logins_count(user)
-        await self.set_failed_logins(user, count + 1)
+        await self.users.find_one_and_update(
+            {"id": user.id}, {"$inc": {"failed_logins": 1}}
+        )
 
     async def get_failed_logins_count(self, user: User) -> int:
         """Get failed login attempts for user, falling back to 0"""

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -240,8 +240,8 @@ def test_reset_valid_password(admin_auth_headers, default_org_id):
 
 
 def test_lock_out_user_after_failed_logins():
-    # Almost lock out user by making 4 consecutive failed login attempts
-    for _ in range(4):
+    # Almost lock out user by making 5 consecutive failed login attempts
+    for _ in range(5):
         requests.post(
             f"{API_PREFIX}/auth/jwt/login",
             data={
@@ -316,8 +316,8 @@ def test_lock_out_user_after_failed_logins():
 
 def test_lock_out_unregistered_user_after_failed_logins():
     unregistered_email = "notregistered@example.com"
-    # Almost lock out email by making 4 consecutive failed login attempts
-    for _ in range(4):
+    # Almost lock out email by making 5 consecutive failed login attempts
+    for _ in range(5):
         requests.post(
             f"{API_PREFIX}/auth/jwt/login",
             data={

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -371,11 +371,16 @@ export class LogInPage extends LiteElement {
       // will result in a route change
     } catch (e: any) {
       if (e.isApiError) {
-        // TODO check error details
+        let message = msg("Sorry, invalid username or password");
+        if (e.message == "Too Many Requests") {
+          message = msg(
+            "Sorry, too many failed login attempts. A reset password link has been sent to your email."
+          );
+        }
         this.formStateService.send({
           type: "ERROR",
           detail: {
-            serverError: msg("Sorry, invalid username or password"),
+            serverError: message,
           },
         });
       } else {


### PR DESCRIPTION
Fixes #1270 

After 5 consecutive failed logins from the same user, we now prevent the user from logging in even with the correct password until they reset it via their email and present the following message in the frontend:

<img width="422" alt="Screen Shot 2023-10-12 at 6 11 26 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/3481bf53-fd4f-47a2-98f3-da51ced75ba0">

`FailedLogin`s are tracked in a new database collection and set to expire after one hour.

Because `FailedLogin`s are tracked by email, after 5 login attempts for an unregistered email address, the backend will return 429 same as for a registered email address to prevent phishing for registered email addresses. A new test has been added to cover this case.

## To test

Backend tests have been added to the same effect but to test manually with the frontend:

1. Make 5 consecutive failed login attempts for a real user (e.g. `username: admin@example.com, password: invalid`)
2. Verify that response goes from 400 to 429 and message pictured above appears
3. Try to log in with correct password and verify 429 is returned and custom response in the frontend telling you to check your email and reset your password appears
4. Reset password from link in email/logs
5. Verify that you can now log in with that user and the new password
6. Verify that five login attempts for an unregistered email address also returns 429 with the custom response in the frontend telling you to check your email and reset your password appears