### PR TITLE
fix: Correct progress ring for analysis run in Chrome

### DIFF
--- a/frontend/src/features/archived-items/archived-item-list.ts
+++ b/frontend/src/features/archived-items/archived-item-list.ts
@@ -47,6 +47,8 @@ export class ArchivedItemListItem extends TailwindElement {
     }
 
     sl-progress-ring {
+      /* Setting size to var(--font-size-base) breaks in chrome,
+      have cell contents inherit size from cell instead */
       --size: 1em;
       --track-width: 1px;
       --indicator-width: 2px;

--- a/frontend/src/features/archived-items/archived-item-list.ts
+++ b/frontend/src/features/archived-items/archived-item-list.ts
@@ -45,6 +45,12 @@ export class ArchivedItemListItem extends TailwindElement {
         var(--btrix-border-radius-bottom, 0);
       height: 2.5rem;
     }
+
+    sl-progress-ring {
+      --size: 1em;
+      --track-width: 1px;
+      --indicator-width: 2px;
+    }
   `;
 
   @property({ type: Object, attribute: false })
@@ -141,7 +147,7 @@ export class ArchivedItemListItem extends TailwindElement {
               </btrix-table-cell>
             `
           : nothing}
-        <btrix-table-cell class="pr-0">
+        <btrix-table-cell class="pr-0 text-base">
           ${this.showStatus
             ? html`
                 <btrix-crawl-status
@@ -158,7 +164,7 @@ export class ArchivedItemListItem extends TailwindElement {
                   hoist
                 >
                   <sl-icon
-                    class="text-base"
+                    class="text-inherit"
                     style="color: ${crawlStatus.cssColor}"
                     name=${typeIcon}
                     label=${typeLabel}
@@ -179,12 +185,12 @@ export class ArchivedItemListItem extends TailwindElement {
               ? html`
                   <sl-progress-ring
                     value="${activeProgress}"
-                    style="color: ${qaStatus.cssColor}; --size: var(--font-size-base); --track-width: 1px; --indicator-width: 2px;"
+                    style="color: ${qaStatus.cssColor};"
                   ></sl-progress-ring>
                 `
               : html`
                   <sl-icon
-                    class="text-base"
+                    class="text-inherit"
                     style="color: ${qaStatus.cssColor}"
                     name=${isUpload ? "slash" : "microscope"}
                     library=${isUpload ? "default" : "app"}


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/1835

### Changes

Switches `sl-progress-ring` and `sl-icon` to inherit font size from table cell for consistent sizing as base size, while also fixing `var(--font-size-base)` not being available when progress ring size is first calculated.

### Manual testing

1. Log in as crawler using Chrome browser
2. Choose an archived item and start QA analysis
3. Navigate back to archived item list. Verify that progress ring updates with the correct size

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Items | <img width="549" alt="Screenshot 2024-06-11 at 12 00 16 PM" src="https://github.com/webrecorder/browsertrix/assets/4672952/73da1400-1239-48b4-8f42-e00c9f67dd70"> |


<!-- ### Follow-ups -->
