### PR TITLE
Adds documentation for exporting files

### DIFF
--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -35,9 +35,11 @@ The Replay tab displays the web content contained within the archived item.
 
 For more details on navigating web archives within ReplayWeb.page, see the [ReplayWeb.page user documentation.](https://replayweb.page/docs/exploring)
 
-### Files
+### Exporting Files
 
-The Files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes.
+While crawling, Browsertrix will output multiple WACZ files — the crawler aims to output files in consistently sized chunks, additionally each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
+
+The Files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
 
 ### Error Logs
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -37,7 +37,7 @@ For more details on navigating web archives within ReplayWeb.page, see the [Repl
 
 ### Exporting Files
 
-While crawling, Browsertrix will output multiple WACZ files — the crawler aims to output files in consistently sized chunks, additionally each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
+While crawling, Browsertrix will output one or more WACZ files — the crawler aims to output files in consistently sized chunks, and each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
 
 The Files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -39,7 +39,7 @@ For more details on navigating web archives within ReplayWeb.page, see the [Repl
 
 While crawling, Browsertrix will output multiple WACZ files — the crawler aims to output files in consistently sized chunks, additionally each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
 
-The Files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
+The Files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
 
 ### Error Logs
 

--- a/docs/user-guide/collections.md
+++ b/docs/user-guide/collections.md
@@ -17,6 +17,10 @@ A crawl workflow can also be set to [automatically add any completed archived it
 
 Collections are private by default, but can be made public by marking them as sharable in the Metadata step of collection creation, or by toggling the _Collection is Shareable_ switch in the share collection dialogue.
 
-After a collection has been made public, it can be shared with others using the public URL available in the share collection dialogue. The collection can also be embedded into other websites using the provided embed code. Unsharing the collection will break any previously shared links.
+After a collection has been made public, it can be shared with others using the public URL available in the share collection dialogue. The collection can also be embedded into other websites using the provided embed code. Un-sharing the collection will break any previously shared links.
 
 For further resources on embedding archived web content into your own website, see the [ReplayWeb.page docs page on embedding](https://replayweb.page/docs/embedding).
+
+## Downloading Collections
+
+Downloading a collection will export every archived item within it as a single WACZ file. To download a collection, use the _Download Collection_ option under the collection's _Actions_ dropdown.


### PR DESCRIPTION
Closes #1642 

### Changes
- Adds section to the collections page on downloading collections
- Changes the Files section on the archived items page to be more explicit about downloading files because that's the only action you can do there!