### PR TITLE
Fix dashboard usage history off-by-one labels

### DIFF
--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -778,7 +778,7 @@ export class Dashboard extends LiteElement {
         const tableRows = [
           html`
             <sl-format-date
-              date="${mY}-01T00:00:00.000Z"
+              date="${mY}-15T00:00:00.000Z"
               timeZone="utc"
               month="long"
               year="numeric"


### PR DESCRIPTION
Fixes #1430 

Uses a date squarely in the middle of the month to avoid timezone differences from displaying the previous month's name for monthly usage and execution time data