### PR TITLE
Implement retry API endpoint for failed background jobs

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -17,6 +17,7 @@ from .models import (
     DeleteReplicaJob,
     PaginatedResponse,
     AnyJob,
+    StorageRef,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
@@ -83,9 +84,8 @@ class BackgroundJobOps:
 
     async def create_replica_jobs(
         self, oid: UUID, file: BaseFile, object_id: str, object_type: str
-    ) -> Dict:
-        """Create k8s background job to replicate a file to another storage location."""
-
+    ) -> Dict[str, Union[bool, List[str]]]:
+        """Create k8s background job to replicate a file to all replica storage locations."""
         org = await self.org_ops.get_org_by_id(oid)
 
         primary_storage = self.storage_ops.get_org_storage_by_ref(org, file.storage)
@@ -98,99 +98,138 @@ class BackgroundJobOps:
         ids = []
 
         for replica_ref in self.storage_ops.get_org_replicas_storage_refs(org):
-            replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
-            replica_endpoint, bucket_suffix = self.strip_bucket(
-                replica_storage.endpoint_url
-            )
-            replica_file_path = bucket_suffix + file.filename
-
-            # print(f"primary: {file.storage.get_storage_secret_name(str(oid))}")
-            # print(f"  endpoint: {primary_endpoint}")
-            # print(f"  path: {primary_file_path}")
-            # print(f"replica: {replica_ref.get_storage_secret_name(str(oid))}")
-            # print(f"  endpoint: {replica_endpoint}")
-            # print(f"  path: {replica_file_path}")
-
-            job_type = BgJobType.CREATE_REPLICA.value
-
-            job_id = await self.crawl_manager.run_replica_job(
-                oid=str(oid),
-                job_type=job_type,
-                primary_storage=file.storage,
-                primary_file_path=primary_file_path,
-                primary_endpoint=primary_endpoint,
-                replica_storage=replica_ref,
-                replica_file_path=replica_file_path,
-                replica_endpoint=replica_endpoint,
-                job_id_prefix=f"{job_type}-{object_id}",
-            )
-            replication_job = CreateReplicaJob(
-                id=job_id,
-                oid=oid,
-                started=datetime.now(),
-                file_path=file.filename,
-                object_type=object_type,
-                object_id=object_id,
-                primary=file.storage,
-                replica_storage=replica_ref,
-            )
-            # print(
-            #    f"File path written into replication_job: {file.filename}", flush=True
-            # )
-            await self.jobs.find_one_and_update(
-                {"_id": job_id}, {"$set": replication_job.to_dict()}, upsert=True
+            job_id = await self.create_replica_job(
+                org,
+                file,
+                object_id,
+                object_type,
+                replica_ref,
+                primary_file_path,
+                primary_endpoint,
             )
             ids.append(job_id)
 
         return {"added": True, "ids": ids}
+
+    async def create_replica_job(
+        self,
+        org: Organization,
+        file: BaseFile,
+        object_id: str,
+        object_type: str,
+        replica_ref: StorageRef,
+        primary_file_path: str,
+        primary_endpoint: str,
+        previous_job_id: Optional[str] = None,
+    ) -> str:
+        """Create k8s background job to replicate a file to a specific replica storage location."""
+        replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
+        replica_endpoint, bucket_suffix = self.strip_bucket(
+            replica_storage.endpoint_url
+        )
+        replica_file_path = bucket_suffix + file.filename
+
+        # print(f"primary: {file.storage.get_storage_secret_name(str(oid))}")
+        # print(f"  endpoint: {primary_endpoint}")
+        # print(f"  path: {primary_file_path}")
+        # print(f"replica: {replica_ref.get_storage_secret_name(str(oid))}")
+        # print(f"  endpoint: {replica_endpoint}")
+        # print(f"  path: {replica_file_path}")
+
+        job_type = BgJobType.CREATE_REPLICA.value
+
+        job_id = await self.crawl_manager.run_replica_job(
+            oid=str(org.id),
+            job_type=job_type,
+            primary_storage=file.storage,
+            primary_file_path=primary_file_path,
+            primary_endpoint=primary_endpoint,
+            replica_storage=replica_ref,
+            replica_file_path=replica_file_path,
+            replica_endpoint=replica_endpoint,
+            job_id_prefix=f"{job_type}-{object_id}",
+        )
+        replication_job = CreateReplicaJob(
+            id=job_id,
+            oid=org.id,
+            started=datetime.now(),
+            file_path=file.filename,
+            object_type=object_type,
+            object_id=object_id,
+            primary=file.storage,
+            replica_storage=replica_ref,
+            previous_job_id=previous_job_id,
+        )
+        # print(
+        #    f"File path written into replication_job: {file.filename}", flush=True
+        # )
+        await self.jobs.find_one_and_update(
+            {"_id": job_id}, {"$set": replication_job.to_dict()}, upsert=True
+        )
+
+        return job_id
 
     async def create_delete_replica_jobs(
         self, org: Organization, file: BaseFile, object_id: str, object_type: str
     ) -> Dict[str, Union[bool, List[str]]]:
         """Create a job to delete each replica for the given file"""
-
         ids = []
-        oid = str(org.id)
 
         for replica_ref in file.replicas or []:
-            replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
-            replica_endpoint, bucket_suffix = self.strip_bucket(
-                replica_storage.endpoint_url
+            job_id = await self.create_delete_replica_job(
+                org, file, object_id, object_type, replica_ref
             )
-            replica_file_path = bucket_suffix + file.filename
-
-            # print(f"replica: {replica_ref.get_storage_secret_name(oid)}")
-            # print(f"  endpoint: {replica_endpoint}")
-            # print(f"  path: {replica_file_path}")
-
-            job_type = BgJobType.DELETE_REPLICA.value
-
-            job_id = await self.crawl_manager.run_replica_job(
-                oid=oid,
-                job_type=job_type,
-                replica_storage=replica_ref,
-                replica_file_path=replica_file_path,
-                replica_endpoint=replica_endpoint,
-                job_id_prefix=f"{job_type}-{object_id}",
-            )
-
-            delete_replica_job = DeleteReplicaJob(
-                id=job_id,
-                oid=oid,
-                started=datetime.now(),
-                file_path=file.filename,
-                object_id=object_id,
-                object_type=object_type,
-                replica_storage=replica_ref,
-            )
-
-            await self.jobs.find_one_and_update(
-                {"_id": job_id}, {"$set": delete_replica_job.to_dict()}, upsert=True
-            )
-
             ids.append(job_id)
 
         return {"added": True, "ids": ids}
+
+    async def create_delete_replica_job(
+        self,
+        org: Organization,
+        file: BaseFile,
+        object_id: str,
+        object_type: str,
+        replica_ref: StorageRef,
+        previous_job_id: Optional[str] = None,
+    ) -> str:
+        """Create a job to delete one replica of a given file"""
+        replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
+        replica_endpoint, bucket_suffix = self.strip_bucket(
+            replica_storage.endpoint_url
+        )
+        replica_file_path = bucket_suffix + file.filename
+
+        # print(f"replica: {replica_ref.get_storage_secret_name(oid)}")
+        # print(f"  endpoint: {replica_endpoint}")
+        # print(f"  path: {replica_file_path}")
+
+        job_type = BgJobType.DELETE_REPLICA.value
+
+        job_id = await self.crawl_manager.run_replica_job(
+            oid=str(org.id),
+            job_type=job_type,
+            replica_storage=replica_ref,
+            replica_file_path=replica_file_path,
+            replica_endpoint=replica_endpoint,
+            job_id_prefix=f"{job_type}-{object_id}",
+        )
+
+        delete_replica_job = DeleteReplicaJob(
+            id=job_id,
+            oid=org.id,
+            started=datetime.now(),
+            file_path=file.filename,
+            object_id=object_id,
+            object_type=object_type,
+            replica_storage=replica_ref,
+            previous_job_id=previous_job_id,
+        )
+
+        await self.jobs.find_one_and_update(
+            {"_id": job_id}, {"$set": delete_replica_job.to_dict()}, upsert=True
+        )
+
+        return job_id
 
     async def job_finished(
         self,
@@ -219,7 +258,9 @@ class BackgroundJobOps:
             {"$set": {"success": success, "finished": finished}},
         )
 
-    async def get_background_job(self, job_id: str, oid: UUID) -> BackgroundJob:
+    async def get_background_job(
+        self, job_id: str, oid: UUID
+    ) -> Union[CreateReplicaJob, DeleteReplicaJob]:
         """Get background job"""
         query: dict[str, object] = {"_id": job_id, "oid": oid}
         res = await self.jobs.find_one(query)
@@ -233,10 +274,9 @@ class BackgroundJobOps:
         if data["type"] == BgJobType.CREATE_REPLICA:
             return CreateReplicaJob.from_dict(data)
 
-        if data["type"] == BgJobType.DELETE_REPLICA:
-            return DeleteReplicaJob.from_dict(data)
+        return DeleteReplicaJob.from_dict(data)
 
-        return BackgroundJob.from_dict(data)
+        # return BackgroundJob.from_dict(data)
 
     async def list_background_jobs(
         self,
@@ -302,6 +342,64 @@ class BackgroundJobOps:
 
         return jobs, total
 
+    async def retry_background_job(
+        self, job_id: str, org: Organization
+    ) -> Dict[str, Union[bool, Optional[str]]]:
+        """Retry background job and return new job id"""
+        job = await self.get_background_job(job_id, org.id)
+        if not job:
+            raise HTTPException(status_code=404, detail="job_not_found")
+
+        if job.success:
+            raise HTTPException(status_code=400, detail="job_already_succeeded")
+
+        new_job_id = None
+
+        if job.object_type == "profile":
+            profile = await self.profile_ops.get_profile(UUID(job.object_id), org)
+            if not profile:
+                raise HTTPException(status_code=404, detail="profile_not_found")
+            file = profile.resource or None
+        else:
+            item_res = await self.base_crawl_ops.get_crawl_raw(job.object_id, org)
+            matching_files = [
+                f for f in item_res.get("files", []) if f["filename"] == job.file_path
+            ]
+            file = matching_files[0] if matching_files else None
+
+        if not file:
+            raise HTTPException(status_code=404, detail="file_not_found")
+        file = BaseFile(**file)
+
+        if job.type == BgJobType.CREATE_REPLICA:
+            primary_storage = self.storage_ops.get_org_storage_by_ref(org, file.storage)
+            primary_endpoint, bucket_suffix = self.strip_bucket(
+                primary_storage.endpoint_url
+            )
+            primary_file_path = bucket_suffix + file.filename
+            new_job_id = await self.create_replica_job(
+                org,
+                file,
+                job.object_id,
+                job.object_type,
+                job.replica_storage,
+                primary_file_path,
+                primary_endpoint,
+                job_id,
+            )
+
+        if job.type == BgJobType.DELETE_REPLICA:
+            new_job_id = await self.create_delete_replica_job(
+                org,
+                file,
+                job.object_id,
+                job.object_type,
+                job.replica_storage,
+                job_id,
+            )
+
+        return {"success": True, "new_job_id": new_job_id}
+
 
 # ============================================================================
 # pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
@@ -327,6 +425,17 @@ def init_background_jobs_api(mdb, org_ops, crawl_manager, storage_ops):
     ):
         """Retrieve information for background job"""
         return await ops.get_background_job(job_id, org.id)
+
+    @router.post(
+        "/{job_id}/retry",
+        tags=["backgroundjobs"],
+    )
+    async def retry_background_job(
+        job_id: str,
+        org: Organization = Depends(org_crawl_dep),
+    ):
+        """Retry background job"""
+        return await ops.retry_background_job(job_id, org)
 
     @router.get("", tags=["backgroundjobs"], response_model=PaginatedResponse)
     async def list_background_jobs(

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -449,7 +449,6 @@ def init_background_jobs_api(mdb, org_ops, crawl_manager, storage_ops):
 
     @router.get(
         "/{job_id}",
-        tags=["backgroundjobs"],
         response_model=AnyJob,
     )
     async def get_background_job(
@@ -461,7 +460,6 @@ def init_background_jobs_api(mdb, org_ops, crawl_manager, storage_ops):
 
     @router.post(
         "/{job_id}/retry",
-        tags=["backgroundjobs"],
     )
     async def retry_background_job(
         job_id: str,
@@ -470,7 +468,7 @@ def init_background_jobs_api(mdb, org_ops, crawl_manager, storage_ops):
         """Retry background job"""
         return await ops.retry_background_job(job_id, org)
 
-    @router.get("", tags=["backgroundjobs"], response_model=PaginatedResponse)
+    @router.get("", response_model=PaginatedResponse)
     async def list_background_jobs(
         org: Organization = Depends(org_crawl_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -404,8 +404,6 @@ class BackgroundJobOps:
         if job.success:
             raise HTTPException(status_code=400, detail="job_already_succeeded")
 
-        new_job_id = None
-
         file = await self.get_replica_job_file(job, org)
 
         if job.type == BgJobType.CREATE_REPLICA:

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -149,7 +149,6 @@ class BackgroundJobOps:
                 previous_attempt = {
                     "started": replication_job.started,
                     "finished": replication_job.finished,
-                    "success": replication_job.success,
                 }
                 if replication_job.previousAttempts:
                     replication_job.previousAttempts.append(previous_attempt)
@@ -229,7 +228,6 @@ class BackgroundJobOps:
                 previous_attempt = {
                     "started": delete_replica_job.started,
                     "finished": delete_replica_job.finished,
-                    "success": delete_replica_job.success,
                 }
                 if delete_replica_job.previousAttempts:
                     delete_replica_job.previousAttempts.append(previous_attempt)

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -129,13 +129,6 @@ class BackgroundJobOps:
         )
         replica_file_path = bucket_suffix + file.filename
 
-        # print(f"primary: {file.storage.get_storage_secret_name(str(oid))}")
-        # print(f"  endpoint: {primary_endpoint}")
-        # print(f"  path: {primary_file_path}")
-        # print(f"replica: {replica_ref.get_storage_secret_name(str(oid))}")
-        # print(f"  endpoint: {replica_endpoint}")
-        # print(f"  path: {replica_file_path}")
-
         job_type = BgJobType.CREATE_REPLICA.value
 
         job_id = await self.crawl_manager.run_replica_job(
@@ -160,9 +153,7 @@ class BackgroundJobOps:
             replica_storage=replica_ref,
             previous_job_id=previous_job_id,
         )
-        # print(
-        #    f"File path written into replication_job: {file.filename}", flush=True
-        # )
+
         await self.jobs.find_one_and_update(
             {"_id": job_id}, {"$set": replication_job.to_dict()}, upsert=True
         )
@@ -198,10 +189,6 @@ class BackgroundJobOps:
             replica_storage.endpoint_url
         )
         replica_file_path = bucket_suffix + file.filename
-
-        # print(f"replica: {replica_ref.get_storage_secret_name(oid)}")
-        # print(f"  endpoint: {replica_endpoint}")
-        # print(f"  path: {replica_file_path}")
 
         job_type = BgJobType.DELETE_REPLICA.value
 

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -349,6 +349,8 @@ class BackgroundJobOps:
             file = profile.resource or None
         else:
             item_res = await self.base_crawl_ops.get_crawl_raw(job.object_id, org)
+            if not item_res:
+                raise HTTPException(status_code=404, detail="item_not_found")
             matching_files = [
                 f for f in item_res.get("files", []) if f["filename"] == job.file_path
             ]

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -146,10 +146,15 @@ class BackgroundJobOps:
             )
             if existing_job_id:
                 replication_job = await self.get_background_job(existing_job_id, org.id)
+                previous_attempt = {
+                    "started": replication_job.started,
+                    "finished": replication_job.finished,
+                    "success": replication_job.success,
+                }
                 if replication_job.previousAttempts:
-                    replication_job.previousAttempts.append(replication_job.to_dict())
+                    replication_job.previousAttempts.append(previous_attempt)
                 else:
-                    replication_job.previousAttempts = [replication_job.to_dict()]
+                    replication_job.previousAttempts = [previous_attempt]
                 replication_job.started = datetime.now()
                 replication_job.finished = None
                 replication_job.success = None
@@ -221,12 +226,15 @@ class BackgroundJobOps:
                 delete_replica_job = await self.get_background_job(
                     existing_job_id, org.id
                 )
+                previous_attempt = {
+                    "started": delete_replica_job.started,
+                    "finished": delete_replica_job.finished,
+                    "success": delete_replica_job.success,
+                }
                 if delete_replica_job.previousAttempts:
-                    delete_replica_job.previousAttempts.append(
-                        delete_replica_job.to_dict()
-                    )
+                    delete_replica_job.previousAttempts.append(previous_attempt)
                 else:
-                    delete_replica_job.previousAttempts = [delete_replica_job.to_dict()]
+                    delete_replica_job.previousAttempts = [previous_attempt]
                 delete_replica_job.started = datetime.now()
                 delete_replica_job.finished = None
                 delete_replica_job.success = None

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -74,14 +74,18 @@ class CrawlManager(K8sAPI):
         primary_file_path: Optional[str] = None,
         primary_endpoint: Optional[str] = None,
         job_id_prefix: Optional[str] = None,
+        existing_job_id: Optional[str] = None,
     ):
         """run job to replicate file from primary storage to replica storage"""
 
-        if not job_id_prefix:
-            job_id_prefix = job_type
+        if existing_job_id:
+            job_id = existing_job_id
+        else:
+            if not job_id_prefix:
+                job_id_prefix = job_type
 
-        # ensure name is <=63 characters
-        job_id = f"{job_id_prefix[:52]}-{secrets.token_hex(5)}"
+            # ensure name is <=63 characters
+            job_id = f"{job_id_prefix[:52]}-{secrets.token_hex(5)}"
 
         params = {
             "id": job_id,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1237,7 +1237,7 @@ class BackgroundJob(BaseMongoModel):
     started: datetime
     finished: Optional[datetime] = None
 
-    previousAttempts: Optional[List[Dict[str, Union[datetime, bool]]]] = None
+    previousAttempts: Optional[List[Dict[str, Optional[datetime]]]] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1237,7 +1237,7 @@ class BackgroundJob(BaseMongoModel):
     started: datetime
     finished: Optional[datetime] = None
 
-    previous_job_id: Optional[str] = None
+    previousAttempts: Optional[List[Dict[str, Any]]] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1237,7 +1237,7 @@ class BackgroundJob(BaseMongoModel):
     started: datetime
     finished: Optional[datetime] = None
 
-    previousAttempts: Optional[List[Dict[str, Any]]] = None
+    previousAttempts: Optional[List[Dict[str, Union[datetime, bool]]]] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1237,6 +1237,8 @@ class BackgroundJob(BaseMongoModel):
     started: datetime
     finished: Optional[datetime] = None
 
+    previous_job_id: Optional[str] = None
+
 
 # ============================================================================
 class CreateReplicaJob(BackgroundJob):

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -400,7 +400,7 @@ def init_event_webhooks_api(mdb, org_ops, app):
     ):
         return await ops.get_notification(org, notificationid)
 
-    @router.get("/{notificationid}/retry")
+    @router.post("/{notificationid}/retry")
     async def retry_notification(
         notificationid: UUID,
         org: Organization = Depends(org_owner_dep),

--- a/backend/test/test_webhooks.py
+++ b/backend/test/test_webhooks.py
@@ -99,7 +99,7 @@ def test_get_webhook_event(admin_auth_headers, default_org_id):
 
 def test_retry_webhook_event(admin_auth_headers, default_org_id):
     # Expect to fail because we haven't set up URLs that accept webhooks
-    r = requests.get(
+    r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/webhooks/{_webhook_event_id}/retry",
         headers=admin_auth_headers,
     )


### PR DESCRIPTION
Fixes #1328 

When a failed background job is retried, a new k8s job with identical inputs is kicked off and the new job id is returned. In addition, we add the previous failed job's id to `BackgroundJob.previous_job_id` to establish a chain connecting like jobs.

This PR also amends the similar webhook /retry endpoint to use `POST` for consistency.

It's not really possible too add good tests for this at the moment until we support for adding org-specific storage locations (after that we could e.g. pass an incorrect secret access key to ensure jobs fail). For now I've done something similar in manual testing, following up on a successful crawl that had a failed replication job due to invalid s3 credentials set in my local instance for the replica location:

## Manual testing

```
on ⛵ docker-desktop ~
❯ curl -H "Authorization: Bearer <token>" http://localhost:30870/api/orgs/e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd/jobs
{"items":[{"id":"create-replica-manual-20231108155905-7679c48c-b80-7c60c0613e","type":"create-replica","oid":"e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd","success":false,"started":"2023-11-08T15:59:42.367000","finished":"2023-11-08T16:01:03","previous_job_id":null,"file_path":"e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd/20231108155941447-7679c48c-b80-0.wacz","object_type":"crawl","object_id":"manual-20231108155905-7679c48c-b80","replica_storage":{"name":"replica-0","custom":null}}],"total":1,"page":1,"pageSize":1000}%

on ⛵ docker-desktop ~
➜ curl -X POST -H "Authorization: Bearer <token>" http://localhost:30870/api/orgs/e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd/jobs/create-replica-manual-20231108155905-7679c48c-b80-7c60c0613e/retry
{"success":true,"new_job_id":"create-replica-manual-20231108155905-7679c48c-b80-baac20b500"}%

on ⛵ docker-desktop ~
➜ curl -H "Authorization: Bearer <token>" http://localhost:30870/api/orgs/e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd/jobs
{"items":[{"id":"create-replica-manual-20231108155905-7679c48c-b80-7c60c0613e","type":"create-replica","oid":"e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd","success":false,"started":"2023-11-08T15:59:42.367000","finished":"2023-11-08T16:01:03","previous_job_id":null,"file_path":"e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd/20231108155941447-7679c48c-b80-0.wacz","object_type":"crawl","object_id":"manual-20231108155905-7679c48c-b80","replica_storage":{"name":"replica-0","custom":null}},{"id":"create-replica-manual-20231108155905-7679c48c-b80-baac20b500","type":"create-replica","oid":"e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd","success":null,"started":"2023-11-08T16:13:44.539000","finished":null,"previous_job_id":"create-replica-manual-20231108155905-7679c48c-b80-7c60c0613e","file_path":"e5f2b4d5-73d4-404a-b2f9-ff9c02b0aabd/20231108155941447-7679c48c-b80-0.wacz","object_type":"crawl","object_id":"manual-20231108155905-7679c48c-b80","replica_storage":{"name":"replica-0","custom":null}}],"total":2,"page":1,"pageSize":1000}%
```