### PR TITLE
Update tag spacing and styling for remove button

### DIFF
--- a/frontend/src/components/tag.ts
+++ b/frontend/src/components/tag.ts
@@ -62,15 +62,30 @@ export class Tag extends SLTag {
       .tag__remove {
         color: var(--sl-color-blue-600);
         border-radius: 100%;
+        margin-left: 0.25rem;
+        padding: 0.125rem;
       }
 
       .tag__remove:hover {
-        background-color: var(--sl-color-blue-600);
+        background-color: var(--sl-color-blue-500);
         color: var(--sl-color-neutral-0);
+      }
+
+      :focus .tag__remove:hover {
+        color: var(--sl-color-blue-500);
+        background-color: var(--sl-color-neutral-0);
       }
 
       .tag--small {
         font-size: var(--sl-font-size-x-small);
+      }
+
+      .tag--medium {
+        padding: 0 0.5rem;
+      }
+
+      .tag--medium:is(.tag--removable) {
+        padding: 0 0.125rem 0 0.5rem;
       }
     `,
   ];


### PR DESCRIPTION
### Context

I learned about `:is` and `:has` the other day! These pseudo classes mean we can add custom padding quite easily depending on if the tag is removable or not thanks to Shoelace's nice classes.  Neat!

### Changes
- Adds custom padding to each side based on if the tag is removable or not
- Improves hover state for the remove button when the tag is focused
- Adds padding to the remove button

Sadly does not change the icon from `x-lg` to `x` because Shoelace doesn't let us :(

### Screenshots

#### Before

<img width="569" alt="Screenshot 2023-10-13 at 1 57 21 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/afd42aa4-6435-4567-85d6-49756d91767d">

#### After

**Tag unfocused, remove button hovered**
<img width="684" alt="Screenshot 2023-10-13 at 1 28 02 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/0c36e8d3-784d-4c76-a329-6c238e59554a">

**Tag focused, remove button hovered**
<img width="689" alt="Screenshot 2023-10-13 at 1 27 52 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/efac951f-5956-466b-96ed-3b771bb6be20">

**Tag without remove button**
<img width="579" alt="Screenshot 2023-10-13 at 1 28 10 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/fbf89e67-674a-4535-882e-8e2939fa56ac">