### PR TITLE
Email Templates

### DIFF
--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -7,12 +7,13 @@ import ssl
 from typing import Optional, Union
 
 from email.message import EmailMessage
+from fastapi.templating import Jinja2Templates
 
 from .models import CreateReplicaJob, DeleteReplicaJob, Organization
 from .utils import is_bool
 
 
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class EmailSender:
     """SMTP Email Sender"""
 
@@ -27,14 +28,29 @@ class EmailSender:
         self.sender = os.environ.get("EMAIL_SENDER") or "Browsertrix admin"
         self.password = os.environ.get("EMAIL_PASSWORD") or ""
         self.reply_to = os.environ.get("EMAIL_REPLY_TO") or self.sender
+        self.support_email = os.environ.get("EMAIL_SUPPORT_EMAIL") or self.reply_to
         self.smtp_server = os.environ.get("EMAIL_SMTP_HOST")
         self.smtp_port = int(os.environ.get("EMAIL_SMTP_PORT", 587))
         self.smtp_use_tls = is_bool(os.environ.get("EMAIL_SMTP_USE_TLS"))
 
         self.default_origin = os.environ.get("APP_ORIGIN")
 
-    def _send_encrypted(self, receiver, subject, message) -> None:
-        """Send Encrypted SMTP Message"""
+        self.templates = Jinja2Templates(
+            directory=os.path.join(os.path.dirname(__file__), "email-templates")
+        )
+
+    def _send_encrypted(self, receiver: str, name: str, **kwargs) -> None:
+        """Send Encrypted SMTP Message using given template name"""
+
+        full = self.templates.env.get_template(name).render(kwargs)
+        if full.startswith("Subject:"):
+            subject, message = full.split("\n", 1)
+            subject = subject.split(":", 1)[1].strip()
+            message = message.strip("\n")
+        else:
+            subject = ""
+            message = full
+
         print(message, flush=True)
 
         if not self.smtp_server:
@@ -76,18 +92,7 @@ class EmailSender:
 
         origin = self.get_origin(headers)
 
-        message = f"""
-Please verify your registration for Browsertrix Cloud for {receiver_email}
-
-You can verify by clicking here: {origin}/verify?token={token}
-
-The verification token is: {token}"""
-
-        self._send_encrypted(
-            receiver_email,
-            "Welcome to Browsertrix Cloud, Verify your Registration",
-            message,
-        )
+        self._send_encrypted(receiver_email, "validate", origin=origin, token=token)
 
     # pylint: disable=too-many-arguments
     def send_new_user_invite(
@@ -97,17 +102,14 @@ The verification token is: {token}"""
 
         origin = self.get_origin(headers)
 
-        message = f"""
-You are invited by {sender} to join their organization, "{org_name}" on Browsertrix Cloud!
-
-You can join by clicking here: {origin}/join/{token}?email={receiver_email}
-
-The invite token is: {token}"""
-
         self._send_encrypted(
             receiver_email,
-            f'You\'ve been invited to join "{org_name}" on Browsertrix Cloud',
-            message,
+            "invite",
+            origin=origin,
+            token=token,
+            sender=sender,
+            org_name=org_name,
+            support_email=self.support_email
         )
 
     # pylint: disable=too-many-arguments
@@ -117,29 +119,22 @@ The invite token is: {token}"""
         """Send email to invite new user"""
         origin = self.get_origin(headers)
 
-        message = f"""
-You are invited by {sender} to join their organization, "{org_name}" on Browsertrix Cloud!
-
-You can join by clicking here: {origin}/invite/accept/{token}?email={receiver_email}
-
-The invite token is: {token}"""
-
         self._send_encrypted(
             receiver_email,
-            f'You\'ve been invited to join "{org_name}" on Browsertrix Cloud',
-            message,
+            "invite_existing",
+            origin=origin,
+            token=token,
+            sender=sender,
+            org_name=org_name,
         )
 
     def send_user_forgot_password(self, receiver_email, token, headers=None):
         """Send password reset email with token"""
         origin = self.get_origin(headers)
 
-        message = f"""
-We received your password reset request. Please click here: {origin}/reset-password?token={token}
-to create a new password
-        """
-
-        self._send_encrypted(receiver_email, "Password Reset", message)
+        self._send_encrypted(
+            receiver_email, "password_reset", origin=origin, token=token
+        )
 
     def send_background_job_failed(
         self,
@@ -149,21 +144,6 @@ to create a new password
         receiver_email: str,
     ):
         """Send background job failed email to superuser"""
-        message = f"""
-Failed Background Job
----------------------
-
-Organization: {org.name} ({job.oid})
-Job type: {job.type}
-
-Job ID: {job.id}
-Started: {job.started.isoformat(sep=" ", timespec="seconds")}Z
-Finished: {finished.isoformat(sep=" ", timespec="seconds")}Z
-
-Object type: {job.object_type}
-Object ID: {job.object_id}
-File path: {job.file_path}
-Replica storage name: {job.replica_storage.name}
-        """
-
-        self._send_encrypted(receiver_email, "Failed Background Job", message)
+        self._send_encrypted(
+            receiver_email, "failed_bg_job", job=job, org=org, finished=finished
+        )

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -23,6 +23,8 @@ class EmailSender:
     smtp_server: Optional[str]
     smtp_port: int
     smtp_use_tls: bool
+    support_email: str
+    templates: Jinja2Templates
 
     def __init__(self):
         self.sender = os.environ.get("EMAIL_SENDER") or "Browsertrix admin"
@@ -109,7 +111,7 @@ class EmailSender:
             token=token,
             sender=sender,
             org_name=org_name,
-            support_email=self.support_email
+            support_email=self.support_email,
         )
 
     # pylint: disable=too-many-arguments

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -71,13 +71,7 @@ class InviteOps:
 
         await self.invites.insert_one(new_user_invite.to_dict())
 
-        self.email.send_new_user_invite(
-            new_user_invite.email,
-            new_user_invite.inviterEmail,
-            org_name,
-            new_user_invite.id,
-            headers,
-        )
+        self.email.send_new_user_invite(new_user_invite, org_name, headers)
 
     async def get_valid_invite(self, invite_token: UUID, email):
         """Retrieve a valid invite data from db, or throw if invalid"""
@@ -148,8 +142,8 @@ class InviteOps:
             role=invite.role if hasattr(invite, "role") else None,
             # URL decode email address just in case
             email=urllib.parse.unquote(invite.email),
-            # inviterEmail=user.email if not user.is_superuser else None,
             inviterEmail=user.email,
+            fromSuperuser=user.is_superuser,
         )
 
         other_user = await user_manager.get_by_email(invite.email)

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -11,7 +11,8 @@ from pymongo.errors import AutoReconnect
 from fastapi import HTTPException
 
 from .pagination import DEFAULT_PAGE_SIZE
-from .models import UserRole, InvitePending, InviteRequest
+from .models import UserRole, InvitePending, InviteRequest, User
+from .users import UserManager
 from .utils import is_bool
 
 
@@ -118,8 +119,8 @@ class InviteOps:
     async def invite_user(
         self,
         invite: InviteRequest,
-        user,
-        user_manager,
+        user: User,
+        user_manager: UserManager,
         org=None,
         allow_existing=False,
         headers: Optional[dict] = None,
@@ -147,7 +148,7 @@ class InviteOps:
             role=invite.role if hasattr(invite, "role") else None,
             # URL decode email address just in case
             email=urllib.parse.unquote(invite.email),
-            inviterEmail=user.email,
+            inviterEmail=user.email if not user.is_superuser else None,
         )
 
         other_user = await user_manager.get_by_email(invite.email)

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -148,7 +148,8 @@ class InviteOps:
             role=invite.role if hasattr(invite, "role") else None,
             # URL decode email address just in case
             email=urllib.parse.unquote(invite.email),
-            inviterEmail=user.email if not user.is_superuser else None,
+            # inviterEmail=user.email if not user.is_superuser else None,
+            inviterEmail=user.email,
         )
 
         other_user = await user_manager.get_by_email(invite.email)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -47,7 +47,8 @@ class InvitePending(BaseMongoModel):
     """An invite for a new user, with an email and invite token as id"""
 
     created: datetime
-    inviterEmail: Optional[str]
+    inviterEmail: str
+    fromSuperuser: Optional[bool]
     oid: Optional[UUID]
     role: Optional[UserRole] = UserRole.VIEWER
     email: Optional[str]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -47,7 +47,7 @@ class InvitePending(BaseMongoModel):
     """An invite for a new user, with an email and invite token as id"""
 
     created: datetime
-    inviterEmail: str
+    inviterEmail: Optional[str]
     oid: Optional[UUID]
     role: Optional[UserRole] = UserRole.VIEWER
     email: Optional[str]

--- a/chart/email-templates/failed_bg_job
+++ b/chart/email-templates/failed_bg_job
@@ -1,5 +1,5 @@
-Subject: Failed Background Job
-
+Failed Background Job
+~~~
 Failed Background Job
 ---------------------
 

--- a/chart/email-templates/failed_bg_job
+++ b/chart/email-templates/failed_bg_job
@@ -1,0 +1,16 @@
+Subject: Failed Background Job
+
+Failed Background Job
+---------------------
+
+Organization: {{ org.name }} ({{ job.oid }})
+Job type: {{ job.type }}
+
+Job ID: {{ job.id }}
+Started: {{ job.started.isoformat(sep=" ", timespec="seconds") }}Z
+Finished: {{ finished.isoformat(sep=" ", timespec="seconds") }}Z
+
+Object type: {{ job.object_type }}
+Object ID: {{ job.object_id }}
+File path: {{ job.file_path }}
+Replica storage name: {{ job.replica_storage.name }}

--- a/chart/email-templates/invite
+++ b/chart/email-templates/invite
@@ -12,20 +12,26 @@ Welcome to Browsertrix Cloud!
 {% endif %}
 
 {% if is_new %}
-<p style="font-weight: bold; padding: 12px; background-color: lightgrey"><a href="{{ invite_url }}">Click here to sign up for an account!</a></p>
+<p>You can now set up your account using the link below.</p>
+
+<p style="font-weight: bold; padding: 12px; background-color: lightgrey"><a href="{{ invite_url }}">Click here to create an account.</a></p>
 {% else %}
 <p style="font-weight: bold; padding: 12px; background-color: lightgrey"><a href="{{ invite_url }}">Click here to accept this invite.</a></p>
 {% endif %}
 
-<p>When you first access your account, you’ll be directed to your Dashboard. It contains information you may want to view frequently including: Storage Usage, Crawling Info,  Collections, and Monthly Usage History.</p>
+<p>When you first access your account, you’ll be directed to your Dashboard. It contains information you may want to view frequently including: Storage Usage, Crawling Info,  Collections, and Monthly Usage History. From there, you can click <i>+ Create New</i> to create your first Crawl Workflow!
 
 
 <p>For more info, check out the <b><a href="https://docs.browsertrix.cloud/user-guide/">Browsertrix Cloud User Guide</a></b></p>
 
 
 <p>
-We want you to get the most from your Browsertrix Cloud experience. Let us know if you need any questions or feedback.
+We want you to get the most from your Browsertrix Cloud experience!
+</p>
+
+<p>Let us know if you need any questions or feedback.</p>
 You can connect with our team at <a href="mailto:{{ support_email }}">{{ support_email }}</a></p>
+</p>
 
 <p><i>The Webrecorder Team</i></p>
 </body>

--- a/chart/email-templates/invite
+++ b/chart/email-templates/invite
@@ -1,5 +1,36 @@
-Subject: Welcome to Browsertrix Cloud!
+Welcome to Browsertrix Cloud!
+~~~
+<html>
+<body>
+<p>Hello!</p>
 
+<p>Welcome to Browsertrix Cloud!</p>
+
+{% if sender %}
+<p>You have been invited by {{ sender }} to join "{{ org_name }}" on Browsertrix Cloud!
+</p>
+{% endif %}
+
+{% if is_new %}
+<p style="font-weight: bold; padding: 12px; background-color: lightgrey"><a href="{{ invite_url }}">Click here to sign up for an account!</a></p>
+{% else %}
+<p style="font-weight: bold; padding: 12px; background-color: lightgrey"><a href="{{ invite_url }}">Click here to accept this invite.</a></p>
+{% endif %}
+
+<p>When you first access your account, you’ll be directed to your Dashboard. It contains information you may want to view frequently including: Storage Usage, Crawling Info,  Collections, and Monthly Usage History.</p>
+
+
+<p>For more info, check out the <b><a href="https://docs.browsertrix.cloud/user-guide/">Browsertrix Cloud User Guide</a></b></p>
+
+
+<p>
+We want you to get the most from your Browsertrix Cloud experience. Let us know if you need any questions or feedback.
+You can connect with our team at <a href="mailto:{{ support_email }}">{{ support_email }}</a></p>
+
+<p><i>The Webrecorder Team</i></p>
+</body>
+</html>
+~~~
 Hello!
 
 Welcome to Browsertrix Cloud!
@@ -7,21 +38,21 @@ Welcome to Browsertrix Cloud!
 {% if sender %}
 You have been invited by {{ sender }} to join their organization, "{{ org_name }}" on Browsertrix Cloud!
 
-You can join by clicking here: {{ origin }}/invite/accept/{{ token }}?email={{ receiver_email }}
 {% else %}
 
-You can join by clicking here: {{ origin }}/join/{{ token }}?email={{ receiver_email }}
+You can join by clicking here: {{ invite_url }}
 {% endif %}
 
 When you first access your account, you’ll be directed to your Dashboard. It contains information you may want to view frequently including: Storage Usage, Crawling Info,  Collections, and Monthly Usage History.
 
-For more info, check out the <a href="https://docs.browsertrix.cloud/user-guide/">Browsertrix Cloud User Guide</a>
+For more info, check out Browsertrix Cloud User Guide at: https://docs.browsertrix.cloud/user-guide/
 
 
-If you ever need to reset your password, go here: <a href="{{ origin }}/log-in/forgot-password">Reset my password please!</a>
+If you ever need to reset your password, go here: {{ origin }}/log-in/forgot-password
 
 
 We want you to get the most from your Browsertrix Cloud experience. Let us know if you need any questions or feedback.
-You can connect with our team at {{ email }}.
+You can connect with our team at {{ support_email }}.
 
-Webrecorder Team
+
+

--- a/chart/email-templates/invite
+++ b/chart/email-templates/invite
@@ -1,0 +1,27 @@
+Subject: Welcome to Browsertrix Cloud!
+
+Hello!
+
+Welcome to Browsertrix Cloud!
+
+{% if sender %}
+You have been invited by {{ sender }} to join their organization, "{{ org_name }}" on Browsertrix Cloud!
+
+You can join by clicking here: {{ origin }}/invite/accept/{{ token }}?email={{ receiver_email }}
+{% else %}
+
+You can join by clicking here: {{ origin }}/join/{{ token }}?email={{ receiver_email }}
+{% endif %}
+
+When you first access your account, you’ll be directed to your Dashboard. It contains information you may want to view frequently including: Storage Usage, Crawling Info,  Collections, and Monthly Usage History.
+
+For more info, check out the <a href="https://docs.browsertrix.cloud/user-guide/">Browsertrix Cloud User Guide</a>
+
+
+If you ever need to reset your password, go here: <a href="{{ origin }}/log-in/forgot-password">Reset my password please!</a>
+
+
+We want you to get the most from your Browsertrix Cloud experience. Let us know if you need any questions or feedback.
+You can connect with our team at {{ email }}.
+
+Webrecorder Team

--- a/chart/email-templates/invite_existing
+++ b/chart/email-templates/invite_existing
@@ -1,7 +1,0 @@
-You've been invited to join "{{ org_name }}" on Browsertrix Cloud
-~~~
-You are invited by {{ sender }} to join their organization, "{{ org_name }}" on Browsertrix Cloud!
-
-You can join by clicking here: {{ origin }}/invite/accept/{{ token }}?email={receiver_email}
-
-The invite token is: {{ token }}

--- a/chart/email-templates/invite_existing
+++ b/chart/email-templates/invite_existing
@@ -1,5 +1,5 @@
-Subject: You've been invited to join "{{ org_name }}" on Browsertrix Cloud
-
+You've been invited to join "{{ org_name }}" on Browsertrix Cloud
+~~~
 You are invited by {{ sender }} to join their organization, "{{ org_name }}" on Browsertrix Cloud!
 
 You can join by clicking here: {{ origin }}/invite/accept/{{ token }}?email={receiver_email}

--- a/chart/email-templates/invite_existing
+++ b/chart/email-templates/invite_existing
@@ -1,0 +1,7 @@
+Subject: You've been invited to join "{{ org_name }}" on Browsertrix Cloud
+
+You are invited by {{ sender }} to join their organization, "{{ org_name }}" on Browsertrix Cloud!
+
+You can join by clicking here: {{ origin }}/invite/accept/{{ token }}?email={receiver_email}
+
+The invite token is: {{ token }}

--- a/chart/email-templates/password_reset
+++ b/chart/email-templates/password_reset
@@ -1,0 +1,4 @@
+Subject: Password Reset
+
+We received your password reset request. Please click here: {{ origin }}/reset-password?token={{ token }}
+to create a new password.

--- a/chart/email-templates/password_reset
+++ b/chart/email-templates/password_reset
@@ -1,4 +1,4 @@
-Subject: Password Reset
-
+Password Reset
+~~~
 We received your password reset request. Please click here: {{ origin }}/reset-password?token={{ token }}
 to create a new password.

--- a/chart/email-templates/password_reset
+++ b/chart/email-templates/password_reset
@@ -1,4 +1,10 @@
 Password Reset
 ~~~
-We received your password reset request. Please click here: {{ origin }}/reset-password?token={{ token }}
-to create a new password.
+We received your password reset request.
+
+If you were locked out of your account, this request is sent automatically.
+
+If you did not attempt to log in and did not request this email, please let us know immediately at:
+{{ support_email }}
+
+Please click here: {{ origin }}/reset-password?token={{ token }} to create a new password.

--- a/chart/email-templates/validate
+++ b/chart/email-templates/validate
@@ -1,5 +1,5 @@
-Subject: Welcome to Browsertrix Cloud, Verify your Registration.
-
+Welcome to Browsertrix Cloud, Verify your Registration.
+~~~
 Please verify your registration for Browsertrix Cloud for {{ receiver_email }}
 
 You can verify by clicking here: {{ origin }}/verify?token={{ token }}

--- a/chart/email-templates/validate
+++ b/chart/email-templates/validate
@@ -1,0 +1,7 @@
+Subject: Welcome to Browsertrix Cloud, Verify your Registration.
+
+Please verify your registration for Browsertrix Cloud for {{ receiver_email }}
+
+You can verify by clicking here: {{ origin }}/verify?token={{ token }}
+
+The verification token is: {{ token }}

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -45,6 +45,10 @@ spec:
           configMap:
             name: app-templates
 
+        - name: email-templates
+          configMap:
+            name: email-templates
+
       containers:
         - name: api
           image: {{ .Values.backend_image }}
@@ -67,6 +71,9 @@ spec:
 
             - name: app-templates
               mountPath: /app/btrixcloud/templates/
+
+            - name: email-templates
+              mountPath: /app/btrixcloud/email-templates/
 
           resources:
             limits:
@@ -138,6 +145,9 @@ spec:
 
             - name: app-templates
               mountPath: /app/btrixcloud/templates/
+
+            - name: email-templates
+              mountPath: /app/btrixcloud/email-templates/
 
           resources:
             limits:

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -48,6 +48,8 @@ data:
 
   STORAGES_JSON: "/ops-configs/storages.json"
 
+  SUPPORT_EMAIL: "{{ .Values.email.support_email }}"
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -135,3 +137,13 @@ metadata:
 
 data:
 {{ (.Files.Glob "app-templates/*.yaml").AsConfig | indent 2 }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: email-templates
+  namespace: {{ .Release.Namespace }}
+
+data:
+{{ (.Files.Glob "email-templates/*").AsConfig | indent 2 }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -48,8 +48,6 @@ data:
 
   STORAGES_JSON: "/ops-configs/storages.json"
 
-  SUPPORT_EMAIL: "{{ .Values.email.support_email }}"
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -15,6 +15,7 @@ stringData:
   EMAIL_REPLY_TO: "{{ .Values.email.reply_to }}"
   EMAIL_PASSWORD: "{{ .Values.email.password }}"
   EMAIL_SMTP_USE_TLS: "{{ .Values.email.use_tls }}"
+  EMAIL_SUPPORT: "{{ .Values.email.support_email }}"
 
   SUPERUSER_EMAIL: "{{ .Values.superuser.email }}"
   SUPERUSER_PASSWORD: "{{ .Values.superuser.password }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -293,6 +293,7 @@ email:
   password: password
   reply_to_email: example@example.com
   use_tls: True
+  support_email: support@example.com
 
 
 # Deployment options


### PR DESCRIPTION
Emails are now processed from Jinja2 templates found in `charts/email-templates`, to support easier updates via helm chart in the future.
The available templates are: `invite`, `password_reset`, `validate` and `failed_bg_job`.
Each template can be text only or also include HTML. The format of the template is:
```
subject
~~~
<html content>
~~~
text
```

Currently, only the invite template includes an HTML version, other templates are text only.
A new `support_email` field is also added to the email block in values.yaml

### Invite Template

Current invite template, configured in `charts/email-templates/invite` is as follows:
<img width="980" alt="Screenshot 2023-11-14 at 10 37 56 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/9e6d2bc5-d479-4f51-a111-0689e669b6d6">

The same template is used for new and existing users, with slightly different text if adding user to an existing org.

If user is invited by the superadmin, the invited by field is not included, otherwise it also includes 'You have been invited by X to join Y'

### Password Reset Template

The password reset template has also been updated (just text so far):

<img width="969" alt="Screenshot 2023-11-14 at 10 39 12 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/1015759/90f67892-4bbd-4bd0-a398-147713d4d183">


