### PR TITLE
Use standard firstSeed/seedCount fallback for workflows with no name in profile details

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -412,10 +412,12 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
 
 
 # ============================================================================
-class CrawlConfigIdNameOut(BaseMongoModel):
-    """Crawl Config id and name output only"""
+class CrawlConfigProfileOut(BaseMongoModel):
+    """Crawl Config basic info for profiles"""
 
     name: str
+    firstSeed: str
+    seedCount: int
 
 
 # ============================================================================
@@ -1197,7 +1199,7 @@ class Profile(BaseMongoModel):
 class ProfileWithCrawlConfigs(Profile):
     """Profile with list of crawlconfigs using this profile"""
 
-    crawlconfigs: List[CrawlConfigIdNameOut] = []
+    crawlconfigs: List[CrawlConfigProfileOut] = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -336,9 +336,7 @@ class ProfileOps:
 
         return Profile.from_dict(res)
 
-    async def get_profile_with_configs(
-        self, profileid: UUID, org: Optional[Organization] = None
-    ):
+    async def get_profile_with_configs(self, profileid: UUID, org: Organization):
         """get profile for api output, with crawlconfigs"""
 
         profile = await self.get_profile(profileid, org)
@@ -369,16 +367,14 @@ class ProfileOps:
         except:
             return None
 
-    async def get_crawl_configs_for_profile(
-        self, profileid: UUID, org: Optional[Organization] = None
-    ):
-        """Get list of crawl config id, names for that use a particular profile"""
+    async def get_crawl_configs_for_profile(self, profileid: UUID, org: Organization):
+        """Get list of crawl configs with basic info for that use a particular profile"""
 
-        crawlconfig_names = await self.crawlconfigs.get_crawl_config_ids_for_profile(
+        crawlconfig_info = await self.crawlconfigs.get_crawl_config_info_for_profile(
             profileid, org
         )
 
-        return crawlconfig_names
+        return crawlconfig_info
 
     async def delete_profile(self, profileid: UUID, org: Organization):
         """delete profile, if not used in active crawlconfig"""

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -238,6 +238,8 @@ def test_get_profile(admin_auth_headers, default_org_id, profile_id, profile_con
             assert len(crawl_configs) == 1
             assert crawl_configs[0]["id"] == profile_config_id
             assert crawl_configs[0]["name"] == "Profile Test Crawl"
+            assert crawl_configs[0]["firstSeed"] == "https://webrecorder.net"
+            assert crawl_configs[0]["seedCount"] == 1
             break
         except:
             if time.monotonic() - start_time > time_limit:

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -238,7 +238,7 @@ def test_get_profile(admin_auth_headers, default_org_id, profile_id, profile_con
             assert len(crawl_configs) == 1
             assert crawl_configs[0]["id"] == profile_config_id
             assert crawl_configs[0]["name"] == "Profile Test Crawl"
-            assert crawl_configs[0]["firstSeed"] == "https://webrecorder.net"
+            assert crawl_configs[0]["firstSeed"] == "https://webrecorder.net/"
             assert crawl_configs[0]["seedCount"] == 1
             break
         except:

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -1,12 +1,12 @@
 import { localized, msg, str } from "@lit/localize";
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import { capitalize } from "lodash/fp";
 import queryString from "query-string";
 
-import type { Profile } from "./types";
+import type { Profile, ProfileWorkflow } from "./types";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import type { Dialog } from "@/components/ui/dialog";
@@ -339,17 +339,16 @@ export class BrowserProfilesDetail extends TailwindElement {
     if (this.profile?.crawlconfigs?.length) {
       return html`<ul>
         ${this.profile.crawlconfigs.map(
-          ({ id, name }) => html`
+          (workflow) => html`
             <li
               class="border-x border-b first:rounded-t first:border-t last:rounded-b"
             >
               <a
                 class="block p-2 transition-colors focus-within:bg-neutral-50 hover:bg-neutral-50"
-                href=${`${this.navigate.orgBasePath}/workflows/crawl/${id}`}
+                href=${`${this.navigate.orgBasePath}/workflows/crawl/${workflow.id}`}
                 @click=${this.navigate.link}
               >
-                ${name ||
-                html`<span class="text-neutral-400">${msg("(no name)")}</span>`}
+                ${this.renderWorkflowName(workflow)}
               </a>
             </li>
           `,
@@ -360,6 +359,30 @@ export class BrowserProfilesDetail extends TailwindElement {
     return html`<div class="rounded border p-5 text-center text-neutral-400">
       ${msg("Not used in any crawl workflows.")}
     </div>`;
+  }
+
+  private renderWorkflowName(workflow: ProfileWorkflow) {
+    if (workflow.name)
+      return html`<span class="truncate">${workflow.name}</span>`;
+    if (!workflow.firstSeed)
+      return html`<span class="truncate">${workflow.id}</span>`;
+    const remainder = workflow.seedCount - 1;
+    let nameSuffix: string | TemplateResult<1> = "";
+    if (remainder) {
+      if (remainder === 1) {
+        nameSuffix = html`<span class="ml-2 text-neutral-500"
+          >${msg(str`+${remainder} URL`)}</span
+        >`;
+      } else {
+        nameSuffix = html`<span class="ml-2 text-neutral-500"
+          >${msg(str`+${remainder} URLs`)}</span
+        >`;
+      }
+    }
+    return html`
+      <span class="primaryUrl truncate">${workflow.firstSeed}</span
+      >${nameSuffix}
+    `;
   }
 
   private readonly renderVisitedSites = () => {

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -365,7 +365,8 @@ export class BrowserProfilesDetail extends TailwindElement {
     if (workflow.name)
       return html`<span class="truncate">${workflow.name}</span>`;
     if (!workflow.firstSeed)
-      return html`<span class="truncate">${workflow.id}</span>`;
+      return html`<span class="truncate font-mono">${workflow.id}</span>
+        <span class="text-neutral-400">${msg("(no name)")}</span>`;
     const remainder = workflow.seedCount - 1;
     let nameSuffix: string | TemplateResult<1> = "";
     if (remainder) {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -93,6 +93,13 @@ export type ProfileReplica = {
   custom?: boolean;
 };
 
+export type ProfileWorkflow = {
+  id: string;
+  name: string;
+  firstSeed: string;
+  seedCount: number;
+};
+
 export type Profile = {
   id: string;
   name: string;
@@ -105,7 +112,7 @@ export type Profile = {
   profileId: string;
   baseProfileName: string;
   oid: string;
-  crawlconfigs?: { id: string; name: string }[];
+  crawlconfigs?: ProfileWorkflow[];
   resource?: {
     name: string;
     path: string;


### PR DESCRIPTION
Fixes #1833 

- Add firstSeed and seedCount to workflow information in profile detail API endpoint (tests updated accordingly), update name of model used for limited workflow information to be more accurate
- Fix name display in Crawl Workflows list at bottom of Profile detail page to be consistent with rest of application

## Screenshots

### Before

<img width="312" alt="Screenshot 2024-06-05 at 1 56 23 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/4939ecbb-58fc-4751-bbfb-f300952281b0">

### After

<img width="388" alt="Screenshot 2024-06-05 at 1 52 21 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/dea3c14d-daef-419d-b24e-78ad68659462">
