### PR TITLE
Use internal rounded bar in `<btrix-meter>` for QA analysis meters

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -654,8 +654,8 @@ export class ArchivedItemDetailQA extends TailwindElement {
             ? html`
                 <btrix-meter-bar
                   value=${(bar.count / analyzedPageCount) * 100}
-                  style="--background-color: ${threshold?.cssColor}"
-                  aria-label=${bar.lowerBoundary}
+                  style="--background-color: ${threshold?.cssColor ?? "none"}"
+                  aria-label=${threshold?.label ?? ""}
                 >
                   <div class="text-center">
                     ${threshold?.label}

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -665,7 +665,8 @@ export class ArchivedItemDetailQA extends TailwindElement {
                         : idx === qaStatsThresholds.length - 1
                           ? `>=${threshold ? +threshold.lowerBoundary * 100 : 0}%`
                           : `${threshold ? +threshold.lowerBoundary * 100 : 0}-${+qaStatsThresholds[idx + 1].lowerBoundary * 100 || 100}%`}
-                      match <br />
+                      ${msg("match", { desc: "label for match percentage" })}
+                      <br />
                       ${formatNumber(bar.count)} ${pluralOf("pages", bar.count)}
                     </div>
                   </div>

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -674,20 +674,24 @@ export class ArchivedItemDetailQA extends TailwindElement {
               `
             : nothing;
         })}
-        <btrix-meter-bar
-          slot="available"
-          value=${(remainingPageCount / pageCount) * 100}
-          aria-label=${remainderBarLabel}
-          style="--background-color: none"
-        >
-          <div class="text-center">
-            ${remainderBarLabel}
-            <div class="text-xs opacity-80">
-              ${formatNumber(remainingPageCount)}
-              ${pluralOf("pages", remainingPageCount)}
-            </div>
-          </div>
-        </btrix-meter-bar>
+        ${remainingPageCount > 0
+          ? html`
+              <btrix-meter-bar
+                slot="available"
+                value=${(remainingPageCount / pageCount) * 100}
+                aria-label=${remainderBarLabel}
+                style="--background-color: none"
+              >
+                <div class="text-center">
+                  ${remainderBarLabel}
+                  <div class="text-xs opacity-80">
+                    ${formatNumber(remainingPageCount)}
+                    ${pluralOf("pages", remainingPageCount)}
+                  </div>
+                </div>
+              </btrix-meter-bar>
+            `
+          : nothing}
       </btrix-meter>
     `;
   }

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -532,15 +532,13 @@ export class ArchivedItemDetailQA extends TailwindElement {
             })}
           </div>
           <div class="flex items-center gap-2 text-neutral-500">
-            ${when(
-              qaRun.stats,
-              (stats) => html`
-                <div class="text-sm font-normal">
-                  ${formatNumber(stats.done)} / ${formatNumber(stats.found)}
-                  ${pluralOf("pages", stats.found)} ${msg("analyzed")}
-                </div>
-              `,
-            )}
+            <div class="text-sm font-normal">
+              ${qaRun.state === "starting"
+                ? msg("Analysis starting")
+                : `${formatNumber(qaRun.stats.done)}/${formatNumber(qaRun.stats.found)}
+                  ${pluralOf("pages", qaRun.stats.found)} ${msg("analyzed")}`}
+            </div>
+
             <sl-tooltip
               content=${msg(
                 "Match analysis compares pages during a crawl against their replay during an analysis run. A good match indicates that the crawl is probably good, whereas severe inconsistencies may indicate a bad crawl.",

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -505,9 +505,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
                 <div>
                   <sl-tooltip
                     content=${mostRecentSelected
-                      ? msg(
-                          "You’re viewing the latest analysis run results.",
-                        )
+                      ? msg("You’re viewing the latest analysis run results.")
                       : msg(
                           "You’re viewing results from an older analysis run.",
                         )}
@@ -614,7 +612,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
   }
 
   private renderMeter(pageCount?: number, barData?: QAStatsThreshold[]) {
-    if (pageCount === undefined || !barData) {
+    if (!pageCount || !barData) {
       return html`<sl-skeleton
         class="h-4 flex-1 [--border-radius:var(--sl-border-radius-medium)]"
         effect="sheen"

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -617,16 +617,6 @@ export class ArchivedItemDetailQA extends TailwindElement {
       ></sl-skeleton>`;
     }
 
-    const barTotal = barData.reduce((prev, cur) => prev + cur.count, 0);
-
-    // TODO remove this once we stop including identical files in "No data" counts
-    // see https://github.com/webrecorder/browsertrix/issues/1859
-    if (barTotal > pageCount) {
-      barData[
-        barData.findIndex((bar) => bar.lowerBoundary === "No data")
-      ].count -= barTotal - pageCount;
-    }
-
     const analyzedPageCount =
       pageCount -
       (barData.find((bar) => bar.lowerBoundary === "No data")?.count ?? 0);


### PR DESCRIPTION
Closes #1851 

This changes how we use the `<btrix-meter>` component: previously, we didn't set a `max` value on it, so it was drawing its internal (rounded) bar at 100% of the meter width, and then drawing the `<btrix-meter-bar>`s inside that 100% width bar. This changes that, and instead it now does the following:

- Draws the internal rounded bar to the width of the proportion of their counts to the total page count;
- Adjusts the `<btrix-meter-bar>`s to be proportional to the completed page count rather than the total page count
- Uses the `"available"` slot in `<btrix-meter>` to draw the remaining "No data" bar & tooltip in the remaining space outside of the internal rounded bar

This also includes a couple unrelated but adjacent changes:

- Changes the page count text to say "Analysis starting" when the analysis run is starting, because there's no meaningful page count at that point.
- Uses the pending state when the total page count is falsy (`undefined` or `0`), rather than just `undefined`


<img width="657" alt="Screenshot 2024-06-14 at 1 03 19 PM" src="https://github.com/webrecorder/browsertrix/assets/5727389/568c0a25-7d36-4108-8084-13ac2a15bdb7">
<img width="652" alt="Screenshot 2024-06-14 at 1 02 27 PM" src="https://github.com/webrecorder/browsertrix/assets/5727389/6dffad1d-9dd2-45f5-8073-f86d651d0c0f">