### PR TITLE
renumber crawl priority classes:

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -347,9 +347,9 @@ class CrawlOperator(BaseOperator):
             print(f"Restart {name}")
 
         if params.get("qa_source_crawl_id"):
-            params["priorityClassName"] = f"qa-crawl-instance-{i}"
+            params["priorityClassName"] = f"qa-crawl-pri-{i}"
         else:
-            params["priorityClassName"] = f"crawl-instance-{i}"
+            params["priorityClassName"] = f"crawl-pri-{i}"
 
         return self.load_from_yaml("crawler.yaml", params)
 

--- a/chart/templates/priorities.yaml
+++ b/chart/templates/priorities.yaml
@@ -4,8 +4,8 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: crawl-instance-{{ . }}
-value: -{{ . }}
+  name: crawl-pri-{{ . }}
+value: {{ sub 0 . }}
 globalDefault: false
 description: "Priority for crawl instance #{{ . }}"
 
@@ -16,8 +16,8 @@ description: "Priority for crawl instance #{{ . }}"
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: qa-crawl-instance-{{ . }}
-value: -{{ add 100 . }}
+  name: qa-crawl-pri-{{ . }}
+value: {{ sub -2 . }}
 globalDefault: false
 description: "Priority for QA crawl instance #{{ . }}"
 


### PR DESCRIPTION
- priority classes <-10 are ignored by cluster-autoscaler so QA jobs with too low priorities never run
- start crawl priorities at 0 going down (same as before)
- start qa run priorities at -2 going down (instead of -100)
- this means a crawl of with scale of 3 can be preempted by 1st qa pod, but otherwise crawls have higher priority
- rename priority classes as they are otherwise immutable and error on helm upgrade

This allows for more room in lower pri classes for other type of objects, while keeping in mind the -10 and below threshold: (see: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md)