### PR TITLE
Remove pages from QA Configmap

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1557,11 +1557,3 @@ class PageOutWithSingleQA(Page):
     """Page out with single QA entry"""
 
     qa: Optional[PageQACompare] = None
-
-
-# ============================================================================
-class PagesAndResources(BaseModel):
-    """moage for qa configmap data, pages + resources"""
-
-    resources: List[CrawlFileOut] = []
-    pages: List[PageOut] = []

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -334,7 +334,13 @@ class CrawlOperator(BaseOperator):
 
         params["name"] = name
         params["qa_source_replay_json"] = res_and_pages.json()
-        # params["qa_source_replay_json"] = crawl_replay.json(include={"resources"})
+        # The configmap can only be 256K - if the page list is too big
+        # we need to clear it out, in which case the crawler will load it directly from WACZ
+        # currently setting it here to deal with pages sometimes being missing from pages.jsonl
+        if len(params["qa_source_replay_json"]) > 200000:
+            print("Pages list too big, loading from WACZ")
+            res_and_pages.pages = []
+            params["qa_source_replay_json"] = res_and_pages.json()
 
         return self.load_from_yaml("qa_configmap.yaml", params)
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -339,8 +339,7 @@ class CrawlOperator(BaseOperator):
         # currently setting it here to deal with pages sometimes being missing from pages.jsonl
         if len(params["qa_source_replay_json"]) > 200000:
             print("Pages list too big, loading from WACZ")
-            res_and_pages.pages = []
-            params["qa_source_replay_json"] = res_and_pages.json()
+            params["qa_source_replay_json"] = res_and_pages.json(exclude={"pages"})
 
         return self.load_from_yaml("qa_configmap.yaml", params)
 


### PR DESCRIPTION
Fixes #1670 

No longer need to pass pages to the ConfigMap. The ConfigMap has a size limit and will fail if there are too many pages.

Note: a previous workaround would keep this, but would check the size of the ConfigMap and add pages if size was <200K. Could still do that, but this seems like a cleaner fix going forward.

With this change, the page list for QA will be read directly from the WACZ files pages.jsonl / extraPages.jsonl entries.