### PR TITLE
Remove collection share access column header icon

### DIFF
--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -382,13 +382,7 @@ export class CollectionsList extends LiteElement {
           <div
             class="hidden md:grid md:grid-cols-[2rem_1fr_repeat(3,12ch)_18ch_2.5rem] gap-3"
           >
-            <div class="col-span-1 pl-3 text-center">
-              <sl-icon
-                class="block text-[15px]"
-                name="eye"
-                label=${msg("Collection share access")}
-              ></sl-icon>
-            </div>
+            <div class="col-span-1"></div>
             <div class="col-span-1 text-xs">${msg("Name")}</div>
             <div class="col-span-1 text-xs">${msg("Archived Items")}</div>
             <div class="col-span-1 text-xs">${msg("Total Size")}</div>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -382,8 +382,7 @@ export class CollectionsList extends LiteElement {
           <div
             class="hidden md:grid md:grid-cols-[2rem_1fr_repeat(3,12ch)_18ch_2.5rem] gap-3"
           >
-            <div class="col-span-1"></div>
-            <div class="col-span-1 text-xs">${msg("Name")}</div>
+            <div class="col-span-2 text-xs pl-12">${msg("Name")}</div>
             <div class="col-span-1 text-xs">${msg("Archived Items")}</div>
             <div class="col-span-1 text-xs">${msg("Total Size")}</div>
             <div class="col-span-1 text-xs">${msg("Total Pages")}</div>


### PR DESCRIPTION
Closes #1351

### Changes
- Removes the collection share access icon's header icon which was just an icon.  This is now mostly in line with how we display status icons in the archived items list (there is a spacing difference between the two lists regarding the placement of the icon vs the label and its alignment with the text (here) vs the icon (archived items list).

### Screenshots

Before / After

<img width="391" alt="Screenshot 2023-11-13 at 4 41 45 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/51093f1d-497f-430f-a8b3-fe9e82356b3f">
<img width="356" alt="Screenshot 2023-11-13 at 4 41 31 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/16f8a290-1f09-4701-84af-63fb4fd6f8c9">
