### PR TITLE
Redirect if org with slug doesn't exist

### DIFF
--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -183,10 +183,17 @@ export class Org extends LiteElement {
 
   async willUpdate(changedProperties: Map<string, unknown>) {
     if (
-      (changedProperties.has("userInfo") && this.userInfo) ||
-      (changedProperties.has("slug") && this.slug)
+      (changedProperties.has("userInfo") || changedProperties.has("slug")) &&
+      this.userInfo &&
+      this.slug
     ) {
-      void this.updateOrg();
+      if (this.userOrg) {
+        void this.updateOrg();
+      } else {
+        // Couldn't find org with slug, redirect to first org
+        this.navTo(`/orgs/${this.userInfo.orgs[0].slug}`);
+        return;
+      }
     }
     if (changedProperties.has("openDialogName")) {
       // Sync URL to create dialog
@@ -216,9 +223,6 @@ export class Org extends LiteElement {
       this.checkStorageQuota();
       this.checkExecutionMinutesQuota();
     } catch {
-      // TODO handle 404
-      this.org = null;
-
       this.notify({
         message: msg("Sorry, couldn't retrieve organization at this time."),
         variant: "danger",
@@ -253,8 +257,7 @@ export class Org extends LiteElement {
 
   render() {
     if (this.org === null) {
-      // TODO handle 404 and 500s
-      return "";
+      return html`<btrix-not-found></btrix-not-found>`;
     }
 
     if (!this.org || !this.userInfo) {


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1739

<!-- Fixes #issue_number -->

### Changes

Redirect to first user's first org if an org with current slug doesn't exist.

### Manual testing

1. Log in as superadmin
2. Select an org
3. Close all browser windows to end session
4. Log in as non-admin that doesn't belong to previously selected org. Verify that you're redirected to your first org

### Follow-ups

Better long term solution documented in additional details here: https://github.com/webrecorder/browsertrix/issues/1739