### PR TITLE
Make storage deletion work on more S3 providers

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -501,7 +501,7 @@ class StorageOps:
 
         s3storage = self.get_org_storage_by_ref(org, storage)
 
-        async with self.get_s3_client(s3storage, s3storage.use_access_for_presign) as (
+        async with self.get_s3_client(s3storage) as (
             client,
             bucket,
             key,


### PR DESCRIPTION
I came across [this problem](https://forum.webrecorder.net/t/deleting-crawl-failure/512) and noticed that the access URL is used when deleting files, causing my file deletions to fail on OpenStack SWIFT S3 (relates to #1090). This trivial change makes it work there.