### PR TITLE
Add API endpoint to retry all failed bg jobs

### DIFF
--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -90,7 +90,14 @@ def main():
     storage_ops = init_storages_api(org_ops, crawl_manager)
 
     background_job_ops = init_background_jobs_api(
-        mdb, email, user_manager, org_ops, crawl_manager, storage_ops
+        app,
+        mdb,
+        email,
+        user_manager,
+        org_ops,
+        crawl_manager,
+        storage_ops,
+        current_active_user,
     )
 
     profiles = init_profiles_api(

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -10,7 +10,7 @@ API_PREFIX = HOST_PREFIX + "/api"
 ADMIN_USERNAME = "admin@example.com"
 ADMIN_PW = "PASSW0RD!"
 
-CRAWLER_USERNAME = "crawler@example.com"
+CRAWLER_USERNAME = "crawlernightly@example.com"
 CRAWLER_PW = "crawlerPASSWORD!"
 
 

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -10,6 +10,9 @@ API_PREFIX = HOST_PREFIX + "/api"
 ADMIN_USERNAME = "admin@example.com"
 ADMIN_PW = "PASSW0RD!"
 
+CRAWLER_USERNAME = "crawler@example.com"
+CRAWLER_PW = "crawlerPASSWORD!"
+
 
 @pytest.fixture(scope="session")
 def admin_auth_headers():
@@ -42,6 +45,32 @@ def default_org_id(admin_auth_headers):
         except:
             print("Waiting for default org id")
             time.sleep(5)
+
+
+@pytest.fixture(scope="session")
+def crawler_auth_headers(admin_auth_headers, default_org_id):
+    requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/add-user",
+        json={
+            "email": CRAWLER_USERNAME,
+            "password": CRAWLER_PW,
+            "name": "new-crawler",
+            "description": "crawler test crawl",
+            "role": 20,
+        },
+        headers=admin_auth_headers,
+    )
+    r = requests.post(
+        f"{API_PREFIX}/auth/jwt/login",
+        data={
+            "username": CRAWLER_USERNAME,
+            "password": CRAWLER_PW,
+            "grant_type": "password",
+        },
+    )
+    data = r.json()
+    access_token = data.get("access_token")
+    return {"Authorization": f"Bearer {access_token}"}
 
 
 @pytest.fixture(scope="session")

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -98,3 +98,11 @@ def test_get_background_job(admin_auth_headers, default_org_id):
     assert data["object_type"]
     assert data["object_id"]
     assert data["replica_storage"]
+
+
+def test_retry_all_failed_bg_jobs_not_superuser(crawler_auth_headers):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/all/jobs/retryFailed", headers=crawler_auth_headers
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Not Allowed"

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -101,7 +101,7 @@ def test_get_background_job(admin_auth_headers, default_org_id):
 
 
 def test_retry_all_failed_bg_jobs_not_superuser(crawler_auth_headers):
-    r = requests.get(
+    r = requests.post(
         f"{API_PREFIX}/orgs/all/jobs/retryFailed", headers=crawler_auth_headers
     )
     assert r.status_code == 403


### PR DESCRIPTION
Fixes #1395 

Adds new `POST /orgs/jobs/retryFailed` API endpoint to retry all failed background jobs.

Tested manually on local dev instance by setting invalid secret key for replica storage, starting a few crawls/uploads, waiting for replica jobs to fail, then calling new endpoint and verifying via `GET /orgs/jobs` that the failed jobs were restarted.