### PR TITLE
Send email to superuser when background job fails

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -29,6 +29,7 @@ else:
 
 
 # ============================================================================
+# pylint: disable=too-many-instance-attributes
 class BackgroundJobOps:
     """k8s background job management"""
 
@@ -41,8 +42,11 @@ class BackgroundJobOps:
 
     # pylint: disable=too-many-locals, too-many-arguments, invalid-name
 
-    def __init__(self, mdb, org_ops, crawl_manager, storage_ops):
+    def __init__(self, mdb, email, user_manager, org_ops, crawl_manager, storage_ops):
         self.jobs = mdb["jobs"]
+
+        self.email = email
+        self.user_manager = user_manager
 
         self.org_ops = org_ops
         self.crawl_manager = crawl_manager
@@ -213,6 +217,13 @@ class BackgroundJobOps:
         if success:
             if job_type == BgJobType.CREATE_REPLICA:
                 await self.handle_replica_job_finished(cast(CreateReplicaJob, job))
+        else:
+            print(
+                f"Background job {job.id} failed, sending email to superuser",
+                flush=True,
+            )
+            superuser = await self.user_manager.get_superuser()
+            self.email.send_background_job_failed(job, finished, superuser.email)
 
         await self.jobs.find_one_and_update(
             {"_id": job_id, "oid": oid},
@@ -305,11 +316,15 @@ class BackgroundJobOps:
 
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
-def init_background_jobs_api(mdb, org_ops, crawl_manager, storage_ops):
+def init_background_jobs_api(
+    mdb, email, user_manager, org_ops, crawl_manager, storage_ops
+):
     """init background jobs system"""
     # pylint: disable=invalid-name
 
-    ops = BackgroundJobOps(mdb, org_ops, crawl_manager, storage_ops)
+    ops = BackgroundJobOps(
+        mdb, email, user_manager, org_ops, crawl_manager, storage_ops
+    )
 
     router = ops.router
 

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -223,7 +223,8 @@ class BackgroundJobOps:
                 flush=True,
             )
             superuser = await self.user_manager.get_superuser()
-            self.email.send_background_job_failed(job, finished, superuser.email)
+            org = await self.org_ops.get_org_by_id(job.oid)
+            self.email.send_background_job_failed(job, org, finished, superuser.email)
 
         await self.jobs.find_one_and_update(
             {"_id": job_id, "oid": oid},

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -1,4 +1,5 @@
 """k8s background jobs"""
+import asyncio
 from datetime import datetime
 from typing import Optional, Tuple, Union, List, Dict, TYPE_CHECKING, cast
 from uuid import UUID
@@ -224,7 +225,14 @@ class BackgroundJobOps:
             )
             superuser = await self.user_manager.get_superuser()
             org = await self.org_ops.get_org_by_id(job.oid)
-            self.email.send_background_job_failed(job, org, finished, superuser.email)
+            await asyncio.get_event_loop().run_in_executor(
+                None,
+                self.email.send_background_job_failed,
+                job,
+                org,
+                finished,
+                superuser.email,
+            )
 
         await self.jobs.find_one_and_update(
             {"_id": job_id, "oid": oid},

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 from email.message import EmailMessage
 
-from .models import BackgroundJob, CreateReplicaJob, DeleteReplicaJob, Organization
+from .models import CreateReplicaJob, DeleteReplicaJob, Organization
 from .utils import is_bool
 
 
@@ -143,7 +143,7 @@ to create a new password
 
     def send_background_job_failed(
         self,
-        job: Union[BackgroundJob, CreateReplicaJob, DeleteReplicaJob],
+        job: Union[CreateReplicaJob, DeleteReplicaJob],
         org: Organization,
         finished: datetime,
         receiver_email: str,
@@ -159,14 +159,11 @@ Job type: {job.type}
 Job ID: {job.id}
 Started: {job.started.isoformat(sep=" ", timespec="seconds")}Z
 Finished: {finished.isoformat(sep=" ", timespec="seconds")}Z
-        """
 
-        if type(job) in (CreateReplicaJob, DeleteReplicaJob):
-            message += f"""\n
 Object type: {job.object_type}
 Object ID: {job.object_id}
 File path: {job.file_path}
 Replica storage name: {job.replica_storage.name}
-            """
+        """
 
         self._send_encrypted(receiver_email, "Failed Background Job", message)

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 from email.message import EmailMessage
 
-from .models import BackgroundJob, CreateReplicaJob, DeleteReplicaJob
+from .models import BackgroundJob, CreateReplicaJob, DeleteReplicaJob, Organization
 from .utils import is_bool
 
 
@@ -144,6 +144,7 @@ to create a new password
     def send_background_job_failed(
         self,
         job: Union[BackgroundJob, CreateReplicaJob, DeleteReplicaJob],
+        org: Organization,
         finished: datetime,
         receiver_email: str,
     ):
@@ -152,16 +153,16 @@ to create a new password
 Failed Background Job
 ---------------------
 
+Organization: {org.name} ({job.oid})
 Job type: {job.type}
 
 Job ID: {job.id}
-Org ID: {job.oid}
 Started: {job.started.isoformat(sep=" ", timespec="seconds")}Z
 Finished: {finished.isoformat(sep=" ", timespec="seconds")}Z
         """
 
         if type(job) in (CreateReplicaJob, DeleteReplicaJob):
-            message += f"""
+            message += f"""\n
 Object type: {job.object_type}
 Object ID: {job.object_id}
 File path: {job.file_path}

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -90,7 +90,7 @@ def main():
     storage_ops = init_storages_api(org_ops, crawl_manager)
 
     background_job_ops = init_background_jobs_api(
-        mdb, org_ops, crawl_manager, storage_ops
+        mdb, email, user_manager, org_ops, crawl_manager, storage_ops
     )
 
     profiles = init_profiles_api(

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -54,7 +54,9 @@ def main():
 
     storage_ops = init_storages_api(org_ops, crawl_manager)
 
-    background_job_ops = BackgroundJobOps(mdb, org_ops, crawl_manager, storage_ops)
+    background_job_ops = BackgroundJobOps(
+        mdb, email, user_manager, org_ops, crawl_manager, storage_ops
+    )
 
     profile_ops = ProfileOps(
         mdb, org_ops, crawl_manager, storage_ops, background_job_ops


### PR DESCRIPTION
Fixes #1344

Sends email to superadmin when a background job fails.

Sample email (from operator logs, from job that failed because of invalid replica s3 bucket secret access key):

<img width="626" alt="Screen Shot 2023-11-07 at 11 29 23 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/4b9e6dd4-d71d-43fe-a36f-db2752b4d938">
