### PR TITLE
Fix failing Webpack build in CI

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,10 +3,8 @@ FROM --platform=$BUILDPLATFORM docker.io/library/node:18 as build_deps
 
 WORKDIR /app
 COPY yarn.lock package.json ./
-# Uses `yarn cache clean` to let Docker cache layer instead
-# of including yarn cache in the build image
-RUN yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000 && \
-  yarn cache clean
+# Uses a cache mount for the Yarn cache so that it's not included in subsequent steps
+RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn --production --frozen-lockfile --ignore-optional --network-timeout 1000000
 
 COPY --link lit-localize.json \
   postcss.config.js \
@@ -14,6 +12,8 @@ COPY --link lit-localize.json \
   tsconfig.json \
   webpack.config.js \
   webpack.prod.js \
+  .eslintrc.js \
+  tsconfig.eslint.json \
   index.d.ts \
   ./
 

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-const path = require("path");
-
 const ESLintPlugin = require("eslint-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const { merge } = require("webpack-merge");
@@ -36,7 +34,6 @@ module.exports = [
       new ESLintPlugin({
         failOnWarning: true,
         extensions: ["ts", "js"],
-        cwd: path.resolve(__dirname),
       }),
     ],
   }),

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const path = require("path");
+
 const ESLintPlugin = require("eslint-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const { merge } = require("webpack-merge");
@@ -34,6 +36,7 @@ module.exports = [
       new ESLintPlugin({
         failOnWarning: true,
         extensions: ["ts", "js"],
+        cwd: path.resolve(__dirname),
       }),
     ],
   }),


### PR DESCRIPTION
e.g.  https://github.com/webrecorder/browsertrix-cloud/actions/runs/8627953133/job/23668020899#step:17:6

### Changes
- Includes eslint-related files in Dockerfile build step
- Switches to using a cache mount in Dockerfile build step for yarn cache, rather than deleting yarn cache, which should speed up most builds

### Testing
Tested locally with `./scripts/build-frontend.sh` — I was able to reproduce the failing build before these changes, and was able to successfully build after.