### PR TITLE
Support sorting by last QA started time

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -564,8 +564,16 @@ class BaseCrawlOps:
             },
             # Add active QA run to array if exists prior to sorting, taking care not to
             # pass null to $concatArrays so that our result isn't null
-            {"set": {"qaActiveArray": {"$cond": [{"$ne": ["$qa", None]}, ["$qa"], []]}}}
-            {"$set": {"qaArray": {"$concatArrays": [ "$qaFinishedArray", "$qaActiveArray"]}}},
+            {
+                "set": {
+                    "qaActiveArray": {"$cond": [{"$ne": ["$qa", None]}, ["$qa"], []]}
+                }
+            },
+            {
+                "$set": {
+                    "qaArray": {"$concatArrays": ["$qaFinishedArray", "$qaActiveArray"]}
+                }
+            },
             {
                 "$set": {
                     "sortedQARuns": {

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -565,7 +565,7 @@ class BaseCrawlOps:
             # Add active QA run to array if exists prior to sorting, taking care not to
             # pass null to $concatArrays so that our result isn't null
             {
-                "set": {
+                "$set": {
                     "qaActiveArray": {"$cond": [{"$ne": ["$qa", None]}, ["$qa"], []]}
                 }
             },

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -576,6 +576,7 @@ class BaseCrawlOps:
             },
             {"$set": {"lastQARun": {"$arrayElemAt": ["$sortedQARuns", 0]}}},
             {"$set": {"lastQAState": "$lastQARun.state"}},
+            {"$set": {"lastQAStarted": "$lastQARun.started"}},
             {
                 "$set": {
                     "qaRunCount": {
@@ -619,6 +620,7 @@ class BaseCrawlOps:
                 "finished",
                 "fileSize",
                 "reviewStatus",
+                "qaStarted",
                 "qaRunCount",
                 "qaState",
             ):
@@ -632,6 +634,10 @@ class BaseCrawlOps:
             # Tertiary sort for qaState - type, always ascending so crawls are first
             if sort_by == "qaState":
                 sort_query["lastQAState"] = sort_direction
+                sort_query["type"] = 1
+
+            if sort_by == "qaStarted":
+                sort_query["lastQAStarted"] = sort_direction
                 sort_query["type"] = 1
 
             aggregate.extend([{"$sort": sort_query}])

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -183,7 +183,7 @@ class CrawlOps(BaseCrawlOps):
             # Add active QA run to array if exists prior to sorting, taking care not to
             # pass null to $concatArrays so that our result isn't null
             {
-                "set": {
+                "$set": {
                     "qaActiveArray": {"$cond": [{"$ne": ["$qa", None]}, ["$qa"], []]}
                 }
             },

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -182,8 +182,16 @@ class CrawlOps(BaseCrawlOps):
             },
             # Add active QA run to array if exists prior to sorting, taking care not to
             # pass null to $concatArrays so that our result isn't null
-            {"set": {"qaActiveArray": {"$cond": [{"$ne": ["$qa", None]}, ["$qa"], []]}}}
-            {"$set": {"qaArray": {"$concatArrays": [ "$qaFinishedArray", "$qaActiveArray"]}}},
+            {
+                "set": {
+                    "qaActiveArray": {"$cond": [{"$ne": ["$qa", None]}, ["$qa"], []]}
+                }
+            },
+            {
+                "$set": {
+                    "qaArray": {"$concatArrays": ["$qaFinishedArray", "$qaActiveArray"]}
+                }
+            },
             {
                 "$set": {
                     "sortedQARuns": {
@@ -245,7 +253,7 @@ class CrawlOps(BaseCrawlOps):
                 "reviewStatus",
                 "qaRunCount",
                 "lastQAState",
-                "lastQAStarted"
+                "lastQAStarted",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -194,6 +194,7 @@ class CrawlOps(BaseCrawlOps):
             },
             {"$set": {"lastQARun": {"$arrayElemAt": ["$sortedQARuns", 0]}}},
             {"$set": {"lastQAState": "$lastQARun.state"}},
+            {"$set": {"lastQAStarted": "$lastQARun.started"}},
             {
                 "$set": {
                     "qaRunCount": {
@@ -238,6 +239,7 @@ class CrawlOps(BaseCrawlOps):
                 "fileSize",
                 "firstSeed",
                 "reviewStatus",
+                "qaStarted",
                 "qaRunCount",
                 "qaState",
             ):
@@ -250,6 +252,9 @@ class CrawlOps(BaseCrawlOps):
             # Add secondary sort for qaState - sorted by current, then last
             if sort_by == "qaState":
                 sort_query["lastQAState"] = sort_direction
+
+            if sort_by == "qaStarted":
+                sort_query["lastQAStarted"] = sort_direction
 
             aggregate.extend([{"$sort": sort_query}])
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -660,7 +660,6 @@ class CrawlOut(BaseMongoModel):
     reviewStatus: Optional[conint(ge=1, le=5)] = None  # type: ignore
 
     qaRunCount: int = 0
-    activeQAState: Optional[str]
     activeQAStats: Optional[CrawlStats]
     lastQAState: Optional[str]
     lastQAStarted: Optional[datetime]

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -663,6 +663,7 @@ class CrawlOut(BaseMongoModel):
     activeQAState: Optional[str]
     activeQAStats: Optional[CrawlStats]
     lastQAState: Optional[str]
+    lastQAStarted: Optional[datetime]
 
 
 # ============================================================================

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -116,29 +116,52 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     assert qa["started"]
     assert not qa["finished"]
 
-    # Ensure sorting by qaState works as expected - current floated to top
+    # Ensure sorting by lastQAState works as expected - current floated to top
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=qaState",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=lastQAState",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
     assert crawls[0]["id"] == crawler_crawl_id
-    assert crawls[0]["activeQAState"]
     assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
     assert crawls[0]["lastQAStarted"]
 
-    # Ensure sorting by qaState works as expected with all-crawls
+    # Ensure sorting by lastQAState works as expected with all-crawls
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaState",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=lastQAState",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
     assert crawls[0]["id"] == crawler_crawl_id
-    assert crawls[0]["activeQAState"]
     assert crawls[0]["activeQAStats"]
+    assert crawls[0]["lastQAState"]
+    assert crawls[0]["lastQAStarted"]
+
+    # Ensure sorting by lastQAStarted works as expected - current floated to top
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls?sortBy=lastQAStarted",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["activeQAStats"]
+    assert crawls[0]["lastQAState"]
+    assert crawls[0]["lastQAStarted"]
+
+    # Ensure sorting by lastQAState works as expected with all-crawls
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=lastQAStarted",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawls = r.json()["items"]
+    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["activeQAStats"]
+    assert crawls[0]["lastQAState"]
     assert crawls[0]["lastQAStarted"]
 
     # Cancel crawl

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -127,6 +127,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     assert crawls[0]["activeQAState"]
     assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
+    assert crawls[0]["lastQAStarted"]
 
     # Ensure sorting by qaState works as expected with all-crawls
     r = requests.get(
@@ -138,7 +139,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     assert crawls[0]["id"] == crawler_crawl_id
     assert crawls[0]["activeQAState"]
     assert crawls[0]["activeQAStats"]
-    assert crawls[0]["lastQAState"]
+    assert crawls[0]["lastQAStarted"]
 
     # Cancel crawl
     r = requests.post(

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -419,9 +419,22 @@ def test_list_all_crawls(
         assert item["finished"]
         assert item["state"]
 
-    # Test that all-crawls qaState sort always puts crawls before uploads
+    # Test that all-crawls lastQAState and lastQAStarted sorts always puts crawls before uploads
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=qaState",
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=lastQAState",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    last_type = None
+    for item in data["items"]:
+        if last_type == "upload":
+            assert item["type"] != "crawl"
+        last_type = item["type"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?sortBy=lastQAStarted",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200


### PR DESCRIPTION
To support #1683, it would be useful to be able to sort by 'last QA start time' in addition to/instead of last QA state.