### PR TITLE
Profile UX tweaks + sync between new and edit workflows

### DIFF
--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -106,7 +106,7 @@ export class NewBrowserProfileDialog extends LiteElement {
           ?loading=${this.isSubmitting}
           ?disabled=${this.isSubmitting}
           @click=${() => this.dialog?.submit()}
-          >${msg("Configure Browser Profile")}</sl-button
+          >${msg("Start Browsing")}</sl-button
         >
       </div>
     </btrix-dialog>`;

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -151,6 +151,20 @@ export class ProfileBrowser extends TailwindElement {
         ),
       );
     }
+    if (changedProperties.has("browserNotAvailable")) {
+      if (this.browserNotAvailable) {
+        window.removeEventListener("beforeunload", this.onBeforeUnload);
+      } else {
+        window.addEventListener("beforeunload", this.onBeforeUnload);
+      }
+      this.dispatchEvent(
+        new CustomEvent<BrowserErrorDetail>("btrix-browser-error", {
+          detail: {
+            error: new Error(),
+          },
+        }),
+      );
+    }
   }
 
   private animateSidebar() {
@@ -245,7 +259,7 @@ export class ProfileBrowser extends TailwindElement {
             <div class="py-2 text-center">
               <sl-button size="small" @click=${this.onClickReload}>
                 <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-                ${msg("Reload Browser")}
+                ${msg("Load New Browser")}
               </sl-button>
             </div>
           </btrix-alert>
@@ -271,7 +285,7 @@ export class ProfileBrowser extends TailwindElement {
               <btrix-alert variant="danger">
                 <p>
                   ${msg(
-                    `Interactive browser is offline. Waiting to reconnect...`,
+                    `Connection to interactive browser lost. Waiting to reconnect...`,
                   )}
                 </p>
               </btrix-alert>
@@ -373,29 +387,7 @@ export class ProfileBrowser extends TailwindElement {
     this.iframeSrc = undefined;
     this.isIframeLoaded = false;
 
-    try {
-      await this.checkBrowserStatus();
-
-      this.browserNotAvailable = false;
-    } catch (e) {
-      this.browserNotAvailable = true;
-
-      await this.updateComplete;
-
-      this.dispatchEvent(
-        new CustomEvent<BrowserErrorDetail>("btrix-browser-error", {
-          detail: {
-            error: e instanceof Error ? e : new Error(),
-          },
-        }),
-      );
-
-      this.notify.toast({
-        message: msg("Sorry, can't edit browser profile at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
-    }
+    await this.checkBrowserStatus();
   }
 
   /**
@@ -405,6 +397,7 @@ export class ProfileBrowser extends TailwindElement {
     let result: BrowserResponseData;
     try {
       result = await this.getBrowser();
+      this.browserNotAvailable = false;
     } catch (e) {
       this.browserNotAvailable = true;
       return;

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -285,7 +285,7 @@ export class ProfileBrowser extends TailwindElement {
               <btrix-alert variant="danger">
                 <p>
                   ${msg(
-                    `Connection to interactive browser lost. Waiting to reconnect...`,
+                    "Connection to interactive browser lost. Waiting to reconnect...",
                   )}
                 </p>
               </btrix-alert>

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -17,7 +17,7 @@ type BrowserResponseData = {
   url?: string;
 };
 export type BrowserLoadDetail = string;
-export type BrowserErrorDetail = {
+export type BrowserNotAvailableError = {
   error: APIError | Error;
 };
 export type BrowserConnectionChange = {
@@ -158,11 +158,7 @@ export class ProfileBrowser extends TailwindElement {
         window.addEventListener("beforeunload", this.onBeforeUnload);
       }
       this.dispatchEvent(
-        new CustomEvent<BrowserErrorDetail>("btrix-browser-error", {
-          detail: {
-            error: new Error(),
-          },
-        }),
+        new CustomEvent<BrowserNotAvailableError>("btrix-browser-error"),
       );
     }
   }

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -381,10 +381,7 @@ export class BrowserProfilesDetail extends TailwindElement {
   private renderBrowserProfileControls() {
     return html`
       <div class="flex justify-between p-4">
-        <sl-button
-          size="small"
-          @click=${() => void this.discardChangesDialog?.show()}
-        >
+        <sl-button size="small" @click=${this.onCancel}>
           ${msg("Cancel")}
         </sl-button>
         <div>
@@ -492,6 +489,14 @@ export class BrowserProfilesDetail extends TailwindElement {
     e: CustomEvent<BrowserConnectionChange>,
   ) {
     this.isBrowserLoaded = e.detail.connected;
+  }
+
+  private async onCancel() {
+    if (this.isBrowserLoaded) {
+      void this.discardChangesDialog?.show();
+    } else {
+      void this.cancelEditBrowser();
+    }
   }
 
   private async startBrowserPreview() {


### PR DESCRIPTION
Follow up to #1815 

- Improved detection / responsiveness to unavailable browser
- Disable Save buttons when browser disconnected / unavailable
- Only add unload handler when browser is available
- Consistency between new and edit views: new profile view also has cancel button with confirmation
- Don't show cancel confirmation if browser is already unavailable. 

Various text tweaks for consistency / accuracy:
- Save New Profile... to indicate new profile will be saved after dialog
- Load new browser to indicate new browser will be created

Note: ideally, the 'browser-profile-new' and 'browser-profile-detail' views can be combined in some way to avoid some duplication, but that can be for a later refactor.


Testing:
- Test creating new profiles
- Test editing existing profiles
- Load an invalid profile browser and ensure Load New Browser works to load a new browser: http://localhost:9870/orgs/test-org/browser-profiles/profile/browser/prf-invalid?crawlerChannel=default&name=My%20Profile&url=https%3A%2F%2Fexample.com
- Waiting for a browser to expire / deleting browser directly to see UI, can be done locally via `kubectl delete pjs -n crawlers --all` if testing locally.