### PR TITLE
Fix pending exclusion pagination

### DIFF
--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -45,7 +45,7 @@ export class CrawlPendingExclusions extends LiteElement {
   render() {
     return html`
       <btrix-section-heading style="--margin: var(--sl-spacing-small)">
-        <div class="flex items-center justify-between">
+        <div class="flex w-full items-center justify-between">
           <div>${msg("Pending Exclusions")} ${this.renderBadge()}</div>
           ${this.total && this.total > this.pageSize
             ? html`<btrix-pagination

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -49,6 +49,7 @@ export class CrawlPendingExclusions extends LiteElement {
           <div>${msg("Pending Exclusions")} ${this.renderBadge()}</div>
           ${this.total && this.total > this.pageSize
             ? html`<btrix-pagination
+                page=${this.page}
                 size=${this.pageSize}
                 totalCount=${this.total}
                 compact


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-cloud/issues/1545

### Changes

- Fixes not being able to change page
- Fixes pagination alignment

### Manual testing

1. Log in as a crawl and run a crawl with many pagefs
2. Watch crawl and open exclusion editor
3. Type in an exclusion that'll add a lot of URLs to the pending list. Verify that pending list is shown with pagination aligned to right
4. Click pagination controls. Verify page updates as expected