### PR TITLE
Fix error when various execution minutes are undefined, and use execution minute formatter for table

### DIFF
--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -78,7 +78,6 @@ describe("browsertrix-app", () => {
             quotas: {},
             bytesStored: 100,
             usage: null,
-            crawlExecSeconds: null,
           },
         ],
       } as APIUser)
@@ -108,7 +107,6 @@ describe("browsertrix-app", () => {
           quotas: {},
           bytesStored: 100,
           usage: null,
-          crawlExecSeconds: null,
         },
       ],
     });

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -517,8 +517,8 @@ export class Dashboard extends LiteElement {
                     ${humanizeExecutionSeconds(
                       quotaSeconds -
                         usageSeconds +
-                        this.org!.extraExecSecondsAvailable +
-                        this.org!.giftedExecSecondsAvailable,
+                        (this.org!.extraExecSecondsAvailable ?? 0) +
+                        (this.org!.giftedExecSecondsAvailable ?? 0),
                       { style: "short", round: "down" }
                     )}
                     <span class="ml-1">${msg("remaining")}</span>
@@ -678,11 +678,15 @@ export class Dashboard extends LiteElement {
     `;
 
   private hasMonthlyTime = () =>
-    Object.keys(this.org!.monthlyExecSeconds).length;
+    this.org?.monthlyExecSeconds &&
+    Object.keys(this.org.monthlyExecSeconds).length;
 
-  private hasExtraTime = () => Object.keys(this.org!.extraExecSeconds).length;
+  private hasExtraTime = () =>
+    this.org?.extraExecSeconds && Object.keys(this.org.extraExecSeconds).length;
 
-  private hasGiftedTime = () => Object.keys(this.org!.giftedExecSeconds).length;
+  private hasGiftedTime = () =>
+    this.org?.giftedExecSeconds &&
+    Object.keys(this.org.giftedExecSeconds).length;
 
   private renderUsageHistory() {
     if (!this.org) return;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -789,22 +789,26 @@ export class Dashboard extends LiteElement {
             >
             </sl-format-date>
           `,
-          humanizeSeconds(crawlTime || 0),
-          totalSecondsUsed ? humanizeSeconds(totalSecondsUsed) : "--",
+          humanizeExecutionSeconds(crawlTime || 0),
+          totalSecondsUsed ? humanizeExecutionSeconds(totalSecondsUsed) : "--",
         ];
         if (this.hasMonthlyTime()) {
           tableRows.push(
-            monthlySecondsUsed ? humanizeSeconds(monthlySecondsUsed) : "--"
+            monthlySecondsUsed
+              ? humanizeExecutionSeconds(monthlySecondsUsed)
+              : "--"
           );
         }
         if (this.hasExtraTime()) {
           tableRows.push(
-            extraSecondsUsed ? humanizeSeconds(extraSecondsUsed) : "--"
+            extraSecondsUsed ? humanizeExecutionSeconds(extraSecondsUsed) : "--"
           );
         }
         if (this.hasGiftedTime()) {
           tableRows.push(
-            giftedSecondsUsed ? humanizeSeconds(giftedSecondsUsed) : "--"
+            giftedSecondsUsed
+              ? humanizeExecutionSeconds(giftedSecondsUsed)
+              : "--"
           );
         }
         return tableRows;

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -18,24 +18,24 @@ export type OrgData = {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   } | null;
-  crawlExecSeconds: {
+  crawlExecSeconds?: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   };
-  monthlyExecSeconds: {
+  monthlyExecSeconds?: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   };
-  extraExecSeconds: {
+  extraExecSeconds?: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   };
-  giftedExecSeconds: {
+  giftedExecSeconds?: {
     // Keyed by {4-digit year}-{2-digit month}
     [key: string]: number;
   };
-  extraExecSecondsAvailable: number;
-  giftedExecSecondsAvailable: number;
+  extraExecSecondsAvailable?: number;
+  giftedExecSecondsAvailable?: number;
   storageQuotaReached?: boolean;
   execMinutesQuotaReached?: boolean;
   users?: {

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -85,4 +85,5 @@ describe("humanizeExecutionSeconds", () => {
     expect(el.textContent?.trim()).to.equal("1 minute");
     expect(parentNode.innerText).to.equal("1 minute");
   });
+  // TODO(emma) test second logic
 });

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -110,7 +110,7 @@ export const humanizeExecutionSeconds = (
 
   // if the time is less than an hour and lines up exactly on the minute, don't render the details.
   const formattedDetails =
-    minutes === Math.floor(seconds / 60) && seconds < 3600
+    (displaySeconds ? seconds % 60 === 0 : true) && seconds < 3600
       ? nothing
       : `\u00a0(${details})`;
 


### PR DESCRIPTION
(Written at SplinterCon by @emma-sg)

## Changes

- `crawlExecSeconds`, `monthlyExecSeconds`, `extraExecSeconds`, `giftedExecSeconds`, `extraExecSecondsAvailable`, and `giftedExecSecondsAvailable` can all be undefined, so I updated their types and the functions that rely on them being non-null
- Updated the data table to use `formatExecutionSeconds` rather than `formatSeconds`
- Fixed an issue in `formatExecutionSeconds` where the time in minutes would sometimes be displayed twice when `options.displaySeconds` was false or unset

## Testing
Tested locally with orgs with and without execution limits of various kinds set