### PR TITLE
Allow users to configure offset when viewing crawl queued URLs

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -14,6 +14,7 @@ import("./desc-list");
 import("./details");
 import("./dialog");
 import("./file-list");
+import("./inline-input");
 import("./input");
 import("./language-select");
 import("./locale-picker");

--- a/frontend/src/components/ui/inline-input.ts
+++ b/frontend/src/components/ui/inline-input.ts
@@ -1,7 +1,7 @@
-import { css } from "lit";
-import { customElement } from "lit/decorators.js";
 import SlInput from "@shoelace-style/shoelace/dist/components/input/input.js";
 import inputStyles from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
+import { css } from "lit";
+import { customElement } from "lit/decorators.js";
 
 /**
  * Input to use inline with text.

--- a/frontend/src/components/ui/inline-input.ts
+++ b/frontend/src/components/ui/inline-input.ts
@@ -1,0 +1,25 @@
+import { css } from "lit";
+import { customElement } from "lit/decorators.js";
+import SlInput from "@shoelace-style/shoelace/dist/components/input/input.js";
+import inputStyles from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
+
+/**
+ * Input to use inline with text.
+ */
+@customElement("btrix-inline-input")
+export class InlineInput extends SlInput {
+  static styles = [
+    inputStyles,
+    css`
+      :host {
+        --sl-input-height-small: var(--sl-font-size-x-large);
+        --sl-input-color: var(--sl-color-neutral-500);
+      }
+
+      .input--small .input__control {
+        text-align: center;
+        padding: 0 0.5ch;
+      }
+    `,
+  ] as typeof SlInput.styles;
+}

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -33,17 +33,12 @@ export class Pagination extends LitElement {
   static styles = [
     srOnly,
     css`
-      :host {
-        --sl-input-height-small: var(--sl-font-size-x-large);
-        --sl-input-color: var(--sl-color-neutral-500);
-      }
-
       ul {
         align-items: center;
         list-style: none;
         margin: 0;
         padding: 0;
-        color: var(--sl-input-color);
+        color: var(--sl-color-neutral-500);
       }
 
       ul.compact {
@@ -62,11 +57,6 @@ export class Pagination extends LitElement {
         display: flex;
         align-items: center;
         cursor: pointer;
-      }
-
-      sl-input::part(input) {
-        text-align: center;
-        padding: 0 0.5ch;
       }
 
       .currentPage {
@@ -211,7 +201,7 @@ export class Pagination extends LitElement {
     return html`
       <div class="pageInput">
         <div class="totalPages" role="none">${this.pages}</div>
-        <sl-input
+        <btrix-inline-input
           class="input"
           inputmode="numeric"
           size="small"
@@ -256,7 +246,7 @@ export class Pagination extends LitElement {
             // Select text on focus for easy typing
             (e.target as SlInput).select();
           }}
-        ></sl-input>
+        ></btrix-inline-input>
       </div>
     `;
   }

--- a/frontend/src/components/utils/observable.ts
+++ b/frontend/src/components/utils/observable.ts
@@ -31,7 +31,6 @@ export class Observable extends LitElement {
   }
 
   disconnectedCallback(): void {
-    console.log("disconnect?");
     this.observer?.disconnect();
     super.disconnectedCallback();
   }

--- a/frontend/src/components/utils/observable.ts
+++ b/frontend/src/components/utils/observable.ts
@@ -31,7 +31,9 @@ export class Observable extends LitElement {
   }
 
   disconnectedCallback(): void {
+    console.log("disconnect?");
     this.observer?.disconnect();
+    super.disconnectedCallback();
   }
 
   firstUpdated() {

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -109,7 +109,15 @@ export class CrawlQueue extends LiteElement {
   }
 
   private renderOffsetControl() {
-    if (!this.queue) return;
+    if (!this.queue) {
+      return msg("Queued URLs");
+    }
+    if (this.pageOffset === 0 && this.queue.total <= this.pageSize) {
+      return msg(
+        str`Queued URLs from 1 to ${this.queue.total.toLocaleString()}`,
+      );
+    }
+
     const offsetValue = this.pageOffset + 1;
     const countMax = Math.min(
       this.pageOffset + this.pageSize,

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -110,8 +110,13 @@ export class CrawlQueue extends LiteElement {
   }
 
   private renderOffsetControl() {
-    const value = this.pageOffset + 1;
-    const getWidth = (v: number | string) =>
+    if (!this.queue) return;
+    const offsetValue = this.pageOffset + 1;
+    const countMax = Math.min(
+      this.pageOffset + this.pageSize,
+      this.queue.total,
+    );
+    const getInputWIdth = (v: number | string) =>
       `${Math.max(v.toString().length, 3) + 2}ch`;
 
     return html`
@@ -120,23 +125,23 @@ export class CrawlQueue extends LiteElement {
           Viewing
           <btrix-inline-input
             class="mx-1 inline-block"
-            style="width: ${Math.max(value.toString().length, 3) + 2}ch"
-            value=${value}
+            style="width: ${Math.max(offsetValue.toString().length, 3) + 2}ch"
+            value=${offsetValue}
             inputmode="numeric"
             size="small"
             autocomplete="off"
             min="1"
             @sl-input=${(e: SlInputEvent) => {
               const input = e.target as SlInput;
-              input.style.width = getWidth(input.value);
+              input.style.width = getInputWIdth(input.value);
             }}
             @sl-change=${(e: SlChangeEvent) => {
               this.pageOffset =
                 +(e.target as SlInput).value.replace(/\D/g, "") - 1;
             }}
           ></btrix-inline-input>
-          to ${(this.pageOffset + this.pageSize).toLocaleString()} of
-          ${this.queue?.total.toLocaleString()}
+          to ${countMax.toLocaleString()} of
+          ${this.queue.total.toLocaleString()}
         `)}
       </div>
     `;
@@ -185,7 +190,7 @@ export class CrawlQueue extends LiteElement {
 
       <footer class="text-center">
         ${when(
-          this.queue.total === this.queue.results.length,
+          this.queue.total <= this.pageOffset + this.pageSize,
           () =>
             html`<div class="py-3 text-xs text-neutral-400">
               ${msg("End of queue")}

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -102,10 +102,7 @@ export class CrawlQueue extends LiteElement {
   render() {
     return html`
       <btrix-section-heading style="--margin: var(--sl-spacing-small)">
-        <div class="flex w-full items-center justify-between">
-          <div>${msg("Queued URLs")} ${this.renderBadge()}</div>
-          ${this.renderOffsetControl()}
-        </div>
+        ${this.renderOffsetControl()} ${this.renderBadge()}
       </btrix-section-heading>
       ${this.renderContent()}
     `;
@@ -124,10 +121,10 @@ export class CrawlQueue extends LiteElement {
     return html`
       <div class="flex items-center text-neutral-500">
         ${msg(html`
-          Viewing
+          Queued URLs from
           <btrix-inline-input
             class="mx-1 inline-block"
-            style="width: ${Math.max(offsetValue.toString().length, 3) + 2}ch"
+            style="width: ${Math.max(offsetValue.toString().length, 2) + 2}ch"
             value=${offsetValue}
             inputmode="numeric"
             size="small"

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1220,7 +1220,7 @@ export class WorkflowDetail extends LiteElement {
     return html`
       <header class="flex items-center justify-between">
         <h3 class="mb-2 text-base font-semibold leading-none">
-          ${msg("Crawl URLs")}
+          ${msg("Upcoming Pages")}
         </h3>
         <sl-button
           size="small"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1580

<!-- Fixes #issue_number -->

### Changes

Enables users to jump to a URL position in the crawl queue.

### Manual testing

1. Log in as crawler and start a crawl with more than 50 pages.
2. Go to watch crawl. Verify "Queued URLs from [1] to <page size> of <total>" is shown under "Upcoming Pages".
3. Enter number into input. Verify input cannot be less than 1 or more than total - 50, and that list updates as expected.
4. Scroll to load more. Verify list updates as expected, and input number updates if more than the list total.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail - Watch | <img width="1042" alt="Screenshot 2024-03-06 at 9 23 43 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/c6eda877-a60d-4ad7-bb2d-4e00051f51aa"> |
| Workflow Detail - Exclusion Editor | <img width="1316" alt="Screenshot 2024-03-06 at 9 23 50 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/aa73d9ce-4a23-42b4-a1b1-1e02f8a0aa3e"> |
| Workflow Detail - Exclusion Editor | <img width="666" alt="Screenshot 2024-03-06 at 9 24 01 AM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/b3249f20-7e60-42e3-8bb2-9e78206c369f"> |




<!-- ### Follow-ups -->
