### PR TITLE
Set runNow to false when editing existing workflows

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -263,9 +263,6 @@ export class CrawlConfigEditor extends LiteElement {
   @property({ type: Boolean })
   orgExecutionMinutesQuotaReached = false;
 
-  @property({ type: Boolean })
-  newWorkflow = false;
-
   @state()
   private tagOptions: string[] = [];
 
@@ -457,7 +454,7 @@ export class CrawlConfigEditor extends LiteElement {
 
   private getInitialFormState(): FormState {
     const defaultFormState = getDefaultFormState();
-    if (this.newWorkflow) {
+    if (!this.configId) {
       defaultFormState.runNow = true;
     }
     if (!this.initialWorkflow) return defaultFormState;

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -187,7 +187,7 @@ const getDefaultFormState = (): FormState => ({
     minute: 0,
     period: "AM",
   },
-  runNow: true,
+  runNow: false,
   jobName: "",
   browserProfile: null,
   tags: [],
@@ -262,6 +262,9 @@ export class CrawlConfigEditor extends LiteElement {
 
   @property({ type: Boolean })
   orgExecutionMinutesQuotaReached = false;
+
+  @property({ type: Boolean })
+  newWorkflow = false;
 
   @state()
   private tagOptions: string[] = [];
@@ -454,6 +457,9 @@ export class CrawlConfigEditor extends LiteElement {
 
   private getInitialFormState(): FormState {
     const defaultFormState = getDefaultFormState();
+    if (this.newWorkflow) {
+      defaultFormState.runNow = true;
+    }
     if (!this.initialWorkflow) return defaultFormState;
     const formState: Partial<FormState> = {};
     const seedsConfig = this.initialWorkflow.config;

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -125,6 +125,7 @@ export class WorkflowsNew extends LiteElement {
           ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
           ?orgExecutionMinutesQuotaReached=${this
             .orgExecutionMinutesQuotaReached}
+          ?newWorkflow=${true}
           @reset=${async (e: Event) => {
             await (e.target as LitElement).updateComplete;
             this.dispatchEvent(

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -125,7 +125,6 @@ export class WorkflowsNew extends LiteElement {
           ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
           ?orgExecutionMinutesQuotaReached=${this
             .orgExecutionMinutesQuotaReached}
-          ?newWorkflow=${true}
           @reset=${async (e: Event) => {
             await (e.target as LitElement).updateComplete;
             this.dispatchEvent(


### PR DESCRIPTION
Fixes #1339 

## Screenshots

#### New workflow (only seed URL entered, everything else default)

<img width="1252" alt="Screen Shot 2023-12-14 at 4 10 37 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/47610e0f-809b-40de-9c95-7bf1ec03671b">

#### Editing existing workflow

<img width="1251" alt="Screen Shot 2023-12-14 at 4 12 27 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/a76cacb0-a10f-4408-8cff-bd66d5ee0a91">

## Testing

1. Create new Workflow, verify Run on Save is enabled
2. Edit existing Workflow, verify Run on Save is disabled