### PR TITLE
Fix regex escape in exclusion editor text match

### DIFF
--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -6,7 +6,7 @@ import RegexColorize from "regex-colorize";
 
 import type { SeedConfig } from "@/pages/org/types";
 import LiteElement, { html } from "@/utils/LiteElement";
-import { regexEscape } from "@/utils/string";
+import { regexEscape, regexUnescape } from "@/utils/string";
 import type { Exclusion } from "./queue-exclusion-form";
 import { type PageChangeEvent } from "@/components/ui/pagination";
 import { type TemplateResult, type PropertyValues } from "lit";
@@ -115,11 +115,12 @@ export class QueueExclusionTable extends LiteElement {
     this.results = this.exclusions
       .slice((this.page - 1) * this.pageSize, this.page * this.pageSize)
       .map((str: string) => {
+        // if escaped version of string, with '\' removed matches string, then consider it
+        // to be matching text, otherwise, regex
+        const isText = regexEscape(str.replace(/\\/g, "")) === str;
         return {
-          // if escaped version of string, with '\' removed matches string, then consider it
-          // to be matching text, otherwise, regex
-          type: regexEscape(str.replace(/\\/g, "")) === str ? "text" : "regex",
-          value: str,
+          type: isText ? "text" : "regex",
+          value: isText ? regexUnescape(str) : str,
         };
       });
   }

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -27,7 +27,7 @@ import uniq from "lodash/fp/uniq";
 import Fuse from "fuse.js";
 
 import LiteElement, { html } from "@/utils/LiteElement";
-import { regexEscape } from "@/utils/string";
+import { regexEscape, regexUnescape } from "@/utils/string";
 import type { AuthState } from "@/utils/AuthService";
 import {
   getUTCSchedule,
@@ -495,7 +495,7 @@ export class CrawlConfigEditor extends LiteElement {
       if (primarySeedConfig.include?.length) {
         formState.customIncludeUrlList = primarySeedConfig.include
           // Unescape regex
-          .map((url) => url.replace(/(\\|\/\.\*)/g, ""))
+          .map(regexUnescape)
           .join("\n");
         // if we have additional include URLs, set to "custom" scope here
         // to indicate 'Custom Page Prefix' option

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -5,3 +5,7 @@
 export function regexEscape(s: unknown) {
   return String(s).replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
 }
+
+export function regexUnescape(s: unknown) {
+  return String(s).replace(/(\\|\/\.\*)/g, "");
+}


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1566, fixes https://github.com/webrecorder/browsertrix-cloud/issues/1544

<!-- Fixes #issue_number -->

### Changes

Fixes issue where "match text" was being displayed as regex when containing special characters.

### Manual testing

1. Log in as a crawl and run a crawl
2. Watch crawl and open exclusion editor
3. Add exclusion as "match text" with a period, e.g. `test.com`. Verify text is displayed as entered
4. Remove exclusion. Verify exclusion is removed without errors