### PR TITLE
quickfix: nginx: have nginx serve the fallback index.html with a 200 instead of a 404

### DIFF
--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -34,12 +34,10 @@ server {
         root /usr/share/nginx/html;
     }
 
-    # fallback to index for any page
-    error_page 404 /index.html;
-
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;
+      try_files $uri /index.html;
     }
 
     # serve replay service worker, RWP_BASE_URL set in Dockerfile


### PR DESCRIPTION
Nginx serves index.html for all pages, but with a 404. This changes it to instead return a 200.