### PR TITLE
Backend: Add modified field and track created/modifier users for profiles

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1183,6 +1183,7 @@ class Profile(BaseMongoModel):
     resource: Optional[ProfileFile]
 
     created: Optional[datetime]
+    modified: Optional[datetime] = None
     baseid: Optional[UUID] = None
     crawlerChannel: Optional[str]
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1183,7 +1183,12 @@ class Profile(BaseMongoModel):
     resource: Optional[ProfileFile]
 
     created: Optional[datetime]
+    createdBy: Optional[UUID] = None
+    createdByName: Optional[str] = None
     modified: Optional[datetime] = None
+    modifiedBy: Optional[UUID] = None
+    modifiedByName: Optional[str] = None
+
     baseid: Optional[UUID] = None
     crawlerChannel: Optional[str]
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -160,6 +160,8 @@ class ProfileOps:
         existing_created: Optional[datetime] = None,
     ) -> dict[str, Any]:
         """commit profile and shutdown profile browser"""
+        # pylint: disable=too-many-locals
+
         if not profileid:
             profileid = uuid4()
 

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -425,9 +425,9 @@ def test_commit_browser_to_existing_profile(
         # Modified, ascending
         ("modified", 1, 1, 0),
         # Created, descending
-        ("created", -1, 0, 1),
+        ("created", -1, 1, 0),
         # Created, ascending
-        ("created", 1, 1, 0),
+        ("created", 1, 0, 1),
         # Name, descending
         ("name", -1, 0, 1),
         # Name, ascending
@@ -461,7 +461,7 @@ def test_sort_profiles(
 
             profile_1 = profiles[profile_1_index]
             assert profile_1["id"] == profile_id
-            assert profile_1["name"] == PROFILE_NAME
+            assert profile_1["name"] == PROFILE_NAME_UPDATED
 
             profile_2 = profiles[profile_2_index]
             assert profile_2["id"] == profile_2_id

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -122,7 +122,11 @@ def profile_config_id(admin_auth_headers, default_org_id, profile_id):
     assert data["oid"] == default_org_id
     assert data.get("origins") or data.get("origins") == []
     assert data["created"]
+    assert data["createdBy"]
+    assert data["createdByName"] == "admin"
     assert data["modified"]
+    assert data["modifiedBy"]
+    assert data["modifiedByName"] == "admin"
     assert not data["baseid"]
 
     resource = data["resource"]
@@ -213,7 +217,11 @@ def test_get_profile(admin_auth_headers, default_org_id, profile_id, profile_con
             assert data["oid"] == default_org_id
             assert data.get("origins") or data.get("origins") == []
             assert data["created"]
+            assert data["createdBy"]
+            assert data["createdByName"] == "admin"
             assert data["modified"]
+            assert data["modifiedBy"]
+            assert data["modifiedByName"] == "admin"
             assert not data["baseid"]
 
             resource = data["resource"]
@@ -268,7 +276,11 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_1["oid"] == default_org_id
             assert profile_1.get("origins") or data.get("origins") == []
             assert profile_1["created"]
+            assert profile_1["createdBy"]
+            assert profile_1["createdByName"] == "admin"
             assert profile_1["modified"]
+            assert profile_1["modifiedBy"]
+            assert profile_1["modifiedByName"] == "admin"
             assert not profile_1["baseid"]
             resource = profile_1["resource"]
             assert resource
@@ -289,7 +301,11 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_2["oid"] == default_org_id
             assert profile_2.get("origins") or data.get("origins") == []
             assert profile_2["created"]
+            assert profile_2["createdBy"]
+            assert profile_2["createdByName"] == "admin"
             assert profile_2["modified"]
+            assert profile_2["modifiedBy"]
+            assert profile_2["modifiedByName"] == "admin"
             assert not profile_2["baseid"]
             resource = profile_2["resource"]
             assert resource
@@ -332,21 +348,21 @@ def test_delete_profile(admin_auth_headers, default_org_id, profile_2_id):
     assert r.json()["detail"] == "profile_not_found"
 
 
-def test_update_profile_metadata(admin_auth_headers, default_org_id, profile_id):
+def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_id):
     # Get original created/modified times
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
-        headers=admin_auth_headers,
+        headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.jsoN()
+    data = r.json()
     original_created = data["created"]
     original_modified = data["modified"]
 
     # Update name and description
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
-        headers=admin_auth_headers,
+        headers=crawler_auth_headers,
         json={
             "name": PROFILE_NAME_UPDATED,
             "description": PROFILE_DESC_UPDATED,
@@ -360,7 +376,7 @@ def test_update_profile_metadata(admin_auth_headers, default_org_id, profile_id)
     # Verify update
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
-        headers=admin_auth_headers,
+        headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
@@ -370,7 +386,12 @@ def test_update_profile_metadata(admin_auth_headers, default_org_id, profile_id)
 
     # Ensure modified was updated but created was not
     assert data["modified"] > original_modified
+    assert data["modifiedBy"]
+    assert data["modifiedByName"] == "new-crawler"
+
     assert data["created"] == original_created
+    assert data["createdBy"]
+    assert data["createdByName"] == "admin"
 
 
 def test_commit_browser_to_existing_profile(
@@ -403,6 +424,8 @@ def test_commit_browser_to_existing_profile(
     assert r.status_code == 200
     assert r.json()["updated"]
 
+    time.sleep(5)
+
     # Ensure modified was updated but created was not
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
@@ -411,4 +434,9 @@ def test_commit_browser_to_existing_profile(
     assert r.status_code == 200
     data = r.json()
     assert data["modified"] > original_modified
+    assert data["modifiedBy"]
+    assert data["modifiedByName"] == "admin"
+
     assert data["created"] == original_created
+    assert data["createdBy"]
+    assert data["createdByName"] == "admin"

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -122,6 +122,7 @@ def profile_config_id(admin_auth_headers, default_org_id, profile_id):
     assert data["oid"] == default_org_id
     assert data.get("origins") or data.get("origins") == []
     assert data["created"]
+    assert data["modified"]
     assert not data["baseid"]
 
     resource = data["resource"]
@@ -212,6 +213,7 @@ def test_get_profile(admin_auth_headers, default_org_id, profile_id, profile_con
             assert data["oid"] == default_org_id
             assert data.get("origins") or data.get("origins") == []
             assert data["created"]
+            assert data["modified"]
             assert not data["baseid"]
 
             resource = data["resource"]
@@ -266,6 +268,7 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_1["oid"] == default_org_id
             assert profile_1.get("origins") or data.get("origins") == []
             assert profile_1["created"]
+            assert profile_1["modified"]
             assert not profile_1["baseid"]
             resource = profile_1["resource"]
             assert resource
@@ -286,6 +289,7 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_2["oid"] == default_org_id
             assert profile_2.get("origins") or data.get("origins") == []
             assert profile_2["created"]
+            assert profile_2["modified"]
             assert not profile_2["baseid"]
             resource = profile_2["resource"]
             assert resource
@@ -329,6 +333,16 @@ def test_delete_profile(admin_auth_headers, default_org_id, profile_2_id):
 
 
 def test_update_profile_metadata(admin_auth_headers, default_org_id, profile_id):
+    # Get original created/modified times
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.jsoN()
+    original_created = data["created"]
+    original_modified = data["modified"]
+
     # Update name and description
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
@@ -354,10 +368,24 @@ def test_update_profile_metadata(admin_auth_headers, default_org_id, profile_id)
     assert data["name"] == PROFILE_NAME_UPDATED
     assert data["description"] == PROFILE_DESC_UPDATED
 
+    # Ensure modified was updated but created was not
+    assert data["modified"] > original_modified
+    assert data["created"] == original_created
+
 
 def test_commit_browser_to_existing_profile(
     admin_auth_headers, default_org_id, profile_browser_3_id, profile_id
 ):
+    # Get original modified time
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    original_created = data["created"]
+    original_modified = data["modified"]
+
     prepare_browser_for_profile_commit(
         profile_browser_3_id, admin_auth_headers, default_org_id
     )
@@ -374,3 +402,13 @@ def test_commit_browser_to_existing_profile(
     )
     assert r.status_code == 200
     assert r.json()["updated"]
+
+    # Ensure modified was updated but created was not
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["modified"] > original_modified
+    assert data["created"] == original_created

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -266,9 +266,34 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             profiles = data["items"]
             assert len(profiles) == 2
 
-            profile_1 = [
-                profile for profile in profiles if profile["id"] == profile_id
-            ][0]
+            # Second profile should be listed first by default because it was
+            # modified more recently
+            profile_2 = profiles[0]
+            assert profile_2["id"] == profile_2_id
+            assert profile_2["name"] == PROFILE_2_NAME
+            assert profile_2["description"] == PROFILE_2_DESC
+            assert profile_2["userid"]
+            assert profile_2["oid"] == default_org_id
+            assert profile_2.get("origins") or data.get("origins") == []
+            assert profile_2["created"]
+            assert profile_2["createdBy"]
+            assert profile_2["createdByName"] == "admin"
+            assert profile_2["modified"]
+            assert profile_2["modifiedBy"]
+            assert profile_2["modifiedByName"] == "admin"
+            assert not profile_2["baseid"]
+            resource = profile_2["resource"]
+            assert resource
+            assert resource["filename"]
+            assert resource["hash"]
+            assert resource["size"]
+            assert resource["storage"]
+            assert resource["storage"]["name"]
+            assert resource.get("replicas") or resource.get("replicas") == []
+
+            # First profile should be listed second by default because it was
+            # modified less recently
+            profile_1 = profiles[1]
             assert profile_1["id"] == profile_id
             assert profile_1["name"] == PROFILE_NAME
             assert profile_1["description"] == PROFILE_DESC
@@ -291,61 +316,11 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert resource["storage"]["name"]
             assert resource.get("replicas") or resource.get("replicas") == []
 
-            profile_2 = [
-                profile for profile in profiles if profile["id"] == profile_2_id
-            ][0]
-            assert profile_2["id"] == profile_2_id
-            assert profile_2["name"] == PROFILE_2_NAME
-            assert profile_2["description"] == PROFILE_2_DESC
-            assert profile_2["userid"]
-            assert profile_2["oid"] == default_org_id
-            assert profile_2.get("origins") or data.get("origins") == []
-            assert profile_2["created"]
-            assert profile_2["createdBy"]
-            assert profile_2["createdByName"] == "admin"
-            assert profile_2["modified"]
-            assert profile_2["modifiedBy"]
-            assert profile_2["modifiedByName"] == "admin"
-            assert not profile_2["baseid"]
-            resource = profile_2["resource"]
-            assert resource
-            assert resource["filename"]
-            assert resource["hash"]
-            assert resource["size"]
-            assert resource["storage"]
-            assert resource["storage"]["name"]
-            assert resource.get("replicas") or resource.get("replicas") == []
             break
         except:
             if time.monotonic() - start_time > time_limit:
                 raise
             time.sleep(1)
-
-
-def test_delete_profile(admin_auth_headers, default_org_id, profile_2_id):
-    # Delete second profile
-    r = requests.delete(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
-        headers=admin_auth_headers,
-    )
-    assert r.status_code == 200
-    assert r.json()["success"]
-
-    # Verify profile has been deleted
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
-        headers=admin_auth_headers,
-    )
-    assert r.status_code == 404
-    assert r.json()["detail"] == "profile_not_found"
-
-    # Try to delete it again and verify we get a 404
-    r = requests.delete(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
-        headers=admin_auth_headers,
-    )
-    assert r.status_code == 404
-    assert r.json()["detail"] == "profile_not_found"
 
 
 def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_id):
@@ -440,3 +415,86 @@ def test_commit_browser_to_existing_profile(
     assert data["created"] == original_created
     assert data["createdBy"]
     assert data["createdByName"] == "admin"
+
+
+@pytest.mark.parametrize(
+    "sort_by,sort_direction,profile_1_index,profile_2_index",
+    [
+        # Modified, descending
+        ("modified", -1, 0, 1),
+        # Modified, ascending
+        ("modified", 1, 1, 0),
+        # Created, descending
+        ("created", -1, 0, 1),
+        # Created, ascending
+        ("created", 1, 1, 0),
+        # Name, descending
+        ("name", -1, 0, 1),
+        # Name, ascending
+        ("name", 1, 1, 0),
+    ],
+)
+def test_sort_profiles(
+    admin_auth_headers,
+    default_org_id,
+    profile_id,
+    profile_2_id,
+    sort_by,
+    sort_direction,
+    profile_1_index,
+    profile_2_index,
+):
+    start_time = time.monotonic()
+    time_limit = 10
+    while True:
+        try:
+            r = requests.get(
+                f"{API_PREFIX}/orgs/{default_org_id}/profiles?sortBy={sort_by}&sortDirection={sort_direction}",
+                headers=admin_auth_headers,
+            )
+            assert r.status_code == 200
+            data = r.json()
+            assert data["total"] == 2
+
+            profiles = data["items"]
+            assert len(profiles) == 2
+
+            profile_1 = profiles[profile_1_index]
+            assert profile_1["id"] == profile_id
+            assert profile_1["name"] == PROFILE_NAME
+
+            profile_2 = profiles[profile_2_index]
+            assert profile_2["id"] == profile_2_id
+            assert profile_2["name"] == PROFILE_2_NAME
+
+            break
+        except:
+            if time.monotonic() - start_time > time_limit:
+                raise
+            time.sleep(1)
+
+
+def test_delete_profile(admin_auth_headers, default_org_id, profile_2_id):
+    # Delete second profile
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+    # Verify profile has been deleted
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "profile_not_found"
+
+    # Try to delete it again and verify we get a 404
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "profile_not_found"


### PR DESCRIPTION
Fixes #1817 
Connected to #478 
Connected to #1816 
Connected to #1409

This PR introduces backend changes that add the following fields to the Profile model:
- `modified`
- `modifiedBy`
- `modifiedByName`
- `createdBy`
- `createdByName`

Modified fields are set to the same as the created fields when the resource is created, and changed when the profile is updated (profile itself or metadata).

The list profiles endpoint now also supports `sortBy` and `sortDirection` options. The endpoint defaults to sorting by `modified` in descending order, but can also sort on `created` and `name`.

Tests have also been updated to reflect all new behavior.