### PR TITLE
feat: Disable archiving for read-only orgs

### DIFF
--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -156,17 +156,17 @@ export class OrgsList extends TailwindElement {
       <btrix-dialog
         class="[--width:36rem]"
         id="orgReadOnlyDialog"
-        .label=${msg(str`Make Read-Only?`)}
+        .label=${msg(str`Disable Archiving?`)}
         @sl-after-hide=${() => (this.currOrg = null)}
       >
         ${when(this.currOrg, (org) => {
           return html`
             <p class="mb-3">
               ${msg(
-                html`Are you sure you want to make
-                  <strong class="font-semibold">${org.name}</strong>
-                  read-only? Members will no longer be able to crawl, upload
-                  files, create browser profiles, or create collections.`,
+                html`Are you sure you want to disable archiving in
+                  <strong class="font-semibold">${org.name}</strong> org?
+                  Members will no longer be able to crawl, upload files, create
+                  browser profiles, or create collections.`,
               )}
             </p>
             <ul class="mb-3 text-neutral-600">
@@ -195,7 +195,7 @@ export class OrgsList extends TailwindElement {
               <sl-input
                 name="readOnlyReason"
                 label=${msg("Reason")}
-                placeholder=${msg("Enter reason for making org read-only")}
+                placeholder=${msg("Enter reason for disabling archiving")}
                 required
               ></sl-input>
             </form>
@@ -206,7 +206,7 @@ export class OrgsList extends TailwindElement {
                 @click=${this.orgReadOnlyDialog?.submit}
                 variant="primary"
               >
-                ${msg("Make Read-Only")}
+                ${msg("Disable Archiving")}
               </sl-button>
             </div>
           `;
@@ -391,8 +391,8 @@ export class OrgsList extends TailwindElement {
 
       this.notify.toast({
         message: params.readOnly
-          ? msg(str`Org "${org.name}" is read-only.`)
-          : msg(str`Org "${org.name}" is no longer read-only.`),
+          ? msg(str`Archiving in "${org.name}" is disabled.`)
+          : msg(str`Archiving in "${org.name}" is re-enabled.`),
         variant: "success",
         icon: "check2-circle",
       });
@@ -401,7 +401,7 @@ export class OrgsList extends TailwindElement {
 
       this.notify.toast({
         message: msg(
-          "Sorry, couldn't update org read-only state at this time.",
+          "Sorry, couldn't update org archiving ability at this time.",
         ),
         variant: "danger",
         icon: "exclamation-octagon",
@@ -477,13 +477,13 @@ export class OrgsList extends TailwindElement {
       status = {
         icon: html`<sl-icon
           class="text-base text-neutral-400"
-          name="slash-circle"
-          label=${msg("Read-only")}
+          name="ban"
+          label=${msg("disabled")}
         >
         </sl-icon>`,
         description: org.readOnlyReason
-          ? `${msg("Read-only:")} ${org.readOnlyReason}`
-          : msg("Read-only (no reason specified)"),
+          ? `${msg("Archiving Disabled:")} ${org.readOnlyReason}`
+          : msg("Archiving Disabled (no reason specified)"),
       };
     }
 
@@ -550,7 +550,7 @@ export class OrgsList extends TailwindElement {
                         slot="prefix"
                         name="arrow-counterclockwise"
                       ></sl-icon>
-                      ${msg("Undo Read-Only")}
+                      ${msg("Re-enable Archiving")}
                     </sl-menu-item>
                   `
                 : html`
@@ -560,8 +560,8 @@ export class OrgsList extends TailwindElement {
                         void this.orgReadOnlyDialog?.show();
                       }}
                     >
-                      <sl-icon slot="prefix" name="eye"></sl-icon>
-                      ${msg("Make Read-Only")}
+                      <sl-icon slot="prefix" name="ban"></sl-icon>
+                      ${msg("Disable Archiving")}
                     </sl-menu-item>
                   `}
               <sl-divider></sl-divider>

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -128,10 +128,8 @@ export class OrgStatusBanner extends TailwindElement {
           return {
             title:
               daysDiff > 1
-                ? msg(
-                    str`Your org will be set to read-only mode in ${daysDiff} days`,
-                  )
-                : msg("Your org will be set to read-only mode within one day"),
+                ? msg(str`Archiving will be disabled in ${daysDiff} days`)
+                : msg("Archiving will be disabled within one day"),
             detail: html`
               <p>
                 ${msg(
@@ -161,7 +159,7 @@ export class OrgStatusBanner extends TailwindElement {
           !!readOnly && readOnlyReason === OrgReadOnlyReason.SubscriptionPaused,
 
         content: () => ({
-          title: msg(str`Your org has been set to read-only mode`),
+          title: msg(str`Archiving is disabled for this org`),
           detail: msg(
             html`Your subscription has been paused due to payment failure.
             Please go to ${billingTabLink} to update your payment method.`,
@@ -174,7 +172,7 @@ export class OrgStatusBanner extends TailwindElement {
           readOnlyReason === OrgReadOnlyReason.SubscriptionCancelled,
 
         content: () => ({
-          title: msg(str`This org has been set to read-only mode`),
+          title: msg(str`Archiving is disabled for this org`),
           detail: msg(
             `Your subscription has been canceled. Please contact Browsertrix support to renew your plan.`,
           ),
@@ -184,7 +182,7 @@ export class OrgStatusBanner extends TailwindElement {
         test: () => !!readOnly,
 
         content: () => ({
-          title: msg(str`This org has been set to read-only mode`),
+          title: msg(str`Archiving is disabled for this org`),
           detail: msg(`Please contact Browsertrix support to renew your plan.`),
         }),
       },

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -34,6 +34,7 @@ import {
 } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { getLocale } from "@/utils/localization";
+import { isArchivingDisabled } from "@/utils/orgs";
 import appState, { use } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
@@ -1056,11 +1057,7 @@ ${this.crawl?.description}
                 qaRuns.length === 0 ? "primary" : "default"
               }"
               @click=${() => void this.startQARun()}
-              ?disabled=${!this.org ||
-              this.org.readOnly ||
-              this.org.storageQuotaReached ||
-              this.org.execMinutesQuotaReached ||
-              qaIsRunning}
+              ?disabled=${isArchivingDisabled(this.org, true) || qaIsRunning}
             >
               <sl-icon slot="prefix" name="microscope" library="app"></sl-icon>
               ${qaRuns.length ? msg("Rerun Analysis") : msg("Run Analysis")}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -34,6 +34,7 @@ import {
 } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { getLocale } from "@/utils/localization";
+import appState, { use } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
 import "./ui/qa";
@@ -89,6 +90,9 @@ export class ArchivedItemDetail extends TailwindElement {
   @property({ type: Boolean })
   isCrawler = false;
 
+  @use()
+  appState = appState;
+
   @state()
   private qaRunId?: string;
 
@@ -124,6 +128,10 @@ export class ArchivedItemDetail extends TailwindElement {
 
   @query("#cancelQARunDialog")
   private readonly cancelQARunDialog?: Dialog | null;
+
+  private get org() {
+    return this.appState.org;
+  }
 
   private get listUrl(): string {
     let path = "items";
@@ -1048,7 +1056,11 @@ ${this.crawl?.description}
                 qaRuns.length === 0 ? "primary" : "default"
               }"
               @click=${() => void this.startQARun()}
-              ?disabled=${qaIsRunning}
+              ?disabled=${!this.org ||
+              this.org.readOnly ||
+              this.org.storageQuotaReached ||
+              this.org.execMinutesQuotaReached ||
+              qaIsRunning}
             >
               <sl-icon slot="prefix" name="microscope" library="app"></sl-icon>
               ${qaRuns.length ? msg("Rerun Analysis") : msg("Run Analysis")}

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -21,6 +21,7 @@ import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import type { Auth, AuthState } from "@/utils/AuthService";
 import { finishedCrawlStates, isActive } from "@/utils/crawler";
+import { isArchivingDisabled } from "@/utils/orgs";
 import appState, { use } from "@/utils/state";
 
 type ArchivedItems = APIPaginatedList<ArchivedItem>;
@@ -313,9 +314,7 @@ export class CrawlsList extends TailwindElement {
                     size="small"
                     variant="primary"
                     @click=${() => (this.isUploadingArchive = true)}
-                    ?disabled=${!this.org ||
-                    this.org.readOnly ||
-                    this.org.storageQuotaReached}
+                    ?disabled=${isArchivingDisabled(this.org)}
                   >
                     <sl-icon slot="prefix" name="upload"></sl-icon>
                     ${msg("Upload WACZ")}

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -21,6 +21,7 @@ import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import type { Auth, AuthState } from "@/utils/AuthService";
 import { finishedCrawlStates, isActive } from "@/utils/crawler";
+import appState, { use } from "@/utils/state";
 
 type ArchivedItems = APIPaginatedList<ArchivedItem>;
 type SearchFields = "name" | "firstSeed";
@@ -90,13 +91,13 @@ export class CrawlsList extends TailwindElement {
   orgId?: string;
 
   @property({ type: Boolean })
-  orgStorageQuotaReached = false;
-
-  @property({ type: Boolean })
   isCrawler!: boolean;
 
   @property({ type: String })
   itemType: ArchivedItem["type"] | null = null;
+
+  @use()
+  appState = appState;
 
   @state()
   private pagination: Required<APIPaginationQuery> = {
@@ -140,6 +141,10 @@ export class CrawlsList extends TailwindElement {
 
   @query("#stateSelect")
   stateSelect?: SlSelect;
+
+  private get org() {
+    return this.appState.org;
+  }
 
   private readonly archivedItemsTask = new Task(this, {
     task: async (
@@ -302,13 +307,15 @@ export class CrawlsList extends TailwindElement {
               () => html`
                 <sl-tooltip
                   content=${msg("Org Storage Full")}
-                  ?disabled=${!this.orgStorageQuotaReached}
+                  ?disabled=${!this.org?.storageQuotaReached}
                 >
                   <sl-button
                     size="small"
                     variant="primary"
                     @click=${() => (this.isUploadingArchive = true)}
-                    ?disabled=${this.orgStorageQuotaReached}
+                    ?disabled=${!this.org ||
+                    this.org.readOnly ||
+                    this.org.storageQuotaReached}
                   >
                     <sl-icon slot="prefix" name="upload"></sl-icon>
                     ${msg("Upload WACZ")}

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -256,7 +256,9 @@ export class BrowserProfilesDetail extends TailwindElement {
                     )}
                   </p>
                   <sl-button
-                    ?disabled=${!this.org || this.org.readOnly}
+                    ?disabled=${!this.org ||
+                    this.org.readOnly ||
+                    this.org.storageQuotaReached}
                     @click=${this.startBrowserPreview}
                   >
                     <sl-icon slot="prefix" name="gear"></sl-icon>
@@ -447,14 +449,18 @@ export class BrowserProfilesDetail extends TailwindElement {
             ${msg("Edit Metadata")}
           </sl-menu-item>
           <sl-menu-item
-            ?disabled=${!this.org || this.org.readOnly}
+            ?disabled=${!this.org ||
+            this.org.readOnly ||
+            this.org.storageQuotaReached}
             @click=${this.startBrowserPreview}
           >
             <sl-icon slot="prefix" name="gear"></sl-icon>
             ${msg("Configure Browser Profile")}
           </sl-menu-item>
           <sl-menu-item
-            ?disabled=${!this.org || this.org.readOnly}
+            ?disabled=${!this.org ||
+            this.org.readOnly ||
+            this.org.storageQuotaReached}
             @click=${() => void this.duplicateProfile()}
           >
             <sl-icon slot="prefix" name="files"></sl-icon>

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -18,6 +18,7 @@ import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { maxLengthValidator } from "@/utils/form";
 import { formatNumber, getLocale } from "@/utils/localization";
+import appState, { use } from "@/utils/state";
 
 const DESCRIPTION_MAXLENGTH = 500;
 
@@ -45,6 +46,9 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   @property({ type: Boolean })
   isCrawler = false;
+
+  @use()
+  appState = appState;
 
   @state()
   private profile?: Profile;
@@ -82,6 +86,10 @@ export class BrowserProfilesDetail extends TailwindElement {
 
   private readonly validateNameMax = maxLengthValidator(50);
   private readonly validateDescriptionMax = maxLengthValidator(500);
+
+  get org() {
+    return this.appState.org;
+  }
 
   disconnectedCallback() {
     if (this.browserId) {
@@ -247,7 +255,10 @@ export class BrowserProfilesDetail extends TailwindElement {
                       "View or edit the current browser profile configuration.",
                     )}
                   </p>
-                  <sl-button @click=${this.startBrowserPreview}>
+                  <sl-button
+                    ?disabled=${!this.org || this.org.readOnly}
+                    @click=${this.startBrowserPreview}
+                  >
                     <sl-icon slot="prefix" name="gear"></sl-icon>
                     ${msg("Configure Browser Profile")}
                   </sl-button>
@@ -435,11 +446,17 @@ export class BrowserProfilesDetail extends TailwindElement {
             <sl-icon slot="prefix" name="pencil"></sl-icon>
             ${msg("Edit Metadata")}
           </sl-menu-item>
-          <sl-menu-item @click=${this.startBrowserPreview}>
+          <sl-menu-item
+            ?disabled=${!this.org || this.org.readOnly}
+            @click=${this.startBrowserPreview}
+          >
             <sl-icon slot="prefix" name="gear"></sl-icon>
             ${msg("Configure Browser Profile")}
           </sl-menu-item>
-          <sl-menu-item @click=${() => void this.duplicateProfile()}>
+          <sl-menu-item
+            ?disabled=${!this.org || this.org.readOnly}
+            @click=${() => void this.duplicateProfile()}
+          >
             <sl-icon slot="prefix" name="files"></sl-icon>
             ${msg("Duplicate Profile")}
           </sl-menu-item>

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -18,6 +18,7 @@ import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import { maxLengthValidator } from "@/utils/form";
 import { formatNumber, getLocale } from "@/utils/localization";
+import { isArchivingDisabled } from "@/utils/orgs";
 import appState, { use } from "@/utils/state";
 
 const DESCRIPTION_MAXLENGTH = 500;
@@ -256,9 +257,7 @@ export class BrowserProfilesDetail extends TailwindElement {
                     )}
                   </p>
                   <sl-button
-                    ?disabled=${!this.org ||
-                    this.org.readOnly ||
-                    this.org.storageQuotaReached}
+                    ?disabled=${isArchivingDisabled(this.org)}
                     @click=${this.startBrowserPreview}
                   >
                     <sl-icon slot="prefix" name="gear"></sl-icon>
@@ -438,6 +437,8 @@ export class BrowserProfilesDetail extends TailwindElement {
   }
 
   private renderMenu() {
+    const archivingDisabled = isArchivingDisabled(this.org);
+
     return html`
       <sl-dropdown distance="4" placement="bottom-end">
         <sl-button size="small" slot="trigger" caret>
@@ -449,18 +450,14 @@ export class BrowserProfilesDetail extends TailwindElement {
             ${msg("Edit Metadata")}
           </sl-menu-item>
           <sl-menu-item
-            ?disabled=${!this.org ||
-            this.org.readOnly ||
-            this.org.storageQuotaReached}
+            ?disabled=${archivingDisabled}
             @click=${this.startBrowserPreview}
           >
             <sl-icon slot="prefix" name="gear"></sl-icon>
             ${msg("Configure Browser Profile")}
           </sl-menu-item>
           <sl-menu-item
-            ?disabled=${!this.org ||
-            this.org.readOnly ||
-            this.org.storageQuotaReached}
+            ?disabled=${archivingDisabled}
             @click=${() => void this.duplicateProfile()}
           >
             <sl-icon slot="prefix" name="files"></sl-icon>

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -27,6 +27,7 @@ import type { Browser } from "@/types/browser";
 import type { AuthState } from "@/utils/AuthService";
 import { html } from "@/utils/LiteElement";
 import { getLocale } from "@/utils/localization";
+import appState, { use } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
 const INITIAL_PAGE_SIZE = 20;
@@ -52,6 +53,9 @@ export class BrowserProfilesList extends TailwindElement {
   @property({ type: Boolean })
   isCrawler = false;
 
+  @use()
+  appState = appState;
+
   @state()
   browserProfiles?: APIPaginatedList<Profile>;
 
@@ -63,6 +67,10 @@ export class BrowserProfilesList extends TailwindElement {
 
   @state()
   private isLoading = true;
+
+  private get org() {
+    return this.appState.org;
+  }
 
   static styles = css`
     btrix-table {
@@ -119,6 +127,7 @@ export class BrowserProfilesList extends TailwindElement {
               <sl-button
                 variant="primary"
                 size="small"
+                ?disabled=${!this.org || this.org.readOnly}
                 @click=${() => {
                   this.dispatchEvent(
                     new CustomEvent("select-new-dialog", {
@@ -339,6 +348,7 @@ export class BrowserProfilesList extends TailwindElement {
       <btrix-overflow-dropdown @click=${(e: Event) => e.preventDefault()}>
         <sl-menu>
           <sl-menu-item
+            ?disabled=${!this.org || this.org.readOnly}
             @click=${() => {
               void this.duplicateProfile(data);
             }}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -27,6 +27,7 @@ import type { Browser } from "@/types/browser";
 import type { AuthState } from "@/utils/AuthService";
 import { html } from "@/utils/LiteElement";
 import { getLocale } from "@/utils/localization";
+import { isArchivingDisabled } from "@/utils/orgs";
 import appState, { use } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
@@ -127,9 +128,7 @@ export class BrowserProfilesList extends TailwindElement {
               <sl-button
                 variant="primary"
                 size="small"
-                ?disabled=${!this.org ||
-                this.org.readOnly ||
-                this.org.storageQuotaReached}
+                ?disabled=${isArchivingDisabled(this.org)}
                 @click=${() => {
                   this.dispatchEvent(
                     new CustomEvent("select-new-dialog", {
@@ -350,9 +349,7 @@ export class BrowserProfilesList extends TailwindElement {
       <btrix-overflow-dropdown @click=${(e: Event) => e.preventDefault()}>
         <sl-menu>
           <sl-menu-item
-            ?disabled=${!this.org ||
-            this.org.readOnly ||
-            this.org.storageQuotaReached}
+            ?disabled=${isArchivingDisabled(this.org)}
             @click=${() => {
               void this.duplicateProfile(data);
             }}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -127,7 +127,9 @@ export class BrowserProfilesList extends TailwindElement {
               <sl-button
                 variant="primary"
                 size="small"
-                ?disabled=${!this.org || this.org.readOnly}
+                ?disabled=${!this.org ||
+                this.org.readOnly ||
+                this.org.storageQuotaReached}
                 @click=${() => {
                   this.dispatchEvent(
                     new CustomEvent("select-new-dialog", {
@@ -348,7 +350,9 @@ export class BrowserProfilesList extends TailwindElement {
       <btrix-overflow-dropdown @click=${(e: Event) => e.preventDefault()}>
         <sl-menu>
           <sl-menu-item
-            ?disabled=${!this.org || this.org.readOnly}
+            ?disabled=${!this.org ||
+            this.org.readOnly ||
+            this.org.storageQuotaReached}
             @click=${() => {
               void this.duplicateProfile(data);
             }}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -138,6 +138,7 @@ export class CollectionsList extends LiteElement {
               <sl-button
                 variant="primary"
                 size="small"
+                ?disabled=${!this.appState.org || this.appState.org.readOnly}
                 @click=${() => (this.openDialogName = "create")}
               >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -104,7 +104,13 @@ export class Dashboard extends LiteElement {
                 );
               }}
             >
-              <sl-button slot="trigger" size="small" variant="primary" caret>
+              <sl-button
+                slot="trigger"
+                size="small"
+                variant="primary"
+                caret
+                ?disabled=${this.org?.readOnly}
+              >
                 <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                 ${msg("Create New...")}
               </sl-button>

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -508,7 +508,6 @@ export class Org extends LiteElement {
       .authState=${this.authState!}
       userId=${this.userInfo!.id}
       orgId=${this.orgId}
-      ?orgStorageQuotaReached=${this.org?.storageQuotaReached}
       ?isCrawler=${this.isCrawler}
       itemType=${ifDefined(params.itemType || undefined)}
       @select-new-dialog=${this.onSelectNewDialog}
@@ -559,8 +558,6 @@ export class Org extends LiteElement {
     return html`<btrix-workflows-list
       .authState=${this.authState!}
       orgId=${this.orgId}
-      ?orgStorageQuotaReached=${this.org?.storageQuotaReached}
-      ?orgExecutionMinutesQuotaReached=${this.org?.execMinutesQuotaReached}
       userId=${this.userInfo!.id}
       ?isCrawler=${this.isCrawler}
       @select-new-dialog=${this.onSelectNewDialog}
@@ -638,13 +635,11 @@ export class Org extends LiteElement {
     return html`<btrix-org-settings
       .authState=${this.authState}
       .userInfo=${this.userInfo}
-      .org=${this.org}
       .orgId=${this.orgId}
       activePanel=${activePanel}
       ?isAddingMember=${isAddingMember}
       @org-user-role-change=${this.onUserRoleChange}
       @org-remove-member=${this.onOrgRemoveMember}
-      @btrix-update-org=${this.updateOrg}
     ></btrix-org-settings>`;
   }
 

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -527,8 +527,6 @@ export class Org extends LiteElement {
           class="col-span-5 mt-6"
           .authState=${this.authState!}
           orgId=${this.orgId}
-          ?orgStorageQuotaReached=${this.org?.storageQuotaReached}
-          ?orgExecutionMinutesQuotaReached=${this.org?.execMinutesQuotaReached}
           workflowId=${workflowId}
           openDialogName=${this.viewStateData?.dialog}
           ?isEditing=${isEditing}
@@ -549,8 +547,6 @@ export class Org extends LiteElement {
         .initialWorkflow=${workflow}
         .initialSeeds=${seeds}
         jobType=${ifDefined(params.jobType)}
-        ?orgStorageQuotaReached=${this.org?.storageQuotaReached}
-        ?orgExecutionMinutesQuotaReached=${this.org?.execMinutesQuotaReached}
         @select-new-dialog=${this.onSelectNewDialog}
       ></btrix-workflows-new>`;
     }

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -16,6 +16,7 @@ import type { Auth, AuthState } from "@/utils/AuthService";
 import { humanizeSeconds } from "@/utils/executionTimeFormatter";
 import { formatNumber, getLocale } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
+import appState, { use } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
 const linkClassList = tw`transition-color text-primary hover:text-primary-500`;
@@ -24,9 +25,6 @@ const manageLinkClasslist = clsx(
   tw`flex items-center gap-2 p-2 text-sm font-semibold leading-none`,
 );
 
-/**
- * @fires btrix-update-org
- */
 @localized()
 @customElement("btrix-org-settings-billing")
 export class OrgSettingsBilling extends TailwindElement {
@@ -39,13 +37,17 @@ export class OrgSettingsBilling extends TailwindElement {
   @property({ type: Object })
   authState?: AuthState;
 
-  @property({ type: Object, noAccessor: true })
-  org?: OrgData;
-
   @property({ type: String, noAccessor: true })
   salesEmail?: string;
 
+  @use()
+  appState = appState;
+
   private readonly api = new APIController(this);
+
+  private get org() {
+    return this.appState.org;
+  }
 
   get portalUrlLabel() {
     const subscription = this.org?.subscription;

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -141,7 +141,6 @@ export class OrgSettings extends TailwindElement {
                 href=${`${this.navigate.orgBasePath}/settings/members?invite`}
                 variant="primary"
                 size="small"
-                ?disabled=${!this.org || this.org.readOnly}
                 @click=${this.navigate.link}
               >
                 <sl-icon

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -55,12 +55,6 @@ export class WorkflowDetail extends LiteElement {
   @property({ type: String })
   orgId!: string;
 
-  @property({ type: Boolean })
-  orgStorageQuotaReached = false;
-
-  @property({ type: Boolean })
-  orgExecutionMinutesQuotaReached = false;
-
   @property({ type: String })
   workflowId!: string;
 
@@ -120,6 +114,10 @@ export class WorkflowDetail extends LiteElement {
 
   @state()
   private filterBy: Partial<Record<keyof Crawl, string | CrawlState[]>> = {};
+
+  private get org() {
+    return this.appState.org;
+  }
 
   private readonly numberFormatter = new Intl.NumberFormat(getLocale(), {
     // notation: "compact",
@@ -572,9 +570,6 @@ export class WorkflowDetail extends LiteElement {
           configId=${this.workflow!.id}
           orgId=${this.orgId}
           .authState=${this.authState}
-          ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
-          ?orgExecutionMinutesQuotaReached=${this
-            .orgExecutionMinutesQuotaReached}
           @reset=${() =>
             this.navTo(
               `${this.orgBasePath}/workflows/crawl/${this.workflow!.id}`,
@@ -623,14 +618,16 @@ export class WorkflowDetail extends LiteElement {
             content=${msg(
               "Org Storage Full or Monthly Execution Minutes Reached",
             )}
-            ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesQuotaReached}
+            ?disabled=${!this.org?.storageQuotaReached &&
+            !this.org?.execMinutesQuotaReached}
           >
             <sl-button
               size="small"
               variant="primary"
-              ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesQuotaReached}
+              ?disabled=${!this.org ||
+              this.org.readOnly ||
+              this.org.storageQuotaReached ||
+              this.org.execMinutesQuotaReached}
               @click=${() => void this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -670,8 +667,10 @@ export class WorkflowDetail extends LiteElement {
             () => html`
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--success)"
-                ?disabled=${this.orgStorageQuotaReached ||
-                this.orgExecutionMinutesQuotaReached}
+                ?disabled=${!this.org ||
+                this.org.readOnly ||
+                this.org.storageQuotaReached ||
+                this.org.execMinutesQuotaReached}
                 @click=${() => void this.runNow()}
               >
                 <sl-icon name="play" slot="prefix"></sl-icon>
@@ -712,7 +711,13 @@ export class WorkflowDetail extends LiteElement {
             <sl-icon name="tags" slot="prefix"></sl-icon>
             ${msg("Copy Tags")}
           </sl-menu-item>
-          <sl-menu-item @click=${() => void this.duplicateConfig()}>
+          <sl-menu-item
+            ?disabled=${!this.org ||
+            this.org.readOnly ||
+            this.org.storageQuotaReached ||
+            this.org.execMinutesQuotaReached}
+            @click=${() => void this.duplicateConfig()}
+          >
             <sl-icon name="files" slot="prefix"></sl-icon>
             ${msg("Duplicate Workflow")}
           </sl-menu-item>
@@ -1165,14 +1170,14 @@ export class WorkflowDetail extends LiteElement {
             content=${msg(
               "Org Storage Full or Monthly Execution Minutes Reached",
             )}
-            ?disabled=${!this.orgStorageQuotaReached &&
-            !this.orgExecutionMinutesQuotaReached}
+            ?disabled=${!this.org?.storageQuotaReached &&
+            !this.org?.execMinutesQuotaReached}
           >
             <sl-button
               size="small"
               variant="primary"
-              ?disabled=${this.orgStorageQuotaReached ||
-              this.orgExecutionMinutesQuotaReached}
+              ?disabled=${this.org?.storageQuotaReached ||
+              this.org?.execMinutesQuotaReached}
               @click=${() => void this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -33,6 +33,7 @@ import {
 import { humanizeSchedule } from "@/utils/cron";
 import LiteElement, { html } from "@/utils/LiteElement";
 import { getLocale } from "@/utils/localization";
+import { isArchivingDisabled } from "@/utils/orgs";
 
 const SECTIONS = ["crawls", "watch", "settings", "logs"] as const;
 type Tab = (typeof SECTIONS)[number];
@@ -584,6 +585,8 @@ export class WorkflowDetail extends LiteElement {
     if (!this.workflow) return;
     const workflow = this.workflow;
 
+    const archivingDisabled = isArchivingDisabled(this.org, true);
+
     return html`
       ${when(
         this.workflow.isCrawlRunning,
@@ -624,10 +627,7 @@ export class WorkflowDetail extends LiteElement {
             <sl-button
               size="small"
               variant="primary"
-              ?disabled=${!this.org ||
-              this.org.readOnly ||
-              this.org.storageQuotaReached ||
-              this.org.execMinutesQuotaReached}
+              ?disabled=${archivingDisabled}
               @click=${() => void this.runNow()}
             >
               <sl-icon name="play" slot="prefix"></sl-icon>
@@ -667,10 +667,7 @@ export class WorkflowDetail extends LiteElement {
             () => html`
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--success)"
-                ?disabled=${!this.org ||
-                this.org.readOnly ||
-                this.org.storageQuotaReached ||
-                this.org.execMinutesQuotaReached}
+                ?disabled=${archivingDisabled}
                 @click=${() => void this.runNow()}
               >
                 <sl-icon name="play" slot="prefix"></sl-icon>
@@ -712,10 +709,7 @@ export class WorkflowDetail extends LiteElement {
             ${msg("Copy Tags")}
           </sl-menu-item>
           <sl-menu-item
-            ?disabled=${!this.org ||
-            this.org.readOnly ||
-            this.org.storageQuotaReached ||
-            this.org.execMinutesQuotaReached}
+            ?disabled=${archivingDisabled}
             @click=${() => void this.duplicateConfig()}
           >
             <sl-icon name="files" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -68,6 +68,7 @@ import {
 import { maxLengthValidator } from "@/utils/form";
 import LiteElement, { html } from "@/utils/LiteElement";
 import { getLocale } from "@/utils/localization";
+import { isArchivingDisabled } from "@/utils/orgs";
 import { regexEscape, regexUnescape } from "@/utils/string";
 
 type NewCrawlConfigParams = WorkflowParams & {
@@ -919,10 +920,7 @@ export class CrawlConfigEditor extends LiteElement {
       <sl-switch
         class="mr-1"
         ?checked=${this.formState.runNow}
-        ?disabled=${!this.org ||
-        this.org.readOnly ||
-        this.org.storageQuotaReached ||
-        this.org.execMinutesQuotaReached}
+        ?disabled=${isArchivingDisabled(this.org, true)}
         @sl-change=${(e: SlChangeEvent) => {
           this.updateFormState(
             {

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -272,12 +272,6 @@ export class CrawlConfigEditor extends LiteElement {
   @property({ type: Array })
   initialSeeds?: Seed[];
 
-  @property({ type: Boolean })
-  orgStorageQuotaReached = false;
-
-  @property({ type: Boolean })
-  orgExecutionMinutesQuotaReached = false;
-
   @state()
   private showCrawlerChannels = false;
 
@@ -302,6 +296,10 @@ export class CrawlConfigEditor extends LiteElement {
 
   @state()
   private serverError?: TemplateResult | string;
+
+  private get org() {
+    return this.appState.org;
+  }
 
   private maxScale = DEFAULT_MAX_SCALE;
 
@@ -590,7 +588,7 @@ export class CrawlConfigEditor extends LiteElement {
       scheduleType: defaultFormState.scheduleType,
       scheduleFrequency: defaultFormState.scheduleFrequency,
       runNow:
-        this.orgStorageQuotaReached || this.orgExecutionMinutesQuotaReached
+        this.org?.storageQuotaReached || this.org?.execMinutesQuotaReached
           ? false
           : defaultFormState.runNow,
       tags: this.initialWorkflow.tags,
@@ -921,8 +919,10 @@ export class CrawlConfigEditor extends LiteElement {
       <sl-switch
         class="mr-1"
         ?checked=${this.formState.runNow}
-        ?disabled=${this.orgStorageQuotaReached ||
-        this.orgExecutionMinutesQuotaReached}
+        ?disabled=${!this.org ||
+        this.org.readOnly ||
+        this.org.storageQuotaReached ||
+        this.org.execMinutesQuotaReached}
         @sl-change=${(e: SlChangeEvent) => {
           this.updateFormState(
             {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -17,6 +17,7 @@ import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import type { AuthState } from "@/utils/AuthService";
 import LiteElement, { html } from "@/utils/LiteElement";
+import { isArchivingDisabled } from "@/utils/orgs";
 
 type SearchFields = "name" | "firstSeed";
 type SortField = "lastRun" | "name" | "firstSeed" | "created" | "modified";
@@ -451,10 +452,7 @@ export class WorkflowsList extends LiteElement {
         () => html`
           <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
-            ?disabled=${!this.org ||
-            this.org.readOnly ||
-            this.org.storageQuotaReached ||
-            this.org.execMinutesQuotaReached}
+            ?disabled=${isArchivingDisabled(this.org, true)}
             @click=${() => void this.runNow(workflow)}
           >
             <sl-icon name="play" slot="prefix"></sl-icon>
@@ -520,10 +518,7 @@ export class WorkflowsList extends LiteElement {
         this.isCrawler,
         () =>
           html` <sl-menu-item
-            ?disabled=${!this.org ||
-            this.org.readOnly ||
-            this.org.storageQuotaReached ||
-            this.org.execMinutesQuotaReached}
+            ?disabled=${isArchivingDisabled(this.org, true)}
             @click=${() => void this.duplicateConfig(workflow)}
           >
             <sl-icon name="files" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -520,6 +520,10 @@ export class WorkflowsList extends LiteElement {
         this.isCrawler,
         () =>
           html` <sl-menu-item
+            ?disabled=${!this.org ||
+            this.org.readOnly ||
+            this.org.storageQuotaReached ||
+            this.org.execMinutesQuotaReached}
             @click=${() => void this.duplicateConfig(workflow)}
           >
             <sl-icon name="files" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -76,12 +76,6 @@ export class WorkflowsList extends LiteElement {
   @property({ type: String })
   orgId!: string;
 
-  @property({ type: Boolean })
-  orgStorageQuotaReached = false;
-
-  @property({ type: Boolean })
-  orgExecutionMinutesQuotaReached = false;
-
   @property({ type: String })
   userId!: string;
 
@@ -121,6 +115,10 @@ export class WorkflowsList extends LiteElement {
   // Use to cancel requests
   private getWorkflowsController: AbortController | null = null;
   private timerId?: number;
+
+  private get org() {
+    return this.appState.org;
+  }
 
   private get selectedSearchFilterKey() {
     return Object.keys(WorkflowsList.FieldLabels).find((key) =>
@@ -215,6 +213,7 @@ export class WorkflowsList extends LiteElement {
               <sl-button
                 variant="primary"
                 size="small"
+                ?disabled=${this.org?.readOnly}
                 @click=${() => {
                   this.dispatchEvent(
                     new CustomEvent("select-new-dialog", {
@@ -452,8 +451,10 @@ export class WorkflowsList extends LiteElement {
         () => html`
           <sl-menu-item
             style="--sl-color-neutral-700: var(--success)"
-            ?disabled=${this.orgStorageQuotaReached ||
-            this.orgExecutionMinutesQuotaReached}
+            ?disabled=${!this.org ||
+            this.org.readOnly ||
+            this.org.storageQuotaReached ||
+            this.org.execMinutesQuotaReached}
             @click=${() => void this.runNow(workflow)}
           >
             <sl-icon name="play" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -62,12 +62,6 @@ export class WorkflowsNew extends LiteElement {
   @property({ type: String })
   jobType?: JobType;
 
-  @property({ type: Boolean })
-  orgStorageQuotaReached = false;
-
-  @property({ type: Boolean })
-  orgExecutionMinutesQuotaReached = false;
-
   // Use custom property accessor to prevent
   // overriding default Workflow values
   @property({ type: Object })
@@ -79,6 +73,10 @@ export class WorkflowsNew extends LiteElement {
   }
 
   private _initialWorkflow: WorkflowParams = defaultValue;
+
+  private get org() {
+    return this.appState.org;
+  }
 
   private renderHeader() {
     const href = `${this.orgBasePath}/workflows/crawls`;
@@ -129,9 +127,6 @@ export class WorkflowsNew extends LiteElement {
           jobType=${jobType}
           orgId=${this.orgId}
           .authState=${this.authState}
-          ?orgStorageQuotaReached=${this.orgStorageQuotaReached}
-          ?orgExecutionMinutesQuotaReached=${this
-            .orgExecutionMinutesQuotaReached}
           @reset=${async (e: Event) => {
             await (e.target as LitElement).updateComplete;
             this.dispatchEvent(

--- a/frontend/src/utils/orgs.ts
+++ b/frontend/src/utils/orgs.ts
@@ -1,4 +1,4 @@
-import { AccessCode, type UserRole } from "@/types/org";
+import { AccessCode, type OrgData, type UserRole } from "@/types/org";
 
 export * from "@/types/org";
 
@@ -18,4 +18,16 @@ export function isCrawler(accessCode?: (typeof AccessCode)[UserRole]): boolean {
   if (!accessCode) return false;
 
   return accessCode >= AccessCode.crawler;
+}
+
+export function isArchivingDisabled(
+  org?: OrgData | null,
+  checkExecMinutesQuota = false,
+): boolean {
+  return Boolean(
+    !org ||
+      org.readOnly ||
+      org.storageQuotaReached ||
+      (checkExecMinutesQuota ? org.execMinutesQuotaReached : false),
+  );
 }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1915

### Changes

- Disables buttons to create resources, duplicate resources, run crawls, and configure browser profiles.
- Updates copy from "read-only" -> "disable archiving"

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Superadmin Dashboard - Org actions menu | <img width="201" alt="Screenshot 2024-07-23 at 7 43 22 PM" src="https://github.com/user-attachments/assets/e05f0723-9492-4f38-9833-ab21e27658af"> |
| Org - Banner | <img width="1316" alt="Screenshot 2024-07-23 at 7 18 43 PM" src="https://github.com/user-attachments/assets/53ee643c-7f23-42c6-b2b0-97ea26b7a263"> |



<!-- ### Follow-ups -->
