### PR TITLE
Prevent invalid slugs from causing redirects in org settings

### DIFF
--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -239,10 +239,7 @@ export class OrgSettings extends TailwindElement {
                       : this.org.slug
                   }`,
                 )}
-                @sl-input=${(e: InputEvent) => {
-                  const input = e.target as SlInput;
-                  this.slugValue = input.value;
-                }}
+                @sl-input=${this.handleSlugInput}
               ></sl-input>
             `,
             msg(
@@ -273,6 +270,19 @@ export class OrgSettings extends TailwindElement {
         </footer>
       </form>
     </div>`;
+  }
+
+  private handleSlugInput(e: InputEvent) {
+    const input = e.target as SlInput;
+    // Ideally this would match against the full character map that slugify uses
+    // but this'll do for most use cases
+    const end = input.value.match(/[\s*_+~.,()'"!\-:@]$/g) ? "-" : "";
+    input.value = slugifyStrict(input.value) + end;
+    this.slugValue = slugifyStrict(input.value);
+
+    input.setCustomValidity(
+      this.slugValue.length < 2 ? "URL Identifier too short" : "",
+    );
   }
 
   private renderMembers() {

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -281,7 +281,7 @@ export class OrgSettings extends TailwindElement {
     this.slugValue = slugifyStrict(input.value);
 
     input.setCustomValidity(
-      this.slugValue.length < 2 ? "URL Identifier too short" : "",
+      this.slugValue.length < 2 ? msg("URL Identifier too short") : "",
     );
   }
 


### PR DESCRIPTION
Also improves the slug editing experience by partially-slugifying the value as it's entered.

Previously, submitting a org slug value of ".." or similar would cause the frontend to redirect to a "page not found" page, with all accessible links leading to only `/account/settings`. This also causes the backend to reset the org slug to one generated from the org name on a reload.