### PR TITLE
Fix archived item crawl settings

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -77,7 +77,6 @@ export class ConfigDetails extends LiteElement {
     const seedsConfig = crawlConfig?.config;
     const exclusions = seedsConfig?.exclude || [];
     const maxPages = (this.seeds && this.seeds[0]?.limit) ?? seedsConfig?.limit;
-    console.log(crawlConfig);
     const renderTimeLimit = (
       valueSeconds?: number | null,
       fallbackValue?: number
@@ -216,7 +215,7 @@ export class ConfigDetails extends LiteElement {
               >
                 ${crawlConfig?.profileName}
               </a>`,
-              () => msg("Default Profile")
+              () => crawlConfig?.profileName || msg("Default Profile")
             )
           )}
           ${this.renderSetting(

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -39,10 +39,6 @@ export class ConfigDetails extends LiteElement {
   @property({ type: Boolean })
   anchorLinks = false;
 
-  // Hide tag field, e.g. if embedded in crawl detail view
-  @property({ type: Boolean })
-  hideTags = false;
-
   @state()
   private orgDefaults?: {
     pageLoadTimeoutSeconds?: number;
@@ -264,41 +260,47 @@ export class ConfigDetails extends LiteElement {
       </section>
       <section id="crawl-metadata" class="mb-8">
         <btrix-section-heading style="--margin: var(--sl-spacing-medium)">
-          <h4>${msg("Crawl Metadata")}</h4>
+          <h4>${msg("Workflow Metadata")}</h4>
         </btrix-section-heading>
         <btrix-desc-list>
           ${this.renderSetting(msg("Name"), crawlConfig?.name)}
           ${this.renderSetting(
             msg("Description"),
-            html`
-              <p class="font-sans max-w-prose">${crawlConfig?.description}</p>
-            `
+            crawlConfig?.description
+              ? html`
+                  <p class="font-sans max-w-prose">
+                    ${crawlConfig?.description}
+                  </p>
+                `
+              : undefined
           )}
-          ${this.hideTags
-            ? ""
-            : this.renderSetting(
+          ${crawlConfig?.tags
+            ? this.renderSetting(
                 msg("Tags"),
                 crawlConfig?.tags?.length
                   ? crawlConfig.tags.map(
                       (tag) =>
                         html`<btrix-tag class="mt-1 mr-2">${tag}</btrix-tag>`
                     )
+                  : []
+              )
+            : nothing}
+          ${crawlConfig?.autoAddCollections
+            ? this.renderSetting(
+                msg("Collections"),
+                this.collections.length
+                  ? this.collections.map(
+                      (coll) =>
+                        html`<sl-tag class="mt-1 mr-2" variant="neutral">
+                          ${coll.name}
+                          <span class="pl-1 font-monostyle text-xs">
+                            (${msg(str`${coll.crawlCount} items`)})
+                          </span>
+                        </sl-tag>`
+                    )
                   : undefined
-              )}
-          ${this.renderSetting(
-            msg("Collections"),
-            this.collections.length
-              ? this.collections.map(
-                  (coll) =>
-                    html`<sl-tag class="mt-1 mr-2" variant="neutral">
-                      ${coll.name}
-                      <span class="pl-1 font-monostyle text-xs">
-                        (${msg(str`${coll.crawlCount} items`)})
-                      </span>
-                    </sl-tag>`
-                )
-              : undefined
-          )}
+              )
+            : nothing}
         </btrix-desc-list>
       </section>
     `;
@@ -436,6 +438,8 @@ export class ConfigDetails extends LiteElement {
       content = html` <sl-skeleton></sl-skeleton> `;
     } else if (typeof value === "boolean") {
       content = value ? msg("Yes") : msg("No");
+    } else if (Array.isArray(value) && !value.length) {
+      content = html`<span class="text-neutral-400">${msg("None")}</span>`;
     } else if (typeof value !== "number" && !value) {
       content = html`<span class="text-neutral-400"
         >${msg("Not specified")}</span

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -39,6 +39,10 @@ export class ConfigDetails extends LiteElement {
   @property({ type: Boolean })
   anchorLinks = false;
 
+  // Hide metadata section, e.g. if embedded in crawl detail view
+  @property({ type: Boolean })
+  hideMetadata = false;
+
   @state()
   private orgDefaults?: {
     pageLoadTimeoutSeconds?: number;
@@ -258,51 +262,51 @@ export class ConfigDetails extends LiteElement {
           )}
         </btrix-desc-list>
       </section>
-      <section id="crawl-metadata" class="mb-8">
-        <btrix-section-heading style="--margin: var(--sl-spacing-medium)">
-          <h4>${msg("Workflow Metadata")}</h4>
-        </btrix-section-heading>
-        <btrix-desc-list>
-          ${this.renderSetting(msg("Name"), crawlConfig?.name)}
-          ${this.renderSetting(
-            msg("Description"),
-            crawlConfig?.description
-              ? html`
-                  <p class="font-sans max-w-prose">
-                    ${crawlConfig?.description}
-                  </p>
-                `
-              : undefined
-          )}
-          ${crawlConfig?.tags
-            ? this.renderSetting(
-                msg("Tags"),
-                crawlConfig?.tags?.length
-                  ? crawlConfig.tags.map(
-                      (tag) =>
-                        html`<btrix-tag class="mt-1 mr-2">${tag}</btrix-tag>`
-                    )
-                  : []
-              )
-            : nothing}
-          ${crawlConfig?.autoAddCollections
-            ? this.renderSetting(
-                msg("Collections"),
-                this.collections.length
-                  ? this.collections.map(
-                      (coll) =>
-                        html`<sl-tag class="mt-1 mr-2" variant="neutral">
-                          ${coll.name}
-                          <span class="pl-1 font-monostyle text-xs">
-                            (${msg(str`${coll.crawlCount} items`)})
-                          </span>
-                        </sl-tag>`
-                    )
-                  : undefined
-              )
-            : nothing}
-        </btrix-desc-list>
-      </section>
+      ${this.hideMetadata
+        ? nothing
+        : html`
+            <section id="crawl-metadata" class="mb-8">
+              <btrix-section-heading style="--margin: var(--sl-spacing-medium)">
+                <h4>${msg("Metadata")}</h4>
+              </btrix-section-heading>
+              <btrix-desc-list>
+                ${this.renderSetting(msg("Name"), crawlConfig?.name)}
+                ${this.renderSetting(
+                  msg("Description"),
+                  crawlConfig?.description
+                    ? html`
+                        <p class="font-sans max-w-prose">
+                          ${crawlConfig?.description}
+                        </p>
+                      `
+                    : undefined
+                )}
+                ${this.renderSetting(
+                  msg("Tags"),
+                  crawlConfig?.tags?.length
+                    ? crawlConfig.tags.map(
+                        (tag) =>
+                          html`<btrix-tag class="mt-1 mr-2">${tag}</btrix-tag>`
+                      )
+                    : []
+                )}
+                ${this.renderSetting(
+                  msg("Collections"),
+                  this.collections.length
+                    ? this.collections.map(
+                        (coll) =>
+                          html`<sl-tag class="mt-1 mr-2" variant="neutral">
+                            ${coll.name}
+                            <span class="pl-1 font-monostyle text-xs">
+                              (${msg(str`${coll.crawlCount} items`)})
+                            </span>
+                          </sl-tag>`
+                      )
+                    : undefined
+                )}
+              </btrix-desc-list>
+            </section>
+          `}
     `;
   }
 

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -77,6 +77,7 @@ export class ConfigDetails extends LiteElement {
     const seedsConfig = crawlConfig?.config;
     const exclusions = seedsConfig?.exclude || [];
     const maxPages = (this.seeds && this.seeds[0]?.limit) ?? seedsConfig?.limit;
+    console.log(crawlConfig);
     const renderTimeLimit = (
       valueSeconds?: number | null,
       fallbackValue?: number

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -11,7 +11,7 @@ import type { AuthState } from "@/utils/AuthService";
 import LiteElement, { html } from "@/utils/LiteElement";
 import { isActive } from "@/utils/crawler";
 import { CopyButton } from "@/components/ui/copy-button";
-import type { ArchivedItem, Crawl, CrawlConfig, Seed } from "./types";
+import type { ArchivedItem, Crawl, CrawlConfig, Seed, Workflow } from "./types";
 import type { APIPaginatedList } from "@/types/api";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import type { CrawlLog } from "@/features/archived-items/crawl-logs";
@@ -66,6 +66,9 @@ export class CrawlDetail extends LiteElement {
   private crawl?: ArchivedItem;
 
   @state()
+  private workflow?: Workflow;
+
+  @state()
   private seeds?: APIPaginatedList<Seed>;
 
   @state()
@@ -118,6 +121,9 @@ export class CrawlDetail extends LiteElement {
       this.fetchCrawl();
       this.fetchCrawlLogs();
       this.fetchSeeds();
+    }
+    if (changedProperties.has("workflowId") && this.workflowId) {
+      this.fetchWorkflow();
     }
   }
 
@@ -854,12 +860,13 @@ ${this.crawl?.description}
     return html`
       <div aria-live="polite" aria-busy=${!this.crawl || !this.seeds}>
         ${when(
-          this.crawl && this.seeds,
+          this.crawl && this.seeds && (!this.workflowId || this.workflow),
           () => html`
             <btrix-config-details
               .authState=${this.authState!}
               .crawlConfig=${{
                 ...this.crawl,
+                jobType: this.workflow?.jobType,
                 autoAddCollections: this.crawl!.collectionIds,
               } as CrawlConfig}
               .seeds=${this.seeds!.items}
@@ -906,13 +913,19 @@ ${this.crawl?.description}
     }
   }
 
+  private async fetchWorkflow(): Promise<void> {
+    try {
+      this.workflow = await this.getWorkflow();
+    } catch (e: unknown) {
+      console.debug(e);
+    }
+  }
+
   private async getCrawl(): Promise<Crawl> {
     const apiPath = `/orgs/${this.orgId}/${
       this.itemType === "upload" ? "uploads" : "crawls"
     }/${this.crawlId}/replay.json`;
-    const data: Crawl = await this.apiFetch(apiPath, this.authState!);
-
-    return data;
+    return this.apiFetch<Crawl>(apiPath, this.authState!);
   }
 
   private async getSeeds() {
@@ -922,6 +935,13 @@ ${this.crawl?.description}
       this.authState!
     );
     return data;
+  }
+
+  private async getWorkflow(): Promise<Workflow> {
+    return this.apiFetch<Workflow>(
+      `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
+      this.authState!
+    );
   }
 
   private async fetchCrawlLogs(

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -867,11 +867,9 @@ ${this.crawl?.description}
               .crawlConfig=${{
                 ...this.crawl,
                 jobType: this.workflow?.jobType,
-                name: this.workflow?.name,
-                description: this.workflow?.description,
-                tags: this.workflow?.tags,
               } as CrawlConfig}
               .seeds=${this.seeds!.items}
+              hideMetadata
             ></btrix-config-details>
           `,
           this.renderLoading

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -867,10 +867,11 @@ ${this.crawl?.description}
               .crawlConfig=${{
                 ...this.crawl,
                 jobType: this.workflow?.jobType,
-                autoAddCollections: this.crawl!.collectionIds,
+                name: this.workflow?.name,
+                description: this.workflow?.description,
+                tags: this.workflow?.tags,
               } as CrawlConfig}
               .seeds=${this.seeds!.items}
-              hideTags
             ></btrix-config-details>
           `,
           this.renderLoading

--- a/frontend/src/pages/org/crawl-detail.ts
+++ b/frontend/src/pages/org/crawl-detail.ts
@@ -336,7 +336,7 @@ export class CrawlDetail extends LiteElement {
       `;
     };
     return html`
-      <nav class="border-b md:border-b-0 pb-4 md:mt-10">
+      <nav class="sticky top-0 border-b md:border-b-0 pb-4 md:mt-10">
         <ul
           class="flex flex-row md:flex-col gap-2 text-center md:text-start"
           role="menu"


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1418

### Changes
- Fixes crawl detail always showing URL list seed settings
- Removes metadata section from crawl detail settings tab

### Manual testing

1. Log in and go to a seeded workflow with crawls
2. Click "Workflow Settings" tab. Verify "Crawl Metadata" section is renamed to just "Metadata"
3. Click a workflow crawl > "Crawl Settings". Verify seeded crawl settings are all shown
4. Scroll to bottom. Verify "Metadata" section is hidden