### PR TITLE
Extends Org Create endpont + shared secret auth

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -29,7 +29,7 @@ PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", uuid4().hex)
 
 JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME_MINUTES", 60)) * 60
 
-AUTH_SHARED_SECRET = os.environ.get("AUTH_SHARED_SECRET", "")
+BTRIX_SUBS_APP_API_KEY = os.environ.get("BTRIX_SUBS_APP_API_KEY", "")
 
 ALGORITHM = "HS256"
 
@@ -167,7 +167,7 @@ def init_jwt_auth(user_manager):
         # allow superadmin access if token matches the known shared secret
         # if the shared secret is set
         # ensure using a long shared secret (eg. uuid4)
-        if AUTH_SHARED_SECRET and token == AUTH_SHARED_SECRET:
+        if BTRIX_SUBS_APP_API_KEY and token == BTRIX_SUBS_APP_API_KEY:
             return await user_manager.get_superuser()
 
         return await get_current_user(token)

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -118,7 +118,7 @@ class InviteOps:
         org=None,
         allow_existing=False,
         headers: Optional[dict] = None,
-    ):
+    ) -> tuple[bool, str]:
         """Invite user to org (if not specified, to default org).
 
         If allow_existing is false, don't allow invites to existing users.
@@ -156,7 +156,7 @@ class InviteOps:
                 org_name,
                 headers,
             )
-            return True
+            return True, str(invite_pending.id)
 
         if not allow_existing:
             raise HTTPException(status_code=400, detail="User already registered")
@@ -180,7 +180,7 @@ class InviteOps:
             invite_pending, org_name, invitee_user.email, invite_code, headers
         )
 
-        return False
+        return False, invite_code
 
     async def get_pending_invites(
         self, org=None, page_size: int = DEFAULT_PAGE_SIZE, page: int = 1

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -76,9 +76,18 @@ def main():
 
     user_manager = init_user_manager(mdb, email, invites)
 
-    current_active_user = init_users_api(app, user_manager)
+    current_active_user, shared_secret_or_active_user = init_users_api(
+        app, user_manager
+    )
 
-    org_ops = init_orgs_api(app, mdb, user_manager, invites, current_active_user)
+    org_ops = init_orgs_api(
+        app,
+        mdb,
+        user_manager,
+        invites,
+        current_active_user,
+        shared_secret_or_active_user,
+    )
 
     event_webhook_ops = init_event_webhooks_api(mdb, org_ops, app_root)
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1291,7 +1291,7 @@ class UserCreateIn(BaseModel):
 
     inviteToken: Optional[UUID] = None
 
-    newOrg: bool
+    newOrg: Optional[bool] = False
     newOrgName: Optional[str] = ""
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -907,11 +907,6 @@ class RenameOrg(BaseModel):
 
 
 # ============================================================================
-class CreateOrg(RenameOrg):
-    """Create a new org"""
-
-
-# ============================================================================
 class OrgStorageRefs(BaseModel):
     """Input model for setting primary storage + optional replicas"""
 
@@ -961,6 +956,19 @@ class OrgQuotas(BaseModel):
     maxExecMinutesPerMonth: Optional[int] = 0
     extraExecMinutes: Optional[int] = 0
     giftedExecMinutes: Optional[int] = 0
+
+
+# ============================================================================
+class OrgCreate(BaseModel):
+    """Create a new org"""
+
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+    firstAdminInviteEmail: Optional[str] = None
+    quotas: Optional[OrgQuotas] = None
+
+    subData: Optional[Dict[str, Any]] = None
 
 
 # ============================================================================
@@ -1082,6 +1090,8 @@ class Organization(BaseMongoModel):
 
     readOnly: Optional[bool] = False
     readOnlyReason: Optional[str] = None
+
+    subData: Optional[Dict[str, Any]] = None
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -358,15 +358,12 @@ class OrgOps:
 
     async def add_user_by_invite(
         self, invite: InvitePending, user: User
-    ) -> Optional[Organization]:
+    ) -> Organization:
         """Add user to an org from an InvitePending, if any.
 
-        If there's no org to add to (eg. superuser invite), just return.
+        If there's no org to add to, raise exception
         """
-        if not invite.oid:
-            return None
-
-        org = await self.get_org_by_id(invite.oid)
+        org = invite.oid and await self.get_org_by_id(invite.oid)
         if not org:
             raise HTTPException(
                 status_code=400, detail="Invalid Invite Code, No Such Organization"

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -43,6 +43,7 @@ from .models import (
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import slug_from_name, validate_slug
 
+
 if TYPE_CHECKING:
     from .invites import InviteOps
 else:
@@ -727,7 +728,7 @@ class OrgOps:
 
 # ============================================================================
 # pylint: disable=too-many-statements
-def init_orgs_api(app, mdb, user_manager, invites, user_dep):
+def init_orgs_api(app, mdb, user_manager, invites, user_dep, user_or_shared_secret_dep):
     """Init organizations api router for /orgs"""
     # pylint: disable=too-many-locals,invalid-name
 
@@ -803,7 +804,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep):
     async def create_org(
         new_org: OrgCreate,
         request: Request,
-        user: User = Depends(user_dep),
+        user: User = Depends(user_or_shared_secret_dep),
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -825,7 +825,7 @@ def init_orgs_api(app, mdb, user_manager, invites, user_dep, user_or_shared_secr
             slug=slug,
             users={},
             storage=ops.default_primary,
-            org_quotas=new_org.quotas or OrgQuotas(),
+            quotas=new_org.quotas or OrgQuotas(),
             subData=new_org.subData,
         )
         if not await ops.add_org(org):

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -727,7 +727,7 @@ class OrgOps:
 
 
 # ============================================================================
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements, too-many-arguments
 def init_orgs_api(app, mdb, user_manager, invites, user_dep, user_or_shared_secret_dep):
     """Init organizations api router for /orgs"""
     # pylint: disable=too-many-locals,invalid-name

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -643,10 +643,12 @@ def init_user_manager(mdb, emailsender, invites):
 
 # ============================================================================
 # pylint: disable=too-many-locals, raise-missing-from
-def init_users_api(app, user_manager: UserManager) -> APIRouter:
+def init_users_api(app, user_manager: UserManager):
     """init fastapi_users"""
 
-    auth_jwt_router, current_active_user = init_jwt_auth(user_manager)
+    auth_jwt_router, current_active_user, shared_secret_or_active_user = init_jwt_auth(
+        user_manager
+    )
 
     app.include_router(
         auth_jwt_router,
@@ -666,7 +668,7 @@ def init_users_api(app, user_manager: UserManager) -> APIRouter:
         tags=["users"],
     )
 
-    return current_active_user
+    return current_active_user, shared_secret_or_active_user
 
 
 # ============================================================================

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -79,6 +79,13 @@ spec:
             - name: MOTOR_MAX_WORKERS
               value: "{{ .Values.backend_mongodb_workers | default 1 }}"
 
+            - name: BTRIX_SUBS_APP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: btrix-subs-app-secret
+                  key: BTRIX_SUBS_APP_API_KEY
+                  optional: true
+
           volumeMounts:
             - name: ops-configs
               mountPath: /ops-configs/

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 data:
-  APP_ORIGIN: {{ .Values.ingress.tls | ternary "https" "http" }}://{{ .Values.ingress.host | default "localhost:{{ local_service_port }}" }}
+  APP_ORIGIN: {{ .Values.ingress.tls | ternary "https" "http" }}://{{ or .Values.ingress.host ( print "localhost:" ( .Values.local_service_port | default 9870 )) }}
 
   CRAWLER_NAMESPACE: {{ .Values.crawler_namespace }}
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 data:
-  APP_ORIGIN: {{ .Values.ingress.tls | ternary "https" "http" }}://{{ .Values.ingress.host | default "localhost:9870" }}
+  APP_ORIGIN: {{ .Values.ingress.tls | ternary "https" "http" }}://{{ .Values.ingress.host | default "localhost:{{ local_service_port }}" }}
 
   CRAWLER_NAMESPACE: {{ .Values.crawler_namespace }}
 

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -20,6 +20,8 @@ stringData:
   SUPERUSER_EMAIL: "{{ .Values.superuser.email }}"
   SUPERUSER_PASSWORD: "{{ .Values.superuser.password }}"
 
+  AUTH_SHARED_SECRET: "{{ .Values.auth_shared_secret }}"
+
 
 ---
 apiVersion: v1

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -20,8 +20,6 @@ stringData:
   SUPERUSER_EMAIL: "{{ .Values.superuser.email }}"
   SUPERUSER_PASSWORD: "{{ .Values.superuser.password }}"
 
-  AUTH_SHARED_SECRET: "{{ .Values.auth_shared_secret }}"
-
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Updates the /api/orgs/create endpoint to:
- not have name / slug be required, will be renamed on first user via #1870 
- support optional quotas
- support optional first admin user email, who will receive an invite to join the org.

Also supports a new shared secret mechanism, to allow an external automation to access the /api/orgs/create endpoint (and only that endpoint thus far) via a shared secret instead of normal login.