### PR TITLE
Fix 'Review Crawl' button disabled state.

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1454,9 +1454,9 @@ ${this.crawl?.description}
       });
     }
 
-    this.isQAActive =
-      (this.qaRuns?.[0] && QA_RUNNING_STATES.includes(this.qaRuns[0].state)) ||
-      false;
+    this.isQAActive = Boolean(
+      this.qaRuns?.[0] && QA_RUNNING_STATES.includes(this.qaRuns[0].state),
+    );
 
     if (this.isQAActive) {
       // Restart timer for next poll

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -154,11 +154,6 @@ export class ArchivedItemDetail extends TailwindElement {
     return activeCrawlStates.includes(this.crawl.state);
   }
 
-  private getIsQAActive(): boolean {
-    if (!this.qaRuns?.[0]) return false;
-    return QA_RUNNING_STATES.includes(this.qaRuns[0].state);
-  }
-
   private get hasFiles(): boolean | null {
     if (!this.crawl) return null;
     if (!this.crawl.resources) return false;
@@ -1459,7 +1454,9 @@ ${this.crawl?.description}
       });
     }
 
-    this.isQAActive = this.getIsQAActive();
+    this.isQAActive =
+      (this.qaRuns?.[0] && QA_RUNNING_STATES.includes(this.qaRuns[0].state)) ||
+      false;
 
     if (this.isQAActive) {
       // Restart timer for next poll

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -208,9 +208,7 @@ export class ArchivedItemDetail extends TailwindElement {
         this.qaRunId = lastFinishedQARun.id;
       }
       // set last finished run
-      this.lastFinishedQARunId = lastFinishedQARun
-        ? lastFinishedQARun.id
-        : undefined;
+      this.lastFinishedQARunId = lastFinishedQARun?.id;
     }
   }
 

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -93,6 +93,12 @@ export class ArchivedItemDetail extends TailwindElement {
   private qaRunId?: string;
 
   @state()
+  private lastFinishedQARunId?: string;
+
+  @state()
+  private isQAActive = false;
+
+  @state()
   qaRuns?: QARun[];
 
   @state()
@@ -148,8 +154,8 @@ export class ArchivedItemDetail extends TailwindElement {
     return activeCrawlStates.includes(this.crawl.state);
   }
 
-  private get isQAActive(): boolean | null {
-    if (!this.qaRuns?.[0]) return null;
+  private getIsQAActive(): boolean {
+    if (!this.qaRuns?.[0]) return false;
     return QA_RUNNING_STATES.includes(this.qaRuns[0].state);
   }
 
@@ -186,7 +192,7 @@ export class ArchivedItemDetail extends TailwindElement {
       this.qaRuns &&
       this.mostRecentNonFailedQARun
     ) {
-      const firstFinishedQARun = this.qaRuns.find(({ state }) =>
+      const lastFinishedQARun = this.qaRuns.find(({ state }) =>
         finishedCrawlStates.includes(state),
       );
       const prevMostRecentNonFailedQARun =
@@ -198,9 +204,13 @@ export class ArchivedItemDetail extends TailwindElement {
 
       // Update currently selected QA run if there is none,
       // or if a QA run that was previously running is now finished:
-      if (firstFinishedQARun && (!this.qaRunId || mostRecentNowFinished)) {
-        this.qaRunId = firstFinishedQARun.id;
+      if (lastFinishedQARun && (!this.qaRunId || mostRecentNowFinished)) {
+        this.qaRunId = lastFinishedQARun.id;
       }
+      // set last finished run
+      this.lastFinishedQARunId = lastFinishedQARun
+        ? lastFinishedQARun.id
+        : undefined;
     }
   }
 
@@ -1021,8 +1031,16 @@ ${this.crawl?.description}
   }
 
   private readonly renderQAHeader = (qaRuns: QARun[]) => {
-    const qaIsRunning = isActive(qaRuns[0]?.state);
-    const qaIsAvailable = this.mostRecentNonFailedQARun && !qaIsRunning;
+    //const qaIsRunning = isActive(qaRuns[0]?.state);
+    //const qaIsAvailable = this.mostRecentNonFailedQARun && !qaIsRunning;
+    const qaIsRunning = this.isQAActive;
+    const qaIsAvailable = !!this.lastFinishedQARunId;
+
+    const reviewLink =
+      qaIsAvailable && this.qaRunId
+        ? `${this.navigate.orgBasePath}/items/crawl/${this.crawlId}/review/screenshots?qaRunId=${this.qaRunId}`
+        : undefined;
+
     return html`
       ${qaIsRunning
         ? html`
@@ -1065,15 +1083,12 @@ ${this.crawl?.description}
         ? html`
             <sl-tooltip
               ?disabled=${qaIsAvailable}
-              content=${qaIsRunning
-                ? msg("Reviews are disabled during analysis runs.")
-                : msg("No completed analysis runs are available.")}
+              content=${msg("No completed analysis runs are available.")}
             >
               <sl-button
                 variant="primary"
                 size="small"
-                href="${this.navigate.orgBasePath}/items/crawl/${this
-                  .crawlId}/review/screenshots?qaRunId=${this.qaRunId || ""}"
+                href="${ifDefined(reviewLink)}"
                 @click=${this.navigate.link}
                 ?disabled=${!qaIsAvailable}
               >
@@ -1445,6 +1460,8 @@ ${this.crawl?.description}
         icon: "exclamation-octagon",
       });
     }
+
+    this.isQAActive = this.getIsQAActive();
 
     if (this.isQAActive) {
       // Restart timer for next poll


### PR DESCRIPTION
Disable the 'Review Crawl' button only when there are no finished QA Runs:
- track last finished qa run 'lastFinishedQARunId'
- track if qa run is running via 'isQAActive'
- only add tooltip / disabled state when there are no finished qa runs

Also, only add href when not disabled, to avoid clickable link with disabled button


