### PR TITLE
fix: Use correct job type in crawl settings

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1187,7 +1187,11 @@ ${this.crawl?.description}
       }
       this.workflow = await this.getWorkflow(id);
     } catch (e: unknown) {
-      console.debug(e);
+      this.notify.toast({
+        message: msg("Sorry, couldn't load all crawl settings."),
+        variant: "warning",
+        icon: "exclamation-circle",
+      });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2027

### Changes

Fixes crawl settings for archived item not showing the correct fields based on job type.

### Manual testing

Verify against repro case in https://github.com/webrecorder/browsertrix/issues/2027