### PR TITLE
Encode the collection sharing URL

### DIFF
--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -221,7 +221,8 @@ export class CollectionDetail extends LiteElement {
 
   private renderShareInfo = () => {
     const replaySrc = this.getPublicReplayURL();
-    const publicReplayUrl = `https://replayweb.page?source=${replaySrc}`;
+    const encodedReplaySrc = encodeURIComponent(replaySrc);
+    const publicReplayUrl = `https://replayweb.page?source=${encodedReplaySrc}`;
     const embedCode = `<replay-web-page source="${replaySrc}"></replay-web-page>`;
     const importCode = `importScripts("https://replayweb.page/sw.js");`;
 


### PR DESCRIPTION
closes #1357 

### Changes
- Encodes the collection sharing URL available in the `Link to Share` section of the collection sharing dialog

#### Before
```txt
https://replayweb.page?source=http://localhost:9870/api/orgs/c69247f4-415e-4abc-b449-e85d2f26c626/collections/0795d95f-a058-4dd2-b858-3624d3281e4b/public/replay.json
```
#### After:
```txt
https://replayweb.page?source=http%3A%2F%2Flocalhost%3A9870%2Fapi%2Forgs%2Fc69247f4-415e-4abc-b449-e85d2f26c626%2Fcollections%2F0795d95f-a058-4dd2-b858-3624d3281e4b%2Fpublic%2Freplay.json
```