### PR TITLE
Add reviewStatus, qaState, and qaRunCount sort options to crawls/all-crawls list endpoints

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -551,6 +551,8 @@ class BaseCrawlOps:
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
             {"$unset": ["firstSeedObject", "errors", "config"]},
+            {"$set": {"qaRunCount": {"$size": {"$objectToArray": "$qaFinished"}}}},
+            {"$set": {"activeQAState": "$qa.state"}},
         ]
 
         if not resources:
@@ -569,7 +571,14 @@ class BaseCrawlOps:
             aggregate.extend([{"$match": {"collectionIds": {"$in": [collection_id]}}}])
 
         if sort_by:
-            if sort_by not in ("started", "finished", "fileSize"):
+            if sort_by not in (
+                "started",
+                "finished",
+                "fileSize",
+                "reviewStatus",
+                "qaRunCount",
+                "activeQAState",
+            ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -551,29 +551,13 @@ class BaseCrawlOps:
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
             {"$unset": ["firstSeedObject", "errors", "config"]},
-            {
-                "$set": {
-                    "qaFinishedObject": {
-                        "$cond": {
-                            "if": {"$eq": ["$qaFinished", None]},
-                            "then": {},
-                            "else": "$qaFinished",
-                        }
-                    }
-                }
-            },
-            {
-                "$set": {
-                    "qaRunCount": {"$size": {"$objectToArray": "$qaFinishedObject"}}
-                }
-            },
             {"$set": {"qaState": "$qa.state"}},
             {"$set": {"activeQAState": "$qaState"}},
             {
                 "$set": {
                     "qaFinishedArray": {
                         "$map": {
-                            "input": {"$objectToArray": "$qaFinishedObject"},
+                            "input": {"$objectToArray": "$qaFinished"},
                             "in": "$$this.v",
                         }
                     }
@@ -592,9 +576,21 @@ class BaseCrawlOps:
             {"$set": {"lastQARun": {"$arrayElemAt": ["$sortedQARuns", 0]}}},
             {"$set": {"lastQAState": "$lastQARun.state"}},
             {
+                "$set": {
+                    "qaRunCount": {
+                        "$size": {
+                            "$cond": [
+                                {"$isArray": "$qaFinishedArray"},
+                                "$qaFinishedArray",
+                                [],
+                            ]
+                        }
+                    }
+                }
+            },
+            {
                 "$unset": [
                     "lastQARun",
-                    "qaFinishedObject",
                     "qaFinishedArray",
                     "sortedQARuns",
                 ]

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -551,8 +551,54 @@ class BaseCrawlOps:
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
             {"$unset": ["firstSeedObject", "errors", "config"]},
-            {"$set": {"qaRunCount": {"$size": {"$objectToArray": "$qaFinished"}}}},
-            {"$set": {"activeQAState": "$qa.state"}},
+            {
+                "$set": {
+                    "qaFinishedObject": {
+                        "$cond": {
+                            "if": {"$eq": ["$qaFinished", None]},
+                            "then": {},
+                            "else": "$qaFinished",
+                        }
+                    }
+                }
+            },
+            {
+                "$set": {
+                    "qaRunCount": {"$size": {"$objectToArray": "$qaFinishedObject"}}
+                }
+            },
+            {"$set": {"qaState": "$qa.state"}},
+            {"$set": {"activeQAState": "$qaState"}},
+            {
+                "$set": {
+                    "qaFinishedArray": {
+                        "$map": {
+                            "input": {"$objectToArray": "$qaFinishedObject"},
+                            "in": "$$this.v",
+                        }
+                    }
+                }
+            },
+            {
+                "$set": {
+                    "sortedQARuns": {
+                        "$sortArray": {
+                            "input": "$qaFinishedArray",
+                            "sortBy": {"started": -1},
+                        }
+                    }
+                }
+            },
+            {"$set": {"lastQARun": {"$arrayElemAt": ["$sortedQARuns", 0]}}},
+            {"$set": {"lastQAState": "$lastQARun.state"}},
+            {
+                "$unset": [
+                    "lastQARun",
+                    "qaFinishedObject",
+                    "qaFinishedArray",
+                    "sortedQARuns",
+                ]
+            },
         ]
 
         if not resources:
@@ -577,13 +623,19 @@ class BaseCrawlOps:
                 "fileSize",
                 "reviewStatus",
                 "qaRunCount",
-                "activeQAState",
+                "qaState",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
 
-            aggregate.extend([{"$sort": {sort_by: sort_direction}}])
+            sort_query = {sort_by: sort_direction}
+
+            # Add secondary sort for qaState - sorted by current, then last
+            if sort_by == "qaState":
+                sort_query["lastQAState"] = sort_direction
+
+            aggregate.extend([{"$sort": sort_query}])
 
         aggregate.extend(
             [

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -165,6 +165,8 @@ class CrawlOps(BaseCrawlOps):
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
             {"$unset": ["firstSeedObject", "errors", "config"]},
+            {"$set": {"qaRunCount": {"$size": {"$objectToArray": "$qaFinished"}}}},
+            {"$set": {"activeQAState": "$qa.state"}},
         ]
 
         if not resources:
@@ -188,6 +190,9 @@ class CrawlOps(BaseCrawlOps):
                 "finished",
                 "fileSize",
                 "firstSeed",
+                "reviewStatus",
+                "qaRunCount",
+                "activeQAState",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -165,29 +165,13 @@ class CrawlOps(BaseCrawlOps):
             {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
             {"$set": {"firstSeed": "$firstSeedObject.url"}},
             {"$unset": ["firstSeedObject", "errors", "config"]},
-            {
-                "$set": {
-                    "qaFinishedObject": {
-                        "$cond": {
-                            "if": {"$eq": ["$qaFinished", None]},
-                            "then": {},
-                            "else": "$qaFinished",
-                        }
-                    }
-                }
-            },
-            {
-                "$set": {
-                    "qaRunCount": {"$size": {"$objectToArray": "$qaFinishedObject"}}
-                }
-            },
             {"$set": {"qaState": "$qa.state"}},
             {"$set": {"activeQAState": "$qaState"}},
             {
                 "$set": {
                     "qaFinishedArray": {
                         "$map": {
-                            "input": {"$objectToArray": "$qaFinishedObject"},
+                            "input": {"$objectToArray": "$qaFinished"},
                             "in": "$$this.v",
                         }
                     }
@@ -206,9 +190,21 @@ class CrawlOps(BaseCrawlOps):
             {"$set": {"lastQARun": {"$arrayElemAt": ["$sortedQARuns", 0]}}},
             {"$set": {"lastQAState": "$lastQARun.state"}},
             {
+                "$set": {
+                    "qaRunCount": {
+                        "$size": {
+                            "$cond": [
+                                {"$isArray": "$qaFinishedArray"},
+                                "$qaFinishedArray",
+                                [],
+                            ]
+                        }
+                    }
+                }
+            },
+            {
                 "$unset": [
                     "lastQARun",
-                    "qaFinishedObject",
                     "qaFinishedArray",
                     "sortedQARuns",
                 ]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -660,6 +660,7 @@ class CrawlOut(BaseMongoModel):
 
     qaRunCount: int = 0
     activeQAState: Optional[str]
+    lastQAState: Optional[str]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -658,6 +658,9 @@ class CrawlOut(BaseMongoModel):
 
     reviewStatus: Optional[conint(ge=1, le=5)] = None  # type: ignore
 
+    qaRunCount: int = 0
+    activeQAState: Optional[str]
+
 
 # ============================================================================
 class CrawlOutWithResources(CrawlOut):

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -126,6 +126,16 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     assert crawls[0]["id"] == crawler_crawl_id
     assert crawls[0]["activeQAState"]
 
+    # Ensure sorting by activeQAState works as expected with all-crawls
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=activeQAState",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["activeQAState"]
+
     # Cancel crawl
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/cancel",
@@ -377,6 +387,47 @@ def test_sort_crawls_by_qa_runs(
     # Test ascending sort
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=qaRunCount&sortDirection=1",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+
+    assert crawls[-1]["id"] == crawler_crawl_id
+    assert crawls[-1]["qaRunCount"] == 2
+
+    last_count = 0
+    for crawl in crawls:
+        if crawl["id"] == crawler_crawl_id:
+            continue
+        crawl_qa_count = crawl["qaRunCount"]
+        assert isinstance(crawl_qa_count, int)
+        assert crawl_qa_count >= last_count
+        last_count = crawl_qa_count
+
+    # Test same with all-crawls
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaRunCount",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+
+    assert crawls[0]["id"] == crawler_crawl_id
+    qa_run_count = crawls[0]["qaRunCount"]
+    assert qa_run_count > 0
+
+    last_count = qa_run_count
+    for crawl in crawls:
+        if crawl["id"] == crawler_crawl_id:
+            continue
+        crawl_qa_count = crawl["qaRunCount"]
+        assert isinstance(crawl_qa_count, int)
+        assert crawl_qa_count <= last_count
+        last_count = crawl_qa_count
+
+    # Test ascending sort
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaRunCount&sortDirection=1",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -116,25 +116,27 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     assert qa["started"]
     assert not qa["finished"]
 
-    # Ensure sorting by activeQAState works as expected
+    # Ensure sorting by qaState works as expected - current floated to top
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=activeQAState",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=qaState",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
     assert crawls[0]["id"] == crawler_crawl_id
     assert crawls[0]["activeQAState"]
+    assert crawls[0]["lastQAState"]
 
-    # Ensure sorting by activeQAState works as expected with all-crawls
+    # Ensure sorting by qaState works as expected with all-crawls
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=activeQAState",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaState",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
     assert crawls[0]["id"] == crawler_crawl_id
     assert crawls[0]["activeQAState"]
+    assert crawls[0]["lastQAState"]
 
     # Cancel crawl
     r = requests.post(

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -393,7 +393,7 @@ def test_sort_crawls_by_qa_runs(
     crawls = r.json()["items"]
 
     assert crawls[-1]["id"] == crawler_crawl_id
-    assert crawls[-1]["qaRunCount"] == 2
+    assert crawls[-1]["qaRunCount"] > 0
 
     last_count = 0
     for crawl in crawls:
@@ -434,7 +434,7 @@ def test_sort_crawls_by_qa_runs(
     crawls = r.json()["items"]
 
     assert crawls[-1]["id"] == crawler_crawl_id
-    assert crawls[-1]["qaRunCount"] == 2
+    assert crawls[-1]["qaRunCount"] > 0
 
     last_count = 0
     for crawl in crawls:

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -303,6 +303,25 @@ def test_update_crawl(
     assert r.status_code == 200
     assert r.json()["reviewStatus"] == 5
 
+    # Test sorting on reviewStatus
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=reviewStatus",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[0]["id"] == admin_crawl_id
+    assert crawls[0]["reviewStatus"] == 5
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=reviewStatus&sortDirection=1",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[-1]["id"] == admin_crawl_id
+    assert crawls[-1]["reviewStatus"] == 5
+
     # Try to update to invalid reviewStatus
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -322,6 +322,25 @@ def test_update_crawl(
     assert crawls[-1]["id"] == admin_crawl_id
     assert crawls[-1]["reviewStatus"] == 5
 
+    # Test sorting on reviewStatus for all-crawls
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=reviewStatus",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[0]["id"] == admin_crawl_id
+    assert crawls[0]["reviewStatus"] == 5
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=reviewStatus&sortDirection=1",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[-1]["id"] == admin_crawl_id
+    assert crawls[-1]["reviewStatus"] == 5
+
     # Try to update to invalid reviewStatus
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}",


### PR DESCRIPTION
Backend work for #1672 

Adds new sort options to /crawls and /all-crawls GET list endpoints:

- `reviewStatus`
- `qaRunCount`: number of completed QA runs for crawl (also added to CrawlOut)
- `qaState` (sorts by `activeQAState` first, then `lastQAState`, both of which are added to CrawlOut)
