### PR TITLE
Emit more modern code for browsers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -133,5 +133,8 @@
     "**/playwright": "1.32.1",
     "**/lit": "3.1.1",
     "@web/dev-server-esbuild/esbuild": "^0.19.5"
-  }
+  },
+  "browserslist": [
+    "defaults"
+  ]
 }


### PR DESCRIPTION
Adds a `browserlist` field to `package.json`, which Webpack picks up so it doesn't convert nullish coalescing operators into obfuscated messes like `key !== null && key !== void 0 ? key : null`.

This improves output size a little & improves the debugging experience as well.

Tested in Chrome, FF, & Safari locally and didn't encounter any issues.