### PR TITLE
Add paymentSuspended field to org and endpoint to update

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -967,7 +967,7 @@ class OrgQuotaUpdate(BaseModel):
 
 # ============================================================================
 class OrgPaymentSuspendedUpdate(BaseModel):
-    """Organization quota update (to track changes over time)"""
+    """Organization update for paymentSuspended field"""
 
     paymentSuspended: bool
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -966,6 +966,13 @@ class OrgQuotaUpdate(BaseModel):
 
 
 # ============================================================================
+class OrgPaymentSuspendedUpdate(BaseModel):
+    """Organization quota update (to track changes over time)"""
+
+    paymentSuspended: bool
+
+
+# ============================================================================
 class OrgWebhookUrls(BaseModel):
     """Organization webhook URLs"""
 
@@ -1019,6 +1026,8 @@ class OrgOut(BaseMongoModel):
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
+    paymentSuspended: Optional[bool]
+
 
 # ============================================================================
 class Organization(BaseMongoModel):
@@ -1062,6 +1071,8 @@ class Organization(BaseMongoModel):
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
     origin: Optional[AnyHttpUrl] = None
+
+    paymentSuspended: Optional[bool] = False
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -813,7 +813,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
 
         return {"updated": True}
 
-    @router.post("/update-payment-suspended", tags=["organizations"])
+    @router.post("/payment-suspended", tags=["organizations"])
     async def update_org_payment_suspended(
         update: OrgPaymentSuspendedUpdate,
         org: Organization = Depends(org_owner_dep),

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -486,3 +486,28 @@ def test_get_org_slug_lookup_non_superadmin(crawler_auth_headers):
     r = requests.get(f"{API_PREFIX}/orgs/slug-lookup", headers=crawler_auth_headers)
     assert r.status_code == 403
     assert r.json()["detail"] == "Not Allowed"
+
+
+def test_update_payment_suspended(admin_auth_headers, default_org_id):
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.json()["paymentSuspended"] in (False, None)
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/update-payment-suspended",
+        headers=admin_auth_headers,
+        json={"paymentSuspended": True},
+    )
+    assert r.json()["updated"]
+
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.json()["paymentSuspended"] is True
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/update-payment-suspended",
+        headers=admin_auth_headers,
+        json={"paymentSuspended": False},
+    )
+    assert r.json()["updated"]
+
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.json()["paymentSuspended"] is False

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -493,7 +493,7 @@ def test_update_payment_suspended(admin_auth_headers, default_org_id):
     assert r.json()["paymentSuspended"] in (False, None)
 
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/update-payment-suspended",
+        f"{API_PREFIX}/orgs/{default_org_id}/payment-suspended",
         headers=admin_auth_headers,
         json={"paymentSuspended": True},
     )
@@ -503,7 +503,7 @@ def test_update_payment_suspended(admin_auth_headers, default_org_id):
     assert r.json()["paymentSuspended"] is True
 
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/update-payment-suspended",
+        f"{API_PREFIX}/orgs/{default_org_id}/payment-suspended",
         headers=admin_auth_headers,
         json={"paymentSuspended": False},
     )


### PR DESCRIPTION
Backend work for https://github.com/webrecorder/browsertrix/issues/1876

- Adds `Organization.paymentSuspended` field (optional boolean)
- Adds API endpoint to update `paymentSuspended` field

This endpoint (which will be called by Cashew) might also make a nice hook for setting orgs read-only when payment fails or a user cancels their subscription moving forward.