### PR TITLE
node affinity: set to required instead of preferred to keep crawlers on dedicated infrastructure

### DIFF
--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -60,24 +60,28 @@ spec:
         claimName: {{ name }}
 
   affinity:
+{% if crawler_node_type %}
     nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
             - key: nodeType
               operator: In
               values:
                 - "{{ crawler_node_type }}"
+{% endif %}
 
     podAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 2
+        - weight: 10
           podAffinityTerm:
-            topologyKey: "failure-domain.beta.kubernetes.io/zone"
+            topologyKey: "kubernetes.io/hostname"
             labelSelector:
-              matchLabels:
-                crawl: {{ id }}
+              matchExpressions:
+              - key: crawl
+                operator: In
+                values:
+                - {{ id }}
 
   tolerations:
     - key: nodeType

--- a/chart/app-templates/profilebrowser.yaml
+++ b/chart/app-templates/profilebrowser.yaml
@@ -18,16 +18,17 @@ spec:
 
   restartPolicy: OnFailure
 
+{% if crawler_node_type %}
   affinity:
     nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
             - key: nodeType
               operator: In
               values:
                 - "{{ crawler_node_type }}"
+{% endif %}
 
   tolerations:
     - key: nodeType
@@ -74,3 +75,11 @@ spec:
         - name: CHROME_FLAGS
           value: "--proxy-server=socks5://{{ crawler_socks_proxy_host }}:{{ crawler_socks_proxy_port | default('9050') }}"
       {% endif %}
+
+      resources:
+        limits:
+          memory: "{{ crawler_memory }}"
+
+        requests:
+          cpu: "{{ crawler_cpu }}"
+          memory: "{{ crawler_memory }}"


### PR DESCRIPTION
Currently, the crawler pods use preferred node affinity, instead of required node affinity. This results in crawler nodes running on the main node pool. Instead, we want to ensure crawler nodes are running on dedicated node pool (if configured).

This converts the preferred node affinity to require node affinity for the node pool, while keeping preferred pod affinity for keeping all crawler / redis pods together.

Also updates obsolete topology keys.
See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#pod-topology-spread-constraints
