### PR TITLE
chore: Rename upload dialog

### DIFF
--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -124,7 +124,7 @@ export class FileUploader extends TailwindElement {
     const uploadInProgress = this.isUploading || this.isConfirmingCancel;
     return html`
       <btrix-dialog
-        .label=${msg("Upload Archive")}
+        .label=${msg("Upload WACZ")}
         .open=${this.open}
         @sl-show=${() => (this.isDialogVisible = true)}
         @sl-after-hide=${() => (this.isDialogVisible = false)}
@@ -187,8 +187,9 @@ export class FileUploader extends TailwindElement {
             )!;
             form.requestSubmit(submitInput);
           }}
-          >${msg("Upload File")}</sl-button
         >
+          ${msg("Upload")}
+        </sl-button>
       </div>
     `;
   }
@@ -321,7 +322,7 @@ export class FileUploader extends TailwindElement {
     return html`
       <section class="flex flex-col gap-3">
         <h4 class="flex-0 text-lg font-semibold leading-none">
-          ${msg("Uploading File")}
+          ${msg("Uploading WACZ File...")}
         </h4>
         <p class="text-neutral-500">
           ${msg("Keep this window open until your upload finishes.")}

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -322,7 +322,7 @@ export class FileUploader extends TailwindElement {
     return html`
       <section class="flex flex-col gap-3">
         <h4 class="flex-0 text-lg font-semibold leading-none">
-          ${msg("Uploading WACZ File...")}
+          ${msg("Uploading...")}
         </h4>
         <p class="text-neutral-500">
           ${msg("Keep this window open until your upload finishes.")}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1961

<!-- Fixes #issue_number -->

### Changes

Renames "Upload Archive" dialog to reference WACZ.

### Screenshots

<img width="983" alt="Screenshot 2024-07-23 at 8 01 28 PM" src="https://github.com/user-attachments/assets/1408d3a8-21ff-444d-a00d-8b8416a75082">
<img width="675" alt="Screenshot 2024-07-23 at 8 02 53 PM" src="https://github.com/user-attachments/assets/71980534-862f-4ac5-bfe6-05cc5a7676f2">

<!-- ### Follow-ups -->
