### PR TITLE
Allow User to specify custom cluster-issuer

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     {{- if .Values.ingress.tls }}
-    cert-manager.io/cluster-issuer: {{ .Values.cluster-issuer | default "cert-main" }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.custom-cluster-issuer | default "cert-main" }}
     {{- end }}
     nginx.ingress.kubernetes.io/upstream-vhost: "{{ .Values.ingress.host }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -78,7 +78,7 @@ spec:
 
 
 {{ if .Values.ingress.tls }}
-{{ if not .Values.cluster-issuer }}
+{{ if not .Values.ingress.custom-cluster-issuer }}
 ---
 
 apiVersion: cert-manager.io/v1

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     {{- if .Values.ingress.tls }}
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.custom-cluster-issuer | default "cert-main" }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.custom_cluster_issuer | default "cert-main" }}
     {{- end }}
     nginx.ingress.kubernetes.io/upstream-vhost: "{{ .Values.ingress.host }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -78,7 +78,7 @@ spec:
 
 
 {{ if .Values.ingress.tls }}
-{{ if not .Values.ingress.custom-cluster-issuer }}
+{{ if not .Values.ingress.custom_cluster_issuer }}
 ---
 
 apiVersion: cert-manager.io/v1

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     {{- if .Values.ingress.tls }}
-    cert-manager.io/cluster-issuer: "cert-main"
+    cert-manager.io/cluster-issuer: {{ .Values.cluster-issuer | default "cert-main" }}
     {{- end }}
     nginx.ingress.kubernetes.io/upstream-vhost: "{{ .Values.ingress.host }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -78,6 +78,7 @@ spec:
 
 
 {{ if .Values.ingress.tls }}
+{{ if not .Values.cluster-issuer }}
 ---
 
 apiVersion: cert-manager.io/v1
@@ -101,5 +102,6 @@ spec:
           ingressClassName: {{ .Values.ingress_class | default "nginx" }}
           class: {{ .Values.ingress_class | default "nginx" }}
 
+{{ end }}
 {{ end }}
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -304,10 +304,11 @@ ingress:
   #host: ""
   cert_email: "test@example.com"
   tls: false
+  # Optional: Uncomment to use your own cluster-issuer instead of default ACME https validation
+  # custom-cluster-issuer: custom-cluster-issuer-name
 
 ingress_class: nginx
-# Optional: Uncomment to use your own cluster-issuer instead of default ACME https validation
-# cluster-issuer: custom-cluster-issuer
+
 
 
 # Signing Options

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -305,7 +305,7 @@ ingress:
   cert_email: "test@example.com"
   tls: false
   # Optional: Uncomment to use your own cluster-issuer instead of default ACME https validation
-  # custom-cluster-issuer: custom-cluster-issuer-name
+  # custom_cluster_issuer: custom_cluster_issuer-name
 
 ingress_class: nginx
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -306,6 +306,8 @@ ingress:
   tls: false
 
 ingress_class: nginx
+# Optional: Uncomment to use your own cluster-issuer instead of default ACME https validation
+# cluster-issuer: custom-cluster-issuer
 
 
 # Signing Options


### PR DESCRIPTION
Implemented variable and defaults for cluster-issuer to allow users to specify, if needed, their own cluster issuer. (eg. installations with only outbound traffic that cannot solve ACME https challenge)