### PR TITLE
Give test_crawl_timeout 10 mins to finish

### DIFF
--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -17,8 +17,8 @@ def test_crawl_timeout(admin_auth_headers, default_org_id, timeout_crawl):
 
     attempts = 0
     while True:
-        # Try for 2 minutes before failing
-        if attempts > 24:
+        # Try for 10 minutes before failing
+        if attempts > 30:
             assert False
 
         r = requests.get(
@@ -27,7 +27,7 @@ def test_crawl_timeout(admin_auth_headers, default_org_id, timeout_crawl):
         )
         if r.json()["state"] == "complete":
             break
-        time.sleep(10)
+        time.sleep(20)
         attempts += 1
 
 


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix-cloud/issues/1620

Follow-up to https://github.com/webrecorder/browsertrix-cloud/pull/1621, which didn't seem to fix the problem.

I'm giving it much more time here in the hopes that it solves it (since it's a nightly test, time shouldn't be such a pressing issue). If this isn't sufficient, will dig in and see what the issue is. I'm not seeing the same issue locally, where the test passes in under a minute.