### PR TITLE
Add emails to the org settings tables

### DIFF
--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -269,9 +269,10 @@ export class OrgSettings extends LiteElement {
   }
 
   private renderMembers() {
-    const columnWidths = ["1fr", "auto", "min-content"];
+    const columnWidths = ["1fr", "2fr", "auto", "min-content"];
     const rows = Object.entries(this.org.users!).map(([_id, user]) => [
       user.name,
+      user.email,
       this.renderUserRoleSelect(user),
       this.renderRemoveMemberButton(user),
     ]);
@@ -280,6 +281,7 @@ export class OrgSettings extends LiteElement {
         <btrix-data-table
           .columns=${[
             msg("Name"),
+            msg("Email"),
             msg("Role"),
             html`<span class="sr-only">${msg("Delete")}</span>`,
           ]}

--- a/frontend/src/pages/org/settings.ts
+++ b/frontend/src/pages/org/settings.ts
@@ -382,12 +382,12 @@ export class OrgSettings extends LiteElement {
   }
 
   private renderRemoveInviteButton(invite: Invite) {
-    return html`<btrix-button
-      icon
+    return html`<sl-icon-button
+      class="text-base hover:text-danger"
+      name="trash3"
+      label=${msg("Revoke invite")}
       @click=${() => void this.removeInvite(invite)}
-    >
-      <sl-icon name="trash3"></sl-icon>
-    </btrix-button>`;
+    ></sl-icon-button>`;
   }
 
   private hideInviteDialog() {


### PR DESCRIPTION
Fixes #1687

### Changes
- Adds an email field to the table at all times
- Converts the trash icon to `sl-icon-button` in the pending table, makes it red on hover

### Screenshots

Trash icon is hovered (cursor not shown)
<img width="1136" alt="Screenshot 2024-05-04 at 12 20 55 PM" src="https://github.com/webrecorder/browsertrix/assets/5672810/aff98ff5-7ac5-4530-9346-718df3473ef0">
