### PR TITLE
fix execution minutes meter using wrong metric

### DIFF
--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -395,8 +395,8 @@ export class Dashboard extends LiteElement {
     }
 
     let usageSecondsAllTypes = 0;
-    if (this.org.crawlExecSeconds) {
-      const actualUsage = this.org.crawlExecSeconds[currentPeriod];
+    if (this.org.monthlyExecSeconds) {
+      const actualUsage = this.org.monthlyExecSeconds[currentPeriod];
       if (actualUsage) {
         usageSecondsAllTypes = actualUsage;
       }

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -39,7 +39,9 @@ export type OrgData = {
   bytesStoredUploads: number;
   bytesStoredProfiles: number;
   usage: { [key: YearMonth]: number } | null;
+  /* Actual total time used, including time to stop the crawl */
   crawlExecSeconds?: { [key: YearMonth]: number };
+  /* How much of the monthly time quota was used */
   monthlyExecSeconds?: { [key: YearMonth]: number };
   extraExecSeconds?: { [key: YearMonth]: number };
   giftedExecSeconds?: { [key: YearMonth]: number };

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -39,9 +39,9 @@ export type OrgData = {
   bytesStoredUploads: number;
   bytesStoredProfiles: number;
   usage: { [key: YearMonth]: number } | null;
-  /* Actual total time used, including time to stop the crawl */
+  /* Actual total time used, including time to stop the crawl, gifted, and extra time */
   crawlExecSeconds?: { [key: YearMonth]: number };
-  /* How much of the monthly time quota was used */
+  /* Total time within the monthly time quota */
   monthlyExecSeconds?: { [key: YearMonth]: number };
   extraExecSeconds?: { [key: YearMonth]: number };
   giftedExecSeconds?: { [key: YearMonth]: number };


### PR DESCRIPTION
The monthly execution minutes meter was using the wrong metric, `crawlExecSeconds` instead of `monthlyExecSeconds`.
Since the meter is showing minutes used out of the monthly quota, it should be using `monthlyExecSeconds`.

This is a quick fix, however, this system may need another pass at some point.