### PR TITLE
merge 1.9.5 fixes

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,7 +70,7 @@ allow_dupe_invites: "0"
 invite_expire_seconds: 604800
 
 # base url for replayweb.page
-rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.12/"
+rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.15/"
 
 superuser:
   # set this to enable a superuser admin

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -307,6 +307,10 @@ export class ProfileBrowser extends LiteElement {
       try {
         const resp = await fetch(result.url, { method: "HEAD" });
         if (!resp.ok) {
+          this.pollTimerId = window.setTimeout(
+            () => void this.checkBrowserStatus(),
+            POLL_INTERVAL_SECONDS * 1000,
+          );
           return;
         }
       } catch (e) {


### PR DESCRIPTION
retry loading profile if initial load fails, follow-up to #1604
- Add missing setTimeout to retry profile loading

bump RWP to 1.8.15