### PR TITLE
disable behaviors for QA runs via configmap

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -65,8 +65,6 @@ data:
   LOG_SENT_EMAILS: "{{ .Values.email.log_sent_emails }}"
 
 ---
-{{- define "crawler_args" }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }} {{- end }}
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -74,10 +72,12 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  CRAWL_ARGS: {{- include "crawler_args" . }}
+  {{- define "btrix.crawler_args" }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }} {{- end }}
+
+  CRAWL_ARGS: {{- include "btrix.crawler_args" . }}
 
   # disable behaviors for QA runs, otherwise use same args
-  QA_ARGS: {{- include "crawler_args" . }} --behaviors=""
+  QA_ARGS: {{- include "btrix.crawler_args" . }} --behaviors=""
 
 ---
 apiVersion: v1

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -65,6 +65,8 @@ data:
   LOG_SENT_EMAILS: "{{ .Values.email.log_sent_emails }}"
 
 ---
+{{- define "crawler_args" }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }} {{- end }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -72,8 +74,10 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  CRAWL_ARGS: >-
-    --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }}
+  CRAWL_ARGS: {{- include "crawler_args" . }}
+
+  # disable behaviors for QA runs, otherwise use same args
+  QA_ARGS: {{- include "crawler_args" . }} --behaviors=""
 
 ---
 apiVersion: v1


### PR DESCRIPTION
- make crawl args a reusable template
- adds QA_ARGS to configmap, setting to same value as CRAWL_ARGS but with --behaviors= prepended to disable behaviors for QA, to improve performance of QA runs.

fixes #1962 

Testing:
- Start QA run, verify by looking at logs that behaviors are not being run.