### PR TITLE
Add QA screenshot comparison tool

### DIFF
--- a/frontend/config/dev-server.js
+++ b/frontend/config/dev-server.js
@@ -35,6 +35,7 @@ module.exports = {
   onBeforeSetupMiddleware: (server) => {
     server.app.get("/replay/sw.js", (req, res) => {
       res.set("Content-Type", "application/javascript");
+      res.set("Service-Worker-Allowed", "/");
       res.send(`importScripts("${RWP_BASE_URL}sw.js")`);
     });
 

--- a/frontend/config/dev-server.js
+++ b/frontend/config/dev-server.js
@@ -35,7 +35,6 @@ module.exports = {
   onBeforeSetupMiddleware: (server) => {
     server.app.get("/replay/sw.js", (req, res) => {
       res.set("Content-Type", "application/javascript");
-      res.set("Service-Worker-Allowed", "/");
       res.send(`importScripts("${RWP_BASE_URL}sw.js")`);
     });
 

--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -45,7 +45,6 @@ server {
     # serve replay service worker, RWP_BASE_URL set in Dockerfile
     location /replay/sw.js {
       add_header Content-Type application/javascript;
-      add_header Service-Worker-Allowed /;
       return 200 'importScripts("${RWP_BASE_URL}sw.js");';
     }
 

--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -45,6 +45,7 @@ server {
     # serve replay service worker, RWP_BASE_URL set in Dockerfile
     location /replay/sw.js {
       add_header Content-Type application/javascript;
+      add_header Service-Worker-Allowed /;
       return 200 'importScripts("${RWP_BASE_URL}sw.js");';
     }
 

--- a/frontend/src/components/ui/navigation/navigation-button.ts
+++ b/frontend/src/components/ui/navigation/navigation-button.ts
@@ -37,13 +37,20 @@ export class Button extends TailwindElement {
   icon = false;
 
   @property({ type: String, reflect: true })
-  role: ARIAMixin["role"] = "tab";
+  role: ARIAMixin["role"] = null;
 
   @property({ type: String })
   size: "small" | "medium" | "large" = "medium";
 
   @property({ type: String })
   align: "left" | "center" | "right" = "left";
+
+  connectedCallback(): void {
+    if (!this.role && !this.href) {
+      this.role = "tab";
+    }
+    super.connectedCallback();
+  }
 
   protected willUpdate(changedProperties: PropertyValueMap<this>) {
     if (changedProperties.has("active")) {
@@ -89,6 +96,7 @@ export class Button extends TailwindElement {
       href=${ifDefined(this.href)}
       aria-label=${ifDefined(this.label)}
       @click=${this.handleClick}
+      
     >
       <slot></slot>
     </${tag}>`;

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -109,7 +109,7 @@ export class ArchivedItemQA extends TailwindElement {
   private qaRuns?: QARun[];
 
   @state()
-  private replayReady = false;
+  private replaySWReady = false;
 
   private readonly api = new APIController(this);
   private readonly navigate = new NavigateController(this);
@@ -334,7 +334,7 @@ export class ArchivedItemQA extends TailwindElement {
       <div class="flex-1">
         <h3>${msg("Replay Screenshot")}</h3>
         ${when(
-          this.replayReady,
+          this.replaySWReady,
           () => html` <img class="outline" src="${url}" /> `,
         )}
       </div>
@@ -466,9 +466,9 @@ export class ArchivedItemQA extends TailwindElement {
             });
           });
         }
-        this.replayReady = true;
+        this.replaySWReady = true;
       } else {
-        this.replayReady = false;
+        this.replaySWReady = false;
         console.debug("no sw");
       }
     } catch (error) {

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -319,7 +319,22 @@ export class ArchivedItemQA extends TailwindElement {
   };
 
   private readonly renderReplay = () => {
-    return html`[replay]`;
+    if (!this.itemId) return;
+
+    const replaySource = `/api/orgs/${this.orgId}/crawls/${this.itemId}/replay.json`;
+    const headers = this.authState?.headers;
+    const config = JSON.stringify({ headers });
+
+    return html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
+      <replay-web-page
+        source="${replaySource}"
+        coll="${this.itemId}"
+        config="${config}"
+        replayBase="/replay/"
+        noSandbox="true"
+        noCache="true"
+      ></replay-web-page>
+    </div>`;
   };
 
   private async fetchCrawl(): Promise<void> {

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -318,9 +318,15 @@ export class ArchivedItemQA extends TailwindElement {
   }
 
   private readonly renderScreenshots = () => {
-    if (!this.itemId) return;
+    if (!this.page) return; // TODO loading indicator
 
-    const url = `/replay/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:http://example.com/`;
+    console.log(this.page);
+
+    // const url = `/replay/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:http://example.com/`;
+    const timestamp = this.page.ts?.split(".")[0].replace(/\D/g, "");
+    const crawlUrl = `/replay/w/${this.itemId}/:${this.itemPageId}/${timestamp}mp_/urn:view:${window.encodeURIComponent(this.page.url)}`;
+    const qaUrl = `/replay/w/${this.qaRunId}/:${this.itemPageId}/${timestamp}mp_/urn:view:${window.encodeURIComponent(this.page.url)}`;
+    console.log(crawlUrl);
 
     return html`
       <div class="mb-2 flex justify-between text-base font-medium">
@@ -336,7 +342,7 @@ export class ArchivedItemQA extends TailwindElement {
           <iframe
             slot="before"
             name="crawlScreenshot"
-            src="${url}"
+            src="${crawlUrl}"
             class="aspect-video w-full"
             aria-labelledby="crawlScreenshotHeading"
             @load=${this.onScreenshotLoad}
@@ -344,7 +350,7 @@ export class ArchivedItemQA extends TailwindElement {
           <iframe
             slot="after"
             name="replayScreenshot"
-            src="${url}"
+            src="${qaUrl}"
             class="aspect-video w-full"
             aria-labelledby="replayScreenshotHeading"
             @load=${this.onScreenshotLoad}
@@ -462,7 +468,6 @@ export class ArchivedItemQA extends TailwindElement {
       this.authState!,
     );
   }
-<<<<<<< HEAD
 
   private async getQARuns(): Promise<QARun[]> {
     return this.api.fetch<QARun[]>(
@@ -470,36 +475,4 @@ export class ArchivedItemQA extends TailwindElement {
       this.authState!,
     );
   }
-
-  /**
-   * Register ReplayWeb.Page service worker to enable routing to screenshot image
-   */
-  private async registerSw() {
-    try {
-      const reg = await navigator.serviceWorker.register("/replay/sw.js", {
-        scope: "/",
-      });
-      const sw = reg.installing || reg.waiting || reg.active;
-      console.log("archived-item-qa sw state:", sw?.state);
-      if (sw) {
-        if (sw.state !== "activated") {
-          await new Promise((resolve) => {
-            sw.addEventListener("statechange", () => {
-              if (sw.state === "activated") {
-                resolve(null);
-              }
-            });
-          });
-        }
-        this.replaySWReady = true;
-      } else {
-        this.replaySWReady = false;
-        console.debug("no sw");
-      }
-    } catch (error) {
-      console.error(`Registration failed with ${error}`);
-    }
-  }
-=======
->>>>>>> 79085356 (use iframes with image comparer)
 }

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -320,7 +320,6 @@ export class ArchivedItemQA extends TailwindElement {
 
   private readonly renderReplay = () => {
     if (!this.itemId) return;
-
     const replaySource = `/api/orgs/${this.orgId}/crawls/${this.itemId}/replay.json`;
     const headers = this.authState?.headers;
     const config = JSON.stringify({ headers });

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -315,16 +315,55 @@ export class ArchivedItemQA extends TailwindElement {
   }
 
   private readonly renderScreenshots = () => {
-    return html`[screenshots]`;
+    if (!this.itemId) return;
+
+    const url = `/replay/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:${window.encodeURI("http://example.com/")}`;
+
+    return html` <div class="flex gap-3">
+      <div class="flex-1">
+        <h3>${msg("Crawl Screenshot")}</h3>
+      </div>
+      <div class="flex-1">
+        <h3>${msg("Replay Screenshot")}</h3>
+        <div class="bold text-xl">img:</div>
+        <img class="outline" src="${url}?img" loading="lazy" />
+        <div class="bold text-xl">object:</div>
+        <object class="outline" type="image/png" data="${url}"></object>
+        <div class="bold text-xl">iframe:</div>
+        <iframe
+          src="${url}"
+          class="aspect-video w-full overflow-hidden bg-yellow-300 outline"
+          @load=${(e: Event) => {
+            const iframe = e.currentTarget as HTMLIFrameElement;
+
+            const { height, width } = iframe.getBoundingClientRect();
+            const img = iframe.contentDocument?.body.querySelector("img");
+            if (img) {
+              img.style.height = `${height}px`;
+              img.style.width = `${width}px`;
+            }
+            console.log(height, width);
+            // const { scrollHeight, scrollWidth } =
+            //   iframe.contentDocument?.body || {};
+            // if (scrollHeight) {
+            //   iframe.style.height = `${scrollHeight}px`;
+            // }
+            // if (scrollWidth) {
+            //   iframe.style.width = `${scrollWidth}px`;
+            // }
+          }}
+        ></iframe>
+      </div>
+    </div>`;
   };
 
-  private readonly renderReplay = () => {
+  private readonly renderReplay = (crawlId?: string) => {
     if (!this.itemId) return;
-    const replaySource = `/api/orgs/${this.orgId}/crawls/${this.itemId}/replay.json`;
+    const replaySource = `/api/orgs/${this.orgId}/crawls/${crawlId || this.itemId}/replay.json`;
     const headers = this.authState?.headers;
     const config = JSON.stringify({ headers });
 
-    return html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
+    return html`<div class="aspect-4/3 overflow-hidden">
       <replay-web-page
         source="${replaySource}"
         coll="${this.itemId}"

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -368,15 +368,15 @@ export class ArchivedItemQA extends TailwindElement {
   };
 
   private readonly renderReplay = ({ isQA } = { isQA: false }) => {
-    if (!this.itemId) return;
+    if (!this.itemId || !this.qaRunId) return;
     const replaySource = `/api/orgs/${this.orgId}/crawls/${this.itemId}${isQA ? `/qa/${this.qaRunId}` : ""}/replay.json`;
     const headers = this.authState?.headers;
     const config = JSON.stringify({ headers });
 
-    return html`<div class="aspect-4/3 overflow-hidden">
+    return html`<div class="aspect-4/3 overflow-hidden" style="display: none">
       <replay-web-page
         source="${replaySource}"
-        coll="${this.itemId}"
+        coll="${this.qaRunId}"
         config="${config}"
         replayBase="/replay/"
         embed="replayonly"
@@ -422,6 +422,9 @@ export class ArchivedItemQA extends TailwindElement {
   private async fetchQARuns(): Promise<void> {
     try {
       this.qaRuns = await this.getQARuns();
+      if (this.qaRuns.length) {
+        this.qaRunId = this.qaRuns[0].id;
+      }
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't retrieve archived item at this time."),

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -109,16 +109,11 @@ export class ArchivedItemQA extends TailwindElement {
   private qaRuns?: QARun[];
 
   @state()
-  private replaySWReady = false;
+  private screenshotIframesReady: 0 | 1 | 2 = 0;
 
   private readonly api = new APIController(this);
   private readonly navigate = new NavigateController(this);
   private readonly notify = new NotifyController(this);
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    this.registerSw();
-  }
 
   protected willUpdate(
     changedProperties: PropertyValues<this> | Map<PropertyKey, unknown>,
@@ -325,20 +320,38 @@ export class ArchivedItemQA extends TailwindElement {
   private readonly renderScreenshots = () => {
     if (!this.itemId) return;
 
-    const url = `/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:http://example.com/`;
+    const url = `/replay/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:http://example.com/`;
 
-    return html` <div class="flex gap-3">
-      <div class="flex-1">
-        <h3>${msg("Crawl Screenshot")}</h3>
+    return html`
+      <div class="mb-2 flex justify-between text-base font-medium">
+        <h3 id="crawlScreenshotHeading">${msg("Crawl Screenshot")}</h3>
+        <h3 id="replayScreenshotHeading">${msg("Replay Screenshot")}</h3>
       </div>
-      <div class="flex-1">
-        <h3>${msg("Replay Screenshot")}</h3>
-        ${when(
-          this.replaySWReady,
-          () => html` <img class="outline" src="${url}" /> `,
-        )}
+      <div class="overflow-hidden rounded border bg-slate-50">
+        <sl-image-comparer
+          class="${this.screenshotIframesReady === 2
+            ? "visible"
+            : "invisible"} w-full"
+        >
+          <iframe
+            slot="before"
+            name="crawlScreenshot"
+            src="${url}"
+            class="aspect-video w-full"
+            aria-labelledby="crawlScreenshotHeading"
+            @load=${this.onScreenshotLoad}
+          ></iframe>
+          <iframe
+            slot="after"
+            name="replayScreenshot"
+            src="${url}"
+            class="aspect-video w-full"
+            aria-labelledby="replayScreenshotHeading"
+            @load=${this.onScreenshotLoad}
+          ></iframe>
+        </sl-image-comparer>
       </div>
-    </div>`;
+    `;
   };
 
   private readonly renderReplay = (crawlId?: string) => {
@@ -357,6 +370,17 @@ export class ArchivedItemQA extends TailwindElement {
         noCache="true"
       ></replay-web-page>
     </div>`;
+  };
+
+  private readonly onScreenshotLoad = (e: Event) => {
+    const iframe = e.currentTarget as HTMLIFrameElement;
+    const img = iframe.contentDocument?.body.querySelector("img");
+    // Make image fill iframe container
+    if (img) {
+      img.style.height = "auto";
+      img.style.width = "100%";
+    }
+    this.screenshotIframesReady += 1;
   };
 
   private async fetchCrawl(): Promise<void> {
@@ -438,6 +462,7 @@ export class ArchivedItemQA extends TailwindElement {
       this.authState!,
     );
   }
+<<<<<<< HEAD
 
   private async getQARuns(): Promise<QARun[]> {
     return this.api.fetch<QARun[]>(
@@ -475,4 +500,6 @@ export class ArchivedItemQA extends TailwindElement {
       console.error(`Registration failed with ${error}`);
     }
   }
+=======
+>>>>>>> 79085356 (use iframes with image comparer)
 }

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -347,7 +347,7 @@ export class ArchivedItemQA extends TailwindElement {
         coll="${this.itemId}"
         config="${config}"
         replayBase="/replay/"
-        noSandbox="true"
+        embed="replayonly"
         noCache="true"
       ></replay-web-page>
     </div>`;

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -112,6 +112,11 @@ export class ArchivedItemQA extends TailwindElement {
   private readonly navigate = new NavigateController(this);
   private readonly notify = new NotifyController(this);
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.registerSw();
+  }
+
   protected willUpdate(
     changedProperties: PropertyValues<this> | Map<PropertyKey, unknown>,
   ): void {
@@ -317,7 +322,7 @@ export class ArchivedItemQA extends TailwindElement {
   private readonly renderScreenshots = () => {
     if (!this.itemId) return;
 
-    const url = `/replay/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:${window.encodeURI("http://example.com/")}`;
+    const url = `/w/manual-20240226234726-051ed881-37e/:fbc91e679056dc8da1528376ddbc7e5c931ca9b03a0d0f65430c5ee2a76c94c2/20240226234908mp_/urn:view:http://example.com/`;
 
     return html` <div class="flex gap-3">
       <div class="flex-1">
@@ -325,34 +330,7 @@ export class ArchivedItemQA extends TailwindElement {
       </div>
       <div class="flex-1">
         <h3>${msg("Replay Screenshot")}</h3>
-        <div class="bold text-xl">img:</div>
-        <img class="outline" src="${url}?img" loading="lazy" />
-        <div class="bold text-xl">object:</div>
-        <object class="outline" type="image/png" data="${url}"></object>
-        <div class="bold text-xl">iframe:</div>
-        <iframe
-          src="${url}"
-          class="aspect-video w-full overflow-hidden bg-yellow-300 outline"
-          @load=${(e: Event) => {
-            const iframe = e.currentTarget as HTMLIFrameElement;
-
-            const { height, width } = iframe.getBoundingClientRect();
-            const img = iframe.contentDocument?.body.querySelector("img");
-            if (img) {
-              img.style.height = `${height}px`;
-              img.style.width = `${width}px`;
-            }
-            console.log(height, width);
-            // const { scrollHeight, scrollWidth } =
-            //   iframe.contentDocument?.body || {};
-            // if (scrollHeight) {
-            //   iframe.style.height = `${scrollHeight}px`;
-            // }
-            // if (scrollWidth) {
-            //   iframe.style.width = `${scrollWidth}px`;
-            // }
-          }}
-        ></iframe>
+        <img class="outline" src="${url}" />
       </div>
     </div>`;
   };
@@ -460,5 +438,28 @@ export class ArchivedItemQA extends TailwindElement {
       `/orgs/${this.orgId}/crawls/${this.itemId}/qa`,
       this.authState!,
     );
+  }
+
+  /**
+   * Register ReplayWeb.Page service worker to enable routing to screenshot image
+   */
+  private async registerSw() {
+    try {
+      const registration = await navigator.serviceWorker.register(
+        "/replay/sw.js",
+        {
+          scope: "/w/",
+        },
+      );
+      if (registration.installing) {
+        console.debug("Service worker installing!");
+      } else if (registration.waiting) {
+        console.debug("Service worker waiting!");
+      } else if (registration.active) {
+        console.debug("Service worker active!");
+      }
+    } catch (error) {
+      console.error(`Registration failed with ${error}`);
+    }
   }
 }

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -13,6 +13,7 @@ import "@shoelace-style/shoelace/dist/components/input/input";
 import "@shoelace-style/shoelace/dist/components/checkbox/checkbox";
 import "@shoelace-style/shoelace/dist/components/details/details";
 import "@shoelace-style/shoelace/dist/components/button-group/button-group";
+import "@shoelace-style/shoelace/dist/components/image-comparer/image-comparer";
 import "@shoelace-style/shoelace/dist/components/radio/radio";
 import "@shoelace-style/shoelace/dist/components/radio-group/radio-group";
 import "@shoelace-style/shoelace/dist/components/radio-button/radio-button";


### PR DESCRIPTION
Partially addresses https://github.com/webrecorder/browsertrix-cloud/issues/1496

### Changes

Adds initial screenshot comparison tool for testing RWP embeds.

Accessible by adding `/review/screenshots` to archived item URL.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| QA Review | <img width="1123" alt="Screenshot 2024-03-25 at 10 59 37 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/b80d5e78-81b9-4624-8b39-5652576f0b20"> |


### Follow-ups

This is to get the initial embed working, will still need to implement the Shoelace image comparer.