### PR TITLE
feat: Allow superadmins to delete org

### DIFF
--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -1,12 +1,8 @@
 import { localized, msg, str } from "@lit/localize";
-import {
-  // type SlChangeEvent,
-  type SlInput,
-  // type SlMenuItem,
-} from "@shoelace-style/shoelace";
+import type { SlChangeEvent, SlInput } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { css, html, nothing } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
@@ -46,11 +42,17 @@ export class OrgsList extends TailwindElement {
   @property({ type: Object })
   currOrg?: OrgData | null = null;
 
+  @state()
+  private enableDeleteButton = false;
+
   @query("#orgQuotaDialog")
   private readonly orgQuotaDialog?: Dialog | null;
 
   @query("#orgReadOnlyDialog")
   private readonly orgReadOnlyDialog?: Dialog | null;
+
+  @query("#orgDeleteDialog")
+  private readonly orgDeleteDialog?: Dialog | null;
 
   private readonly api = new APIController(this);
   private readonly navigate = new NavigateController(this);
@@ -86,6 +88,7 @@ export class OrgsList extends TailwindElement {
       </btrix-table>
 
       ${this.renderOrgQuotas()} ${this.renderOrgReadOnly()}
+      ${this.renderOrgDelete()}
     `;
   }
 
@@ -157,7 +160,7 @@ export class OrgsList extends TailwindElement {
             <p class="mb-3">
               ${msg(
                 html`Are you sure you want to make
-                  <span class="font-semibold">${org.name}</span>
+                  <strong class="font-semibold">${org.name}</strong>
                   read-only? Members will no longer be able to crawl, upload
                   files, create browser profiles, or create collections.`,
               )}
@@ -204,6 +207,109 @@ export class OrgsList extends TailwindElement {
             </div>
           `;
         })}
+      </btrix-dialog>
+    `;
+  }
+
+  private renderOrgDelete() {
+    return html`
+      <btrix-dialog
+        class="[--width:36rem]"
+        id="orgDeleteDialog"
+        .label=${msg(str`Confirm Org Deletion: ${this.currOrg?.name || ""}`)}
+        @sl-after-hide=${() => (this.currOrg = null)}
+      >
+        ${when(this.currOrg, (org) => {
+          const confirmationStr = msg(str`Delete ${org.name}`);
+          return html`
+            <p class="mb-3">
+              ${msg(
+                html`Are you sure you want to delete
+                  <strong class="font-semibold">${org.name}</strong>? This
+                  cannot be undone.`,
+              )}
+            </p>
+            <ul class="mb-3 text-neutral-600">
+              <li>
+                ${msg(str`Slug:`)}
+                <a
+                  class="font-semibold text-primary hover:text-primary-500"
+                  href="/orgs/${org.slug}"
+                  target="_blank"
+                >
+                  ${org.slug}
+                </a>
+              </li>
+              <li>
+                ${msg("Members:")}
+                <a
+                  class="font-semibold text-primary hover:text-primary-500"
+                  href="/orgs/${org.slug}/settings/members"
+                  target="_blank"
+                >
+                  ${formatNumber(Object.keys(org.users || {}).length)}
+                </a>
+              </li>
+            </ul>
+            <p class="mb-3">
+              ${msg(
+                html`Deleting an org will delete all
+                  <strong class="font-semibold">
+                    <sl-format-bytes value=${org.bytesStored}></sl-format-bytes>
+                  </strong>
+                  of data associated with the org.`,
+              )}
+            </p>
+            <ul class="mb-3 text-neutral-600">
+              <li>
+                ${msg(
+                  html`Crawls:
+                    <sl-format-bytes
+                      value=${org.bytesStoredCrawls}
+                    ></sl-format-bytes>`,
+                )}
+              </li>
+              <li>
+                ${msg(
+                  html`Uploads:
+                    <sl-format-bytes
+                      value=${org.bytesStoredUploads}
+                    ></sl-format-bytes>`,
+                )}
+              </li>
+              <li>
+                ${msg(
+                  html`Profiles:
+                    <sl-format-bytes
+                      value=${org.bytesStoredProfiles}
+                    ></sl-format-bytes>`,
+                )}
+              </li>
+            </ul>
+            <sl-divider></sl-divider>
+            <sl-input
+              placeholder=${confirmationStr}
+              @sl-input=${(e: SlChangeEvent) => {
+                const { value } = e.target as SlInput;
+                this.enableDeleteButton = value === confirmationStr;
+              }}
+            >
+              <strong slot="label" class="font-semibold">
+                ${msg(str`Type "${confirmationStr}" to confirm`)}
+              </strong>
+            </sl-input>
+          `;
+        })}
+        <div slot="footer" class="flex justify-end">
+          <sl-button
+            size="small"
+            @click=${this.deleteOrg}
+            variant="danger"
+            ?disabled=${!this.enableDeleteButton}
+          >
+            ${msg("Delete Org")}
+          </sl-button>
+        </div>
       </btrix-dialog>
     `;
   }
@@ -282,6 +388,30 @@ export class OrgsList extends TailwindElement {
         message: msg(
           "Sorry, couldn't update org read-only state at this time.",
         ),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async deleteOrg(org: OrgData) {
+    try {
+      await this.api.fetch(`/orgs/${org.id}`, this.authState!, {
+        method: "DELETE",
+      });
+
+      this.orgList = this.orgList?.filter((o) => o.id !== org.id);
+
+      this.notify.toast({
+        message: msg(str`Org "${org.name}" has been deleted.`),
+        variant: "success",
+        icon: "check2-circle",
+      });
+    } catch (e) {
+      console.debug(e);
+
+      this.notify.toast({
+        message: msg("Sorry, couldn't delete org at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });
@@ -419,6 +549,17 @@ export class OrgsList extends TailwindElement {
                       ${msg("Make Read-Only")}
                     </sl-menu-item>
                   `}
+              <sl-divider></sl-divider>
+              <sl-menu-item
+                style="--sl-color-neutral-700: var(--danger)"
+                @click=${() => {
+                  this.currOrg = org;
+                  void this.orgDeleteDialog?.show();
+                }}
+              >
+                <sl-icon slot="prefix" name="trash3"></sl-icon>
+                ${msg("Delete Org")}
+              </sl-menu-item>
             </sl-menu>
           </btrix-overflow-dropdown>
         </btrix-table-cell>

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -302,7 +302,13 @@ export class OrgsList extends TailwindElement {
                 ${msg(str`Type "${confirmationStr}" to confirm`)}
               </strong>
             </sl-input>
-            <div slot="footer" class="flex justify-end">
+            <div slot="footer" class="flex justify-between">
+              <sl-button
+                size="small"
+                @click=${() => void this.orgDeleteDialog?.hide()}
+              >
+                ${msg("Cancel")}
+              </sl-button>
               <sl-button
                 id="orgDeleteButton"
                 size="small"

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -1,8 +1,12 @@
 import { localized, msg, str } from "@lit/localize";
-import type { SlChangeEvent, SlInput } from "@shoelace-style/shoelace";
+import type {
+  SlButton,
+  SlChangeEvent,
+  SlInput,
+} from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { css, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
@@ -42,9 +46,6 @@ export class OrgsList extends TailwindElement {
   @property({ type: Object })
   currOrg?: OrgData | null = null;
 
-  @state()
-  private enableDeleteButton = false;
-
   @query("#orgQuotaDialog")
   private readonly orgQuotaDialog?: Dialog | null;
 
@@ -53,6 +54,9 @@ export class OrgsList extends TailwindElement {
 
   @query("#orgDeleteDialog")
   private readonly orgDeleteDialog?: Dialog | null;
+
+  @query("#orgDeleteButton")
+  private readonly orgDeleteButton?: SlButton | null;
 
   private readonly api = new APIController(this);
   private readonly navigate = new NavigateController(this);
@@ -291,25 +295,29 @@ export class OrgsList extends TailwindElement {
               placeholder=${confirmationStr}
               @sl-input=${(e: SlChangeEvent) => {
                 const { value } = e.target as SlInput;
-                this.enableDeleteButton = value === confirmationStr;
+                this.orgDeleteButton!.disabled = value !== confirmationStr;
               }}
             >
               <strong slot="label" class="font-semibold">
                 ${msg(str`Type "${confirmationStr}" to confirm`)}
               </strong>
             </sl-input>
+            <div slot="footer" class="flex justify-end">
+              <sl-button
+                id="orgDeleteButton"
+                size="small"
+                variant="danger"
+                disabled
+                @click=${async () => {
+                  await this.deleteOrg(org);
+                  void this.orgDeleteDialog?.hide();
+                }}
+              >
+                ${msg("Delete Org")}
+              </sl-button>
+            </div>
           `;
         })}
-        <div slot="footer" class="flex justify-end">
-          <sl-button
-            size="small"
-            @click=${this.deleteOrg}
-            variant="danger"
-            ?disabled=${!this.enableDeleteButton}
-          >
-            ${msg("Delete Org")}
-          </sl-button>
-        </div>
       </btrix-dialog>
     `;
   }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1453

<!-- Fixes #issue_number -->

### Changes

Allows superadmins to delete an org.

### Manual testing

1. Log in as superadmin
2. Click "..." overflow action menu icon in org list.
3. Click "Delete Org". Verify dialog is shown with the correct information and disabled submit button
4. Enter prompt text. Verify submit button is enabled
5. Click "Delete Org." Verify org is removed from the list

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Superadmin Dashboard | <img width="205" alt="Screenshot 2024-07-08 at 5 40 20 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/43bac870-18cc-42e4-a70d-0d9b67fd8866"> |
| Superadmin Dashboard - Delete dialog | <img width="586" alt="Screenshot 2024-07-08 at 5 41 45 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/0b38ff5b-aef5-4ce1-8544-207e8d659e4c"> |

<!-- ### Follow-ups -->
