### PR TITLE
Remove URL prefix dropdown from new browser profile screen

### DIFF
--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -47,7 +47,7 @@ export class NewBrowserProfileDialog extends LiteElement {
         @reset=${this.onReset}
         @submit=${this.onSubmit}
       >
-        <div class="grid gap-5">
+        <div class="grid">
           <div>
             <label
               id="startingUrlLabel"
@@ -57,21 +57,10 @@ export class NewBrowserProfileDialog extends LiteElement {
             </label>
 
             <div class="flex">
-              <sl-select
-                class="mr-1 max-w-[8rem] grow-0"
-                name="urlPrefix"
-                value="https://"
-                hoist
-                @sl-hide=${this.stopProp}
-                @sl-after-hide=${this.stopProp}
-              >
-                <sl-option value="http://">http://</sl-option>
-                <sl-option value="https://">https://</sl-option>
-              </sl-select>
               <sl-input
                 class="grow"
                 name="url"
-                placeholder=${msg("example.com")}
+                placeholder=${msg("https://example.com")}
                 autocomplete="off"
                 aria-labelledby="startingUrlLabel"
                 required
@@ -134,13 +123,15 @@ export class NewBrowserProfileDialog extends LiteElement {
     this.isSubmitting = true;
 
     const formData = new FormData(event.target as HTMLFormElement);
-    const url = formData.get("url") as string;
+    let url = formData.get("url") as string;
 
     try {
+      url = url.trim();
+      if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        url = `https://${url}`;
+      }
       const data = await this.createBrowser({
-        url: `${formData.get("urlPrefix")?.toString()}${url.substring(
-          url.indexOf(",") + 1,
-        )}`,
+        url: url,
         crawlerChannel: this.crawlerChannel,
       });
 


### PR DESCRIPTION
Closes #1646 

Switch to a text field and prepend `https://` as prefix if no valid prefix is provided in the provided URL.

I checked and no docs changes seem to be needed for this change.

## Screenshots

### No crawler channels configured

<img width="517" alt="Screen Shot 2024-04-08 at 12 55 30 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/772b4a01-b012-4077-9649-b8b158c408ad">

### Crawler channels configured

<img width="529" alt="Screen Shot 2024-04-08 at 12 51 13 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/4a9d7483-79c5-42d3-b19a-775da5186b73">
