### PR TITLE
Use execution duration formatter in table view

### DIFF
--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -785,22 +785,26 @@ export class Dashboard extends LiteElement {
             >
             </sl-format-date>
           `,
-          humanizeSeconds(crawlTime || 0),
-          totalSecondsUsed ? humanizeSeconds(totalSecondsUsed) : "--",
+          humanizeExecutionSeconds(crawlTime || 0),
+          totalSecondsUsed ? humanizeExecutionSeconds(totalSecondsUsed) : "--",
         ];
         if (this.hasMonthlyTime()) {
           tableRows.push(
-            monthlySecondsUsed ? humanizeSeconds(monthlySecondsUsed) : "--"
+            monthlySecondsUsed
+              ? humanizeExecutionSeconds(monthlySecondsUsed)
+              : "--"
           );
         }
         if (this.hasExtraTime()) {
           tableRows.push(
-            extraSecondsUsed ? humanizeSeconds(extraSecondsUsed) : "--"
+            extraSecondsUsed ? humanizeExecutionSeconds(extraSecondsUsed) : "--"
           );
         }
         if (this.hasGiftedTime()) {
           tableRows.push(
-            giftedSecondsUsed ? humanizeSeconds(giftedSecondsUsed) : "--"
+            giftedSecondsUsed
+              ? humanizeExecutionSeconds(giftedSecondsUsed)
+              : "--"
           );
         }
         return tableRows;

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -85,4 +85,30 @@ describe("humanizeExecutionSeconds", () => {
     expect(el.textContent?.trim()).to.equal("1 minute");
     expect(parentNode.innerText).to.equal("1 minute");
   });
+  it("formats times correctly with seconds when time lines up to a minute", async () => {
+    const parentNode = document.createElement("div");
+    const el = await fixture(
+      humanizeExecutionSeconds(120, { displaySeconds: true }),
+      {
+        parentNode,
+      }
+    );
+    expect(el.getAttribute("title")).to.equal("2 minutes");
+    expect(el.textContent?.trim()).to.equal("2 minutes");
+    expect(parentNode.innerText).to.equal("2 minutes");
+  });
+  it("formats times correctly with seconds when time doesn't line up to a minute", async () => {
+    const parentNode = document.createElement("div");
+    const el = await fixture(
+      humanizeExecutionSeconds(24, {
+        displaySeconds: true,
+      }),
+      {
+        parentNode,
+      }
+    );
+    expect(el.getAttribute("title")).to.equal("1 minute");
+    expect(el.textContent?.trim()).to.equal("1 minute");
+    expect(parentNode.innerText).to.equal("1 minute\u00a0(0m 24s)");
+  });
 });

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -109,10 +109,11 @@ export const humanizeExecutionSeconds = (
   const details = humanizeSeconds(seconds, locale, displaySeconds);
 
   // if the time is less than an hour and lines up exactly on the minute, don't render the details.
+  const detailsRelevant = displaySeconds
+    ? seconds % 60 !== 0
+    : Math.floor(seconds / 60) === 0 && seconds % 60 !== 0;
   const formattedDetails =
-    minutes === Math.floor(seconds / 60) && seconds < 3600
-      ? nothing
-      : `\u00a0(${details})`;
+    detailsRelevant || seconds > 3600 ? `\u00a0(${details})` : nothing;
 
   switch (style) {
     case "long":


### PR DESCRIPTION
More-or-less cherry-picked from #1433 

## Changes
- Updated the data table to use `formatExecutionSeconds` rather than `formatSeconds`
- Fixed an issue in `formatExecutionSeconds` where the time in minutes would sometimes be displayed twice when `options.displaySeconds` was false or unset

## Testing
Tested locally with orgs with and without execution limits of various kinds set