### PR TITLE
fix: Prevent browser profile selection overflow

### DIFF
--- a/frontend/src/components/ui/details.ts
+++ b/frontend/src/components/ui/details.ts
@@ -29,6 +29,7 @@ export class Details extends LitElement {
   // postcss-lit-disable-next-line
   static styles = css`
     :host {
+      --margin-bottom: var(--sl-spacing-2x-small);
       display: block;
     }
 
@@ -47,7 +48,7 @@ export class Details extends LitElement {
 
     details[aria-disabled="false"] summary {
       border-bottom: 1px solid var(--sl-panel-border-color);
-      margin-bottom: var(--sl-spacing-x-small);
+      margin-bottom: var(--margin-bottom);
       cursor: pointer;
       user-select: none;
     }

--- a/frontend/src/components/ui/details.ts
+++ b/frontend/src/components/ui/details.ts
@@ -30,6 +30,7 @@ export class Details extends LitElement {
   static styles = css`
     :host {
       --margin-bottom: var(--sl-spacing-2x-small);
+      --border-bottom: 1px solid var(--sl-panel-border-color);
       display: block;
     }
 
@@ -47,7 +48,7 @@ export class Details extends LitElement {
     }
 
     details[aria-disabled="false"] summary {
-      border-bottom: 1px solid var(--sl-panel-border-color);
+      border-bottom: var(--border-bottom);
       margin-bottom: var(--margin-bottom);
       cursor: pointer;
       user-select: none;

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -99,17 +99,13 @@ export class SelectBrowserProfile extends LiteElement {
     if (!this.selectedProfile) return;
 
     return html`
-      <div
-        class="mt-2 rounded border bg-slate-50 text-neutral-600 shadow-inner shadow-slate-200"
-      >
+      <div class="mt-2 rounded border text-neutral-600">
         ${this.selectedProfile.description
           ? html`<div class="border-b p-3">
-              <div class="mb-2 text-xs text-neutral-400">
+              <div class="mb-2 text-xs text-neutral-500">
                 ${msg("Description:")}
               </div>
-              <div class="truncate text-xs">
-                ${this.selectedProfile.description}
-              </div>
+              <div class="text-xs">${this.selectedProfile.description}</div>
             </div>`
           : ""}
         <div class="flex items-center justify-between p-2">

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import { type SlSelect } from "@shoelace-style/shoelace";
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import orderBy from "lodash/fp/orderBy";
 
@@ -101,16 +101,17 @@ export class SelectBrowserProfile extends LiteElement {
     return html`
       <div class="mt-2 rounded border text-neutral-600">
         ${this.selectedProfile.description
-          ? html`<div class="border-b p-3">
-              <div class="mb-2 text-xs text-neutral-500">
-                ${msg("Description:")}
+          ? html` <btrix-details class="pt-1" style="--margin-bottom: 0">
+              <div slot="title" class="text-neutral-500">
+                ${msg("Description")}
               </div>
               <!-- display: inline -->
-              <div class="whitespace-pre-line text-xs leading-normal"
+              <div
+                class="whitespace-pre-line border-b p-3 text-xs leading-normal"
                 >${this.selectedProfile.description}</div
               >
-            </div>`
-          : ""}
+            </btrix-details>`
+          : nothing}
         <div class="flex items-center justify-between p-2">
           <div class="px-1 text-xs">
             ${msg("Last updated")}

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -89,6 +89,32 @@ export class SelectBrowserProfile extends LiteElement {
         ${this.browserProfiles && !this.browserProfiles.length
           ? this.renderNoProfiles()
           : ""}
+        ${this.selectedProfile
+          ? html`
+              <div slot="help-text" class="flex justify-between">
+                <span>
+                  ${msg("Last updated")}
+                  <sl-format-date
+                    lang=${getLocale()}
+                    date=${`${this.selectedProfile.modified}Z` /** Z for UTC */}
+                    month="2-digit"
+                    day="2-digit"
+                    year="2-digit"
+                    hour="2-digit"
+                    minute="2-digit"
+                  ></sl-format-date>
+                </span>
+                <a
+                  class="flex items-center gap-1 text-blue-500 hover:text-blue-600"
+                  href=${`${this.orgBasePath}/browser-profiles/profile/${this.selectedProfile.id}`}
+                  target="_blank"
+                >
+                  ${msg("Check Profile")}
+                  <sl-icon name="box-arrow-up-right"></sl-icon>
+                </a>
+              </div>
+            `
+          : nothing}
       </sl-select>
 
       ${this.browserProfiles?.length ? this.renderSelectedProfileInfo() : ""}
@@ -96,46 +122,19 @@ export class SelectBrowserProfile extends LiteElement {
   }
 
   private renderSelectedProfileInfo() {
-    if (!this.selectedProfile) return;
+    if (!this.selectedProfile?.description) return;
 
-    return html`
-      <div class="mt-2 rounded border text-neutral-600">
-        ${this.selectedProfile.description
-          ? html` <btrix-details class="pt-1" style="--margin-bottom: 0">
-              <div slot="title" class="text-neutral-500">
-                ${msg("Description")}
-              </div>
-              <!-- display: inline -->
-              <div
-                class="whitespace-pre-line border-b p-3 text-xs leading-normal"
-                >${this.selectedProfile.description}</div
-              >
-            </btrix-details>`
-          : nothing}
-        <div class="flex items-center justify-between p-2">
-          <div class="px-1 text-xs">
-            ${msg("Last updated")}
-            <sl-format-date
-              lang=${getLocale()}
-              date=${`${this.selectedProfile.modified}Z` /** Z for UTC */}
-              month="2-digit"
-              day="2-digit"
-              year="2-digit"
-              hour="2-digit"
-              minute="2-digit"
-            ></sl-format-date>
-          </div>
-          <sl-button
-            size="small"
-            href=${`${this.orgBasePath}/browser-profiles/profile/${this.selectedProfile.id}`}
-            target="_blank"
-          >
-            <sl-icon slot="suffix" name="box-arrow-up-right"></sl-icon>
-            ${msg("Check Profile")}
-          </sl-button>
+    return html`<div class="my-2 rounded border pl-1">
+      <btrix-details style="--margin-bottom: 0; --border-bottom: 0;">
+        <div slot="title" class="text-xs leading-normal text-neutral-600">
+          ${msg("Description")}
         </div>
-      </div>
-    `;
+        <!-- display: inline -->
+        <div class="whitespace-pre-line p-3 text-xs leading-normal"
+          >${this.selectedProfile.description}</div
+        >
+      </btrix-details>
+    </div>`;
   }
 
   private renderNoProfiles() {

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -77,7 +77,7 @@ export class SelectBrowserProfile extends LiteElement {
                 <div class="text-xs">
                   <sl-format-date
                     lang=${getLocale()}
-                    date=${`${profile.created}Z` /** Z for UTC */}
+                    date=${`${profile.modified}Z` /** Z for UTC */}
                     month="2-digit"
                     day="2-digit"
                     year="2-digit"
@@ -100,36 +100,40 @@ export class SelectBrowserProfile extends LiteElement {
 
     return html`
       <div
-        class="mt-2 flex justify-between rounded border bg-neutral-50 p-2 text-sm"
+        class="mt-2 rounded border bg-slate-50 text-neutral-600 shadow-inner shadow-slate-200"
       >
         ${this.selectedProfile.description
-          ? html`<em class="text-slate-500"
-              >${this.selectedProfile.description}</em
-            >`
+          ? html`<div class="border-b p-3">
+              <div class="mb-2 text-xs text-neutral-400">
+                ${msg("Description:")}
+              </div>
+              <div class="truncate text-xs">
+                ${this.selectedProfile.description}
+              </div>
+            </div>`
           : ""}
-        <span>
-          ${msg("Last edited:")}
-          <sl-format-date
-            lang=${getLocale()}
-            date=${`${this.selectedProfile.created}Z` /** Z for UTC */}
-            month="2-digit"
-            day="2-digit"
-            year="2-digit"
-          ></sl-format-date>
-        </span>
-        <a
-          href=${`${this.orgBasePath}/browser-profiles/profile/${this.selectedProfile.id}`}
-          class="font-medium text-primary hover:text-indigo-500"
-          target="_blank"
-        >
-          <span class="mr-1 inline-block align-middle"
-            >${msg("Check profile")}</span
+        <div class="flex items-center justify-between p-2">
+          <div class="px-1 text-xs">
+            ${msg("Last updated")}
+            <sl-format-date
+              lang=${getLocale()}
+              date=${`${this.selectedProfile.modified}Z` /** Z for UTC */}
+              month="2-digit"
+              day="2-digit"
+              year="2-digit"
+              hour="2-digit"
+              minute="2-digit"
+            ></sl-format-date>
+          </div>
+          <sl-button
+            size="small"
+            href=${`${this.orgBasePath}/browser-profiles/profile/${this.selectedProfile.id}`}
+            target="_blank"
           >
-          <sl-icon
-            class="inline-block align-middle"
-            name="box-arrow-up-right"
-          ></sl-icon>
-        </a>
+            <sl-icon slot="suffix" name="box-arrow-up-right"></sl-icon>
+            ${msg("Check Profile")}
+          </sl-button>
+        </div>
       </div>
     `;
   }
@@ -188,7 +192,7 @@ export class SelectBrowserProfile extends LiteElement {
     try {
       const data = await this.getProfiles();
 
-      this.browserProfiles = orderBy(["name", "created"])(["asc", "desc"])(
+      this.browserProfiles = orderBy(["name", "modified"])(["asc", "desc"])(
         data,
       ) as Profile[];
 

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -105,7 +105,10 @@ export class SelectBrowserProfile extends LiteElement {
               <div class="mb-2 text-xs text-neutral-500">
                 ${msg("Description:")}
               </div>
-              <div class="text-xs">${this.selectedProfile.description}</div>
+              <!-- display: inline -->
+              <div class="whitespace-pre-line text-xs leading-normal"
+                >${this.selectedProfile.description}</div
+              >
             </div>`
           : ""}
         <div class="flex items-center justify-between p-2">

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -264,16 +264,18 @@ export class BrowserProfilesDetail extends BtrixElement {
             `,
           )}
         </header>
-        <div class="rounded border p-5">
-          ${this.profile
+        <!-- display: inline -->
+        <div
+          class="leading whitespace-pre-line rounded border p-5 leading-relaxed first-line:leading-[0]"
+          >${this.profile
             ? this.profile.description ||
               html`
                 <div class="text-center text-neutral-400">
-                  ${msg("No description added.")}
+                  &nbsp;${msg("No description added.")}
                 </div>
               `
-            : nothing}
-        </div>
+            : nothing}</div
+        >
       </section>
 
       <section class="mb-7">


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2019

### Changes

- Truncates selected browser profile description and refreshes style
- Order browser profiles by modified date

### Manual testing

1. Update browser profile to have a long description
2. Go to new workflow
3. Go to "Browser Settings"
4. Choose browser profile with long description. Verify description doesn't overflow

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit Workflow - Browser Settings - no description | <img width="591" alt="Screenshot 2024-08-19 at 4 08 05 PM" src="https://github.com/user-attachments/assets/6a72aead-7ab7-4b84-a3d2-a520a8167fb6"> |
| Edit Workflow - Browser Settings - with description | <img width="587" alt="Screenshot 2024-08-19 at 4 05 32 PM" src="https://github.com/user-attachments/assets/a6e00eef-fe8c-4a3f-a708-9766417fec0c"> |



<!-- ### Follow-ups -->
