### PR TITLE
Adds <btrix-details> to org dashboard table

### DIFF
--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -628,7 +628,7 @@ export class CrawlDetail extends LiteElement {
                       ></sl-format-date>`
                     : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 </btrix-desc-list-item>
-                <btrix-desc-list-item label=${msg("Duration")}>
+                <btrix-desc-list-item label=${msg("Elapsed Time")}>
                   ${this.crawl!.finished
                     ? html`${RelativeDuration.humanize(
                         new Date(`${this.crawl!.finished}Z`).valueOf() -

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -419,10 +419,10 @@ export class Dashboard extends LiteElement {
       </sl-tooltip>
     `,
     html`
-      ${msg("Total Crawl Duration")}
+      ${msg("Elapsed Time")}
       <sl-tooltip>
         <div slot="content" style="text-transform: initial">
-          ${msg("Total time elapsed between when crawl starts and ends")}
+          ${msg("Total time elapsed between when crawls started and ended")}
         </div>
         <sl-icon name="info-circle" style="vertical-align: -.175em"></sl-icon>
       </sl-tooltip>
@@ -451,15 +451,15 @@ export class Dashboard extends LiteElement {
         ];
       });
     return html`
-      <h2 class="text-lg font-semibold leading-none mb-6">
-        ${msg("Usage History")}
-      </h2>
-      <div class="border rounded overflow-hidden">
-        <btrix-data-table
-          .columns=${this.usageTableCols}
-          .rows=${rows}
-        ></btrix-data-table>
-      </div>
+      <btrix-details>
+        <span slot="title">${msg("Usage History")}</span>
+        <div class="border rounded overflow-hidden">
+          <btrix-data-table
+            .columns=${this.usageTableCols}
+            .rows=${rows}
+          ></btrix-data-table>
+        </div>
+      </btrix-details>
     `;
   }
 


### PR DESCRIPTION
### Changes
- Updates text with "Elapsed Time" label in the table
- Makes the table collapsible and collapsed by default.

<img width="1792" alt="Screenshot 2023-10-24 at 5 41 18 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/f934ced7-8619-4c0f-8cdc-9213187f8c8e">