### PR TITLE
Fix editing browser profile metadata

### DIFF
--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -300,7 +300,7 @@ export class BrowserProfilesDetail extends LiteElement {
               name="pencil"
             ></sl-icon>
             <span class="inline-block pr-2 align-middle"
-              >${msg("Edit Name & Description")}</span
+              >${msg("Edit Metadata")}</span
             >
           </li>
           <li
@@ -602,7 +602,8 @@ export class BrowserProfilesDetail extends LiteElement {
   }
 
   private async onSubmitEdit(e: SubmitEvent) {
-    e.preventDefault;
+    e.preventDefault();
+
     this.isSubmittingProfileChange = true;
 
     const formData = new FormData(e.target as HTMLFormElement);

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -133,7 +133,7 @@ export class BrowserProfilesList extends LiteElement {
           </sl-tooltip>
         </btrix-table-cell>
         <btrix-table-cell
-          class="flex-col items-start justify-center pl-0"
+          class="flex-col items-center justify-center pl-0"
           rowClickTarget="a"
         >
           <a
@@ -143,13 +143,11 @@ export class BrowserProfilesList extends LiteElement {
           >
             ${data.name}
           </a>
-          <div class="w-full text-xs text-neutral-500">
-            <div class="truncate">
-              ${data.description} ${data.description} ${data.description}
-              ${data.description} ${data.description} ${data.description}
-              ${data.description}
-            </div>
-          </div>
+          ${data.description
+            ? html`<div class="w-full text-xs text-neutral-500">
+                <div class="truncate">${data.description}</div>
+              </div>`
+            : nothing}
         </btrix-table-cell>
         <btrix-table-cell class="whitespace-nowrap">
           <sl-format-date
@@ -163,9 +161,9 @@ export class BrowserProfilesList extends LiteElement {
           ></sl-format-date>
         </btrix-table-cell>
         <btrix-table-cell>${data.origins.join(", ")}</btrix-table-cell>
-        <btrix-table-cell class="px-1"
-          >${this.renderActions(data)}</btrix-table-cell
-        >
+        <btrix-table-cell class="px-1">
+          ${this.renderActions(data)}
+        </btrix-table-cell>
       </btrix-table-row>
     `;
   };


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/1811

### Changes
- Fixes browser profile metadata form submission
- Fixes rendering of browser profile description in list view
- Changes label to "metadata" for consistency with other features

### Manual testing

1. Log in as crawler
2. Go to "Browser Profiles"
3. Click a browser profile
4. Click "Actions" -> "Edit Metadata"
5. Enter description and click save. Verify metadata saves as expected