### PR TITLE
Exec Time Incremental Updates

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -528,16 +528,11 @@ class CrawlOps(BaseCrawlOps):
         query = {"_id": crawl_id, "type": "crawl", "state": "running"}
         return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
 
-    async def store_exec_time(self, crawl_id, exec_time):
-        """set exec time, only if not already set"""
-        query = {
-            "_id": crawl_id,
-            "type": "crawl",
-            "crawlExecSeconds": {"$in": [0, None]},
-        }
+    async def inc_crawl_exec_time(self, crawl_id, exec_time):
+        """increment exec time"""
         return await self.crawls.find_one_and_update(
-            query,
-            {"$set": {"crawlExecSeconds": exec_time}},
+            {"_id": crawl_id, "type": "crawl"},
+            {"$inc": {"crawlExecSeconds": exec_time}},
         )
 
     async def get_crawl_state(self, crawl_id):

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -846,7 +846,6 @@ class BtrixOperator(K8sAPI):
         crawler_running, redis_running, done = self.sync_pod_status(pods, status)
         redis = None
 
-        # self.add_all_crawls_exec_time(crawl.id, status, all_crawls)
 
         try:
             if redis_running:

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -54,6 +54,9 @@ REDIS_TTL = 60
 # time in seconds before a crawl is deemed 'waiting' instead of 'starting'
 STARTING_TIME_SECS = 60
 
+# how often to update execution time seconds
+EXEC_TIME_UPDATE_SECS = 300
+
 
 # ============================================================================
 class MCBaseRequest(BaseModel):
@@ -216,15 +219,19 @@ class CrawlStatus(BaseModel):
     #    DefaultDict[str, Annotated[PodInfo, Field(default_factory=PodInfo)]]
     # ]
     restartTime: Optional[str]
-    execTime: int = 0
     canceled: bool = False
 
-    # Track estimated exec time as crawlers are running to cancel
-    # the crawl quickly if execution minutes hard cap is reached
-    runningExecTime: int = 0
+    # Execution Time -- updated on pod exits and at regular interval
+    crawlExecTime: int = 0
+
+    # last exec time update
+    lastUpdatedTime: str = ""
+
+    # any pods exited
+    anyCrawlPodNewExit: Optional[bool] = Field(default=False, exclude=True)
 
     # don't include in status, use by metacontroller
-    resync_after: Optional[int] = None
+    resync_after: Optional[int] = Field(default=None, exclude=True)
 
 
 # ============================================================================
@@ -258,6 +265,10 @@ class BtrixOperator(K8sAPI):
 
         self._has_pod_metrics = False
         self.compute_crawler_resources()
+
+        # to avoid background tasks being garbage collected
+        # see: https://stackoverflow.com/a/74059981
+        self.bg_tasks = set()
 
     def compute_crawler_resources(self):
         """compute memory / cpu resources for crawlers"""
@@ -299,7 +310,7 @@ class BtrixOperator(K8sAPI):
         browserid = spec.get("id")
 
         if dt_now() >= expire_time:
-            asyncio.create_task(self.delete_profile_browser(browserid))
+            self.run_task(self.delete_profile_browser(browserid))
             return {"status": {}, "children": []}
 
         params = {}
@@ -351,7 +362,12 @@ class BtrixOperator(K8sAPI):
                     raise HTTPException(status_code=400, detail="out_of_sync_status")
 
             return await self.finalize_response(
-                crawl_id, status, spec, data.children, params
+                crawl_id,
+                uuid.UUID(oid),
+                status,
+                spec,
+                data.children,
+                params,
             )
 
         # just in case, finished but not deleted, can only get here if
@@ -360,9 +376,14 @@ class BtrixOperator(K8sAPI):
             print(
                 f"warn crawl {crawl_id} finished but not deleted, post-finish taking too long?"
             )
-            asyncio.create_task(self.delete_crawl_job(crawl_id))
+            self.run_task(self.delete_crawl_job(crawl_id))
             return await self.finalize_response(
-                crawl_id, status, spec, data.children, params
+                crawl_id,
+                uuid.UUID(oid),
+                status,
+                spec,
+                data.children,
+                params,
             )
 
         try:
@@ -400,24 +421,9 @@ class BtrixOperator(K8sAPI):
                 and await self.org_ops.storage_quota_reached(crawl.oid)
             ):
                 await self.mark_finished(
-                    crawl.id,
-                    crawl.cid,
-                    crawl.oid,
-                    status,
-                    "skipped_quota_reached",
+                    crawl.id, crawl.cid, crawl.oid, status, "skipped_quota_reached"
                 )
                 return self._empty_response(status)
-
-        # Gracefully stop crawl when execution minutes hard cap is reached to
-        # ensure that the user still gets their data from the crawl
-        _, exec_mins_hard_cap_reached = await self.org_ops.execution_mins_quota_reached(
-            crawl.oid, status.runningExecTime
-        )
-        if exec_mins_hard_cap_reached:
-            crawl.stopping = True
-
-        # Reset runningExecTime to recalculate below for next sync
-        status.runningExecTime = 0
 
         if status.state in ("starting", "waiting_org_limit"):
             if not await self.can_start_new(crawl, data, status):
@@ -437,7 +443,6 @@ class BtrixOperator(K8sAPI):
                 status,
                 pods,
                 data.related.get(METRICS, {}),
-                crawl.oid,
             )
 
             # auto sizing handled here
@@ -445,10 +450,21 @@ class BtrixOperator(K8sAPI):
 
             if status.finished:
                 return await self.finalize_response(
-                    crawl_id, status, spec, data.children, params
+                    crawl_id,
+                    uuid.UUID(oid),
+                    status,
+                    spec,
+                    data.children,
+                    params,
                 )
+
+            await self.increment_pod_exec_time(
+                pods, status, crawl.id, crawl.oid, EXEC_TIME_UPDATE_SECS
+            )
+
         else:
             status.scale = crawl.scale
+            status.lastUpdatedTime = to_k8s_date(dt_now())
 
         children = self._load_redis(params, status, data.children)
 
@@ -471,7 +487,7 @@ class BtrixOperator(K8sAPI):
             children.extend(self._load_crawler(params, i, status, data.children))
 
         return {
-            "status": status.dict(exclude_none=True, exclude={"resync_after": True}),
+            "status": status.dict(exclude_none=True),
             "children": children,
             "resyncAfterSeconds": status.resync_after,
         }
@@ -706,8 +722,6 @@ class BtrixOperator(K8sAPI):
         await self.mark_for_cancelation(crawl_id)
 
         if not status.canceled:
-            cancel_time = datetime.utcnow()
-
             for name, pod in pods.items():
                 pstatus = pod["status"]
                 role = pod["metadata"]["labels"]["role"]
@@ -720,15 +734,8 @@ class BtrixOperator(K8sAPI):
 
                 cstatus = pstatus["containerStatuses"][0]
 
-                running = cstatus["state"].get("running")
-
-                if running:
-                    await self.inc_exec_time(
-                        name, oid, status, cancel_time, running.get("startedAt")
-                    )
-
-                await self.handle_terminated_pod(
-                    name, oid, role, status, cstatus["state"].get("terminated")
+                self.handle_terminated_pod(
+                    name, role, status, cstatus["state"].get("terminated")
                 )
 
             status.canceled = True
@@ -761,20 +768,21 @@ class BtrixOperator(K8sAPI):
             print(f"============== POD STATUS: {name} ==============")
             pprint(pods[name]["status"])
 
-        asyncio.create_task(self.print_pod_logs(pod_names, self.log_failed_crawl_lines))
+        self.run_task(self.print_pod_logs(pod_names, self.log_failed_crawl_lines))
 
         return True
 
     def _empty_response(self, status):
         """done response for removing crawl"""
         return {
-            "status": status.dict(exclude_none=True, exclude={"resync_after": True}),
+            "status": status.dict(exclude_none=True),
             "children": [],
         }
 
     async def finalize_response(
         self,
         crawl_id: str,
+        oid: uuid.UUID,
         status: CrawlStatus,
         spec: dict,
         children: dict,
@@ -787,25 +795,19 @@ class BtrixOperator(K8sAPI):
 
         finalized = False
 
-        exec_updated = False
-
         pods = children[POD]
 
         if redis_pod in pods:
             # if has other pods, keep redis pod until they are removed
             if len(pods) > 1:
                 new_children = self._load_redis(params, status, children)
+                await self.increment_pod_exec_time(pods, status, crawl_id, oid)
 
         # keep pvs until pods are removed
         if new_children:
             new_children.extend(list(children[PVC].values()))
 
         if not children[POD] and not children[PVC]:
-            # ensure exec time was successfully updated
-            exec_updated = await self.store_exec_time_in_crawl(
-                crawl_id, status.execTime
-            )
-
             # keep parent until ttl expired, if any
             if status.finished:
                 ttl = spec.get("ttlSecondsAfterFinished", DEFAULT_TTL)
@@ -817,9 +819,9 @@ class BtrixOperator(K8sAPI):
                 finalized = True
 
         return {
-            "status": status.dict(exclude_none=True, exclude={"resync_after": True}),
+            "status": status.dict(exclude_none=True),
             "children": new_children,
-            "finalized": finalized and exec_updated,
+            "finalized": finalized,
         }
 
     async def _get_redis(self, redis_url):
@@ -838,13 +840,13 @@ class BtrixOperator(K8sAPI):
 
             return None
 
-    async def sync_crawl_state(self, redis_url, crawl, status, pods, metrics, oid):
+    async def sync_crawl_state(self, redis_url, crawl, status, pods, metrics):
         """sync crawl state for running crawl"""
         # check if at least one crawler pod started running
-        crawler_running, redis_running, done = await self.sync_pod_status(
-            pods, status, oid
-        )
+        crawler_running, redis_running, done = self.sync_pod_status(pods, status)
         redis = None
+
+        # self.add_all_crawls_exec_time(crawl.id, status, all_crawls)
 
         try:
             if redis_running:
@@ -852,7 +854,9 @@ class BtrixOperator(K8sAPI):
 
             await self.add_used_stats(crawl.id, status.podStatus, redis, metrics)
 
-            await self.log_crashes(crawl.id, status.podStatus, redis)
+            # skip if no newly exited pods
+            if status.anyCrawlPodNewExit:
+                await self.log_crashes(crawl.id, status.podStatus, redis)
 
             if not crawler_running:
                 if self.should_mark_waiting(status.state, crawl.started):
@@ -894,7 +898,7 @@ class BtrixOperator(K8sAPI):
                     crawl.id,
                     allowed_from=["starting", "waiting_capacity"],
                 ):
-                    asyncio.create_task(
+                    self.run_task(
                         self.event_webhook_ops.create_crawl_started_notification(
                             crawl.id, crawl.oid, scheduled=crawl.scheduled
                         )
@@ -929,11 +933,12 @@ class BtrixOperator(K8sAPI):
             if redis:
                 await redis.close()
 
-    async def sync_pod_status(self, pods, status, oid):
+    def sync_pod_status(self, pods, status):
         """check status of pods"""
         crawler_running = False
         redis_running = False
         done = True
+
         try:
             for name, pod in pods.items():
                 running = False
@@ -957,12 +962,9 @@ class BtrixOperator(K8sAPI):
                     ):
                         running = True
 
-                    await self.handle_terminated_pod(
-                        name, oid, role, status, cstatus["state"].get("terminated")
+                    self.handle_terminated_pod(
+                        name, role, status, cstatus["state"].get("terminated")
                     )
-
-                    if role == "crawler":
-                        self.increment_running_exec_time(cstatus["state"], status)
 
                 if role == "crawler":
                     crawler_running = crawler_running or running
@@ -977,15 +979,7 @@ class BtrixOperator(K8sAPI):
 
         return crawler_running, redis_running, done
 
-    def increment_running_exec_time(self, container_state, status):
-        """Increment runningExecTime in crawl status for running crawler pod"""
-        running = container_state.get("running")
-        if running:
-            start_time = from_k8s_date(running.get("startedAt"))
-            running_exec_time = int((datetime.now() - start_time).total_seconds())
-            status.runningExecTime += running_exec_time
-
-    async def handle_terminated_pod(self, name, oid, role, status, terminated):
+    def handle_terminated_pod(self, name, role, status, terminated):
         """handle terminated pod state"""
         if not terminated:
             return
@@ -999,10 +993,8 @@ class BtrixOperator(K8sAPI):
 
         pod_status.isNewExit = pod_status.exitTime != exit_time
         if pod_status.isNewExit and role == "crawler":
-            await self.inc_exec_time(
-                name, oid, status, exit_time, terminated.get("startedAt")
-            )
             pod_status.exitTime = exit_time
+            status.anyCrawlPodNewExit = True
 
         # detect reason
         exit_code = terminated.get("exitCode")
@@ -1016,6 +1008,105 @@ class BtrixOperator(K8sAPI):
 
         pod_status.exitCode = exit_code
 
+    async def increment_pod_exec_time(
+        self,
+        pods: dict[str, dict],
+        status: CrawlStatus,
+        crawl_id: str,
+        oid: uuid.UUID,
+        min_duration=0,
+    ) -> None:
+        """inc exec time tracking"""
+        now = dt_now()
+
+        if not status.lastUpdatedTime:
+            status.lastUpdatedTime = to_k8s_date(now)
+            return
+
+        update_start_time = from_k8s_date(status.lastUpdatedTime)
+
+        reason = None
+        update_duration = (now - update_start_time).total_seconds()
+
+        if status.anyCrawlPodNewExit:
+            reason = "new pod exit"
+
+        elif status.canceled:
+            reason = "crawl canceled"
+
+        elif now.month != update_start_time.month:
+            reason = "month change"
+
+        elif update_duration >= min_duration:
+            reason = "duration reached" if min_duration else "finalizing"
+
+        if not reason:
+            return
+
+        exec_time = 0
+        print(
+            f"Exec Time Update: {reason}: {now} - {update_start_time} = {update_duration}"
+        )
+
+        for name, pod in pods.items():
+            pstatus = pod["status"]
+            role = pod["metadata"]["labels"]["role"]
+
+            if role != "crawler":
+                continue
+
+            if "containerStatuses" not in pstatus:
+                continue
+
+            cstate = pstatus["containerStatuses"][0]["state"]
+
+            end_time = None
+            start_time = None
+            pod_state = ""
+
+            if "running" in cstate:
+                pod_state = "running"
+                state = cstate["running"]
+                start_time = from_k8s_date(state.get("startedAt"))
+                if update_start_time and update_start_time > start_time:
+                    start_time = update_start_time
+
+                end_time = now
+            elif "terminated" in cstate:
+                pod_state = "terminated"
+                state = cstate["terminated"]
+                start_time = from_k8s_date(state.get("startedAt"))
+                end_time = from_k8s_date(state.get("finishedAt"))
+                if update_start_time and update_start_time > start_time:
+                    start_time = update_start_time
+
+                # already counted
+                if update_start_time and end_time < update_start_time:
+                    print(
+                        f"  - {name}: {pod_state}: skipping already counted, "
+                        + f"{end_time} < {start_time}"
+                    )
+                    continue
+
+            if end_time and start_time:
+                duration = int((end_time - start_time).total_seconds())
+                print(
+                    f"  - {name}: {pod_state}: {end_time} - {start_time} = {duration}"
+                )
+                exec_time += duration
+
+        if exec_time:
+            await self.crawl_ops.inc_crawl_exec_time(crawl_id, exec_time)
+            await self.org_ops.inc_org_time_stats(oid, exec_time, True)
+            status.crawlExecTime += exec_time
+
+        print(
+            f"  Exec Time Total: {status.crawlExecTime}, Incremented By: {exec_time}",
+            flush=True,
+        )
+
+        status.lastUpdatedTime = to_k8s_date(now)
+
     def should_mark_waiting(self, state, started):
         """Should the crawl be marked as waiting for capacity?"""
         if state in RUNNING_STATES:
@@ -1023,7 +1114,7 @@ class BtrixOperator(K8sAPI):
 
         if state == "starting":
             started = from_k8s_date(started)
-            return (datetime.utcnow() - started).total_seconds() > STARTING_TIME_SECS
+            return (dt_now() - started).total_seconds() > STARTING_TIME_SECS
 
         return False
 
@@ -1085,7 +1176,7 @@ class BtrixOperator(K8sAPI):
     def get_log_line(self, message, details):
         """get crawler error line for logging"""
         err = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": dt_now().isoformat(),
             "logLevel": "error",
             "context": "k8s",
             "message": message,
@@ -1128,7 +1219,7 @@ class BtrixOperator(K8sAPI):
             return True
 
         # check crawl expiry
-        if crawl.expire_time and datetime.utcnow() > crawl.expire_time:
+        if crawl.expire_time and dt_now() > crawl.expire_time:
             print(f"Graceful Stop: Job duration expired at {crawl.expire_time}")
             return True
 
@@ -1178,6 +1269,16 @@ class BtrixOperator(K8sAPI):
 
         status.stopping = self.is_crawl_stopping(crawl, status.size)
 
+        # check exec time quotas and stop if reached limit
+        if not status.stopping:
+            (
+                _,
+                exec_mins_hard_cap_reached,
+            ) = await self.org_ops.execution_mins_quota_reached(crawl.oid)
+            if exec_mins_hard_cap_reached:
+                status.stopping = True
+
+        # mark crawl as stopping
         if status.stopping:
             await redis.set(f"{crawl.id}:stopping", "1")
             # backwards compatibility with older crawler
@@ -1285,7 +1386,7 @@ class BtrixOperator(K8sAPI):
         if crawl and state in SUCCESSFUL_STATES:
             await self.inc_crawl_complete_stats(crawl, finished)
 
-        asyncio.create_task(
+        self.run_task(
             self.do_crawl_finished_tasks(
                 crawl_id, cid, oid, status.filesAddedSize, state
             )
@@ -1318,30 +1419,6 @@ class BtrixOperator(K8sAPI):
 
         # finally, delete job
         await self.delete_crawl_job(crawl_id)
-
-    async def inc_exec_time(self, name, oid, status, finished_at, started_at):
-        """increment execTime on pod status and in org"""
-        end_time = (
-            from_k8s_date(finished_at)
-            if not isinstance(finished_at, datetime)
-            else finished_at
-        )
-        start_time = from_k8s_date(started_at)
-        exec_time = int((end_time - start_time).total_seconds())
-        await self.org_ops.inc_org_time_stats(oid, exec_time, True)
-        status.execTime += exec_time
-        print(f"{name} exec time: {exec_time}")
-        return exec_time
-
-    async def store_exec_time_in_crawl(self, crawl_id: str, exec_time: int):
-        """store crawlExecSeconds in crawl (if not already set)"""
-        try:
-            await self.crawl_ops.store_exec_time(crawl_id, exec_time)
-            return True
-        # pylint: disable=broad-except
-        except Exception as exc:
-            print(exc, flush=True)
-            return False
 
     async def inc_crawl_complete_stats(self, crawl, finished):
         """Increment Crawl Stats"""
@@ -1490,6 +1567,12 @@ class BtrixOperator(K8sAPI):
         return {
             "attachments": attachments,
         }
+
+    def run_task(self, func):
+        """add bg tasks to set to avoid premature garbage collection"""
+        task = asyncio.create_task(func)
+        self.bg_tasks.add(task)
+        task.add_done_callback(self.bg_tasks.discard)
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -55,7 +55,7 @@ REDIS_TTL = 60
 STARTING_TIME_SECS = 60
 
 # how often to update execution time seconds
-EXEC_TIME_UPDATE_SECS = 300
+EXEC_TIME_UPDATE_SECS = 60
 
 
 # ============================================================================
@@ -845,7 +845,6 @@ class BtrixOperator(K8sAPI):
         # check if at least one crawler pod started running
         crawler_running, redis_running, done = self.sync_pod_status(pods, status)
         redis = None
-
 
         try:
             if redis_running:

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -336,9 +336,7 @@ class OrgOps:
         except KeyError:
             return 0
 
-    async def execution_mins_quota_reached(
-        self, oid: uuid.UUID, running_exec_seconds: int = 0
-    ) -> Tuple[bool, bool]:
+    async def execution_mins_quota_reached(self, oid: uuid.UUID) -> Tuple[bool, bool]:
         """Return bools for if execution minutes quota and hard cap are reached."""
         quota = await self.get_org_execution_mins_quota(oid)
         if not quota:
@@ -351,7 +349,6 @@ class OrgOps:
         hard_cap_quota = quota + hard_cap_additional_mins
 
         monthly_exec_seconds = await self.get_this_month_crawl_exec_seconds(oid)
-        monthly_exec_seconds = monthly_exec_seconds + running_exec_seconds
         monthly_exec_minutes = math.floor(monthly_exec_seconds / 60)
 
         if monthly_exec_minutes >= quota:


### PR DESCRIPTION
This adds an slight refactor to #1284 to ensure execution minutes are updated incrementally while a crawl is running.
The execution minutes are updated on the org and on the crawl if:
- 300 seconds elapsed from last update
- any pod has newly exited
- crawl has been canceled (compute to current time)
- if month has changed

This should ensure that the execution time quota is accurate within 5 minutes, and also that crawls running at the end of the month properly count towards old and new month quotas (a bit of an edge case yes, but bound to happen!)

other cleanup:
- add background tasks to a set to avoid premature garbage collection (see: https://stackoverflow.com/a/74059981)
- use dt_now() consistently instead of datetime.utcnow() to store second-rounded dates