### PR TITLE
Disable Prettier check in CI

### DIFF
--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -35,7 +35,9 @@ jobs:
         run: yarn lint:check
       - name: Format
         working-directory: frontend
-        run: yarn format:check
+        # TODO Reenable when https://github.com/webrecorder/browsertrix-cloud/issues/1618 is addressed
+        # run: yarn format:check
+        run: yarn prettier --list-different .
       - name: Unit tests
         working-directory: frontend
         run: yarn test


### PR DESCRIPTION
Disables `prettier:check` until discrepancies are handled in https://github.com/webrecorder/browsertrix-cloud/issues/1618 so that formatting issues don't fail CI runs.