### PR TITLE
include workflow config in QA runs + different browser instances for QA

### DIFF
--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -47,12 +47,12 @@ class K8sOpAPI(K8sAPI):
     def compute_crawler_resources(self):
         """compute memory / cpu resources for crawlers"""
         p = self.shared_params
-        num = max(int(p["crawler_browser_instances"]) - 1, 0)
+        num_workers = max(int(p["crawler_browser_instances"]), 1)
         try:
-            qa_num = max(int(p["qa_browser_instances"]) - 1, 0)
+            qa_num_workers = max(int(p["qa_browser_instances"]), 1)
         # pylint: disable=bare-except
         except:
-            qa_num = num
+            qa_num_workers = num_workers
         crawler_cpu: float = 0
         crawler_memory: int = 0
         qa_cpu: float = 0
@@ -63,11 +63,11 @@ class K8sOpAPI(K8sAPI):
             extra = parse_quantity(p["crawler_extra_cpu_per_browser"])
 
             # cpu is a floating value of cpu cores
-            crawler_cpu = float(base + num * extra)
-            qa_cpu = float(base + qa_num * extra)
+            crawler_cpu = float(base + (num_workers - 1) * extra)
+            qa_cpu = float(base + (qa_num_workers - 1) * extra)
 
-            print(f"cpu = {base} + {num} * {extra} = {crawler_cpu}")
-            print(f"qa_cpu = {base} + {qa_num} * {extra} = {qa_cpu}")
+            print(f"cpu = {base} + {num_workers - 1} * {extra} = {crawler_cpu}")
+            print(f"qa_cpu = {base} + {qa_num_workers - 1} * {extra} = {qa_cpu}")
         else:
             crawler_cpu = float(parse_quantity(p["crawler_cpu"]))
             qa_cpu = crawler_cpu
@@ -78,11 +78,11 @@ class K8sOpAPI(K8sAPI):
             extra = parse_quantity(p["crawler_extra_memory_per_browser"])
 
             # memory is always an int
-            crawler_memory = int(base + num * extra)
-            qa_memory = int(base + qa_num * extra)
+            crawler_memory = int(base + (num_workers - 1) * extra)
+            qa_memory = int(base + (qa_num_workers - 1) * extra)
 
-            print(f"memory = {base} + {num} * {extra} = {crawler_memory}")
-            print(f"qa_memory = {base} + {qa_num} * {extra} = {qa_memory}")
+            print(f"memory = {base} + {num_workers - 1} * {extra} = {crawler_memory}")
+            print(f"qa_memory = {base} + {qa_num_workers - 1} * {extra} = {qa_memory}")
         else:
             crawler_memory = int(parse_quantity(p["crawler_memory"]))
             qa_memory = crawler_memory
@@ -99,10 +99,10 @@ class K8sOpAPI(K8sAPI):
 
         p["crawler_cpu"] = crawler_cpu
         p["crawler_memory"] = crawler_memory
-        p["crawler_workers"] = num + 1
+        p["crawler_workers"] = num_workers
         p["qa_cpu"] = qa_cpu
         p["qa_memory"] = qa_memory
-        p["qa_workers"] = qa_num + 1
+        p["qa_workers"] = qa_num_workers
 
     def compute_profile_resources(self):
         """compute memory /cpu resources for a single profile browser"""

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -52,7 +52,8 @@ class K8sOpAPI(K8sAPI):
             qa_num_workers = max(int(p["qa_browser_instances"]), 1)
         # pylint: disable=bare-except
         except:
-            qa_num_workers = num_workers
+            # default to 1 for now for best results (to revisit in the future)
+            qa_num_workers = 1
         crawler_cpu: float = 0
         crawler_memory: int = 0
         qa_cpu: float = 0

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -61,11 +61,12 @@ spec:
   volumes:
     - name: crawl-config
       configMap:
-      {% if not qa_source_crawl_id %}
         name: crawl-config-{{ cid }}
-      {% else %}
+    {% if qa_source_crawl_id %}
+    - name: qa-config
+      configMap:
         name: qa-replay-{{ qa_source_crawl_id }}
-      {% endif %}
+    {% endif %}
     - name: crawl-data
       persistentVolumeClaim:
         claimName: {{ name }}
@@ -114,30 +115,32 @@ spec:
       image: {{ crawler_image }}
       imagePullPolicy: {{ crawler_image_pull_policy }}
       command:
-      {% if not qa_source_crawl_id %}
-        - crawl
+        - {{ "crawl" if not qa_source_crawl_id else "qa" }}
         - --config
         - /tmp/crawl-config.json
+        - --workers
+        - "{{ workers }}"
         - --redisStoreUrl
         - {{ redis_url }}
-      {%- if profile_filename %}
+      {% if qa_source_crawl_id %}
+        - --qaSource
+        - /tmp/qa-config.json
+      {% elif profile_filename %}
         - --profile
         - "@{{ profile_filename }}"
-      {%- endif %}
-
-      {% else %}
-        - qa
-        - --qaSource
-        - /tmp/crawl-config.json
-        - --redisStoreUrl
-        - {{ redis_url }}
-        - --writePagesToRedis
-       {% endif %}
+      {% endif %}
       volumeMounts:
         - name: crawl-config
           mountPath: /tmp/crawl-config.json
           subPath: crawl-config.json
           readOnly: True
+
+      {% if qa_source_crawl_id %}
+        - name: qa-config
+          mountPath: /tmp/qa-config.json
+          subPath: qa-config.json
+          readOnly: True
+      {% endif %}
 
         - name: crawl-data
           mountPath: /crawls

--- a/chart/app-templates/qa_configmap.yaml
+++ b/chart/app-templates/qa_configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     role: crawler
 
 data:
-  crawl-config.json: {{ qa_source_replay_json | tojson }}
+  qa-config.json: {{ qa_source_replay_json | tojson }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -67,7 +67,7 @@ metadata:
 
 data:
   CRAWL_ARGS: >-
-    --workers {{ .Values.crawler_browser_instances | default 1 }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }}
+    --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }}
 
 ---
 apiVersion: v1
@@ -105,6 +105,7 @@ data:
     crawler_extra_memory_per_browser: "{{ .Values.crawler_extra_memory_per_browser | default 0 }}"
 
     crawler_browser_instances: "{{ .Values.crawler_browser_instances }}"
+    qa_browser_instances: "{{ .Values.qa_browser_instances }}"
 
     crawler_cpu: "{{ .Values.crawler_cpu }}"
     crawler_memory: "{{ .Values.crawler_memory }}"


### PR DESCRIPTION
Currently, the workflow crawl settings were not being included at all in QA runs.
This mounts the crawl workflow config, as well as QA configmap, into QA run crawls, allowing for page limits from crawl workflow to be applied to QA runs.

It also allows a different number of browser instances to be used for QA runs, as QA runs might work better with less browsers, (eg. 2 instead of 4). This can be set with `qa_browser_instances` in helm chart.

Partially addresses #1828 

Testing:
- Run a crawl with limits, eg. postLoadDelay.
- Start assistive QA Run
- Observer from logs that postLoadDelay is applied to QA runs (from pod logs)
- Set a different number for `qa_browser_instances` than `crawler_browser_instances`. Observer QA is using different number of browsers than crawling (from pod logs)