### PR TITLE
Hotfix: ignore everything in `./tests` and `playwright.config.ts` when checking types during webpack build

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -152,7 +152,11 @@ const main = {
     }),
 
     new ForkTsCheckerWebpackPlugin({
-      typescript: { configOverwrite: { exclude: ["**/*.test.ts"] } },
+      typescript: {
+        configOverwrite: {
+          exclude: ["**/*.test.ts", "tests/**/*.ts", "playwright.config.ts"],
+        },
+      },
     }),
 
     new HtmlWebpackPlugin({


### PR DESCRIPTION
[Frontend Build Check](https://github.com/webrecorder/browsertrix-cloud/actions/workflows/frontend-build-check.yaml) was failing on main bc Webpack was type-checking a number of files that require various `devDependencies`, which are purposefully not installed at this point to mirror `frontend/Dockerfile` behaviour.