### PR TITLE
Properly pluralize "Pages" in QA, and display skeletons instead of incorrect fallback values

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -249,23 +249,32 @@ export class ArchivedItemDetailQA extends BtrixElement {
                 </sl-tooltip>
               </div>
             </div>
-            <div>
-              <p>
-                <span class="text-primary">${htmlCount}</span> ${msg(
-                  "HTML Pages",
-                )}
-              </p>
-              <p>
-                <span class="text-neutral-600">${fileCount}</span> ${msg(
-                  "Non-HTML Files Captured As Pages",
-                )}
-              </p>
-              <p>
-                <span class="text-danger">${errorCount}</span> ${msg(
-                  "Failed Pages",
-                )}
-              </p>
-            </div>
+            ${this.crawl
+              ? html`<div class="tabular-nums">
+                  <p>
+                    ${msg(html`
+                      <span class="text-primary">${htmlCount}</span>
+                      HTML ${pluralOf("Pages", htmlCount)}
+                    `)}
+                  </p>
+                  <p>
+                    ${msg(html`
+                      <span class="text-neutral-600">${fileCount}</span>
+                      Non-HTML Files Captured As ${pluralOf("Pages", fileCount)}
+                    `)}
+                  </p>
+                  <p>
+                    ${msg(html`
+                      <span class="text-danger">${errorCount}</span>
+                      Failed ${pluralOf("Pages", errorCount)}
+                    `)}
+                  </p>
+                </div> `
+              : html`
+                  <sl-skeleton class="mb-[5px] w-24"></sl-skeleton>
+                  <sl-skeleton class="mb-[5px] w-64"></sl-skeleton>
+                  <sl-skeleton class="mb-[5px] w-28"></sl-skeleton>
+                `}
             ${when(this.mostRecentNonFailedQARun && this.qaRuns, (qaRuns) =>
               this.renderAnalysis(qaRuns),
             )}
@@ -273,9 +282,12 @@ export class ArchivedItemDetailQA extends BtrixElement {
 
           <div>
             <h4 class="mb-2 mt-4 text-lg leading-8">
-              <span class="font-semibold">${msg("Pages")}</span> (${(
-                this.pages?.total ?? 0
-              ).toLocaleString()})
+              <span class="font-semibold tabular-nums">${msg("Pages")}</span>
+              ${this.pages != null
+                ? `(${this.pages.total.toLocaleString()})`
+                : html`<sl-skeleton
+                    class="inline-block h-6 w-5 align-[-6px]"
+                  ></sl-skeleton>`}
             </h4>
           </div>
           ${this.renderPageListControls()} ${this.renderPageList()}

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -281,8 +281,8 @@ export class ArchivedItemDetailQA extends BtrixElement {
           </btrix-card>
 
           <div>
-            <h4 class="mb-2 mt-4 text-lg leading-8">
-              <span class="font-semibold tabular-nums">${msg("Pages")}</span>
+            <h4 class="mb-2 mt-4 text-lg tabular-nums leading-8">
+              <span class="font-semibold">${msg("Pages")}</span>
               ${this.pages != null
                 ? `(${this.pages.total.toLocaleString()})`
                 : html`<sl-skeleton

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -254,19 +254,19 @@ export class ArchivedItemDetailQA extends BtrixElement {
                   <p>
                     ${msg(html`
                       <span class="text-primary">${htmlCount}</span>
-                      HTML ${pluralOf("Pages", htmlCount)}
+                      HTML ${pluralOf("pages", htmlCount)}
                     `)}
                   </p>
                   <p>
                     ${msg(html`
                       <span class="text-neutral-600">${fileCount}</span>
-                      Non-HTML Files Captured As ${pluralOf("Pages", fileCount)}
+                      Non-HTML files captured as ${pluralOf("pages", fileCount)}
                     `)}
                   </p>
                   <p>
                     ${msg(html`
                       <span class="text-danger">${errorCount}</span>
-                      Failed ${pluralOf("Pages", errorCount)}
+                      Failed ${pluralOf("pages", errorCount)}
                     `)}
                   </p>
                 </div> `

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -56,32 +56,6 @@ const plurals = {
       id: "pages.plural.other",
     }),
   },
-  Pages: {
-    zero: msg("Pages", {
-      desc: 'plural form of "Page" for zero pages',
-      id: "Pages.plural.zero",
-    }),
-    one: msg("Page", {
-      desc: 'singular form for "Page"',
-      id: "Pages.plural.one",
-    }),
-    two: msg("Pages", {
-      desc: 'plural form of "Page" for two pages',
-      id: "Pages.plural.two",
-    }),
-    few: msg("Pages", {
-      desc: 'plural form of "Page" for few pages',
-      id: "Pages.plural.few",
-    }),
-    many: msg("Pages", {
-      desc: 'plural form of "Page" for many pages',
-      id: "Pages.plural.many",
-    }),
-    other: msg("Pages", {
-      desc: 'plural form of "Page" for multiple/other pages',
-      id: "Pages.plural.other",
-    }),
-  },
   comments: {
     zero: msg("comments", {
       desc: 'plural form of "comment" for zero comments',

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -56,6 +56,32 @@ const plurals = {
       id: "pages.plural.other",
     }),
   },
+  Pages: {
+    zero: msg("Pages", {
+      desc: 'plural form of "Page" for zero pages',
+      id: "Pages.plural.zero",
+    }),
+    one: msg("Page", {
+      desc: 'singular form for "Page"',
+      id: "Pages.plural.one",
+    }),
+    two: msg("Pages", {
+      desc: 'plural form of "Page" for two pages',
+      id: "Pages.plural.two",
+    }),
+    few: msg("Pages", {
+      desc: 'plural form of "Page" for few pages',
+      id: "Pages.plural.few",
+    }),
+    many: msg("Pages", {
+      desc: 'plural form of "Page" for many pages',
+      id: "Pages.plural.many",
+    }),
+    other: msg("Pages", {
+      desc: 'plural form of "Page" for multiple/other pages',
+      id: "Pages.plural.other",
+    }),
+  },
   comments: {
     zero: msg("comments", {
       desc: 'plural form of "comment" for zero comments',


### PR DESCRIPTION

https://github.com/user-attachments/assets/bf8961e5-db1a-4a16-81e4-a35a21ace00b

Ideally I'd also like to fix the layout shift from the desc list loading, but will poke at that later