### PR TITLE
Add webhooks for qaAnalysisStarted, qaAnalysisFinished, and crawlReviewed

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -8,8 +8,8 @@ import urllib.parse
 
 import asyncio
 from fastapi import HTTPException, Depends
-import pymongo
 from fastapi.responses import StreamingResponse
+import pymongo
 
 from .models import (
     CrawlFile,
@@ -251,9 +251,9 @@ class BaseCrawlOps:
         if not result:
             raise HTTPException(status_code=404, detail="crawl_not_found")
 
-        crawl = BaseCrawl.from_dict(result)
-
         if update_values.get("reviewStatus"):
+            crawl = BaseCrawl.from_dict(result)
+
             await self.event_webhook_ops.create_crawl_reviewed_notification(
                 crawl.id, crawl.oid, crawl.reviewStatus, crawl.description
             )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -929,12 +929,15 @@ class CrawlOps(BaseCrawlOps):
         if crawl.qa.finished and crawl.qa.state in NON_RUNNING_STATES:
             query[f"qaFinished.{crawl.qa.id}"] = crawl.qa.dict()
 
-        if await self.crawls.find_one_and_update(
+        res = await self.crawls.find_one_and_update(
             {"_id": crawl_id, "type": "crawl"}, {"$set": query}
-        ):
-            return True
+        )
 
-        return False
+        await self.event_webhook_ops.create_qa_analysis_finished_notification(
+            crawl.qa, crawl.oid, crawl.id
+        )
+
+        return res
 
     async def get_qa_runs(
         self,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1267,6 +1267,9 @@ class OrgWebhookUrls(BaseModel):
     crawlStarted: Optional[AnyHttpUrl] = None
     crawlFinished: Optional[AnyHttpUrl] = None
     crawlDeleted: Optional[AnyHttpUrl] = None
+    qaAnalysisStarted: Optional[AnyHttpUrl] = None
+    qaAnalysisFinished: Optional[AnyHttpUrl] = None
+    crawlReviewed: Optional[AnyHttpUrl] = None
     uploadFinished: Optional[AnyHttpUrl] = None
     uploadDeleted: Optional[AnyHttpUrl] = None
     addedToCollection: Optional[AnyHttpUrl] = None
@@ -1725,6 +1728,11 @@ class WebhookEventType(str, Enum):
     CRAWL_FINISHED = "crawlFinished"
     CRAWL_DELETED = "crawlDeleted"
 
+    QA_ANALYSIS_STARTED = "qaAnalysisStarted"
+    QA_ANALYSIS_FINISHED = "qaAnalysisFinished"
+
+    CRAWL_REVIEWED = "crawlReviewed"
+
     UPLOAD_FINISHED = "uploadFinished"
     UPLOAD_DELETED = "uploadDeleted"
 
@@ -1822,6 +1830,39 @@ class UploadDeletedBody(BaseArchivedItemBody):
 
 
 # ============================================================================
+class QaAnalysisStartedBody(BaseArchivedItemBody):
+    """Webhook notification POST body for when qa analysis run starts"""
+
+    event: Literal[WebhookEventType.QA_ANALYSIS_STARTED] = (
+        WebhookEventType.QA_ANALYSIS_STARTED
+    )
+
+    qaRunId: str
+
+
+# ============================================================================
+class QaAnalysisFinishedBody(BaseArchivedItemFinishedBody):
+    """Webhook notification POST body for when qa analysis run finishes"""
+
+    event: Literal[WebhookEventType.QA_ANALYSIS_FINISHED] = (
+        WebhookEventType.QA_ANALYSIS_FINISHED
+    )
+
+    qaRunId: str
+
+
+# ============================================================================
+class CrawlReviewedBody(BaseArchivedItemBody):
+    """Webhook notification POST body for when crawl is reviewed in qa"""
+
+    event: Literal[WebhookEventType.CRAWL_REVIEWED] = WebhookEventType.CRAWL_REVIEWED
+
+    reviewStatus: ReviewStatus
+    reviewStatusLabel: str
+    description: Optional[str] = None
+
+
+# ============================================================================
 class WebhookNotification(BaseMongoModel):
     """Base POST body model for webhook notifications"""
 
@@ -1831,6 +1872,9 @@ class WebhookNotification(BaseMongoModel):
         CrawlStartedBody,
         CrawlFinishedBody,
         CrawlDeletedBody,
+        QaAnalysisStartedBody,
+        QaAnalysisFinishedBody,
+        CrawlReviewedBody,
         UploadFinishedBody,
         UploadDeletedBody,
         CollectionItemAddedBody,

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -15,6 +15,9 @@ from .models import (
     CrawlStartedBody,
     CrawlFinishedBody,
     CrawlDeletedBody,
+    QaAnalysisStartedBody,
+    QaAnalysisFinishedBody,
+    CrawlReviewedBody,
     UploadFinishedBody,
     UploadDeletedBody,
     CollectionItemAddedBody,
@@ -195,7 +198,7 @@ class EventWebhookOps:
         crawl_id: str,
         org: Organization,
         event: str,
-        body: Union[CrawlFinishedBody, UploadFinishedBody],
+        body: Union[CrawlFinishedBody, QaAnalysisFinishedBody, UploadFinishedBody],
     ):
         """Create webhook notification for finished crawl/upload."""
         crawl = await self.crawl_ops.get_crawl_out(crawl_id, org)
@@ -262,6 +265,60 @@ class EventWebhookOps:
                 resources=[],
             ),
         )
+
+    async def create_qa_analysis_finished_notification(
+        self, qa_run_id: str, oid: UUID, state: str, crawl_id: Optional[str] = ""
+    ) -> None:
+        """Create webhook notification for finished qa analysis run."""
+        org = await self.org_ops.get_org_by_id(oid)
+
+        if not org.webhookUrls or not org.webhookUrls.qaAnalysisFinished:
+            return
+
+        if crawl_id is None:
+            crawl_id = ""
+
+        qa_files = []
+        qa_resources = []
+
+        # Check both crawl.qa and crawl.qaFinished for files because we don't
+        # know for certain what state the crawl will be in at this point
+        try:
+            crawl = await self.crawl_ops.get_crawl(crawl_id)
+            if crawl.qa:
+                qa_files = crawl.qa.files
+
+            qa_finished = crawl.qaFinished
+            if qa_finished:
+                qa_run = qa_finished.get(qa_run_id)
+                if qa_run:
+                    qa_files = qa_run.files
+
+            if qa_files:
+                qa_resources = await self.crawl_ops.resolve_signed_urls(
+                    qa_files, org, crawl_id, qa_run_id
+                )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(f"Error trying to get QA run resources: {err}", flush=True)
+
+        notification = WebhookNotification(
+            id=uuid4(),
+            event=WebhookEventType.QA_ANALYSIS_FINISHED,
+            oid=oid,
+            body=QaAnalysisFinishedBody(
+                itemId=crawl_id,
+                qaRunId=qa_run_id,
+                orgId=str(org.id),
+                state=state,
+                resources=qa_resources,
+            ),
+            created=dt_now(),
+        )
+
+        await self.webhooks.insert_one(notification.to_dict())
+
+        await self.send_notification(org, notification)
 
     async def create_crawl_deleted_notification(
         self, crawl_id: str, org: Organization
@@ -337,6 +394,85 @@ class EventWebhookOps:
                 itemId=crawl_id,
                 orgId=str(oid),
                 scheduled=scheduled,
+            ),
+            created=dt_now(),
+        )
+
+        await self.webhooks.insert_one(notification.to_dict())
+
+        await self.send_notification(org, notification)
+
+    async def create_qa_analysis_started_notification(
+        self, qa_run_id: str, oid: UUID, crawl_id: Optional[str] = ""
+    ) -> None:
+        """Create webhook notification for started qa analysis run."""
+        org = await self.org_ops.get_org_by_id(oid)
+
+        if not org.webhookUrls or not org.webhookUrls.qaAnalysisStarted:
+            return
+
+        # Check if already created this event
+        existing_notification = await self.webhooks.find_one(
+            {
+                "event": WebhookEventType.QA_ANALYSIS_STARTED,
+                "body.qaRunId": qa_run_id,
+            }
+        )
+        if existing_notification:
+            return
+
+        if crawl_id is None:
+            crawl_id = ""
+
+        notification = WebhookNotification(
+            id=uuid4(),
+            event=WebhookEventType.QA_ANALYSIS_STARTED,
+            oid=oid,
+            body=QaAnalysisStartedBody(
+                itemId=crawl_id,
+                qaRunId=qa_run_id,
+                orgId=str(oid),
+            ),
+            created=dt_now(),
+        )
+
+        await self.webhooks.insert_one(notification.to_dict())
+
+        await self.send_notification(org, notification)
+
+    async def create_crawl_reviewed_notification(
+        self,
+        crawl_id: str,
+        oid: UUID,
+        review_status: Optional[int],
+        description: Optional[str],
+    ) -> None:
+        """Create webhook notification for crawl being reviewed in qa"""
+        org = await self.org_ops.get_org_by_id(oid)
+
+        if not org.webhookUrls or not org.webhookUrls.crawlReviewed:
+            return
+
+        review_status_labels = {
+            1: "Bad",
+            2: "Poor",
+            3: "Fair",
+            4: "Good",
+            5: "Excellent",
+        }
+
+        notification = WebhookNotification(
+            id=uuid4(),
+            event=WebhookEventType.CRAWL_REVIEWED,
+            oid=oid,
+            body=CrawlReviewedBody(
+                itemId=crawl_id,
+                orgId=str(oid),
+                reviewStatus=review_status,
+                reviewStatusLabel=(
+                    review_status_labels.get(review_status, "") if review_status else ""
+                ),
+                description=description,
             ),
             created=dt_now(),
         )
@@ -506,6 +642,18 @@ def init_openapi_webhooks(app):
     @app.webhooks.post(WebhookEventType.CRAWL_DELETED)
     def crawl_deleted(body: CrawlDeletedBody):
         """Sent when a crawl is deleted"""
+
+    @app.webhooks.post(WebhookEventType.QA_ANALYSIS_STARTED)
+    def qa_analysis_started(body: QaAnalysisStartedBody):
+        """Sent when a qa analysis run is started"""
+
+    @app.webhooks.post(WebhookEventType.QA_ANALYSIS_FINISHED)
+    def qa_analysis_finished(body: QaAnalysisFinishedBody):
+        """Sent when a qa analysis run has finished"""
+
+    @app.webhooks.post(WebhookEventType.CRAWL_REVIEWED)
+    def crawl_reviewed(body: CrawlReviewedBody):
+        """Sent when a crawl has been reviewed in qa"""
 
     @app.webhooks.post(WebhookEventType.UPLOAD_FINISHED)
     def upload_finished(body: UploadFinishedBody):


### PR DESCRIPTION
Fixes #1957 

Adds three new webhook events related to QA: analysis started, analysis ended, and crawl reviewed.

Tests have been updated accordingly.