### PR TITLE
Attempt to auto-adjust storage if usage is running out while crawl is running

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1335,11 +1335,19 @@ class CrawlOperator(BaseOperator):
                     status.state == "running"
                     and pod_info.allocated.storage
                     and pod_info.used.storage * 2.2 > pod_info.allocated.storage
-                    or ((pod_info.allocated.storage - pod_info.used.storage) < 1_000_000_000)
-                ):
-                    pod_info.newStorage = (
-                        f"{math.ceil((pod_info.used.storage * 2.2) / 1_000_000_000)}Gi"
+                    or (
+                        (pod_info.allocated.storage - pod_info.used.storage)
+                        < 1_000_000_000
                     )
+                ):
+                    new_storage = math.ceil(
+                        max(
+                            pod_info.used.storage * 2.2,
+                            pod_info.used.storage + 1_000_000_000,
+                        )
+                        / 1_000_000_000
+                    )
+                    pod_info.newStorage = f"{new_storage}Gi"
                     print(
                         f"Attempting to adjust storage to {pod_info.newStorage} for {key}"
                     )

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -2,6 +2,7 @@
 
 import traceback
 import os
+import math
 from pprint import pprint
 from typing import Optional, Any, Sequence
 from datetime import datetime
@@ -1335,7 +1336,9 @@ class CrawlOperator(BaseOperator):
                     and pod_info.allocated.storage
                     and pod_info.used.storage * 2.2 > pod_info.allocated.storage
                 ):
-                    pod_info.newStorage = int(pod_info.used.storage * 2.2)
+                    pod_info.newStorage = (
+                        f"{math.ceil((pod_info.used.storage * 2.2) / 1_000_000_000)}Gi"
+                    )
                     print(
                         f"Attempting to adjust storage to {pod_info.newStorage} for {key}"
                     )

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -76,6 +76,9 @@ MEM_SOFT_OOM_THRESHOLD = 1.0
 # set memory limit to this much of request for extra padding
 MEM_LIMIT_PADDING = 1.2
 
+# ensure available storage is at least this much times used storage
+AVAIL_STORAGE_THRESHOLD = 2.5
+
 
 # pylint: disable=too-many-public-methods, too-many-locals, too-many-branches, too-many-statements
 # pylint: disable=invalid-name, too-many-lines, too-many-return-statements
@@ -1334,18 +1337,11 @@ class CrawlOperator(BaseOperator):
                 if (
                     status.state == "running"
                     and pod_info.allocated.storage
-                    and pod_info.used.storage * 2.2 > pod_info.allocated.storage
-                    or (
-                        (pod_info.allocated.storage - pod_info.used.storage)
-                        < 1_000_000_000
-                    )
+                    and pod_info.used.storage * AVAIL_STORAGE_THRESHOLD
+                    > pod_info.allocated.storage
                 ):
                     new_storage = math.ceil(
-                        max(
-                            pod_info.used.storage * 2.2,
-                            pod_info.used.storage + 1_000_000_000,
-                        )
-                        / 1_000_000_000
+                        pod_info.used.storage * AVAIL_STORAGE_THRESHOLD / 1_000_000_000
                     )
                     pod_info.newStorage = f"{new_storage}Gi"
                     print(

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1335,6 +1335,7 @@ class CrawlOperator(BaseOperator):
                     status.state == "running"
                     and pod_info.allocated.storage
                     and pod_info.used.storage * 2.2 > pod_info.allocated.storage
+                    or ((pod_info.allocated.storage - pod_info.used.storage) < 1_000_000_000)
                 ):
                     pod_info.newStorage = (
                         f"{math.ceil((pod_info.used.storage * 2.2) / 1_000_000_000)}Gi"

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -482,8 +482,12 @@ class CrawlOperator(BaseOperator):
 
         pvc = children[PVC].get(name)
         if pvc:
-            src = pvc["spec"]["resources"]["requests"]
-            resources.storage = int(parse_quantity(src.get("storage")))
+            try:
+                src = pvc["status"]["capacity"]
+                resources.storage = int(parse_quantity(src.get("storage")))
+            # pylint: disable=bare-except
+            except:
+                pass
 
     async def set_state(
         self,

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -77,7 +77,7 @@ MEM_SOFT_OOM_THRESHOLD = 1.0
 MEM_LIMIT_PADDING = 1.2
 
 # ensure available storage is at least this much times used storage
-AVAIL_STORAGE_THRESHOLD = 2.5
+AVAIL_STORAGE_RATIO = 2.5
 
 
 # pylint: disable=too-many-public-methods, too-many-locals, too-many-branches, too-many-statements
@@ -1337,11 +1337,11 @@ class CrawlOperator(BaseOperator):
                 if (
                     status.state == "running"
                     and pod_info.allocated.storage
-                    and pod_info.used.storage * AVAIL_STORAGE_THRESHOLD
+                    and pod_info.used.storage * AVAIL_STORAGE_RATIO
                     > pod_info.allocated.storage
                 ):
                     new_storage = math.ceil(
-                        pod_info.used.storage * AVAIL_STORAGE_THRESHOLD / 1_000_000_000
+                        pod_info.used.storage * AVAIL_STORAGE_RATIO / 1_000_000_000
                     )
                     pod_info.newStorage = f"{new_storage}Gi"
                     print(

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -132,7 +132,7 @@ class PodInfo(BaseModel):
 
     newCpu: Optional[int] = None
     newMemory: Optional[int] = None
-    newStorage: Optional[int] = None
+    newStorage: Optional[str] = None
     signalAtMem: Optional[int] = None
 
     evicted: Optional[bool] = False

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -132,6 +132,7 @@ class PodInfo(BaseModel):
 
     newCpu: Optional[int] = None
     newMemory: Optional[int] = None
+    newStorage: Optional[int] = None
     signalAtMem: Optional[int] = None
 
     evicted: Optional[bool] = False

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -17,7 +17,7 @@ spec:
 
   resources:
     requests:
-      storage: {{ crawler_storage }}
+      storage: {{ storage }}
 
   {% if volume_storage_class %}
   storageClassName: {{ volume_storage_class }}


### PR DESCRIPTION
Attempt to auto-adjust PVC storage if:
- used storage (as reported in redis by the crawler) * 2.5 > total_storage
- will cause PVC to resize, if possible (not supported by all drivers)
- uses multiples of 1Gi, rounding up to next GB
- AVAIL_STORAGE_RATIO hard-coded to 2.5 for now, to account for 2x space for WACZ plus change for fast updating crawls

Some caveats:
- only works if the storageClass used for PVCs has `allowVolumeExpansion: true`, if not, it will have no effect
- designed as a last resort option: the `crawl_storage` in values and `--sizeLimit` and `--diskUtilization` should generally result in this not being needed.
- can be useful in cases where a crawl is rapidly capturing a lot of content in one page, and there's no time to interrupt / restart, since the other limits apply only at page end.
- May want to have crawler update the disk usage more frequently, not just at page end to make this more effective.

Testing:
- A bit hard to test on docker desktop
- Was able to test on dev by setting low `crawler_storage` and disabling disk_utilization_threshold