### PR TITLE
Fix queue response models + additional testing for queue + exclusions

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -713,7 +713,7 @@ class BaseCrawlOps:
         delete_list: DeleteCrawlList,
         org: Organization,
         user: Optional[User] = None,
-    ):
+    ) -> dict[str, bool]:
         """Delete uploaded crawls"""
         crawls: list[str] = []
         uploads: list[str] = []

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -262,7 +262,7 @@ class CrawlConfigOps:
 
     async def add_new_crawl(
         self, crawl_id: str, crawlconfig: CrawlConfig, user: User, manual: bool
-    ):
+    ) -> None:
         """increments crawl count for this config and adds new crawl"""
 
         started = dt_now()
@@ -277,7 +277,7 @@ class CrawlConfigOps:
 
         await asyncio.gather(inc, add, info)
 
-    async def inc_crawl_count(self, cid: UUID):
+    async def inc_crawl_count(self, cid: UUID) -> None:
         """inc crawl count for config"""
         await self.crawl_configs.find_one_and_update(
             {"_id": cid, "inactive": {"$ne": True}},
@@ -286,7 +286,7 @@ class CrawlConfigOps:
 
     def check_attr_changed(
         self, crawlconfig: CrawlConfig, update: UpdateCrawlConfig, attr_name: str
-    ):
+    ) -> bool:
         """check if attribute is set and has changed. if not changed, clear it on the update"""
         if getattr(update, attr_name) is not None:
             if getattr(update, attr_name) != getattr(crawlconfig, attr_name):
@@ -296,7 +296,7 @@ class CrawlConfigOps:
 
     async def update_crawl_config(
         self, cid: UUID, org: Organization, user: User, update: UpdateCrawlConfig
-    ) -> dict[str, bool]:
+    ) -> dict[str, bool | str]:
         # pylint: disable=too-many-locals
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
 
@@ -403,7 +403,7 @@ class CrawlConfigOps:
                     status_code=404, detail=f"Crawl Config '{cid}' not found"
                 )
 
-        ret = {
+        ret: dict[str, bool | str] = {
             "updated": True,
             "settings_changed": changed,
             "metadata_changed": metadata_changed,

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -423,7 +423,7 @@ class CrawlOps(BaseCrawlOps):
     ) -> CrawlQueueResponse:
         """get crawl queue"""
 
-        state = await self.get_crawl_state(crawl_id, False)
+        state, _ = await self.get_crawl_state(crawl_id, False)
 
         if state not in RUNNING_AND_STARTING_STATES:
             raise HTTPException(status_code=400, detail="crawl_not_running")
@@ -461,7 +461,7 @@ class CrawlOps(BaseCrawlOps):
         """get list of urls that match regex, starting at offset and at most
         around 'limit'. (limit rounded to next step boundary, so
         limit <= next_offset < limit + step"""
-        state = await self.get_crawl_state(crawl_id, False)
+        state, _ = await self.get_crawl_state(crawl_id, False)
 
         if state not in RUNNING_AND_STARTING_STATES:
             raise HTTPException(status_code=400, detail="crawl_not_running")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -10,11 +10,12 @@ import urllib.parse
 from datetime import datetime
 from uuid import UUID
 
-from typing import Optional, List, Dict, Union, Any, Sequence
+from typing import Optional, List, Dict, Union, Any, Sequence, AsyncIterator
 
 from fastapi import Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from redis import asyncio as exceptions
+from redis.asyncio.client import Redis
 import pymongo
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
@@ -39,6 +40,7 @@ from .models import (
     DeleteQARunList,
     Organization,
     User,
+    Seed,
     PaginatedCrawlOutResponse,
     PaginatedSeedResponse,
     PaginatedCrawlErrorResponse,
@@ -115,7 +117,7 @@ class CrawlOps(BaseCrawlOps):
         return Crawl.from_dict(res)
 
     @contextlib.asynccontextmanager
-    async def get_redis(self, crawl_id):
+    async def get_redis(self, crawl_id: str) -> AsyncIterator[Redis]:
         """get redis url for crawl id"""
         redis_url = self.crawl_manager.get_redis_url(crawl_id)
 
@@ -317,7 +319,7 @@ class CrawlOps(BaseCrawlOps):
         delete_list: DeleteCrawlList,
         type_="crawl",
         user: Optional[User] = None,
-    ):
+    ) -> tuple[int, dict[UUID, dict[str, int]], bool]:
         """Delete a list of crawls by id for given org"""
 
         count, cids_to_update, quota_reached = await super().delete_crawls(
@@ -332,7 +334,7 @@ class CrawlOps(BaseCrawlOps):
             cid_inc = cid_dict["inc"]
             await self.crawl_configs.stats_recompute_last(cid, -cid_size, -cid_inc)
 
-        return {"deleted": True, "storageQuotaReached": quota_reached}
+        return count, cids_to_update, quota_reached
 
     # pylint: disable=too-many-arguments
     async def add_new_crawl(
@@ -343,7 +345,7 @@ class CrawlOps(BaseCrawlOps):
         started: str,
         manual: bool,
         username: str = "",
-    ):
+    ) -> None:
         """initialize new crawl"""
         if not username:
             user = await self.user_manager.get_by_id(userid)
@@ -377,14 +379,13 @@ class CrawlOps(BaseCrawlOps):
 
         try:
             await self.crawls.insert_one(crawl.to_dict())
-            return dt_now
 
         except pymongo.errors.DuplicateKeyError:
-            return None
+            pass
 
     async def update_crawl_scale(
         self, crawl_id: str, org: Organization, crawl_scale: CrawlScale, user: User
-    ):
+    ) -> bool:
         """Update crawl scale in the db"""
         crawl = await self.get_crawl(crawl_id, org)
         update = UpdateCrawlConfig(scale=crawl_scale.scale)
@@ -401,21 +402,23 @@ class CrawlOps(BaseCrawlOps):
 
         return True
 
-    async def _crawl_queue_len(self, redis, key):
+    async def _crawl_queue_len(self, redis, key) -> int:
         try:
             return await redis.zcard(key)
         except exceptions.ResponseError:
             # fallback to old crawler queue
             return await redis.llen(key)
 
-    async def _crawl_queue_range(self, redis, key, offset, count):
+    async def _crawl_queue_range(self, redis: Redis, key: str, offset: int, count: int):
         try:
             return await redis.zrangebyscore(key, 0, "inf", offset, count)
         except exceptions.ResponseError:
             # fallback to old crawler queue
             return reversed(await redis.lrange(key, -offset - count, -offset - 1))
 
-    async def get_crawl_queue(self, crawl_id, offset, count, regex):
+    async def get_crawl_queue(
+        self, crawl_id: str, offset: int, count: int, regex: str
+    ) -> CrawlQueueResponse:
         """get crawl queue"""
 
         total = 0
@@ -436,15 +439,17 @@ class CrawlOps(BaseCrawlOps):
         matched = []
         if regex:
             try:
-                regex = re.compile(regex)
+                regex_re = re.compile(regex)
             except re.error as exc:
                 raise HTTPException(status_code=400, detail="invalid_regex") from exc
 
-            matched = [result for result in results if regex.search(result)]
+            matched = [result for result in results if regex_re.search(result)]
 
-        return {"total": total, "results": results, "matched": matched}
+        return CrawlQueueResponse(total=total, results=results, matched=matched)
 
-    async def match_crawl_queue(self, crawl_id, regex, offset=0):
+    async def match_crawl_queue(
+        self, crawl_id: str, regex: str, offset: int = 0
+    ) -> MatchCrawlQueueResponse:
         """get list of urls that match regex, starting at offset and at most
         around 'limit'. (limit rounded to next step boundary, so
         limit <= next_offset < limit + step"""
@@ -460,7 +465,7 @@ class CrawlOps(BaseCrawlOps):
                 pass
 
             try:
-                regex = re.compile(regex)
+                regex_re = re.compile(regex)
             except re.error as exc:
                 raise HTTPException(status_code=400, detail="invalid_regex") from exc
 
@@ -473,7 +478,7 @@ class CrawlOps(BaseCrawlOps):
                 )
                 for result in results:
                     url = json.loads(result)["url"]
-                    if regex.search(url):
+                    if regex_re.search(url):
                         size += len(url)
                         matched.append(url)
 
@@ -483,9 +488,13 @@ class CrawlOps(BaseCrawlOps):
                     next_offset = count + step
                     break
 
-        return {"total": total, "matched": matched, "nextOffset": next_offset}
+        return MatchCrawlQueueResponse(
+            total=total, matched=matched, nextOffset=next_offset
+        )
 
-    async def add_or_remove_exclusion(self, crawl_id, regex, org, user, add):
+    async def add_or_remove_exclusion(
+        self, crawl_id, regex, org, user, add
+    ) -> dict[str, bool]:
         """add new exclusion to config or remove exclusion from config
         for given crawl_id, update config on crawl"""
 
@@ -524,7 +533,7 @@ class CrawlOps(BaseCrawlOps):
         allowed_from: Sequence[TYPE_ALL_CRAWL_STATES],
         finished: Optional[datetime] = None,
         stats: Optional[CrawlStats] = None,
-    ):
+    ) -> bool:
         """update crawl state and other properties in db if state has changed"""
         prefix = "" if not is_qa else "qa."
 
@@ -538,25 +547,29 @@ class CrawlOps(BaseCrawlOps):
         if allowed_from:
             query[f"{prefix}state"] = {"$in": allowed_from}
 
-        return await self.crawls.find_one_and_update(query, {"$set": update})
+        res = await self.crawls.find_one_and_update(query, {"$set": update})
+        return res is not None
 
     async def update_running_crawl_stats(
         self, crawl_id: str, is_qa: bool, stats: CrawlStats
-    ):
+    ) -> bool:
         """update running crawl stats"""
         prefix = "" if not is_qa else "qa."
         query = {"_id": crawl_id, "type": "crawl", f"{prefix}state": "running"}
-        return await self.crawls.find_one_and_update(
-            query, {"$set": {f"{prefix}stats": stats.dict()}}
+        return (
+            await self.crawls.find_one_and_update(
+                query, {"$set": {f"{prefix}stats": stats.dict()}}
+            )
+            is not None
         )
 
     async def inc_crawl_exec_time(
         self,
         crawl_id: str,
         is_qa: bool,
-        exec_time,
-        last_updated_time,
-    ):
+        exec_time: int,
+        last_updated_time: str,
+    ) -> bool:
         """increment exec time"""
         # update both crawl-shared qa exec seconds and per-qa run exec seconds
         if is_qa:
@@ -567,26 +580,33 @@ class CrawlOps(BaseCrawlOps):
         else:
             inc_update = {"crawlExecSeconds": exec_time}
 
-        return await self.crawls.find_one_and_update(
-            {
-                "_id": crawl_id,
-                "type": "crawl",
-                "_lut": {"$ne": last_updated_time},
-            },
-            {
-                "$inc": inc_update,
-                "$set": {"_lut": last_updated_time},
-            },
+        return (
+            await self.crawls.find_one_and_update(
+                {
+                    "_id": crawl_id,
+                    "type": "crawl",
+                    "_lut": {"$ne": last_updated_time},
+                },
+                {
+                    "$inc": inc_update,
+                    "$set": {"_lut": last_updated_time},
+                },
+            )
+            is not None
         )
 
-    async def get_crawl_exec_last_update_time(self, crawl_id):
+    async def get_crawl_exec_last_update_time(
+        self, crawl_id: str
+    ) -> Optional[datetime]:
         """get crawl last updated time"""
         res = await self.crawls.find_one(
             {"_id": crawl_id, "type": "crawl"}, projection=["_lut"]
         )
         return res and res.get("_lut")
 
-    async def get_crawl_state(self, crawl_id: str, is_qa: bool):
+    async def get_crawl_state(
+        self, crawl_id: str, is_qa: bool
+    ) -> tuple[Optional[TYPE_ALL_CRAWL_STATES], Optional[datetime]]:
         """return current crawl state of a crawl"""
         prefix = "" if not is_qa else "qa."
 
@@ -603,27 +623,29 @@ class CrawlOps(BaseCrawlOps):
         crawl_id: str,
         is_qa: bool,
         error: str,
-    ):
+    ) -> bool:
         """add crawl error from redis to mongodb errors field"""
         prefix = "" if not is_qa else "qa."
 
-        await self.crawls.find_one_and_update(
+        res = await self.crawls.find_one_and_update(
             {"_id": crawl_id}, {"$push": {f"{prefix}errors": error}}
         )
+        return res is not None
 
     async def add_crawl_file(
         self, crawl_id: str, is_qa: bool, crawl_file: CrawlFile, size: int
-    ):
+    ) -> bool:
         """add new crawl file to crawl"""
         prefix = "" if not is_qa else "qa."
 
-        await self.crawls.find_one_and_update(
+        res = await self.crawls.find_one_and_update(
             {"_id": crawl_id},
             {
                 "$push": {f"{prefix}files": crawl_file.dict()},
                 "$inc": {f"{prefix}fileCount": 1, f"{prefix}fileSize": size},
             },
         )
+        return res is not None
 
     async def get_crawl_seeds(
         self,
@@ -631,7 +653,7 @@ class CrawlOps(BaseCrawlOps):
         org: Organization,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-    ):
+    ) -> tuple[list[Seed], int]:
         """Get paginated list of seeds from crawl"""
         skip = (page - 1) * page_size
         upper_bound = skip + page_size
@@ -744,7 +766,9 @@ class CrawlOps(BaseCrawlOps):
         # return whatever detail may be included in the response
         raise HTTPException(status_code=400, detail=result)
 
-    async def start_crawl_qa_run(self, crawl_id: str, org: Organization, user: User):
+    async def start_crawl_qa_run(
+        self, crawl_id: str, org: Organization, user: User
+    ) -> str:
         """Start crawl QA run"""
 
         crawl = await self.get_crawl(crawl_id, org)
@@ -820,7 +844,7 @@ class CrawlOps(BaseCrawlOps):
 
     async def stop_crawl_qa_run(
         self, crawl_id: str, org: Organization, graceful: bool = True
-    ):
+    ) -> dict[str, bool]:
         """Stop crawl QA run, QA run removed when actually finished"""
         crawl = await self.get_crawl(crawl_id, org)
 
@@ -847,7 +871,7 @@ class CrawlOps(BaseCrawlOps):
 
     async def delete_crawl_qa_runs(
         self, crawl_id: str, delete_list: DeleteQARunList, org: Organization
-    ):
+    ) -> dict[str, int]:
         """delete specified finished QA run"""
         count = 0
         for qa_run_id in delete_list.qa_run_ids:
@@ -866,7 +890,7 @@ class CrawlOps(BaseCrawlOps):
 
     async def delete_crawl_qa_run_files(
         self, crawl_id: str, qa_run_id: str, org: Organization
-    ):
+    ) -> None:
         """delete crawl qa wacz files"""
         qa_run = await self.get_qa_run(crawl_id, qa_run_id, org)
         for file_ in qa_run.files:
@@ -877,7 +901,7 @@ class CrawlOps(BaseCrawlOps):
             #     org, file_, qa_run_id, "qa"
             # )
 
-    async def qa_run_finished(self, crawl_id: str):
+    async def qa_run_finished(self, crawl_id: str) -> bool:
         """clear active qa, add qa run to finished list, if successful"""
         crawl = await self.get_crawl(crawl_id)
 
@@ -988,7 +1012,7 @@ class CrawlOps(BaseCrawlOps):
 
 
 # ============================================================================
-async def recompute_crawl_file_count_and_size(crawls, crawl_id):
+async def recompute_crawl_file_count_and_size(crawls, crawl_id: str):
     """Fully recompute file count and size for given crawl"""
     file_count = 0
     size = 0
@@ -1143,7 +1167,12 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         user: User = Depends(user_dep),
         org: Organization = Depends(org_crawl_dep),
     ):
-        return await ops.delete_crawls(org, delete_list, "crawl", user)
+        count, _, quota_reached = await ops.delete_crawls(
+            org, delete_list, "crawl", user
+        )
+        return DeletedResponseQuota(
+            deleted=count > 1, storageQuotaReached=quota_reached
+        )
 
     @app.get("/orgs/all/crawls/stats", tags=["crawls"], response_model=bytes)
     async def get_all_orgs_crawl_stats(
@@ -1376,7 +1405,7 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         crawl_id,
         offset: int,
         count: int,
-        regex: Optional[str] = "",
+        regex: str = "",
         org: Organization = Depends(org_crawl_dep),
     ):
         await ops.get_crawl_raw(crawl_id, org)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2110,6 +2110,13 @@ class DeletedCountResponse(BaseModel):
 
 
 # ============================================================================
+class DeletedCountResponseQuota(DeletedCountResponse):
+    """Response for delete API endpoints"""
+
+    storageQuotaReached: bool
+
+
+# ============================================================================
 class RemovedResponse(BaseModel):
     """Response for API endpoints for removing resources"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -794,24 +794,12 @@ class CrawlSearchValuesResponse(BaseModel):
 
 
 # ============================================================================
-class CrawlQueueUrl(BaseModel):
-    """Model for item in crawl queue"""
-
-    seedId: int
-    url: AnyHttpUrl
-    depth: int
-    extraHops: int
-    ts: int
-    pageid: Optional[str]
-
-
-# ============================================================================
 class CrawlQueueResponse(BaseModel):
     """Response model for GET crawl queue"""
 
     total: int
-    results: List[CrawlQueueUrl]
-    matched: List[CrawlQueueUrl]
+    results: List[AnyHttpUrl]
+    matched: List[AnyHttpUrl]
 
 
 # ============================================================================
@@ -819,7 +807,7 @@ class MatchCrawlQueueResponse(BaseModel):
     """Response model for match crawl queue"""
 
     total: int
-    matched: List[CrawlQueueUrl]
+    matched: List[AnyHttpUrl]
     nextOffset: int
 
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -907,7 +907,9 @@ class CrawlOperator(BaseOperator):
 
         return crawler_running, redis_running, pod_done_count
 
-    def handle_terminated_pod(self, name, role, status: CrawlStatus, terminated):
+    def handle_terminated_pod(
+        self, name, role, status: CrawlStatus, terminated: Optional[dict[str, Any]]
+    ) -> None:
         """handle terminated pod state"""
         if not terminated:
             return
@@ -1001,7 +1003,7 @@ class CrawlOperator(BaseOperator):
                 pod_state = "running"
                 state = cstate["running"]
                 start_time = from_k8s_date(state.get("startedAt"))
-                if update_start_time and update_start_time > start_time:
+                if update_start_time and start_time and update_start_time > start_time:
                     start_time = update_start_time
 
                 end_time = now
@@ -1010,11 +1012,11 @@ class CrawlOperator(BaseOperator):
                 state = cstate["terminated"]
                 start_time = from_k8s_date(state.get("startedAt"))
                 end_time = from_k8s_date(state.get("finishedAt"))
-                if update_start_time and update_start_time > start_time:
+                if update_start_time and start_time and update_start_time > start_time:
                     start_time = update_start_time
 
                 # already counted
-                if update_start_time and end_time < update_start_time:
+                if update_start_time and end_time and end_time < update_start_time:
                     print(
                         f"  - {name}: {pod_state}: skipping already counted, "
                         + f"{end_time} < {start_time}"

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -741,7 +741,7 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 2
+    assert len(data["names"]) == 3
     expected_names = [
         "Crawler User Test Crawl",
         "All Crawls Test Crawl",

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -489,7 +489,7 @@ def test_get_all_crawls_by_first_seed(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 3
+    assert data["total"] == 4
     for item in data["items"]:
         assert item["firstSeed"] == first_seed
 
@@ -504,7 +504,7 @@ def test_get_all_crawls_by_type(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 3
+    assert data["total"] == 4
     for item in data["items"]:
         assert item["type"] == "crawl"
 
@@ -608,9 +608,9 @@ def test_sort_all_crawls(
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 7
+    assert data["total"] == 8
     items = data["items"]
-    assert len(items) == 7
+    assert len(items) == 8
 
     last_created = None
     for crawl in items:
@@ -720,7 +720,7 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 5
+    assert len(data["names"]) == 6
     expected_names = [
         "Crawler User Test Crawl",
         "My Upload Updated",


### PR DESCRIPTION
Follow-up to regressions from #1928, this PR:
- Fixes response models for queue endpoints, which had incorrect model
- Adds tests for queue get, queue match, and exclusions add / remove to ensure regressions like this can be caught via tests. This involves starting a new crawl in test_run_crawls() instead of relying on implicit running via fixtures, make it easier to test crawl while it's running.
- Adds additional typing for crawls apis, including making delete_crawls() have correct typing, consistent derived class override
- Adds check to ensure queue + exclusion operations can not be called when crawl is not running