### PR TITLE
Fix org settings help and info text

### DIFF
--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -213,7 +213,7 @@ export class OrgSettings extends LiteElement {
               help-text=${msg(
                 str`Org home page: ${window.location.protocol}//${
                   window.location.hostname
-                }/${
+                }/orgs/${
                   this.slugValue ? this.slugify(this.slugValue) : this.org.slug
                 }`
               )}

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -249,7 +249,7 @@ export class OrgSettings extends LiteElement {
             <div class="text-base">
               <sl-icon name="info-circle"></sl-icon>
             </div>
-            <div class="mt-0.5 text-xs text-neutral-400">
+            <div class="mt-0.5 text-xs text-neutral-500">
               ${msg(
                 "Use this ID to reference this org in the Browsertrix API."
               )}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1400

<!-- Fixes #issue_number -->

### Changes

- Adds `/orgs` to "Custom URL Identifier" help text
- Fixes color mismatch between info text

### Manual testing

Log in as org admin and go to "Org Settings". Verify "Custom URL Identifier" field help text URL includes `/orgs`.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Org Settings - General | <img width="535" alt="Screenshot 2023-11-20 at 8 48 47 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/2e206dad-0745-47ef-b37a-aa72b6c68e19"> |


<!-- ### Follow-ups -->
