### PR TITLE
Add crawl pages and related API endpoints

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import timedelta
-from typing import Optional, List, Union, Type, TYPE_CHECKING
+from typing import Optional, List, Union, Dict, Any, Type, TYPE_CHECKING
 from uuid import UUID
 import urllib.parse
 import contextlib
@@ -367,9 +367,9 @@ class BaseCrawlOps:
 
         return res.deleted_count, cids_to_update, quota_reached
 
-    async def _delete_crawl_files(self, crawl, org: Organization):
+    async def _delete_crawl_files(self, crawl_raw: Dict[str, Any], org: Organization):
         """Delete files associated with crawl from storage."""
-        crawl = BaseCrawl.from_dict(crawl)
+        crawl = BaseCrawl.from_dict(crawl_raw)
         size = 0
         for file_ in crawl.files:
             size += file_.size
@@ -380,6 +380,12 @@ class BaseCrawlOps:
             )
 
         return size
+
+    async def delete_crawl_files(self, crawl_id: str, oid: UUID):
+        """Delete crawl files"""
+        crawl_raw = await self.get_crawl_raw(crawl_id)
+        org = await self.orgs.get_org_by_id(oid)
+        return await self._delete_crawl_files(crawl_raw, org)
 
     async def _resolve_crawl_refs(
         self,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -94,6 +94,10 @@ class BaseCrawlOps:
             min(presign_duration_minutes, PRESIGN_MINUTES_MAX) * 60
         )
 
+    def set_page_ops(self, page_ops):
+        """set page ops reference"""
+        self.page_ops = page_ops
+
     async def get_crawl_raw(
         self,
         crawlid: str,
@@ -333,6 +337,9 @@ class BaseCrawlOps:
                     raise HTTPException(
                         status_code=400, detail=f"Error Stopping Crawl: {exc}"
                     )
+
+            if type_ == "crawl":
+                await self.page_ops.delete_crawl_pages(crawl_id, org.id)
 
             crawl_size = await self._delete_crawl_files(crawl, org)
             size += crawl_size

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import timedelta
-from typing import Optional, List, Union, Dict, Any, Type, TYPE_CHECKING
+from typing import Optional, List, Union, Dict, Any, Type, TYPE_CHECKING, cast
 from uuid import UUID
 import urllib.parse
 import contextlib

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -37,9 +37,10 @@ if TYPE_CHECKING:
     from .storages import StorageOps
     from .webhooks import EventWebhookOps
     from .background_jobs import BackgroundJobOps
+    from .pages import PageOps
 
 else:
-    CrawlConfigOps = UserManager = OrgOps = CollectionOps = object
+    CrawlConfigOps = UserManager = OrgOps = CollectionOps = PageOps = object
     CrawlManager = StorageOps = EventWebhookOps = BackgroundJobOps = object
 
 # Presign duration must be less than 604800 seconds (one week),
@@ -63,6 +64,7 @@ class BaseCrawlOps:
     storage_ops: StorageOps
     event_webhook_ops: EventWebhookOps
     background_job_ops: BackgroundJobOps
+    page_ops: PageOps
 
     def __init__(
         self,
@@ -85,6 +87,7 @@ class BaseCrawlOps:
         self.storage_ops = storage_ops
         self.event_webhook_ops = event_webhook_ops
         self.background_job_ops = background_job_ops
+        self.page_ops = cast(PageOps, None)
 
         presign_duration_minutes = int(
             os.environ.get("PRESIGN_DURATION_MINUTES") or PRESIGN_MINUTES_DEFAULT

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -145,6 +145,8 @@ def main():
         app, mdb, crawls, org_ops, storage_ops, current_active_user
     )
 
+    base_crawl_ops.set_page_ops(page_ops)
+
     init_uploads_api(*base_crawl_init)
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -141,7 +141,9 @@ def main():
 
     crawls = init_crawls_api(*base_crawl_init)
 
-    init_pages_api(app, mdb, crawls, org_ops, storage_ops, current_active_user)
+    page_ops = init_pages_api(
+        app, mdb, crawls, org_ops, storage_ops, current_active_user
+    )
 
     init_uploads_api(*base_crawl_init)
 
@@ -163,6 +165,7 @@ def main():
                 coll_ops,
                 invites,
                 storage_ops,
+                page_ops,
                 db_inited,
             )
         )

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -146,8 +146,6 @@ def main():
     )
 
     base_crawl_ops.set_page_ops(page_ops)
-
-    # Might be unnecessary
     crawls.set_page_ops(page_ops)
 
     init_uploads_api(*base_crawl_init)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -29,6 +29,7 @@ from .crawls import init_crawls_api
 from .basecrawls import init_base_crawls_api
 from .webhooks import init_event_webhooks_api
 from .background_jobs import init_background_jobs_api
+from .pages import init_pages_api
 
 from .crawlmanager import CrawlManager
 from .utils import run_once_lock, register_exit_handler, is_bool
@@ -139,6 +140,8 @@ def main():
     base_crawl_ops = init_base_crawls_api(*base_crawl_init)
 
     crawls = init_crawls_api(*base_crawl_init)
+
+    init_pages_api(app, mdb, crawls, org_ops, storage_ops, current_active_user)
 
     init_uploads_api(*base_crawl_init)
 

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -147,6 +147,9 @@ def main():
 
     base_crawl_ops.set_page_ops(page_ops)
 
+    # Might be unnecessary
+    crawls.set_page_ops(page_ops)
+
     init_uploads_api(*base_crawl_init)
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -90,6 +90,8 @@ def main():
 
     page_ops = PageOps(mdb, crawl_ops, org_ops, storage_ops)
 
+    crawl_ops.set_page_ops(page_ops)
+
     background_job_ops.set_ops(crawl_ops, profile_ops)
 
     return init_operator_api(

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -21,6 +21,7 @@ from .profiles import ProfileOps
 from .storages import init_storages_api
 from .webhooks import EventWebhookOps
 from .background_jobs import BackgroundJobOps
+from .pages import PageOps
 
 app_root = FastAPI()
 
@@ -87,6 +88,8 @@ def main():
         background_job_ops,
     )
 
+    page_ops = PageOps(mdb, crawl_ops, org_ops, storage_ops)
+
     background_job_ops.set_ops(crawl_ops, profile_ops)
 
     return init_operator_api(
@@ -98,6 +101,7 @@ def main():
         storage_ops,
         event_webhook_ops,
         background_job_ops,
+        page_ops,
     )
 
 

--- a/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
+++ b/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
@@ -24,8 +24,9 @@ class Migration(BaseMigration):
         "profiles",
     ]
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up."""

--- a/backend/btrixcloud/migrations/migration_0002_crawlconfig_crawlstats.py
+++ b/backend/btrixcloud/migrations/migration_0002_crawlconfig_crawlstats.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0002"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -14,8 +14,9 @@ MIGRATION_VERSION = "0003"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0004_config_seeds.py
+++ b/backend/btrixcloud/migrations/migration_0004_config_seeds.py
@@ -14,8 +14,9 @@ MIGRATION_VERSION = "0004"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0005_operator_scheduled_jobs.py
+++ b/backend/btrixcloud/migrations/migration_0005_operator_scheduled_jobs.py
@@ -13,8 +13,9 @@ MIGRATION_VERSION = "0005"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
+++ b/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
@@ -12,8 +12,9 @@ MIGRATION_VERSION = "0006"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
+++ b/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
@@ -15,8 +15,9 @@ MIGRATION_VERSION = "0007"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up."""

--- a/backend/btrixcloud/migrations/migration_0008_precompute_crawl_file_stats.py
+++ b/backend/btrixcloud/migrations/migration_0008_precompute_crawl_file_stats.py
@@ -12,8 +12,9 @@ MIGRATION_VERSION = "0008"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0009_crawl_types.py
+++ b/backend/btrixcloud/migrations/migration_0009_crawl_types.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0009"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -12,8 +12,9 @@ MIGRATION_VERSION = "0010"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0011_crawl_timeout_configmap.py
+++ b/backend/btrixcloud/migrations/migration_0011_crawl_timeout_configmap.py
@@ -15,8 +15,9 @@ MIGRATION_VERSION = "0011"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0012_notes_to_description.py
+++ b/backend/btrixcloud/migrations/migration_0012_notes_to_description.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0012"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0013_crawl_name.py
+++ b/backend/btrixcloud/migrations/migration_0013_crawl_name.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0013"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0014_to_collection_ids.py
+++ b/backend/btrixcloud/migrations/migration_0014_to_collection_ids.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0014"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0015_org_storage_usage.py
+++ b/backend/btrixcloud/migrations/migration_0015_org_storage_usage.py
@@ -12,8 +12,9 @@ MIGRATION_VERSION = "0015"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0016_operator_scheduled_jobs_v2.py
+++ b/backend/btrixcloud/migrations/migration_0016_operator_scheduled_jobs_v2.py
@@ -14,8 +14,9 @@ MIGRATION_VERSION = "0016"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0017_storage_by_type.py
+++ b/backend/btrixcloud/migrations/migration_0017_storage_by_type.py
@@ -12,8 +12,9 @@ MIGRATION_VERSION = "0017"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0018_usernames.py
+++ b/backend/btrixcloud/migrations/migration_0018_usernames.py
@@ -16,8 +16,9 @@ MIGRATION_VERSION = "0018"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0019_org_slug.py
+++ b/backend/btrixcloud/migrations/migration_0019_org_slug.py
@@ -12,8 +12,9 @@ MIGRATION_VERSION = "0019"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0020_org_storage_refs.py
+++ b/backend/btrixcloud/migrations/migration_0020_org_storage_refs.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0020"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0021_profile_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0021_profile_filenames.py
@@ -14,8 +14,9 @@ MIGRATION_VERSION = "0021"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0022_partial_complete.py
+++ b/backend/btrixcloud/migrations/migration_0022_partial_complete.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0022"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
+++ b/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
@@ -11,8 +11,9 @@ MIGRATION_VERSION = "0023"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0024_crawlerchannel.py
+++ b/backend/btrixcloud/migrations/migration_0024_crawlerchannel.py
@@ -13,8 +13,9 @@ MIGRATION_VERSION = "0024"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0025_workflow_db_configmap_fixes.py
+++ b/backend/btrixcloud/migrations/migration_0025_workflow_db_configmap_fixes.py
@@ -13,8 +13,9 @@ MIGRATION_VERSION = "0025"
 class Migration(BaseMigration):
     """Migration class."""
 
-    def __init__(self, mdb, migration_version=MIGRATION_VERSION):
-        super().__init__(mdb, migration_version)
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
     async def migrate_up(self):
         """Perform migration up.

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -2,8 +2,6 @@
 Migration 0026 -- Crawl Pages
 """
 
-import asyncio
-
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.utils import gather_tasks_with_concurrency
 

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -5,7 +5,7 @@ Migration 0026 -- Crawl Pages
 import asyncio
 
 from btrixcloud.migrations import BaseMigration
-from btrix.utils import gather_tasks_with_concurrency
+from btrixcloud.utils import gather_tasks_with_concurrency
 
 
 MIGRATION_VERSION = "0026"

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -26,7 +26,7 @@ class Migration(BaseMigration):
         crawls_mdb = self.mdb["crawls"]
         pages_mdb = self.mdb["pages"]
 
-        crawl_ids = await crawls_mdb.distinct("_id")
+        crawl_ids = await crawls_mdb.distinct("_id", {"type": "crawl"})
         crawl_ids_with_pages = await pages_mdb.distinct("crawl_id")
 
         crawl_ids_no_pages = list(set(crawl_ids) - set(crawl_ids_with_pages))

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -1,0 +1,36 @@
+"""
+Migration 0026 -- Crawl Pages
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0026"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+        self.page_ops = kwargs["page_ops"]
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Add pages to database for each crawl without them, pulling from WACZ files.
+        """
+        # pylint: disable=duplicate-code
+        crawls_mdb = self.mdb["crawls"]
+        pages_mdb = self.mdb["pages"]
+
+        crawl_ids = await crawls_mdb.distinct("_id")
+        crawl_ids_with_pages = await pages_mdb.distinct("crawl_id")
+
+        crawl_ids_no_pages = list(set(crawl_ids) - set(crawl_ids_with_pages))
+        if not crawl_ids_no_pages:
+            return
+
+        for crawl_id in crawl_ids_no_pages:
+            print(f"Adding pages from crawl {crawl_id} to db", flush=True)
+            await self.page_ops.add_crawl_pages_to_db_from_wacz(crawl_id)

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -4,6 +4,8 @@ Migration 0026 -- Crawl Pages
 
 from btrixcloud.migrations import BaseMigration
 
+import asyncio
+
 
 MIGRATION_VERSION = "0026"
 
@@ -32,5 +34,16 @@ class Migration(BaseMigration):
             return
 
         for crawl_id in crawl_ids_no_pages:
-            print(f"Adding pages from crawl {crawl_id} to db", flush=True)
-            await self.page_ops.add_crawl_pages_to_db_from_wacz(crawl_id)
+            try:
+                print(
+                    f"Starting async task to add pages from crawl {crawl_id} to db",
+                    flush=True,
+                )
+                asyncio.create_task(
+                    self.page_ops.add_crawl_pages_to_db_from_wacz(crawl_id)
+                )
+            # pylint: disable=broad-exception-caught, raise-missing-from
+            except Exception as err:
+                print(
+                    f"Error adding pages to db for crawl {crawl_id}: {err}", flush=True
+                )

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -25,7 +25,9 @@ class Migration(BaseMigration):
         crawls_mdb = self.mdb["crawls"]
         pages_mdb = self.mdb["pages"]
 
-        crawl_ids = await crawls_mdb.distinct("_id", {"type": "crawl"})
+        crawl_ids = await crawls_mdb.distinct(
+            "_id", {"type": "crawl", "finished": {"$ne": None}}
+        )
         crawl_ids_with_pages = await pages_mdb.distinct("crawl_id")
 
         crawl_ids_no_pages = list(set(crawl_ids) - set(crawl_ids_with_pages))

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -2,9 +2,9 @@
 Migration 0026 -- Crawl Pages
 """
 
-from btrixcloud.migrations import BaseMigration
-
 import asyncio
+
+from btrixcloud.migrations import BaseMigration
 
 
 MIGRATION_VERSION = "0026"

--- a/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_pages.py
@@ -44,6 +44,4 @@ class Migration(BaseMigration):
             await gather_tasks_with_concurrency(*all_coroutines)
         # pylint: disable=broad-exception-caught, raise-missing-from
         except Exception as err:
-            print(
-                f"Error adding pages to db: {err}", flush=True
-            )
+            print(f"Error adding pages to db: {err}", flush=True)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1382,6 +1382,12 @@ class PageReviewUpdate(BaseModel):
 
 
 # ============================================================================
+class PageResource(BaseModel):
+    url: AnyHttpUrl
+    status: int
+
+
+# ============================================================================
 class Page(BaseMongoModel):
     """Model for crawl pages"""
 
@@ -1392,9 +1398,12 @@ class Page(BaseMongoModel):
     timestamp: Optional[datetime] = None
     load_state: Optional[int]
 
-    # automated heuristics
+    resources: Optional[List[PageResource]] = []
+
+    # automated heuristics, keyed by QA run id
     screenshot_comparison: Optional[Dict[str, int]] = {}
     text_comparison: Optional[Dict[str, int]] = {}
+    qa_resources: Optional[Dict[str, List[PageResource]]] = {}
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1394,6 +1394,7 @@ class Page(BaseMongoModel):
 
     # automated heuristics
     screenshot_comparison: Optional[Dict[str, int]] = {}
+    text_comparison: Optional[Dict[str, int]] = {}
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1375,10 +1375,41 @@ class AnyJob(BaseModel):
 
 # ============================================================================
 class PageReviewUpdate(BaseModel):
-    """Update model for page manual review"""
+    """Update model for page manual review/approval"""
 
-    notes: Optional[List[str]] = None
     approved: Optional[bool] = None
+
+
+# ============================================================================
+class PageNoteIn(BaseModel):
+    """Input model for adding page notes"""
+
+    text: str
+
+
+# ============================================================================
+class PageNoteEdit(BaseModel):
+    """Input model for editing page notes"""
+
+    id: UUID
+    text: str
+
+
+# ============================================================================
+class PageNoteDelete(BaseModel):
+    """Delete model for page notes"""
+
+    delete_list: List[UUID] = []
+
+
+# ============================================================================
+class PageNote(BaseMongoModel):
+    """Model for page notes, tracking user and time"""
+
+    text: str
+    created: datetime = datetime.now()
+    userid: UUID
+    userName: str
 
 
 # ============================================================================
@@ -1402,7 +1433,7 @@ class Page(BaseMongoModel):
     userid: Optional[UUID] = None
     modified: Optional[datetime] = None
     approved: Optional[bool] = None
-    notes: Optional[List[str]] = []
+    notes: List[PageNote] = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1403,9 +1403,10 @@ class PageNoteDelete(BaseModel):
 
 
 # ============================================================================
-class PageNote(BaseMongoModel):
+class PageNote(BaseModel):
     """Model for page notes, tracking user and time"""
 
+    id: UUID
     text: str
     created: datetime = datetime.now()
     userid: UUID
@@ -1427,7 +1428,7 @@ class Page(BaseMongoModel):
     # automated heuristics, keyed by QA run id
     screenshotMatch: Optional[Dict[str, float]] = {}
     textMatch: Optional[Dict[str, float]] = {}
-    resourceCounts: Optional[Dict[str, Dict[str, int]]]
+    resourceCounts: Optional[Dict[str, Dict[str, int]]] = {}
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1438,6 +1438,13 @@ class Page(BaseMongoModel):
 
 
 # ============================================================================
+class PageOut(Page):
+    """Model for pages output"""
+
+    status: Optional[int] = 200
+
+
+# ============================================================================
 class PageQAUpdate(BaseModel):
     """Model for updating pages from QA run"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1382,14 +1382,6 @@ class PageReviewUpdate(BaseModel):
 
 
 # ============================================================================
-class PageResource(BaseModel):
-    """Page resource"""
-
-    url: AnyHttpUrl
-    status: int
-
-
-# ============================================================================
 class Page(BaseMongoModel):
     """Model for crawl pages"""
 
@@ -1400,15 +1392,11 @@ class Page(BaseMongoModel):
     timestamp: Optional[datetime] = None
     load_state: Optional[int] = None
     status: Optional[int] = None
-    mime: Optional[str] = None
-    type: Optional[str] = None
-
-    resources: Optional[List[PageResource]] = []
 
     # automated heuristics, keyed by QA run id
-    screenshot_comparison: Optional[Dict[str, int]] = {}
-    text_comparison: Optional[Dict[str, int]] = {}
-    qa_resources: Optional[Dict[str, List[PageResource]]] = {}
+    screenshotMatch: Optional[Dict[str, float]] = {}
+    textMatch: Optional[Dict[str, float]] = {}
+    resourceCounts: Optional[Dict[str, Dict[str, int]]]
 
     # manual review
     userid: Optional[UUID] = None
@@ -1421,10 +1409,6 @@ class Page(BaseMongoModel):
 class PageQAUpdate(BaseModel):
     """Model for updating pages from QA run"""
 
-    mime: Optional[str] = None
-    type: Optional[str] = None
-
-    # automated heuristics, keyed by QA run id
-    screenshot_comparison: Optional[int] = None
-    text_comparison: Optional[int] = None
-    qa_resources: Optional[List[PageResource]] = None
+    screenshotMatch: Optional[int] = None
+    textMatch: Optional[int] = None
+    resourceCounts: Optional[Dict[str, Dict[str, int]]]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1366,3 +1366,37 @@ class AnyJob(BaseModel):
     """Union of all job types, for response model"""
 
     __root__: Union[CreateReplicaJob, DeleteReplicaJob, BackgroundJob]
+
+
+# ============================================================================
+
+### PAGES ###
+
+
+# ============================================================================
+class PageReviewUpdate(BaseModel):
+    """Update model for page manual review"""
+
+    notes: Optional[List[str]] = None
+    approved: Optional[bool] = None
+
+
+# ============================================================================
+class Page(BaseMongoModel):
+    """Model for crawl pages"""
+
+    oid: UUID
+    crawl_id: str
+    url: AnyHttpUrl
+    title: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    load_state: Optional[int]
+
+    # automated heuristics
+    screenshot_comparison: Optional[Dict[str, int]] = {}
+
+    # manual review
+    userid: Optional[UUID] = None
+    modified: Optional[datetime] = None
+    approved: Optional[bool] = None
+    notes: Optional[List[str]] = []

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1400,6 +1400,8 @@ class Page(BaseMongoModel):
     timestamp: Optional[datetime] = None
     load_state: Optional[int] = None
     status: Optional[int] = None
+    mime: Optional[str] = None
+    type: Optional[str] = None
 
     resources: Optional[List[PageResource]] = []
 
@@ -1413,3 +1415,16 @@ class Page(BaseMongoModel):
     modified: Optional[datetime] = None
     approved: Optional[bool] = None
     notes: Optional[List[str]] = []
+
+
+# ============================================================================
+class PageQAUpdate(BaseModel):
+    """Model for updating pages from QA run"""
+
+    mime: Optional[str] = None
+    type: Optional[str] = None
+
+    # automated heuristics, keyed by QA run id
+    screenshot_comparison: Optional[int] = None
+    text_comparison: Optional[int] = None
+    qa_resources: Optional[List[PageResource]] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1396,7 +1396,8 @@ class Page(BaseMongoModel):
     url: AnyHttpUrl
     title: Optional[str] = None
     timestamp: Optional[datetime] = None
-    load_state: Optional[int]
+    load_state: Optional[int] = None
+    status: Optional[int] = None
 
     resources: Optional[List[PageResource]] = []
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1383,6 +1383,8 @@ class PageReviewUpdate(BaseModel):
 
 # ============================================================================
 class PageResource(BaseModel):
+    """Page resource"""
+
     url: AnyHttpUrl
     status: int
 

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -65,7 +65,7 @@ METRICS = f"PodMetrics.{METRICS_API}"
 
 DEFAULT_TTL = 30
 
-REDIS_TTL = 60
+REDIS_TTL = 120
 
 # time in seconds before a crawl is deemed 'waiting' instead of 'starting'
 STARTING_TIME_SECS = 60

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -33,6 +33,7 @@ from .models import (
     RUNNING_AND_STARTING_ONLY,
     RUNNING_AND_STARTING_STATES,
     SUCCESSFUL_STATES,
+    FAILED_STATES,
     CrawlFile,
     CrawlCompleteIn,
     StorageRef,
@@ -1540,6 +1541,10 @@ class BtrixOperator(K8sAPI):
         if state in SUCCESSFUL_STATES and oid:
             await self.org_ops.inc_org_bytes_stored(oid, files_added_size, "crawl")
             await self.coll_ops.add_successful_crawl_to_collections(crawl_id, cid)
+
+        if state in FAILED_STATES:
+            await self.crawl_ops.delete_crawl_files(crawl_id, oid)
+            await self.page_ops.delete_crawl_pages(crawl_id, oid)
 
         await self.event_webhook_ops.create_crawl_finished_notification(
             crawl_id, oid, state

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1012,7 +1012,7 @@ class BtrixOperator(K8sAPI):
 
             while page_crawled:
                 page_dict = json.loads(page_crawled)
-                await self.page_ops.add_page_to_db(page_dict, crawl.id)
+                await self.page_ops.add_page_to_db(page_dict, crawl.id, crawl.oid)
                 page_crawled = await redis.lpop(f"{crawl.id}:{self.pages_key}")
 
             # ensure filesAdded and filesAddedSize always set

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -43,15 +43,19 @@ class PageOps:
 
     async def add_crawl_pages_to_db_from_wacz(self, crawl_id: str):
         """Add pages to database from WACZ files"""
-        crawl = await self.crawl_ops.get_crawl(crawl_id, None)
-        org = await self.org_ops.get_org_by_id(crawl.oid)
-        wacz_files = await self.crawl_ops.get_wacz_files(crawl_id, org)
-        stream = await self.storage_ops.sync_stream_pages_from_wacz(org, wacz_files)
-        for page_dict in stream:
-            if not page_dict.get("url"):
-                continue
+        try:
+            crawl = await self.crawl_ops.get_crawl(crawl_id, None)
+            org = await self.org_ops.get_org_by_id(crawl.oid)
+            wacz_files = await self.crawl_ops.get_wacz_files(crawl_id, org)
+            stream = await self.storage_ops.sync_stream_pages_from_wacz(org, wacz_files)
+            for page_dict in stream:
+                if not page_dict.get("url"):
+                    continue
 
-            await self.add_page_to_db(page_dict, crawl_id, crawl.oid)
+                await self.add_page_to_db(page_dict, crawl_id, crawl.oid)
+        # pylint: disable=broad-exception-caught, raise-missing-from
+        except Exception as err:
+            print(f"Error adding pages for crawl {crawl_id} to db: {err}", flush=True)
 
     async def add_page_to_db(
         self, page_dict: Dict[str, Any], crawl_id: str, oid: Optional[UUID] = None

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -149,21 +149,12 @@ class PageOps:
         if len(query) == 0:
             raise HTTPException(status_code=400, detail="no_update_data")
 
-        # Reformat fields to be keyed by QA crawl id
-        screenshot_score = query.get("screenshotMatch")
-        if screenshot_score:
-            query[f"screenshotMatch.{qa_run_id}"] = screenshot_score
-            query.pop("screenshotMatch", None)
-
-        text_score = query.get("textMatch")
-        if text_score:
-            query[f"textMatch.{qa_run_id}"] = text_score
-            query.pop("textMatch", None)
-
-        resource_counts = query.get("resourceCounts")
-        if resource_counts:
-            query[f"resourceCounts.{qa_run_id}"] = resource_counts
-            query.pop("resourceCounts", None)
+        keyed_fields = ("screenshotMatch", "textMatch", "resourceCounts")
+        for field in keyed_fields:
+            score = query.get(field)
+            if score:
+                query[f"{field}.{qa_run_id}"] = score
+                query.pop(field, None)
 
         query["modified"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -48,19 +48,22 @@ class PageOps:
             if not page:
                 continue
 
+            print(page, flush=True)
+
             page_dict = json.loads(page)
             await self._add_page_to_db(page_dict, crawl_id, oid)
 
-    async def add_crawl_pages_to_db_from_wacz(self, crawl_id: str, oid: UUID):
+    async def add_crawl_pages_to_db_from_wacz(self, crawl_id: str):
         """Add pages to database from WACZ files"""
-        org = await self.org_ops.get_org_by_id(oid)
+        crawl = await self.crawl_ops.get_crawl(crawl_id, None)
+        org = await self.org_ops.get_org_by_id(crawl.oid)
         wacz_files = await self.crawl_ops.get_wacz_files(crawl_id, org)
         stream = await self.storage_ops.sync_stream_pages_from_wacz(org, wacz_files)
         for page_dict in stream:
             if not page_dict.get("url"):
                 continue
 
-            await self._add_page_to_db(page_dict, crawl_id, oid)
+            await self._add_page_to_db(page_dict, crawl_id, crawl.oid)
 
     async def _add_page_to_db(
         self, page_dict: Dict[str, Any], crawl_id: str, oid: UUID

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -1,0 +1,258 @@
+"""crawl pages"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional, Tuple, List, Dict, Any, Union
+from uuid import UUID, uuid4
+
+from fastapi import Depends, HTTPException
+import pymongo
+
+from .models import Page, PageReviewUpdate, Organization, PaginatedResponse, User
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .utils import from_k8s_date
+
+if TYPE_CHECKING:
+    from .crawls import CrawlOps
+    from .orgs import OrgOps
+    from .storages import StorageOps
+else:
+    CrawlOps = StorageOps = OrgOps = object
+
+
+# ============================================================================
+# pylint: disable=too-many-instance-attributes, too-many-arguments
+class PageOps:
+    """crawl pages"""
+
+    crawl_ops: CrawlOps
+    org_ops: OrgOps
+    storage_ops: StorageOps
+
+    def __init__(self, mdb, crawl_ops, org_ops, storage_ops):
+        self.pages = mdb["pages"]
+        self.crawl_ops = crawl_ops
+        self.org_ops = org_ops
+        self.storage_ops = storage_ops
+
+    async def add_crawl_pages_to_db(self, crawl_id: str, oid: UUID):
+        """Add pages to database"""
+        org = await self.org_ops.get_org_by_id(oid)
+        wacz_files = await self.crawl_ops.get_wacz_files(crawl_id, org)
+        stream = await self.storage_ops.sync_stream_pages_from_wacz(org, wacz_files)
+        for page_dict in stream:
+            if not page_dict.get("url"):
+                continue
+
+            page = Page(
+                id=page_dict.get("id", uuid4()),
+                oid=oid,
+                crawl_id=crawl_id,
+                url=page_dict.get("url"),
+                title=page_dict.get("title"),
+                load_state=page_dict.get("loadState"),
+                timestamp=(
+                    from_k8s_date(page_dict.get("ts")) if page_dict.get("ts") else None
+                ),
+            )
+            await self.pages.insert_one(page.to_dict())
+
+    async def get_page_raw(
+        self,
+        page_id: UUID,
+        oid: UUID,
+        crawl_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return page dict by id"""
+        query: Dict[str, Union[str, UUID]] = {"_id": page_id, "oid": oid}
+        if crawl_id:
+            query["crawl_id"] = crawl_id
+
+        page = await self.pages.find_one(query)
+        if not page:
+            raise HTTPException(status_code=404, detail="page_not_found")
+        return page
+
+    async def get_page(
+        self,
+        page_id: UUID,
+        oid: UUID,
+        crawl_id: Optional[str] = None,
+    ) -> Page:
+        """Return Page object by id"""
+        page_raw = await self.get_page_raw(page_id, oid, crawl_id)
+        return Page.from_dict(page_raw)
+
+    async def add_automated_heuristic(
+        self,
+        page_id: UUID,
+        oid: UUID,
+        qa_run_id: str,
+        comparison_score: int,
+        comparison_type: str = "screenshot_comparison",
+    ) -> Dict[str, bool]:
+        """Add automated heuristic score to page"""
+        result = await self.pages.find_one_and_update(
+            {"_id": page_id, "oid": oid},
+            {"$set": {f"{comparison_type}.{qa_run_id}": comparison_score}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+
+        if not result:
+            raise HTTPException(status_code=404, detail="page_not_found")
+
+        return {"updated": True}
+
+    async def update_page_review(
+        self,
+        page_id: UUID,
+        oid: UUID,
+        update: PageReviewUpdate,
+        crawl_id: Optional[str] = None,
+        user: Optional[User] = None,
+    ) -> Dict[str, bool]:
+        """Update page manual review"""
+        query = update.dict(exclude_unset=True)
+
+        if len(query) == 0:
+            raise HTTPException(status_code=400, detail="no_update_data")
+
+        query["modified"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
+        if user:
+            query["userid"] = user.id
+
+        result = await self.pages.find_one_and_update(
+            {"_id": page_id, "oid": oid, "crawl_id": crawl_id},
+            {"$set": query},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+
+        if not result:
+            raise HTTPException(status_code=404, detail="page_not_found")
+
+        return {"updated": True}
+
+    async def list_pages(
+        self,
+        org: Organization,
+        crawl_id: str,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_direction: Optional[int] = -1,
+    ) -> Tuple[List[Page], int]:
+        """List all pages in crawl"""
+        # pylint: disable=duplicate-code, too-many-locals
+        # Zero-index page for query
+        page = page - 1
+        skip = page_size * page
+
+        query: dict[str, object] = {
+            "oid": org.id,
+            "crawl_id": crawl_id,
+        }
+
+        aggregate = [{"$match": query}]
+
+        if sort_by:
+            # Sorting options to add:
+            # - automated heuristics like screenshot_comparison (dict keyed by QA run id)
+            # - Ensure notes sorting works okay with notes in list
+            sort_fields = ("url", "title", "notes", "approved", "notes")
+            if sort_by not in sort_fields:
+                raise HTTPException(status_code=400, detail="invalid_sort_by")
+            if sort_direction not in (1, -1):
+                raise HTTPException(status_code=400, detail="invalid_sort_direction")
+            aggregate.extend([{"$sort": {sort_by: sort_direction}}])
+
+        aggregate.extend(
+            [
+                {
+                    "$facet": {
+                        "items": [
+                            {"$skip": skip},
+                            {"$limit": page_size},
+                        ],
+                        "total": [{"$count": "count"}],
+                    }
+                },
+            ]
+        )
+
+        # Get total
+        cursor = self.pages.aggregate(aggregate)
+        results = await cursor.to_list(length=1)
+        result = results[0]
+        items = result["items"]
+
+        try:
+            total = int(result["total"][0]["count"])
+        except (IndexError, ValueError):
+            total = 0
+
+        pages = [Page.from_dict(data) for data in items]
+
+        return pages, total
+
+
+# ============================================================================
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
+def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
+    """init pages API"""
+    # pylint: disable=invalid-name
+
+    ops = PageOps(mdb, crawl_ops, org_ops, storage_ops)
+
+    org_crawl_dep = org_ops.org_crawl_dep
+
+    @app.get(
+        "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}",
+        tags=["pages"],
+        response_model=Page,
+    )
+    async def get_page(
+        crawl_id: str,
+        page_id: UUID,
+        org: Organization = Depends(org_crawl_dep),
+    ):
+        """Retrieve paginated list of pages"""
+        return await ops.get_page(page_id, org.id, crawl_id)
+
+    @app.patch(
+        "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}",
+        tags=["pages"],
+    )
+    async def update_page_review(
+        crawl_id: str,
+        page_id: UUID,
+        update: PageReviewUpdate,
+        org: Organization = Depends(org_crawl_dep),
+        user: User = Depends(user_dep),
+    ):
+        """Retrieve paginated list of pages"""
+        return await ops.update_page_review(page_id, org.id, update, crawl_id, user)
+
+    @app.get(
+        "/orgs/{oid}/crawls/{crawl_id}/pages",
+        tags=["pages"],
+        response_model=PaginatedResponse,
+    )
+    async def get_pages_list(
+        crawl_id: str,
+        org: Organization = Depends(org_crawl_dep),
+        pageSize: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
+        sortBy: Optional[str] = None,
+        sortDirection: Optional[int] = -1,
+    ):
+        """Retrieve paginated list of pages"""
+        pages, total = await ops.list_pages(
+            org,
+            crawl_id=crawl_id,
+            page_size=pageSize,
+            page=page,
+            sort_by=sortBy,
+            sort_direction=sortDirection,
+        )
+        return paginated_format(pages, total, page, pageSize)
+
+    return ops

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -247,6 +247,7 @@ class PageOps:
             ][0]
 
         except IndexError:
+            # pylint: disable=raise-missing-from
             raise HTTPException(status_code=404, detail="page_note_not_found")
 
         new_note = PageNote(

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -109,6 +109,20 @@ class PageOps:
 
         return {"updated": True}
 
+    async def delete_crawl_pages(self, crawl_id: str, oid: Optional[UUID] = None):
+        """Delete crawl pages from db"""
+        query: Dict[str, Union[str, UUID]] = {"crawl_id": crawl_id}
+        if oid:
+            query["oid"] = oid
+        try:
+            await self.pages.delete_many(query)
+        # pylint: disable=broad-except
+        except Exception as err:
+            print(
+                f"Error deleting pages from crawl {crawl_id}: {err}",
+                flush=True,
+            )
+
     async def get_page_raw(
         self,
         page_id: UUID,

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -179,6 +179,7 @@ class PageOps:
             query.pop("text_comparison", None)
 
         # TODO: Double check formatting of page resources from what crawler passes
+        # Should we add the original crawl's resources here too?
         resources = query.get("qa_resources")
         if resources:
             query[f"qa_resources.{qa_run_id}"] = [

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -179,8 +179,6 @@ class PageOps:
             query.pop("text_comparison", None)
 
         query["modified"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
-        if user:
-            query["userid"] = user.id
 
         result = await self.pages.find_one_and_update(
             {"_id": page_id, "oid": oid},

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -48,8 +48,6 @@ class PageOps:
             if not page:
                 continue
 
-            print(page, flush=True)
-
             page_dict = json.loads(page)
             await self._add_page_to_db(page_dict, crawl_id, oid)
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -216,7 +216,7 @@ class PageOps:
         result = await self.pages.find_one_and_update(
             {"_id": page_id, "oid": oid, "crawl_id": crawl_id},
             {
-                "$push": {"notes": note.to_dict()},
+                "$push": {"notes": note.dict()},
                 "$set": {"modified": modified},
             },
             return_document=pymongo.ReturnDocument.AFTER,
@@ -239,11 +239,14 @@ class PageOps:
         page = await self.get_page_raw(page_id, oid)
         page_notes = page.get("notes", [])
 
-        matching_index = [
-            index for index, note in enumerate(page_notes) if note["id"] == note_in.id
-        ]
+        try:
+            matching_index = [
+                index
+                for index, note in enumerate(page_notes)
+                if note["id"] == note_in.id
+            ][0]
 
-        if not matching_index:
+        except IndexError:
             raise HTTPException(status_code=404, detail="page_note_not_found")
 
         new_note = PageNote(

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -68,9 +68,6 @@ class PageOps:
             print(f'Page {page_dict.get("url")} has no id - assigning UUID', flush=True)
             page_id = uuid4()
 
-        if await self.pages.find_one({"_id": page_id}):
-            return
-
         try:
             page = Page(
                 id=page_id,
@@ -86,6 +83,8 @@ class PageOps:
                 ),
             )
             await self.pages.insert_one(page.to_dict())
+        except pymongo.errors.DuplicateKeyError:
+            return
         # pylint: disable=broad-except
         except Exception as err:
             print(

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -427,8 +427,8 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
         """Edit page note"""
         return await ops.update_page_note(page_id, org.id, note, user, crawl_id)
 
-    @app.delete(
-        "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}/notes",
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}/notes/delete",
         tags=["pages"],
     )
     async def delete_page_notes(

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -9,6 +9,7 @@ import pymongo
 
 from .models import (
     Page,
+    PageOut,
     PageReviewUpdate,
     PageQAUpdate,
     Organization,
@@ -82,7 +83,11 @@ class PageOps:
                     else datetime.now()
                 ),
             )
-            await self.pages.insert_one(page.to_dict())
+            await self.pages.insert_one(
+                page.to_dict(
+                    exclude_unset=True, exclude_none=True, exclude_defaults=True
+                )
+            )
         except pymongo.errors.DuplicateKeyError:
             return
         # pylint: disable=broad-except
@@ -347,7 +352,7 @@ class PageOps:
         except (IndexError, ValueError):
             total = 0
 
-        pages = [Page.from_dict(data) for data in items]
+        pages = [PageOut.from_dict(data) for data in items]
 
         return pages, total
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -61,9 +61,7 @@ class PageOps:
         except Exception as err:
             print(f"Error adding pages for crawl {crawl_id} to db: {err}", flush=True)
 
-    async def add_page_to_db(
-        self, page_dict: Dict[str, Any], crawl_id: str, oid: Optional[UUID] = None
-    ):
+    async def add_page_to_db(self, page_dict: Dict[str, Any], crawl_id: str, oid: UUID):
         """Add page to database"""
         page_id = page_dict.get("id")
         if not page_id:
@@ -72,11 +70,6 @@ class PageOps:
 
         if await self.pages.find_one({"_id": page_id}):
             return
-
-        if not oid:
-            crawl = await self.crawl_ops.get_crawl(crawl_id, None)
-            org = await self.org_ops.get_org_by_id(crawl.oid)
-            oid = org.id
 
         try:
             page = Page(

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -178,6 +178,14 @@ class PageOps:
             query[f"text_comparison.{qa_run_id}"] = text_score
             query.pop("text_comparison", None)
 
+        # TODO: Double check formatting of page resources from what crawler passes
+        resources = query.get("qa_resources")
+        if resources:
+            query[f"qa_resources.{qa_run_id}"] = [
+                PageResource(**res).dict() for res in resources
+            ]
+            query.pop("qa_resources", None)
+
         query["modified"] = datetime.utcnow().replace(microsecond=0, tzinfo=None)
 
         result = await self.pages.find_one_and_update(

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -272,11 +272,12 @@ class PageOps:
         crawl_id: str,
     ) -> Dict[str, bool]:
         """Delete specific page notes"""
-        page = await self.get_page(page_id, oid)
+        page = await self.get_page_raw(page_id, oid)
+        page_notes = page.get("notes", [])
 
         remaining_notes = []
-        for note in page.notes:
-            if not note.id in delete.delete_list:
+        for note in page_notes:
+            if not note.get("id") in delete.delete_list:
                 remaining_notes.append(note)
 
         modified = datetime.utcnow().replace(microsecond=0, tzinfo=None)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     AsyncIterator,
     TYPE_CHECKING,
+    Any,
 )
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
@@ -44,7 +45,7 @@ from .models import (
 )
 from .zip import (
     sync_get_zip_file,
-    sync_get_log_stream,
+    sync_get_filestream,
 )
 
 from .utils import is_bool, slug_from_name
@@ -511,6 +512,24 @@ class StorageOps:
 
         return status_code == 204
 
+    async def sync_stream_pages_from_wacz(
+        self,
+        org: Organization,
+        wacz_files: List[CrawlFile],
+    ) -> Iterator[Dict[Any, Any]]:
+        """Return stream of page dicts from last of WACZs"""
+        with self.get_sync_client(org) as (client, bucket, key):
+            stream = await asyncio.get_event_loop().run_in_executor(
+                None,
+                self._sync_get_pages,
+                wacz_files,
+                client,
+                bucket,
+                key,
+            )
+
+            return stream
+
     async def sync_stream_wacz_logs(
         self,
         org: Organization,
@@ -556,7 +575,7 @@ class StorageOps:
                 f"Fetching log {log_zipinfo.filename} from {wacz_filename}", flush=True
             )
 
-            line_iter: Iterator[bytes] = sync_get_log_stream(
+            line_iter: Iterator[bytes] = sync_get_filestream(
                 client, bucket, wacz_key, log_zipinfo, cd_start
             )
 
@@ -620,6 +639,53 @@ class StorageOps:
         heap_iter = heapq.merge(*log_generators, key=lambda entry: entry["timestamp"])
 
         return stream_json_lines(heap_iter, log_levels, contexts)
+
+    def _sync_get_pages(
+        self,
+        wacz_files: List[CrawlFile],
+        client,
+        bucket: str,
+        key: str,
+    ) -> Iterator[Dict[Any, Any]]:
+        """Generate stream of page dicts from specified WACZs"""
+
+        # pylint: disable=too-many-function-args
+        def stream_page_lines(
+            wacz_key, wacz_filename, cd_start, pagefile_zipinfo
+        ) -> Iterator[Dict[Any, Any]]:
+            """Pass lines as json objects"""
+            print(
+                f"Fetching JSON lines from {pagefile_zipinfo.filename} in {wacz_filename}",
+                flush=True,
+            )
+
+            line_iter: Iterator[bytes] = sync_get_filestream(
+                client, bucket, wacz_key, pagefile_zipinfo, cd_start
+            )
+            for line in line_iter:
+                yield _parse_json(line.decode("utf-8", errors="ignore"))
+
+        page_generators: List[Iterator[Dict[Any, Any]]] = []
+
+        for wacz_file in wacz_files:
+            wacz_key = key + wacz_file.filename
+            cd_start, zip_file = sync_get_zip_file(client, bucket, wacz_key)
+
+            page_files = [
+                f
+                for f in zip_file.filelist
+                if f.filename.startswith("pages/")
+                and f.filename.endswith(".jsonl")
+                and not f.is_dir()
+            ]
+            for pagefile_zipinfo in page_files:
+                page_generators.append(
+                    stream_page_lines(
+                        wacz_key, wacz_file.filename, cd_start, pagefile_zipinfo
+                    )
+                )
+
+        return itertools.chain(*page_generators)
 
     def _sync_dl(
         self, all_files: List[CrawlFileOut], client: S3Client, bucket: str, key: str

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -518,8 +518,10 @@ class StorageOps:
         wacz_files: List[CrawlFile],
     ) -> Iterator[Dict[Any, Any]]:
         """Return stream of page dicts from last of WACZs"""
-        with self.get_sync_client(org) as (client, bucket, key):
-            stream = await asyncio.get_event_loop().run_in_executor(
+        async with self.get_sync_client(org) as (client, bucket, key):
+            loop = asyncio.get_event_loop()
+
+            stream = await loop.run_in_executor(
                 None,
                 self._sync_get_pages,
                 wacz_files,

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -120,3 +120,14 @@ def stream_dict_list_as_csv(data: List[Dict[str, Union[str, int]]], filename: st
         media_type="text/csv",
         headers={"Content-Disposition": f"attachment;filename={filename}"},
     )
+
+
+async def gather_tasks_with_concurrency(*tasks, n=5):
+    """Limit concurrency to n tasks at a time"""
+    semaphore = asyncio.Semaphore(n)
+
+    async def semaphore_task(task):
+        async with semaphore:
+            return await task
+
+    return await asyncio.gather(*(semaphore_task(task) for task in tasks))

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -461,7 +461,7 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
     assert r.status_code == 200
     data = r.json()
 
-    page_id = data.items[0]["id"]
+    page_id = data["items"][0]["id"]
     assert page_id
 
     note_text = "testing"

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -527,8 +527,8 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
     assert second_note_id
 
     # Delete both notes
-    r = requests.delete(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages/{page_id}/notes",
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages/{page_id}/notes/delete",
         headers=crawler_auth_headers,
         json={"delete_list": [first_note_id, second_note_id]},
     )

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -559,6 +559,14 @@ def test_delete_crawls_crawler(
     data = r.json()
     assert data["detail"] == "not_allowed"
 
+    # Check that pages exist for crawl
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["total"] > 0
+
     # Test that crawler user can delete own crawl
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/delete",
@@ -570,12 +578,22 @@ def test_delete_crawls_crawler(
     assert data["deleted"] == 1
     assert data["storageQuotaReached"] is False
 
+    time.sleep(5)
+
     # Test that crawl is not found after deleting
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 404
+
+    # Test that associated pages are also deleted
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["total"] == 0
 
 
 def test_delete_crawls_org_owner(

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -482,7 +482,6 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
     assert len(data["notes"]) == 1
 
     first_note = data["notes"][0]
-    print(first_note, flush=True)
 
     first_note_id = first_note["id"]
     assert first_note_id
@@ -524,13 +523,11 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
     updated_note = [note for note in notes if note["id"] == first_note_id][0]
     assert updated_note["text"] == updated_note_text
 
-    second_note_id = [note["id"] for note in notes if note["text"] == "untouched_text"][
-        0
-    ]
+    second_note_id = [note["id"] for note in notes if note["text"] == untouched_text][0]
     assert second_note_id
 
     # Delete both notes
-    r = requests.patch(
+    r = requests.delete(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages/{page_id}/notes",
         headers=crawler_auth_headers,
         json={"delete_list": [first_note_id, second_note_id]},

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -416,7 +416,9 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page.get("title") or page.get("title") is None
     assert page["load_state"]
 
-    assert page["screenshot_comparison"] == {}
+    assert page["screenshotMatch"] == {}
+    assert page["textMatch"] == {}
+    assert page["resourceCounts"] == {}
 
     assert page["notes"] == []
     assert page.get("userid") is None
@@ -449,7 +451,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page.get("title") or page.get("title") is None
     assert page["load_state"]
 
-    assert page["notes"] == ["first note"]
+    assert page["notes"] == []
     assert page["userid"]
     assert page["modified"]
     assert page["approved"]
@@ -480,6 +482,7 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
     assert len(data["notes"]) == 1
 
     first_note = data["notes"][0]
+    print(first_note, flush=True)
 
     first_note_id = first_note["id"]
     assert first_note_id

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -16,6 +16,8 @@ wacz_hash = None
 
 wacz_content = None
 
+page_id = None
+
 
 def test_list_orgs(admin_auth_headers, default_org_id):
     r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
@@ -397,6 +399,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["load_state"]
 
     # Test GET page endpoint
+    global page_id
     page_id = pages[0]["id"]
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages/{page_id}",
@@ -453,17 +456,6 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
 
 
 def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id):
-    # Get page ID
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    data = r.json()
-
-    page_id = data["items"][0]["id"]
-    assert page_id
-
     note_text = "testing"
     updated_note_text = "updated"
     untouched_text = "untouched"

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -1,5 +1,6 @@
 import requests
 import os
+import time
 from urllib.parse import urljoin
 
 from .conftest import API_PREFIX
@@ -933,6 +934,8 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     assert data["storageUsedBytes"] == org_bytes - total_size
     assert data["storageUsedCrawls"] == org_crawl_bytes - combined_crawl_size
     assert data["storageUsedUploads"] == org_upload_bytes - upload_size
+
+    time.sleep(10)
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{all_crawls_delete_config_id}",

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -59,7 +59,7 @@ metadata:
 
 data:
   CRAWL_ARGS: >-
-    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }}
+    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }}
 
 ---
 apiVersion: v1

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -22,7 +22,7 @@ crawler_channels:
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
   - id: test
-    image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    image: "docker.io/webrecorder/browsertrix-crawler:1.0.0-beta.4"
 
 mongo_auth:
   # specify either username + password (for local mongo)


### PR DESCRIPTION
Fixes #1502 

- Adds pages to database as they get added to Redis during crawl
- Adds migration to add pages to database for older crawls from pages.jsonl/extraPages.jsonl files in WACZ
- Adds GET, list GET, and PATCH update endpoints for pages
- Adds POST (add), PATCH, and POST (delete) endpoints for page notes, each with their own id, timestamp, and user info in addition to text
- Adds page_ops methods for 1. adding resources/urls to page, and 2. adding automated heuristics and supplemental info (mime, type, etc.) to page (for use in crawl QA job)
- Modifies `Migration` class to accept kwargs so that we can pass in ops classes as needed for migrations
- Deletes WACZ files and pages from database for failed crawls during crawl_finished process
- Deletes crawl pages when a crawl is deleted

Note: Requires a crawler version 1.0.0 beta3 or later, with support for `--writePagesToRedis` to populate pages at crawl completion. Beta 4 is configured in the test chart, which should be upgraded to stable 1.0.0 when it's released.

Connected to https://github.com/webrecorder/browsertrix-crawler/pull/464