### PR TITLE
fix issue with incorrect number of total pages if any of the seeds is a redirect

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1178,6 +1178,11 @@ class CrawlOperator(BaseOperator):
             pages_done = await redis.llen(f"{crawl_id}:d")
 
         pages_found = await redis.scard(f"{crawl_id}:s")
+        # account for extra seeds and subtract from seen list
+        extra_seeds = await redis.llen(f"{crawl_id}:extraSeeds")
+        if extra_seeds:
+            pages_found -= extra_seeds
+
         sizes = await redis.hgetall(f"{crawl_id}:size")
         archive_size = sum(int(x) for x in sizes.values())
 


### PR DESCRIPTION
Following changes in webrecorder/browsertrix-crawler#475, webrecorder/browsertrix-crawler#509, the crawler adds a redirected seed to the seen list. To account for this, it needs to be subtracted to get the total page count.

To test, run a crawl with page limit (eg. 3) and a seed that redirects (eg. www.webrecorder.net).
Before PR, setting a limit of 3 will result in 3/4 pages, with this fix, it should say 3/3.