### PR TITLE
Update QA tab page list and standardize review statuses

### DIFF
--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -106,6 +106,7 @@ export class Pagination extends LitElement {
         transition: opacity 0.2s;
         min-height: 1.5rem;
         min-width: 1.5rem;
+        user-select: none;
       }
 
       .navButton[disabled] {

--- a/frontend/src/features/qa/index.ts
+++ b/frontend/src/features/qa/index.ts
@@ -1,3 +1,3 @@
 export * from "./page-list";
-import("./page-qa-toolbar");
+import("./page-qa-approval");
 import("./qa-run-dropdown");

--- a/frontend/src/features/qa/page-list/helpers/reviewStatus.ts
+++ b/frontend/src/features/qa/page-list/helpers/reviewStatus.ts
@@ -1,4 +1,6 @@
-import { type ArchivedItemPage } from "@/types/crawler";
+import { msg } from "@lit/localize";
+
+import type { ArchivedItemPage } from "@/types/crawler";
 import { cached } from "@/utils/weakCache";
 
 export type ReviewStatus = "approved" | "rejected" | "commentOnly" | null;
@@ -13,3 +15,19 @@ export const approvalFromPage = cached(
         ? "approved"
         : "rejected",
 );
+
+export const labelFor = cached((status: ReviewStatus) => {
+  switch (status) {
+    // Approval
+    case "approved":
+      return msg("Approved");
+    case "rejected":
+      return msg("Rejected");
+    case "commentOnly":
+      return msg("Comments Only");
+
+    // No data
+    default:
+      return;
+  }
+});

--- a/frontend/src/features/qa/page-list/page-list.ts
+++ b/frontend/src/features/qa/page-list/page-list.ts
@@ -10,7 +10,11 @@ import type { APIPaginatedList, APISortQuery } from "@/types/api";
 import type { ArchivedItemQAPage } from "@/types/qa";
 
 export type SortDirection = "asc" | "desc";
-export type SortableFieldNames = "textMatch" | "screenshotMatch" | "approved";
+export type SortableFieldNames =
+  | "textMatch"
+  | "screenshotMatch"
+  | "approved"
+  | "notes";
 type SortableFields = Record<
   SortableFieldNames,
   {
@@ -30,6 +34,10 @@ const sortableFields = {
   approved: {
     label: msg("Review"),
     // defaultDirection: "asc",
+  },
+  notes: {
+    label: msg("Comments"),
+    defaultDirection: "desc",
   },
   // url: {
   //   label: msg("Page URL"),
@@ -138,7 +146,9 @@ export class PageList extends TailwindElement {
                   <btrix-qa-page
                     class="is-leaf -my-4 scroll-my-8 py-4 first-of-type:mt-0 last-of-type:mb-0"
                     .page=${page}
-                    statusField=${this.orderBy.field}
+                    statusField=${this.orderBy.field === "notes"
+                      ? "approved"
+                      : this.orderBy.field}
                     ?selected=${page.id === this.itemPageId}
                   >
                   </btrix-qa-page>
@@ -211,6 +221,10 @@ export class PageList extends TailwindElement {
                 detail.sortBy = "approved";
                 detail.sortDirection = 1;
                 break;
+              case "comments":
+                detail.sortBy = "notes";
+                detail.sortDirection = -1;
+                break;
               // case "url":
               //   detail.sortBy = "url";
               //   detail.sortDirection = 1;
@@ -235,6 +249,7 @@ export class PageList extends TailwindElement {
           <sl-option value="textMatch"
             >${msg("Worst extracted text match")}</sl-option
           >
+          <sl-option value="comments">${msg("Most comments")}</sl-option>
           <sl-option value="approved">${msg("Recently approved")}</sl-option>
           <sl-option value="notApproved">${msg("Not approved")}</sl-option>
         </sl-select>

--- a/frontend/src/features/qa/page-list/page-list.ts
+++ b/frontend/src/features/qa/page-list/page-list.ts
@@ -32,7 +32,7 @@ const sortableFields = {
     defaultDirection: "desc",
   },
   approved: {
-    label: msg("Review"),
+    label: msg("Approval"),
     // defaultDirection: "asc",
   },
   notes: {

--- a/frontend/src/features/qa/page-list/page-list.ts
+++ b/frontend/src/features/qa/page-list/page-list.ts
@@ -28,7 +28,7 @@ const sortableFields = {
     defaultDirection: "desc",
   },
   approved: {
-    label: msg("Review Status"),
+    label: msg("Review"),
     // defaultDirection: "asc",
   },
   // url: {
@@ -85,6 +85,13 @@ export class PageList extends TailwindElement {
     field: "screenshotMatch",
     direction: "asc",
   };
+
+  @property({ type: Object })
+  filterBy: {
+    reviewed?: boolean;
+    approved?: boolean;
+    hasNotes?: boolean;
+  } = {};
 
   @query(".scrollContainer")
   private readonly scrollContainer?: HTMLElement | null;
@@ -236,11 +243,20 @@ export class PageList extends TailwindElement {
   }
 
   private renderFilterControl() {
+    const value = () => {
+      if (this.filterBy.approved) return "approved";
+      if (this.filterBy.approved === false) return "rejected";
+      if (this.filterBy.reviewed) return "reviewed";
+      if (this.filterBy.reviewed === false) return "notReviewed";
+      if (this.filterBy.hasNotes) return "hasNotes";
+      return "";
+    };
     return html`
       <div class="w-full">
         <sl-select
           class="label-same-line"
-          label=${msg("Review status:")}
+          label=${msg("Approval:")}
+          value=${value()}
           @sl-change=${(e: SlChangeEvent) => {
             const { value } = e.target as SlSelect;
             const detail: QaFilterChangeDetail = {
@@ -277,13 +293,13 @@ export class PageList extends TailwindElement {
           size="small"
         >
           <sl-option value="">${msg("Any")}</sl-option>
-          <sl-option value="notReviewed">${msg("No review")}</sl-option>
-          <sl-option value="reviewed">${msg("Reviewed")}</sl-option>
-          <sl-option value="approved">${msg("Reviewed as approved")}</sl-option>
-          <sl-option value="rejected">${msg("Reviewed as rejected")}</sl-option>
-          <sl-option value="hasNotes"
-            >${msg("Reviewed with comment")}</sl-option
+          <sl-option value="notReviewed">${msg("None")}</sl-option>
+          <sl-option value="reviewed"
+            >${msg("Approved, rejected, or commented")}</sl-option
           >
+          <sl-option value="approved">${msg("Approved")}</sl-option>
+          <sl-option value="rejected">${msg("Rejected")}</sl-option>
+          <sl-option value="hasNotes">${msg("Commented")}</sl-option>
         </sl-select>
       </div>
     `;

--- a/frontend/src/features/qa/page-list/ui/page-details.ts
+++ b/frontend/src/features/qa/page-list/ui/page-details.ts
@@ -86,21 +86,18 @@ export const pageDetails = (page: ArchivedItemQAPage) =>
         </span>
       </li>
     </ul>
-    ${page.notes?.[0]
+    ${page.notes?.length
       ? html` <sl-divider
             class="[--color:theme(colors.gray.200)] [--spacing:theme(spacing.3)]"
           ></sl-divider>
-          <ul class="text-xs leading-4">
-            ${page.notes.map(
-              (note) => html`
-                <li class="my-3 flex">
-                  <sl-icon
-                    name="chat-square-text-fill"
-                    class="mr-2 h-4 w-4 flex-none text-blue-600"
-                  ></sl-icon>
-                  ${note.text}
-                </li>
-              `,
-            )}
-          </ul>`
+          <div class="my-2 text-xs text-neutral-400">
+            ${msg("Newest comment:")}
+          </div>
+          <div class="mb-3 flex text-xs leading-4">
+            <sl-icon
+              name="chat-square-text-fill"
+              class="mr-2 h-4 w-4 flex-none text-blue-600"
+            ></sl-icon>
+            ${page.notes[page.notes.length - 1]?.text}
+          </div>`
       : nothing}`;

--- a/frontend/src/features/qa/page-list/ui/page.ts
+++ b/frontend/src/features/qa/page-list/ui/page.ts
@@ -10,7 +10,6 @@ import {
   severityFromMatch,
 } from "../helpers";
 import { approvalFromPage } from "../helpers/reviewStatus";
-import { type SortableFieldNames } from "../page-list";
 
 import { animateTo, shimKeyframesHeightAuto } from "./animate";
 import { pageDetails } from "./page-details";
@@ -25,7 +24,7 @@ export class QaPage extends TailwindElement {
   page?: ArchivedItemQAPage;
 
   @property({ type: String })
-  statusField: SortableFieldNames = "screenshotMatch";
+  statusField: "textMatch" | "screenshotMatch" | "approved" = "screenshotMatch";
 
   @property({ type: Boolean })
   selected = false;

--- a/frontend/src/features/qa/page-qa-approval.ts
+++ b/frontend/src/features/qa/page-qa-approval.ts
@@ -23,12 +23,12 @@ export type UpdateItemPageDetail = {
 };
 
 /**
- * Manage crawl QA page review
+ * Manage crawl QA page approval
  *
  * @fires btrix-update-item-page
  */
 @localized()
-@customElement("btrix-page-qa-toolbar")
+@customElement("btrix-page-qa-approval")
 export class PageQAToolbar extends TailwindElement {
   static styles = css`
     :host {
@@ -253,7 +253,7 @@ export class PageQAToolbar extends TailwindElement {
       </fieldset>
 
       <btrix-dialog
-        label=${msg("Page Review Comments")}
+        label=${msg("Page Comments")}
         ?open=${this.showComments}
         @sl-hide=${() => (this.showComments = false)}
       >
@@ -351,7 +351,7 @@ export class PageQAToolbar extends TailwindElement {
     } catch (e: unknown) {
       console.debug(e);
       this.notify.toast({
-        message: msg("Sorry, couldn't submit page review at this time."),
+        message: msg("Sorry, couldn't submit page approval at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/features/qa/page-qa-toolbar.ts
+++ b/frontend/src/features/qa/page-qa-toolbar.ts
@@ -277,7 +277,7 @@ export class PageQAToolbar extends TailwindElement {
       ${when(
         comments.length,
         () => html`
-          <btrix-details>
+          <btrix-details open>
             <span slot="title"
               >${msg(str`Comments (${comments.length.toLocaleString()})`)}</span
             >

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -56,7 +56,7 @@ type SectionName = (typeof SECTIONS)[number];
 @customElement("btrix-archived-item-detail")
 export class ArchivedItemDetail extends TailwindElement {
   static styles = css`
-    .qaPageList {
+    btrix-table {
       --btrix-cell-padding-top: var(--sl-spacing-x-small);
       --btrix-cell-padding-bottom: var(--sl-spacing-x-small);
       --btrix-cell-padding-left: var(--sl-spacing-small);
@@ -89,7 +89,7 @@ export class ArchivedItemDetail extends TailwindElement {
   isCrawler!: boolean;
 
   @state()
-  private crawl?: ArchivedItem;
+  crawl?: ArchivedItem;
 
   @state()
   private workflow?: Workflow;
@@ -101,13 +101,13 @@ export class ArchivedItemDetail extends TailwindElement {
   private logs?: APIPaginatedList<CrawlLog>;
 
   @state()
-  private qaRuns?: QARun[];
+  qaRuns?: QARun[];
 
   @state()
-  private pages?: APIPaginatedList<ArchivedItemPage>;
+  pages?: APIPaginatedList<ArchivedItemPage>;
 
   @state()
-  private qaRunId?: string;
+  qaRunId?: string;
 
   @state()
   activeTab: SectionName | undefined = "overview";
@@ -132,7 +132,7 @@ export class ArchivedItemDetail extends TailwindElement {
   // TODO localize
   private readonly numberFormatter = new Intl.NumberFormat();
   private readonly api = new APIController(this);
-  private readonly navigate = new NavigateController(this);
+  readonly navigate = new NavigateController(this);
   private readonly notify = new NotifyController(this);
 
   private get isActive(): boolean | null {
@@ -243,13 +243,14 @@ export class ArchivedItemDetail extends TailwindElement {
                 this.pages,
               ],
               () =>
-                renderQA({
-                  reviewStatus: this.crawl?.reviewStatus,
-                  qaCrawlExecSeconds: this.crawl?.qaCrawlExecSeconds,
-                  qaRuns: this.qaRuns,
-                  qaRunId: this.qaRunId,
-                  pages: this.pages,
-                }),
+                html`<div
+                  @btrix-qa-pages-page-change=${(e: PageChangeEvent) => {
+                    console.log(e);
+                    // e.stopPropagation();
+                  }}
+                >
+                  ${renderQA(this)}
+                </div>`,
             )}
           `,
         );
@@ -1240,7 +1241,7 @@ ${this.crawl?.description}
     );
   }
 
-  private async fetchPages(params?: APIPaginationQuery): Promise<void> {
+  async fetchPages(params?: APIPaginationQuery): Promise<void> {
     try {
       this.pages = await this.getPages({
         page: params?.page ?? this.pages?.page ?? 1,

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1249,7 +1249,7 @@ ${this.crawl?.description}
       let sortDirection = params?.sortDirection;
 
       if (!sortBy && this.qaPagesSortBySelect?.value[0]) {
-        const value = this.qaPagesSortBySelect?.value;
+        const value = this.qaPagesSortBySelect.value;
         if (value) {
           const [field, direction] = (
             Array.isArray(value) ? value[0] : value

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -145,7 +145,7 @@ function renderPageListControls(component: ArchivedItemDetail) {
             });
           }}
         >
-          <sl-option value="title.1">${msg("Title")} ></sl-option>
+          <sl-option value="title.1">${msg("Title")}</sl-option>
           <sl-option value="url.1">${msg("URL")}</sl-option>
           <sl-option value="notes.-1">${msg("Most comments")}</sl-option>
           <sl-option value="approved.-1">${msg("Recently approved")}</sl-option>

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -46,7 +46,7 @@ export const labelForCrawlReview = (severity: ArchivedItem["reviewStatus"]) => {
     case "failure":
       return msg("Poor");
     case "acceptable":
-      return msg("Acceptable");
+      return msg("Fair");
     case "good":
       return msg("Good");
     default:
@@ -273,14 +273,13 @@ export function renderQA(component: ArchivedItemDetail) {
             renderSpinner,
           )}
         </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Review")}>
+        <btrix-desc-list-item label=${msg("Crawl Rating")}>
           ${when(
             reviewStatus !== undefined,
             () => displayReviewStatus(reviewStatus),
             renderSpinner,
           )}
         </btrix-desc-list-item>
-
         <btrix-desc-list-item label=${msg("Elapsed Time")}>
           ${when(
             qaCrawlExecSeconds !== undefined,

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -138,7 +138,7 @@ function renderPageListControls(component: ArchivedItemDetail) {
             const [field, direction] = (
               Array.isArray(value) ? value[0] : value
             ).split(".");
-            component.fetchPages({
+            void component.fetchPages({
               sortBy: field,
               sortDirection: +direction,
               page: 1,

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -461,6 +461,7 @@ export class ArchivedItemQA extends TailwindElement {
                 ? "desc"
                 : "asc") as SortDirection,
             }}
+            .filterBy=${this.filterPagesBy}
             totalPages=${+(this.item?.stats?.done || 0)}
             @btrix-qa-pagination-change=${(
               e: CustomEvent<QaPaginationChangeDetail>,
@@ -493,7 +494,7 @@ export class ArchivedItemQA extends TailwindElement {
           <sl-radio-group
             class="mb-5"
             name="reviewStatus"
-            label=${msg("Crawl quality assessment")}
+            label=${msg("Crawl quality")}
             value=${this.item?.reviewStatus ?? ""}
             required
           >

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -950,6 +950,8 @@ export class ArchivedItemQA extends TailwindElement {
       this.pages = await this.getPages({
         page: params?.page ?? this.pages?.page ?? 1,
         pageSize: params?.pageSize ?? this.pages?.pageSize ?? DEFAULT_PAGE_SIZE,
+        sortBy: this.sortPagesBy.sortBy,
+        sortDirection: this.sortPagesBy.sortDirection,
       });
     } catch {
       this.notify.toast({
@@ -961,12 +963,10 @@ export class ArchivedItemQA extends TailwindElement {
   }
 
   private async getPages(
-    params?: APIPaginationQuery & { reviewed?: boolean },
+    params?: APIPaginationQuery & APISortQuery & { reviewed?: boolean },
   ): Promise<APIPaginatedList<ArchivedItemQAPage>> {
     const query = queryString.stringify(
       {
-        sortBy: this.sortPagesBy.sortBy,
-        sortDirection: this.sortPagesBy.sortDirection,
         ...(this.qaRunId ? this.filterPagesBy : {}),
         ...params,
       },

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -494,26 +494,10 @@ export class ArchivedItemQA extends TailwindElement {
           <sl-radio-group
             class="mb-5"
             name="reviewStatus"
-            label=${msg("Crawl Quality")}
+            label=${msg("Rate this crawl:")}
             value=${this.item?.reviewStatus ?? ""}
             required
           >
-            <sl-radio-button value="failure">
-              <sl-icon
-                name="patch-exclamation"
-                slot="prefix"
-                class="text-base"
-              ></sl-icon>
-              ${msg("Poor")}
-            </sl-radio-button>
-            <sl-radio-button value="acceptable" checked>
-              <sl-icon
-                name="patch-minus"
-                slot="prefix"
-                class="text-base"
-              ></sl-icon>
-              ${msg("Acceptable")}
-            </sl-radio-button>
             <sl-radio-button value="good">
               <sl-icon
                 name="patch-check"
@@ -521,6 +505,22 @@ export class ArchivedItemQA extends TailwindElement {
                 class="text-base"
               ></sl-icon>
               ${msg("Good")}
+            </sl-radio-button>
+            <sl-radio-button value="acceptable" checked>
+              <sl-icon
+                name="patch-minus"
+                slot="prefix"
+                class="text-base"
+              ></sl-icon>
+              ${msg("Fair")}
+            </sl-radio-button>
+            <sl-radio-button value="failure">
+              <sl-icon
+                name="patch-exclamation"
+                slot="prefix"
+                class="text-base"
+              ></sl-icon>
+              ${msg("Poor")}
             </sl-radio-button>
           </sl-radio-group>
           <sl-textarea

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -31,7 +31,7 @@ import {
   type SortableFieldNames,
   type SortDirection,
 } from "@/features/qa/page-list/page-list";
-import { type UpdateItemPageDetail } from "@/features/qa/page-qa-toolbar";
+import { type UpdateItemPageDetail } from "@/features/qa/page-qa-approval";
 import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
 import type {
   APIPaginatedList,
@@ -375,14 +375,14 @@ export class ArchivedItemQA extends TailwindElement {
               <sl-icon slot="prefix" name="arrow-left"></sl-icon>
               ${msg("Previous Page")}
             </sl-button>
-            <btrix-page-qa-toolbar
+            <btrix-page-qa-approval
               .authState=${this.authState}
               .orgId=${this.orgId}
               .itemId=${this.itemId}
               .pageId=${this.itemPageId}
               .page=${this.page}
               @btrix-update-item-page=${this.onUpdateItemPage}
-            ></btrix-page-qa-toolbar>
+            ></btrix-page-qa-approval>
             <sl-button
               variant="primary"
               size="small"

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -494,7 +494,7 @@ export class ArchivedItemQA extends TailwindElement {
           <sl-radio-group
             class="mb-5"
             name="reviewStatus"
-            label=${msg("Crawl quality")}
+            label=${msg("Crawl Quality")}
             value=${this.item?.reviewStatus ?? ""}
             required
           >
@@ -504,7 +504,7 @@ export class ArchivedItemQA extends TailwindElement {
                 slot="prefix"
                 class="text-base"
               ></sl-icon>
-              ${msg("Failed")}
+              ${msg("Poor")}
             </sl-radio-button>
             <sl-radio-button value="acceptable" checked>
               <sl-icon


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1508

### Changes

- Paginates QA tab page list
- Sort QA tab page list by title, URL, comments, and approval; displays all sortable fields
- Standardizes page "reviews" -> "approvals"
- Standardizes crawl review rating labels
- Displays only latest comment in review page list

Main difference from mocks is I added a separate "Comments" column since we can sort by comment count.

### Manual testing

1. Log in as crawler
2. Go to Archived Items and click archived item with review
3. Click QA. Verify "Crawl Rating" and page list renders as expected
4. Update page list sorting and pagination controls. Verify list updates as expected
5. Click page in list. Verify you've navigated to page in crawl review view

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Item - QA tab | <img width="1044" alt="Screenshot 2024-04-08 at 4 13 54 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/ae0d688f-d0a7-4646-a6ef-b4bde8e550fa"> |
| Crawl Review - Pages list sort | <img width="328" alt="Screenshot 2024-04-08 at 4 15 24 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/3f14b8b0-0a0e-4fe9-bbae-1def503fc1fd"> |
| Crawl Review - Pages list filter | <img width="582" alt="Screenshot 2024-04-08 at 12 54 20 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/b634d34f-85d5-4670-8faf-8f3a60ae11a8"> |


<!-- ### Follow-ups -->
