### PR TITLE
feat: Show details of invalid invite

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -188,6 +188,7 @@ export class App extends LiteElement {
         maxScale: 0,
         billingEnabled: false,
         salesEmail: "",
+        supportEmail: "",
       };
     }
   }

--- a/frontend/src/pages/invite/join.ts
+++ b/frontend/src/pages/invite/join.ts
@@ -1,4 +1,4 @@
-import { localized, msg } from "@lit/localize";
+import { localized, msg, str } from "@lit/localize";
 import { Task } from "@lit/task";
 import { customElement, property, state } from "lit/decorators.js";
 
@@ -132,16 +132,27 @@ export class Join extends LiteElement {
       `/api/users/invite/${token}?email=${encodeURIComponent(email)}`,
     );
 
-    if (resp.status === 200) {
-      return (await resp.json()) as UserOrgInviteInfo;
-    } else if (resp.status === 404) {
-      throw new Error(
-        msg(
-          "This invite doesn't exist or has expired. Please ask the organization administrator to resend an invitation.",
-        ),
-      );
-    } else {
-      throw new Error(msg("This invitation is not valid."));
+    switch (resp.status) {
+      case 200:
+        return (await resp.json()) as UserOrgInviteInfo;
+      case 404:
+        throw new Error(
+          msg(
+            "This invite doesn't exist or has expired. Please ask the organization administrator to resend an invitation.",
+          ),
+        );
+      case 400:
+        throw new Error(
+          msg(
+            str`This is not a valid invite, or it may have expired. If you believe this is an error, please contact ${this.appState.settings?.supportEmail || msg("your Browsertrix administrator")} for help.`,
+          ),
+        );
+      default:
+        throw new Error(
+          msg(
+            str`Something unexpected went wrong retrieving this invite. Please contact ${this.appState.settings?.supportEmail || msg("your Browsertrix administrator")} for help.`,
+          ),
+        );
     }
   }
 

--- a/frontend/src/types/app.ts
+++ b/frontend/src/types/app.ts
@@ -7,4 +7,5 @@ export type AppSettings = {
   maxScale: number;
   billingEnabled: boolean;
   salesEmail: string;
+  supportEmail: string;
 };


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1912

### Changes

- Show support email, if available, in invalid invite error message
- Separate error message for invite email that doesn't match current user's

### Manual testing

1. Log-in as existing user.
2. Navigate to an invalid invite URL with current email address, eg. `http://localhost:9870/invite/accept/ABC?email=<current user email>`. Verify support email is shown in email
3. Navigate to an invalid invite URL with wrong email address, eg. `http://localhost:9870/invite/accept/ABC?email=<any other email address except that of current user>`. Verify invite email and current user email is shown

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Accept Invite - Wrong user | <img width="938" alt="Screenshot 2024-07-24 at 4 20 27 PM" src="https://github.com/user-attachments/assets/8aa19777-786c-4485-a1cf-341f9da98ff5"> |

<!-- ### Follow-ups -->
