### PR TITLE
feat: support both ipv6 / ipv4 in resolv.conf (was: only use ipv4 addresses from resolv.conf)

### DIFF
--- a/frontend/00-browsertrix-nginx-init.sh
+++ b/frontend/00-browsertrix-nginx-init.sh
@@ -13,6 +13,6 @@ else
 fi
 
 mkdir -p /etc/nginx/resolvers/
-echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) valid=10s ipv6=off";" > /etc/nginx/resolvers/resolvers.conf
+echo resolver $(grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' /etc/resolv.conf) valid=10s ipv6=off";" > /etc/nginx/resolvers/resolvers.conf
 
 cat /etc/nginx/resolvers/resolvers.conf

--- a/frontend/00-browsertrix-nginx-init.sh
+++ b/frontend/00-browsertrix-nginx-init.sh
@@ -13,6 +13,6 @@ else
 fi
 
 mkdir -p /etc/nginx/resolvers/
-echo resolver $(grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' /etc/resolv.conf) valid=10s ipv6=off";" > /etc/nginx/resolvers/resolvers.conf
+echo resolver $(grep -oP '(?<=nameserver\s)[^\s]+' /etc/resolv.conf | awk '{ if ($1 ~ /:/) { printf "[" $1 "] "; } else { printf $1 " "; } }') valid=10s ipv6=off";" > /etc/nginx/resolvers/resolvers.conf
 
 cat /etc/nginx/resolvers/resolvers.conf


### PR DESCRIPTION
if the first nameserver in /etc/resolv.conf is ipv6 the current command creates a broken config.
I assume that you added the ipv6=off for a reasen so i changed the command to only select ipv4 addresses.