### PR TITLE
Disable collection share button actions for viewer users

### DIFF
--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -111,14 +111,19 @@ export class CollectionDetail extends LiteElement {
             html`<sl-skeleton class="w-96"></sl-skeleton>`}
           </h1>
         </div>
-        <sl-button
-          variant="primary"
-          size="small"
-          @click=${() => (this.showShareInfo = true)}
-        >
-          <sl-icon name="box-arrow-up" slot="prefix"></sl-icon>
-          Share
-        </sl-button>
+        ${when(
+          this.isCrawler || (!this.isCrawler && this.collection?.isPublic),
+          () => html`
+            <sl-button
+              variant="primary"
+              size="small"
+              @click=${() => (this.showShareInfo = true)}
+            >
+              <sl-icon name="box-arrow-up" slot="prefix"></sl-icon>
+              Share
+            </sl-button>
+          `
+        )}
         ${when(this.isCrawler, this.renderActions)}
       </header>
       <div class="border rounded-lg py-2 px-4 mb-3">
@@ -180,20 +185,29 @@ export class CollectionDetail extends LiteElement {
         @sl-request-close=${() => (this.showShareInfo = false)}
         style="--width: 32rem;"
       >
-        ${this.collection?.isPublic
-          ? ""
-          : html`<p class="mb-3">
-              ${msg(
-                "Make this collection shareable to enable a public viewing link."
-              )}
-            </p>`}
-        <div class="mb-5">
-          <sl-switch
-            ?checked=${this.collection?.isPublic}
-            @sl-change=${(e: CustomEvent) =>
-              this.onTogglePublic((e.target as SlCheckbox).checked)}
-            >${msg("Collection is Shareable")}</sl-switch
-          >
+        ${
+          this.collection?.isPublic
+            ? ""
+            : html`<p class="mb-3">
+                ${msg(
+                  "Make this collection shareable to enable a public viewing link."
+                )}
+              </p>`
+        }
+        ${when(
+          this.isCrawler,
+          () =>
+            html`
+              <div class="mb-5">
+                <sl-switch
+                  ?checked=${this.collection?.isPublic}
+                  @sl-change=${(e: CustomEvent) =>
+                    this.onTogglePublic((e.target as SlCheckbox).checked)}
+                  >${msg("Collection is Shareable")}</sl-switch
+                >
+              </div>
+            `
+        )}
         </div>
         ${when(this.collection?.isPublic, this.renderShareInfo)}
         <div slot="footer" class="flex justify-end">


### PR DESCRIPTION
Closes #1273 

### Changes
- Viewers can see the share button and the dialogue's sharing info if the collection is sharable
  - Viewers can't see or change the share toggle
- Viewers can't see the share button if the collection is not sharable

### Testing

1. Log in as a user with "viewer" status, attempt to share a collection that is not currently sharable, the button should be missing
2. Toggle the collection to make it sharable on a different account
3. Confirm with the "viewer" user that it is now sharable and that the button & dialogue can be seen.  Confirm that the share toggle switch is not visible as the "viewer" user
4. Check that everything works as expected as a crawler user and nothing is hidden!

### Screenshots
**The collection sharing dialogue for users without the crawler role (no toggle switch)**
<img width="548" alt="Screenshot 2023-10-12 at 6 57 48 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/bde11bff-52c1-4b9b-abcc-ee4143d89464">
