### PR TITLE
Add extra and gifted execution minutes

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -16,7 +16,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0022"
+CURR_DB_VERSION = "0023"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0022_partial_complete.py
+++ b/backend/btrixcloud/migrations/migration_0022_partial_complete.py
@@ -1,5 +1,5 @@
 """
-Migration 00233 -- Partial Complete
+Migration 0022 -- Partial Complete
 """
 from btrixcloud.migrations import BaseMigration
 

--- a/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
+++ b/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
@@ -51,9 +51,9 @@ class Migration(BaseMigration):
         async for org in mdb_orgs.find({"monthlyExecSeconds": None}):
             oid = org["_id"]
             try:
-                await mdb_orgs.find_one_and_update(
+                await mdb_orgs.update_one(
                     {"_id": oid},
-                    {"$set": {"monthlyExecSeconds": "$crawlExecSeconds"}},
+                    [{"$set": {"monthlyExecSeconds": "$crawlExecSeconds"}}],
                 )
             # pylint: disable=broad-exception-caught
             except Exception as err:

--- a/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
+++ b/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
@@ -1,0 +1,45 @@
+"""
+Migration 0023 -- Available extra/gifted minutes
+"""
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0023"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
+        super().__init__(mdb, migration_version)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Add extraExecSecondsAvailable and giftedExecSecondsAvailable to org.
+        Initialize at 0 to avoid them being None.
+        """
+        # pylint: disable=duplicate-code
+        mdb_orgs = self.mdb["organizations"]
+        query = {
+            "extraExecSecondsAvailable": None,
+            "giftedExecSecondsAvailable": None,
+        }
+        async for org in mdb_orgs.find(query):
+            oid = org["_id"]
+            try:
+                await mdb_orgs.find_one_and_update(
+                    {"_id": oid},
+                    {
+                        "$set": {
+                            "extraExecSecondsAvailable": 0,
+                            "giftedExecSecondsAvailable": 0,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error adding exec seconds available fields to org {oid}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -910,7 +910,6 @@ class Organization(BaseMongoModel):
 
     origin: Optional[AnyHttpUrl] = None
 
-    # TODO: Add migration so that we are sure this is not None
     extraExecSecondsAvailable: int = 0
     giftedExecSecondsAvailable: int = 0
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -851,8 +851,7 @@ class OrgOut(BaseMongoModel):
     name: str
     slug: str
     users: Optional[Dict[str, Any]]
-    usage: Optional[Dict[str, int]]
-    crawlExecSeconds: Optional[Dict[str, int]]
+
     default: bool = False
     bytesStored: int
     bytesStoredCrawls: int
@@ -860,18 +859,22 @@ class OrgOut(BaseMongoModel):
     bytesStoredProfiles: int
     origin: Optional[AnyHttpUrl] = None
 
-    webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
-    quotas: Optional[OrgQuotas] = OrgQuotas()
-    quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
-
     storageQuotaReached: Optional[bool]
     execMinutesQuotaReached: Optional[bool]
 
+    usage: Optional[Dict[str, int]]
+    crawlExecSeconds: Dict[str, int] = {}
+    monthlyExecSeconds: Dict[str, int] = {}
     extraExecSeconds: Dict[str, int] = {}
     giftedExecSeconds: Dict[str, int] = {}
 
     extraExecSecondsAvailable: int = 0
     giftedExecSecondsAvailable: int = 0
+
+    quotas: Optional[OrgQuotas] = OrgQuotas()
+    quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
+
+    webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
 
 # ============================================================================
@@ -879,29 +882,29 @@ class Organization(BaseMongoModel):
     """Organization Base Model"""
 
     id: UUID
-
     name: str
     slug: str
-
     users: Dict[str, UserRole]
 
+    default: bool = False
+
     storage: StorageRef
-
     storageReplicas: List[StorageRef] = []
-
     customStorages: Dict[str, S3Storage] = {}
-
-    usage: Dict[str, int] = {}
-    crawlExecSeconds: Dict[str, int] = {}
-    extraExecSeconds: Dict[str, int] = {}
-    giftedExecSeconds: Dict[str, int] = {}
 
     bytesStored: int = 0
     bytesStoredCrawls: int = 0
     bytesStoredUploads: int = 0
     bytesStoredProfiles: int = 0
 
-    default: bool = False
+    usage: Dict[str, int] = {}
+    crawlExecSeconds: Dict[str, int] = {}
+    monthlyExecSeconds: Dict[str, int] = {}
+    extraExecSeconds: Dict[str, int] = {}
+    giftedExecSeconds: Dict[str, int] = {}
+
+    extraExecSecondsAvailable: int = 0
+    giftedExecSecondsAvailable: int = 0
 
     quotas: Optional[OrgQuotas] = OrgQuotas()
     quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
@@ -909,9 +912,6 @@ class Organization(BaseMongoModel):
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
     origin: Optional[AnyHttpUrl] = None
-
-    extraExecSecondsAvailable: int = 0
-    giftedExecSecondsAvailable: int = 0
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -817,6 +817,16 @@ class OrgQuotas(BaseModel):
     maxPagesPerCrawl: Optional[int] = 0
     storageQuota: Optional[int] = 0
     maxExecMinutesPerMonth: Optional[int] = 0
+    extraExecMinutes: Optional[int] = 0
+    giftedExecMinutes: Optional[int] = 0
+
+
+# ============================================================================
+class OrgQuotaUpdate(BaseModel):
+    """Organization quota update (to track changes over time)"""
+
+    modified: datetime
+    update: OrgQuotas
 
 
 # ============================================================================
@@ -852,9 +862,16 @@ class OrgOut(BaseMongoModel):
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
     quotas: Optional[OrgQuotas] = OrgQuotas()
+    quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
 
     storageQuotaReached: Optional[bool]
     execMinutesQuotaReached: Optional[bool]
+
+    extraExecSeconds: Dict[str, int] = {}
+    giftedExecSeconds: Dict[str, int] = {}
+
+    extraExecSecondsAvailable: int = 0
+    giftedExecSecondsAvailable: int = 0
 
 
 # ============================================================================
@@ -876,6 +893,8 @@ class Organization(BaseMongoModel):
 
     usage: Dict[str, int] = {}
     crawlExecSeconds: Dict[str, int] = {}
+    extraExecSeconds: Dict[str, int] = {}
+    giftedExecSeconds: Dict[str, int] = {}
 
     bytesStored: int = 0
     bytesStoredCrawls: int = 0
@@ -885,10 +904,15 @@ class Organization(BaseMongoModel):
     default: bool = False
 
     quotas: Optional[OrgQuotas] = OrgQuotas()
+    quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
     origin: Optional[AnyHttpUrl] = None
+
+    # TODO: Add migration so that we are sure this is not None
+    extraExecSecondsAvailable: int = 0
+    giftedExecSecondsAvailable: int = 0
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -303,7 +303,7 @@ class OrgOps:
         )
 
         # Inc org available fields for extra/gifted execution time as needed
-        if quotas.extraExecMinutes or quotas.extraExecMinutes == 0:
+        if quotas.extraExecMinutes is not None:
             extra_secs_diff = (quotas.extraExecMinutes - previous_extra_mins) * 60
             if org.extraExecSecondsAvailable + extra_secs_diff <= 0:
                 await self.orgs.find_one_and_update(
@@ -316,7 +316,7 @@ class OrgOps:
                     {"$inc": {"extraExecSecondsAvailable": extra_secs_diff}},
                 )
 
-        if quotas.giftedExecMinutes or quotas.giftedExecMinutes == 0:
+        if quotas.giftedExecMinutes is not None:
             gifted_secs_diff = (quotas.giftedExecMinutes - previous_gifted_mins) * 60
             if org.giftedExecSecondsAvailable + gifted_secs_diff <= 0:
                 await self.orgs.find_one_and_update(

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -534,7 +534,7 @@ class OrgOps:
                 {"_id": oid}, {"$inc": {f"monthlyExecSeconds.{yymm}": duration}}
             )
 
-        # Otherwise, add execution seconds to montlyExecSeconds up to quota
+        # Otherwise, add execution seconds to monthlyExecSeconds up to quota
         await self.orgs.find_one_and_update(
             {"_id": oid},
             {"$inc": {f"monthlyExecSeconds.{yymm}": monthly_remaining_time}},
@@ -562,7 +562,7 @@ class OrgOps:
                 )
 
             # If seconds over quota is higher than gifted seconds available,
-            # use remaining gifted gifted time
+            # use remaining gifted gifted time and then move on
             await self.orgs.find_one_and_update(
                 {"_id": oid},
                 {

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -270,15 +270,23 @@ class OrgOps:
     async def update_quotas(self, org: Organization, quotas: OrgQuotas):
         """update organization quotas"""
 
-        previous_extra_mins = org.quotas.extraExecMinutes or 0
-        previous_gifted_mins = org.quotas.giftedExecMinutes or 0
+        previous_extra_mins = (
+            org.quotas.extraExecMinutes
+            if (org.quotas and org.quotas.extraExecMinutes)
+            else 0
+        )
+        previous_gifted_mins = (
+            org.quotas.giftedExecMinutes
+            if (org.quotas and org.quotas.giftedExecMinutes)
+            else 0
+        )
 
         update = quotas.dict(
             exclude_unset=True, exclude_defaults=True, exclude_none=True
         )
 
         quota_updates = []
-        for prev_update in org.quotaUpdates:
+        for prev_update in org.quotaUpdates or []:
             quota_updates.append(prev_update.dict())
         quota_updates.append(
             OrgQuotaUpdate(update=update, modified=datetime.now()).dict()

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -317,6 +317,19 @@ class OrgOps:
                 {"$inc": {"giftedExecSecondsAvailable": gifted_secs_diff}},
             )
 
+        # If extra/gifted time was previously set but now 0, clear available seconds
+        if quotas.extraExecMinutes == 0 and org.extraExecSecondsAvailable:
+            await self.orgs.find_one_and_update(
+                {"_id": org.id},
+                {"$set": {"extraExecSecondsAvailable": 0}},
+            )
+
+        if quotas.giftedExecMinutes == 0 and org.giftedExecSecondsAvailable:
+            await self.orgs.find_one_and_update(
+                {"_id": org.id},
+                {"$set": {"giftedExecSecondsAvailable": 0}},
+            )
+
     async def update_event_webhook_urls(self, org: Organization, urls: OrgWebhookUrls):
         """Update organization event webhook URLs"""
         return await self.orgs.find_one_and_update(

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -548,7 +548,7 @@ class OrgOps:
                         # Reduce crawlExecSecs by amount we're adding to gifted
                         f"crawlExecSeconds.{yymm}": -gifted_secs_available,
                     },
-                    "$set": {"giftedExecSecondsAvailable": 0}
+                    "$set": {"giftedExecSecondsAvailable": 0},
                 },
             )
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -497,7 +497,11 @@ class OrgOps:
         )
 
     async def inc_org_time_stats(self, oid, duration, is_exec_time=False):
-        """inc crawl duration stats for org"""
+        """inc crawl duration stats for org
+
+        Overage is applied only to crawlExecSeconds - monthlyExecSeconds,
+        giftedExecSeconds, and extraExecSeconds are added to only up to quotas
+        """
         # pylint: disable=too-many-return-statements
         key = "crawlExecSeconds" if is_exec_time else "usage"
         yymm = datetime.utcnow().strftime("%Y-%m")
@@ -515,26 +519,30 @@ class OrgOps:
         monthly_quota_mins = await self.get_org_exec_mins_monthly_quota(oid)
         monthly_quota_secs = monthly_quota_mins * 60
 
-        if not monthly_quota_mins:
-            return await self.orgs.find_one_and_update(
-                {"_id": oid}, {"$inc": {f"monthlyExecSeconds.{yymm}": duration}}
-            )
+        if (
+            not monthly_quota_secs
+            and not org.giftedExecSecondsAvailable
+            and not org.extraExecSecondsAvailable
+        ):
+            return
 
         monthly_remaining_time = monthly_quota_secs - monthly_exec_secs_used
+
+        # If adding duration won't pass monthly quota, add duration and return
         if duration <= monthly_remaining_time:
             return await self.orgs.find_one_and_update(
                 {"_id": oid}, {"$inc": {f"monthlyExecSeconds.{yymm}": duration}}
             )
 
-        if not org.giftedExecSecondsAvailable and not org.extraExecSecondsAvailable:
-            return await self.orgs.find_one_and_update(
-                {"_id": oid}, {"$inc": {f"monthlyExecSeconds.{yymm}": duration}}
-            )
-
+        # Otherwise, add execution seconds to montlyExecSeconds up to quota
         await self.orgs.find_one_and_update(
             {"_id": oid},
             {"$inc": {f"monthlyExecSeconds.{yymm}": monthly_remaining_time}},
         )
+
+        if not org.giftedExecSecondsAvailable and not org.extraExecSecondsAvailable:
+            return
+
         secs_over_quota = duration - monthly_remaining_time
 
         # If we've surpassed monthly base quota, use gifted and extra exec minutes
@@ -553,22 +561,8 @@ class OrgOps:
                     },
                 )
 
-            # If seconds over quota is higher than gifted minutes available
-            # and no extra seconds are available, write overage to gifted
-            if not org.extraExecSecondsAvailable:
-                return await self.orgs.find_one_and_update(
-                    {"_id": oid},
-                    {
-                        "$inc": {
-                            f"giftedExecSeconds.{yymm}": secs_over_quota,
-                        },
-                        "$set": {"giftedExecSecondsAvailable": 0},
-                    },
-                )
-
-            # If seconds over quota is higher than gifted minutes available
-            # and extra seconds are available, use remaining gifted time and
-            # then apply overage to extra
+            # If seconds over quota is higher than gifted seconds available,
+            # use remaining gifted gifted time
             await self.orgs.find_one_and_update(
                 {"_id": oid},
                 {
@@ -578,13 +572,14 @@ class OrgOps:
             )
             secs_over_quota = secs_over_quota - gifted_secs_available
 
+        # If we still have an overage, apply to extra up to quota
         secs_to_use = min(secs_over_quota, org.extraExecSecondsAvailable)
         if secs_to_use:
             return await self.orgs.find_one_and_update(
                 {"_id": oid},
                 {
                     "$inc": {
-                        f"extraExecSeconds.{yymm}": secs_over_quota,
+                        f"extraExecSeconds.{yymm}": secs_to_use,
                         "extraExecSecondsAvailable": -secs_to_use,
                     }
                 },

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -2,14 +2,18 @@ import math
 import requests
 import time
 from datetime import datetime
+from typing import Dict
 
 from .conftest import API_PREFIX
 from .utils import get_crawl_status
 
 
 EXEC_MINS_QUOTA = 1
-EXEC_MINS_ALLOWED_OVERAGE = 10
-EXEC_MINS_HARD_CAP = EXEC_MINS_QUOTA + EXEC_MINS_ALLOWED_OVERAGE
+EXEC_SECS_QUOTA = EXEC_MINS_QUOTA * 60
+GIFTED_MINS_QUOTA = 3
+GIFTED_SECS_QUOTA = GIFTED_MINS_QUOTA * 60
+EXTRA_MINS_QUOTA = 5
+EXTRA_SECS_QUOTA = EXTRA_MINS_QUOTA * 60
 
 config_id = None
 
@@ -72,6 +76,92 @@ def test_crawl_stopped_when_quota_reached(org_with_quotas, admin_auth_headers):
     assert r.json()["detail"] == "exec_minutes_quota_reached"
 
 
+def test_set_execution_mins_extra_quotas(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={
+            "maxExecMinutesPerMonth": EXEC_MINS_QUOTA,
+            "extraExecMinutes": EXTRA_MINS_QUOTA,
+            "giftedExecMinutes": GIFTED_MINS_QUOTA,
+        },
+    )
+    data = r.json()
+    assert data.get("updated") == True
+
+    # Ensure org data looks as we expect
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_with_quotas}",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    assert data["extraExecSecondsAvailable"] == EXTRA_SECS_QUOTA
+    assert data["giftedExecSecondsAvailable"] == GIFTED_SECS_QUOTA
+    assert data["extraExecSeconds"] == {}
+    assert data["giftedExecSeconds"] == {}
+    assert get_total_exec_seconds(data["crawlExecSeconds"]) >= EXEC_SECS_QUOTA
+    assert len(data["quotaUpdates"])
+    for update in data["quotaUpdates"]:
+        assert update["modified"]
+        assert update["update"]
+
+
+def test_crawl_stopped_when_quota_reached_with_extra(
+    org_with_quotas, admin_auth_headers
+):
+    # Run crawl
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    crawl_id = r.json()["started"]
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "starting",
+        "waiting_capacity",
+    ):
+        time.sleep(2)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "running",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
+        time.sleep(2)
+
+    # Ensure that crawl was stopped by quota
+    assert (
+        get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
+        == "stopped_quota_reached"
+    )
+
+    time.sleep(5)
+
+    # Ensure org data looks as we expect
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_with_quotas}",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    assert data["extraExecSecondsAvailable"] == 0
+    assert data["giftedExecSecondsAvailable"] == 0
+    assert get_total_exec_seconds(data["extraExecSeconds"]) >= EXTRA_SECS_QUOTA
+    assert get_total_exec_seconds(data["giftedExecSeconds"]) == GIFTED_SECS_QUOTA
+    assert get_total_exec_seconds(data["crawlExecSeconds"]) >= EXEC_SECS_QUOTA
+
+    time.sleep(5)
+
+    # Ensure we can't start another crawl when over the quota
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "exec_minutes_quota_reached"
+
+
 def run_crawl(org_id, headers):
     crawl_data = {
         "runNow": True,
@@ -89,3 +179,7 @@ def run_crawl(org_id, headers):
     data = r.json()
 
     return data["run_now_job"], data["id"]
+
+
+def get_total_exec_seconds(execSeconds: Dict[str, int]) -> int:
+    return sum(list(execSeconds.values()))

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -64,6 +64,12 @@ export class OrgsList extends LiteElement {
             case "maxExecMinutesPerMonth":
               label = msg("Max Execution Minutes Per Month");
               break;
+            case "extraExecMinutes":
+              label = msg("Extra Execution Minutes");
+              break;
+            case "giftedExecMinutes":
+              label = msg("Gifted Execution Minutes");
+              break;
             default:
               label = msg("Unlabeled");
           }

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -73,20 +73,18 @@ export class DividedMeterBar extends LitElement {
   `;
 
   render() {
-    const remainder = this.quota - this.value;
     return html`<sl-tooltip>
       <div slot="content"><slot></slot></div>
-      ${when(this.value, () => {
-        return html`<div
-          class="bar ${this.value < this.quota
-            ? css`rightBorderRadius`
-            : css``}"
-          style="width:${this.value}%"
-        ></div>`;
-      })}
-      ${when(remainder, () => {
-        return html`<div class="quotaBar" style="width:${remainder}%"></div>`;
-      })}
+      <div class="quotaBar" style="width:100%">
+        ${when(this.value, () => {
+          return html`<div
+            class="bar ${this.value < this.quota
+              ? css`rightBorderRadius`
+              : css``}"
+            style="width:${(this.value / this.quota) * 100}%"
+          ></div>`;
+        })}
+      </div>
     </sl-tooltip>`;
   }
 }

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -85,10 +85,7 @@ export class DividedMeterBar extends LitElement {
         ></div>`;
       })}
       ${when(remainder, () => {
-        return html`<div
-          class="quotaBar"
-          style="width:${this.quota - this.value}%"
-        ></div>`;
+        return html`<div class="quotaBar" style="width:${remainder}%"></div>`;
       })}
     </sl-tooltip>`;
   }

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -48,6 +48,9 @@ export class DividedMeterBar extends LitElement {
   @property({ type: Number })
   quota = 0;
 
+  @property({ type: Number })
+  allQuotas = 0;
+
   static styles = css`
     :host {
       display: contents;
@@ -75,7 +78,7 @@ export class DividedMeterBar extends LitElement {
   render() {
     return html`<sl-tooltip>
       <div slot="content"><slot></slot></div>
-      <div class="quotaBar" style="width:100%">
+      <div class="quotaBar" style="width:${this.quota}%">
         ${when(this.value, () => {
           return html`<div
             class="bar ${this.value < this.quota

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -59,6 +59,11 @@ export class DividedMeterBar extends LitElement {
       min-width: 4px;
     }
 
+    .rightBorderRadius {
+      border-radius: 0 var(--sl-border-radius-medium)
+        var(--sl-border-radius-medium) 0;
+    }
+
     .quotaBar {
       height: 1rem;
       background-color: var(--quota-background-color, var(--sl-color-blue-100));
@@ -72,7 +77,12 @@ export class DividedMeterBar extends LitElement {
     return html`<sl-tooltip>
       <div slot="content"><slot></slot></div>
       ${when(this.value, () => {
-        return html`<div class="bar" style="width:${this.value}%"></div>`;
+        return html`<div
+          class="bar ${this.value < this.quota
+            ? css`rightBorderRadius`
+            : css``}"
+          style="width:${this.value}%"
+        ></div>`;
       })}
       ${when(remainder, () => {
         return html`<div

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -7,6 +7,7 @@ import {
   customElement,
 } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 import debounce from "lodash/fp/debounce";
 
 @customElement("btrix-meter-bar")
@@ -14,9 +15,6 @@ export class MeterBar extends LitElement {
   /* Percentage of value / max */
   @property({ type: Number })
   value = 0;
-
-  @property({ type: Boolean })
-  isBackground = false;
 
   static styles = css`
     :host {
@@ -28,10 +26,6 @@ export class MeterBar extends LitElement {
       background-color: var(--background-color, var(--sl-color-blue-500));
       min-width: 4px;
     }
-
-    .boxShadow {
-      box-shadow: inset 0px 1px 1px 0px rgba(0, 0, 0, 0.25);
-    }
   `;
 
   render() {
@@ -40,10 +34,52 @@ export class MeterBar extends LitElement {
     }
     return html`<sl-tooltip>
       <div slot="content"><slot></slot></div>
-      <div
-        class="bar ${this.isBackground ? css`boxShadow` : css``}"
-        style="width:${this.value}%"
-      ></div>
+      <div class="bar" style="width:${this.value}%"></div>
+    </sl-tooltip>`;
+  }
+}
+
+@customElement("btrix-divided-meter-bar")
+export class DividedMeterBar extends LitElement {
+  /* Percentage of value / max */
+  @property({ type: Number })
+  value = 0;
+
+  @property({ type: Number })
+  quota = 0;
+
+  static styles = css`
+    :host {
+      display: contents;
+    }
+
+    .bar {
+      height: 1rem;
+      background-color: var(--background-color, var(--sl-color-blue-400));
+      min-width: 4px;
+    }
+
+    .quotaBar {
+      height: 1rem;
+      background-color: var(--quota-background-color, var(--sl-color-blue-100));
+      min-width: 4px;
+      box-shadow: inset 0px 1px 1px 0px rgba(0, 0, 0, 0.25);
+    }
+  `;
+
+  render() {
+    const remainder = this.quota - this.value;
+    return html`<sl-tooltip>
+      <div slot="content"><slot></slot></div>
+      ${when(this.value, () => {
+        return html`<div class="bar" style="width:${this.value}%"></div>`;
+      })}
+      ${when(remainder, () => {
+        return html`<div
+          class="quotaBar"
+          style="width:${this.quota - this.value}%"
+        ></div>`;
+      })}
     </sl-tooltip>`;
   }
 }

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -24,7 +24,6 @@ export class MeterBar extends LitElement {
       height: 1rem;
       background-color: var(--background-color, var(--sl-color-blue-500));
       min-width: 4px;
-      border-right: var(--border-right, 0);
     }
   `;
 

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -15,6 +15,9 @@ export class MeterBar extends LitElement {
   @property({ type: Number })
   value = 0;
 
+  @property({ type: Boolean })
+  isBackground = false;
+
   static styles = css`
     :host {
       display: contents;
@@ -25,6 +28,10 @@ export class MeterBar extends LitElement {
       background-color: var(--background-color, var(--sl-color-blue-500));
       min-width: 4px;
     }
+
+    .boxShadow {
+      box-shadow: inset 0px 1px 1px 0px rgba(0, 0, 0, 0.25);
+    }
   `;
 
   render() {
@@ -33,7 +40,10 @@ export class MeterBar extends LitElement {
     }
     return html`<sl-tooltip>
       <div slot="content"><slot></slot></div>
-      <div class="bar" style="width:${this.value}%"></div>
+      <div
+        class="bar ${this.isBackground ? css`boxShadow` : css``}"
+        style="width:${this.value}%"
+      ></div>
     </sl-tooltip>`;
   }
 }

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -48,9 +48,6 @@ export class DividedMeterBar extends LitElement {
   @property({ type: Number })
   quota = 0;
 
-  @property({ type: Number })
-  allQuotas = 0;
-
   static styles = css`
     :host {
       display: contents;

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -622,7 +622,7 @@ export class CrawlDetail extends LiteElement {
                   ${this.crawl!.finished
                     ? html`<span
                         >${humanizeExecutionSeconds(
-                          this.crawl!.crawlExecSeconds * 1000
+                          this.crawl!.crawlExecSeconds
                         )}</span
                       >`
                     : html`<span class="text-0-400">${msg("Pending")}</span>`}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -462,7 +462,12 @@ export class Dashboard extends LiteElement {
             hasQuota
               ? html`
                   <span class="inline-flex items-center">
-                    ${humanizeExecutionSeconds((quotaSecondsAllTypes - usageSecondsAllTypes), "short"}
+                    ${humanizeExecutionSeconds(
+                      (quotaSecondsAllTypes - usageSecondsAllTypes),
+                      "short",
+                      false,
+                      true
+                    }
                     ${msg("Available")}
                   </span>
                 `
@@ -474,7 +479,10 @@ export class Dashboard extends LiteElement {
         () => html`
           <div class="mb-2">
             <btrix-meter
-              value=${quotaSecondsAllTypes}
+              value=${this.org!.giftedExecSecondsAvailable ||
+              this.org!.extraExecSecondsAvailable
+                ? quotaSecondsAllTypes
+                : usageSeconds}
               max=${quotaSecondsAllTypes}
               valueText=${msg("time")}
             >
@@ -503,12 +511,17 @@ export class Dashboard extends LiteElement {
                   "red-400"
                 )
               )}
-              ${when(quotaSeconds && usageSeconds < quotaSeconds, () =>
-                renderBar(
-                  quotaSeconds - usageSeconds,
-                  msg("Monthly Execution Time Available"),
-                  "green-100"
-                )
+              ${when(
+                (this.org!.giftedExecSecondsAvailable ||
+                  this.org!.extraExecSecondsAvailable) &&
+                  quotaSeconds &&
+                  usageSeconds < quotaSeconds,
+                () =>
+                  renderBar(
+                    quotaSeconds - usageSeconds,
+                    msg("Monthly Execution Time Available"),
+                    "green-100"
+                  )
               )}
               ${when(this.org!.giftedExecSecondsAvailable, () =>
                 renderBar(
@@ -716,22 +729,17 @@ export class Dashboard extends LiteElement {
             >
             </sl-format-date>
           `,
-<<<<<<< HEAD
-          value ? humanizeExecutionSeconds(value) : "--",
-          humanizeSeconds(crawlTime || 0),
-=======
-          humanizeMilliseconds((crawlTime || 0) * 1000),
+          humanizeSeconds((crawlTime || 0)),
           totalTimeSeconds
-            ? humanizeMilliseconds(totalTimeSeconds * 1000)
+            ? humanizeSeconds(totalTimeSeconds)
             : "--",
-          value ? humanizeMilliseconds(value * 1000) : "--",
+          value ? humanizeSeconds(value) : "--",
           extraSecondsUsed
-            ? humanizeMilliseconds(extraSecondsUsed * 1000)
+            ? humanizeSeconds(extraSecondsUsed)
             : "--",
           giftedSecondsUsed
-            ? humanizeMilliseconds(giftedSecondsUsed * 1000)
+            ? humanizeSeconds(giftedSecondsUsed)
             : "--",
->>>>>>> 7bd5ab86 (Implement extra and gifted execution minutes)
         ];
       });
     return html`

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -485,7 +485,7 @@ export class Dashboard extends LiteElement {
                       false,
                       true
                     )}
-                    ${msg("Available")}
+                    <span class="ml-1">${msg("Available")}</span>
                   </span>
                 `
               : ""

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -485,7 +485,7 @@ export class Dashboard extends LiteElement {
                       false,
                       true
                     )}
-                    <span class="ml-1">${msg("Available")}</span>
+                    <span class="ml-1">${msg("Remaining")}</span>
                   </span>
                 `
               : ""
@@ -511,6 +511,18 @@ export class Dashboard extends LiteElement {
                   "green-400"
                 )
               )}
+              ${when(
+                (this.org!.giftedExecSecondsAvailable ||
+                  this.org!.extraExecSecondsAvailable) &&
+                  quotaSeconds &&
+                  usageSeconds < quotaSeconds,
+                () =>
+                  renderBar(
+                    quotaSeconds - usageSeconds,
+                    msg("Monthly Execution Time Remaining"),
+                    "green-100"
+                  )
+              )}
               ${when(usageSecondsGifted, () =>
                 renderBar(
                   usageSecondsGifted > quotaSecondsGifted
@@ -518,6 +530,13 @@ export class Dashboard extends LiteElement {
                     : usageSecondsGifted,
                   msg("Gifted Execution Time"),
                   "blue-400"
+                )
+              )}
+              ${when(this.org!.giftedExecSecondsAvailable, () =>
+                renderBar(
+                  this.org!.giftedExecSecondsAvailable,
+                  msg("Gifted Execution Time Remaining"),
+                  "blue-100"
                 )
               )}
               ${when(usageSecondsExtra, () =>
@@ -529,36 +548,17 @@ export class Dashboard extends LiteElement {
                   "red-400"
                 )
               )}
-              ${when(
-                (this.org!.giftedExecSecondsAvailable ||
-                  this.org!.extraExecSecondsAvailable) &&
-                  quotaSeconds &&
-                  usageSeconds < quotaSeconds,
-                () =>
-                  renderBar(
-                    quotaSeconds - usageSeconds,
-                    msg("Monthly Execution Time Available"),
-                    "green-100"
-                  )
-              )}
-              ${when(this.org!.giftedExecSecondsAvailable, () =>
-                renderBar(
-                  this.org!.giftedExecSecondsAvailable,
-                  msg("Gifted Execution Time Available"),
-                  "blue-100"
-                )
-              )}
               ${when(this.org!.extraExecSecondsAvailable, () =>
                 renderBar(
                   this.org!.extraExecSecondsAvailable,
-                  msg("Extra Execution Time Available"),
+                  msg("Extra Execution Time Remaining"),
                   "red-100"
                 )
               )}
               <div slot="available" class="flex-1">
                 <sl-tooltip class="text-center">
                   <div slot="content">
-                    <div>${msg("Monthly Execution Time Available")}</div>
+                    <div>${msg("Monthly Execution Time Remaining")}</div>
                     <div class="text-xs opacity-80">
                       ${humanizeExecutionSeconds(quotaSeconds - usageSeconds)} |
                       ${this.renderPercentage(

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -378,9 +378,9 @@ export class Dashboard extends LiteElement {
     const now = new Date();
 
     let usageSeconds = 0;
-    if (this.org!.crawlExecSeconds) {
+    if (this.org!.monthlyExecSeconds) {
       const actualUsage =
-        this.org!.crawlExecSeconds[
+        this.org!.monthlyExecSeconds[
           `${now.getFullYear()}-${now.getUTCMonth() + 1}`
         ];
       if (actualUsage) {
@@ -392,7 +392,16 @@ export class Dashboard extends LiteElement {
       usageSeconds = quotaSeconds;
     }
 
-    let usageSecondsAllTypes = usageSeconds;
+    let usageSecondsAllTypes = 0;
+    if (this.org!.crawlExecSeconds) {
+      const actualUsage =
+        this.org!.crawlExecSeconds[
+          `${now.getFullYear()}-${now.getUTCMonth() + 1}`
+        ];
+      if (actualUsage) {
+        usageSecondsAllTypes = actualUsage;
+      }
+    }
 
     let usageSecondsExtra = 0;
     if (this.org!.extraExecSeconds) {
@@ -410,7 +419,6 @@ export class Dashboard extends LiteElement {
       usageSecondsExtra = maxExecSecsExtra;
     }
     if (usageSecondsExtra) {
-      usageSecondsAllTypes += usageSecondsExtra;
       // Quota for extra = this month's usage + remaining available
       quotaSecondsAllTypes += usageSecondsExtra;
       quotaSecondsExtra += usageSecondsExtra;
@@ -432,7 +440,6 @@ export class Dashboard extends LiteElement {
       usageSecondsGifted = maxExecSecsGifted;
     }
     if (usageSecondsGifted) {
-      usageSecondsAllTypes += usageSecondsGifted;
       // Quota for gifted = this month's usage + remaining available
       quotaSecondsAllTypes += usageSecondsGifted;
       quotaSecondsGifted += usageSecondsGifted;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -470,8 +470,8 @@ export class Dashboard extends LiteElement {
           <div class="text-center">
             <div>${label}</div>
             <div class="text-xs opacity-80">
-              ${humanizeExecutionSeconds(used, "full", true)} /
-              ${humanizeExecutionSeconds(quota, "full", true)}
+              ${humanizeExecutionSeconds(used, { displaySeconds: true })} /
+              ${humanizeExecutionSeconds(quota, { displaySeconds: true })}
             </div>
           </div>
         </btrix-divided-meter-bar>`;
@@ -483,7 +483,7 @@ export class Dashboard extends LiteElement {
           <div class="text-center">
             <div>${label}</div>
             <div class="text-xs opacity-80">
-              ${humanizeExecutionSeconds(used, "full", true)} |
+              ${humanizeExecutionSeconds(used, { displaySeconds: true })} |
               ${this.renderPercentage(used / quota)}
             </div>
           </div>
@@ -512,9 +512,7 @@ export class Dashboard extends LiteElement {
                         usageSeconds +
                         this.org!.extraExecSecondsAvailable +
                         this.org!.giftedExecSecondsAvailable,
-                      "short",
-                      false,
-                      true
+                      { style: "short", round: "down" }
                     )}
                     <span class="ml-1">${msg("Remaining")}</span>
                   </span>
@@ -573,11 +571,9 @@ export class Dashboard extends LiteElement {
                   <div slot="content">
                     <div>${msg("Monthly Execution Time Remaining")}</div>
                     <div class="text-xs opacity-80">
-                      ${humanizeExecutionSeconds(
-                        quotaSeconds - usageSeconds,
-                        "full",
-                        true
-                      )}
+                      ${humanizeExecutionSeconds(quotaSeconds - usageSeconds, {
+                        displaySeconds: true,
+                      })}
                       |
                       ${this.renderPercentage(
                         (quotaSeconds - usageSeconds) / quotaSeconds
@@ -588,10 +584,14 @@ export class Dashboard extends LiteElement {
                 </sl-tooltip>
               </div>
               <span slot="valueLabel">
-                ${humanizeExecutionSeconds(usageSecondsAllTypes, "short")}
+                ${humanizeExecutionSeconds(usageSecondsAllTypes, {
+                  style: "short",
+                })}
               </span>
               <span slot="maxLabel">
-                ${humanizeExecutionSeconds(quotaSecondsAllTypes, "short")}
+                ${humanizeExecutionSeconds(quotaSecondsAllTypes, {
+                  style: "short",
+                })}
               </span>
             </btrix-meter>
           </div>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -388,6 +388,10 @@ export class Dashboard extends LiteElement {
       }
     }
 
+    if (usageSeconds > quotaSeconds) {
+      usageSeconds = quotaSeconds;
+    }
+
     let usageSecondsAllTypes = usageSeconds;
 
     let usageSecondsExtra = 0;
@@ -396,6 +400,11 @@ export class Dashboard extends LiteElement {
         this.org!.extraExecSeconds[
           `${now.getFullYear()}-${now.getUTCMonth() + 1}`
         ];
+    }
+    const maxExecSecsExtra = this.org!.quotas.extraExecMinutes * 60;
+    // Cap usage at quota for display purposes
+    if (usageSecondsExtra > maxExecSecsExtra) {
+      usageSecondsExtra = maxExecSecsExtra;
     }
     if (usageSecondsExtra) {
       usageSecondsAllTypes += usageSecondsExtra;
@@ -410,6 +419,11 @@ export class Dashboard extends LiteElement {
         this.org!.giftedExecSeconds[
           `${now.getFullYear()}-${now.getUTCMonth() + 1}`
         ];
+    }
+    const maxExecSecsGifted = this.org!.quotas.giftedExecMinutes * 60;
+    // Cap usage at quota for display purposes
+    if (usageSecondsGifted > maxExecSecsGifted) {
+      usageSecondsGifted = maxExecSecsGifted;
     }
     if (usageSecondsGifted) {
       usageSecondsAllTypes += usageSecondsGifted;
@@ -463,7 +477,10 @@ export class Dashboard extends LiteElement {
               ? html`
                   <span class="inline-flex items-center">
                     ${humanizeExecutionSeconds(
-                      (quotaSecondsAllTypes - usageSecondsAllTypes),
+                      (quotaSeconds -
+                        usageSeconds +
+                        this.org!.extraExecSecondsAvailable +
+                        this.org!.giftedExecSecondsAvailable),
                       "short",
                       false,
                       true
@@ -480,7 +497,8 @@ export class Dashboard extends LiteElement {
           <div class="mb-2">
             <btrix-meter
               value=${this.org!.giftedExecSecondsAvailable ||
-              this.org!.extraExecSecondsAvailable
+              this.org!.extraExecSecondsAvailable ||
+              isReached
                 ? quotaSecondsAllTypes
                 : usageSeconds}
               max=${quotaSecondsAllTypes}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -477,14 +477,14 @@ export class Dashboard extends LiteElement {
               ? html`
                   <span class="inline-flex items-center">
                     ${humanizeExecutionSeconds(
-                      (quotaSeconds -
+                      quotaSeconds -
                         usageSeconds +
                         this.org!.extraExecSecondsAvailable +
-                        this.org!.giftedExecSecondsAvailable),
+                        this.org!.giftedExecSecondsAvailable,
                       "short",
                       false,
                       true
-                    }
+                    )}
                     ${msg("Available")}
                   </span>
                 `
@@ -747,17 +747,11 @@ export class Dashboard extends LiteElement {
             >
             </sl-format-date>
           `,
-          humanizeSeconds((crawlTime || 0)),
-          totalTimeSeconds
-            ? humanizeSeconds(totalTimeSeconds)
-            : "--",
+          humanizeSeconds(crawlTime || 0),
+          totalTimeSeconds ? humanizeSeconds(totalTimeSeconds) : "--",
           value ? humanizeSeconds(value) : "--",
-          extraSecondsUsed
-            ? humanizeSeconds(extraSecondsUsed)
-            : "--",
-          giftedSecondsUsed
-            ? humanizeSeconds(giftedSecondsUsed)
-            : "--",
+          extraSecondsUsed ? humanizeSeconds(extraSecondsUsed) : "--",
+          giftedSecondsUsed ? humanizeSeconds(giftedSecondsUsed) : "--",
         ];
       });
     return html`

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -445,10 +445,12 @@ export class Dashboard extends LiteElement {
       /** Time in Seconds */
       value: number,
       label: string,
-      color: string
+      color: string,
+      isBackground: boolean = false
     ) => html`
       <btrix-meter-bar
         value=${(value / quotaSecondsAllTypes) * 100}
+        isBackground=${isBackground}
         style="--background-color:var(--sl-color-${color})"
       >
         <div class="text-center">
@@ -520,7 +522,8 @@ export class Dashboard extends LiteElement {
                   renderBar(
                     quotaSeconds - usageSeconds,
                     msg("Monthly Execution Time Remaining"),
-                    "green-100"
+                    "green-100",
+                    true
                   )
               )}
               ${when(usageSecondsGifted, () =>
@@ -536,7 +539,8 @@ export class Dashboard extends LiteElement {
                 renderBar(
                   this.org!.giftedExecSecondsAvailable,
                   msg("Gifted Execution Time Remaining"),
-                  "blue-100"
+                  "blue-100",
+                  true
                 )
               )}
               ${when(usageSecondsExtra, () =>
@@ -552,7 +556,8 @@ export class Dashboard extends LiteElement {
                 renderBar(
                   this.org!.extraExecSecondsAvailable,
                   msg("Extra Execution Time Remaining"),
-                  "red-100"
+                  "red-100",
+                  true
                 )
               )}
               <div slot="available" class="flex-1">

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -514,7 +514,7 @@ export class Dashboard extends LiteElement {
                         this.org!.giftedExecSecondsAvailable,
                       { style: "short", round: "down" }
                     )}
-                    <span class="ml-1">${msg("Remaining")}</span>
+                    <span class="ml-1">${msg("remaining")}</span>
                   </span>
                 `
               : ""

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -396,10 +396,13 @@ export class Dashboard extends LiteElement {
 
     let usageSecondsExtra = 0;
     if (this.org!.extraExecSeconds) {
-      usageSecondsExtra =
+      const actualUsageExtra =
         this.org!.extraExecSeconds[
           `${now.getFullYear()}-${now.getUTCMonth() + 1}`
         ];
+      if (actualUsageExtra) {
+        usageSecondsExtra = actualUsageExtra;
+      }
     }
     const maxExecSecsExtra = this.org!.quotas.extraExecMinutes * 60;
     // Cap usage at quota for display purposes
@@ -415,10 +418,13 @@ export class Dashboard extends LiteElement {
 
     let usageSecondsGifted = 0;
     if (this.org!.giftedExecSeconds) {
-      usageSecondsGifted =
+      const actualUsageGifted =
         this.org!.giftedExecSeconds[
           `${now.getFullYear()}-${now.getUTCMonth() + 1}`
         ];
+      if (actualUsageGifted) {
+        usageSecondsGifted = actualUsageGifted;
+      }
     }
     const maxExecSecsGifted = this.org!.quotas.giftedExecMinutes * 60;
     // Cap usage at quota for display purposes
@@ -444,6 +450,8 @@ export class Dashboard extends LiteElement {
     const renderBar = (
       /** Time in Seconds */
       value: number,
+      used: number,
+      quota: number,
       label: string,
       color: string,
       isBackground: boolean = false
@@ -456,7 +464,8 @@ export class Dashboard extends LiteElement {
         <div class="text-center">
           <div>${label}</div>
           <div class="text-xs opacity-80">
-            ${humanizeExecutionSeconds(value, "short")}
+            ${humanizeExecutionSeconds(used, "full", true)} /
+            ${humanizeExecutionSeconds(quota, "full", true)}
           </div>
         </div>
       </btrix-meter-bar>
@@ -509,7 +518,9 @@ export class Dashboard extends LiteElement {
               ${when(usageSeconds, () =>
                 renderBar(
                   usageSeconds > quotaSeconds ? quotaSeconds : usageSeconds,
-                  msg("Monthly Execution Time"),
+                  usageSeconds > quotaSeconds ? quotaSeconds : usageSeconds,
+                  quotaSeconds,
+                  msg("Monthly Execution Time Used"),
                   "green-400"
                 )
               )}
@@ -521,7 +532,9 @@ export class Dashboard extends LiteElement {
                 () =>
                   renderBar(
                     quotaSeconds - usageSeconds,
-                    msg("Monthly Execution Time Remaining"),
+                    usageSeconds > quotaSeconds ? quotaSeconds : usageSeconds,
+                    quotaSeconds,
+                    msg("Monthly Execution Time Used"),
                     "green-100",
                     true
                   )
@@ -531,14 +544,22 @@ export class Dashboard extends LiteElement {
                   usageSecondsGifted > quotaSecondsGifted
                     ? quotaSecondsGifted
                     : usageSecondsGifted,
-                  msg("Gifted Execution Time"),
+                  usageSecondsGifted > quotaSecondsGifted
+                    ? quotaSecondsGifted
+                    : usageSecondsGifted,
+                  quotaSecondsGifted,
+                  msg("Gifted Execution Time Used"),
                   "blue-400"
                 )
               )}
               ${when(this.org!.giftedExecSecondsAvailable, () =>
                 renderBar(
                   this.org!.giftedExecSecondsAvailable,
-                  msg("Gifted Execution Time Remaining"),
+                  usageSecondsGifted > quotaSecondsGifted
+                    ? quotaSecondsGifted
+                    : usageSecondsGifted,
+                  quotaSecondsGifted,
+                  msg("Gifted Execution Time Used"),
                   "blue-100",
                   true
                 )
@@ -548,14 +569,22 @@ export class Dashboard extends LiteElement {
                   usageSecondsExtra > quotaSecondsExtra
                     ? quotaSecondsExtra
                     : usageSecondsExtra,
-                  msg("Extra Execution Time"),
+                  usageSecondsExtra > quotaSecondsExtra
+                    ? quotaSecondsExtra
+                    : usageSecondsExtra,
+                  quotaSecondsExtra,
+                  msg("Extra Execution Time Used"),
                   "red-400"
                 )
               )}
               ${when(this.org!.extraExecSecondsAvailable, () =>
                 renderBar(
                   this.org!.extraExecSecondsAvailable,
-                  msg("Extra Execution Time Remaining"),
+                  usageSecondsExtra > quotaSecondsExtra
+                    ? quotaSecondsExtra
+                    : usageSecondsExtra,
+                  quotaSecondsExtra,
+                  msg("Extra Execution Time Used"),
                   "red-100",
                   true
                 )

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -22,6 +22,10 @@ export type OrgData = {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   } | null;
+  monthlyExecSeconds: {
+    // Keyed by {4-digit year}-{2-digit month}
+    [key: string]: number;
+  } | null;
   extraExecSeconds: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -21,19 +21,19 @@ export type OrgData = {
   crawlExecSeconds: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
-  } | null;
+  };
   monthlyExecSeconds: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
-  } | null;
+  };
   extraExecSeconds: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
-  } | null;
+  };
   giftedExecSeconds: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
-  } | null;
+  };
   extraExecSecondsAvailable: number;
   giftedExecSecondsAvailable: number;
   storageQuotaReached?: boolean;

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -22,6 +22,16 @@ export type OrgData = {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   } | null;
+  extraExecSeconds: {
+    // Keyed by {4-digit year}-{2-digit month}
+    [key: string]: number;
+  } | null;
+  giftedExecSeconds: {
+    // Keyed by {4-digit year}-{2-digit month}
+    [key: string]: number;
+  } | null;
+  extraExecSecondsAvailable: number;
+  giftedExecSecondsAvailable: number;
   storageQuotaReached?: boolean;
   execMinutesQuotaReached?: boolean;
   users?: {

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -73,4 +73,15 @@ describe("humanizeExecutionSeconds", () => {
     expect(el.textContent?.trim()).to.equal("59 minutes");
     expect(parentNode.innerText).to.equal("59 minutes");
   });
+  it("rounds minutes down when set", async () => {
+    const parentNode = document.createElement("div");
+    const el = await fixture(humanizeExecutionSeconds(90, "full", false, true), {
+      parentNode,
+    });
+    expect(el.getAttribute("title")).to.equal(
+      "1 minute\u00a0(1m)"
+    );
+    expect(el.textContent?.trim()).to.equal("1 minute");
+    expect(parentNode.innerText).to.equal("1 minute");
+  })
 });

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -75,13 +75,14 @@ describe("humanizeExecutionSeconds", () => {
   });
   it("rounds minutes down when set", async () => {
     const parentNode = document.createElement("div");
-    const el = await fixture(humanizeExecutionSeconds(90, "full", false, true), {
-      parentNode,
-    });
-    expect(el.getAttribute("title")).to.equal(
-      "1 minute\u00a0(1m)"
+    const el = await fixture(
+      humanizeExecutionSeconds(90, "full", false, true),
+      {
+        parentNode,
+      }
     );
+    expect(el.getAttribute("title")).to.equal("1 minute");
     expect(el.textContent?.trim()).to.equal("1 minute");
     expect(parentNode.innerText).to.equal("1 minute");
-  })
+  });
 });

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -55,14 +55,17 @@ describe("humanizeExecutionSeconds", () => {
 
   it("shows a short version when set", async () => {
     const parentNode = document.createElement("div");
-    const el = await fixture(humanizeExecutionSeconds(1_234_567_890, "short"), {
-      parentNode,
-    });
+    const el = await fixture(
+      humanizeExecutionSeconds(1_234_567_890, { style: "short" }),
+      {
+        parentNode,
+      }
+    );
     expect(el.getAttribute("title")).to.equal(
       "20,576,132 minutes\u00a0(342,935h 32m)"
     );
-    expect(el.textContent?.trim()).to.equal("21M minutes");
-    expect(parentNode.innerText).to.equal("21M minutes");
+    expect(el.textContent?.trim()).to.equal("21M min");
+    expect(parentNode.innerText).to.equal("21M min");
   });
   it("skips the details when given a time less than an hour that is exactly in minutes", async () => {
     const parentNode = document.createElement("div");
@@ -75,12 +78,9 @@ describe("humanizeExecutionSeconds", () => {
   });
   it("rounds minutes down when set", async () => {
     const parentNode = document.createElement("div");
-    const el = await fixture(
-      humanizeExecutionSeconds(90, "full", false, true),
-      {
-        parentNode,
-      }
-    );
+    const el = await fixture(humanizeExecutionSeconds(90, { round: "down" }), {
+      parentNode,
+    });
     expect(el.getAttribute("title")).to.equal("1 minute");
     expect(el.textContent?.trim()).to.equal("1 minute");
     expect(parentNode.innerText).to.equal("1 minute");

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -70,7 +70,7 @@ export const humanizeExecutionSeconds = (
   options?: {
     /**
      * When this is "long", the time in hours is also displayed
-     * @default "full"
+     * @default "long"
      */
     style?: "short" | "long";
     /**

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -68,10 +68,16 @@ export function humanizeSeconds(
 export const humanizeExecutionSeconds = (
   seconds: number,
   style: "short" | "full" = "full",
-  displaySeconds = false
+  displaySeconds = false,
+  roundDown = false
 ) => {
   const locale = getLocale();
-  const minutes = Math.ceil(seconds / 60);
+  let minutes = 0;
+  if (roundDown) {
+    minutes = Math.floor(seconds / 60);
+  } else {
+    minutes = Math.ceil(seconds / 60);
+  }
 
   const compactMinuteFormatter = new Intl.NumberFormat(locale, {
     notation: "compact",

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -67,23 +67,36 @@ export function humanizeSeconds(
  */
 export const humanizeExecutionSeconds = (
   seconds: number,
-  style: "short" | "full" = "full",
-  displaySeconds = false,
-  roundDown = false
-) => {
-  const locale = getLocale();
-  let minutes = 0;
-  if (roundDown) {
-    minutes = Math.floor(seconds / 60);
-  } else {
-    minutes = Math.ceil(seconds / 60);
+  options?: {
+    /**
+     * When this is "long", the time in hours is also displayed
+     * @default "full"
+     */
+    style?: "short" | "long";
+    /**
+     * @default false
+     */
+    displaySeconds?: boolean;
+    /**
+     * @default "up"
+     */
+    round?: "up" | "down";
   }
+) => {
+  const {
+    style = "long",
+    displaySeconds = false,
+    round = "up",
+  } = options || {};
+  const locale = getLocale();
+  const minutes =
+    round === "down" ? Math.floor(seconds / 60) : Math.ceil(seconds / 60);
 
   const compactMinuteFormatter = new Intl.NumberFormat(locale, {
     notation: "compact",
     style: "unit",
     unit: "minute",
-    unitDisplay: "long",
+    unitDisplay: style,
   });
 
   const longMinuteFormatter = new Intl.NumberFormat(locale, {
@@ -102,7 +115,7 @@ export const humanizeExecutionSeconds = (
       : `\u00a0(${details})`;
 
   switch (style) {
-    case "full":
+    case "long":
       return html`<span title="${longMinuteFormatter.format(minutes)}">
           ${compactMinuteFormatter.format(minutes)}</span
         >${formattedDetails}`;


### PR DESCRIPTION
Fixes #1358 

Could use a good bit of additional manual testing, edge cases/fuzz testing welcomed (e.g. this has not been tested across months yet)! And very open to any suggestions to simplify the implementation on backend and/or frontend.

## Overview

- Adds `extraExecMinutes` and `giftedExecMinutes` org quotas, which are not reset monthly but a one-time update-able bucket
- Adds `quotaUpdate` field to `Organization` to track when quotas were updated with timestamp
- Adds `extraExecMinutesAvailable` and `giftedExecMinutesAvailable` fields to `Organization` to help with tracking available time left (includes tested migration to initialize these to 0)
- Modifies org backend to track time across multiple categories, using monthly exec time first, then gifted, then extra
- Updates Dashboard crawling meter to include all types of execution time if `extraExecMinutes` and/or `giftedExecMinutes` are set above 0
- Updates Dashboard Usage History table to include all types of execution time
- Adds backend nightly test to check handling of quotas and execution time

## Screenshots

#### Only monthly quota set, no execution time used yet

<img width="376" alt="Screen Shot 2023-11-15 at 1 20 50 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/2a038d76-c8dc-403d-906a-7081af5db75b">

#### Only monthly quota set, with some execution time used

<img width="386" alt="Screen Shot 2023-11-15 at 1 24 15 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/8b14a623-78b8-49f1-88f8-d695691f2192">

#### All three quotas set, no execution time used yet

<img width="380" alt="Screen Shot 2023-11-15 at 2 05 32 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/84b0b0ae-a520-413b-889d-1e8472b7ebaf">

#### All three quotas set, some execution time used

<img width="1189" alt="Screen Shot 2023-11-15 at 2 27 24 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/f2575602-8bc6-4633-8d61-3190dbccf887">

<img width="380" alt="Screen Shot 2023-11-15 at 2 43 30 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/4104a20a-7322-405a-87da-72418a2e9845">

<img width="383" alt="Screen Shot 2023-11-15 at 2 47 22 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/198278db-07cc-4aa7-87ec-ae62e3a5a5e4">

<img width="1172" alt="Screen Shot 2023-11-15 at 2 59 35 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/5b7d7aae-2cb3-4b87-846f-7dc919983676">

#### Tooltips

<img width="388" alt="Screen Shot 2023-11-15 at 2 27 36 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/f7750d02-4232-420e-a837-acb13296d249">

<img width="387" alt="Screen Shot 2023-11-15 at 2 27 39 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/43e4c6fb-1c6a-4d7a-81e3-106ccb525600">

#### Quota reached

<img width="1229" alt="Screen Shot 2023-11-15 at 3 04 20 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/51e79594-17e6-42b6-83b8-db17bc3f78b8">

#### With storage quota also enabled

<img width="1236" alt="Screen Shot 2023-11-15 at 3 05 36 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/c112917f-26bf-43f8-aef4-8f3db935f2f7">