### PR TITLE
Backend: Move page file and error counts to crawl replay.json endpoint

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -178,21 +178,6 @@ class BaseCrawlOps:
 
         crawl = CrawlOutWithResources.from_dict(res)
 
-        if (
-            crawl.type == "crawl"
-            and crawl.state in SUCCESSFUL_STATES
-            and (crawl.filePageCount is None or crawl.errorPageCount is None)
-        ):
-            crawl.filePageCount = await self.page_ops.get_crawl_file_count(crawl.id)
-            crawl.errorPageCount = await self.page_ops.get_crawl_error_count(crawl.id)
-
-            # If all crawl pages have been added to database, cache counts
-            pages_in_db = await self.page_ops.get_crawl_page_count(crawl.id)
-            if crawl.stats and crawl.stats.done == pages_in_db:
-                await self.page_ops.add_file_error_page_counts_to_crawl(
-                    crawl.id, crawl.filePageCount, crawl.errorPageCount
-                )
-
         if not skip_resources:
             crawl = await self._resolve_crawl_refs(crawl, org, files)
             if crawl.config and crawl.config.seeds:

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -178,6 +178,21 @@ class BaseCrawlOps:
 
         crawl = CrawlOutWithResources.from_dict(res)
 
+        if (
+            crawl.type == "crawl"
+            and crawl.state in SUCCESSFUL_STATES
+            and (crawl.filePageCount is None or crawl.errorPageCount is None)
+        ):
+            crawl.filePageCount = await self.page_ops.get_crawl_file_count(crawl.id)
+            crawl.errorPageCount = await self.page_ops.get_crawl_error_count(crawl.id)
+
+            # If all crawl pages have been added to database, cache counts
+            pages_in_db = await self.page_ops.get_crawl_page_count(crawl.id)
+            if crawl.stats and crawl.stats.done == pages_in_db:
+                await self.page_ops.add_file_error_page_counts_to_crawl(
+                    crawl.id, crawl.filePageCount, crawl.errorPageCount
+                )
+
         if not skip_resources:
             crawl = await self._resolve_crawl_refs(crawl, org, files)
             if crawl.config and crawl.config.seeds:

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -17,7 +17,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0027"
+CURR_DB_VERSION = "0028"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
+++ b/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
@@ -1,0 +1,65 @@
+"""
+Migration 0028 - Page files and errors
+"""
+
+from btrixcloud.migrations import BaseMigration
+from btrixcloud.models import Page, Crawl
+
+
+MIGRATION_VERSION = "0028"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Update older crawls and their pages:
+        - Add crawl.filePageCount and crawl.errorPageCount
+        - Set Page.isFile and Page.isError
+        """
+        pages_db = self.mdb["pages"]
+        crawls_db = self.mdb["crawls"]
+
+        cursor = self.crawls_db.find({"type": "crawl", "filePageCount": None})
+        async for crawl_dict in cursor:
+            try:
+                crawl = Crawl.from_dict(crawl_dict)
+                crawl.filePageCount = 0
+                crawl.errorPageCount = 0
+
+                cursor = self.pages_db.find({"crawl_id": crawl.id})
+                async for page_dict in cursor:
+                    page = Page.from_dict(page_dict)
+
+                    if page.loadState == 2 and "html" not in page.mime:
+                        crawl.filePageCount += 1
+                        page.isFile = True
+                    else:
+                        page.isFile = False
+
+                    if page.loadState == 0:
+                        crawl.errorPageCount += 1
+                        page.isError = True
+                    else:
+                        page.isError = False
+
+                    await self.pages_db.find_one_and_update(
+                        {"_id": page.id}, {"$set": page.to_dict()}
+                    )
+
+                await self.crawls_db.find_one_and_update(
+                    {"_id": crawl.id, "type": "crawl"}, {"$set": crawl.to_dict()}
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                crawl_id = crawl_dict.get("_id")
+                print(
+                    f"Error updating page counts and pages for crawl {crawl_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
+++ b/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
@@ -57,7 +57,7 @@ class Migration(BaseMigration):
                 await crawls_db.find_one_and_update(
                     {"_id": crawl.id, "type": "crawl"},
                     {
-                        "$inc": crawl.dict(
+                        "$set": crawl.dict(
                             include={"filePageCount": True, "errorPageCount": True}
                         )
                     },

--- a/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
+++ b/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
@@ -37,6 +37,7 @@ class Migration(BaseMigration):
                 async for page_dict in cursor:
                     page = Page.from_dict(page_dict)
 
+                    # pylint: disable=unsupported-membership-test
                     if page.loadState == 2 and page.mime and "html" not in page.mime:
                         crawl.filePageCount += 1
                         page.isFile = True

--- a/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
+++ b/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
@@ -37,7 +37,7 @@ class Migration(BaseMigration):
                 async for page_dict in cursor:
                     page = Page.from_dict(page_dict)
 
-                    if page.loadState == 2 and "html" not in page.mime:
+                    if page.loadState == 2 and page.mime and "html" not in page.mime:
                         crawl.filePageCount += 1
                         page.isFile = True
                     else:

--- a/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
+++ b/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
@@ -26,14 +26,14 @@ class Migration(BaseMigration):
         pages_db = self.mdb["pages"]
         crawls_db = self.mdb["crawls"]
 
-        cursor = self.crawls_db.find({"type": "crawl", "filePageCount": None})
+        cursor = crawls_db.find({"type": "crawl", "filePageCount": None})
         async for crawl_dict in cursor:
             try:
                 crawl = Crawl.from_dict(crawl_dict)
                 crawl.filePageCount = 0
                 crawl.errorPageCount = 0
 
-                cursor = self.pages_db.find({"crawl_id": crawl.id})
+                cursor = pages_db.find({"crawl_id": crawl.id})
                 async for page_dict in cursor:
                     page = Page.from_dict(page_dict)
 
@@ -49,11 +49,11 @@ class Migration(BaseMigration):
                     else:
                         page.isError = False
 
-                    await self.pages_db.find_one_and_update(
+                    await pages_db.find_one_and_update(
                         {"_id": page.id}, {"$set": page.to_dict()}
                     )
 
-                await self.crawls_db.find_one_and_update(
+                await crawls_db.find_one_and_update(
                     {"_id": crawl.id, "type": "crawl"}, {"$set": crawl.to_dict()}
                 )
             # pylint: disable=broad-exception-caught

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1580,13 +1580,12 @@ class Page(BaseMongoModel):
         """sets self.isFile or self.isError flags"""
         self.isFile = False
         self.isError = False
-        # pylint: disable=unsupported-membership-test
         if self.loadState == 2:
-            if self.mime:
-                if "html" not in self.mime:
-                    self.isFile = True
-                elif self.title is None and (not self.status or self.status == 200):
-                    self.isFile = True
+            # pylint: disable=unsupported-membership-test
+            if self.mime and "html" not in self.mime:
+                self.isFile = True
+            elif self.title is None and (not self.status or self.status == 200):
+                self.isFile = True
 
         elif self.loadState == 0:
             self.isError = True

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1573,8 +1573,8 @@ class Page(BaseMongoModel):
     approved: Optional[bool] = None
     notes: List[PageNote] = []
 
-    isFile: bool = False
-    isError: bool = False
+    isFile: Optional[bool] = False
+    isError: Optional[bool] = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1573,6 +1573,9 @@ class Page(BaseMongoModel):
     approved: Optional[bool] = None
     notes: List[PageNote] = []
 
+    isFile: bool = False
+    isError: bool = False
+
 
 # ============================================================================
 class PageWithAllQA(Page):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -666,8 +666,8 @@ class CrawlOut(BaseMongoModel):
     lastQAState: Optional[str]
     lastQAStarted: Optional[datetime]
 
-    filePageCount: Optional[int]
-    errorPageCount: Optional[int]
+    filePageCount: Optional[int] = 0
+    errorPageCount: Optional[int] = 0
 
 
 # ============================================================================
@@ -1575,6 +1575,17 @@ class Page(BaseMongoModel):
 
     isFile: Optional[bool] = False
     isError: Optional[bool] = False
+
+    def compute_page_type(self):
+        """sets self.isFile or self.isError flags"""
+        self.isFile = False
+        self.isError = False
+        # pylint: disable=unsupported-membership-test
+        if self.loadState == 2 and (self.mime and "html" not in self.mime):
+            self.isFile = True
+
+        elif self.loadState == 0:
+            self.isError = True
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1585,7 +1585,7 @@ class Page(BaseMongoModel):
             if self.mime:
                 if "html" not in self.mime:
                     self.isFile = True
-                elif self.title is None and self.status == 200:
+                elif self.title is None and (not self.status or self.status == 200):
                     self.isFile = True
 
         elif self.loadState == 0:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -783,8 +783,8 @@ class Crawl(BaseCrawl, CrawlConfigCore):
     qa: Optional[QARun] = None
     qaFinished: Optional[Dict[str, QARun]] = {}
 
-    filePageCount: Optional[int]
-    errorPageCount: Optional[int]
+    filePageCount: Optional[int] = 0
+    errorPageCount: Optional[int] = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1581,8 +1581,12 @@ class Page(BaseMongoModel):
         self.isFile = False
         self.isError = False
         # pylint: disable=unsupported-membership-test
-        if self.loadState == 2 and (self.mime and "html" not in self.mime):
-            self.isFile = True
+        if self.loadState == 2:
+            if self.mime:
+                if "html" not in self.mime:
+                    self.isFile = True
+                elif self.title is None and self.status == 200:
+                    self.isFile = True
 
         elif self.loadState == 0:
             self.isError = True

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -666,6 +666,9 @@ class CrawlOut(BaseMongoModel):
     lastQAState: Optional[str]
     lastQAStarted: Optional[datetime]
 
+    filePageCount: Optional[int]
+    errorPageCount: Optional[int]
+
 
 # ============================================================================
 class CrawlOutWithResources(CrawlOut):
@@ -779,6 +782,9 @@ class Crawl(BaseCrawl, CrawlConfigCore):
 
     qa: Optional[QARun] = None
     qaFinished: Optional[Dict[str, QARun]] = {}
+
+    filePageCount: Optional[int]
+    errorPageCount: Optional[int]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1584,7 +1584,7 @@ class Page(BaseMongoModel):
             # pylint: disable=unsupported-membership-test
             if self.mime and "html" not in self.mime:
                 self.isFile = True
-            elif self.title is None and (not self.status or self.status == 200):
+            elif self.title is None and self.status == 200:
                 self.isFile = True
 
         elif self.loadState == 0:

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -68,7 +68,7 @@ class PageOps:
                     continue
 
                 if len(pages_buffer) > batch_size:
-                    await self._add_pages_to_db(pages_buffer)
+                    await self._add_pages_to_db(crawl_id, pages_buffer)
 
                 pages_buffer.append(
                     self._get_page_from_dict(page_dict, crawl_id, crawl.oid)
@@ -76,7 +76,7 @@ class PageOps:
 
             # Add any remaining pages in buffer to db
             if pages_buffer:
-                await self._add_pages_to_db(pages_buffer)
+                await self._add_pages_to_db(crawl_id, pages_buffer)
 
             print(f"Added pages for crawl {crawl_id} to db", flush=True)
         # pylint: disable=broad-exception-caught, raise-missing-from
@@ -110,7 +110,7 @@ class PageOps:
             ),
         )
 
-    async def _add_pages_to_db(self, pages: List[Page]):
+    async def _add_pages_to_db(self, crawl_id: str, pages: List[Page]):
         """Add batch of pages to db in one insert"""
         result = await self.pages.insert_many(
             [

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -23,6 +23,7 @@ from .models import (
     PageNoteEdit,
     PageNoteDelete,
     QARunBucketStats,
+    Crawl,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import from_k8s_date, str_list_to_bools
@@ -191,9 +192,11 @@ class PageOps:
         if file_count == 0 and error_count == 0:
             return
 
-        crawl = await self.crawls.find_one({"_id": crawl_id, "type": "crawl"})
-        if not crawl:
+        crawl_dict = await self.crawls.find_one({"_id": crawl_id, "type": "crawl"})
+        if not crawl_dict:
             raise HTTPException(status_code=404, detail="crawl_not_found")
+
+        crawl = Crawl.from_dict(crawl_dict)
 
         file_update_operator = "$inc"
         if crawl.filePageCount is None:

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -175,10 +175,18 @@ class PageOps:
         error_count = 0
 
         for page in pages:
-            if page.loadState == 0:
-                error_count += 1
             if page.loadState == 2 and "html" not in page.mime:
                 file_count += 1
+                page.isFile = True
+
+            if page.loadState == 0:
+                error_count += 1
+                page.isError = True
+
+            if page.isFile or page.isError:
+                await self.pages.find_one_and_update(
+                    {"_id": page.id}, {"$set": page.to_dict()}
+                )
 
         if file_count == 0 and error_count == 0:
             return

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -175,7 +175,7 @@ class PageOps:
         error_count = 0
 
         for page in pages:
-            if page.loadState == 2 and "html" not in page.mime:
+            if page.loadState == 2 and page.mime and "html" not in page.mime:
                 file_count += 1
                 page.isFile = True
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -196,6 +196,18 @@ def test_crawls_exclude_full_seeds(admin_auth_headers, default_org_id, admin_cra
         assert config is None or config.get("seeds") is None
 
 
+def test_crawls_include_file_error_page_counts(
+    admin_auth_headers, default_org_id, admin_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}/replay.json",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    assert data["filePageCount"] >= 0
+    assert data["errorPageCount"] >= 0
+
+
 def test_download_wacz():
     r = requests.get(HOST_PREFIX + wacz_path)
     assert r.status_code == 200

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -486,6 +486,8 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["loadState"]
         assert page["status"]
         assert page["mime"]
+        assert page["isError"] in (True, False)
+        assert page["isFile"] in (True, False)
 
     # Test GET page endpoint
     global page_id
@@ -505,6 +507,8 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page.get("title") or page.get("title") is None
     assert page["loadState"]
     assert page["mime"]
+    assert page["isError"] in (True, False)
+    assert page["isFile"] in (True, False)
 
     assert page["notes"] == []
     assert page.get("userid") is None
@@ -603,6 +607,8 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page.get("title") or page.get("title") is None
     assert page["loadState"]
     assert page["mime"]
+    assert page["isError"] in (True, False)
+    assert page["isFile"] in (True, False)
 
     assert page["notes"] == []
     assert page["userid"]
@@ -680,6 +686,8 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         assert page["loadState"]
         assert page["status"]
         assert page["mime"]
+        assert page["isError"] in (True, False)
+        assert page["isFile"] in (True, False)
 
     # Ensure only superuser can re-add pages for all crawls in an org
     r = requests.post(


### PR DESCRIPTION
Backend work for https://github.com/webrecorder/browsertrix/issues/1859

- Remove file count from qa stats endpoint
- Add file and error counts to crawl replay.json endpoint
- Calculate counts on the fly once and then cache in database if crawl is successfully finished and all pages added

## Testing instructions

1. Run a crawl with files and unresolvable URLs (e.g. URL list workflow with `https://webrecorder.net`, `https://www.bitarchivist.net/static/usersurvey-1-demographics-9121af3ce1bce7c80e5643dbbc7b9f5e-29b25.png`, and `https://example.invalid` as the URLs)
2. When crawl completes, open dev tools, go to Replay tab in the Browsertrix UI, and check the `replay.json` response in the dev tools network tab. You should see as part of the response:

```
...
filePageCount: 1,
errorPageCount: 1,
...
```