### PR TITLE
feat: Enable deleting workflow from list

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1486,13 +1486,15 @@ export class WorkflowDetail extends LiteElement {
       this.navTo(`${this.orgBasePath}/workflows/crawls`);
 
       this.notify({
-        message: msg(html`Deleted <strong>${this.renderName()}</strong>.`),
+        message: msg(
+          html`Deleted <strong>${this.renderName()}</strong> Workflow.`,
+        ),
         variant: "success",
         icon: "check2-circle",
       });
     } catch {
       this.notify({
-        message: msg("Sorry, couldn't delete Crawl Workflow at this time."),
+        message: msg("Sorry, couldn't delete Workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -702,24 +702,19 @@ export class WorkflowDetail extends LiteElement {
             <sl-icon name="files" slot="prefix"></sl-icon>
             ${msg("Duplicate Workflow")}
           </sl-menu-item>
-          ${when(!this.lastCrawlId, () => {
-            const shouldDeactivate = workflow.crawlCount && !workflow.inactive;
-            return html`
+          ${when(
+            !this.lastCrawlId,
+            () => html`
               <sl-divider></sl-divider>
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--danger)"
-                @click=${() =>
-                  shouldDeactivate
-                    ? void this.deactivate()
-                    : void this.delete()}
+                @click=${() => void this.delete()}
               >
                 <sl-icon name="trash3" slot="prefix"></sl-icon>
-                ${shouldDeactivate
-                  ? msg("Deactivate Workflow")
-                  : msg("Delete Workflow")}
+                ${msg("Delete Workflow")}
               </sl-menu-item>
-            `;
-          })}
+            `,
+          )}
         </sl-menu>
       </sl-dropdown>
     `;
@@ -1477,40 +1472,8 @@ export class WorkflowDetail extends LiteElement {
     });
   }
 
-  private async deactivate(): Promise<void> {
-    if (!this.workflow) return;
-
-    try {
-      await this.apiFetch(
-        `/orgs/${this.orgId}/crawlconfigs/${this.workflow.id}`,
-        {
-          method: "DELETE",
-        },
-      );
-
-      this.workflow = {
-        ...this.workflow,
-        inactive: true,
-      };
-
-      this.notify({
-        message: msg(html`Deactivated <strong>${this.renderName()}</strong>.`),
-        variant: "success",
-        icon: "check2-circle",
-      });
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't deactivate Workflow at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
-    }
-  }
-
   private async delete(): Promise<void> {
     if (!this.workflow) return;
-
-    const isDeactivating = this.workflow.crawlCount > 0;
 
     try {
       await this.apiFetch(
@@ -1523,17 +1486,13 @@ export class WorkflowDetail extends LiteElement {
       this.navTo(`${this.orgBasePath}/workflows/crawls`);
 
       this.notify({
-        message: isDeactivating
-          ? msg(html`Deactivated <strong>${this.renderName()}</strong>.`)
-          : msg(html`Deleted <strong>${this.renderName()}</strong>.`),
+        message: msg(html`Deleted <strong>${this.renderName()}</strong>.`),
         variant: "success",
         icon: "check2-circle",
       });
     } catch {
       this.notify({
-        message: isDeactivating
-          ? msg("Sorry, couldn't deactivate Workflow at this time.")
-          : msg("Sorry, couldn't delete Workflow at this time."),
+        message: msg("Sorry, couldn't delete Crawl Workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -500,14 +500,28 @@ export class WorkflowsList extends LiteElement {
       </sl-menu-item>
       ${when(
         this.appState.isCrawler,
-        () =>
-          html` <sl-menu-item
+        () => html`
+          <sl-menu-item
             ?disabled=${isArchivingDisabled(this.org, true)}
             @click=${() => void this.duplicateConfig(workflow)}
           >
             <sl-icon name="files" slot="prefix"></sl-icon>
             ${msg("Duplicate Workflow")}
-          </sl-menu-item>`,
+          </sl-menu-item>
+          ${when(
+            !workflow.lastCrawlId,
+            () => html`
+              <sl-divider></sl-divider>
+              <sl-menu-item
+                style="--sl-color-neutral-700: var(--danger)"
+                @click=${() => void this.delete(workflow)}
+              >
+                <sl-icon name="trash3" slot="prefix"></sl-icon>
+                ${msg("Delete Workflow")}
+              </sl-menu-item>
+            `,
+          )}
+        `,
       )}
     `;
   }
@@ -656,29 +670,6 @@ export class WorkflowsList extends LiteElement {
     }
   }
 
-  private async deactivate(workflow: ListWorkflow): Promise<void> {
-    try {
-      await this.apiFetch(`/orgs/${this.orgId}/crawlconfigs/${workflow.id}`, {
-        method: "DELETE",
-      });
-
-      void this.fetchWorkflows();
-      this.notify({
-        message: msg(
-          html`Deactivated <strong>${this.renderName(workflow)}</strong>.`,
-        ),
-        variant: "success",
-        icon: "check2-circle",
-      });
-    } catch {
-      this.notify({
-        message: msg("Sorry, couldn't deactivate Workflow at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-      });
-    }
-  }
-
   private async delete(workflow: ListWorkflow): Promise<void> {
     try {
       await this.apiFetch(`/orgs/${this.orgId}/crawlconfigs/${workflow.id}`, {
@@ -688,7 +679,7 @@ export class WorkflowsList extends LiteElement {
       void this.fetchWorkflows();
       this.notify({
         message: msg(
-          html`Deleted <strong>${this.renderName(workflow)}</strong>.`,
+          html`Deleted <strong>${this.renderName(workflow)}</strong> Workflow.`,
         ),
         variant: "success",
         icon: "check2-circle",


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1195

### Changes

Adds back workflow list menu item to delete workflows if it's never been run.

### Manual testing

1. Log in as crawler
2. Go to crawl workflows
3. Click action menu for workflow with crawls. Verify "Delete Workflow" option is not shown
4. Click action menu for workflow without crawls. Verify "Delete Workflow" option is shown
5. Click "Delete Workflow". Verify workflow is removed from the list