### PR TITLE
Add API endpoints for crawl statistics

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -726,12 +726,9 @@ def init_crawls_api(app, user_dep, *args):
 
     @app.get("/orgs/{oid}/crawls/stats", tags=["crawls"])
     async def get_org_crawl_stats(
-        org: Organization = Depends(org_viewer_dep),
+        org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ):
-        if not user.is_superuser:
-            raise HTTPException(status_code=403, detail="Not Allowed")
-
         crawl_stats = await ops.get_crawl_stats(org)
         return stream_dict_list_as_csv(crawl_stats, f"crawling-stats-{org.id}.csv")
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -727,7 +727,6 @@ def init_crawls_api(app, user_dep, *args):
     @app.get("/orgs/{oid}/crawls/stats", tags=["crawls"])
     async def get_org_crawl_stats(
         org: Organization = Depends(org_crawl_dep),
-        user: User = Depends(user_dep),
     ):
         crawl_stats = await ops.get_crawl_stats(org)
         return stream_dict_list_as_csv(crawl_stats, f"crawling-stats-{org.id}.csv")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -6,7 +6,7 @@ import re
 import urllib.parse
 from uuid import UUID
 
-from typing import Optional, List
+from typing import Optional, List, Dict, Union
 
 from fastapi import Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -14,7 +14,7 @@ from redis import asyncio as exceptions
 import pymongo
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import dt_now, parse_jsonl_error_messages
+from .utils import dt_now, parse_jsonl_error_messages, stream_dict_list_as_csv
 from .basecrawls import BaseCrawlOps
 from .models import (
     UpdateCrawl,
@@ -497,6 +497,74 @@ class CrawlOps(BaseCrawlOps):
         except Exception:
             return [], 0
 
+    async def get_crawl_stats(
+        self, org: Optional[Organization] = None
+    ) -> List[Dict[str, Union[str, int]]]:
+        """Return crawl statistics"""
+        # pylint: disable=too-many-locals
+        org_slugs = await self.orgs.get_org_slugs_by_ids()
+        user_emails = await self.user_manager.get_user_emails_by_ids()
+
+        crawls_data: List[Dict[str, Union[str, int]]] = []
+
+        query: Dict[str, Union[str, UUID]] = {"type": "crawl"}
+        if org:
+            query["oid"] = org.id
+
+        async for crawl in self.crawls.find(query):
+            data: Dict[str, Union[str, int]] = {}
+            data["id"] = str(crawl.get("_id"))
+
+            oid = crawl.get("oid")
+            data["oid"] = str(oid)
+            data["org"] = org_slugs[oid]
+
+            data["cid"] = str(crawl.get("cid"))
+            crawl_name = crawl.get("name")
+            data["name"] = f'"{crawl_name}"' if crawl_name else ""
+            data["state"] = crawl.get("state")
+
+            userid = crawl.get("userid")
+            data["userid"] = str(userid)
+            data["user"] = user_emails.get(userid)
+
+            started = crawl.get("started")
+            finished = crawl.get("finished")
+
+            data["started"] = str(started)
+            data["finished"] = str(finished)
+
+            data["duration"] = 0
+            if started and finished:
+                duration = finished - started
+                duration_seconds = int(duration.total_seconds())
+                if duration_seconds:
+                    data["duration"] = duration_seconds
+
+            done_stats = None
+            if crawl.get("stats") and crawl.get("stats").get("done"):
+                done_stats = crawl["stats"]["done"]
+
+            data["pages"] = 0
+            if done_stats:
+                data["pages"] = done_stats
+
+            data["filesize"] = crawl.get("fileSize", 0)
+
+            data["avg_page_time"] = 0
+            if (
+                done_stats
+                and done_stats != 0
+                and started
+                and finished
+                and duration_seconds
+            ):
+                data["avg_page_time"] = int(duration_seconds / done_stats)
+
+            crawls_data.append(data)
+
+        return crawls_data
+
 
 # ============================================================================
 async def recompute_crawl_file_count_and_size(crawls, crawl_id):
@@ -645,6 +713,27 @@ def init_crawls_api(app, user_dep, *args):
         org: Organization = Depends(org_crawl_dep),
     ):
         return await ops.delete_crawls(org, delete_list, "crawl", user)
+
+    @app.get("/orgs/all/crawls/stats", tags=["crawls"])
+    async def get_all_orgs_crawl_stats(
+        user: User = Depends(user_dep),
+    ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
+        crawl_stats = await ops.get_crawl_stats()
+        return stream_dict_list_as_csv(crawl_stats, "crawling-stats.csv")
+
+    @app.get("/orgs/{oid}/crawls/stats", tags=["crawls"])
+    async def get_org_crawl_stats(
+        org: Organization = Depends(org_viewer_dep),
+        user: User = Depends(user_dep),
+    ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
+        crawl_stats = await ops.get_crawl_stats(org)
+        return stream_dict_list_as_csv(crawl_stats, f"crawling-stats-{org.id}.csv")
 
     @app.get(
         "/orgs/all/crawls/{crawl_id}/replay.json",

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1,6 +1,7 @@
 """
 Organization API handling
 """
+# pylint: disable=too-many-lines
 import math
 import os
 import time
@@ -653,7 +654,7 @@ class OrgOps:
         slugs = await self.orgs.distinct("slug", {})
         return {"slugs": slugs}
 
-    async def get_all_org_slugs_with_ids(self):
+    async def get_org_slugs_by_ids(self):
         """Return dict with {id: slug} for all orgs."""
         slug_id_map = {}
         async for org in self.orgs.find({}):
@@ -933,6 +934,6 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
     async def get_all_org_slugs_with_ids(user: User = Depends(user_dep)):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
-        return await ops.get_all_org_slugs_with_ids()
+        return await ops.get_org_slugs_by_ids()
 
     return ops

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -213,6 +213,13 @@ class UserManager:
         )
         return await cursor.to_list(length=1000)
 
+    async def get_user_emails_by_ids(self):
+        """return dict of user emails keyed by id"""
+        email_id_map = {}
+        async for user in self.users.find({}):
+            email_id_map[user["id"]] = user["email"]
+        return email_id_map
+
     async def get_superuser(self) -> Optional[User]:
         """return current superuser, if any"""
         user_data = await self.users.find_one({"is_superuser": True})

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -339,17 +339,10 @@ def test_crawl_stats_all_orgs(admin_auth_headers):
             assert row["avg_page_time"] or row["avg_page_time"] == 0
 
 
-def test_crawl_stats_not_superadmin(crawler_auth_headers, default_org_id):
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/stats", headers=crawler_auth_headers
-    )
-    assert r.status_code == 403
-
-
-def test_crawl_stats(admin_auth_headers, default_org_id):
+def test_crawl_stats(crawler_auth_headers, default_org_id):
     with requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/stats",
-        headers=admin_auth_headers,
+        headers=crawler_auth_headers,
         stream=True,
     ) as r:
         assert r.status_code == 200

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -4,6 +4,8 @@ import time
 import io
 import zipfile
 import re
+import csv
+import codecs
 
 from .conftest import API_PREFIX, HOST_PREFIX
 from .test_collections import UPDATED_NAME as COLLECTION_NAME
@@ -295,6 +297,88 @@ def test_update_crawl(
     data = r.json()
     assert data["tags"] == []
     assert not data["description"]
+
+
+def test_crawl_stats_all_orgs_not_superadmin(crawler_auth_headers):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/all/crawls/stats", headers=crawler_auth_headers
+    )
+    assert r.status_code == 403
+
+
+def test_crawl_stats_all_orgs(admin_auth_headers):
+    with requests.get(
+        f"{API_PREFIX}/orgs/all/crawls/stats", headers=admin_auth_headers, stream=True
+    ) as r:
+        assert r.status_code == 200
+
+        # Wait for stream content
+        if not r.content:
+            while True:
+                if r.content:
+                    break
+                time.sleep(5)
+
+        buffer = r.iter_lines()
+        for row in csv.DictReader(
+            codecs.iterdecode(buffer, "utf-8"), skipinitialspace=True
+        ):
+            assert row["id"]
+            assert row["oid"]
+            assert row["org"]
+            assert row["cid"]
+            assert row["name"] or row["name"] == ""
+            assert row["state"]
+            assert row["userid"]
+            assert row["user"]
+            assert row["started"]
+            assert row["finished"] or row["finished"] is None
+            assert row["duration"] or row["duration"] == 0
+            assert row["pages"] or row["pages"] == 0
+            assert row["filesize"] or row["filesize"] == 0
+            assert row["avg_page_time"] or row["avg_page_time"] == 0
+
+
+def test_crawl_stats_not_superadmin(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/stats", headers=crawler_auth_headers
+    )
+    assert r.status_code == 403
+
+
+def test_crawl_stats(admin_auth_headers, default_org_id):
+    with requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/stats",
+        headers=admin_auth_headers,
+        stream=True,
+    ) as r:
+        assert r.status_code == 200
+
+        # Wait for stream content
+        if not r.content:
+            while True:
+                if r.content:
+                    break
+                time.sleep(5)
+
+        buffer = r.iter_lines()
+        for row in csv.DictReader(
+            codecs.iterdecode(buffer, "utf-8"), skipinitialspace=True
+        ):
+            assert row["id"]
+            assert row["oid"] == default_org_id
+            assert row["org"]
+            assert row["cid"]
+            assert row["name"] or row["name"] == ""
+            assert row["state"]
+            assert row["userid"]
+            assert row["user"]
+            assert row["started"]
+            assert row["finished"] or row["finished"] is None
+            assert row["duration"] or row["duration"] == 0
+            assert row["pages"] or row["pages"] == 0
+            assert row["filesize"] or row["filesize"] == 0
+            assert row["avg_page_time"] or row["avg_page_time"] == 0
 
 
 def test_delete_crawls_crawler(


### PR DESCRIPTION
Fixes #1158 

Introduces two new API endpoints that stream crawling statistics CSVs (with a suggested attachment filename header):

- `GET /api/orgs/all/crawls/stats` - crawls from all orgs (superuser only)
- `GET /api/orgs/{oid}/crawls/stats` - crawls from just one org (available to org crawler/admin users as well as superusers)

Also includes tests for both endpoints.