### PR TITLE
add a crawling defaults on the Org to allow setting certain crawl workflow fields as defaults:

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -500,7 +500,8 @@ class UpdateCrawlConfig(BaseModel):
 class CrawlConfigDefaults(BaseModel):
     """Crawl Config Org Defaults"""
 
-    limit: Optional[int] = None
+    crawlTimeout: Optional[int] = None
+    maxCrawlSize: Optional[int] = None
 
     pageLoadTimeout: Optional[int] = None
     postLoadDelay: Optional[int] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -497,6 +497,29 @@ class UpdateCrawlConfig(BaseModel):
 
 
 # ============================================================================
+class CrawlConfigDefaults(BaseModel):
+    """Crawl Config Org Defaults"""
+
+    limit: Optional[int] = None
+
+    pageLoadTimeout: Optional[int] = None
+    postLoadDelay: Optional[int] = None
+    behaviorTimeout: Optional[int] = None
+    pageExtraDelay: Optional[int] = None
+
+    blockAds: Optional[bool] = None
+
+    profileid: Optional[UUID] = None
+    crawlerChannel: Optional[str] = None
+
+    lang: Optional[str] = None
+
+    userAgent: Optional[str] = None
+
+    exclude: Optional[List[str]] = None
+
+
+# ============================================================================
 class CrawlConfigAddedResponse(BaseModel):
     """Response model for adding crawlconfigs"""
 
@@ -1337,6 +1360,8 @@ class OrgOut(BaseMongoModel):
 
     subscription: Optional[Subscription] = None
 
+    crawlingDefaults: Optional[CrawlConfigDefaults] = None
+
 
 # ============================================================================
 class Organization(BaseMongoModel):
@@ -1387,6 +1412,8 @@ class Organization(BaseMongoModel):
     readOnlyReason: Optional[str] = None
 
     subscription: Optional[Subscription] = None
+
+    crawlingDefaults: Optional[CrawlConfigDefaults] = None
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -590,7 +590,7 @@ class OrgOps:
         """Update crawling defaults"""
         res = await self.orgs.find_one_and_update(
             {"_id": org.id},
-            {"$set": {"crawlingDefaults": defaults.dict()}},
+            {"$set": {"crawlingDefaults": defaults.model_dump()}},
             return_document=ReturnDocument.AFTER,
         )
         return res is not None

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -60,19 +60,17 @@ def test_update_org_crawling_defaults(admin_auth_headers, default_org_id):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/defaults/crawling",
         headers=admin_auth_headers,
-        json={"limit": 2, "lang": "fr"},
+        json={"maxCrawlSize": 200000, "lang": "fr"},
     )
 
     assert r.status_code == 200
     assert r.json()["updated"] == True
 
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers
-    )
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
 
     data = r.json()
     assert data["crawlingDefaults"]
-    assert data["crawlingDefaults"]["limit"] == 2
+    assert data["crawlingDefaults"]["maxCrawlSize"] == 200000
     assert data["crawlingDefaults"]["lang"] == "fr"
 
 

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -56,6 +56,26 @@ def test_get_org_crawler(crawler_auth_headers, default_org_id):
     assert data.get("users") == {}
 
 
+def test_update_org_crawling_defaults(admin_auth_headers, default_org_id):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/defaults/crawling",
+        headers=admin_auth_headers,
+        json={"limit": 2, "lang": "fr"},
+    )
+
+    assert r.status_code == 200
+    assert r.json()["updated"] == True
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers
+    )
+
+    data = r.json()
+    assert data["crawlingDefaults"]
+    assert data["crawlingDefaults"]["limit"] == 2
+    assert data["crawlingDefaults"]["lang"] == "fr"
+
+
 def test_rename_org(admin_auth_headers, default_org_id):
     UPDATED_NAME = "updated org name"
     UPDATED_SLUG = "updated-org-name"


### PR DESCRIPTION
- add POST /orgs/<id>/defaults/crawling API to update all defaults (defaults unset are cleared)
- defaults returned as 'crawlingDefaults' object on Org, if set
- fixes #2016