### PR TITLE
Stop, cancel, and download QA run

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -19,6 +19,7 @@ import("./language-select");
 import("./locale-picker");
 import("./markdown-editor");
 import("./markdown-viewer");
+import("./menu-item-link");
 import("./meter");
 import("./numbered-list");
 import("./overflow-dropdown");

--- a/frontend/src/components/ui/menu-item-link.ts
+++ b/frontend/src/components/ui/menu-item-link.ts
@@ -1,0 +1,67 @@
+import { localized } from "@lit/localize";
+import type { SlDropdown } from "@shoelace-style/shoelace";
+import menuItemStyles from "@shoelace-style/shoelace/dist/components/menu-item/menu-item.styles.js";
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
+import { NavigateController } from "@/controllers/navigate";
+
+/**
+ * Enables `href` on menu items
+ * See https://github.com/shoelace-style/shoelace/discussions/1629
+ */
+@localized()
+@customElement("btrix-menu-item-link")
+export class Component extends TailwindElement {
+  static styles = [menuItemStyles];
+
+  @property({ type: String })
+  href = "";
+
+  @property({ type: Boolean })
+  download: boolean | string = false;
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  private readonly navigate = new NavigateController(this);
+
+  render() {
+    return html`<a
+      href=${this.href}
+      id="anchor"
+      part="base"
+      class=${classMap({
+        "menu-item": true,
+        "menu-item--disabled": this.disabled,
+      })}
+      download=${this.download}
+      aria-disabled=${this.disabled}
+      @click=${(e: MouseEvent) => {
+        if (this.disabled) return;
+
+        if (this.download) {
+          const dropdown = this.shadowRoot!.host.closest<
+            SlDropdown | OverflowDropdown
+          >("sl-dropdown, btrix-overflow-dropdown");
+
+          if (dropdown) {
+            dropdown.hide();
+          }
+        } else {
+          this.navigate.link(e);
+        }
+      }}
+    >
+      <span part="checked-icon" class="menu-item__check">
+        <sl-icon name="check" library="system" aria-hidden="true"></sl-icon>
+      </span>
+      <slot name="prefix" part="prefix" class="menu-item__prefix"></slot>
+      <slot part="label" class="menu-item__label"></slot>
+      <slot name="suffix" part="suffix" class="menu-item__suffix"></slot>
+    </a>`;
+  }
+}

--- a/frontend/src/components/ui/menu-item-link.ts
+++ b/frontend/src/components/ui/menu-item-link.ts
@@ -12,10 +12,12 @@ import { NavigateController } from "@/controllers/navigate";
 /**
  * Enables `href` on menu items
  * See https://github.com/shoelace-style/shoelace/discussions/1629
+ *
+ * Based on https://github.com/shoelace-style/shoelace/blob/d0b71adb81e21687a5ef036565dad44bc609bcce/src/components/menu-item/menu-item.component.ts
  */
 @localized()
 @customElement("btrix-menu-item-link")
-export class Component extends TailwindElement {
+export class MenuItemLink extends TailwindElement {
   static styles = [menuItemStyles];
 
   @property({ type: String })
@@ -27,6 +29,9 @@ export class Component extends TailwindElement {
   @property({ type: Boolean })
   disabled = false;
 
+  @property({ type: Boolean })
+  loading = false;
+
   private readonly navigate = new NavigateController(this);
 
   render() {
@@ -37,11 +42,12 @@ export class Component extends TailwindElement {
       class=${classMap({
         "menu-item": true,
         "menu-item--disabled": this.disabled,
+        "menu-item--loading": this.loading,
       })}
       download=${this.download}
       aria-disabled=${this.disabled}
       @click=${(e: MouseEvent) => {
-        if (this.disabled) return;
+        if (this.disabled || this.loading) return;
 
         if (this.download) {
           const dropdown = this.shadowRoot!.host.closest<
@@ -62,6 +68,10 @@ export class Component extends TailwindElement {
       <slot name="prefix" part="prefix" class="menu-item__prefix"></slot>
       <slot part="label" class="menu-item__label"></slot>
       <slot name="suffix" part="suffix" class="menu-item__suffix"></slot>
+      <span part="submenu-icon" class="menu-item__chevron">
+        <!-- This also functions as a spacer in sl-menu-item -->
+      </span>
+      ${this.loading ? html` <sl-spinner part="spinner"></sl-spinner> ` : ""}
     </a>`;
   }
 }

--- a/frontend/src/components/ui/menu-item-link.ts
+++ b/frontend/src/components/ui/menu-item-link.ts
@@ -55,7 +55,7 @@ export class MenuItemLink extends TailwindElement {
           >("sl-dropdown, btrix-overflow-dropdown");
 
           if (dropdown) {
-            dropdown.hide();
+            void dropdown.hide();
           }
         } else {
           this.navigate.link(e);

--- a/frontend/src/features/qa/page-qa-approval.ts
+++ b/frontend/src/features/qa/page-qa-approval.ts
@@ -198,8 +198,7 @@ export class PageQAToolbar extends TailwindElement {
   private readonly notify = new NotifyController(this);
 
   render() {
-    console.log(this.disabled);
-    const disabled = this.disabled ?? !this.page;
+    const disabled = this.disabled || !this.page;
     const approved = this.page?.approved === true;
     const rejected = this.page?.approved === false;
     const commented = Boolean(this.page?.notes?.length);

--- a/frontend/src/features/qa/page-qa-approval.ts
+++ b/frontend/src/features/qa/page-qa-approval.ts
@@ -167,20 +167,23 @@ export class PageQAToolbar extends TailwindElement {
     }
   `;
 
-  @property({ type: Object })
+  @property({ type: Object, attribute: false })
   authState?: AuthState;
 
-  @property({ type: String })
+  @property({ type: String, attribute: false })
   orgId?: string;
 
-  @property({ type: String })
+  @property({ type: String, attribute: false })
   itemId?: string;
 
-  @property({ type: String })
+  @property({ type: String, attribute: false })
   pageId?: string;
 
-  @property({ type: Object })
+  @property({ type: Object, attribute: false })
   page?: ArchivedItemPage;
+
+  @property({ type: Boolean })
+  disabled = false;
 
   @state()
   private showComments = false;
@@ -195,7 +198,8 @@ export class PageQAToolbar extends TailwindElement {
   private readonly notify = new NotifyController(this);
 
   render() {
-    const disabled = !this.page;
+    console.log(this.disabled);
+    const disabled = this.disabled ?? !this.page;
     const approved = this.page?.approved === true;
     const rejected = this.page?.approved === false;
     const commented = Boolean(this.page?.notes?.length);

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -26,7 +26,7 @@ import type {
 import type { QARun } from "@/types/qa";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
-import { isActive } from "@/utils/crawler";
+import { finishedCrawlStates, isActive } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { tw } from "@/utils/tailwind";
 
@@ -162,8 +162,13 @@ export class ArchivedItemDetail extends TailwindElement {
       void this.fetchWorkflow();
     }
     if (changedProperties.has("qaRuns") && this.qaRuns) {
-      if (!this.qaRunId && this.qaRuns[0]?.id) {
-        this.qaRunId = this.qaRuns[0].id;
+      if (!this.qaRunId) {
+        const firstFinishedQARun = this.qaRuns.find(({ state }) =>
+          finishedCrawlStates.includes(state),
+        );
+        if (firstFinishedQARun) {
+          this.qaRunId = firstFinishedQARun.id;
+        }
       }
     }
   }

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -32,7 +32,6 @@ import { tw } from "@/utils/tailwind";
 
 import "./ui/qa";
 
-
 const SECTIONS = [
   "overview",
   "qa",
@@ -103,10 +102,10 @@ export class ArchivedItemDetail extends TailwindElement {
   private openDialogName?: "scale" | "metadata" | "exclusions";
 
   @query("#stopQARunDialog")
-  private stopQARunDialog?: Dialog | null;
+  private readonly stopQARunDialog?: Dialog | null;
 
   @query("#cancelQARunDialog")
-  private cancelQARunDialog?: Dialog | null;
+  private readonly cancelQARunDialog?: Dialog | null;
 
   private get listUrl(): string {
     let path = "items";
@@ -947,14 +946,14 @@ ${this.crawl?.description}
             <sl-button-group>
               <sl-button
                 size="small"
-                @click=${() => this.stopQARunDialog?.show()}
+                @click=${() => void this.stopQARunDialog?.show()}
               >
                 <sl-icon name="slash-square" slot="prefix"></sl-icon>
                 <span>${msg("Stop Analysis")}</span>
               </sl-button>
               <sl-button
                 size="small"
-                @click=${() => this.cancelQARunDialog?.show()}
+                @click=${() => void this.cancelQARunDialog?.show()}
               >
                 <sl-icon
                   name="x-octagon"
@@ -1008,7 +1007,7 @@ ${this.crawl?.description}
           <sl-button
             size="small"
             .autofocus=${true}
-            @click=${() => this.stopQARunDialog?.hide()}
+            @click=${() => void this.stopQARunDialog?.hide()}
           >
             ${msg("Keep Running")}
           </sl-button>
@@ -1017,7 +1016,7 @@ ${this.crawl?.description}
             variant="primary"
             @click=${async () => {
               await this.stopQARun();
-              this.stopQARunDialog?.hide();
+              void this.stopQARunDialog?.hide();
             }}
             >${msg("Stop Analysis")}</sl-button
           >
@@ -1031,7 +1030,7 @@ ${this.crawl?.description}
           <sl-button
             size="small"
             .autofocus=${true}
-            @click=${() => this.cancelQARunDialog?.hide()}
+            @click=${async () => this.cancelQARunDialog?.hide()}
           >
             ${msg("Keep Running")}
           </sl-button>
@@ -1040,7 +1039,7 @@ ${this.crawl?.description}
             variant="primary"
             @click=${async () => {
               await this.cancelQARun();
-              this.cancelQARunDialog?.hide();
+              void this.cancelQARunDialog?.hide();
             }}
             >${msg("Cancel Analysis")}</sl-button
           >

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -326,14 +326,13 @@ export class ArchivedItemDetailQA extends TailwindElement {
                 }}
               >
                 <sl-menu>
-                  <sl-menu-item
-                    @click=${() => {
-                      console.log("download");
-                    }}
+                  <btrix-menu-item-link
+                    href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/qa/${run.id}/replay.json`}
+                    download
                   >
                     <sl-icon name="download" slot="prefix"></sl-icon>
                     ${msg("Download QA Run")}
-                  </sl-menu-item>
+                  </btrix-menu-item-link>
                   <sl-divider></sl-divider>
                   <sl-menu-item
                     @click=${() => {

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -36,6 +36,7 @@ import type {
 import type { ArchivedItem, ArchivedItemPage } from "@/types/crawler";
 import type { QARun } from "@/types/qa";
 import { type AuthState } from "@/utils/AuthService";
+import { finishedCrawlStates } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 
 const iconForCrawlReview = (status: ArchivedItem["reviewStatus"]) => {
@@ -215,8 +216,8 @@ export class ArchivedItemDetailQA extends TailwindElement {
                 ${msg("QA Analysis")}
               </h4>
               ${when(this.qaRuns, (qaRuns) => {
-                const finishedQARuns = qaRuns.filter(
-                  ({ finished }) => finished,
+                const finishedQARuns = qaRuns.filter(({ state }) =>
+                  finishedCrawlStates.includes(state),
                 );
                 return html`
                   <btrix-qa-run-dropdown
@@ -292,7 +293,6 @@ export class ArchivedItemDetailQA extends TailwindElement {
   }
 
   private readonly renderQARunRows = (qaRuns: QARun[]) => {
-    console.log(qaRuns);
     return qaRuns.map(
       (run, idx) => html`
         <btrix-table-row class=${idx > 0 ? "border-t" : ""}>

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -215,9 +215,9 @@ export class ArchivedItemDetailQA extends TailwindElement {
                 ${msg("QA Analysis")}
               </h4>
               ${when(this.qaRuns, (qaRuns) => {
-                const finishedQARuns = qaRuns.length
-                  ? qaRuns.filter(({ finished }) => finished)
-                  : [];
+                const finishedQARuns = qaRuns.filter(
+                  ({ finished }) => finished,
+                );
                 return html`
                   <btrix-qa-run-dropdown
                     .items=${finishedQARuns}
@@ -328,9 +328,9 @@ export class ArchivedItemDetailQA extends TailwindElement {
               <btrix-overflow-dropdown
                 @sl-show=${async (e: SlShowEvent) => {
                   const dropdown = e.currentTarget as OverflowDropdown;
-                  const downloadLink = dropdown.querySelector(
+                  const downloadLink = dropdown.querySelector<MenuItemLink>(
                     "btrix-menu-item-link",
-                  ) as MenuItemLink;
+                  );
 
                   if (!downloadLink) {
                     console.debug("no download link");
@@ -358,7 +358,6 @@ export class ArchivedItemDetailQA extends TailwindElement {
                         </btrix-menu-item-link>
                         <sl-divider></sl-divider>
                       `}
-
                   <sl-menu-item
                     @click=${() => {
                       console.log("delete");

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -1,5 +1,5 @@
 import { localized, msg } from "@lit/localize";
-import { serialize } from "@shoelace-style/shoelace";
+import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { merge } from "immutable";
 import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -41,7 +41,7 @@ import type {
 import type { ArchivedItem } from "@/types/crawler";
 import type { ArchivedItemQAPage, QARun } from "@/types/qa";
 import { type AuthState } from "@/utils/AuthService";
-import { renderName } from "@/utils/crawler";
+import { isActive, renderName } from "@/utils/crawler";
 
 const DEFAULT_PAGE_SIZE = 100;
 
@@ -103,7 +103,7 @@ export class ArchivedItemQA extends TailwindElement {
   private item?: ArchivedItem;
 
   @state()
-  private qaRuns: QARun[] | undefined = [];
+  qaRuns: QARun[] | undefined = [];
 
   @state()
   private pages?: APIPaginatedList<ArchivedItemQAPage>;
@@ -220,15 +220,15 @@ export class ArchivedItemQA extends TailwindElement {
     if (changedProperties.has("itemId") && this.itemId) {
       void this.initItem();
     } else if (
-      changedProperties.get("filterPagesBy") ||
-      changedProperties.get("sortPagesBy") ||
-      changedProperties.get("qaRunId")
+      changedProperties.has("filterPagesBy") ||
+      changedProperties.has("sortPagesBy") ||
+      changedProperties.has("qaRunId")
     ) {
       void this.fetchPages();
     }
     if (
       (changedProperties.has("itemPageId") ||
-        changedProperties.get("qaRunId")) &&
+        changedProperties.has("qaRunId")) &&
       this.itemPageId
     ) {
       void this.fetchPage();
@@ -251,20 +251,18 @@ export class ArchivedItemQA extends TailwindElement {
 
   private async initItem() {
     void this.fetchCrawl();
-
-    if (this.qaRunId) {
-      void this.fetchQARuns();
-    } else {
-      await this.fetchQARuns();
-    }
-
-    if (this.itemPageId) {
-      void this.fetchPages({ page: 1 });
-    } else {
-      await this.fetchPages({ page: 1 });
-    }
+    await this.fetchQARuns();
 
     const searchParams = new URLSearchParams(window.location.search);
+
+    if (this.qaRunId) {
+      if (this.itemPageId) {
+        void this.fetchPages({ page: 1 });
+      } else {
+        await this.fetchPages({ page: 1 });
+      }
+    }
+
     const firstQaRun = this.qaRuns?.[0];
     const firstPage = this.pages?.items[0];
 
@@ -315,6 +313,8 @@ export class ArchivedItemQA extends TailwindElement {
     const finishedQARuns = this.qaRuns
       ? this.qaRuns.filter(({ finished }) => finished)
       : [];
+    const currentQARun = this.qaRuns?.find(({ id }) => id === this.qaRunId);
+    const disableReview = !currentQARun || isActive(currentQARun.state);
 
     return html`
       ${this.renderHidden()}
@@ -347,16 +347,24 @@ export class ArchivedItemQA extends TailwindElement {
               @click=${this.navigate.link}
               >${msg("Exit Review")}</sl-button
             >
-            <sl-button
-              variant="success"
-              size="small"
-              @click=${() => void this.reviewDialog?.show()}
+            <sl-tooltip
+              content=${msg(
+                "Reviews are temporarily disabled during analysis runs.",
+              )}
+              ?disabled=${!disableReview}
             >
-              <sl-icon slot="prefix" name="patch-check"> </sl-icon>
-              ${this.item?.reviewStatus
-                ? msg("Update Review")
-                : msg("Finish Review")}</sl-button
-            >
+              <sl-button
+                variant="success"
+                size="small"
+                @click=${() => void this.reviewDialog?.show()}
+                ?disabled=${disableReview}
+              >
+                <sl-icon slot="prefix" name="patch-check"> </sl-icon>
+                ${this.item?.reviewStatus
+                  ? msg("Update Review")
+                  : msg("Finish Review")}
+              </sl-button>
+            </sl-tooltip>
           </div>
         </header>
 
@@ -375,14 +383,22 @@ export class ArchivedItemQA extends TailwindElement {
               <sl-icon slot="prefix" name="arrow-left"></sl-icon>
               ${msg("Previous Page")}
             </sl-button>
-            <btrix-page-qa-approval
-              .authState=${this.authState}
-              .orgId=${this.orgId}
-              .itemId=${this.itemId}
-              .pageId=${this.itemPageId}
-              .page=${this.page}
-              @btrix-update-item-page=${this.onUpdateItemPage}
-            ></btrix-page-qa-approval>
+            <sl-tooltip
+              content=${msg(
+                "Approvals are temporarily disabled during analysis runs.",
+              )}
+              ?disabled=${!disableReview}
+            >
+              <btrix-page-qa-approval
+                .authState=${this.authState}
+                .orgId=${this.orgId}
+                .itemId=${this.itemId}
+                .pageId=${this.itemPageId}
+                .page=${this.page}
+                ?disabled=${disableReview}
+                @btrix-update-item-page=${this.onUpdateItemPage}
+              ></btrix-page-qa-approval>
+            </sl-tooltip>
             <sl-button
               variant="primary"
               size="small"
@@ -950,12 +966,11 @@ export class ArchivedItemQA extends TailwindElement {
       this.pages = await this.getPages({
         page: params?.page ?? this.pages?.page ?? 1,
         pageSize: params?.pageSize ?? this.pages?.pageSize ?? DEFAULT_PAGE_SIZE,
-        sortBy: this.sortPagesBy.sortBy,
-        sortDirection: this.sortPagesBy.sortDirection,
+        ...this.sortPagesBy,
       });
     } catch {
       this.notify.toast({
-        message: msg("Sorry, couldn't retrieve archived item at this time."),
+        message: msg("Sorry, couldn't retrieve pages at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });
@@ -967,7 +982,7 @@ export class ArchivedItemQA extends TailwindElement {
   ): Promise<APIPaginatedList<ArchivedItemQAPage>> {
     const query = queryString.stringify(
       {
-        ...(this.qaRunId ? this.filterPagesBy : {}),
+        ...this.filterPagesBy,
         ...params,
       },
       {
@@ -975,9 +990,7 @@ export class ArchivedItemQA extends TailwindElement {
       },
     );
     return this.api.fetch<APIPaginatedList<ArchivedItemQAPage>>(
-      this.qaRunId
-        ? `/orgs/${this.orgId}/crawls/${this.itemId}/qa/${this.qaRunId}/pages?${query}`
-        : `/orgs/${this.orgId}/crawls/${this.itemId}/pages?${query}`,
+      `/orgs/${this.orgId}/crawls/${this.itemId ?? ""}/qa/${this.qaRunId ?? ""}/pages?${query}`,
       this.authState!,
     );
   }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -451,20 +451,13 @@ export class CollectionDetail extends LiteElement {
                   ${msg("Make Private")}
                 </sl-menu-item>
               `}
-          <!-- Shoelace doesn't allow "href" on menu items,
-              see https://github.com/shoelace-style/shoelace/issues/1351 -->
-          <a
+          <btrix-menu-item-link
             href=${`/api/orgs/${this.orgId}/collections/${this.collectionId}/download?auth_bearer=${authToken}`}
-            class="flex items-center gap-2 whitespace-nowrap px-6 py-[0.6rem] hover:bg-neutral-100"
-            @click=${(e: MouseEvent) => {
-              void (e.target as HTMLAnchorElement)
-                .closest("sl-dropdown")
-                ?.hide();
-            }}
+            download
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>
             ${msg("Download Collection")}
-          </a>
+          </btrix-menu-item-link>
           <sl-divider></sl-divider>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -10,7 +10,6 @@ import queryString from "query-string";
 
 import type { SelectNewDialogEvent } from ".";
 
-import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import type { CollectionSavedEvent } from "@/features/collections/collection-metadata-dialog";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
@@ -603,21 +602,13 @@ export class CollectionsList extends LiteElement {
                   ${msg("Make Private")}
                 </sl-menu-item>
               `}
-          <!-- Shoelace doesn't allow "href" on menu items,
-              see https://github.com/shoelace-style/shoelace/issues/1351 -->
-          <a
+          <btrix-menu-item-link
             href=${`/api/orgs/${this.orgId}/collections/${col.id}/download?auth_bearer=${authToken}`}
-            class="flex items-center gap-2 whitespace-nowrap px-6 py-[0.6rem] hover:bg-neutral-100"
             download
-            @click=${(e: MouseEvent) => {
-              (e.target as HTMLAnchorElement)
-                .closest<OverflowDropdown>("btrix-overflow-dropdown")
-                ?.hide();
-            }}
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>
             ${msg("Download Collection")}
-          </a>
+          </btrix-menu-item-link>
           <sl-divider></sl-divider>
           <sl-menu-item
             style="--sl-color-neutral-700: var(--danger)"

--- a/frontend/src/types/qa.ts
+++ b/frontend/src/types/qa.ts
@@ -12,6 +12,7 @@ export type QARun = {
     done: number;
     size: number;
   };
+  resources?: { crawlId: string; name: string; path: string }[];
 };
 
 export type ArchivedItemQAPage = ArchivedItemPage & {


### PR DESCRIPTION
Partially addresses https://github.com/webrecorder/browsertrix-cloud/issues/1651

### Changes

- Disables review actions if analysis is running
- Enables downloading run
- Enables stopping and canceling runs
- Minor refactor to create and implement `btrix-menu-item-link` for download menu option
- Hides canceled QA runs from dropdown

### Manual testing

1. Log in as crawler
2. Go to Archived Items -> click a crawl
3. Click "[re]Run Analysis". Verify stop and cancel buttons are shown
4. Click "Stop". Verify confirmation dialog is shown
5. Click "Keep running". Verify analysis continues to run
6. Click "Stop" again and then "Stop Analysis". Leave tab and revisit tab. Verify analysis is stopped or stopping (see follow-ups for note on polling updates)
7. Repeat for "Cancel"
8. Click "Analysis Runs"
9. Click "..." action overflow menu for a canceled run. Verify download option is not visible
10. Click "..." for a completed run. Verify download option is enabled after a short delay
11. Click "Download". Verify QA run is downloaded

### Follow-ups
Following isn't handled in this PR
- Polling for currently running QA run (should be in `frontend-qa-overview-page`)
- Download multiple resource files. Changes in this PR only downloads the first file
