### PR TITLE
Hide QA UI from users without crawler role

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -558,11 +558,13 @@ export class ArchivedItemDetail extends TailwindElement {
                 </sl-button-group>
               `
             : ""}
-          ${this.crawl && this.isCrawler
-            ? this.renderMenu()
-            : html`<sl-skeleton
-                class="h-8 w-24 [--border-radius:theme(borderRadius.sm)]"
-              ></sl-skeleton>`}
+          ${this.isCrawler
+            ? this.crawl
+              ? this.renderMenu()
+              : html`<sl-skeleton
+                  class="h-8 w-24 [--border-radius:theme(borderRadius.sm)]"
+                ></sl-skeleton>`
+            : nothing}
         </div>
       </header>
     `;

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -253,32 +253,32 @@ export class ArchivedItemDetail extends TailwindElement {
 
     switch (this.activeTab) {
       case "qa": {
-        if (this.isCrawler) {
-          sectionContent = this.renderPanel(
-            html`${this.renderTitle(
-                html`${msg("Quality Assurance")}
-                  <btrix-beta-badge></btrix-beta-badge>`,
-              )}
-              <div class="ml-auto flex flex-wrap justify-end gap-2">
-                ${when(this.qaRuns, this.renderQAHeader)}
-              </div> `,
-            html`
-              <btrix-archived-item-detail-qa
-                .authState=${this.authState}
-                .orgId=${this.orgId}
-                .crawlId=${this.crawlId}
-                .itemType=${this.itemType}
-                .crawl=${this.crawl}
-                .qaRuns=${this.qaRuns}
-                .qaRunId=${this.qaRunId}
-                .mostRecentNonFailedQARun=${this.mostRecentNonFailedQARun}
-                @btrix-qa-runs-update=${() => void this.fetchQARuns()}
-              ></btrix-archived-item-detail-qa>
-            `,
-          );
+        if (!this.isCrawler) {
+          sectionContent = "";
           break;
         }
-        sectionContent = "";
+        sectionContent = this.renderPanel(
+          html`${this.renderTitle(
+              html`${msg("Quality Assurance")}
+                <btrix-beta-badge></btrix-beta-badge>`,
+            )}
+            <div class="ml-auto flex flex-wrap justify-end gap-2">
+              ${when(this.qaRuns, this.renderQAHeader)}
+            </div> `,
+          html`
+            <btrix-archived-item-detail-qa
+              .authState=${this.authState}
+              .orgId=${this.orgId}
+              .crawlId=${this.crawlId}
+              .itemType=${this.itemType}
+              .crawl=${this.crawl}
+              .qaRuns=${this.qaRuns}
+              .qaRunId=${this.qaRunId}
+              .mostRecentNonFailedQARun=${this.mostRecentNonFailedQARun}
+              @btrix-qa-runs-update=${() => void this.fetchQARuns()}
+            ></btrix-archived-item-detail-qa>
+          `,
+        );
         break;
       }
       case "replay":

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -249,33 +249,38 @@ export class ArchivedItemDetail extends TailwindElement {
 
   render() {
     const authToken = this.authState!.headers.Authorization.split(" ")[1];
-    let sectionContent: string | TemplateResult = "";
+    let sectionContent: string | TemplateResult<1> = "";
 
     switch (this.activeTab) {
-      case "qa":
-        sectionContent = this.renderPanel(
-          html`${this.renderTitle(
-              html`${msg("Quality Assurance")}
-                <btrix-beta-badge></btrix-beta-badge>`,
-            )}
-            <div class="ml-auto flex flex-wrap justify-end gap-2">
-              ${when(this.qaRuns, this.renderQAHeader)}
-            </div> `,
-          html`
-            <btrix-archived-item-detail-qa
-              .authState=${this.authState}
-              .orgId=${this.orgId}
-              .crawlId=${this.crawlId}
-              .itemType=${this.itemType}
-              .crawl=${this.crawl}
-              .qaRuns=${this.qaRuns}
-              .qaRunId=${this.qaRunId}
-              .mostRecentNonFailedQARun=${this.mostRecentNonFailedQARun}
-              @btrix-qa-runs-update=${() => void this.fetchQARuns()}
-            ></btrix-archived-item-detail-qa>
-          `,
-        );
+      case "qa": {
+        if (this.isCrawler) {
+          sectionContent = this.renderPanel(
+            html`${this.renderTitle(
+                html`${msg("Quality Assurance")}
+                  <btrix-beta-badge></btrix-beta-badge>`,
+              )}
+              <div class="ml-auto flex flex-wrap justify-end gap-2">
+                ${when(this.qaRuns, this.renderQAHeader)}
+              </div> `,
+            html`
+              <btrix-archived-item-detail-qa
+                .authState=${this.authState}
+                .orgId=${this.orgId}
+                .crawlId=${this.crawlId}
+                .itemType=${this.itemType}
+                .crawl=${this.crawl}
+                .qaRuns=${this.qaRuns}
+                .qaRunId=${this.qaRunId}
+                .mostRecentNonFailedQARun=${this.mostRecentNonFailedQARun}
+                @btrix-qa-runs-update=${() => void this.fetchQARuns()}
+              ></btrix-archived-item-detail-qa>
+            `,
+          );
+          break;
+        }
+        sectionContent = "";
         break;
+      }
       case "replay":
         sectionContent = this.renderPanel(msg("Replay"), this.renderReplay(), [
           tw`overflow-hidden rounded-lg border`,
@@ -478,7 +483,7 @@ export class ArchivedItemDetail extends TailwindElement {
           label: msg("Overview"),
         })}
         ${when(
-          this.itemType === "crawl",
+          this.itemType === "crawl" && this.isCrawler,
           () => html`
             ${renderNavItem({
               section: "qa",

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -99,9 +99,6 @@ export class ArchivedItemQA extends TailwindElement {
   @property({ type: String })
   qaRunId?: string;
 
-  @property({ type: Boolean })
-  isCrawler = false;
-
   @property({ type: String })
   tab: QATypes.QATab = "screenshots";
 
@@ -840,7 +837,7 @@ export class ArchivedItemQA extends TailwindElement {
       );
     } catch {
       this.notify.toast({
-        message: msg("Sorry, couldn't retrieve QA data at this time."),
+        message: msg("Sorry, couldn't retrieve analysis runs at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -527,7 +527,13 @@ export class Org extends LiteElement {
 
     if (params.itemId) {
       if (params.qaTab) {
-        return html` <btrix-archived-item-qa
+        if (!this.isCrawler) {
+          return html`<btrix-not-found
+            class="flex items-center justify-center"
+          ></btrix-not-found>`;
+        }
+
+        return html`<btrix-archived-item-qa
           class="flex-1"
           .authState=${this.authState!}
           orgId=${this.orgId}
@@ -535,7 +541,6 @@ export class Org extends LiteElement {
           itemPageId=${ifDefined(params.itemPageId)}
           qaRunId=${ifDefined(params.qaRunId)}
           tab=${params.qaTab}
-          ?isCrawler=${this.isCrawler}
         ></btrix-archived-item-qa>`;
       }
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1732

<!-- Fixes #issue_number -->

### Changes

- Hides QA tab and QA review page from users with viewer role
- Fixes empty menu button rendering for viewers on archived item detail page

### Manual testing

1. Log in as viewer
2. Go to "Archived Items" -> archived item. Verify "Quality Assurance" tab is hidden.
3. Add `/review` to browser URL. Verify that page 404s