### PR TITLE
Add additional filters to page list endpoints

### DIFF
--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -94,8 +94,28 @@ def parse_jsonl_error_messages(errors):
 def is_bool(stri: Optional[str]) -> bool:
     """Check if the string parameter is stringly true"""
     if stri:
-        return stri.lower() in ("true", "1", "yes")
+        return stri.lower() in ("true", "1", "yes", "on")
     return False
+
+
+def is_falsy_bool(stri: Optional[str]) -> bool:
+    """Check if the string parameter is stringly false"""
+    if stri:
+        return stri.lower() in ("false", "0", "no", "off")
+    return False
+
+
+def str_list_to_bools(str_list: List[str], allow_none=True) -> List[Union[bool, None]]:
+    """Return version of input string list cast to bool or None, ignoring other values"""
+    output: List[Union[bool, None]] = []
+    for val in str_list:
+        if is_bool(val):
+            output.append(True)
+        if is_falsy_bool(val):
+            output.append(False)
+        if val.lower() in ("none", "null") and allow_none:
+            output.append(None)
+    return output
 
 
 def slug_from_name(name: str) -> str:


### PR DESCRIPTION
Fixes #1617 

Filters added:

- reviewed: filter by page has approval or at least one note (true) or neither (false)
- approved: filter by approval value (accepts list of strings, comma-separated, each of which are coerced into True, False, or None, or ignored if they are invalid values)
- hasNotes: filter by has at least one note (true) or not (false)

Tests have also been added to ensure that results are as expected.