### PR TITLE
test: Remove temporary commonjs module mocks

### DIFF
--- a/frontend/src/__mocks__/color.js
+++ b/frontend/src/__mocks__/color.js
@@ -1,6 +1,0 @@
-import { stub } from "sinon";
-
-export default stub(() => ({
-  lighten: () => {},
-  darken: () => {},
-}));

--- a/frontend/src/__mocks__/slugify.js
+++ b/frontend/src/__mocks__/slugify.js
@@ -1,3 +1,0 @@
-export default function slugify(value) {
-  return value;
-}

--- a/frontend/src/pages/invite/ui/org-form.test.ts
+++ b/frontend/src/pages/invite/ui/org-form.test.ts
@@ -1,5 +1,5 @@
 import { expect, fixture, oneEvent } from "@open-wc/testing";
-import type { SlInput } from "@shoelace-style/shoelace";
+import { serialize, type SlInput } from "@shoelace-style/shoelace";
 import { html } from "lit/static-html.js";
 import { restore, stub } from "sinon";
 
@@ -65,14 +65,22 @@ describe("btrix-org-form", () => {
 
     const form = el.shadowRoot!.querySelector<HTMLFormElement>("form")!;
 
-    form
-      .querySelector('sl-input[name="orgName"]')
-      ?.setAttribute("value", "Fake Org Name");
-    form
-      .querySelector('sl-input[name="orgSlug"]')
-      ?.setAttribute("value", "fake-org-name");
+    const orgName = form.querySelector<SlInput>('sl-input[name="orgName"]')!;
+    const orgSlug = form.querySelector<SlInput>('sl-input[name="orgSlug"]')!;
+
+    orgName.setAttribute("value", "Fake Org Name");
+    orgSlug.setAttribute("value", "fake-org-name");
+
+    await orgName.updateComplete;
+    await orgSlug.updateComplete;
 
     const listener = oneEvent(form, "submit");
+
+    // HACK Not completely sure why this works, but without calling `serialize`
+    // the form will not be serialized in `org-form`.
+    // Maybe due the implementation with `Reflect`?
+    // https://github.com/shoelace-style/shoelace/blob/0aecf6959986817d9315df90c898da55a8a64290/src/utilities/form.ts#L12
+    serialize(form);
 
     form.requestSubmit();
 

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -49,6 +49,9 @@ export default {
         // web-test-runner expects es modules,
         // include umd/commonjs modules here:
         "node_modules/url-pattern/**/*",
+        "node_modules/lodash/**/*",
+        "node_modules/color/**/*",
+        "node_modules/slugify/**/*",
       ],
     }),
     importMapsPlugin({
@@ -64,12 +67,6 @@ export default {
             ),
             "@shoelace-style/shoelace/dist/themes/light.css": fileURLToPath(
               new URL("./src/__mocks__/_empty.js", import.meta.url),
-            ),
-            color: fileURLToPath(
-              new URL("./src/__mocks__/color.js", import.meta.url),
-            ),
-            slugify: fileURLToPath(
-              new URL("./src/__mocks__/slugify.js", import.meta.url),
             ),
           },
         },


### PR DESCRIPTION
No issue created, but noticed issue here https://github.com/webrecorder/browsertrix/pull/1909/commits/ed0d489cdad75d2e212e6eb607e460162798aa98

### Changes

- Removes unused node module mocks and use commonjs plugin to import modules in tests
- Fixes org form test after removing temporary stub