### PR TITLE
Add crawl, upload, and collection delete webhook event notifications

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import urllib.parse
 import contextlib
 
+import asyncio
 from fastapi import HTTPException, Depends
 
 from .models import (
@@ -345,6 +346,10 @@ class BaseCrawlOps:
                     cids_to_update[cid] = {}
                     cids_to_update[cid]["inc"] = 1
                     cids_to_update[cid]["size"] = crawl_size
+
+            asyncio.create_task(
+                self.event_webhook_ops.create_crawl_deleted_notification(crawl_id, org)
+            )
 
         query = {"_id": {"$in": delete_list.crawl_ids}, "oid": org.id, "type": type_}
         res = await self.crawls.delete_many(query)

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -347,9 +347,18 @@ class BaseCrawlOps:
                     cids_to_update[cid]["inc"] = 1
                     cids_to_update[cid]["size"] = crawl_size
 
-            asyncio.create_task(
-                self.event_webhook_ops.create_crawl_deleted_notification(crawl_id, org)
-            )
+            if type_ == "crawl":
+                asyncio.create_task(
+                    self.event_webhook_ops.create_crawl_deleted_notification(
+                        crawl_id, org
+                    )
+                )
+            if type_ == "upload":
+                asyncio.create_task(
+                    self.event_webhook_ops.create_upload_deleted_notification(
+                        crawl_id, org
+                    )
+                )
 
         query = {"_id": {"$in": delete_list.crawl_ids}, "oid": org.id, "type": type_}
         res = await self.crawls.delete_many(query)

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -305,6 +305,10 @@ class CollectionOps:
         if result.deleted_count < 1:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
+        asyncio.create_task(
+            self.event_webhook_ops.create_collection_deleted_notification(coll_id, org)
+        )
+
         return {"success": True}
 
     async def download_collection(self, coll_id: UUID, org: Organization):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1119,8 +1119,6 @@ class UserUpdatePassword(BaseModel):
 class WebhookNotificationBody(BaseModel):
     """Base POST body model for webhook notifications"""
 
-    downloadUrls: Optional[List] = None
-
     # Store as str, not UUID, to make JSON-serializable
     orgId: str
 
@@ -1143,6 +1141,7 @@ class BaseCollectionItemBody(WebhookNotificationBody):
 
     collectionId: str
     itemIds: List[str]
+    downloadUrl: str
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -824,9 +824,12 @@ class OrgWebhookUrls(BaseModel):
 
     crawlStarted: Optional[AnyHttpUrl] = None
     crawlFinished: Optional[AnyHttpUrl] = None
+    crawlDeleted: Optional[AnyHttpUrl] = None
     uploadFinished: Optional[AnyHttpUrl] = None
+    uploadDeleted: Optional[AnyHttpUrl] = None
     addedToCollection: Optional[AnyHttpUrl] = None
     removedFromCollection: Optional[AnyHttpUrl] = None
+    collectionDeleted: Optional[AnyHttpUrl] = None
 
 
 # ============================================================================
@@ -1129,10 +1132,14 @@ class WebhookEventType(str, Enum):
 
     CRAWL_STARTED = "crawlStarted"
     CRAWL_FINISHED = "crawlFinished"
+    CRAWL_DELETED = "crawlDeleted"
+
     UPLOAD_FINISHED = "uploadFinished"
+    UPLOAD_DELETED = "uploadDeleted"
 
     ADDED_TO_COLLECTION = "addedToCollection"
     REMOVED_FROM_COLLECTION = "removedFromCollection"
+    COLLECTION_DELETED = "collectionDeleted"
 
 
 # ============================================================================
@@ -1163,6 +1170,16 @@ class CollectionItemRemovedBody(BaseCollectionItemBody):
 
 
 # ============================================================================
+class CollectionDeletedBody(WebhookNotificationBody):
+    """Webhook notification base POST body for collection changes"""
+
+    event: Literal[
+        WebhookEventType.COLLECTION_DELETED
+    ] = WebhookEventType.COLLECTION_DELETED
+    collectionId: str
+
+
+# ============================================================================
 class BaseArchivedItemBody(WebhookNotificationBody):
     """Webhook notification POST body for when archived item is started or finished"""
 
@@ -1187,11 +1204,25 @@ class CrawlFinishedBody(BaseArchivedItemBody):
 
 
 # ============================================================================
+class CrawlDeletedBody(BaseArchivedItemBody):
+    """Webhook notification POST body for when crawl is deleted"""
+
+    event: Literal[WebhookEventType.CRAWL_DELETED] = WebhookEventType.CRAWL_DELETED
+    state: str
+
+
+# ============================================================================
 class UploadFinishedBody(BaseArchivedItemBody):
     """Webhook notification POST body for when upload finishes"""
 
     event: Literal[WebhookEventType.UPLOAD_FINISHED] = WebhookEventType.UPLOAD_FINISHED
-    state: str
+
+
+# ============================================================================
+class UploadDeletedBody(BaseArchivedItemBody):
+    """Webhook notification POST body for when upload finishes"""
+
+    event: Literal[WebhookEventType.UPLOAD_DELETED] = WebhookEventType.UPLOAD_DELETED
 
 
 # ============================================================================
@@ -1203,9 +1234,12 @@ class WebhookNotification(BaseMongoModel):
     body: Union[
         CrawlStartedBody,
         CrawlFinishedBody,
+        CrawlDeletedBody,
         UploadFinishedBody,
+        UploadDeletedBody,
         CollectionItemAddedBody,
         CollectionItemRemovedBody,
+        CollectionDeletedBody,
     ]
     success: bool = False
     attempts: int = 0

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1208,7 +1208,6 @@ class CrawlDeletedBody(BaseArchivedItemBody):
     """Webhook notification POST body for when crawl is deleted"""
 
     event: Literal[WebhookEventType.CRAWL_DELETED] = WebhookEventType.CRAWL_DELETED
-    state: str
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1184,7 +1184,14 @@ class BaseArchivedItemBody(WebhookNotificationBody):
     """Webhook notification POST body for when archived item is started or finished"""
 
     itemId: str
-    resources: Optional[List[CrawlFileOut]] = None
+
+
+# ============================================================================
+class BaseArchivedItemFinishedBody(BaseArchivedItemBody):
+    """Webhook notification POST body for when archived item is finished"""
+
+    resources: List[CrawlFileOut]
+    state: str
 
 
 # ============================================================================
@@ -1196,11 +1203,10 @@ class CrawlStartedBody(BaseArchivedItemBody):
 
 
 # ============================================================================
-class CrawlFinishedBody(BaseArchivedItemBody):
+class CrawlFinishedBody(BaseArchivedItemFinishedBody):
     """Webhook notification POST body for when crawl finishes"""
 
     event: Literal[WebhookEventType.CRAWL_FINISHED] = WebhookEventType.CRAWL_FINISHED
-    state: str
 
 
 # ============================================================================
@@ -1211,7 +1217,7 @@ class CrawlDeletedBody(BaseArchivedItemBody):
 
 
 # ============================================================================
-class UploadFinishedBody(BaseArchivedItemBody):
+class UploadFinishedBody(BaseArchivedItemFinishedBody):
     """Webhook notification POST body for when upload finishes"""
 
     event: Literal[WebhookEventType.UPLOAD_FINISHED] = WebhookEventType.UPLOAD_FINISHED

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -304,7 +304,7 @@ class EventWebhookOps:
                 f"{org.origin}/api/orgs/{org.id}/collections/{coll_id}/download"
             )
 
-        body.downloadUrls = [coll_download_url]
+        body.downloadUrl = coll_download_url
 
         notification = WebhookNotification(
             id=uuid4(),

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -256,6 +256,7 @@ class EventWebhookOps:
                 itemId=crawl_id,
                 orgId=str(org.id),
                 state=state,
+                resources=[],
             ),
         )
 
@@ -289,7 +290,7 @@ class EventWebhookOps:
             org,
             event=WebhookEventType.UPLOAD_FINISHED,
             body=UploadFinishedBody(
-                itemId=crawl_id, orgId=str(org.id), state="complete"
+                itemId=crawl_id, orgId=str(org.id), state="complete", resources=[]
             ),
         )
 

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -259,10 +259,10 @@ class EventWebhookOps:
             ),
         )
 
-    async def create_crawl_deleted_notification(self, crawl_id: str, oid: UUID) -> None:
+    async def create_crawl_deleted_notification(
+        self, crawl_id: str, org: Organization
+    ) -> None:
         """Create webhook notification for deleted crawl."""
-        org = await self.org_ops.get_org_by_id(oid)
-
         if not org.webhookUrls or not org.webhookUrls.crawlDeleted:
             return
 
@@ -294,11 +294,9 @@ class EventWebhookOps:
         )
 
     async def create_upload_deleted_notification(
-        self, crawl_id: str, oid: UUID
+        self, crawl_id: str, org: Organization
     ) -> None:
         """Create webhook notification for deleted upload."""
-        org = await self.org_ops.get_org_by_id(oid)
-
         if not org.webhookUrls or not org.webhookUrls.uploadDeleted:
             return
 
@@ -387,6 +385,7 @@ class EventWebhookOps:
             event=WebhookEventType.ADDED_TO_COLLECTION,
             body=CollectionItemAddedBody(
                 itemIds=crawl_ids,
+                downloadUrl="",
                 collectionId=str(coll_id),
                 orgId=str(org.id),
             ),
@@ -408,6 +407,7 @@ class EventWebhookOps:
             event=WebhookEventType.REMOVED_FROM_COLLECTION,
             body=CollectionItemRemovedBody(
                 itemIds=crawl_ids,
+                downloadUrl="",
                 collectionId=str(coll_id),
                 orgId=str(org.id),
             ),
@@ -425,7 +425,7 @@ class EventWebhookOps:
         await self._create_deleted_notification(
             org,
             event=WebhookEventType.REMOVED_FROM_COLLECTION,
-            body=CollectionItemRemovedBody(
+            body=CollectionDeletedBody(
                 collectionId=str(coll_id),
                 orgId=str(org.id),
             ),

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -497,11 +497,19 @@ def init_openapi_webhooks(app):
 
     @app.webhooks.post(WebhookEventType.CRAWL_FINISHED)
     def crawl_finished(body: CrawlFinishedBody):
-        """Sent when a crawl if finished"""
+        """Sent when a crawl has finished"""
+
+    @app.webhooks.post(WebhookEventType.CRAWL_DELETED)
+    def crawl_deleted(body: CrawlDeletedBody):
+        """Sent when a crawl is deleted"""
 
     @app.webhooks.post(WebhookEventType.UPLOAD_FINISHED)
     def upload_finished(body: UploadFinishedBody):
         """Sent when an upload has finished"""
+
+    @app.webhooks.post(WebhookEventType.UPLOAD_DELETED)
+    def upload_deleted(body: UploadDeletedBody):
+        """Sent when an upload is deleted"""
 
     @app.webhooks.post(WebhookEventType.ADDED_TO_COLLECTION)
     def added_to_collection(body: CollectionItemAddedBody):
@@ -509,6 +517,10 @@ def init_openapi_webhooks(app):
         is added to a collection"""
 
     @app.webhooks.post(WebhookEventType.REMOVED_FROM_COLLECTION)
-    def remove_from_collection(body: CrawlStartedBody):
+    def remove_from_collection(body: CollectionItemRemovedBody):
         """Sent when an archived item (crawl or upload)
         is removed from a collection"""
+
+    @app.webhooks.post(WebhookEventType.COLLECTION_DELETED)
+    def collection_deleted(body: CollectionDeletedBody):
+        """Sent when a collection is deleted"""

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -344,16 +344,22 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
         webhooks = data.get("webhooks")
         assert webhooks.get("crawlStarted") is None
         assert webhooks.get("crawlFinished") is None
+        assert webhooks.get("crawlDeleted") is None
         assert webhooks.get("uploadFinished") is None
+        assert webhooks.get("uploadDeleted") is None
         assert webhooks.get("addedToCollection") is None
         assert webhooks.get("removedFromCollection") is None
+        assert webhooks.get("collectionDeleted") is None
 
     # Set URLs and verify
     CRAWL_STARTED_URL = "https://example.com/crawl/started"
     CRAWL_FINISHED_URL = "https://example.com/crawl/finished"
-    UPLOAD_FINISHED_URL = "https://example.com/crawl/finished"
+    CRAWL_DELETED_URL = "https://example.com/crawl/deleted"
+    UPLOAD_FINISHED_URL = "https://example.com/upload/finished"
+    UPLOAD_DELETED_URL = "https://example.com/upload/deleted"
     COLL_ADDED_URL = "https://example.com/coll/added"
     COLL_REMOVED_URL = "http://example.com/coll/removed"
+    COLL_DELETED_URL = "http://example.com/coll/deleted"
 
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/event-webhook-urls",
@@ -361,9 +367,12 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
         json={
             "crawlStarted": CRAWL_STARTED_URL,
             "crawlFinished": CRAWL_FINISHED_URL,
+            "crawlDeleted": CRAWL_DELETED_URL,
             "uploadFinished": UPLOAD_FINISHED_URL,
+            "uploadDeleted": UPLOAD_DELETED_URL,
             "addedToCollection": COLL_ADDED_URL,
             "removedFromCollection": COLL_REMOVED_URL,
+            "collectionDeleted": COLL_DELETED_URL,
         },
     )
     assert r.status_code == 200
@@ -378,9 +387,14 @@ def test_update_event_webhook_urls_org_admin(admin_auth_headers, default_org_id)
     urls = data["webhookUrls"]
     assert urls["crawlStarted"] == CRAWL_STARTED_URL
     assert urls["crawlFinished"] == CRAWL_FINISHED_URL
+    assert urls["crawlDeleted"] == CRAWL_DELETED_URL
+
     assert urls["uploadFinished"] == UPLOAD_FINISHED_URL
+    assert urls["uploadDeleted"] == UPLOAD_DELETED_URL
+
     assert urls["addedToCollection"] == COLL_ADDED_URL
     assert urls["removedFromCollection"] == COLL_REMOVED_URL
+    assert urls["collectionDeleted"] == COLL_DELETED_URL
 
 
 def test_update_event_webhook_urls_org_crawler(crawler_auth_headers, default_org_id):


### PR DESCRIPTION
Fixes #1307
Fixes #1132
Related to #1306

Deleted webhook notifications include the org id and item/collection id. This PR also includes API docs for the new webhooks and extends the existing tests to account for the new webhooks. 

This PR also does some additional cleanup for existing webhooks:
- Remove `downloadUrls` from item finished webhook bodies
- Rename collection webhook body `downloadUrls` to `downloadUrl`, since we only ever have one per collection
- Fix API docs for existing webhooks, one of which had the wrong response body