### PR TITLE
Recreate configmaps if missing

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -802,12 +802,6 @@ class CrawlConfigOps:
         except:
             await self.readd_configmap(crawlconfig, org)
 
-            # pylint: disable=broad-exception-raised,raise-missing-from
-            # raise HTTPException(
-            #    status_code=404,
-            #    detail=f"crawl-config-{cid} missing, can not start crawl",
-            # )
-
         if await self.org_ops.storage_quota_reached(org.id):
             raise HTTPException(status_code=403, detail="storage_quota_reached")
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -254,6 +254,25 @@ class CrawlConfigOps:
 
         return False
 
+    async def readd_configmap(
+        self,
+        crawlconfig: CrawlConfig,
+        org: Organization,
+        profile_filename: Optional[str] = None,
+    ) -> None:
+        """readd configmap that may have been deleted / is invalid"""
+
+        if profile_filename is None:
+            _, profile_filename = await self._lookup_profile(crawlconfig.profileid, org)
+
+        await self.crawl_manager.add_crawl_config(
+            crawlconfig=crawlconfig,
+            storage=org.storage,
+            run_now=False,
+            out_filename=self.default_filename_template,
+            profile_filename=profile_filename or "",
+        )
+
     async def update_crawl_config(
         self, cid: UUID, org: Organization, user: User, update: UpdateCrawlConfig
     ) -> dict[str, bool]:
@@ -352,6 +371,9 @@ class CrawlConfigOps:
                 await self.crawl_manager.update_crawl_config(
                     crawlconfig, update, profile_filename
                 )
+            except FileNotFoundError:
+                await self.readd_configmap(crawlconfig, org, profile_filename)
+
             except Exception as exc:
                 print(exc, flush=True)
                 # pylint: disable=raise-missing-from
@@ -776,12 +798,15 @@ class CrawlConfigOps:
         # ensure crawlconfig exists
         try:
             await self.crawl_manager.get_configmap(crawlconfig.id)
+        # pylint: disable=bare-except
         except:
+            await self.readd_configmap(crawlconfig, org)
+
             # pylint: disable=broad-exception-raised,raise-missing-from
-            raise HTTPException(
-                status_code=404,
-                detail=f"crawl-config-{cid} missing, can not start crawl",
-            )
+            # raise HTTPException(
+            #    status_code=404,
+            #    detail=f"crawl-config-{cid} missing, can not start crawl",
+            # )
 
         if await self.org_ops.storage_quota_reached(org.id):
             raise HTTPException(status_code=403, detail="storage_quota_reached")

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -386,7 +386,11 @@ class CrawlManager(K8sAPI):
         profile_filename: Optional[str] = None,
         update_config: bool = False,
     ) -> None:
-        config_map = await self.get_configmap(str(crawlconfig.id))
+        try:
+            config_map = await self.get_configmap(str(crawlconfig.id))
+        # pylint: disable=raise-missing-from
+        except:
+            raise FileNotFoundError(str(crawlconfig.id))
 
         if update.scale is not None:
             config_map.data["INITIAL_SCALE"] = str(update.scale)


### PR DESCRIPTION
If configmap is missing (eg. was accidentally deleted from k8s) recreate the configmap when updating the crawl workflow or running a crawl. Previously, this would result in an error, but now the configmap should be correctly recreated.

To test:
- delete configmap in k8s, run a crawl
- delete configmap in k8s, update crawl workflow