### PR TITLE
Adds GitHub and Forum to the email invite template

### DIFF
--- a/chart/email-templates/invite
+++ b/chart/email-templates/invite
@@ -37,7 +37,9 @@ How do I create a <a href="https://docs.browsertrix.com/user-guide/browser-profi
 How do I <a href="https://docs.browsertrix.com/user-guide/archived-items/#crawl-settings">export my archived items</a>?
 </p>
 
-<p>If you need any assistance, please direct your questions to <a href="mailto:{{ support_email }}">{{ support_email }}</a></p>
+<p>
+If you need any assistance, please direct your questions to the <a href="https://github.com/webrecorder/browsertrix">Browsertrix GitHub repo</a> or the <a href="https://forum.webrecorder.net">Webrecorder community forum</a>. If included in your plan, you can also contact us at: <a href="mailto:{{ support_email }}">{{ support_email }}</a>
+</p>
 
 <p>Best Regards,</p>
 <p>The Webrecorder Team</p>
@@ -74,7 +76,7 @@ How do I crawl my first website? (https://docs.browsertrix.com/user-guide/workfl
 How do I create a browser profile? (https://docs.browsertrix.com/user-guide/browser-profiles/)
 How do I export my archived items? (https://docs.browsertrix.com/user-guide/archived-items/#crawl-settings)
 
-If you need any assistance, please direct your questions to {{ support_email }}.
+If you need any assistance, please direct your questions to the Browsertrix GitHub repo (https://github.com/webrecorder/browsertrix) or the  Webrecorder community forum (https://forum.webrecorder.net). If included in your plan, you can also contact us at: {{ support_email }}.
 
 Best Regards,
 The Webrecorder Team

--- a/chart/email-templates/invite
+++ b/chart/email-templates/invite
@@ -38,7 +38,7 @@ How do I <a href="https://docs.browsertrix.com/user-guide/archived-items/#crawl-
 </p>
 
 <p>
-If you need any assistance, please direct your questions to the <a href="https://github.com/webrecorder/browsertrix">Browsertrix GitHub repo</a> or the <a href="https://forum.webrecorder.net">Webrecorder community forum</a>. If included in your plan, you can also contact us at: <a href="mailto:{{ support_email }}">{{ support_email }}</a>
+If you need any assistance, please direct your questions to the <a href="https://github.com/webrecorder/browsertrix">Browsertrix GitHub repo</a> or the <a href="https://forum.webrecorder.net">Webrecorder community forum</a>. If dedicated support is included in your plan, you can also contact us at: <a href="mailto:{{ support_email }}">{{ support_email }}</a>
 </p>
 
 <p>Best Regards,</p>
@@ -76,7 +76,7 @@ How do I crawl my first website? (https://docs.browsertrix.com/user-guide/workfl
 How do I create a browser profile? (https://docs.browsertrix.com/user-guide/browser-profiles/)
 How do I export my archived items? (https://docs.browsertrix.com/user-guide/archived-items/#crawl-settings)
 
-If you need any assistance, please direct your questions to the Browsertrix GitHub repo (https://github.com/webrecorder/browsertrix) or the  Webrecorder community forum (https://forum.webrecorder.net). If included in your plan, you can also contact us at: {{ support_email }}.
+If you need any assistance, please direct your questions to the Browsertrix GitHub repo (https://github.com/webrecorder/browsertrix) or the Webrecorder community forum (https://forum.webrecorder.net). If dedicated support is included in your plan, you can also contact us at: {{ support_email }}.
 
 Best Regards,
 The Webrecorder Team


### PR DESCRIPTION
Closes https://github.com/webrecorder/browsertrix-cloud-ops/issues/3

Please make any changes you think would improve this!

### Changes

- Adds Browsertrix GitHub repo and Webrecorder forum to the bottom of the support email.
- Adds note about having an applicable plan to contact support

### Caveats

Because of the way the email system is set up, we can't currently restrict the support email to users in orgs with an applicable plan.  This is also something we may not even want to do, in general everyone should probably be able to email support, but now they have other, potentially more applicable options!