### PR TITLE
feat: Add help shortcuts to app header & footer

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -277,7 +277,6 @@ export class App extends LiteElement {
           <sl-icon slot="suffix" name="box-arrow-up-right"></sl-icon>
           ${msg("Open in new window")}</sl-button
         >
-        <sl-button size="small" slot="footer">${msg("Close")}</sl-button>
       </sl-drawer>
     `;
   }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -326,9 +326,9 @@ export class App extends LiteElement {
     return html`
       <div class="border-b bg-neutral-50">
         <nav
-          class="mx-auto box-border flex h-12 items-center justify-between px-3 xl:pl-6"
+          class="box-border flex min-h-12 flex-wrap items-center gap-x-5 gap-y-3 p-3 md:py-0 xl:pl-6"
         >
-          <div class="flex items-center">
+          <div class="order-1 flex flex-1 items-center">
             <a
               class="items-between flex gap-2"
               aria-label="home"
@@ -343,7 +343,7 @@ export class App extends LiteElement {
               <div
                 class="${showFullLogo
                   ? "w-[10.5rem]"
-                  : "w-6 md:w-[10.5rem]"} h-6 bg-cover bg-no-repeat"
+                  : "w-6 lg:w-[10.5rem]"} h-6 bg-cover bg-no-repeat"
                 style="background-image: url(${brandLockupColor})"
                 role="img"
                 title="Browsertrix logo"
@@ -379,25 +379,16 @@ export class App extends LiteElement {
               `,
             )}
           </div>
-          <div class="grid auto-cols-max grid-flow-col items-center gap-5">
-            ${isSuperAdmin
-              ? html`
-                  <a
-                    class="font-medium text-neutral-500 hover:text-primary"
-                    href="/crawls"
-                    @click=${this.navLink}
-                    >${msg("Running Crawls")}</a
-                  >
-                  <div class="hidden md:block">${this.renderFindCrawl()}</div>
-                `
-              : ""}
-            ${this.authService.authState
-              ? html`<button
+          <div class="order-2 flex flex-grow-0 items-center gap-4 md:order-3">
+            ${this.authState
+              ? html` <button
                     class="flex items-center gap-2 leading-none text-neutral-500 hover:text-primary"
                     @click=${() => void this.userGuideDrawer.show()}
                   >
                     <sl-icon name="book" class="size-4 text-base"></sl-icon>
-                    ${msg("User Guide")}
+                    <span class="sr-only lg:not-sr-only"
+                      >${msg("User Guide")}</span
+                    >
                   </button>
                   <sl-tooltip
                     content=${msg(
@@ -414,10 +405,14 @@ export class App extends LiteElement {
                         name="patch-question"
                         class="size-4 text-base"
                       ></sl-icon>
-                      ${msg("Help")}
+                      <span class="sr-only lg:not-sr-only">${msg("Help")}</span>
                     </a>
                   </sl-tooltip>
-                  <sl-dropdown placement="bottom-end" distance="4">
+                  <sl-dropdown
+                    class="ml-auto"
+                    placement="bottom-end"
+                    distance="4"
+                  >
                     <button slot="trigger">
                       <sl-avatar
                         label=${msg("Open user menu")}
@@ -450,6 +445,21 @@ export class App extends LiteElement {
                     </sl-menu>
                   </sl-dropdown>`
               : this.renderSignUpLink()}
+          </div>
+          <div
+            class="order-3 grid w-full auto-cols-max grid-flow-col items-center gap-5 md:order-2 md:w-auto"
+          >
+            ${isSuperAdmin
+              ? html`
+                  <a
+                    class="font-medium text-neutral-500 hover:text-primary"
+                    href="/crawls"
+                    @click=${this.navLink}
+                    >${msg("Running Crawls")}</a
+                  >
+                  <div class="hidden md:block">${this.renderFindCrawl()}</div>
+                `
+              : nothing}
           </div>
         </nav>
       </div>
@@ -487,21 +497,23 @@ export class App extends LiteElement {
     const orgNameLength = 50;
 
     return html`
-      ${selectedOption.slug
-        ? html`
-            <a
-              class="font-medium text-neutral-600"
-              href=${this.orgBasePath}
-              @click=${this.navLink}
-            >
-              ${selectedOption.name.slice(0, orgNameLength)}
-            </a>
-          `
-        : html`
-            <span class="text-neutral-500">
-              ${selectedOption.name.slice(0, orgNameLength)}
-            </span>
-          `}
+      <div class="w-32 truncate sm:w-52 md:w-auto">
+        ${selectedOption.slug
+          ? html`
+              <a
+                class="font-medium text-neutral-600"
+                href=${this.orgBasePath}
+                @click=${this.navLink}
+              >
+                ${selectedOption.name.slice(0, orgNameLength)}
+              </a>
+            `
+          : html`
+              <span class="text-neutral-500">
+                ${selectedOption.name.slice(0, orgNameLength)}
+              </span>
+            `}
+      </div>
       ${when(
         orgs.length > 1,
         () => html`

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -253,7 +253,9 @@ export class App extends LiteElement {
       <div class="min-w-screen flex min-h-screen flex-col">
         ${this.renderNavBar()} ${this.renderAlertBanner()}
         <main class="relative flex flex-auto">${this.renderPage()}</main>
-        <div class="border-t border-neutral-100">${this.renderFooter()}</div>
+        <div class="mt-7 border-t border-neutral-100">
+          ${this.renderFooter()}
+        </div>
       </div>
 
       <sl-dialog
@@ -267,8 +269,12 @@ export class App extends LiteElement {
       <sl-drawer
         id="userGuideDrawer"
         label=${msg("User Guide")}
-        style="--body-spacing: 0; --header-spacing: var(--sl-spacing-small); --footer-spacing: var(--sl-spacing-2x-small);"
+        style="--body-spacing: 0; --footer-spacing: var(--sl-spacing-2x-small);"
       >
+        <span slot="label" class="flex items-center gap-3">
+          <sl-icon name="book" class=""></sl-icon>
+          <span>${msg("User Guide")}</span>
+        </span>
         <iframe
           class="size-full"
           src="https://docs.browsertrix.com/user-guide/"
@@ -325,7 +331,7 @@ export class App extends LiteElement {
     return html`
       <div class="border-b bg-neutral-50">
         <nav
-          class="box-border flex min-h-12 flex-wrap items-center gap-x-5 gap-y-3 p-3 md:py-0 xl:pl-6"
+          class="box-border flex min-h-12 flex-wrap items-center gap-x-5 gap-y-3 p-3 leading-none md:py-0 xl:pl-6"
         >
           <div class="order-1 flex flex-1 items-center">
             <a
@@ -349,7 +355,7 @@ export class App extends LiteElement {
               ></div>
             </a>
             ${when(
-              this.authService.authState,
+              this.userInfo,
               () => html`
                 ${isSuperAdmin
                   ? html`
@@ -380,33 +386,22 @@ export class App extends LiteElement {
           </div>
           <div class="order-2 flex flex-grow-0 items-center gap-4 md:order-3">
             ${this.authState
-              ? html` <button
-                    class="flex items-center gap-2 leading-none text-neutral-500 hover:text-primary"
-                    @click=${() => void this.userGuideDrawer.show()}
-                  >
-                    <sl-icon name="book" class="size-4 text-base"></sl-icon>
-                    <span class="sr-only lg:not-sr-only"
-                      >${msg("User Guide")}</span
-                    >
-                  </button>
-                  <sl-tooltip
-                    content=${msg(
-                      "Need help with something that's not covered in our guide? Ask the community help forum",
-                    )}
-                  >
-                    <a
-                      class="flex items-center gap-2 leading-none text-neutral-500 hover:text-primary"
-                      href="https://forum.webrecorder.net/c/help/5"
-                      target="_blank"
-                      rel="noopener"
-                    >
-                      <sl-icon
-                        name="patch-question"
-                        class="size-4 text-base"
-                      ></sl-icon>
-                      <span class="sr-only lg:not-sr-only">${msg("Help")}</span>
-                    </a>
-                  </sl-tooltip>
+              ? html`${this.userInfo && !isSuperAdmin
+                    ? html`
+                        <button
+                          class="flex items-center gap-2 leading-none text-neutral-500 hover:text-primary"
+                          @click=${() => void this.userGuideDrawer.show()}
+                        >
+                          <sl-icon
+                            name="book"
+                            class="mt-px size-4 text-base"
+                          ></sl-icon>
+                          <span class="sr-only lg:not-sr-only"
+                            >${msg("User Guide")}</span
+                          >
+                        </button>
+                      `
+                    : nothing}
                   <sl-dropdown
                     class="ml-auto"
                     placement="bottom-end"
@@ -445,11 +440,11 @@ export class App extends LiteElement {
                   </sl-dropdown>`
               : this.renderSignUpLink()}
           </div>
-          <div
-            class="order-3 grid w-full auto-cols-max grid-flow-col items-center gap-5 md:order-2 md:w-auto"
-          >
-            ${isSuperAdmin
-              ? html`
+          ${isSuperAdmin
+            ? html`
+                <div
+                  class="order-3 grid w-full auto-cols-max grid-flow-col items-center gap-5 md:order-2 md:w-auto"
+                >
                   <a
                     class="font-medium text-neutral-500 hover:text-primary"
                     href="/crawls"
@@ -457,9 +452,9 @@ export class App extends LiteElement {
                     >${msg("Running Crawls")}</a
                   >
                   <div class="hidden md:block">${this.renderFindCrawl()}</div>
-                `
-              : nothing}
-          </div>
+                </div>
+              `
+            : nothing}
         </nav>
       </div>
     `;
@@ -496,7 +491,7 @@ export class App extends LiteElement {
     const orgNameLength = 50;
 
     return html`
-      <div class="w-32 truncate sm:w-52 md:w-auto">
+      <div class="max-w-32 truncate sm:max-w-52 md:max-w-none">
         ${selectedOption.slug
           ? html`
               <a
@@ -620,12 +615,12 @@ export class App extends LiteElement {
         <div>
           <a
             class="flex items-center gap-2 leading-none text-neutral-400 hover:text-primary"
-            href="https://docs.browsertrix.com"
+            href="https://forum.webrecorder.net/c/help/5"
             target="_blank"
             rel="noopener"
           >
-            <sl-icon name="book-half" class="size-4 text-base"></sl-icon>
-            ${msg("Documentation")}
+            <sl-icon name="patch-question" class="size-4 text-base"></sl-icon>
+            <span class="sr-only lg:not-sr-only">${msg("Help Forum")}</span>
           </a>
         </div>
         ${this.version

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -267,7 +267,7 @@ export class App extends LiteElement {
       <sl-drawer
         id="userGuideDrawer"
         label=${msg("User Guide")}
-        style="--body-spacing: 0; --header-spacing: var(--sl-spacing-small); --footer-spacing: var(--sl-spacing-x-small);"
+        style="--body-spacing: 0; --header-spacing: var(--sl-spacing-small); --footer-spacing: var(--sl-spacing-2x-small);"
       >
         <iframe
           class="size-full"

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,5 +1,5 @@
 import { localized, msg, str } from "@lit/localize";
-import type { SlDialog } from "@shoelace-style/shoelace";
+import type { SlDialog, SlDrawer } from "@shoelace-style/shoelace";
 import { nothing, render, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
@@ -71,6 +71,9 @@ export class App extends LiteElement {
 
   @query("#globalDialog")
   private readonly globalDialog!: SlDialog;
+
+  @query("#userGuideDrawer")
+  private readonly userGuideDrawer!: SlDrawer;
 
   async connectedCallback() {
     let authState: AuthService["authState"] = null;
@@ -260,6 +263,22 @@ export class App extends LiteElement {
         @sl-after-hide=${() => (this.globalDialogContent = {})}
         >${this.globalDialogContent.body}</sl-dialog
       >
+
+      <sl-drawer
+        id="userGuideDrawer"
+        label=${msg("User Guide")}
+        style="--body-spacing: 0; --header-spacing: var(--sl-spacing-small); --footer-spacing: var(--sl-spacing-x-small);"
+      >
+        <iframe
+          class="size-full"
+          src="https://docs.browsertrix.com/user-guide/"
+        ></iframe>
+        <sl-button size="small" slot="footer" variant="text">
+          <sl-icon slot="suffix" name="box-arrow-up-right"></sl-icon>
+          ${msg("Open in new window")}</sl-button
+        >
+        <sl-button size="small" slot="footer">${msg("Close")}</sl-button>
+      </sl-drawer>
     `;
   }
 
@@ -373,38 +392,63 @@ export class App extends LiteElement {
                 `
               : ""}
             ${this.authService.authState
-              ? html`<sl-dropdown placement="bottom-end" distance="4">
-                  <button slot="trigger">
-                    <sl-avatar
-                      label=${msg("Open user menu")}
-                      shape="rounded"
-                      class="[--size:1.75rem]"
-                    ></sl-avatar>
+              ? html`<button
+                    class="flex items-center gap-2 leading-none text-neutral-500 hover:text-primary"
+                    @click=${() => void this.userGuideDrawer.show()}
+                  >
+                    <sl-icon name="book" class="size-4 text-base"></sl-icon>
+                    ${msg("User Guide")}
                   </button>
-                  <sl-menu class="w-60 min-w-min max-w-full">
-                    <div class="px-7 py-2">${this.renderMenuUserInfo()}</div>
-                    <sl-divider></sl-divider>
-                    <sl-menu-item
-                      @click=${() => this.navigate(ROUTES.accountSettings)}
+                  <sl-tooltip
+                    content=${msg(
+                      "Need help with something that's not covered in our guide? Ask the community help forum",
+                    )}
+                  >
+                    <a
+                      class="flex items-center gap-2 leading-none text-neutral-500 hover:text-primary"
+                      href="https://forum.webrecorder.net/c/help/5"
+                      target="_blank"
+                      rel="noopener"
                     >
-                      <sl-icon slot="prefix" name="person-gear"></sl-icon>
-                      ${msg("Account Settings")}
-                    </sl-menu-item>
-                    ${this.userInfo?.isSuperAdmin
-                      ? html` <sl-menu-item
-                          @click=${() => this.navigate(ROUTES.usersInvite)}
-                        >
-                          <sl-icon slot="prefix" name="person-plus"></sl-icon>
-                          ${msg("Invite Users")}
-                        </sl-menu-item>`
-                      : ""}
-                    <sl-divider></sl-divider>
-                    <sl-menu-item @click="${this.onLogOut}">
-                      <sl-icon slot="prefix" name="door-open"></sl-icon>
-                      ${msg("Log Out")}
-                    </sl-menu-item>
-                  </sl-menu>
-                </sl-dropdown>`
+                      <sl-icon
+                        name="patch-question"
+                        class="size-4 text-base"
+                      ></sl-icon>
+                      ${msg("Help")}
+                    </a>
+                  </sl-tooltip>
+                  <sl-dropdown placement="bottom-end" distance="4">
+                    <button slot="trigger">
+                      <sl-avatar
+                        label=${msg("Open user menu")}
+                        shape="rounded"
+                        class="[--size:1.75rem]"
+                      ></sl-avatar>
+                    </button>
+                    <sl-menu class="w-60 min-w-min max-w-full">
+                      <div class="px-7 py-2">${this.renderMenuUserInfo()}</div>
+                      <sl-divider></sl-divider>
+                      <sl-menu-item
+                        @click=${() => this.navigate(ROUTES.accountSettings)}
+                      >
+                        <sl-icon slot="prefix" name="person-gear"></sl-icon>
+                        ${msg("Account Settings")}
+                      </sl-menu-item>
+                      ${this.userInfo?.isSuperAdmin
+                        ? html` <sl-menu-item
+                            @click=${() => this.navigate(ROUTES.usersInvite)}
+                          >
+                            <sl-icon slot="prefix" name="person-plus"></sl-icon>
+                            ${msg("Invite Users")}
+                          </sl-menu-item>`
+                        : ""}
+                      <sl-divider></sl-divider>
+                      <sl-menu-item @click="${this.onLogOut}">
+                        <sl-icon slot="prefix" name="door-open"></sl-icon>
+                        ${msg("Log Out")}
+                      </sl-menu-item>
+                    </sl-menu>
+                  </sl-dropdown>`
               : this.renderSignUpLink()}
           </div>
         </nav>

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -9,6 +9,7 @@ import "@shoelace-style/shoelace/dist/themes/light.css";
 import "@shoelace-style/shoelace/dist/components/alert/alert";
 import "@shoelace-style/shoelace/dist/components/avatar/avatar";
 import "@shoelace-style/shoelace/dist/components/button/button";
+import "@shoelace-style/shoelace/dist/components/drawer/drawer";
 import "@shoelace-style/shoelace/dist/components/icon/icon";
 import "@shoelace-style/shoelace/dist/components/input/input";
 import "@shoelace-style/shoelace/dist/components/checkbox/checkbox";

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -340,6 +340,15 @@
     border: 1px solid theme(colors.gray.200);
     border-radius: var(--sl-input-border-radius-small);
   }
+
+  sl-drawer::part(title) {
+    font-size: var(--font-size-base);
+    font-weight: var(--sl-font-weight-medium);
+  }
+
+  sl-drawer::part(footer) {
+    border-top: 1px solid var(--sl-panel-border-color);
+  }
 }
 
 /* Following styles won't work with layers */

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -341,9 +341,14 @@
     border-radius: var(--sl-input-border-radius-small);
   }
 
+  sl-drawer::part(header) {
+    --header-spacing: var(--sl-spacing-small);
+  }
+
   sl-drawer::part(title) {
     font-size: var(--font-size-base);
     font-weight: var(--sl-font-weight-medium);
+    line-height: 1.5;
   }
 
   sl-drawer::part(footer) {


### PR DESCRIPTION
WIP for https://github.com/webrecorder/browsertrix/issues/2041

<!-- Fixes #issue_number -->

### Changes

- Adds button to open embedded support guide
- Adds link to help forum
- Refactors app bar to look nicer on smaller screens

### Screenshots

#### App bar
<img width="251" alt="Screenshot 2024-08-21 at 11 41 25 AM" src="https://github.com/user-attachments/assets/c1fab980-8047-445d-abbb-3b00143c79f4">

#### Drawer open

<img width="426" alt="Screenshot 2024-08-21 at 11 41 33 AM" src="https://github.com/user-attachments/assets/6087957c-98e7-4de2-ada4-47c289c10e71">


### Opinions

The user guide currently saves your last place/page, which I think it fine behavior, unless there's strong opinions otherwise to change that behavior (until we can map user guide pages to app pages.)
