### PR TITLE
operator: use 'default' CRAWLER_CHANNEL if none is set

### DIFF
--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1645,7 +1645,7 @@ class BtrixOperator(K8sAPI):
             userid=userid,
             oid=oid,
             storage=org.storage,
-            crawler_channel=configmap["CRAWLER_CHANNEL"],
+            crawler_channel=configmap.get("CRAWLER_CHANNEL", "default"),
             scale=int(configmap.get("INITIAL_SCALE", 1)),
             crawl_timeout=int(configmap.get("CRAWL_TIMEOUT", 0)),
             max_crawl_size=int(configmap.get("MAX_CRAWL_SIZE", "0")),


### PR DESCRIPTION
Use default channel if CRAWLER_CHANNEL not set in crawlconfig configmap, consistent with how other configmap settings for cronjobs are used.