### PR TITLE
Show QA meter while analysis is running

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -957,12 +957,11 @@ class CrawlOps(BaseCrawlOps):
         thresholds: Dict[str, List[float]],
     ) -> QARunAggregateStatsOut:
         """Get aggregate stats for QA run"""
-        file_count = await self.page_ops.get_crawl_file_count(crawl_id)
         screenshot_results = await self.page_ops.get_qa_run_aggregate_counts(
-            crawl_id, qa_run_id, thresholds, file_count, key="screenshotMatch"
+            crawl_id, qa_run_id, thresholds, key="screenshotMatch"
         )
         text_results = await self.page_ops.get_qa_run_aggregate_counts(
-            crawl_id, qa_run_id, thresholds, file_count, key="textMatch"
+            crawl_id, qa_run_id, thresholds, key="textMatch"
         )
         return QARunAggregateStatsOut(
             screenshotMatch=screenshot_results,

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -548,7 +548,6 @@ class PageOps:
         crawl_id: str,
         qa_run_id: str,
         thresholds: Dict[str, List[float]],
-        file_count: int,
         key: str = "screenshotMatch",
     ):
         """Get counts for pages in QA run in buckets by score key based on thresholds"""
@@ -585,17 +584,11 @@ class PageOps:
         return_data = []
 
         for result in results:
-            key = str(result.get("_id"))
-            if key == "No data":
-                count = result.get("count", 0) - file_count
-                return_data.append(QARunBucketStats(lowerBoundary=key, count=count))
-            else:
-                return_data.append(
-                    QARunBucketStats(lowerBoundary=key, count=result.get("count", 0))
+            return_data.append(
+                QARunBucketStats(
+                    lowerBoundary=str(result.get("_id")), count=result.get("count", 0)
                 )
-
-        # Add file count
-        return_data.append(QARunBucketStats(lowerBoundary="Files", count=file_count))
+            )
 
         # Add missing boundaries to result and re-sort
         for boundary in boundaries:

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -329,13 +329,11 @@ def test_qa_stats(
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
-        {"lowerBoundary": "Files", "count": 0},
     ]
     assert data["textMatch"] == [
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
-        {"lowerBoundary": "Files", "count": 0},
     ]
 
     # Test we get expected results with explicit 0 boundary
@@ -350,13 +348,11 @@ def test_qa_stats(
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
-        {"lowerBoundary": "Files", "count": 0},
     ]
     assert data["textMatch"] == [
         {"lowerBoundary": "0.0", "count": 0},
         {"lowerBoundary": "0.7", "count": 0},
         {"lowerBoundary": "0.9", "count": 1},
-        {"lowerBoundary": "Files", "count": 0},
     ]
 
     # Test that missing threshold values result in 422 HTTPException

--- a/frontend/src/components/ui/meter.ts
+++ b/frontend/src/components/ui/meter.ts
@@ -30,6 +30,7 @@ export class MeterBar extends TailwindElement {
       height: 1rem;
       background-color: var(--background-color, var(--sl-color-blue-500));
       min-width: 4px;
+      transition: 400ms width;
     }
   `;
 
@@ -151,6 +152,7 @@ export class Meter extends TailwindElement {
       display: flex;
       border-radius: var(--sl-border-radius-medium);
       overflow: hidden;
+      transition: 400ms width;
     }
 
     .labels {

--- a/frontend/src/features/qa/qa-run-dropdown.ts
+++ b/frontend/src/features/qa/qa-run-dropdown.ts
@@ -39,7 +39,9 @@ export class QaRunDropdown extends TailwindElement {
                   slot="prefix"
                   hoist
                 ></btrix-crawl-status>
-                ${formatISODateString(selectedRun.finished)} `
+                ${selectedRun.finished
+                  ? formatISODateString(selectedRun.finished)
+                  : msg("In progress")}`
             : msg("Select a QA run")}
         </sl-button>
         <sl-menu>
@@ -52,7 +54,9 @@ export class QaRunDropdown extends TailwindElement {
                 ?disabled=${isSelected}
                 ?checked=${isSelected}
               >
-                ${formatISODateString(run.finished)}
+                ${run.finished
+                  ? formatISODateString(run.finished)
+                  : msg("In progress")}
                 <btrix-crawl-status
                   type="qa"
                   hideLabel

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1439,6 +1439,10 @@ ${this.crawl?.description}
     );
 
     if (this.isQAActive) {
+      // Clear current timer, if it exists
+      if (this.timerId != null) {
+        this.stopPoll();
+      }
       // Restart timer for next poll
       this.timerId = window.setTimeout(() => {
         void this.fetchQARuns();

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -507,7 +507,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                   <sl-tooltip
                     content=${mostRecentSelected
                       ? msg(
-                          "You’re viewing the latest results from an analysis run.",
+                          "You’re viewing the latest analysis run results.",
                         )
                       : msg(
                           "You’re viewing results from an older analysis run.",

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -44,7 +44,7 @@ import { formatNumber, getLocale } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
 
 type QAStatsThreshold = {
-  lowerBoundary: `${number}` | "No data" | "Files";
+  lowerBoundary: `${number}` | "No data";
   count: number;
 };
 type QAStats = Record<"screenshotMatch" | "textMatch", QAStatsThreshold[]>;
@@ -64,11 +64,6 @@ const qaStatsThresholds = [
     lowerBoundary: "0.9",
     cssColor: "var(--sl-color-success-500)",
     label: msg("Good Match"),
-  },
-  {
-    lowerBoundary: "Files",
-    cssColor: "var(--sl-color-neutral-500)",
-    label: msg("Identical Files"),
   },
 ];
 
@@ -647,7 +642,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                       ? msg("No Data")
                       : threshold?.label}
                     <div class="text-xs opacity-80">
-                      ${!["No data", "Files"].includes(bar.lowerBoundary)
+                      ${bar.lowerBoundary !== "No data"
                         ? html`${idx === 0
                               ? `<${+qaStatsThresholds[idx + 1].lowerBoundary * 100}%`
                               : idx === qaStatsThresholds.length - 1

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -574,12 +574,12 @@ export class ArchivedItemDetailQA extends TailwindElement {
                   ${msg("Screenshots")}
                 </btrix-table-cell>
                 <btrix-table-cell class="p-0">
-                  ${this.qaStats.render({
-                    complete: ({ screenshotMatch }) =>
-                      this.renderMeter(qaRun.stats.found, screenshotMatch),
-                    pending: () => this.renderMeter(),
-                    initial: () => this.renderMeter(),
-                  })}
+                  ${this.qaStats.value
+                    ? this.renderMeter(
+                        qaRun.stats.found,
+                        this.qaStats.value.screenshotMatch,
+                      )
+                    : this.renderMeter()}
                 </btrix-table-cell>
               </btrix-table-row>
               <btrix-table-row>
@@ -587,12 +587,12 @@ export class ArchivedItemDetailQA extends TailwindElement {
                   ${msg("Text")}
                 </btrix-table-cell>
                 <btrix-table-cell class="p-0">
-                  ${this.qaStats.render({
-                    complete: ({ textMatch }) =>
-                      this.renderMeter(qaRun.stats.found, textMatch),
-                    pending: () => this.renderMeter(),
-                    initial: () => this.renderMeter(),
-                  })}
+                  ${this.qaStats.value
+                    ? this.renderMeter(
+                        qaRun.stats.found,
+                        this.qaStats.value.textMatch,
+                      )
+                    : this.renderMeter()}
                 </btrix-table-cell>
               </btrix-table-row>
             </btrix-table-body>


### PR DESCRIPTION
Fixes #1846 

- Ensure meter auto-updates as new stats are ready
- Switch meter to new QA run when new analysis run is started

## Screenshots

### In progress QA run

<img width="1428" alt="Screenshot 2024-06-07 at 1 00 20 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/8b8b870d-8003-4d83-9004-d9cb53c507d6">

### QA runs dropdown with active QA

<img width="565" alt="Screenshot 2024-06-07 at 1 02 53 PM" src="https://github.com/webrecorder/browsertrix/assets/6758804/ed7be68c-e099-4680-bb43-bc580a8cf662">

## Testing Instructions

In a local dev environment or the dev server:

1. Create a new crawl
2. Go to Quality Assurance tab and click "Run Analysis"
3. Verify QA meter appears and updates in real time
4. Re-run analysis
5. Verify meter switches to current run and updates in real time
6. Verify you can navigate between previous and current runs in dropdown