### PR TITLE
Crawler pod memory padding + auto scaling

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -288,3 +288,29 @@ class K8sAPI:
         # pylint: disable=broad-exception-caught
         except Exception:
             return False
+
+    async def send_signal_to_pod(self, pod_name, signame) -> bool:
+        """send signal to all pods"""
+        command = ["bash", "-c", f"kill -s {signame} 1"]
+        signaled = False
+
+        try:
+            print(f"Sending {signame} to {pod_name}", flush=True)
+
+            res = await self.core_api_ws.connect_get_namespaced_pod_exec(
+                name=pod_name,
+                namespace=self.namespace,
+                command=command,
+                stdout=True,
+            )
+            if res:
+                print("Result", res, flush=True)
+
+            else:
+                signaled = True
+
+        # pylint: disable=broad-except
+        except Exception as exc:
+            print(f"Send Signal Error: {exc}", flush=True)
+
+        return signaled

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -42,28 +42,35 @@ class K8sOpAPI(K8sAPI):
         """compute memory / cpu resources for crawlers"""
         p = self.shared_params
         num = max(int(p["crawler_browser_instances"]) - 1, 0)
+        crawler_cpu: float = 0
+        crawler_memory: int = 0
         print("crawler resources")
         if not p.get("crawler_cpu"):
             base = parse_quantity(p["crawler_cpu_base"])
             extra = parse_quantity(p["crawler_extra_cpu_per_browser"])
 
             # cpu is a floating value of cpu cores
-            p["crawler_cpu"] = float(base + num * extra)
+            crawler_cpu = float(base + num * extra)
 
-            print(f"cpu = {base} + {num} * {extra} = {p['crawler_cpu']}")
+            print(f"cpu = {base} + {num} * {extra} = {crawler_cpu}")
         else:
-            print(f"cpu = {p['crawler_cpu']}")
+            crawler_cpu = float(parse_quantity(p["crawler_cpu"]))
+            print(f"cpu = {crawler_cpu}")
 
         if not p.get("crawler_memory"):
             base = parse_quantity(p["crawler_memory_base"])
             extra = parse_quantity(p["crawler_extra_memory_per_browser"])
 
             # memory is always an int
-            p["crawler_memory"] = int(base + num * extra)
+            crawler_memory = int(base + num * extra)
 
-            print(f"memory = {base} + {num} * {extra} = {p['crawler_memory']}")
+            print(f"memory = {base} + {num} * {extra} = {crawler_memory}")
         else:
-            print(f"memory = {p['crawler_memory']}")
+            crawler_memory = int(parse_quantity(p["crawler_memory"]))
+            print(f"memory = {crawler_memory}")
+
+        p["crawler_cpu"] = crawler_cpu
+        p["crawler_memory"] = crawler_memory
 
     def compute_profile_resources(self):
         """compute memory /cpu resources for a single profile browser"""

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -222,8 +222,10 @@ class CrawlOperator(BaseOperator):
                 data.related.get(METRICS, {}),
             )
 
-            # auto sizing handled here
-            await self.handle_auto_size(status.podStatus)
+            # auto-scaling not possible without pod metrics
+            if self.k8s.has_pod_metrics:
+                # auto sizing handled here
+                await self.handle_auto_size(status.podStatus)
 
             if status.finished:
                 return await self.finalize_response(

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -772,8 +772,6 @@ class CrawlOperator(BaseOperator):
             qa_run_id = crawl.id if crawl.is_qa else None
 
             while page_crawled:
-                print("PAGE DATA", flush=True)
-                print(page_crawled, flush=True)
                 page_dict = json.loads(page_crawled)
                 await self.page_ops.add_page_to_db(
                     page_dict, crawl.db_crawl_id, qa_run_id, crawl.oid

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -114,6 +114,7 @@ class PodInfo(BaseModel):
 
     newCpu: Optional[int] = None
     newMemory: Optional[int] = None
+    signalAtMem: Optional[int] = None
 
     def dict(self, *a, **kw):
         res = super().dict(*a, **kw)
@@ -180,7 +181,7 @@ class CrawlStatus(BaseModel):
     initRedis: bool = False
     crawlerImage: Optional[str] = None
     lastActiveTime: str = ""
-    podStatus: Optional[DefaultDict[str, PodInfo]] = defaultdict(
+    podStatus: DefaultDict[str, PodInfo] = defaultdict(
         lambda: PodInfo()  # pylint: disable=unnecessary-lambda
     )
     # placeholder for pydantic 2.0 -- will require this version

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -175,7 +175,7 @@ spec:
 
       resources:
         limits:
-          memory: "{{ memory }}"
+          memory: "{{ memory_limit }}"
 
         requests:
           cpu: "{{ cpu }}"

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/exec", "pods/log", "services", "configmaps", "secrets", "events", "persistentvolumeclaims"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "exec"]
 
 - apiGroups: ["batch", "extensions", "apps"]
   resources: ["jobs", "cronjobs", "statefulsets"]


### PR DESCRIPTION
- set memory limit to 1.2x memory request to provide extra padding and avoid OOM
- attempt to resize crawler pods by 1.2 when exceeding 90% of available memory
- do a 'soft OOM' (send extra SIGTERM) to pod when reaching 100% of requested memory, resulting in faster graceful restart, but avoiding a system-instant OOM Kill
- Fixes #1632 