### PR TITLE
Adds a link to the new ReplayWebpage replay issue form in GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Report a replay issue
     about: Issues related to archived content not displaying properly should be reported in the ReplayWeb.page repo.
-    url: https://github.com/webrecorder/replayweb.page/issues/new/choose
+    url: https://github.com/webrecorder/replayweb.page/issues/new?template=replay-bug.yml&title=%5BReplay+Bug%5D%3A+
   - name: Report a security vulnerability
     about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
     url: https://webrecorder.net/.well-known/security.txt

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,8 +2,12 @@
 blank_issues_enabled: true
 
 contact_links:
+  - name: Report a replay issue
+    about: Issues related to archived content not displaying properly should be reported in the ReplayWeb.page repo.
+    url: https://github.com/webrecorder/replayweb.page/issues/new/choose
   - name: Report a security vulnerability
     about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
+    url: mailto:security@webrecorder.org
   - name: Get help on our forum
     url: https://forum.webrecorder.net/
     about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://github.com/webrecorder/replayweb.page/issues/new/choose
   - name: Report a security vulnerability
     about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
-    url: mailto:security@webrecorder.org
+    url: https://webrecorder.net/.well-known/security.txt
   - name: Get help on our forum
     url: https://forum.webrecorder.net/
     about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Report a replay issue
     about: Issues related to archived content not displaying properly should be reported in the ReplayWeb.page repo.
-    url: https://github.com/webrecorder/replayweb.page/issues/new?template=replay-bug.yml&title=%5BReplay+Bug%5D%3A+
+    url: https://github.com/webrecorder/replayweb.page/issues/new?&labels=replay+bug%2Cbug&projects=&template=replay-bug.yml&title=[Replay+Bug]%3A+
   - name: Report a security vulnerability
     about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
     url: https://webrecorder.net/.well-known/security.txt


### PR DESCRIPTION
~~Blocked by https://github.com/webrecorder/replayweb.page/pull/262~~

- Adds a link to the new ReplayWeb.page issue type selection list where users can file replay specific bugs.
- Updates security email URL now that we have one so this actually gets shown!