### PR TITLE
Fix response model for crawl errors API endpoint

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -41,6 +41,7 @@ from .models import (
     User,
     PaginatedCrawlOutResponse,
     PaginatedSeedResponse,
+    PaginatedCrawlErrorResponse,
     RUNNING_AND_STARTING_STATES,
     SUCCESSFUL_STATES,
     NON_RUNNING_STATES,
@@ -1469,7 +1470,9 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         raise HTTPException(status_code=400, detail="crawl_not_finished")
 
     @app.get(
-        "/orgs/{oid}/crawls/{crawl_id}/errors", tags=["crawls"], response_model=bytes
+        "/orgs/{oid}/crawls/{crawl_id}/errors",
+        tags=["crawls"],
+        response_model=PaginatedCrawlErrorResponse,
     )
     async def get_crawl_errors(
         crawl_id: str,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -929,6 +929,17 @@ class CrawlScaleResponse(BaseModel):
 
 
 # ============================================================================
+class CrawlError(BaseModel):
+    """Crawl error"""
+
+    timestamp: str
+    logLevel: str
+    context: str
+    message: str
+    details: Any
+
+
+# ============================================================================
 
 ### UPLOADED CRAWLS ###
 
@@ -2221,3 +2232,10 @@ class PaginatedWebhookNotificationResponse(PaginatedResponse):
     """Response model for paginated webhook notifications"""
 
     items: List[WebhookNotification]
+
+
+# ============================================================================
+class PaginatedCrawlErrorResponse(PaginatedResponse):
+    """Response model for crawl errors"""
+
+    items: List[CrawlError]


### PR DESCRIPTION
Follow-up fix for #1920 for crawl errors endpoint, which returns a 500 following #1928, caught in nightly tests.

To test, run the following nightly test:

`python -m pytest backend/test_nightly/test_crawl_errors.py`