### PR TITLE
Handle registration when user already exists

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -50,7 +50,7 @@ class InvitePending(BaseMongoModel):
     inviterEmail: str
     fromSuperuser: Optional[bool]
     oid: Optional[UUID]
-    role: Optional[UserRole] = UserRole.VIEWER
+    role: UserRole = UserRole.VIEWER
     email: Optional[str]
 
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -367,11 +367,12 @@ class OrgOps:
         await self.add_user_to_org(org, user.id, invite.role)
         return True
 
-    async def add_user_to_org(
-        self, org: Organization, userid: UUID, role: Optional[UserRole] = None
-    ):
+    async def add_user_to_org(self, org: Organization, userid: UUID, role: UserRole):
         """Add user to organization with specified role"""
-        org.users[str(userid)] = role or UserRole.OWNER
+        if str(userid) in org.users:
+            raise HTTPException(status_code=400, detail="user_already_is_org_member")
+
+        org.users[str(userid)] = role
         await self.update_users(org)
 
     async def get_org_owners(self, org: Organization):

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -364,7 +364,11 @@ class UserManager:
         try:
             await self.users.insert_one(user.dict())
         except DuplicateKeyError:
-            user = await self.get_by_email(create.email)
+            maybe_user = await self.get_by_email(create.email)
+            # shouldn't happen since user should exist if we have duplicate key, but just in case!
+            if not maybe_user:
+                raise HTTPException(status_code=400, detail="user_missing")
+            user = maybe_user
             user_already_exists = True
 
         add_to_org = False

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -364,6 +364,7 @@ class UserManager:
         try:
             await self.users.insert_one(user.dict())
         except DuplicateKeyError:
+            user = await self.get_by_email(create.email)
             user_already_exists = True
 
         add_to_org = False
@@ -382,7 +383,7 @@ class UserManager:
 
         else:
             add_to_org = True
-            if not is_verified:
+            if not is_verified and not user_already_exists:
                 asyncio.create_task(self.request_verify(user, request))
 
         # org to auto-add user to, if any

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -359,10 +359,12 @@ class UserManager:
             is_verified=is_verified,
         )
 
+        user_already_exists = False
+
         try:
             await self.users.insert_one(user.dict())
         except DuplicateKeyError:
-            raise HTTPException(status_code=400, detail="user_already_exists")
+            user_already_exists = True
 
         add_to_org = False
 
@@ -385,6 +387,10 @@ class UserManager:
 
         # org to auto-add user to, if any
         auto_add_org: Optional[Organization] = None
+
+        # if user already exists, and not adding to a new org, error
+        if user_already_exists and not add_to_org:
+            raise HTTPException(status_code=400, detail="user_already_exists")
 
         # if add to default, then get default org
         if add_to_org:


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/1743

On the backend, support adding user to new org and improved error messaging:
- if user exists is not part of the org to be added to, add user to the registration org, return 201
- if user is already part of the org, return 400 with 'user_already_is_org_member' error
- if user is not being added to a new org but already exists, return 'user_already_exists'

frontend:
- if user user same password, they will just be logged in and added to registration org (same as before)
- if user uses wrong password, show alert message
- handle both user_already_is_org_member and user_already_registered with alert message and link to log-in page.

note: this means existing user is added to the registration org even if they provide wrong password, but they won't be able
to login until they use correct password/reset/etc...

We may want to tweak this later, provide additional info that they're being added to a new org, but this is hopefully alright for now.


## Testing
For now, this requires some manual testing

Register with same password:
- Add user to one org (not the default registration org)
- Attempt to register with same user, using correct password
- User should be logged in and part of both orgs

Register with wrong password, then log in with right one:
- Add user to one org (not the default registration org)
- Attempt to register with same user, but wrong password
- Then login with right password - user should now be part of both orgs