### PR TITLE
fix: Hide login link on login page

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -405,23 +405,23 @@ export class App extends LiteElement {
                     </sl-menu-item>
                   </sl-menu>
                 </sl-dropdown>`
-              : html`
-                  <a href="/log-in"> ${msg("Log In")} </a>
-                  ${this.appState.settings?.registrationEnabled
-                    ? html`
-                        <sl-button
-                          variant="text"
-                          @click="${() => this.navigate("/sign-up")}"
-                        >
-                          ${msg("Sign up")}
-                        </sl-button>
-                      `
-                    : html``}
-                `}
+              : this.renderSignUpLink()}
           </div>
         </nav>
       </div>
     `;
+  }
+
+  private renderSignUpLink() {
+    if (!this.appState.settings) return;
+
+    if (this.appState.settings.registrationEnabled) {
+      return html`
+        <sl-button variant="text" @click="${() => this.navigate("/sign-up")}">
+          ${msg("Sign Up")}
+        </sl-button>
+      `;
+    }
   }
 
   private renderOrgs() {

--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -20,7 +20,7 @@ test("test", async ({ baseURL }) => {
       );
     }
     await page.fill('input[name="password"]', devPassword);
-    await page.click('a:has-text("Log In")');
+    await page.click('sl-button:has-text("Log In")');
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2037

### Changes

- Removes log in link when on log in page
- Fix e2e test, which wasn't actually logging the test user in before

### Manual testing

Log out. Verify "Log In" is no longer shown in app bar