### PR TITLE
Fix newly created org missing from user's org list

### DIFF
--- a/frontend/src/features/accounts/account-settings.ts
+++ b/frontend/src/features/accounts/account-settings.ts
@@ -19,7 +19,7 @@ const { PASSWORD_MINLENGTH, PASSWORD_MAXLENGTH, PASSWORD_MIN_SCORE } =
   PasswordService;
 
 /**
- * @fires update-user-info
+ * @fires btrix-update-user-info
  */
 @localized()
 @customElement("btrix-request-verify")
@@ -337,7 +337,7 @@ export class AccountSettings extends LiteElement {
         }),
       });
 
-      this.dispatchEvent(new CustomEvent("update-user-info"));
+      this.dispatchEvent(new CustomEvent("btrix-update-user-info"));
       this.notify({
         message: msg("Your name has been updated."),
         variant: "success",
@@ -377,7 +377,7 @@ export class AccountSettings extends LiteElement {
         }),
       });
 
-      this.dispatchEvent(new CustomEvent("update-user-info"));
+      this.dispatchEvent(new CustomEvent("btrix-update-user-info"));
       this.notify({
         message: msg("Your email has been updated."),
         variant: "success",
@@ -417,7 +417,7 @@ export class AccountSettings extends LiteElement {
       });
 
       this.isChangingPassword = false;
-      this.dispatchEvent(new CustomEvent("update-user-info"));
+      this.dispatchEvent(new CustomEvent("btrix-update-user-info"));
       this.notify({
         message: msg("Your password has been updated."),
         variant: "success",

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -365,7 +365,7 @@ export class App extends LiteElement {
       : { slug: "", name: msg("All Organizations") };
     if (!selectedOption) {
       console.debug(
-        `Could't find organization with slug ${this.appState.orgSlug}`,
+        `Couldn't find organization with slug ${this.appState.orgSlug}`,
         orgs,
       );
       return;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -575,7 +575,7 @@ export class App extends LiteElement {
       case "home":
         return html`<btrix-home
           class="w-full md:bg-neutral-50"
-          @update-user-info=${(e: CustomEvent) => {
+          @btrix-update-user-info=${(e: CustomEvent) => {
             e.stopPropagation();
             void this.updateUserInfo();
           }}
@@ -601,7 +601,7 @@ export class App extends LiteElement {
             .split("/")[0] || "home";
         return html`<btrix-org
           class="w-full"
-          @update-user-info=${(e: CustomEvent) => {
+          @btrix-update-user-info=${(e: CustomEvent) => {
             e.stopPropagation();
             void this.updateUserInfo();
           }}
@@ -619,7 +619,7 @@ export class App extends LiteElement {
       case "accountSettings":
         return html`<btrix-account-settings
           class="mx-auto box-border w-full max-w-screen-desktop p-2 md:py-8"
-          @update-user-info=${(e: CustomEvent) => {
+          @btrix-update-user-info=${(e: CustomEvent) => {
             e.stopPropagation();
             void this.updateUserInfo();
           }}

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -13,7 +13,7 @@ import LiteElement, { html } from "@/utils/LiteElement";
 import type { OrgData } from "@/utils/orgs";
 
 /**
- * @fires update-user-info
+ * @fires btrix-update-user-info
  */
 @localized()
 @customElement("btrix-home")
@@ -307,7 +307,7 @@ export class Home extends LiteElement {
       });
 
       // Update user info since orgs are checked against userInfo.orgs
-      this.dispatchEvent(new CustomEvent("update-user-info"));
+      this.dispatchEvent(new CustomEvent("btrix-update-user-info"));
       await this.updateComplete;
 
       void this.fetchOrgs();

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -12,6 +12,9 @@ import { maxLengthValidator } from "@/utils/form";
 import LiteElement, { html } from "@/utils/LiteElement";
 import type { OrgData } from "@/utils/orgs";
 
+/**
+ * @fires update-user-info
+ */
 @localized()
 @customElement("btrix-home")
 export class Home extends LiteElement {
@@ -219,8 +222,9 @@ export class Home extends LiteElement {
                   size="small"
                   ?loading=${this.isSubmittingNewOrg}
                   ?disabled=${this.isSubmittingNewOrg}
-                  >${msg("Create Org")}</sl-button
                 >
+                  ${msg("Create Org")}
+                </sl-button>
               </div>
             `
           : ""}
@@ -302,7 +306,12 @@ export class Home extends LiteElement {
         body: JSON.stringify(params),
       });
 
+      // Update user info since orgs are checked against userInfo.orgs
+      this.dispatchEvent(new CustomEvent("update-user-info"));
+      await this.updateComplete;
+
       void this.fetchOrgs();
+
       this.notify({
         message: msg(str`Created new org named "${params.name}".`),
         variant: "success",

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -156,9 +156,6 @@ export class Home extends LiteElement {
             <btrix-orgs-list
               .userInfo=${this.userInfo}
               .orgList=${this.orgList}
-              .defaultOrg=${this.userInfo?.orgs.find(
-                (org) => org.default === true,
-              )}
               @update-quotas=${this.onUpdateOrgQuotas}
             ></btrix-orgs-list>
           </section>
@@ -308,8 +305,8 @@ export class Home extends LiteElement {
 
       // Update user info since orgs are checked against userInfo.orgs
       this.dispatchEvent(new CustomEvent("btrix-update-user-info"));
-      await this.updateComplete;
 
+      await this.updateComplete;
       void this.fetchOrgs();
 
       this.notify({

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -80,7 +80,7 @@ const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 /**
- * @fires update-user-info
+ * @fires btrix-update-user-info
  */
 @localized()
 @customElement("btrix-org")
@@ -725,7 +725,7 @@ export class Org extends LiteElement {
       });
 
       await this.dispatchEvent(
-        new CustomEvent("update-user-info", { bubbles: true }),
+        new CustomEvent("btrix-update-user-info", { bubbles: true }),
       );
       const newSlug = e.detail.slug;
       if (newSlug) {


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1398

<!-- Fixes #issue_number -->

### Changes
- Updates org list in user info state after an org is created
- Minor refactor to add `btrix` prefix to custom `update-user-info` event and replace unnecessary `defaultOrg` property

### Manual testing

1. Log in as superadmin
2. Go to superadmin dashboard
3. Create new org
4. Click org in list. Verify that you've navigated to new org page