### PR TITLE
Fix forgot password for invalid user

### DIFF
--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -606,10 +606,8 @@ def init_auth_router(user_manager: UserManager) -> APIRouter:
         email: EmailStr = Body(..., embed=True),
     ):
         user = await user_manager.get_by_email(email)
-        if not user:
-            return None
-
-        await user_manager.forgot_password(user, request)
+        if user:
+            await user_manager.forgot_password(user, request)
         return {"success": True}
 
     @auth_router.post("/reset-password", response_model=SuccessResponse)

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -422,6 +422,23 @@ def test_user_change_role(admin_auth_headers, default_org_id):
     assert r.json()["updated"] == True
 
 
+def test_forgot_password():
+    r = requests.post(
+        f"{API_PREFIX}/auth/forgot-password",
+        json={"email": "no-such-user@example.com"}
+    )
+    # always return success for security reasons even if user doesn't exist
+    assert r.status_code == 202
+    detail = r.json()["success"] == True
+
+    r = requests.post(
+        f"{API_PREFIX}/auth/forgot-password",
+        json={"email": VALID_USER_EMAIL}
+    )
+    assert r.status_code == 202
+    detail = r.json()["success"] == True
+
+
 def test_reset_invalid_password(admin_auth_headers):
     r = requests.put(
         f"{API_PREFIX}/users/me/password-change",


### PR DESCRIPTION
- fix validation error if user doesn'r exist
- always return success even if user doesn't exist for security reasons
- add test for forgot password endpoint