### PR TITLE
Improve reliability of backend tests

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -733,6 +733,12 @@ class CrawlOps(BaseCrawlOps):
         """Stop crawl QA run, QA run removed when actually finished"""
         crawl = await self.get_crawl(crawl_id, org)
 
+        active_qa = await self.get_active_qa(crawl_id, org)
+        if not active_qa:
+            return HTTPException(status_code=400, detail="qa_not_running")
+
+        qa_run_id = active_qa.id
+
         state_update = "stopped_by_user"
         if not graceful:
             state_update = "canceled"

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -734,7 +734,7 @@ class CrawlOps(BaseCrawlOps):
         crawl = await self.get_crawl(crawl_id, org)
 
         if not crawl.qa:
-            return HTTPException(status_code=400, detail="qa_not_running")
+            raise HTTPException(status_code=400, detail="qa_not_running")
 
         try:
             result = await self.crawl_manager.shutdown_crawl(

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -370,7 +370,7 @@ def test_delete_qa_runs(
         time.sleep(5)
         count += 1
 
-    # Ensure associated files are also deleted
+    # Ensure associated qa run information in pages is also deleted
     for qa_run in (qa_run_id, failed_qa_run_id):
         count = 0
         while count < MAX_ATTEMPTS:
@@ -379,7 +379,14 @@ def test_delete_qa_runs(
                 headers=crawler_auth_headers,
             )
             data = r.json()
-            if data.get("count") == 0 and len(data.get("items", [])) == 0:
+
+            pages_with_qa_run = [
+                page
+                for page in data["items"]
+                if page.get("qa") and page.get("qa").get(qa_run)
+            ]
+
+            if not pages_with_qa_run:
                 break
 
             if count + 1 == MAX_ATTEMPTS:

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -376,9 +376,7 @@ def test_delete_qa_runs(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
         headers=crawler_auth_headers,
     )
-    data = r.json()
-    assert data["count"] == 0
-    assert len(data["items"]) == 0
+    assert len(r.json()) == 0
 
     # Ensure associated files are also deleted
     for qa_run in (qa_run_id, failed_qa_run_id):

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -143,25 +143,6 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     return failed_qa_run_id
 
 
-def test_qa_list(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_pages_ready
-):
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
-        headers=crawler_auth_headers,
-    )
-
-    data = r.json()
-
-    assert len(data) == 1
-
-    qa = data[0]
-    assert qa
-    assert qa["state"]
-    assert qa["started"]
-    assert not qa["finished"]
-
-
 def test_qa_completed(
     crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_pages_ready
 ):
@@ -172,16 +153,16 @@ def test_qa_completed(
 
     data = r.json()
 
-    assert len(data) == 1
+    assert len(data) >= 1
 
-    qa = data[0]
-    assert qa
-    assert qa["state"] == "complete"
-    assert qa["started"]
-    assert qa["finished"]
-    assert qa["stats"]["found"] == 1
-    assert qa["stats"]["done"] == 1
-    assert qa["crawlExecSeconds"] > 0
+    for qa in data:
+        assert qa
+        assert qa["state"]
+        assert qa["started"]
+        assert qa["finished"]
+        assert qa["stats"]["found"] == 1
+        assert qa["stats"]["done"] == 1
+        assert qa["crawlExecSeconds"] > 0
 
 
 def test_qa_org_stats(

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -353,7 +353,7 @@ def test_delete_qa_runs(
     assert r.status_code == 200
     assert r.json()["deleted"] == 2
 
-    # Wait for QA runs and their pages to be deleted
+    # Wait for QA runs to be delete
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
@@ -361,8 +361,7 @@ def test_delete_qa_runs(
             headers=crawler_auth_headers,
         )
 
-        data = r.json()
-        if data.get("count") == 0:
+        if len(r.json()) == 0:
             break
 
         if count + 1 == MAX_ATTEMPTS:
@@ -370,13 +369,6 @@ def test_delete_qa_runs(
 
         time.sleep(5)
         count += 1
-
-    # Ensure runs are deleted from finished qa list
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
-        headers=crawler_auth_headers,
-    )
-    assert len(r.json()) == 0
 
     # Ensure associated files are also deleted
     for qa_run in (qa_run_id, failed_qa_run_id):

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -127,7 +127,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/replay.json",
             headers=crawler_auth_headers,
         )
         data = r.json()

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -353,7 +353,7 @@ def test_delete_qa_runs(
     assert r.status_code == 200
     assert r.json()["deleted"] == 2
 
-    # Wait for QA runs to be delete
+    # Wait for QA runs to be deleted
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -124,6 +124,8 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     assert r.status_code == 200
     assert r.json()["success"]
 
+    time.sleep(10)
+
     return failed_qa_run_id
 
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -43,6 +43,7 @@ def qa_run_pages_ready(
         count += 1
 
 
+@pytest.fixture(scope="module")
 def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/start",

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -202,7 +202,11 @@ def test_qa_org_stats(crawler_crawl_id, crawler_auth_headers, default_org_id):
 
 
 def test_qa_page_data(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_id
+    crawler_crawl_id,
+    crawler_auth_headers,
+    default_org_id,
+    qa_run_id,
+    qa_run_pages_ready,
 ):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/pages",
@@ -244,7 +248,13 @@ def test_qa_page_data(
     }
 
 
-def test_qa_replay(crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_id):
+def test_qa_replay(
+    crawler_crawl_id,
+    crawler_auth_headers,
+    default_org_id,
+    qa_run_id,
+    qa_run_pages_ready,
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/replay.json",
         headers=crawler_auth_headers,
@@ -265,7 +275,11 @@ def test_run_qa_not_running(crawler_crawl_id, crawler_auth_headers, default_org_
 
 
 def test_failed_qa_run(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, failed_qa_run_id
+    crawler_crawl_id,
+    crawler_auth_headers,
+    default_org_id,
+    failed_qa_run_id,
+    qa_run_pages_ready,
 ):
     # Ensure failed QA run is included in list endpoint
     r = requests.get(
@@ -306,7 +320,11 @@ def test_failed_qa_run(
 
 
 def test_delete_qa_run(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_id, failed_qa_run_id
+    crawler_crawl_id,
+    crawler_auth_headers,
+    default_org_id,
+    qa_run_pages_ready,
+    failed_qa_run_id,
 ):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/delete",

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -122,25 +122,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-
-    # Wait until it stops with canceled state
-    count = 0
-    while count < MAX_ATTEMPTS:
-        r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/replay.json",
-            headers=crawler_auth_headers,
-        )
-        data = r.json()
-        print(f"Canceled crawl info, attempt {count}", flush=True)
-        print(data, flush=True)
-        if data.get("state") == "canceled":
-            break
-
-        if count + 1 == MAX_ATTEMPTS:
-            assert False
-
-        time.sleep(5)
-        count += 1
+    assert r.json()["success"]
 
     return failed_qa_run_id
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -378,7 +378,8 @@ def test_delete_qa_runs(
                 f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run}/pages",
                 headers=crawler_auth_headers,
             )
-            if len(r.json()) == 0:
+            data = r.json()
+            if data.get("count") == 0 and len(data.get("items", [])) == 0:
                 break
 
             if count + 1 == MAX_ATTEMPTS:

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -127,7 +127,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/pages",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}",
             headers=crawler_auth_headers,
         )
         data = r.json()

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -264,6 +264,24 @@ def test_run_qa_not_running(
     failed_qa_run_id,
     qa_run_pages_ready,
 ):
+    # Make sure no active QA is running
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/activeQA",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data.get("qa") is None:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(5)
+        count += 1
+
+    # Try to stop when there's no running QA run
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/stop",
         headers=crawler_auth_headers,

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -131,6 +131,8 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
             headers=crawler_auth_headers,
         )
         data = r.json()
+        print(f"Canceled crawl info, attempt {count}", flush=True)
+        print(data, flush=True)
         if data.get("state") == "canceled":
             break
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -258,7 +258,11 @@ def test_qa_replay(
 
 
 def test_run_qa_not_running(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, failed_qa_run_id
+    crawler_crawl_id,
+    crawler_auth_headers,
+    default_org_id,
+    failed_qa_run_id,
+    qa_run_pages_ready,
 ):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/stop",
@@ -318,6 +322,7 @@ def test_delete_qa_runs(
     crawler_crawl_id,
     crawler_auth_headers,
     default_org_id,
+    qa_run_id,
     qa_run_pages_ready,
     failed_qa_run_id,
 ):

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -370,8 +370,7 @@ def test_delete_qa_runs(
                 f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run}/pages",
                 headers=crawler_auth_headers,
             )
-            data = r.json()
-            if data["count"] == 0 and len(data["items"]) == 0:
+            if len(r.json()) == 0:
                 break
 
             if count + 1 == MAX_ATTEMPTS:

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -896,7 +896,8 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     all_crawls_delete_config_id,
     upload_id_2,
 ):
-    crawls_to_delete = [all_crawls_delete_crawl_ids, upload_id_2]
+    crawls_to_delete = all_crawls_delete_crawl_ids
+    crawls_to_delete.append(upload_id_2)
 
     # Get org metrics
     r = requests.get(
@@ -985,7 +986,7 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
                 f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{all_crawls_delete_config_id}",
                 headers=admin_auth_headers,
             )
-            assert r.json()["totalSize"] == workflow_size - crawl_1_size
+            assert r.json()["totalSize"] == workflow_size - combined_crawl_size
         except:
             if time.monotonic() - start_time_workflow > time_limit:
                 raise

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -970,9 +970,14 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
             )
             data = r.json()
 
-            assert data["storageUsedBytes"] == org_bytes - total_size
-            assert data["storageUsedCrawls"] == org_crawl_bytes - combined_crawl_size
-            assert data["storageUsedUploads"] == org_upload_bytes - upload_size
+            if data["storageUsedBytes"] != org_bytes - total_size:
+                raise Exception("not true on this pass")
+
+            if data["storageUsedCrawls"] != org_crawl_bytes - combined_crawl_size:
+                raise Exception("not true on this pass")
+
+            if data["storageUsedUploads"] != org_upload_bytes - upload_size:
+                raise Exception("not true on this pass")
             break
         except:
             if time.monotonic() - start_time > time_limit:
@@ -986,8 +991,9 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
                 f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{all_crawls_delete_config_id}",
                 headers=admin_auth_headers,
             )
-            assert r.json()["totalSize"] == workflow_size - combined_crawl_size
-            break
+            if r.json()["totalSize"] == workflow_size - combined_crawl_size:
+                break
+            raise Exception("not true on this pass")
         except:
             if time.monotonic() - start_time_workflow > time_limit:
                 raise

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -11,6 +11,8 @@ from .utils import read_in_chunks
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 
+MAX_ATEMPTS = 24
+
 
 @pytest.fixture(scope="module")
 def upload_id(admin_auth_headers, default_org_id, uploads_collection_id):
@@ -957,8 +959,6 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     data = r.json()
     assert data["deleted"]
     assert data["storageQuotaReached"] is False
-
-    max_attempts = 24
 
     # Check that org and workflow size figures are as expected
     count = 0

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -896,8 +896,7 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     all_crawls_delete_config_id,
     upload_id_2,
 ):
-    crawls_to_delete = all_crawls_delete_crawl_ids
-    crawls_to_delete.append(upload_id_2)
+    crawls_to_delete = [all_crawls_delete_crawl_ids, upload_id_2]
 
     # Get org metrics
     r = requests.get(
@@ -959,7 +958,7 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     assert data["deleted"]
     assert data["storageQuotaReached"] is False
 
-    time_limit_seconds = 60
+    time_limit = 10
 
     # Check that org and workflow size figures are as expected
     start_time = time.monotonic()
@@ -975,19 +974,19 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
             assert data["storageUsedCrawls"] == org_crawl_bytes - combined_crawl_size
             assert data["storageUsedUploads"] == org_upload_bytes - upload_size
         except:
-            if time.monotonic() - start_time > time_limit_seconds:
+            if time.monotonic() - start_time > time_limit:
                 raise
-            time.sleep(5)
+            time.sleep(1)
 
-    start_time = time.monotonic()
+    start_time_workflow = time.monotonic()
     while True:
         try:
             r = requests.get(
                 f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{all_crawls_delete_config_id}",
                 headers=admin_auth_headers,
             )
-            assert r.json()["totalSize"] == workflow_size - combined_crawl_size
+            assert r.json()["totalSize"] == workflow_size - crawl_1_size
         except:
-            if time.monotonic() - start_time > time_limit_seconds:
+            if time.monotonic() - start_time_workflow > time_limit:
                 raise
-            time.sleep(5)
+            time.sleep(1)

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -560,7 +560,6 @@ def test_get_all_crawls_by_collection_id(
     assert r.status_code == 200
     new_coll_id = r.json()["id"]
     assert new_coll_id
-    return new_coll_id
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?collectionId={new_coll_id}",

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -11,7 +11,7 @@ from .utils import read_in_chunks
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 
-MAX_ATEMPTS = 24
+MAX_ATTEMPTS = 24
 
 
 @pytest.fixture(scope="module")

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -3,20 +3,17 @@ import os
 import time
 from urllib.parse import urljoin
 
+import pytest
+
 from .conftest import API_PREFIX
 from .utils import read_in_chunks
-
-upload_id = None
-upload_id_2 = None
-upload_dl_path = None
-
-_coll_id = None
 
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_upload_stream(admin_auth_headers, default_org_id, uploads_collection_id):
+@pytest.fixture(scope="module")
+def upload_id(admin_auth_headers, default_org_id, uploads_collection_id):
     with open(os.path.join(curr_dir, "data", "example.wacz"), "rb") as fh:
         r = requests.put(
             f"{API_PREFIX}/orgs/{default_org_id}/uploads/stream?filename=test.wacz&name=My%20Upload&description=Testing%0AData&collections={uploads_collection_id}&tags=one%2Ctwo",
@@ -27,11 +24,55 @@ def test_upload_stream(admin_auth_headers, default_org_id, uploads_collection_id
     assert r.status_code == 200
     assert r.json()["added"]
 
-    global upload_id
     upload_id = r.json()["id"]
+    assert upload_id
+    return upload_id
 
 
-def test_list_stream_upload(admin_auth_headers, default_org_id, uploads_collection_id):
+@pytest.fixture(scope="module")
+def upload_id_2(admin_auth_headers, default_org_id, uploads_collection_id):
+    with open(os.path.join(curr_dir, "data", "example.wacz"), "rb") as fh:
+        data = fh.read()
+
+    files = [
+        ("uploads", ("test.wacz", data, "application/octet-stream")),
+        ("uploads", ("test-2.wacz", data, "application/octet-stream")),
+        ("uploads", ("test.wacz", data, "application/octet-stream")),
+    ]
+
+    r = requests.put(
+        f"{API_PREFIX}/orgs/{default_org_id}/uploads/formdata?name=test2.wacz&collections={uploads_collection_id}&tags=three%2Cfour",
+        headers=admin_auth_headers,
+        files=files,
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["added"]
+    assert data["storageQuotaReached"] is False
+
+    upload_id_2 = r.json()["id"]
+    assert upload_id_2
+    return upload_id_2
+
+
+@pytest.fixture(scope="module")
+def replaced_upload_id(
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id
+):
+    # Replace upload_id with a non-existent upload
+    actual_id = do_upload_replace(
+        admin_auth_headers, default_org_id, upload_id, uploads_collection_id
+    )
+
+    assert actual_id
+    assert actual_id != upload_id
+    return actual_id
+
+
+def test_list_stream_upload(
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads",
         headers=admin_auth_headers,
@@ -55,7 +96,9 @@ def test_list_stream_upload(admin_auth_headers, default_org_id, uploads_collecti
     assert "resources" not in found
 
 
-def test_get_stream_upload(admin_auth_headers, default_org_id, uploads_collection_id):
+def test_get_stream_upload(
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}/replay.json",
         headers=admin_auth_headers,
@@ -85,32 +128,9 @@ def test_get_stream_upload(admin_auth_headers, default_org_id, uploads_collectio
     assert r.status_code == 200
 
 
-def test_upload_form(admin_auth_headers, default_org_id, uploads_collection_id):
-    with open(os.path.join(curr_dir, "data", "example.wacz"), "rb") as fh:
-        data = fh.read()
-
-    files = [
-        ("uploads", ("test.wacz", data, "application/octet-stream")),
-        ("uploads", ("test-2.wacz", data, "application/octet-stream")),
-        ("uploads", ("test.wacz", data, "application/octet-stream")),
-    ]
-
-    r = requests.put(
-        f"{API_PREFIX}/orgs/{default_org_id}/uploads/formdata?name=test2.wacz&collections={uploads_collection_id}&tags=three%2Cfour",
-        headers=admin_auth_headers,
-        files=files,
-    )
-
-    assert r.status_code == 200
-    data = r.json()
-    assert data["added"]
-    assert data["storageQuotaReached"] is False
-
-    global upload_id_2
-    upload_id_2 = r.json()["id"]
-
-
-def test_list_uploads(admin_auth_headers, default_org_id, uploads_collection_id):
+def test_list_uploads(
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id_2
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads",
         headers=admin_auth_headers,
@@ -134,7 +154,9 @@ def test_list_uploads(admin_auth_headers, default_org_id, uploads_collection_id)
     assert "resources" not in res
 
 
-def test_collection_uploads(admin_auth_headers, default_org_id, uploads_collection_id):
+def test_collection_uploads(
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id, upload_id_2
+):
     # Test uploads filtered by collection
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads?collectionId={uploads_collection_id}",
@@ -161,7 +183,7 @@ def test_collection_uploads(admin_auth_headers, default_org_id, uploads_collecti
 
 
 def test_get_upload_replay_json(
-    admin_auth_headers, default_org_id, uploads_collection_id
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id
 ):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}/replay.json",
@@ -184,7 +206,7 @@ def test_get_upload_replay_json(
 
 
 def test_get_upload_replay_json_admin(
-    admin_auth_headers, default_org_id, uploads_collection_id
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id
 ):
     r = requests.get(
         f"{API_PREFIX}/orgs/all/uploads/{upload_id}/replay.json",
@@ -206,7 +228,9 @@ def test_get_upload_replay_json_admin(
     assert "files" not in data
 
 
-def test_replace_upload(admin_auth_headers, default_org_id, uploads_collection_id):
+def test_replace_upload(
+    admin_auth_headers, default_org_id, uploads_collection_id, upload_id
+):
     actual_id = do_upload_replace(
         admin_auth_headers, default_org_id, upload_id, uploads_collection_id
     )
@@ -251,7 +275,7 @@ def do_upload_replace(
     return actual_id
 
 
-def test_update_upload_metadata(admin_auth_headers, default_org_id):
+def test_update_upload_metadata(admin_auth_headers, default_org_id, upload_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}",
         headers=admin_auth_headers,
@@ -269,13 +293,13 @@ def test_update_upload_metadata(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
         json={"name": "Patch Update Test Collection"},
     )
-    new_coll_id = r.json()["id"]
+    patch_coll_id = r.json()["id"]
 
     # Submit patch request to update name, tags, and description
     UPDATED_NAME = "New Upload Name"
     UPDATED_TAGS = ["wr-test-1-updated", "wr-test-2-updated"]
     UPDATED_DESC = "Lorem ipsum test note."
-    UPDATED_COLLECTION_IDS = [new_coll_id]
+    UPDATED_COLLECTION_IDS = [patch_coll_id]
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}",
         headers=admin_auth_headers,
@@ -303,7 +327,9 @@ def test_update_upload_metadata(admin_auth_headers, default_org_id):
     assert data["collectionIds"] == UPDATED_COLLECTION_IDS
 
 
-def test_delete_stream_upload(admin_auth_headers, crawler_auth_headers, default_org_id):
+def test_delete_stream_upload(
+    admin_auth_headers, crawler_auth_headers, default_org_id, upload_id
+):
     # Verify non-admin user who didn't upload crawl can't delete it
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/delete",
@@ -324,7 +350,7 @@ def test_delete_stream_upload(admin_auth_headers, crawler_auth_headers, default_
     assert data["storageQuotaReached"] is False
 
 
-def test_ensure_deleted(admin_auth_headers, default_org_id):
+def test_ensure_deleted(admin_auth_headers, default_org_id, upload_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads",
         headers=admin_auth_headers,
@@ -336,23 +362,9 @@ def test_ensure_deleted(admin_auth_headers, default_org_id):
             assert False
 
 
-def test_replace_upload_non_existent(
-    admin_auth_headers, default_org_id, uploads_collection_id
+def test_verify_from_upload_resource_count(
+    admin_auth_headers, default_org_id, upload_id_2
 ):
-    global upload_id
-
-    # same replacement, but now to a non-existent upload
-    actual_id = do_upload_replace(
-        admin_auth_headers, default_org_id, upload_id, uploads_collection_id
-    )
-
-    # new upload_id created
-    assert actual_id != upload_id
-
-    upload_id = actual_id
-
-
-def test_verify_from_upload_resource_count(admin_auth_headers, default_org_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id_2}/replay.json",
         headers=admin_auth_headers,
@@ -370,7 +382,9 @@ def test_verify_from_upload_resource_count(admin_auth_headers, default_org_id):
     assert r.status_code == 200
 
 
-def test_list_all_crawls(admin_auth_headers, default_org_id):
+def test_list_all_crawls(
+    admin_auth_headers, default_org_id, replaced_upload_id, upload_id_2
+):
     """Test that /all-crawls lists crawls and uploads before deleting uploads"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls",
@@ -404,7 +418,9 @@ def test_list_all_crawls(admin_auth_headers, default_org_id):
         assert item["state"]
 
 
-def test_get_all_crawls_by_name(admin_auth_headers, default_org_id):
+def test_get_all_crawls_by_name(
+    admin_auth_headers, default_org_id, replaced_upload_id, upload_id_2
+):
     """Test filtering /all-crawls by name"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?name=test2.wacz",
@@ -430,7 +446,11 @@ def test_get_all_crawls_by_name(admin_auth_headers, default_org_id):
 
 
 def test_get_all_crawls_by_first_seed(
-    admin_auth_headers, default_org_id, crawler_crawl_id
+    admin_auth_headers,
+    default_org_id,
+    crawler_crawl_id,
+    replaced_upload_id,
+    upload_id_2,
 ):
     """Test filtering /all-crawls by first seed"""
     first_seed = "https://webrecorder.net/"
@@ -445,7 +465,9 @@ def test_get_all_crawls_by_first_seed(
         assert item["firstSeed"] == first_seed
 
 
-def test_get_all_crawls_by_type(admin_auth_headers, default_org_id, admin_crawl_id):
+def test_get_all_crawls_by_type(
+    admin_auth_headers, default_org_id, admin_crawl_id, replaced_upload_id, upload_id_2
+):
     """Test filtering /all-crawls by crawl type"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?crawlType=crawl",
@@ -475,7 +497,9 @@ def test_get_all_crawls_by_type(admin_auth_headers, default_org_id, admin_crawl_
     assert r.json()["detail"] == "invalid_crawl_type"
 
 
-def test_get_all_crawls_by_user(admin_auth_headers, default_org_id, crawler_userid):
+def test_get_all_crawls_by_user(
+    admin_auth_headers, default_org_id, crawler_userid, replaced_upload_id, upload_id_2
+):
     """Test filtering /all-crawls by userid"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?userid={crawler_userid}",
@@ -502,7 +526,9 @@ def test_get_all_crawls_by_cid(
     assert data["items"][0]["cid"] == all_crawls_config_id
 
 
-def test_get_all_crawls_by_state(admin_auth_headers, default_org_id, admin_crawl_id):
+def test_get_all_crawls_by_state(
+    admin_auth_headers, default_org_id, admin_crawl_id, replaced_upload_id, upload_id_2
+):
     """Test filtering /all-crawls by cid"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?state=complete,stopped_by_user",
@@ -523,7 +549,6 @@ def test_get_all_crawls_by_collection_id(
     admin_auth_headers, default_org_id, admin_config_id, all_crawls_crawl_id
 ):
     """Test filtering /all-crawls by collection id"""
-    # Create collection and add upload to it
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=admin_auth_headers,
@@ -533,11 +558,12 @@ def test_get_all_crawls_by_collection_id(
         },
     )
     assert r.status_code == 200
-    global _coll_id
-    _coll_id = r.json()["id"]
+    new_coll_id = r.json()["id"]
+    assert new_coll_id
+    return new_coll_id
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?collectionId={_coll_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?collectionId={new_coll_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -545,7 +571,9 @@ def test_get_all_crawls_by_collection_id(
     assert r.json()["items"][0]["id"] == all_crawls_crawl_id
 
 
-def test_sort_all_crawls(admin_auth_headers, default_org_id, admin_crawl_id):
+def test_sort_all_crawls(
+    admin_auth_headers, default_org_id, admin_crawl_id, replaced_upload_id, upload_id_2
+):
     # Sort by started, descending (default)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=started",
@@ -653,7 +681,9 @@ def test_sort_all_crawls(admin_auth_headers, default_org_id, admin_crawl_id):
     assert r.json()["detail"] == "invalid_sort_direction"
 
 
-def test_all_crawls_search_values(admin_auth_headers, default_org_id):
+def test_all_crawls_search_values(
+    admin_auth_headers, default_org_id, replaced_upload_id, upload_id_2
+):
     """Test that all-crawls search values return expected results"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values",
@@ -722,7 +752,7 @@ def test_all_crawls_search_values(admin_auth_headers, default_org_id):
     assert r.json()["detail"] == "invalid_crawl_type"
 
 
-def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id):
+def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id, upload_id_2):
     """Test that /all-crawls lists crawls and uploads before deleting uploads"""
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id_2}",
@@ -737,7 +767,9 @@ def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id):
     assert data["resources"]
 
 
-def test_get_upload_replay_json_from_all_crawls(admin_auth_headers, default_org_id):
+def test_get_upload_replay_json_from_all_crawls(
+    admin_auth_headers, default_org_id, upload_id_2
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id_2}/replay.json",
         headers=admin_auth_headers,
@@ -757,7 +789,7 @@ def test_get_upload_replay_json_from_all_crawls(admin_auth_headers, default_org_
 
 
 def test_get_upload_replay_json_admin_from_all_crawls(
-    admin_auth_headers, default_org_id
+    admin_auth_headers, default_org_id, upload_id_2
 ):
     r = requests.get(
         f"{API_PREFIX}/orgs/all/all-crawls/{upload_id_2}/replay.json",
@@ -777,9 +809,11 @@ def test_get_upload_replay_json_admin_from_all_crawls(
     assert "files" not in data
 
 
-def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
+def test_update_upload_metadata_all_crawls(
+    admin_auth_headers, default_org_id, replaced_upload_id
+):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{replaced_upload_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -795,15 +829,15 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
         json={"name": "Patch Update Test Collection 2"},
     )
-    new_coll_id = r.json()["id"]
+    patch_coll_id_2 = r.json()["id"]
 
     # Submit patch request to update name, tags, and description
     UPDATED_NAME = "New Upload Name 2"
     UPDATED_TAGS = ["wr-test-1-updated-again", "wr-test-2-updated-again"]
     UPDATED_DESC = "Lorem ipsum test note 2."
-    UPDATED_COLLECTION_IDS = [new_coll_id]
+    UPDATED_COLLECTION_IDS = [patch_coll_id_2]
     r = requests.patch(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{replaced_upload_id}",
         headers=admin_auth_headers,
         json={
             "tags": UPDATED_TAGS,
@@ -818,7 +852,7 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
 
     # Verify update was successful
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{replaced_upload_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -831,7 +865,7 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
     # Submit patch request to set collections to empty list
     UPDATED_COLLECTION_IDS = []
     r = requests.patch(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{replaced_upload_id}",
         headers=admin_auth_headers,
         json={
             "collectionIds": UPDATED_COLLECTION_IDS,
@@ -843,7 +877,7 @@ def test_update_upload_metadata_all_crawls(admin_auth_headers, default_org_id):
 
     # Verify update was successful
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{upload_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/{replaced_upload_id}",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -860,6 +894,7 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     default_org_id,
     all_crawls_delete_crawl_ids,
     all_crawls_delete_config_id,
+    upload_id_2,
 ):
     crawls_to_delete = all_crawls_delete_crawl_ids
     crawls_to_delete.append(upload_id_2)

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -959,7 +959,7 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
     assert data["deleted"]
     assert data["storageQuotaReached"] is False
 
-    time_limit = 10
+    time_limit = 60
 
     # Check that org and workflow size figures are as expected
     start_time = time.monotonic()
@@ -974,10 +974,11 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
             assert data["storageUsedBytes"] == org_bytes - total_size
             assert data["storageUsedCrawls"] == org_crawl_bytes - combined_crawl_size
             assert data["storageUsedUploads"] == org_upload_bytes - upload_size
+            break
         except:
             if time.monotonic() - start_time > time_limit:
                 raise
-            time.sleep(1)
+            time.sleep(5)
 
     start_time_workflow = time.monotonic()
     while True:
@@ -987,7 +988,8 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
                 headers=admin_auth_headers,
             )
             assert r.json()["totalSize"] == workflow_size - combined_crawl_size
+            break
         except:
             if time.monotonic() - start_time_workflow > time_limit:
                 raise
-            time.sleep(1)
+            time.sleep(5)

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -22,7 +22,7 @@ crawler_channels:
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
   - id: test
-    image: "docker.io/webrecorder/browsertrix-crawler:1.1.0-beta.1"
+    image: "docker.io/webrecorder/browsertrix-crawler:1.1.0-beta.4"
 
 mongo_auth:
   # specify either username + password (for local mongo)


### PR DESCRIPTION
While debugging tests for #1625, I stumbled upon over the use of globals instead of fixtures in `test_profiles.py`. I also added some limits to the `while True` - loops to avoid blocking a CI worker for several hours.