### PR TITLE
Frontend QA: Add Text + Resources Tabs + Optimizations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "copy-webpack-plugin": "^9.1.0",
     "css-loader": "^6.3.0",
     "del-cli": "^4.0.1",
+    "diff": "^5.2.0",
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^7.0.3",
     "eslint": "^8.56.0",
@@ -96,6 +97,7 @@
   },
   "devDependencies": {
     "@lit/localize-tools": "^0.7.1",
+    "@types/diff": "^5.0.9",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/dev-server-import-maps": "^0.2.0",
     "@web/dev-server-rollup": "^0.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@shoelace-style/shoelace": "~2.13.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@types/color": "^3.0.2",
+    "@types/diff": "^5.0.9",
     "@types/lodash": "^4.14.178",
     "@types/sinon": "^10.0.6",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -97,7 +98,6 @@
   },
   "devDependencies": {
     "@lit/localize-tools": "^0.7.1",
-    "@types/diff": "^5.0.9",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/dev-server-import-maps": "^0.2.0",
     "@web/dev-server-rollup": "^0.6.1",

--- a/frontend/src/components/ui/button.ts
+++ b/frontend/src/components/ui/button.ts
@@ -59,7 +59,7 @@ export class Button extends TailwindElement {
       type=${this.type === "submit" ? "submit" : "button"}
       class=${[
         tw`flex h-6 cursor-pointer items-center justify-center gap-2 rounded-sm text-center font-medium transition-all disabled:cursor-not-allowed disabled:text-neutral-300`,
-        this.icon ? tw`min-h-6 min-w-6 px-1` : tw`h-6 px-2`,
+        this.icon ? tw`min-h-8 min-w-8 px-1` : tw`h-6 px-2`,
         this.raised ? tw`shadow-sm` : "",
         {
           primary: tw`bg-blue-50 text-blue-600 shadow-blue-800/20 hover:bg-blue-100`,

--- a/frontend/src/components/ui/card.ts
+++ b/frontend/src/components/ui/card.ts
@@ -1,0 +1,21 @@
+import { html } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+
+@customElement("btrix-card")
+export class Card extends TailwindElement {
+  render() {
+    return html`
+      <section class="flex h-full flex-col rounded border p-4">
+        <h2 class="mb-3 border-b pb-3 text-base font-semibold leading-none">
+          <slot name="title"></slot>
+        </h2>
+        <div class="flex-1">
+          <slot></slot>
+        </div>
+        <slot name="footer"></slot>
+      </section>
+    `;
+  }
+}

--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -60,7 +60,7 @@ export class DescListItem extends LitElement {
   render() {
     return html`<div class="item">
       <div class="content">
-        <dt>${this.label}</dt>
+        <dt>${this.label}<slot name="label"></slot></dt>
         <dd><slot></slot></dd>
       </div>
     </div>`;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -3,6 +3,7 @@ import "./badge";
 import "./navigation";
 
 import("./button");
+import("./card");
 import("./code");
 import("./combobox");
 import("./config-details");

--- a/frontend/src/controllers/navigate.ts
+++ b/frontend/src/controllers/navigate.ts
@@ -57,7 +57,7 @@ export class NavigateController implements ReactiveController {
    * ```
    * @param event Click event
    */
-  link = (event: MouseEvent, _href?: string): void => {
+  link = (event: MouseEvent, _href?: string, resetScroll = true): void => {
     if (
       // Detect keypress for opening in a new tab
       event.ctrlKey ||
@@ -75,7 +75,7 @@ export class NavigateController implements ReactiveController {
     const evt = new CustomEvent<NavigateEventDetail>(NAVIGATE_EVENT_NAME, {
       detail: {
         url: (event.currentTarget as HTMLAnchorElement).href,
-        resetScroll: true,
+        resetScroll,
       },
       bubbles: true,
       composed: true,

--- a/frontend/src/features/qa/page-list/page-list.ts
+++ b/frontend/src/features/qa/page-list/page-list.ts
@@ -95,7 +95,7 @@ export class PageList extends TailwindElement {
       changedProperties.get("pages") &&
       this.pages
     ) {
-      this.scrollContainer?.scrollTo({ top: 0 });
+      this.scrollContainer?.scrollTo({ top: 0, left: 0 });
     }
   }
 
@@ -106,7 +106,9 @@ export class PageList extends TailwindElement {
       >
         ${this.renderSortControl()} ${this.renderFilterControl()}
       </div>
-      <div class="scrollContainer relative -mx-2 overflow-y-auto px-2">
+      <div
+        class="scrollContainer relative -mx-2 overflow-y-auto overscroll-contain px-2"
+      >
         ${this.pages?.total
           ? html`
               <div

--- a/frontend/src/features/qa/page-list/page-list.ts
+++ b/frontend/src/features/qa/page-list/page-list.ts
@@ -163,7 +163,7 @@ export class PageList extends TailwindElement {
           : html`<div
               class="flex flex-col items-center justify-center gap-4 py-8 text-xs text-gray-600"
             >
-              <sl-icon name="dash-circle" class="h-4 w-4"></sl-icon>
+              <sl-icon name="slash-circle"></sl-icon>
               ${msg("No matching pages found")}
             </div>`}
       </div>

--- a/frontend/src/features/qa/page-list/ui/page.ts
+++ b/frontend/src/features/qa/page-list/ui/page.ts
@@ -106,6 +106,7 @@ export class QaPage extends TailwindElement {
         this.scrollIntoView({
           behavior: "smooth",
           block: "center",
+          inline: "start",
         });
       } else if (changedProperties.get("selected") === true) {
         void this.animateCollapse();

--- a/frontend/src/features/qa/page-list/ui/page.ts
+++ b/frontend/src/features/qa/page-list/ui/page.ts
@@ -102,12 +102,11 @@ export class QaPage extends TailwindElement {
   protected async updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("selected")) {
       if (this.selected) {
-        await this.animateExpand();
         this.scrollIntoView({
           behavior: "smooth",
-          block: "center",
-          inline: "start",
+          block: "nearest",
         });
+        await this.animateExpand();
       } else if (changedProperties.get("selected") === true) {
         void this.animateCollapse();
       }

--- a/frontend/src/features/qa/qa-run-dropdown.ts
+++ b/frontend/src/features/qa/qa-run-dropdown.ts
@@ -1,4 +1,4 @@
-import { localized, msg } from "@lit/localize";
+import { localized, msg, str } from "@lit/localize";
 import type { SlSelectEvent } from "@shoelace-style/shoelace";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -42,7 +42,7 @@ export class QaRunDropdown extends TailwindElement {
       <sl-dropdown @sl-select=${this.onSelect} distance="-2">
         <sl-button slot="trigger" variant="text" size="small" caret>
           ${selectedRun
-            ? formatDate(selectedRun.finished)
+            ? msg(str`Analysis from ${formatDate(selectedRun.finished)}`)
             : msg("Select a QA run")}
         </sl-button>
         <sl-menu>

--- a/frontend/src/features/qa/qa-run-dropdown.ts
+++ b/frontend/src/features/qa/qa-run-dropdown.ts
@@ -1,4 +1,4 @@
-import { localized, msg, str } from "@lit/localize";
+import { localized, msg } from "@lit/localize";
 import type { SlSelectEvent } from "@shoelace-style/shoelace";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -42,7 +42,7 @@ export class QaRunDropdown extends TailwindElement {
       <sl-dropdown @sl-select=${this.onSelect} distance="-2">
         <sl-button slot="trigger" variant="text" size="small" caret>
           ${selectedRun
-            ? msg(str`Analysis from ${formatDate(selectedRun.finished)}`)
+            ? formatDate(selectedRun.finished)
             : msg("Select a QA run")}
         </sl-button>
         <sl-menu>

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -459,9 +459,6 @@ export class ArchivedItemDetail extends TailwindElement {
               iconLibrary: "default",
               icon: "clipboard2-data-fill",
               label: msg("QA"),
-              detail: html`
-                <btrix-badge variant="primary">${msg("Ready")}</btrix-badge>
-              `,
             })}
           `,
         )}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1,25 +1,37 @@
 import { localized, msg, str } from "@lit/localize";
-import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import capitalize from "lodash/fp/capitalize";
+import queryString from "query-string";
 
-import type { ArchivedItem, Crawl, CrawlConfig, Seed, Workflow } from "./types";
+import { renderQA } from "./ui/qa";
 
+import { TailwindElement } from "@/classes/TailwindElement";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { RelativeDuration } from "@/components/ui/relative-duration";
+import { APIController } from "@/controllers/api";
+import { NavigateController } from "@/controllers/navigate";
+import { NotifyController } from "@/controllers/notify";
 import type { CrawlLog } from "@/features/archived-items/crawl-logs";
-import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
-import type { APIPaginatedList } from "@/types/api";
-import { type QARun } from "@/types/qa";
+import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
+import type {
+  ArchivedItem,
+  ArchivedItemPage,
+  Crawl,
+  CrawlConfig,
+  Seed,
+  Workflow,
+} from "@/types/crawler";
+import type { QARun } from "@/types/qa";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { isActive } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
-import LiteElement, { html } from "@/utils/LiteElement";
 
 const SECTIONS = [
   "overview",
@@ -41,7 +53,16 @@ type SectionName = (typeof SECTIONS)[number];
  */
 @localized()
 @customElement("btrix-archived-item-detail")
-export class CrawlDetail extends LiteElement {
+export class ArchivedItemDetail extends TailwindElement {
+  static styles = css`
+    .qaPageList {
+      --btrix-cell-padding-top: var(--sl-spacing-x-small);
+      --btrix-cell-padding-bottom: var(--sl-spacing-x-small);
+      --btrix-cell-padding-left: var(--sl-spacing-small);
+      --btrix-cell-padding-right: var(--sl-spacing-small);
+    }
+  `;
+
   @property({ type: Object })
   authState?: AuthState;
 
@@ -82,10 +103,13 @@ export class CrawlDetail extends LiteElement {
   private qaRuns?: QARun[];
 
   @state()
+  private pages?: APIPaginatedList<ArchivedItemPage>;
+
+  @state()
   private qaRunId?: string;
 
   @state()
-  private sectionName: SectionName = "overview";
+  activeTab: SectionName = "overview";
 
   @state()
   private openDialogName?: "scale" | "metadata" | "exclusions";
@@ -101,11 +125,14 @@ export class CrawlDetail extends LiteElement {
     } else if (this.crawl?.type === "crawl") {
       path = "items/crawl";
     }
-    return `${this.orgBasePath}/${path}`;
+    return `${this.navigate.orgBasePath}/${path}`;
   }
 
   // TODO localize
   private readonly numberFormatter = new Intl.NumberFormat();
+  private api = new APIController(this);
+  private navigate = new NavigateController(this);
+  private notify = new NotifyController(this);
 
   private get isActive(): boolean | null {
     if (!this.crawl) return null;
@@ -131,10 +158,27 @@ export class CrawlDetail extends LiteElement {
       void this.fetchCrawl();
       void this.fetchCrawlLogs();
       void this.fetchSeeds();
-      void this.fetchQARuns();
+
+      this.fetchTabData();
+    } else {
+      if (changedProperties.has("activeTab") && this.activeTab) {
+        this.fetchTabData();
+      }
     }
     if (changedProperties.has("workflowId") && this.workflowId) {
       void this.fetchWorkflow();
+    }
+  }
+
+  private fetchTabData() {
+    switch (this.activeTab) {
+      case "qa":
+        void this.fetchPages();
+        void this.fetchQARuns();
+        break;
+
+      default:
+        break;
     }
   }
 
@@ -142,7 +186,7 @@ export class CrawlDetail extends LiteElement {
     // Set initial active section based on URL #hash value
     const hash = window.location.hash.slice(1);
     if ((SECTIONS as readonly string[]).includes(hash)) {
-      this.sectionName = hash as SectionName;
+      this.activeTab = hash as SectionName;
     }
     super.connectedCallback();
   }
@@ -151,7 +195,7 @@ export class CrawlDetail extends LiteElement {
     const authToken = this.authState!.headers.Authorization.split(" ")[1];
     let sectionContent: string | TemplateResult = "";
 
-    switch (this.sectionName) {
+    switch (this.activeTab) {
       case "qa":
         sectionContent = this.renderPanel(
           html`${this.renderTitle(msg("Quality Assurance (QA)"))}
@@ -159,9 +203,9 @@ export class CrawlDetail extends LiteElement {
               <sl-button
                 variant="primary"
                 size="small"
-                href="${this.orgBasePath}/items/crawl/${this
+                href="${this.navigate.orgBasePath}/items/crawl/${this
                   .crawlId}/review/screenshots?qaRunId=${this.qaRunId || ""}"
-                @click=${this.navLink}
+                @click=${this.navigate.link}
               >
                 ${msg("Review Crawl")}
               </sl-button>
@@ -171,11 +215,29 @@ export class CrawlDetail extends LiteElement {
                 ?loading=${!this.qaRuns}
               >
                 ${this.qaRuns?.length
-                  ? msg("Rerun QA Analysis")
-                  : msg("Run QA Analysis")}
+                  ? msg("Rerun Analysis")
+                  : msg("Run Analysis")}
               </sl-button>
             </div>`,
-          this.renderQA(),
+          html`
+            ${guard(
+              [
+                this.crawl?.reviewStatus,
+                this.crawl?.qaCrawlExecSeconds,
+                this.qaRuns,
+                this.qaRunId,
+                this.pages,
+              ],
+              () =>
+                renderQA({
+                  reviewStatus: this.crawl?.reviewStatus,
+                  qaCrawlExecSeconds: this.crawl?.qaCrawlExecSeconds,
+                  qaRuns: this.qaRuns,
+                  qaRunId: this.qaRunId,
+                  pages: this.pages,
+                }),
+            )}
+          `,
         );
         break;
       case "replay":
@@ -283,7 +345,7 @@ export class CrawlDetail extends LiteElement {
         <a
           class="text-sm font-medium text-neutral-500 hover:text-neutral-600"
           href=${this.listUrl}
-          @click=${this.navLink}
+          @click=${this.navigate.link}
         >
           <sl-icon
             name="arrow-left"
@@ -358,7 +420,7 @@ export class CrawlDetail extends LiteElement {
       icon: string;
       detail?: TemplateResult<1>;
     }) => {
-      const isActive = section === this.sectionName;
+      const isActive = section === this.activeTab;
       const baseUrl = window.location.pathname.split("#")[0];
       return html`
         <btrix-navigation-button
@@ -366,7 +428,7 @@ export class CrawlDetail extends LiteElement {
           .active=${isActive}
           href=${`${baseUrl}${window.location.search}#${section}`}
           @click=${() => {
-            this.sectionName = section;
+            this.activeTab = section;
           }}
           ><sl-icon
             class="h-4 w-4 shrink-0"
@@ -507,8 +569,8 @@ export class CrawlDetail extends LiteElement {
             () => html`
               <sl-menu-item
                 @click=${() =>
-                  this.navTo(
-                    `${this.orgBasePath}/workflows/crawl/${
+                  this.navigate.to(
+                    `${this.navigate.orgBasePath}/workflows/crawl/${
                       (this.crawl as Crawl).cid
                     }`,
                   )}
@@ -575,56 +637,6 @@ export class CrawlDetail extends LiteElement {
       >
         ${content}
       </div>
-    `;
-  }
-
-  private renderQA() {
-    const finishedQARuns = this.qaRuns
-      ? this.qaRuns.filter(({ finished }) => finished)
-      : [];
-    return html`
-      <div class="outline">
-        TEMP running crawl:
-        <pre>
-${JSON.stringify(
-            this.qaRuns?.filter(({ finished }) => !finished),
-            null,
-            2,
-          )}
-      </pre
-        >
-      </div>
-      <section class="mb-5 rounded-lg border p-4">[summary]</section>
-      <btrix-tab-group>
-        <btrix-tab-group-tab slot="nav" panel="pages">
-          ${msg("Review")}
-        </btrix-tab-group-tab>
-        <btrix-tab-group-tab slot="nav" panel="runs">
-          ${msg("QA Runs")}
-        </btrix-tab-group-tab>
-
-        <btrix-tab-group-panel name="pages">
-          <div class="flex items-center gap-1">
-            <h4 class="text-base font-semibold leading-8">
-              ${msg("QA Analysis")}
-            </h4>
-            <btrix-qa-run-dropdown
-              .items=${finishedQARuns}
-              selectedId=${this.qaRunId || ""}
-              @btrix-select=${(e: CustomEvent<SelectDetail>) =>
-                (this.qaRunId = e.detail.item.id)}
-            ></btrix-qa-run-dropdown>
-          </div>
-          <section class="mb-7 rounded-lg border p-4">[stats]</section>
-          <h4 class="mb-2 text-base font-semibold leading-8">
-            ${msg("Page Reviews")}
-          </h4>
-          <section>[pages]</section>
-        </btrix-tab-group-panel>
-        <btrix-tab-group-panel name="runs">
-          <section>[runs]</section>
-        </btrix-tab-group-panel>
-      </btrix-tab-group>
     `;
   }
 
@@ -779,7 +791,7 @@ ${JSON.stringify(
                               +this.crawl.stats.found,
                             )}
                           </span>
-                          <span> pages</span>`
+                          <span>${msg("pages")}</span>`
                       : ""}`
                 : html`<span class="text-0-400">${msg("Unknown")}</span>`}`
             : html`<sl-skeleton class="h-[16px] w-24"></sl-skeleton>`}
@@ -863,8 +875,8 @@ ${this.crawl?.description}
                         html`<li class="mt-1">
                           <a
                             class="text-primary hover:text-indigo-400"
-                            href=${`${this.orgBasePath}/collections/view/${id}`}
-                            @click=${this.navLink}
+                            href=${`${this.navigate.orgBasePath}/collections/view/${id}`}
+                            @click=${this.navigate.link}
                             >${name}</a
                           >
                         </li>`,
@@ -995,7 +1007,7 @@ ${this.crawl?.description}
     try {
       this.crawl = await this.getCrawl();
     } catch {
-      this.notify({
+      this.notify.toast({
         message: msg("Sorry, couldn't retrieve crawl at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
@@ -1007,7 +1019,7 @@ ${this.crawl?.description}
     try {
       this.seeds = await this.getSeeds();
     } catch {
-      this.notify({
+      this.notify.toast({
         message: msg(
           "Sorry, couldn't retrieve all crawl settings at this time.",
         ),
@@ -1029,12 +1041,12 @@ ${this.crawl?.description}
     const apiPath = `/orgs/${this.orgId}/${
       this.itemType === "upload" ? "uploads" : "crawls"
     }/${this.crawlId}/replay.json`;
-    return this.apiFetch<Crawl>(apiPath, this.authState!);
+    return this.api.fetch<Crawl>(apiPath, this.authState!);
   }
 
   private async getSeeds() {
     // NOTE Returns first 1000 seeds (backend pagination max)
-    const data = await this.apiFetch<APIPaginatedList<Seed>>(
+    const data = await this.api.fetch<APIPaginatedList<Seed>>(
       `/orgs/${this.orgId}/crawls/${this.crawlId}/seeds`,
       this.authState!,
     );
@@ -1042,7 +1054,7 @@ ${this.crawl?.description}
   }
 
   private async getWorkflow(): Promise<Workflow> {
-    return this.apiFetch<Workflow>(
+    return this.api.fetch<Workflow>(
       `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
       this.authState!,
     );
@@ -1059,7 +1071,7 @@ ${this.crawl?.description}
     } catch (e: unknown) {
       console.debug(e);
 
-      this.notify({
+      this.notify.toast({
         message: msg("Sorry, couldn't retrieve crawl logs at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
@@ -1071,7 +1083,7 @@ ${this.crawl?.description}
     const page = params.page || this.logs?.page || 1;
     const pageSize = params.pageSize || this.logs?.pageSize || 50;
 
-    const data = (await this.apiFetch)<APIPaginatedList<CrawlLog>>(
+    const data = (await this.api.fetch)<APIPaginatedList<CrawlLog>>(
       `/orgs/${this.orgId}/crawls/${this.crawlId}/errors?page=${page}&pageSize=${pageSize}`,
       this.authState!,
     );
@@ -1081,7 +1093,7 @@ ${this.crawl?.description}
 
   private async cancel() {
     if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
-      const data = await this.apiFetch<{ success: boolean }>(
+      const data = await this.api.fetch<{ success: boolean }>(
         `/orgs/${this.crawl!.oid}/crawls/${this.crawlId}/cancel`,
         this.authState!,
         {
@@ -1092,7 +1104,7 @@ ${this.crawl?.description}
       if (data.success) {
         void this.fetchCrawl();
       } else {
-        this.notify({
+        this.notify.toast({
           message: msg("Sorry, couldn't cancel crawl at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
@@ -1103,7 +1115,7 @@ ${this.crawl?.description}
 
   private async stop() {
     if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
-      const data = await this.apiFetch<{ success: boolean }>(
+      const data = await this.api.fetch<{ success: boolean }>(
         `/orgs/${this.crawl!.oid}/crawls/${this.crawlId}/stop`,
         this.authState!,
         {
@@ -1114,7 +1126,7 @@ ${this.crawl?.description}
       if (data.success) {
         void this.fetchCrawl();
       } else {
-        this.notify({
+        this.notify.toast({
           message: msg("Sorry, couldn't stop crawl at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
@@ -1144,7 +1156,7 @@ ${this.crawl?.description}
     }
 
     try {
-      const _data = await this.apiFetch(
+      const _data = await this.api.fetch(
         `/orgs/${this.crawl!.oid}/${
           this.crawl!.type === "crawl" ? "crawls" : "uploads"
         }/delete`,
@@ -1156,8 +1168,8 @@ ${this.crawl?.description}
           }),
         },
       );
-      this.navTo(this.listUrl);
-      this.notify({
+      this.navigate.to(this.listUrl);
+      this.notify.toast({
         message: msg(`Successfully deleted crawl`),
         variant: "success",
         icon: "check2-circle",
@@ -1175,7 +1187,7 @@ ${this.crawl?.description}
           message = e.message;
         }
       }
-      this.notify({
+      this.notify.toast({
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
@@ -1185,7 +1197,7 @@ ${this.crawl?.description}
 
   private async startQARun() {
     try {
-      const data = await this.apiFetch<{ started: string }>(
+      const data = await this.api.fetch<{ started: string }>(
         `/orgs/${this.orgId}/crawls/${this.crawlId}/qa/start`,
         this.authState!,
         {
@@ -1196,7 +1208,7 @@ ${this.crawl?.description}
       console.debug("qa run id: ", data.started);
       this.fetchQARuns();
 
-      this.notify({
+      this.notify.toast({
         message: msg("Starting QA analysis..."),
         variant: "success",
         icon: "check2-circle",
@@ -1204,7 +1216,7 @@ ${this.crawl?.description}
     } catch (e: unknown) {
       console.debug(e);
 
-      this.notify({
+      this.notify.toast({
         message: msg("Sorry, couldn't start QA run at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
@@ -1217,7 +1229,7 @@ ${this.crawl?.description}
       this.qaRuns = await this.getQARuns();
       this.qaRunId = this.qaRunId || this.qaRuns[0]?.id;
     } catch {
-      this.notify({
+      this.notify.toast({
         message: msg("Sorry, couldn't retrieve archived item at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
@@ -1226,8 +1238,44 @@ ${this.crawl?.description}
   }
 
   private async getQARuns(): Promise<QARun[]> {
-    return this.apiFetch<QARun[]>(
+    return this.api.fetch<QARun[]>(
       `/orgs/${this.orgId}/crawls/${this.crawlId}/qa`,
+      this.authState!,
+    );
+  }
+
+  private async fetchPages(params?: APIPaginationQuery): Promise<void> {
+    try {
+      this.pages = await this.getPages({
+        page: params?.page ?? this.pages?.page ?? 1,
+        pageSize: params?.pageSize ?? this.pages?.pageSize ?? 10,
+      });
+    } catch {
+      this.notify.toast({
+        message: msg("Sorry, couldn't retrieve archived item at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async getPages(
+    params?: APIPaginationQuery & { reviewed?: boolean },
+  ): Promise<APIPaginatedList<ArchivedItemPage>> {
+    const query = queryString.stringify(
+      {
+        // sortBy: this.sortPagesBy.sortBy,
+        // sortDirection: this.sortPagesBy.sortDirection,
+        ...params,
+      },
+      {
+        arrayFormat: "comma",
+      },
+    );
+    return this.api.fetch<APIPaginatedList<ArchivedItemPage>>(
+      this.qaRunId
+        ? `/orgs/${this.orgId}/crawls/${this.crawlId}/qa/${this.qaRunId}/pages?${query}`
+        : `/orgs/${this.orgId}/crawls/${this.crawlId}/pages?${query}`,
       this.authState!,
     );
   }

--- a/frontend/src/pages/org/archived-item-detail/index.ts
+++ b/frontend/src/pages/org/archived-item-detail/index.ts
@@ -1,0 +1,1 @@
+import "./archived-item-detail";

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -1,0 +1,176 @@
+import { msg } from "@lit/localize";
+import { html } from "lit";
+import { when } from "lit/directives/when.js";
+
+import type { ArchivedItemDetail } from "../archived-item-detail";
+
+import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
+import type { ArchivedItem } from "@/types/crawler";
+import type { QARun } from "@/types/qa";
+import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
+
+type RenderParams = {
+  reviewStatus: ArchivedItem["reviewStatus"] | undefined;
+  qaCrawlExecSeconds: ArchivedItem["qaCrawlExecSeconds"] | undefined;
+  qaRuns: ArchivedItemDetail["qaRuns"];
+  qaRunId: ArchivedItemDetail["qaRunId"];
+  pages: ArchivedItemDetail["pages"];
+};
+
+function runAnalysisStatus(qaRun: QARun) {
+  return html` <btrix-crawl-status state=${qaRun.state}></btrix-crawl-status> `;
+}
+
+function renderAnalysis() {
+  return html`
+    <div class="flex flex-col gap-6 md:flex-row">
+      <btrix-card class="flex-1">
+        <span slot="title">${msg("Screenshots")}</span>
+        TODO
+      </btrix-card>
+      <btrix-card class="flex-1">
+        <span slot="title">${msg("Extracted Text")}</span>
+        TODO
+      </btrix-card>
+      <btrix-card class="flex-1">
+        <span slot="title">${msg("Page Resources")}</span>
+        TODO
+      </btrix-card>
+    </div>
+  `;
+}
+
+export function renderQA({
+  reviewStatus,
+  qaCrawlExecSeconds,
+  qaRuns,
+  qaRunId,
+  pages,
+}: RenderParams) {
+  const finishedQARuns = qaRuns
+    ? qaRuns.filter(({ finished }) => finished)
+    : [];
+  const renderEmpty = () => html`--`;
+
+  return html`
+    <div class="mb-5 rounded-lg border p-4">
+      <btrix-desc-list horizontal>
+        <btrix-desc-list-item label=${msg("Review Status")}>
+          ${when(
+            reviewStatus !== undefined,
+            () => (reviewStatus ? html`${reviewStatus}` : msg("No Review")),
+            renderEmpty,
+          )}
+        </btrix-desc-list-item>
+        <btrix-desc-list-item label=${msg("Analysis Status")}>
+          ${when(
+            qaRuns,
+            (qaRuns) =>
+              qaRuns[0] ? runAnalysisStatus(qaRuns[0]) : msg("No Analysis"),
+            renderEmpty,
+          )}
+        </btrix-desc-list-item>
+        <btrix-desc-list-item label=${msg("Analysis Elapsed Time")}>
+          ${when(
+            qaCrawlExecSeconds !== undefined,
+            () =>
+              qaRuns?.[0] && qaCrawlExecSeconds
+                ? humanizeExecutionSeconds(qaCrawlExecSeconds)
+                : msg("N/A"),
+            renderEmpty,
+          )}
+        </btrix-desc-list-item>
+      </btrix-desc-list>
+    </div>
+    <section class="mb-7">
+      <div class="flex items-center gap-1">
+        <h4 class="text-base font-semibold leading-8">${msg("Analysis")}</h4>
+        <btrix-qa-run-dropdown
+          .items=${finishedQARuns}
+          selectedId=${qaRunId || ""}
+          @btrix-select=${(e: CustomEvent<SelectDetail>) =>
+            (qaRunId = e.detail.item.id)}
+        ></btrix-qa-run-dropdown>
+      </div>
+      ${when(qaRuns, (qaRuns) =>
+        qaRuns[0]
+          ? renderAnalysis()
+          : html`
+              <div
+                class="rounded-lg border bg-slate-50 p-4 text-center text-slate-600"
+              >
+                ${msg(
+                  "This crawl hasn’t been analyzed yet. Run an analysis to access crawl quality metrics.",
+                )}
+              </div>
+            `,
+      )}
+    </section>
+    <btrix-tab-group>
+      <btrix-tab-group-tab slot="nav" panel="pages">
+        ${msg("Page Reviews")}
+      </btrix-tab-group-tab>
+      <btrix-tab-group-tab slot="nav" panel="runs" ?disabled=${!qaRuns?.length}>
+        ${msg("Analysis Runs")}
+      </btrix-tab-group-tab>
+
+      <btrix-tab-group-panel name="pages">
+        <btrix-table class="qaPageList">
+          <btrix-table-head>
+            <btrix-table-header-cell> ${msg("Page")} </btrix-table-header-cell>
+            <btrix-table-header-cell>
+              ${msg("Review Status")}
+            </btrix-table-header-cell>
+          </btrix-table-head>
+          <btrix-table-body class="rounded border">
+            ${pages?.items.map(
+              (page, idx) => html`
+                <btrix-table-row class=${idx > 0 ? "border-t" : ""}>
+                  <btrix-table-cell class="block">
+                    <div class="text-medium">${page.title}</div>
+                    <div class="text-xs">${page.url}</div>
+                  </btrix-table-cell>
+                  <btrix-table-cell>
+                    ${page.approved === true
+                      ? msg("Approved")
+                      : page.approved === false
+                        ? msg("Rejected")
+                        : msg("No Review")}
+                  </btrix-table-cell>
+                </btrix-table-row>
+              `,
+            )}
+          </btrix-table-body>
+        </btrix-table>
+      </btrix-tab-group-panel>
+      <btrix-tab-group-panel name="runs">
+        <btrix-table class="qaPageList">
+          <btrix-table-head>
+            <btrix-table-header-cell>
+              ${msg("Started")}
+            </btrix-table-header-cell>
+            <btrix-table-header-cell>
+              ${msg("Finished")}
+            </btrix-table-header-cell>
+            <btrix-table-header-cell>
+              ${msg("Started by")}
+            </btrix-table-header-cell>
+          </btrix-table-head>
+          <btrix-table-body class="rounded border">
+            ${qaRuns?.map(
+              (run, idx) => html`
+                <btrix-table-row class=${idx > 0 ? "border-t" : ""}>
+                  <btrix-table-cell class="block">
+                    ${run.started}
+                  </btrix-table-cell>
+                  <btrix-table-cell>${run.finished}</btrix-table-cell>
+                  <btrix-table-cell>${run.userName}</btrix-table-cell>
+                </btrix-table-row>
+              `,
+            )}
+          </btrix-table-body>
+        </btrix-table>
+      </btrix-tab-group-panel>
+    </btrix-tab-group>
+  `;
+}

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -1,11 +1,11 @@
 import { msg } from "@lit/localize";
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { when } from "lit/directives/when.js";
 
 import type { ArchivedItemDetail } from "../archived-item-detail";
 
 import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
-import type { ArchivedItem } from "@/types/crawler";
+import type { ArchivedItem, ArchivedItemPage } from "@/types/crawler";
 import type { QARun } from "@/types/qa";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 
@@ -38,6 +38,19 @@ function renderAnalysis() {
       </btrix-card>
     </div>
   `;
+}
+
+function pageReviewStatus(page: ArchivedItemPage) {
+  if (page.approved === true) {
+    return msg("Approved");
+  }
+  if (page.approved === false) {
+    return msg("Rejected");
+  }
+  if (page.notes?.length) {
+    return msg("Reviewed with comment");
+  }
+  return msg("No review");
 }
 
 export function renderQA({
@@ -131,17 +144,26 @@ export function renderQA({
                     <div class="text-xs">${page.url}</div>
                   </btrix-table-cell>
                   <btrix-table-cell>
-                    ${page.approved === true
-                      ? msg("Approved")
-                      : page.approved === false
-                        ? msg("Rejected")
-                        : msg("No Review")}
+                    ${pageReviewStatus(page)}
                   </btrix-table-cell>
                 </btrix-table-row>
               `,
             )}
           </btrix-table-body>
         </btrix-table>
+        ${when(pages, (pages) =>
+          pages.total > pages.pageSize
+            ? html`
+                <footer class="mt-3 flex justify-center">
+                  <btrix-pagination
+                    page=${pages.page}
+                    size=${pages.pageSize}
+                    totalCount=${pages.total}
+                  ></btrix-pagination>
+                </footer>
+              `
+            : nothing,
+        )}
       </btrix-tab-group-panel>
       <btrix-tab-group-panel name="runs">
         <btrix-table class="qaPageList">

--- a/frontend/src/pages/org/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa.ts
@@ -593,32 +593,35 @@ export class ArchivedItemQA extends TailwindElement {
 
   private readonly renderScreenshots = () => {
     return html`
-      <div class="mb-2 flex justify-between text-base font-medium">
-        <h3 id="crawlScreenshotHeading">${msg("Crawl Screenshot")}</h3>
-        <h3 id="replayScreenshotHeading">${msg("Replay Screenshot")}</h3>
-      </div>
-      <div class="aspect-video overflow-hidden rounded border bg-slate-50">
-        ${when(
-          this.crawlData.blobUrl && this.qaData.blobUrl,
-          () => html`
-            <sl-image-comparer>
-              <img
-                slot="before"
-                src="${this.crawlData.blobUrl || ""}"
-                class="h-full w-full"
-                aria-labelledby="crawlScreenshotHeading"
-              />
-              <img
-                slot="after"
-                src="${this.qaData.blobUrl || ""}"
-                class="h-full w-full"
-                aria-labelledby="replayScreenshotHeading"
-              />
-            </sl-image-comparer>
-          `,
-          this.renderSpinner,
-        )}
-      </div>
+      ${guard(
+        [this.crawlData.blobUrl, this.qaData.blobUrl],
+        () => html`
+          <div class="mb-2 flex justify-between text-base font-medium">
+            <h3 id="crawlScreenshotHeading">${msg("Crawl Screenshot")}</h3>
+            <h3 id="replayScreenshotHeading">${msg("Replay Screenshot")}</h3>
+          </div>
+          <div class="aspect-video overflow-hidden rounded border bg-slate-50">
+            ${when(
+              this.crawlData.blobUrl && this.qaData.blobUrl,
+              () => html`
+                <sl-image-comparer>
+                  <img
+                    slot="before"
+                    src="${this.crawlData.blobUrl || ""}"
+                    aria-labelledby="crawlScreenshotHeading"
+                  />
+                  <img
+                    slot="after"
+                    src="${this.qaData.blobUrl || ""}"
+                    aria-labelledby="replayScreenshotHeading"
+                  />
+                </sl-image-comparer>
+              `,
+              this.renderSpinner,
+            )}
+          </div>
+        `,
+      )}
     `;
   };
 

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -464,7 +464,7 @@ export class ArchivedItemQA extends TailwindElement {
           <iframe
             class="hidden"
             id="replayframe"
-            src="/replay/"
+            src="/replay/placeholder"
             @load=${onLoad}
           ></iframe>
         `;

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -76,7 +76,7 @@ const initialReplayData: QATypes.ReplayData = {
   blobUrl: "",
   text: "",
   replayUrl: "",
-  resources: "",
+  resources: {},
 };
 
 @localized()
@@ -621,6 +621,7 @@ export class ArchivedItemQA extends TailwindElement {
       const urlPrefix = tabToPrefix[tab];
       const urlPart = `${timestamp}mp_/${urlPrefix ? `urn:${urlPrefix}:` : ""}${pageUrl}`;
       const url = `/replay/w/${replayId}/${urlPart}`;
+      // TODO check status code
       const resp = await frameWindow.fetch(url);
 
       if (tab === "screenshots") {
@@ -668,13 +669,13 @@ export class ArchivedItemQA extends TailwindElement {
 
         typeMap.set("Total", { good, bad });
 
-        const text = JSON.stringify(
-          Object.fromEntries(typeMap.entries()),
-          null,
-          2,
-        );
+        // const text = JSON.stringify(
+        //   Object.fromEntries(typeMap.entries()),
+        //   null,
+        //   2,
+        // );
 
-        return { resources: text } as T;
+        return { resources: Object.fromEntries(typeMap.entries()) } as T;
       }
       return { text: "" } as T;
     };

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -423,7 +423,7 @@ export class ArchivedItemQA extends TailwindElement {
                 ? "desc"
                 : "asc") as SortDirection,
             }}
-            totalPages=${+(this.item?.stats?.found || 0)}
+            totalPages=${+(this.item?.stats?.done || 0)}
             @btrix-qa-pagination-change=${(
               e: CustomEvent<QaPaginationChangeDetail>,
             ) => {

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -202,12 +202,17 @@ export class ArchivedItemQA extends TailwindElement {
     if (changedProperties.has("itemId") && this.itemId) {
       void this.initItem();
     } else if (
-      changedProperties.get("filterPagesBy") ??
-      changedProperties.get("sortPagesBy")
+      changedProperties.get("filterPagesBy") ||
+      changedProperties.get("sortPagesBy") ||
+      changedProperties.get("qaRunId")
     ) {
       void this.fetchPages();
     }
-    if (changedProperties.has("itemPageId") && this.itemPageId) {
+    if (
+      (changedProperties.has("itemPageId") ||
+        changedProperties.get("qaRunId")) &&
+      this.itemPageId
+    ) {
       void this.fetchPage();
     }
     // Re-fetch when tab, archived item page, or QA run ID changes

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -291,13 +291,14 @@ export class ArchivedItemQA extends TailwindElement {
     return html`
       ${this.renderHidden()}
 
-      <article class="grid gap-x-4 gap-y-3">
-        <header class="mainHeader flex items-center justify-between gap-1">
-          <h1 class="text-base font-semibold leading-tight">
-            ${msg("Reviewing")} ${itemName}
-          </h1>
-          <div class="flex items-center">
-            <span class="font-medium text-neutral-400">${msg("QA run:")}</span>
+      <article class="grid gap-x-6 gap-y-4 md:gap-y-0">
+        <header
+          class="grid--header flex items-center justify-between gap-1 border-b pb-2"
+        >
+          <div class="flex items-center gap-2 overflow-hidden">
+            <h1 class="flex-1 truncate text-base font-semibold leading-tight">
+              ${msg("Reviewing")} ${itemName}
+            </h1>
             <btrix-qa-run-dropdown
               .items=${finishedQARuns}
               selectedId=${this.qaRunId || ""}
@@ -308,107 +309,113 @@ export class ArchivedItemQA extends TailwindElement {
               }}
             ></btrix-qa-run-dropdown>
           </div>
-        </header>
-        <section class="main">
-          <nav class="mb-3 flex flex-col-reverse">
-            <div class="mt-3 flex gap-8 self-start">
-              <btrix-navigation-button
-                id="screenshot-tab"
-                href=${`${crawlBaseUrl}/review/screenshots?${searchParams}`}
-                ?active=${this.tab === "screenshots"}
-                @click=${this.navigate.link}
-              >
-                ${msg("Screenshots")}
-                ${when(currentPage, (page) => {
-                  let variant: BadgeVariant = "neutral";
-                  switch (severityFromMatch(currentPage.qa.screenshotMatch)) {
-                    case "severe":
-                      variant = "danger";
-                      break;
-                    case "moderate":
-                      variant = "warning";
-                      break;
-                    case "good":
-                      variant = "success";
-                      break;
-                    default:
-                      break;
-                  }
-
-                  return html`
-                    <btrix-badge variant=${variant}
-                      >${formatPercentage(
-                        page.qa.screenshotMatch,
-                      )}%</btrix-badge
-                    >
-                  `;
-                })}
-              </btrix-navigation-button>
-              <btrix-navigation-button
-                id="text-tab"
-                href=${`${crawlBaseUrl}/review/text?${searchParams}`}
-                ?active=${this.tab === "text"}
-                @click=${this.navigate.link}
-              >
-                ${msg("Text")}
-              </btrix-navigation-button>
-              <btrix-navigation-button
-                id="text-tab"
-                href=${`${crawlBaseUrl}/review/resources?${searchParams}`}
-                ?active=${this.tab === "resources"}
-                @click=${this.navigate.link}
-              >
-                ${msg("Resources")}
-              </btrix-navigation-button>
-              <btrix-navigation-button
-                id="replay-tab"
-                href=${`${crawlBaseUrl}/review/replay?${searchParams}`}
-                ?active=${this.tab === "replay"}
-                @click=${this.navigate.link}
-              >
-                ${msg("Replay")}
-              </btrix-navigation-button>
-            </div>
-            <div class="flex gap-4 self-end">
-              <sl-button
-                size="small"
-                @click=${this.navPrevPage}
-                ?disabled=${!prevPage}
-              >
-                <sl-icon slot="prefix" name="arrow-left"></sl-icon>
-                ${msg("Previous Page")}
-              </sl-button>
-              <btrix-page-qa-toolbar
-                .authState=${this.authState}
-                .orgId=${this.orgId}
-                .itemId=${this.itemId}
-                .pageId=${this.itemPageId}
-                .page=${this.page}
-                @btrix-update-item-page=${this.onUpdateItemPage}
-              ></btrix-page-qa-toolbar>
-              <sl-button
-                variant="primary"
-                size="small"
-                ?disabled=${!nextPage}
-                @click=${this.navNextPage}
-              >
-                <sl-icon slot="suffix" name="arrow-right"></sl-icon>
-                ${msg("Next Page")}
-              </sl-button>
-            </div>
-          </nav>
-          ${this.renderToolbar()} ${this.renderPanel()}
-        </section>
-        <div class="pageListHeader flex items-center justify-between">
-          <h2 class="text-base font-semibold leading-none">${msg("Pages")}</h2>
           <sl-button
             size="small"
             href=${`${crawlBaseUrl}#qa`}
             @click=${this.navigate.link}
             >${msg("Done Reviewing")}</sl-button
           >
+        </header>
+
+        <div
+          class="grid--pageToolbar flex items-center justify-between overflow-hidden border-b py-2"
+        >
+          <h2 class="mr-4 truncate font-semibold text-neutral-600">
+            ${this.page ? this.page.title || msg("no page title") : nothing}
+          </h2>
+          <div class="flex gap-4">
+            <sl-button
+              size="small"
+              @click=${this.navPrevPage}
+              ?disabled=${!prevPage}
+            >
+              <sl-icon slot="prefix" name="arrow-left"></sl-icon>
+              ${msg("Previous Page")}
+            </sl-button>
+            <btrix-page-qa-toolbar
+              .authState=${this.authState}
+              .orgId=${this.orgId}
+              .itemId=${this.itemId}
+              .pageId=${this.itemPageId}
+              .page=${this.page}
+              @btrix-update-item-page=${this.onUpdateItemPage}
+            ></btrix-page-qa-toolbar>
+            <sl-button
+              variant="primary"
+              size="small"
+              ?disabled=${!nextPage}
+              @click=${this.navNextPage}
+            >
+              <sl-icon slot="suffix" name="arrow-right"></sl-icon>
+              ${msg("Next Page")}
+            </sl-button>
+          </div>
         </div>
-        <section class="pageList">
+
+        <div class="grid--tabGroup flex flex-col">
+          <nav class="my-2 flex gap-2">
+            <btrix-navigation-button
+              id="screenshot-tab"
+              href=${`${crawlBaseUrl}/review/screenshots?${searchParams}`}
+              ?active=${this.tab === "screenshots"}
+              @click=${this.navigate.link}
+            >
+              ${msg("Screenshots")}
+              ${when(currentPage, (page) => {
+                let variant: BadgeVariant = "neutral";
+                switch (severityFromMatch(currentPage.qa.screenshotMatch)) {
+                  case "severe":
+                    variant = "danger";
+                    break;
+                  case "moderate":
+                    variant = "warning";
+                    break;
+                  case "good":
+                    variant = "success";
+                    break;
+                  default:
+                    break;
+                }
+
+                return html`
+                  <btrix-badge variant=${variant}
+                    >${formatPercentage(page.qa.screenshotMatch)}%</btrix-badge
+                  >
+                `;
+              })}
+            </btrix-navigation-button>
+            <btrix-navigation-button
+              id="text-tab"
+              href=${`${crawlBaseUrl}/review/text?${searchParams}`}
+              ?active=${this.tab === "text"}
+              @click=${this.navigate.link}
+            >
+              ${msg("Text")}
+            </btrix-navigation-button>
+            <btrix-navigation-button
+              id="text-tab"
+              href=${`${crawlBaseUrl}/review/resources?${searchParams}`}
+              ?active=${this.tab === "resources"}
+              @click=${this.navigate.link}
+            >
+              ${msg("Resources")}
+            </btrix-navigation-button>
+            <btrix-navigation-button
+              id="replay-tab"
+              href=${`${crawlBaseUrl}/review/replay?${searchParams}`}
+              ?active=${this.tab === "replay"}
+              @click=${this.navigate.link}
+            >
+              ${msg("Replay")}
+            </btrix-navigation-button>
+          </nav>
+          ${this.renderPanelToolbar()} ${this.renderPanel()}
+        </div>
+
+        <section class="grid--pageList overflow-hidden">
+          <h2 class="my-4 font-semibold leading-none text-neutral-700">
+            ${msg("Pages")}
+          </h2>
           <btrix-qa-page-list
             class="flex h-full flex-col"
             .qaRunId=${this.qaRunId}
@@ -494,7 +501,7 @@ export class ArchivedItemQA extends TailwindElement {
     );
   }
 
-  private renderToolbar() {
+  private renderPanelToolbar() {
     // TODO
     const buttons = nothing;
     // html`
@@ -519,8 +526,8 @@ export class ArchivedItemQA extends TailwindElement {
     return html`
       <div
         class="${this.tab === "replay"
-          ? "rounded-t-lg m2-2"
-          : "rounded-lg my-2"} flex h-12 items-center border bg-neutral-50 text-base"
+          ? "rounded-t-lg"
+          : "rounded-lg mb-3"} flex h-12 items-center border bg-neutral-50 text-base"
       >
         ${buttons}
         <div
@@ -566,7 +573,7 @@ export class ArchivedItemQA extends TailwindElement {
       }
     };
     return html`
-      <section aria-labelledby="${this.tab}-tab">
+      <section aria-labelledby="${this.tab}-tab" class="flex-1 overflow-hidden">
         ${cache(choosePanel())}
       </section>
     `;

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -3,7 +3,7 @@ import { merge } from "immutable";
 import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { cache } from "lit/directives/cache.js";
-import { choose } from "lit/directives/choose.js";
+// import { choose } from "lit/directives/choose.js";
 import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
@@ -495,29 +495,34 @@ export class ArchivedItemQA extends TailwindElement {
   }
 
   private renderToolbar() {
+    // TODO
+    const buttons = nothing;
+    // html`
+    // <div class="ml-1 flex">
+    //       ${choose(this.tab, [
+    //         [
+    //           "replay",
+    //           () => html`
+    //             <sl-icon-button name="arrow-clockwise"></sl-icon-button>
+    //           `,
+    //         ],
+    //         [
+    //           "screenshots",
+    //           () => html`
+    //             <sl-icon-button name="intersect"></sl-icon-button>
+    //             <sl-icon-button name="vr"></sl-icon-button>
+    //           `,
+    //         ],
+    //       ])}
+    //     </div>
+    // `
     return html`
       <div
         class="${this.tab === "replay"
           ? "rounded-t-lg m2-2"
           : "rounded-lg my-2"} flex h-12 items-center border bg-neutral-50 text-base"
       >
-        <div class="ml-1 flex">
-          ${choose(this.tab, [
-            [
-              "replay",
-              () => html`
-                <sl-icon-button name="arrow-clockwise"></sl-icon-button>
-              `,
-            ],
-            [
-              "screenshots",
-              () => html`
-                <sl-icon-button name="intersect"></sl-icon-button>
-                <sl-icon-button name="vr"></sl-icon-button>
-              `,
-            ],
-          ])}
-        </div>
+        ${buttons}
         <div
           class="mx-1.5 flex h-8 min-w-0 flex-1 items-center justify-between gap-2 overflow-hidden whitespace-nowrap rounded border bg-neutral-0 px-2 text-sm"
         >
@@ -786,7 +791,11 @@ export class ArchivedItemQA extends TailwindElement {
     } catch (e: unknown) {
       console.log("[debug] error:", e);
       if (e === 404) {
-        // TODO
+        if (qa) {
+          this.qaData = {};
+        } else {
+          this.crawlData = {};
+        }
       }
     }
   }

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -299,7 +299,7 @@ export class ArchivedItemQA extends TailwindElement {
 
       <article class="grid gap-x-6 gap-y-4 md:gap-y-0">
         <header
-          class="grid--header flex items-center justify-between gap-1 border-b pb-2"
+          class="grid--header flex items-center justify-between gap-1 border-b py-2"
         >
           <div class="flex items-center gap-2 overflow-hidden">
             <h1 class="flex-1 truncate text-base font-semibold leading-tight">
@@ -364,7 +364,7 @@ export class ArchivedItemQA extends TailwindElement {
               id="screenshot-tab"
               href=${`${crawlBaseUrl}/review/screenshots?${searchParams}`}
               ?active=${this.tab === "screenshots"}
-              @click=${this.navigate.link}
+              @click=${this.onTabNavClick}
             >
               <sl-icon name="camera-fill"></sl-icon>
               ${msg("Screenshots")}
@@ -376,7 +376,7 @@ export class ArchivedItemQA extends TailwindElement {
               id="text-tab"
               href=${`${crawlBaseUrl}/review/text?${searchParams}`}
               ?active=${this.tab === "text"}
-              @click=${this.navigate.link}
+              @click=${this.onTabNavClick}
             >
               <sl-icon name="file-text-fill"></sl-icon>
               ${msg("Text")}
@@ -388,7 +388,7 @@ export class ArchivedItemQA extends TailwindElement {
               id="text-tab"
               href=${`${crawlBaseUrl}/review/resources?${searchParams}`}
               ?active=${this.tab === "resources"}
-              @click=${this.navigate.link}
+              @click=${this.onTabNavClick}
             >
               <sl-icon name="list-check"></sl-icon>
               ${msg("Resources")}
@@ -397,7 +397,7 @@ export class ArchivedItemQA extends TailwindElement {
               id="replay-tab"
               href=${`${crawlBaseUrl}/review/replay?${searchParams}`}
               ?active=${this.tab === "replay"}
-              @click=${this.navigate.link}
+              @click=${this.onTabNavClick}
             >
               <sl-icon name="link-replay" library="app"></sl-icon>
               ${msg("Replay")}
@@ -607,6 +607,10 @@ export class ArchivedItemQA extends TailwindElement {
         ></replay-web-page>
       `,
     );
+  };
+
+  private readonly onTabNavClick = (e: MouseEvent) => {
+    this.navigate.link(e, undefined, /* resetScroll: */ false);
   };
 
   private async onUpdateItemPage(e: CustomEvent<UpdateItemPageDetail>) {

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -315,12 +315,23 @@ export class ArchivedItemQA extends TailwindElement {
               }}
             ></btrix-qa-run-dropdown>
           </div>
-          <sl-button
-            size="small"
-            href=${`${crawlBaseUrl}#qa`}
-            @click=${this.navigate.link}
-            >${msg("Done Reviewing")}</sl-button
-          >
+          <div>
+            <sl-button
+              size="small"
+              variant="text"
+              href=${`${crawlBaseUrl}#qa`}
+              @click=${this.navigate.link}
+              >${msg("Exit Review")}</sl-button
+            >
+            <sl-button
+              variant="success"
+              size="small"
+              href=${`${crawlBaseUrl}#qa`}
+            >
+              <sl-icon name="patch-check" slot="prefix"></sl-icon>
+              ${msg("Finish Review")}</sl-button
+            >
+          </div>
         </header>
 
         <div

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -505,14 +505,21 @@ export class ArchivedItemQA extends TailwindElement {
           [
             "screenshots",
             () => html`
-              <sl-icon-button
-                name="intersect"
-                @click="${() => (this.splitView = true)}"
-              ></sl-icon-button>
-              <sl-icon-button
-                name="vr"
-                @click="${() => (this.splitView = false)}"
-              ></sl-icon-button>
+              <sl-tooltip
+                content=${msg("Toggle split view")}
+                placement="bottom-start"
+              >
+                <btrix-button
+                  icon
+                  variant=${this.splitView ? "primary" : "neutral"}
+                >
+                  <sl-icon
+                    name="vr"
+                    label=${msg("Split view")}
+                    @click="${() => (this.splitView = !this.splitView)}"
+                  ></sl-icon>
+                </btrix-button>
+              </sl-tooltip>
             `,
           ],
         ])}

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -506,18 +506,17 @@ export class ArchivedItemQA extends TailwindElement {
             "screenshots",
             () => html`
               <sl-tooltip
-                content=${msg("Toggle split view")}
+                content=${this.splitView
+                  ? msg("Compare with slider")
+                  : msg("View separate")}
                 placement="bottom-start"
               >
                 <btrix-button
                   icon
                   variant=${this.splitView ? "primary" : "neutral"}
+                  @click="${() => (this.splitView = !this.splitView)}"
                 >
-                  <sl-icon
-                    name="vr"
-                    label=${msg("Split view")}
-                    @click="${() => (this.splitView = !this.splitView)}"
-                  ></sl-icon>
+                  <sl-icon name="vr" label=${msg("Split view")}></sl-icon>
                 </btrix-button>
               </sl-tooltip>
             `,

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -300,7 +300,7 @@ export class ArchivedItemQA extends TailwindElement {
         >
           <div class="flex items-center gap-2 overflow-hidden">
             <h1 class="flex-1 truncate text-base font-semibold leading-tight">
-              ${msg("Reviewing")} ${itemName}
+              ${itemName}
             </h1>
             <btrix-qa-run-dropdown
               .items=${finishedQARuns}
@@ -323,7 +323,7 @@ export class ArchivedItemQA extends TailwindElement {
         <div
           class="grid--pageToolbar flex items-center justify-between overflow-hidden border-b py-2"
         >
-          <h2 class="mr-4 truncate font-semibold text-neutral-600">
+          <h2 class="mr-4 truncate text-base font-semibold text-neutral-700">
             ${this.page ? this.page.title || msg("no page title") : nothing}
           </h2>
           <div class="flex gap-4">
@@ -416,7 +416,9 @@ export class ArchivedItemQA extends TailwindElement {
         </div>
 
         <section class="grid--pageList overflow-hidden">
-          <h2 class="my-4 font-semibold leading-none text-neutral-700">
+          <h2
+            class="my-4 text-base font-semibold leading-none text-neutral-800"
+          >
             ${msg("Pages")}
           </h2>
           <btrix-qa-page-list

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -464,7 +464,7 @@ export class ArchivedItemQA extends TailwindElement {
           <iframe
             class="hidden"
             id="replayframe"
-            src="/replay/placeholder"
+            src="/replay/"
             @load=${onLoad}
           ></iframe>
         `;
@@ -499,16 +499,14 @@ export class ArchivedItemQA extends TailwindElement {
           [
             "replay",
             () => html`
-              <sl-icon-button name="arrow-clockwise"></sl-icon-button>
+              <!-- <sl-icon-button name="arrow-clockwise"></sl-icon-button> -->
             `,
           ],
           [
             "screenshots",
             () => html`
               <sl-tooltip
-                content=${this.splitView
-                  ? msg("Compare with slider")
-                  : msg("View separate")}
+                content=${msg("Toggle view")}
                 placement="bottom-start"
               >
                 <btrix-button

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -3,7 +3,7 @@ import { merge } from "immutable";
 import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { cache } from "lit/directives/cache.js";
-// import { choose } from "lit/directives/choose.js";
+import { choose } from "lit/directives/choose.js";
 import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
@@ -95,6 +95,9 @@ export class ArchivedItemQA extends TailwindElement {
 
   @property({ type: Boolean })
   isCrawler = false;
+
+  @property({ type: Boolean })
+  splitView = true;
 
   @property({ type: String })
   tab: QATypes.QATab = "screenshots";
@@ -502,27 +505,31 @@ export class ArchivedItemQA extends TailwindElement {
   }
 
   private renderPanelToolbar() {
-    // TODO
-    const buttons = nothing;
-    // html`
-    // <div class="ml-1 flex">
-    //       ${choose(this.tab, [
-    //         [
-    //           "replay",
-    //           () => html`
-    //             <sl-icon-button name="arrow-clockwise"></sl-icon-button>
-    //           `,
-    //         ],
-    //         [
-    //           "screenshots",
-    //           () => html`
-    //             <sl-icon-button name="intersect"></sl-icon-button>
-    //             <sl-icon-button name="vr"></sl-icon-button>
-    //           `,
-    //         ],
-    //       ])}
-    //     </div>
-    // `
+    const buttons = html`
+      <div class="ml-1 flex">
+        ${choose(this.tab, [
+          [
+            "replay",
+            () => html`
+              <sl-icon-button name="arrow-clockwise"></sl-icon-button>
+            `,
+          ],
+          [
+            "screenshots",
+            () => html`
+              <sl-icon-button
+                name="intersect"
+                @click="${() => (this.splitView = true)}"
+              ></sl-icon-button>
+              <sl-icon-button
+                name="vr"
+                @click="${() => (this.splitView = false)}"
+              ></sl-icon-button>
+            `,
+          ],
+        ])}
+      </div>
+    `;
     return html`
       <div
         class="${this.tab === "replay"
@@ -561,7 +568,7 @@ export class ArchivedItemQA extends TailwindElement {
     const choosePanel = () => {
       switch (this.tab) {
         case "screenshots":
-          return renderScreenshots(this.crawlData, this.qaData);
+          return renderScreenshots(this.crawlData, this.qaData, this.splitView);
         case "text":
           return renderText(this.crawlData, this.qaData);
         case "resources":

--- a/frontend/src/pages/org/archived-item-qa/index.ts
+++ b/frontend/src/pages/org/archived-item-qa/index.ts
@@ -1,0 +1,1 @@
+import "./archived-item-qa";

--- a/frontend/src/pages/org/archived-item-qa/styles.ts
+++ b/frontend/src/pages/org/archived-item-qa/styles.ts
@@ -49,11 +49,13 @@ export const styles = css`
   }
 
   sl-image-comparer::part(divider) {
-    background-color: yellow;
-    /* mix-blend-mode: difference; */
+    width: 1rem;
+    border-left: 1px solid var(--sl-panel-border-color);
+    border-right: 1px solid var(--sl-panel-border-color);
+    box-shadow: var(--sl-shadow-large);
   }
 
   sl-image-comparer::part(handle) {
-    background-color: red;
+    background-color: transparent;
   }
 `;

--- a/frontend/src/pages/org/archived-item-qa/styles.ts
+++ b/frontend/src/pages/org/archived-item-qa/styles.ts
@@ -3,46 +3,48 @@ import { css } from "lit";
 import { TWO_COL_SCREEN_MIN_CSS } from "@/components/ui/tab-list";
 
 export const styles = css`
-  article {
-    /* TODO calculate screen space instead of hardcoding */
-    height: 100vh;
-    grid-template:
-      "mainHeader"
-      "main"
-      "pageListHeader"
-      "pageList";
-    grid-template-columns: 100%;
-    grid-template-rows: repeat(4, max-content);
-    min-height: 0;
-  }
-
   article > * {
     min-height: 0;
   }
 
+  .grid {
+    grid-template:
+      "header"
+      "pageToolbar"
+      "tabNav"
+      "tabGroup"
+      "pageList";
+    grid-template-columns: 100%;
+    grid-template-rows: repeat(5, max-content);
+  }
+
   @media only screen and (min-width: ${TWO_COL_SCREEN_MIN_CSS}) {
-    article {
+    .grid {
+      /* TODO calculate screen space instead of hardcoding */
+      height: 100vh;
+      /* overflow: hidden; */
       grid-template:
-        "mainHeader pageListHeader"
-        "main pageList";
+        "header header"
+        "pageToolbar pageList"
+        "tabGroup pageList";
       grid-template-columns: 1fr 35rem;
-      grid-template-rows: min-content 1fr;
+      grid-template-rows: repeat(2, min-content) 1fr;
     }
   }
 
-  .mainHeader {
-    grid-area: mainHeader;
+  .grid--header {
+    grid-area: header;
   }
 
-  .pageListHeader {
-    grid-area: pageListHeader;
+  .grid--pageToolbar {
+    grid-area: pageToolbar;
   }
 
-  .main {
-    grid-area: main;
+  .grid--tabGroup {
+    grid-area: tabGroup;
   }
 
-  .pageList {
+  .grid--pageList {
     grid-area: pageList;
   }
 

--- a/frontend/src/pages/org/archived-item-qa/styles.ts
+++ b/frontend/src/pages/org/archived-item-qa/styles.ts
@@ -1,0 +1,57 @@
+import { css } from "lit";
+
+import { TWO_COL_SCREEN_MIN_CSS } from "@/components/ui/tab-list";
+
+export const styles = css`
+  article {
+    /* TODO calculate screen space instead of hardcoding */
+    height: 100vh;
+    grid-template:
+      "mainHeader"
+      "main"
+      "pageListHeader"
+      "pageList";
+    grid-template-columns: 100%;
+    grid-template-rows: repeat(4, max-content);
+    min-height: 0;
+  }
+
+  article > * {
+    min-height: 0;
+  }
+
+  @media only screen and (min-width: ${TWO_COL_SCREEN_MIN_CSS}) {
+    article {
+      grid-template:
+        "mainHeader pageListHeader"
+        "main pageList";
+      grid-template-columns: 1fr 35rem;
+      grid-template-rows: min-content 1fr;
+    }
+  }
+
+  .mainHeader {
+    grid-area: mainHeader;
+  }
+
+  .pageListHeader {
+    grid-area: pageListHeader;
+  }
+
+  .main {
+    grid-area: main;
+  }
+
+  .pageList {
+    grid-area: pageList;
+  }
+
+  sl-image-comparer::part(divider) {
+    background-color: yellow;
+    /* mix-blend-mode: difference; */
+  }
+
+  sl-image-comparer::part(handle) {
+    background-color: red;
+  }
+`;

--- a/frontend/src/pages/org/archived-item-qa/types.ts
+++ b/frontend/src/pages/org/archived-item-qa/types.ts
@@ -1,0 +1,16 @@
+export const TABS = ["screenshots", "text", "resources", "replay"] as const;
+export type QATab = (typeof TABS)[number];
+
+export type GoodBad = {
+  good: number;
+  bad: number;
+};
+
+export type BlobPayload = { blobUrl: string };
+export type TextPayload = { text: string };
+export type ReplayPayload = { replayUrl: string };
+export type ResourcesPayload = { resources: string };
+export type ReplayData = BlobPayload &
+  TextPayload &
+  ReplayPayload &
+  ResourcesPayload;

--- a/frontend/src/pages/org/archived-item-qa/types.ts
+++ b/frontend/src/pages/org/archived-item-qa/types.ts
@@ -10,7 +10,6 @@ export type BlobPayload = { blobUrl: string };
 export type TextPayload = { text: string };
 export type ReplayPayload = { replayUrl: string };
 export type ResourcesPayload = { resources: { [key: string]: GoodBad } };
-export type ReplayData = BlobPayload &
-  TextPayload &
-  ReplayPayload &
-  ResourcesPayload;
+export type ReplayData = Partial<
+  BlobPayload & TextPayload & ReplayPayload & ResourcesPayload
+> | null;

--- a/frontend/src/pages/org/archived-item-qa/types.ts
+++ b/frontend/src/pages/org/archived-item-qa/types.ts
@@ -9,7 +9,7 @@ export type GoodBad = {
 export type BlobPayload = { blobUrl: string };
 export type TextPayload = { text: string };
 export type ReplayPayload = { replayUrl: string };
-export type ResourcesPayload = { resources: string };
+export type ResourcesPayload = { resources: { [key: string]: GoodBad } };
 export type ReplayData = BlobPayload &
   TextPayload &
   ReplayPayload &

--- a/frontend/src/pages/org/archived-item-qa/ui/replay.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/replay.ts
@@ -11,16 +11,14 @@ export function renderReplay(crawlData: ReplayData) {
     <div
       class=${tw`relative aspect-video overflow-hidden rounded-b-lg border-x border-b`}
     >
-      ${guard(
-        [crawlData],
-        () => html`
-          ${when(crawlData.replayUrl, () => {
-            return html`<iframe
-              src=${crawlData.replayUrl}
-              class=${tw`h-full w-full outline`}
-            ></iframe>`;
-          })}
-        `,
+      ${guard([crawlData], () =>
+        when(crawlData?.replayUrl, (replayUrl) => {
+          console.log("[debug] replayUrl:", replayUrl);
+          return html`<iframe
+            src=${replayUrl}
+            class=${tw`h-full w-full outline`}
+          ></iframe>`;
+        }),
       )}
     </div>
   `;

--- a/frontend/src/pages/org/archived-item-qa/ui/replay.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/replay.ts
@@ -4,6 +4,8 @@ import { when } from "lit/directives/when.js";
 
 import type { ReplayData } from "../types";
 
+import { renderSpinner } from "./spinner";
+
 import { tw } from "@/utils/tailwind";
 
 export function renderReplay(crawlData: ReplayData) {
@@ -12,13 +14,15 @@ export function renderReplay(crawlData: ReplayData) {
       class=${tw`relative aspect-video overflow-hidden rounded-b-lg border-x border-b`}
     >
       ${guard([crawlData], () =>
-        when(crawlData?.replayUrl, (replayUrl) => {
-          console.log("[debug] replayUrl:", replayUrl);
-          return html`<iframe
-            src=${replayUrl}
-            class=${tw`h-full w-full outline`}
-          ></iframe>`;
-        }),
+        when(
+          crawlData?.replayUrl,
+          (replayUrl) =>
+            html`<iframe
+              src=${replayUrl}
+              class=${tw`h-full w-full outline`}
+            ></iframe>`,
+          renderSpinner,
+        ),
       )}
     </div>
   `;

--- a/frontend/src/pages/org/archived-item-qa/ui/replay.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/replay.ts
@@ -1,0 +1,25 @@
+import { html } from "lit";
+import { guard } from "lit/directives/guard.js";
+import { when } from "lit/directives/when.js";
+
+import type { ReplayData } from "../types";
+
+export function renderReplay(crawlData: ReplayData) {
+  return html`
+    <div
+      class="relative aspect-video overflow-hidden rounded-b-lg border-x border-b"
+    >
+      ${guard(
+        [crawlData],
+        () => html`
+          ${when(crawlData.replayUrl, () => {
+            return html`<iframe
+              src=${crawlData.replayUrl}
+              class="h-full w-full outline"
+            ></iframe>`;
+          })}
+        `,
+      )}
+    </div>
+  `;
+}

--- a/frontend/src/pages/org/archived-item-qa/ui/replay.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/replay.ts
@@ -4,10 +4,12 @@ import { when } from "lit/directives/when.js";
 
 import type { ReplayData } from "../types";
 
+import { tw } from "@/utils/tailwind";
+
 export function renderReplay(crawlData: ReplayData) {
   return html`
     <div
-      class="relative aspect-video overflow-hidden rounded-b-lg border-x border-b"
+      class=${tw`relative aspect-video overflow-hidden rounded-b-lg border-x border-b`}
     >
       ${guard(
         [crawlData],
@@ -15,7 +17,7 @@ export function renderReplay(crawlData: ReplayData) {
           ${when(crawlData.replayUrl, () => {
             return html`<iframe
               src=${crawlData.replayUrl}
-              class="h-full w-full outline"
+              class=${tw`h-full w-full outline`}
             ></iframe>`;
           })}
         `,

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -16,35 +16,43 @@ function renderDiff(
 ) {
   return until(
     diffImport.then(({ diffJson }) => {
-      const diff = diffJson(crawlResources, qaResources);
+      const diff = diffJson(qaResources, crawlResources);
 
       const addedText = tw`bg-red-100 text-red-700`;
-      const removedText = tw`hidden`;
+      const removedText = tw`bg-red-100 text-red-100`;
 
       return html`
-        <div class=${tw`flex-1`}>
+        <div
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
+          aria-labelledby="qaResourcesHeading"
+        >
           ${diff.map((part) => {
             return html`
-              <div
-                class=${`${
-                  part.added ? removedText : part.removed ? addedText : ""
-                } ${tw`whitespace-pre-line`}`}
+              <span
+                class=${part.added
+                  ? removedText
+                  : part.removed
+                    ? addedText
+                    : ""}
+                >${part.value}</span
               >
-                ${part.value}
-              </div>
             `;
           })}
         </div>
-        <div class=${tw`flex-1`}>
+        <div
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg p-4`}
+          aria-labelledby="crawlResourcesHeading"
+        >
           ${diff.map((part) => {
             return html`
-              <div
-                class=${`${
-                  part.added ? addedText : part.removed ? removedText : ""
-                } ${tw`whitespace-pre-line`}`}
+              <span
+                class=${part.added
+                  ? addedText
+                  : part.removed
+                    ? removedText
+                    : ""}
+                >${part.value}</span
               >
-                ${part.value}
-              </div>
             `;
           })}
         </div>
@@ -55,19 +63,29 @@ function renderDiff(
 
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   return html`
-    <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
-      <h3 id="qaResourcesHeading">${msg("QA Resources")}</h3>
-      <h3 id="crawlResourcesHeading">${msg("Crawl Resources")}</h3>
+    <div class=${tw`flex h-full flex-col outline`}>
+      <div class=${tw`mb-2 flex text-base font-medium`}>
+        <h3 id="qaResourcesHeading" class=${tw`flex-1`}>
+          ${msg("Crawl Resources")}
+        </h3>
+        <h3 id="crawlResourcesHeading" class=${tw`flex-1`}>
+          ${msg("Replay Resources")}
+        </h3>
+      </div>
+      <div
+        class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}
+      >
+        ${guard(
+          [crawlData, qaData],
+          () => html`
+            <div class=${tw`flex`}>
+              ${when(crawlData?.resources && qaData?.resources, () =>
+                renderDiff(crawlData!.resources!, qaData!.resources!),
+              )}
+            </div>
+          `,
+        )}
+      </div>
     </div>
-    ${guard(
-      [crawlData, qaData],
-      () => html`
-        <div class=${tw`flex border placeholder:rounded`}>
-          ${when(crawlData?.resources && qaData?.resources, () =>
-            renderDiff(qaData!.resources!, crawlData!.resources!),
-          )}
-        </div>
-      `,
-    )}
   `;
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -23,7 +23,7 @@ function renderDiff(
 
       return html`
         <div
-          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg p-4`}
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-dashed p-4 first-of-type:border-r`}
           aria-labelledby="crawlResourcesHeading"
         >
           ${diff.map((part) => {
@@ -40,7 +40,7 @@ function renderDiff(
           })}
         </div>
         <div
-          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-dashed p-4 first-of-type:border-r`}
           aria-labelledby="qaResourcesHeading"
         >
           ${diff.map((part) => {

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -64,12 +64,12 @@ function renderDiff(
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
-      <div class=${tw`mb-2 flex text-base font-medium`}>
+      <div class=${tw`mb-2 flex font-semibold`}>
         <h3 id="crawlResourcesHeading" class=${tw`flex-1`}>
-          ${msg("Crawl Resources")}
+          ${msg("Resources loaded during crawl")}
         </h3>
         <h3 id="qaResourcesHeading" class=${tw`flex-1`}>
-          ${msg("QA Resources")}
+          ${msg("Resources loaded in replay")}
         </h3>
       </div>
       <div

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -1,29 +1,71 @@
 import { msg } from "@lit/localize";
 import { html } from "lit";
+import { until } from "lit/directives/until.js";
+import { when } from "lit/directives/when.js";
 
 import type { ReplayData } from "../types";
 
+import { tw } from "@/utils/tailwind";
+
+const diffImport = import("diff");
+
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   return html`
-    <div class="mb-2 flex justify-between text-base font-medium">
+    <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
       <h3 id="crawlResourcesHeading">${msg("Crawl Resources")}</h3>
       <h3 id="replayResourcesHeading">${msg("Replay Resources")}</h3>
     </div>
-    <div class="flex rounded border bg-slate-50">
-      <div
-        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-green-400"
-        style="max-width: 50%"
-        aria-labelledby="crawlResourcesHeading"
-      >
-        ${crawlData.resources}
-      </div>
-      <div
-        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-yellow-400"
-        style="max-width: 50%"
-        aria-labelledby="replayResourcesHeading"
-      >
-        ${qaData.resources}
-      </div>
-    </div>
+    ${when(
+      crawlData && qaData,
+      () => html`
+        <div class=${tw`flex border placeholder:rounded`}>
+          ${until(
+            diffImport.then(({ diffJson }) => {
+              const diff = diffJson(crawlData.resources, qaData.resources);
+
+              const addedText = tw`bg-red-100 text-red-700`;
+              const removedText = tw`hidden`;
+
+              return html`
+                <div class=${tw`flex-1`}>
+                  ${diff.map((part) => {
+                    return html`
+                      <div
+                        class=${`${
+                          part.added
+                            ? removedText
+                            : part.removed
+                              ? addedText
+                              : ""
+                        } ${tw`whitespace-pre-line`}`}
+                      >
+                        ${part.value}
+                      </div>
+                    `;
+                  })}
+                </div>
+                <div class=${tw`flex-1`}>
+                  ${diff.map((part) => {
+                    return html`
+                      <div
+                        class=${`${
+                          part.added
+                            ? addedText
+                            : part.removed
+                              ? removedText
+                              : ""
+                        } ${tw`whitespace-pre-line`}`}
+                      >
+                        ${part.value}
+                      </div>
+                    `;
+                  })}
+                </div>
+              `;
+            }),
+          )}
+        </div>
+      `,
+    )}
   `;
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -1,0 +1,29 @@
+import { msg } from "@lit/localize";
+import { html } from "lit";
+
+import type { ReplayData } from "../types";
+
+export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
+  return html`
+    <div class="mb-2 flex justify-between text-base font-medium">
+      <h3 id="crawlResourcesHeading">${msg("Crawl Resources")}</h3>
+      <h3 id="replayResourcesHeading">${msg("Replay Resources")}</h3>
+    </div>
+    <div class="flex rounded border bg-slate-50">
+      <div
+        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-green-400"
+        style="max-width: 50%"
+        aria-labelledby="crawlResourcesHeading"
+      >
+        ${crawlData.resources}
+      </div>
+      <div
+        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-yellow-400"
+        style="max-width: 50%"
+        aria-labelledby="replayResourcesHeading"
+      >
+        ${qaData.resources}
+      </div>
+    </div>
+  `;
+}

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -1,5 +1,6 @@
 import { msg } from "@lit/localize";
 import { html } from "lit";
+import { guard } from "lit/directives/guard.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 
@@ -9,60 +10,61 @@ import { tw } from "@/utils/tailwind";
 
 const diffImport = import("diff");
 
+function renderDiff(
+  crawlResources: ReplayData["resources"],
+  qaResources: ReplayData["resources"],
+) {
+  return until(
+    diffImport.then(({ diffJson }) => {
+      const diff = diffJson(crawlResources, qaResources);
+
+      const addedText = tw`bg-red-100 text-red-700`;
+      const removedText = tw`hidden`;
+
+      return html`
+        <div class=${tw`flex-1`}>
+          ${diff.map((part) => {
+            return html`
+              <div
+                class=${`${
+                  part.added ? removedText : part.removed ? addedText : ""
+                } ${tw`whitespace-pre-line`}`}
+              >
+                ${part.value}
+              </div>
+            `;
+          })}
+        </div>
+        <div class=${tw`flex-1`}>
+          ${diff.map((part) => {
+            return html`
+              <div
+                class=${`${
+                  part.added ? addedText : part.removed ? removedText : ""
+                } ${tw`whitespace-pre-line`}`}
+              >
+                ${part.value}
+              </div>
+            `;
+          })}
+        </div>
+      `;
+    }),
+  );
+}
+
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
       <h3 id="crawlResourcesHeading">${msg("Crawl Resources")}</h3>
       <h3 id="replayResourcesHeading">${msg("Replay Resources")}</h3>
     </div>
-    ${when(
-      crawlData && qaData,
+    ${guard(
+      [crawlData, qaData],
       () => html`
         <div class=${tw`flex border placeholder:rounded`}>
-          ${until(
-            diffImport.then(({ diffJson }) => {
-              const diff = diffJson(crawlData.resources, qaData.resources);
-
-              const addedText = tw`bg-red-100 text-red-700`;
-              const removedText = tw`hidden`;
-
-              return html`
-                <div class=${tw`flex-1`}>
-                  ${diff.map((part) => {
-                    return html`
-                      <div
-                        class=${`${
-                          part.added
-                            ? removedText
-                            : part.removed
-                              ? addedText
-                              : ""
-                        } ${tw`whitespace-pre-line`}`}
-                      >
-                        ${part.value}
-                      </div>
-                    `;
-                  })}
-                </div>
-                <div class=${tw`flex-1`}>
-                  ${diff.map((part) => {
-                    return html`
-                      <div
-                        class=${`${
-                          part.added
-                            ? addedText
-                            : part.removed
-                              ? removedText
-                              : ""
-                        } ${tw`whitespace-pre-line`}`}
-                      >
-                        ${part.value}
-                      </div>
-                    `;
-                  })}
-                </div>
-              `;
-            }),
+          ${when(crawlData.resources && qaData.resources, () =>
+            renderDiff(crawlData.resources, qaData.resources),
           )}
         </div>
       `,

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -4,15 +4,15 @@ import { guard } from "lit/directives/guard.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 
-import type { ReplayData } from "../types";
+import type { ReplayData, ResourcesPayload } from "../types";
 
 import { tw } from "@/utils/tailwind";
 
 const diffImport = import("diff");
 
 function renderDiff(
-  crawlResources: ReplayData["resources"],
-  qaResources: ReplayData["resources"],
+  crawlResources: ResourcesPayload["resources"],
+  qaResources: ResourcesPayload["resources"],
 ) {
   return until(
     diffImport.then(({ diffJson }) => {
@@ -63,8 +63,8 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
       [crawlData, qaData],
       () => html`
         <div class=${tw`flex border placeholder:rounded`}>
-          ${when(crawlData.resources && qaData.resources, () =>
-            renderDiff(crawlData.resources, qaData.resources),
+          ${when(crawlData?.resources && qaData?.resources, () =>
+            renderDiff(crawlData!.resources!, qaData!.resources!),
           )}
         </div>
       `,

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -16,29 +16,12 @@ function renderDiff(
 ) {
   return until(
     diffImport.then(({ diffJson }) => {
-      const diff = diffJson(qaResources, crawlResources);
+      const diff = diffJson(crawlResources, qaResources);
 
       const addedText = tw`bg-red-100 text-red-700`;
       const removedText = tw`bg-red-100 text-red-100`;
 
       return html`
-        <div
-          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
-          aria-labelledby="qaResourcesHeading"
-        >
-          ${diff.map((part) => {
-            return html`
-              <span
-                class=${part.added
-                  ? removedText
-                  : part.removed
-                    ? addedText
-                    : ""}
-                >${part.value}</span
-              >
-            `;
-          })}
-        </div>
         <div
           class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg p-4`}
           aria-labelledby="crawlResourcesHeading"
@@ -56,6 +39,23 @@ function renderDiff(
             `;
           })}
         </div>
+        <div
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
+          aria-labelledby="qaResourcesHeading"
+        >
+          ${diff.map((part) => {
+            return html`
+              <span
+                class=${part.added
+                  ? removedText
+                  : part.removed
+                    ? addedText
+                    : ""}
+                >${part.value}</span
+              >
+            `;
+          })}
+        </div>
       `;
     }),
   );
@@ -65,11 +65,11 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
       <div class=${tw`mb-2 flex text-base font-medium`}>
-        <h3 id="qaResourcesHeading" class=${tw`flex-1`}>
+        <h3 id="crawlResourcesHeading" class=${tw`flex-1`}>
           ${msg("Crawl Resources")}
         </h3>
-        <h3 id="crawlResourcesHeading" class=${tw`flex-1`}>
-          ${msg("Replay Resources")}
+        <h3 id="qaResourcesHeading" class=${tw`flex-1`}>
+          ${msg("QA Resources")}
         </h3>
       </div>
       <div

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -56,15 +56,15 @@ function renderDiff(
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
+      <h3 id="qaResourcesHeading">${msg("QA Resources")}</h3>
       <h3 id="crawlResourcesHeading">${msg("Crawl Resources")}</h3>
-      <h3 id="replayResourcesHeading">${msg("Replay Resources")}</h3>
     </div>
     ${guard(
       [crawlData, qaData],
       () => html`
         <div class=${tw`flex border placeholder:rounded`}>
           ${when(crawlData?.resources && qaData?.resources, () =>
-            renderDiff(crawlData!.resources!, qaData!.resources!),
+            renderDiff(qaData!.resources!, crawlData!.resources!),
           )}
         </div>
       `,

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -6,6 +6,8 @@ import { when } from "lit/directives/when.js";
 
 import type { ReplayData, ResourcesPayload } from "../types";
 
+import { renderSpinner } from "./spinner";
+
 import { tw } from "@/utils/tailwind";
 
 const diffImport = import("diff");
@@ -62,6 +64,13 @@ function renderDiff(
 }
 
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
+  const noData = html`<div
+    class=${tw`flex flex-col items-center justify-center gap-2 text-xs text-neutral-500`}
+  >
+    <sl-icon name="slash-circle"></sl-icon>
+    ${msg("Resources data not available")}
+  </div>`;
+
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
       <div class=${tw`mb-2 flex font-semibold`}>
@@ -75,15 +84,20 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
       <div
         class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}
       >
-        ${guard(
-          [crawlData, qaData],
-          () => html`
-            <div class=${tw`flex`}>
-              ${when(crawlData?.resources && qaData?.resources, () =>
-                renderDiff(crawlData!.resources!, qaData!.resources!),
-              )}
-            </div>
-          `,
+        ${guard([crawlData, qaData], () =>
+          when(
+            crawlData && qaData,
+            () => html`
+              <div
+                class=${tw`flex min-h-full ${crawlData?.text && qaData?.text ? "" : tw`items-center justify-center`}`}
+              >
+                ${crawlData?.resources && qaData?.resources
+                  ? renderDiff(crawlData.resources, qaData.resources)
+                  : noData}
+              </div>
+            `,
+            renderSpinner,
+          ),
         )}
       </div>
     </div>

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -22,60 +22,58 @@ function image(data: ReplayData) {
 }
 
 export function renderScreenshots(crawlData: ReplayData, qaData: ReplayData) {
-  return html`
-    ${guard(
-      [crawlData, qaData],
-      () => html`
-        <div class=${tw`flex flex-col gap-2 md:flex-row`}>
-          <div class=${tw`flex-1`}>
-            <h3
-              id="qaScreenshotHeading"
-              class=${tw`mb-2 flex text-base font-medium`}
-            >
-              ${msg("Crawl Screenshot")}
-            </h3>
-            <div
-              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-              aria-labelledby="qaScreenshotHeading"
-            >
-              ${when(qaData, image, renderSpinner)}
-            </div>
-          </div>
-          <div class=${tw`flex-1`}>
-            <h3
-              id="crawlScreenshotHeading"
-              class=${tw`mb-2 flex text-base font-medium`}
-            >
-              ${msg("Replay Screenshot")}
-            </h3>
-            <div
-              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-              aria-labelledby="crawlScreenshotHeading"
-            >
-              ${when(crawlData, image, renderSpinner)}
-            </div>
+  return guard(
+    [crawlData, qaData],
+    () => html`
+      <div class=${tw`flex flex-col gap-2 md:flex-row`}>
+        <div class=${tw`flex-1`}>
+          <h3
+            id="qaScreenshotHeading"
+            class=${tw`mb-2 flex text-base font-medium`}
+          >
+            ${msg("Crawl Screenshot")}
+          </h3>
+          <div
+            class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
+            aria-labelledby="qaScreenshotHeading"
+          >
+            ${when(qaData, image, renderSpinner)}
           </div>
         </div>
+        <div class=${tw`flex-1`}>
+          <h3
+            id="crawlScreenshotHeading"
+            class=${tw`mb-2 flex text-base font-medium`}
+          >
+            ${msg("Replay Screenshot")}
+          </h3>
+          <div
+            class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
+            aria-labelledby="crawlScreenshotHeading"
+          >
+            ${when(crawlData, image, renderSpinner)}
+          </div>
+        </div>
+      </div>
 
-        ${when(
-          crawlData && qaData,
-          () => {},
-          // html`
-          //   <sl-image-comparer>
-          //     <img
-          //       slot="before"
-          //       src="${crawlData?.blobUrl || ""}"
-          //       aria-labelledby="crawlScreenshotHeading"
-          //     />
-          //     <img
-          //       slot="after"
-          //       src="${qaData?.blobUrl || ""}"
-          //       aria-labelledby="replayScreenshotHeading"
-          //     />
-          //   </sl-image-comparer>
-          // `
-        )}
-      `,
-    )}
-  `;
+      ${when(
+        crawlData && qaData,
+        () => {},
+        // html`
+        //   <sl-image-comparer>
+        //     <img
+        //       slot="before"
+        //       src="${crawlData?.blobUrl || ""}"
+        //       aria-labelledby="crawlScreenshotHeading"
+        //     />
+        //     <img
+        //       slot="after"
+        //       src="${qaData?.blobUrl || ""}"
+        //       aria-labelledby="replayScreenshotHeading"
+        //     />
+        //   </sl-image-comparer>
+        // `
+      )}
+    `,
+  );
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -1,0 +1,42 @@
+import { msg } from "@lit/localize";
+import { html } from "lit";
+import { guard } from "lit/directives/guard.js";
+import { when } from "lit/directives/when.js";
+
+import type { ReplayData } from "../types";
+
+import { renderSpinner } from "./spinner";
+
+export function renderScreenshots(crawlData: ReplayData, qaData: ReplayData) {
+  return html`
+    ${guard(
+      [crawlData, qaData],
+      () => html`
+        <div class="mb-2 flex justify-between text-base font-medium">
+          <h3 id="crawlScreenshotHeading">${msg("Crawl Screenshot")}</h3>
+          <h3 id="replayScreenshotHeading">${msg("Replay Screenshot")}</h3>
+        </div>
+        <div class="aspect-video overflow-hidden rounded border bg-slate-50">
+          ${when(
+            crawlData.blobUrl && qaData.blobUrl,
+            () => html`
+              <sl-image-comparer>
+                <img
+                  slot="before"
+                  src="${crawlData.blobUrl || ""}"
+                  aria-labelledby="crawlScreenshotHeading"
+                />
+                <img
+                  slot="after"
+                  src="${qaData.blobUrl || ""}"
+                  aria-labelledby="replayScreenshotHeading"
+                />
+              </sl-image-comparer>
+            `,
+            renderSpinner,
+          )}
+        </div>
+      `,
+    )}
+  `;
+}

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -7,52 +7,74 @@ import type { ReplayData } from "../types";
 
 import { renderSpinner } from "./spinner";
 
+import { tw } from "@/utils/tailwind";
+
+function image(data: ReplayData) {
+  if (!data?.blobUrl) {
+    return html`<div
+      class=${tw`flex h-full w-full flex-col items-center justify-center gap-2 text-xs text-neutral-500`}
+    >
+      <sl-icon name="slash-circle"></sl-icon>
+      ${msg("Screenshot not available")}
+    </div>`;
+  }
+  return html` <img class=${tw`h-full w-full`} src=${data.blobUrl} /> `;
+}
+
 export function renderScreenshots(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     ${guard(
       [crawlData, qaData],
       () => html`
-        <div class="mb-2 flex justify-between text-base font-medium">
-          <h3 id="crawlScreenshotHeading">${msg("Crawl Screenshot")}</h3>
-          <h3 id="replayScreenshotHeading">${msg("Replay Screenshot")}</h3>
+        <div class=${tw`flex flex-col gap-2 md:flex-row`}>
+          <div class=${tw`flex-1`}>
+            <h3
+              id="qaScreenshotHeading"
+              class=${tw`mb-2 flex text-base font-medium`}
+            >
+              ${msg("Crawl Screenshot")}
+            </h3>
+            <div
+              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
+              aria-labelledby="qaScreenshotHeading"
+            >
+              ${when(qaData, image, renderSpinner)}
+            </div>
+          </div>
+          <div class=${tw`flex-1`}>
+            <h3
+              id="crawlScreenshotHeading"
+              class=${tw`mb-2 flex text-base font-medium`}
+            >
+              ${msg("Replay Screenshot")}
+            </h3>
+            <div
+              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
+              aria-labelledby="crawlScreenshotHeading"
+            >
+              ${when(crawlData, image, renderSpinner)}
+            </div>
+          </div>
         </div>
-        <div class=" overflow-hidden rounded border bg-slate-50">
-          ${when(
-            crawlData?.blobUrl && qaData?.blobUrl,
-            () =>
-              html` <div class="flex">
-                <div class="aspect-video flex-1">
-                  <img
-                    class="flex-1"
-                    src="${crawlData?.blobUrl || ""}"
-                    aria-labelledby="crawlScreenshotHeading"
-                  />
-                </div>
-                <div class="aspect-video flex-1">
-                  <img
-                    class="flex-1"
-                    src="${qaData?.blobUrl || ""}"
-                    aria-labelledby="replayScreenshotHeading"
-                  />
-                </div>
-              </div>`,
-            // html`
-            //   <sl-image-comparer>
-            //     <img
-            //       slot="before"
-            //       src="${crawlData?.blobUrl || ""}"
-            //       aria-labelledby="crawlScreenshotHeading"
-            //     />
-            //     <img
-            //       slot="after"
-            //       src="${qaData?.blobUrl || ""}"
-            //       aria-labelledby="replayScreenshotHeading"
-            //     />
-            //   </sl-image-comparer>
-            // `
-            renderSpinner,
-          )}
-        </div>
+
+        ${when(
+          crawlData && qaData,
+          () => {},
+          // html`
+          //   <sl-image-comparer>
+          //     <img
+          //       slot="before"
+          //       src="${crawlData?.blobUrl || ""}"
+          //       aria-labelledby="crawlScreenshotHeading"
+          //     />
+          //     <img
+          //       slot="after"
+          //       src="${qaData?.blobUrl || ""}"
+          //       aria-labelledby="replayScreenshotHeading"
+          //     />
+          //   </sl-image-comparer>
+          // `
+        )}
       `,
     )}
   `;

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -65,7 +65,7 @@ export function renderScreenshots(
             <img
               slot="before"
               src="${qaData?.blobUrl || ""}"
-              aria-labelledby="replayScreenshotHeading"
+              aria-labelledby="qaScreenshotHeading"
             />
           </sl-image-comparer>
         `,

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -28,30 +28,30 @@ export function renderScreenshots(crawlData: ReplayData, qaData: ReplayData) {
       <div class=${tw`flex flex-col gap-2 md:flex-row`}>
         <div class=${tw`flex-1`}>
           <h3
-            id="qaScreenshotHeading"
+            id="crawlScreenshotHeading"
             class=${tw`mb-2 flex text-base font-medium`}
           >
             ${msg("Crawl Screenshot")}
           </h3>
           <div
             class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-            aria-labelledby="qaScreenshotHeading"
+            aria-labelledby="crawlScreenshotHeading"
           >
-            ${when(qaData, image, renderSpinner)}
+            ${when(crawlData, image, renderSpinner)}
           </div>
         </div>
         <div class=${tw`flex-1`}>
           <h3
-            id="crawlScreenshotHeading"
+            id="qaScreenshotHeading"
             class=${tw`mb-2 flex text-base font-medium`}
           >
-            ${msg("Replay Screenshot")}
+            ${msg("QA Screenshot")}
           </h3>
           <div
             class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-            aria-labelledby="crawlScreenshotHeading"
+            aria-labelledby="qaScreenshotHeading"
           >
-            ${when(crawlData, image, renderSpinner)}
+            ${when(qaData, image, renderSpinner)}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -32,9 +32,9 @@ export function renderScreenshots(
           <div class=${tw`flex-1`}>
             <h3
               id="crawlScreenshotHeading"
-              class=${tw`mb-2 flex text-base font-medium`}
+              class=${tw`mb-2 flex font-semibold`}
             >
-              ${msg("Crawl Screenshot")}
+              ${msg("Screenshot during crawl")}
             </h3>
             <div
               class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
@@ -44,11 +44,8 @@ export function renderScreenshots(
             </div>
           </div>
           <div class=${tw`flex-1`}>
-            <h3
-              id="qaScreenshotHeading"
-              class=${tw`mb-2 flex text-base font-medium`}
-            >
-              ${msg("QA Screenshot")}
+            <h3 id="qaScreenshotHeading" class=${tw`mb-2 flex font-semibold`}>
+              ${msg("Screenshot from replay")}
             </h3>
             <div
               class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -16,23 +16,40 @@ export function renderScreenshots(crawlData: ReplayData, qaData: ReplayData) {
           <h3 id="crawlScreenshotHeading">${msg("Crawl Screenshot")}</h3>
           <h3 id="replayScreenshotHeading">${msg("Replay Screenshot")}</h3>
         </div>
-        <div class="aspect-video overflow-hidden rounded border bg-slate-50">
+        <div class=" overflow-hidden rounded border bg-slate-50">
           ${when(
-            crawlData.blobUrl && qaData.blobUrl,
-            () => html`
-              <sl-image-comparer>
-                <img
-                  slot="before"
-                  src="${crawlData.blobUrl || ""}"
-                  aria-labelledby="crawlScreenshotHeading"
-                />
-                <img
-                  slot="after"
-                  src="${qaData.blobUrl || ""}"
-                  aria-labelledby="replayScreenshotHeading"
-                />
-              </sl-image-comparer>
-            `,
+            crawlData?.blobUrl && qaData?.blobUrl,
+            () =>
+              html` <div class="flex">
+                <div class="aspect-video flex-1">
+                  <img
+                    class="flex-1"
+                    src="${crawlData?.blobUrl || ""}"
+                    aria-labelledby="crawlScreenshotHeading"
+                  />
+                </div>
+                <div class="aspect-video flex-1">
+                  <img
+                    class="flex-1"
+                    src="${qaData?.blobUrl || ""}"
+                    aria-labelledby="replayScreenshotHeading"
+                  />
+                </div>
+              </div>`,
+            // html`
+            //   <sl-image-comparer>
+            //     <img
+            //       slot="before"
+            //       src="${crawlData?.blobUrl || ""}"
+            //       aria-labelledby="crawlScreenshotHeading"
+            //     />
+            //     <img
+            //       slot="after"
+            //       src="${qaData?.blobUrl || ""}"
+            //       aria-labelledby="replayScreenshotHeading"
+            //     />
+            //   </sl-image-comparer>
+            // `
             renderSpinner,
           )}
         </div>

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -61,12 +61,12 @@ export function renderScreenshots(
       : html`
           <sl-image-comparer>
             <img
-              slot="before"
+              slot="after"
               src="${crawlData?.blobUrl || ""}"
               aria-labelledby="crawlScreenshotHeading"
             />
             <img
-              slot="after"
+              slot="before"
               src="${qaData?.blobUrl || ""}"
               aria-labelledby="replayScreenshotHeading"
             />

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -26,48 +26,54 @@ export function renderScreenshots(
   qaData: ReplayData,
   splitView: boolean,
 ) {
-  return guard([crawlData, qaData, splitView], () =>
-    splitView
+  const content = html`
+    <div class=${tw`flex${splitView ? "" : tw` justify-between`}`}>
+      <h3
+        id="crawlScreenshotHeading"
+        class=${tw`mb-2 font-semibold ${splitView ? tw`flex-1` : "flex-grow-0"}`}
+      >
+        ${msg("Screenshot during crawl")}
+      </h3>
+      <h3
+        id="qaScreenshotHeading"
+        class=${tw`mb-2 font-semibold ${splitView ? tw`flex-1` : "flex-grow-0"}`}
+      >
+        ${msg("Screenshot from replay")}
+      </h3>
+    </div>
+    ${splitView
       ? html` <div class=${tw`flex flex-col gap-2 md:flex-row`}>
-          <div class=${tw`flex-1`}>
-            <h3
-              id="crawlScreenshotHeading"
-              class=${tw`mb-2 flex font-semibold`}
-            >
-              ${msg("Screenshot during crawl")}
-            </h3>
-            <div
-              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-              aria-labelledby="crawlScreenshotHeading"
-            >
-              ${when(crawlData, image, renderSpinner)}
-            </div>
+          <div
+            class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50`}
+            aria-labelledby="crawlScreenshotHeading"
+          >
+            ${when(crawlData, image, renderSpinner)}
           </div>
-          <div class=${tw`flex-1`}>
-            <h3 id="qaScreenshotHeading" class=${tw`mb-2 flex font-semibold`}>
-              ${msg("Screenshot from replay")}
-            </h3>
-            <div
-              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-              aria-labelledby="qaScreenshotHeading"
-            >
-              ${when(qaData, image, renderSpinner)}
-            </div>
+          <div
+            class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50`}
+            aria-labelledby="qaScreenshotHeading"
+          >
+            ${when(qaData, image, renderSpinner)}
           </div>
         </div>`
       : html`
-          <sl-image-comparer>
-            <img
-              slot="after"
-              src="${crawlData?.blobUrl || ""}"
-              aria-labelledby="crawlScreenshotHeading"
-            />
-            <img
-              slot="before"
-              src="${qaData?.blobUrl || ""}"
-              aria-labelledby="qaScreenshotHeading"
-            />
-          </sl-image-comparer>
-        `,
-  );
+          <div
+            class=${tw`aspect-video overflow-hidden rounded-lg border bg-slate-50`}
+          >
+            <sl-image-comparer>
+              <img
+                slot="after"
+                src="${crawlData?.blobUrl || ""}"
+                aria-labelledby="crawlScreenshotHeading"
+              />
+              <img
+                slot="before"
+                src="${qaData?.blobUrl || ""}"
+                aria-labelledby="qaScreenshotHeading"
+              />
+            </sl-image-comparer>
+          </div>
+        `}
+  `;
+  return guard([crawlData, qaData, splitView], () => content);
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/screenshots.ts
@@ -21,59 +21,56 @@ function image(data: ReplayData) {
   return html` <img class=${tw`h-full w-full`} src=${data.blobUrl} /> `;
 }
 
-export function renderScreenshots(crawlData: ReplayData, qaData: ReplayData) {
-  return guard(
-    [crawlData, qaData],
-    () => html`
-      <div class=${tw`flex flex-col gap-2 md:flex-row`}>
-        <div class=${tw`flex-1`}>
-          <h3
-            id="crawlScreenshotHeading"
-            class=${tw`mb-2 flex text-base font-medium`}
-          >
-            ${msg("Crawl Screenshot")}
-          </h3>
-          <div
-            class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-            aria-labelledby="crawlScreenshotHeading"
-          >
-            ${when(crawlData, image, renderSpinner)}
+export function renderScreenshots(
+  crawlData: ReplayData,
+  qaData: ReplayData,
+  splitView: boolean,
+) {
+  return guard([crawlData, qaData, splitView], () =>
+    splitView
+      ? html` <div class=${tw`flex flex-col gap-2 md:flex-row`}>
+          <div class=${tw`flex-1`}>
+            <h3
+              id="crawlScreenshotHeading"
+              class=${tw`mb-2 flex text-base font-medium`}
+            >
+              ${msg("Crawl Screenshot")}
+            </h3>
+            <div
+              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
+              aria-labelledby="crawlScreenshotHeading"
+            >
+              ${when(crawlData, image, renderSpinner)}
+            </div>
           </div>
-        </div>
-        <div class=${tw`flex-1`}>
-          <h3
-            id="qaScreenshotHeading"
-            class=${tw`mb-2 flex text-base font-medium`}
-          >
-            ${msg("QA Screenshot")}
-          </h3>
-          <div
-            class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
-            aria-labelledby="qaScreenshotHeading"
-          >
-            ${when(qaData, image, renderSpinner)}
+          <div class=${tw`flex-1`}>
+            <h3
+              id="qaScreenshotHeading"
+              class=${tw`mb-2 flex text-base font-medium`}
+            >
+              ${msg("QA Screenshot")}
+            </h3>
+            <div
+              class=${tw`aspect-video flex-1 overflow-hidden rounded-lg border bg-slate-50 shadow-sm`}
+              aria-labelledby="qaScreenshotHeading"
+            >
+              ${when(qaData, image, renderSpinner)}
+            </div>
           </div>
-        </div>
-      </div>
-
-      ${when(
-        crawlData && qaData,
-        () => {},
-        // html`
-        //   <sl-image-comparer>
-        //     <img
-        //       slot="before"
-        //       src="${crawlData?.blobUrl || ""}"
-        //       aria-labelledby="crawlScreenshotHeading"
-        //     />
-        //     <img
-        //       slot="after"
-        //       src="${qaData?.blobUrl || ""}"
-        //       aria-labelledby="replayScreenshotHeading"
-        //     />
-        //   </sl-image-comparer>
-        // `
-      )}
-    `,
+        </div>`
+      : html`
+          <sl-image-comparer>
+            <img
+              slot="before"
+              src="${crawlData?.blobUrl || ""}"
+              aria-labelledby="crawlScreenshotHeading"
+            />
+            <img
+              slot="after"
+              src="${qaData?.blobUrl || ""}"
+              aria-labelledby="replayScreenshotHeading"
+            />
+          </sl-image-comparer>
+        `,
   );
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/severityBadge.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/severityBadge.ts
@@ -6,7 +6,7 @@ import { severityFromMatch } from "@/features/qa/page-list/helpers";
 import { formatPercentage } from "@/features/qa/page-list/ui/page-details";
 
 export function renderSeverityBadge(value: number) {
-  if (value === undefined) {
+  if (value === undefined || value === null) {
     return;
   }
 

--- a/frontend/src/pages/org/archived-item-qa/ui/severityBadge.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/severityBadge.ts
@@ -1,0 +1,31 @@
+import { html } from "lit";
+
+import type { BadgeVariant } from "@/components/ui/badge";
+// import { tw } from "@/utils/tailwind";
+import { severityFromMatch } from "@/features/qa/page-list/helpers";
+import { formatPercentage } from "@/features/qa/page-list/ui/page-details";
+
+export function renderSeverityBadge(value: number) {
+  if (value === undefined) {
+    return;
+  }
+
+  let variant: BadgeVariant = "neutral";
+  switch (severityFromMatch(value)) {
+    case "severe":
+      variant = "danger";
+      break;
+    case "moderate":
+      variant = "warning";
+      break;
+    case "good":
+      variant = "success";
+      break;
+    default:
+      break;
+  }
+
+  return html`
+    <btrix-badge variant=${variant}>${formatPercentage(value)}%</btrix-badge>
+  `;
+}

--- a/frontend/src/pages/org/archived-item-qa/ui/spinner.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/spinner.ts
@@ -1,8 +1,10 @@
 import { html } from "lit";
 
+import { tw } from "@/utils/tailwind";
+
 export function renderSpinner() {
   return html`<div
-    class="flex h-full w-full items-center justify-center text-2xl"
+    class=${tw`flex h-full w-full items-center justify-center text-2xl`}
   >
     <sl-spinner></sl-spinner>
   </div>`;

--- a/frontend/src/pages/org/archived-item-qa/ui/spinner.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/spinner.ts
@@ -1,0 +1,9 @@
+import { html } from "lit";
+
+export function renderSpinner() {
+  return html`<div
+    class="flex h-full w-full items-center justify-center text-2xl"
+  >
+    <sl-spinner></sl-spinner>
+  </div>`;
+}

--- a/frontend/src/pages/org/archived-item-qa/ui/spinner.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/spinner.ts
@@ -4,7 +4,7 @@ import { tw } from "@/utils/tailwind";
 
 export function renderSpinner() {
   return html`<div
-    class=${tw`flex h-full w-full items-center justify-center text-2xl`}
+    class=${tw`flex h-full w-full items-center justify-center p-9 text-2xl`}
   >
     <sl-spinner></sl-spinner>
   </div>`;

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -1,29 +1,65 @@
 import { msg } from "@lit/localize";
 import { html } from "lit";
+import { until } from "lit/directives/until.js";
+import { when } from "lit/directives/when.js";
 
 import type { ReplayData } from "../types";
 
+import { tw } from "@/utils/tailwind";
+
+const diffImport = import("diff");
+
 export function renderText(crawlData: ReplayData, qaData: ReplayData) {
   return html`
-    <div class="mb-2 flex justify-between text-base font-medium">
+    <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
       <h3 id="crawlTextHeading">${msg("Crawl Text")}</h3>
       <h3 id="replayTextHeading">${msg("Replay Text")}</h3>
     </div>
-    <div class="flex rounded border bg-slate-50">
-      <div
-        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-green-400"
-        style="max-width: 50%"
-        aria-labelledby="crawlTextHeading"
-      >
-        ${crawlData.text}
-      </div>
-      <div
-        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-yellow-400"
-        style="max-width: 50%"
-        aria-labelledby="replayTextHeading"
-      >
-        ${qaData.text}
-      </div>
-    </div>
+    ${when(
+      crawlData && qaData,
+      () => html`
+        <div class=${tw`flex border placeholder:rounded`}>
+          ${until(
+            diffImport.then(({ diffChars }) => {
+              const diff = diffChars(crawlData.text, qaData.text);
+
+              const addedText = tw`bg-red-100 text-red-700`;
+              const removedText = tw`bg-red-100 text-red-100`;
+
+              return html`
+                <div class=${tw`flex-1 whitespace-pre-line`}>
+                  ${diff.map((part) => {
+                    return html`
+                      <span
+                        class=${part.added
+                          ? removedText
+                          : part.removed
+                            ? addedText
+                            : ""}
+                        >${part.value}</span
+                      >
+                    `;
+                  })}
+                </div>
+                <div class=${tw`flex-1 whitespace-pre-line`}>
+                  ${diff.map((part) => {
+                    return html`
+                      <span
+                        class=${part.added
+                          ? addedText
+                          : part.removed
+                            ? removedText
+                            : ""}
+                        >${part.value}</span
+                      >
+                    `;
+                  })}
+                </div>
+              `;
+            }),
+          )}
+        </div>
+      `,
+    )}
   `;
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -1,0 +1,29 @@
+import { msg } from "@lit/localize";
+import { html } from "lit";
+
+import type { ReplayData } from "../types";
+
+export function renderText(crawlData: ReplayData, qaData: ReplayData) {
+  return html`
+    <div class="mb-2 flex justify-between text-base font-medium">
+      <h3 id="crawlTextHeading">${msg("Crawl Text")}</h3>
+      <h3 id="replayTextHeading">${msg("Replay Text")}</h3>
+    </div>
+    <div class="flex rounded border bg-slate-50">
+      <div
+        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-green-400"
+        style="max-width: 50%"
+        aria-labelledby="crawlTextHeading"
+      >
+        ${crawlData.text}
+      </div>
+      <div
+        class="aspect-video h-full flex-1 overflow-auto whitespace-pre-line p-4 outline -outline-offset-2 outline-yellow-400"
+        style="max-width: 50%"
+        aria-labelledby="replayTextHeading"
+      >
+        ${qaData.text}
+      </div>
+    </div>
+  `;
+}

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -58,15 +58,15 @@ function renderDiff(
 export function renderText(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
-      <h3 id="crawlTextHeading">${msg("Crawl Text")}</h3>
-      <h3 id="replayTextHeading">${msg("Replay Text")}</h3>
+      <h3 id="qaTextHeading">${msg("Crawl Text")}</h3>
+      <h3 id="crawlTextHeading">${msg("Replay Text")}</h3>
     </div>
     ${guard(
       [crawlData, qaData],
       () => html`
         <div class=${tw`flex border placeholder:rounded`}>
           ${when(crawlData?.text && qaData?.text, () =>
-            renderDiff(crawlData!.text!, qaData!.text!),
+            renderDiff(qaData!.text!, crawlData!.text!),
           )}
         </div>
       `,

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -23,7 +23,7 @@ function renderDiff(
 
       return html`
         <div
-          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg p-4`}
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-dashed p-4 first-of-type:border-r`}
           aria-labelledby="crawlTextHeading"
         >
           ${diff.map((part) => {
@@ -40,7 +40,7 @@ function renderDiff(
           })}
         </div>
         <div
-          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-dashed p-4 first-of-type:border-r`}
           aria-labelledby="qaTextHeading"
         >
           ${diff.map((part) => {

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -4,13 +4,16 @@ import { guard } from "lit/directives/guard.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 
-import type { ReplayData } from "../types";
+import type { ReplayData, TextPayload } from "../types";
 
 import { tw } from "@/utils/tailwind";
 
 const diffImport = import("diff");
 
-function renderDiff(crawlText: ReplayData["text"], qaText: ReplayData["text"]) {
+function renderDiff(
+  crawlText: TextPayload["text"],
+  qaText: TextPayload["text"],
+) {
   return until(
     diffImport.then(({ diffWords }) => {
       const diff = diffWords(crawlText, qaText);
@@ -62,8 +65,8 @@ export function renderText(crawlData: ReplayData, qaData: ReplayData) {
       [crawlData, qaData],
       () => html`
         <div class=${tw`flex border placeholder:rounded`}>
-          ${when(crawlData.text && qaData.text, () =>
-            renderDiff(crawlData.text, qaData.text),
+          ${when(crawlData?.text && qaData?.text, () =>
+            renderDiff(crawlData!.text!, qaData!.text!),
           )}
         </div>
       `,

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -16,29 +16,12 @@ function renderDiff(
 ) {
   return until(
     diffImport.then(({ diffWords }) => {
-      const diff = diffWords(qaText, crawlText);
+      const diff = diffWords(crawlText, qaText);
 
       const addedText = tw`bg-red-100 text-red-700`;
       const removedText = tw`bg-red-100 text-red-100`;
 
       return html`
-        <div
-          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
-          aria-labelledby="qaTextHeading"
-        >
-          ${diff.map((part) => {
-            return html`
-              <span
-                class=${part.added
-                  ? removedText
-                  : part.removed
-                    ? addedText
-                    : ""}
-                >${part.value}</span
-              >
-            `;
-          })}
-        </div>
         <div
           class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg p-4`}
           aria-labelledby="crawlTextHeading"
@@ -56,6 +39,23 @@ function renderDiff(
             `;
           })}
         </div>
+        <div
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
+          aria-labelledby="qaTextHeading"
+        >
+          ${diff.map((part) => {
+            return html`
+              <span
+                class=${part.added
+                  ? removedText
+                  : part.removed
+                    ? addedText
+                    : ""}
+                >${part.value}</span
+              >
+            `;
+          })}
+        </div>
       `;
     }),
   );
@@ -65,8 +65,8 @@ export function renderText(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
       <div class=${tw`mb-2 flex text-base font-medium`}>
-        <h3 id="qaTextHeading" class=${tw`flex-1`}>${msg("Crawl Text")}</h3>
-        <h3 id="crawlTextHeading" class=${tw`flex-1`}>${msg("Replay Text")}</h3>
+        <h3 id="crawlTextHeading" class=${tw`flex-1`}>${msg("Craw Text")}</h3>
+        <h3 id="qaTextHeading" class=${tw`flex-1`}>${msg("QA Text")}</h3>
       </div>
       <div
         class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -6,6 +6,8 @@ import { when } from "lit/directives/when.js";
 
 import type { ReplayData, TextPayload } from "../types";
 
+import { renderSpinner } from "./spinner";
+
 import { tw } from "@/utils/tailwind";
 
 const diffImport = import("diff");
@@ -62,6 +64,13 @@ function renderDiff(
 }
 
 export function renderText(crawlData: ReplayData, qaData: ReplayData) {
+  const noData = html`<div
+    class=${tw`flex flex-col items-center justify-center gap-2 text-xs text-neutral-500`}
+  >
+    <sl-icon name="slash-circle"></sl-icon>
+    ${msg("Text data not available")}
+  </div>`;
+
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
       <div class=${tw`mb-2 flex font-semibold`}>
@@ -75,15 +84,20 @@ export function renderText(crawlData: ReplayData, qaData: ReplayData) {
       <div
         class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}
       >
-        ${guard(
-          [crawlData, qaData],
-          () => html`
-            <div class=${tw`flex`}>
-              ${when(crawlData?.text && qaData?.text, () =>
-                renderDiff(crawlData!.text!, qaData!.text!),
-              )}
-            </div>
-          `,
+        ${guard([crawlData, qaData], () =>
+          when(
+            crawlData && qaData,
+            () => html`
+              <div
+                class=${tw`flex min-h-full ${crawlData?.text && qaData?.text ? "" : tw`items-center justify-center`}`}
+              >
+                ${crawlData?.text && qaData?.text
+                  ? renderDiff(crawlData.text, qaData.text)
+                  : noData}
+              </div>
+            `,
+            renderSpinner,
+          ),
         )}
       </div>
     </div>

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -64,9 +64,13 @@ function renderDiff(
 export function renderText(crawlData: ReplayData, qaData: ReplayData) {
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
-      <div class=${tw`mb-2 flex text-base font-medium`}>
-        <h3 id="crawlTextHeading" class=${tw`flex-1`}>${msg("Craw Text")}</h3>
-        <h3 id="qaTextHeading" class=${tw`flex-1`}>${msg("QA Text")}</h3>
+      <div class=${tw`mb-2 flex font-semibold`}>
+        <h3 id="crawlTextHeading" class=${tw`flex-1`}>
+          ${msg("Text extracted during crawl")}
+        </h3>
+        <h3 id="qaTextHeading" class=${tw`flex-1`}>
+          ${msg("Text extracted from replay")}
+        </h3>
       </div>
       <div
         class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}

--- a/frontend/src/pages/org/archived-item-qa/ui/text.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/text.ts
@@ -16,13 +16,16 @@ function renderDiff(
 ) {
   return until(
     diffImport.then(({ diffWords }) => {
-      const diff = diffWords(crawlText, qaText);
+      const diff = diffWords(qaText, crawlText);
 
       const addedText = tw`bg-red-100 text-red-700`;
       const removedText = tw`bg-red-100 text-red-100`;
 
       return html`
-        <div class=${tw`flex-1 whitespace-pre-line`}>
+        <div
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg border-r border-dashed p-4`}
+          aria-labelledby="qaTextHeading"
+        >
           ${diff.map((part) => {
             return html`
               <span
@@ -36,7 +39,10 @@ function renderDiff(
             `;
           })}
         </div>
-        <div class=${tw`flex-1 whitespace-pre-line`}>
+        <div
+          class=${tw`flex-1 overflow-hidden whitespace-pre-line rounded-lg p-4`}
+          aria-labelledby="crawlTextHeading"
+        >
           ${diff.map((part) => {
             return html`
               <span
@@ -57,19 +63,25 @@ function renderDiff(
 
 export function renderText(crawlData: ReplayData, qaData: ReplayData) {
   return html`
-    <div class=${tw`mb-2 flex justify-between text-base font-medium`}>
-      <h3 id="qaTextHeading">${msg("Crawl Text")}</h3>
-      <h3 id="crawlTextHeading">${msg("Replay Text")}</h3>
+    <div class=${tw`flex h-full flex-col outline`}>
+      <div class=${tw`mb-2 flex text-base font-medium`}>
+        <h3 id="qaTextHeading" class=${tw`flex-1`}>${msg("Crawl Text")}</h3>
+        <h3 id="crawlTextHeading" class=${tw`flex-1`}>${msg("Replay Text")}</h3>
+      </div>
+      <div
+        class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}
+      >
+        ${guard(
+          [crawlData, qaData],
+          () => html`
+            <div class=${tw`flex`}>
+              ${when(crawlData?.text && qaData?.text, () =>
+                renderDiff(crawlData!.text!, qaData!.text!),
+              )}
+            </div>
+          `,
+        )}
+      </div>
     </div>
-    ${guard(
-      [crawlData, qaData],
-      () => html`
-        <div class=${tw`flex border placeholder:rounded`}>
-          ${when(crawlData?.text && qaData?.text, () =>
-            renderDiff(qaData!.text!, crawlData!.text!),
-          )}
-        </div>
-      `,
-    )}
   `;
 }

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -603,21 +603,18 @@ export class Dashboard extends LiteElement {
     renderFooter?: (metric: Metrics) => TemplateResult,
   ) {
     return html`
-      <section class="flex flex-1 flex-col rounded border p-4">
-        <h2 class="mb-3 border-b pb-3 text-lg font-semibold leading-none">
-          ${title}
-        </h2>
-        <div class="flex-1">
-          ${when(
-            this.metrics,
-            () => renderContent(this.metrics!),
-            this.renderCardSkeleton,
-          )}
-        </div>
-        ${when(renderFooter && this.metrics, () =>
-          renderFooter!(this.metrics!),
+      <btrix-card class="flex-1">
+        <span slot="title">${title}</span>
+        ${when(
+          this.metrics,
+          () => renderContent(this.metrics!),
+          this.renderCardSkeleton,
         )}
-      </section>
+        ${when(
+          renderFooter && this.metrics,
+          () => html`<div slot="footer">${renderFooter!(this.metrics!)}</div>`,
+        )}
+      </btrix-card>
     `;
   }
 

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
-import type { QATab } from "./archived-item-qa";
+import type { QATab } from "./archived-item-qa/types";
 import type { Tab as CollectionTab } from "./collection-detail";
 import type {
   Member,
@@ -31,7 +31,7 @@ import "./workflows-list";
 import "./workflows-new";
 import "./archived-item-detail";
 import "./archived-items";
-import "./archived-item-qa";
+import "./archived-item-qa/archived-item-qa";
 import "./collections-list";
 import "./collection-detail";
 import "./browser-profiles-detail";

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -278,10 +278,12 @@
 
   .offscreen {
     position: absolute;
-    left: -9999px;
-    bottom: -9999px;
+    left: -100vw;
+    bottom: -100vh;
     visibility: hidden;
-    clip: rect(0 0 0 0);
+    width: 0;
+    height: 0;
+    overflow: hidden;
   }
 
   .scrollbar-hidden {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -146,6 +146,8 @@ type ArchivedItemBase = {
   seedCount: number | null;
   tags: string[];
   crawlExecSeconds: number;
+  qaCrawlExecSeconds: number;
+  reviewStatus: "good" | "acceptable" | "failure" | null;
 };
 
 export type Crawl = ArchivedItemBase &

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1354,6 +1354,11 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/diff@^5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.0.9.tgz#31977962175079c2048315febeb8fd5f520192c6"
+  integrity sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -3591,6 +3596,11 @@ diff@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
+
+diff@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Optimize loading: create a proxy iframe for loading from service worker, to be able to fetch() directly from serviceworker:
- fetch to blob and use blob URL for `<img>`
- fetch to text for text tab
- fetch json for resources

Text Tab: Show text content in each pane (no diff yet)

Resources: Aggregate resources JSON by 'type', also group into good (status < 400) /bad (status >= 400)

Minor styling tweaks: split nav bar into two rows, add height to replay. Only load url in RWP when actually showing replay to avoid unnecessary background loading.