### PR TITLE
Fix browser profile name in crawl endpoints

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -551,6 +551,8 @@ class CrawlOut(BaseMongoModel):
     userName: Optional[str]
     oid: UUID
 
+    profileid: Optional[UUID]
+
     name: Optional[str]
     description: Optional[str]
 


### PR DESCRIPTION
Fixes #1388 

Fixes browser profile name lookup by ensuring profileid is in CrawlOut model.

## Screenshots

#### Workflow

<img width="482" alt="Screen Shot 2023-12-20 at 2 30 55 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/6e867160-0946-4997-98f3-8ab5ae9423ea">

#### Crawl details

<img width="286" alt="Screen Shot 2023-12-20 at 2 30 40 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/66de096a-2d86-4b1f-a992-ace55e546a89">

