### PR TITLE
allow disabling of auto-resize of crawler pods

### DIFF
--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 from typing import TYPE_CHECKING, Any
-from kubernetes.utils import parse_quantity
+from kubernetes.utils import parse_quantity, is_bool
 
 import yaml
 from btrixcloud.k8sapi import K8sAPI
@@ -30,6 +30,7 @@ class K8sOpAPI(K8sAPI):
     """Additional k8s api for operators"""
 
     has_pod_metrics: bool
+    enable_auto_resize: bool
     max_crawler_memory_size: int
 
     def __init__(self):
@@ -39,6 +40,7 @@ class K8sOpAPI(K8sAPI):
             self.shared_params = yaml.safe_load(fh_config)
 
         self.has_pod_metrics = False
+        self.enable_auto_resize = False
         self.max_crawler_memory_size = 0
 
         self.compute_crawler_resources()
@@ -126,6 +128,11 @@ class K8sOpAPI(K8sAPI):
         """perform any async init here"""
         self.has_pod_metrics = await self.is_pod_metrics_available()
         print("Pod Metrics Available:", self.has_pod_metrics)
+
+        self.enable_auto_resize = self.has_pod_metrics and is_bool(
+            os.environ.get("ENABLE_AUTO_RESIZE_CRAWLERS")
+        )
+        print("Auto-Resize Enabled", self.enable_auto_resize)
 
 
 # pylint: disable=too-many-instance-attributes, too-many-arguments

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -3,10 +3,11 @@
 import asyncio
 import os
 from typing import TYPE_CHECKING, Any
-from kubernetes.utils import parse_quantity, is_bool
+from kubernetes.utils import parse_quantity
 
 import yaml
 from btrixcloud.k8sapi import K8sAPI
+from btrixcloud.utils import is_bool
 
 
 if TYPE_CHECKING:

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -58,6 +58,8 @@ data:
 
   MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"
 
+  ENABLE_AUTO_RESIZE_CRAWLERS: "{{ .Values.enable_auto_resize_crawlers }}"
+
   BILLING_ENABLED: "{{ .Values.billing_enabled }}"
 
   SALES_EMAIL: "{{ .Values.sales_email }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -262,6 +262,12 @@ crawler_extra_memory_per_browser: 768Mi
 # crawler_memory = crawler_memory_base + crawler_memory_per_extra_browser * (crawler_browser_instances - 1)
 # crawler_memory:
 
+# Crawler Autoscaling
+# ---------------------
+
+# if set to true, automatically adjust crawler memory usage up to max_crawler_memory
+enable_auto_resize_crawlers: false
+
 
 # max crawler memory, if set, will enable auto-resizing of crawler pods up to this size
 # if not set, no auto-resizing is done, and crawls always use 'crawler_memory' memory


### PR DESCRIPTION
- only enable if 'enable_auto_resize' is true, default to false
- if true, set memory limit to 1.2 of memory requests, resize when hitting 'soft oom' of initial request, adjust by 1.2 (current behavior) up to max_crawler_memory
- if false, set memory limit to max_crawler_memory and never adjust memory requests or memory limits
- part of #1959 