### PR TITLE
UX improvements to browser profile editing & creating view

### DIFF
--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -50,7 +50,6 @@ export class DescListItem extends LitElement {
 
     .content {
       width: var(--width-full, initial);
-      overflow: hidden;
     }
   `;
 
@@ -93,8 +92,7 @@ export class DescList extends LitElement {
       position: relative;
       display: inline-block;
       flex: 1 0 0;
-      /* min-width: min-content; */
-      max-width: 100%;
+      min-width: min-content;
     }
 
     .horizontal ::slotted(btrix-desc-list-item)::before {

--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -50,6 +50,7 @@ export class DescListItem extends LitElement {
 
     .content {
       width: var(--width-full, initial);
+      overflow: hidden;
     }
   `;
 
@@ -92,7 +93,8 @@ export class DescList extends LitElement {
       position: relative;
       display: inline-block;
       flex: 1 0 0;
-      min-width: min-content;
+      /* min-width: min-content; */
+      max-width: 100%;
     }
 
     .horizontal ::slotted(btrix-desc-list-item)::before {

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -1,6 +1,12 @@
 import { localized, msg, str } from "@lit/localize";
 import { type SlInput } from "@shoelace-style/shoelace";
-import { customElement, property, queryAsync, state } from "lit/decorators.js";
+import {
+  customElement,
+  property,
+  query,
+  queryAsync,
+  state,
+} from "lit/decorators.js";
 
 import type { Dialog } from "@/components/ui/dialog";
 import { type SelectCrawlerChangeEvent } from "@/components/ui/select-crawler";
@@ -24,6 +30,9 @@ export class NewBrowserProfileDialog extends LiteElement {
 
   @state()
   private crawlerChannel = "default";
+
+  @query("btrix-dialog")
+  private readonly dialog?: Dialog;
 
   @queryAsync("#browserProfileForm")
   private readonly form!: Promise<HTMLFormElement>;
@@ -91,20 +100,12 @@ export class NewBrowserProfileDialog extends LiteElement {
           >${msg("Cancel")}</sl-button
         >
         <sl-button
-          variant="primary"
+          variant="success"
           size="small"
           ?loading=${this.isSubmitting}
           ?disabled=${this.isSubmitting}
-          @click=${async () => {
-            // Using submit method instead of type="submit" fixes
-            // incorrect getRootNode in Chrome
-            const form = await this.form;
-            const submitInput = form.querySelector<HTMLElement>(
-              'input[type="submit"]',
-            );
-            form.requestSubmit(submitInput);
-          }}
-          >${msg("Start Profile Creator")}</sl-button
+          @click=${() => this.dialog?.submit()}
+          >${msg("Configure Browser Profile")}</sl-button
         >
       </div>
     </btrix-dialog>`;
@@ -145,8 +146,8 @@ export class NewBrowserProfileDialog extends LiteElement {
         `${this.orgBasePath}/browser-profiles/profile/browser/${
           data.browserid
         }?name=${window.encodeURIComponent(
-          "My Profile",
-        )}&description=&profileId=&crawlerChannel=${this.crawlerChannel}`,
+          msg("My Profile"),
+        )}&description=&profileId=&url=${window.encodeURIComponent(url)}&crawlerChannel=${this.crawlerChannel}`,
       );
     } catch (e) {
       this.notify({
@@ -178,14 +179,5 @@ export class NewBrowserProfileDialog extends LiteElement {
         body: JSON.stringify(params),
       },
     );
-  }
-
-  /**
-   * Stop propgation of sl-select events.
-   * Prevents bug where sl-dialog closes when dropdown closes
-   * https://github.com/shoelace-style/shoelace/issues/170
-   */
-  private stopProp(e: CustomEvent) {
-    e.stopPropagation();
   }
 }

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -136,7 +136,7 @@ export class NewBrowserProfileDialog extends LiteElement {
       });
 
       this.notify({
-        message: msg("Starting up browser for profile creation."),
+        message: msg("Starting up browser for new profile..."),
         variant: "success",
         icon: "check2-circle",
       });

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -7,6 +7,7 @@ import {
   queryAsync,
   state,
 } from "lit/decorators.js";
+import queryString from "query-string";
 
 import type { Dialog } from "@/components/ui/dialog";
 import { type SelectCrawlerChangeEvent } from "@/components/ui/select-crawler";
@@ -145,9 +146,11 @@ export class NewBrowserProfileDialog extends LiteElement {
       this.navTo(
         `${this.orgBasePath}/browser-profiles/profile/browser/${
           data.browserid
-        }?name=${window.encodeURIComponent(
-          msg("My Profile"),
-        )}&description=&profileId=&url=${window.encodeURIComponent(url)}&crawlerChannel=${this.crawlerChannel}`,
+        }?${queryString.stringify({
+          url,
+          name: msg("My Profile"),
+          crawlerChannel: this.crawlerChannel,
+        })}`,
       );
     } catch (e) {
       this.notify({

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -150,11 +150,12 @@ export class ProfileBrowser extends LiteElement {
           class="fixed left-1/2 top-2 z-50 flex -translate-x-1/2 items-center rounded-lg bg-white text-base shadow"
         >
           ${this.renderSidebarButton()}
-          <sl-icon-button
-            name="fullscreen-exit"
-            label=${msg("Exit fullscreen")}
-            @click=${() => void document.exitFullscreen()}
-          ></sl-icon-button>
+          <sl-tooltip content=${msg("Exit fullscreen")}>
+            <sl-icon-button
+              name="fullscreen-exit"
+              @click=${() => void document.exitFullscreen()}
+            ></sl-icon-button>
+          </sl-tooltip>
         </div>
       `;
     }
@@ -176,11 +177,12 @@ export class ProfileBrowser extends LiteElement {
         </div>
         <div class="p-1 text-base">
           ${this.renderSidebarButton()}
-          <sl-icon-button
-            name="arrows-fullscreen"
-            label=${msg("Enter fullscreen")}
-            @click=${() => void this.enterFullscreen()}
-          ></sl-icon-button>
+          <sl-tooltip content=${msg("Enter fullscreen")}>
+            <sl-icon-button
+              name="arrows-fullscreen"
+              @click=${() => void this.enterFullscreen()}
+            ></sl-icon-button>
+          </sl-tooltip>
         </div>
       </div>
     `;
@@ -217,14 +219,13 @@ export class ProfileBrowser extends LiteElement {
 
   private renderSidebarButton() {
     return html`
-      <sl-icon-button
-        name="layout-sidebar-reverse"
-        label=${!this.showOriginSidebar
-          ? msg("Show sidebar")
-          : msg("Hide sidebar")}
-        class="${this.showOriginSidebar ? "text-blue-600" : ""}"
-        @click=${() => (this.showOriginSidebar = !this.showOriginSidebar)}
-      ></sl-icon-button>
+      <sl-tooltip content=${msg("Toggle visited site list")}>
+        <sl-icon-button
+          name="layout-sidebar-reverse"
+          class="${this.showOriginSidebar ? "text-blue-600" : ""}"
+          @click=${() => (this.showOriginSidebar = !this.showOriginSidebar)}
+        ></sl-icon-button>
+      </sl-tooltip>
     `;
   }
 

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -94,11 +94,11 @@ export class ProfileBrowser extends LiteElement {
   }
 
   disconnectedCallback() {
-    super.disconnectedCallback();
-
     window.clearTimeout(this.pollTimerId);
     document.removeEventListener("fullscreenchange", this.onFullscreenChange);
     window.removeEventListener("beforeunload", this.onBeforeUnload);
+
+    super.disconnectedCallback();
   }
 
   private onBeforeUnload(e: BeforeUnloadEvent) {

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -12,6 +12,10 @@ import type { AuthState } from "@/utils/AuthService";
 const POLL_INTERVAL_SECONDS = 2;
 const hiddenClassList = ["translate-x-2/3", "opacity-0", "pointer-events-none"];
 
+type BrowserResponseData = {
+  detail?: string;
+  url?: string;
+};
 export type BrowserLoadDetail = string;
 export type BrowserErrorDetail = {
   error: APIError | Error;
@@ -378,7 +382,13 @@ export class ProfileBrowser extends TailwindElement {
    * Check whether temporary browser is up
    **/
   private async checkBrowserStatus() {
-    const result = await this.getBrowser();
+    let result: BrowserResponseData;
+    try {
+      result = await this.getBrowser();
+    } catch (e) {
+      this.browserNotAvailable = true;
+      return;
+    }
 
     if (result.detail === "waiting_for_browser") {
       this.pollTimerId = window.setTimeout(
@@ -425,10 +435,7 @@ export class ProfileBrowser extends TailwindElement {
   }
 
   private async getBrowser() {
-    const data = await this.api.fetch<{
-      detail?: string;
-      url?: string;
-    }>(
+    const data = await this.api.fetch<BrowserResponseData>(
       `/orgs/${this.orgId}/profiles/browser/${this.browserId}`,
       this.authState!,
     );

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -186,7 +186,7 @@ export class ProfileBrowser extends LiteElement {
           <span id="profileBrowserLabel"> ${msg("Interactive Browser")} </span>
           <sl-tooltip
             content=${msg(
-              "Interact with this embedded browser to set up your browser profile. The embedded browser will exit and discard changes after a few minutes of inactivity.",
+              "Interact with this embedded browser to set up your browser profile. The embedded browser will exit without saving changes after a few minutes of inactivity.",
             )}
             hoist
           >

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -160,13 +160,28 @@ export class ProfileBrowser extends LiteElement {
     }
 
     return html`
-      <div class="p-1 text-right text-base">
-        ${this.renderSidebarButton()}
-        <sl-icon-button
-          name="arrows-fullscreen"
-          label=${msg("Enter fullscreen")}
-          @click=${() => void this.enterFullscreen()}
-        ></sl-icon-button>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2 px-3 font-medium text-neutral-700">
+          <span id="profileBrowserLabel">
+            ${msg("Interactive Profile Browser")}
+          </span>
+          <sl-tooltip
+            content=${msg(
+              "Interact with the browsing tool to set up the browser profile.  Workflows that use this browser profile will behave as if they have logged into the same websites and have the same cookies that have been set here.",
+            )}
+            hoist
+          >
+            <sl-icon class="text-base" name="info-circle"></sl-icon>
+          </sl-tooltip>
+        </div>
+        <div class="p-1 text-base">
+          ${this.renderSidebarButton()}
+          <sl-icon-button
+            name="arrows-fullscreen"
+            label=${msg("Enter fullscreen")}
+            @click=${() => void this.enterFullscreen()}
+          ></sl-icon-button>
+        </div>
       </div>
     `;
   }
@@ -183,9 +198,9 @@ export class ProfileBrowser extends LiteElement {
     if (this.iframeSrc) {
       return html`<iframe
         class="h-full w-full"
-        title=${msg("Interactive browser for creating browser profile")}
         src=${this.iframeSrc}
         @load=${this.onIframeLoad}
+        aria-labelledby="profileBrowserLabel"
       ></iframe>`;
     }
 

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -89,11 +89,11 @@ export class ProfileBrowser extends LiteElement {
   }
 
   disconnectedCallback() {
-    super.disconnectedCallback();
-
     window.clearTimeout(this.pollTimerId);
     document.removeEventListener("fullscreenchange", this.onFullscreenChange);
     window.removeEventListener("beforeunload", this.onBeforeUnload);
+
+    super.disconnectedCallback();
   }
 
   private onBeforeUnload(e: BeforeUnloadEvent) {

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -85,11 +85,19 @@ export class ProfileBrowser extends LiteElement {
     super.connectedCallback();
 
     document.addEventListener("fullscreenchange", this.onFullscreenChange);
+    window.addEventListener("beforeunload", this.onBeforeUnload);
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
+
     window.clearTimeout(this.pollTimerId);
     document.removeEventListener("fullscreenchange", this.onFullscreenChange);
+    window.removeEventListener("beforeunload", this.onBeforeUnload);
+  }
+
+  private onBeforeUnload(e: BeforeUnloadEvent) {
+    e.preventDefault();
   }
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -20,6 +20,9 @@ export type BrowserLoadDetail = string;
 export type BrowserErrorDetail = {
   error: APIError | Error;
 };
+export type BrowserConnectionChange = {
+  connected: boolean;
+};
 
 /**
  * View embedded profile browser
@@ -38,6 +41,7 @@ export type BrowserErrorDetail = {
  * @fires btrix-browser-load Event on iframe load, with src URL
  * @fires btrix-browser-error
  * @fires btrix-browser-reload
+ * @fires btrix-browser-connection-change
  */
 @localized()
 @customElement("btrix-profile-browser")
@@ -131,6 +135,21 @@ export class ProfileBrowser extends TailwindElement {
       changedProperties.get("showOriginSidebar") !== undefined
     ) {
       this.animateSidebar();
+    }
+  }
+
+  updated(changedProperties: PropertyValues<this> & Map<string, unknown>) {
+    if (changedProperties.has("browserDisconnected")) {
+      this.dispatchEvent(
+        new CustomEvent<BrowserConnectionChange>(
+          "btrix-browser-connection-change",
+          {
+            detail: {
+              connected: !this.browserDisconnected,
+            },
+          },
+        ),
+      );
     }
   }
 
@@ -493,14 +512,6 @@ export class ProfileBrowser extends TailwindElement {
       }
 
       await this.updateComplete;
-
-      this.dispatchEvent(
-        new CustomEvent<BrowserErrorDetail>("btrix-browser-error", {
-          detail: {
-            error: e instanceof Error ? e : new Error(),
-          },
-        }),
-      );
     }
 
     this.pollTimerId = window.setTimeout(

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -240,7 +240,7 @@ export class ProfileBrowser extends TailwindElement {
         <div class="flex h-full w-full items-center justify-center">
           <btrix-alert variant="danger">
             <p>
-              ${msg(`Interactive browser is unavailable due to inactivity.`)}
+              ${msg(`Interactive browser session timed out due to inactivity.`)}
             </p>
             <div class="py-2 text-center">
               <sl-button size="small" @click=${this.onClickReload}>

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -60,6 +60,9 @@ export class ProfileBrowser extends LiteElement {
   @state()
   private newOrigins?: string[] = [];
 
+  @query("#interactiveBrowser")
+  private readonly interactiveBrowser?: HTMLElement;
+
   @query("#profileBrowserSidebar")
   private readonly sidebar?: HTMLElement;
 
@@ -113,7 +116,7 @@ export class ProfileBrowser extends LiteElement {
 
   render() {
     return html`
-      <div id="interactive-browser" class="flex h-full w-full flex-col">
+      <div id="interactiveBrowser" class="flex h-full w-full flex-col">
         ${this.renderControlBar()}
         <div
           id="iframeWrapper"
@@ -162,7 +165,7 @@ export class ProfileBrowser extends LiteElement {
         <sl-icon-button
           name="arrows-fullscreen"
           label=${msg("Enter fullscreen")}
-          @click=${() => void this.enterFullscreen("interactive-browser")}
+          @click=${() => void this.enterFullscreen()}
         ></sl-icon-button>
       </div>
     `;
@@ -393,11 +396,10 @@ export class ProfileBrowser extends LiteElement {
 
   /**
    * Enter fullscreen mode
-   * @param id ID of element to fullscreen
    */
-  private async enterFullscreen(id: string) {
+  private async enterFullscreen() {
     try {
-      await document.getElementById(id)!.requestFullscreen({
+      await this.interactiveBrowser?.requestFullscreen({
         // Hide browser navigation controls
         navigationUI: "hide",
       });

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -299,6 +299,7 @@ export class ProfileBrowser extends TailwindElement {
           name="layout-sidebar-reverse"
           class="${this.showOriginSidebar ? "text-blue-600" : ""}"
           @click=${() => (this.showOriginSidebar = !this.showOriginSidebar)}
+          aria-pressed=${this.showOriginSidebar}
         ></sl-icon-button>
       </sl-tooltip>
     `;

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -16,6 +16,8 @@ import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { getLocale } from "@/utils/localization";
 
+const DESCRIPTION_MAXLENGTH = 500;
+
 /**
  * Usage:
  * ```ts
@@ -124,7 +126,13 @@ export class BrowserProfilesDetail extends TailwindElement {
         <dl class="grid grid-cols-3 gap-5">
           <div class="col-span-3 md:col-span-1">
             <dt class="text-sm text-0-600">${msg("Description")}</dt>
-            <dd>${this.profile ? this.profile.description || none : ""}</dd>
+            <dd>
+              ${this.profile
+                ? this.profile.description
+                  ? this.profile.description.slice(0, DESCRIPTION_MAXLENGTH)
+                  : none
+                : ""}
+            </dd>
           </div>
           <div class="col-span-3 md:col-span-1">
             <dt class="text-sm text-0-600">
@@ -456,7 +464,7 @@ export class BrowserProfilesDetail extends TailwindElement {
         }?${queryString.stringify({
           url,
           name: this.profile.name,
-          description: this.profile.description,
+          description: this.profile.description.slice(0, DESCRIPTION_MAXLENGTH),
           profileId: this.profile.id,
           crawlerChannel: this.profile.crawlerChannel,
         })}`,

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -195,35 +195,32 @@ export class BrowserProfilesDetail extends TailwindElement {
 
       <div class="flex flex-col gap-5 lg:flex-row">
         <section class="flex-1">
-          <header class="mb-3">
-            <h2 class="text-lg font-medium leading-none">
-              ${msg("Browser Profile")}
-            </h2>
-          </header>
+          <h2 class="text-lg font-medium leading-none">
+            ${msg("Browser Profile")}
+          </h2>
           ${when(this.isCrawler, () =>
             this.browserId || this.isBrowserLoading
               ? html`
-                  <div
-                    id="profileBrowserContainer"
-                    class="flex h-screen flex-col rounded-lg border"
-                  >
-                    <btrix-profile-browser
-                      class="flex-1"
-                      .authState=${this.authState}
-                      orgId=${this.orgId}
-                      browserId=${ifDefined(this.browserId)}
-                      .origins=${this.profile?.origins}
-                      @load=${() => (this.isBrowserLoaded = true)}
-                    ></btrix-profile-browser>
-                    <div
-                      class="flex-0 sticky bottom-0 rounded-b-lg border-t bg-neutral-0"
-                    >
-                      ${this.renderBrowserProfileControls()}
+                  <div id="profileBrowserContainer" class="flex h-screen py-3">
+                    <div class="flex flex-1 flex-col gap-2">
+                      <btrix-profile-browser
+                        class="flex-1 overflow-hidden rounded border"
+                        .authState=${this.authState}
+                        orgId=${this.orgId}
+                        browserId=${ifDefined(this.browserId)}
+                        .origins=${this.profile?.origins}
+                        @load=${() => (this.isBrowserLoaded = true)}
+                      ></btrix-profile-browser>
+                      <div
+                        class="flex-0 sticky bottom-2 rounded-lg border bg-neutral-0 shadow"
+                      >
+                        ${this.renderBrowserProfileControls()}
+                      </div>
                     </div>
                   </div>
                 `
               : html`<div
-                  class="flex aspect-video flex-col items-center justify-center rounded-lg border bg-neutral-50"
+                  class="mt-3 flex aspect-video flex-col items-center justify-center rounded-lg border bg-neutral-50"
                 >
                   <p
                     class="mx-auto mb-4 max-w-prose text-center text-neutral-600"
@@ -276,26 +273,17 @@ export class BrowserProfilesDetail extends TailwindElement {
   private renderBrowserProfileControls() {
     return html`
       <div class="flex justify-between p-4">
-        <div class="max-w-prose">
-          <p class="mx-1 text-xs text-neutral-500">
-            ${msg(
-              "Interact with the browsing tool to set up the browser profile.  Workflows that use this browser profile will behave as if they have logged into the same websites and have the same cookies that have been set here.",
-            )}
-          </p>
-        </div>
-        <div>
-          <sl-button size="small" @click=${this.cancelEditBrowser}
-            >${msg("Cancel")}</sl-button
-          >
-          <sl-button
-            variant="primary"
-            size="small"
-            ?loading=${this.isSubmittingBrowserChange}
-            ?disabled=${this.isSubmittingBrowserChange || !this.isBrowserLoaded}
-            @click=${this.saveBrowser}
-            >${msg("Save Browser Profile")}</sl-button
-          >
-        </div>
+        <sl-button size="small" @click=${this.cancelEditBrowser}>
+          ${msg("Discard Changes")}
+        </sl-button>
+        <sl-button
+          variant="primary"
+          size="small"
+          ?loading=${this.isSubmittingBrowserChange}
+          ?disabled=${this.isSubmittingBrowserChange || !this.isBrowserLoaded}
+          @click=${this.saveBrowser}
+          >${msg("Save Browser Profile")}</sl-button
+        >
       </div>
     `;
   }

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -12,6 +12,7 @@ import type { Dialog } from "@/components/ui/dialog";
 import { APIController } from "@/controllers/api";
 import { NavigateController } from "@/controllers/navigate";
 import { NotifyController } from "@/controllers/notify";
+import type { BrowserConnectionChange } from "@/features/browser-profiles/profile-browser";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { getLocale } from "@/utils/localization";
@@ -210,6 +211,8 @@ export class BrowserProfilesDetail extends TailwindElement {
                           (this.isBrowserLoaded = true)}
                         @btrix-browser-error=${this.onBrowserError}
                         @btrix-browser-reload=${this.startBrowserPreview}
+                        @btrix-browser-connection-change=${this
+                          .onBrowserConnectionChange}
                       ></btrix-profile-browser>
                       <div
                         class="flex-0 sticky bottom-2 rounded-lg border bg-neutral-0 shadow"
@@ -397,6 +400,12 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   private async onBrowserError() {
     this.isBrowserLoaded = false;
+  }
+
+  private async onBrowserConnectionChange(
+    e: CustomEvent<BrowserConnectionChange>,
+  ) {
+    this.isBrowserLoaded = e.detail.connected;
   }
 
   private async startBrowserPreview() {

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -51,9 +51,6 @@ export class BrowserProfilesDetail extends TailwindElement {
   private isBrowserLoaded = false;
 
   @state()
-  private isBrowserLoadingFailed = false;
-
-  @state()
   private isSubmittingBrowserChange = false;
 
   @state()
@@ -218,6 +215,7 @@ export class BrowserProfilesDetail extends TailwindElement {
                         @btrix-browser-load=${() =>
                           (this.isBrowserLoaded = true)}
                         @btrix-browser-error=${this.onBrowserError}
+                        @btrix-browser-reload=${this.startBrowserPreview}
                       ></btrix-profile-browser>
                       <div
                         class="flex-0 sticky bottom-2 rounded-lg border bg-neutral-0 shadow"
@@ -312,14 +310,6 @@ export class BrowserProfilesDetail extends TailwindElement {
           ${msg("Cancel")}
         </sl-button>
         <div>
-          ${this.isBrowserLoadingFailed
-            ? html`
-                <sl-button size="small" @click=${this.startBrowserPreview}>
-                  <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-                  ${msg("Reload Browser")}
-                </sl-button>
-              `
-            : nothing}
           <sl-button
             variant="primary"
             size="small"
@@ -413,13 +403,11 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   private async onBrowserError() {
     this.isBrowserLoaded = false;
-    this.isBrowserLoadingFailed = true;
   }
 
   private async startBrowserPreview() {
     if (!this.profile) return;
 
-    this.isBrowserLoadingFailed = false;
     this.isBrowserLoading = true;
 
     const url = this.profile.origins[0];

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -1,7 +1,7 @@
 import { localized, msg, str } from "@lit/localize";
 import { type SlDropdown } from "@shoelace-style/shoelace";
 import { html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import { capitalize } from "lodash/fp";
@@ -64,6 +64,9 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   @state()
   private isEditDialogContentVisible = false;
+
+  @query("#profileBrowserContainer")
+  private readonly profileBrowserContainer?: HTMLElement | null;
 
   private readonly api = new APIController(this);
   private readonly navigate = new NavigateController(this);
@@ -201,7 +204,8 @@ export class BrowserProfilesDetail extends TailwindElement {
             this.browserId || this.isBrowserLoading
               ? html`
                   <div
-                    class="flex h-screen flex-col overflow-hidden rounded-lg border"
+                    id="profileBrowserContainer"
+                    class="flex h-screen flex-col rounded-lg border"
                   >
                     <btrix-profile-browser
                       class="flex-1"
@@ -211,7 +215,9 @@ export class BrowserProfilesDetail extends TailwindElement {
                       .origins=${this.profile?.origins}
                       @load=${() => (this.isBrowserLoaded = true)}
                     ></btrix-profile-browser>
-                    <div class="flex-0 border-t">
+                    <div
+                      class="flex-0 sticky bottom-0 rounded-b-lg border-t bg-neutral-0"
+                    >
                       ${this.renderBrowserProfileControls()}
                     </div>
                   </div>
@@ -412,6 +418,10 @@ export class BrowserProfilesDetail extends TailwindElement {
 
       this.browserId = data.browserid;
       this.isBrowserLoading = false;
+
+      await this.updateComplete;
+
+      this.profileBrowserContainer?.scrollIntoView({ behavior: "smooth" });
     } catch (e) {
       this.isBrowserLoading = false;
 

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -264,7 +264,7 @@ export class BrowserProfilesDetail extends TailwindElement {
               void this.cancelEditBrowser();
               void this.discardChangesDialog?.hide();
             }}
-            >${msg("Yes, discard changes")}
+            >${msg("Yes, Discard Changes")}
           </sl-button>
         </div>
       </btrix-dialog>

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -9,6 +9,7 @@ import { capitalize } from "lodash/fp";
 import type { Profile } from "./types";
 
 import { TailwindElement } from "@/classes/TailwindElement";
+import type { Dialog } from "@/components/ui/dialog";
 import { APIController } from "@/controllers/api";
 import { NavigateController } from "@/controllers/navigate";
 import { NotifyController } from "@/controllers/notify";
@@ -67,6 +68,9 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   @query("#profileBrowserContainer")
   private readonly profileBrowserContainer?: HTMLElement | null;
+
+  @query("#discardChangesDialog")
+  private readonly discardChangesDialog?: Dialog | null;
 
   private readonly api = new APIController(this);
   private readonly navigate = new NavigateController(this);
@@ -242,6 +246,30 @@ export class BrowserProfilesDetail extends TailwindElement {
         )}
       </div>
 
+      <btrix-dialog id="discardChangesDialog" .label=${msg("Cancel Editing?")}>
+        ${msg(
+          "Are you sure you want to discard changes to this browser profile?",
+        )}
+        <div slot="footer" class="flex justify-between">
+          <sl-button
+            size="small"
+            .autofocus=${true}
+            @click=${() => void this.discardChangesDialog?.hide()}
+          >
+            ${msg("No, continue to edit")}
+          </sl-button>
+          <sl-button
+            size="small"
+            variant="danger"
+            @click=${() => {
+              void this.cancelEditBrowser();
+              void this.discardChangesDialog?.hide();
+            }}
+            >${msg("Yes, discard changes")}
+          </sl-button>
+        </div>
+      </btrix-dialog>
+
       <btrix-dialog
         .label=${msg(str`Edit Metadata`)}
         .open=${this.isEditDialogOpen}
@@ -273,8 +301,11 @@ export class BrowserProfilesDetail extends TailwindElement {
   private renderBrowserProfileControls() {
     return html`
       <div class="flex justify-between p-4">
-        <sl-button size="small" @click=${this.cancelEditBrowser}>
-          ${msg("Discard Changes")}
+        <sl-button
+          size="small"
+          @click=${() => void this.discardChangesDialog?.show()}
+        >
+          ${msg("Cancel")}
         </sl-button>
         <sl-button
           variant="primary"
@@ -569,16 +600,6 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   private async saveBrowser() {
     if (!this.browserId) return;
-
-    if (
-      !window.confirm(
-        msg(
-          "Save browser changes to profile? You will need to re-load the browsing tool to make additional changes.",
-        ),
-      )
-    ) {
-      return;
-    }
 
     this.isSubmittingBrowserChange = true;
 

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -52,6 +52,9 @@ export class BrowserProfilesDetail extends TailwindElement {
   private isBrowserLoaded = false;
 
   @state()
+  private isBrowserLoadingFailed = false;
+
+  @state()
   private isSubmittingBrowserChange = false;
 
   @state()
@@ -88,7 +91,6 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   render() {
     const none = html`<span class="text-neutral-400">${msg("None")}</span>`;
-    console.log(this.profile?.crawlconfigs);
 
     return html`<div class="mb-7">
         <a
@@ -213,7 +215,9 @@ export class BrowserProfilesDetail extends TailwindElement {
                         orgId=${this.orgId}
                         browserId=${ifDefined(this.browserId)}
                         .origins=${this.profile?.origins}
-                        @load=${() => (this.isBrowserLoaded = true)}
+                        @btrix-browser-load=${() =>
+                          (this.isBrowserLoaded = true)}
+                        @btrix-browser-error=${this.onBrowserError}
                       ></btrix-profile-browser>
                       <div
                         class="flex-0 sticky bottom-2 rounded-lg border bg-neutral-0 shadow"
@@ -307,14 +311,25 @@ export class BrowserProfilesDetail extends TailwindElement {
         >
           ${msg("Cancel")}
         </sl-button>
-        <sl-button
-          variant="primary"
-          size="small"
-          ?loading=${this.isSubmittingBrowserChange}
-          ?disabled=${this.isSubmittingBrowserChange || !this.isBrowserLoaded}
-          @click=${this.saveBrowser}
-          >${msg("Save Browser Profile")}</sl-button
-        >
+        <div>
+          ${this.isBrowserLoadingFailed
+            ? html`
+                <sl-button size="small" @click=${this.startBrowserPreview}>
+                  <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+                  ${msg("Reload Browser")}
+                </sl-button>
+              `
+            : nothing}
+          <sl-button
+            variant="primary"
+            size="small"
+            ?loading=${this.isSubmittingBrowserChange}
+            ?disabled=${this.isSubmittingBrowserChange || !this.isBrowserLoaded}
+            @click=${this.saveBrowser}
+          >
+            ${msg("Save Browser Profile")}
+          </sl-button>
+        </div>
       </div>
     `;
   }
@@ -423,6 +438,11 @@ export class BrowserProfilesDetail extends TailwindElement {
         </div>
       </form>
     `;
+  }
+
+  private async onBrowserError() {
+    this.isBrowserLoaded = false;
+    this.isBrowserLoadingFailed = true;
   }
 
   private async startBrowserPreview() {

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -121,8 +121,19 @@ export class BrowserProfilesDetail extends TailwindElement {
         </div>
       </header>
 
-      <section class="mb-5 rounded-lg border px-4 py-2">
+      <section class="mb-7 rounded-lg border px-4 py-2">
         <btrix-desc-list horizontal>
+          <btrix-desc-list-item label=${msg("Description")}>
+            ${this.profile
+              ? this.profile.description
+                ? html`
+                    <div class="max-h-12 overflow-auto">
+                      ${this.profile.description}
+                    </div>
+                  `
+                : none
+              : nothing}
+          </btrix-desc-list-item>
           <btrix-desc-list-item label=${msg("Created At")}>
             ${this.profile
               ? html`
@@ -166,35 +177,6 @@ export class BrowserProfilesDetail extends TailwindElement {
               : none}
           </btrix-desc-list-item>
         </btrix-desc-list>
-      </section>
-
-      <section class="mb-5">
-        <header class="flex items-center justify-between">
-          <h2 class="mb-1 text-lg font-medium leading-none">
-            ${msg("Description")}
-          </h2>
-          ${when(
-            this.isCrawler,
-            () => html`
-              <sl-icon-button
-                class="text-base"
-                name="pencil"
-                @click=${() => (this.isEditDialogOpen = true)}
-                label=${msg("Edit description")}
-              ></sl-icon-button>
-            `,
-          )}
-        </header>
-        <div class="rounded border p-5">
-          ${this.profile
-            ? this.profile.description ||
-              html`
-                <div class="text-center text-neutral-400">
-                  ${msg("No description added.")}
-                </div>
-              `
-            : nothing}
-        </div>
       </section>
 
       <div class="flex flex-col gap-5 lg:flex-row">

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -4,6 +4,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import { capitalize } from "lodash/fp";
+import queryString from "query-string";
 
 import type { Profile } from "./types";
 
@@ -467,11 +468,13 @@ export class BrowserProfilesDetail extends TailwindElement {
       this.navigate.to(
         `${this.navigate.orgBasePath}/browser-profiles/profile/browser/${
           data.browserid
-        }?name=${window.encodeURIComponent(
-          this.profile.name,
-        )}&description=${window.encodeURIComponent(
-          this.profile.description || "",
-        )}&profileId=${window.encodeURIComponent(this.profile.id)}&navigateUrl=`,
+        }?${queryString.stringify({
+          url,
+          name: this.profile.name,
+          description: this.profile.description,
+          profileId: this.profile.id,
+          crawlerChannel: this.profile.crawlerChannel,
+        })}`,
       );
     } catch (e) {
       this.isBrowserLoading = false;

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -3,7 +3,6 @@ import { html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
-import { capitalize } from "lodash/fp";
 import queryString from "query-string";
 
 import type { Profile } from "./types";
@@ -121,60 +120,66 @@ export class BrowserProfilesDetail extends TailwindElement {
         </div>
       </header>
 
-      <section class="mb-7 rounded-lg border px-4 py-2">
-        <btrix-desc-list horizontal>
-          <btrix-desc-list-item label=${msg("Created At")}>
-            ${this.profile
-              ? html`
-                  <sl-format-date
-                    lang=${getLocale()}
-                    date=${`${this.profile.created}Z` /** Z for UTC */}
-                    month="2-digit"
-                    day="2-digit"
-                    year="2-digit"
-                    hour="numeric"
-                    minute="numeric"
-                    time-zone-name="short"
-                  ></sl-format-date>
-                `
-              : nothing}
-          </btrix-desc-list-item>
-          <btrix-desc-list-item label=${msg("Crawler Release Channel")}>
-            ${this.profile
-              ? this.profile.crawlerChannel
-                ? capitalize(this.profile.crawlerChannel)
-                : none
-              : nothing}
-          </btrix-desc-list-item>
-          <btrix-desc-list-item label=${msg("Crawl Workflows")}>
-            ${this.profile?.crawlconfigs?.length
-              ? html`<ul class="text-sm font-medium">
-                  ${this.profile.crawlconfigs.map(
-                    ({ id, name }) => html`
-                      <li>
-                        <a
-                          class="text-neutral-600 hover:underline"
-                          href=${`${this.navigate.orgBasePath}/workflows/crawl/${id}`}
-                          @click=${this.navigate.link}
-                        >
-                          ${name || msg("(no name)")}
-                        </a>
-                      </li>
-                    `,
-                  )}
-                </ul>`
-              : none}
-          </btrix-desc-list-item>
-          <btrix-desc-list-item label=${msg("Description")}>
-            ${this.profile
-              ? this.profile.description
+      <section class="mb-5 rounded border p-4">
+        <dl class="grid grid-cols-3 gap-5">
+          <div class="col-span-3 md:col-span-1">
+            <dt class="text-sm text-0-600">${msg("Description")}</dt>
+            <dd>${this.profile ? this.profile.description || none : ""}</dd>
+          </div>
+          <div class="col-span-3 md:col-span-1">
+            <dt class="text-sm text-0-600">
+              <span class="inline-block align-middle"
+                >${msg("Created at")}</span
+              >
+            </dt>
+            <dd>
+              ${this.profile
                 ? html`
-                    <div class="truncate">${this.profile.description}</div>
+                    <sl-format-date
+                      lang=${getLocale()}
+                      date=${`${this.profile.created}Z` /** Z for UTC */}
+                      month="2-digit"
+                      day="2-digit"
+                      year="2-digit"
+                      hour="numeric"
+                      minute="numeric"
+                      time-zone-name="short"
+                    ></sl-format-date>
                   `
-                : none
-              : nothing}
-          </btrix-desc-list-item>
-        </btrix-desc-list>
+                : ""}
+            </dd>
+          </div>
+          <div class="col-span-3 md:col-span-1">
+            <dt class="text-sm text-0-600">
+              <span class="inline-block align-middle"
+                >${msg("Crawl Workflows")}</span
+              >
+              <sl-tooltip content=${msg("Crawl workflows using this profile")}>
+                <sl-icon
+                  class="inline-block align-middle"
+                  name="info-circle"
+                ></sl-icon>
+              </sl-tooltip>
+            </dt>
+            <dd>
+              <ul class="text-sm font-medium">
+                ${this.profile?.crawlconfigs?.map(
+                  ({ id, name }) => html`
+                    <li>
+                      <a
+                        class="text-neutral-600 hover:underline"
+                        href=${`${this.navigate.orgBasePath}/workflows/crawl/${id}`}
+                        @click=${this.navigate.link}
+                      >
+                        ${name}
+                      </a>
+                    </li>
+                  `,
+                )}
+              </ul>
+            </dd>
+          </div>
+        </dl>
       </section>
 
       <div class="flex flex-col gap-5 lg:flex-row">

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -123,17 +123,6 @@ export class BrowserProfilesDetail extends TailwindElement {
 
       <section class="mb-7 rounded-lg border px-4 py-2">
         <btrix-desc-list horizontal>
-          <btrix-desc-list-item label=${msg("Description")}>
-            ${this.profile
-              ? this.profile.description
-                ? html`
-                    <div class="max-h-12 overflow-auto">
-                      ${this.profile.description}
-                    </div>
-                  `
-                : none
-              : nothing}
-          </btrix-desc-list-item>
           <btrix-desc-list-item label=${msg("Created At")}>
             ${this.profile
               ? html`
@@ -175,6 +164,15 @@ export class BrowserProfilesDetail extends TailwindElement {
                   )}
                 </ul>`
               : none}
+          </btrix-desc-list-item>
+          <btrix-desc-list-item label=${msg("Description")}>
+            ${this.profile
+              ? this.profile.description
+                ? html`
+                    <div class="truncate">${this.profile.description}</div>
+                  `
+                : none
+              : nothing}
           </btrix-desc-list-item>
         </btrix-desc-list>
       </section>

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -1,5 +1,4 @@
 import { localized, msg, str } from "@lit/localize";
-import { type SlDropdown } from "@shoelace-style/shoelace";
 import { html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -83,6 +82,7 @@ export class BrowserProfilesDetail extends TailwindElement {
     if (this.browserId) {
       void this.deleteBrowser(this.browserId);
     }
+    super.disconnectedCallback();
   }
 
   firstUpdated() {
@@ -123,7 +123,7 @@ export class BrowserProfilesDetail extends TailwindElement {
         </div>
       </header>
 
-      <section class="mb-3 rounded-lg border px-4 py-2">
+      <section class="mb-5 rounded-lg border px-4 py-2">
         <btrix-desc-list horizontal>
           <btrix-desc-list-item label=${msg("Created At")}>
             ${this.profile
@@ -234,12 +234,12 @@ export class BrowserProfilesDetail extends TailwindElement {
                     class="mx-auto mb-4 max-w-prose text-center text-neutral-600"
                   >
                     ${msg(
-                      "Edit the profile to make changes or view its present configuration",
+                      "View or edit the current browser profile configuration.",
                     )}
                   </p>
                   <sl-button @click=${this.startBrowserPreview}>
-                    <sl-icon slot="prefix" name="pencil-square"></sl-icon>
-                    ${msg("Edit Browser Profile")}
+                    <sl-icon slot="prefix" name="gear"></sl-icon>
+                    ${msg("Configure Browser Profile")}
                   </sl-button>
                 </div>`,
           )}
@@ -336,61 +336,32 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   private renderMenu() {
     return html`
-      <sl-dropdown placement="bottom-end" distance="4">
-        <sl-button size="small" slot="trigger" caret
-          >${msg("Actions")}</sl-button
-        >
-
-        <ul
-          class="whitespace-nowrap bg-white text-left text-sm text-neutral-800"
-          role="menu"
-        >
-          <li
-            class="cursor-pointer p-2 hover:bg-zinc-100"
-            role="menuitem"
-            @click=${(e: Event) => {
-              void (e.target as HTMLElement)
-                .closest<SlDropdown>("sl-dropdown")!
-                .hide();
-              this.isEditDialogOpen = true;
-            }}
+      <sl-dropdown distance="4" placement="bottom-end">
+        <sl-button size="small" slot="trigger" caret>
+          ${msg("Actions")}
+        </sl-button>
+        <sl-menu>
+          <sl-menu-item @click=${() => (this.isEditDialogOpen = true)}>
+            <sl-icon slot="prefix" name="pencil"></sl-icon>
+            ${msg("Edit Metadata")}
+          </sl-menu-item>
+          <sl-menu-item @click=${this.startBrowserPreview}>
+            <sl-icon slot="prefix" name="gear"></sl-icon>
+            ${msg("Configure Browser Profile")}
+          </sl-menu-item>
+          <sl-menu-item @click=${() => void this.duplicateProfile()}>
+            <sl-icon slot="prefix" name="files"></sl-icon>
+            ${msg("Duplicate Profile")}
+          </sl-menu-item>
+          <sl-divider></sl-divider>
+          <sl-menu-item
+            style="--sl-color-neutral-700: var(--danger)"
+            @click=${() => void this.deleteProfile()}
           >
-            <sl-icon
-              class="inline-block px-1 align-middle"
-              name="pencil"
-            ></sl-icon>
-            <span class="inline-block pr-2 align-middle"
-              >${msg("Edit Metadata")}</span
-            >
-          </li>
-          <li
-            class="cursor-pointer p-2 hover:bg-zinc-100"
-            role="menuitem"
-            @click=${() => void this.duplicateProfile()}
-          >
-            <sl-icon
-              class="inline-block px-1 align-middle"
-              name="files"
-            ></sl-icon>
-            <span class="inline-block pr-2 align-middle"
-              >${msg("Duplicate Profile")}</span
-            >
-          </li>
-          <hr />
-          <li
-            class="cursor-pointer p-2 text-danger hover:bg-danger hover:text-white"
-            role="menuitem"
-            @click=${() => {
-              void this.deleteProfile();
-            }}
-          >
-            <sl-icon
-              class="inline-block px-1 align-middle"
-              name="trash3"
-            ></sl-icon>
-            <span class="inline-block pr-2 align-middle">${msg("Delete")}</span>
-          </li>
-        </ul>
+            <sl-icon slot="prefix" name="trash3"></sl-icon>
+            ${msg("Delete")}
+          </sl-menu-item>
+        </sl-menu>
       </sl-dropdown>
     `;
   }
@@ -448,6 +419,7 @@ export class BrowserProfilesDetail extends TailwindElement {
   private async startBrowserPreview() {
     if (!this.profile) return;
 
+    this.isBrowserLoadingFailed = false;
     this.isBrowserLoading = true;
 
     const url = this.profile.origins[0];

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -255,7 +255,7 @@ export class BrowserProfilesDetail extends TailwindElement {
             .autofocus=${true}
             @click=${() => void this.discardChangesDialog?.hide()}
           >
-            ${msg("No, continue to edit")}
+            ${msg("No, Continue Editing")}
           </sl-button>
           <sl-button
             size="small"

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -2,6 +2,7 @@ import { localized, msg } from "@lit/localize";
 import { nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
+import queryString from "query-string";
 
 import type { Profile } from "./types";
 
@@ -209,11 +210,13 @@ export class BrowserProfilesList extends LiteElement {
       this.navTo(
         `${this.orgBasePath}/browser-profiles/profile/browser/${
           data.browserid
-        }?name=${window.encodeURIComponent(
-          profile.name,
-        )}&description=${window.encodeURIComponent(
-          profile.description || "",
-        )}&profileId=${window.encodeURIComponent(profile.id)}&navigateUrl=`,
+        }?${queryString.stringify({
+          url,
+          name: profile.name,
+          description: profile.description,
+          profileId: profile.id,
+          crawlerChannel: profile.crawlerChannel,
+        })}`,
       );
     } catch (e) {
       this.notify({

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -80,6 +80,26 @@ export class BrowserProfilesNew extends LiteElement {
         </a>
       </div>
 
+      <header class="mb-3">
+        <h1 class="min-w-0 flex-1 truncate text-xl font-medium leading-7">
+          ${msg("New Browser Profile")}
+        </h1>
+      </header>
+
+      <p class="mb-5 leading-normal text-neutral-700">
+        ${msg(
+          "Interact with the browsing tool to record your browser profile. It is highly recommended to create dedicated accounts to use when crawling.",
+        )}
+        <br />
+        ${msg("For details refer to the best practices on the ")}
+        <a
+          class="text-primary hover:text-indigo-400"
+          href="https://docs.browsertrix.com/user-guide/browser-profiles/"
+          target="_blank"
+          >${msg("browser profiles documentation page.")}</a
+        >
+      </p>
+
       ${this.params.profileId
         ? html`
             <div class="mb-2">
@@ -92,31 +112,7 @@ export class BrowserProfilesNew extends LiteElement {
           `
         : ""}
 
-      <div class="flex h-screen flex-col">
-        <div
-          class="flex-0 mb-3 flex items-center justify-between rounded-lg bg-slate-100 p-2"
-        >
-          <p class="mr-3 p-1 text-sm text-slate-600">
-            ${msg(
-              "Interact with the browsing tool to record your browser profile. It is highly recommended to create dedicated accounts to use when crawling. For details refer to the best practices on the ",
-            )}
-            <a
-              class="text-primary hover:text-indigo-400"
-              href="https://docs.browsertrix.com/user-guide/browser-profiles/"
-              target="_blank"
-              >${msg("browser profiles documentation page.")}</a
-            >
-          </p>
-
-          <sl-button
-            variant="primary"
-            size="small"
-            @click=${() => (this.isDialogVisible = true)}
-          >
-            ${msg("Finish Browsing")}
-          </sl-button>
-        </div>
-
+      <div class="sticky top-0 flex h-screen flex-col gap-2">
         <btrix-profile-browser
           class="flex-1 overflow-hidden rounded-lg border"
           .authState=${this.authState}
@@ -124,6 +120,21 @@ export class BrowserProfilesNew extends LiteElement {
           browserId=${this.browserId}
           initialNavigateUrl=${ifDefined(this.params.navigateUrl)}
         ></btrix-profile-browser>
+
+        <div
+          class="sticky bottom-2 z-10 mb-3 flex items-center justify-between rounded-lg border bg-neutral-0 p-2 shadow"
+        >
+          <sl-button size="small" @click=${() => console.log("TODO")}>
+            ${msg("Cancel")}
+          </sl-button>
+          <sl-button
+            variant="success"
+            size="small"
+            @click=${() => (this.isDialogVisible = true)}
+          >
+            ${msg("Finish Browsing")}
+          </sl-button>
+        </div>
       </div>
 
       <btrix-dialog

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -96,7 +96,7 @@ export class BrowserProfilesNew extends LiteElement {
             href="https://docs.browsertrix.com/user-guide/browser-profiles/"
             target="_blank"
           >
-            ${msg("browser profiles best practivecs")}</a
+            ${msg("browser profile best practices")}</a
           >.
         `)}
       </p>

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -48,6 +48,13 @@ export class BrowserProfilesNew extends LiteElement {
   @state()
   private isDialogVisible = false;
 
+  disconnectedCallback(): void {
+    if (this.browserId) {
+      void this.deleteBrowser(this.browserId);
+    }
+    super.disconnectedCallback();
+  }
+
   render() {
     return html`
       <div class="mb-7">
@@ -117,11 +124,8 @@ export class BrowserProfilesNew extends LiteElement {
         ></btrix-profile-browser>
 
         <div
-          class="sticky bottom-2 z-10 mb-3 flex items-center justify-between rounded-lg border bg-neutral-0 p-2 shadow"
+          class="sticky bottom-2 z-10 mb-3 flex items-center justify-end rounded-lg border bg-neutral-0 p-2 shadow"
         >
-          <sl-button size="small" @click=${() => console.log("TODO")}>
-            ${msg("Cancel")}
-          </sl-button>
           <sl-button
             variant="success"
             size="small"
@@ -288,6 +292,16 @@ export class BrowserProfilesNew extends LiteElement {
       {
         method: "POST",
         body: JSON.stringify(params),
+      },
+    );
+  }
+
+  private async deleteBrowser(id: string) {
+    return this.apiFetch(
+      `/orgs/${this.orgId}/profiles/browser/${id}`,
+      this.authState!,
+      {
+        method: "DELETE",
       },
     );
   }

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -297,12 +297,19 @@ export class BrowserProfilesNew extends LiteElement {
   }
 
   private async deleteBrowser(id: string) {
-    return this.apiFetch(
-      `/orgs/${this.orgId}/profiles/browser/${id}`,
-      this.authState!,
-      {
-        method: "DELETE",
-      },
-    );
+    try {
+      const data = await this.apiFetch(
+        `/orgs/${this.orgId}/profiles/browser/${id}`,
+        this.authState!,
+        {
+          method: "DELETE",
+        },
+      );
+
+      return data;
+    } catch (e) {
+      // TODO Investigate DELETE returning 404
+      console.debug(e);
+    }
   }
 }

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -88,17 +88,18 @@ export class BrowserProfilesNew extends LiteElement {
 
       <p class="mb-5 leading-normal text-neutral-700">
         ${msg(
-          "Interact with the embedded website browser to record your browser profile. It is highly recommended to create dedicated accounts to use when crawling.",
+          "Workflows that use this browser profile will behave as if they have logged into the same websites and have the same web cookies.",
         )}
         <br />
         ${msg(html`
-          For details, refer to the best practices on the
+          It is highly recommended to create dedicated accounts to use when
+          crawling. For details, refer to
           <a
             class="text-primary hover:text-indigo-400"
             href="https://docs.browsertrix.com/user-guide/browser-profiles/"
             target="_blank"
           >
-            ${msg("browser profiles documentation page")}</a
+            ${msg("browser profiles best practivecs")}</a
           >.
         `)}
       </p>

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -88,16 +88,19 @@ export class BrowserProfilesNew extends LiteElement {
 
       <p class="mb-5 leading-normal text-neutral-700">
         ${msg(
-          "Interact with the browsing tool to record your browser profile. It is highly recommended to create dedicated accounts to use when crawling.",
+          "Interact with the embedded website browser to record your browser profile. It is highly recommended to create dedicated accounts to use when crawling.",
         )}
         <br />
-        ${msg("For details refer to the best practices on the ")}
-        <a
-          class="text-primary hover:text-indigo-400"
-          href="https://docs.browsertrix.com/user-guide/browser-profiles/"
-          target="_blank"
-          >${msg("browser profiles documentation page.")}</a
-        >
+        ${msg(html`
+          For details, refer to the best practices on the
+          <a
+            class="text-primary hover:text-indigo-400"
+            href="https://docs.browsertrix.com/user-guide/browser-profiles/"
+            target="_blank"
+          >
+            ${msg("browser profiles documentation page")}</a
+          >.
+        `)}
       </p>
 
       ${this.params.profileId

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -630,6 +630,7 @@ export class Org extends LiteElement {
         .authState=${this.authState!}
         .orgId=${this.orgId}
         profileId=${params.browserProfileId}
+        ?isCrawler=${this.isCrawler}
       ></btrix-browser-profiles-detail>`;
     }
 

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -63,6 +63,12 @@ export type OrgParams = {
     browserProfileId?: string;
     browserId?: string;
     new?: ResourceName;
+    name?: string;
+    url?: string;
+    description?: string;
+    crawlerChannel?: string;
+    profileId?: string;
+    navigateUrl?: string;
   };
   collections: {
     collectionId?: string;
@@ -639,6 +645,14 @@ export class Org extends LiteElement {
         .authState=${this.authState!}
         .orgId=${this.orgId}
         .browserId=${params.browserId}
+        .browserParams=${{
+          name: params.name || "",
+          url: params.url || "",
+          description: params.description,
+          crawlerChannel: params.crawlerChannel,
+          profileId: params.profileId,
+          navigateUrl: params.navigateUrl,
+        }}
       ></btrix-browser-profiles-new>`;
     }
 

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -110,6 +110,7 @@ export type Profile = {
     size: number;
     replicas: ProfileReplica[] | null;
   };
+  crawlerChannel?: string;
 };
 
 export type CrawlState =


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/438

<!-- Fixes #issue_number -->

### Changes
- Layout and design pass on profile detail view to better match other detail views
- Ensures profile save buttons are always visible when creating or editing a profile
- Handle temporarily disconnected browser pings
- Enable recreating browser after it expires
- Show confirmation dialog when attempting to navigate away from active browser
- Tweak copy referencing profiles
- Refactors `profile-browser` into `TailwindComponent`

### Manual testing

1. Log in as crawler
2. Go to "Browser Profiles"
3. Click "New Browser Profile"
  a. Fill form
  b. Click "Configure Browser Profile". Verify "Interactive Browser" loads with website
  c. Scroll up and down page. Verify "Finish Browsing" control bar is visible while interactive browser is visible
  d. Open dev tools and switch to offline mode. Verify alert message is shown
  e. Wait until screen turns gray and then switch back to online mode. Verify "Reload" button is shown
  f. Click "Reload". Verify browser profile URL is reloaded
  g. Click "Finish Browsing" and save. Verify profile saves as expected
4. Click existing browser profile and repeat test steps 3c-3f.


### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Browser Profile Detail (updated copy) | <img width="1331" alt="Screenshot 2024-05-22 at 10 45 28 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/f1a46e29-aeb7-45fc-8b22-7ae73f43a983"> |
| Browser Profile Detail (updated action dropdown) | <img width="273" alt="Screenshot 2024-05-22 at 10 45 33 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/15e95679-b1ea-4ee2-be2c-27d1a6b2eed0"> |
| Browser Profile Detail - Editing (tooltip hover) | <img width="1335" alt="Screenshot 2024-05-22 at 10 50 31 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/7a35b988-62fa-43eb-a4c5-e3d94bff848a"> |
| Browser Profile Detail - Editing - Cancellation dialog | <img width="529" alt="Screenshot 2024-05-22 at 10 51 13 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/947b720a-5c78-45ca-8c33-8eaa355ee137"> |
| Browser Profile Detail - Editing (connection lost) | <img width="1320" alt="Screenshot 2024-05-22 at 10 58 35 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/72e706ef-b3da-4c46-adb0-f4e12e99d64f"> |
| Browser Profile Detail - Editing (browser expired) | <img width="1316" alt="Screenshot 2024-05-22 at 10 50 36 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/ff55b42f-663c-455b-946b-d9dd9ab5cc5a"> |
| New Browser Profile | <img width="1360" alt="Screenshot 2024-05-22 at 10 59 13 AM" src="https://github.com/webrecorder/browsertrix/assets/4672952/30bade00-729a-43ab-be42-bf69091cb676"> |

### Follow-ups

UX improvements to the browser profile detail layout and list view will be handled in https://github.com/webrecorder/browsertrix/issues/1816