### PR TITLE
stats recompute fixes:

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -593,7 +593,7 @@ class CrawlConfigOps:
             update_query["lastCrawlSize"] = sum(
                 file_.get("size", 0) for file_ in last_crawl.get("files", [])
             )
-            update_query["lastCrawlStopping"] = last_crawl.get("stopping", False)
+            update_query["lastCrawlStopping"] = False
             update_query["isCrawlRunning"] = False
 
             if last_crawl_finished:
@@ -960,7 +960,7 @@ async def stats_recompute_all(crawl_configs, crawls, cid: UUID):
             update_query["lastStartedByName"] = last_crawl.get("userName")
             update_query["lastCrawlState"] = last_crawl.get("state")
             update_query["lastCrawlSize"] = last_crawl_size
-            update_query["lastCrawlStopping"] = last_crawl.get("stopping", False)
+            update_query["lastCrawlStopping"] = False
             update_query["isCrawlRunning"] = False
 
             last_crawl_finished = last_crawl.get("finished")


### PR DESCRIPTION
- fix stats_recompute_last() and stats_recompute_all() to not update the lastCrawl* properties of a crawl workflow if a crawl is running, as those stats now point to the running crawl
- refactor _add_running_curr_crawl_stats() to make it clear stats only updated if crawl is running
- stats_recompute_all() change order to ascending to actually get last crawl, not first!