### PR TITLE
Upgrade to lit 3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@cheap-glitch/mi-cron": "^1.0.1",
-    "@lit/localize": "^0.11.4",
+    "@lit/localize": "^0.12.1",
     "@novnc/novnc": "^1.4.0-beta",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@shoelace-style/shoelace": "^2.8.0",
@@ -41,7 +41,7 @@
     "html-webpack-plugin": "^5.5.0",
     "immutable": "^4.1.0",
     "iso-639-1": "^2.1.15",
-    "lit": "2.7.5",
+    "lit": "3.1.1",
     "lit-shared-state": "^0.2.1",
     "lodash": "^4.17.21",
     "micromark": "^4.0.0",
@@ -88,7 +88,7 @@
     "localize:build": "lit-localize build"
   },
   "devDependencies": {
-    "@lit/localize-tools": "^0.6.9",
+    "@lit/localize-tools": "^0.7.1",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/dev-server-rollup": "^0.3.21",
@@ -124,6 +124,7 @@
     "node": ">=16"
   },
   "resolutions": {
-    "**/playwright": "1.32.1"
+    "**/playwright": "1.32.1",
+    "**/lit": "3.1.1"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -493,46 +493,41 @@
   resolved "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz"
   integrity sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==
 
-"@lit-labs/ssr-dom-shim@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz#64df34e2f12e68e78ac57e571d25ec07fa460ca9"
-  integrity sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ==
-
 "@lit-labs/ssr-dom-shim@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz#d693d972974a354034454ec1317eb6afd0b00312"
   integrity sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==
 
-"@lit/localize-tools@^0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@lit/localize-tools/-/localize-tools-0.6.9.tgz#647ac72cbc932ea69525a875f4dcc973c38bac33"
-  integrity sha512-eG2EVRBYDzii/yHpR4NYpLB+L+Pc6Y+W7Q4Xcqk9KsHsElzr/4yKJxMIU2/LpudrnBr0JGYDQa1sxb0orezDJw==
+"@lit/localize-tools@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@lit/localize-tools/-/localize-tools-0.7.1.tgz#cb80af296d99c029c59cec57813ae8f11d43a777"
+  integrity sha512-qqJw501aEPF1j9QQmiVC25yU1By1DKEUIFgjszIierwr5jJzfVtGTj67D8UU0hF3vA2yAaWxcl4eooM1Yr0zKQ==
   dependencies:
-    "@lit/localize" "^0.11.0"
+    "@lit/localize" "^0.12.0"
+    "@parse5/tools" "^0.3.0"
     "@xmldom/xmldom" "^0.8.2"
     fast-glob "^3.2.7"
     fs-extra "^10.0.0"
     jsonschema "^1.4.0"
-    lit "^2.7.0"
+    lit "^2.0.0 || ^3.0.0"
     minimist "^1.2.5"
-    parse5 "^6.0.1"
+    parse5 "^7.1.1"
     source-map-support "^0.5.19"
-    typescript "^4.7.4"
+    typescript "~5.2.0"
 
-"@lit/localize@^0.11.0", "@lit/localize@^0.11.4":
-  version "0.11.4"
-  resolved "https://registry.npmjs.org/@lit/localize/-/localize-0.11.4.tgz"
-  integrity sha512-RRIwIX2tAm3+DuEndoXSJrFjGrAK5cb5IXo5K6jcJ6sbgD829B8rSqHC5MaKVUmXTVLIR1bk5IZOZDf9wFereA==
+"@lit/localize@^0.12.0", "@lit/localize@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@lit/localize/-/localize-0.12.1.tgz#e0a15412270c7674ab419f9acfc10844de98ba0d"
+  integrity sha512-uuF6OO6fjqomCf3jXsJ5cTGf1APYuN88S4Gvo/fjt9YkG4OMaMvpEUqd5oWhyzrJfY+HcenAbLJNi2Cq3H7gdg==
   dependencies:
-    "@lit/reactive-element" "^1.4.0"
-    lit "^2.3.0"
+    lit "^2.0.0 || ^3.0.0"
 
 "@lit/react@^1.0.0":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@lit/react/-/react-1.0.2.tgz#4951ff1590d69aad912d0a950b3518d19eb7e220"
   integrity sha512-UJ5TQ46DPcJDIzyjbwbj6Iye0XcpCxL2yb03zcWq1BpWchpXS3Z0BPVhg7zDfZLF6JemPml8u/gt/+KwJ/23sg==
 
-"@lit/reactive-element@^1.0.0", "@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.4.0", "@lit/reactive-element@^1.6.0":
+"@lit/reactive-element@^1.0.0":
   version "1.6.1"
   resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz"
   integrity sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==
@@ -633,6 +628,13 @@
     "@types/chai-dom" "^1.11.0"
     "@types/sinon-chai" "^3.2.3"
     chai-a11y-axe "^1.5.0"
+
+"@parse5/tools@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@parse5/tools/-/tools-0.3.0.tgz#4cac601408065a84c31a88431b02f9f69f92434a"
+  integrity sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==
+  dependencies:
+    parse5 "^7.0.0"
 
 "@playwright/test@1.32.1":
   version "1.32.1"
@@ -3231,6 +3233,11 @@ entities@^2.0.0:
   resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
 envinfo@^7.7.3:
   version "7.8.1"
   resolved "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz"
@@ -4946,15 +4953,6 @@ lit-analyzer@^2.0.1:
     vscode-html-languageservice "3.1.0"
     web-component-analyzer "^2.0.0"
 
-lit-element@^3.3.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.3.2.tgz#9913bf220b85065f0e5f1bb8878cc44f36b50cfa"
-  integrity sha512-xXAeVWKGr4/njq0rGC9dethMnYCq5hpKYrgQZYTzawt9YQhMiXfD+T1RgrdY3NamOxwq2aXlb0vOI6e29CKgVQ==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.1.0"
-    "@lit/reactive-element" "^1.3.0"
-    lit-html "^2.7.0"
-
 lit-element@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.0.2.tgz#1a519896d5ab7c7be7a8729f400499e38779c093"
@@ -4964,7 +4962,7 @@ lit-element@^4.0.0:
     "@lit/reactive-element" "^2.0.0"
     lit-html "^3.1.0"
 
-lit-html@^2.0.0, lit-html@^2.7.0:
+lit-html@^2.0.0:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.7.4.tgz#6d75001977c206683685b9d76594a516afda2954"
   integrity sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==
@@ -4983,19 +4981,10 @@ lit-shared-state@^0.2.1:
   resolved "https://registry.yarnpkg.com/lit-shared-state/-/lit-shared-state-0.2.1.tgz#967884e08974f96646e11fd0b4edbd4112e11c0f"
   integrity sha512-4KnwRCVTqMWxVxO5u50+Q+RZJWAbCo34w5MxRh1GwbpW8sO7rupnNVYwqtp3WTmXN5Pdp2ZuaRWpPu/shfIauA==
 
-lit@2.7.5, lit@^2.0.0, lit@^2.3.0, lit@^2.7.0:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.7.5.tgz#60bc82990cfad169d42cd786999356dcf79b035f"
-  integrity sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==
-  dependencies:
-    "@lit/reactive-element" "^1.6.0"
-    lit-element "^3.3.0"
-    lit-html "^2.7.0"
-
-lit@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-3.1.0.tgz#76429b85dc1f5169fed499a0f7e89e2e619010c9"
-  integrity sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==
+lit@3.1.1, lit@^2.0.0, "lit@^2.0.0 || ^3.0.0", lit@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.1.1.tgz#49340c8875019a777cc83904f75a2bf7764617dc"
+  integrity sha512-hF1y4K58+Gqrz+aAPS0DNBwPqPrg6P04DuWK52eMkt/SM9Qe9keWLcFgRcEKOLuDlRZlDsDbNL37Vr7ew1VCuw==
   dependencies:
     "@lit/reactive-element" "^2.0.0"
     lit-element "^4.0.0"
@@ -5828,6 +5817,13 @@ parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parse5@^7.0.0, parse5@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
+  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+  dependencies:
+    entities "^4.4.0"
 
 parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -7297,7 +7293,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.5.2, typescript@^4.7.4:
+typescript@^4.5.2:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1456

<!-- Fixes #issue_number -->

### Changes

- Upgrades to lit 3 to access new features
- Reduces number of installed lit versions

Before:
```
=> Found "lit@2.7.5"
info Has been hoisted to "lit"
info Reasons this module exists
   - Specified in "dependencies"
   - Hoisted from "@lit#localize#lit"
   - Hoisted from "@lit#localize-tools#lit"
   - Hoisted from "@open-wc#testing#@open-wc#testing-helpers#lit"
info Disk size without dependencies: "1.3MB"
info Disk size with unique dependencies: "5.89MB"
info Disk size with transitive dependencies: "5.98MB"
info Number of shared dependencies: 5
=> Found "@shoelace-style/shoelace#lit@3.1.0"
info This module exists because "@shoelace-style#shoelace" depends on it.
info Disk size without dependencies: "1.24MB"
info Disk size with unique dependencies: "5.83MB"
info Disk size with transitive dependencies: "5.92MB"
info Number of shared dependencies: 5
```

After:
```
warning Resolution field "lit@3.1.1" is incompatible with requested version "lit@^2.0.0"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "lit@3.1.1"
info Has been hoisted to "lit"
info Reasons this module exists
   - Specified in "dependencies"
   - Hoisted from "@lit#localize#lit"
   - Hoisted from "@lit#localize-tools#lit"
   - Hoisted from "@shoelace-style#shoelace#lit"
   - Hoisted from "@open-wc#testing#@open-wc#testing-helpers#lit"
info Disk size without dependencies: "1.24MB"
info Disk size with unique dependencies: "5.54MB"
info Disk size with transitive dependencies: "5.62MB"
info Number of shared dependencies: 5
```

The warning is coming from `@open-wc/testing`. There appears to be no issues resolving to lit 3 when running `yarn test`.

### Manual testing

Manually tested by running all yarn scripts and doing a quick pass around the app.