### PR TITLE
Add scale to CrawlOut

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -609,6 +609,7 @@ class CrawlOut(BaseMongoModel):
     stopping: Optional[bool]
     manual: Optional[bool]
     cid_rev: Optional[int]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
 
     storageQuotaReached: Optional[bool]
     execMinutesQuotaReached: Optional[bool]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -609,7 +609,7 @@ class CrawlOut(BaseMongoModel):
     stopping: Optional[bool]
     manual: Optional[bool]
     cid_rev: Optional[int]
-    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]
+    scale: Optional[conint(ge=1, le=MAX_CRAWL_SCALE)]  # type: ignore
 
     storageQuotaReached: Optional[bool]
     execMinutesQuotaReached: Optional[bool]


### PR DESCRIPTION
Fixes #1486 

`scale` is already saved in the crawl but needed to be added to `CrawlOut`.

## Screenshots

### `replay.json` response

<img width="1037" alt="Screen Shot 2024-01-23 at 2 38 54 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/1fec4130-1e37-4fda-8464-adc5a8f98489">

### Crawl Settings

<img width="728" alt="Screen Shot 2024-01-23 at 2 39 49 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/e1b63554-25a5-40e4-b499-24d895f471a0">
