### PR TITLE
feat: Improve UX when user doesn't belong to any orgs

### DIFF
--- a/frontend/src/features/accounts/account-settings.ts
+++ b/frontend/src/features/accounts/account-settings.ts
@@ -134,17 +134,14 @@ export class AccountSettings extends LiteElement {
     if (!this.userInfo) return;
     return html`
       <div class="mx-auto max-w-screen-sm">
-        <h1 class="mb-7 border-b pb-3 text-xl font-semibold leading-8">
+        <h1 class="mb-7 text-xl font-semibold leading-8">
           ${msg("Account Settings")}
         </h1>
-        <h2 class="mb-3 text-lg font-semibold leading-none">
-          ${msg("Profile")}
-        </h2>
-        <form class="mb-7 rounded border" @submit=${this.onSubmitName}>
+        <form class="mb-5 rounded border" @submit=${this.onSubmitName}>
           <div class="p-4">
-            <h3 class="mb-3 text-base font-medium leading-none">
+            <h2 class="mb-4 text-lg font-semibold leading-none">
               ${msg("Display Name")}
-            </h3>
+            </h2>
             <p class="mb-2">
               ${msg(
                 "Enter your full name, or another name to display in the orgs you belong to.",
@@ -169,14 +166,11 @@ export class AccountSettings extends LiteElement {
             >
           </footer>
         </form>
-        <h2 class="mb-3 text-lg font-semibold leading-none">
-          ${msg("Account")}
-        </h2>
         <form class="mb-5 rounded border" @submit=${this.onSubmitEmail}>
           <div class="p-4">
-            <h3 class="mb-3 text-base font-medium leading-none">
+            <h2 class="mb-4 text-lg font-semibold leading-none">
               ${msg("Email")}
-            </h3>
+            </h2>
             <p class="mb-2">${msg("Update the email you use to log in.")}</p>
             <sl-input
               name="email"
@@ -222,15 +216,15 @@ export class AccountSettings extends LiteElement {
             >
           </footer>
         </form>
-        <section class="mb-7 rounded border">
+        <section class="mb-5 rounded border">
           ${when(
             this.isChangingPassword,
             () => html`
               <form @submit=${this.onSubmitPassword}>
                 <div class="p-4">
-                  <h3 class="mb-3 text-base font-medium leading-none">
+                  <h2 class="mb-4 text-lg font-semibold leading-none">
                     ${msg("Password")}
-                  </h3>
+                  </h2>
                   <sl-input
                     class="mb-3"
                     name="password"
@@ -285,10 +279,10 @@ export class AccountSettings extends LiteElement {
               </form>
             `,
             () => html`
-              <div class="flex items-center justify-between px-4 py-3">
-                <h3 class="text-base font-medium leading-none">
+              <div class="flex items-center justify-between px-4 py-2.5">
+                <h2 class="text-lg font-semibold leading-none">
                   ${msg("Password")}
-                </h3>
+                </h2>
                 <sl-button
                   size="small"
                   @click=${() => (this.isChangingPassword = true)}

--- a/frontend/src/features/accounts/account-settings.ts
+++ b/frontend/src/features/accounts/account-settings.ts
@@ -134,14 +134,17 @@ export class AccountSettings extends LiteElement {
     if (!this.userInfo) return;
     return html`
       <div class="mx-auto max-w-screen-sm">
-        <h1 class="mb-7 text-xl font-semibold leading-8">
+        <h1 class="mb-7 border-b pb-3 text-xl font-semibold leading-8">
           ${msg("Account Settings")}
         </h1>
-        <form class="mb-5 rounded border" @submit=${this.onSubmitName}>
+        <h2 class="mb-3 text-lg font-semibold leading-none">
+          ${msg("Profile")}
+        </h2>
+        <form class="mb-7 rounded border" @submit=${this.onSubmitName}>
           <div class="p-4">
-            <h2 class="mb-4 text-lg font-semibold leading-none">
+            <h3 class="mb-3 text-base font-medium leading-none">
               ${msg("Display Name")}
-            </h2>
+            </h3>
             <p class="mb-2">
               ${msg(
                 "Enter your full name, or another name to display in the orgs you belong to.",
@@ -166,11 +169,14 @@ export class AccountSettings extends LiteElement {
             >
           </footer>
         </form>
+        <h2 class="mb-3 text-lg font-semibold leading-none">
+          ${msg("Account")}
+        </h2>
         <form class="mb-5 rounded border" @submit=${this.onSubmitEmail}>
           <div class="p-4">
-            <h2 class="mb-4 text-lg font-semibold leading-none">
+            <h3 class="mb-3 text-base font-medium leading-none">
               ${msg("Email")}
-            </h2>
+            </h3>
             <p class="mb-2">${msg("Update the email you use to log in.")}</p>
             <sl-input
               name="email"
@@ -216,15 +222,15 @@ export class AccountSettings extends LiteElement {
             >
           </footer>
         </form>
-        <section class="mb-5 rounded border">
+        <section class="mb-7 rounded border">
           ${when(
             this.isChangingPassword,
             () => html`
               <form @submit=${this.onSubmitPassword}>
                 <div class="p-4">
-                  <h2 class="mb-4 text-lg font-semibold leading-none">
+                  <h3 class="mb-3 text-base font-medium leading-none">
                     ${msg("Password")}
-                  </h2>
+                  </h3>
                   <sl-input
                     class="mb-3"
                     name="password"
@@ -258,6 +264,15 @@ export class AccountSettings extends LiteElement {
                     )}
                   </p>
                   <sl-button
+                    type="reset"
+                    size="small"
+                    variant="text"
+                    class="mx-2"
+                    @click=${() => (this.isChangingPassword = false)}
+                  >
+                    ${msg("Cancel")}
+                  </sl-button>
+                  <sl-button
                     type="submit"
                     size="small"
                     variant="primary"
@@ -271,9 +286,9 @@ export class AccountSettings extends LiteElement {
             `,
             () => html`
               <div class="flex items-center justify-between px-4 py-3">
-                <h2 class="text-lg font-semibold leading-none">
+                <h3 class="text-base font-medium leading-none">
                   ${msg("Password")}
-                </h2>
+                </h3>
                 <sl-button
                   size="small"
                   @click=${() => (this.isChangingPassword = true)}

--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -103,7 +103,7 @@ describe("browsertrix-app", () => {
       email: "test-user@example.com",
       name: "Test User",
       isVerified: false,
-      isAdmin: false,
+      isSuperAdmin: false,
       orgs: [
         {
           id: "test_org_id",

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -261,7 +261,7 @@ export class App extends LiteElement {
           <sl-alert variant="warning" open>
             <sl-icon slot="icon" name="exclamation-triangle-fill"></sl-icon>
             <strong class="block font-semibold">
-              ${msg("Your account isn't quite set up, yet")}
+              ${msg("Your account isn't quite set up yet")}
             </strong>
             ${msg(
               "You must belong to at least one org in order to access Browsertrix features.",

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,4 +1,4 @@
-import { localized, msg } from "@lit/localize";
+import { localized, msg, str } from "@lit/localize";
 import type { SlDialog } from "@shoelace-style/shoelace";
 import { nothing, render, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -233,7 +233,7 @@ export class App extends LiteElement {
   render() {
     return html`
       <div class="min-w-screen flex min-h-screen flex-col">
-        ${this.renderNavBar()}
+        ${this.renderNavBar()} ${this.renderAlertBanner()}
         <main class="relative flex flex-auto">${this.renderPage()}</main>
         <div class="border-t border-neutral-100">${this.renderFooter()}</div>
       </div>
@@ -245,6 +245,37 @@ export class App extends LiteElement {
         @sl-after-hide=${() => (this.globalDialogContent = {})}
         >${this.globalDialogContent.body}</sl-dialog
       >
+    `;
+  }
+
+  private renderAlertBanner() {
+    if (this.appState.userInfo?.orgs && !this.appState.userInfo.orgs.length) {
+      return this.renderNoOrgsBanner();
+    }
+  }
+
+  private renderNoOrgsBanner() {
+    return html`
+      <div class="border-b bg-slate-100 py-5">
+        <div class="mx-auto box-border w-full max-w-screen-desktop px-3">
+          <sl-alert variant="warning" open>
+            <sl-icon slot="icon" name="exclamation-triangle-fill"></sl-icon>
+            <strong class="block font-semibold">
+              ${msg("Your account isn't quite set up, yet")}
+            </strong>
+            ${msg(
+              "You must belong to at least one org in order to access Browsertrix features.",
+            )}
+            ${this.appState.settings?.salesEmail
+              ? msg(
+                  str`If you haven't received an invitation to an org, please contact us at ${this.appState.settings.salesEmail}.`,
+                )
+              : msg(
+                  str`If you haven't received an invitation to an org, please contact your Browsertrix administrator.`,
+                )}
+          </sl-alert>
+        </div>
+      </div>
     `;
   }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -150,7 +150,7 @@ export class App extends LiteElement {
 
       if (
         orgs.length &&
-        !this.appState.userInfo!.isAdmin &&
+        !this.appState.userInfo!.isSuperAdmin &&
         !this.appState.orgSlug
       ) {
         const firstOrg = orgs[0].slug;
@@ -249,9 +249,9 @@ export class App extends LiteElement {
   }
 
   private renderNavBar() {
-    const isAdmin = this.appState.userInfo?.isAdmin;
+    const isSuperAdmin = this.appState.userInfo?.isSuperAdmin;
     let homeHref = "/";
-    if (!isAdmin && this.appState.orgSlug) {
+    if (!isSuperAdmin && this.appState.orgSlug) {
       homeHref = `/orgs/${this.appState.orgSlug}`;
     }
 
@@ -264,7 +264,7 @@ export class App extends LiteElement {
             aria-label="home"
             href=${homeHref}
             @click=${(e: MouseEvent) => {
-              if (isAdmin) {
+              if (isSuperAdmin) {
                 this.clearSelectedOrg();
               }
               this.navLink(e);
@@ -272,7 +272,7 @@ export class App extends LiteElement {
           >
             <img class="h-6" alt="Browsertrix logo" src=${brandLockupColor} />
           </a>
-          ${isAdmin
+          ${isSuperAdmin
             ? html`
                 <div
                   class="grid grid-flow-col items-center gap-3 text-xs md:gap-5 md:text-sm"
@@ -317,7 +317,7 @@ export class App extends LiteElement {
                         <sl-icon slot="prefix" name="gear"></sl-icon>
                         ${msg("Account Settings")}
                       </sl-menu-item>
-                      ${this.appState.userInfo?.isAdmin
+                      ${this.appState.userInfo?.isSuperAdmin
                         ? html` <sl-menu-item
                             @click=${() => this.navigate(ROUTES.usersInvite)}
                           >
@@ -390,7 +390,7 @@ export class App extends LiteElement {
           }}
         >
           ${when(
-            this.appState.userInfo.isAdmin,
+            this.appState.userInfo.isSuperAdmin,
             () => html`
               <sl-menu-item
                 type="checkbox"
@@ -418,7 +418,7 @@ export class App extends LiteElement {
 
   private renderMenuUserInfo() {
     if (!this.appState.userInfo) return;
-    if (this.appState.userInfo.isAdmin) {
+    if (this.appState.userInfo.isSuperAdmin) {
       return html`
         <div class="mb-2">
           <sl-tag class="uppercase" variant="primary" size="small"
@@ -617,7 +617,7 @@ export class App extends LiteElement {
 
       case "usersInvite": {
         if (this.appState.userInfo) {
-          if (this.appState.userInfo.isAdmin) {
+          if (this.appState.userInfo.isSuperAdmin) {
             return html`<btrix-users-invite
               class="mx-auto box-border w-full max-w-screen-desktop p-2 md:py-8"
               .authState="${this.authService.authState}"
@@ -634,7 +634,7 @@ export class App extends LiteElement {
       case "crawls":
       case "crawl": {
         if (this.appState.userInfo) {
-          if (this.appState.userInfo.isAdmin) {
+          if (this.appState.userInfo.isSuperAdmin) {
             return html`<btrix-crawls
               class="w-full"
               @notify=${this.onNotify}

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -60,8 +60,12 @@ export class Home extends LiteElement {
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("slug") && this.slug) {
       this.navTo(`/orgs/${this.slug}`);
-    } else if (changedProperties.has("authState") && this.authState) {
-      void this.fetchOrgs();
+    } else if (changedProperties.has("userInfo") && this.userInfo) {
+      if (this.userInfo.isSuperAdmin) {
+        void this.fetchOrgs();
+      } else {
+        this.navTo(`/account/settings`);
+      }
     }
   }
 

--- a/frontend/src/pages/home.ts
+++ b/frontend/src/pages/home.ts
@@ -71,7 +71,7 @@ export class Home extends LiteElement {
     const orgListUpdated = changedProperties.has("orgList") && this.orgList;
     const userInfoUpdated = changedProperties.has("userInfo") && this.userInfo;
     if (orgListUpdated || userInfoUpdated) {
-      if (this.userInfo?.isAdmin && this.orgList && !this.orgList.length) {
+      if (this.userInfo?.isSuperAdmin && this.orgList && !this.orgList.length) {
         this.isAddingOrg = true;
       }
     }
@@ -89,7 +89,7 @@ export class Home extends LiteElement {
     let title: string | undefined;
     let content: TemplateResult<1> | undefined;
 
-    if (this.userInfo.isAdmin) {
+    if (this.userInfo.isSuperAdmin) {
       title = msg("Welcome");
       content = this.renderAdminOrgs();
     } else {

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -197,16 +197,7 @@ export class Org extends LiteElement {
         if (org) {
           this.navTo(`/orgs/${org.slug}`);
         } else {
-          // Handle edge case where user does not belong
-          // to any orgs but is attempting to log in
-          // TODO check if hosted instance and show support email if so
-          this.notify({
-            message: msg(
-              "You must belong to at least one org in order to log in. Please contact your Browsertrix admin to resolve the issue.",
-            ),
-            variant: "danger",
-            icon: "exclamation-octagon",
-          });
+          this.navTo(`/account/settings`);
         }
 
         return;

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -376,7 +376,7 @@ export class Org extends LiteElement {
               path: "browser-profiles",
             }),
           )}
-          ${when(this.isAdmin || this.userInfo?.isAdmin, () =>
+          ${when(this.isAdmin || this.userInfo?.isSuperAdmin, () =>
             this.renderNavTab({
               tabName: "settings",
               label: msg("Org Settings"),

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -30,6 +30,6 @@ export type CurrentUser = {
   email: string;
   name: string;
   isVerified: boolean;
-  isAdmin: boolean;
+  isSuperAdmin: boolean;
   orgs: UserOrg[];
 };

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -54,7 +54,9 @@ export function maxLengthValidator(maxLength: number): MaxLengthValidator {
 
     el.setCustomValidity(
       isInvalid
-        ? msg(str`Please shorten this text to ${maxLength} or fewer characters.`)
+        ? msg(
+            str`Please shorten this text to ${maxLength} or fewer characters.`,
+          )
         : "",
     );
 

--- a/frontend/src/utils/user.ts
+++ b/frontend/src/utils/user.ts
@@ -7,7 +7,7 @@ export function formatAPIUser(userData: APIUser): CurrentUser {
     email: userData.email,
     name: userData.name,
     isVerified: userData.is_verified,
-    isAdmin: userData.is_superuser,
+    isSuperAdmin: userData.is_superuser,
     orgs: userData.orgs,
   };
 }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1911

<!-- Fixes #issue_number -->

### Changes

Directs user that doesn't belong to any orgs to account settings page, with banner.

Also contains some minor out-of-scope changes:
- Refactors `isAdmin` key to `isSuperAdmin` for more legibility on whether current user is superadmin or regular user without orgs
- Adds "cancel" button to change password form

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Account Settings  | <img width="1512" alt="Screenshot 2024-07-22 at 1 33 51 PM" src="https://github.com/user-attachments/assets/1944fd8b-17d7-47e1-b5eb-090584266474"> |

<!-- ### Follow-ups -->
