### PR TITLE
Fix scheduler date input and display

### DIFF
--- a/frontend/src/components/ui/time-input.ts
+++ b/frontend/src/components/ui/time-input.ts
@@ -86,7 +86,8 @@ export class TimeInput extends LitElement {
               value=${this.hour}
               ?disabled=${this.disabled}
               required
-              @keyup=${(e: KeyboardEvent) => {
+              @sl-change=${async (e: Event) => {
+                e.stopPropagation();
                 const input = e.target as SlInput;
                 if (input.value) {
                   const int = +input.value.replace(/[^0-9]/g, "");
@@ -94,10 +95,7 @@ export class TimeInput extends LitElement {
                 } else {
                   input.value = "12";
                 }
-              }}
-              @sl-change=${async (e: Event) => {
-                e.stopPropagation();
-                const input = e.target as SlInput;
+
                 await input.updateComplete;
                 this.hour = +input.value;
                 this.dispatchChange();
@@ -114,18 +112,19 @@ export class TimeInput extends LitElement {
                 : this.minute}
               ?disabled=${this.disabled}
               required
-              @keyup=${(e: KeyboardEvent) => {
-                const input = e.target as SlInput;
-                if (input.value) {
-                  const int = +input.value.replace(/[^0-9]/g, "");
-                  input.value = `${Math.min(59, Math.max(0, int))}`;
-                } else {
-                  input.value = "00";
-                }
-              }}
               @sl-change=${async (e: Event) => {
                 e.stopPropagation();
                 const input = e.target as SlInput;
+                if (input.value) {
+                  const int = Math.min(
+                    59,
+                    Math.max(0, +input.value.replace(/[^0-9]/g, ""))
+                  );
+                  input.value = int < 10 ? `0${int}` : `${int}`;
+                } else {
+                  input.value = "00";
+                }
+
                 await input.updateComplete;
                 this.minute = +input.value;
                 this.dispatchChange();

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -1672,7 +1672,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           label=${msg("User Agent")}
           autocomplete="off"
           placeholder=${msg("Default")}
-          value=${this.formState.userAgent}
+          value=${this.formState.userAgent || ""}
         >
         </sl-input>
       `)}

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -168,9 +168,15 @@ export function getUTCSchedule({
 
   localDate.setHours(+hour + periodOffset);
   localDate.setMinutes(+minute);
-  const date =
-    interval === "monthly" ? dayOfMonth || localDate.getUTCDate() : "*";
-  const day = interval === "weekly" ? dayOfWeek || localDate.getUTCDay() : "*";
+
+  if (interval === "monthly" && dayOfMonth) {
+    localDate.setDate(dayOfMonth);
+  } else if (interval == "weekly" && dayOfWeek) {
+    localDate.setDate(localDate.getDate() + dayOfWeek - localDate.getDay());
+  }
+
+  const date = interval === "monthly" ? localDate.getUTCDate() : "*";
+  const day = interval === "weekly" ? localDate.getUTCDay() : "*";
   const month = "*";
 
   const schedule = `${localDate.getUTCMinutes()} ${localDate.getUTCHours()} ${date} ${month} ${day}`;

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -123,7 +123,7 @@ export function humanizeSchedule(
         break;
       case "monthly":
         intervalMsg = msg(
-          str`On day ${days[0]} of the month at ${formattedTime}`
+          str`On day ${nextDate.getDate()} of the month at ${formattedTime}`
         );
         break;
       default:

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -10,11 +10,9 @@ export type ScheduleInterval = "daily" | "weekly" | "monthly";
 /**
  * Parse interval from cron expression
  **/
-export function getScheduleInterval(
-  schedule: string
-): "daily" | "weekly" | "monthly" {
-  const [_minute, _hour, dayofMonth, _month, dayOfWeek] = schedule.split(" ");
-  if (dayofMonth === "*") {
+export function getScheduleInterval(schedule: string): ScheduleInterval {
+  const [_minute, _hour, dayOfMonth, _month, dayOfWeek] = schedule.split(" ");
+  if (dayOfMonth === "*") {
     if (dayOfWeek === "*") {
       return "daily";
     }
@@ -63,7 +61,7 @@ export function humanizeNextDate(
 export function humanizeSchedule(
   schedule: string,
   options: { length?: "short" } = {},
-  numberFormatter: any = numberUtils.numberFormatter
+  numberFormatter = numberUtils.numberFormatter
 ): string {
   const interval = getScheduleInterval(schedule);
   const parsed = parseCron(schedule);
@@ -77,7 +75,7 @@ export function humanizeSchedule(
     weekday: "long",
   });
 
-  let intervalMsg: any = "";
+  let intervalMsg = "";
 
   if (options.length === "short") {
     switch (interval) {


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1255

### Changes

- Fixes incorrect time zone conversion when generating UTC schedule in workflow.
- Fixes minute input display not prefixing single digits with `0`

### Manual testing

1. Log in as user with crawler role
2. Go to New Workflow > Scheduling
3. Choose "Run on recurring basis" > Frequency: Weekly
4. Update start time. Verify "Schedule" help text shows correct schedule for every hour
5. Choose Frequency: Monthly
6. Update day of month. Verify "Schedule" help text accuracy
7. Save workflow. Verify schedule saves as expected

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Settings - Scheduling | <img width="523" alt="Screenshot 2024-01-17 at 5 12 42 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/98a8ded4-ed62-445a-a97d-fd1b7a2099c9"> |

<!-- ### Follow-ups -->
