### PR TITLE
Add QA run aggregate stats API endpoint

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -34,6 +34,7 @@ from .models import (
     QARun,
     QARunOut,
     QARunWithResources,
+    QARunAggregateStatsOut,
     DeleteQARunList,
     Organization,
     User,
@@ -853,6 +854,23 @@ class CrawlOps(BaseCrawlOps):
 
         return QARunWithResources(**qa_run_dict)
 
+    async def get_qa_run_aggregate_stats(
+        self,
+        crawl_id: str,
+        qa_run_id: str,
+        thresholds: Dict[str, List[float]],
+    ) -> QARunAggregateStatsOut:
+        """Get aggregate stats for QA run"""
+        screenshot_results = await self.page_ops.get_qa_run_aggregate_counts(
+            crawl_id, qa_run_id, thresholds, key="screenshotMatch"
+        )
+        text_results = await self.page_ops.get_qa_run_aggregate_counts(
+            crawl_id, qa_run_id, thresholds, key="textMatch"
+        )
+        return QARunAggregateStatsOut(
+            screenshotMatch=screenshot_results, textMatch=text_results
+        )
+
 
 # ============================================================================
 async def recompute_crawl_file_count_and_size(crawls, crawl_id):
@@ -1060,6 +1078,37 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         crawl_id, qa_run_id, org: Organization = Depends(org_viewer_dep)
     ):
         return await ops.get_qa_run_for_replay(crawl_id, qa_run_id, org)
+
+    @app.get(
+        "/orgs/{oid}/crawls/{crawl_id}/qa/{qa_run_id}/stats",
+        tags=["qa"],
+        response_model=QARunAggregateStatsOut,
+    )
+    async def get_qa_run_aggregate_stats(
+        crawl_id,
+        qa_run_id,
+        screenshotThresholds: str,
+        textThresholds: str,
+        # pylint: disable=unused-argument
+        org: Organization = Depends(org_viewer_dep),
+    ):
+        thresholds: Dict[str, List[float]] = {}
+        try:
+            thresholds["screenshotMatch"] = [
+                float(threshold) for threshold in screenshotThresholds.split(",")
+            ]
+            thresholds["textMatch"] = [
+                float(threshold) for threshold in textThresholds.split(",")
+            ]
+        # pylint: disable=broad-exception-caught,raise-missing-from
+        except Exception:
+            raise HTTPException(status_code=400, detail="invalid_thresholds")
+
+        return await ops.get_qa_run_aggregate_stats(
+            crawl_id,
+            qa_run_id,
+            thresholds,
+        )
 
     @app.post("/orgs/{oid}/crawls/{crawl_id}/qa/start", tags=["qa"])
     async def start_crawl_qa_run(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -735,6 +735,22 @@ class QARunOut(BaseModel):
 
 
 # ============================================================================
+class QARunBucketStats(BaseModel):
+    """Model for per-bucket aggregate stats results"""
+
+    lowerBoundary: str
+    count: int
+
+
+# ============================================================================
+class QARunAggregateStatsOut(BaseModel):
+    """QA Run aggregate stats out"""
+
+    screenshotMatch: List[QARunBucketStats]
+    textMatch: List[QARunBucketStats]
+
+
+# ============================================================================
 class Crawl(BaseCrawl, CrawlConfigCore):
     """Store State of a Crawl (Finished or Running)"""
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -559,7 +559,20 @@ class PageOps:
                 )
             )
 
-        return return_data
+        # Add missing boundaries to result and re-sort
+        for boundary in boundaries:
+            if boundary < 1.0:
+                matching_return_data = [
+                    bucket
+                    for bucket in return_data
+                    if bucket.lowerBoundary == str(boundary)
+                ]
+                if not matching_return_data:
+                    return_data.append(
+                        QARunBucketStats(lowerBoundary=str(boundary), count=0)
+                    )
+
+        return sorted(return_data, key=lambda bucket: bucket.lowerBoundary)
 
 
 # ============================================================================

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -528,7 +528,7 @@ class PageOps:
 
         # Make sure boundaries start with 0
         if boundaries[0] != 0:
-            boundaries.insert(0, 0)
+            boundaries.insert(0, 0.0)
 
         # Make sure we have upper boundary just over 1 to be inclusive of scores of 1
         if boundaries[-1] <= 1:

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -22,6 +22,7 @@ from .models import (
     PageNoteIn,
     PageNoteEdit,
     PageNoteDelete,
+    QARunBucketStats,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import from_k8s_date, str_list_to_bools
@@ -510,6 +511,55 @@ class PageOps:
         )
         for crawl_id in crawl_ids:
             await self.re_add_crawl_pages(crawl_id, oid)
+
+    async def get_qa_run_aggregate_counts(
+        self,
+        crawl_id: str,
+        qa_run_id: str,
+        thresholds: Dict[str, List[float]],
+        key: str = "screenshotMatch",
+    ):
+        """Get counts for pages in QA run in buckets by score key based on thresholds"""
+        boundaries = thresholds.get(key, [])
+        if not boundaries:
+            raise HTTPException(status_code=400, detail="missing_thresholds")
+
+        boundaries = sorted(boundaries)
+
+        # Make sure boundaries start with 0
+        if boundaries[0] != 0:
+            boundaries.insert(0, 0)
+
+        # Make sure we have upper boundary just over 1 to be inclusive of scores of 1
+        if boundaries[-1] <= 1:
+            boundaries.append(1.1)
+
+        aggregate = [
+            {"$match": {"crawl_id": crawl_id}},
+            {
+                "$bucket": {
+                    "groupBy": f"$qa.{qa_run_id}.{key}",
+                    "default": "No data",
+                    "boundaries": boundaries,
+                    "output": {
+                        "count": {"$sum": 1},
+                    },
+                }
+            },
+        ]
+        cursor = self.pages.aggregate(aggregate)
+        results = await cursor.to_list(length=len(boundaries))
+
+        return_data = []
+
+        for result in results:
+            return_data.append(
+                QARunBucketStats(
+                    lowerBoundary=str(result.get("_id")), count=result.get("count", 0)
+                )
+            )
+
+        return return_data
 
 
 # ============================================================================

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -273,8 +273,16 @@ def test_qa_stats(
     assert r.status_code == 200
 
     data = r.json()
-    assert data["screenshotMatch"] == [{"lowerBoundary": "0.9", "count": 1}]
-    assert data["textMatch"] == [{"lowerBoundary": "0.9", "count": 1}]
+    assert data["screenshotMatch"] == [
+        {"lowerBoundary": "0.0", "count": 0},
+        {"lowerBoundary": "0.7", "count": 0},
+        {"lowerBoundary": "0.9", "count": 1},
+    ]
+    assert data["textMatch"] == [
+        {"lowerBoundary": "0.0", "count": 0},
+        {"lowerBoundary": "0.7", "count": 0},
+        {"lowerBoundary": "0.9", "count": 1},
+    ]
 
     # Test we get expected results with explicit 0 boundary
     r = requests.get(
@@ -284,8 +292,16 @@ def test_qa_stats(
     assert r.status_code == 200
 
     data = r.json()
-    assert data["screenshotMatch"] == [{"lowerBoundary": "0.9", "count": 1}]
-    assert data["textMatch"] == [{"lowerBoundary": "0.9", "count": 1}]
+    assert data["screenshotMatch"] == [
+        {"lowerBoundary": "0.0", "count": 0},
+        {"lowerBoundary": "0.7", "count": 0},
+        {"lowerBoundary": "0.9", "count": 1},
+    ]
+    assert data["textMatch"] == [
+        {"lowerBoundary": "0.0", "count": 0},
+        {"lowerBoundary": "0.7", "count": 0},
+        {"lowerBoundary": "0.9", "count": 1},
+    ]
 
     # Test that missing threshold values result in 422 HTTPException
     r = requests.get(


### PR DESCRIPTION
Fixes #1659 

Takes an arbitrary set of thresholds for text and screenshot matches as a comma-separated list of floats.

Returns a list of groupings for each that include the lower boundary and count for all sets that have matching data. Would be good if @ikreymer @SuaYoo you can test the return values to see if it's in a form that works for us. Current format of response, with arbitrary made-up data:

```json
{
    "screenshotMatch": [{"lowerBoundary": "0.0", "count": 0},{"lowerBoundary": "0.7", "count": 3}, {"lowerBoundary": "0.9", "count": 5}]
    "textMatch": [{"lowerBoundary": "0.0", "count": 0}, {"lowerBoundary": "0.7", "count": 1}, {"lowerBoundary": "0.9", "count": 2}, {"lowerBoundary": "0.95", "count": 5}]
}
```