### PR TITLE
Ensure linting & formatting runs in CI

### DIFF
--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -30,6 +30,12 @@ jobs:
         env:
           HUSKY: 0
         run: yarn install --frozen-lockfile
+      - name: Lint
+        working-directory: frontend
+        run: yarn lint:check
+      - name: Format
+        working-directory: frontend
+        run: yarn format:check
       - name: Unit tests
         working-directory: frontend
         run: yarn test

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   parser: "@typescript-eslint/parser",
@@ -91,11 +90,18 @@ module.exports = {
     "@typescript-eslint/unbound-method": "off",
   },
   reportUnusedDisableDirectives: true,
-  ignorePatterns: ["__generated__", "__mocks__"],
+  ignorePatterns: ["__generated__", "__mocks__", "dist"],
   overrides: [
     {
       extends: ["plugin:@typescript-eslint/disable-type-checked"],
-      files: ["webpack.*.js"],
+      files: [
+        "webpack.*.js",
+        "config/*.js",
+        "scripts/*.js",
+        ".*.js",
+        "*.config.js",
+      ],
+      env: { node: true },
       rules: {
         "@typescript-eslint/no-var-requires": "off",
       },

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,4 @@ __generated__
 __mocks__
 xliff
 assets
+dist

--- a/frontend/config/dev-server.js
+++ b/frontend/config/dev-server.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-env node */
 const path = require("path");
 require(path.resolve(process.cwd(), "./webpack.config.js"));
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,9 +80,11 @@
     "build:analyze": "BUNDLE_ANALYZER=true webpack --config webpack.prod.js",
     "start": "webpack serve --mode=development --config webpack.dev.js",
     "serve": "node scripts/serve.js",
-    "lint": "eslint --fix \"src/**/*.{ts,js}\"",
+    "lint": "eslint --fix .",
+    "lint:check": "eslint .",
     "lint:lit-analyzer": "lit-analyzer",
-    "format": "prettier --write \"src/**/*.{ts,js,html,css,json}\"",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "localize:prepare": "yarn localize:extract && yarn localize:build",
     "localize:extract": "lit-localize extract",
     "localize:build": "lit-localize build"

--- a/frontend/src/components/ui/table/table-cell.ts
+++ b/frontend/src/components/ui/table/table-cell.ts
@@ -50,7 +50,7 @@ export class TableCell extends LitElement {
     if (!this.rowClickTarget) return;
     const elems = (e.target as HTMLSlotElement).assignedElements();
     const rowClickTarget = elems.find(
-      (el) => el.tagName.toLowerCase() === this.rowClickTarget,
+      (el) => el.tagName.toLowerCase() === this.rowClickTarget
     );
 
     if (!rowClickTarget) return;

--- a/frontend/src/features/archived-items/archived-item-list.ts
+++ b/frontend/src/features/archived-items/archived-item-list.ts
@@ -91,8 +91,8 @@ export class ArchivedItemListItem extends TailwindElement {
                           detail: {
                             checked: (e.currentTarget as SlCheckbox).checked,
                           },
-                        },
-                      ),
+                        }
+                      )
                     );
                   }}
                 ></sl-checkbox>
@@ -101,7 +101,7 @@ export class ArchivedItemListItem extends TailwindElement {
           : nothing}
         <btrix-table-cell
           rowClickTarget=${ifDefined(
-            this.href ? "a" : this.checkbox ? "label" : undefined,
+            this.href ? "a" : this.checkbox ? "label" : undefined
           )}
         >
           ${this.href
@@ -109,17 +109,17 @@ export class ArchivedItemListItem extends TailwindElement {
                 ${rowName}
               </a>`
             : this.checkbox
-              ? html`<label
-                  for=${checkboxId}
-                  @click=${() => {
-                    // We need to simulate click anyway, since external label click
-                    // won't work with the shoelace checkbox
-                    this.checkboxEl?.click();
-                  }}
-                >
-                  ${rowName}
-                </label>`
-              : html`<div>${rowName}</div>`}
+            ? html`<label
+                for=${checkboxId}
+                @click=${() => {
+                  // We need to simulate click anyway, since external label click
+                  // won't work with the shoelace checkbox
+                  this.checkboxEl?.click();
+                }}
+              >
+                ${rowName}
+              </label>`
+            : html`<div>${rowName}</div>`}
         </btrix-table-cell>
         <btrix-table-cell>
           <sl-format-date

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -90,7 +90,7 @@ export class CrawlListItem extends TailwindElement {
                 hour="2-digit"
                 minute="2-digit"
               ></sl-format-date>
-            `,
+            `
           )}
         </div>
       `;
@@ -140,7 +140,7 @@ export class CrawlListItem extends TailwindElement {
                 state=${workflow.state}
                 hideLabel
               ></btrix-crawl-status>
-            `,
+            `
           )}
         </btrix-table-cell>
         ${idCell}
@@ -158,7 +158,7 @@ export class CrawlListItem extends TailwindElement {
                       hour="2-digit"
                       minute="2-digit"
                     ></sl-format-date>
-                  `,
+                  `
                 )}
               </btrix-table-cell>
             `}
@@ -177,7 +177,7 @@ export class CrawlListItem extends TailwindElement {
                 `
               : html`<span class="text-neutral-400" role="presentation"
                   >---</span
-                >`,
+                >`
           )}
         </btrix-table-cell>
         <btrix-table-cell>
@@ -186,8 +186,8 @@ export class CrawlListItem extends TailwindElement {
               (crawl.finished
                 ? new Date(`${crawl.finished}Z`)
                 : new Date()
-              ).valueOf() - new Date(`${crawl.started}Z`).valueOf(),
-            ),
+              ).valueOf() - new Date(`${crawl.started}Z`).valueOf()
+            )
           )}
         </btrix-table-cell>
         <btrix-table-cell>
@@ -208,13 +208,13 @@ export class CrawlListItem extends TailwindElement {
             return pagesFound === 1
               ? msg(
                   str`${this.numberFormatter.format(
-                    pagesComplete,
-                  )} / ${this.numberFormatter.format(pagesFound)} page`,
+                    pagesComplete
+                  )} / ${this.numberFormatter.format(pagesFound)} page`
                 )
               : msg(
                   str`${this.numberFormatter.format(
-                    pagesComplete,
-                  )} / ${this.numberFormatter.format(pagesFound)} pages`,
+                    pagesComplete
+                  )} / ${this.numberFormatter.format(pagesFound)} pages`
                 );
           })}
         </btrix-table-cell>
@@ -231,7 +231,7 @@ export class CrawlListItem extends TailwindElement {
   }
 
   private safeRender(
-    render: (crawl: Crawl) => string | TemplateResult<1> | undefined,
+    render: (crawl: Crawl) => string | TemplateResult<1> | undefined
   ) {
     if (!this.crawl) {
       return html`<sl-skeleton></sl-skeleton>`;
@@ -346,7 +346,7 @@ export class CrawlList extends TailwindElement {
   private handleSlotchange() {
     const assignProp = (
       el: HTMLElement,
-      attr: { name: string; value: string },
+      attr: { name: string; value: string }
     ) => {
       if (!el.attributes.getNamedItem(attr.name)) {
         el.setAttribute(attr.name, attr.value);

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -301,7 +301,7 @@ export class CollectionItemsDialog extends TailwindElement {
             .sortOptions=${crawlSortOptions}
             .sortBy=${this.sortCrawlsBy}
             @btrix-filter-change=${(
-              e: CustomEvent<FilterChangeEventDetail>,
+              e: CustomEvent<FilterChangeEventDetail>
             ) => {
               this.filterCrawlsBy = e.detail;
             }}
@@ -320,10 +320,10 @@ export class CollectionItemsDialog extends TailwindElement {
               () =>
                 this.showOnlyInCollection
                   ? msg(
-                      str`Crawls in Collection (${data!.total.toLocaleString()})`,
+                      str`Crawls in Collection (${data!.total.toLocaleString()})`
                     )
                   : msg(str`All Workflows (${data!.total.toLocaleString()})`),
-              () => msg("Loading..."),
+              () => msg("Loading...")
             )}
           </div>
         </btrix-section-heading>
@@ -331,7 +331,7 @@ export class CollectionItemsDialog extends TailwindElement {
       ${cache(
         this.showOnlyInCollection
           ? this.renderCollectionCrawls()
-          : this.renderOrgWorkflows(),
+          : this.renderOrgWorkflows()
       )}
     `;
   };
@@ -350,7 +350,7 @@ export class CollectionItemsDialog extends TailwindElement {
             .sortOptions=${uploadSortOptions}
             .sortBy=${this.sortUploadsBy}
             @btrix-filter-change=${(
-              e: CustomEvent<FilterChangeEventDetail>,
+              e: CustomEvent<FilterChangeEventDetail>
             ) => {
               this.filterUploadsBy = e.detail;
             }}
@@ -369,12 +369,12 @@ export class CollectionItemsDialog extends TailwindElement {
               () =>
                 this.showOnlyInCollection
                   ? msg(
-                      str`Uploads in Collection (${this.uploads!.total.toLocaleString()})`,
+                      str`Uploads in Collection (${this.uploads!.total.toLocaleString()})`
                     )
                   : msg(
-                      str`All Uploads (${this.uploads!.total.toLocaleString()})`,
+                      str`All Uploads (${this.uploads!.total.toLocaleString()})`
                     ),
-              () => msg("Loading..."),
+              () => msg("Loading...")
             )}
           </div>
         </btrix-section-heading>
@@ -391,7 +391,7 @@ export class CollectionItemsDialog extends TailwindElement {
           () =>
             html`<p class="p-5 text-center text-neutral-500">
               ${msg("No matching uploads found.")}
-            </p>`,
+            </p>`
         )}
       </section>
       <footer class="flex justify-center pb-3">
@@ -409,7 +409,7 @@ export class CollectionItemsDialog extends TailwindElement {
               }}
             >
             </btrix-pagination>
-          `,
+          `
         )}
       </footer>
     `;
@@ -434,7 +434,7 @@ export class CollectionItemsDialog extends TailwindElement {
           () =>
             html`<p class="p-5 text-center text-neutral-500">
               ${msg("No matching crawls found.")}
-            </p>`,
+            </p>`
         )}
       </section>
 
@@ -453,7 +453,7 @@ export class CollectionItemsDialog extends TailwindElement {
               }}
             >
             </btrix-pagination>
-          `,
+          `
         )}
       </footer>
     `;
@@ -480,7 +480,7 @@ export class CollectionItemsDialog extends TailwindElement {
           @btrix-auto-add-change=${(e: CustomEvent<AutoAddChangeDetail>) => {
             const { id, checked } = e.detail;
             const workflow = this.workflows?.items.find(
-              (workflow) => workflow.id === id,
+              (workflow) => workflow.id === id
             );
             if (workflow) {
               void this.saveAutoAdd({
@@ -509,7 +509,7 @@ export class CollectionItemsDialog extends TailwindElement {
               }}
             >
             </btrix-pagination>
-          `,
+          `
         )}
       </footer> `;
   };
@@ -547,7 +547,7 @@ export class CollectionItemsDialog extends TailwindElement {
         checkbox
         ?checked=${isInCollection}
         @btrix-checkbox-change=${(
-          e: CustomEvent<CheckboxChangeEventDetail>,
+          e: CustomEvent<CheckboxChangeEventDetail>
         ) => {
           this.selection = {
             ...this.selection,
@@ -572,14 +572,14 @@ export class CollectionItemsDialog extends TailwindElement {
         messages.push(
           addCount === 1
             ? msg(str`Adding 1 item`)
-            : msg(str`Adding ${addCount.toLocaleString()} items`),
+            : msg(str`Adding ${addCount.toLocaleString()} items`)
         );
       }
       if (removeCount) {
         messages.push(
           removeCount === 1
             ? msg(str`Removing 1 item`)
-            : msg(str`Removing ${removeCount.toLocaleString()} items`),
+            : msg(str`Removing ${removeCount.toLocaleString()} items`)
         );
       }
 
@@ -663,8 +663,8 @@ export class CollectionItemsDialog extends TailwindElement {
           {
             method: "POST",
             body: JSON.stringify({ crawlIds: add }),
-          },
-        ),
+          }
+        )
       );
     }
     if (remove.length) {
@@ -675,8 +675,8 @@ export class CollectionItemsDialog extends TailwindElement {
           {
             method: "POST",
             body: JSON.stringify({ crawlIds: remove }),
-          },
-        ),
+          }
+        )
       );
     }
 
@@ -799,7 +799,7 @@ export class CollectionItemsDialog extends TailwindElement {
       collectionId?: string;
       firstSeed?: string;
     } & APIPaginationQuery &
-      APISortQuery = {},
+      APISortQuery = {}
   ) {
     const query = queryString.stringify(
       {
@@ -808,11 +808,11 @@ export class CollectionItemsDialog extends TailwindElement {
       },
       {
         arrayFormat: "comma",
-      },
+      }
     );
     const data = await this.api.fetch<APIPaginatedList<Crawl>>(
       `/orgs/${this.orgId}/crawls?${query}`,
-      this.authState!,
+      this.authState!
     );
 
     return data;
@@ -824,14 +824,14 @@ export class CollectionItemsDialog extends TailwindElement {
       name?: string;
       firstSeed?: string;
     } & APIPaginationQuery &
-      APISortQuery = {},
+      APISortQuery = {}
   ) {
     const query = queryString.stringify({
       ...params,
     });
     const data = await this.api.fetch<APIPaginatedList<Workflow>>(
       `/orgs/${this.orgId}/crawlconfigs?${query}`,
-      this.authState!,
+      this.authState!
     );
 
     return data;
@@ -843,7 +843,7 @@ export class CollectionItemsDialog extends TailwindElement {
       collectionId?: string;
       name?: string;
     } & APIPaginationQuery &
-      APISortQuery = {},
+      APISortQuery = {}
   ) {
     const query = queryString.stringify({
       state: "complete",
@@ -851,7 +851,7 @@ export class CollectionItemsDialog extends TailwindElement {
     });
     const data = await this.api.fetch<APIPaginatedList<Upload>>(
       `/orgs/${this.orgId}/uploads?${query}`,
-      this.authState!,
+      this.authState!
     );
 
     return data;
@@ -861,12 +861,12 @@ export class CollectionItemsDialog extends TailwindElement {
     if (searchType === "workflow") {
       return this.api.fetch<SearchValues>(
         `/orgs/${this.orgId}/crawlconfigs/search-values`,
-        this.authState!,
+        this.authState!
       );
     }
     return this.api.fetch<SearchValues>(
       `/orgs/${this.orgId}/all-crawls/search-values?crawlType=${searchType}`,
-      this.authState!,
+      this.authState!
     );
   }
 
@@ -883,7 +883,7 @@ export class CollectionItemsDialog extends TailwindElement {
           body: JSON.stringify({
             autoAddCollections: autoAddCollections,
           }),
-        },
+        }
       );
       this.notify.toast({
         message: msg(str`Updated.`),
@@ -895,7 +895,7 @@ export class CollectionItemsDialog extends TailwindElement {
       console.debug(e);
       this.notify.toast({
         message: msg(
-          "Something unexpected went wrong, couldn't save auto-add setting.",
+          "Something unexpected went wrong, couldn't save auto-add setting."
         ),
         variant: "warning",
         icon: "exclamation-circle",

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -72,7 +72,7 @@ export class Crawls extends LiteElement {
   private getCrawlsController: AbortController | null = null;
 
   protected async willUpdate(
-    changedProperties: PropertyValues<this> & Map<string, unknown>,
+    changedProperties: PropertyValues<this> & Map<string, unknown>
   ) {
     if (changedProperties.has("crawlId") && this.crawlId) {
       // Redirect to org crawl page
@@ -155,11 +155,11 @@ export class Crawls extends LiteElement {
                       }}
                     ></btrix-pagination>
                   </footer>
-                `,
+                `
               )}
             `;
           },
-          this.renderLoading,
+          this.renderLoading
         )}
       </main>
     `;
@@ -213,7 +213,7 @@ export class Crawls extends LiteElement {
     const options = Object.entries(sortableFields).map(
       ([value, { label }]) => html`
         <sl-option value=${value}>${label}</sl-option>
-      `,
+      `
     );
     return html`
       <sl-select
@@ -340,7 +340,7 @@ export class Crawls extends LiteElement {
   }
 
   private async getCrawls(
-    queryParams?: APIPaginationQuery & { state?: CrawlState[] },
+    queryParams?: APIPaginationQuery & { state?: CrawlState[] }
   ) {
     const query = queryString.stringify(
       {
@@ -353,7 +353,7 @@ export class Crawls extends LiteElement {
       },
       {
         arrayFormat: "comma",
-      },
+      }
     );
 
     this.getCrawlsController = new AbortController();
@@ -362,7 +362,7 @@ export class Crawls extends LiteElement {
       this.authState!,
       {
         signal: this.getCrawlsController.signal,
-      },
+      }
     );
     this.getCrawlsController = null;
 
@@ -372,7 +372,7 @@ export class Crawls extends LiteElement {
   private async getCrawl() {
     const data: Crawl = await this.apiFetch<Crawl>(
       `/orgs/all/crawls/${this.crawlId}/replay.json`,
-      this.authState!,
+      this.authState!
     );
 
     return data;
@@ -381,7 +381,7 @@ export class Crawls extends LiteElement {
   private async getSlugLookup() {
     const data = await this.apiFetch<Record<string, string>>(
       `/orgs/slug-lookup`,
-      this.authState!,
+      this.authState!
     );
 
     return data;

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -118,7 +118,7 @@ export class CrawlsList extends LiteElement {
 
   private get selectedSearchFilterKey() {
     return Object.keys(CrawlsList.FieldLabels).find((key) =>
-      Boolean((this.filterBy as Record<string, unknown>)[key]),
+      Boolean((this.filterBy as Record<string, unknown>)[key])
     );
   }
 
@@ -130,7 +130,7 @@ export class CrawlsList extends LiteElement {
   }
 
   protected willUpdate(
-    changedProperties: PropertyValues<this> & Map<string, unknown>,
+    changedProperties: PropertyValues<this> & Map<string, unknown>
   ) {
     if (
       changedProperties.has("filterByCurrentUser") ||
@@ -155,7 +155,7 @@ export class CrawlsList extends LiteElement {
       if (changedProperties.has("filterByCurrentUser")) {
         window.sessionStorage.setItem(
           FILTER_BY_CURRENT_USER_STORAGE_KEY,
-          this.filterByCurrentUser.toString(),
+          this.filterByCurrentUser.toString()
         );
       }
     }
@@ -216,7 +216,7 @@ export class CrawlsList extends LiteElement {
                     ${msg("Upload WACZ")}
                   </sl-button>
                 </sl-tooltip>
-              `,
+              `
             )}
           </div>
           <div class="flex gap-2 mb-3">
@@ -272,7 +272,7 @@ export class CrawlsList extends LiteElement {
                       }}
                     ></btrix-pagination>
                   </footer>
-                `,
+                `
               )}
             `;
           },
@@ -280,7 +280,7 @@ export class CrawlsList extends LiteElement {
             <div class="w-full flex items-center justify-center my-12 text-2xl">
               <sl-spinner></sl-spinner>
             </div>
-          `,
+          `
         )}
       </main>
       ${when(
@@ -299,7 +299,7 @@ export class CrawlsList extends LiteElement {
               }
             }}
           ></btrix-file-uploader>
-        `,
+        `
       )}
     `;
   }
@@ -367,7 +367,7 @@ export class CrawlsList extends LiteElement {
     const options = Object.entries(sortableFields).map(
       ([value, { label }]) => html`
         <sl-option value=${value}>${label}</sl-option>
-      `,
+      `
     );
     return html`
       <sl-select
@@ -409,8 +409,8 @@ export class CrawlsList extends LiteElement {
         placeholder=${this.itemType === "upload"
           ? msg("Search all uploads by name")
           : this.itemType === "crawl"
-            ? msg("Search all crawls by name or Crawl Start URL")
-            : msg("Search all items by name or Crawl Start URL")}
+          ? msg("Search all crawls by name or Crawl Start URL")
+          : msg("Search all items by name or Crawl Start URL")}
         @on-select=${(e: CustomEvent) => {
           const { key, value } = e.detail;
           this.filterBy = {
@@ -465,8 +465,8 @@ export class CrawlsList extends LiteElement {
         ${msg("This item will be removed from any Collection it is a part of.")}
         ${when(this.itemToDelete?.type === "crawl", () =>
           msg(
-            "All files and logs associated with this item will also be deleted, and the crawl will no longer be visible in its associated Workflow.",
-          ),
+            "All files and logs associated with this item will also be deleted, and the crawl will no longer be visible in its associated Workflow."
+          )
         )}
         <div slot="footer" class="flex justify-between">
           <sl-button size="small" .autofocus=${true}
@@ -486,7 +486,7 @@ export class CrawlsList extends LiteElement {
                 this.itemToDelete?.type === "upload"
                   ? msg("Upload")
                   : msg("Crawl")
-              }`,
+              }`
             )}</sl-button
           >
         </div>
@@ -537,7 +537,7 @@ export class CrawlsList extends LiteElement {
             ${msg("Edit Metadata")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-        `,
+        `
       )}
       ${item.type === "crawl"
         ? html`
@@ -576,7 +576,7 @@ export class CrawlsList extends LiteElement {
             <sl-icon name="trash3" slot="prefix"></sl-icon>
             ${msg("Delete Item")}
           </sl-menu-item>
-        `,
+        `
       )}
     `;
 
@@ -660,7 +660,7 @@ export class CrawlsList extends LiteElement {
   }
 
   private async getArchivedItems(
-    queryParams?: APIPaginationQuery & { state?: CrawlState[] },
+    queryParams?: APIPaginationQuery & { state?: CrawlState[] }
   ): Promise<ArchivedItems> {
     const query = queryString.stringify(
       {
@@ -680,7 +680,7 @@ export class CrawlsList extends LiteElement {
       },
       {
         arrayFormat: "comma",
-      },
+      }
     );
 
     this.getArchivedItemsController = new AbortController();
@@ -689,7 +689,7 @@ export class CrawlsList extends LiteElement {
       this.authState!,
       {
         signal: this.getArchivedItemsController.signal,
-      },
+      }
     );
 
     this.getArchivedItemsController = null;
@@ -709,7 +709,7 @@ export class CrawlsList extends LiteElement {
         firstSeeds: string[];
       } = await this.apiFetch(
         `/orgs/${this.orgId}/all-crawls/search-values?${query}`,
-        this.authState!,
+        this.authState!
       );
 
       // Update search/filter collection
@@ -754,7 +754,7 @@ export class CrawlsList extends LiteElement {
           body: JSON.stringify({
             crawl_ids: [item.id],
           }),
-        },
+        }
       );
       const { items, ...crawlsData } = this.archivedItems!;
       this.itemToDelete = null;
@@ -773,12 +773,12 @@ export class CrawlsList extends LiteElement {
         this.confirmDeleteItem(this.itemToDelete);
       }
       let message = msg(
-        str`Sorry, couldn't delete archived item at this time.`,
+        str`Sorry, couldn't delete archived item at this time.`
       );
       if (isApiError(e)) {
         if (e.details == "not_allowed") {
           message = msg(
-            str`Only org owners can delete other users' archived items.`,
+            str`Only org owners can delete other users' archived items.`
           );
         } else if (e.message) {
           message = e.message;
@@ -795,7 +795,7 @@ export class CrawlsList extends LiteElement {
   async getWorkflow(crawl: Crawl): Promise<Workflow> {
     const data: Workflow = await this.apiFetch(
       `/orgs/${crawl.oid}/crawlconfigs/${crawl.cid}`,
-      this.authState!,
+      this.authState!
     );
 
     return data;

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -45,7 +45,7 @@ export class BrowserProfilesList extends LiteElement {
               this.dispatchEvent(
                 new CustomEvent("select-new-dialog", {
                   detail: "browser-profile",
-                }) as SelectNewDialogEvent,
+                }) as SelectNewDialogEvent
               );
             }}
           >
@@ -196,10 +196,10 @@ export class BrowserProfilesList extends LiteElement {
         `${this.orgBasePath}/browser-profiles/profile/browser/${
           data.browserid
         }?name=${window.encodeURIComponent(
-          profile.name,
+          profile.name
         )}&description=${window.encodeURIComponent(
-          profile.description || "",
-        )}&profileId=${window.encodeURIComponent(profile.id)}&navigateUrl=`,
+          profile.description || ""
+        )}&profileId=${window.encodeURIComponent(profile.id)}&navigateUrl=`
       );
     } catch (e) {
       this.notify({
@@ -217,7 +217,7 @@ export class BrowserProfilesList extends LiteElement {
         this.authState!,
         {
           method: "DELETE",
-        },
+        }
       );
 
       if (data.error && data.crawlconfigs) {
@@ -226,7 +226,7 @@ export class BrowserProfilesList extends LiteElement {
             html`Could not delete <strong>${profile.name}</strong>, in use by
               <strong
                 >${data.crawlconfigs.map(({ name }) => name).join(", ")}</strong
-              >. Please remove browser profile from Workflow to continue.`,
+              >. Please remove browser profile from Workflow to continue.`
           ),
           variant: "warning",
           icon: "exclamation-triangle",
@@ -240,7 +240,7 @@ export class BrowserProfilesList extends LiteElement {
         });
 
         this.browserProfiles = this.browserProfiles!.filter(
-          (p) => p.id !== profile.id,
+          (p) => p.id !== profile.id
         );
       }
     } catch (e) {
@@ -263,7 +263,7 @@ export class BrowserProfilesList extends LiteElement {
       {
         method: "POST",
         body: JSON.stringify(params),
-      },
+      }
     );
   }
 
@@ -287,7 +287,7 @@ export class BrowserProfilesList extends LiteElement {
   private async getProfiles() {
     const data = await this.apiFetch<APIPaginatedList<Profile>>(
       `/orgs/${this.orgId}/profiles`,
-      this.authState!,
+      this.authState!
     );
 
     return data.items;

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -94,7 +94,7 @@ export class CollectionDetail extends LiteElement {
   }
 
   protected async updated(
-    changedProperties: PropertyValues<this> & Map<string, unknown>,
+    changedProperties: PropertyValues<this> & Map<string, unknown>
   ) {
     if (changedProperties.has("collection") && this.collection) {
       void this.checkTruncateDescription();
@@ -132,7 +132,7 @@ export class CollectionDetail extends LiteElement {
               <sl-icon name="box-arrow-up" slot="prefix"></sl-icon>
               ${msg("Share")}
             </sl-button>
-          `,
+          `
         )}
         ${when(this.isCrawler, this.renderActions)}
       </header>
@@ -155,7 +155,7 @@ export class CollectionDetail extends LiteElement {
               <sl-icon name="ui-checks" slot="prefix"></sl-icon>
               ${msg("Select Items")}
             </sl-button>
-          `,
+          `
         )}
       </div>
       ${choose(
@@ -168,7 +168,7 @@ export class CollectionDetail extends LiteElement {
           ],
         ],
 
-        () => html`<btrix-not-found></btrix-not-found>`,
+        () => html`<btrix-not-found></btrix-not-found>`
       )}
       <div class="my-7">${this.renderDescription()}</div>
 
@@ -179,7 +179,7 @@ export class CollectionDetail extends LiteElement {
       >
         ${msg(
           html`Are you sure you want to delete
-            <strong>${this.collection?.name}</strong>?`,
+            <strong>${this.collection?.name}</strong>?`
         )}
         <div slot="footer" class="flex justify-between">
           <sl-button
@@ -225,7 +225,7 @@ export class CollectionDetail extends LiteElement {
             @btrix-collection-saved=${() => this.fetchCollection()}
           >
           </btrix-collection-metadata-dialog>
-        `,
+        `
       )}
       ${this.renderShareDialog()}`;
   }
@@ -233,7 +233,7 @@ export class CollectionDetail extends LiteElement {
   private getPublicReplayURL() {
     return new URL(
       `/api/orgs/${this.orgId}/collections/${this.collectionId}/public/replay.json`,
-      window.location.href,
+      window.location.href
     ).href;
   }
 
@@ -250,7 +250,7 @@ export class CollectionDetail extends LiteElement {
             ? ""
             : html`<p class="mb-3">
                 ${msg(
-                  "Make this collection shareable to enable a public viewing link.",
+                  "Make this collection shareable to enable a public viewing link."
                 )}
               </p>`
         }
@@ -265,7 +265,7 @@ export class CollectionDetail extends LiteElement {
                 >${msg("Collection is Shareable")}</sl-switch
               >
             </div>
-          `,
+          `
         )}
         </div>
         ${when(this.collection?.isPublic, this.renderShareInfo)}
@@ -312,7 +312,7 @@ export class CollectionDetail extends LiteElement {
       <section class="mt-3">
         <p class="mb-3">
           ${msg(
-            html`Share this collection by embedding it into an existing webpage.`,
+            html`Share this collection by embedding it into an existing webpage.`
           )}
         </p>
         <p class="mb-3">
@@ -332,7 +332,7 @@ export class CollectionDetail extends LiteElement {
         <p class="mb-3">
           ${msg(
             html`Add the following JavaScript to your
-              <code class="text-[0.9em]">/replay/sw.js</code>:`,
+              <code class="text-[0.9em]">/replay/sw.js</code>:`
           )}
         </p>
         <div class="relative mb-5 border rounded p-3 pr-9 bg-slate-50">
@@ -356,7 +356,7 @@ export class CollectionDetail extends LiteElement {
               >
                 our embedding guide</a
               >
-              for more details.`,
+              for more details.`
           )}
         </p>
       </section>`;
@@ -482,7 +482,7 @@ export class CollectionDetail extends LiteElement {
         ${this.renderDetailItem(msg("Archived Items"), (col) =>
           col.crawlCount === 1
             ? msg("1 item")
-            : msg(str`${this.numberFormatter.format(col.crawlCount)} items`),
+            : msg(str`${this.numberFormatter.format(col.crawlCount)} items`)
         )}
         ${this.renderDetailItem(
           msg("Total Size"),
@@ -490,12 +490,12 @@ export class CollectionDetail extends LiteElement {
             html`<sl-format-bytes
               value=${col.totalSize || 0}
               display="narrow"
-            ></sl-format-bytes>`,
+            ></sl-format-bytes>`
         )}
         ${this.renderDetailItem(msg("Total Pages"), (col) =>
           col.pageCount === 1
             ? msg("1 page")
-            : msg(str`${this.numberFormatter.format(col.pageCount)} pages`),
+            : msg(str`${this.numberFormatter.format(col.pageCount)} pages`)
         )}
         ${this.renderDetailItem(
           msg("Last Updated"),
@@ -507,7 +507,7 @@ export class CollectionDetail extends LiteElement {
               year="2-digit"
               hour="2-digit"
               minute="2-digit"
-            ></sl-format-date>`,
+            ></sl-format-date>`
         )}
       </btrix-desc-list>
     `;
@@ -515,14 +515,14 @@ export class CollectionDetail extends LiteElement {
 
   private renderDetailItem(
     label: string | TemplateResult,
-    renderContent: (collection: Collection) => TemplateResult | string,
+    renderContent: (collection: Collection) => TemplateResult | string
   ) {
     return html`
       <btrix-desc-list-item label=${label}>
         ${when(
           this.collection,
           () => renderContent(this.collection!),
-          () => html`<sl-skeleton class="w-full"></sl-skeleton>`,
+          () => html`<sl-skeleton class="w-full"></sl-skeleton>`
         )}
       </btrix-desc-list-item>
     `;
@@ -544,7 +544,7 @@ export class CollectionDetail extends LiteElement {
                 @click=${() => (this.openDialogName = "editMetadata")}
                 label=${msg("Edit description")}
               ></sl-icon-button>
-            `,
+            `
           )}
         </header>
         <main>
@@ -589,7 +589,7 @@ export class CollectionDetail extends LiteElement {
                 style=${`max-height: ${DESCRIPTION_MAX_HEIGHT_PX}px`}
               >
                 <sl-spinner></sl-spinner>
-              </div>`,
+              </div>`
           )}
         </main>
       </section>
@@ -628,7 +628,7 @@ export class CollectionDetail extends LiteElement {
                     }}
                   ></btrix-pagination>
                 </footer>
-              `,
+              `
             )}
           `;
         },
@@ -636,7 +636,7 @@ export class CollectionDetail extends LiteElement {
           <div class="w-full flex items-center justify-center my-12 text-2xl">
             <sl-spinner></sl-spinner>
           </div>
-        `,
+        `
       )}
     </section>`;
 
@@ -651,7 +651,7 @@ export class CollectionDetail extends LiteElement {
         ${repeat(
           this.archivedItems.items,
           ({ id }) => id,
-          this.renderArchivedItem,
+          this.renderArchivedItem
         )}
       </btrix-archived-item-list>
     `;
@@ -671,7 +671,7 @@ export class CollectionDetail extends LiteElement {
 
   private readonly renderArchivedItem = (
     item: ArchivedItem,
-    idx: number,
+    idx: number
   ) => html`
     <btrix-archived-item-list-item
       href=${`/orgs/${this.appState.orgSlug}/items/${item.type}/${item.id}?collectionId=${this.collectionId}`}
@@ -767,7 +767,7 @@ export class CollectionDetail extends LiteElement {
       {
         method: "PATCH",
         body: JSON.stringify({ isPublic }),
-      },
+      }
     );
 
     if (res.updated && this.collection) {
@@ -789,7 +789,7 @@ export class CollectionDetail extends LiteElement {
         this.authState!,
         {
           method: "DELETE",
-        },
+        }
       );
 
       this.navTo(`${this.orgBasePath}/collections`);
@@ -823,7 +823,7 @@ export class CollectionDetail extends LiteElement {
   private async getCollection() {
     const data = await this.apiFetch<Collection>(
       `/orgs/${this.orgId}/collections/${this.collectionId}/replay.json`,
-      this.authState!,
+      this.authState!
     );
 
     return data;
@@ -861,7 +861,7 @@ export class CollectionDetail extends LiteElement {
       state: CrawlState[];
     }> &
       APIPaginationQuery &
-      APISortQuery,
+      APISortQuery
   ) {
     const query = queryString.stringify(
       {
@@ -874,11 +874,11 @@ export class CollectionDetail extends LiteElement {
       },
       {
         arrayFormat: "comma",
-      },
+      }
     );
     const data = await this.apiFetch<APIPaginatedList<Crawl | Upload>>(
       `/orgs/${this.orgId}/all-crawls?collectionId=${this.collectionId}&${query}`,
-      this.authState!,
+      this.authState!
     );
 
     return data;
@@ -892,7 +892,7 @@ export class CollectionDetail extends LiteElement {
         {
           method: "POST",
           body: JSON.stringify({ crawlIds: [id] }),
-        },
+        }
       );
 
       const { page, items } = this.archivedItems!;
@@ -911,7 +911,7 @@ export class CollectionDetail extends LiteElement {
       console.debug((e as Error)?.message);
       this.notify({
         message: msg(
-          "Sorry, couldn't remove item from Collection at this time.",
+          "Sorry, couldn't remove item from Collection at this time."
         ),
         variant: "danger",
         icon: "exclamation-octagon",

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -112,7 +112,7 @@ export class CollectionsList extends LiteElement {
   });
 
   protected async willUpdate(
-    changedProperties: PropertyValues<this> & Map<string, unknown>,
+    changedProperties: PropertyValues<this> & Map<string, unknown>
   ) {
     if (changedProperties.has("orgId")) {
       this.collections = undefined;
@@ -143,7 +143,7 @@ export class CollectionsList extends LiteElement {
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                 ${msg("New Collection")}
               </sl-button>
-            `,
+            `
           )}
         </div>
       </header>
@@ -161,7 +161,7 @@ export class CollectionsList extends LiteElement {
                 ${guard([this.collections], this.renderList)}
               </div>
             `
-          : this.renderLoading(),
+          : this.renderLoading()
       )}
 
       <btrix-dialog
@@ -172,7 +172,7 @@ export class CollectionsList extends LiteElement {
       >
         ${msg(
           html`Are you sure you want to delete
-            <strong>${this.selectedCollection?.name}</strong>?`,
+            <strong>${this.selectedCollection?.name}</strong>?`
         )}
         <div slot="footer" class="flex justify-between">
           <sl-button
@@ -204,7 +204,7 @@ export class CollectionsList extends LiteElement {
         @btrix-collection-saved=${(e: CollectionSavedEvent) => {
           if (this.openDialogName === "create") {
             this.navTo(
-              `${this.orgBasePath}/collections/view/${e.detail.id}/items`,
+              `${this.orgBasePath}/collections/view/${e.detail.id}/items`
             );
           } else {
             void this.fetchCollections();
@@ -239,7 +239,7 @@ export class CollectionsList extends LiteElement {
         () => html`
           <p class="max-w-[18em]">
             ${msg(
-              "Organize your crawls into a Collection to easily replay them together.",
+              "Organize your crawls into a Collection to easily replay them together."
             )}
           </p>
           <div>
@@ -249,7 +249,7 @@ export class CollectionsList extends LiteElement {
                 this.dispatchEvent(
                   new CustomEvent("select-new-dialog", {
                     detail: "collection",
-                  }) as SelectNewDialogEvent,
+                  }) as SelectNewDialogEvent
                 );
               }}
             >
@@ -262,7 +262,7 @@ export class CollectionsList extends LiteElement {
           <p class="max-w-[18em]">
             ${msg("Your organization doesn't have any Collections, yet.")}
           </p>
-        `,
+        `
       )}
     </div>
   `;
@@ -297,7 +297,7 @@ export class CollectionsList extends LiteElement {
               ${Object.entries(sortableFields).map(
                 ([value, { label }]) => html`
                   <sl-option value=${value}>${label}</sl-option>
-                `,
+                `
               )}
             </sl-select>
             <sl-icon-button
@@ -391,7 +391,7 @@ export class CollectionsList extends LiteElement {
           >
             ${item.value}
           </sl-menu-item>
-        `,
+        `
       )}
     `;
   }
@@ -448,7 +448,7 @@ export class CollectionsList extends LiteElement {
                 }}
               ></btrix-pagination>
             </footer>
-          `,
+          `
         )}
       `;
     }
@@ -463,7 +463,7 @@ export class CollectionsList extends LiteElement {
           () => html`
             <p class="p-4 text-center">
               ${msg(
-                "Organize your crawls into a Collection to easily replay them together.",
+                "Organize your crawls into a Collection to easily replay them together."
               )}
             </p>
             <div>
@@ -473,7 +473,7 @@ export class CollectionsList extends LiteElement {
                   this.dispatchEvent(
                     new CustomEvent("select-new-dialog", {
                       detail: "collection",
-                    }) as SelectNewDialogEvent,
+                    }) as SelectNewDialogEvent
                   );
                 }}
               >
@@ -486,7 +486,7 @@ export class CollectionsList extends LiteElement {
             <p class="max-w-[18em] text-center">
               ${msg("Your organization doesn't have any Collections, yet.")}
             </p>
-          `,
+          `
         )}
       </div>
     `;
@@ -588,7 +588,7 @@ export class CollectionsList extends LiteElement {
                     target="_blank"
                     slot="prefix"
                     href="https://replayweb.page?source=${this.getPublicReplayURL(
-                      col,
+                      col
                     )}"
                   >
                     Visit Shareable URL
@@ -660,7 +660,7 @@ export class CollectionsList extends LiteElement {
       {
         method: "PATCH",
         body: JSON.stringify({ isPublic }),
-      },
+      }
     );
 
     void this.fetchCollections();
@@ -669,13 +669,13 @@ export class CollectionsList extends LiteElement {
   private getPublicReplayURL(col: Collection) {
     return new URL(
       `/api/orgs/${this.orgId}/collections/${col.id}/public/replay.json`,
-      window.location.href,
+      window.location.href
     ).href;
   }
 
   private readonly manageCollection = async (
     collection: Collection,
-    dialogName: CollectionsList["openDialogName"],
+    dialogName: CollectionsList["openDialogName"]
   ) => {
     this.selectedCollection = collection;
     await this.updateComplete;
@@ -691,7 +691,7 @@ export class CollectionsList extends LiteElement {
         // FIXME API method is GET right now
         {
           method: "DELETE",
-        },
+        }
       );
 
       this.selectedCollection = undefined;
@@ -715,7 +715,7 @@ export class CollectionsList extends LiteElement {
     try {
       const searchValues: CollectionSearchValues = await this.apiFetch(
         `/orgs/${this.orgId}/collections/search-values`,
-        this.authState!,
+        this.authState!
       );
       const names = searchValues.names;
 
@@ -764,12 +764,12 @@ export class CollectionsList extends LiteElement {
       },
       {
         arrayFormat: "comma",
-      },
+      }
     );
 
     const data = await this.apiFetch<APIPaginatedList<Collection>>(
       `/orgs/${this.orgId}/collections?${query}`,
-      this.authState!,
+      this.authState!
     );
 
     return data;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const { tailwindTransform } = require("postcss-lit");
 const Color = require("color");
 

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -1,6 +1,6 @@
 # Running Tests Locally
 
-This guide will show you how to run tests locally for a frontend application using `yarn start` and `npx playwright test`. 
+This guide will show you how to run tests locally for a frontend application using `yarn start` and `npx playwright test`.
 
 ## Prerequisites
 

--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -1,28 +1,27 @@
-import { chromium } from 'playwright';
-import { test, expect } from '@playwright/test';
+import { chromium } from "playwright";
+import { test } from "@playwright/test";
 
-test('test', async ({ baseURL }) => {
+test("test", async ({ baseURL }) => {
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext();
   const page = await context.newPage();
 
   try {
     await page.goto(baseURL!);
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
     await page.waitForSelector('input[name="username"]');
     await page.click('input[name="username"]');
-    await page.fill('input[name="username"]', 'dev@webrecorder.net');
+    await page.fill('input[name="username"]', "dev@webrecorder.net");
     await page.click('input[name="password"]');
     const devPassword = process.env.DEV_PASSWORD;
     if (!devPassword) {
-      throw new Error('DEV_PASSWORD environment variable is not defined or null.');
+      throw new Error(
+        "DEV_PASSWORD environment variable is not defined or null."
+      );
     }
     await page.fill('input[name="password"]', devPassword);
     await page.click('a:has-text("Log In")');
-
-
   } finally {
     await browser.close();
   }
 });
-

--- a/frontend/tsconfig.eslint.json
+++ b/frontend/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "extends": "./tsconfig.json",
-  "include": ["**/*.ts", "*.js", ".*.js"]
+  "include": ["**/*.ts", "**/*.js"]
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -62,7 +62,9 @@ const version = (() => {
 
   try {
     return fs.readFileSync("../version.txt", { encoding: "utf-8" }).trim();
-  } catch (e) {}
+  } catch (e) {
+    /* empty */
+  }
 
   return packageJSON.version;
 })();


### PR DESCRIPTION
Makes sure code quality stays high by checking that code is linted & formatted in CI.

### Reason

Frustration — so that [things like this](https://github.com/webrecorder/browsertrix-cloud/pull/1500#issuecomment-1920087667) don't happen in the future. I tried to merge `main` into a branch to get it up to date with main, and main isn't totally formatted or linted properly, and then formatting the codebase introduced a whole bunch of unrelated changes. Running a formatter or linter shouldn't cause unrelated code changes, and `main` should always be in a correct state in terms of linting and formatting.

### Testing

- [x] Test run with failing lint checks errors: https://github.com/webrecorder/browsertrix-cloud/actions/runs/7733354321/job/21085236200
- [x] Test run with failing formatting check errors: https://github.com/webrecorder/browsertrix-cloud/actions/runs/7733501666/job/21085717519
- [x] Test run with both passing lint & formatting checks passes: https://github.com/webrecorder/browsertrix-cloud/actions/runs/7733529142/job/21085796727