### PR TITLE
charts cleanup:

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -78,7 +78,7 @@ class StorageOps:
 
         self.is_local_minio = is_bool(os.environ.get("IS_LOCAL_MINIO"))
 
-        with open("/tmp/storages/storages.json", encoding="utf-8") as fh:
+        with open(os.environ["STORAGES_JSON"], encoding="utf-8") as fh:
             storage_list = json.loads(fh.read())
 
         for storage in storage_list:

--- a/chart/app-templates/crawl_cron_job.yaml
+++ b/chart/app-templates/crawl_cron_job.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 2
 
   schedule: "{{ schedule }}"

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -37,9 +37,9 @@ spec:
               - key: config.yaml
                 path: config.yaml
 
-        - name: storages
+        - name: ops-configs
           secret:
-            secretName: storages
+            secretName: ops-configs
 
         - name: app-templates
           configMap:
@@ -51,9 +51,9 @@ spec:
           imagePullPolicy: {{ .Values.backend_pull_policy }}
           envFrom:
             - configMapRef:
-                name: {{ .Values.name }}-env-config
+                name: backend-env-config
             - secretRef:
-                name: auth-secrets
+                name: backend-auth
             - secretRef:
                 name: mongo-auth
 
@@ -62,8 +62,8 @@ spec:
               value: "{{ .Values.backend_workers | default 4 }}"
 
           volumeMounts:
-            - name: storages
-              mountPath: /tmp/storages/
+            - name: ops-configs
+              mountPath: /ops-configs/
 
             - name: app-templates
               mountPath: /app/btrixcloud/templates/
@@ -119,9 +119,9 @@ spec:
 
           envFrom:
             - configMapRef:
-                name: {{ .Values.name }}-env-config
+                name: backend-env-config
             - secretRef:
-                name: auth-secrets
+                name: backend-auth
             - secretRef:
                 name: mongo-auth
 
@@ -133,8 +133,8 @@ spec:
             - name: config-volume
               mountPath: /config
 
-            - name: storages
-              mountPath: /tmp/storages/
+            - name: ops-configs
+              mountPath: /ops-configs/
 
             - name: app-templates
               mountPath: /app/btrixcloud/templates/

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-env-config
+  name: backend-env-config
   namespace: {{ .Release.Namespace }}
 
 data:
@@ -45,6 +45,8 @@ data:
   LOG_FAILED_CRAWL_LINES: "{{ .Values.log_failed_crawl_lines | default 0 }}"
 
   IS_LOCAL_MINIO: "{{ .Values.minio_local }}"
+
+  STORAGES_JSON: "/ops-configs/storages.json"
 
 ---
 apiVersion: v1
@@ -110,7 +112,7 @@ data:
     crawler_node_type: "{{ .Values.crawler_node_type }}"
     redis_node_type: "{{ .Values.redis_node_type }}"
 
-    signing_secret: {{ .Values.signer.enabled | ternary "signing-secret" "" }}
+    signing_secret: {{ and .Values.signer.enabled (not (empty .Values.signer.auth_token)) | ternary "signing-secret" "" }}
 
 ---
 apiVersion: v1

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: auth-secrets
+  name: backend-auth
   namespace: {{ .Release.Namespace }}
 
 type: Opaque
@@ -19,31 +19,17 @@ stringData:
   SUPERUSER_EMAIL: "{{ .Values.superuser.email }}"
   SUPERUSER_PASSWORD: "{{ .Values.superuser.password }}"
 
+
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: storages
+  name: ops-configs
   namespace: {{ .Release.Namespace }}
 
 type: Opaque
 data:
   storages.json: {{ .Values.storages | toJson | b64enc | quote }}
-
-
-{{- if $.Values.signer.auth_token }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: signing-secret
-  namespace: {{ $.Values.crawler_namespace }}
-
-type: Opaque
-stringData:
-  WACZ_SIGN_URL: "http://auth-signer.{{ .Release.Namespace }}:5053/sign"
-  WACZ_SIGN_TOKEN: "{{ $.Values.signer.auth_token }}"
-{{- end }}
 
 
 {{- range $storage := .Values.storages }}

--- a/chart/templates/signer.yaml
+++ b/chart/templates/signer.yaml
@@ -1,5 +1,21 @@
 {{- if .Values.signer.enabled }}
 
+{{ $signer_port := default "5053" .Values.signer.port }}
+
+{{- if .Values.signer.auth_token }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: signing-secret
+  namespace: {{ .Values.crawler_namespace }}
+
+type: Opaque
+stringData:
+  WACZ_SIGN_URL: "http://auth-signer.{{ .Release.Namespace }}:{{ $signer_port }}/sign"
+  WACZ_SIGN_TOKEN: "{{ .Values.signer.auth_token }}"
+{{- end }}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -95,7 +111,7 @@ spec:
         - name: signer
           image: {{ .Values.signer.image }}
           imagePullPolicy: {{ .Values.signer.image_pull_policy }}
-          command: ["uvicorn", "authsign.main:app", "--port", "5053", "--host", "0.0.0.0", "--log-config", "/app/log.json"]
+          command: ["uvicorn", "authsign.main:app", "--port", "{{ $signer_port }}", "--host", "0.0.0.0", "--log-config", "/app/log.json"]
           env:
             - name: CONFIG
               value: "/app-config/config.yaml"
@@ -141,7 +157,7 @@ spec:
       name: signer-cert
 
     - protocol: TCP
-      port: 5053
+      port: {{ $signer_port }}
       name: signer-api
 
 


### PR DESCRIPTION
- move authsign secret to signer and make port configurable
- rename storages to more general ops-configs
- put 'storages.json' path into env var
- rename backend secret to backend-auth
- cronjobs: don't keep succeeded jobs around, triggers operator update