### PR TITLE
kubernetes api: avoid overriding content-type header in kubernetes-asyncio, pass in via arg instead

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -216,13 +216,7 @@ class K8sAPI:
         )
 
     async def _patch_job(self, crawl_id, body, pluraltype="crawljobs") -> dict:
-        content_type = self.api_client.default_headers.get("Content-Type")
-
         try:
-            self.api_client.set_default_header(
-                "Content-Type", "application/merge-patch+json"
-            )
-
             await self.custom_api.patch_namespaced_custom_object(
                 group="btrix.cloud",
                 version="v1",
@@ -230,18 +224,13 @@ class K8sAPI:
                 plural=pluraltype,
                 name=f"{pluraltype[:-1]}-{crawl_id}",
                 body={"spec": body},
+                _content_type="application/merge-patch+json",
             )
             return {"success": True}
         # pylint: disable=broad-except
         except Exception as exc:
             traceback.print_exc()
             return {"error": str(exc)}
-
-        finally:
-            if content_type:
-                self.api_client.set_default_header("Content-Type", content_type)
-            else:
-                del self.api_client.default_headers["Content-Type"]
 
     async def print_pod_logs(self, pod_names, lines=100):
         """print pod logs"""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ email-validator
 #fastapi-users[mongodb]==9.2.2
 loguru
 aiofiles
-kubernetes-asyncio==25.11.0
+kubernetes-asyncio==29.0.0
 kubernetes
 aiobotocore
 redis>=5.0.0


### PR DESCRIPTION
- instead of overriding the content-type header globally, pass 'application/merge-patch+json' to self.custom_api.patch_namespaced_custom_object() directly
- bump kubernetes-asyncio to 29.0.0
- fixes potential issues with global override of the header in kubernetes-asyncio