### PR TITLE
add missing 'Z' for iso-dates until ISO-formatting is fixed

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -376,7 +376,7 @@ export class WorkflowListItem extends LitElement {
             (workflow) => html`
               <sl-format-date
                 lang=${getLocale()}
-                date=${workflow.modified.toString()}
+                date="${workflow.modified.toString()}Z"
                 month="2-digit"
                 day="2-digit"
                 year="2-digit"

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -142,7 +142,7 @@ export class OrgSettingsBilling extends TailwindElement {
                                   <sl-format-date
                                     lang=${getLocale()}
                                     class="truncate"
-                                    date=${org.subscription.futureCancelDate}
+                                    date="${org.subscription.futureCancelDate}Z"
                                     month="long"
                                     day="numeric"
                                     year="numeric"


### PR DESCRIPTION
Adds missing 'Z' that is added explicitly now, until #1922 is fixed. It was missing from
workflow last modified and billing cancelation dates