### PR TITLE
feat: Minor improvements to superadmin view

### DIFF
--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -476,7 +476,7 @@ export class OrgsList extends TailwindElement {
     if (org.readOnly) {
       status = {
         icon: html`<sl-icon
-          class="text-base text-neutral-400"
+          class="text-base text-neutral-500"
           name="slash-circle"
           label=${msg("Read-only")}
         >
@@ -500,7 +500,7 @@ export class OrgsList extends TailwindElement {
         </btrix-table-cell>
         <btrix-table-cell class="p-2" rowClickTarget="a">
           <a
-            class=${org.readOnly ? "text-neutral-400" : "text-neutral-900"}
+            class=${org.readOnly ? "text-neutral-500" : "text-neutral-900"}
             href="/orgs/${org.slug}"
             @click=${this.navigate.link}
             aria-disabled="${!isUserOrg}"
@@ -508,7 +508,9 @@ export class OrgsList extends TailwindElement {
             ${org.default
               ? html`<btrix-tag class="mr-1">${msg("Default")}</btrix-tag>`
               : nothing}
-            ${org.name}
+            ${org.name === org.id
+              ? html`<code class="text-neutral-400">${org.id}</code>`
+              : org.name}
           </a>
         </btrix-table-cell>
         <btrix-table-cell class="p-2">

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -16,7 +16,7 @@ import { NavigateController } from "@/controllers/navigate";
 import { NotifyController } from "@/controllers/notify";
 import type { CurrentUser } from "@/types/user";
 import type { AuthState } from "@/utils/AuthService";
-import { formatNumber } from "@/utils/localization";
+import { formatNumber, getLocale } from "@/utils/localization";
 import type { OrgData } from "@/utils/orgs";
 
 /**
@@ -27,7 +27,7 @@ import type { OrgData } from "@/utils/orgs";
 export class OrgsList extends TailwindElement {
   static styles = css`
     btrix-table {
-      grid-template-columns: min-content [clickable-start] 50ch auto auto [clickable-end] min-content;
+      grid-template-columns: min-content [clickable-start] 50ch auto auto auto [clickable-end] min-content;
     }
   `;
 
@@ -75,6 +75,9 @@ export class OrgsList extends TailwindElement {
           </btrix-table-header-cell>
           <btrix-table-header-cell class="px-2">
             ${msg("Name")}
+          </btrix-table-header-cell>
+          <btrix-table-header-cell class="px-2">
+            ${msg("Created")}
           </btrix-table-header-cell>
           <btrix-table-header-cell class="px-2">
             ${msg("Members")}
@@ -512,6 +515,17 @@ export class OrgsList extends TailwindElement {
               ? html`<code class="text-neutral-400">${org.id}</code>`
               : org.name}
           </a>
+        </btrix-table-cell>
+
+        <btrix-table-cell class="p-2">
+          <sl-format-date
+            lang=${getLocale()}
+            class="truncate"
+            date=${`${org.created}Z`}
+            month="2-digit"
+            day="2-digit"
+            year="2-digit"
+          ></sl-format-date>
         </btrix-table-cell>
         <btrix-table-cell class="p-2">
           ${memberCount ? formatNumber(memberCount) : none}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -291,6 +291,7 @@ export class App extends LiteElement {
           class="mx-auto box-border flex h-12 items-center justify-between px-3 xl:pl-6"
         >
           <a
+            class="items-between flex gap-2"
             aria-label="home"
             href=${homeHref}
             @click=${(e: MouseEvent) => {
@@ -301,6 +302,9 @@ export class App extends LiteElement {
             }}
           >
             <img class="h-6" alt="Browsertrix logo" src=${brandLockupColor} />
+            ${isSuperAdmin
+              ? html`<btrix-tag>${msg("Admin")}</btrix-tag>`
+              : nothing}
           </a>
           ${isSuperAdmin
             ? html`

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -31,6 +31,7 @@ export type OrgQuotas = {
 export type OrgData = {
   id: string;
   name: string;
+  created: string;
   slug: string;
   default: boolean;
   quotas: OrgQuotas;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1951

### Changes

- Shows date org was created in superadmin org list
- Visually differentiates unnamed org ID
- Adds "Admin" badge to app header to make current login more apparent
- Fixes logic to show "create org" dialog if there are no orgs in an instance
- Refactors `btrix-home` to remove unused references to non-superadmin org list

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Superadmin - Org list | <img width="874" alt="Screenshot 2024-07-24 at 5 15 07 PM" src="https://github.com/user-attachments/assets/6929f4ea-91da-4129-84d4-5ba6ab780655"> |


### Follow-ups

We'll probably want to clean up and refactor `btrix-home` now that it's primarily the superadmin view, and the old logic to show orgs list has been removed. https://github.com/webrecorder/browsertrix/issues/1972
