### PR TITLE
Standardize handling of storage and execution time quotas

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -17,7 +17,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0032"
+CURR_DB_VERSION = "0033"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
+++ b/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
@@ -22,6 +22,9 @@ class Migration(BaseMigration):
         Migration stopped_quota_reached to stopped_time_quota_reached
         """
         crawls_db = self.mdb["crawls"]
+        crawl_configs_db = self.mdb["crawl_configs"]
+
+        ## CRAWLS ##
 
         try:
             res = await crawls_db.update_many(
@@ -54,5 +57,41 @@ class Migration(BaseMigration):
         except Exception as err:
             print(
                 f"Error migrating crawls with state stopped_quota_reached: {err}",
+                flush=True,
+            )
+
+        ## WORKFLOWS ##
+
+        try:
+            res = await crawl_configs_db.update_many(
+                {"lastCrawlState": "skipped_quota_reached"},
+                {"$set": {"lastCrawlState": "skipped_storage_quota_reached"}},
+            )
+            updated = res.modified_count
+            print(
+                f"{updated} crawl configs with lastCrawlState skipped_quota_reached migrated",
+                flush=True,
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error migrating crawlconfigs with lastCrawlState skipped_quota_reached: {err}",
+                flush=True,
+            )
+
+        try:
+            res = await crawl_configs_db.update_many(
+                {"lastCrawlState": "stopped_quota_reached"},
+                {"$set": {"lastCrawlState": "stopped_time_quota_reached"}},
+            )
+            updated = res.modified_count
+            print(
+                f"{updated} crawl configs with lastCrawlState stopped_quota_reached migrated",
+                flush=True,
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error migrating crawl configs with lastCrawlState stopped_quota_reached: {err}",
                 flush=True,
             )

--- a/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
+++ b/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
@@ -19,7 +19,8 @@ class Migration(BaseMigration):
         """Perform migration up.
 
         Migrate skipped_quota_reached state to skipped_storage_quota_reached
-        Migration stopped_quota_reached to stopped_time_quota_reached
+        Migrate stopped_quota_reached to stopped_time_quota_reached
+        Also update lastCrawlStates in workflows with these states
         """
         crawls_db = self.mdb["crawls"]
         crawl_configs_db = self.mdb["crawl_configs"]

--- a/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
+++ b/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
@@ -1,0 +1,58 @@
+"""
+Migration 0033 - Standardizing quota-based crawl states
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0033"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Migrate skipped_quota_reached state to skipped_storage_quota_reached
+        Migration stopped_quota_reached to stopped_exec_mins_quota_reached
+        """
+        crawls_db = self.mdb["crawls"]
+
+        try:
+            res = await crawls_db.update_many(
+                {"type": "crawl", "state": "skipped_quota_reached"},
+                {"$set": {"state": "skipped_storage_quota_reached"}},
+            )
+            updated = res.modified_count
+            print(
+                f"{updated} crawls with state skipped_quota_reached migrated",
+                flush=True,
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error migrating crawls with state skipped_quota_reached: {err}",
+                flush=True,
+            )
+
+        try:
+            res = await crawls_db.update_many(
+                {"type": "crawl", "state": "stopped_quota_reached"},
+                {"$set": {"state": "stopped_exec_mins_quota_reached"}},
+            )
+            updated = res.modified_count
+            print(
+                f"{updated} crawls with state stopped_quota_reached migrated",
+                flush=True,
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error migrating crawls with state stopped_quota_reached: {err}",
+                flush=True,
+            )

--- a/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
+++ b/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
@@ -19,7 +19,7 @@ class Migration(BaseMigration):
         """Perform migration up.
 
         Migrate skipped_quota_reached state to skipped_storage_quota_reached
-        Migration stopped_quota_reached to stopped_exec_mins_quota_reached
+        Migration stopped_quota_reached to stopped_time_quota_reached
         """
         crawls_db = self.mdb["crawls"]
 
@@ -43,7 +43,7 @@ class Migration(BaseMigration):
         try:
             res = await crawls_db.update_many(
                 {"type": "crawl", "state": "stopped_quota_reached"},
-                {"$set": {"state": "stopped_exec_mins_quota_reached"}},
+                {"$set": {"state": "stopped_time_quota_reached"}},
             )
             updated = res.modified_count
             print(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -215,7 +215,7 @@ TYPE_FAILED_STATES = Literal[
     "canceled",
     "failed",
     "skipped_storage_quota_reached",
-    "skipped_exec_mins_quota_reached",
+    "skipped_time_quota_reached",
 ]
 FAILED_STATES = get_args(TYPE_FAILED_STATES)
 
@@ -223,7 +223,7 @@ TYPE_SUCCESSFUL_STATES = Literal[
     "complete",
     "stopped_by_user",
     "stopped_storage_quota_reached",
-    "stopped_exec_mins_quota_reached",
+    "stopped_time_quota_reached",
 ]
 SUCCESSFUL_STATES = get_args(TYPE_SUCCESSFUL_STATES)
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -211,10 +211,20 @@ RUNNING_STATES = get_args(TYPE_RUNNING_STATES)
 TYPE_STARTING_STATES = Literal["starting", "waiting_capacity", "waiting_org_limit"]
 STARTING_STATES = get_args(TYPE_STARTING_STATES)
 
-TYPE_FAILED_STATES = Literal["canceled", "failed", "skipped_quota_reached"]
+TYPE_FAILED_STATES = Literal[
+    "canceled",
+    "failed",
+    "skipped_storage_quota_reached",
+    "skipped_exec_mins_quota_reached",
+]
 FAILED_STATES = get_args(TYPE_FAILED_STATES)
 
-TYPE_SUCCESSFUL_STATES = Literal["complete", "stopped_by_user", "stopped_quota_reached"]
+TYPE_SUCCESSFUL_STATES = Literal[
+    "complete",
+    "stopped_by_user",
+    "stopped_storage_quota_reached",
+    "stopped_exec_mins_quota_reached",
+]
 SUCCESSFUL_STATES = get_args(TYPE_SUCCESSFUL_STATES)
 
 TYPE_RUNNING_AND_STARTING_STATES = Literal[TYPE_STARTING_STATES, TYPE_RUNNING_STATES]

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1234,6 +1234,8 @@ class CrawlOperator(BaseOperator):
             return "size-limit"
 
         # gracefully stop crawl if current running crawl sizes reach storage quota
+        org = await self.org_ops.get_org_by_id(crawl.oid)
+
         running_crawls_total_size = 0
         for crawl_sorted in data.related[CJS].values():
             crawl_status = crawl_sorted.get("status", {})

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -193,7 +193,11 @@ class CrawlOperator(BaseOperator):
             return {"status": status.dict(exclude_none=True), "children": []}
 
         # first, check storage quota, and fail immediately if quota reached
-        if status.state in ("starting", "skipped_quota_reached"):
+        if status.state in (
+            "starting",
+            "skipped_storage_quota_reached",
+            "skipped_time_quota_reached",
+        ):
             # only check on very first run, before any pods/pvcs created
             # for now, allow if crawl has already started (pods/pvcs created)
             if not pods and not data.children[PVC]:

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -205,7 +205,7 @@ class CrawlOperator(BaseOperator):
 
                 if await self.org_ops.exec_mins_quota_reached(crawl.oid):
                     await self.mark_finished(
-                        crawl, status, "skipped_exec_mins_quota_reached"
+                        crawl, status, "skipped_time_quota_reached"
                     )
                     return self._empty_response(status)
 
@@ -1238,7 +1238,7 @@ class CrawlOperator(BaseOperator):
             return "stopped_storage_quota_reached"
 
         if await self.org_ops.exec_mins_quota_reached(crawl.oid):
-            return "stopped_exec_mins_quota_reached"
+            return "stopped_time_quota_reached"
 
         return None
 
@@ -1339,8 +1339,8 @@ class CrawlOperator(BaseOperator):
                 state = "stopped_by_user"
             elif status.stopReason == "stopped_storage_quota_reached":
                 state = "stopped_storage_quota_reached"
-            elif status.stopReason == "stopped_exec_mins_quota_reached":
-                state = "stopped_exec_mins_quota_reached"
+            elif status.stopReason == "stopped_time_quota_reached":
+                state = "stopped_time_quota_reached"
             else:
                 state = "complete"
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -197,13 +197,13 @@ class CrawlOperator(BaseOperator):
             # only check on very first run, before any pods/pvcs created
             # for now, allow if crawl has already started (pods/pvcs created)
             if not pods and not data.children[PVC]:
-                if self.org_ops.storage_quota_reached(crawl.oid):
+                if await self.org_ops.storage_quota_reached(crawl.oid):
                     await self.mark_finished(
                         crawl, status, "skipped_storage_quota_reached"
                     )
                     return self._empty_response(status)
 
-                if self.org_ops.exec_mins_quota_reached(crawl.oid):
+                if await self.org_ops.exec_mins_quota_reached(crawl.oid):
                     await self.mark_finished(
                         crawl, status, "skipped_exec_mins_quota_reached"
                     )

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -16,7 +16,11 @@ POD = "Pod.v1"
 CJS = f"CrawlJob.{BTRIX_API}"
 
 StopReason = Literal[
-    "stopped_by_user", "time-limit", "size-limit", "stopped_quota_reached"
+    "stopped_by_user",
+    "time-limit",
+    "size-limit",
+    "stopped_storage_quota_reached",
+    "stopped_exec_mins_quota_reached",
 ]
 
 

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -20,7 +20,7 @@ StopReason = Literal[
     "time-limit",
     "size-limit",
     "stopped_storage_quota_reached",
-    "stopped_exec_mins_quota_reached",
+    "stopped_time_quota_reached",
 ]
 
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -758,7 +758,7 @@ class OrgOps:
         return False
 
     async def get_org_storage_quota(self, oid: UUID) -> int:
-        """return max allowed concurrent crawls, if any"""
+        """return org storage quota, if any"""
         org_data = await self.orgs.find_one({"_id": oid})
         if org_data:
             org = Organization.from_dict(org_data)

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -183,3 +183,13 @@ def run_crawl(org_id, headers):
 
 def get_total_exec_seconds(execSeconds: Dict[str, int]) -> int:
     return sum(list(execSeconds.values()))
+
+
+def test_unset_execution_mins_quota(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={"maxExecMinutesPerMonth": 0},
+    )
+    data = r.json()
+    assert data.get("updated") == True

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -51,7 +51,7 @@ def test_crawl_stopped_when_quota_reached(org_with_quotas, admin_auth_headers):
     # Ensure that crawl was stopped by quota
     assert (
         get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
-        == "stopped_quota_reached"
+        == "stopped_exec_mins_quota_reached"
     )
 
     time.sleep(5)
@@ -134,7 +134,7 @@ def test_crawl_stopped_when_quota_reached_with_extra(
     # Ensure that crawl was stopped by quota
     assert (
         get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
-        == "stopped_quota_reached"
+        == "stopped_exec_mins_quota_reached"
     )
 
     time.sleep(5)

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -51,7 +51,7 @@ def test_crawl_stopped_when_quota_reached(org_with_quotas, admin_auth_headers):
     # Ensure that crawl was stopped by quota
     assert (
         get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
-        == "stopped_exec_mins_quota_reached"
+        == "stopped_time_quota_reached"
     )
 
     time.sleep(5)
@@ -134,7 +134,7 @@ def test_crawl_stopped_when_quota_reached_with_extra(
     # Ensure that crawl was stopped by quota
     assert (
         get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
-        == "stopped_exec_mins_quota_reached"
+        == "stopped_time_quota_reached"
     )
 
     time.sleep(5)

--- a/backend/test_nightly/test_storage_quota.py
+++ b/backend/test_nightly/test_storage_quota.py
@@ -8,8 +8,8 @@ from .conftest import API_PREFIX
 from .utils import get_crawl_status
 
 
-STORAGE_QUOTA_MB = 5
-STORAGE_QUOTA_BYTES = STORAGE_QUOTA_MB * 1000
+STORAGE_QUOTA_KB = 5
+STORAGE_QUOTA_BYTES = STORAGE_QUOTA_KB * 1000
 
 config_id = None
 

--- a/backend/test_nightly/test_storage_quota.py
+++ b/backend/test_nightly/test_storage_quota.py
@@ -50,11 +50,11 @@ def test_crawl_stopped_when_storage_quota_reached(org_with_quotas, admin_auth_he
         == "stopped_storage_quota_reached"
     )
 
-    time.sleep(5)
+    time.sleep(10)
 
     # Ensure crawl storage went over quota
     r = requests.get(
-        f"{API_PREFIX}/orgs/{org_with_quotas}/crawls/{crawl_id}/replay.json",
+        f"{API_PREFIX}/orgs/{org_with_quotas}",
         headers=admin_auth_headers,
     )
     data = r.json()
@@ -81,6 +81,8 @@ def test_storage_checked_first(org_with_quotas, admin_auth_headers):
     )
     assert r.status_code == 200
     assert r.json()["updated"]
+
+    time.sleep(5)
 
     # Try to start a crawl and ensure the reason we can't start it is
     # still storage quota, as that should be checked before execution time

--- a/backend/test_nightly/test_storage_quota.py
+++ b/backend/test_nightly/test_storage_quota.py
@@ -1,0 +1,121 @@
+import math
+import requests
+import time
+from datetime import datetime
+from typing import Dict
+
+from .conftest import API_PREFIX
+from .utils import get_crawl_status
+
+
+STORAGE_QUOTA_MB = 5
+STORAGE_QUOTA_BYTES = STORAGE_QUOTA_MB * 1000
+
+config_id = None
+
+
+def test_storage_quota(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={"storageQuota": STORAGE_QUOTA_BYTES},
+    )
+    assert r.status_code == 200
+    assert r.json()["updated"]
+
+
+def test_crawl_stopped_when_storage_quota_reached(org_with_quotas, admin_auth_headers):
+    # Run crawl
+    global config_id
+    crawl_id, config_id = run_crawl(org_with_quotas, admin_auth_headers)
+    time.sleep(1)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "starting",
+        "waiting_capacity",
+    ):
+        time.sleep(2)
+
+    while get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers) in (
+        "running",
+        "generate-wacz",
+        "uploading-wacz",
+        "pending-wait",
+    ):
+        time.sleep(2)
+
+    # Ensure that crawl was stopped by quota
+    assert (
+        get_crawl_status(org_with_quotas, crawl_id, admin_auth_headers)
+        == "stopped_storage_quota_reached"
+    )
+
+    time.sleep(5)
+
+    # Ensure crawl storage went over quota
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawls/{crawl_id}/replay.json",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    bytes_stored = data["storageUsedBytes"]
+    assert bytes_stored >= STORAGE_QUOTA_BYTES
+
+    time.sleep(5)
+
+    # Ensure we can't start another crawl when over the quota
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "storage_quota_reached"
+
+
+def test_storage_checked_first(org_with_quotas, admin_auth_headers):
+    # Set to value that's already exceeded in previous test
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={"maxExecMinutesPerMonth": 1},
+    )
+    assert r.status_code == 200
+    assert r.json()["updated"]
+
+    # Try to start a crawl and ensure the reason we can't start it is
+    # still storage quota, as that should be checked before execution time
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/crawlconfigs/{config_id}/run",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "storage_quota_reached"
+
+
+def run_crawl(org_id, headers):
+    crawl_data = {
+        "runNow": True,
+        "name": "Storage Quota",
+        "config": {
+            "seeds": [{"url": "https://webrecorder.net/"}],
+            "extraHops": 1,
+        },
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_id}/crawlconfigs/",
+        headers=headers,
+        json=crawl_data,
+    )
+    data = r.json()
+
+    return data["run_now_job"], data["id"]
+
+
+def test_unset_quotas(org_with_quotas, admin_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={"maxExecMinutesPerMonth": 0, "storageQuota": 0},
+    )
+    assert r.status_code == 200
+    assert r.json()["updated"]

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -188,7 +188,7 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Skipped: Storage Quota Reached");
         break;
 
-      case "skipped_exec_mins_quota_reached":
+      case "skipped_time_quota_reached":
         color = "var(--danger)";
         icon = html`<sl-icon
           name="exclamation-triangle-fill"
@@ -218,7 +218,7 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Stopped: Storage Quota Reached");
         break;
 
-      case "stopped_exec_mins_quota_reached":
+      case "stopped_time_quota_reached":
         color = "var(--warning)";
         icon = html`<sl-icon
           name="exclamation-square-fill"

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -178,7 +178,7 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Failed");
         break;
 
-      case "skipped_quota_reached":
+      case "skipped_storage_quota_reached":
         color = "var(--danger)";
         icon = html`<sl-icon
           name="exclamation-triangle-fill"
@@ -186,6 +186,16 @@ export class CrawlStatus extends TailwindElement {
           style="color: ${color}"
         ></sl-icon>`;
         label = msg("Skipped: Storage Quota Reached");
+        break;
+
+      case "skipped_exec_mins_quota_reached":
+        color = "var(--danger)";
+        icon = html`<sl-icon
+          name="exclamation-triangle-fill"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Skipped: Time Quota Reached");
         break;
 
       case "stopped_by_user":
@@ -198,7 +208,17 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Stopped");
         break;
 
-      case "stopped_quota_reached":
+      case "stopped_storage_quota_reached":
+        color = "var(--warning)";
+        icon = html`<sl-icon
+          name="exclamation-square-fill"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Stopped: Storage Quota Reached");
+        break;
+
+      case "stopped_exec_mins_quota_reached":
         color = "var(--warning)";
         icon = html`<sl-icon
           name="exclamation-square-fill"

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -134,10 +134,12 @@ export type CrawlState =
   | "stopping"
   | "complete"
   | "failed"
-  | "skipped_quota_reached"
+  | "skipped_storage_quota_reached"
+  | "skipped_exec_mins_quota_reached"
   | "canceled"
   | "stopped_by_user"
-  | "stopped_quota_reached";
+  | "stopped_storage_quota_reached"
+  | "stopped_exec_mins_quota_reached";
 
 // TODO maybe convert this to an enum?
 export enum ReviewStatus {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -135,11 +135,11 @@ export type CrawlState =
   | "complete"
   | "failed"
   | "skipped_storage_quota_reached"
-  | "skipped_exec_mins_quota_reached"
+  | "skipped_time_quota_reached"
   | "canceled"
   | "stopped_by_user"
   | "stopped_storage_quota_reached"
-  | "stopped_exec_mins_quota_reached";
+  | "stopped_time_quota_reached";
 
 // TODO maybe convert this to an enum?
 export enum ReviewStatus {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -20,14 +20,14 @@ export const finishedCrawlStates: CrawlState[] = [
   "complete",
   "stopped_by_user",
   "stopped_storage_quota_reached",
-  "stopped_exec_mins_quota_reached",
+  "stopped_time_quota_reached",
 ];
 
 export const inactiveCrawlStates: CrawlState[] = [
   ...finishedCrawlStates,
   "canceled",
   "skipped_storage_quota_reached",
-  "skipped_exec_mins_quota_reached",
+  "skipped_time_quota_reached",
   "failed",
 ];
 

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -19,13 +19,15 @@ export const activeCrawlStates: CrawlState[] = [
 export const finishedCrawlStates: CrawlState[] = [
   "complete",
   "stopped_by_user",
-  "stopped_quota_reached",
+  "stopped_storage_quota_reached",
+  "stopped_exec_mins_quota_reached",
 ];
 
 export const inactiveCrawlStates: CrawlState[] = [
   ...finishedCrawlStates,
   "canceled",
-  "skipped_quota_reached",
+  "skipped_storage_quota_reached",
+  "skipped_exec_mins_quota_reached",
   "failed",
 ];
 


### PR DESCRIPTION
Fixes #1968 

Changes:
- `stopped_quota_reached` and `skipped_quota_reached` migrated to new values that indicate which quota was reached
- Before crawls are run, the operator checks if storage or exec mins quotas are reached and if so fails the crawl with the appropriate state of `skipped_storage_quota_reached` or `skipped_time_quota_reached`
- While crawls are running, the operator checks if the exec mins quota is reached or if the size of all running crawls will mean the storage quota is reached once uploaded; if so, the crawl is stopped gracefully and given `stopped_storage_quota_needed` or `stopped_time_quota_reached` state as appropriate
- Adds new nightly tests for enforcing storage quota

To run the nightly tests, build the local backend and then run:

- `python -m pytest backend/test_nightly/test_storage_quota.py`
- `python -m pytest backend/test_nightly/test_execution_minutes_quota.py`