### PR TITLE
add a 'stopped_org_readonly' state for crawls that are running while org is made read-only

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -224,6 +224,7 @@ TYPE_SUCCESSFUL_STATES = Literal[
     "stopped_by_user",
     "stopped_storage_quota_reached",
     "stopped_time_quota_reached",
+    "stopped_org_readonly",
 ]
 SUCCESSFUL_STATES = get_args(TYPE_SUCCESSFUL_STATES)
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1242,6 +1242,9 @@ class CrawlOperator(BaseOperator):
         # gracefully stop crawl if current running crawl sizes reach storage quota
         org = await self.org_ops.get_org_by_id(crawl.oid)
 
+        if org.readOnly:
+            return "stopped_org_readonly"
+
         if org.quotas.storageQuota:
             running_crawls_total_size = status.size
             for crawl_job in data.related[CJS].values():
@@ -1366,6 +1369,8 @@ class CrawlOperator(BaseOperator):
                 state = "stopped_storage_quota_reached"
             elif status.stopReason == "stopped_time_quota_reached":
                 state = "stopped_time_quota_reached"
+            elif status.stopReason == "stopped_org_readonly":
+                state = "stopped_org_readonly"
             else:
                 state = "complete"
 

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -21,6 +21,7 @@ StopReason = Literal[
     "size-limit",
     "stopped_storage_quota_reached",
     "stopped_time_quota_reached",
+    "stopped_org_readonly",
 ]
 
 

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -228,6 +228,16 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Stopped: Time Quota Reached");
         break;
 
+      case "stopped_org_readonly":
+        color = "var(--warning)";
+        icon = html`<sl-icon
+          name="exclamation-square-fill"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Stopped: Crawling Disabled");
+        break;
+
       case "canceled":
         color = "var(--sl-color-orange-600)";
         icon = html`<sl-icon

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -139,7 +139,8 @@ export type CrawlState =
   | "canceled"
   | "stopped_by_user"
   | "stopped_storage_quota_reached"
-  | "stopped_time_quota_reached";
+  | "stopped_time_quota_reached"
+  | "stopped_org_readonly";
 
 // TODO maybe convert this to an enum?
 export enum ReviewStatus {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -21,6 +21,7 @@ export const finishedCrawlStates: CrawlState[] = [
   "stopped_by_user",
   "stopped_storage_quota_reached",
   "stopped_time_quota_reached",
+  "stopped_org_readonly",
 ];
 
 export const inactiveCrawlStates: CrawlState[] = [


### PR DESCRIPTION
an org is made read-only while crawls are running:
- treat similar to other stopped_* states, do a graceful stop
- update UI to display "Stopped: Crawling Disabled" for this status
- don't add corresponding skipped status - just skip running crawls if org is read-only