### PR TITLE
Add 'activeQAStats' field

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -553,6 +553,7 @@ class BaseCrawlOps:
             {"$unset": ["firstSeedObject", "errors", "config"]},
             {"$set": {"qaState": "$qa.state"}},
             {"$set": {"activeQAState": "$qaState"}},
+            {"$set": {"activeQAStats": "$qa.stats"}},
             {
                 "$set": {
                     "qaFinishedArray": {

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -171,6 +171,7 @@ class CrawlOps(BaseCrawlOps):
             {"$unset": ["firstSeedObject", "errors", "config"]},
             {"$set": {"qaState": "$qa.state"}},
             {"$set": {"activeQAState": "$qaState"}},
+            {"$set": {"activeQAStats": "$qa.stats"}},
             {
                 "$set": {
                     "qaFinishedArray": {

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -660,6 +660,7 @@ class CrawlOut(BaseMongoModel):
 
     qaRunCount: int = 0
     activeQAState: Optional[str]
+    activeQAStats: Optional[CrawlStats]
     lastQAState: Optional[str]
 
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -125,6 +125,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     crawls = r.json()["items"]
     assert crawls[0]["id"] == crawler_crawl_id
     assert crawls[0]["activeQAState"]
+    assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
 
     # Ensure sorting by qaState works as expected with all-crawls
@@ -136,6 +137,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     crawls = r.json()["items"]
     assert crawls[0]["id"] == crawler_crawl_id
     assert crawls[0]["activeQAState"]
+    assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
 
     # Cancel crawl


### PR DESCRIPTION
As additional support for #1683, include the active QA stats in the crawl response, along with active QA state.
This will allow showing progress of QA run in the archived items list.