### PR TITLE
Improves user documentation intro

### DIFF
--- a/docs/develop/docs.md
+++ b/docs/develop/docs.md
@@ -110,20 +110,20 @@ There are a lot of different options provided by Material for MkDocs — So many
 ???+ Note
     The default call-out, used to highlight something if there isn't a more relevant one — should generally be expanded by default but can be collapsable by the user if the note is long.
 
-!!! Tip "Tip — May have a title stating the tip or best practice"
+!!! Tip "Tip: May have a title stating the tip or best practice"
     Used to highlight a point that is useful for everyone to understand about the documented subject — should be expanded and kept brief.
 
-???+ Info "Info — Must have a title describing the context under which this information is useful"
+???+ Info "Info: Must have a title describing the context under which this information is useful"
     Used to deliver context-based content such as things that are dependant on operating system or environment — should be collapsed by default.
 
-???+ Example "Example — Must have a title describing the content"
+???+ Example "Example: Must have a title describing the content"
     Used to deliver additional information about a feature that could be useful in a _specific circumstance_ or that might not otherwise be considered — should be collapsed by default.
 
-???+ Question "Question — Must have a title phrased in the form of a question"
+???+ Question "Question: Must have a title phrased in the form of a question"
     Used to answer frequently asked questions about the documented subject — should be collapsed by default.
 
-!!! Warning "Warning — Must have a title stating the warning"
+!!! Warning "Warning: Must have a title stating the warning"
     Used to deliver important information — should always be expanded.
 
-!!! Danger "Danger — Must have a title stating the warning"
+!!! Danger "Danger: Must have a title stating the warning"
     Used to deliver information about serious unrecoverable actions such as deleting large amounts of data or resetting things — should always be expanded.

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,6 +1,6 @@
 # Archived Items
 
-Archived Items consist of one or more WACZ files created by a Crawl Workflow, or uploaded to Browsertrix. They can be individually replayed, or combind with other Archived Items in a a [Collection](collections.md).  The Archived Items page lists all items in the organization.
+Archived Items consist of one or more WACZ files created by a Crawl Workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other Archived Items in a a [Collection](collections.md).  The Archived Items page lists all items in the organization.
 
 ## Uploading Web Archives
 
@@ -24,11 +24,11 @@ For more details on navigating web archives within ReplayWeb.page, see the [Repl
 
 ### Files
 
-The Fies tab lists the individually downloadable WACZ files that make up the Archived Item as well as their file sizes.
+The Files tab lists the individually downloadable WACZ files that make up the Archived Item as well as their file sizes.
 
 ### Error Logs
 
-The Error Logs tab displays a list of errors encountered durring crawling. Clicking an errors in the list will reveal additional information.
+The Error Logs tab displays a list of errors encountered during crawling. Clicking an errors in the list will reveal additional information.
 
 All log entries with that were recorded in the creation of the Archived Item can be downloaded in JSONL format by pressing the _Download Logs_ button.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -2,7 +2,7 @@
 
 Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configued, with any cookies or saved login sessions. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
 
-!!! tip "Best practice — Create and use web archiving-specific accounts for crawling with browser profiles"
+!!! tip "Best practice: Create and use web archiving-specific accounts for crawling with browser profiles"
 
     For the following reasons, we recommend creating dedicated accounts for archiving anything that is locked behind login credentials but otherwise public, especially on social media platforms.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -1,6 +1,6 @@
 # Browser Profiles
 
-Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configued, with any cookies or saved login sessions. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
+Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configured, with any cookies or saved login sessions. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
 
 !!! tip "Best practice: Create and use web archiving-specific accounts for crawling with browser profiles"
 

--- a/docs/user-guide/collections.md
+++ b/docs/user-guide/collections.md
@@ -3,7 +3,7 @@
 Collections are the primary way of organizing and combining archived items into groups for presentation.
 
 !!! tip "Tip — Combining items from multiple sources"
-    If the crawler has not captured every resource or interaction on a webpage, the [ArchiveWebpage browser extension](https://archiveweb.page/) can be used to manually capture missing content and upload it directly to your org.
+    If the crawler has not captured every resource or interaction on a webpage, the [ArchiveWeb.page browser extension](https://archiveweb.page/) can be used to manually capture missing content and upload it directly to your org.
 
     After adding the crawl and the upload to a collection, the content from both will become available in the replay viewer.
 
@@ -19,4 +19,4 @@ Collections are private by default, but can be made public by marking them as sh
 
 After a collection has been made public, it can be shared with others using the public URL available in the share collection dialogue. The collection can also be embedded into other websites using the provided embed code. Unsharing the collection will break any previously shared links.
 
-For further resources on embedding archived web content into your own website, see the [ReplayWebpage docs page on embedding](https://replayweb.page/docs/embedding).
+For further resources on embedding archived web content into your own website, see the [ReplayWeb.page docs page on embedding](https://replayweb.page/docs/embedding).

--- a/docs/user-guide/collections.md
+++ b/docs/user-guide/collections.md
@@ -2,7 +2,7 @@
 
 Collections are the primary way of organizing and combining archived items into groups for presentation.
 
-!!! tip "Tip — Combining items from multiple sources"
+!!! tip "Tip: Combining items from multiple sources"
     If the crawler has not captured every resource or interaction on a webpage, the [ArchiveWeb.page browser extension](https://archiveweb.page/) can be used to manually capture missing content and upload it directly to your org.
 
     After adding the crawl and the upload to a collection, the content from both will become available in the replay viewer.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,26 +1,26 @@
 # Browsertrix User Guide
 
-Welcome to the Browsertrix User Guide. This guide covers the basics of using Browsertrix high-fidelity web archiving system as a new user.
+Welcome to the Browsertrix User Guide. This page covers the basics of using Browsertrix, Webrecorder's high-fidelity web archiving system.
 
 ## Getting Started
 
-To get started crawling with Browsertrix Cloud, you can:
+To get started crawling with Browsertrix:
 
-1. Create an account as described on [sign-up](signup) and join an Organization.
-2. You'll be redirected to the [Organization Overview](overview) page.
-3. From here, you can click **+ Create New** button in the top right and select [Crawl Workflow](crawl-workflows) to begin configuring your first crawl!
-4. For a simple crawl, you can choose Seeded Crawl option, and enter a page url in the *Crawl Start URL* box. (By default, the crawler will crawl all pages under the starting path).
-5. Next, click *Review & Save*, and ensure the *Run on Save* option is selected. Then click *Save Workflow*
-6. Your crawl should now be starting up!
+1. Create an account and join an Organization [as described here](signup).
+2. After being redirected to the organization's [Overview page](overview), click the _Create New_ button in the top right and select _[Crawl Workflow](crawl-workflows)_ to begin configuring your first crawl!
+3. For a simple crawl, choose the _Seeded Crawl_ option, and enter a page url in the _Crawl Start URL_ field. By default, the crawler will archive all pages under the starting path.
+4. Next, click _Review & Save_, and ensure the _Run on Save_ option is selected. Then click _Save Workflow_.
+5. Wait a moment for the crawler to start and watch as it archives the website!
 
-<hr>
-This guide provides additional topics around crawling and curation, including:
+---
+
+After running your first crawl, check out the following to learn more about Browsertrix's features:
 
 - A detailed list of [crawl workflow setup](workflow-setup) options.
 - Adding [exclusions](workflow-setup/#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](crawl-workflows/#live-exclusion-editing).
 - Best practices for crawling with [browser profiles](browser-profiles) to capture content only available when logged in to a website.
-- Managing archived items, including [uploading external archives](archived-items/#uploading-web-archives).
-- Organizing and combining archived items with [Collections](collections) for sharing and export.
+- Managing archived items, including [uploading previously archived content](archived-items/#uploading-web-archives).
+- Organizing and combining archived items with [collections](collections) for sharing and export.
 - If you're an admin: [Inviting collaborators to your org](org-settings/#members).
 
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -26,4 +26,4 @@ After running your first crawl, check out the following to learn more about Brow
 
 ### Have more questions?
 
-While our aim is to create intuitive interfaces, sometimes the complexities of web archiving require a little more explanation. If there's something that you found especially confusing or frustrating [please get in touch](docs-feedback@webrecorder.net)!
+While our aim is to create intuitive interfaces, sometimes the complexities of web archiving require a little more explanation. If there's something that you found especially confusing or frustrating [please get in touch](mailto:docs-feedback@webrecorder.net)!

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,14 +1,29 @@
 # Browsertrix User Guide
 
-Welcome to the Browsertrix user guide! While our aim is to create intuitive interfaces, sometimes the complexities of web archiving require a little more explanation. If there's something that you found especially confusing or frustrating [please get in touch](docs-feedback@webrecorder.net)!
+Welcome to the Browsertrix User Guide. This guide covers the basics of using Browsertrix high-fidelity web archiving system as a new user.
 
 ## Getting Started
 
-A [Crawl Workflow](crawl-workflows) must be created in order to crawl websites automatically. A detailed list of all available workflow configuration options can be found on the [Crawl Workflow Setup](workflow-setup) page.
+To get started crawling with Browsertrix Cloud, you can:
 
-Once you've created your first Crawl Workflow, here's a few more topics you may want to delve into:
+1. Create an account as described on [sign-up](signup) and join an Organization.
+2. You'll be redirected to the [Organization Overview](overview) page.
+3. From here, you can click **+ Create New** button in the top right and select [Crawl Workflow](crawl-workflows) to begin configuring your first crawl!
+4. For a simple crawl, you can choose Seeded Crawl option, and enter a page url in the *Crawl Start URL* box. (By default, the crawler will crawl all pages under the starting path).
+5. Next, click *Review & Save*, and ensure the *Run on Save* option is selected. Then click *Save Workflow*
+6. Your crawl should now be starting up!
 
+<hr>
+This guide provides additional topics around crawling and curation, including:
+
+- A detailed list of [crawl workflow setup](workflow-setup) options.
 - Adding [exclusions](workflow-setup/#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](crawl-workflows/#live-exclusion-editing).
 - Best practices for crawling with [browser profiles](browser-profiles) to capture content only available when logged in to a website.
+- Managing archived items, including [uploading external archives](archived-items/#uploading-web-archives).
 - Organizing and combining archived items with [Collections](collections) for sharing and export.
 - If you're an admin: [Inviting collaborators to your org](org-settings/#members).
+
+
+### Have more questions?
+
+While our aim is to create intuitive interfaces, sometimes the complexities of web archiving require a little more explanation. If there's something that you found especially confusing or frustrating [please get in touch](docs-feedback@webrecorder.net)!

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,7 +1,14 @@
 # Browsertrix User Guide
 
-Welcome to the Browsertrix user guide! 
+Welcome to the Browsertrix user guide! While our aim with our software is to create interfaces so intuitive no additional explination is needed, sometimes the complexities of web archiving require a little more expansion. If there's something that you found especially confusing or frustrating and — after searching for it here — no satisfactory answer was given, we'd like to know about it, [please get in touch](docs-feedback@webrecorder.net)!
 
 ## Getting Started
 
 A [Crawl Workflow](crawl-workflows) must be created in order to crawl websites automatically. A detailed list of all available workflow configuration options can be found on the [Crawl Workflow Setup](workflow-setup) page.
+
+Once you've created your first Crawl Workflow, here's a few more topics you may want to delve into:
+
+- Adding [exclusions](workflow-setup/#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](crawl-workflows/#live-exclusion-editing).
+- Best practices for crawling with [browser profiles](browser-profiles) to capture content only available when logged in to a website.
+- Organizing and combining archived items with [Collections](collections) for sharing and export.
+- If you're an admin: [Inviting collaborators to your org](org-settings/#members).

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,6 +1,6 @@
 # Browsertrix User Guide
 
-Welcome to the Browsertrix user guide! While our aim with our software is to create interfaces so intuitive no additional explination is needed, sometimes the complexities of web archiving require a little more expansion. If there's something that you found especially confusing or frustrating and — after searching for it here — no satisfactory answer was given, we'd like to know about it, [please get in touch](docs-feedback@webrecorder.net)!
+Welcome to the Browsertrix user guide! While our aim with our software is to create interfaces so intuitive no additional explination is needed, sometimes the complexities of web archiving require a little more expansion. If there's something that you found especially confusing or frustrating and — after searching for it here — if no satisfactory answer was given, we'd like to know about it, [please get in touch](docs-feedback@webrecorder.net)!
 
 ## Getting Started
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,6 +1,6 @@
 # Browsertrix User Guide
 
-Welcome to the Browsertrix user guide! While our aim with our software is to create interfaces so intuitive no additional explination is needed, sometimes the complexities of web archiving require a little more expansion. If there's something that you found especially confusing or frustrating and — after searching for it here — if no satisfactory answer was given, we'd like to know about it, [please get in touch](docs-feedback@webrecorder.net)!
+Welcome to the Browsertrix user guide! While our aim is to create intuitive interfaces, sometimes the complexities of web archiving require a little more explanation. If there's something that you found especially confusing or frustrating [please get in touch](docs-feedback@webrecorder.net)!
 
 ## Getting Started
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,17 +1,7 @@
-# Getting Started
+# Browsertrix User Guide
 
-## Signup
+Welcome to the Browsertrix user guide! 
 
-### Invite Link
-
-If you have been sent an [invite](org-settings#members), enter a password and name to create a new account. Your account will be added to the organization you were invited to by an organization admin.
-
-### Open Registration
-
-If the server has enabled signups and you have been given a registration link, enter your email address, password, and name to create a new account. Your account will be added to the server's default organization.
-
----
-
-## Start Crawling!
+## Getting Started
 
 A [Crawl Workflow](crawl-workflows) must be created in order to crawl websites automatically. A detailed list of all available workflow configuration options can be found on the [Crawl Workflow Setup](workflow-setup) page.

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,4 +1,4 @@
-# Overview
+# Org Overview
 
 The overview page delivers key statistics about the organization's resource usage. It also lets users create crawl workflows, uploaded archived items, collections, and browser profiles through the _Create New ..._ button.
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -12,7 +12,7 @@ For all organizations the storage panel displays the total number of archived it
 
 ## Crawling
 
-For orgnaizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT
+For orgnaizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT.
 
 The crawling panel also lists the number of currently running and waiting crawls as well as the number of total pages captured.
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -14,7 +14,7 @@ For all organizations the storage panel displays the total number of archived it
 
 For orgnaizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT.
 
-The crawling panel also lists the number of currently running and waiting crawls as well as the number of total pages captured.
+The crawling panel also lists the number of currently running and waiting crawls, as well as the total number of pages captured.
 
 ## Collections
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -12,7 +12,9 @@ For all organizations the storage panel displays the total number of archived it
 
 ## Crawling
 
-The crawling panel lists the amount of currently running and waiting crawls as well as the number of total pages captured.
+For orgnaizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT
+
+The crawling panel also lists the number of currently running and waiting crawls as well as the number of total pages captured.
 
 ## Collections
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -12,7 +12,7 @@ For all organizations the storage panel displays the total number of archived it
 
 ## Crawling
 
-For orgnaizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT.
+For organizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT.
 
 The crawling panel also lists the number of currently running and waiting crawls, as well as the total number of pages captured.
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -1,0 +1,9 @@
+# Signup
+
+## Invite Link
+
+If you have been sent an [invite](org-settings#members), enter a password and name to create a new account. Your account will be added to the organization you were invited to by an organization admin.
+
+## Open Registration
+
+If the server has enabled signups and you have been given a registration link, enter your email address, password, and name to create a new account. Your account will be added to the server's default organization.

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -2,7 +2,7 @@
 
 ## Invite Link
 
-If you have been sent an [invite](../org-settings/#members), enter a password and name to create a new account. Your account will be added to the organization you were invited to by an organization admin.
+If you have been sent an [invite](../org-settings/#members), enter a name and password to create a new account. Your account will be added to the organization you were invited to by an organization admin.
 
 ## Open Registration
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -2,7 +2,7 @@
 
 ## Invite Link
 
-If you have been sent an [invite](org-settings#members), enter a password and name to create a new account. Your account will be added to the organization you were invited to by an organization admin.
+If you have been sent an [invite](../org-settings/#members), enter a password and name to create a new account. Your account will be added to the organization you were invited to by an organization admin.
 
 ## Open Registration
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -6,4 +6,4 @@ If you have been sent an [invite](../org-settings/#members), enter a name and pa
 
 ## Open Registration
 
-If the server has enabled signups and you have been given a registration link, enter your email address, password, and name to create a new account. Your account will be added to the server's default organization.
+If the server has enabled signups and you have been given a registration link, enter your email address, name, and password to create a new account. Your account will be added to the server's default organization.

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -27,7 +27,7 @@ It is also available under the _Additional URLs_ section for Seeded Crawls where
 When enabled, the crawler will visit all the links it finds within each page defined in the _List of URLs_ field.
 
 ??? example "Crawling tags & search queries with URL List crawls"
-    This setting can be useful for crawling the content of specific tags or searh queries. Specify the tag or search query URL(s) in the _List of URLs_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
+    This setting can be useful for crawling the content of specific tags or search queries. Specify the tag or search query URL(s) in the _List of URLs_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
 
 ### Fail Crawl on Failed URL
 
@@ -205,7 +205,7 @@ Leave optional notes about the workflow's configuration.
 
 ### Tags
 
-Apply tags to the workflow. Tags applied to the workflow will propigate to every crawl created with it at the time of crawl creation.
+Apply tags to the workflow. Tags applied to the workflow will propagate to every crawl created with it at the time of crawl creation.
 
 ### Collection Auto-Add
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,11 +59,11 @@ nav:
   - User Guide:
       - user-guide/index.md
       - user-guide/signup.md
-      - user-guide/overview.md
       - Crawling:
         - user-guide/crawl-workflows.md
         - user-guide/workflow-setup.md
         - user-guide/browser-profiles.md
+      - user-guide/overview.md
       - user-guide/archived-items.md
       - user-guide/collections.md
       - user-guide/org-settings.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,8 +57,8 @@ nav:
       - develop/frontend-dev.md
       - develop/docs.md
   - User Guide:
-      - user-guide/overview.md
       - user-guide/index.md
+      - user-guide/overview.md
       - Crawling:
         - user-guide/crawl-workflows.md
         - user-guide/workflow-setup.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - develop/docs.md
   - User Guide:
       - user-guide/index.md
+      - user-guide/signup.md
       - user-guide/overview.md
       - Crawling:
         - user-guide/crawl-workflows.md


### PR DESCRIPTION
Closes #1369 

### Changes
- Adds improved getting started steps and intro contact information to the User Guide homepage
- Adds a small section about the execution minutes graph for orgs with a quota set
- Moves existing signup content to a dedicated signup page
- Changes admonitions from using em dashes to using colons.
  - Em dashes are great and I love em.... But sometimes I love them a little _too_ much and they were a bad fit here.
- Fixes user guide homepage link
- Fixes `ReplayWeb.page` and `ArchiveWeb.page` names
- Fixes broken links (would be good to have a CI system for this I think)