### PR TITLE
better handling of failed redis connection + exec time updates

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -451,11 +451,14 @@ class CrawlOps(BaseCrawlOps):
         query = {"_id": crawl_id, "type": "crawl", "state": "running"}
         return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
 
-    async def inc_crawl_exec_time(self, crawl_id, exec_time):
+    async def inc_crawl_exec_time(self, crawl_id, exec_time, last_updated_time):
         """increment exec time"""
         return await self.crawls.find_one_and_update(
-            {"_id": crawl_id, "type": "crawl"},
-            {"$inc": {"crawlExecSeconds": exec_time}},
+            {"_id": crawl_id, "type": "crawl", "_lut": {"$ne": last_updated_time}},
+            {
+                "$inc": {"crawlExecSeconds": exec_time},
+                "$set": {"_lut": last_updated_time},
+            },
         )
 
     async def get_crawl_state(self, crawl_id):

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -67,7 +67,10 @@ class K8sAPI:
     async def get_redis_client(self, redis_url):
         """return redis client with correct params for one-time use"""
         return aioredis.from_url(
-            redis_url, decode_responses=True, auto_close_connection_pool=True
+            redis_url,
+            decode_responses=True,
+            auto_close_connection_pool=True,
+            socket_timeout=20,
         )
 
     # pylint: disable=too-many-arguments, too-many-locals


### PR DESCRIPTION
This PR addresses a possible failure when Redis pod was inaccessible from Crawler pod.
- Ensure crawl is set to 'waiting_for_capacity' if either no crawler pods are available or no redis pod. previously, missing/inaccessible redis would not result in 'waiting_for_capacity' if crawler pods are available
- Rework logic: if no crawler and redis after >60 seconds, shutdown redis. if crawler and no redis, init (or reinit) redis
- track 'lastUpdatedTime' in db when incrementing exec time to avoid double counting if lastUpdatedTime has not changed, eg. if operator sync fails.
- add redis timeout of 20 seconds to avoid timing out operator responses if redis conn takes too long, assume unavailable