### PR TITLE
Only load webpack-bundle-analyzer if BUNDLE_ANALYZER env var is present

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -10,7 +10,6 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const childProcess = require("child_process");
 const packageJSON = require("./package.json");
 const fs = require("fs");
-const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 const isDevServer = process.env.WEBPACK_SERVE;
 
@@ -175,7 +174,9 @@ const main = {
         },
       ],
     }),
-    ...(process.env.BUNDLE_ANALYZER ? [new BundleAnalyzerPlugin()] : []),
+    ...(process.env.BUNDLE_ANALYZER
+      ? [new (require("webpack-bundle-analyzer").BundleAnalyzerPlugin)()]
+      : []),
   ],
 };
 


### PR DESCRIPTION
Fixes build failing in main

Tested with a local build (`./scripts/build-frontend.sh`)