### PR TITLE
chore: Improve time to load org UI

### DIFF
--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -156,7 +156,6 @@ export class Screencast extends BtrixElement {
     changedProperties: PropertyValues<this> & Map<string, unknown>,
   ) {
     if (
-      changedProperties.get("appState.userOrg") ||
       changedProperties.get("crawlId") ||
       changedProperties.get("authToken")
     ) {

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -10,6 +10,7 @@ import RegexColorize from "regex-colorize";
 import { RelativeDuration } from "./relative-duration";
 
 import type { CrawlConfig, Seed, SeedConfig } from "@/pages/org/types";
+import type { AppSettings } from "@/types/app";
 import type { Collection } from "@/types/collection";
 import { isApiError } from "@/utils/api";
 import { DEPTH_SUPPORTED_SCOPES } from "@/utils/crawler";
@@ -506,28 +507,33 @@ export class ConfigDetails extends LiteElement {
 
   private async fetchAPIDefaults() {
     try {
-      const resp = await fetch("/api/settings", {
-        headers: { "Content-Type": "application/json" },
-      });
-      if (!resp.ok) {
-        throw new Error(resp.statusText);
+      let settings: AppSettings;
+
+      if (!this.appState.settings) {
+        const resp = await fetch("/api/settings", {
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!resp.ok) {
+          throw new Error(resp.statusText);
+        }
+        settings = (await resp.json()) as AppSettings;
+      } else {
+        settings = this.appState.settings;
       }
       const orgDefaults = {
         ...this.orgDefaults,
       };
-      const data = (await resp.json()) as {
-        defaultBehaviorTimeSeconds: number;
-        defaultPageLoadTimeSeconds: number;
-        maxPagesPerCrawl: number;
-      };
-      if (data.defaultBehaviorTimeSeconds > 0) {
-        orgDefaults.behaviorTimeoutSeconds = data.defaultBehaviorTimeSeconds;
+
+      if (settings.defaultBehaviorTimeSeconds > 0) {
+        orgDefaults.behaviorTimeoutSeconds =
+          settings.defaultBehaviorTimeSeconds;
       }
-      if (data.defaultPageLoadTimeSeconds > 0) {
-        orgDefaults.pageLoadTimeoutSeconds = data.defaultPageLoadTimeSeconds;
+      if (settings.defaultPageLoadTimeSeconds > 0) {
+        orgDefaults.pageLoadTimeoutSeconds =
+          settings.defaultPageLoadTimeSeconds;
       }
-      if (data.maxPagesPerCrawl > 0) {
-        orgDefaults.maxPagesPerCrawl = data.maxPagesPerCrawl;
+      if (settings.maxPagesPerCrawl > 0) {
+        orgDefaults.maxPagesPerCrawl = settings.maxPagesPerCrawl;
       }
       this.orgDefaults = orgDefaults;
     } catch (e) {

--- a/frontend/src/features/accounts/account-settings.ts
+++ b/frontend/src/features/accounts/account-settings.ts
@@ -337,7 +337,7 @@ export class AccountSettings extends LiteElement {
         }),
       });
 
-      AppStateService.updateUserInfo({
+      AppStateService.updateUser({
         ...this.userInfo,
         name: newName,
       });
@@ -381,7 +381,7 @@ export class AccountSettings extends LiteElement {
         }),
       });
 
-      AppStateService.updateUserInfo({
+      AppStateService.updateUser({
         ...this.userInfo,
         email: newEmail,
       });

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -157,7 +157,7 @@ export class App extends LiteElement {
     try {
       const user = await this.getUserInfo();
 
-      AppStateService.updateUserInfo(formatAPIUser(user));
+      AppStateService.updateUser(formatAPIUser(user));
     } catch (err) {
       if ((err as Error | null | undefined)?.message === "Unauthorized") {
         console.debug(
@@ -167,19 +167,6 @@ export class App extends LiteElement {
         this.clearUser();
         this.navigate(ROUTES.login);
       }
-    }
-  }
-
-  private async updateUserInfoState(user: APIUser) {
-    const userInfo = formatAPIUser(user);
-
-    AppStateService.updateUserInfo(userInfo);
-
-    const orgs = userInfo.orgs;
-
-    if (orgs.length && !userInfo.isSuperAdmin && !this.appState.orgSlug) {
-      const firstOrg = orgs[0].slug;
-      AppStateService.updateOrgSlug(firstOrg);
     }
   }
 
@@ -820,7 +807,7 @@ export class App extends LiteElement {
 
     if (!this.userInfo) {
       if (detail.user) {
-        AppStateService.updateUserInfo(formatAPIUser(detail.user));
+        AppStateService.updateUser(formatAPIUser(detail.user));
       } else {
         void this.fetchAndUpdateUserInfo();
       }
@@ -858,7 +845,7 @@ export class App extends LiteElement {
   };
 
   onUserInfoChange(event: CustomEvent<Partial<UserInfo>>) {
-    AppStateService.updateUserInfo({
+    AppStateService.updateUser({
       ...this.userInfo,
       ...event.detail,
     } as UserInfo);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -99,7 +99,10 @@ export class App extends LiteElement {
     });
 
     this.startSyncBrowserTabs();
-    void this.fetchAppSettings();
+
+    if (!this.appState.settings) {
+      void this.fetchAppSettings();
+    }
   }
 
   willUpdate(changedProperties: Map<string, unknown>) {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -655,7 +655,6 @@ export class App extends LiteElement {
           .viewStateData=${this.viewState.data}
           .params=${this.viewState.params}
           .maxScale=${this.appState.settings?.maxScale || DEFAULT_MAX_SCALE}
-          slug=${slug}
           orgPath=${orgPath.split(slug)[1]}
           orgTab=${orgTab as OrgTab}
         ></btrix-org>`;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -84,8 +84,7 @@ export class App extends LiteElement {
       this.authService.saveLogin(authState);
     }
     this.syncViewState();
-    if (authState) {
-      console.log("connectedCallback userInfo?:", this.userInfo);
+    if (authState && !this.userInfo) {
       void this.fetchAndUpdateUserInfo();
     }
     super.connectedCallback();
@@ -177,8 +176,6 @@ export class App extends LiteElement {
     AppStateService.updateUserInfo(userInfo);
 
     const orgs = userInfo.orgs;
-
-    console.log(userInfo, orgs, this.appState.orgSlug);
 
     if (orgs.length && !userInfo.isSuperAdmin && !this.appState.orgSlug) {
       const firstOrg = orgs[0].slug;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -157,7 +157,8 @@ export class App extends LiteElement {
     }
     try {
       const user = await this.getUserInfo();
-      void this.updateUserInfoState(user);
+
+      AppStateService.updateUserInfo(formatAPIUser(user));
     } catch (err) {
       if ((err as Error | null | undefined)?.message === "Unauthorized") {
         console.debug(
@@ -820,10 +821,12 @@ export class App extends LiteElement {
       this.onFirstLogin({ email: detail.username });
     }
 
-    if (detail.user) {
-      void this.updateUserInfoState(detail.user);
-    } else {
-      void this.fetchAndUpdateUserInfo();
+    if (!this.userInfo) {
+      if (detail.user) {
+        AppStateService.updateUserInfo(formatAPIUser(detail.user));
+      } else {
+        void this.fetchAndUpdateUserInfo();
+      }
     }
   }
 

--- a/frontend/src/pages/admin.ts
+++ b/frontend/src/pages/admin.ts
@@ -359,7 +359,7 @@ export class Home extends LiteElement {
         body: JSON.stringify(params),
       });
       const userInfo = await this.getUserInfo();
-      AppStateService.updateUserInfo(formatAPIUser(userInfo));
+      AppStateService.updateUser(formatAPIUser(userInfo));
 
       this.notify({
         message: msg(str`Created new org named "${params.name}".`),

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,7 +1,8 @@
+import "./org";
+
 import(/* webpackChunkName: "admin" */ "./admin");
 import(/* webpackChunkName: "sign-up" */ "./sign-up");
 import(/* webpackChunkName: "log-in" */ "./log-in");
-import(/* webpackChunkName: "org" */ "./org");
 import(/* webpackChunkName: "crawls" */ "./crawls");
 import(/* webpackChunkName: "join" */ "./invite/join");
 import(/* webpackChunkName: "verify" */ "./verify");

--- a/frontend/src/pages/invite/accept.ts
+++ b/frontend/src/pages/invite/accept.ts
@@ -228,8 +228,7 @@ export class AcceptInvite extends BtrixElement {
       } else {
         const user = await this._getCurrentUser();
 
-        AppStateService.updateUserInfo(formatAPIUser(user));
-        AppStateService.updateOrgSlug(org.slug);
+        AppStateService.updateUser(formatAPIUser(user), org.slug);
 
         await this.updateComplete;
 

--- a/frontend/src/pages/invite/ui/org-form.test.ts
+++ b/frontend/src/pages/invite/ui/org-form.test.ts
@@ -7,6 +7,7 @@ import { OrgForm } from "./org-form";
 
 import AuthService from "@/utils/AuthService";
 import { AppStateService } from "@/utils/state";
+import { formatAPIUser } from "@/utils/user";
 
 describe("btrix-org-form", () => {
   beforeEach(() => {
@@ -116,32 +117,32 @@ describe("btrix-org-form", () => {
 
   describe("#_renameOrg", () => {
     it("updates user app state on success", async () => {
+      const user = {
+        id: "740d7b63-b257-4311-ba3f-adc46a5fafb8",
+        email: "fake@example.com",
+        name: "Fake User",
+        is_verified: false,
+        is_superuser: false,
+        orgs: [],
+      };
       const el = await fixture<OrgForm>(
         html`<btrix-org-form
           newOrgId="e21ab647-2d0e-489d-97d1-88ac91774942"
         ></btrix-org-form>`,
       );
       stub(el.api, "fetch").callsFake(async () => Promise.resolve());
-      stub(el, "_getCurrentUser").callsFake(async () =>
-        Promise.resolve({
-          id: "740d7b63-b257-4311-ba3f-adc46a5fafb8",
-          email: "fake@example.com",
-          name: "Fake User",
-          is_verified: false,
-          is_superuser: false,
-          orgs: [],
-        }),
-      );
-      stub(AppStateService, "updateUserInfo");
-      stub(AppStateService, "updateOrgSlug");
+      stub(el, "_getCurrentUser").callsFake(async () => Promise.resolve(user));
+      stub(AppStateService, "updateUser");
 
       await el._renameOrg("e21ab647-2d0e-489d-97d1-88ac91774942", {
         name: "Fake Org Name 2",
         slug: "fake-org-name-2",
       });
 
-      expect(AppStateService.updateUserInfo).to.have.callCount(1);
-      expect(AppStateService.updateOrgSlug).to.have.callCount(1);
+      expect(AppStateService.updateUser).to.have.been.calledWith(
+        formatAPIUser(user),
+        "fake-org-name-2",
+      );
     });
 
     it("fires the correct event on success", async () => {

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -210,8 +210,7 @@ export class OrgForm extends BtrixElement {
     try {
       const user = await this._getCurrentUser();
 
-      AppStateService.updateUserInfo(formatAPIUser(user));
-      AppStateService.updateOrgSlug(data.slug);
+      AppStateService.updateUser(formatAPIUser(user), data.slug);
     } catch (e) {
       console.debug(e);
     }

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -362,7 +362,7 @@ export class LogInPage extends LiteElement {
     try {
       const data = await AuthService.login({ email: username, password });
 
-      AppStateService.updateUserInfo(formatAPIUser(data.user));
+      AppStateService.updateUser(formatAPIUser(data.user));
 
       await this.updateComplete;
 

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -8,6 +8,8 @@ import { isApiError } from "@/utils/api";
 import type { ViewState } from "@/utils/APIRouter";
 import AuthService from "@/utils/AuthService";
 import LiteElement, { html } from "@/utils/LiteElement";
+import { AppStateService } from "@/utils/state";
+import { formatAPIUser } from "@/utils/user";
 
 type FormContext = {
   successMessage?: string;
@@ -359,6 +361,10 @@ export class LogInPage extends LiteElement {
 
     try {
       const data = await AuthService.login({ email: username, password });
+
+      AppStateService.updateUserInfo(formatAPIUser(data.user));
+
+      await this.updateComplete;
 
       this.dispatchEvent(
         AuthService.createLoggedInEvent({

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -340,6 +340,12 @@ export class LogInPage extends LiteElement {
   }
 
   async checkBackendInitialized() {
+    if (this.appState.settings) {
+      this.formStateService.send("BACKEND_INITIALIZED");
+
+      return;
+    }
+
     const resp = await fetch("/api/settings");
     if (resp.status === 200) {
       this.formStateService.send("BACKEND_INITIALIZED");

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -9,7 +9,7 @@ import { choose } from "lit/directives/choose.js";
 import { guard } from "lit/directives/guard.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
-import { throttle } from "lodash/fp";
+import throttle from "lodash/fp/throttle";
 import queryString from "query-string";
 
 import stylesheet from "./archived-item-qa.stylesheet.css";

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -3,7 +3,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
-import { capitalize } from "lodash/fp";
+import capitalize from "lodash/fp/capitalize";
 import queryString from "query-string";
 
 import type { Profile, ProfileWorkflow } from "./types";

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -46,7 +46,7 @@ export class Dashboard extends LiteElement {
   };
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
-    if (changedProperties.has("appState.userOrg") && this.orgId) {
+    if (changedProperties.has("appState.orgSlug") && this.orgId) {
       void this.fetchMetrics();
     }
   }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -138,12 +138,7 @@ export class Org extends LiteElement {
   }
 
   async willUpdate(changedProperties: Map<string, unknown>) {
-    if (
-      (changedProperties.has("appState.userInfo") ||
-        changedProperties.has("slug")) &&
-      this.userInfo &&
-      this.slug
-    ) {
+    if (changedProperties.has("slug") && this.userInfo && this.slug) {
       if (this.userOrg) {
         void this.updateOrg();
       } else {

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -5,7 +5,7 @@ import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
-import { capitalize } from "lodash";
+import capitalize from "lodash/fp/capitalize";
 
 import { columns } from "../ui/columns";
 

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -678,8 +678,7 @@ export class OrgSettings extends BtrixElement {
 
       const user = await this.getCurrentUser();
 
-      AppStateService.updateUserInfo(formatAPIUser(user));
-      AppStateService.updateOrgSlug(slug);
+      AppStateService.updateUser(formatAPIUser(user), slug);
 
       this.navigate.to(`${this.navigate.orgBasePath}/settings`);
 

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -55,6 +55,7 @@ import type {
   ExclusionChangeEvent,
   ExclusionRemoveEvent,
 } from "@/features/crawl-workflows/queue-exclusion-table";
+import type { AppSettings } from "@/types/app";
 import { isApiError, type Detail } from "@/utils/api";
 import { DEFAULT_MAX_SCALE, DEPTH_SUPPORTED_SCOPES } from "@/utils/crawler";
 import {
@@ -2547,27 +2548,36 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private async fetchAPIDefaults() {
     try {
-      const resp = await fetch("/api/settings", {
-        headers: { "Content-Type": "application/json" },
-      });
-      if (!resp.ok) {
-        throw new Error(resp.statusText);
+      let settings: AppSettings;
+
+      if (!this.appState.settings) {
+        const resp = await fetch("/api/settings", {
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!resp.ok) {
+          throw new Error(resp.statusText);
+        }
+        settings = (await resp.json()) as AppSettings;
+      } else {
+        settings = this.appState.settings;
       }
+
       const orgDefaults = {
         ...this.orgDefaults,
       };
-      const data = await resp.json();
-      if (data.defaultBehaviorTimeSeconds > 0) {
-        orgDefaults.behaviorTimeoutSeconds = data.defaultBehaviorTimeSeconds;
+      if (settings.defaultBehaviorTimeSeconds > 0) {
+        orgDefaults.behaviorTimeoutSeconds =
+          settings.defaultBehaviorTimeSeconds;
       }
-      if (data.defaultPageLoadTimeSeconds > 0) {
-        orgDefaults.pageLoadTimeoutSeconds = data.defaultPageLoadTimeSeconds;
+      if (settings.defaultPageLoadTimeSeconds > 0) {
+        orgDefaults.pageLoadTimeoutSeconds =
+          settings.defaultPageLoadTimeSeconds;
       }
-      if (data.maxPagesPerCrawl > 0) {
-        orgDefaults.maxPagesPerCrawl = data.maxPagesPerCrawl;
+      if (settings.maxPagesPerCrawl > 0) {
+        orgDefaults.maxPagesPerCrawl = settings.maxPagesPerCrawl;
       }
-      if (data.maxScale) {
-        this.maxScale = data.maxScale;
+      if (settings.maxScale) {
+        this.maxScale = settings.maxScale;
       }
       this.orgDefaults = orgDefaults;
     } catch (e) {

--- a/frontend/src/pages/org/workflow-editor.ts
+++ b/frontend/src/pages/org/workflow-editor.ts
@@ -407,9 +407,6 @@ export class CrawlConfigEditor extends LiteElement {
         }
       }
     }
-    if (changedProperties.get("appState.userOrg") && this.orgId) {
-      await this.fetchTags();
-    }
   }
 
   async updated(

--- a/frontend/src/utils/AuthService.ts
+++ b/frontend/src/utils/AuthService.ts
@@ -1,6 +1,7 @@
 import { APIError } from "./api";
 import appState, { AppStateService } from "./state";
 
+import type { APIUser } from "@/index";
 import { ROUTES } from "@/routes";
 import type { Auth } from "@/types/auth";
 
@@ -15,6 +16,7 @@ export type LoggedInEventDetail = Auth & {
   api?: boolean;
   firstLogin?: boolean;
   redirectUrl?: string;
+  user?: APIUser;
 };
 
 export type NeedLoginEventDetail = {
@@ -127,7 +129,7 @@ export default class AuthService {
   }: {
     email: string;
     password: string;
-  }): Promise<Auth> {
+  }): Promise<Auth & { user: APIUser }> {
     const resp = await fetch("/api/auth/jwt/login", {
       method: "POST",
       headers: {
@@ -150,6 +152,7 @@ export default class AuthService {
     const data = (await resp.json()) as {
       token_type: string;
       access_token: string;
+      user_info: APIUser;
     };
     const token = AuthService.decodeToken(data.access_token);
     const authHeaders = AuthService.parseAuthHeaders(data);
@@ -158,6 +161,7 @@ export default class AuthService {
       username: email,
       headers: authHeaders,
       tokenExpiresAt: token.exp * 1000,
+      user: data.user_info,
     };
   }
 

--- a/frontend/src/utils/persist.ts
+++ b/frontend/src/utils/persist.ts
@@ -12,10 +12,7 @@ const STORAGE_KEY_PREFIX = "btrix.app";
 export const persist = (storage: Storage): StateOptions => ({
   set(stateVar: StateVar, v: string) {
     storage.setItem(`${STORAGE_KEY_PREFIX}.${stateVar.key}`, JSON.stringify(v));
-    stateVar.notifyObservers(
-      `${STORAGE_KEY_PREFIX}.${stateVar.key}`,
-      stateVar.value,
-    );
+    stateVar.value = v;
   },
   get(stateVar: ReadonlyStateVar) {
     const stored = storage.getItem(`${STORAGE_KEY_PREFIX}.${stateVar.key}`);

--- a/frontend/src/utils/state.ts
+++ b/frontend/src/utils/state.ts
@@ -24,10 +24,11 @@ export function makeAppStateService() {
   class AppState {
     // TODO persist
     settings: AppSettings | null = null;
+
+    @options(persist(window.sessionStorage))
     userInfo: UserInfo | null = null;
 
     // TODO persist here
-    // @options(persist(window.sessionStorage))
     auth: Auth | null = null;
 
     // Store org slug in local storage in order to redirect
@@ -42,7 +43,7 @@ export function makeAppStateService() {
 
     // Use `userOrg` to retrieve the basic org info like name,
     // since `userInfo` will` always available before `org`
-    userOrg: UserOrg | undefined = undefined;
+    userOrg: UserOrg | null = null;
 
     get orgId() {
       return this.userOrg?.id || "";
@@ -86,6 +87,8 @@ export function makeAppStateService() {
       userInfoSchema.nullable().parse(userInfo);
 
       appState.userInfo = userInfo;
+
+      console.log(appState.orgSlug);
 
       if (
         userInfo?.orgs.length &&
@@ -140,13 +143,18 @@ export function makeAppStateService() {
     private _resetUser() {
       appState.auth = null;
       appState.userInfo = null;
+      appState.userOrg = null;
       appState.orgSlug = null;
     }
 
     private _updateUserOrg() {
-      appState.userOrg = appState.userInfo?.orgs.find(
-        ({ slug }) => slug === appState.orgSlug,
-      );
+      console.log("appState.orgSlug:", appState.orgSlug);
+      appState.userOrg =
+        (appState.orgSlug &&
+          appState.userInfo?.orgs.find(
+            ({ slug }) => slug === appState.orgSlug,
+          )) ||
+        null;
     }
   }
 

--- a/frontend/src/utils/state.ts
+++ b/frontend/src/utils/state.ts
@@ -87,6 +87,14 @@ export function makeAppStateService() {
 
       appState.userInfo = userInfo;
 
+      if (
+        userInfo?.orgs.length &&
+        !userInfo.isSuperAdmin &&
+        !appState.orgSlug
+      ) {
+        appState.orgSlug = userInfo.orgs[0].slug;
+      }
+
       this._updateUserOrg();
     }
 

--- a/frontend/src/utils/state.ts
+++ b/frontend/src/utils/state.ts
@@ -22,7 +22,7 @@ export function makeAppStateService() {
 
   @state()
   class AppState {
-    // TODO persist
+    @options(persist(window.localStorage))
     settings: AppSettings | null = null;
 
     @options(persist(window.sessionStorage))

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,6 +13,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
     "plugins": [
       {
         "name": "ts-lit-plugin",

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -53,6 +53,7 @@ export default {
         "node_modules/color/**/*",
         "node_modules/slugify/**/*",
         "node_modules/pretty-ms/**/*",
+        "node_modules/parse-ms/**/*",
       ],
     }),
     importMapsPlugin({

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -52,6 +52,7 @@ export default {
         "node_modules/lodash/**/*",
         "node_modules/color/**/*",
         "node_modules/slugify/**/*",
+        "node_modules/pretty-ms/**/*",
       ],
     }),
     importMapsPlugin({


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2015

<!-- Fixes #issue_number -->

### Changes

Improves time to first load an org with the following:
- Users user info from login response to set org slug and route user on log in
- Stores user info in session storage so that it's available on reload
- Stores app settings in local storage until user logs out
- Loads critical org components synchronously

### Manual testing

Log in as superadmin and regular user. App should feel like it loads slightly faster/more responsive.

### Follow-ups

We could probably store app settings for longer in local storage. Maybe based on the app version number, or a longer expiry date.