### PR TITLE
Fixes workflow selector keyboard navigation

### DIFF
--- a/frontend/src/features/crawl-workflows/new-workflow-dialog.ts
+++ b/frontend/src/features/crawl-workflows/new-workflow-dialog.ts
@@ -41,9 +41,14 @@ export class NewWorkflowDialog extends LitElement {
     }
 
     .jobTypeButton {
+      padding: 0.25rem;
       display: block;
       width: min-content;
       cursor: pointer;
+      background: none;
+      text-align: left;
+      border: none;
+      border-radius: 0.75rem;
     }
 
     figure {
@@ -72,14 +77,13 @@ export class NewWorkflowDialog extends LitElement {
   render() {
     return html`
       <btrix-dialog
-        .label=${msg("Create a New Crawl Workflow")}
+        .label=${msg("Choose New Workflow Type")}
         .open=${this.open}
         style="--width: 46rem"
       >
-        <h3 class="title heading">${msg("Choose Crawl Type")}</h3>
         <div class="container">
-          <div
-            role="button"
+          <button
+            tabindex="2"
             class="jobTypeButton"
             @click=${() => {
               this.dispatchEvent(
@@ -100,9 +104,9 @@ export class NewWorkflowDialog extends LitElement {
                 </p>
               </figcaption>
             </figure>
-          </div>
-          <div
-            role="button"
+          </button>
+          <button
+            tabindex="1"
             class="jobTypeButton"
             @click=${() => {
               this.dispatchEvent(
@@ -124,7 +128,7 @@ export class NewWorkflowDialog extends LitElement {
               </figcaption>
             </figure>
           </div>
-        </div>
+        </button>
       </btrix-dialog>
     `;
   }

--- a/frontend/src/features/crawl-workflows/new-workflow-dialog.ts
+++ b/frontend/src/features/crawl-workflows/new-workflow-dialog.ts
@@ -43,7 +43,7 @@ export class NewWorkflowDialog extends LitElement {
     .jobTypeButton {
       padding: 0.25rem;
       display: block;
-      width: min-content;
+      width: 16.5rem;
       cursor: pointer;
       background: none;
       text-align: left;
@@ -61,6 +61,8 @@ export class NewWorkflowDialog extends LitElement {
     }
 
     .jobTypeImg {
+      width: 100%;
+      max-height: 9rem;
       transition-property: transform;
       transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
       transition-duration: 150ms;


### PR DESCRIPTION
Fixes #1387

### Context

While checking some other keyboard navigation issues, I found that I was unable to create a crawl workflow using only keyboard navigation.  This PR fixes that!

### Changes
- Changes from `<div>`s to `<button>`s so that these can be selected with tab and enter.
- Adds tabindex for correct selection of items
- Removes the H3 & combines with window title
- Adds width and height to image and width to its container, should make for a more stable layout while loading (#1387)

### Screenshots

**Before** — Image not loaded VS loaded
<img width="1792" alt="Screenshot 2024-01-31 at 11 50 43 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/8c32c13a-bc02-4011-8ef3-fb03d21f86af">

**After** — Both images loaded, URL list focused!
<img width="1792" alt="Screenshot 2024-01-31 at 11 38 50 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/de8a3db4-3592-4b1c-8da4-1c6ece375798">

Image not loaded VS loaded
<img width="1792" alt="Screenshot 2024-01-31 at 11 49 50 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/5672810/56a2827a-cdfa-46eb-b7af-b68eded0211e">