### PR TITLE
Prompt user to confirm workflow crawl deletion

### DIFF
--- a/frontend/src/components/dialog.ts
+++ b/frontend/src/components/dialog.ts
@@ -23,14 +23,19 @@ export class Dialog extends SlDialog {
       }
 
       .dialog__title {
-        padding-top: var(--sl-spacing-small);
+        padding-top: calc(var(--sl-spacing-small) + 0.2rem);
         padding-bottom: var(--sl-spacing-small);
-        font-size: var(--sl-font-size-medium);
+        font-size: var(--font-size-base);
         font-weight: var(--sl-font-weight-medium);
+        line-height: 1;
       }
 
       .dialog__close {
-        --header-spacing: var(--sl-spacing-2x-small);
+        --header-spacing: var(--sl-spacing-x-small);
+      }
+
+      .dialog__body {
+        line-height: var(--sl-line-height-normal);
       }
 
       .dialog__footer {

--- a/frontend/src/components/dialog.ts
+++ b/frontend/src/components/dialog.ts
@@ -1,40 +1,43 @@
 import { css } from "lit";
-import SLDialog from "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
+import SlDialog from "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
 import dialogStyles from "@shoelace-style/shoelace/dist/components/dialog/dialog.styles.js";
 import { customElement } from "lit/decorators.js";
 
 /**
- * Customized <sl-dialog>
+ * <sl-dialog> with custom CSS
  *
  * Usage: see https://shoelace.style/components/dialog
  */
 @customElement("btrix-dialog")
-export class Dialog extends SLDialog {
-  static styles = css`
-    ${dialogStyles} .dialog__panel {
-      overflow: hidden;
-    }
+export class Dialog extends SlDialog {
+  static styles = [
+    dialogStyles,
+    css`
+      .dialog__panel {
+        overflow: hidden;
+      }
 
-    .dialog__header {
-      background-color: var(--sl-color-neutral-50);
-      border-bottom: 1px solid var(--sl-color-neutral-100);
-    }
+      .dialog__header {
+        background-color: var(--sl-color-neutral-50);
+        border-bottom: 1px solid var(--sl-color-neutral-100);
+      }
 
-    .dialog__title {
-      padding-top: var(--sl-spacing-small);
-      padding-bottom: var(--sl-spacing-small);
-      font-size: var(--sl-font-size-medium);
-      font-weight: var(--sl-font-weight-medium);
-    }
+      .dialog__title {
+        padding-top: var(--sl-spacing-small);
+        padding-bottom: var(--sl-spacing-small);
+        font-size: var(--sl-font-size-medium);
+        font-weight: var(--sl-font-weight-medium);
+      }
 
-    .dialog__close {
-      --header-spacing: var(--sl-spacing-2x-small);
-    }
+      .dialog__close {
+        --header-spacing: var(--sl-spacing-2x-small);
+      }
 
-    .dialog__footer {
-      padding-top: var(--sl-spacing-small);
-      padding-bottom: var(--sl-spacing-small);
-      border-top: 1px solid var(--sl-color-neutral-100);
-    }
-  `;
+      .dialog__footer {
+        padding-top: var(--sl-spacing-small);
+        padding-bottom: var(--sl-spacing-small);
+        border-top: 1px solid var(--sl-color-neutral-100);
+      }
+    `,
+  ];
 }

--- a/frontend/src/pages/org/components/file-uploader.ts
+++ b/frontend/src/pages/org/components/file-uploader.ts
@@ -454,7 +454,7 @@ export class FileUploader extends LiteElement {
               class="underline hover:no-underline"
               href="${this.orgBasePath}/items/upload/${data.id}"
               @click="${this.navLink.bind(this)}"
-              >View Archive</a
+              >View Item</a
             > `),
           variant: "success",
           icon: "check2-circle",

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -450,22 +450,11 @@ export class CrawlsList extends LiteElement {
         ?open=${this.itemToDelete !== null}
         @sl-after-hide=${() => (this.itemToDelete = null)}
       >
-        ${when(
-          this.itemToDelete?.name,
-          () => html`
-            ${msg(
-              str`Are you sure you want to delete “${this.itemToDelete?.name}”?`
-            )}
-          `,
-          () => html`
-            ${msg(
-              str`Are you sure you want to delete this ${
-                this.itemToDelete?.type === "upload"
-                  ? msg("upload")
-                  : msg("crawl")
-              }?`
-            )}
-          `
+        ${msg("This item will be removed from any Collection it is a part of.")}
+        ${when(this.itemToDelete?.type === "crawl", () =>
+          msg(
+            "All files and logs associated with this item will also be deleted, and the crawl will no longer be visible in its associated Workflow."
+          )
         )}
         <div slot="footer" class="flex justify-between">
           <sl-button size="small" autofocus>${msg("Cancel")}</sl-button>

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -471,7 +471,7 @@ export class CrawlsList extends LiteElement {
           <sl-button size="small" autofocus>${msg("Cancel")}</sl-button>
           <sl-button
             size="small"
-            variant="primary"
+            variant="danger"
             @click=${async () => {
               if (this.itemToDelete) {
                 await this.deleteItem(this.itemToDelete);

--- a/frontend/src/pages/org/crawls-list.ts
+++ b/frontend/src/pages/org/crawls-list.ts
@@ -447,8 +447,8 @@ export class CrawlsList extends LiteElement {
       ></btrix-crawl-metadata-editor>
       <btrix-dialog
         label=${msg("Delete Archived Item?")}
-        ?open=${this.itemToDelete !== null}
-        @sl-after-hide=${() => (this.itemToDelete = null)}
+        ?open=${this.isDeletingItem}
+        @sl-after-hide=${() => (this.isDeletingItem = false)}
       >
         ${msg("This item will be removed from any Collection it is a part of.")}
         ${when(this.itemToDelete?.type === "crawl", () =>
@@ -462,6 +462,7 @@ export class CrawlsList extends LiteElement {
             size="small"
             variant="danger"
             @click=${async () => {
+              this.isDeletingItem = false;
               if (this.itemToDelete) {
                 await this.deleteItem(this.itemToDelete);
               }
@@ -541,7 +542,7 @@ export class CrawlsList extends LiteElement {
           <sl-divider></sl-divider>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"
-            @click=${() => (this.itemToDelete = item)}
+            @click=${() => this.confirmDeleteItem(item)}
           >
             <sl-icon name="trash3" slot="prefix"></sl-icon>
             ${msg("Delete Item")}
@@ -695,6 +696,11 @@ export class CrawlsList extends LiteElement {
     }
   }
 
+  private confirmDeleteItem = (item: Crawl | Upload) => {
+    this.itemToDelete = item;
+    this.isDeletingItem = true;
+  };
+
   private async deleteItem(item: Crawl | Upload) {
     let apiPath;
 
@@ -734,6 +740,9 @@ export class CrawlsList extends LiteElement {
       });
       this.fetchArchivedItems();
     } catch (e: any) {
+      if (this.itemToDelete) {
+        this.confirmDeleteItem(this.itemToDelete);
+      }
       let message = msg(
         str`Sorry, couldn't delete archived item at this time.`
       );

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -389,7 +389,7 @@ export class WorkflowDetail extends LiteElement {
           >
           <sl-button
             size="small"
-            variant="primary"
+            variant="danger"
             @click=${async () => {
               if (this.crawlToDelete) {
                 await this.deleteCrawl(this.crawlToDelete);

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -374,10 +374,7 @@ export class WorkflowDetail extends LiteElement {
         ?open=${this.openDialogName === "delete"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
         @sl-show=${this.showDialog}
-        @sl-after-hide=${() => {
-          this.isDialogVisible = false;
-          this.crawlToDelete = null;
-        }}
+        @sl-after-hide=${() => (this.isDialogVisible = false)}
       >
         ${msg(
           "All files and logs associated with this crawl will also be deleted, and the crawl will be removed from any Collection it is a part of."
@@ -393,10 +390,10 @@ export class WorkflowDetail extends LiteElement {
             size="small"
             variant="danger"
             @click=${async () => {
+              this.openDialogName = undefined;
               if (this.crawlToDelete) {
                 await this.deleteCrawl(this.crawlToDelete);
               }
-              this.openDialogName = undefined;
             }}
             >${msg("Delete Crawl")}</sl-button
           >
@@ -1711,6 +1708,10 @@ export class WorkflowDetail extends LiteElement {
       });
       this.fetchCrawls();
     } catch (e: any) {
+      if (this.crawlToDelete) {
+        this.confirmDeleteCrawl(this.crawlToDelete);
+      }
+
       let message = msg(
         str`Sorry, couldn't delete archived item at this time.`
       );

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -379,7 +379,7 @@ export class WorkflowDetail extends LiteElement {
           this.crawlToDelete = null;
         }}
       >
-        ${msg("Are you sure you want to permanently delete this crawl?")}
+        ${msg("Are you sure you want to delete this crawl?")}
         <div slot="footer" class="flex justify-between">
           <sl-button
             size="small"
@@ -1697,6 +1697,7 @@ export class WorkflowDetail extends LiteElement {
           }),
         }
       );
+      this.crawlToDelete = null;
       this.crawls = {
         ...this.crawls!,
         items: this.crawls!.items.filter((c) => c.id !== crawl.id),

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -108,7 +108,7 @@ export class WorkflowDetail extends LiteElement {
   private isCancelingOrStoppingCrawl: boolean = false;
 
   @state()
-  private crawlToDelete?: Crawl;
+  private crawlToDelete: Crawl | null = null;
 
   @state()
   private filterBy: Partial<Record<keyof Crawl, any>> = {};
@@ -374,7 +374,10 @@ export class WorkflowDetail extends LiteElement {
         ?open=${this.openDialogName === "delete"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
         @sl-show=${this.showDialog}
-        @sl-after-hide=${() => (this.isDialogVisible = false)}
+        @sl-after-hide=${() => {
+          this.isDialogVisible = false;
+          this.crawlToDelete = null;
+        }}
       >
         ${msg("Are you sure you want to permanently delete this crawl?")}
         <div slot="footer" class="flex justify-between">
@@ -391,7 +394,6 @@ export class WorkflowDetail extends LiteElement {
               if (this.crawlToDelete) {
                 await this.deleteCrawl(this.crawlToDelete);
               }
-
               this.openDialogName = undefined;
             }}
             >${msg("Delete Crawl")}</sl-button

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -379,7 +379,9 @@ export class WorkflowDetail extends LiteElement {
           this.crawlToDelete = null;
         }}
       >
-        ${msg("Are you sure you want to delete this crawl?")}
+        ${msg(
+          "All files and logs associated with this crawl will also be deleted, and the crawl will be removed from any Collection it is a part of."
+        )}
         <div slot="footer" class="flex justify-between">
           <sl-button
             size="small"

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -23,6 +23,7 @@ const theme = css`
     /* Custom font variables */
     --font-monostyle-family: var(--sl-font-mono);
     --font-monostyle-variation: "MONO" 0.51, "CASL" 0, "slnt" 0, "CRSV" 0;
+    --font-size-base: 1rem;
 
     /*
      * Shoelace Theme Tokens


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1104

<!-- Fixes #issue_number -->

### Changes

- Adds confirmation dialog for workflow crawls
- Changes archived item confirmation from default browser dialog to shoelace dialog
- Increase dialog title size
- Out of scope: Localizes other workflow detail confirmation buttons
- Out of scope: Reword missed "Archive" reference in file uploader

### Manual testing

1. Log in as user with crawler permissions and go to "Crawling"
2. Click workflow with crawls
3. Click crawl item action menu button -> "Delete Crawl". Verify confirmation is prompted
4. Click "Cancel". Verify crawl is not deleted
5. Repeat 3 and click "Delete Crawl". Verify crawl is deleted
6. Go to "Archived Items"
7. Click item action menu button -> "Delete Item". Repeat 4-5 for item.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail - Crawls | <img width="509" alt="Screenshot 2023-11-20 at 8 36 01 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/5ff77241-b254-46cb-8695-6dfd9f1b6ecd"> |


### Follow-ups

Once crawl downloading is enabled, we could offer users the option to download their crawl before deleting it.
