### PR TITLE
Auto-load seed url when replaying seeded crawls

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -683,6 +683,7 @@ export class ArchivedItemDetail extends TailwindElement {
           ? html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
               <replay-web-page
                 source="${replaySource}"
+                url="${this.crawl.seedCount === 1 ? this.crawl.firstSeed : ""}"
                 coll="${ifDefined(this.crawl.id)}"
                 config="${config}"
                 replayBase="/replay/"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -683,11 +683,7 @@ export class ArchivedItemDetail extends TailwindElement {
           ? html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
               <replay-web-page
                 source="${replaySource}"
-                url="${String(
-                  this.crawl.seedCount === 1
-                    ? ifDefined(this.crawl.firstSeed)
-                    : "",
-                )}"
+                url="${this.crawl.seedCount === 1 && this.crawl.firstSeed || ""}"
                 coll="${ifDefined(this.crawl.id)}"
                 config="${config}"
                 replayBase="/replay/"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -683,9 +683,11 @@ export class ArchivedItemDetail extends TailwindElement {
           ? html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
               <replay-web-page
                 source="${replaySource}"
-                url="${this.crawl.seedCount === 1
-                  ? ifDefined(this.crawl.firstSeed)
-                  : ""}"
+                url="${String(
+                  this.crawl.seedCount === 1
+                    ? ifDefined(this.crawl.firstSeed)
+                    : "",
+                )}"
                 coll="${ifDefined(this.crawl.id)}"
                 config="${config}"
                 replayBase="/replay/"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -683,7 +683,9 @@ export class ArchivedItemDetail extends TailwindElement {
           ? html`<div id="replay-crawl" class="aspect-4/3 overflow-hidden">
               <replay-web-page
                 source="${replaySource}"
-                url="${this.crawl.seedCount === 1 ? this.crawl.firstSeed : ""}"
+                url="${this.crawl.seedCount === 1
+                  ? ifDefined(this.crawl.firstSeed)
+                  : ""}"
                 coll="${ifDefined(this.crawl.id)}"
                 config="${config}"
                 replayBase="/replay/"

--- a/frontend/src/replayWebPage.d.ts
+++ b/frontend/src/replayWebPage.d.ts
@@ -5,6 +5,7 @@
  * @attr {String} replayBase
  * @attr {String} noSandbox
  * @attr {String} noCache
+ * @attr {String} url
  */
 class ReplayWebPage {}
 


### PR DESCRIPTION
Closes #1787

### Changes

- Crawls with only one seed will load viewing that seed URL
- URL list crawls will continue to load the pages list as no ReplayWeb.page enbed URL has been defined

### Testing
1. Visit the details page and replay a seeded crawl with multiple pages in it, verify that the first page that loads is the crawl start URL
2. Visit the details page and replay a URL list crawl with more than one URL, verify that it shows the pages list on load