### PR TITLE
QA analysis scale configurable in helm chart

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -146,6 +146,9 @@ class CrawlOperator(BaseOperator):
             qa_source_crawl_id=spec.get("qaSourceCrawlId"),
         )
 
+        if crawl.qa_source_crawl_id:
+            crawl.scale = int(params.get("qa_scale", 1))
+
         # if finalizing, crawl is being deleted
         if data.finalizing:
             if not status.finished:

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -128,6 +128,8 @@ data:
 
     profile_browser_workdir_size: "{{ .Values.profile_browser_workdir_size | default "4Gi" }}"
 
+    qa_scale: "{{ .Values.qa_scale | default 1 }}"
+
     crawler_node_type: "{{ .Values.crawler_node_type }}"
     redis_node_type: "{{ .Values.redis_node_type }}"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -232,8 +232,15 @@ crawler_cpu_base: 900m
 # base memory per for 1 browser
 crawler_memory_base: 1024Mi
 
-# number of browsers per crawler instances
+# number of browser workers per crawler instances
 crawler_browser_instances: 2
+
+# number of browser workers per crawler instances for QA runs
+# defaults to 'crawler_browser_instances' if not set
+# qa_browser_instances: 2
+
+# fixed scale (number of crawler pods) for QA runs
+qa_scale: 1
 
 # this value is added to crawler_cpu_base, for each additional browser
 # crawler_cpu = crawler_cpu_base + crawler_pu_per_extra_browser * (crawler_browser_instances - 1)


### PR DESCRIPTION
- allow configuring QA run scale via 'qa_scale' setting in helm values (overriding any setting on the qa crawljob)
- adds additional comments to browser instances helm values settings for clarity
- fixes #1842

Testing:
- set `qa_scale` to 2 or greater, start QA run