### PR TITLE
enable screenshots by default + fix py version formatting

### DIFF
--- a/backend/btrixcloud/version.py
+++ b/backend/btrixcloud/version.py
@@ -1,2 +1,3 @@
 """ current version """
+
 __version__ = "1.9.0-beta.3"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -59,7 +59,7 @@ metadata:
 
 data:
   CRAWL_ARGS: >-
-    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --restartsOnError --headless {{ .Values.crawler_extra_args }}
+    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }}
 
 ---
 apiVersion: v1

--- a/update-version.sh
+++ b/update-version.sh
@@ -5,6 +5,7 @@ jq ".version=\"$version\"" ./frontend/package.json > ./tmp-package.json
 mv ./tmp-package.json ./frontend/package.json
 
 echo '""" current version """' > ./backend/btrixcloud/version.py
+echo "" >> ./backend/btrixcloud/version.py
 echo "__version__ = \"$version\"" >> ./backend/btrixcloud/version.py
 
 sed -E -i "" "s/^version:.*$/version: v$version/" chart/Chart.yaml


### PR DESCRIPTION
configmap: add --screenshot thumbnail,view as default screenshots 
version: update update-version.sh to add newline in version.py to match new black formatting (from changes in #1507)
Fixes #1519