### PR TITLE
Change resource table to be based on mime type

### DIFF
--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -984,15 +984,8 @@ export class ArchivedItemQA extends TailwindElement {
           const { status = 0, type, mime } = entry;
           const resType = this.resolveType(url, entry);
 
-          console.log(
-            isQA ? "replay" : "crawl",
-            status >= 400 ? "bad" : "good",
-            resType,
-            type,
-            mime,
-            status,
-            url,
-          );
+          // for debugging
+          logResource(isQA, resType, url, type, mime, status);
 
           if (!typeMap.has(resType)) {
             if (status < 400) {
@@ -1150,4 +1143,24 @@ export class ArchivedItemQA extends TailwindElement {
       });
     }
   }
+}
+
+// leaving here for further debugging of resources
+function logResource(
+  _isQA: boolean,
+  _resType: string,
+  _url: string,
+  _type?: string,
+  _mime?: string,
+  _status = 0,
+) {
+  // console.log(
+  //   _isQA ? "replay" : "crawl",
+  //   _status >= 400 ? "bad" : "good",
+  //   _resType,
+  //   _type,
+  //   _mime,
+  //   _status,
+  //   _url,
+  // );
 }

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -887,9 +887,6 @@ export class ArchivedItemQA extends TailwindElement {
         let good = 0,
           bad = 0;
 
-        // Initialize favicon so it shows even if only present in replay
-        typeMap.set("favicon", { good: 0, bad: 0 });
-
         for (const [url, entry] of Object.entries(json.urls)) {
           const { mime = "", status = 0 } = entry;
           let resType = mime.split("/")[0];
@@ -910,6 +907,9 @@ export class ArchivedItemQA extends TailwindElement {
           }
           if (url.includes("favicon.ico")) {
             resType = "favicon";
+          }
+          if (!mime) {
+            resType = "other";
           }
 
           if (!typeMap.has(resType)) {

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -905,7 +905,7 @@ export class ArchivedItemQA extends TailwindElement {
           if (mime.includes("html")) {
             resType = "html";
           }
-          if (url.includes("favicon.ico")) {
+          if (url.endsWith("favicon.ico")) {
             resType = "favicon";
           }
           if (!mime) {

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -22,7 +22,9 @@ function renderDiff(
   ];
   const rows = [
     [
-      html`<span class=${tw`font-semibold`}>${msg("All Resources")}</span>`,
+      html`<span class=${tw`font-semibold capitalize`}
+        >${msg("All Resources")}</span
+      >`,
       html`<span class=${tw`font-semibold`}
         >${crawlResources[TOTAL].good.toLocaleString()}</span
       >`,
@@ -49,7 +51,7 @@ function renderDiff(
     ...Object.keys(crawlResources)
       .filter((key) => key !== TOTAL)
       .map((key) => [
-        html`<span>${key}</span>`,
+        html`<span class=${tw`capitalize`}>${key}</span>`,
         html`${crawlResources[key].good.toLocaleString()}`,
         html`${crawlResources[key].bad.toLocaleString()}`,
         html`<span

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -22,9 +22,7 @@ function renderDiff(
   ];
   const rows = [
     [
-      html`<span class=${tw`font-semibold capitalize`}
-        >${msg("All Resources")}</span
-      >`,
+      html`<span class=${tw`font-semibold`}>${msg("All Resources")}</span>`,
       html`<span class=${tw`font-semibold`}
         >${crawlResources[TOTAL].good.toLocaleString()}</span
       >`,
@@ -51,7 +49,7 @@ function renderDiff(
     ...Object.keys(crawlResources)
       .filter((key) => key !== TOTAL)
       .map((key) => [
-        html`<span class=${tw`capitalize`}>${key}</span>`,
+        html`<span>${key}</span>`,
         html`${crawlResources[key].good.toLocaleString()}`,
         html`${crawlResources[key].bad.toLocaleString()}`,
         html`<span

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -14,7 +14,7 @@ function renderDiff(
   qaResources: ResourcesPayload["resources"],
 ) {
   const columns = [
-    msg("MIME Type"),
+    msg("Resource Type"),
     msg("Good During Crawl"),
     msg("Bad During Crawl"),
     msg("Good in Replay"),

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -48,23 +48,29 @@ function renderDiff(
         ${qaResources[TOTAL].bad.toLocaleString()}
       </span>`,
     ],
-    ...Object.keys(crawlResources)
+    ...Object.keys(qaResources)
       .filter((key) => key !== TOTAL)
       .map((key) => [
         html`<span class=${tw`capitalize`}>${key}</span>`,
-        html`${crawlResources[key].good.toLocaleString()}`,
-        html`${crawlResources[key].bad.toLocaleString()}`,
+        html`${Object.prototype.hasOwnProperty.call(crawlResources, key)
+          ? crawlResources[key].good.toLocaleString()
+          : 0}`,
+        html`${Object.prototype.hasOwnProperty.call(crawlResources, key)
+          ? crawlResources[key].bad.toLocaleString()
+          : 0}`,
         html`<span
-          class=${crawlResources[key].good !== qaResources[key].good
-            ? tw`text-danger`
-            : tw`text-neutral-400`}
+          class=${Object.prototype.hasOwnProperty.call(crawlResources, key) &&
+          crawlResources[key].good === qaResources[key].good
+            ? tw`text-neutral-400`
+            : tw`text-danger`}
         >
           ${qaResources[key].good.toLocaleString()}
         </span>`,
         html`<span
-          class=${crawlResources[key].bad !== qaResources[key].bad
-            ? tw`font-semibold text-danger`
-            : tw`text-neutral-400`}
+          class=${Object.prototype.hasOwnProperty.call(crawlResources, key) &&
+          crawlResources[key].bad === qaResources[key].bad
+            ? tw`text-neutral-400`
+            : tw`font-semibold text-danger`}
         >
           ${qaResources[key].bad.toLocaleString()}
         </span>`,

--- a/frontend/src/pages/org/archived-item-qa/ui/resources.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/resources.ts
@@ -14,7 +14,7 @@ function renderDiff(
   qaResources: ResourcesPayload["resources"],
 ) {
   const columns = [
-    msg("Resource Type"),
+    msg("MIME Type"),
     msg("Good During Crawl"),
     msg("Bad During Crawl"),
     msg("Good in Replay"),


### PR DESCRIPTION
Follow-up to #1689 

Instead of using resource types, let's use the first half of mime types now, with a few manual substitutions to ensure that favicons, javascript, html, and stylesheets are put into better categories than just e.g. `text`.

<img width="1177" alt="Screen Shot 2024-04-18 at 5 12 55 PM" src="https://github.com/webrecorder/browsertrix-cloud/assets/6758804/695ae5a1-b41e-4a27-bf45-82e6be291426">
