### PR TITLE
Fix QA run downloads as a single WACZ

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -1,10 +1,6 @@
 import { localized, msg, str } from "@lit/localize";
 import { Task } from "@lit/task";
-import type {
-  SlChangeEvent,
-  SlSelect,
-  SlShowEvent,
-} from "@shoelace-style/shoelace";
+import type { SlChangeEvent, SlSelect } from "@shoelace-style/shoelace";
 import {
   css,
   html,
@@ -21,8 +17,6 @@ import { QA_RUNNING_STATES } from "../archived-item-detail";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { type Dialog } from "@/components/ui/dialog";
-import type { MenuItemLink } from "@/components/ui/menu-item-link";
-import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { APIController } from "@/controllers/api";
 import { NavigateController } from "@/controllers/navigate";
@@ -353,6 +347,7 @@ export class ArchivedItemDetailQA extends TailwindElement {
         </div>
       `;
     }
+    const authToken = this.authState!.headers.Authorization.split(" ")[1];
     return qaRuns.map(
       (run, idx) => html`
         <btrix-table-row class=${idx > 0 ? "border-t" : ""}>
@@ -391,28 +386,15 @@ export class ArchivedItemDetailQA extends TailwindElement {
           <btrix-table-cell>${run.userName}</btrix-table-cell>
           <btrix-table-cell class="p-0">
             <div class="col action">
-              <btrix-overflow-dropdown
-                @sl-show=${async (e: SlShowEvent) => {
-                  const dropdown = e.currentTarget as OverflowDropdown;
-                  const downloadLink = dropdown.querySelector<MenuItemLink>(
-                    "btrix-menu-item-link",
-                  );
-
-                  if (!downloadLink) {
-                    console.debug("no download link");
-                    return;
-                  }
-
-                  downloadLink.loading = true;
-                  downloadLink.disabled = false;
-                  downloadLink.href = `/orgs/${this.orgId}/crawls/${this.crawlId}/qa/${run.id}/download`;
-                }}
-              >
+              <btrix-overflow-dropdown>
                 <sl-menu>
                   ${run.state === "canceled"
                     ? nothing
                     : html`
-                        <btrix-menu-item-link href="#" download>
+                        <btrix-menu-item-link
+                          href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/qa/${run.id}/download?auth_bearer=${authToken}`}
+                          download
+                        >
                           <sl-icon
                             name="cloud-download"
                             slot="prefix"


### PR DESCRIPTION
Follow up to #1412, fix QA run downloads as a single (multi) WACZ, containing other WACZ files from all workers.

Testing:
- Go to a QA run
- Click the ... menu, verify 'Download Analysis Run' is working 