### PR TITLE
operator: add 'max_crawler_memory' to limit autosizing of crawler pods

### DIFF
--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -29,19 +29,20 @@ else:
 class K8sOpAPI(K8sAPI):
     """Additional k8s api for operators"""
 
+    has_pod_metrics: bool
+    max_crawler_memory_size: int
+
     def __init__(self):
         super().__init__()
         self.config_file = "/config/config.yaml"
         with open(self.config_file, encoding="utf-8") as fh_config:
             self.shared_params = yaml.safe_load(fh_config)
 
-        self.max_crawler_memory_size = int(
-            parse_quantity(os.environ.get("MAX_CRAWLER_MEMORY_SIZE", "0"))
-        )
-
         self.has_pod_metrics = False
         self.compute_crawler_resources()
         self.compute_profile_resources()
+
+        self.max_crawler_memory_size = 0
 
     def compute_crawler_resources(self):
         """compute memory / cpu resources for crawlers"""
@@ -73,6 +74,12 @@ class K8sOpAPI(K8sAPI):
         else:
             crawler_memory = int(parse_quantity(p["crawler_memory"]))
             print(f"memory = {crawler_memory}")
+
+        max_crawler_memory_size = os.environ.get("MAX_CRAWLER_MEMORY_SIZE")
+        if not max_crawler_memory_size:
+            self.max_crawler_memory_size = crawler_memory
+        else:
+            self.max_crawler_memory_size = int(parse_quantity(max_crawler_memory_size))
 
         print("max crawler memory size", self.max_crawler_memory_size)
 

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -75,11 +75,12 @@ class K8sOpAPI(K8sAPI):
             crawler_memory = int(parse_quantity(p["crawler_memory"]))
             print(f"memory = {crawler_memory}")
 
-        max_crawler_memory_size = os.environ.get("MAX_CRAWLER_MEMORY")
-        if not max_crawler_memory_size:
-            self.max_crawler_memory_size = crawler_memory
-        else:
-            self.max_crawler_memory_size = int(parse_quantity(max_crawler_memory_size))
+        max_crawler_memory_size = 0
+        max_crawler_memory = os.environ.get("MAX_CRAWLER_MEMORY")
+        if max_crawler_memory:
+            max_crawler_memory_size = int(parse_quantity(max_crawler_memory_size))
+
+        self.max_crawler_memory_size = max_crawler_memory_size or crawler_memory
 
         print("max crawler memory size", self.max_crawler_memory_size)
 

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -75,7 +75,7 @@ class K8sOpAPI(K8sAPI):
             crawler_memory = int(parse_quantity(p["crawler_memory"]))
             print(f"memory = {crawler_memory}")
 
-        max_crawler_memory_size = os.environ.get("MAX_CRAWLER_MEMORY_SIZE")
+        max_crawler_memory_size = os.environ.get("MAX_CRAWLER_MEMORY")
         if not max_crawler_memory_size:
             self.max_crawler_memory_size = crawler_memory
         else:

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -1,6 +1,7 @@
 """ Base Operator class for all operators """
 
 import asyncio
+import os
 from typing import TYPE_CHECKING
 from kubernetes.utils import parse_quantity
 
@@ -33,6 +34,10 @@ class K8sOpAPI(K8sAPI):
         self.config_file = "/config/config.yaml"
         with open(self.config_file, encoding="utf-8") as fh_config:
             self.shared_params = yaml.safe_load(fh_config)
+
+        self.max_crawler_memory_size = int(
+            parse_quantity(os.environ.get("MAX_CRAWLER_MEMORY_SIZE", "0"))
+        )
 
         self.has_pod_metrics = False
         self.compute_crawler_resources()
@@ -68,6 +73,8 @@ class K8sOpAPI(K8sAPI):
         else:
             crawler_memory = int(parse_quantity(p["crawler_memory"]))
             print(f"memory = {crawler_memory}")
+
+        print("max crawler memory size", self.max_crawler_memory_size)
 
         p["crawler_cpu"] = crawler_cpu
         p["crawler_memory"] = crawler_memory

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -66,7 +66,7 @@ EXEC_TIME_UPDATE_SECS = 60
 
 
 # scale up if exceeded this threshold of mem usage (eg. 90%)
-MEM_SCALE_UP_THRESHOLD = 0.90
+MEM_SCALE_UP_THRESHOLD = 0.95
 
 # scale up by this much
 MEM_SCALE_UP = 1.2
@@ -1033,6 +1033,13 @@ class CrawlOperator(BaseOperator):
 
             # if pod is using >MEM_SCALE_UP_THRESHOLD of its memory, increase mem
             if mem_usage > MEM_SCALE_UP_THRESHOLD:
+                if new_memory > self.k8s.max_crawler_memory_size:
+                    print(
+                        f"Mem {mem_usage}: Not resizing pod {name}: "
+                        + f"mem {new_memory} > max allowed {self.k8s.max_crawler_memory_size}"
+                    )
+                    return
+
                 pod.newMemory = new_memory
                 print(
                     f"Mem {mem_usage}: Resizing pod {name} -> mem {pod.newMemory} - Scale Up"

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -66,7 +66,7 @@ EXEC_TIME_UPDATE_SECS = 60
 
 
 # scale up if exceeded this threshold of mem usage (eg. 90%)
-MEM_SCALE_UP_THRESHOLD = 0.95
+MEM_SCALE_UP_THRESHOLD = 0.90
 
 # scale up by this much
 MEM_SCALE_UP = 1.2

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -56,6 +56,8 @@ data:
 
   MIN_QA_CRAWLER_IMAGE: "{{ .Values.min_qa_crawler_image }}"
 
+  MAX_CRAWLER_MEMORY_SIZE: "{{ .Values.max_crawler_memory_size | default 0 }}"
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -56,7 +56,7 @@ data:
 
   MIN_QA_CRAWLER_IMAGE: "{{ .Values.min_qa_crawler_image }}"
 
-  MAX_CRAWLER_MEMORY_SIZE: "{{ .Values.max_crawler_memory_size | default 0 }}"
+  MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory | default 0 }}"
 
 ---
 apiVersion: v1

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -56,7 +56,7 @@ data:
 
   MIN_QA_CRAWLER_IMAGE: "{{ .Values.min_qa_crawler_image }}"
 
-  MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory | default 0 }}"
+  MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -250,8 +250,9 @@ crawler_extra_memory_per_browser: 768Mi
 # crawler_memory:
 
 
-# max crawler memory size, if set, will ensure crawler autoscaling can not exceed this size
-# max_crawler_memory_size: 
+# max crawler memory, if set, will enable auto-resizing of crawler pods up to this size
+# if not set, no auto-resizing is done, and crawls always use 'crawler_memory' memory
+# max_crawler_memory:
 
 # optional: defaults to crawler_memory_base and crawler_cpu_base if not set
 # profile_browser_memory:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -249,6 +249,10 @@ crawler_extra_memory_per_browser: 768Mi
 # crawler_memory = crawler_memory_base + crawler_memory_per_extra_browser * (crawler_browser_instances - 1)
 # crawler_memory:
 
+
+# max crawler memory size, if set, will ensure crawler autoscaling can not exceed this size
+# max_crawler_memory_size: 
+
 # optional: defaults to crawler_memory_base and crawler_cpu_base if not set
 # profile_browser_memory:
 #


### PR DESCRIPTION
The autoscaling of pods allows pods to grow if a threshold of memory is exceeded (to avoid OOMs). 
However, a upper limit is still need to be able to fit in within infrastructure limits.
This adds a `max_crawler_memory` chart setting, which, if set, will defines the upper crawler memory limit that pods can be resized upto.
If not set, auto resizing is disabled and pods are always set to 'crawler_memory' memory