### PR TITLE
Fix regression with saving new workflow due to profileid type error

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -188,9 +188,13 @@ class CrawlConfigOps:
         if not self.get_channel_crawler_image(config_in.crawlerChannel):
             raise HTTPException(status_code=404, detail="crawler_not_found")
 
+        profile_id = None
+        if isinstance(config_in.profileid, UUID):
+            profile_id = config_in.profileid
+
         # ensure profile is valid, if provided
-        if config_in.profileid:
-            await self.profiles.get_profile(config_in.profileid, org)
+        if profile_id:
+            await self.profiles.get_profile(profile_id, org)
 
         now = dt_now()
         crawlconfig = CrawlConfig(
@@ -212,7 +216,7 @@ class CrawlConfigOps:
             maxCrawlSize=config_in.maxCrawlSize,
             scale=config_in.scale,
             autoAddCollections=config_in.autoAddCollections,
-            profileid=config_in.profileid,
+            profileid=profile_id,
             crawlerChannel=config_in.crawlerChannel,
             crawlFilenameTemplate=config_in.crawlFilenameTemplate,
         )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -314,7 +314,7 @@ class CrawlConfigIn(BaseModel):
 
     jobType: Optional[JobType] = JobType.CUSTOM
 
-    profileid: Optional[UUID] = None
+    profileid: Union[UUID, EmptyStr, None] = None
     crawlerChannel: str = "default"
 
     autoAddCollections: Optional[List[UUID]] = []

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -32,6 +32,7 @@ def test_crawl_config_usernames(
 def test_add_crawl_config(crawler_auth_headers, default_org_id, sample_crawl_data):
     # Create crawl config
     sample_crawl_data["schedule"] = "0 0 * * *"
+    sample_crawl_data["profileid"] = ""
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
         headers=crawler_auth_headers,

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -2452,7 +2452,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       name: this.formState.jobName || "",
       description: this.formState.description,
       scale: this.formState.scale,
-      profileid: this.formState.browserProfile?.id || "",
+      profileid: this.formState.browserProfile?.id || null,
       runNow: this.formState.runNow,
       schedule: this.formState.scheduleType === "cron" ? this.utcSchedule : "",
       crawlTimeout: this.formState.crawlTimeoutMinutes * 60,

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -2452,7 +2452,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       name: this.formState.jobName || "",
       description: this.formState.description,
       scale: this.formState.scale,
-      profileid: this.formState.browserProfile?.id || null,
+      profileid: this.formState.browserProfile?.id || "",
       runNow: this.formState.runNow,
       schedule: this.formState.scheduleType === "cron" ? this.utcSchedule : "",
       crawlTimeout: this.formState.crawlTimeoutMinutes * 60,


### PR DESCRIPTION
Fixes #1945 

## Testing

1. Deploy latest main, verify that you are unable to create workflow with the default browser profile and instead see error `profileid value is not a valid uuid`
2. Deploy this branch, verify workflows without browser profiles can be created and edited without issue