### PR TITLE
QA stats aggregation: exclude isFile / isError pages from stats

### DIFF
--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -584,7 +584,6 @@ class PageOps:
                     "isError": {"$ne": True},
                 }
             },
-            # {"$match": {"crawl_id": crawl_id}},
             {
                 "$bucket": {
                     "groupBy": f"$qa.{qa_run_id}.{key}",

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -577,7 +577,14 @@ class PageOps:
             boundaries.append(1.1)
 
         aggregate = [
-            {"$match": {"crawl_id": crawl_id, "isFile": False, "isError": False}},
+            {
+                "$match": {
+                    "crawl_id": crawl_id,
+                    "isFile": {"$ne": True},
+                    "isError": {"$ne": True},
+                }
+            },
+            # {"$match": {"crawl_id": crawl_id}},
             {
                 "$bucket": {
                     "groupBy": f"$qa.{qa_run_id}.{key}",

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -577,7 +577,7 @@ class PageOps:
             boundaries.append(1.1)
 
         aggregate = [
-            {"$match": {"crawl_id": crawl_id}},
+            {"$match": {"crawl_id": crawl_id, "isFile": False, "isError": False}},
             {
                 "$bucket": {
                     "groupBy": f"$qa.{qa_run_id}.{key}",


### PR DESCRIPTION
Follow-up to: #1868, exclude pages that have isFile or isError set to true from the stats aggregation.