### PR TITLE
Subscription Update Quotas

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1211,7 +1211,7 @@ class SubscriptionPortalUrlRequest(BaseModel):
     planId: str
 
     bytesStored: int
-    minutesUsed: int
+    execSeconds: int
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1205,6 +1205,8 @@ class SubscriptionCancelOut(SubscriptionCancel, SubscriptionEventOut):
 class SubscriptionPortalUrlRequest(BaseModel):
     """Request for subscription update pull"""
 
+    returnUrl: str
+
     subId: str
     planId: str
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1177,6 +1177,7 @@ class SubscriptionUpdate(BaseModel):
     planId: str
 
     futureCancelDate: Optional[datetime] = None
+    quotas: Optional[OrgQuotas] = None
 
 
 # ============================================================================
@@ -1206,6 +1207,9 @@ class SubscriptionPortalUrlRequest(BaseModel):
 
     subId: str
     planId: str
+
+    bytesStored: int
+    minutesUsed: int
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -484,7 +484,14 @@ class OrgOps:
             {"$set": query},
             return_document=ReturnDocument.AFTER,
         )
-        return Organization.from_dict(org_data) if org_data else None
+        if not org_data:
+            return None
+
+        org = Organization.from_dict(org_data)
+        if update.quotas:
+            await self.update_quotas(org, update.quotas)
+
+        return org
 
     async def cancel_subscription_data(
         self, cancel: SubscriptionCancel

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -270,10 +270,15 @@ class SubOps:
         if not org.subscription:
             return SubscriptionPortalUrlResponse()
 
+        minutesUsed = self.org_ops.get_monthly_crawl_exec_seconds(org) / 60
+
         if external_subs_app_api_url:
             try:
                 req = SubscriptionPortalUrlRequest(
-                    subId=org.subscription.subId, planId=org.subscription.planId
+                    subId=org.subscription.subId,
+                    planId=org.subscription.planId,
+                    bytesStored=org.bytesStored,
+                    minutesUsed=minutesUsed,
                 )
                 async with aiohttp.ClientSession() as session:
                     async with session.request(

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -270,7 +270,7 @@ class SubOps:
         if not org.subscription:
             return SubscriptionPortalUrlResponse()
 
-        minutes_used = self.org_ops.get_monthly_crawl_exec_seconds(org) / 60
+        minutes_used = int(self.org_ops.get_monthly_crawl_exec_seconds(org) / 60)
         return_url = f"{get_origin(headers)}/orgs/{org.slug}/settings/billing"
 
         if external_subs_app_api_url:

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -270,7 +270,7 @@ class SubOps:
         if not org.subscription:
             return SubscriptionPortalUrlResponse()
 
-        minutesUsed = self.org_ops.get_monthly_crawl_exec_seconds(org) / 60
+        minutes_used = self.org_ops.get_monthly_crawl_exec_seconds(org) / 60
 
         if external_subs_app_api_url:
             try:
@@ -278,7 +278,7 @@ class SubOps:
                     subId=org.subscription.subId,
                     planId=org.subscription.planId,
                     bytesStored=org.bytesStored,
-                    minutesUsed=minutesUsed,
+                    minutesUsed=minutes_used,
                 )
                 async with aiohttp.ClientSession() as session:
                     async with session.request(

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -11,7 +11,7 @@ import aiohttp
 
 from .orgs import OrgOps
 from .users import UserManager
-from .utils import is_bool
+from .utils import is_bool, get_origin
 from .models import (
     SubscriptionCreate,
     SubscriptionImport,
@@ -264,13 +264,14 @@ class SubOps:
         return subs, total
 
     async def get_billing_portal_url(
-        self, org: Organization
+        self, org: Organization, headers: dict[str, str]
     ) -> SubscriptionPortalUrlResponse:
         """Get subscription info, fetching portal url if available"""
         if not org.subscription:
             return SubscriptionPortalUrlResponse()
 
         minutes_used = self.org_ops.get_monthly_crawl_exec_seconds(org) / 60
+        return_url = f"{get_origin(headers)}/orgs/{org.slug}/settings/billing"
 
         if external_subs_app_api_url:
             try:
@@ -279,6 +280,7 @@ class SubOps:
                     planId=org.subscription.planId,
                     bytesStored=org.bytesStored,
                     minutesUsed=minutes_used,
+                    returnUrl=return_url,
                 )
                 async with aiohttp.ClientSession() as session:
                     async with session.request(
@@ -393,8 +395,9 @@ def init_subs_api(
         response_model=SubscriptionPortalUrlResponse,
     )
     async def get_billing_portal_url(
+        request: Request,
         org: Organization = Depends(org_ops.org_owner_dep),
     ):
-        return await ops.get_billing_portal_url(org)
+        return await ops.get_billing_portal_url(org, dict(request.headers))
 
     return ops

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -270,7 +270,6 @@ class SubOps:
         if not org.subscription:
             return SubscriptionPortalUrlResponse()
 
-        minutes_used = int(self.org_ops.get_monthly_crawl_exec_seconds(org) / 60)
         return_url = f"{get_origin(headers)}/orgs/{org.slug}/settings/billing"
 
         if external_subs_app_api_url:
@@ -279,7 +278,7 @@ class SubOps:
                     subId=org.subscription.subId,
                     planId=org.subscription.planId,
                     bytesStored=org.bytesStored,
-                    minutesUsed=minutes_used,
+                    execSeconds=self.org_ops.get_monthly_crawl_exec_seconds(org),
                     returnUrl=return_url,
                 )
                 async with aiohttp.ClientSession() as session:

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -20,6 +20,9 @@ from pymongo.errors import DuplicateKeyError
 from slugify import slugify
 
 
+default_origin = os.environ.get("APP_ORIGIN", "")
+
+
 class JSONSerializer(json.JSONEncoder):
     """Serializer class for json.dumps with UUID and datetime support"""
 
@@ -180,3 +183,16 @@ def get_duplicate_key_error_field(err: DuplicateKeyError) -> str:
             except IndexError:
                 pass
     return dupe_field
+
+
+def get_origin(headers) -> str:
+    """Return origin of the received request"""
+    if not headers:
+        return default_origin
+
+    scheme = headers.get("X-Forwarded-Proto")
+    host = headers.get("Host")
+    if not scheme or not host:
+        return default_origin
+
+    return scheme + "://" + host

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -276,6 +276,10 @@ def test_update_sub_2(admin_auth_headers):
             "futureCancelDate": None,
             # not updateable here, only by superadmin
             "readOnlyOnCancel": True,
+            "quotas": {
+                "maxPagesPerCrawl": 50,
+                "storageQuota": 500000,
+            },
         },
     )
 
@@ -472,7 +476,14 @@ def test_subscription_events_log(admin_auth_headers, non_default_org_id):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
-            "quotas": None,
+            "quotas": {
+                "maxPagesPerCrawl": 50,
+                "storageQuota": 500000,
+                "extraExecMinutes": 0,
+                "giftedExecMinutes": 0,
+                "maxConcurrentCrawls": 0,
+                "maxExecMinutesPerMonth": 0,
+            },
         },
         {"subId": "123", "oid": new_subs_oid, "type": "cancel"},
         {"subId": "234", "oid": new_subs_oid_2, "type": "cancel"},
@@ -533,7 +544,14 @@ def test_subscription_events_log_filter_sub_id(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
-            "quotas": None,
+            "quotas": {
+                "maxPagesPerCrawl": 50,
+                "storageQuota": 500000,
+                "extraExecMinutes": 0,
+                "giftedExecMinutes": 0,
+                "maxConcurrentCrawls": 0,
+                "maxExecMinutesPerMonth": 0,
+            },
         },
         {"subId": "123", "oid": new_subs_oid, "type": "cancel"},
     ]
@@ -587,7 +605,14 @@ def test_subscription_events_log_filter_oid(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
-            "quotas": None,
+            "quotas": {
+                "maxPagesPerCrawl": 50,
+                "storageQuota": 500000,
+                "extraExecMinutes": 0,
+                "giftedExecMinutes": 0,
+                "maxConcurrentCrawls": 0,
+                "maxExecMinutesPerMonth": 0,
+            },
         },
         {"subId": "123", "oid": new_subs_oid, "type": "cancel"},
     ]
@@ -615,8 +640,15 @@ def test_subscription_events_log_filter_plan_id(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
-            "quotas": None,
-        },
+            "quotas": {
+                "maxPagesPerCrawl": 50,
+                "storageQuota": 500000,
+                "extraExecMinutes": 0,
+                "giftedExecMinutes": 0,
+                "maxConcurrentCrawls": 0,
+                "maxExecMinutesPerMonth": 0,
+            },
+        }
     ]
 
 
@@ -659,7 +691,14 @@ def test_subscription_events_log_filter_status(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
-            "quotas": None,
+            "quotas": {
+                "maxPagesPerCrawl": 50,
+                "storageQuota": 500000,
+                "extraExecMinutes": 0,
+                "giftedExecMinutes": 0,
+                "maxConcurrentCrawls": 0,
+                "maxExecMinutesPerMonth": 0,
+            },
         },
     ]
 

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -463,6 +463,7 @@ def test_subscription_events_log(admin_auth_headers, non_default_org_id):
             "status": "paused_payment_failed",
             "planId": "basic",
             "futureCancelDate": "2028-12-26T01:02:03",
+            "quotas": None,
         },
         {
             "type": "update",
@@ -471,6 +472,7 @@ def test_subscription_events_log(admin_auth_headers, non_default_org_id):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
+            "quotas": None,
         },
         {"subId": "123", "oid": new_subs_oid, "type": "cancel"},
         {"subId": "234", "oid": new_subs_oid_2, "type": "cancel"},
@@ -522,6 +524,7 @@ def test_subscription_events_log_filter_sub_id(admin_auth_headers):
             "status": "paused_payment_failed",
             "planId": "basic",
             "futureCancelDate": "2028-12-26T01:02:03",
+            "quotas": None,
         },
         {
             "type": "update",
@@ -530,6 +533,7 @@ def test_subscription_events_log_filter_sub_id(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
+            "quotas": None,
         },
         {"subId": "123", "oid": new_subs_oid, "type": "cancel"},
     ]
@@ -574,6 +578,7 @@ def test_subscription_events_log_filter_oid(admin_auth_headers):
             "status": "paused_payment_failed",
             "planId": "basic",
             "futureCancelDate": "2028-12-26T01:02:03",
+            "quotas": None,
         },
         {
             "type": "update",
@@ -582,6 +587,7 @@ def test_subscription_events_log_filter_oid(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
+            "quotas": None,
         },
         {"subId": "123", "oid": new_subs_oid, "type": "cancel"},
     ]
@@ -609,6 +615,7 @@ def test_subscription_events_log_filter_plan_id(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
+            "quotas": None,
         },
     ]
 
@@ -652,6 +659,7 @@ def test_subscription_events_log_filter_status(admin_auth_headers):
             "status": "active",
             "planId": "basic2",
             "futureCancelDate": None,
+            "quotas": None,
         },
     ]
 

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -202,7 +202,7 @@ export class OrgSettingsBilling extends TailwindElement {
         return msg("Starter");
 
       case "standard":
-        return msg("Starter");
+        return msg("Standard");
 
       case "plus":
         return msg("Plus");

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -5,6 +5,7 @@ import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
+import { capitalize } from "lodash";
 
 import { columns } from "../ui/columns";
 
@@ -171,7 +172,7 @@ export class OrgSettingsBilling extends TailwindElement {
                               html`To upgrade to Pro, contact us at
                                 <a
                                   class=${linkClassList}
-                                  href=${`mailto:${this.salesEmail}?subject=${msg(str`Upgrade Starter plan (${this.org?.name})`)}`}
+                                  href=${`mailto:${this.salesEmail}?subject=${msg(str`Upgrade Browsertrix plan (${this.org?.name})`)}`}
                                   rel="noopener noreferrer nofollow"
                                   >${this.salesEmail}</a
                                 >.`,
@@ -195,6 +196,22 @@ export class OrgSettingsBilling extends TailwindElement {
     `;
   }
 
+  private getPlanName(planId: string) {
+    switch (planId) {
+      case "starter":
+        return msg("Starter");
+
+      case "standard":
+        return msg("Starter");
+
+      case "plus":
+        return msg("Plus");
+
+      default:
+        return capitalize(planId);
+    }
+  }
+
   private readonly renderSubscriptionDetails = (
     subscription: OrgData["subscription"],
   ) => {
@@ -204,7 +221,7 @@ export class OrgSettingsBilling extends TailwindElement {
     if (subscription) {
       tierLabel = html`
         <sl-icon class="text-neutral-500" name="nut"></sl-icon>
-        ${msg("Starter")}
+        ${this.getPlanName(subscription.planId)}
       `;
 
       switch (subscription.status) {

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -263,7 +263,7 @@ export class OrgSettingsBilling extends TailwindElement {
     <ul class="leading-relaxed text-neutral-700">
       <li>
         ${msg(
-          str`${quotas.maxPagesPerCrawl ? formatNumber(quotas.maxPagesPerCrawl) : msg("Unlimited")} ${pluralOf("pages", quotas.maxPagesPerCrawl)} per crawl`,
+          str`${quotas.maxExecMinutesPerMonth ? humanizeSeconds(quotas.maxExecMinutesPerMonth * 60, undefined, undefined, "long") : msg("Unlimited minutes")} of crawling and QA analysis time per month`,
         )}
       </li>
       <li>
@@ -273,17 +273,17 @@ export class OrgSettingsBilling extends TailwindElement {
                 value=${quotas.storageQuota}
               ></sl-format-bytes>`
             : msg("Unlimited")}
-          base disk space`,
+          storage`,
+        )}
+      </li>
+      <li>
+        ${msg(
+          str`${quotas.maxPagesPerCrawl ? formatNumber(quotas.maxPagesPerCrawl) : msg("Unlimited")} ${pluralOf("pages", quotas.maxPagesPerCrawl)} per crawl`,
         )}
       </li>
       <li>
         ${msg(
           str`${quotas.maxConcurrentCrawls ? formatNumber(quotas.maxConcurrentCrawls) : msg("Unlimited")} concurrent ${pluralOf("crawls", quotas.maxConcurrentCrawls)}`,
-        )}
-      </li>
-      <li>
-        ${msg(
-          str`${quotas.maxExecMinutesPerMonth ? humanizeSeconds(quotas.maxExecMinutesPerMonth * 60, undefined, undefined, "long") : msg("Unlimited minutes")} of base crawling time per month`,
         )}
       </li>
     </ul>

--- a/frontend/src/types/billing.ts
+++ b/frontend/src/types/billing.ts
@@ -6,6 +6,7 @@ export enum SubscriptionStatus {
 
 export type Subscription = {
   status: SubscriptionStatus;
+  planId: string;
   futureCancelDate: null | string; // UTC datetime string
 };
 


### PR DESCRIPTION
- Follow-up to #1914, allows SubscriptionUpdate event to also update quotas.
- Passes current usage info + current billing page URL to portalUrl request for external app to be able to respond with best portalUrl
- get_origin() moved to utils to be available more generally.
- Updates billing tab to show current plans, switches order of quotas to list execution time, storage first