### PR TITLE
Fix profile deletion

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -345,7 +345,7 @@ class StorageOps:
     ) -> bool:
         """delete crawl file from storage."""
         return await self.delete_file(
-            org, crawlfile.filename, crawlfile.def_storage_name
+            org, crawlfile.filename, crawlfile.def_storage_name or "default"
         )
 
     async def delete_file(


### PR DESCRIPTION
Fixes #1310

Use "default" if crawlfile doesn't have def_storage_name.

Fix in case it takes a while to merge https://github.com/webrecorder/browsertrix-cloud/pull/1296, which otherwise makes this irrelevant. If we merge that soon, can close this PR.