### PR TITLE
Fix QA run deletion

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -272,6 +272,7 @@ export class ArchivedItemDetail extends TailwindElement {
               .qaRuns=${this.qaRuns}
               .qaRunId=${this.qaRunId}
               .mostRecentNonFailedQARun=${this.mostRecentNonFailedQARun}
+              @btrix-qa-runs-update=${() => void this.fetchQARuns()}
             ></btrix-archived-item-detail-qa>
           `,
         );

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -105,6 +105,9 @@ function statusWithIcon(
   `;
 }
 
+/**
+ * @fires btrix-qa-runs-update
+ */
 @localized()
 @customElement("btrix-archived-item-detail-qa")
 export class ArchivedItemDetailQA extends TailwindElement {
@@ -376,6 +379,16 @@ export class ArchivedItemDetailQA extends TailwindElement {
   }
 
   private readonly renderQARunRows = (qaRuns: QARun[]) => {
+    if (!qaRuns.length) {
+      return html`
+        <div
+          class="col-span-4 flex h-full flex-col items-center justify-center gap-2 p-3 text-xs text-neutral-500"
+        >
+          <sl-icon name="slash-circle"></sl-icon>
+          ${msg("No analysis runs found")}
+        </div>
+      `;
+    }
     return qaRuns.map(
       (run, idx) => html`
         <btrix-table-row class=${idx > 0 ? "border-t" : ""}>
@@ -511,6 +524,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
               variant="danger"
               @click=${async () => {
                 await this.deleteQARun(runToBeDeleted.id);
+                this.dispatchEvent(new CustomEvent("btrix-qa-runs-update"));
                 this.deleting = null;
                 void this.deleteQADialog?.hide();
               }}

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -768,7 +768,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
   async deleteQARun(id: string) {
     try {
       await this.api.fetch(
-        `/orgs/${this.orgId}/crawls/${this.crawlId}`,
+        `/orgs/${this.orgId}/crawls/${this.crawlId}/qa/delete`,
         this.authState!,
         { method: "POST", body: JSON.stringify({ qa_run_ids: [id] }) },
       );


### PR DESCRIPTION
Related: https://github.com/webrecorder/browsertrix/issues/1477

<!-- Fixes #issue_number -->

### Changes

Fixes unable to delete QA run from the QA tab "Analysis Runs" list.

### Manual testing

1. Log in as crawler
2. Go to Archived Item with analysis runs
3. Click "Analysis Runs"
4. Open run action menu and "Delete Analysis Run"
5. Confirm deletion. Verify item is removed from list