### PR TITLE
Increase startup probe time to account for long-running migrations

### DIFF
--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -180,10 +180,18 @@ def main():
     async def openapi() -> JSONResponse:
         return JSONResponse(app_root.openapi())
 
+    # Used for readiness + liveness probe
+    # Returns 200 only when migrations are done
     @app_root.get("/healthz", include_in_schema=False)
     async def healthz():
         if not db_inited.get("inited"):
             raise HTTPException(status_code=503, detail="not_ready_yet")
+        return {}
+
+    # Used for startup probe
+    # Always returns 200 while running to account for migration work
+    @app_root.get("/healthzStartup", include_in_schema=False)
+    async def healthzStartup():
         return {}
 
     app_root.include_router(app, prefix=API_PREFIX)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -191,7 +191,7 @@ def main():
     # Used for startup probe
     # Always returns 200 while running to account for migration work
     @app_root.get("/healthzStartup", include_in_schema=False)
-    async def healthzStartup():
+    async def healthz_startup():
         return {}
 
     app_root.include_router(app, prefix=API_PREFIX)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -180,18 +180,18 @@ def main():
     async def openapi() -> JSONResponse:
         return JSONResponse(app_root.openapi())
 
-    # Used for readiness + liveness probe
-    # Returns 200 only when migrations are done
-    @app_root.get("/healthz", include_in_schema=False)
-    async def healthz():
+    # Used for startup
+    # Returns 200 only when db is available + migrations are done
+    @app_root.get("/healthzStartup", include_in_schema=False)
+    async def healthz_startup():
         if not db_inited.get("inited"):
             raise HTTPException(status_code=503, detail="not_ready_yet")
         return {}
 
-    # Used for startup probe
-    # Always returns 200 while running to account for migration work
-    @app_root.get("/healthzStartup", include_in_schema=False)
-    async def healthz_startup():
+    # Used for readiness + liveness
+    # Always returns 200 while running
+    @app_root.get("/healthz", include_in_schema=False)
+    async def healthz():
         return {}
 
     app_root.include_router(app, prefix=API_PREFIX)

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -171,11 +171,11 @@ spec:
 
           startupProbe:
             httpGet:
-              path: /healthzStarted
+              path: /healthz
               port: {{ .Values.opPort }}
             initialDelaySeconds: 5
             periodSeconds: 5
-            failureThreshold: 30
+            failureThreshold: 5
             successThreshold: 1
 
           readinessProbe:
@@ -193,7 +193,7 @@ spec:
               port: {{ .Values.opPort }}
             initialDelaySeconds: 5
             periodSeconds: 30
-            failureThreshold: 5
+            failureThreshold: 15
             successThreshold: 1
 
 

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -97,11 +97,10 @@ spec:
 
           startupProbe:
             httpGet:
-              path: /healthz
+              path: /healthzStartup
               port: 8000
-            initialDelaySeconds: 5
             periodSeconds: 5
-            failureThreshold: 30
+            failureThreshold: 60
             successThreshold: 1
 
           readinessProbe:
@@ -119,7 +118,7 @@ spec:
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 30
-            failureThreshold: 5
+            failureThreshold: 15
             successThreshold: 1
 
         - name: op
@@ -172,7 +171,7 @@ spec:
 
           startupProbe:
             httpGet:
-              path: /healthz
+              path: /healthzStarted
               port: {{ .Values.opPort }}
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
- increases the failureThreshold for startupProbe for the api backend container to account for long running migrations, upto 300 seconds
- add `/healthzStartup` which checks if db is ready
- bump 
- keeps `/healthz` to always return 200 when running
- increases livenessProbe failureThreshold to be higher than readiness probe, following recommended best practice of liveness probe > readiness probe
- fixes #1559