### PR TITLE
Remove non-prod & optional dependencies when building frontend in ci

### DIFF
--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Localization build
         working-directory: frontend
         run: yarn localize:prepare
+      - name: Remove non-production dependencies
+        working-directory: frontend
+        run: yarn install --frozen-lockfile --ignore-optional --production
       - name: Webpack build
         working-directory: frontend
         run: yarn build


### PR DESCRIPTION
Fixes #1454 

## Motivation

We've had a number of cases recently where a build dependency is added to `devDependencies`, the PR passes the frontend build check (`frontend-build-check.yaml`) in the branch, and then fails the cluster run (`k3d-ci.yaml`) in `main` because the frontend build check installs all dependencies, whereas the cluster run uses the frontend Dockerfile, which skips everything but prod dependencies.

## Changes

This runs an additional step in the frontend build check, after running unit tests and the l10n build but before doing the build, that re-runs `yarn` with the same arguments as are in the frontend Dockerfile, installing just prod dependencies.

This results in slightly longer frontend build check runtimes, but should save us some wasted time fixing broken `main`.