### PR TITLE
Fix archived item status icon size + minor review UI updates

### DIFF
--- a/frontend/src/features/archived-items/archived-item-list.ts
+++ b/frontend/src/features/archived-items/archived-item-list.ts
@@ -154,6 +154,7 @@ export class ArchivedItemListItem extends TailwindElement {
                   @sl-after-hide=${(e: SlHideEvent) => e.stopPropagation()}
                 >
                   <sl-icon
+                    class="text-base"
                     style="color: ${crawlStatus.cssColor}"
                     name=${typeIcon}
                     label=${typeLabel}
@@ -276,11 +277,11 @@ export class ArchivedItemListItem extends TailwindElement {
                       str`Last run started on ${formatISODateString(lastQAStarted)}`,
                     )}
                   >
-                    <span>
+                    <div class="min-w-4">
                       ${formatNumber(qaRunCount, {
                         notation: "compact",
                       })}
-                    </span>
+                    </div>
                   </sl-tooltip>
                 `
               : none}

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -330,18 +330,21 @@ export class ArchivedItemQA extends TailwindElement {
     return html`
       ${this.renderHidden()}
 
-      <btrix-beta-badge placement="right"></btrix-beta-badge>
+      <h1 class="font-medium text-neutral-500">
+        ${msg("Review Archived Item")}
+        <btrix-beta-badge placement="right"></btrix-beta-badge>
+      </h1>
 
       <article class="qa-grid grid gap-x-6 gap-y-0">
         <header
           class="grid--header flex flex-wrap items-center justify-between gap-1 border-b py-2"
         >
           <div class="flex items-center gap-2 overflow-hidden">
-            <h1
+            <h2
               class="flex-1 flex-shrink-0 basis-32 truncate text-base font-semibold leading-tight"
             >
               ${itemName}
-            </h1>
+            </h2>
             ${when(
               this.finishedQARuns,
               (qaRuns) => html`
@@ -389,15 +392,15 @@ export class ArchivedItemQA extends TailwindElement {
         <div
           class="grid--pageToolbar flex flex-wrap items-center justify-stretch gap-2 overflow-hidden border-b py-2 @container"
         >
-          <h2
+          <h3
             class="flex-auto flex-shrink-0 flex-grow basis-32 truncate text-base font-semibold text-neutral-700"
             title="${this.page?.title ?? ""}"
           >
-            ${
-              this.page?.title ||
-              html`<span class="opacity-50">${msg("No page title")}</span>`
-            }
-          </h2>
+          ${
+            this.page?.title ||
+            html`<span class="opacity-50">${msg("No page title")}</span>`
+          }
+          </h3>
           <div
             class="ml-auto flex flex-grow basis-auto flex-wrap justify-between gap-2 @lg:flex-grow-0"
           >
@@ -495,11 +498,11 @@ export class ArchivedItemQA extends TailwindElement {
         <section
           class="grid--pageList grid grid-rows-[auto_1fr] *:min-h-0 *:min-w-0"
         >
-          <h2
+          <h3
             class="my-4 text-base font-semibold leading-none text-neutral-800"
           >
             ${msg("Pages")}
-          </h2>
+          </h3>
           <btrix-qa-page-list
             class="flex flex-col"
             .qaRunId=${this.qaRunId}

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -330,10 +330,24 @@ export class ArchivedItemQA extends TailwindElement {
     return html`
       ${this.renderHidden()}
 
-      <h1 class="font-medium text-neutral-500">
-        ${msg("Review Archived Item")}
-        <btrix-beta-badge placement="right"></btrix-beta-badge>
-      </h1>
+      <div class="flex gap-2">
+        <a
+          class="font-medium text-neutral-500 hover:text-neutral-600"
+          href=${`${crawlBaseUrl}#qa`}
+          @click=${this.navigate.link}
+        >
+          <sl-icon
+            name="arrow-left"
+            class="inline-block align-middle"
+          ></sl-icon>
+          <span class="inline-block align-middle"> ${msg("Back")} </span>
+        </a>
+        <div class="text-neutral-400" role="separator">/</div>
+        <h1 class="text-neutral-400">
+          ${msg("Review Archived Item")}
+          <btrix-beta-badge placement="right"></btrix-beta-badge>
+        </h1>
+      </div>
 
       <article class="qa-grid grid gap-x-6 gap-y-0">
         <header

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -330,7 +330,7 @@ export class ArchivedItemQA extends TailwindElement {
     return html`
       ${this.renderHidden()}
 
-      <div class="flex gap-2">
+      <div class="flex items-center gap-2">
         <a
           class="font-medium text-neutral-500 hover:text-neutral-600"
           href=${`${crawlBaseUrl}#qa`}

--- a/frontend/src/pages/org/archived-item-qa/ui/severityBadge.ts
+++ b/frontend/src/pages/org/archived-item-qa/ui/severityBadge.ts
@@ -26,6 +26,6 @@ export function renderSeverityBadge(value?: number | null) {
   }
 
   return html`
-    <btrix-badge variant=${variant}>${formatPercentage(value)}%</btrix-badge>
+    <btrix-badge variant=${variant}>${formatPercentage(value, 0)}%</btrix-badge>
   `;
 }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -304,7 +304,7 @@ export class Org extends LiteElement {
         <main
           class="${noMaxWidth
             ? "w-full"
-            : "w-full max-w-screen-desktop"} mx-auto box-border flex flex-1 flex-col p-3 pt-7"
+            : "w-full max-w-screen-desktop pt-7"} mx-auto box-border flex flex-1 flex-col p-3"
           aria-labelledby="${this.orgTab}-tab"
         >
           ${tabPanelContent}


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/1477, minor UI tweaks as fast follow:

<!-- Fixes #issue_number -->

### Changes

- Makes archived item status icons all the same size
- Increases hover hit target of archived item cells
- Reduces top padding of QA review page
- Adds "Back" button to QA review page to match all other pages
- Updates percentage formatting of tab labels to match pages

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Items | <img width="528" alt="Screenshot 2024-04-23 at 1 26 27 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/04848ea6-6fde-44ac-a176-25f3d47aa711"> |
| QA Review | <img width="568" alt="Screenshot 2024-04-23 at 1 43 17 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/0b4fe470-b840-4814-9d2e-6aa6a09c6ae3"> |
| QA Review | <img width="530" alt="Screenshot 2024-04-23 at 1 30 34 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/f380aa75-b126-43a6-9ce1-1b3774df29c9"> |


<!-- ### Follow-ups -->
