### PR TITLE
Create `ArchivedItemPage` and `ArchivedItemPageComment` types

### DIFF
--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -181,3 +181,40 @@ export type CrawlerChannel = {
 };
 
 export type ArchivedItem = Crawl | Upload;
+
+export type ArchivedItemPageComment = {
+  id: string;
+  created: string;
+  modified: string;
+  userName: string;
+  text: string;
+};
+
+export type ArchivedItemPage = {
+  id?: string;
+  oid: string;
+  crawl_id: string;
+  url: string;
+  title?: string;
+  timestamp?: string; // Date
+  load_state?: number;
+  status?: number;
+  /** screenshot match percent, keyed by QA run ID */
+  screenshotMatch?: Record<string, number>;
+  /** text match percent, keyed by QA run ID */
+  textMatch?: Record<string, number>;
+  /** resource counts, keyed by QA run ID */
+  resourceCounts?: Record<
+    string,
+    {
+      crawlGood?: number;
+      crawlBad?: number;
+      replayGood?: number;
+      replayBad?: number;
+    }
+  >;
+  userid?: string;
+  modified?: string;
+  approved?: boolean;
+  notes?: ArchivedItemPageComment[];
+};


### PR DESCRIPTION
Based on #1534

Figured this should be in place so we can work on other front-end things with these, rather than dealing with refactoring later 

<!-- Fixes #issue_number -->

### Changes

- Adds `ArchivedItemPage` and `ArchivedItemPageComment` types from #1534 (thank you @SuaYoo!)
- Adds typedefs for match and resource count properties
- sets properties optional in the db schema to optional in the type as well

### Manual testing

1.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
|      |             |

<!-- ### Follow-ups -->
