### PR TITLE
QA review tooltip + comment improvements

### DIFF
--- a/frontend/src/features/qa/page-list/ui/page-details.ts
+++ b/frontend/src/features/qa/page-list/ui/page-details.ts
@@ -93,7 +93,7 @@ export const pageDetails = (page: ArchivedItemQAPage) =>
           <div class="my-2 text-xs text-neutral-400">
             ${msg("Newest comment:")}
           </div>
-          <div class="mb-3 flex max-w-60 text-xs leading-4">
+          <div class="mb-3 flex text-xs leading-4">
             <sl-icon
               name="chat-square-text-fill"
               class="mr-2 h-4 w-4 flex-none text-blue-600"

--- a/frontend/src/features/qa/page-list/ui/page-details.ts
+++ b/frontend/src/features/qa/page-list/ui/page-details.ts
@@ -93,7 +93,7 @@ export const pageDetails = (page: ArchivedItemQAPage) =>
           <div class="my-2 text-xs text-neutral-400">
             ${msg("Newest comment:")}
           </div>
-          <div class="mb-3 flex text-xs leading-4">
+          <div class="mb-3 flex max-w-60 text-xs leading-4">
             <sl-icon
               name="chat-square-text-fill"
               class="mr-2 h-4 w-4 flex-none text-blue-600"

--- a/frontend/src/features/qa/page-list/ui/page-details.ts
+++ b/frontend/src/features/qa/page-list/ui/page-details.ts
@@ -98,6 +98,6 @@ export const pageDetails = (page: ArchivedItemQAPage) =>
               name="chat-square-text-fill"
               class="mr-2 h-4 w-4 flex-none text-blue-600"
             ></sl-icon>
-            ${page.notes[page.notes.length - 1]?.text}
+            ${page.notes[page.notes.length - 1].text}
           </div>`
       : nothing}`;

--- a/frontend/src/features/qa/page-list/ui/page.ts
+++ b/frontend/src/features/qa/page-list/ui/page.ts
@@ -139,7 +139,9 @@ export class QaPage extends TailwindElement {
           aria-selected=${this.selected}
         >
           <sl-tooltip class="invert-tooltip" placement="left" hoist>
-            <div slot="content" class="text-xs">${pageDetails(page)}</div>
+            <div slot="content" class="max-w-60 text-xs">
+              ${pageDetails(page)}
+            </div>
             <div
               class="absolute -left-4 top-[50%] flex w-8 translate-y-[-50%] flex-col place-items-center gap-1 rounded-full border border-gray-300 bg-neutral-0 p-2 leading-[14px] shadow transition-transform hover:scale-110"
             >

--- a/frontend/src/features/qa/page-list/ui/page.ts
+++ b/frontend/src/features/qa/page-list/ui/page.ts
@@ -138,7 +138,7 @@ export class QaPage extends TailwindElement {
           tabindex="0"
           aria-selected=${this.selected}
         >
-          <sl-tooltip placement="left" hoist>
+          <sl-tooltip class="invert-tooltip" placement="left" hoist>
             <div slot="content" class="text-xs">${pageDetails(page)}</div>
             <div
               class="absolute -left-4 top-[50%] flex w-8 translate-y-[-50%] flex-col place-items-center gap-1 rounded-full border border-gray-300 bg-neutral-0 p-2 leading-[14px] shadow transition-transform hover:scale-110"

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -770,7 +770,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                             <div class="text-xs text-neutral-400">
                               ${msg("Newest comment:")}
                             </div>
-                            <div class="text-xs">
+                            <div class="leading04 max-w-60 text-xs">
                               ${page.notes[page.notes.length - 1].text}
                             </div>
                           </div>

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -762,19 +762,31 @@ export class ArchivedItemDetailQA extends TailwindElement {
                 <btrix-table-cell
                   >${this.renderApprovalStatus(page)}</btrix-table-cell
                 >
-                <btrix-table-cell
-                  >${page.notes?.length
-                    ? statusWithIcon(
-                        html`<sl-icon
-                          name="chat-square-text-fill"
-                          class="text-blue-600"
-                        ></sl-icon>`,
-                        `${page.notes.length.toLocaleString()} ${pluralOf("comments", page.notes.length)}`,
-                      )
-                    : html`<span class="text-neutral-400"
-                        >${msg("None")}</span
-                      >`}</btrix-table-cell
-                >
+                <btrix-table-cell>
+                  ${page.notes?.length
+                    ? html`
+                        <sl-tooltip class="invert-tooltip">
+                          <div slot="content">
+                            <div class="text-xs text-neutral-400">
+                              ${msg("Newest comment:")}
+                            </div>
+                            <div class="text-xs">
+                              ${page.notes[page.notes.length - 1].text}
+                            </div>
+                          </div>
+                          ${statusWithIcon(
+                            html`<sl-icon
+                              name="chat-square-text-fill"
+                              class="text-blue-600"
+                            ></sl-icon>`,
+                            `${page.notes.length.toLocaleString()} ${pluralOf("comments", page.notes.length)}`,
+                          )}
+                        </sl-tooltip>
+                      `
+                    : html`<span class="text-neutral-400">
+                        ${msg("None")}
+                      </span>`}
+                </btrix-table-cell>
               </btrix-table-row>
             `,
           )}

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -43,6 +43,7 @@ import type { ArchivedItem, ArchivedItemPageComment } from "@/types/crawler";
 import type { ArchivedItemQAPage, QARun } from "@/types/qa";
 import { type AuthState } from "@/utils/AuthService";
 import { finishedCrawlStates, isActive, renderName } from "@/utils/crawler";
+import { maxLengthValidator } from "@/utils/form";
 import { formatISODateString, getLocale } from "@/utils/localization";
 
 const DEFAULT_PAGE_SIZE = 100;
@@ -581,6 +582,15 @@ export class ArchivedItemQA extends TailwindElement {
         </sl-button>
       </btrix-dialog>
 
+      ${this.renderReviewDialog()}
+    `;
+  }
+
+  private readonly validateCrawlDescriptionMax = maxLengthValidator(500);
+
+  private renderReviewDialog() {
+    const { helpText, validate } = this.validateCrawlDescriptionMax;
+    return html`
       <btrix-dialog
         class="reviewDialog [--width:60rem]"
         label=${msg("QA Review")}
@@ -642,7 +652,11 @@ export class ArchivedItemQA extends TailwindElement {
                 label=${msg("Update archived item description?")}
                 name="description"
                 value=${this.item?.description ?? ""}
-                placeholder=${msg("No description")}
+                placeholder=${msg("No description, yet")}
+                rows="8"
+                autocomplete="off"
+                help-text=${helpText}
+                @sl-input=${validate}
               ></sl-textarea>
             </div>
           </div>

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -159,6 +159,8 @@ export class ArchivedItemQA extends TailwindElement {
   private readonly notify = new NotifyController(this);
   private readonly replaySwReg =
     navigator.serviceWorker.getRegistration("/replay/");
+  private readonly validateItemDescriptionMax = maxLengthValidator(500);
+  private readonly validatePageCommentMax = maxLengthValidator(500);
 
   @query("#replayframe")
   private readonly replayFrame?: HTMLIFrameElement | null;
@@ -586,10 +588,8 @@ export class ArchivedItemQA extends TailwindElement {
     `;
   }
 
-  private readonly validateCrawlDescriptionMax = maxLengthValidator(500);
-
   private renderReviewDialog() {
-    const { helpText, validate } = this.validateCrawlDescriptionMax;
+    const { helpText, validate } = this.validateItemDescriptionMax;
     return html`
       <btrix-dialog
         class="reviewDialog [--width:60rem]"
@@ -653,7 +653,7 @@ export class ArchivedItemQA extends TailwindElement {
                 name="description"
                 value=${this.item?.description ?? ""}
                 placeholder=${msg("No description, yet")}
-                rows="8"
+                rows="10"
                 autocomplete="off"
                 help-text=${helpText}
                 @sl-input=${validate}
@@ -734,6 +734,7 @@ export class ArchivedItemQA extends TailwindElement {
   }
 
   private renderComments() {
+    const { helpText, validate } = this.validatePageCommentMax;
     return html`
       ${when(
         this.page?.notes?.length,
@@ -784,8 +785,10 @@ export class ArchivedItemQA extends TailwindElement {
           name="pageComment"
           label=${msg("Add a comment")}
           placeholder=${msg("Enter page feedback")}
-          minlength="1"
-          maxlength="500"
+          rows="4"
+          autocomplete="off"
+          help-text=${helpText}
+          @sl-input=${validate}
         ></sl-textarea>
       </form>
     `;

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -595,7 +595,7 @@ export class ArchivedItemQA extends TailwindElement {
         class="reviewDialog [--width:60rem]"
         label=${msg("QA Review")}
       >
-        <form class="qaReviewForm" @submit=${this.onReviewSubmit}>
+        <form class="qaReviewForm" @submit=${this.onSubmitReview}>
           <div class="flex flex-col gap-6 md:flex-row">
             <div>
               <sl-radio-group
@@ -958,6 +958,9 @@ export class ArchivedItemQA extends TailwindElement {
 
     if (!value) return;
 
+    const formEl = e.target as HTMLFormElement;
+    if (!(await this.checkFormValidity(formEl))) return;
+
     void this.commentDialog?.hide();
 
     try {
@@ -990,6 +993,11 @@ export class ArchivedItemQA extends TailwindElement {
         icon: "exclamation-octagon",
       });
     }
+  }
+
+  async checkFormValidity(formEl: HTMLFormElement) {
+    await this.updateComplete;
+    return !formEl.querySelector("[data-invalid]");
   }
 
   private async deletePageComment(commentId: string): Promise<void> {
@@ -1310,14 +1318,15 @@ export class ArchivedItemQA extends TailwindElement {
     );
   }
 
-  private async onReviewSubmit(e: SubmitEvent) {
+  private async onSubmitReview(e: SubmitEvent) {
     e.preventDefault();
     const form = e.currentTarget as HTMLFormElement;
     const params = serialize(form);
 
-    if (!params.reviewStatus) {
-      return;
-    }
+    if (!params.reviewStatus) return;
+
+    const formEl = e.target as HTMLFormElement;
+    if (!(await this.checkFormValidity(formEl))) return;
 
     try {
       const data = await this.api.fetch<{ updated: boolean }>(

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -196,6 +196,18 @@
     min-width: min-content;
   }
 
+  /* Style tooltip with white background */
+  sl-tooltip.invert-tooltip {
+    --sl-tooltip-arrow-size: 0;
+    --sl-tooltip-background-color: var(--sl-color-neutral-0);
+    --sl-tooltip-color: var(--sl-color-neutral-700);
+  }
+
+  sl-tooltip.invert-tooltip::part(body) {
+    outline: 1px solid var(--sl-panel-border-color);
+    box-shadow: var(--sl-shadow-large);
+  }
+
   /* For single-input forms with submit button inline */
   /* Requires form control and button to be direct children */
   .inline-control-input,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1761

<!-- Fixes #issue_number -->

### Changes

- Switches QA review page chip tooltip colors to dark text on light background
- Shows newest comment when hovering over comment cell in QA tab page list to match tooltip in QA review page list
- Validates textarea max entry for description and comments

### Manual testing

1. Log in as crawler
2. Select to reviewed archived item with page comments
3. Go to QA tab
4. Hover over comment icon in "Pages" table. Verify tooltip with latest comment is shown
5. Click page to go into review
6. Hover over page heuristic preview chip. Verify tooltip renders dark-on-light
7. Click page comment button to open comment dialog
8. Enter text. Verify max length text help updates as expected
9. Try to save with over max length. Verify you're prevented from saving
10. Limit text to max length. Verify you're able to save
11. Repeat 8-10 for review description

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Item Detail - QA - Pages | Short comment:<br/><img width="165" alt="Screenshot 2024-05-01 at 9 58 17 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/1ffdb861-97a9-424b-92c8-4e8b4c9bde6b"><br/>Long comment:<br/><img width="352" alt="Screenshot 2024-05-01 at 9 58 24 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/3ad53735-014a-4881-92cf-91bcb0936c40"> |
| Archived Item - QA Review - Page comment dialog | <img width="517" alt="Screenshot 2024-05-01 at 9 56 53 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/fb62b9da-e1ab-42b3-a571-b04868e4cda8"> |
| Archived Item - QA Review - Item review dialog | <img width="984" alt="Screenshot 2024-05-01 at 9 57 48 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/cade0069-a61e-46a4-b07c-c9a7b106fe75"> |
| Archived Item - QA Review - Page heuristic chip tooltip | <img width="265" alt="Screenshot 2024-05-01 at 10 09 01 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/f2e6e873-3bdd-489c-b02f-1072661f37d9"> |


<!-- ### Follow-ups -->
