### PR TITLE
optimize org quota lookups

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -123,7 +123,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 # ============================================================================
 def verify_and_update_password(
     plain_password: str, hashed_password: str
-) -> Tuple[bool, str]:
+) -> Tuple[bool, Optional[str]]:
     """verify password and return updated hash, if any"""
     return PWD_CONTEXT.verify_and_update(plain_password, hashed_password)
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -357,7 +357,9 @@ class BaseCrawlOps:
         query = {"_id": {"$in": delete_list.crawl_ids}, "oid": org.id, "type": type_}
         res = await self.crawls.delete_many(query)
 
-        quota_reached = await self.orgs.inc_org_bytes_stored(org, -size, type_)
+        await self.orgs.inc_org_bytes_stored(org.id, -size, type_)
+
+        quota_reached = self.orgs.storage_quota_reached(org)
 
         return res.deleted_count, cids_to_update, quota_reached
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -357,7 +357,7 @@ class BaseCrawlOps:
         query = {"_id": {"$in": delete_list.crawl_ids}, "oid": org.id, "type": type_}
         res = await self.crawls.delete_many(query)
 
-        quota_reached = await self.orgs.inc_org_bytes_stored(org.id, -size, type_)
+        quota_reached = await self.orgs.inc_org_bytes_stored(org, -size, type_)
 
         return res.deleted_count, cids_to_update, quota_reached
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -187,10 +187,11 @@ class BaseCrawlOps:
             if crawl.config and crawl.config.seeds:
                 crawl.config.seeds = None
 
-        crawl.storageQuotaReached = await self.orgs.storage_quota_reached(crawl.oid)
-        crawl.execMinutesQuotaReached = await self.orgs.exec_mins_quota_reached(
-            crawl.oid
-        )
+        if not org:
+            org = await self.orgs.get_org_by_id(crawl.oid)
+
+        crawl.storageQuotaReached = self.orgs.storage_quota_reached(org)
+        crawl.execMinutesQuotaReached = self.orgs.exec_mins_quota_reached(org)
 
         return crawl
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -248,8 +248,8 @@ class CrawlConfigOps:
                     exec_mins_quota_reached = True
                 print(f"Can't run crawl now: {e.detail}", flush=True)
         else:
-            storage_quota_reached = await self.org_ops.storage_quota_reached(org.id)
-            exec_mins_quota_reached = await self.org_ops.exec_mins_quota_reached(org.id)
+            storage_quota_reached = self.org_ops.storage_quota_reached(org)
+            exec_mins_quota_reached = self.org_ops.exec_mins_quota_reached(org)
 
         return CrawlConfigAddedResponse(
             added=True,
@@ -406,10 +406,8 @@ class CrawlConfigOps:
             "updated": True,
             "settings_changed": changed,
             "metadata_changed": metadata_changed,
-            "storageQuotaReached": await self.org_ops.storage_quota_reached(org.id),
-            "execMinutesQuotaReached": await self.org_ops.exec_mins_quota_reached(
-                org.id
-            ),
+            "storageQuotaReached": self.org_ops.storage_quota_reached(org),
+            "execMinutesQuotaReached": self.org_ops.exec_mins_quota_reached(org),
         }
         if run_now:
             crawl_id = await self.run_now(cid, org, user)
@@ -827,7 +825,7 @@ class CrawlConfigOps:
         self, crawlconfig: CrawlConfig, org: Organization, user: User
     ) -> str:
         """run new crawl for specified crawlconfig now"""
-        await self.org_ops.can_run_crawls(org)
+        self.org_ops.can_write_data(org)
 
         if await self.get_running_crawl(crawlconfig):
             raise HTTPException(status_code=400, detail="crawl_already_running")

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -225,7 +225,7 @@ class CrawlConfigOps:
             crawlconfig.lastStartedByName = user.name
 
         # Ensure page limit is below org maxPagesPerCall if set
-        max_pages = await self.org_ops.get_max_pages_per_crawl(org.id)
+        max_pages = org.quotas.maxPagesPerCrawl or 0
         if max_pages > 0:
             crawlconfig.config.limit = max_pages
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -813,7 +813,7 @@ class CrawlOps(BaseCrawlOps):
         if not crawl.cid or crawl.type != "crawl":
             raise HTTPException(status_code=400, detail="invalid_crawl_for_qa")
 
-        await self.orgs.can_run_crawls(org)
+        self.orgs.can_write_data(org)
 
         crawlconfig = await self.crawl_configs.get_crawl_config(crawl.cid, org.id)
 

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -144,13 +144,13 @@ class BaseOperator:
     k8s: K8sOpAPI
     crawl_config_ops: CrawlConfigOps
     crawl_ops: CrawlOps
-    orgs_ops: OrgOps
+    org_ops: OrgOps
     coll_ops: CollectionOps
     storage_ops: StorageOps
-    event_webhook_ops: EventWebhookOps
     background_job_ops: BackgroundJobOps
-    user_ops: UserManager
+    event_webhook_ops: EventWebhookOps
     page_ops: PageOps
+    user_ops: UserManager
 
     def __init__(
         self,
@@ -173,7 +173,6 @@ class BaseOperator:
         self.background_job_ops = background_job_ops
         self.event_webhook_ops = event_webhook_ops
         self.page_ops = page_ops
-
         self.user_ops = crawl_config_ops.user_manager
 
         # to avoid background tasks being garbage collected

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1450,8 +1450,9 @@ class CrawlOperator(BaseOperator):
         )
 
         if state in SUCCESSFUL_STATES and crawl.oid:
-            org = await self.org_ops.get_org_by_id(crawl.oid)
-            await self.org_ops.inc_org_bytes_stored(org, status.filesAddedSize, "crawl")
+            await self.org_ops.inc_org_bytes_stored(
+                crawl.oid, status.filesAddedSize, "crawl"
+            )
             await self.coll_ops.add_successful_crawl_to_collections(crawl.id, crawl.cid)
 
         if state in FAILED_STATES:

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1450,9 +1450,8 @@ class CrawlOperator(BaseOperator):
         )
 
         if state in SUCCESSFUL_STATES and crawl.oid:
-            await self.org_ops.inc_org_bytes_stored(
-                crawl.oid, status.filesAddedSize, "crawl"
-            )
+            org = await self.org_ops.get_org_by_id(crawl.oid)
+            await self.org_ops.inc_org_bytes_stored(org, status.filesAddedSize, "crawl")
             await self.coll_ops.add_successful_crawl_to_collections(crawl.id, crawl.cid)
 
         if state in FAILED_STATES:

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -113,7 +113,7 @@ class CronJobOperator(BaseOperator):
             cid=str(cid),
             userid=str(userid),
             oid=str(oid),
-            storage=org.storage,
+            storage=str(org.storage),
             crawler_channel=crawlconfig.crawlerChannel or "default",
             scale=crawlconfig.scale,
             crawl_timeout=crawlconfig.crawlTimeout,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -681,27 +681,23 @@ class OrgOps:
             return org.quotas.maxPagesPerCrawl or 0
         return 0
 
-    async def inc_org_bytes_stored(
-        self, org: Organization, size: int, type_="crawl"
-    ) -> bool:
+    async def inc_org_bytes_stored(self, oid: UUID, size: int, type_="crawl") -> None:
         """Increase org bytesStored count (pass negative value to subtract)."""
         if type_ == "crawl":
             await self.orgs.find_one_and_update(
-                {"_id": org.id},
+                {"_id": oid},
                 {"$inc": {"bytesStored": size, "bytesStoredCrawls": size}},
             )
         elif type_ == "upload":
             await self.orgs.find_one_and_update(
-                {"_id": org.id},
+                {"_id": oid},
                 {"$inc": {"bytesStored": size, "bytesStoredUploads": size}},
             )
         elif type_ == "profile":
             await self.orgs.find_one_and_update(
-                {"_id": org.id},
+                {"_id": oid},
                 {"$inc": {"bytesStored": size, "bytesStoredProfiles": size}},
             )
-
-        return self.storage_quota_reached(org)
 
     def can_write_data(self, org: Organization, include_time=True) -> None:
         """check crawl quotas and readOnly state, throw if can not run"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -681,22 +681,23 @@ class OrgOps:
             return org.quotas.maxPagesPerCrawl or 0
         return 0
 
-    async def inc_org_bytes_stored(self, oid: UUID, size: int, type_="crawl") -> bool:
+    async def inc_org_bytes_stored(
+        self, org: Organization, size: int, type_="crawl"
+    ) -> bool:
         """Increase org bytesStored count (pass negative value to subtract)."""
-        org = await self.get_org_by_id(oid)
-
         if type_ == "crawl":
             await self.orgs.find_one_and_update(
-                {"_id": oid}, {"$inc": {"bytesStored": size, "bytesStoredCrawls": size}}
+                {"_id": org.id},
+                {"$inc": {"bytesStored": size, "bytesStoredCrawls": size}},
             )
         elif type_ == "upload":
             await self.orgs.find_one_and_update(
-                {"_id": oid},
+                {"_id": org.id},
                 {"$inc": {"bytesStored": size, "bytesStoredUploads": size}},
             )
         elif type_ == "profile":
             await self.orgs.find_one_and_update(
-                {"_id": oid},
+                {"_id": org.id},
                 {"$inc": {"bytesStored": size, "bytesStoredProfiles": size}},
             )
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -673,14 +673,6 @@ class OrgOps:
                 org_owners.append(key)
         return org_owners
 
-    async def get_max_pages_per_crawl(self, oid: UUID) -> int:
-        """Return org-specific max pages per crawl setting or 0."""
-        org_data = await self.orgs.find_one({"_id": oid})
-        if org_data:
-            org = Organization.from_dict(org_data)
-            return org.quotas.maxPagesPerCrawl or 0
-        return 0
-
     async def inc_org_bytes_stored(self, oid: UUID, size: int, type_="crawl") -> None:
         """Increase org bytesStored count (pass negative value to subtract)."""
         if type_ == "crawl":
@@ -861,19 +853,11 @@ class OrgOps:
                 },
             )
 
-    async def get_max_concurrent_crawls(self, oid) -> int:
-        """return max allowed concurrent crawls, if any"""
-        org_data = await self.orgs.find_one({"_id": oid})
-        if org_data:
-            org = Organization.from_dict(org_data)
-            return org.quotas.maxConcurrentCrawls or 0
-        return 0
-
     async def get_org_metrics(self, org: Organization) -> dict[str, int]:
         """Calculate and return org metrics"""
         # pylint: disable=too-many-locals
         storage_quota = org.quotas.storageQuota or 0
-        max_concurrent_crawls = await self.get_max_concurrent_crawls(org.id)
+        max_concurrent_crawls = org.quotas.maxConcurrentCrawls or 0
 
         # Calculate these counts in loop to avoid having db iterate through
         # archived items several times.

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -170,7 +170,6 @@ class PageOps:
                 return
 
             compare = PageQACompare(**compare_dict)
-            print("Adding QA Run Data for Page", page_dict.get("url"), compare)
 
             await self.add_qa_run_for_page(page.id, oid, qa_run_id, compare)
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -248,12 +248,12 @@ class ProfileOps:
             org.id, profile_file, str(profileid), "profile"
         )
 
-        quota_reached = await self.orgs.inc_org_bytes_stored(org, file_size, "profile")
+        await self.orgs.inc_org_bytes_stored(org.id, file_size, "profile")
 
         return {
             "added": True,
             "id": str(profile.id),
-            "storageQuotaReached": quota_reached,
+            "storageQuotaReached": self.orgs.storage_quota_reached(org),
         }
 
     async def update_profile_metadata(
@@ -415,7 +415,9 @@ class ProfileOps:
         # Delete file from storage
         if profile.resource:
             await self.storage_ops.delete_crawl_file_object(org, profile.resource)
-            await self.orgs.inc_org_bytes_stored(org, -profile.resource.size, "profile")
+            await self.orgs.inc_org_bytes_stored(
+                org.id, -profile.resource.size, "profile"
+            )
             await self.background_job_ops.create_delete_replica_jobs(
                 org, profile.resource, str(profile.id), "profile"
             )

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -222,11 +222,7 @@ class ProfileOps:
 
         oid = UUID(metadata.get("btrix.org"))
 
-        if org.readOnly:
-            raise HTTPException(status_code=403, detail="org_set_to_read_only")
-
-        if await self.orgs.storage_quota_reached(oid):
-            raise HTTPException(status_code=403, detail="storage_quota_reached")
+        self.orgs.can_write_data(org, include_time=False)
 
         profile = Profile(
             id=profileid,
@@ -432,7 +428,7 @@ class ProfileOps:
         if not res or res.deleted_count != 1:
             raise HTTPException(status_code=404, detail="profile_not_found")
 
-        quota_reached = await self.orgs.storage_quota_reached(org.id)
+        quota_reached = self.orgs.storage_quota_reached(org)
 
         return {"success": True, "storageQuotaReached": quota_reached}
 

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -195,9 +195,7 @@ class UploadOps(BaseCrawlOps):
             self.event_webhook_ops.create_upload_finished_notification(crawl_id, org.id)
         )
 
-        quota_reached = await self.orgs.inc_org_bytes_stored(
-            org.id, file_size, "upload"
-        )
+        quota_reached = await self.orgs.inc_org_bytes_stored(org, file_size, "upload")
 
         if uploaded.files:
             for file in uploaded.files:

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -195,7 +195,9 @@ class UploadOps(BaseCrawlOps):
             self.event_webhook_ops.create_upload_finished_notification(crawl_id, org.id)
         )
 
-        quota_reached = await self.orgs.inc_org_bytes_stored(org, file_size, "upload")
+        await self.orgs.inc_org_bytes_stored(org.id, file_size, "upload")
+
+        quota_reached = self.orgs.storage_quota_reached(org)
 
         if uploaded.files:
             for file in uploaded.files:

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -67,11 +67,7 @@ class UploadOps(BaseCrawlOps):
         replaceId: Optional[str],
     ) -> dict[str, Any]:
         """Upload streaming file, length unknown"""
-        if org.readOnly:
-            raise HTTPException(status_code=403, detail="org_set_to_read_only")
-
-        if await self.orgs.storage_quota_reached(org.id):
-            raise HTTPException(status_code=403, detail="storage_quota_reached")
+        self.orgs.can_write_data(org, include_time=False)
 
         prev_upload = None
         if replaceId:
@@ -129,11 +125,7 @@ class UploadOps(BaseCrawlOps):
         user: User,
     ) -> dict[str, Any]:
         """handle uploading content to uploads subdir + request subdir"""
-        if org.readOnly:
-            raise HTTPException(status_code=403, detail="org_set_to_read_only")
-
-        if await self.orgs.storage_quota_reached(org.id):
-            raise HTTPException(status_code=403, detail="storage_quota_reached")
+        self.orgs.can_write_data(org, include_time=False)
 
         id_ = uuid.uuid4()
         files: List[CrawlFile] = []


### PR DESCRIPTION
- instead of looking up storage and exec min quotas from oid, and loading an org each time, load org once and then check quotas on the org object - many times the org was already available, and was looked up again
- storage and exec quota checks become sync
- rename can_run_crawl() to more generic can_write_data(), optionally also checks exec minutes
- typing: get_org_by_id() always returns org, or throws, adjust methods accordingly (don't check for none, catch exception)
- typing: fix typo in BaseOperator, catch type errors in operator 'org_ops'
- operator quota check: use up-to-date 'status.size' for current job, ignore current job in all jobs list to avoid double-counting
- follow up to #1969