### PR TITLE
Add checkmark next to replicated/backed up files

### DIFF
--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -109,7 +109,7 @@ export class BrowserProfilesList extends LiteElement {
                 () => html` <sl-tooltip content=${msg("Profile replicated")}>
                   <sl-icon
                     name="cloud-check"
-                    class="pl-2 text-success"
+                    class="ml-2 text-success"
                   ></sl-icon>
                 </sl-tooltip>`
               )}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -1,5 +1,6 @@
 import { state, property } from "lit/decorators.js";
 import { msg, localized, str } from "@lit/localize";
+import { when } from "lit/directives/when.js";
 
 import type { AuthState } from "../../utils/AuthService";
 import LiteElement, { html } from "../../utils/LiteElement";
@@ -101,7 +102,18 @@ export class BrowserProfilesList extends LiteElement {
       >
         <div class="grid grid-cols-8 gap-3 md:gap-5" role="row">
           <div class="col-span-8 md:col-span-3 p-2" role="cell">
-            <div class="font-medium mb-1">${data.name}</div>
+            <div class="font-medium mb-1">
+              ${data.name}
+              ${when(
+                data.resource && data.resource.replicas.length > 0,
+                () => html` <sl-tooltip content=${msg("Profile replicated")}>
+                  <sl-icon
+                    name="cloud-check"
+                    class="pl-1 shrink-0 text-success"
+                  ></sl-icon>
+                </sl-tooltip>`
+              )}
+            </div>
             <div class="text-sm truncate" title=${data.description}>
               ${data.description}
             </div>

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -102,14 +102,14 @@ export class BrowserProfilesList extends LiteElement {
       >
         <div class="grid grid-cols-8 gap-3 md:gap-5" role="row">
           <div class="col-span-8 md:col-span-3 p-2" role="cell">
-            <div class="font-medium mb-1">
-              ${data.name}
+            <div class="font-medium flex items-end">
+              <span>${data.name}</span>
               ${when(
                 data.resource && data.resource.replicas.length > 0,
                 () => html` <sl-tooltip content=${msg("Profile replicated")}>
                   <sl-icon
                     name="cloud-check"
-                    class="pl-1 shrink-0 text-success"
+                    class="pl-1 text-success"
                   ></sl-icon>
                 </sl-tooltip>`
               )}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -109,7 +109,7 @@ export class BrowserProfilesList extends LiteElement {
                 () => html` <sl-tooltip content=${msg("Profile replicated")}>
                   <sl-icon
                     name="cloud-check"
-                    class="ml-2 text-success"
+                    class="w-4 h-4 ml-2 align-text-bottom text-success"
                   ></sl-icon>
                 </sl-tooltip>`
               )}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -109,7 +109,7 @@ export class BrowserProfilesList extends LiteElement {
                 () => html` <sl-tooltip content=${msg("Profile replicated")}>
                   <sl-icon
                     name="cloud-check"
-                    class="pl-1 text-success"
+                    class="pl-2 text-success"
                   ></sl-icon>
                 </sl-tooltip>`
               )}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -106,7 +106,7 @@ export class BrowserProfilesList extends LiteElement {
               <span>${data.name}</span>
               ${when(
                 data.resource && data.resource.replicas.length > 0,
-                () => html` <sl-tooltip content=${msg("Profile replicated")}>
+                () => html` <sl-tooltip content=${msg("Backed up")}>
                   <sl-icon
                     name="clouds"
                     class="w-4 h-4 ml-2 align-text-bottom text-success"

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -108,7 +108,7 @@ export class BrowserProfilesList extends LiteElement {
                 data.resource && data.resource.replicas.length > 0,
                 () => html` <sl-tooltip content=${msg("Profile replicated")}>
                   <sl-icon
-                    name="cloud-check"
+                    name="clouds"
                     class="w-4 h-4 ml-2 align-text-bottom text-success"
                   ></sl-icon>
                 </sl-tooltip>`

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -102,7 +102,7 @@ export class BrowserProfilesList extends LiteElement {
       >
         <div class="grid grid-cols-8 gap-3 md:gap-5" role="row">
           <div class="col-span-8 md:col-span-3 p-2" role="cell">
-            <div class="font-medium flex items-end">
+            <div class="font-medium text-sm">
               <span>${data.name}</span>
               ${when(
                 data.resource && data.resource.replicas.length > 0,

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -803,7 +803,7 @@ ${this.crawl?.description}
                         >
                           <sl-icon
                             name="cloud-check"
-                            class="h-4 pr-2 shrink-0 text-success"
+                            class="h-4 mr-2 shrink-0 text-success"
                           ></sl-icon>
                         </sl-tooltip>`
                       )}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -803,7 +803,7 @@ ${this.crawl?.description}
                         >
                           <sl-icon
                             name="cloud-check"
-                            class="h-4 mr-2 shrink-0 text-success"
+                            class="w-4 h-4 mr-2 align-text-bottom shrink-0 text-success"
                           ></sl-icon>
                         </sl-tooltip>`
                       )}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -790,14 +790,14 @@ ${this.crawl?.description}
                       ></sl-icon>
                       ${when(
                         file.numReplicas > 0,
-                        () => html`
-                          <sl-tooltip content=${msg("File replicated")}>
-                            <sl-icon
-                              name="cloud-check"
-                              class="h-4 pr-2 shrink-0 text-success"
-                            ></sl-icon>
-                          </sl-tooltip>
-                        `
+                        () => html` <sl-tooltip
+                          content=${msg("File replicated")}
+                        >
+                          <sl-icon
+                            name="cloud-check"
+                            class="h-4 pr-2 shrink-0 text-success"
+                          ></sl-icon>
+                        </sl-tooltip>`
                       )}
                       <a
                         class="text-primary hover:underline truncate mr-2"

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -802,7 +802,7 @@ ${this.crawl?.description}
                           content=${msg("File replicated")}
                         >
                           <sl-icon
-                            name="cloud-check"
+                            name="clouds"
                             class="w-4 h-4 mr-2 align-text-bottom shrink-0 text-success"
                           ></sl-icon>
                         </sl-tooltip>`

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -794,7 +794,7 @@ ${this.crawl?.description}
                       </a>
                     </div>
                     <div
-                      class="whitespace-nowrap text-sm font-mono text-neutral-400 flex items-end"
+                      class="whitespace-nowrap text-sm font-mono text-neutral-400"
                     >
                       ${when(
                         file.numReplicas > 0,

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -157,10 +157,7 @@ export class CrawlDetail extends LiteElement {
         });
         break;
       case "files":
-        sectionContent = this.renderPanel(
-          msg("Download Files"),
-          this.renderFiles()
-        );
+        sectionContent = this.renderPanel(msg("Files"), this.renderFiles());
         break;
       case "logs":
         sectionContent = this.renderPanel(
@@ -788,6 +785,17 @@ ${this.crawl?.description}
                         name="file-earmark-zip-fill"
                         class="h-4 pr-2 shrink-0 text-neutral-600"
                       ></sl-icon>
+                      <a
+                        class="text-primary hover:underline truncate mr-2"
+                        href=${file.path}
+                        download
+                        title=${file.name}
+                        >${file.name.slice(file.name.lastIndexOf("/") + 1)}
+                      </a>
+                    </div>
+                    <div
+                      class="whitespace-nowrap text-sm font-mono text-neutral-400 flex items-end"
+                    >
                       ${when(
                         file.numReplicas > 0,
                         () => html` <sl-tooltip
@@ -799,17 +807,6 @@ ${this.crawl?.description}
                           ></sl-icon>
                         </sl-tooltip>`
                       )}
-                      <a
-                        class="text-primary hover:underline truncate mr-2"
-                        href=${file.path}
-                        download
-                        title=${file.name}
-                        >${file.name.slice(file.name.lastIndexOf("/") + 1)}
-                      </a>
-                    </div>
-                    <div
-                      class="whitespace-nowrap text-sm font-mono text-neutral-400"
-                    >
                       <sl-format-bytes value=${file.size}></sl-format-bytes>
                     </div>
                   </li>

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -788,6 +788,17 @@ ${this.crawl?.description}
                         name="file-earmark-zip-fill"
                         class="h-4 pr-2 shrink-0 text-neutral-600"
                       ></sl-icon>
+                      ${when(
+                        file.numReplicas > 0,
+                        () => html`
+                          <sl-tooltip content=${msg("File replicated")}>
+                            <sl-icon
+                              name="cloud-check"
+                              class="h-4 pr-2 shrink-0 text-success"
+                            ></sl-icon>
+                          </sl-tooltip>
+                        `
+                      )}
                       <a
                         class="text-primary hover:underline truncate mr-2"
                         href=${file.path}

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -798,9 +798,7 @@ ${this.crawl?.description}
                     >
                       ${when(
                         file.numReplicas > 0,
-                        () => html` <sl-tooltip
-                          content=${msg("File replicated")}
-                        >
+                        () => html` <sl-tooltip content=${msg("Backed up")}>
                           <sl-icon
                             name="clouds"
                             class="w-4 h-4 mr-2 align-text-bottom shrink-0 text-success"

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -124,7 +124,13 @@ export type Crawl = CrawlConfig & {
   state: CrawlState;
   scale: number;
   stats: { done: string; found: string; size: string } | null;
-  resources?: { name: string; path: string; hash: string; size: number }[];
+  resources?: {
+    name: string;
+    path: string;
+    hash: string;
+    size: number;
+    numReplicas: number;
+  }[];
   fileCount?: number;
   fileSize?: number;
   completions?: number;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -83,6 +83,11 @@ export type Workflow = CrawlConfig & {
 
 export type ListWorkflow = Omit<Workflow, "config">;
 
+export type ProfileReplica = {
+  name: string;
+  custom?: boolean;
+};
+
 export type Profile = {
   id: string;
   name: string;
@@ -93,6 +98,13 @@ export type Profile = {
   baseProfileName: string;
   oid: string;
   crawlconfigs: { id: string; name: string }[];
+  resource?: {
+    name: string;
+    path: string;
+    hash: string;
+    size: number;
+    replicas: ProfileReplica[];
+  };
 };
 
 export type CrawlState =


### PR DESCRIPTION
Fixes #1291

Please feel free to suggest different placement/styles or make changes yourself! I tried a few different placements and settled on this for now but I don't have the design eye some of you have :)

We may want to make profiles more consistent with files in exposing a `numReplicas` int rather than the `replicas` array but it would involve some more extensive changes to profiles backend so it seemed out of scope for this PR.

## Screenshots

### Crawl

<img width="1130" alt="Screen Shot 2023-11-07 at 4 20 02 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/fce351af-a42d-493a-9813-d109898d1be3">

### Upload

<img width="1128" alt="Screen Shot 2023-11-07 at 4 20 28 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/3a73aff1-7e9f-4fa8-9fd7-9d119b331acd">


### Crawl/Upload Tooltip

<img width="147" alt="Screen Shot 2023-11-07 at 4 20 09 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/27c987fe-3fe3-43a3-9c9c-9d829e18a842">


### Browser Profile

<img width="1128" alt="Screen Shot 2023-11-07 at 4 20 38 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/5425f1ba-89cf-45b1-9f99-28d9ebff5753">

### Browser Profile Tooltip

<img width="160" alt="Screen Shot 2023-11-07 at 4 20 55 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/9286da66-9981-42e3-bd19-e74335ae1547">



