### PR TITLE
Include number of Identical Files in QA stats and meter

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -957,14 +957,16 @@ class CrawlOps(BaseCrawlOps):
         thresholds: Dict[str, List[float]],
     ) -> QARunAggregateStatsOut:
         """Get aggregate stats for QA run"""
+        file_count = await self.page_ops.get_crawl_file_count(crawl_id)
         screenshot_results = await self.page_ops.get_qa_run_aggregate_counts(
-            crawl_id, qa_run_id, thresholds, key="screenshotMatch"
+            crawl_id, qa_run_id, thresholds, file_count, key="screenshotMatch"
         )
         text_results = await self.page_ops.get_qa_run_aggregate_counts(
-            crawl_id, qa_run_id, thresholds, key="textMatch"
+            crawl_id, qa_run_id, thresholds, file_count, key="textMatch"
         )
         return QARunAggregateStatsOut(
-            screenshotMatch=screenshot_results, textMatch=text_results
+            screenshotMatch=screenshot_results,
+            textMatch=text_results,
         )
 
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -520,8 +520,6 @@ class PageOps:
         if not results:
             return 0
 
-        print("Crawl file count results:", flush=True)
-        print(results, flush=True)
         result = results[0]
 
         try:
@@ -587,14 +585,17 @@ class PageOps:
         return_data = []
 
         for result in results:
-            return_data.append(
-                QARunBucketStats(
-                    lowerBoundary=str(result.get("_id")), count=result.get("count", 0)
+            key = str(result.get("_id"))
+            if key == "No data":
+                count = result.get("count", 0) - file_count
+                return_data.append(QARunBucketStats(lowerBoundary=key, count=count))
+            else:
+                return_data.append(
+                    QARunBucketStats(lowerBoundary=key, count=result.get("count", 0))
                 )
-            )
 
         # Add file count
-        return_data.append(QARunBucketStats(lowerBoundary="files", count=file_count))
+        return_data.append(QARunBucketStats(lowerBoundary="Files", count=file_count))
 
         # Add missing boundaries to result and re-sort
         for boundary in boundaries:

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -329,11 +329,13 @@ def test_qa_stats(
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
+        {"lowerBoundary": "Files", "count": 0},
     ]
     assert data["textMatch"] == [
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
+        {"lowerBoundary": "Files", "count": 0},
     ]
 
     # Test we get expected results with explicit 0 boundary
@@ -348,11 +350,13 @@ def test_qa_stats(
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
+        {"lowerBoundary": "Files", "count": 0},
     ]
     assert data["textMatch"] == [
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
+        {"lowerBoundary": "Files", "count": 0},
     ]
 
     # Test that missing threshold values result in 422 HTTPException

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -44,7 +44,7 @@ import { formatNumber, getLocale } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
 
 type QAStatsThreshold = {
-  lowerBoundary: `${number}` | "No data";
+  lowerBoundary: `${number}` | "No data" | "Files";
   count: number;
 };
 type QAStats = Record<"screenshotMatch" | "textMatch", QAStatsThreshold[]>;
@@ -64,6 +64,11 @@ const qaStatsThresholds = [
     lowerBoundary: "0.9",
     cssColor: "var(--sl-color-success-500)",
     label: msg("Good Match"),
+  },
+  {
+    lowerBoundary: "Files",
+    cssColor: "var(--sl-color-neutral-500)",
+    label: msg("Identical Files"),
   },
 ];
 
@@ -653,7 +658,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                   ? msg("No Data")
                   : threshold?.label}
                 <div class="text-xs opacity-80">
-                  ${bar.lowerBoundary !== "No data"
+                  ${!["No data", "Files"].includes(bar.lowerBoundary)
                     ? html`${idx === 0
                           ? `<${+qaStatsThresholds[idx + 1].lowerBoundary * 100}%`
                           : idx === qaStatsThresholds.length - 1

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -663,7 +663,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                           ? `<${+qaStatsThresholds[idx + 1].lowerBoundary * 100}%`
                           : idx === qaStatsThresholds.length - 1
                             ? `>=${threshold ? +threshold.lowerBoundary * 100 : 0}%`
-                            : `${threshold ? +threshold.lowerBoundary * 100 : 0}-${+qaStatsThresholds[idx + 1].lowerBoundary * 100}%`}
+                            : `${threshold ? +threshold.lowerBoundary * 100 : 0}-100%`}
                         match <br />`
                     : nothing}
                   ${formatNumber(bar.count)} ${pluralOf("pages", bar.count)}

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -533,26 +533,6 @@ export class ArchivedItemDetailQA extends TailwindElement {
           </div>
           <div class="flex items-center gap-2 text-neutral-500">
             ${when(
-              qaRun.state.startsWith("stop") ||
-                (qaRun.state === "complete" &&
-                  qaRun.stats.done < qaRun.stats.found),
-              () =>
-                html`<sl-tooltip
-                  content=${qaRun.state.startsWith("stop")
-                    ? msg("This analysis run was stopped and is not complete.")
-                    : msg(
-                        "Not all pages in this crawl were analyzed. This is likely because some pages are not HTML pages, but other types of documents.",
-                      )}
-                  class="[--max-width:theme(spacing.56)]"
-                >
-                  <sl-icon
-                    name="exclamation-triangle-fill"
-                    class="text-warning"
-                    label=${msg("Note about page counts")}
-                  ></sl-icon>
-                </sl-tooltip> `,
-            )}
-            ${when(
               qaRun.stats,
               (stats) => html`
                 <div class="text-sm font-normal">
@@ -663,7 +643,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                           ? `<${+qaStatsThresholds[idx + 1].lowerBoundary * 100}%`
                           : idx === qaStatsThresholds.length - 1
                             ? `>=${threshold ? +threshold.lowerBoundary * 100 : 0}%`
-                            : `${threshold ? +threshold.lowerBoundary * 100 : 0}-100%`}
+                            : `${threshold ? +threshold.lowerBoundary * 100 : 0}-${+qaStatsThresholds[idx + 1].lowerBoundary * 100 || 100}%`}
                         match <br />`
                     : nothing}
                   ${formatNumber(bar.count)} ${pluralOf("pages", bar.count)}

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -644,7 +644,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                           : idx === qaStatsThresholds.length - 1
                             ? `>=${threshold ? +threshold.lowerBoundary * 100 : 0}%`
                             : `${threshold ? +threshold.lowerBoundary * 100 : 0}-${+qaStatsThresholds[idx + 1].lowerBoundary * 100 || 100}%`}
-                        match <br />`
+                        ${msg("match")} <br />`
                     : nothing}
                   ${formatNumber(bar.count)} ${pluralOf("pages", bar.count)}
                 </div>


### PR DESCRIPTION
Fixes #1831 

This PR adds Identical Files to the QA Page Match Analysis meter bars. To do this, the backend calculates the number of non-HTML pages once and includes it under the key `Files` in each of the `screenshotMatch` and `textMatch` QA stats return arrays.

The backend additionally removes the file count from "No Data" to prevent these from being counted twice.

## Screenshots

### QA run complete, all pages analyzed

<img width="965" alt="Screenshot 2024-06-04 at 2 08 13 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/915ddf5a-22e9-446c-9455-b6c2af43284f">

### QA run stopped prematurely, pages with no data

<img width="970" alt="Screenshot 2024-06-04 at 2 07 42 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/7955130e-69a2-424b-84ab-78825a5193df">

<img width="973" alt="Screenshot 2024-06-04 at 2 07 53 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/d2f70b7a-d640-4cbe-aa1f-1744dee62d11">

<img width="965" alt="Screenshot 2024-06-04 at 2 07 59 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/72c8b7f4-4e8d-46ba-b77d-51fc4ab2c69a">

<img width="965" alt="Screenshot 2024-06-04 at 2 08 35 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/82fab3a4-e62c-4cf0-b416-fcb52a283b24">

