### PR TITLE
Update authsigner to 0.5.2

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -379,7 +379,7 @@ ingress_class: nginx
 # optionally enable signer
 signer:
   enabled: false
-  image: webrecorder/authsign:0.5.0
+  image: webrecorder/authsign:0.5.2
   # host: <set to signer domain>
   # cert_email: "test@example.com
   # image_pull_policy: "IfNotPresent"
@@ -387,7 +387,7 @@ signer:
 
 signer_cpu: "5m"
 
-signer_memory: "40Mi"
+signer_memory: "50Mi"
 
 
 # Optional: configure load balancing annotations


### PR DESCRIPTION
Also has slightly increased memory requirements due to new versions of some libraries.
0.5.2 adds a fix to dropping the fractional part of the second, to make it work with ISO strings that have microseconds, such as those from js-wacz.