### PR TITLE
Fix execution time checking by keeping lastUpdatedTime in db

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -451,14 +451,26 @@ class CrawlOps(BaseCrawlOps):
         query = {"_id": crawl_id, "type": "crawl", "state": "running"}
         return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
 
-    async def inc_crawl_exec_time(self, crawl_id, exec_time, last_updated_time):
+    async def inc_crawl_exec_time(self, crawl_id, exec_time):
         """increment exec time"""
         return await self.crawls.find_one_and_update(
-            {"_id": crawl_id, "type": "crawl", "_lut": {"$ne": last_updated_time}},
+            {"_id": crawl_id, "type": "crawl"},
             {
                 "$inc": {"crawlExecSeconds": exec_time},
-                "$set": {"_lut": last_updated_time},
             },
+        )
+
+    async def get_crawl_exec_last_update_time(self, crawl_id):
+        """get crawl last updated time"""
+        res = await self.crawls.find_one(
+            {"_id": crawl_id, "type": "crawl"}, projection=["_lut"]
+        )
+        return res and res.get("_lut")
+
+    async def set_crawl_exec_last_update_time(self, crawl_id, last_update_time):
+        """set crawl last update time"""
+        return await self.crawls.find_one_and_update(
+            {"_id": crawl_id, "type": "crawl"}, {"$set": {"_lut": last_update_time}}
         )
 
     async def get_crawl_state(self, crawl_id):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -451,12 +451,13 @@ class CrawlOps(BaseCrawlOps):
         query = {"_id": crawl_id, "type": "crawl", "state": "running"}
         return await self.crawls.find_one_and_update(query, {"$set": {"stats": stats}})
 
-    async def inc_crawl_exec_time(self, crawl_id, exec_time):
+    async def inc_crawl_exec_time(self, crawl_id, exec_time, last_updated_time):
         """increment exec time"""
         return await self.crawls.find_one_and_update(
-            {"_id": crawl_id, "type": "crawl"},
+            {"_id": crawl_id, "type": "crawl", "_lut": {"$ne": last_updated_time}},
             {
                 "$inc": {"crawlExecSeconds": exec_time},
+                "$set": {"_lut": last_updated_time},
             },
         )
 
@@ -466,12 +467,6 @@ class CrawlOps(BaseCrawlOps):
             {"_id": crawl_id, "type": "crawl"}, projection=["_lut"]
         )
         return res and res.get("_lut")
-
-    async def set_crawl_exec_last_update_time(self, crawl_id, last_update_time):
-        """set crawl last update time"""
-        return await self.crawls.find_one_and_update(
-            {"_id": crawl_id, "type": "crawl"}, {"$set": {"_lut": last_update_time}}
-        )
 
     async def get_crawl_state(self, crawl_id):
         """return current crawl state of a crawl"""

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -516,7 +516,7 @@ class BtrixOperator(K8sAPI):
         else:
             status.scale = crawl.scale
             now = dt_now()
-            await self.crawl_ops.set_crawl_exec_last_update_time(crawl_id, now)
+            await self.crawl_ops.inc_crawl_exec_time(crawl_id, 0, now)
             status.lastUpdatedTime = to_k8s_date(now)
 
         children = self._load_redis(params, status, data.children)
@@ -1114,7 +1114,7 @@ class BtrixOperator(K8sAPI):
         )
 
         if not update_start_time:
-            await self.crawl_ops.set_crawl_exec_last_update_time(crawl_id, now)
+            await self.crawl_ops.inc_crawl_exec_time(crawl_id, 0, now)
             status.lastUpdatedTime = to_k8s_date(now)
             return
 
@@ -1191,8 +1191,6 @@ class BtrixOperator(K8sAPI):
                 max_duration = max(duration, max_duration)
 
         if exec_time:
-            await self.crawl_ops.inc_crawl_exec_time(crawl_id, exec_time)
-
             await self.org_ops.inc_org_time_stats(oid, exec_time, True)
             status.crawlExecTime += exec_time
             status.elapsedCrawlTime += max_duration
@@ -1202,7 +1200,7 @@ class BtrixOperator(K8sAPI):
             flush=True,
         )
 
-        await self.crawl_ops.set_crawl_exec_last_update_time(crawl_id, now)
+        await self.crawl_ops.inc_crawl_exec_time(crawl_id, exec_time, now)
         status.lastUpdatedTime = to_k8s_date(now)
 
     def should_mark_waiting(self, state, started):

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -1191,9 +1191,10 @@ class BtrixOperator(K8sAPI):
             ):
                 # if lastUpdatedTime is same as previous, something is wrong, don't update!
                 print(
-                    "Already updated for lastUpdatedTime, skipping execTime update!",
+                    f"Already updated for lastUpdatedTime {status.lastUpdatedTime}, skipping execTime update!",
                     flush=True,
                 )
+                status.lastUpdatedTime = to_k8s_date(now)
                 return
 
             await self.org_ops.inc_org_time_stats(oid, exec_time, True)

--- a/backend/btrixcloud/operator.py
+++ b/backend/btrixcloud/operator.py
@@ -515,7 +515,9 @@ class BtrixOperator(K8sAPI):
 
         else:
             status.scale = crawl.scale
-            status.lastUpdatedTime = to_k8s_date(dt_now())
+            now = dt_now()
+            await self.crawl_ops.set_crawl_exec_last_update_time(crawl_id, now)
+            status.lastUpdatedTime = to_k8s_date(now)
 
         children = self._load_redis(params, status, data.children)
 
@@ -1107,11 +1109,14 @@ class BtrixOperator(K8sAPI):
         """inc exec time tracking"""
         now = dt_now()
 
-        if not status.lastUpdatedTime:
+        update_start_time = await self.crawl_ops.get_crawl_exec_last_update_time(
+            crawl_id
+        )
+
+        if not update_start_time:
+            await self.crawl_ops.set_crawl_exec_last_update_time(crawl_id, now)
             status.lastUpdatedTime = to_k8s_date(now)
             return
-
-        update_start_time = from_k8s_date(status.lastUpdatedTime)
 
         reason = None
         update_duration = (now - update_start_time).total_seconds()
@@ -1186,16 +1191,7 @@ class BtrixOperator(K8sAPI):
                 max_duration = max(duration, max_duration)
 
         if exec_time:
-            if not await self.crawl_ops.inc_crawl_exec_time(
-                crawl_id, exec_time, status.lastUpdatedTime
-            ):
-                # if lastUpdatedTime is same as previous, something is wrong, don't update!
-                print(
-                    f"Already updated for lastUpdatedTime {status.lastUpdatedTime}, skipping execTime update!",
-                    flush=True,
-                )
-                status.lastUpdatedTime = to_k8s_date(now)
-                return
+            await self.crawl_ops.inc_crawl_exec_time(crawl_id, exec_time)
 
             await self.org_ops.inc_org_time_stats(oid, exec_time, True)
             status.crawlExecTime += exec_time
@@ -1206,6 +1202,7 @@ class BtrixOperator(K8sAPI):
             flush=True,
         )
 
+        await self.crawl_ops.set_crawl_exec_last_update_time(crawl_id, now)
         status.lastUpdatedTime = to_k8s_date(now)
 
     def should_mark_waiting(self, state, started):


### PR DESCRIPTION
Instead of relying on status to keep track of lastUpdatedTime, just keep track of it in the db to ensure it is property updated each time. Fixes issues on not counting execution time while avoiding previous issues of double-counting