### PR TITLE
Fix redirect to login page

### DIFF
--- a/frontend/src/features/accounts/account-settings.ts
+++ b/frontend/src/features/accounts/account-settings.ts
@@ -88,9 +88,9 @@ export class RequestVerify extends LitElement {
   }
 }
 
-@needLogin
 @localized()
 @customElement("btrix-account-settings")
+@needLogin
 export class AccountSettings extends LiteElement {
   @property({ type: Object })
   authState?: AuthState;

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -36,9 +36,9 @@ const sortableFields: Record<
 };
 const ABORT_REASON_THROTTLE = "throttled";
 
-@needLogin
 @localized()
 @customElement("btrix-crawls")
+@needLogin
 export class Crawls extends LiteElement {
   @property({ type: Object })
   authState!: AuthState;

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -78,7 +78,6 @@ const defaultTab = "home";
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
-@needLogin
 @localized()
 @customElement("btrix-org")
 export class Org extends LiteElement {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -80,6 +80,7 @@ const UUID_REGEX =
 
 @localized()
 @customElement("btrix-org")
+@needLogin
 export class Org extends LiteElement {
   @property({ type: Object })
   authState?: AuthState;

--- a/frontend/src/pages/orgs.ts
+++ b/frontend/src/pages/orgs.ts
@@ -8,9 +8,9 @@ import LiteElement, { html } from "@/utils/LiteElement";
 import { needLogin } from "@/utils/auth";
 import type { APIPaginatedList } from "@/types/api";
 
-@needLogin
 @localized()
 @customElement("btrix-orgs")
+@needLogin
 export class Orgs extends LiteElement {
   @property({ type: Object })
   authState?: AuthState;

--- a/frontend/src/pages/users-invite.ts
+++ b/frontend/src/pages/users-invite.ts
@@ -6,9 +6,9 @@ import LiteElement, { html } from "@/utils/LiteElement";
 import { needLogin } from "@/utils/auth";
 import type { CurrentUser } from "@/types/user";
 
-@needLogin
 @localized()
 @customElement("btrix-users-invite")
+@needLogin
 export class UsersInvite extends LiteElement {
   @property({ type: Object })
   authState?: AuthState;

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -3,10 +3,13 @@ import type { AuthState } from "@/utils/AuthService";
 import AuthService from "@/utils/AuthService";
 
 /**
- * Block rendering and dispatch event if user is not logged in
+ * Block rendering and dispatch event if user is not logged in.
+ * When using with other class decorators, `@needLogin` should
+ * be closest to the component (see usage example.)
  *
- * Usage example:
+ * @example Usage:
  * ```ts
+ * @customElement("my-component")
  * @needLogin
  * MyComponent extends LiteElement {}
  * ```


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1436, regression introduced in https://github.com/webrecorder/browsertrix-cloud/pull/1381

### Changes

- Changes order of `needLogin` class decorator to fix login redirect
- Documents `needLogin` usage in jsdoc comment

### Manual testing

1. Log in and copy org URL
2. Log out
3. Paste in org URL in browser location bar. Verify that you're redirected to the login page with a notification

### Follow-ups

Could refactor this into a page/route component as part of the ongoing `LiteElement` refactor.