### PR TITLE
regression fix: remove 'project' from non-raw crawl object getters, 

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -149,10 +149,9 @@ class BaseCrawlOps:
         crawlid: str,
         org: Optional[Organization] = None,
         type_: Optional[str] = None,
-        project: Optional[dict[str, bool]] = None,
     ) -> BaseCrawl:
         """Get crawl data for internal use"""
-        res = await self.get_crawl_raw(crawlid, org, type_, project)
+        res = await self.get_crawl_raw(crawlid, org, type_)
         return BaseCrawl.from_dict(res)
 
     async def get_crawl_out(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -98,10 +98,9 @@ class CrawlOps(BaseCrawlOps):
         self,
         crawlid: str,
         org: Optional[Organization] = None,
-        project: Optional[dict[str, bool]] = None,
     ) -> Crawl:
         """Get crawl data for internal use"""
-        res = await self.get_crawl_raw(crawlid, org, "crawl", project)
+        res = await self.get_crawl_raw(crawlid, org, "crawl")
         return Crawl.from_dict(res)
 
     @contextlib.asynccontextmanager
@@ -479,7 +478,7 @@ class CrawlOps(BaseCrawlOps):
         """add new exclusion to config or remove exclusion from config
         for given crawl_id, update config on crawl"""
 
-        crawl = await self.get_crawl(crawl_id, org, project={"cid": True})
+        crawl = await self.get_crawl(crawl_id, org)
 
         cid = crawl.cid
 


### PR DESCRIPTION
unnecessary projection prevents creating Crawl object, now removed

Fixes #1777 