### PR TITLE
Ensure /all-crawls?sortBy=qaState always sorts crawls above uploads

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -627,9 +627,11 @@ class BaseCrawlOps:
 
             sort_query = {sort_by: sort_direction}
 
-            # Add secondary sort for qaState - sorted by current, then last
+            # Secondary sort for qaState - sorted by current, then last
+            # Tertiary sort for qaState - type, always ascending so crawls are first
             if sort_by == "qaState":
                 sort_query["lastQAState"] = sort_direction
+                sort_query["type"] = 1
 
             aggregate.extend([{"$sort": sort_query}])
 

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -419,6 +419,20 @@ def test_list_all_crawls(
         assert item["finished"]
         assert item["state"]
 
+    # Test that all-crawls qaState sort always puts cralws before uploads
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaState",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    last_type = None
+    for item in data["items"]:
+        if last_type == "upload":
+            assert item["type"] != "crawl"
+        last_type = item["type"]
+
 
 def test_get_all_crawls_by_name(
     admin_auth_headers, default_org_id, replaced_upload_id, upload_id_2

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -419,7 +419,7 @@ def test_list_all_crawls(
         assert item["finished"]
         assert item["state"]
 
-    # Test that all-crawls qaState sort always puts cralws before uploads
+    # Test that all-crawls qaState sort always puts crawls before uploads
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaState",
         headers=admin_auth_headers,


### PR DESCRIPTION
Follow-up to #1686 