### PR TITLE
feat: Show single org status alert banner

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "color": "^4.0.1",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.3.0",
+    "date-fns": "^3.6.0",
     "del-cli": "^4.0.1",
     "diff": "^5.2.0",
     "dotenv": "^10.0.0",

--- a/frontend/src/features/index.ts
+++ b/frontend/src/features/index.ts
@@ -3,4 +3,5 @@ import "./archived-items";
 import "./browser-profiles";
 import "./collections";
 import "./crawl-workflows";
+import "./org";
 import "./qa";

--- a/frontend/src/features/org/index.ts
+++ b/frontend/src/features/org/index.ts
@@ -1,0 +1,1 @@
+import("./org-status-banner");

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -7,6 +7,7 @@ import { TailwindElement } from "@/classes/TailwindElement";
 import { NavigateController } from "@/controllers/navigate";
 import { OrgReadOnlyReason, type OrgData } from "@/types/org";
 import { formatISODateString } from "@/utils/localization";
+import appState, { use } from "@/utils/state";
 
 type Alert = {
   test: () => boolean;
@@ -22,6 +23,9 @@ type Alert = {
 export class OrgStatusBanner extends TailwindElement {
   @property({ type: Object })
   org?: OrgData;
+
+  @use()
+  appState = appState;
 
   @state()
   isAlertOpen = false;
@@ -70,7 +74,7 @@ export class OrgStatusBanner extends TailwindElement {
     const content = this.alert.content();
 
     return html`
-      <strong>${content.title}</strong>
+      <strong class="block font-semibold">${content.title}</strong>
       ${content.detail}
     `;
   }
@@ -165,7 +169,7 @@ export class OrgStatusBanner extends TailwindElement {
                       year: "numeric",
                       hour: "numeric",
                     },
-                  )}. You will no longer be able to run crawls, upload files, create browser profile, or create collections.`,
+                  )}. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.`,
                 )}
               </p>
               <p>
@@ -181,6 +185,7 @@ export class OrgStatusBanner extends TailwindElement {
       {
         test: () =>
           !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
+        persist: true,
         content: () => ({
           title: msg(str`Your org has been deactivated`),
           detail: msg(
@@ -192,6 +197,7 @@ export class OrgStatusBanner extends TailwindElement {
       {
         test: () =>
           !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
+        persist: true,
         content: () => ({
           title: msg(str`This org has been deactivated`),
           detail: msg(
@@ -201,6 +207,7 @@ export class OrgStatusBanner extends TailwindElement {
       },
       {
         test: () => !!readOnly,
+        persist: true,
         content: () => ({
           title: msg(str`This org has been deactivated`),
           detail: msg(`Please contact Browsertrix support to renew your plan.`),
@@ -211,7 +218,7 @@ export class OrgStatusBanner extends TailwindElement {
         content: () => ({
           title: msg(str`Your org has reached its storage limit`),
           detail: msg(
-            `To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact us to upgrade your storage plan.`,
+            str`To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact ${this.appState.settings?.salesEmail || msg("Browsertrix host administrator")} to upgrade your storage plan.`,
           ),
         }),
       },
@@ -222,7 +229,7 @@ export class OrgStatusBanner extends TailwindElement {
             str`Your org has reached its monthly execution minutes limit`,
           ),
           detail: msg(
-            `To purchase additional monthly execution minutes, contact us to upgrade your plan.`,
+            str`Contact ${this.appState.settings?.salesEmail || msg("Browsertrix host administrator")} to purchase additional monthly execution minutes or upgrade your plan.`,
           ),
         }),
       },

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -1,0 +1,231 @@
+import { localized, msg, str } from "@lit/localize";
+import { differenceInDays } from "date-fns/fp";
+import { html, type PropertyValues, type TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import { NavigateController } from "@/controllers/navigate";
+import { OrgReadOnlyReason, type OrgData } from "@/types/org";
+import { formatISODateString } from "@/utils/localization";
+
+type Alert = {
+  test: () => boolean;
+  persist?: boolean;
+  content: () => {
+    title: string | TemplateResult;
+    detail: string | TemplateResult;
+  };
+};
+
+@localized()
+@customElement("btrix-org-status-banner")
+export class OrgStatusBanner extends TailwindElement {
+  @property({ type: Object })
+  org?: OrgData;
+
+  @state()
+  isAlertOpen = false;
+
+  private readonly navigate = new NavigateController(this);
+
+  private alert?: Alert;
+
+  protected willUpdate(_changedProperties: PropertyValues): void {
+    if (_changedProperties.has("org") && this.org) {
+      this.alert = this.alerts.find(({ test }) => test());
+
+      if (this.alert) {
+        this.isAlertOpen = true;
+      }
+    }
+  }
+
+  render() {
+    if (!this.org) return;
+
+    return html`
+      <div
+        class="${this.isAlertOpen
+          ? "bg-slate-100 border-b py-5"
+          : ""} transition-all"
+      >
+        <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
+          <sl-alert
+            variant="danger"
+            ?closable=${!this.alert?.persist}
+            ?open=${this.isAlertOpen}
+            @sl-after-hide=${() => (this.isAlertOpen = false)}
+          >
+            <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+            ${this.renderContent()}
+          </sl-alert>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderContent() {
+    if (!this.alert || !this.org) return;
+
+    const content = this.alert.content();
+
+    return html`
+      <strong>${content.title}</strong>
+      ${content.detail}
+    `;
+  }
+
+  /**
+   * Alerts ordered by priority
+   */
+  private get alerts(): Alert[] {
+    if (!this.org) return [];
+
+    const billingTabLink = html`<a
+      class="underline hover:no-underline"
+      href=${`${this.navigate.orgBasePath}/settings/billing`}
+      @click=${this.navigate.link}
+      >${msg("billing settings")}</a
+    >`;
+
+    const {
+      readOnly,
+      readOnlyReason,
+      readOnlyOnCancel,
+      subscription,
+      storageQuotaReached,
+      execMinutesQuotaReached,
+    } = this.org;
+
+    return [
+      {
+        test: () =>
+          !readOnly && !readOnlyOnCancel && !!subscription?.futureCancelDate,
+        persist: true,
+        content: () => {
+          const daysDiff = differenceInDays(
+            new Date(),
+            new Date(subscription!.futureCancelDate!),
+          );
+          return {
+            title:
+              daysDiff > 1
+                ? msg(
+                    str`Your org will be deleted in
+              ${daysDiff} days`,
+                  )
+                : `Your org will be deleted within one day`,
+            detail: html`
+              <p>
+                ${msg(
+                  str`Your subscription ends on ${formatISODateString(
+                    subscription!.futureCancelDate!,
+                    {
+                      month: "long",
+                      day: "numeric",
+                      year: "numeric",
+                      hour: "numeric",
+                    },
+                  )}. Your user account, org, and all associated data will be deleted.`,
+                )}
+              </p>
+              <p>
+                ${msg(
+                  html`We suggest downloading your archived items before they
+                  are deleted. To keep your plan and data, see
+                  ${billingTabLink}.`,
+                )}
+              </p>
+            `,
+          };
+        },
+      },
+      {
+        test: () =>
+          !readOnly && readOnlyOnCancel && !!subscription?.futureCancelDate,
+        persist: true,
+        content: () => {
+          const daysDiff = differenceInDays(
+            new Date(),
+            new Date(subscription!.futureCancelDate!),
+          );
+          return {
+            title:
+              daysDiff > 1
+                ? msg(str`Your org will be deactivated in ${daysDiff} days`)
+                : msg("Your org will be deactivated within one day"),
+            detail: html`
+              <p>
+                ${msg(
+                  str`Your subscription ends on ${formatISODateString(
+                    subscription!.futureCancelDate!,
+                    {
+                      month: "long",
+                      day: "numeric",
+                      year: "numeric",
+                      hour: "numeric",
+                    },
+                  )}. You will no longer be able to run crawls, upload files, create browser profile, or create collections.`,
+                )}
+              </p>
+              <p>
+                ${msg(
+                  html`To keep your plan and continue crawling, see
+                  ${billingTabLink}.`,
+                )}
+              </p>
+            `,
+          };
+        },
+      },
+      {
+        test: () =>
+          !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
+        content: () => ({
+          title: msg(str`Your org has been deactivated`),
+          detail: msg(
+            html`Your subscription has been paused due to payment failure.
+            Please go to ${billingTabLink} to update your payment method.`,
+          ),
+        }),
+      },
+      {
+        test: () =>
+          !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
+        content: () => ({
+          title: msg(str`This org has been deactivated`),
+          detail: msg(
+            `Your subscription has been canceled. Please contact Browsertrix support to renew your plan.`,
+          ),
+        }),
+      },
+      {
+        test: () => !!readOnly,
+        content: () => ({
+          title: msg(str`This org has been deactivated`),
+          detail: msg(`Please contact Browsertrix support to renew your plan.`),
+        }),
+      },
+      {
+        test: () => !readOnly && !!storageQuotaReached,
+        content: () => ({
+          title: msg(str`Your org has reached its storage limit`),
+          detail: msg(
+            `To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact us to upgrade your storage plan.`,
+          ),
+        }),
+      },
+      {
+        test: () => !readOnly && !!execMinutesQuotaReached,
+        content: () => ({
+          title: msg(
+            str`Your org has reached its monthly execution minutes limit`,
+          ),
+          detail: msg(
+            `To purchase additional monthly execution minutes, contact us to upgrade your plan.`,
+          ),
+        }),
+      },
+    ];
+  }
+}

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -156,8 +156,10 @@ export class OrgStatusBanner extends TailwindElement {
           return {
             title:
               daysDiff > 1
-                ? msg(str`Your org will be deactivated in ${daysDiff} days`)
-                : msg("Your org will be deactivated within one day"),
+                ? msg(
+                    str`Your org will be set to read-only mode in ${daysDiff} days`,
+                  )
+                : msg("Your org will be set to read-only mode within one day"),
             detail: html`
               <p>
                 ${msg(
@@ -187,7 +189,7 @@ export class OrgStatusBanner extends TailwindElement {
           !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
         persist: true,
         content: () => ({
-          title: msg(str`Your org has been deactivated`),
+          title: msg(str`Your org has been set to read-only mode`),
           detail: msg(
             html`Your subscription has been paused due to payment failure.
             Please go to ${billingTabLink} to update your payment method.`,
@@ -196,10 +198,11 @@ export class OrgStatusBanner extends TailwindElement {
       },
       {
         test: () =>
-          !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionCancelled,
+          !!readOnly &&
+          readOnlyReason === OrgReadOnlyReason.SubscriptionCancelled,
         persist: true,
         content: () => ({
-          title: msg(str`This org has been deactivated`),
+          title: msg(str`This org has been set to read-only mode`),
           detail: msg(
             `Your subscription has been canceled. Please contact Browsertrix support to renew your plan.`,
           ),
@@ -209,7 +212,7 @@ export class OrgStatusBanner extends TailwindElement {
         test: () => !!readOnly,
         persist: true,
         content: () => ({
-          title: msg(str`This org has been deactivated`),
+          title: msg(str`This org has been set to read-only mode`),
           detail: msg(`Please contact Browsertrix support to renew your plan.`),
         }),
       },

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -60,7 +60,7 @@ export class OrgStatusBanner extends TailwindElement {
             ?open=${this.isAlertOpen}
             @sl-after-hide=${() => (this.isAlertOpen = false)}
           >
-            <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+            <sl-icon slot="icon" name="exclamation-triangle-fill"></sl-icon>
             ${this.renderContent()}
           </sl-alert>
         </div>

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -196,7 +196,7 @@ export class OrgStatusBanner extends TailwindElement {
       },
       {
         test: () =>
-          !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
+          !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionCancelled,
         persist: true,
         content: () => ({
           title: msg(str`This org has been deactivated`),

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -1,5 +1,5 @@
 import { localized, msg, str } from "@lit/localize";
-import { type TemplateResult } from "lit";
+import { nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
@@ -23,7 +23,13 @@ import { needLogin } from "@/utils/auth";
 import type { AuthState } from "@/utils/AuthService";
 import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
 import LiteElement, { html } from "@/utils/LiteElement";
-import { isAdmin, isCrawler, type OrgData } from "@/utils/orgs";
+import { getLocale } from "@/utils/localization";
+import {
+  isAdmin,
+  isCrawler,
+  OrgReadOnlyReason,
+  type OrgData,
+} from "@/utils/orgs";
 
 import "./workflow-detail";
 import "./workflows-list";
@@ -119,6 +125,9 @@ export class Org extends LiteElement {
   private orgStorageQuotaReached = false;
 
   @state()
+  private showReadOnlyAlert = false;
+
+  @state()
   private showStorageQuotaAlert = false;
 
   @state()
@@ -155,6 +164,16 @@ export class Org extends LiteElement {
     const userOrg = this.userOrg;
     if (userOrg) return isCrawler(userOrg.role);
     return false;
+  }
+
+  get hasAlert() {
+    if (!this.org) return false;
+
+    return (
+      this.showReadOnlyAlert ||
+      this.showStorageQuotaAlert ||
+      this.showExecutionMinutesQuotaAlert
+    );
   }
 
   connectedCallback() {
@@ -240,6 +259,11 @@ export class Org extends LiteElement {
     if (!this.userInfo || !this.orgId) return;
     try {
       this.org = await this.getOrg(this.orgId);
+
+      this.showReadOnlyAlert = Boolean(
+        this.org?.readOnly || this.org?.subscription?.futureCancelDate,
+      );
+
       this.checkStorageQuota();
       this.checkExecutionMinutesQuota();
     } catch {
@@ -325,7 +349,14 @@ export class Org extends LiteElement {
 
     return html`
       <div class="flex min-h-full flex-col">
-        ${this.renderStorageAlert()} ${this.renderExecutionMinutesAlert()}
+        <div
+          class="${this.hasAlert
+            ? "bg-slate-100 border-b py-5"
+            : ""} transition-all"
+        >
+          ${this.renderReadOnlyAlert()} ${this.renderStorageAlert()}
+          ${this.renderExecutionMinutesAlert()}
+        </div>
         ${this.renderOrgNavBar()}
         <main
           class="${noMaxWidth
@@ -340,58 +371,135 @@ export class Org extends LiteElement {
     `;
   }
 
+  private renderReadOnlyAlert() {
+    if (!this.org) return;
+
+    const { readOnly, readOnlyReason, readOnlyOnCancel, subscription } =
+      this.org;
+    const billingTabLink = html`<a
+      class="underline hover:no-underline"
+      href=${`${this.orgBasePath}/settings/billing`}
+      @click=${this.navLink}
+      >${msg("billing settings")}</a
+    >`;
+    let title: string | TemplateResult = "";
+    let detail: string | TemplateResult = "";
+
+    if (readOnly) {
+      title = msg("Your org is read-only");
+
+      switch (readOnlyReason) {
+        case OrgReadOnlyReason.SubscriptionPaused: {
+          detail = msg(html`
+            Your subscription has been paused due to payment failure. Please go
+            to ${billingTabLink} to update your payment method.
+          `);
+          break;
+        }
+        case OrgReadOnlyReason.SubscriptionCancelled: {
+          detail = msg(html`
+            Your subscription has been canceled. Please contact support to renew
+            your plan.
+          `);
+          break;
+        }
+        default:
+          break;
+      }
+    } else if (subscription) {
+      if (subscription.futureCancelDate) {
+        title = msg(
+          html`Your subscription will end on
+            <sl-format-date
+              lang=${getLocale()}
+              class="truncate"
+              date=${subscription.futureCancelDate}
+              month="long"
+              day="numeric"
+              year="numeric"
+            >
+            </sl-format-date>`,
+        );
+        if (readOnlyOnCancel) {
+          detail = msg(
+            html`Your org will become read-only and you will no longer be able
+            to run crawls. To keep your plan, go to ${billingTabLink}.`,
+          );
+        } else {
+          detail = msg(
+            html`Your user account, org, and all associated data will be
+            deleted. To keep your plan, go to ${billingTabLink}.`,
+          );
+        }
+      }
+    }
+
+    if (!title) return;
+
+    return html`
+      <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
+        <sl-alert
+          variant="danger"
+          closable
+          ?open=${this.showReadOnlyAlert}
+          @sl-after-hide=${() => (this.showReadOnlyAlert = false)}
+        >
+          <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+          <strong>${title}</strong><br />
+          ${readOnly
+            ? html`
+                <p class="mb-3">
+                  ${msg(
+                    "Running crawls, uploading files, browser profiles, and collection creation is disabled.",
+                  )}
+                </p>
+              `
+            : nothing}
+          <p>${detail}</p>
+        </sl-alert>
+      </div>
+    `;
+  }
+
   private renderStorageAlert() {
     return html`
-      <div
-        class="${this.showStorageQuotaAlert
-          ? "bg-slate-100 border-b py-5"
-          : ""} transition-all"
-      >
-        <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
-          <sl-alert
-            variant="warning"
-            closable
-            ?open=${this.showStorageQuotaAlert}
-            @sl-after-hide=${() => (this.showStorageQuotaAlert = false)}
-          >
-            <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
-            <strong>${msg("Your org has reached its storage limit")}</strong
-            ><br />
-            ${msg(
-              "To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact us to upgrade your storage plan.",
-            )}
-          </sl-alert>
-        </div>
+      <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
+        <sl-alert
+          variant="warning"
+          closable
+          ?open=${this.showStorageQuotaAlert}
+          @sl-after-hide=${() => (this.showStorageQuotaAlert = false)}
+        >
+          <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+          <strong>${msg("Your org has reached its storage limit")}</strong
+          ><br />
+          ${msg(
+            "To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact us to upgrade your storage plan.",
+          )}
+        </sl-alert>
       </div>
     `;
   }
 
   private renderExecutionMinutesAlert() {
     return html`
-      <div
-        class="${this.showExecutionMinutesQuotaAlert
-          ? "bg-slate-100 border-b py-5"
-          : ""} transition-all"
-      >
-        <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
-          <sl-alert
-            variant="warning"
-            closable
-            ?open=${this.showExecutionMinutesQuotaAlert}
-            @sl-after-hide=${() =>
-              (this.showExecutionMinutesQuotaAlert = false)}
-          >
-            <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
-            <strong
-              >${msg(
-                "Your org has reached its monthly execution minutes limit",
-              )}</strong
-            ><br />
-            ${msg(
-              "To purchase additional monthly execution minutes, contact us to upgrade your plan.",
-            )}
-          </sl-alert>
-        </div>
+      <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
+        <sl-alert
+          variant="warning"
+          closable
+          ?open=${this.showExecutionMinutesQuotaAlert}
+          @sl-after-hide=${() => (this.showExecutionMinutesQuotaAlert = false)}
+        >
+          <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+          <strong
+            >${msg(
+              "Your org has reached its monthly execution minutes limit",
+            )}</strong
+          ><br />
+          ${msg(
+            "To purchase additional monthly execution minutes, contact us to upgrade your plan.",
+          )}
+        </sl-alert>
       </div>
     `;
   }

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -4,6 +4,11 @@ import type { Range } from "./utils";
 // From UserRole in backend
 export type UserRole = "viewer" | "crawler" | "owner" | "superadmin";
 
+export enum OrgReadOnlyReason {
+  SubscriptionPaused = "subscriptionPaused",
+  SubscriptionCancelled = "subscriptionCancelled",
+}
+
 export const AccessCode: Record<UserRole, number> = {
   superadmin: 100,
   viewer: 10,
@@ -50,7 +55,8 @@ export type OrgData = {
     };
   };
   readOnly: boolean | null;
-  readOnlyReason: string | null;
+  readOnlyReason: OrgReadOnlyReason | string | null;
+  readOnlyOnCancel: boolean;
   subscription: null | Subscription;
 };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3501,6 +3501,11 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
 debounce@^1.2.0, debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1876

<!-- Fixes #issue_number -->

### Changes

Displays single banner for critical org alerts.


### Screenshots

Ordered by priority:

1. Active org, cancellation date set, and account will be deleted on that date
<img width="1315" alt="Screenshot 2024-07-16 at 7 38 22 PM" src="https://github.com/user-attachments/assets/a54cc7bd-87b8-463f-8d76-e6dffbb98477">


2. Active org, cancellation date set, and account will become read only on that date
<img width="1315" alt="Screenshot 2024-07-16 at 7 38 54 PM" src="https://github.com/user-attachments/assets/2275f992-ddc4-484b-b981-02b7fbd3bbc5">

3. Read-only org, subscription paused due to payment failure
<img width="1314" alt="Screenshot 2024-07-16 at 7 50 40 PM" src="https://github.com/user-attachments/assets/17d4087a-6376-4e8d-a87a-e7f678c8b1ec">


4. Read-only org, subscription canceled (i.e. `readOnlyOnCancel` was true)
<img width="1306" alt="Screenshot 2024-07-16 at 7 40 53 PM" src="https://github.com/user-attachments/assets/6efe0071-3101-4dc4-a005-64357d9508c0">



5. Read-only org, other reason
<img width="1306" alt="Screenshot 2024-07-16 at 7 41 03 PM" src="https://github.com/user-attachments/assets/402ea6df-8728-45e9-b27d-4c053663e9df">



6. Active org, over storage quota
<img width="1310" alt="Screenshot 2024-07-16 at 7 46 15 PM" src="https://github.com/user-attachments/assets/371c3b92-b187-4d7f-a598-5139fc237cf9">



7. Active org, over execution minutes
<img width="1317" alt="Screenshot 2024-07-16 at 7 47 20 PM" src="https://github.com/user-attachments/assets/f3ab2cf8-8364-4f28-b2ac-e6d4cd035ced">

