### PR TITLE
Add updatable QA reviewStatus field to crawls

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -523,6 +523,15 @@ class CrawlFileOut(BaseModel):
 
 
 # ============================================================================
+class ReviewStatus(str, Enum):
+    """QA review statuses"""
+
+    GOOD = "good"
+    ACCEPTABLE = "acceptable"
+    FAILURE = "failure"
+
+
+# ============================================================================
 class BaseCrawl(BaseMongoModel):
     """Base Crawl object (representing crawls, uploads and manual sessions)"""
 
@@ -553,6 +562,8 @@ class BaseCrawl(BaseMongoModel):
 
     fileSize: int = 0
     fileCount: int = 0
+
+    reviewStatus: Optional[ReviewStatus] = None
 
 
 # ============================================================================
@@ -617,6 +628,8 @@ class CrawlOut(BaseMongoModel):
     crawlerChannel: str = "default"
     image: Optional[str]
 
+    reviewStatus: Optional[ReviewStatus] = None
+
 
 # ============================================================================
 class CrawlOutWithResources(CrawlOut):
@@ -634,6 +647,7 @@ class UpdateCrawl(BaseModel):
     description: Optional[str]
     tags: Optional[List[str]]
     collectionIds: Optional[List[UUID]]
+    reviewStatus: Optional[ReviewStatus]
 
 
 # ============================================================================

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -283,6 +283,42 @@ def test_update_crawl(
     assert data["name"] == UPDATED_NAME
     assert data["collectionIds"] == UPDATED_COLLECTION_IDS
 
+    # Update reviewStatus and verify
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
+        headers=admin_auth_headers,
+        json={
+            "reviewStatus": "good",
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["updated"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["reviewStatus"] == "good"
+
+    # Try to update to invalid reviewStatus
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
+        headers=admin_auth_headers,
+        json={
+            "reviewStatus": "invalid",
+        },
+    )
+    assert r.status_code == 422
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["reviewStatus"] == "good"
+
     # Verify deleting works as well
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -282,6 +282,7 @@ def test_update_crawl(
     assert data["description"] == UPDATED_DESC
     assert data["name"] == UPDATED_NAME
     assert data["collectionIds"] == UPDATED_COLLECTION_IDS
+    assert data.get("reviewStatus") is None
 
     # Update reviewStatus and verify
     r = requests.patch(


### PR DESCRIPTION
Fixes #1539 

Adds `reviewStatus` field to `BaseCrawl` model, updatable via the crawl update API endpoint. Acceptable values are "good", "acceptable" or "failure", enforced by an Enum.

Added to `BaseCrawl` so that we can extend support to uploads more easily later on, but for now we'll only display this for crawls in the frontend.