### PR TITLE
Fix fetch helper 

### DIFF
--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -47,7 +47,6 @@ export default class LiteElement extends LitElement {
   /**
    * @deprecated New components should use APIController directly
    */
-  async apiFetch<T = unknown>(...args: Parameters<APIController["fetch"]>) {
-    return this.apiController.fetch<T>(...args);
-  }
+  apiFetch = async <T = unknown>(...args: Parameters<APIController["fetch"]>) =>
+    this.apiController.fetch<T>(...args);
 }


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1441, regression introduced in https://github.com/webrecorder/browsertrix-cloud/pull/1423

### Manual testing

1. Log in and go to "Archived Items"
2. Click a crawl. Verify that "Sorry, couldn't retrieve crawl logs" notification doesn't show and logs fetch as expected.

### Follow-ups

Consistency pass on rest of `LitElement` helpers here: https://github.com/webrecorder/browsertrix-cloud/pull/1443