### PR TITLE
Add detailed permissions & permission summaries to user invite popup

### DIFF
--- a/frontend/config/tailwind/plugins/attributes.js
+++ b/frontend/config/tailwind/plugins/attributes.js
@@ -1,4 +1,6 @@
 const plugin = require("tailwindcss/plugin");
 module.exports = plugin(function ({ matchVariant }) {
   matchVariant("attr", (value) => `&[${value}]`);
+  matchVariant("group-attr", (value) => `:merge(.group)[${value}] &`);
+  matchVariant("peer-attr", (value) => `:merge(.peer)[${value}] ~ &`);
 });

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,8 @@
 /** @type {import('postcss-load-config').Config} */
 module.exports = {
-  plugins: [require("tailwindcss"), require("autoprefixer")],
+  plugins: {
+    "tailwindcss/nesting": {},
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };

--- a/frontend/src/pages/org/settings/settings.stylesheet.css
+++ b/frontend/src/pages/org/settings/settings.stylesheet.css
@@ -1,0 +1,41 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  sl-radio.radio-card {
+    @apply cursor-pointer rounded-md border border-neutral-300 p-2 transition-colors;
+    &:hover {
+      @apply border-neutral-400;
+    }
+    &[aria-checked="true"] {
+      @apply border-primary bg-primary-50;
+    }
+    &::part(base) {
+      @apply grid grid-cols-[auto_minmax(0,1fr)] gap-x-1;
+    }
+    &::part(control) {
+      @apply col-start-1 col-end-2 row-start-1 row-end-2;
+    }
+    &::part(label) {
+      @apply col-start-1 col-end-3 row-start-1 row-end-3 ml-0 grid flex-auto grid-cols-subgrid gap-y-2;
+    }
+  }
+  sl-details.details-card {
+    @apply col-span-2;
+    &::part(header) {
+      @apply p-2;
+    }
+    &::part(content) {
+      @apply p-2 pt-0;
+    }
+  }
+  sl-radio.radio-card[aria-checked="true"] sl-details.details-card {
+    &::part(base) {
+      @apply border-primary/50;
+    }
+    &::part(summary-icon) {
+      @apply text-primary-700;
+    }
+  }
+}

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -510,6 +510,7 @@ export class OrgSettings extends BtrixElement {
                     </li>`}
                   <li>${msg("Edit org name and URL")}</li>
                   <li>${msg("Manage org members")}</li>
+                  <li>${msg("View and edit org defaults")}</li>
                 </ul>
               </sl-details>
             </sl-radio>

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -427,7 +427,9 @@ export class OrgSettings extends BtrixElement {
               value=${AccessCode.owner}
               class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
-              <div class="col-start-2">
+              <div
+                class="col-start-2 flex items-baseline justify-between gap-2"
+              >
                 ${msg("Admin")}
                 <span class="text-xs text-gray-500">
                   ${msg("Manage org and billing settings")}
@@ -461,7 +463,9 @@ export class OrgSettings extends BtrixElement {
               value=${AccessCode.crawler}
               class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
-              <div class="col-start-2">
+              <div
+                class="col-start-2 flex items-baseline justify-between gap-2"
+              >
                 ${msg("Crawler")}
                 <span class="text-xs text-gray-500">
                   ${msg("Create, evaluate, and curate archives")}
@@ -487,7 +491,9 @@ export class OrgSettings extends BtrixElement {
               value=${AccessCode.viewer}
               class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
-              <div class="col-start-2">
+              <div
+                class="col-start-2 flex items-baseline justify-between gap-2"
+              >
                 ${msg("Viewer")}
                 <span class="text-xs text-gray-500">
                   ${msg("View archives and collections")}

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -434,7 +434,9 @@ export class OrgSettings extends BtrixElement {
               >
                 ${msg("Admin")}
                 <span class="text-xs text-gray-500">
-                  ${msg("Manage org and billing settings")}
+                  ${this.appState.settings?.billingEnabled
+                    ? msg("Manage org and billing settings")
+                    : msg("Manage org")}
                 </span>
               </div>
               <sl-details
@@ -450,10 +452,10 @@ export class OrgSettings extends BtrixElement {
                   <li class="text-warning">${msg("Manage org members")}</li>
                   ${this.appState.settings?.billingEnabled &&
                   html`<li class="text-warning">
-                      ${msg("Edit billing details")}
+                      ${msg("Manage subscription")}
                     </li>
                     <li class="text-warning">
-                      ${msg("Update or cancel subscription")}
+                      ${msg("Manage billing details")}
                     </li>`}
                   <li>${msg("Create crawl workflows")}</li>
                   <li>${msg("Create browser profiles")}</li>
@@ -506,7 +508,7 @@ export class OrgSettings extends BtrixElement {
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">
                   <li>${msg("View crawl workflows")}</li>
-                  <li>${msg("View archived items")}</li>
+                  <li>${msg("View, replay, and download archived items")}</li>
                   <li>${msg("View collections")}</li>
                 </ul>
               </sl-details>

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -422,19 +422,83 @@ export class OrgSettings extends BtrixElement {
           </sl-input>
         </div>
         <div class="mb-5">
-          <sl-radio-group
-            name="role"
-            label="Permission"
-            value=${AccessCode.viewer}
-          >
-            <sl-radio value=${AccessCode.owner}>
-              ${msg("Admin — Can create crawls and manage org members")}
+          <sl-radio-group name="role" label="Role" value=${AccessCode.viewer}>
+            <sl-radio
+              value=${AccessCode.owner}
+              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[label]:ml-0 part-[base]:flex part-[control]:hidden part-[label]:flex-auto"
+            >
+              ${msg("Admin")}
+              <span class="text-xs text-gray-500">
+                ${msg("Manage org and billing settings")}
+              </span>
+              <sl-details
+                @sl-hide=${this.stopProp}
+                @sl-after-hide=${this.stopProp}
+                class="mt-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+              >
+                <span slot="summary" class="text-xs">Permissions</span>
+                <ul class="ms-4 list-disc text-xs text-gray-500">
+                  <li class="text-warning">${msg("Manage org members")}</li>
+                  ${this.appState.settings?.billingEnabled &&
+                  html`<li class="text-warning">
+                      ${msg("Edit billing details")}
+                    </li>
+                    <li class="text-warning">
+                      ${msg("Update or cancel subscription")}
+                    </li>`}
+                  <li>${msg("Create crawl workflows")}</li>
+                  <li>${msg("Create browser profiles")}</li>
+                  <li>${msg("Upload archived items")}</li>
+                  <li>${msg("Run QA analysis")}</li>
+                  <li>${msg("Rate and review archived items")}</li>
+                  <li>${msg("Create, edit, and share collections")}</li>
+                </ul>
+              </sl-details>
             </sl-radio>
-            <sl-radio value=${AccessCode.crawler}>
-              ${msg("Crawler — Can create crawls")}
+            <sl-radio
+              value=${AccessCode.crawler}
+              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[label]:ml-0 part-[base]:flex part-[control]:hidden part-[label]:flex-auto"
+            >
+              ${msg("Crawler")}
+              <span class="text-xs text-gray-500">
+                ${msg("Create, evaluate, and curate archives")}
+              </span>
+              <sl-details
+                @sl-hide=${this.stopProp}
+                @sl-after-hide=${this.stopProp}
+                class="mt-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+              >
+                <span slot="summary" class="text-xs">Permissions</span>
+                <ul class="ms-4 list-disc text-xs text-gray-500">
+                  <li>${msg("Create crawl workflows")}</li>
+                  <li>${msg("Create browser profiles")}</li>
+                  <li>${msg("Upload archived items")}</li>
+                  <li>${msg("Run QA analysis")}</li>
+                  <li>${msg("Rate and review archived items")}</li>
+                  <li>${msg("Create, edit, and share collections")}</li>
+                </ul>
+              </sl-details>
             </sl-radio>
-            <sl-radio value=${AccessCode.viewer}>
-              ${msg("Viewer — Can view crawls")}
+            <sl-radio
+              value=${AccessCode.viewer}
+              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[label]:ml-0 part-[base]:flex part-[control]:hidden part-[label]:flex-auto"
+            >
+              ${msg("Viewer")}
+              <span class="text-xs text-gray-500">
+                ${msg("View archives and collections")}
+              </span>
+              <sl-details
+                @sl-hide=${this.stopProp}
+                @sl-after-hide=${this.stopProp}
+                class="mt-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+              >
+                <span slot="summary" class="text-xs">Permissions</span>
+                <ul class="ms-4 list-disc text-xs text-gray-500">
+                  <li>${msg("View crawl workflows")}</li>
+                  <li>${msg("View archived items")}</li>
+                  <li>${msg("View collections")}</li>
+                </ul>
+              </sl-details>
             </sl-radio>
           </sl-radio-group>
         </div>
@@ -641,5 +705,14 @@ export class OrgSettings extends BtrixElement {
 
   private async getCurrentUser(): Promise<APIUser> {
     return this.api.fetch("/users/me");
+  }
+
+  /**
+   * Stop propgation of sl-tooltip events.
+   * Prevents bug where sl-dialog closes when tooltip closes
+   * https://github.com/shoelace-style/shoelace/issues/170
+   */
+  private stopProp(e: Event) {
+    e.stopPropagation();
   }
 }

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -428,6 +428,58 @@ export class OrgSettings extends BtrixElement {
         </div>
         <div class="mb-5">
           <sl-radio-group name="role" label="Role" value=${AccessCode.viewer}>
+            <sl-radio value=${AccessCode.viewer} class="radio-card">
+              <div
+                class="col-start-2 flex items-baseline justify-between gap-2"
+              >
+                ${msg("Viewer")}
+                <span class="text-xs text-gray-500">
+                  ${msg("View archived items and collections")}
+                </span>
+              </div>
+              <sl-details
+                @sl-hide=${this.stopProp}
+                @sl-after-hide=${this.stopProp}
+                class="details-card text-xs"
+              >
+                <span slot="summary">Permissions</span>
+                <ul class="ms-4 list-disc text-gray-500">
+                  <li>${msg("View crawl workflows")}</li>
+                  <li>${msg("View, replay, and download archived items")}</li>
+                  <li>${msg("View collections")}</li>
+                </ul>
+              </sl-details>
+            </sl-radio>
+
+            <sl-radio value=${AccessCode.crawler} class="radio-card">
+              <div
+                class="col-start-2 flex items-baseline justify-between gap-2"
+              >
+                ${msg("Crawler")}
+                <span class="text-xs text-gray-500">
+                  ${msg("Create, evaluate, and curate archived items")}
+                </span>
+              </div>
+              <sl-details
+                @sl-hide=${this.stopProp}
+                @sl-after-hide=${this.stopProp}
+                class="details-card text-xs"
+              >
+                <span slot="summary">Permissions</span>
+                <p class="mb-1 text-gray-500">
+                  ${msg("All Viewer permissions, plus:")}
+                </p>
+                <ul class="ms-4 list-disc text-gray-500">
+                  <li>${msg("Create crawl workflows")}</li>
+                  <li>${msg("Create browser profiles")}</li>
+                  <li>${msg("Upload archived items")}</li>
+                  <li>${msg("Run QA analysis")}</li>
+                  <li>${msg("Rate and review archived items")}</li>
+                  <li>${msg("Create, edit, and share collections")}</li>
+                </ul>
+              </sl-details>
+            </sl-radio>
+
             <sl-radio value=${AccessCode.owner} class="radio-card">
               <div
                 class="col-start-2 flex items-baseline justify-between gap-2"
@@ -442,14 +494,13 @@ export class OrgSettings extends BtrixElement {
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="details-card"
+                class="details-card text-xs"
               >
-                <span slot="summary" class="text-xs"
-                  >${msg("Permissions")}</span
-                >
-                <ul class="ms-4 list-disc text-xs text-gray-500">
-                  <li class="text-warning">${msg("Edit org name and URL")}</li>
-                  <li class="text-warning">${msg("Manage org members")}</li>
+                <span slot="summary">${msg("Permissions")}</span>
+                <p class="mb-1 text-gray-500">
+                  ${msg("All Crawler permissions, plus:")}
+                </p>
+                <ul class="ms-4 list-disc text-gray-500">
                   ${this.appState.settings?.billingEnabled &&
                   html`<li class="text-warning">
                       ${msg("Manage subscription")}
@@ -457,59 +508,8 @@ export class OrgSettings extends BtrixElement {
                     <li class="text-warning">
                       ${msg("Manage billing details")}
                     </li>`}
-                  <li>${msg("Create crawl workflows")}</li>
-                  <li>${msg("Create browser profiles")}</li>
-                  <li>${msg("Upload archived items")}</li>
-                  <li>${msg("Run QA analysis")}</li>
-                  <li>${msg("Rate and review archived items")}</li>
-                  <li>${msg("Create, edit, and share collections")}</li>
-                </ul>
-              </sl-details>
-            </sl-radio>
-            <sl-radio value=${AccessCode.crawler} class="radio-card">
-              <div
-                class="col-start-2 flex items-baseline justify-between gap-2"
-              >
-                ${msg("Crawler")}
-                <span class="text-xs text-gray-500">
-                  ${msg("Create, evaluate, and curate archived items")}
-                </span>
-              </div>
-              <sl-details
-                @sl-hide=${this.stopProp}
-                @sl-after-hide=${this.stopProp}
-                class="details-card"
-              >
-                <span slot="summary" class="text-xs">Permissions</span>
-                <ul class="ms-4 list-disc text-xs text-gray-500">
-                  <li>${msg("Create crawl workflows")}</li>
-                  <li>${msg("Create browser profiles")}</li>
-                  <li>${msg("Upload archived items")}</li>
-                  <li>${msg("Run QA analysis")}</li>
-                  <li>${msg("Rate and review archived items")}</li>
-                  <li>${msg("Create, edit, and share collections")}</li>
-                </ul>
-              </sl-details>
-            </sl-radio>
-            <sl-radio value=${AccessCode.viewer} class="radio-card">
-              <div
-                class="col-start-2 flex items-baseline justify-between gap-2"
-              >
-                ${msg("Viewer")}
-                <span class="text-xs text-gray-500">
-                  ${msg("View archived items and collections")}
-                </span>
-              </div>
-              <sl-details
-                @sl-hide=${this.stopProp}
-                @sl-after-hide=${this.stopProp}
-                class="details-card"
-              >
-                <span slot="summary" class="text-xs">Permissions</span>
-                <ul class="ms-4 list-disc text-xs text-gray-500">
-                  <li>${msg("View crawl workflows")}</li>
-                  <li>${msg("View, replay, and download archived items")}</li>
-                  <li>${msg("View collections")}</li>
+                  <li>${msg("Edit org name and URL")}</li>
+                  <li>${msg("Manage org members")}</li>
                 </ul>
               </sl-details>
             </sl-radio>

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -1,13 +1,13 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlInput } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
-import clsx from "clsx";
-import { html, type PropertyValues } from "lit";
+import { html, unsafeCSS, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
+import stylesheet from "./settings.stylesheet.css";
 import { columns } from "./ui/columns";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -21,6 +21,8 @@ import { AppStateService } from "@/utils/state";
 import { formatAPIUser } from "@/utils/user";
 
 import "./components/billing";
+
+const styles = unsafeCSS(stylesheet);
 
 type Tab = "information" | "members" | "billing";
 type User = {
@@ -57,6 +59,8 @@ export type OrgRemoveMemberEvent = CustomEvent<{
 @localized()
 @customElement("btrix-org-settings")
 export class OrgSettings extends BtrixElement {
+  static styles = styles;
+
   @property({ type: String })
   activePanel: Tab = "information";
 
@@ -424,25 +428,7 @@ export class OrgSettings extends BtrixElement {
         </div>
         <div class="mb-5">
           <sl-radio-group name="role" label="Role" value=${AccessCode.viewer}>
-            <sl-radio
-              value=${AccessCode.owner}
-              class=${clsx([
-                // Base styles
-                "group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400",
-
-                // When checked
-                "attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50",
-
-                // Part: radio control
-                "part-[control]:col-start-1 part-[control]:col-end-2  part-[control]:row-start-1  part-[control]:row-end-2",
-
-                // Part: radio base
-                "part-[base]:grid part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[base]:gap-x-1",
-
-                // Part: radio label
-                "part-[label]:col-start-1 part-[label]:col-end-3 part-[label]:row-start-1 part-[label]:row-end-3 part-[label]:ml-0 part-[label]:grid part-[label]:flex-auto part-[label]:grid-cols-subgrid part-[label]:gap-y-2",
-              ])}
-            >
+            <sl-radio value=${AccessCode.owner} class="radio-card">
               <div
                 class="col-start-2 flex items-baseline justify-between gap-2"
               >
@@ -454,12 +440,13 @@ export class OrgSettings extends BtrixElement {
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
+                class="details-card"
               >
                 <span slot="summary" class="text-xs"
                   >${msg("Permissions")}</span
                 >
                 <ul class="ms-4 list-disc text-xs text-gray-500">
+                  <li class="text-warning">${msg("Edit org name and URL")}</li>
                   <li class="text-warning">${msg("Manage org members")}</li>
                   ${this.appState.settings?.billingEnabled &&
                   html`<li class="text-warning">
@@ -477,22 +464,19 @@ export class OrgSettings extends BtrixElement {
                 </ul>
               </sl-details>
             </sl-radio>
-            <sl-radio
-              value=${AccessCode.crawler}
-              class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
-            >
+            <sl-radio value=${AccessCode.crawler} class="radio-card">
               <div
                 class="col-start-2 flex items-baseline justify-between gap-2"
               >
                 ${msg("Crawler")}
                 <span class="text-xs text-gray-500">
-                  ${msg("Create, evaluate, and curate archives")}
+                  ${msg("Create, evaluate, and curate archived items")}
                 </span>
               </div>
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
+                class="details-card"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">
@@ -505,22 +489,19 @@ export class OrgSettings extends BtrixElement {
                 </ul>
               </sl-details>
             </sl-radio>
-            <sl-radio
-              value=${AccessCode.viewer}
-              class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
-            >
+            <sl-radio value=${AccessCode.viewer} class="radio-card">
               <div
                 class="col-start-2 flex items-baseline justify-between gap-2"
               >
                 ${msg("Viewer")}
                 <span class="text-xs text-gray-500">
-                  ${msg("View archives and collections")}
+                  ${msg("View archived items and collections")}
                 </span>
               </div>
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
+                class="details-card"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -1,6 +1,7 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlInput } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
+import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
@@ -425,7 +426,22 @@ export class OrgSettings extends BtrixElement {
           <sl-radio-group name="role" label="Role" value=${AccessCode.viewer}>
             <sl-radio
               value=${AccessCode.owner}
-              class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
+              class=${clsx([
+                // Base styles
+                "group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400",
+
+                // When checked
+                "attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50",
+
+                // Part: radio control
+                "part-[control]:col-start-1 part-[control]:col-end-2  part-[control]:row-start-1  part-[control]:row-end-2",
+
+                // Part: radio base
+                "part-[base]:grid part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[base]:gap-x-1",
+
+                // Part: radio label
+                "part-[label]:col-start-1 part-[label]:col-end-3 part-[label]:row-start-1 part-[label]:row-end-3 part-[label]:ml-0 part-[label]:grid part-[label]:flex-auto part-[label]:grid-cols-subgrid part-[label]:gap-y-2",
+              ])}
             >
               <div
                 class="col-start-2 flex items-baseline justify-between gap-2"
@@ -440,7 +456,9 @@ export class OrgSettings extends BtrixElement {
                 @sl-after-hide=${this.stopProp}
                 class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
               >
-                <span slot="summary" class="text-xs">Permissions</span>
+                <span slot="summary" class="text-xs"
+                  >${msg("Permissions")}</span
+                >
                 <ul class="ms-4 list-disc text-xs text-gray-500">
                   <li class="text-warning">${msg("Manage org members")}</li>
                   ${this.appState.settings?.billingEnabled &&

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -425,16 +425,18 @@ export class OrgSettings extends BtrixElement {
           <sl-radio-group name="role" label="Role" value=${AccessCode.viewer}>
             <sl-radio
               value=${AccessCode.owner}
-              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[label]:ml-0 part-[base]:flex part-[control]:hidden part-[label]:flex-auto"
+              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
-              ${msg("Admin")}
-              <span class="text-xs text-gray-500">
-                ${msg("Manage org and billing settings")}
-              </span>
+              <div class="col-start-2">
+                ${msg("Admin")}
+                <span class="text-xs text-gray-500">
+                  ${msg("Manage org and billing settings")}
+                </span>
+              </div>
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="mt-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">
@@ -457,16 +459,18 @@ export class OrgSettings extends BtrixElement {
             </sl-radio>
             <sl-radio
               value=${AccessCode.crawler}
-              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[label]:ml-0 part-[base]:flex part-[control]:hidden part-[label]:flex-auto"
+              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
-              ${msg("Crawler")}
-              <span class="text-xs text-gray-500">
-                ${msg("Create, evaluate, and curate archives")}
-              </span>
+              <div class="col-start-2">
+                ${msg("Crawler")}
+                <span class="text-xs text-gray-500">
+                  ${msg("Create, evaluate, and curate archives")}
+                </span>
+              </div>
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="mt-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">
@@ -481,16 +485,18 @@ export class OrgSettings extends BtrixElement {
             </sl-radio>
             <sl-radio
               value=${AccessCode.viewer}
-              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[label]:ml-0 part-[base]:flex part-[control]:hidden part-[label]:flex-auto"
+              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
-              ${msg("Viewer")}
-              <span class="text-xs text-gray-500">
-                ${msg("View archives and collections")}
-              </span>
+              <div class="col-start-2">
+                ${msg("Viewer")}
+                <span class="text-xs text-gray-500">
+                  ${msg("View archives and collections")}
+                </span>
+              </div>
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="mt-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -425,7 +425,7 @@ export class OrgSettings extends BtrixElement {
           <sl-radio-group name="role" label="Role" value=${AccessCode.viewer}>
             <sl-radio
               value=${AccessCode.owner}
-              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
+              class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
               <div class="col-start-2">
                 ${msg("Admin")}
@@ -436,7 +436,7 @@ export class OrgSettings extends BtrixElement {
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">
@@ -459,7 +459,7 @@ export class OrgSettings extends BtrixElement {
             </sl-radio>
             <sl-radio
               value=${AccessCode.crawler}
-              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
+              class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
               <div class="col-start-2">
                 ${msg("Crawler")}
@@ -470,7 +470,7 @@ export class OrgSettings extends BtrixElement {
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">
@@ -485,7 +485,7 @@ export class OrgSettings extends BtrixElement {
             </sl-radio>
             <sl-radio
               value=${AccessCode.viewer}
-              class="rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
+              class="group rounded-md border border-neutral-300 p-2 transition-colors hover:border-neutral-400 attr-[aria-checked=true]:border-primary attr-[aria-checked=true]:bg-primary-50 part-[control]:col-start-1 part-[label]:col-start-1 part-[control]:col-end-2 part-[label]:col-end-3 part-[control]:row-start-1 part-[label]:row-start-1 part-[control]:row-end-2 part-[label]:row-end-3 part-[label]:ml-0 part-[base]:grid part-[label]:grid part-[label]:flex-auto part-[base]:grid-cols-[auto_minmax(0,1fr)] part-[label]:grid-cols-subgrid part-[base]:gap-x-1 part-[label]:gap-y-2"
             >
               <div class="col-start-2">
                 ${msg("Viewer")}
@@ -496,7 +496,7 @@ export class OrgSettings extends BtrixElement {
               <sl-details
                 @sl-hide=${this.stopProp}
                 @sl-after-hide=${this.stopProp}
-                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0"
+                class="col-span-2 part-[content]:p-2 part-[header]:p-2 part-[content]:pt-0 group-attr-[aria-checked=true]:part-[base]:border-primary/50 group-attr-[aria-checked=true]:part-[summary-icon]:text-primary-700"
               >
                 <span slot="summary" class="text-xs">Permissions</span>
                 <ul class="ms-4 list-disc text-xs text-gray-500">


### PR DESCRIPTION
Adds more details to the role selection area of the user invite popup.

Highlights potentially dangerous permissions when inviting someone as an admin. Also adds group and peer versions of the custom tailwind `attr-[]` selector.

| Default view | Expanded view |
|--------|--------|
| <img width="496" src="https://github.com/user-attachments/assets/5b4b787c-f3c7-45e3-82ac-924e48c103af" alt="localhost_9870_orgs_default-org_settings_members_invite (2)"> | <img width="496" src="https://github.com/user-attachments/assets/98acc528-cd50-45e2-8c98-2501252e387f" alt="localhost_9870_orgs_default-org_settings_members_invite (3)"> | 

Also enables tailwind's nesting plugin in postcss.
