### PR TITLE
Add and enforce readOnly field in Organization

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -219,6 +219,10 @@ class CrawlConfigOps:
         storage_quota_reached = await self.org_ops.storage_quota_reached(org.id)
         exec_mins_quota_reached = await self.org_ops.exec_mins_quota_reached(org.id)
 
+        if org.readOnly:
+            run_now = False
+            print(f"Org {org.id} set to read-only", flush=True)
+
         if storage_quota_reached:
             run_now = False
             print(f"Storage quota exceeded for org {org.id}", flush=True)
@@ -842,6 +846,9 @@ class CrawlConfigOps:
         # pylint: disable=bare-except
         except:
             await self.readd_configmap(crawlconfig, org)
+
+        if org.readOnly:
+            raise HTTPException(status_code=400, detail="org_set_to_read_only")
 
         if await self.org_ops.storage_quota_reached(org.id):
             raise HTTPException(status_code=403, detail="storage_quota_reached")

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -848,7 +848,7 @@ class CrawlConfigOps:
             await self.readd_configmap(crawlconfig, org)
 
         if org.readOnly:
-            raise HTTPException(status_code=400, detail="org_set_to_read_only")
+            raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
         if await self.org_ops.storage_quota_reached(org.id):
             raise HTTPException(status_code=403, detail="storage_quota_reached")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -738,6 +738,10 @@ class CrawlOps(BaseCrawlOps):
 
         crawl = await self.get_crawl(crawl_id, org)
 
+        # ensure org execution is allowed
+        if org.readOnly:
+            raise HTTPException(status_code=400, detail="org_set_to_read_only")
+
         # can only QA finished crawls
         if not crawl.finished:
             raise HTTPException(status_code=400, detail="crawl_not_finished")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -740,7 +740,7 @@ class CrawlOps(BaseCrawlOps):
 
         # ensure org execution is allowed
         if org.readOnly:
-            raise HTTPException(status_code=400, detail="org_set_to_read_only")
+            raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
         # can only QA finished crawls
         if not crawl.finished:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -972,6 +972,14 @@ class OrgQuotaUpdate(BaseModel):
 
 
 # ============================================================================
+class OrgReadOnlyUpdate(BaseModel):
+    """Organization readonly update"""
+
+    readOnly: bool
+    readOnlyReason: Optional[str] = None
+
+
+# ============================================================================
 class OrgWebhookUrls(BaseModel):
     """Organization webhook URLs"""
 
@@ -1025,6 +1033,9 @@ class OrgOut(BaseMongoModel):
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
+    readOnly: Optional[bool]
+    readOnlyReason: Optional[str]
+
 
 # ============================================================================
 class Organization(BaseMongoModel):
@@ -1068,6 +1079,9 @@ class Organization(BaseMongoModel):
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 
     origin: Optional[AnyHttpUrl] = None
+
+    readOnly: Optional[bool] = False
+    readOnlyReason: Optional[str] = None
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -98,6 +98,12 @@ class CronJobOperator(BaseOperator):
 
             warc_prefix = self.crawl_config_ops.get_warc_prefix(org, crawlconfig)
 
+            if org.readOnly:
+                print(
+                    f"org {org.id} set to read-only. skipping scheduled crawl for workflow {cid}"
+                )
+                return {"attachments": []}
+
             await self.crawl_config_ops.add_new_crawl(
                 crawl_id,
                 crawlconfig,


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/1883
Backend work for https://github.com/webrecorder/browsertrix/issues/1876

- If readOnly is set true, disallow crawls and QA analysis runs
- If readOnly is set to true, skip scheduled crawls
- Add endpoint to set `readOnly` with optional `readOnlyReason` (which is automatically set back to an empty string when `readOnly` is being set to false), which can be displayed in banner

This supercedes the previous PR that had a separate `paymentSuspended` boolean, as we can accomplish the same thing in a manner that's more generic for the open source project with `readOnly` and `readOnlyReason`.