### PR TITLE
Add migration to set profile modified date

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -17,7 +17,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0026"
+CURR_DB_VERSION = "0027"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0027_profile_modified.py
+++ b/backend/btrixcloud/migrations/migration_0027_profile_modified.py
@@ -1,0 +1,34 @@
+"""
+Migration 0027 - Profile modified date fallback
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0027"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        If profile doesn't have modified date, set to created
+        """
+        # pylint: disable=duplicate-code
+        profiles = self.mdb["profiles"]
+        try:
+            await profiles.update_many(
+                {"modified": None}, [{"$set": {"modified": "$created"}}]
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error adding modified date to profiles: {err}",
+                flush=True,
+            )


### PR DESCRIPTION
Follow-up to #1817 
Related to #1822 

If modified field doesn't exist on older browser profiles, set it equal to created date to match what we do for new profile creation.

To test:
1. Checkout commit 6a94c64fa23633d339c1c3e57c00b7899bbb6547 and create a profile
2. Checkout latest main and create another profile
3. Checkout this branch, run the migration, and verify that the older profile created in step 1 has a modified date equal to created, same as the profile created in step 2