### PR TITLE
Fix crawl list action menu positioning

### DIFF
--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -27,7 +27,7 @@ import queryString from "query-string";
 import type { Button } from "./button";
 import { RelativeDuration } from "./relative-duration";
 import type { Crawl } from "../types/crawler";
-import { srOnly, truncate, dropdown } from "../utils/css";
+import { srOnly, truncate } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { isActive } from "../utils/crawler";
 
@@ -77,7 +77,6 @@ const hostVars = css`
 export class CrawlListItem extends LitElement {
   static styles = [
     truncate,
-    dropdown,
     rowCss,
     columnCss,
     hostVars,

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -227,10 +227,7 @@ export class CrawlListItem extends LitElement {
       class="item row"
       role="button"
       @click=${async (e: MouseEvent) => {
-        if (
-          e.target === this.dropdownTrigger &&
-          !this.dropdownTrigger.disabled
-        ) {
+        if (e.target === this.dropdownTrigger && this.hasMenuItems) {
           return;
         }
         e.preventDefault();
@@ -394,6 +391,11 @@ export class CrawlListItem extends LitElement {
         <slot
           name="menu"
           @slotchange=${() => (this.hasMenuItems = this.menuArr.length > 0)}
+          @click=${(e: MouseEvent) => {
+            // Prevent navigation to detail view
+            e.preventDefault();
+            e.stopPropagation();
+          }}
         ></slot>
       </sl-dropdown>
     </div>`;

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -30,6 +30,7 @@ import type { Crawl } from "../types/crawler";
 import { srOnly, truncate } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { isActive } from "../utils/crawler";
+import type { DropdownMenu } from "./dropdown-menu";
 
 const mediumBreakpointCss = css`30rem`;
 const largeBreakpointCss = css`60rem`;
@@ -167,14 +168,6 @@ export class CrawlListItem extends LitElement {
         align-items: center;
         justify-content: center;
       }
-
-      .dropdownTrigger {
-        font-size: 1rem;
-      }
-
-      .dropdownTrigger[disabled] {
-        visibility: hidden;
-      }
     `,
   ];
 
@@ -193,15 +186,8 @@ export class CrawlListItem extends LitElement {
   @query(".row")
   row!: HTMLElement;
 
-  // TODO consolidate with btrix-combobox
-  @query(".dropdown")
-  dropdown!: HTMLElement;
-
-  @query(".dropdownTrigger")
-  dropdownTrigger!: SlIconButton;
-
-  @queryAssignedElements({ selector: "sl-menu", slot: "menu" })
-  private menuArr!: Array<SlMenu>;
+  @query("btrix-dropdown-menu")
+  dropdownMenu!: DropdownMenu;
 
   @state()
   private hasMenuItems?: boolean;
@@ -226,7 +212,7 @@ export class CrawlListItem extends LitElement {
       class="item row"
       role="button"
       @click=${async (e: MouseEvent) => {
-        if (e.target === this.dropdownTrigger && this.hasMenuItems) {
+        if (e.target === this.dropdownMenu) {
           return;
         }
         e.preventDefault();
@@ -378,25 +364,16 @@ export class CrawlListItem extends LitElement {
 
   private renderActions() {
     return html` <div class="col action">
-      <sl-dropdown ?disabled=${!this.hasMenuItems}>
-        <sl-icon-button
-          slot="trigger"
-          class="dropdownTrigger"
-          label=${msg("Actions")}
-          name="three-dots-vertical"
-          ?disabled=${!this.hasMenuItems}
-        >
-        </sl-icon-button>
+      <btrix-dropdown-menu>
         <slot
           name="menu"
-          @slotchange=${() => (this.hasMenuItems = this.menuArr.length > 0)}
           @click=${(e: MouseEvent) => {
             // Prevent navigation to detail view
             e.preventDefault();
             e.stopPropagation();
           }}
         ></slot>
-      </sl-dropdown>
+      </btrix-dropdown-menu>
     </div>`;
   }
 }

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -11,6 +11,7 @@
  * </btrix-crawl-list>
  * ```
  */
+import type { TemplateResult } from "lit";
 import { LitElement, html, css } from "lit";
 import {
   customElement,
@@ -325,7 +326,9 @@ export class CrawlListItem extends LitElement {
     </div>`;
   }
 
-  private safeRender(render: (crawl: Crawl) => any) {
+  private safeRender(
+    render: (crawl: Crawl) => string | TemplateResult<1> | undefined
+  ) {
     if (!this.crawl) {
       return html`<sl-skeleton></sl-skeleton>`;
     }
@@ -337,7 +340,7 @@ export class CrawlListItem extends LitElement {
     if (!crawl.firstSeed)
       return html`<span class="truncate">${crawl.id}</span>`;
     const remainder = crawl.seedCount - 1;
-    let nameSuffix: any = "";
+    let nameSuffix: string | TemplateResult<1> = "";
     if (remainder) {
       if (remainder === 1) {
         nameSuffix = html`<span class="additionalUrls"

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -30,7 +30,7 @@ import type { Crawl } from "../types/crawler";
 import { srOnly, truncate } from "../utils/css";
 import type { NavigateEvent } from "../utils/LiteElement";
 import { isActive } from "../utils/crawler";
-import type { DropdownMenu } from "./dropdown-menu";
+import type { OverflowDropdown } from "./overflow-dropdown";
 
 const mediumBreakpointCss = css`30rem`;
 const largeBreakpointCss = css`60rem`;
@@ -186,8 +186,8 @@ export class CrawlListItem extends LitElement {
   @query(".row")
   row!: HTMLElement;
 
-  @query("btrix-dropdown-menu")
-  dropdownMenu!: DropdownMenu;
+  @query("btrix-overflow-dropdown")
+  dropdownMenu!: OverflowDropdown;
 
   @state()
   private hasMenuItems?: boolean;
@@ -364,7 +364,7 @@ export class CrawlListItem extends LitElement {
 
   private renderActions() {
     return html` <div class="col action">
-      <btrix-dropdown-menu>
+      <btrix-overflow-dropdown>
         <slot
           name="menu"
           @click=${(e: MouseEvent) => {
@@ -373,7 +373,7 @@ export class CrawlListItem extends LitElement {
             e.stopPropagation();
           }}
         ></slot>
-      </btrix-dropdown-menu>
+      </btrix-overflow-dropdown>
     </div>`;
   }
 }

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -21,7 +21,6 @@ import {
 } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import { msg, localized, str } from "@lit/localize";
-import type { SlIconButton, SlMenu } from "@shoelace-style/shoelace";
 import queryString from "query-string";
 
 import type { Button } from "./button";
@@ -188,9 +187,6 @@ export class CrawlListItem extends LitElement {
 
   @query("btrix-overflow-dropdown")
   dropdownMenu!: OverflowDropdown;
-
-  @state()
-  private hasMenuItems?: boolean;
 
   // TODO localize
   private numberFormatter = new Intl.NumberFormat(undefined, {

--- a/frontend/src/components/crawl-list.ts
+++ b/frontend/src/components/crawl-list.ts
@@ -213,10 +213,6 @@ export class CrawlListItem extends LitElement {
   });
 
   render() {
-    return this.renderRow();
-  }
-
-  renderRow() {
     const search =
       this.collectionId || this.workflowId
         ? `?${queryString.stringify(

--- a/frontend/src/components/dropdown-menu.ts
+++ b/frontend/src/components/dropdown-menu.ts
@@ -1,0 +1,47 @@
+import { LitElement, html, css } from "lit";
+import { customElement, state, queryAssignedElements } from "lit/decorators.js";
+import { msg, localized } from "@lit/localize";
+import type { SlMenu } from "@shoelace-style/shoelace";
+
+/**
+ * Dropdown action menu
+ */
+@localized()
+@customElement("btrix-dropdown-menu")
+export class DropdownMenu extends LitElement {
+  static style = [
+    css`
+      .trigger {
+        font-size: 1rem;
+      }
+
+      .trigger[disabled] {
+        visibility: hidden;
+      }
+    `,
+  ];
+
+  @state()
+  private hasMenuItems?: boolean;
+
+  @queryAssignedElements({ selector: "sl-menu", flatten: true })
+  private menu!: Array<SlMenu>;
+
+  render() {
+    return html`
+      <sl-dropdown ?disabled=${!this.hasMenuItems}>
+        <sl-icon-button
+          slot="trigger"
+          class="trigger"
+          label=${msg("Actions")}
+          name="three-dots-vertical"
+          ?disabled=${!this.hasMenuItems}
+        >
+        </sl-icon-button>
+        <slot
+          @slotchange=${() => (this.hasMenuItems = this.menu.length > 0)}
+        ></slot>
+      </sl-dropdown>
+    `;
+  }
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -48,3 +48,4 @@ import("./code");
 import("./pw-strength-alert");
 import("./search-combobox");
 import("./meter");
+import("./dropdown-menu");

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -48,4 +48,4 @@ import("./code");
 import("./pw-strength-alert");
 import("./search-combobox");
 import("./meter");
-import("./dropdown-menu");
+import("./overflow-dropdown");

--- a/frontend/src/components/overflow-dropdown.ts
+++ b/frontend/src/components/overflow-dropdown.ts
@@ -4,11 +4,21 @@ import { msg, localized } from "@lit/localize";
 import type { SlMenu } from "@shoelace-style/shoelace";
 
 /**
- * Dropdown action menu
+ * Dropdown for additional actions.
+ *
+ * Usage:
+ * ```ts
+ * <btrix-overflow-dropdown>
+ *   <sl-menu>
+ *     <sl-menu-item>Item 1</sl-menu-item>
+ *     <sl-menu-item>Item 2</sl-menu-item>
+ *   </sl-menu>
+ *< /btrix-overflow-dropdown>
+ * ```
  */
 @localized()
-@customElement("btrix-dropdown-menu")
-export class DropdownMenu extends LitElement {
+@customElement("btrix-overflow-dropdown")
+export class OverflowDropdown extends LitElement {
   static style = [
     css`
       .trigger {
@@ -24,7 +34,7 @@ export class DropdownMenu extends LitElement {
   @state()
   private hasMenuItems?: boolean;
 
-  @queryAssignedElements({ selector: "sl-menu", flatten: true })
+  @queryAssignedElements({ selector: "sl-menu-item", flatten: true })
   private menu!: Array<SlMenu>;
 
   render() {

--- a/frontend/src/components/overflow-dropdown.ts
+++ b/frontend/src/components/overflow-dropdown.ts
@@ -34,7 +34,7 @@ export class OverflowDropdown extends LitElement {
   @state()
   private hasMenuItems?: boolean;
 
-  @queryAssignedElements({ selector: "sl-menu-item", flatten: true })
+  @queryAssignedElements({ selector: "sl-menu", flatten: true })
   private menu!: Array<SlMenu>;
 
   render() {

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -11,6 +11,7 @@
  * </btrix-workflow-list>
  * ```
  */
+import type { TemplateResult } from "lit";
 import { LitElement, html, css } from "lit";
 import {
   property,
@@ -403,7 +404,9 @@ export class WorkflowListItem extends LitElement {
     </div>`;
   }
 
-  private safeRender(render: (workflow: ListWorkflow) => any) {
+  private safeRender(
+    render: (workflow: ListWorkflow) => string | TemplateResult<1>
+  ) {
     if (!this.workflow) {
       return html`<sl-skeleton></sl-skeleton>`;
     }
@@ -417,7 +420,7 @@ export class WorkflowListItem extends LitElement {
     if (!workflow.firstSeed)
       return html`<span class="truncate">${workflow.id}</span>`;
     const remainder = workflow.seedCount - 1;
-    let nameSuffix: any = "";
+    let nameSuffix: string | TemplateResult<1> = "";
     if (remainder) {
       if (remainder === 1) {
         nameSuffix = html`<span class="additionalUrls"

--- a/frontend/src/components/workflow-list.ts
+++ b/frontend/src/components/workflow-list.ts
@@ -82,7 +82,7 @@ export class WorkflowListItem extends LitElement {
       }
 
       .item {
-        content-visibility: auto;
+        contain: size;
         contain-intrinsic-height: auto 4rem;
         cursor: pointer;
         transition-property: background-color, box-shadow, margin;


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1111 (also reported in https://github.com/webrecorder/browsertrix-cloud/issues/1346)

<!-- Fixes #issue_number -->

### Changes

Refactors `btrix-crawl-list` dropdown action menu to use `sl-dropdown` auto-positioning to fix menu clipping.

### Manual testing

1. Log in as user with crawler permissions and go to "Archived Items"
2. Click "..." action menu button. Verify menu is visible in all wide viewport sizes
3. Regression test:
  - Clicking archived item takes you to detail page
  - Clicking each menu item works as expected
4. Go to "Crawling" page and click into a workflow with items
5. Click "..." in item. Verify menu opens without clipping
6. Log out and log back in as user with viewer permissions
7. Go to "Crawling" page and click into a workflow with items. Verify that "..." action menu button is hidden

### Demo


https://github.com/webrecorder/browsertrix-cloud/assets/4672952/813c08a3-50e9-4ba7-a65e-20c9ecde451e



<!-- ### Follow-ups -->
