### PR TITLE
Disable useSitemap by default in new workflows

### DIFF
--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -172,7 +172,7 @@ const getDefaultFormState = (): FormState => ({
   primarySeedUrl: "",
   urlList: "",
   includeLinkedPages: false,
-  useSitemap: true,
+  useSitemap: false,
   failOnFailedSeed: false,
   customIncludeUrlList: "",
   crawlTimeoutMinutes: 0,
@@ -596,7 +596,7 @@ export class CrawlConfigEditor extends LiteElement {
       includeLinkedPages: Boolean(
         primarySeedConfig.extraHops || seedsConfig.extraHops,
       ),
-      useSitemap: defaultFormState.useSitemap,
+      useSitemap: seedsConfig.useSitemap ?? defaultFormState.useSitemap,
       failOnFailedSeed:
         seedsConfig.failOnFailedSeed ?? defaultFormState.failOnFailedSeed,
       pageLimit:


### PR DESCRIPTION
Fixes #1540 

## To test

- Open new workflow, verify "Check for Sitemap" is unchecked
- Save workflow with "Check for Sitemap" checked, then edit it and verify checked setting stays