### PR TITLE
Additional operator edge case fixes

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -305,7 +305,7 @@ class CrawlOperator(BaseOperator):
             "resyncAfterSeconds": status.resync_after,
         }
 
-    def _load_redis(self, params, status, children):
+    def _load_redis(self, params, status: CrawlStatus, children):
         name = f"redis-{params['id']}"
         has_pod = name in children[POD]
 
@@ -313,11 +313,13 @@ class CrawlOperator(BaseOperator):
         params["name"] = name
         params["cpu"] = pod_info.newCpu or params.get("redis_cpu")
         params["memory"] = pod_info.newMemory or params.get("redis_memory")
-        restart = pod_info.should_restart_pod() and has_pod
-        if restart:
-            print(f"Restart {name}")
+        restart_reason = None
+        if has_pod:
+            restart_reason = pod_info.should_restart_pod()
+            if restart_reason:
+                print(f"Restarting {name}, reason: {restart_reason}")
 
-        params["init_redis"] = status.initRedis and not restart
+        params["init_redis"] = status.initRedis and not restart_reason
 
         return self.load_from_yaml("redis.yaml", params)
 
@@ -362,7 +364,7 @@ class CrawlOperator(BaseOperator):
         params["qa_source_replay_json"] = crawl_replay.json(include={"resources"})
         return self.load_from_yaml("qa_configmap.yaml", params)
 
-    def _load_crawler(self, params, i, status, children):
+    def _load_crawler(self, params, i, status: CrawlStatus, children):
         name = f"crawl-{params['id']}-{i}"
         has_pod = name in children[POD]
 
@@ -387,11 +389,12 @@ class CrawlOperator(BaseOperator):
         else:
             params["memory_limit"] = self.k8s.max_crawler_memory_size
         params["workers"] = params.get(worker_field) or 1
-        params["do_restart"] = (
-            pod_info.should_restart_pod() or params.get("force_restart")
-        ) and has_pod
-        if params.get("do_restart"):
-            print(f"Restart {name}")
+        params["do_restart"] = False
+        if has_pod:
+            restart_reason = pod_info.should_restart_pod(params.get("force_restart"))
+            if restart_reason:
+                print(f"Restarting {name}, reason: {restart_reason}")
+                params["do_restart"] = True
 
         return self.load_from_yaml("crawler.yaml", params)
 
@@ -523,7 +526,7 @@ class CrawlOperator(BaseOperator):
                 finished=finished,
                 stats=stats,
             )
-            if res:
+            if res and status.state != state:
                 print(f"Setting state: {status.state} -> {state}, {crawl.id}")
                 status.state = state
                 return True

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -890,14 +890,16 @@ class CrawlOperator(BaseOperator):
                 if "containerStatuses" in pstatus:
                     cstatus = pstatus["containerStatuses"][0]
 
-                    # consider 'ContainerCreating' as running
-                    waiting = cstatus["state"].get("waiting")
-                    if (
-                        phase == "Pending"
-                        and waiting
-                        and waiting.get("reason") == "ContainerCreating"
-                    ):
-                        running = True
+                    # don't consider 'ContainerCreating' as running for now
+                    # may be stuck in this state for other reasons
+                    #
+                    # waiting = cstatus["state"].get("waiting")
+                    # if (
+                    #    phase == "Pending"
+                    #    and waiting
+                    #    and waiting.get("reason") == "ContainerCreating"
+                    # ):
+                    #    running = True
 
                     self.handle_terminated_pod(
                         name, role, status, cstatus["state"].get("terminated")

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -170,19 +170,21 @@ class PodInfo(BaseModel):
             else 0
         )
 
-    def should_restart_pod(self):
+    def should_restart_pod(self, forced: bool = False) -> Optional[str]:
         """return true if pod should be restarted"""
         if self.newMemory and self.newMemory != self.allocated.memory:
-            return True
+            return "newMemory"
 
         if self.newCpu and self.newCpu != self.allocated.cpu:
-            return True
+            return "newCpu"
 
         if self.evicted:
-            print("Restarting evicted pod")
-            return True
+            return "evicted"
 
-        return False
+        if forced:
+            return "forced"
+
+        return None
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -134,6 +134,8 @@ class PodInfo(BaseModel):
     newMemory: Optional[int] = None
     signalAtMem: Optional[int] = None
 
+    evicted: Optional[bool] = False
+
     def dict(self, *a, **kw):
         res = super().dict(*a, **kw)
         percent = {
@@ -174,6 +176,10 @@ class PodInfo(BaseModel):
             return True
 
         if self.newCpu and self.newCpu != self.allocated.cpu:
+            return True
+
+        if self.evicted:
+            print("Restarting evicted pod")
             return True
 
         return False


### PR DESCRIPTION
Fix a few edge-case situations:
- Restart evicted pods that have reached the terminal `Failed` state with reason `Evicted`, by just recreating them. These pods will not be automatically retried, so need to be recreated (usually happens due to memory pressure from the node)
- Don't treat containers in ContainerCreating as running, even though this state is usually quick, its possible for containers to get stuck there, and will improve accuracy of exec seconds tracking.
- Consolidate state transition for running states, either sets to running or to pending-wait/generate-wacz/upload-wacz and allows changing from to either of these states from each other or waiting_capacity