### PR TITLE
Fix missing page component imports

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -101,7 +101,7 @@ module.exports = {
     /* end recommended rules */
 
     /* start import rules */
-    "import-x/no-duplicates": ["error", { "prefer-inline": true }],
+    // "import-x/no-duplicates": ["error", { "prefer-inline": true }],
     "import-x/order": [
       "error",
       {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -31,10 +31,13 @@ import "./workflows-list";
 import "./workflows-new";
 import "./archived-item-detail";
 import "./archived-items";
+import "./archived-item-qa";
 import "./collections-list";
+import "./collection-detail";
 import "./browser-profiles-detail";
 import "./browser-profiles-list";
 import "./browser-profiles-new";
+import "./settings";
 import "./dashboard";
 
 const RESOURCE_NAMES = ["workflow", "collection", "browser-profile", "upload"];


### PR DESCRIPTION
Missed bug introduced in https://github.com/webrecorder/browsertrix-cloud/pull/1608, adds back imports and disables `import-x` rule. [See Discord thread](https://discord.com/channels/895426029194207262/1219487806779428956/1219488222388818051)