### PR TITLE
Allow superadmins to set role when inviting user

### DIFF
--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -13,18 +13,18 @@ import type { AuthState } from "@/utils/AuthService";
 const sortByName = sortBy("name");
 
 /**
- * @event success
+ * @event btrix-invite-success
  */
 @localized()
 @customElement("btrix-invite-form")
 export class InviteForm extends TailwindElement {
-  @property({ type: Object })
+  @property({ type: Object, attribute: false })
   authState?: AuthState;
 
-  @property({ type: Array })
+  @property({ type: Array, attribute: false })
   orgs?: OrgData[] = [];
 
-  @property({ type: Object })
+  @property({ type: Object, attribute: false })
   defaultOrg: Partial<OrgData> | null = null;
 
   @state()
@@ -145,7 +145,7 @@ export class InviteForm extends TailwindElement {
       );
 
       this.dispatchEvent(
-        new CustomEvent("success", {
+        new CustomEvent("btrix-invite-success", {
           detail: {
             inviteEmail,
             isExistingUser: data.invited === "existing_user",

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -1,12 +1,13 @@
 import { localized, msg } from "@lit/localize";
-import { html, type PropertyValues } from "lit";
+import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
+import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import sortBy from "lodash/fp/sortBy";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { APIController } from "@/controllers/api";
-import type { OrgData } from "@/types/org";
+import { AccessCode, type OrgData } from "@/types/org";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 
@@ -33,20 +34,7 @@ export class InviteForm extends TailwindElement {
   @state()
   private serverError?: string;
 
-  @state()
-  private selectedOrgId?: string;
-
   private readonly api = new APIController(this);
-
-  willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
-    if (
-      changedProperties.has("defaultOrg") &&
-      this.defaultOrg &&
-      !this.selectedOrgId
-    ) {
-      this.selectedOrgId = this.defaultOrg.id;
-    }
-  }
 
   render() {
     let formError;
@@ -71,12 +59,10 @@ export class InviteForm extends TailwindElement {
       >
         <div class="mb-5">
           <sl-select
+            name="orgId"
             label=${msg("Organization")}
             placeholder=${msg("Select an org")}
             value=${ifDefined(this.defaultOrg?.id)}
-            @sl-change=${(e: Event) => {
-              this.selectedOrgId = (e.target as HTMLSelectElement).value;
-            }}
             ?disabled=${sortedOrgs.length === 1}
             required
           >
@@ -85,6 +71,17 @@ export class InviteForm extends TailwindElement {
                 <sl-option value=${org.id}>${org.name}</sl-option>
               `,
             )}
+          </sl-select>
+        </div>
+        <div class="mb-5">
+          <sl-select
+            label=${msg("Role")}
+            value=${AccessCode.crawler}
+            name="inviteRole"
+          >
+            <sl-option value=${AccessCode.owner}>${"Admin"}</sl-option>
+            <sl-option value=${AccessCode.crawler}>${"Crawler"}</sl-option>
+            <sl-option value=${AccessCode.viewer}>${"Viewer"}</sl-option>
           </sl-select>
         </div>
         <div class="mb-5">
@@ -109,7 +106,7 @@ export class InviteForm extends TailwindElement {
             size="small"
             type="submit"
             ?loading=${this.isSubmitting}
-            ?disabled=${!this.selectedOrgId || this.isSubmitting}
+            ?disabled=${this.isSubmitting}
             >${msg("Invite")}</sl-button
           >
         </div>
@@ -118,27 +115,29 @@ export class InviteForm extends TailwindElement {
   }
 
   async onSubmit(event: SubmitEvent) {
-    event.preventDefault();
-    if (!this.authState || !this.selectedOrgId) return;
-
     const formEl = event.target as HTMLFormElement;
+    event.preventDefault();
+
     if (!(await this.checkFormValidity(formEl))) return;
 
     this.serverError = undefined;
     this.isSubmitting = true;
 
-    const formData = new FormData(event.target as HTMLFormElement);
-    const inviteEmail = formData.get("inviteEmail") as string;
+    const { orgId, inviteEmail, inviteRole } = serialize(formEl) as {
+      orgId: string;
+      inviteEmail: string;
+      inviteRole: string;
+    };
 
     try {
       const data = await this.api.fetch<{ invited: string }>(
-        `/orgs/${this.selectedOrgId}/invite`,
-        this.authState,
+        `/orgs/${orgId}/invite`,
+        this.authState!,
         {
           method: "POST",
           body: JSON.stringify({
             email: inviteEmail,
-            role: 10,
+            role: +inviteRole,
           }),
         },
       );

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -11,6 +11,12 @@ import { AccessCode, type OrgData } from "@/types/org";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 
+export type InviteSuccessDetail = {
+  inviteEmail: string;
+  orgId: string;
+  isExistingUser: boolean;
+};
+
 const sortByName = sortBy("name");
 
 /**
@@ -145,10 +151,13 @@ export class InviteForm extends TailwindElement {
         },
       );
 
+      formEl.reset();
+
       this.dispatchEvent(
-        new CustomEvent("btrix-invite-success", {
+        new CustomEvent<InviteSuccessDetail>("btrix-invite-success", {
           detail: {
             inviteEmail,
+            orgId,
             isExistingUser: data.invited === "existing_user",
           },
           composed: true,

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -1,4 +1,5 @@
 import { localized, msg } from "@lit/localize";
+import type { SlSelect } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -151,7 +152,9 @@ export class InviteForm extends TailwindElement {
         },
       );
 
+      // Reset fields except selected org ID
       formEl.reset();
+      formEl.querySelector<SlSelect>('[name="orgId"]')!.value = orgId;
 
       this.dispatchEvent(
         new CustomEvent<InviteSuccessDetail>("btrix-invite-success", {

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -72,9 +72,8 @@ export class InviteForm extends TailwindElement {
         <div class="mb-5">
           <sl-select
             label=${msg("Organization")}
-            value=${ifDefined(
-              this.defaultOrg ? this.defaultOrg.id : sortedOrgs[0]?.id,
-            )}
+            placeholder=${msg("Select an org")}
+            value=${ifDefined(this.defaultOrg?.id)}
             @sl-change=${(e: Event) => {
               this.selectedOrgId = (e.target as HTMLSelectElement).value;
             }}

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -62,7 +62,10 @@ export class InviteForm extends TailwindElement {
             name="orgId"
             label=${msg("Organization")}
             placeholder=${msg("Select an org")}
-            value=${ifDefined(this.defaultOrg?.id)}
+            value=${ifDefined(
+              this.defaultOrg?.id ||
+                (this.orgs?.length === 1 ? this.orgs[0].id : undefined),
+            )}
             ?disabled=${sortedOrgs.length === 1}
             required
           >

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -1,13 +1,14 @@
 import { localized, msg } from "@lit/localize";
-import { type PropertyValues } from "lit";
+import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import sortBy from "lodash/fp/sortBy";
 
+import { TailwindElement } from "@/classes/TailwindElement";
+import { APIController } from "@/controllers/api";
 import type { OrgData } from "@/types/org";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
-import LiteElement, { html } from "@/utils/LiteElement";
 
 const sortByName = sortBy("name");
 
@@ -16,7 +17,7 @@ const sortByName = sortBy("name");
  */
 @localized()
 @customElement("btrix-invite-form")
-export class InviteForm extends LiteElement {
+export class InviteForm extends TailwindElement {
   @property({ type: Object })
   authState?: AuthState;
 
@@ -34,6 +35,8 @@ export class InviteForm extends LiteElement {
 
   @state()
   private selectedOrgId?: string;
+
+  private readonly api = new APIController(this);
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
     if (
@@ -129,7 +132,7 @@ export class InviteForm extends LiteElement {
     const inviteEmail = formData.get("inviteEmail") as string;
 
     try {
-      const data = await this.apiFetch<{ invited: string }>(
+      const data = await this.api.fetch<{ invited: string }>(
         `/orgs/${this.selectedOrgId}/invite`,
         this.authState,
         {
@@ -147,6 +150,7 @@ export class InviteForm extends LiteElement {
             inviteEmail,
             isExistingUser: data.invited === "existing_user",
           },
+          composed: true,
         }),
       );
     } catch (e) {

--- a/frontend/src/features/accounts/invite-form.ts
+++ b/frontend/src/features/accounts/invite-form.ts
@@ -86,7 +86,7 @@ export class InviteForm extends TailwindElement {
         <div class="mb-5">
           <sl-select
             label=${msg("Role")}
-            value=${AccessCode.crawler}
+            value=${AccessCode.owner}
             name="inviteRole"
           >
             <sl-option value=${AccessCode.owner}>${"Admin"}</sl-option>

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -265,7 +265,7 @@ export class Home extends LiteElement {
         .authState=${this.authState}
         .orgs=${this.orgList}
         .defaultOrg=${defaultOrg}
-        @success=${() => (this.isInviteComplete = true)}
+        @btrix-invite-success=${() => (this.isInviteComplete = true)}
       ></btrix-invite-form>
     `;
   }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -255,17 +255,17 @@ export class Home extends LiteElement {
           const org = this.orgList?.find(({ id }) => id === e.detail.orgId);
 
           this.notify({
-            message: msg(
-              html`Invite sent!
-                <br />
-                <a
-                  class="underline hover:no-underline"
-                  href="/orgs/${org?.slug || e.detail.orgId}/settings/members"
-                  @click=${this.navLink.bind(this)}
-                >
-                  View org members
-                </a> `,
-            ),
+            message: html`
+              ${msg("Invite sent!")}
+              <br />
+              <a
+                class="underline hover:no-underline"
+                href="/orgs/${org?.slug || e.detail.orgId}/settings/members"
+                @click=${this.navLink.bind(this)}
+              >
+                ${msg("View org members")}
+              </a>
+            `,
             variant: "success",
             icon: "check2-circle",
           });

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -3,6 +3,7 @@ import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
+import type { InviteSuccessDetail } from "@/features/accounts/invite-form";
 import type { APIPaginatedList } from "@/types/api";
 import type { CurrentUser } from "@/types/user";
 import { isApiError } from "@/utils/api";
@@ -22,9 +23,6 @@ export class Home extends LiteElement {
 
   @property({ type: String })
   slug?: string;
-
-  @state()
-  private isInviteComplete?: boolean;
 
   @state()
   private orgList?: OrgData[];
@@ -249,19 +247,29 @@ export class Home extends LiteElement {
   }
 
   private renderInvite() {
-    if (this.isInviteComplete) {
-      return html`
-        <sl-button @click=${() => (this.isInviteComplete = false)}
-          >${msg("Send another invite")}</sl-button
-        >
-      `;
-    }
-
     return html`
       <btrix-invite-form
         .authState=${this.authState}
         .orgs=${this.orgList}
-        @btrix-invite-success=${() => (this.isInviteComplete = true)}
+        @btrix-invite-success=${(e: CustomEvent<InviteSuccessDetail>) => {
+          const org = this.orgList?.find(({ id }) => id === e.detail.orgId);
+
+          this.notify({
+            message: msg(
+              html`Invite sent!
+                <br />
+                <a
+                  class="underline hover:no-underline"
+                  href="/orgs/${org?.slug || e.detail.orgId}/settings/members"
+                  @click=${this.navLink.bind(this)}
+                >
+                  View org members
+                </a> `,
+            ),
+            variant: "success",
+            icon: "check2-circle",
+          });
+        }}
       ></btrix-invite-form>
     `;
   }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -257,14 +257,10 @@ export class Home extends LiteElement {
       `;
     }
 
-    const defaultOrg = this.userInfo?.orgs.find(
-      (org) => org.default === true,
-    ) || { name: "" };
     return html`
       <btrix-invite-form
         .authState=${this.authState}
         .orgs=${this.orgList}
-        .defaultOrg=${defaultOrg}
         @btrix-invite-success=${() => (this.isInviteComplete = true)}
       ></btrix-invite-form>
     `;

--- a/frontend/src/pages/users-invite.ts
+++ b/frontend/src/pages/users-invite.ts
@@ -49,7 +49,7 @@ export class UsersInvite extends LiteElement {
           .defaultOrg=${this.userInfo?.orgs.find(
             (org) => org.default === true,
           ) ?? null}
-          @success=${this.onSuccess}
+          @btrix-invite-success=${this.onSuccess}
         ></btrix-invite-form>
       </main>
     </div>`;

--- a/frontend/src/pages/users-invite.ts
+++ b/frontend/src/pages/users-invite.ts
@@ -46,9 +46,6 @@ export class UsersInvite extends LiteElement {
         <btrix-invite-form
           .authState=${this.authState}
           .orgs=${this.userInfo?.orgs || []}
-          .defaultOrg=${this.userInfo?.orgs.find(
-            (org) => org.default === true,
-          ) ?? null}
           @btrix-invite-success=${this.onSuccess}
         ></btrix-invite-form>
       </main>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/733

<!-- Fixes #issue_number -->

### Changes
- Adds user role select to superadmin dashboard
- Requires org selection (unless there's only one org) to prevent accidental crawler invites to default testing org
- Shows link to org members after invite, retaining form for quick re-invite
- Refactor `invite-form` into `TailwindComponent`

### Manual testing

1. Log in as superadmin
2. Invite new user. Verify email input is reset and notification with link to members is shown
3. Click link to org members. Verify new user is added as expected

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Dashboard | <img width="530" alt="Screenshot 2024-05-15 at 3 08 11 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/e499bfc9-0b1f-4c09-986a-37b25ed95424"> |
| Dashboard (Invite sent notification) | <img width="453" alt="Screenshot 2024-05-15 at 3 36 30 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/07fb9136-0f57-4c18-817e-85f5b615c267"> |

<!-- ### Follow-ups -->
