### PR TITLE
allow configuring designated registration org to which new users can register

### DIFF
--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -169,6 +169,9 @@ class OrgOps:
     async def get_org_by_id(self, oid: UUID):
         """Get an org by id"""
         res = await self.orgs.find_one({"_id": oid})
+        if not res:
+            raise HTTPException(status_code=400, detail="invalid_org_id")
+
         return Organization.from_dict(res)
 
     async def get_default_org(self):

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -86,6 +86,7 @@ class UserManager:
         self.email_collation = Collation("en", strength=2)
 
         self.registration_enabled = is_bool(os.environ.get("REGISTRATION_ENABLED"))
+        self.register_to_org_id = os.environ.get("REGISTER_TO_ORG_ID")
 
     # pylint: disable=attribute-defined-outside-init
     def set_ops(self, org_ops, crawl_config_ops, base_crawl_ops):
@@ -362,7 +363,7 @@ class UserManager:
         except DuplicateKeyError:
             raise HTTPException(status_code=400, detail="user_already_exists")
 
-        add_to_default_org = False
+        add_to_org = False
 
         if create.inviteToken:
             new_user_invite = None
@@ -377,7 +378,7 @@ class UserManager:
                 add_to_default_org = True
 
         else:
-            add_to_default_org = True
+            add_to_org = True
             if not is_verified:
                 asyncio.create_task(self.request_verify(user, request))
 
@@ -385,8 +386,13 @@ class UserManager:
         auto_add_org: Optional[Organization] = None
 
         # if add to default, then get default org
-        if add_to_default_org:
-            auto_add_org = await self.org_ops.get_default_org()
+        if add_to_org:
+            if self.register_to_org_id:
+                auto_add_org = await self.org_ops.get_org_by_id(
+                    UUID(self.register_to_org_id)
+                )
+            else:
+                auto_add_org = await self.org_ops.get_default_org()
 
         # if creating new org, create here
         elif create.newOrg is True:
@@ -401,7 +407,7 @@ class UserManager:
 
         # if org set, add user to org
         if auto_add_org:
-            await self.org_ops.add_user_to_org(auto_add_org, user.id)
+            await self.org_ops.add_user_to_org(auto_add_org, user.id, UserRole.CRAWLER)
 
         return user
 

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -336,6 +336,7 @@ class UserManager:
         self, create: UserCreateIn, request: Optional[Request] = None
     ) -> User:
         """create new user in db"""
+        # pylint: disable=too-many-branches
         await self.validate_password(create.password)
 
         hashed_password = get_password_hash(create.password)
@@ -375,7 +376,7 @@ class UserManager:
                 print(exc)
 
             if new_user_invite and not new_user_invite.oid:
-                add_to_default_org = True
+                add_to_org = True
 
         else:
             add_to_org = True

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -22,6 +22,8 @@ data:
 
   REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default 0 }}"
 
+  REGISTER_TO_ORG_ID: "{{ .Values.registration_org_id }}"
+
   ALLOW_DUPE_INVITES: "{{ .Values.allow_dupe_invites | default 0 }}"
 
   JWT_TOKEN_LIFETIME_MINUTES: "{{ .Values.jwt_token_lifetime_minutes | default 60 }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,6 +61,10 @@ volume_storage_class:
 # crawler_node_type:
 
 registration_enabled: "0"
+
+# if set, along with 'registration_enabled', will add registrated users to this org
+# registration_org_id: ""
+
 jwt_token_lifetime_minutes: 1440
 
 # if set to "1", allow inviting same user to same org multiple times


### PR DESCRIPTION
 if 'registration_enabled' is set, check 'registration_org_id' for org id of an existing org that new users should be added to when they register. if omitted, default to the default org

Fixes #1729

Test instructions:
1) Create a new org
2) set 'registration_org_id' in local chart to new org's id
3) set 'registration_enabled: 1'
4) Register as new user
5) Ensure new user is added to the designated registration org, not the default org