### PR TITLE
Fix icons in 1.9.8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "@lit/localize": "^0.12.1",
     "@novnc/novnc": "^1.4.0-beta",
     "@rollup/plugin-commonjs": "^18.0.0",
-    "@shoelace-style/shoelace": "^2.8.0",
+    "@shoelace-style/shoelace": "~2.10.0",
     "@types/color": "^3.0.2",
     "@types/lodash": "^4.14.178",
     "@types/sinon": "^10.0.6",

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -7,6 +7,7 @@ import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/ico
 import "@shoelace-style/shoelace/dist/themes/light.css";
 import "@shoelace-style/shoelace/dist/components/alert/alert";
 import "@shoelace-style/shoelace/dist/components/button/button";
+import "@shoelace-style/shoelace/dist/components/icon/icon";
 import "@shoelace-style/shoelace/dist/components/input/input";
 import "@shoelace-style/shoelace/dist/components/checkbox/checkbox";
 import "@shoelace-style/shoelace/dist/components/details/details";
@@ -22,6 +23,7 @@ import "@shoelace-style/shoelace/dist/components/switch/switch";
 import "@shoelace-style/shoelace/dist/components/textarea/textarea";
 import "@shoelace-style/shoelace/dist/components/mutation-observer/mutation-observer";
 import "@shoelace-style/shoelace/dist/components/progress-bar/progress-bar";
+
 import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/dialog/dialog"
 );
@@ -33,9 +35,6 @@ import(
 );
 import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/format-date/format-date"
-);
-import(
-  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/icon/icon"
 );
 import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/menu/menu"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -753,10 +753,10 @@
   resolved "https://registry.yarnpkg.com/@shoelace-style/localize/-/localize-3.1.2.tgz#2c63f16d8aa80842dbe5127845c76ed53f6a5e8e"
   integrity sha512-Hf45HeO+vdQblabpyZOTxJ4ZeZsmIUYXXPmoYrrR4OJ5OKxL+bhMz5mK8JXgl7HsoEowfz7+e248UGi861de9Q==
 
-"@shoelace-style/shoelace@^2.8.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@shoelace-style/shoelace/-/shoelace-2.12.0.tgz#8fa21ccfc28114cb5ce8126adb412dc4abf855df"
-  integrity sha512-1Amirj0c5WLkymDcP6ZQmBfMC6zTNmGGK7/mjmGq4yhljrVaECVlBoKm0tfmo1jd3r8XJ8xYbQ8cxPAlwiDDvw==
+"@shoelace-style/shoelace@~2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@shoelace-style/shoelace/-/shoelace-2.10.0.tgz#373660831f3f0f161ebae5a29e3e27f92f6c0fb8"
+  integrity sha512-bS9S2yqFZE+P4CqOa3vP1kMgSzVLKi1aTx9VYEW47YoR+TZuMkwgcPsJlAHb4Dw+MmaBqGO9XLhSIfq9pZpCug==
   dependencies:
     "@ctrl/tinycolor" "^4.0.2"
     "@floating-ui/dom" "^1.5.3"


### PR DESCRIPTION
Closes #1676.

Loads `sl-icon` synchronously to get correct base path when running webpack-dev-server.

Partially cherry-picked from 548261e663736eff1700f12e247d36dce5405dfa by @SuaYoo.

Confirmed icons load with local dev & with a local prod build where they didn't before these changes.