### PR TITLE
fix: Make footer translatable

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -562,7 +562,7 @@ export class App extends LiteElement {
               name="github"
               class="inline-block size-4 align-middle text-base"
             ></sl-icon>
-            Source Code
+            ${msg("Source Code")}
           </a>
         </div>
         <div class="flex items-center justify-center">
@@ -576,7 +576,7 @@ export class App extends LiteElement {
               name="book-half"
               class="inline-block size-4 align-middle text-base"
             ></sl-icon>
-            Documentation
+            ${msg("Documentation")}
           </a>
         </div>
         <div class="flex items-center justify-center">

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -579,7 +579,7 @@ export class App extends LiteElement {
                 <btrix-copy-button
                   class="size-4 text-neutral-400"
                   .getValue=${() => this.version}
-                  content=${msg("Copy Version Code")}
+                  content=${msg("Copy Browsertrix Version")}
                   size="x-small"
                 ></btrix-copy-button>
                 <span class="font-monostyle text-xs text-neutral-400">

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -573,9 +573,9 @@ export class App extends LiteElement {
             ${msg("Documentation")}
           </a>
         </div>
-        <div class="flex items-center justify-center gap-2 leading-none">
-          ${this.version
-            ? html`
+        ${this.version
+          ? html`
+              <div class="flex items-center justify-center gap-2 leading-none">
                 <btrix-copy-button
                   class="size-4 text-neutral-400"
                   .getValue=${() => this.version}
@@ -585,9 +585,9 @@ export class App extends LiteElement {
                 <span class="font-monostyle text-xs text-neutral-400">
                   ${this.version}
                 </span>
-              `
-            : ""}
-        </div>
+              </div>
+            `
+          : nothing}
       </footer>
     `;
   }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -545,52 +545,44 @@ export class App extends LiteElement {
   private renderFooter() {
     return html`
       <footer
-        class="mx-auto box-border flex w-full max-w-screen-desktop flex-col justify-between gap-4 p-3 md:flex-row"
+        class="mx-auto box-border flex w-full max-w-screen-desktop flex-col items-center justify-between gap-4 p-3 md:flex-row"
       >
         <!-- <div> -->
         <!-- TODO re-enable when translations are added -->
         <!-- <btrix-locale-picker></btrix-locale-picker> -->
         <!-- </div> -->
-        <div class="flex items-center justify-center">
+        <div>
           <a
-            class="flex items-center gap-2 text-neutral-400 hover:text-primary"
+            class="flex items-center gap-2 leading-none text-neutral-400 hover:text-primary"
             href="https://github.com/webrecorder/browsertrix"
             target="_blank"
             rel="noopener"
           >
-            <sl-icon
-              name="github"
-              class="inline-block size-4 align-middle text-base"
-            ></sl-icon>
+            <sl-icon name="github" class="size-4 text-base"></sl-icon>
             ${msg("Source Code")}
           </a>
         </div>
-        <div class="flex items-center justify-center">
+        <div>
           <a
-            class="flex items-center gap-2 text-neutral-400 hover:text-primary"
+            class="flex items-center gap-2 leading-none text-neutral-400 hover:text-primary"
             href="https://docs.browsertrix.com"
             target="_blank"
             rel="noopener"
           >
-            <sl-icon
-              name="book-half"
-              class="inline-block size-4 align-middle text-base"
-            ></sl-icon>
+            <sl-icon name="book-half" class="size-4 text-base"></sl-icon>
             ${msg("Documentation")}
           </a>
         </div>
-        <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center gap-2 leading-none">
           ${this.version
             ? html`
                 <btrix-copy-button
-                  class="mr-2 size-4 text-neutral-400"
+                  class="size-4 text-neutral-400"
                   .getValue=${() => this.version}
                   content=${msg("Copy Version Code")}
                   size="x-small"
                 ></btrix-copy-button>
-                <span
-                  class="font-monostyle inline-block align-middle text-xs text-neutral-400"
-                >
+                <span class="font-monostyle text-xs text-neutral-400">
                   ${this.version}
                 </span>
               `


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/1416

### Changes

- Wraps footer strings to prepare for localization
- Removes extraneous class names
- Updates copy button tooltip to match bug report field