### PR TITLE
feat: Improve org name and slug validation

### DIFF
--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -397,10 +397,12 @@ export class Home extends LiteElement {
         if (e.details === "duplicate_org_name") {
           message = msg("This org name is already taken, try another one.");
         } else if (e.details === "duplicate_org_slug") {
-          message = msg("This org URL is already taken, try another one.");
+          message = msg(
+            "This org URL identifier is already taken, try another one.",
+          );
         } else if (e.details === "invalid_slug") {
           message = msg(
-            "This org URL is invalid. Please use alphanumeric characters and dashes (-) only.",
+            "This org URL identifier is invalid. Please use alphanumeric characters and dashes (-) only.",
           );
         }
       }

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -39,7 +39,7 @@ export class Home extends LiteElement {
   @state()
   private isSubmittingNewOrg = false;
 
-  private readonly validateOrgNameMax = maxLengthValidator(50);
+  private readonly validateOrgNameMax = maxLengthValidator(40);
 
   connectedCallback() {
     if (this.authState) {

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -391,10 +391,22 @@ export class Home extends LiteElement {
       });
       this.isAddingOrg = false;
     } catch (e) {
+      let message = msg("Sorry, couldn't create organization at this time.");
+
+      if (isApiError(e)) {
+        if (e.details === "duplicate_org_name") {
+          message = msg("This org name is already taken, try another one.");
+        } else if (e.details === "duplicate_org_slug") {
+          message = msg("This org URL is already taken, try another one.");
+        } else if (e.details === "invalid_slug") {
+          message = msg(
+            "This org URL is invalid. Please use alphanumeric characters and dashes (-) only.",
+          );
+        }
+      }
+
       this.notify({
-        message: isApiError(e)
-          ? e.message
-          : msg("Sorry, couldn't create organization at this time."),
+        message,
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -12,6 +12,7 @@ import { NotifyController } from "@/controllers/notify";
 import { type APIUser } from "@/index";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
+import { maxLengthValidator } from "@/utils/form";
 import { AppStateService } from "@/utils/state";
 import { formatAPIUser } from "@/utils/user";
 
@@ -45,6 +46,8 @@ export class OrgForm extends TailwindElement {
   readonly _api = new APIController(this);
   readonly _notify = new NotifyController(this);
 
+  private readonly validateOrgNameMax = maxLengthValidator(40);
+
   readonly _renameOrgTask = new Task(this, {
     autoRun: false,
     task: async ([id, name, slug]) => {
@@ -72,9 +75,9 @@ export class OrgForm extends TailwindElement {
             autocomplete="off"
             value=${this.name === this.orgId ? "" : this.name}
             minlength="2"
-            maxlength="40"
             help-text=${msg("You can change this in your org settings later.")}
             required
+            @sl-input=${this.validateOrgNameMax.validate}
           ></sl-input>
         </div>
         <div class="mb-5">

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -4,7 +4,6 @@ import type { SlInput } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
-import slugify from "slugify";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { APIController } from "@/controllers/api";
@@ -13,6 +12,7 @@ import { type APIUser } from "@/index";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { maxLengthValidator } from "@/utils/form";
+import slugifyStrict from "@/utils/slugify";
 import { AppStateService } from "@/utils/state";
 import { formatAPIUser } from "@/utils/user";
 
@@ -96,7 +96,7 @@ export class OrgForm extends TailwindElement {
             required
             @sl-input=${(e: InputEvent) => {
               const input = e.target as SlInput;
-              input.helpText = helpText(slugify(input.value, { strict: true }));
+              input.helpText = helpText(slugifyStrict(input.value));
             }}
           >
           </sl-input>
@@ -129,7 +129,7 @@ export class OrgForm extends TailwindElement {
 
     const params = serialize(form) as FormValues;
     const orgName = params.orgName;
-    const orgSlug = slugify(params.orgSlug, { strict: true });
+    const orgSlug = slugifyStrict(params.orgSlug);
 
     void this._renameOrgTask.run([this.orgId, orgName, orgSlug]);
   }

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -165,13 +165,15 @@ export class OrgForm extends TailwindElement {
         } else if (e.details === "duplicate_org_slug") {
           fieldName = "orgSlug";
           error = new Error(
-            msg(str`The org URL "${slug}" is already taken, try another one.`),
+            msg(
+              str`The org URL identifier "${slug}" is already taken, try another one.`,
+            ),
           );
         } else if (e.details === "invalid_slug") {
           fieldName = "orgSlug";
           error = new Error(
             msg(
-              str`The org URL "${slug}" is not a valid URL. Please use alphanumeric characters and dashes (-) only`,
+              str`The org URL identifier "${slug}" is not a valid URL. Please use alphanumeric characters and dashes (-) only`,
             ),
           );
         }

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -73,7 +73,7 @@ export class OrgForm extends TailwindElement {
         <div class="mb-5">
           <sl-input
             name="orgName"
-            label=${msg("Org name")}
+            label=${msg("Org Name")}
             placeholder=${msg("My Organization")}
             autocomplete="off"
             value=${this.name === this.orgId ? "" : this.name}
@@ -86,7 +86,7 @@ export class OrgForm extends TailwindElement {
         <div class="mb-5">
           <sl-input
             name="orgSlug"
-            label=${msg("Custom URL identifier")}
+            label=${msg("Custom URL Identifier")}
             placeholder="my-organization"
             autocomplete="off"
             value=${this.slug}

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -5,7 +5,6 @@ import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
-import slugify from "slugify";
 
 import { columns } from "./ui/columns";
 
@@ -20,6 +19,7 @@ import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { maxLengthValidator } from "@/utils/form";
 import { AccessCode, isAdmin, isCrawler, type OrgData } from "@/utils/orgs";
+import slugifyStrict from "@/utils/slugify";
 import appState, { AppStateService, use } from "@/utils/state";
 import { formatAPIUser } from "@/utils/user";
 
@@ -233,7 +233,7 @@ export class OrgSettings extends TailwindElement {
                     window.location.hostname
                   }/orgs/${
                     this.slugValue
-                      ? this.slugify(this.slugValue)
+                      ? slugifyStrict(this.slugValue)
                       : this.org.slug
                   }`,
                 )}
@@ -454,12 +454,6 @@ export class OrgSettings extends TailwindElement {
     `;
   }
 
-  private slugify(value: string) {
-    return slugify(value, {
-      strict: true,
-    });
-  }
-
   private async checkFormValidity(formEl: HTMLFormElement) {
     await this.updateComplete;
     return !formEl.querySelector("[data-invalid]");
@@ -502,7 +496,7 @@ export class OrgSettings extends TailwindElement {
     };
 
     if (this.slugValue) {
-      params.slug = this.slugify(this.slugValue);
+      params.slug = slugifyStrict(this.slugValue);
     }
 
     this.isSavingOrgName = true;

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -628,10 +628,12 @@ export class OrgSettings extends TailwindElement {
         if (e.details === "duplicate_org_name") {
           message = msg("This org name is already taken, try another one.");
         } else if (e.details === "duplicate_org_slug") {
-          message = msg("This org URL is already taken, try another one.");
+          message = msg(
+            "This org URL identifier is already taken, try another one.",
+          );
         } else if (e.details === "invalid_slug") {
           message = msg(
-            "This org URL is invalid. Please use alphanumeric characters and dashes (-) only.",
+            "This org URL identifier is invalid. Please use alphanumeric characters and dashes (-) only.",
           );
         }
       }

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -166,14 +166,15 @@
     box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-color-danger-100);
   }
 
-  [data-user-invalid]:not([disabled])::part(form-control-label):after {
-    /* Required asterisk color */
-    color: var(--sl-color-danger-500);
+  [data-user-invalid]:not([disabled])::part(form-control-label),
+  /* Required asterisk color */
+  [data-user-invalid]:not([disabled])::part(form-control-label)::after {
+    color: var(--sl-color-danger-700);
   }
 
   [data-user-invalid]:not([disabled])::part(form-control-help-text),
   [data-user-invalid]:not([disabled]) .form-help-text {
-    color: var(--sl-color-danger-500);
+    color: var(--sl-color-danger-700);
   }
 
   /* TODO tailwind sets border-width: 0, see if this can be fixed in tw */

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -39,17 +39,27 @@ export function getHelpText(maxLength: number, currentLength: number) {
  * ```
  */
 export function maxLengthValidator(maxLength: number): MaxLengthValidator {
-  const helpText = msg(str`Maximum ${maxLength} characters`);
+  const validityHelpText = msg(str`Maximum ${maxLength} characters`);
+  let origHelpText: null | string = null;
+
   const validate = (e: CustomEvent) => {
     const el = e.target as SlTextarea | SlInput;
-    const helpText = getHelpText(maxLength, el.value.length);
+
+    if (origHelpText === null && el.helpText) {
+      origHelpText = el.helpText;
+    }
+
+    const validityText = getHelpText(maxLength, el.value.length);
+    const isInvalid = el.value.length > maxLength;
+
     el.setCustomValidity(
-      el.value.length > maxLength
+      isInvalid
         ? msg(str`Please shorten this text to ${maxLength} or less characters.`)
         : "",
     );
-    el.helpText = helpText;
+
+    el.helpText = isInvalid ? validityText : origHelpText || validityHelpText;
   };
 
-  return { helpText, validate };
+  return { helpText: validityHelpText, validate };
 }

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -54,7 +54,7 @@ export function maxLengthValidator(maxLength: number): MaxLengthValidator {
 
     el.setCustomValidity(
       isInvalid
-        ? msg(str`Please shorten this text to ${maxLength} or less characters.`)
+        ? msg(str`Please shorten this text to ${maxLength} or fewer characters.`)
         : "",
     );
 

--- a/frontend/src/utils/slugify.ts
+++ b/frontend/src/utils/slugify.ts
@@ -1,0 +1,7 @@
+import slugify from "slugify";
+
+import { getLocale } from "./localization";
+
+export default function slugifyStrict(value: string) {
+  return slugify(value, { strict: true, lower: true, locale: getLocale() });
+}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1892

### Changes

- Verifies org slug (name) availability when creating new org
- Show org max length error when signing up
- Highlights org error field when signing up
- Fixes org name max length discrepancy
- Standardizes org slug to lowercase

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Superadmin dashboard - New org dialog | <img width="525" alt="Screenshot 2024-07-15 at 12 03 16 PM" src="https://github.com/user-attachments/assets/c6d9a2e4-3499-425b-aebf-2bbc59a6dc5f"> |
| Self sign-up - Org form | <img width="467" alt="Screenshot 2024-07-15 at 11 02 26 AM" src="https://github.com/user-attachments/assets/7a17fbfb-020a-44ee-8536-c1ac51a6cb24"><br/><br/><img width="475" alt="Screenshot 2024-07-15 at 11 01 23 AM" src="https://github.com/user-attachments/assets/7faf7cd9-1ea3-47a7-968b-66fc2db4fe6c"><br/><br/><img width="472" alt="Screenshot 2024-07-15 at 11 01 46 AM" src="https://github.com/user-attachments/assets/5b3c93c5-e3a0-4324-8cea-46cdd31114cc"> |

<!-- ### Follow-ups -->
