### PR TITLE
More stringent UUID types for user input / avoid 500 errors

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1017,7 +1017,7 @@ def init_crawl_config_api(
         return {"started": crawl_id}
 
     @router.delete("/{cid}")
-    async def make_inactive(cid: str, org: Organization = Depends(org_crawl_dep)):
+    async def make_inactive(cid: uuid.UUID, org: Organization = Depends(org_crawl_dep)):
         crawlconfig = await ops.get_crawl_config(cid, org.id)
 
         if not crawlconfig:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -115,14 +115,15 @@ class CrawlConfigOps:
         """sanitize string for use in wacz filename"""
         return self._file_rx.sub("-", string.lower())
 
-    async def _lookup_profile(self, profileid, org):
+    async def _lookup_profile(
+        self, profileid: Optional[uuid.UUID], org: Organization
+    ) -> tuple[Optional[uuid.UUID], Optional[str]]:
         if profileid is None:
             return None, None
 
         if profileid == "":
             return None, ""
 
-        profileid = uuid.UUID(profileid)
         profile_filename = await self.profiles.get_profile_storage_path(profileid, org)
         if not profile_filename:
             raise HTTPException(status_code=400, detail="invalid_profile_id")
@@ -135,7 +136,7 @@ class CrawlConfigOps:
         config: CrawlConfigIn,
         org: Organization,
         user: User,
-    ):
+    ) -> tuple[str, str, bool]:
         """Add new crawl config"""
         data = config.dict()
         data["oid"] = org.id
@@ -227,7 +228,7 @@ class CrawlConfigOps:
 
     async def update_crawl_config(
         self, cid: uuid.UUID, org: Organization, user: User, update: UpdateCrawlConfig
-    ):
+    ) -> dict[str, bool]:
         # pylint: disable=too-many-locals
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
 
@@ -336,7 +337,7 @@ class CrawlConfigOps:
             "metadata_changed": metadata_changed,
         }
         if run_now:
-            crawl_id = await self.run_now(str(cid), org, user)
+            crawl_id = await self.run_now(cid, org, user)
             ret["started"] = crawl_id
         return ret
 
@@ -728,9 +729,9 @@ class CrawlConfigOps:
             "workflowIds": workflow_ids,
         }
 
-    async def run_now(self, cid: str, org: Organization, user: User):
+    async def run_now(self, cid: uuid.UUID, org: Organization, user: User):
         """run specified crawlconfig now"""
-        crawlconfig = await self.get_crawl_config(uuid.UUID(cid), org.id)
+        crawlconfig = await self.get_crawl_config(cid, org.id)
 
         if not crawlconfig:
             raise HTTPException(
@@ -957,29 +958,29 @@ def init_crawl_config_api(
 
     @router.get("/{cid}/seeds", response_model=PaginatedResponse)
     async def get_crawl_config_seeds(
-        cid: str,
+        cid: uuid.UUID,
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
     ):
-        seeds, total = await ops.get_seeds(uuid.UUID(cid), org.id, pageSize, page)
+        seeds, total = await ops.get_seeds(cid, org.id, pageSize, page)
         return paginated_format(seeds, total, page, pageSize)
 
     @router.get("/{cid}", response_model=CrawlConfigOut)
     async def get_crawl_config_out(
-        cid: str, org: Organization = Depends(org_viewer_dep)
+        cid: uuid.UUID, org: Organization = Depends(org_viewer_dep)
     ):
-        return await ops.get_crawl_config_out(uuid.UUID(cid), org)
+        return await ops.get_crawl_config_out(cid, org)
 
     @router.get(
         "/{cid}/revs",
         dependencies=[Depends(org_viewer_dep)],
     )
     async def get_crawl_config_revisions(
-        cid: str, pageSize: int = DEFAULT_PAGE_SIZE, page: int = 1
+        cid: uuid.UUID, pageSize: int = DEFAULT_PAGE_SIZE, page: int = 1
     ):
         revisions, total = await ops.get_crawl_config_revs(
-            uuid.UUID(cid), page_size=pageSize, page=page
+            cid, page_size=pageSize, page=page
         )
         return paginated_format(revisions, total, page, pageSize)
 
@@ -1000,24 +1001,24 @@ def init_crawl_config_api(
     @router.patch("/{cid}", dependencies=[Depends(org_crawl_dep)])
     async def update_crawl_config(
         update: UpdateCrawlConfig,
-        cid: str,
+        cid: uuid.UUID,
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ):
-        return await ops.update_crawl_config(uuid.UUID(cid), org, user, update)
+        return await ops.update_crawl_config(cid, org, user, update)
 
     @router.post("/{cid}/run")
     async def run_now(
-        cid: str,
+        cid: uuid.UUID,
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
-    ):
+    ) -> dict[str, str]:
         crawl_id = await ops.run_now(cid, org, user)
         return {"started": crawl_id}
 
     @router.delete("/{cid}")
     async def make_inactive(cid: str, org: Organization = Depends(org_crawl_dep)):
-        crawlconfig = await ops.get_crawl_config(uuid.UUID(cid), org.id)
+        crawlconfig = await ops.get_crawl_config(cid, org.id)
 
         if not crawlconfig:
             raise HTTPException(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -23,6 +23,7 @@ from .models import (
     CrawlConfig,
     CrawlConfigOut,
     CrawlConfigIdNameOut,
+    EmptyStr,
     UpdateCrawlConfig,
     Organization,
     User,
@@ -116,12 +117,12 @@ class CrawlConfigOps:
         return self._file_rx.sub("-", string.lower())
 
     async def _lookup_profile(
-        self, profileid: Optional[uuid.UUID], org: Organization
+        self, profileid: Union[uuid.UUID, EmptyStr, None], org: Organization
     ) -> tuple[Optional[uuid.UUID], Optional[str]]:
         if profileid is None:
             return None, None
 
-        if profileid == "":
+        if isinstance(profileid, EmptyStr) or profileid == "":
             return None, ""
 
         profile_filename = await self.profiles.get_profile_storage_path(profileid, org)
@@ -184,7 +185,7 @@ class CrawlConfigOps:
             storage=org.storage,
             run_now=run_now,
             out_filename=out_filename,
-            profile_filename=profile_filename,
+            profile_filename=profile_filename or "",
         )
 
         if crawl_id and run_now:

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -141,7 +141,7 @@ class CrawlManager(K8sAPI):
             has_scale_update
             or has_config_update
             or has_timeout_update
-            or profile_filename
+            or profile_filename is not None
             or has_max_crawl_size_update
         ):
             await self._update_config_map(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -7,7 +7,16 @@ from enum import Enum, IntEnum
 import os
 
 from typing import Optional, List, Dict, Union, Literal, Any
-from pydantic import BaseModel, UUID4, conint, Field, HttpUrl, AnyHttpUrl, EmailStr
+from pydantic import (
+    BaseModel,
+    UUID4,
+    conint,
+    Field,
+    HttpUrl,
+    AnyHttpUrl,
+    EmailStr,
+    ConstrainedStr,
+)
 
 # from fastapi_users import models as fastapi_users_models
 
@@ -166,6 +175,14 @@ class ScopeType(str, Enum):
 
 
 # ============================================================================
+class EmptyStr(ConstrainedStr):
+    """empty string only"""
+
+    min_length = 0
+    max_length = 0
+
+
+# ============================================================================
 class Seed(BaseModel):
     """Crawl seed"""
 
@@ -231,7 +248,7 @@ class CrawlConfigIn(BaseModel):
 
     jobType: Optional[JobType] = JobType.CUSTOM
 
-    profileid: Optional[UUID4]
+    profileid: Union[UUID4, EmptyStr, None]
 
     autoAddCollections: Optional[List[UUID4]] = []
     tags: Optional[List[str]] = []
@@ -372,7 +389,7 @@ class UpdateCrawlConfig(BaseModel):
 
     # crawl data: revision tracked
     schedule: Optional[str] = None
-    profileid: Optional[UUID4] = None
+    profileid: Union[UUID4, EmptyStr, None] = None
     crawlTimeout: Optional[int] = None
     maxCrawlSize: Optional[int] = None
     scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = None  # type: ignore

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -746,7 +746,7 @@ class Organization(BaseMongoModel):
     name: str
     slug: str
 
-    users: Dict[UUID4, UserRole]
+    users: Dict[str, UserRole]
 
     storage: Union[S3Storage, DefaultStorage]
 
@@ -810,11 +810,11 @@ class Organization(BaseMongoModel):
         if self.is_owner(user):
             result["users"] = {}
 
-            keys: List[UUID4] = list(self.users.keys())
+            keys = list(self.users.keys())
             user_list = await user_manager.get_user_names_by_ids(keys)
 
             for org_user in user_list:
-                id_ = org_user["id"]
+                id_ = str(org_user["id"])
                 role = self.users.get(id_)
                 if not role:
                     continue

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -231,7 +231,7 @@ class CrawlConfigIn(BaseModel):
 
     jobType: Optional[JobType] = JobType.CUSTOM
 
-    profileid: Optional[str]
+    profileid: Optional[UUID4]
 
     autoAddCollections: Optional[List[UUID4]] = []
     tags: Optional[List[str]] = []
@@ -372,7 +372,7 @@ class UpdateCrawlConfig(BaseModel):
 
     # crawl data: revision tracked
     schedule: Optional[str] = None
-    profileid: Optional[str] = None
+    profileid: Optional[UUID4] = None
     crawlTimeout: Optional[int] = None
     maxCrawlSize: Optional[int] = None
     scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)] = None  # type: ignore

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -746,7 +746,7 @@ class Organization(BaseMongoModel):
     name: str
     slug: str
 
-    users: Dict[str, UserRole]
+    users: Dict[UUID4, UserRole]
 
     storage: Union[S3Storage, DefaultStorage]
 
@@ -810,11 +810,11 @@ class Organization(BaseMongoModel):
         if self.is_owner(user):
             result["users"] = {}
 
-            keys = list(self.users.keys())
+            keys: List[UUID4] = list(self.users.keys())
             user_list = await user_manager.get_user_names_by_ids(keys)
 
             for org_user in user_list:
-                id_ = str(org_user["id"])
+                id_ = org_user["id"]
                 role = self.users.get(id_)
                 if not role:
                     continue

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -263,7 +263,7 @@ class OrgOps:
         self, org: Organization, userid: uuid.UUID, role: Optional[UserRole] = None
     ):
         """Add user to organization with specified role"""
-        org.users[userid] = role or UserRole.OWNER
+        org.users[str(userid)] = role or UserRole.OWNER
         await self.update_users(org)
 
     async def get_org_owners(self, org: Organization):
@@ -649,7 +649,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
     @router.post("/remove", tags=["invites"])
     async def remove_user_from_org(
         remove: RemoveFromOrg, org: Organization = Depends(org_owner_dep)
-    ):
+    ) -> dict[str, bool]:
         other_user = await user_manager.get_by_email(remove.email)
 
         if org.is_owner(other_user):
@@ -659,7 +659,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
                     status_code=400, detail="Can't remove only owner from org"
                 )
         try:
-            del org.users[other_user.id]
+            del org.users[str(other_user.id)]
         except KeyError:
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=404, detail="no_such_org_user")

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -263,7 +263,7 @@ class OrgOps:
         self, org: Organization, userid: uuid.UUID, role: Optional[UserRole] = None
     ):
         """Add user to organization with specified role"""
-        org.users[str(userid)] = role or UserRole.OWNER
+        org.users[userid] = role or UserRole.OWNER
         await self.update_users(org)
 
     async def get_org_owners(self, org: Organization):
@@ -659,7 +659,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
                     status_code=400, detail="Can't remove only owner from org"
                 )
         try:
-            del org.users[str(other_user.id)]
+            del org.users[other_user.id]
         except KeyError:
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=404, detail="no_such_org_user")

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -431,12 +431,10 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
 
     ops = OrgOps(mdb, invites)
 
-    async def org_dep(oid: str, user: User = Depends(user_dep)):
-        org = await ops.get_org_for_user_by_id(uuid.UUID(oid), user)
+    async def org_dep(oid: uuid.UUID, user: User = Depends(user_dep)):
+        org = await ops.get_org_for_user_by_id(oid, user)
         if not org:
-            raise HTTPException(
-                status_code=404, detail=f"Organization '{oid}' not found"
-            )
+            raise HTTPException(status_code=404, detail="org_not_found")
         if not org.is_viewer(user):
             raise HTTPException(
                 status_code=403,
@@ -466,8 +464,8 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
 
         return org
 
-    async def org_public(oid: str):
-        org = await ops.get_org_by_id(uuid.UUID(oid))
+    async def org_public(oid: uuid.UUID):
+        org = await ops.get_org_by_id(oid)
         if not org:
             raise HTTPException(status_code=404, detail="org_not_found")
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -161,7 +161,8 @@ class ProfileOps:
 
         await self.crawl_manager.delete_profile_browser(browser_commit.browserid)
 
-        file_size = resource["bytes"]
+        # backwards compatibility
+        file_size = resource.get("size") or resource.get("bytes")
 
         profile_file = ProfileFile(
             hash=resource["hash"],

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -178,10 +178,11 @@ class UserManager:
 
         return None
 
-    async def get_user_names_by_ids(self, user_ids: List[uuid.UUID]) -> dict[str, str]:
+    async def get_user_names_by_ids(self, user_ids: List[str]) -> dict[str, str]:
         """return list of user names for given ids"""
+        user_uuid_ids = [uuid.UUID(id_) for id_ in user_ids]
         cursor = self.users.find(
-            {"id": {"$in": user_ids}}, projection=["id", "name", "email"]
+            {"id": {"$in": user_uuid_ids}}, projection=["id", "name", "email"]
         )
         return await cursor.to_list(length=1000)
 

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -6,9 +6,9 @@ import os
 import uuid
 import asyncio
 
-from typing import Optional
+from typing import Optional, List
 
-from pydantic import UUID4, EmailStr
+from pydantic import EmailStr
 
 from fastapi import (
     Request,
@@ -178,9 +178,8 @@ class UserManager:
 
         return None
 
-    async def get_user_names_by_ids(self, user_ids):
+    async def get_user_names_by_ids(self, user_ids: List[uuid.UUID]) -> dict[str, str]:
         """return list of user names for given ids"""
-        user_ids = [UUID4(id_) for id_ in user_ids]
         cursor = self.users.find(
             {"id": {"$in": user_ids}}, projection=["id", "name", "email"]
         )
@@ -369,7 +368,7 @@ class UserManager:
 
         return user
 
-    async def get_by_id(self, _id: UUID4) -> Optional[User]:
+    async def get_by_id(self, _id: uuid.UUID) -> Optional[User]:
         """get user by unique id"""
         user = await self.users.find_one({"id": _id})
 
@@ -409,7 +408,7 @@ class UserManager:
             raise exc
 
         try:
-            user_uuid = UUID4(user_id)
+            user_uuid = uuid.UUID(user_id)
         except ValueError:
             raise exc
 
@@ -456,7 +455,7 @@ class UserManager:
         user_id = data["user_id"]
 
         try:
-            user_uuid = UUID4(user_id)
+            user_uuid = uuid.UUID(user_id)
         except ValueError:
             raise HTTPException(
                 status_code=400,
@@ -699,8 +698,8 @@ def init_users_router(current_active_user, user_manager) -> APIRouter:
         return await user_manager.format_invite(invite)
 
     @users_router.get("/invite/{token}", tags=["invites"])
-    async def get_invite_info(token: str, email: str):
-        invite = await user_manager.invites.get_valid_invite(uuid.UUID(token), email)
+    async def get_invite_info(token: uuid.UUID, email: str):
+        invite = await user_manager.invites.get_valid_invite(token, email)
         return await user_manager.format_invite(invite)
 
     # pylint: disable=invalid-name


### PR DESCRIPTION
Fixes #1297 
Ensures proper typing for UUIDs in FastAPI input models, to avoid explicit conversions, which may throw errors.
This avoids possible 500 errors (due to ValueError exceptions) when converting UUIDs from user input.
Instead, will get more 422 errors from FastAPI. 

UUID conversions remaining are in operator / profile handling where UUIDs are retrieved from previously set fields, remaining user input conversions in user auth and collection list are wrapped in exceptions.

For `profileid`, update fastapi models to support union of UUID, null, and EmptyStr (new empty string only type), to differentiate removing profile (empty string) vs not changing at all (null) for config updates
