### PR TITLE
Check for empty string for SMTP password

### DIFF
--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -43,7 +43,7 @@ class EmailSender:
                 server.ehlo()
                 server.starttls(context=context)
             server.ehlo()
-            if self.password is not None:
+            if self.password:
                 server.login(self.sender, self.password)
             server.send_message(msg)
             # server.sendmail(self.sender, receiver, message)


### PR DESCRIPTION
Follow-up fix for #1136 based on this comment: https://github.com/webrecorder/browsertrix-cloud/issues/1136#issuecomment-1777119534