### PR TITLE
Clean up ESLint warnings in main

### DIFF
--- a/frontend/src/components/ui/dialog.ts
+++ b/frontend/src/components/ui/dialog.ts
@@ -66,9 +66,6 @@ export class Dialog extends SlDialog {
    * TODO refactor dialog instances that self implements `form.requestSubmit`
    */
   submit = () => {
-    const form = this.formElems[0];
-    if (!form) return;
-
-    form.requestSubmit();
+    this.formElems[0]?.requestSubmit();
   };
 }

--- a/frontend/src/features/qa/page-qa-toolbar.ts
+++ b/frontend/src/features/qa/page-qa-toolbar.ts
@@ -407,7 +407,7 @@ export class PageQAToolbar extends TailwindElement {
         },
       );
 
-      this.fetchPage();
+      void this.fetchPage();
 
       this.notify.toast({
         message: msg("Successfully deleted comment."),

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -215,9 +215,7 @@ export class ArchivedItemQA extends TailwindElement {
             )}
           </ul>
           pg ${this.pages.page} of
-          ${this.pages
-            ? Math.ceil(this.pages.total / this.pages.pageSize)
-            : "unknown"}
+          ${Math.ceil(this.pages.total / this.pages.pageSize)}
         </section>
       </article>
     `;


### PR DESCRIPTION
See title.

The only place this changes behaviour is in the placeholder page list, which will be replaced by the real one shortly, so I'm going to just merge this.