### PR TITLE
Show execution/running minutes meter in dashboard

### DIFF
--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -372,7 +372,7 @@ export class Dashboard extends LiteElement {
                 class="text-danger"
                 name="exclamation-triangle"
               ></sl-icon>
-              <span>${msg("Time Quota Reached")}</span>
+              <span>${msg("Monthly Execution Minutes Quota Reached")}</span>
             </div>
           `,
           () =>
@@ -381,7 +381,7 @@ export class Dashboard extends LiteElement {
                   <span class="inline-flex items-center">
                     ${humanizeDuration((quotaSeconds - usageSeconds) * 1000)}
                     ${msg("Available")}
-                    <sl-tooltip content=${msg("Total running time available")}>
+                    <sl-tooltip content=${msg("Total execution time available")}>
                       <sl-icon
                         name="info-circle"
                         class="ml-1 text-neutral-500"
@@ -404,7 +404,7 @@ export class Dashboard extends LiteElement {
               ${when(usageSeconds, () =>
                 renderBar(
                   usageSeconds,
-                  msg("Running Time"),
+                  msg("Execution Time"),
                   isReached ? "warning" : this.colors.runningTime
                 )
               )}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -415,6 +415,8 @@ export class Dashboard extends LiteElement {
                   <div slot="content">
                     <div>${msg("Monthly Execution Time Available")}</div>
                     <div class="text-xs opacity-80">
+                      ${humanizeDuration((quotaSeconds - usageSeconds) * 1000)}
+                      |
                       ${this.renderPercentage(
                         (quotaSeconds - usageSeconds) / quotaSeconds
                       )}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -339,7 +339,10 @@ export class Dashboard extends LiteElement {
   }
 
   private renderCrawlingMeter(metrics: Metrics) {
-    const quotaSeconds = this.org!.quotas.crawlExecMinutesQuota * 60 || 0;
+    let quotaSeconds = 0;
+    if (this.org!.quotas && this.org!.quotas.maxExecMinutesPerMonth) {
+      quotaSeconds = this.org!.quotas.maxExecMinutesPerMonth * 60;
+    }
     const now = new Date();
     const usageSeconds =
       this.org!.crawlExecSeconds[

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -49,6 +49,7 @@ export class Dashboard extends LiteElement {
     crawls: "green",
     uploads: "sky",
     browserProfiles: "indigo",
+    runningTime: "blue",
   };
 
   willUpdate(changedProperties: PropertyValues<this>) {
@@ -371,7 +372,7 @@ export class Dashboard extends LiteElement {
                 class="text-danger"
                 name="exclamation-triangle"
               ></sl-icon>
-              <span>${msg("Execution Time Quota Reached")}</span>
+              <span>${msg("Time Quota Reached")}</span>
             </div>
           `,
           () =>
@@ -379,12 +380,8 @@ export class Dashboard extends LiteElement {
               ? html`
                   <span class="inline-flex items-center">
                     ${humanizeDuration((quotaSeconds - usageSeconds) * 1000)}
-                    ${msg("of Running Time Available")}
-                    <sl-tooltip
-                      content=${msg(
-                        "Total running time of all crawler instances"
-                      )}
-                    >
+                    ${msg("Available")}
+                    <sl-tooltip content=${msg("Total running time available")}>
                       <sl-icon
                         name="info-circle"
                         class="ml-1 text-neutral-500"
@@ -405,7 +402,11 @@ export class Dashboard extends LiteElement {
               valueText=${msg("time")}
             >
               ${when(usageSeconds, () =>
-                renderBar(usageSeconds, msg("Run Time"), this.colors.crawls)
+                renderBar(
+                  usageSeconds,
+                  msg("Running Time"),
+                  isReached ? "warning" : this.colors.runningTime
+                )
               )}
               <div slot="available" class="flex-1">
                 <sl-tooltip>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -339,7 +339,7 @@ export class Dashboard extends LiteElement {
   }
 
   private renderCrawlingMeter(metrics: Metrics) {
-    const quotaSeconds = this.org!.quotas.crawlExecMinutesQuota * 60;
+    const quotaSeconds = this.org!.quotas.crawlExecMinutesQuota * 60 || 0;
     const now = new Date();
     const usageSeconds =
       this.org!.crawlExecSeconds[

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -356,8 +356,8 @@ export class Dashboard extends LiteElement {
         <div class="text-center">
           <div>${label}</div>
           <div class="text-xs opacity-80">
-            <sl-format-bytes value=${value} display="narrow"></sl-format-bytes>
-            | ${this.renderPercentage(value / usageSeconds)}
+            ${humanizeDuration(value * 1000)} |
+            ${this.renderPercentage(value / quotaSeconds)}
           </div>
         </div>
       </btrix-meter-bar>
@@ -381,7 +381,9 @@ export class Dashboard extends LiteElement {
                   <span class="inline-flex items-center">
                     ${humanizeDuration((quotaSeconds - usageSeconds) * 1000)}
                     ${msg("Available")}
-                    <sl-tooltip content=${msg("Total execution time available")}>
+                    <sl-tooltip
+                      content=${msg("Total monthly execution time available")}
+                    >
                       <sl-icon
                         name="info-circle"
                         class="ml-1 text-neutral-500"
@@ -404,14 +406,14 @@ export class Dashboard extends LiteElement {
               ${when(usageSeconds, () =>
                 renderBar(
                   usageSeconds,
-                  msg("Execution Time"),
+                  msg("Monthly Execution Time Used"),
                   isReached ? "warning" : this.colors.runningTime
                 )
               )}
               <div slot="available" class="flex-1">
                 <sl-tooltip>
                   <div slot="content">
-                    <div>${msg("Available")}</div>
+                    <div>${msg("Monthly Execution Time Available")}</div>
                     <div class="text-xs opacity-80">
                       ${this.renderPercentage(
                         (quotaSeconds - usageSeconds) / quotaSeconds

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -343,11 +343,19 @@ export class Dashboard extends LiteElement {
     if (this.org!.quotas && this.org!.quotas.maxExecMinutesPerMonth) {
       quotaSeconds = this.org!.quotas.maxExecMinutesPerMonth * 60;
     }
+
+    let usageSeconds = 0;
     const now = new Date();
-    const usageSeconds =
-      this.org!.crawlExecSeconds[
-        `${now.getFullYear()}-${now.getUTCMonth() + 1}`
-      ] || 0;
+    if (this.org!.crawlExecSeconds) {
+      const actualUsage =
+        this.org!.crawlExecSeconds[
+          `${now.getFullYear()}-${now.getUTCMonth() + 1}`
+        ];
+      if (actualUsage) {
+        usageSeconds = actualUsage;
+      }
+    }
+
     const hasQuota = Boolean(quotaSeconds);
     const isReached = hasQuota && usageSeconds >= quotaSeconds;
 


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix-cloud/pull/1284 -- merge into that branch or rebase main afterwards
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1223

<!-- Fixes #issue_number -->

### Changes

Adds meter to show running time quota in dashboard


### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Dashboard | <img width="374" alt="Screenshot 2023-10-21 at 10 08 34 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/1a172a2f-bcb4-4100-8e05-4e4161958b74"> |

<!-- ### Follow-ups -->
