### PR TITLE
Add note on checking browser profiles for scheduled crawls

### DIFF
--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -176,6 +176,11 @@ Sets the browser's language setting. Useful for crawling websites that detect th
 
 ## Scheduling
 
+!!! tip "Tip: Scheduling crawl workflows with logged-in browser profiles"
+    Some websites will log users out after a set period of time. When crawling with a custom [browser profile](browser-profiles.md) that is logged into a website, we recommend checking the profile before crawling to ensure it is still logged in.
+
+    This can cause issues with scheduled crawl workflows — which will run even if the selected browser profile has been logged out.
+
 ### Crawl Schedule Type
 
 `Run Immediately on Save`


### PR DESCRIPTION
Closes #1762 

### Changes
- Add note on why it's important to check browser profiles, even for for scheduled crawls

### Screenshots

<img width="1226" alt="Screenshot 2024-04-29 at 11 28 28 PM" src="https://github.com/webrecorder/browsertrix/assets/5672810/cbd326da-205d-49c7-9764-18f526e99bff">
