### PR TITLE
Enforce quota and hard cap for monthly execution minutes

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -127,6 +127,9 @@ class BaseCrawlOps:
                 crawl.config.seeds = None
 
         crawl.storageQuotaReached = await self.orgs.storage_quota_reached(crawl.oid)
+        crawl.executionMinutesQuotaReached = (
+            await self.orgs.execution_mins_quota_reached(crawl.oid)
+        )
 
         return crawl
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -136,10 +136,9 @@ class BaseCrawlOps:
                 crawl.config.seeds = None
 
         crawl.storageQuotaReached = await self.orgs.storage_quota_reached(crawl.oid)
-        (
-            crawl.executionMinutesQuotaReached,
-            crawl.executionMinutesHardCapReached,
-        ) = await self.orgs.execution_mins_quota_reached(crawl.oid)
+        crawl.execMinutesQuotaReached = await self.orgs.exec_mins_quota_reached(
+            crawl.oid
+        )
 
         return crawl
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -127,9 +127,10 @@ class BaseCrawlOps:
                 crawl.config.seeds = None
 
         crawl.storageQuotaReached = await self.orgs.storage_quota_reached(crawl.oid)
-        crawl.executionMinutesQuotaReached = (
-            await self.orgs.execution_mins_quota_reached(crawl.oid)
-        )
+        (
+            crawl.executionMinutesQuotaReached,
+            crawl.executionMinutesHardCapReached,
+        ) = await self.orgs.execution_mins_quota_reached(crawl.oid)
 
         return crawl
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -347,7 +347,9 @@ class CrawlConfigOps:
             "settings_changed": changed,
             "metadata_changed": metadata_changed,
             "storageQuotaReached": await this.org_ops.storage_quota_reached(org.id),
-            "execMinutesQuotaReached": await this.org_ops.exec_mins_quota_reached(org.id),
+            "execMinutesQuotaReached": await this.org_ops.exec_mins_quota_reached(
+                org.id
+            ),
         }
         if run_now:
             crawl_id = await self.run_now(cid, org, user)

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -137,7 +137,7 @@ class CrawlConfigOps:
         config: CrawlConfigIn,
         org: Organization,
         user: User,
-    ) -> Tuple[str, str, bool, bool]:
+    ) -> Tuple[str, Optional[str], bool, bool]:
         """Add new crawl config"""
         data = config.dict()
         data["oid"] = org.id
@@ -197,8 +197,8 @@ class CrawlConfigOps:
             await self.add_new_crawl(crawl_id, crawlconfig, user, manual=True)
 
         return (
-            result.inserted_id or "",
-            crawl_id or "",
+            result.inserted_id,
+            crawl_id or None,
             storage_quota_reached,
             exec_mins_quota_reached,
         )

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -346,8 +346,8 @@ class CrawlConfigOps:
             "updated": True,
             "settings_changed": changed,
             "metadata_changed": metadata_changed,
-            "storageQuotaReached": await this.org_ops.storage_quota_reached(org.id),
-            "execMinutesQuotaReached": await this.org_ops.exec_mins_quota_reached(
+            "storageQuotaReached": await self.org_ops.storage_quota_reached(org.id),
+            "execMinutesQuotaReached": await self.org_ops.exec_mins_quota_reached(
                 org.id
             ),
         }

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -3,7 +3,7 @@ Crawl Config API handling
 """
 # pylint: disable=too-many-lines
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Tuple
 
 import uuid
 import asyncio
@@ -135,7 +135,7 @@ class CrawlConfigOps:
         config: CrawlConfigIn,
         org: Organization,
         user: User,
-    ):
+    ) -> Tuple[str, str, bool, bool]:
         """Add new crawl config"""
         data = config.dict()
         data["oid"] = org.id
@@ -195,8 +195,8 @@ class CrawlConfigOps:
             await self.add_new_crawl(crawl_id, crawlconfig, user, manual=True)
 
         return (
-            result.inserted_id,
-            crawl_id,
+            result.inserted_id or "",
+            crawl_id or "",
             storage_quota_reached,
             exec_mins_quota_reached,
         )

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -346,6 +346,8 @@ class CrawlConfigOps:
             "updated": True,
             "settings_changed": changed,
             "metadata_changed": metadata_changed,
+            "storageQuotaReached": await this.org_ops.storage_quota_reached(org.id),
+            "execMinutesQuotaReached": await this.org_ops.exec_mins_quota_reached(org.id),
         }
         if run_now:
             crawl_id = await self.run_now(cid, org, user)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -530,9 +530,14 @@ class CrawlOps(BaseCrawlOps):
 
     async def store_exec_time(self, crawl_id, exec_time):
         """set exec time, only if not already set"""
-        query = {"_id": crawl_id, "type": "crawl", "execTime": {"$in": [0, None]}}
+        query = {
+            "_id": crawl_id,
+            "type": "crawl",
+            "crawlExecSeconds": {"$in": [0, None]},
+        }
         return await self.crawls.find_one_and_update(
-            query, {"$set": {"execTime": exec_time}}
+            query,
+            {"$set": {"crawlExecSeconds": exec_time}},
         )
 
     async def get_crawl_state(self, crawl_id):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -528,16 +528,11 @@ class CrawlOps(BaseCrawlOps):
         query = {"_id": crawl_id, "type": "crawl", "state": "running"}
         return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
 
-    async def store_exec_time(self, crawl_id, exec_time):
-        """set exec time, only if not already set"""
-        query = {
-            "_id": crawl_id,
-            "type": "crawl",
-            "crawlExecSeconds": {"$in": [0, None]},
-        }
+    async def inc_crawl_exec_time(self, crawl_id, exec_time):
+        """increment exec time"""
         return await self.crawls.find_one_and_update(
-            query,
-            {"$set": {"crawlExecSeconds": exec_time}},
+            {"_id": crawl_id, "type": "crawl"},
+            {"$inc": {"crawlExecSeconds": exec_time}},
         )
 
     async def get_crawl_state(self, crawl_id):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -479,6 +479,7 @@ class CrawlOut(BaseMongoModel):
 
     storageQuotaReached: Optional[bool]
     executionMinutesQuotaReached: Optional[bool]
+    executionMinutesHardCapReached: Optional[bool]
 
 
 # ============================================================================
@@ -689,6 +690,7 @@ class OrgQuotas(BaseModel):
     maxPagesPerCrawl: Optional[int] = 0
     storageQuota: Optional[int] = 0
     crawlExecMinutesQuota: Optional[int] = 0
+    crawlExecExtraMinutesHardCap: Optional[int] = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -496,8 +496,7 @@ class CrawlOut(BaseMongoModel):
     cid_rev: Optional[int]
 
     storageQuotaReached: Optional[bool]
-    executionMinutesQuotaReached: Optional[bool]
-    executionMinutesHardCapReached: Optional[bool]
+    execMinutesQuotaReached: Optional[bool]
 
 
 # ============================================================================
@@ -678,13 +677,6 @@ class RenameOrg(BaseModel):
 
 
 # ============================================================================
-class OrgUpdateExecMinsOverage(BaseModel):
-    """Update allowed exec mins overage"""
-
-    crawlExecMinutesAllowedOverage: int
-
-
-# ============================================================================
 class DefaultStorage(BaseModel):
     """Storage reference"""
 
@@ -714,7 +706,7 @@ class OrgQuotas(BaseModel):
     maxConcurrentCrawls: Optional[int] = 0
     maxPagesPerCrawl: Optional[int] = 0
     storageQuota: Optional[int] = 0
-    crawlExecMinutesQuota: Optional[int] = 0
+    maxCrawlMinutesPerMonth: Optional[int] = 0
 
 
 # ============================================================================
@@ -747,7 +739,9 @@ class OrgOut(BaseMongoModel):
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
     quotas: Optional[OrgQuotas] = OrgQuotas()
-    crawlExecMinutesAllowedOverage: int = 0
+
+    storageQuotaReached: Optional[bool]
+    execMinutesQuotaReached: Optional[bool]
 
 
 # ============================================================================
@@ -774,8 +768,6 @@ class Organization(BaseMongoModel):
     default: bool = False
 
     quotas: Optional[OrgQuotas] = OrgQuotas()
-
-    crawlExecMinutesAllowedOverage: Optional[int] = 0
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -706,7 +706,7 @@ class OrgQuotas(BaseModel):
     maxConcurrentCrawls: Optional[int] = 0
     maxPagesPerCrawl: Optional[int] = 0
     storageQuota: Optional[int] = 0
-    maxCrawlMinutesPerMonth: Optional[int] = 0
+    maxExecMinutesPerMonth: Optional[int] = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -663,7 +663,7 @@ class RenameOrg(BaseModel):
 class OrgUpdateExecMinsOverage(BaseModel):
     """Update allowed exec mins overage"""
 
-    allowedOverage: int
+    crawlExecMinutesAllowedOverage: int
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -660,6 +660,13 @@ class RenameOrg(BaseModel):
 
 
 # ============================================================================
+class OrgUpdateExecMinsOverage(BaseModel):
+    """Update allowed exec mins overage"""
+
+    allowedOverage: int
+
+
+# ============================================================================
 class DefaultStorage(BaseModel):
     """Storage reference"""
 
@@ -690,7 +697,6 @@ class OrgQuotas(BaseModel):
     maxPagesPerCrawl: Optional[int] = 0
     storageQuota: Optional[int] = 0
     crawlExecMinutesQuota: Optional[int] = 0
-    crawlExecExtraMinutesHardCap: Optional[int] = 0
 
 
 # ============================================================================
@@ -749,6 +755,8 @@ class Organization(BaseMongoModel):
     default: bool = False
 
     quotas: Optional[OrgQuotas] = OrgQuotas()
+
+    crawlExecMinutesAllowedOverage: Optional[int] = 0
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -478,6 +478,7 @@ class CrawlOut(BaseMongoModel):
     cid_rev: Optional[int]
 
     storageQuotaReached: Optional[bool]
+    executionMinutesQuotaReached: Optional[bool]
 
 
 # ============================================================================
@@ -687,6 +688,7 @@ class OrgQuotas(BaseModel):
     maxConcurrentCrawls: Optional[int] = 0
     maxPagesPerCrawl: Optional[int] = 0
     storageQuota: Optional[int] = 0
+    crawlExecMinutesQuota: Optional[int] = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -729,6 +729,7 @@ class OrgOut(BaseMongoModel):
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
     quotas: Optional[OrgQuotas] = OrgQuotas()
+    crawlExecMinutesAllowedOverage: int = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1317,7 +1317,7 @@ class BtrixOperator(K8sAPI):
         return exec_time
 
     async def store_exec_time_in_crawl(self, crawl_id: str, exec_time: int):
-        """store execTime in crawl (if not already set)"""
+        """store crawlExecSeconds in crawl (if not already set)"""
         try:
             await self.crawl_ops.store_exec_time(crawl_id, exec_time)
             return True

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1316,11 +1316,10 @@ class BtrixOperator(K8sAPI):
         print(f"{name} exec time: {exec_time}")
         return exec_time
 
-    async def store_exec_time_in_crawl(self, crawl_id, exec_time):
+    async def store_exec_time_in_crawl(self, crawl_id: str, exec_time: int):
         """store execTime in crawl (if not already set)"""
         try:
-            if await self.crawl_ops.store_exec_time(crawl_id, exec_time):
-                print(f"Exec Time stored in crawl: {exec_time}", flush=True)
+            await self.crawl_ops.store_exec_time(crawl_id, exec_time)
             return True
         # pylint: disable=broad-except
         except Exception as exc:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1269,11 +1269,7 @@ class BtrixOperator(K8sAPI):
 
         # check exec time quotas and stop if reached limit
         if not status.stopping:
-            (
-                _,
-                exec_mins_hard_cap_reached,
-            ) = await self.org_ops.execution_mins_quota_reached(crawl.oid)
-            if exec_mins_hard_cap_reached:
+            if await self.org_ops.exec_mins_quota_reached(crawl.oid):
                 status.stopping = True
 
         # mark crawl as stopping

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -408,13 +408,13 @@ class BtrixOperator(K8sAPI):
                 )
                 return self._empty_response(status)
 
+        # Gracefully stop crawl when execution minutes hard cap is reached to
+        # ensure that the user still gets their data from the crawl
         _, exec_mins_hard_cap_reached = await self.org_ops.execution_mins_quota_reached(
             crawl.oid, status.runningExecTime
         )
         if exec_mins_hard_cap_reached:
-            await self.cancel_crawl(
-                crawl.id, uuid.UUID(cid), uuid.UUID(oid), status, data.children[POD]
-            )
+            crawl.stopping = True
 
         # Reset runningExecTime to recalculate below for next sync
         status.runningExecTime = 0

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -404,8 +404,11 @@ class BtrixOperator(K8sAPI):
                 )
                 return self._empty_response(status)
 
-        # Cancel crawl if execution minutes quota is reached while running
-        if await self.org_ops.execution_mins_quota_reached(crawl.oid):
+        # Cancel crawl if execution minutes hard cap is reached while running
+        _, exec_mins_hard_cap_reached = await self.org_ops.execution_mins_quota_reached(
+            crawl.oid
+        )
+        if exec_mins_hard_cap_reached:
             await self.cancel_crawl(
                 crawl.id, uuid.UUID(cid), uuid.UUID(oid), status, data.children[POD]
             )

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -624,7 +624,6 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
     async def update_org_billing_settings(
         settings: OrgUpdateExecMinsOverage,
         org: Organization = Depends(org_owner_dep),
-        user: User = Depends(user_dep),
     ):
         await ops.update_execution_mins_overage(
             org, settings.crawlExecMinutesAllowedOverage

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -302,7 +302,7 @@ class OrgOps:
         return await self.storage_quota_reached(oid)
 
     # pylint: disable=invalid-name
-    async def storage_quota_reached(self, oid: uuid.UUID):
+    async def storage_quota_reached(self, oid: uuid.UUID) -> bool:
         """Return boolean indicating if storage quota is met or exceeded."""
         quota = await self.get_org_storage_quota(oid)
         if not quota:
@@ -316,7 +316,7 @@ class OrgOps:
 
         return False
 
-    async def execution_mins_quota_reached(self, oid: uuid.UUID):
+    async def execution_mins_quota_reached(self, oid: uuid.UUID) -> bool:
         """Return boolean indicating if execution minutes quota is met or exceeded."""
         quota = await self.get_org_execution_mins_quota(oid)
         if not quota:
@@ -337,7 +337,7 @@ class OrgOps:
 
         return False
 
-    async def get_org_storage_quota(self, oid):
+    async def get_org_storage_quota(self, oid: uuid.UUID) -> int:
         """return max allowed concurrent crawls, if any"""
         org = await self.orgs.find_one({"_id": oid})
         if org:
@@ -345,7 +345,7 @@ class OrgOps:
             return org.quotas.storageQuota
         return 0
 
-    async def get_org_execution_mins_quota(self, oid):
+    async def get_org_execution_mins_quota(self, oid: uuid.UUID) -> int:
         """return max allowed execution mins per month, if any"""
         org = await self.orgs.find_one({"_id": oid})
         if org:

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -626,8 +626,8 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
 
         return {"updated": True}
 
-    @router.post("/billing", tags=["organizations"])
-    async def update_org_billing_settings(
+    @router.post("/limits", tags=["organizations"])
+    async def update_org_limits_settings(
         settings: OrgUpdateExecMinsOverage,
         org: Organization = Depends(org_owner_dep),
     ):

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -356,7 +356,7 @@ class OrgOps:
         org = await self.orgs.find_one({"_id": oid})
         if org:
             org = Organization.from_dict(org)
-            return org.quotas.maxCrawlMinutesPerMonth
+            return org.quotas.maxExecMinutesPerMonth
         return 0
 
     async def set_origin(self, org: Organization, request: Request):

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -336,9 +336,7 @@ class OrgOps:
         except KeyError:
             return 0
 
-    async def execution_mins_quota_reached(
-        self, oid: uuid.UUID, running_exec_seconds: int = 0
-    ) -> Tuple[bool, bool]:
+    async def execution_mins_quota_reached(self, oid: uuid.UUID) -> Tuple[bool, bool]:
         """Return bools for if execution minutes quota and hard cap are reached."""
         quota = await self.get_org_execution_mins_quota(oid)
         if not quota:
@@ -351,7 +349,6 @@ class OrgOps:
         hard_cap_quota = quota + hard_cap_additional_mins
 
         monthly_exec_seconds = await self.get_this_month_crawl_exec_seconds(oid)
-        monthly_exec_seconds = monthly_exec_seconds + running_exec_seconds
         monthly_exec_minutes = math.floor(monthly_exec_seconds / 60)
 
         if monthly_exec_minutes >= quota:

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -435,3 +435,33 @@ def test_get_org_slug_lookup_non_superadmin(crawler_auth_headers):
     r = requests.get(f"{API_PREFIX}/orgs/slug-lookup", headers=crawler_auth_headers)
     assert r.status_code == 403
     assert r.json()["detail"] == "Not Allowed"
+
+
+def test_set_org_execution_time_overage(admin_auth_headers, default_org_id):
+    NEW_VALUE = 30
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.status_code == 200
+    data = r.json()
+    value_before = data.get("crawlExecMinutesAllowedOverage", 0)
+    assert value_before != NEW_VALUE
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/billing",
+        headers=admin_auth_headers,
+        json={"crawlExecMinutesAllowedOverage": NEW_VALUE},
+    )
+    assert r.status_code == 200
+
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.json()["crawlExecMinutesAllowedOverage"] == NEW_VALUE
+
+
+def test_set_org_execution_time_overage_non_superadmin(
+    crawler_auth_headers, default_org_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/billing",
+        headers=crawler_auth_headers,
+        json={"crawlExecMinutesAllowedOverage": 60},
+    )
+    assert r.status_code == 403

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -446,7 +446,7 @@ def test_set_org_execution_time_overage(admin_auth_headers, default_org_id):
     assert value_before != NEW_VALUE
 
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/billing",
+        f"{API_PREFIX}/orgs/{default_org_id}/limits",
         headers=admin_auth_headers,
         json={"crawlExecMinutesAllowedOverage": NEW_VALUE},
     )
@@ -460,7 +460,7 @@ def test_set_org_execution_time_overage_non_superadmin(
     crawler_auth_headers, default_org_id
 ):
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/billing",
+        f"{API_PREFIX}/orgs/{default_org_id}/limits",
         headers=crawler_auth_headers,
         json={"crawlExecMinutesAllowedOverage": 60},
     )

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -435,33 +435,3 @@ def test_get_org_slug_lookup_non_superadmin(crawler_auth_headers):
     r = requests.get(f"{API_PREFIX}/orgs/slug-lookup", headers=crawler_auth_headers)
     assert r.status_code == 403
     assert r.json()["detail"] == "Not Allowed"
-
-
-def test_set_org_execution_time_overage(admin_auth_headers, default_org_id):
-    NEW_VALUE = 30
-    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
-    assert r.status_code == 200
-    data = r.json()
-    value_before = data.get("crawlExecMinutesAllowedOverage", 0)
-    assert value_before != NEW_VALUE
-
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/limits",
-        headers=admin_auth_headers,
-        json={"crawlExecMinutesAllowedOverage": NEW_VALUE},
-    )
-    assert r.status_code == 200
-
-    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
-    assert r.json()["crawlExecMinutesAllowedOverage"] == NEW_VALUE
-
-
-def test_set_org_execution_time_overage_non_superadmin(
-    crawler_auth_headers, default_org_id
-):
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/limits",
-        headers=crawler_auth_headers,
-        json={"crawlExecMinutesAllowedOverage": 60},
-    )
-    assert r.status_code == 403

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -2,6 +2,7 @@ import requests
 import time
 
 from .conftest import API_PREFIX
+from .utils import get_crawl_status
 
 crawl_id_a = None
 crawl_id_b = None
@@ -103,12 +104,3 @@ def run_crawl(org_id, headers):
     data = r.json()
 
     return data["run_now_job"]
-
-
-def get_crawl_status(org_id, crawl_id, headers):
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
-        headers=headers,
-    )
-    data = r.json()
-    return data["state"]

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -75,7 +75,7 @@ def test_crawl_stopped_when_quota_reached(org_with_quotas, admin_auth_headers):
 def test_crawl_stopped_when_card_cap_reached(org_with_quotas, admin_auth_headers):
     # Set allowed overage on org
     r = requests.post(
-        f"{API_PREFIX}/orgs/{org_with_quotas}/billing",
+        f"{API_PREFIX}/orgs/{org_with_quotas}/limits",
         headers=admin_auth_headers,
         json={"crawlExecMinutesAllowedOverage": EXEC_MINS_ALLOWED_OVERAGE},
     )

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -1,0 +1,156 @@
+import math
+import requests
+import time
+from datetime import datetime
+
+from .conftest import API_PREFIX
+from .utils import get_crawl_status
+
+
+EXEC_MINS_QUOTA = 1
+EXEC_MINS_ALLOWED_OVERAGE = 10
+EXEC_MINS_HARD_CAP = EXEC_MINS_QUOTA + EXEC_MINS_ALLOWED_OVERAGE
+
+config_id = None
+
+
+def test_set_execution_mins_quota(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={"crawlExecMinutesQuota": EXEC_MINS_QUOTA},
+    )
+    data = r.json()
+    assert data.get("updated") == True
+
+
+def test_crawl_stopped_when_quota_reached(org_with_quotas, admin_auth_headers):
+    # Run crawl
+    global config_id
+    crawl_id, config_id = run_crawl(org_with_quotas, admin_auth_headers)
+    time.sleep(1)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "starting",
+        "waiting_capacity",
+    ):
+        time.sleep(2)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "running",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
+        time.sleep(2)
+
+    # Ensure that crawl was stopped by quota
+    assert (
+        get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
+        == "partial_complete"
+    )
+
+    time.sleep(5)
+
+    # Ensure crawl execution seconds went over quota
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawls/{crawl_id}/replay.json",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    execution_seconds = data["crawlExecSeconds"]
+    assert math.floor(execution_seconds / 60) >= EXEC_MINS_QUOTA
+
+    time.sleep(5)
+
+    # Ensure we can't start another crawl when over the quota
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "execution_minutes_hard_cap_reached"
+
+
+def test_crawl_stopped_when_card_cap_reached(org_with_quotas, admin_auth_headers):
+    # Set allowed overage on org
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/billing",
+        headers=admin_auth_headers,
+        json={"crawlExecMinutesAllowedOverage": EXEC_MINS_ALLOWED_OVERAGE},
+    )
+    assert r.status_code == 200
+
+    time.sleep(10)
+
+    # Run new crawl from config
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    crawl_id = r.json()["started"]
+    assert crawl_id
+
+    time.sleep(1)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "starting",
+        "waiting_capacity",
+    ):
+        time.sleep(2)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "running",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
+        time.sleep(2)
+
+    # Ensure that crawl was stopped when hard cap reached
+    assert (
+        get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
+        == "partial_complete"
+    )
+
+    time.sleep(5)
+
+    # Ensure crawl execution seconds went over hard cap (stopping takes a while)
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_with_quotas}",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    execution_seconds = data["crawlExecSeconds"]
+    yymm = datetime.utcnow().strftime("%Y-%m")
+    assert math.floor(execution_seconds[yymm] / 60) >= EXEC_MINS_HARD_CAP
+
+    time.sleep(5)
+
+    # Ensure we can't start another crawl when over the hard cap
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "execution_minutes_hard_cap_reached"
+
+
+def run_crawl(org_id, headers):
+    crawl_data = {
+        "runNow": True,
+        "name": "Execution Mins Quota",
+        "config": {
+            "seeds": [{"url": "https://webrecorder.net/"}],
+            "extraHops": 1,
+        },
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_id}/crawlconfigs/",
+        headers=headers,
+        json=crawl_data,
+    )
+    data = r.json()
+
+    return data["run_now_job"], data["id"]

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -18,7 +18,7 @@ def test_set_execution_mins_quota(org_with_quotas, admin_auth_headers):
     r = requests.post(
         f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
         headers=admin_auth_headers,
-        json={"maxCrawlMinutesPerMonth": EXEC_MINS_QUOTA},
+        json={"maxExecMinutesPerMonth": EXEC_MINS_QUOTA},
     )
     data = r.json()
     assert data.get("updated") == True

--- a/backend/test_nightly/utils.py
+++ b/backend/test_nightly/utils.py
@@ -1,0 +1,14 @@
+"""nightly test utils"""
+
+import requests
+
+from .conftest import API_PREFIX
+
+
+def get_crawl_status(org_id, crawl_id, headers):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_id}/crawls/{crawl_id}/replay.json",
+        headers=headers,
+    )
+    data = r.json()
+    return data["state"]

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -25,6 +25,6 @@ Sent invites can be invalidated by pressing the trash button in the relevant _Pe
 `Admin`
 :   Users with the administrator role have full access to the organization, including its settings page.
 
-## Billing
+## Limits
 
 This page lets organization admins set an additional number of allowed overage minutes when the organization's monthly execution minutes quota has been reached. If set, this serves as a hard cap after which all running crawls will be stopped. When set at the default of 0, crawls will be stopped as soon as the monthly quota is reached.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -24,3 +24,7 @@ Sent invites can be invalidated by pressing the trash button in the relevant _Pe
 
 `Admin`
 :   Users with the administrator role have full access to the organization, including its settings page.
+
+## Billing
+
+This page lets organization admins set an additional number of allowed overage minutes over the monthly execution minutes quota for their organization. If set, this serves as a hard cap after which all running crawls will be stopped. When set at the default of 0, crawls will be stopped as soon as the quota is reached.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -27,4 +27,4 @@ Sent invites can be invalidated by pressing the trash button in the relevant _Pe
 
 ## Billing
 
-This page lets organization admins set an additional number of allowed overage minutes over the monthly execution minutes quota for their organization. If set, this serves as a hard cap after which all running crawls will be stopped. When set at the default of 0, crawls will be stopped as soon as the quota is reached.
+This page lets organization admins set an additional number of allowed overage minutes when the organization's monthly execution minutes quota has been reached. If set, this serves as a hard cap after which all running crawls will be stopped. When set at the default of 0, crawls will be stopped as soon as the monthly quota is reached.

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -61,8 +61,8 @@ export class OrgsList extends LiteElement {
               label = msg("Org Storage Quota (GB)");
               value = Math.floor(value / 1e9);
               break;
-            case "maxCrawlMinutesPerMonth":
-              label = msg("Org Monthly Execution Minutes Quota");
+            case "maxExecMinutesPerMonth":
+              label = msg("Max Execution Minutes Per Month");
               break;
             default:
               label = msg("Unlabeled");

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -61,6 +61,9 @@ export class OrgsList extends LiteElement {
               label = msg("Org Storage Quota (GB)");
               value = Math.floor(value / 1e9);
               break;
+            case "crawlExecMinutesQuota":
+              label = msg("Org Monthly Execution Minutes Quota");
+              break;
             default:
               label = msg("Unlabeled");
           }

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -61,7 +61,7 @@ export class OrgsList extends LiteElement {
               label = msg("Org Storage Quota (GB)");
               value = Math.floor(value / 1e9);
               break;
-            case "crawlExecMinutesQuota":
+            case "maxCrawlMinutesPerMonth":
               label = msg("Org Monthly Execution Minutes Quota");
               break;
             default:

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -64,6 +64,11 @@ export class OrgsList extends LiteElement {
             case "crawlExecMinutesQuota":
               label = msg("Org Monthly Execution Minutes Quota");
               break;
+            case "crawlExecExtraMinutesHardCap":
+              label = msg(
+                "Additional Minutes Over Monthly Execution Quota Before Hard Cap"
+              );
+              break;
             default:
               label = msg("Unlabeled");
           }

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -64,11 +64,6 @@ export class OrgsList extends LiteElement {
             case "crawlExecMinutesQuota":
               label = msg("Org Monthly Execution Minutes Quota");
               break;
-            case "crawlExecExtraMinutesHardCap":
-              label = msg(
-                "Additional Minutes Over Monthly Execution Quota Before Hard Cap"
-              );
-              break;
             default:
               label = msg("Unlabeled");
           }

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -4,6 +4,7 @@ import { when } from "lit/directives/when.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { classMap } from "lit/directives/class-map.js";
 import { msg, localized, str } from "@lit/localize";
+import humanizeDuration from "pretty-ms";
 
 import type { PageChangeEvent } from "../../components/pagination";
 import { RelativeDuration } from "../../components/relative-duration";
@@ -643,6 +644,15 @@ export class CrawlDetail extends LiteElement {
                           ></btrix-relative-duration>
                         </span>
                       `}
+                </btrix-desc-list-item>
+                <btrix-desc-list-item label=${msg("Execution Time")}>
+                  ${this.crawl!.finished
+                    ? html`<span
+                        >${humanizeDuration(
+                          this.crawl!.crawlExecSeconds * 1000
+                        )}</span
+                      >`
+                    : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 </btrix-desc-list-item>
                 <btrix-desc-list-item label=${msg("Initiator")}>
                   ${this.crawl!.manual

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -359,6 +359,10 @@ export class Dashboard extends LiteElement {
     const hasQuota = Boolean(quotaSeconds);
     const isReached = hasQuota && usageSeconds >= quotaSeconds;
 
+    if (isReached) {
+      usageSeconds = quotaSeconds;
+    }
+
     const renderBar = (value: number, label: string, color: string) => html`
       <btrix-meter-bar
         value=${(value / usageSeconds) * 100}
@@ -392,14 +396,6 @@ export class Dashboard extends LiteElement {
                   <span class="inline-flex items-center">
                     ${humanizeDuration((quotaSeconds - usageSeconds) * 1000)}
                     ${msg("Available")}
-                    <sl-tooltip
-                      content=${msg("Total monthly execution time available")}
-                    >
-                      <sl-icon
-                        name="info-circle"
-                        class="ml-1 text-neutral-500"
-                      ></sl-icon
-                    ></sl-tooltip>
                   </span>
                 `
               : ""
@@ -410,7 +406,7 @@ export class Dashboard extends LiteElement {
         () => html`
           <div class="mb-2">
             <btrix-meter
-              value=${usageSeconds}
+              value=${isReached ? quotaSeconds : usageSeconds}
               max=${ifDefined(quotaSeconds || undefined)}
               valueText=${msg("time")}
             >

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -812,7 +812,7 @@ export class Org extends LiteElement {
     }
   }
 
-  checkExecutionMinutesQuota(hardCap = false) {
+  checkExecutionMinutesQuota() {
     if (
       !this.org ||
       !this.org.quotas.crawlExecMinutesQuota ||
@@ -822,56 +822,32 @@ export class Org extends LiteElement {
       return;
     }
 
-    const todaysDate = new Date().toISOString();
-    const todaysYear = todaysDate.slice(0, 4);
-    const todaysMonth = todaysDate.slice(5, 7);
-    const monthKey = `${todaysYear}-${todaysMonth}`;
-
+    const monthKey = new Date().toISOString().slice(0, 7);
     const monthlyExecutionSeconds = this.org.crawlExecSeconds[monthKey];
+    const quota = this.org.quotas.crawlExecMinutesQuota;
+    const hardCap = quota + (this.org.crawlExecMinutesAllowedOverage || 0);
+
     if (monthlyExecutionSeconds) {
       const monthlyExecutionMinutes = Math.floor(monthlyExecutionSeconds / 60);
-      if (monthlyExecutionMinutes >= this.org.quotas.crawlExecMinutesQuota) {
+
+      if (monthlyExecutionMinutes >= quota) {
         this.orgExecutionMinutesQuotaReached = true;
       } else {
         this.orgExecutionMinutesQuotaReached = false;
       }
-    } else {
-      this.orgExecutionMinutesQuotaReached = false;
-    }
 
-    if (this.orgExecutionMinutesQuotaReached) {
-      this.showExecutionMinutesQuotaAlert = true;
-    }
-  }
-
-  checkExecutionMinutesHardCap() {
-    if (
-      !this.org ||
-      !this.org.quotas.crawlExecMinutesQuota ||
-      this.org.quotas.crawlExecMinutesQuota == 0
-    ) {
-      this.orgExecutionMinutesQuotaReached = false;
-      return;
-    }
-
-    let quota = this.org.quotas.crawlExecMinutesQuota;
-    if (this.org.quotas.crawlExecExtraMinutesHardCap) {
-      quota = quota + this.org.quotas.crawlExecExtraMinutesHardCap;
-    }
-
-    const todaysDate = new Date().toISOString();
-    const monthKey = todaysDate.slice(0, 7);
-
-    const monthlyExecutionSeconds = this.org.crawlExecSeconds[monthKey];
-    if (monthlyExecutionSeconds) {
-      const monthlyExecutionMinutes = Math.floor(monthlyExecutionSeconds / 60);
-      if (monthlyExecutionMinutes >= quota) {
+      if (monthlyExecutionMinutes >= hardCap) {
         this.orgExecutionMinutesHardCapReached = true;
       } else {
         this.orgExecutionMinutesHardCapReached = false;
       }
     } else {
+      this.orgExecutionMinutesQuotaReached = false;
       this.orgExecutionMinutesHardCapReached = false;
+    }
+
+    if (this.orgExecutionMinutesQuotaReached) {
+      this.showExecutionMinutesQuotaAlert = true;
     }
   }
 }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -59,6 +59,7 @@ type Params = {
   collectionTab?: string;
   itemType?: Crawl["type"];
   jobType?: JobType;
+  settingsTab?: string;
   new?: ResourceName;
 };
 const defaultTab = "home";
@@ -598,7 +599,7 @@ export class Org extends LiteElement {
 
   private renderOrgSettings() {
     if (!this.userInfo || !this.org) return;
-    const activePanel = "information";
+    const activePanel = this.params.settingsTab || "information";
     const isAddingMember = this.params.hasOwnProperty("invite");
 
     return html`<btrix-org-settings

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -505,7 +505,7 @@ export class Org extends LiteElement {
           ?isEditing=${isEditing}
           ?isCrawler=${this.isCrawler}
           @storage-quota-update=${this.onStorageQuotaUpdate}
-          @execution-mins-update=${this.onExecutionMinutesQuotaUpdate}
+          @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
         ></btrix-workflow-detail>
       `;
     }
@@ -522,7 +522,7 @@ export class Org extends LiteElement {
         .initialSeeds=${seeds}
         jobType=${ifDefined(this.params.jobType)}
         @storage-quota-update=${this.onStorageQuotaUpdate}
-        @execution-mins-update=${this.onExecutionMinutesQuotaUpdate}
+        @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
         @select-new-dialog=${this.onSelectNewDialog}
       ></btrix-workflows-new>`;
     }
@@ -535,7 +535,7 @@ export class Org extends LiteElement {
       userId=${this.userInfo!.id}
       ?isCrawler=${this.isCrawler}
       @storage-quota-update=${this.onStorageQuotaUpdate}
-      @execution-mins-update=${this.onExecutionMinutesQuotaUpdate}
+      @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
       @select-new-dialog=${this.onSelectNewDialog}
     ></btrix-workflows-list>`;
   }
@@ -809,14 +809,13 @@ export class Org extends LiteElement {
     }
 
     const todaysDate = new Date().toISOString();
-    const todaysYear = todaysDate.slice(2, 4);
+    const todaysYear = todaysDate.slice(0, 4);
     const todaysMonth = todaysDate.slice(5, 7);
+    const monthKey = `${todaysYear}-${todaysMonth}`;
 
-    const monthlyExecutionSeconds =
-      this.org.crawlExecSeconds[`${todaysYear}${todaysMonth}`];
+    const monthlyExecutionSeconds = this.org.crawlExecSeconds[monthKey];
     if (monthlyExecutionSeconds) {
       const monthlyExecutionMinutes = Math.floor(monthlyExecutionSeconds / 60);
-
       if (monthlyExecutionMinutes >= this.org.quotas.crawlExecMinutesQuota) {
         this.orgExecutionMinutesQuotaReached = true;
       } else {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -59,6 +59,7 @@ type Params = {
   collectionTab?: string;
   itemType?: Crawl["type"];
   jobType?: JobType;
+  settingsTab?: string;
   new?: ResourceName;
 };
 const defaultTab = "home";
@@ -607,9 +608,7 @@ export class Org extends LiteElement {
 
   private renderOrgSettings() {
     if (!this.userInfo || !this.org) return;
-    const activePanel = this.orgPath.includes("/members")
-      ? "members"
-      : "information";
+    const activePanel = this.params.settingsTab || "information";
     const isAddingMember = this.params.hasOwnProperty("invite");
 
     return html`<btrix-org-settings

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -815,6 +815,7 @@ export class Org extends LiteElement {
   checkExecutionMinutesQuota() {
     if (
       !this.org ||
+      !this.org.crawlExecSeconds ||
       !this.org.quotas.crawlExecMinutesQuota ||
       this.org.quotas.crawlExecMinutesQuota == 0
     ) {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -314,7 +314,7 @@ export class Org extends LiteElement {
               )}</strong
             ><br />
             ${msg(
-              "To run crawls again before the montly limit resets, contact us to upgrade your plan."
+              "To purchase additional monthly execution minutes, contact us to upgrade your plan."
             )}
           </sl-alert>
         </div>

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -522,6 +522,8 @@ export class Org extends LiteElement {
         .initialWorkflow=${workflow}
         .initialSeeds=${seeds}
         jobType=${ifDefined(this.params.jobType)}
+        ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
+        ?orgExecutionMinutesQuotaReached=${this.orgExecutionMinutesQuotaReached}
         @storage-quota-update=${this.onStorageQuotaUpdate}
         @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
         @select-new-dialog=${this.onSelectNewDialog}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -59,7 +59,6 @@ type Params = {
   collectionTab?: string;
   itemType?: Crawl["type"];
   jobType?: JobType;
-  settingsTab?: string;
   new?: ResourceName;
 };
 const defaultTab = "home";
@@ -103,9 +102,6 @@ export class Org extends LiteElement {
 
   @state()
   private showExecutionMinutesQuotaAlert = false;
-
-  @state()
-  private orgExecutionMinutesHardCapReached = false;
 
   @state()
   private openDialogName?: ResourceName;
@@ -502,16 +498,14 @@ export class Org extends LiteElement {
           .authState=${this.authState!}
           orgId=${this.orgId!}
           ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
-          ?orgExecutionMinutesHardCapReached=${this
-            .orgExecutionMinutesHardCapReached}
+          ?orgExecutionMinutesQuotaReached=${this
+            .orgExecutionMinutesQuotaReached}
           workflowId=${workflowId}
           openDialogName=${this.viewStateData?.dialog}
           ?isEditing=${isEditing}
           ?isCrawler=${this.isCrawler}
           @storage-quota-update=${this.onStorageQuotaUpdate}
           @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
-          @execution-minutes-hard-cap-update=${this
-            .onExecutionMinutesHardCapUpdate}
         ></btrix-workflow-detail>
       `;
     }
@@ -529,8 +523,6 @@ export class Org extends LiteElement {
         jobType=${ifDefined(this.params.jobType)}
         @storage-quota-update=${this.onStorageQuotaUpdate}
         @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
-        @execution-minutes-hard-cap-update=${this
-          .onExecutionMinutesHardCapUpdate}
         @select-new-dialog=${this.onSelectNewDialog}
       ></btrix-workflows-new>`;
     }
@@ -539,13 +531,11 @@ export class Org extends LiteElement {
       .authState=${this.authState!}
       orgId=${this.orgId!}
       ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
-      ?orgExecutionMinutesHardCapReached=${this
-        .orgExecutionMinutesHardCapReached}
+      ?orgExecutionMinutesQuotaReached=${this.orgExecutionMinutesQuotaReached}
       userId=${this.userInfo!.id}
       ?isCrawler=${this.isCrawler}
       @storage-quota-update=${this.onStorageQuotaUpdate}
       @execution-minutes-quota-update=${this.onExecutionMinutesQuotaUpdate}
-      @execution-minutes-hard-cap-update=${this.onExecutionMinutesHardCapUpdate}
       @select-new-dialog=${this.onSelectNewDialog}
     ></btrix-workflows-list>`;
   }
@@ -608,7 +598,7 @@ export class Org extends LiteElement {
 
   private renderOrgSettings() {
     if (!this.userInfo || !this.org) return;
-    const activePanel = this.params.settingsTab || "information";
+    const activePanel = "information";
     const isAddingMember = this.params.hasOwnProperty("invite");
 
     return html`<btrix-org-settings
@@ -692,12 +682,6 @@ export class Org extends LiteElement {
     if (reached) {
       this.showExecutionMinutesQuotaAlert = true;
     }
-  }
-
-  private async onExecutionMinutesHardCapUpdate(e: CustomEvent) {
-    e.stopPropagation();
-    const { reached } = e.detail;
-    this.orgExecutionMinutesHardCapReached = reached;
   }
 
   private async onUserRoleChange(e: UserRoleChangeEvent) {
@@ -792,63 +776,12 @@ export class Org extends LiteElement {
   }
 
   checkStorageQuota() {
-    if (
-      !this.org ||
-      !this.org.quotas.storageQuota ||
-      this.org.quotas.storageQuota == 0
-    ) {
-      this.orgStorageQuotaReached = false;
-      return;
-    }
-
-    if (this.org.bytesStored > this.org.quotas.storageQuota) {
-      this.orgStorageQuotaReached = true;
-    } else {
-      this.orgStorageQuotaReached = false;
-    }
-
-    if (this.orgStorageQuotaReached) {
-      this.showStorageQuotaAlert = true;
-    }
+    this.orgStorageQuotaReached = !!this.org?.storageQuotaReached;
+    this.showStorageQuotaAlert = this.orgStorageQuotaReached;
   }
 
   checkExecutionMinutesQuota() {
-    if (
-      !this.org ||
-      !this.org.crawlExecSeconds ||
-      !this.org.quotas.crawlExecMinutesQuota ||
-      this.org.quotas.crawlExecMinutesQuota == 0
-    ) {
-      this.orgExecutionMinutesQuotaReached = false;
-      return;
-    }
-
-    const monthKey = new Date().toISOString().slice(0, 7);
-    const monthlyExecutionSeconds = this.org.crawlExecSeconds[monthKey];
-    const quota = this.org.quotas.crawlExecMinutesQuota;
-    const hardCap = quota + (this.org.crawlExecMinutesAllowedOverage || 0);
-
-    if (monthlyExecutionSeconds) {
-      const monthlyExecutionMinutes = Math.floor(monthlyExecutionSeconds / 60);
-
-      if (monthlyExecutionMinutes >= quota) {
-        this.orgExecutionMinutesQuotaReached = true;
-      } else {
-        this.orgExecutionMinutesQuotaReached = false;
-      }
-
-      if (monthlyExecutionMinutes >= hardCap) {
-        this.orgExecutionMinutesHardCapReached = true;
-      } else {
-        this.orgExecutionMinutesHardCapReached = false;
-      }
-    } else {
-      this.orgExecutionMinutesQuotaReached = false;
-      this.orgExecutionMinutesHardCapReached = false;
-    }
-
-    if (this.orgExecutionMinutesQuotaReached) {
-      this.showExecutionMinutesQuotaAlert = true;
-    }
+    this.orgExecutionMinutesQuotaReached = !!this.org?.execMinutesQuotaReached;
+    this.showExecutionMinutesQuotaAlert = this.orgExecutionMinutesQuotaReached;
   }
 }

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -14,7 +14,7 @@ import type { CurrentUser } from "../../types/user";
 import type { APIPaginatedList } from "../../types/api";
 import { maxLengthValidator } from "../../utils/form";
 
-type Tab = "information" | "members" | "billing";
+type Tab = "information" | "members" | "limits";
 type User = {
   email: string;
   role: number;
@@ -79,7 +79,7 @@ export class OrgSettings extends LiteElement {
   isSavingOrgName = false;
 
   @property({ type: Boolean })
-  isSavingOrgBilling = false;
+  isSavingOrgLimits = false;
 
   @state()
   pendingInvites: Invite[] = [];
@@ -97,7 +97,7 @@ export class OrgSettings extends LiteElement {
     return {
       information: msg("General"),
       members: msg("Members"),
-      billing: msg("Billing"),
+      limits: msg("Limits"),
     };
   }
 
@@ -146,7 +146,7 @@ export class OrgSettings extends LiteElement {
         </header>
         ${this.renderTab("information", "settings")}
         ${this.renderTab("members", "settings/members")}
-        ${this.renderTab("billing", "settings/billing")}
+        ${this.renderTab("limits", "settings/limits")}
 
         <btrix-tab-panel name="information"
           >${this.renderInformation()}</btrix-tab-panel
@@ -154,9 +154,7 @@ export class OrgSettings extends LiteElement {
         <btrix-tab-panel name="members"
           >${this.renderMembers()}</btrix-tab-panel
         >
-        <btrix-tab-panel name="billing"
-          >${this.renderBilling()}</btrix-tab-panel
-        >
+        <btrix-tab-panel name="limits">${this.renderLimits()}</btrix-tab-panel>
       </btrix-tab-list>`;
   }
 
@@ -330,9 +328,9 @@ export class OrgSettings extends LiteElement {
     `;
   }
 
-  private renderBilling() {
+  private renderLimits() {
     return html`<div class="rounded border">
-      <form @submit=${this.onOrgBillingSubmit}>
+      <form @submit=${this.onOrgLimitsSubmit}>
         <div class="grid grid-cols-5 gap-x-4 p-4">
           <div class="col-span-5 md:col-span-3">
             <sl-input
@@ -363,8 +361,8 @@ export class OrgSettings extends LiteElement {
             type="submit"
             size="small"
             variant="primary"
-            ?disabled=${this.isSavingOrgBilling}
-            ?loading=${this.isSavingOrgBilling}
+            ?disabled=${this.isSavingOrgLimits}
+            ?loading=${this.isSavingOrgLimits}
             >${msg("Save Changes")}</sl-button
           >
         </footer>
@@ -602,19 +600,19 @@ export class OrgSettings extends LiteElement {
     this.isSubmittingInvite = false;
   }
 
-  private async onOrgBillingSubmit(e: SubmitEvent) {
+  private async onOrgLimitsSubmit(e: SubmitEvent) {
     e.preventDefault();
 
     const formEl = e.target as HTMLFormElement;
     if (!(await this.checkFormValidity(formEl))) return;
 
-    this.isSavingOrgBilling = true;
+    this.isSavingOrgLimits = true;
 
     const { execMinutesOverage } = serialize(formEl);
 
     try {
       const data = await this.apiFetch(
-        `/orgs/${this.orgId}/billing`,
+        `/orgs/${this.orgId}/limits`,
         this.authState!,
         {
           method: "POST",
@@ -625,7 +623,7 @@ export class OrgSettings extends LiteElement {
       );
 
       this.notify({
-        message: msg(str`Successfully updated org billing settings.`),
+        message: msg(str`Successfully updated org limits settings.`),
         variant: "success",
         icon: "check2-circle",
       });
@@ -639,7 +637,7 @@ export class OrgSettings extends LiteElement {
       });
     }
 
-    this.isSavingOrgBilling = false;
+    this.isSavingOrgLimits = false;
   }
 
   private async removeInvite(invite: Invite) {

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -356,6 +356,7 @@ export class OrgSettings extends LiteElement {
               )}
             </div>
           </div>
+        </div>
         <footer class="border-t flex justify-end px-4 py-3">
           <sl-button
             class="inline-control-button"

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -161,7 +161,6 @@ export class OrgSettings extends LiteElement {
   }
 
   private renderTab(name: Tab, path: string) {
-    console.log(`Active panel: ${this.activePanel}`);
     const isActive = name === this.activePanel;
     return html`
       <a

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -337,11 +337,14 @@ export class OrgSettings extends LiteElement {
           <div class="col-span-5 md:col-span-3">
             <sl-input
               type="number"
+              inputmode="numeric"
               name="execMinutesOverage"
               size="small"
               label=${msg("Allowed Execution Minutes Overage")}
               value=${this.org.crawlExecMinutesAllowedOverage || 0}
-            ></sl-input>
+            >
+              <span slot="suffix">${msg("minutes")}</span>
+            </sl-input>
           </div>
           <div class="col-span-5 md:col-span-2 flex gap-2 pt-6">
             <div class="text-base">

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -349,7 +349,7 @@ export class OrgSettings extends LiteElement {
             </div>
             <div class="mt-0.5 text-xs text-neutral-500">
               ${msg(
-                "Allowed overage minutes beyond monthly execution minutes quota before users are no longer allowed to create new crawls."
+                "Allowed overage minutes beyond the organization's monthly quota. Once reached, crawl workflows will not run."
               )}
             </div>
           </div>

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -14,7 +14,7 @@ import type { CurrentUser } from "../../types/user";
 import type { APIPaginatedList } from "../../types/api";
 import { maxLengthValidator } from "../../utils/form";
 
-type Tab = "information" | "members";
+type Tab = "information" | "members" | "billing";
 type User = {
   email: string;
   role: number;
@@ -78,6 +78,9 @@ export class OrgSettings extends LiteElement {
   @property({ type: Boolean })
   isSavingOrgName = false;
 
+  @property({ type: Boolean })
+  isSavingOrgBilling = false;
+
   @state()
   pendingInvites: Invite[] = [];
 
@@ -94,6 +97,7 @@ export class OrgSettings extends LiteElement {
     return {
       information: msg("General"),
       members: msg("Members"),
+      billing: msg("Billing"),
     };
   }
 
@@ -142,6 +146,7 @@ export class OrgSettings extends LiteElement {
         </header>
         ${this.renderTab("information", "settings")}
         ${this.renderTab("members", "settings/members")}
+        ${this.renderTab("billing", "settings/billing")}
 
         <btrix-tab-panel name="information"
           >${this.renderInformation()}</btrix-tab-panel
@@ -149,10 +154,14 @@ export class OrgSettings extends LiteElement {
         <btrix-tab-panel name="members"
           >${this.renderMembers()}</btrix-tab-panel
         >
+        <btrix-tab-panel name="billing"
+          >${this.renderBilling()}</btrix-tab-panel
+        >
       </btrix-tab-list>`;
   }
 
   private renderTab(name: Tab, path: string) {
+    console.log(`Active panel: ${this.activePanel}`);
     const isActive = name === this.activePanel;
     return html`
       <a
@@ -320,6 +329,44 @@ export class OrgSettings extends LiteElement {
         ${this.isAddMemberFormVisible ? this.renderInviteForm() : ""}
       </btrix-dialog>
     `;
+  }
+
+  private renderBilling() {
+    return html`<div class="rounded border">
+      <form @submit=${this.onOrgBillingSubmit}>
+        <div class="grid grid-cols-5 gap-x-4 p-4">
+          <div class="col-span-5 md:col-span-3">
+            <sl-input
+              type="number"
+              name="execMinutesOverage"
+              size="small"
+              label=${msg("Allowed Execution Minutes Overage")}
+              value=${this.org.crawlExecMinutesAllowedOverage || 0}
+            ></sl-input>
+          </div>
+          <div class="col-span-5 md:col-span-2 flex gap-2 pt-6">
+            <div class="text-base">
+              <sl-icon name="info-circle"></sl-icon>
+            </div>
+            <div class="mt-0.5 text-xs text-neutral-500">
+              ${msg(
+                "Allowed overage minutes beyond monthly execution minutes quota before users are no longer allowed to create new crawls."
+              )}
+            </div>
+          </div>
+        <footer class="border-t flex justify-end px-4 py-3">
+          <sl-button
+            class="inline-control-button"
+            type="submit"
+            size="small"
+            variant="primary"
+            ?disabled=${this.isSavingOrgBilling}
+            ?loading=${this.isSavingOrgBilling}
+            >${msg("Save Changes")}</sl-button
+          >
+        </footer>
+      </form>
+    </div>`;
   }
 
   private renderUserRole({ role }: User) {
@@ -550,6 +597,46 @@ export class OrgSettings extends LiteElement {
     }
 
     this.isSubmittingInvite = false;
+  }
+
+  private async onOrgBillingSubmit(e: SubmitEvent) {
+    e.preventDefault();
+
+    const formEl = e.target as HTMLFormElement;
+    if (!(await this.checkFormValidity(formEl))) return;
+
+    this.isSavingOrgBilling = true;
+
+    const { execMinutesOverage } = serialize(formEl);
+
+    try {
+      const data = await this.apiFetch(
+        `/orgs/${this.orgId}/billing`,
+        this.authState!,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            crawlExecMinutesAllowedOverage: execMinutesOverage,
+          }),
+        }
+      );
+
+      this.notify({
+        message: msg(str`Successfully updated org billing settings.`),
+        variant: "success",
+        icon: "check2-circle",
+      });
+    } catch (e: any) {
+      this.notify({
+        message: e.isApiError
+          ? e.message
+          : msg("Sorry, couldn't update org at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+
+    this.isSavingOrgBilling = false;
   }
 
   private async removeInvite(invite: Invite) {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1610,6 +1610,10 @@ export class WorkflowDetail extends LiteElement {
       if (e.isApiError && e.statusCode === 403) {
         if (e.details === "storage_quota_reached") {
           message = msg("Your org does not have enough storage to run crawls.");
+        } else if (e.details === "execution_minutes_quota_reached") {
+          message = msg(
+            "Your org has used all of its execution minutes for this month."
+          );
         } else {
           message = msg("You do not have permission to run crawls.");
         }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -49,6 +49,9 @@ export class WorkflowDetail extends LiteElement {
   @property({ type: Boolean })
   orgStorageQuotaReached = false;
 
+  @property({ type: Boolean })
+  orgExecutionMinutesQuotaReached = false;
+
   @property({ type: String })
   workflowId!: string;
 
@@ -578,14 +581,18 @@ export class WorkflowDetail extends LiteElement {
         `,
         () => html`
           <sl-tooltip
-            content=${msg("Org Storage Full")}
-            ?disabled=${!this.orgStorageQuotaReached}
+            content=${msg(
+              "Org Storage Full or Monthly Execution Minutes Reached"
+            )}
+            ?disabled=${!this.orgStorageQuotaReached &&
+            !this.orgExecutionMinutesQuotaReached}
           >
             <sl-button
               size="small"
               variant="primary"
               class="mr-2"
-              ?disabled=${this.orgStorageQuotaReached}
+              ?disabled=${this.orgStorageQuotaReached ||
+              this.orgExecutionMinutesQuotaReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -625,7 +632,8 @@ export class WorkflowDetail extends LiteElement {
             () => html`
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--success)"
-                ?disabled=${this.orgStorageQuotaReached}
+                ?disabled=${this.orgStorageQuotaReached ||
+                this.orgExecutionMinutesQuotaReached}
                 @click=${() => this.runNow()}
               >
                 <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1023,12 +1031,16 @@ export class WorkflowDetail extends LiteElement {
           )}
 
           <sl-tooltip
-            content=${msg("Org Storage Full")}
-            ?disabled=${!this.orgStorageQuotaReached}
+            content=${msg(
+              "Org Storage Full or Monthly Execution Minutes Reached"
+            )}
+            ?disabled=${!this.orgStorageQuotaReached &&
+            !this.orgExecutionMinutesQuotaReached}
           >
             <sl-button
               size="small"
-              ?disabled=${this.orgStorageQuotaReached}
+              ?disabled=${this.orgStorageQuotaReached ||
+              this.orgExecutionMinutesQuotaReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1107,13 +1119,17 @@ export class WorkflowDetail extends LiteElement {
         </p>
         <div class="mt-4">
           <sl-tooltip
-            content=${msg("Org Storage Full")}
-            ?disabled=${!this.orgStorageQuotaReached}
+            content=${msg(
+              "Org Storage Full or Monthly Execution Minutes Reached"
+            )}
+            ?disabled=${!this.orgStorageQuotaReached &&
+            !this.orgExecutionMinutesQuotaReached}
           >
             <sl-button
               size="small"
               variant="primary"
-              ?disabled=${this.orgStorageQuotaReached}
+              ?disabled=${this.orgStorageQuotaReached ||
+              this.orgExecutionMinutesQuotaReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1610,7 +1610,7 @@ export class WorkflowDetail extends LiteElement {
       if (e.isApiError && e.statusCode === 403) {
         if (e.details === "storage_quota_reached") {
           message = msg("Your org does not have enough storage to run crawls.");
-        } else if (e.details === "execution_minutes_quota_reached") {
+        } else if (e.details === "execution_minutes_hard_cap_reached") {
           message = msg(
             "Your org has used all of its execution minutes for this month."
           );

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -536,6 +536,9 @@ export class WorkflowDetail extends LiteElement {
           configId=${this.workflow!.id}
           orgId=${this.orgId}
           .authState=${this.authState}
+          ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
+          ?orgExecutionMinutesQuotaReached=${this
+            .orgExecutionMinutesQuotaReached}
           @reset=${(e: Event) =>
             this.navTo(
               `${this.orgBasePath}/workflows/crawl/${this.workflow!.id}`

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -50,7 +50,7 @@ export class WorkflowDetail extends LiteElement {
   orgStorageQuotaReached = false;
 
   @property({ type: Boolean })
-  orgExecutionMinutesHardCapReached = false;
+  orgExecutionMinutesQuotaReached = false;
 
   @property({ type: String })
   workflowId!: string;
@@ -585,14 +585,14 @@ export class WorkflowDetail extends LiteElement {
               "Org Storage Full or Monthly Execution Minutes Reached"
             )}
             ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesHardCapReached}
+            !this.orgExecutionMinutesQuotaReached}
           >
             <sl-button
               size="small"
               variant="primary"
               class="mr-2"
               ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesHardCapReached}
+              this.orgExecutionMinutesQuotaReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -633,7 +633,7 @@ export class WorkflowDetail extends LiteElement {
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--success)"
                 ?disabled=${this.orgStorageQuotaReached ||
-                this.orgExecutionMinutesHardCapReached}
+                this.orgExecutionMinutesQuotaReached}
                 @click=${() => this.runNow()}
               >
                 <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1035,12 +1035,12 @@ export class WorkflowDetail extends LiteElement {
               "Org Storage Full or Monthly Execution Minutes Reached"
             )}
             ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesHardCapReached}
+            !this.orgExecutionMinutesQuotaReached}
           >
             <sl-button
               size="small"
               ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesHardCapReached}
+              this.orgExecutionMinutesQuotaReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1123,13 +1123,13 @@ export class WorkflowDetail extends LiteElement {
               "Org Storage Full or Monthly Execution Minutes Reached"
             )}
             ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesHardCapReached}
+            !this.orgExecutionMinutesQuotaReached}
           >
             <sl-button
               size="small"
               variant="primary"
               ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesHardCapReached}
+              this.orgExecutionMinutesQuotaReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1610,7 +1610,7 @@ export class WorkflowDetail extends LiteElement {
       if (e.isApiError && e.statusCode === 403) {
         if (e.details === "storage_quota_reached") {
           message = msg("Your org does not have enough storage to run crawls.");
-        } else if (e.details === "execution_minutes_hard_cap_reached") {
+        } else if (e.details === "exec_minutes_quota_reached") {
           message = msg(
             "Your org has used all of its execution minutes for this month."
           );

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -50,7 +50,7 @@ export class WorkflowDetail extends LiteElement {
   orgStorageQuotaReached = false;
 
   @property({ type: Boolean })
-  orgExecutionMinutesQuotaReached = false;
+  orgExecutionMinutesHardCapReached = false;
 
   @property({ type: String })
   workflowId!: string;
@@ -585,14 +585,14 @@ export class WorkflowDetail extends LiteElement {
               "Org Storage Full or Monthly Execution Minutes Reached"
             )}
             ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesQuotaReached}
+            !this.orgExecutionMinutesHardCapReached}
           >
             <sl-button
               size="small"
               variant="primary"
               class="mr-2"
               ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesQuotaReached}
+              this.orgExecutionMinutesHardCapReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -633,7 +633,7 @@ export class WorkflowDetail extends LiteElement {
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--success)"
                 ?disabled=${this.orgStorageQuotaReached ||
-                this.orgExecutionMinutesQuotaReached}
+                this.orgExecutionMinutesHardCapReached}
                 @click=${() => this.runNow()}
               >
                 <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1035,12 +1035,12 @@ export class WorkflowDetail extends LiteElement {
               "Org Storage Full or Monthly Execution Minutes Reached"
             )}
             ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesQuotaReached}
+            !this.orgExecutionMinutesHardCapReached}
           >
             <sl-button
               size="small"
               ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesQuotaReached}
+              this.orgExecutionMinutesHardCapReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -1123,13 +1123,13 @@ export class WorkflowDetail extends LiteElement {
               "Org Storage Full or Monthly Execution Minutes Reached"
             )}
             ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesQuotaReached}
+            !this.orgExecutionMinutesHardCapReached}
           >
             <sl-button
               size="small"
               variant="primary"
               ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesQuotaReached}
+              this.orgExecutionMinutesHardCapReached}
               @click=${() => this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -2160,12 +2160,23 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
       const crawlId = data.run_now_job;
       const storageQuotaReached = data.storageQuotaReached;
+      const executionMinutesQuotaReached = data.executionMinutesQuotaReached;
 
-      if (crawlId && storageQuotaReached) {
+      if (storageQuotaReached) {
         this.notify({
           title: msg("Workflow saved without starting crawl."),
           message: msg(
             "Could not run crawl with new workflow settings due to storage quota."
+          ),
+          variant: "warning",
+          icon: "exclamation-circle",
+          duration: 12000,
+        });
+      } else if (executionMinutesQuotaReached) {
+        this.notify({
+          title: msg("Workflow saved without starting crawl."),
+          message: msg(
+            "Could not run crawl with new workflow settings due to execution minutes quota."
           ),
           variant: "warning",
           icon: "exclamation-circle",

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -242,6 +242,12 @@ export class CrawlConfigEditor extends LiteElement {
   @property({ type: Array })
   initialSeeds?: Seed[];
 
+  @property({ type: Boolean })
+  orgStorageQuotaReached = false;
+
+  @property({ type: Boolean })
+  orgExecutionMinutesQuotaReached = false;
+
   @state()
   private tagOptions: string[] = [];
 
@@ -535,7 +541,10 @@ export class CrawlConfigEditor extends LiteElement {
       lang: this.initialWorkflow.config.lang,
       scheduleType: defaultFormState.scheduleType,
       scheduleFrequency: defaultFormState.scheduleFrequency,
-      runNow: defaultFormState.runNow,
+      runNow:
+        this.orgStorageQuotaReached || this.orgExecutionMinutesQuotaReached
+          ? false
+          : defaultFormState.runNow,
       tags: this.initialWorkflow.tags,
       autoAddCollections: this.initialWorkflow.autoAddCollections,
       jobName: this.initialWorkflow.name || defaultFormState.jobName,
@@ -864,6 +873,8 @@ export class CrawlConfigEditor extends LiteElement {
       <sl-switch
         class="mr-1"
         ?checked=${this.formState.runNow}
+        ?disabled=${this.orgStorageQuotaReached ||
+        this.orgExecutionMinutesQuotaReached}
         @sl-change=${(e: SlChangeEvent) => {
           this.updateFormState(
             {

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -2169,9 +2169,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
             body: JSON.stringify(config),
           }));
 
-      const crawlId = data.run_now_job;
+      const crawlId = data.run_now_job || data.started || null;
       const storageQuotaReached = data.storageQuotaReached;
-      const executionMinutesQuotaReached = data.executionMinutesQuotaReached;
+      const executionMinutesQuotaReached = data.execMinutesQuotaReached;
 
       if (storageQuotaReached) {
         this.notify({
@@ -2210,7 +2210,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
       this.navTo(
         `${this.orgBasePath}/workflows/crawl/${this.configId || data.id}${
-          crawlId && !storageQuotaReached ? "#watch" : ""
+          crawlId && !storageQuotaReached && !executionMinutesQuotaReached
+            ? "#watch"
+            : ""
         }`
       );
     } catch (e: any) {

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -2173,40 +2173,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
       const storageQuotaReached = data.storageQuotaReached;
       const executionMinutesQuotaReached = data.execMinutesQuotaReached;
 
-      if (storageQuotaReached) {
-        this.notify({
-          title: msg("Workflow saved without starting crawl."),
-          message: msg(
-            "Could not run crawl with new workflow settings due to storage quota."
-          ),
-          variant: "warning",
-          icon: "exclamation-circle",
-          duration: 12000,
-        });
-      } else if (executionMinutesQuotaReached) {
-        this.notify({
-          title: msg("Workflow saved without starting crawl."),
-          message: msg(
-            "Could not run crawl with new workflow settings due to execution minutes quota."
-          ),
-          variant: "warning",
-          icon: "exclamation-circle",
-          duration: 12000,
-        });
-      } else {
-        let message = msg("Workflow created.");
-        if (crawlId) {
-          message = msg("Crawl started with new workflow settings.");
-        } else if (this.configId) {
-          message = msg("Workflow updated.");
-        }
-
-        this.notify({
-          message,
-          variant: "success",
-          icon: "check2-circle",
-        });
+      let message = msg("Workflow created.");
+      if (crawlId) {
+        message = msg("Crawl started with new workflow settings.");
+      } else if (this.configId) {
+        message = msg("Workflow updated.");
       }
+
+      this.notify({
+        message,
+        variant: "success",
+        icon: "check2-circle",
+      });
 
       this.navTo(
         `${this.orgBasePath}/workflows/crawl/${this.configId || data.id}${

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -74,6 +74,9 @@ export class WorkflowsList extends LiteElement {
   @property({ type: Boolean })
   orgStorageQuotaReached = false;
 
+  @property({ type: Boolean })
+  orgExecutionMinutesQuotaReached = false;
+
   @property({ type: String })
   userId!: string;
 
@@ -440,7 +443,8 @@ export class WorkflowsList extends LiteElement {
         () => html`
           <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
-            ?disabled=${this.orgStorageQuotaReached}
+            ?disabled=${this.orgStorageQuotaReached ||
+            this.orgExecutionMinutesQuotaReached}
             @click=${() => this.runNow(workflow)}
           >
             <sl-icon name="play" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -75,7 +75,7 @@ export class WorkflowsList extends LiteElement {
   orgStorageQuotaReached = false;
 
   @property({ type: Boolean })
-  orgExecutionMinutesQuotaReached = false;
+  orgExecutionMinutesHardCapReached = false;
 
   @property({ type: String })
   userId!: string;
@@ -444,7 +444,7 @@ export class WorkflowsList extends LiteElement {
           <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
             ?disabled=${this.orgStorageQuotaReached ||
-            this.orgExecutionMinutesQuotaReached}
+            this.orgExecutionMinutesHardCapReached}
             @click=${() => this.runNow(workflow)}
           >
             <sl-icon name="play" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -802,6 +802,10 @@ export class WorkflowsList extends LiteElement {
       if (e.isApiError && e.statusCode === 403) {
         if (e.details === "storage_quota_reached") {
           message = msg("Your org does not have enough storage to run crawls.");
+        } else if (e.details === "execution_minutes_quota_reached") {
+          message = msg(
+            "Your org has used all of its execution minutes for this month."
+          );
         } else {
           message = msg("You do not have permission to run crawls.");
         }

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -802,7 +802,7 @@ export class WorkflowsList extends LiteElement {
       if (e.isApiError && e.statusCode === 403) {
         if (e.details === "storage_quota_reached") {
           message = msg("Your org does not have enough storage to run crawls.");
-        } else if (e.details === "execution_minutes_quota_reached") {
+        } else if (e.details === "execution_minutes_hard_cap_reached") {
           message = msg(
             "Your org has used all of its execution minutes for this month."
           );

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -75,7 +75,7 @@ export class WorkflowsList extends LiteElement {
   orgStorageQuotaReached = false;
 
   @property({ type: Boolean })
-  orgExecutionMinutesHardCapReached = false;
+  orgExecutionMinutesQuotaReached = false;
 
   @property({ type: String })
   userId!: string;
@@ -444,7 +444,7 @@ export class WorkflowsList extends LiteElement {
           <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
             ?disabled=${this.orgStorageQuotaReached ||
-            this.orgExecutionMinutesHardCapReached}
+            this.orgExecutionMinutesQuotaReached}
             @click=${() => this.runNow(workflow)}
           >
             <sl-icon name="play" slot="prefix"></sl-icon>
@@ -802,7 +802,7 @@ export class WorkflowsList extends LiteElement {
       if (e.isApiError && e.statusCode === 403) {
         if (e.details === "storage_quota_reached") {
           message = msg("Your org does not have enough storage to run crawls.");
-        } else if (e.details === "execution_minutes_hard_cap_reached") {
+        } else if (e.details === "exec_minutes_quota_reached") {
           message = msg(
             "Your org has used all of its execution minutes for this month."
           );

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -56,6 +56,12 @@ export class WorkflowsNew extends LiteElement {
   @property({ type: String })
   jobType?: JobType;
 
+  @property({ type: Boolean })
+  orgStorageQuotaReached = false;
+
+  @property({ type: Boolean })
+  orgExecutionMinutesQuotaReached = false;
+
   // Use custom property accessor to prevent
   // overriding default Workflow values
   @property({ type: Object })
@@ -116,6 +122,9 @@ export class WorkflowsNew extends LiteElement {
           jobType=${jobType}
           orgId=${this.orgId}
           .authState=${this.authState}
+          ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
+          ?orgExecutionMinutesQuotaReached=${this
+            .orgExecutionMinutesQuotaReached}
           @reset=${async (e: Event) => {
             await (e.target as LitElement).updateComplete;
             this.dispatchEvent(

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
     "(/items(/:itemType(/:itemId)))",
     "(/collections(/new)(/view/:collectionId(/:collectionTab))(/edit/:collectionId))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
-    "(/settings(/members)(/billing))",
+    "(/settings(/:settingsTab))",
   ].join(""),
   users: "/users",
   usersInvite: "/users/invite",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
     "(/items(/:itemType(/:itemId)))",
     "(/collections(/new)(/view/:collectionId(/:collectionTab))(/edit/:collectionId))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
-    "(/settings(/members))",
+    "(/settings(/members)(/billing))",
   ].join(""),
   users: "/users",
   usersInvite: "/users/invite",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
     "(/items(/:itemType(/:itemId)))",
     "(/collections(/new)(/view/:collectionId(/:collectionTab))(/edit/:collectionId))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
-    "(/settings(/members))",
+    "(/settings(/:settingsTab))",
   ].join(""),
   users: "/users",
   usersInvite: "/users/invite",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -17,7 +17,7 @@ export const ROUTES = {
     "(/items(/:itemType(/:itemId)))",
     "(/collections(/new)(/view/:collectionId(/:collectionTab))(/edit/:collectionId))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
-    "(/settings(/:settingsTab))",
+    "(/settings(/members))",
   ].join(""),
   users: "/users",
   usersInvite: "/users/invite",

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -135,6 +135,7 @@ export type Crawl = CrawlConfig & {
   collectionIds: string[];
   collections: { id: string; name: string }[];
   type?: "crawl" | "upload" | null;
+  crawlExecSeconds: number;
 };
 
 export type Upload = Omit<
@@ -146,6 +147,7 @@ export type Upload = Omit<
   | "stopping"
   | "firstSeed"
   | "seedCount"
+  | "crawlExecSeconds"
 > & {
   type: "upload";
 };

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -15,6 +15,7 @@ export type OrgData = {
   quotas: Record<string, number>;
   bytesStored: number;
   crawlExecSeconds: Record<string, number>;
+  crawlExecMinutesAllowedOverage: number;
   users?: {
     [id: string]: {
       role: (typeof AccessCode)[UserRole];

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -22,7 +22,8 @@ export type OrgData = {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   } | null;
-  crawlExecMinutesAllowedOverage: number;
+  storageQuotaReached?: boolean;
+  execMinutesQuotaReached?: boolean;
   users?: {
     [id: string]: {
       role: (typeof AccessCode)[UserRole];

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -14,6 +14,7 @@ export type OrgData = {
   slug: string;
   quotas: Record<string, number>;
   bytesStored: number;
+  crawlExecSeconds: Record<string, number>;
   users?: {
     [id: string]: {
       role: (typeof AccessCode)[UserRole];

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -139,10 +139,19 @@ export default class LiteElement extends LitElement {
     if (resp.ok) {
       const body = await resp.json();
       const storageQuotaReached = body.storageQuotaReached;
+      const executionMinutesQuotaReached = body.executionMinutesQuotaReached;
       if (typeof storageQuotaReached === "boolean") {
         this.dispatchEvent(
           new CustomEvent("storage-quota-update", {
             detail: { reached: storageQuotaReached },
+            bubbles: true,
+          })
+        );
+      }
+      if (typeof executionMinutesQuotaReached === "boolean") {
+        this.dispatchEvent(
+          new CustomEvent("execution-minutes-quota-update", {
+            detail: { reached: executionMinutesQuotaReached },
             bubbles: true,
           })
         );
@@ -173,6 +182,16 @@ export default class LiteElement extends LitElement {
             })
           );
           errorMessage = msg("Storage quota reached");
+          break;
+        }
+        if (errorDetail === "execution_minutes_quota_reached") {
+          this.dispatchEvent(
+            new CustomEvent("execution-minutes-quota-update", {
+              detail: { reached: true },
+              bubbles: true,
+            })
+          );
+          errorMessage = msg("Monthly execution minutes quota reached");
           break;
         }
       }

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -184,7 +184,7 @@ export default class LiteElement extends LitElement {
           errorMessage = msg("Storage quota reached");
           break;
         }
-        if (errorDetail === "execution_minutes_quota_reached") {
+        if (errorDetail === "exec_minutes_quota_reached") {
           this.dispatchEvent(
             new CustomEvent("execution-minutes-quota-update", {
               detail: { reached: true },

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -184,6 +184,16 @@ export default class LiteElement extends LitElement {
           errorMessage = msg("Storage quota reached");
           break;
         }
+        if (errorDetail === "execution_minutes_hard_cap_reached") {
+          this.dispatchEvent(
+            new CustomEvent("execution-minutes-hard-cap-update", {
+              detail: { reached: true },
+              bubbles: true,
+            })
+          );
+          errorMessage = msg("Monthly execution minutes hard cap reached");
+          break;
+        }
         if (errorDetail === "execution_minutes_quota_reached") {
           this.dispatchEvent(
             new CustomEvent("execution-minutes-quota-update", {

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -184,16 +184,6 @@ export default class LiteElement extends LitElement {
           errorMessage = msg("Storage quota reached");
           break;
         }
-        if (errorDetail === "execution_minutes_hard_cap_reached") {
-          this.dispatchEvent(
-            new CustomEvent("execution-minutes-hard-cap-update", {
-              detail: { reached: true },
-              bubbles: true,
-            })
-          );
-          errorMessage = msg("Monthly execution minutes hard cap reached");
-          break;
-        }
         if (errorDetail === "execution_minutes_quota_reached") {
           this.dispatchEvent(
             new CustomEvent("execution-minutes-quota-update", {


### PR DESCRIPTION
Fixes #1261 Closes #1092

The quota for monthly execution minutes is treated as a hard cap. Once it is exceeded, an alert indicating that an org has exceeded its monthly execution minutes will display and the user will be unable to start new crawls. Any running crawls will be stopped once the quota is exceeded.

An execution minutes meter bar is also added in the Org Dashboard and displayed if a quota is set. More detail in https://github.com/webrecorder/browsertrix-cloud/pull/1305, which was merged into this branch.

## Changes

- Enable setting Max Execution Minutes Per Month in orgs list quotas:

<img width="535" alt="Screen Shot 2023-10-26 at 12 45 25 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/f29cd77e-3439-4428-91e0-2bb1fd88e2ff">

- Enforce quota by stopping crawls in operator once quota is reached
- Show alert banner once execution time quota is hit:

<img width="1182" alt="Screen Shot 2023-10-17 at 2 15 55 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/fd451bd9-7543-492e-a87b-960cab31e03b">

- Once quota is hit, disable Run Crawl buttons in frontend, return 403 message with `execution_minutes_quota_reached` detail in backend from crawl config `/run` endpoint, and don't run new workflows on creation (similar to storage quota)
- Display execution time for crawls in the crawl details overview, immediately below Duration:

<img width="1142" alt="Screen Shot 2023-10-17 at 2 56 24 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/2664ee07-be88-4bea-ae96-422f75fd0892">


## To test

### Manually

1. In org quotas, set the `Org Monthly Execution Minutes Quota` to a low number of minutes
2. Start a big crawl (e.g. `https://webrecorder.net` with extra hops enabled and no page limit)
3. Verify that the big crawl starts to stop once the quota has been passed
4. Verify that once the crawl finishes, it has Partial Complete status and the execution minutes alert appears at the top of the screen
6. Verify that you can no longer run crawls
7. Verify that the execution time displays in the crawl detail Overview page
8. Verify that execution minutes meter in Org Dashboard displays and is accurate

### Nightly tests

To run the nightly tests locally (requires pytest): `pytest backend/test_nightly/test_execution_minutes_quota.py`

These tests may take 5 or so minutes to complete.