### PR TITLE
Upgrade Node 16 > 18

### DIFF
--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
           cache-dependency-path: frontend/yarn.lock
       - name: Restore cache

--- a/.github/workflows/ui-tests-playwright.yml
+++ b/.github/workflows/ui-tests-playwright.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
           cache-dependency-path: frontend/yarn.lock
       - name: Install dependencies

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,21 +1,21 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM docker.io/library/node:16 as build_deps
+FROM --platform=$BUILDPLATFORM docker.io/library/node:18 as build_deps
 
 WORKDIR /app
 COPY yarn.lock package.json ./
 # Uses `yarn cache clean` to let Docker cache layer instead
 # of including yarn cache in the build image
 RUN yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000 && \
-    yarn cache clean
+  yarn cache clean
 
 COPY --link lit-localize.json \
-    postcss.config.js \
-    tailwind.config.js \
-    tsconfig.json \
-    webpack.config.js \
-    webpack.prod.js \
-    index.d.ts \
-    ./
+  postcss.config.js \
+  tailwind.config.js \
+  tsconfig.json \
+  webpack.config.js \
+  webpack.prod.js \
+  index.d.ts \
+  ./
 
 COPY --link src ./src/
 
@@ -27,8 +27,8 @@ ARG GIT_BRANCH_NAME
 ARG VERSION
 
 ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
-    GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
-    VERSION=${VERSION}
+  GIT_BRANCH_NAME=${GIT_BRANCH_NAME} \
+  VERSION=${VERSION}
 
 # Prevent Docker image including node_modules to save space
 RUN yarn build && \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -127,7 +127,7 @@
     }
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "resolutions": {
     "**/playwright": "1.32.1",


### PR DESCRIPTION
Upgrades node from [maintenance version to active](https://nodejs.github.io/nodejs.dev/en/about/releases/). Tested manually with local instance with no issues. This blocks upgrading some of the frontend dev tool libraries, like unit test helpers.

Note: we'll need to upgrade to node 20 to address `Node.js 16 actions are deprecated.` notice in github actions.