### PR TITLE
Display QA resources as table

### DIFF
--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -426,7 +426,7 @@ export class ArchivedItemQA extends TailwindElement {
               ?active=${this.tab === "screenshots"}
               @click=${this.onTabNavClick}
             >
-              <sl-icon name="camera-fill"></sl-icon>
+              <sl-icon name="images"></sl-icon>
               ${msg("Screenshots")}
               ${when(this.page?.qa || currentPage?.qa, (qa) =>
                 renderSeverityBadge(qa.screenshotMatch),

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -450,7 +450,7 @@ export class ArchivedItemQA extends TailwindElement {
               ?active=${this.tab === "resources"}
               @click=${this.onTabNavClick}
             >
-              <sl-icon name="list-check"></sl-icon>
+              <sl-icon name="database-down"></sl-icon>
               ${msg("Resources")}
             </btrix-navigation-button>
             <btrix-navigation-button

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -450,7 +450,7 @@ export class ArchivedItemQA extends TailwindElement {
               ?active=${this.tab === "resources"}
               @click=${this.onTabNavClick}
             >
-              <sl-icon name="database"></sl-icon>
+              <sl-icon name="server"></sl-icon>
               ${msg("Resources")}
             </btrix-navigation-button>
             <btrix-navigation-button

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -450,7 +450,7 @@ export class ArchivedItemQA extends TailwindElement {
               ?active=${this.tab === "resources"}
               @click=${this.onTabNavClick}
             >
-              <sl-icon name="database-down"></sl-icon>
+              <sl-icon name="database"></sl-icon>
               ${msg("Resources")}
             </btrix-navigation-button>
             <btrix-navigation-button

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -20,8 +20,20 @@ function renderDiff(
     html`<span class=${tw`capitalize`}>${key}</span>`,
     html`${crawlResources[key].good.toLocaleString()}`,
     html`${crawlResources[key].bad.toLocaleString()}`,
-    html`${qaResources[key].good.toLocaleString()}`,
-    html`${qaResources[key].bad.toLocaleString()}`,
+    html`<span
+      class=${crawlResources[key].good !== qaResources[key].good
+        ? tw`font-semibold text-danger`
+        : tw`text-neutral-400`}
+    >
+      ${qaResources[key].good.toLocaleString()}
+    </span>`,
+    html`<span
+      class=${crawlResources[key].bad !== qaResources[key].bad
+        ? tw`font-semibold text-danger`
+        : tw`text-neutral-400`}
+    >
+      ${qaResources[key].bad.toLocaleString()}
+    </span>`,
   ]);
 
   return html`

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -3,6 +3,8 @@ import { html } from "lit";
 
 import type { ReplayData, ResourcesPayload } from "../types";
 
+import { renderSpinner } from "./spinner";
+
 import { tw } from "@/utils/tailwind";
 
 function renderDiff(
@@ -51,14 +53,14 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
 
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
-      <div
-        class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}
-      >
-        ${crawlData?.resources && qaData?.resources
-          ? renderDiff(crawlData.resources, qaData.resources)
-          : noData}
+      <div class=${tw`flex-1 overflow-auto overscroll-contain pb-2`}>
+        ${crawlData && qaData
+          ? crawlData.resources && qaData.resources
+            ? renderDiff(crawlData.resources, qaData.resources)
+            : noData
+          : renderSpinner()}
       </div>
-      <footer class=${tw`mt-3 text-xs text-neutral-600`}>
+      <footer class=${tw`border-t pt-2 text-xs text-neutral-600`}>
         <p class=${tw`mb-2`}>
           ${msg('"Good" and "Bad" indicates the status code of the resource.')}
         </p>

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -35,7 +35,7 @@ function renderDiff(
         class="${tw`font-semibold`} ${crawlResources[TOTAL].good !==
         qaResources[TOTAL].good
           ? tw`text-danger`
-          : tw`text-success`}"
+          : tw`text-neutral-700`}"
       >
         ${qaResources[TOTAL].good.toLocaleString()}
       </span>`,
@@ -43,7 +43,7 @@ function renderDiff(
         class="${tw`font-semibold`} ${crawlResources[TOTAL].bad !==
         qaResources[TOTAL].bad
           ? tw`text-danger`
-          : tw`text-success`}"
+          : tw`text-neutral-700`}"
       >
         ${qaResources[TOTAL].bad.toLocaleString()}
       </span>`,

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -31,7 +31,7 @@ function renderDiff(
 
 export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
   const noData = html`<div
-    class=${tw`flex flex-col items-center justify-center gap-2 text-xs text-neutral-500`}
+    class=${tw`flex h-full flex-col items-center justify-center gap-2 text-xs text-neutral-500`}
   >
     <sl-icon name="slash-circle"></sl-icon>
     ${msg("Resources data not available")}
@@ -39,14 +39,6 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
 
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
-      <div class=${tw`mb-2 flex font-semibold`}>
-        <h3 id="crawlResourcesHeading" class=${tw`flex-1`}>
-          ${msg("Resources loaded during crawl")}
-        </h3>
-        <h3 id="qaResourcesHeading" class=${tw`flex-1`}>
-          ${msg("Resources loaded in replay")}
-        </h3>
-      </div>
       <div
         class=${tw`flex-1 overflow-auto overscroll-contain rounded-lg border`}
       >
@@ -54,6 +46,21 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
           ? renderDiff(crawlData.resources, qaData.resources)
           : noData}
       </div>
+      <footer class=${tw`mt-3 text-xs text-neutral-600`}>
+        <p class=${tw`mb-2`}>
+          ${msg('"Good" and "Bad" indicates the status code of the resource.')}
+        </p>
+        <dl>
+          <div class=${tw`flex gap-1`}>
+            <dt class=${tw`font-semibold`}>${msg("Good:")}</dt>
+            <dd>${msg("Status code between 200-399")}</dd>
+          </div>
+          <div class=${tw`flex gap-1`}>
+            <dt class=${tw`font-semibold`}>${msg("Bad:")}</dt>
+            <dd>${msg("Status code between 400-599")}</dd>
+          </div>
+        </dl>
+      </footer>
     </div>
   `;
 }

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -7,6 +7,8 @@ import { renderSpinner } from "./spinner";
 
 import { tw } from "@/utils/tailwind";
 
+const TOTAL = "Total";
+
 function renderDiff(
   crawlResources: ResourcesPayload["resources"],
   qaResources: ResourcesPayload["resources"],
@@ -18,25 +20,56 @@ function renderDiff(
     msg("Good in Replay"),
     msg("Bad in Replay"),
   ];
-  const rows = Object.keys(crawlResources).map((key) => [
-    html`<span class=${tw`capitalize`}>${key}</span>`,
-    html`${crawlResources[key].good.toLocaleString()}`,
-    html`${crawlResources[key].bad.toLocaleString()}`,
-    html`<span
-      class=${crawlResources[key].good !== qaResources[key].good
-        ? tw`font-semibold text-danger`
-        : tw`text-neutral-400`}
-    >
-      ${qaResources[key].good.toLocaleString()}
-    </span>`,
-    html`<span
-      class=${crawlResources[key].bad !== qaResources[key].bad
-        ? tw`font-semibold text-danger`
-        : tw`text-neutral-400`}
-    >
-      ${qaResources[key].bad.toLocaleString()}
-    </span>`,
-  ]);
+  const rows = [
+    [
+      html`<span class=${tw`font-semibold capitalize`}
+        >${msg("All Resources")}</span
+      >`,
+      html`<span class=${tw`font-semibold`}
+        >${crawlResources[TOTAL].good.toLocaleString()}</span
+      >`,
+      html`<span class=${tw`font-semibold`}
+        >${crawlResources[TOTAL].bad.toLocaleString()}</span
+      >`,
+      html`<span
+        class="${tw`font-semibold`} ${crawlResources[TOTAL].good !==
+        qaResources[TOTAL].good
+          ? tw`text-danger`
+          : tw`text-success`}"
+      >
+        ${qaResources[TOTAL].good.toLocaleString()}
+      </span>`,
+      html`<span
+        class="${tw`font-semibold`} ${crawlResources[TOTAL].bad !==
+        qaResources[TOTAL].bad
+          ? tw`text-danger`
+          : tw`text-success`}"
+      >
+        ${qaResources[TOTAL].bad.toLocaleString()}
+      </span>`,
+    ],
+    ...Object.keys(crawlResources)
+      .filter((key) => key !== TOTAL)
+      .map((key) => [
+        html`<span class=${tw`capitalize`}>${key}</span>`,
+        html`${crawlResources[key].good.toLocaleString()}`,
+        html`${crawlResources[key].bad.toLocaleString()}`,
+        html`<span
+          class=${crawlResources[key].good !== qaResources[key].good
+            ? tw`text-danger`
+            : tw`text-neutral-400`}
+        >
+          ${qaResources[key].good.toLocaleString()}
+        </span>`,
+        html`<span
+          class=${crawlResources[key].bad !== qaResources[key].bad
+            ? tw`font-semibold text-danger`
+            : tw`text-neutral-400`}
+        >
+          ${qaResources[key].bad.toLocaleString()}
+        </span>`,
+      ]),
+  ];
 
   return html`
     <btrix-data-table .columns=${columns} .rows=${rows}></btrix-data-table>
@@ -53,7 +86,7 @@ export function renderResources(crawlData: ReplayData, qaData: ReplayData) {
 
   return html`
     <div class=${tw`flex h-full flex-col outline`}>
-      <div class=${tw`flex-1 overflow-auto overscroll-contain pb-2`}>
+      <div class=${tw`flex-1 overflow-auto overscroll-contain pb-3`}>
         ${crawlData && qaData
           ? crawlData.resources && qaData.resources
             ? renderDiff(crawlData.resources, qaData.resources)


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix-cloud/issues/1689

### Changes

- Renders QA resource data as a basic table
- Updates screenshot and resource tab icons

### Manual testing

1. Log in as crawler
2. Go to the detail page for an archived item with QA analysis
3. Click "Review Crawl"
4. Click "Resources". Verify resources that do not match are highlighted in red in the replay columns.

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| QA Review - Resources | <img width="908" alt="Screenshot 2024-04-17 at 4 02 48 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/2f4eed21-fb53-4ae8-b294-661c398133f8"> |
| QA Review | <img width="596" alt="Screenshot 2024-04-17 at 7 11 54 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/4672952/55bb037b-fef4-4f7d-9971-2c575eb860bd"> |





<!-- ### Follow-ups -->
