### PR TITLE
feat: Show usage history in dashboard

### DIFF
--- a/frontend/src/features/org/usage-history-table.ts
+++ b/frontend/src/features/org/usage-history-table.ts
@@ -29,7 +29,9 @@ export class UsageHistoryTable extends TailwindElement {
 
     if (this.org.usage && !Object.keys(this.org.usage).length) {
       return html`
-        <p class="text-center text-neutral-500">
+        <p
+          class="rounded border bg-neutral-50 p-3 text-center text-neutral-500"
+        >
           ${msg("No usage history to show.")}
         </p>
       `;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -251,21 +251,14 @@ export class Dashboard extends LiteElement {
             `,
           )}
         </div>
-        ${when(
-          this.appState.settings &&
-            !this.appState.settings.billingEnabled &&
-            this.org,
-          (org) => html`
-            <section class="mb-10">
-              <btrix-details open>
-                <span slot="title">${msg("Usage History")}</span>
-                <btrix-usage-history-table
-                  .org=${org}
-                ></btrix-usage-history-table>
-              </btrix-details>
-            </section>
-          `,
-        )}
+        <section class="mb-10">
+          <btrix-details>
+            <span slot="title">${msg("Usage History")}</span>
+            <btrix-usage-history-table
+              .org=${this.org}
+            ></btrix-usage-history-table>
+          </btrix-details>
+        </section>
       </main> `;
   }
 


### PR DESCRIPTION
Following https://github.com/webrecorder/browsertrix/pull/1995, we want to keep the usage history table on the dashboard for now for video demos.

### Changes

- Adds usage history table back to org dashboard
- Makes "No usage history" message more apparent

### Screenshots

<img width="1325" alt="Screenshot 2024-08-06 at 6 22 26 PM" src="https://github.com/user-attachments/assets/65955b91-4d72-4d0d-a303-b045ad3fdbd4">

