### PR TITLE
Document all API endpoints with response models

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -19,10 +19,11 @@ from .models import (
     BgJobType,
     CreateReplicaJob,
     DeleteReplicaJob,
-    PaginatedResponse,
+    PaginatedBackgroundJobResponse,
     AnyJob,
     StorageRef,
     User,
+    SuccessResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
@@ -520,9 +521,7 @@ def init_background_jobs_api(
         """Retrieve information for background job"""
         return await ops.get_background_job(job_id, org.id)
 
-    @router.post(
-        "/{job_id}/retry",
-    )
+    @router.post("/{job_id}/retry", response_model=SuccessResponse)
     async def retry_background_job(
         job_id: str,
         org: Organization = Depends(org_crawl_dep),
@@ -530,9 +529,7 @@ def init_background_jobs_api(
         """Retry background job"""
         return await ops.retry_background_job(job_id, org)
 
-    @app.post(
-        "/orgs/all/jobs/retryFailed",
-    )
+    @app.post("/orgs/all/jobs/retryFailed", response_model=SuccessResponse)
     async def retry_all_failed_background_jobs(user: User = Depends(user_dep)):
         """Retry failed background jobs from all orgs"""
         if not user.is_superuser:
@@ -540,16 +537,14 @@ def init_background_jobs_api(
 
         return await ops.retry_all_failed_background_jobs()
 
-    @router.post(
-        "/retryFailed",
-    )
+    @router.post("/retryFailed", response_model=SuccessResponse)
     async def retry_failed_background_jobs(
         org: Organization = Depends(org_crawl_dep),
     ):
         """Retry failed background jobs"""
         return await ops.retry_failed_background_jobs(org)
 
-    @router.get("", response_model=PaginatedResponse)
+    @router.get("", response_model=PaginatedBackgroundJobResponse)
     async def list_background_jobs(
         org: Organization = Depends(org_crawl_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -18,12 +18,15 @@ from .models import (
     UpdateCrawl,
     DeleteCrawlList,
     Organization,
-    PaginatedResponse,
+    PaginatedCrawlOutResponse,
     User,
     StorageRef,
     RUNNING_AND_STARTING_STATES,
     SUCCESSFUL_STATES,
     QARun,
+    UpdatedResponse,
+    DeletedResponseQuota,
+    CrawlSearchValuesResponse,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .utils import dt_now
@@ -806,7 +809,7 @@ def init_base_crawls_api(app, user_dep, *args):
     @app.get(
         "/orgs/{oid}/all-crawls",
         tags=["all-crawls"],
-        response_model=PaginatedResponse,
+        response_model=PaginatedCrawlOutResponse,
     )
     async def list_all_base_crawls(
         org: Organization = Depends(org_viewer_dep),
@@ -854,7 +857,11 @@ def init_base_crawls_api(app, user_dep, *args):
         )
         return paginated_format(crawls, total, page, pageSize)
 
-    @app.get("/orgs/{oid}/all-crawls/search-values", tags=["all-crawls"])
+    @app.get(
+        "/orgs/{oid}/all-crawls/search-values",
+        tags=["all-crawls"],
+        response_model=CrawlSearchValuesResponse,
+    )
     async def get_all_crawls_search_values(
         org: Organization = Depends(org_viewer_dep),
         crawlType: Optional[str] = None,
@@ -891,13 +898,21 @@ def init_base_crawls_api(app, user_dep, *args):
     async def get_crawl_out(crawl_id, org: Organization = Depends(org_viewer_dep)):
         return await ops.get_crawl_out(crawl_id, org)
 
-    @app.patch("/orgs/{oid}/all-crawls/{crawl_id}", tags=["all-crawls"])
+    @app.patch(
+        "/orgs/{oid}/all-crawls/{crawl_id}",
+        tags=["all-crawls"],
+        response_model=UpdatedResponse,
+    )
     async def update_crawl(
         update: UpdateCrawl, crawl_id: str, org: Organization = Depends(org_crawl_dep)
     ):
         return await ops.update_crawl(crawl_id, org, update)
 
-    @app.post("/orgs/{oid}/all-crawls/delete", tags=["all-crawls"])
+    @app.post(
+        "/orgs/{oid}/all-crawls/delete",
+        tags=["all-crawls"],
+        response_model=DeletedResponseQuota,
+    )
     async def delete_crawls_all_types(
         delete_list: DeleteCrawlList,
         user: User = Depends(user_dep),

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -5,7 +5,7 @@ Collections API
 from collections import Counter
 from datetime import datetime
 from uuid import UUID, uuid4
-from typing import Optional, List, TYPE_CHECKING, cast
+from typing import Optional, List, TYPE_CHECKING, cast, Dict
 
 import asyncio
 import pymongo
@@ -22,9 +22,15 @@ from .models import (
     AddRemoveCrawlList,
     BaseCrawl,
     CrawlOutWithResources,
+    CrawlFileOut,
     Organization,
-    PaginatedResponse,
+    PaginatedCollOutResponse,
     SUCCESSFUL_STATES,
+    AddedResponseIdName,
+    EmptyResponse,
+    UpdatedResponse,
+    SuccessResponse,
+    CollectionSearchValuesResponse,
 )
 
 if TYPE_CHECKING:
@@ -389,7 +395,11 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
     org_viewer_dep = orgs.org_viewer_dep
     org_public = orgs.org_public
 
-    @app.post("/orgs/{oid}/collections", tags=["collections"])
+    @app.post(
+        "/orgs/{oid}/collections",
+        tags=["collections"],
+        response_model=AddedResponseIdName,
+    )
     async def add_collection(
         new_coll: CollIn, org: Organization = Depends(org_crawl_dep)
     ):
@@ -398,7 +408,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
     @app.get(
         "/orgs/{oid}/collections",
         tags=["collections"],
-        response_model=PaginatedResponse,
+        response_model=PaginatedCollOutResponse,
     )
     async def list_collection_all(
         org: Organization = Depends(org_viewer_dep),
@@ -423,6 +433,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
     @app.get(
         "/orgs/{oid}/collections/$all",
         tags=["collections"],
+        response_model=Dict[str, List[CrawlFileOut]],
     )
     async def get_collection_all(org: Organization = Depends(org_viewer_dep)):
         results = {}
@@ -440,7 +451,11 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
 
         return results
 
-    @app.get("/orgs/{oid}/collections/search-values", tags=["collections"])
+    @app.get(
+        "/orgs/{oid}/collections/search-values",
+        tags=["collections"],
+        response_model=CollectionSearchValuesResponse,
+    )
     async def get_collection_search_values(
         org: Organization = Depends(org_viewer_dep),
     ):
@@ -453,23 +468,29 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
     )
     async def get_collection(
         coll_id: UUID, org: Organization = Depends(org_viewer_dep)
-    ) -> CollOut:
+    ):
         return await colls.get_collection(coll_id, org)
 
-    @app.get("/orgs/{oid}/collections/{coll_id}/replay.json", tags=["collections"])
+    @app.get(
+        "/orgs/{oid}/collections/{coll_id}/replay.json",
+        tags=["collections"],
+        response_model=CollOut,
+    )
     async def get_collection_replay(
         coll_id: UUID, org: Organization = Depends(org_viewer_dep)
-    ) -> CollOut:
+    ):
         return await colls.get_collection(coll_id, org, resources=True)
 
     @app.get(
-        "/orgs/{oid}/collections/{coll_id}/public/replay.json", tags=["collections"]
+        "/orgs/{oid}/collections/{coll_id}/public/replay.json",
+        tags=["collections"],
+        response_model=CollOut,
     )
     async def get_collection_public_replay(
         response: Response,
         coll_id: UUID,
         org: Organization = Depends(org_public),
-    ) -> CollOut:
+    ):
         coll = await colls.get_collection(
             coll_id, org, resources=True, public_only=True
         )
@@ -478,7 +499,9 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
         return coll
 
     @app.options(
-        "/orgs/{oid}/collections/{coll_id}/public/replay.json", tags=["collections"]
+        "/orgs/{oid}/collections/{coll_id}/public/replay.json",
+        tags=["collections"],
+        response_model=EmptyResponse,
     )
     async def get_replay_preflight(response: Response):
         response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
@@ -486,7 +509,11 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
         response.headers["Access-Control-Allow-Headers"] = "*"
         return {}
 
-    @app.patch("/orgs/{oid}/collections/{coll_id}", tags=["collections"])
+    @app.patch(
+        "/orgs/{oid}/collections/{coll_id}",
+        tags=["collections"],
+        response_model=UpdatedResponse,
+    )
     async def update_collection(
         coll_id: UUID,
         update: UpdateColl,
@@ -523,13 +550,18 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
     @app.delete(
         "/orgs/{oid}/collections/{coll_id}",
         tags=["collections"],
+        response_model=SuccessResponse,
     )
     async def delete_collection(
         coll_id: UUID, org: Organization = Depends(org_crawl_dep)
     ):
         return await colls.delete_collection(coll_id, org)
 
-    @app.get("/orgs/{oid}/collections/{coll_id}/download", tags=["collections"])
+    @app.get(
+        "/orgs/{oid}/collections/{coll_id}/download",
+        tags=["collections"],
+        response_model=bytes,
+    )
     async def download_collection(
         coll_id: UUID, org: Organization = Depends(org_viewer_dep)
     ):

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -39,12 +39,22 @@ from .models import (
     DeleteQARunList,
     Organization,
     User,
-    PaginatedResponse,
+    PaginatedCrawlOutResponse,
+    PaginatedSeedResponse,
     RUNNING_AND_STARTING_STATES,
     SUCCESSFUL_STATES,
     NON_RUNNING_STATES,
     ALL_CRAWL_STATES,
     TYPE_ALL_CRAWL_STATES,
+    UpdatedResponse,
+    SuccessResponse,
+    StartedResponse,
+    DeletedResponseQuota,
+    DeletedCountResponse,
+    EmptyResponse,
+    CrawlScaleResponse,
+    CrawlQueueResponse,
+    MatchCrawlQueueResponse,
 )
 
 
@@ -1003,7 +1013,9 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     org_viewer_dep = ops.orgs.org_viewer_dep
     org_crawl_dep = ops.orgs.org_crawl_dep
 
-    @app.get("/orgs/all/crawls", tags=["crawls"])
+    @app.get(
+        "/orgs/all/crawls", tags=["crawls"], response_model=PaginatedCrawlOutResponse
+    )
     async def list_crawls_admin(
         user: User = Depends(user_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
@@ -1052,7 +1064,9 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         )
         return paginated_format(crawls, total, page, pageSize)
 
-    @app.get("/orgs/{oid}/crawls", tags=["crawls"], response_model=PaginatedResponse)
+    @app.get(
+        "/orgs/{oid}/crawls", tags=["crawls"], response_model=PaginatedCrawlOutResponse
+    )
     async def list_crawls(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
@@ -1101,6 +1115,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/cancel",
         tags=["crawls"],
+        response_model=SuccessResponse,
     )
     async def crawl_cancel_immediately(
         crawl_id, org: Organization = Depends(org_crawl_dep)
@@ -1110,11 +1125,16 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/stop",
         tags=["crawls"],
+        response_model=SuccessResponse,
     )
     async def crawl_graceful_stop(crawl_id, org: Organization = Depends(org_crawl_dep)):
         return await ops.shutdown_crawl(crawl_id, org, graceful=True)
 
-    @app.post("/orgs/{oid}/crawls/delete", tags=["crawls"])
+    @app.post(
+        "/orgs/{oid}/crawls/delete",
+        tags=["crawls"],
+        response_model=DeletedResponseQuota,
+    )
     async def delete_crawls(
         delete_list: DeleteCrawlList,
         user: User = Depends(user_dep),
@@ -1122,7 +1142,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     ):
         return await ops.delete_crawls(org, delete_list, "crawl", user)
 
-    @app.get("/orgs/all/crawls/stats", tags=["crawls"])
+    @app.get("/orgs/all/crawls/stats", tags=["crawls"], response_model=bytes)
     async def get_all_orgs_crawl_stats(
         user: User = Depends(user_dep),
     ):
@@ -1132,7 +1152,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         crawl_stats = await ops.get_crawl_stats()
         return stream_dict_list_as_csv(crawl_stats, "crawling-stats.csv")
 
-    @app.get("/orgs/{oid}/crawls/stats", tags=["crawls"])
+    @app.get("/orgs/{oid}/crawls/stats", tags=["crawls"], response_model=bytes)
     async def get_org_crawl_stats(
         org: Organization = Depends(org_crawl_dep),
     ):
@@ -1212,7 +1232,11 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
             thresholds,
         )
 
-    @app.post("/orgs/{oid}/crawls/{crawl_id}/qa/start", tags=["qa"])
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/qa/start",
+        tags=["qa"],
+        response_model=StartedResponse,
+    )
     async def start_crawl_qa_run(
         crawl_id: str,
         org: Organization = Depends(org_crawl_dep),
@@ -1221,21 +1245,33 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         qa_run_id = await ops.start_crawl_qa_run(crawl_id, org, user)
         return {"started": qa_run_id}
 
-    @app.post("/orgs/{oid}/crawls/{crawl_id}/qa/stop", tags=["qa"])
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/qa/stop",
+        tags=["qa"],
+        response_model=SuccessResponse,
+    )
     async def stop_crawl_qa_run(
         crawl_id: str, org: Organization = Depends(org_crawl_dep)
     ):
         # pylint: disable=unused-argument
         return await ops.stop_crawl_qa_run(crawl_id, org)
 
-    @app.post("/orgs/{oid}/crawls/{crawl_id}/qa/cancel", tags=["qa"])
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/qa/cancel",
+        tags=["qa"],
+        response_model=SuccessResponse,
+    )
     async def cancel_crawl_qa_run(
         crawl_id: str, org: Organization = Depends(org_crawl_dep)
     ):
         # pylint: disable=unused-argument
         return await ops.stop_crawl_qa_run(crawl_id, org, graceful=False)
 
-    @app.post("/orgs/{oid}/crawls/{crawl_id}/qa/delete", tags=["qa"])
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/qa/delete",
+        tags=["qa"],
+        response_model=DeletedCountResponse,
+    )
     async def delete_crawl_qa_runs(
         crawl_id: str,
         qa_run_ids: DeleteQARunList,
@@ -1290,7 +1326,9 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
 
         return crawls[0]
 
-    @app.patch("/orgs/{oid}/crawls/{crawl_id}", tags=["crawls"])
+    @app.patch(
+        "/orgs/{oid}/crawls/{crawl_id}", tags=["crawls"], response_model=UpdatedResponse
+    )
     async def update_crawl_api(
         update: UpdateCrawl, crawl_id: str, org: Organization = Depends(org_crawl_dep)
     ):
@@ -1299,6 +1337,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/scale",
         tags=["crawls"],
+        response_model=CrawlScaleResponse,
     )
     async def scale_crawl(
         scale: CrawlScale,
@@ -1319,6 +1358,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/access",
         tags=["crawls"],
+        response_model=EmptyResponse,
     )
     async def access_check(crawl_id, org: Organization = Depends(org_crawl_dep)):
         if await ops.get_crawl_raw(crawl_id, org):
@@ -1327,6 +1367,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/queue",
         tags=["crawls"],
+        response_model=CrawlQueueResponse,
     )
     async def get_crawl_queue(
         crawl_id,
@@ -1342,6 +1383,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/queueMatchAll",
         tags=["crawls"],
+        response_model=MatchCrawlQueueResponse,
     )
     async def match_crawl_queue(
         crawl_id,
@@ -1356,6 +1398,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/exclusions",
         tags=["crawls"],
+        response_model=SuccessResponse,
     )
     async def add_exclusion(
         crawl_id,
@@ -1368,6 +1411,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.delete(
         "/orgs/{oid}/crawls/{crawl_id}/exclusions",
         tags=["crawls"],
+        response_model=SuccessResponse,
     )
     async def remove_exclusion(
         crawl_id,
@@ -1380,7 +1424,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/seeds",
         tags=["crawls"],
-        response_model=PaginatedResponse,
+        response_model=PaginatedSeedResponse,
     )
     async def get_crawl_config_seeds(
         crawl_id: str,
@@ -1391,7 +1435,9 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         seeds, total = await ops.get_crawl_seeds(crawl_id, org, pageSize, page)
         return paginated_format(seeds, total, page, pageSize)
 
-    @app.get("/orgs/{oid}/crawls/{crawl_id}/logs", tags=["crawls"])
+    @app.get(
+        "/orgs/{oid}/crawls/{crawl_id}/logs", tags=["crawls"], response_model=bytes
+    )
     async def stream_crawl_logs(
         crawl_id,
         org: Organization = Depends(org_viewer_dep),
@@ -1423,8 +1469,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         raise HTTPException(status_code=400, detail="crawl_not_finished")
 
     @app.get(
-        "/orgs/{oid}/crawls/{crawl_id}/errors",
-        tags=["crawls"],
+        "/orgs/{oid}/crawls/{crawl_id}/errors", tags=["crawls"], response_model=bytes
     )
     async def get_crawl_errors(
         crawl_id: str,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -97,6 +97,16 @@ class AddToOrgRequest(InviteRequest):
 
 
 # ============================================================================
+class InviteAddedResponse(BaseModel):
+    """Response for API endpoints that add resource and return id and name"""
+
+    added: bool
+    id: UUID
+    invited: str
+    token: UUID
+
+
+# ============================================================================
 
 ### MAIN USER MODEL ###
 
@@ -461,6 +471,56 @@ class UpdateCrawlConfig(BaseModel):
 
 
 # ============================================================================
+class CrawlConfigAddedResponse(BaseModel):
+    """Response model for adding crawlconfigs"""
+
+    added: bool
+    id: str
+    run_now_job: Optional[str]
+    storageQuotaReached: bool
+    execMinutesQuotaReached: bool
+
+
+# ============================================================================
+class CrawlConfigTags(BaseModel):
+    """Response model for crawlconfig tags"""
+
+    tags: List[str]
+
+
+# ============================================================================
+class CrawlConfigSearchValues(BaseModel):
+    """Response model for adding crawlconfigs"""
+
+    names: List[str]
+    descriptions: List[str]
+    firstSeeds: List[AnyHttpUrl]
+    workflowIds: List[UUID]
+
+
+# ============================================================================
+class CrawlConfigUpdateResponse(BaseModel):
+    """Response model for updating crawlconfigs"""
+
+    updated: bool
+    settings_changed: bool
+    metadata_changed: bool
+
+    storageQuotaReached: Optional[bool]
+    execMinutesQuotaReached: Optional[bool]
+
+    started: Optional[str]
+
+
+# ============================================================================
+class CrawlConfigDeletedResponse(BaseModel):
+    """Response model for deleting crawlconfigs"""
+
+    success: bool
+    status: str
+
+
+# ============================================================================
 
 ### CRAWLER VERSIONS ###
 
@@ -722,6 +782,45 @@ class DeleteQARunList(BaseModel):
 
 
 # ============================================================================
+class CrawlSearchValuesResponse(BaseModel):
+    """Response model for crawl search values"""
+
+    names: List[str]
+    descriptions: List[str]
+    firstSeeds: List[AnyHttpUrl]
+
+
+# ============================================================================
+class CrawlQueueUrl(BaseModel):
+    """Model for item in crawl queue"""
+
+    seedId: int
+    url: AnyHttpUrl
+    depth: int
+    extraHops: int
+    ts: int
+    pageid: Optional[str]
+
+
+# ============================================================================
+class CrawlQueueResponse(BaseModel):
+    """Response model for GET crawl queue"""
+
+    total: int
+    results: List[CrawlQueueUrl]
+    matched: List[CrawlQueueUrl]
+
+
+# ============================================================================
+class MatchCrawlQueueResponse(BaseModel):
+    """Response model for match crawl queue"""
+
+    total: int
+    matched: List[CrawlQueueUrl]
+    nextOffset: int
+
+
+# ============================================================================
 
 ### AUTOMATED CRAWLS ###
 
@@ -822,6 +921,13 @@ class CrawlCompleteIn(BaseModel):
 
 
 # ============================================================================
+class CrawlScaleResponse(BaseModel):
+    """Response model for modifying crawl scale"""
+
+    scaled: int
+
+
+# ============================================================================
 
 ### UPLOADED CRAWLS ###
 
@@ -894,6 +1000,13 @@ class AddRemoveCrawlList(BaseModel):
     """Collections to add or remove from collection"""
 
     crawlIds: List[str] = []
+
+
+# ============================================================================
+class CollectionSearchValuesResponse(BaseModel):
+    """Response model for collections search values"""
+
+    names: List[str]
 
 
 # ============================================================================
@@ -1071,6 +1184,14 @@ class Subscription(BaseModel):
 
     futureCancelDate: Optional[datetime] = None
     readOnlyOnCancel: bool = False
+
+
+# ============================================================================
+class SubscriptionCanceledResponse(BaseModel):
+    """Response model for subscription cancel"""
+
+    deleted: bool
+    canceled: bool
 
 
 # ============================================================================
@@ -1353,6 +1474,44 @@ class OrgImportExport(BaseModel):
 
 
 # ============================================================================
+class OrgInviteResponse(BaseModel):
+    """Model for org invite response"""
+
+    invited: str
+    token: UUID
+
+
+# ============================================================================
+class OrgAcceptInviteResponse(BaseModel):
+    """Model for org invite response"""
+
+    added: bool
+    org: OrgOut
+
+
+# ============================================================================
+class OrgDeleteInviteResponse(BaseModel):
+    """Model for org invite response"""
+
+    removed: bool
+    count: int
+
+
+# ============================================================================
+class OrgSlugsResponse(BaseModel):
+    """Model for org slugs response"""
+
+    slugs: List[str]
+
+
+# ============================================================================
+class OrgImportResponse(BaseModel):
+    """Model for org import response"""
+
+    imported: bool
+
+
+# ============================================================================
 
 ### PAGINATION ###
 
@@ -1361,7 +1520,6 @@ class OrgImportExport(BaseModel):
 class PaginatedResponse(BaseModel):
     """Paginated response model"""
 
-    items: List[Any]
     total: int
     page: int
     pageSize: int
@@ -1447,6 +1605,26 @@ class ProfileUpdate(BaseModel):
     browserid: Optional[str] = ""
     name: str
     description: Optional[str] = ""
+
+
+# ============================================================================
+class ProfilePingResponse(BaseModel):
+    """Response model for pinging profile"""
+
+    success: bool
+    origins: List[AnyHttpUrl]
+
+
+# ============================================================================
+class ProfileBrowserGetUrlResponse(BaseModel):
+    """Response model for profile get URL endpoint"""
+
+    path: str
+    password: str
+    oid: UUID
+    auth_bearer: str
+    scale: float
+    url: AnyHttpUrl
 
 
 # ============================================================================
@@ -1799,3 +1977,220 @@ class PageOutWithSingleQA(Page):
     """Page out with single QA entry"""
 
     qa: Optional[PageQACompare] = None
+
+
+# ============================================================================
+class PageNoteAddedResponse(BaseModel):
+    """Model for response to adding page"""
+
+    added: bool
+    data: PageNote
+
+
+# ============================================================================
+class PageNoteUpdatedResponse(BaseModel):
+    """Model for response to updating page"""
+
+    updated: bool
+    data: PageNote
+
+
+# ============================================================================
+
+### GENERIC RESPONSE MODELS ###
+
+
+# ============================================================================
+class UpdatedResponse(BaseModel):
+    """Response for update API endpoints"""
+
+    updated: bool
+
+
+# ============================================================================
+class SuccessResponse(BaseModel):
+    """Response for API endpoints that return success"""
+
+    success: bool
+
+
+# ============================================================================
+class SuccessResponseStorageQuota(SuccessResponse):
+    """Response for API endpoints that return success and storageQuotaReached"""
+
+    storageQuotaReached: bool
+
+
+# ============================================================================
+class StartedResponse(BaseModel):
+    """Response for API endpoints that start crawls"""
+
+    started: str
+
+
+# ============================================================================
+class AddedResponse(BaseModel):
+    """Response for API endpoints that return added"""
+
+    added: bool
+
+
+# ============================================================================
+class AddedResponseId(AddedResponse):
+    """Response for API endpoints that return added + id"""
+
+    id: UUID
+
+
+# ============================================================================
+class AddedResponseName(AddedResponse):
+    """Response for API endpoints that add resources and return name"""
+
+    name: str
+
+
+# ============================================================================
+class AddedResponseIdQuota(AddedResponse):
+    """Response for API endpoints that return str id and storageQuotaReached"""
+
+    id: str
+    storageQuotaReached: bool
+
+
+# ============================================================================
+class AddedResponseIdName(AddedResponse):
+    """Response for API endpoints that add resource and return id and name"""
+
+    id: UUID
+    name: str
+
+
+# ============================================================================
+class DeletedResponse(BaseModel):
+    """Response for delete API endpoints"""
+
+    deleted: bool
+
+
+# ============================================================================
+class DeletedResponseQuota(DeletedResponse):
+    """Response for delete API endpoints"""
+
+    storageQuotaReached: bool
+
+
+# ============================================================================
+class DeletedCountResponse(BaseModel):
+    """Response for delete API endpoints that return count"""
+
+    deleted: int
+
+
+# ============================================================================
+class RemovedResponse(BaseModel):
+    """Response for API endpoints for removing resources"""
+
+    removed: bool
+
+
+# ============================================================================
+class EmptyResponse(BaseModel):
+    """Response for API endpoints that return nothing"""
+
+
+# ============================================================================
+
+### SPECIFIC PAGINATED RESPONSE MODELS ###
+
+
+# ============================================================================
+class PaginatedBackgroundJobResponse(PaginatedResponse):
+    """Response model for paginated background jobs"""
+
+    items: List[Union[CreateReplicaJob, DeleteReplicaJob]]
+
+
+# ============================================================================
+class PaginatedCrawlOutResponse(PaginatedResponse):
+    """Response model for paginated crawls"""
+
+    items: List[Union[CrawlOut, CrawlOutWithResources]]
+
+
+# ============================================================================
+class PaginatedCollOutResponse(PaginatedResponse):
+    """Response model for paginated collections"""
+
+    items: List[CollOut]
+
+
+# ============================================================================
+class PaginatedCrawlConfigOutResponse(PaginatedResponse):
+    """Response model for paginated crawlconfigs"""
+
+    items: List[CrawlConfigOut]
+
+
+# ============================================================================
+class PaginatedSeedResponse(PaginatedResponse):
+    """Response model for paginated seeds"""
+
+    items: List[Seed]
+
+
+# ============================================================================
+class PaginatedConfigRevisionResponse(PaginatedResponse):
+    """Response model for paginated crawlconfig revisions"""
+
+    items: List[ConfigRevision]
+
+
+# ============================================================================
+class PaginatedOrgOutResponse(PaginatedResponse):
+    """Response model for paginated orgs"""
+
+    items: List[OrgOut]
+
+
+# ============================================================================
+class PaginatedInvitePendingResponse(PaginatedResponse):
+    """Response model for paginated orgs"""
+
+    items: List[InviteOut]
+
+
+# ============================================================================
+class PaginatedPageOutResponse(PaginatedResponse):
+    """Response model for paginated pages"""
+
+    items: List[PageOut]
+
+
+# ============================================================================
+class PaginatedPageOutWithQAResponse(PaginatedResponse):
+    """Response model for paginated pages with single QA info"""
+
+    items: List[PageOutWithSingleQA]
+
+
+# ============================================================================
+class PaginatedProfileResponse(PaginatedResponse):
+    """Response model for paginated profiles"""
+
+    items: List[Profile]
+
+
+# ============================================================================
+class PaginatedSubscriptionEventResponse(PaginatedResponse):
+    """Response model for paginated subscription events"""
+
+    items: List[
+        Union[SubscriptionCreateOut, SubscriptionUpdateOut, SubscriptionCancelOut]
+    ]
+
+
+# ============================================================================
+class PaginatedWebhookNotificationResponse(PaginatedResponse):
+    """Response model for paginated webhook notifications"""
+
+    items: List[WebhookNotification]

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -16,13 +16,19 @@ from .models import (
     PageReviewUpdate,
     PageQACompare,
     Organization,
-    PaginatedResponse,
+    PaginatedPageOutResponse,
+    PaginatedPageOutWithQAResponse,
     User,
     PageNote,
     PageNoteIn,
     PageNoteEdit,
     PageNoteDelete,
     QARunBucketStats,
+    StartedResponse,
+    UpdatedResponse,
+    DeletedResponse,
+    PageNoteAddedResponse,
+    PageNoteUpdatedResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import from_k8s_date, str_list_to_bools
@@ -633,7 +639,11 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
 
     org_crawl_dep = org_ops.org_crawl_dep
 
-    @app.post("/orgs/{oid}/crawls/all/pages/reAdd", tags=["pages"])
+    @app.post(
+        "/orgs/{oid}/crawls/all/pages/reAdd",
+        tags=["pages"],
+        response_model=StartedResponse,
+    )
     async def re_add_all_crawl_pages(
         org: Organization = Depends(org_crawl_dep), user: User = Depends(user_dep)
     ):
@@ -644,7 +654,11 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
         asyncio.create_task(ops.re_add_all_crawl_pages(org.id))
         return {"started": True}
 
-    @app.post("/orgs/{oid}/crawls/{crawl_id}/pages/reAdd", tags=["pages"])
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/pages/reAdd",
+        tags=["pages"],
+        response_model=StartedResponse,
+    )
     async def re_add_crawl_pages(
         crawl_id: str, org: Organization = Depends(org_crawl_dep)
     ):
@@ -682,6 +696,7 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
     @app.patch(
         "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}",
         tags=["pages"],
+        response_model=UpdatedResponse,
     )
     async def update_page_approval(
         crawl_id: str,
@@ -698,6 +713,7 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}/notes",
         tags=["pages"],
+        response_model=PageNoteAddedResponse,
     )
     async def add_page_note(
         crawl_id: str,
@@ -712,6 +728,7 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
     @app.patch(
         "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}/notes",
         tags=["pages"],
+        response_model=PageNoteUpdatedResponse,
     )
     async def edit_page_note(
         crawl_id: str,
@@ -726,6 +743,7 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
     @app.post(
         "/orgs/{oid}/crawls/{crawl_id}/pages/{page_id}/notes/delete",
         tags=["pages"],
+        response_model=DeletedResponse,
     )
     async def delete_page_notes(
         crawl_id: str,
@@ -739,7 +757,7 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/pages",
         tags=["pages"],
-        response_model=PaginatedResponse,
+        response_model=PaginatedPageOutResponse,
     )
     async def get_pages_list(
         crawl_id: str,
@@ -773,7 +791,7 @@ def init_pages_api(app, mdb, crawl_ops, org_ops, storage_ops, user_dep):
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/qa/{qa_run_id}/pages",
         tags=["pages", "qa"],
-        response_model=PaginatedResponse,
+        response_model=PaginatedPageOutWithQAResponse,
     )
     async def get_pages_list_with_qa(
         crawl_id: str,

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -22,8 +22,15 @@ from .models import (
     ProfileUpdate,
     Organization,
     User,
-    PaginatedResponse,
+    PaginatedProfileResponse,
     StorageRef,
+    EmptyResponse,
+    SuccessResponse,
+    AddedResponseIdQuota,
+    UpdatedResponse,
+    SuccessResponseStorageQuota,
+    ProfilePingResponse,
+    ProfileBrowserGetUrlResponse,
 )
 
 if TYPE_CHECKING:
@@ -469,7 +476,7 @@ def init_profiles_api(
         await browser_get_metadata(browserid, org)
         return browserid
 
-    @router.get("", response_model=PaginatedResponse)
+    @router.get("", response_model=PaginatedProfileResponse)
     async def list_profiles(
         org: Organization = Depends(org_crawl_dep),
         userid: Optional[UUID] = None,
@@ -488,7 +495,7 @@ def init_profiles_api(
         )
         return paginated_format(profiles, total, page, pageSize)
 
-    @router.post("")
+    @router.post("", response_model=AddedResponseIdQuota)
     async def commit_browser_to_new(
         browser_commit: ProfileCreate,
         org: Organization = Depends(org_crawl_dep),
@@ -498,7 +505,7 @@ def init_profiles_api(
 
         return await ops.commit_to_profile(browser_commit, org, user, metadata)
 
-    @router.patch("/{profileid}")
+    @router.patch("/{profileid}", response_model=UpdatedResponse)
     async def commit_browser_to_existing(
         browser_commit: ProfileUpdate,
         profileid: UUID,
@@ -533,7 +540,7 @@ def init_profiles_api(
     ):
         return await ops.get_profile_with_configs(profileid, org)
 
-    @router.delete("/{profileid}")
+    @router.delete("/{profileid}", response_model=SuccessResponseStorageQuota)
     async def delete_profile(
         profileid: UUID,
         org: Organization = Depends(org_crawl_dep),
@@ -548,17 +555,17 @@ def init_profiles_api(
     ):
         return await ops.create_new_browser(org, user, profile_launch)
 
-    @router.post("/browser/{browserid}/ping")
+    @router.post("/browser/{browserid}/ping", response_model=ProfilePingResponse)
     async def ping_profile_browser(browserid: str = Depends(browser_dep)):
         return await ops.ping_profile_browser(browserid)
 
-    @router.post("/browser/{browserid}/navigate")
+    @router.post("/browser/{browserid}/navigate", response_model=SuccessResponse)
     async def navigate_profile_browser(
         urlin: UrlIn, browserid: str = Depends(browser_dep)
     ):
         return await ops.navigate_profile_browser(browserid, urlin)
 
-    @router.get("/browser/{browserid}")
+    @router.get("/browser/{browserid}", response_model=ProfileBrowserGetUrlResponse)
     async def get_profile_browser_url(
         request: Request,
         browserid: str = Depends(browser_dep),
@@ -569,11 +576,11 @@ def init_profiles_api(
         )
 
     # pylint: disable=unused-argument
-    @router.get("/browser/{browserid}/access")
+    @router.get("/browser/{browserid}/access", response_model=EmptyResponse)
     async def access_check(browserid: str = Depends(browser_dep)):
         return {}
 
-    @router.delete("/browser/{browserid}")
+    @router.delete("/browser/{browserid}", response_model=SuccessResponse)
     async def delete_profile_browser(browserid: str = Depends(browser_dep)):
         return await ops.delete_profile_browser(browserid)
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -44,6 +44,9 @@ from .models import (
     S3Storage,
     S3StorageIn,
     OrgStorageRefs,
+    DeletedResponse,
+    UpdatedResponse,
+    AddedResponseName,
 )
 
 from .utils import is_bool, slug_from_name
@@ -763,7 +766,7 @@ def init_storages_api(org_ops, crawl_manager):
         """get storage refs for an org"""
         return OrgStorageRefs(storage=org.storage, storageReplicas=org.storageReplicas)
 
-    @router.get("/allStorages", tags=["organizations"])
+    @router.get("/allStorages", tags=["organizations"], response_model=List[StorageRef])
     def get_available_storages(org: Organization = Depends(org_owner_dep)):
         return storage_ops.get_available_storages(org)
 
@@ -771,19 +774,23 @@ def init_storages_api(org_ops, crawl_manager):
     # todo: enable when ready to support custom storage
     return storage_ops
 
-    @router.post("/customStorage", tags=["organizations"])
+    @router.post(
+        "/customStorage", tags=["organizations"], response_model=AddedResponseName
+    )
     async def add_custom_storage(
         storage: S3StorageIn, org: Organization = Depends(org_owner_dep)
     ):
         return await storage_ops.add_custom_storage(storage, org)
 
-    @router.delete("/customStorage/{name}", tags=["organizations"])
+    @router.delete(
+        "/customStorage/{name}", tags=["organizations"], response_model=DeletedResponse
+    )
     async def remove_custom_storage(
         name: str, org: Organization = Depends(org_owner_dep)
     ):
         return await storage_ops.remove_custom_storage(name, org)
 
-    @router.post("/storage", tags=["organizations"])
+    @router.post("/storage", tags=["organizations"], response_model=UpdatedResponse)
     async def update_storage_refs(
         storage: OrgStorageRefs,
         org: Organization = Depends(org_owner_dep),

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -24,10 +24,14 @@ from .models import (
     Subscription,
     SubscriptionPortalUrlRequest,
     SubscriptionPortalUrlResponse,
+    SubscriptionCanceledResponse,
     Organization,
     InviteToOrgRequest,
+    InviteAddedResponse,
     User,
     UserRole,
+    UpdatedResponse,
+    PaginatedSubscriptionEventResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 
@@ -274,7 +278,11 @@ def init_subs_api(
 
     ops = SubOps(mdb, org_ops, user_manager)
 
-    @app.post("/subscriptions/create", tags=["subscriptions"])
+    @app.post(
+        "/subscriptions/create",
+        tags=["subscriptions"],
+        response_model=InviteAddedResponse,
+    )
     async def new_sub(
         create: SubscriptionCreate,
         request: Request,
@@ -286,6 +294,7 @@ def init_subs_api(
         "/subscriptions/update",
         tags=["subscriptions"],
         dependencies=[Depends(user_or_shared_secret_dep)],
+        response_model=UpdatedResponse,
     )
     async def update_subscription(
         update: SubscriptionUpdate,
@@ -296,6 +305,7 @@ def init_subs_api(
         "/subscriptions/cancel",
         tags=["subscriptions"],
         dependencies=[Depends(user_or_shared_secret_dep)],
+        response_model=SubscriptionCanceledResponse,
     )
     async def cancel_subscription(
         cancel: SubscriptionCancel,
@@ -308,6 +318,7 @@ def init_subs_api(
         "/subscriptions/events",
         tags=["subscriptions"],
         dependencies=[Depends(user_or_shared_secret_dep)],
+        response_model=PaginatedSubscriptionEventResponse,
     )
     async def get_sub_events(
         status: Optional[str] = None,

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -24,9 +24,12 @@ from .models import (
     UploadedCrawl,
     UpdateUpload,
     Organization,
-    PaginatedResponse,
+    PaginatedCrawlOutResponse,
     User,
     StorageRef,
+    UpdatedResponse,
+    DeletedResponseQuota,
+    AddedResponseIdQuota,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .utils import dt_now
@@ -286,7 +289,11 @@ def init_uploads_api(app, user_dep, *args):
     org_viewer_dep = ops.orgs.org_viewer_dep
     org_crawl_dep = ops.orgs.org_crawl_dep
 
-    @app.put("/orgs/{oid}/uploads/formdata", tags=["uploads"])
+    @app.put(
+        "/orgs/{oid}/uploads/formdata",
+        tags=["uploads"],
+        response_model=AddedResponseIdQuota,
+    )
     async def upload_formdata(
         uploads: List[UploadFile] = File(...),
         name: str = "",
@@ -310,7 +317,11 @@ def init_uploads_api(app, user_dep, *args):
             uploads, name, description, colls_list, tags_list, org, user
         )
 
-    @app.put("/orgs/{oid}/uploads/stream", tags=["uploads"])
+    @app.put(
+        "/orgs/{oid}/uploads/stream",
+        tags=["uploads"],
+        response_model=AddedResponseIdQuota,
+    )
     async def upload_stream(
         request: Request,
         filename: str,
@@ -344,7 +355,11 @@ def init_uploads_api(app, user_dep, *args):
             replaceId,
         )
 
-    @app.get("/orgs/{oid}/uploads", tags=["uploads"], response_model=PaginatedResponse)
+    @app.get(
+        "/orgs/{oid}/uploads",
+        tags=["uploads"],
+        response_model=PaginatedCrawlOutResponse,
+    )
     async def list_uploads(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
@@ -407,13 +422,21 @@ def init_uploads_api(app, user_dep, *args):
     async def get_upload_replay(crawl_id, org: Organization = Depends(org_viewer_dep)):
         return await ops.get_crawl_out(crawl_id, org, "upload")
 
-    @app.patch("/orgs/{oid}/uploads/{crawl_id}", tags=["uploads"])
+    @app.patch(
+        "/orgs/{oid}/uploads/{crawl_id}",
+        tags=["uploads"],
+        response_model=UpdatedResponse,
+    )
     async def update_uploads_api(
         update: UpdateUpload, crawl_id: str, org: Organization = Depends(org_crawl_dep)
     ):
         return await ops.update_crawl(crawl_id, org, update, "upload")
 
-    @app.post("/orgs/{oid}/uploads/delete", tags=["uploads"])
+    @app.post(
+        "/orgs/{oid}/uploads/delete",
+        tags=["uploads"],
+        response_model=DeletedResponseQuota,
+    )
     async def delete_uploads(
         delete_list: DeleteCrawlList,
         user: User = Depends(user_dep),

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -21,7 +21,7 @@ from .models import (
     CollectionItemAddedBody,
     CollectionItemRemovedBody,
     CollectionDeletedBody,
-    PaginatedResponse,
+    PaginatedWebhookNotificationResponse,
     Organization,
 )
 
@@ -444,7 +444,7 @@ def init_event_webhooks_api(mdb, org_ops, app):
 
     org_owner_dep = org_ops.org_owner_dep
 
-    @router.get("", response_model=PaginatedResponse)
+    @router.get("", response_model=PaginatedWebhookNotificationResponse)
     async def list_notifications(
         org: Organization = Depends(org_owner_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,


### PR DESCRIPTION
Fixes #1920 

Adds response models to all API endpoints that were missing them, documenting current behavior without making any changes at this stage to standardize responses.

The `response_model` for streaming responses is currently set to `bytes`, there may be a better way to document these - perhaps `Iterator[bytes]` or `AsyncIterator[bytes]` would be better? (edit: maybe nevermind, FastAPI doesn't seem to like this)