### PR TITLE
ensure QA configmap is updated for long running QA runs:

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -64,7 +64,8 @@ class BaseCrawlOps:
     background_job_ops: BackgroundJobOps
     page_ops: PageOps
 
-    presign_duration: int
+    presign_duration_seconds: int
+    expire_at_duration_seconds: int
 
     def __init__(
         self,
@@ -94,6 +95,9 @@ class BaseCrawlOps:
         self.presign_duration_seconds = (
             min(presign_duration_minutes, PRESIGN_MINUTES_MAX) * 60
         )
+
+        # renew when <25% of time remaining
+        self.expire_at_duration_seconds = int(self.presign_duration_seconds * 0.75)
 
     def set_page_ops(self, page_ops):
         """set page ops reference"""
@@ -434,7 +438,7 @@ class BaseCrawlOps:
             print("no files")
             return []
 
-        delta = timedelta(seconds=self.presign_duration_seconds)
+        delta = timedelta(seconds=self.expire_at_duration_seconds)
 
         out_files = []
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -383,7 +383,7 @@ def test_run_qa_not_running(
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/activeQA",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/activeQA",
             headers=crawler_auth_headers,
         )
         data = r.json()

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -124,7 +124,7 @@ spec:
         - {{ redis_url }}
       {% if qa_source_crawl_id %}
         - --qaSource
-        - /tmp/qa-config.json
+        - /tmp/qa/qa-config.json
       {% elif profile_filename %}
         - --profile
         - "@{{ profile_filename }}"
@@ -137,8 +137,7 @@ spec:
 
       {% if qa_source_crawl_id %}
         - name: qa-config
-          mountPath: /tmp/qa-config.json
-          subPath: qa-config.json
+          mountPath: /tmp/qa/
           readOnly: True
       {% endif %}
 

--- a/chart/templates/operators.yaml
+++ b/chart/templates/operators.yaml
@@ -23,7 +23,7 @@ spec:
   - apiVersion: v1
     resource: configmaps
     updateStrategy:
-      method: OnDelete
+      method: InPlace
 
   hooks:
     sync:


### PR DESCRIPTION
- add a 'expire_at_duration_seconds' which is 75% of actual presign duration time, or <25% remaining until presigned URL actually expires to ensure presigned URLs are updated early than when they actually expire
- set cached expireAt time to the renew at time for more frequent updates
- update QA configmap in place with updated presigned URLs when expireAt time is reached
- mount qa config volume under /tmp/qa/ without subPath to get automatic updates, which crawler will handle
- tests: fix qa test typo (from main)
- fixes #1864 