### PR TITLE
Move copy-field label outside of field

### DIFF
--- a/frontend/src/components/ui/copy-field.ts
+++ b/frontend/src/components/ui/copy-field.ts
@@ -55,6 +55,13 @@ export class CopyField extends TailwindElement {
 
   render() {
     return html`
+      <label
+        class="${clsx(
+          "mb-1.5 inline-block font-sans text-xs leading-[1.4] text-neutral-800",
+          !this.label && !this.slottedChildren?.length && tw`hidden`,
+        )} "
+        ><slot name="label">${this.label}</slot></label
+      >
       <div
         role="group"
         class=${clsx(
@@ -63,13 +70,6 @@ export class CopyField extends TailwindElement {
           this.monostyle && tw`font-monostyle`,
         )}
       >
-        <label
-          class="${clsx(
-            "mb-1.5 inline-block font-sans text-xs leading-[1.4] text-neutral-800",
-            !this.label && !this.slottedChildren?.length && tw`hidden`,
-          )} "
-          ><slot name="label">${this.label}</slot></label
-        >
         <div class="relative inline-flex w-full items-stretch justify-start">
           <slot name="prefix"></slot>
           <span


### PR DESCRIPTION
Fixes #1844 

### Changes
- Moves `copy-field` label outside of the div that contains the content

### Screenshots



**Before**
<img width="976" alt="Screenshot 2024-05-31 at 7 19 15 PM" src="https://github.com/webrecorder/browsertrix/assets/5672810/d8d29136-70b7-43ac-826a-783d2277c417">

**After**
<img width="1005" alt="Screenshot 2024-05-31 at 7 19 27 PM" src="https://github.com/webrecorder/browsertrix/assets/5672810/84105fc8-66b4-4ab9-9b33-eafd8e9f4997">