### PR TITLE
Frontend: Fixes the "Replay Latest Crawl" button path

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1043,7 +1043,7 @@ export class WorkflowDetail extends LiteElement {
         class="flex h-56 min-h-max flex-col items-center justify-center rounded-lg border p-4"
       >
         <p class="text-base font-medium">
-          ${msg("Crawl is not currently running.")}
+          ${msg("Crawl workflow is not currently running.")}
         </p>
         <div class="mt-4">
           ${when(
@@ -1053,7 +1053,7 @@ export class WorkflowDetail extends LiteElement {
                 class="mr-2"
                 href=${`${this.orgBasePath}/items/crawl/${
                   this.workflow!.lastCrawlId
-                }?workflowId=${this.workflowId}#replay`}
+                }#replay`}
                 variant="primary"
                 size="small"
                 @click=${this.navLink}


### PR DESCRIPTION
No issue for this one, but another minor gripe that has bugged me for a while :)

### Changes
- Fixes the path for the "Replay Latest Crawl" button on the watch crawl page when the crawl workflow isn't running
  - Removes the extra `?workflowid` in the URL after the `#replay` that causes the app to not direct the user to the correct tab
  - This also means the back button won't direct users back to the previous crawl workflow and instead to the all crawls list... I think this is reasonable and probably better than directing them to the wrong page, but should also be improved with breadcrumb navigation in the future.