### PR TITLE
docs: Reorganize user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 &nbsp;
 
-Browsertrix is an open source cloud-native high-fidelity browser-based crawling service designed
+Browsertrix is a cloud-native, high-fidelity, browser-based crawling service designed
 to make web archiving easier and more accessible for everyone.
 
 The service provides an API and UI for scheduling crawls and viewing results, and managing all aspects of crawling process. This system provides the orchestration and management around crawling, while the actual crawling is performed using [Browsertrix Crawler](https://github.com/webrecorder/browsertrix-crawler) containers, which are launched for each crawl.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 &nbsp;
 
-Browsertrix is an open-source cloud-native high-fidelity browser-based crawling service designed
+Browsertrix is an open source cloud-native high-fidelity browser-based crawling service designed
 to make web archiving easier and more accessible for everyone.
 
 The service provides an API and UI for scheduling crawls and viewing results, and managing all aspects of crawling process. This system provides the orchestration and management around crawling, while the actual crawling is performed using [Browsertrix Crawler](https://github.com/webrecorder/browsertrix-crawler) containers, which are launched for each crawl.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ See [browsertrix.com](https://browsertrix.com) for a feature overview and inform
 
 The full docs for using, deploying, and developing Browsertrix are available at: [https://docs.browsertrix.com](https://docs.browsertrix.com)
 
+Our docs are created with [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/).
+
 ## Deployment
 
 The latest deployment documentation is available at: [https://docs.browsertrix.com/deploy](https://docs.browsertrix.com/deploy)

--- a/docs/deploy/customization.md
+++ b/docs/deploy/customization.md
@@ -143,6 +143,10 @@ Text
 
 The `~~~` is used to separate the sections. If only two sections are provided, the email template is treated as plain text, if three, an HTML email with plain text fallback is sent.
 
-## Signing WACZ files
+## Signing WACZ Files
 
 Browsertrix has the ability to cryptographically sign WACZ files with [Authsign](https://github.com/webrecorder/authsign). The ``signer`` setting can be used to enable this feature and configure Authsign.
+
+## Enable Open Registration
+
+You can enable sign-ups by setting `registration_enabled` to `"1"`. Once enabled, your users can register by visiting `/sign-up`.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -25,8 +25,17 @@
     src: url('../assets/fonts/Inter-Italic.var.woff2') format('woff2');
     font-feature-settings: "ss03";
 }
+
+@font-face {
+    font-family: 'Konsole';
+    font-weight: 100 900;
+    font-display: swap;
+    font-style: normal;
+    src: url('https://wr-static.sfo3.cdn.digitaloceanspaces.com/fonts/konsole/Konsolev1.1-VF.woff2') format('woff2');
+}
   
 :root {
+    --md-display-font: "Konsole", "Helvetica", sans-serif;
     --md-code-font: "Recursive", monospace;
     --md-text-font: "Inter", "Helvetica", "Arial", sans-serif;
     --wr-blue-primary: #088eaf;
@@ -45,14 +54,21 @@
 
 /* Nav changes */
 
-.md-header__title {
-    font-family: var(--md-code-font);
-    font-variation-settings: "MONO" 0.51;
+.md-header__title, .md-nav__title {
+    font-family: var(--md-display-font);
+    text-transform: uppercase;
+    font-variation-settings: "wght" 750, "wdth" 87;
+    margin-left: 0 !important;
 }
 
 .md-header__title--active {
-    font-family: var(--md-text-font);
-    font-weight: 600;
+    font-family: var(--md-display-font);
+    text-transform: none;
+    font-variation-settings: "wght" 550, "wdth" 90;
+}
+
+.md-header__button {
+    margin-right: 0 !important;
 }
 
 /* Custom menu item hover */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -29,17 +29,17 @@
 :root {
     --md-code-font: "Recursive", monospace;
     --md-text-font: "Inter", "Helvetica", "Arial", sans-serif;
-    --wr-blue-primary: #0891B2;
-    --wr-orange-primary: #C96509;
+    --wr-blue-primary: #088eaf;
+    --wr-orange-primary: #bb4a00;
 }
 
 [data-md-color-scheme="webrecorder"] {
     --md-primary-fg-color: #4D7C0F;
-    --md-primary-fg-color--light: #0782A1;
-    --md-primary-fg-color--dark: #066B84;
+    --md-primary-fg-color--light: #057894;
+    --md-primary-fg-color--dark: #035b71;
     --md-typeset-color: black;
-    --md-accent-fg-color: #0782A1;
-    --md-typeset-a-color: #066B84;
+    --md-accent-fg-color: #057894;
+    --md-typeset-a-color: #035b71;
     --md-code-bg-color: #F9FAFB;
   }
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -32,7 +32,7 @@ Metadata can be edited by pressing the pencil icon at the top right of the metad
 
 ### Quality Assurance
 
-The Quality Assurance tab displays crawl quality information collected from analysis runs and user assessment of pages. This is where you can start new analysis runs, view quality metrics from older runs, and delete previous analysis runs. This tab is not available for uploaded archived items and not accessible for users with [viewer permissions](org-settings.md#permission-levels).
+The Quality Assurance tab displays crawl quality information collected from analysis runs and user assessment of pages. This is where you can start new analysis runs, view quality metrics from older runs, and delete previous analysis runs. This tab is not available for uploaded archived items and not accessible for users with [viewer permissions](org-members.md).
 
 The pages list provides a record of all pages within the archived item, as well as any ratings or notes given to the page during review. If analysis has been run, clicking on a page in the pages list will go to that page in the review interface.
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,6 +1,6 @@
 # Intro to Archived Items
 
-Archived items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The **Archived Items** page lists all items in the organization.
+Archived items consist of one or more WACZ files created by a crawl workflow or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The **Archived Items** page lists all items in the organization.
 
 ## Uploading Web Archives
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,4 +1,4 @@
-# Archived Items
+# Introduction to archived items
 
 Archived Items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The Archived Items page lists all items in the organization.
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -58,7 +58,11 @@ For more details on navigating web archives within ReplayWeb.page, see the [Repl
 
 While crawling, Browsertrix will output one or more WACZ files — the crawler aims to output files in consistently sized chunks, and each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
 
-The files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
+The files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status.
+
+To download an entire archived item as a single WACZ file, click the _Download Item_ button at the top of the files tab or the _Download Item_ entry in the crawl's _Actions_ menu.
+
+To combine multiple archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
 
 ### Error Logs
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,4 +1,4 @@
-# Introduction to archived items
+# Overview of archived items
 
 Archived Items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The Archived Items page lists all items in the organization.
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,6 +1,6 @@
 # Intro to archived items
 
-Archived Items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The Archived Items page lists all items in the organization.
+Archived items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The **Archived Items** page lists all items in the organization.
 
 ## Uploading Web Archives
 
@@ -26,13 +26,13 @@ The archived item details page is composed of the following sections, though som
 
 ### Overview
 
-The Overview tab displays the item's metadata and statistics associated with its creation process.
+View the item's metadata and statistics associated with its creation process.
 
 Metadata can be edited by pressing the pencil icon at the top right of the metadata section to edit the item's description, tags, and collections it is associated with.
 
 ### Quality Assurance
 
-The Quality Assurance tab displays crawl quality information collected from analysis runs and user assessment of pages. This is where you can start new analysis runs, view quality metrics from older runs, and delete previous analysis runs. This tab is not available for uploaded archived items and not accessible for users with [viewer permissions](org-members.md).
+View crawl quality information collected from analysis runs, review crawled pages, and start new analysis runs. QA is only available for crawls and org members with [crawler permissions](org-members.md).
 
 The pages list provides a record of all pages within the archived item, as well as any ratings or notes given to the page during review. If analysis has been run, clicking on a page in the pages list will go to that page in the review interface.
 
@@ -50,7 +50,7 @@ Like running a crawl workflow, running crawl analysis also uses execution time. 
 
 ### Replay
 
-The Replay tab displays the web content contained within the archived item.
+View a high-fidelity replay of the website at the time it was archived.
 
 For more details on navigating web archives within ReplayWeb.page, see the [ReplayWeb.page user documentation.](https://replayweb.page/docs/user-guide/exploring/)
 
@@ -58,14 +58,14 @@ For more details on navigating web archives within ReplayWeb.page, see the [Repl
 
 While crawling, Browsertrix will output one or more WACZ files — the crawler aims to output files in consistently sized chunks, and each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
 
-The Files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
+The files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status. To combine one or more archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
 
 ### Error Logs
 
-The Error Logs tab displays a list of errors encountered during crawling. Clicking an errors in the list will reveal additional information.
+View a list of errors that may have been encountered during crawling. Clicking an errors in the list will reveal additional information.
 
-All log entries with that were recorded in the creation of the Archived Item can be downloaded in JSONL format by pressing the _Download Logs_ button.
+All log entries with that were recorded in the creation of the archived item can be downloaded in JSONL format by pressing the _Download Logs_ button.
 
 ### Crawl Settings
 
-The Crawl Settings tab displays the crawl workflow configuration options that were used to generate the resulting archived item. Many of these settings also apply when running crawl analysis.
+View the crawl workflow configuration options that were used to generate the resulting archived item. Many of these settings also apply when running crawl analysis.

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,4 +1,4 @@
-# Intro to archived items
+# Intro to Archived Items
 
 Archived items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The **Archived Items** page lists all items in the organization.
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -26,7 +26,7 @@ The archived item details page is composed of the following sections, though som
 
 ### Overview
 
-View the item's metadata and statistics associated with its creation process.
+View metadata and statistics associated with how the archived item was created.
 
 Metadata can be edited by pressing the pencil icon at the top right of the metadata section to edit the item's description, tags, and collections it is associated with.
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -1,4 +1,4 @@
-# Overview of archived items
+# Intro to archived items
 
 Archived Items consist of one or more WACZ files created by a crawl workflow, or uploaded to Browsertrix. They can be individually replayed, or combined with other archived items in a [collection](collections.md). The Archived Items page lists all items in the organization.
 

--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -62,7 +62,7 @@ The files tab lists the individually downloadable WACZ files that make up the ar
 
 ### Error Logs
 
-View a list of errors that may have been encountered during crawling. Clicking an errors in the list will reveal additional information.
+View a list of errors that may have been encountered during crawling. Clicking an error in the list will reveal additional information.
 
 All log entries with that were recorded in the creation of the archived item can be downloaded in JSONL format by pressing the _Download Logs_ button.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -1,4 +1,4 @@
-# Overview of browser profiles
+# Intro to browser profiles
 
 Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configured, with any cookies, saved login sessions, or browser settings. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -1,4 +1,4 @@
-# Browser Profiles
+# Create a browser profile
 
 Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configured, with any cookies, saved login sessions, or browser settings. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -18,7 +18,7 @@ Browser profiles are saved instances of a web browsing session that can be reuse
 
 ## Creating New Browser Profiles
 
-New browser profiles can be created on the Browser Profiles page by pressing the _New Browser Profile_ button and providing a starting URL. 
+New browser profiles can be created on the **Browser Profiles** page by pressing the _New Browser Profile_ button and providing a starting URL. 
 
 Press the _Finish Browsing_ button to save the browser profile with a _Name_ and _Description_ of what is logged in or otherwise notable about this browser session.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -1,4 +1,4 @@
-# Create a browser profile
+# Overview of browser profiles
 
 Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configured, with any cookies, saved login sessions, or browser settings. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
 

--- a/docs/user-guide/browser-profiles.md
+++ b/docs/user-guide/browser-profiles.md
@@ -1,4 +1,4 @@
-# Intro to browser profiles
+# Intro to Browser Profiles
 
 Browser profiles are saved instances of a web browsing session that can be reused to crawl websites as they were configured, with any cookies, saved login sessions, or browser settings. Using a pre-configured profile also means that content that can only be viewed by logged in users can be archived, without archiving the actual login credentials.
 

--- a/docs/user-guide/collection.md
+++ b/docs/user-guide/collection.md
@@ -1,0 +1,14 @@
+# Overview of collections
+
+## Create a Collection
+
+You can create a collection from the Collections page, or the  _Create New ..._ shortcut from the org overview.
+
+## Sharing Collections
+
+Collections are private by default, but can be made public by marking them as sharable in the Metadata step of collection creation, or by toggling the _Collection is Shareable_ switch in the share collection dialogue.
+
+After a collection has been made public, it can be shared with others using the public URL available in the share collection dialogue. The collection can also be embedded into other websites using the provided embed code. Un-sharing the collection will break any previously shared links.
+
+For further resources on embedding archived web content into your own website, see the [ReplayWeb.page docs page on embedding](https://replayweb.page/docs/embedding).
+

--- a/docs/user-guide/collection.md
+++ b/docs/user-guide/collection.md
@@ -1,4 +1,4 @@
-# Intro to collections
+# Intro to Collections
 
 ## Create a Collection
 

--- a/docs/user-guide/collection.md
+++ b/docs/user-guide/collection.md
@@ -1,4 +1,4 @@
-# Overview of collections
+# Intro to collections
 
 ## Create a Collection
 

--- a/docs/user-guide/collections.md
+++ b/docs/user-guide/collections.md
@@ -1,4 +1,4 @@
-# Collections
+# Organize archived items into a collection
 
 Collections are the primary way of organizing and combining archived items into groups for presentation.
 

--- a/docs/user-guide/collections.md
+++ b/docs/user-guide/collections.md
@@ -1,4 +1,4 @@
-# Add to collection
+# Add to Collection
 
 Collections are the primary way of organizing and combining archived items into groups for presentation.
 

--- a/docs/user-guide/collections.md
+++ b/docs/user-guide/collections.md
@@ -1,4 +1,4 @@
-# Organize archived items into a collection
+# Add to collection
 
 Collections are the primary way of organizing and combining archived items into groups for presentation.
 
@@ -7,19 +7,12 @@ Collections are the primary way of organizing and combining archived items into 
 
     After adding the crawl and the upload to a collection, the content from both will become available in the replay viewer.
 
-## Adding Content to Collections
+## Adding Archived Items to Collections
 
 Crawls and uploads can be added to a collection after creation by selecting _Select Archived Items_ from the collection's actions menu.
 
 A crawl workflow can also be set to [automatically add any completed archived items to a collection](workflow-setup.md#collection-auto-add) in the workflow's settings.
 
-## Sharing Collections
-
-Collections are private by default, but can be made public by marking them as sharable in the Metadata step of collection creation, or by toggling the _Collection is Shareable_ switch in the share collection dialogue.
-
-After a collection has been made public, it can be shared with others using the public URL available in the share collection dialogue. The collection can also be embedded into other websites using the provided embed code. Un-sharing the collection will break any previously shared links.
-
-For further resources on embedding archived web content into your own website, see the [ReplayWeb.page docs page on embedding](https://replayweb.page/docs/embedding).
 
 ## Downloading Collections
 

--- a/docs/user-guide/contribute.md
+++ b/docs/user-guide/contribute.md
@@ -1,0 +1,9 @@
+# Contribute
+
+We hope our user guide is a useful tool for you. Like Browsertrix itself, our user guide is open source. We greatly appreciate any feedback and open source contributions to our docs [on GitHub](https://github.com/webrecorder/browsertrix).
+
+Other ways to contribute:
+
+1. Answer questions from the web archiving community on the [community help forum](https://forum.webrecorder.net/c/help/5).
+2. [Let us know](mailto:docs-feedback@webrecorder.net) how we can improve our documentation.
+3. If you encounter any bugs while using Browsertrix, please open a [GitHub issue](https://github.com/webrecorder/browsertrix/issues/new/choose) or [contact support](mailto:support@webrecorder.org).

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -1,4 +1,4 @@
-# Crawl Workflows
+# Introduction to crawl workflows
 
 Crawl Workflows consist of a list of configuration options that instruct the crawler what it should capture.
 

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -1,54 +1,19 @@
 # Introduction to crawl workflows
 
-Crawl Workflows consist of a list of configuration options that instruct the crawler what it should capture.
+Crawl workflows enable you to run crawls, which in turn produces an [archived item](./archived-items.md). A crawl workflow consists of a list of configuration options that instruct the crawler what it should capture and metadata about the workflow itself.
 
-## Creating and Editing Crawl Workflows
+## Create a Crawl Workflow
 
-New Crawl Workflows can be created from the Crawling page. A detailed breakdown of available settings can be found [here](workflow-setup.md).
+You can create new crawl workflows from the Crawling page, or the  _Create New ..._ shortcut from the org overview. A detailed breakdown of available settings can be found in the [workflow configuration guide](workflow-setup.md).
 
-## Status
+## Run Crawl
 
-Crawl Workflows inherit the [status of the last item they created](archived-items.md#status). When a workflow has been instructed to run it can have have five possible states:
+Run a crawl workflow by clicking _Run Crawl_ in the actions menu of the workflow in the crawl workflow list, or by clicking the _Run Crawl_ button on the workflow's details page.
 
-| Status | Description |
-| ---- | ---- |
-| <span class="status-waiting">:bootstrap-hourglass-split: Waiting</span>     | The workflow can't start running yet but it is queued to run when resources are available. |
-| <span class="status-waiting">:btrix-status-dot: Starting</span>       | New resources are starting up. Crawling should begin shortly.|
-| <span class="status-success">:btrix-status-dot: Running</span>        | The crawler is finding and capturing pages! |
-| <span class="status-waiting">:btrix-status-dot: Stopping</span> | A user has instructed this workflow to stop. Finishing capture of the current pages.|
-| <span class="status-waiting">:btrix-status-dot: Finishing Crawl</span> | The workflow has finished crawling and data is being packaged into WACZ files.|
-| <span class="status-waiting">:btrix-status-dot: Uploading WACZ</span> | WACZ files have been created and are being transferred to storage.|
-
-## Running Crawl Workflows
-
-Crawl workflows can be run from the actions menu of the workflow in the crawl workflow list, or by clicking the _Run Crawl_ button on the workflow's details page.
-
-While crawling, the Watch Crawl page displays a list of queued URLs that will be visited, and streams the current state of the browser windows as they visit pages from the queue.
+While crawling, the Watch Crawl page displays a list of queued URLs that will be visited, and streams the current state of the browser windows as they visit pages from the queue. You can [modify the crawl live](./running-crawl.md) by adding URL exclusions or changing the number of crawling instances.
 
 Running a crawl workflow that has successfully run previously can be useful to capture content as it changes over time, or to run with an updated [Crawl Scope](workflow-setup.md#scope).
 
-### Live Exclusion Editing
+## Status
 
-While [exclusions](workflow-setup.md#exclusions) can be set before running a crawl workflow, sometimes while crawling the crawler may find new parts of the site that weren't previously known about and shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
-
-If the crawl queue is filled with URLs that should not be crawled, use the _Edit Exclusions_ button on the Watch Crawl page to instruct the crawler what pages should be excluded from the queue.
-
-Exclusions added while crawling are applied to the same exclusion table saved in the workflow's settings and will be used the next time the crawl workflow is run unless they are manually removed.
-
-### Changing the Amount of Crawler Instances
-
-Like exclusions, the [crawler instance](workflow-setup.md#crawler-instances) scale can also be adjusted while crawling. On the Watch Crawl page, press the _Edit Crawler Instances_ button, and set the desired value.
-
-Unlike exclusions, this change will not be applied to future workflow runs.
-
-## Ending a Crawl
-
-If a crawl workflow is not crawling websites as intended it may be preferable to end crawling operations and update the crawl workflow's settings before trying again. There are two operations to end crawls, available both on the workflow's details page, or as part of the actions menu in the workflow list.
-
-### Stopping
-
-Stopping a crawl will throw away the crawl queue but otherwise gracefully end the process and save anything that has been collected. Stopped crawls show up in the list of Archived Items and can be used like any other item in the app.
-
-### Canceling
-
-Canceling a crawl will throw away all data collected and immediately end the process. Canceled crawls do not show up in the list of Archived Items, though a record of the runtime and workflow settings can be found in the crawl workflow's list of crawls.
+Finished crawl workflows inherit the [status of the last archived item they created](archived-items.md#status).

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -1,14 +1,14 @@
-# Getting started with crawl workflows
+# Intro to crawl workflows
 
 Crawl workflows enable you to run crawls, which in turn produces an [archived item](./archived-items.md). A crawl workflow consists of a list of configuration options that instruct the crawler what it should capture and metadata about the workflow itself.
 
 ## Create a Crawl Workflow
 
-You can create new crawl workflows from the Crawling page, or the  _Create New ..._ shortcut from the org overview.
+You can create new crawl workflows from the **Crawling** page, or the  _Create New ..._ shortcut from **Overview**.
 
 ### Choose what to crawl
 
-The first step in creating a new [crawl workflow](crawl-workflows.md) is to choose what you'd like to crawl. This determines whether the crawl type will be **URL List** or **Seeded Crawl**. Crawl types can't be changed after the workflow is created—you'll need to create a new crawl workflow.
+The first step in creating a new crawl workflow is to choose what you'd like to crawl. This determines whether the crawl type will be **URL List** or **Seeded Crawl**. Crawl types can't be changed after the workflow is created—you'll need to create a new crawl workflow.
 
 #### Known URLs `URL List`{ .badge-blue }
 
@@ -28,10 +28,10 @@ Upon choosing you can begin to set up your workflow. A detailed breakdown of ava
 
 Run a crawl workflow by clicking _Run Crawl_ in the actions menu of the workflow in the crawl workflow list, or by clicking the _Run Crawl_ button on the workflow's details page.
 
-While crawling, the Watch Crawl page displays a list of queued URLs that will be visited, and streams the current state of the browser windows as they visit pages from the queue. You can [modify the crawl live](./running-crawl.md) by adding URL exclusions or changing the number of crawling instances.
+While crawling, the **Watch Crawl** section displays a list of queued URLs that will be visited, and streams the current state of the browser windows as they visit pages from the queue. You can [modify the crawl live](./running-crawl.md) by adding URL exclusions or changing the number of crawling instances.
 
-Running a crawl workflow that has successfully run previously can be useful to capture content as it changes over time, or to run with an updated [Crawl Scope](workflow-setup.md#scope).
+Running a crawl workflow that has successfully run previously can be useful to capture content as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#scope).
 
 ## Status
 
-Finished crawl workflows inherit the [status of the last archived item they created](archived-items.md#status).
+Finished crawl workflows inherit the [status of the last archived item they created](archived-items.md#status). Crawl workflows that are in progress maintain their [own statuses](./running-crawl.md#in-progress-status).

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -30,7 +30,7 @@ Run a crawl workflow by clicking _Run Crawl_ in the actions menu of the workflow
 
 While crawling, the **Watch Crawl** section displays a list of queued URLs that will be visited, and streams the current state of the browser windows as they visit pages from the queue. You can [modify the crawl live](./running-crawl.md) by adding URL exclusions or changing the number of crawling instances.
 
-Running a crawl workflow that has successfully run previously can be useful to capture content as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#scope).
+Running a crawl workflow that has successfully run previously can be useful to capture a website as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#scope).
 
 ## Status
 

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -1,6 +1,6 @@
-# Intro to crawl workflows
+# Intro to Crawl Workflows
 
-Crawl workflows enable you to run crawls, which in turn produces an [archived item](./archived-items.md). A crawl workflow consists of a list of configuration options that instruct the crawler what it should capture and metadata about the workflow itself.
+Crawl workflows enable you to run crawls, which in turn produce [archived items](./archived-items.md). A crawl workflow consists of configuration options that instruct the crawler what it should capture and metadata about the workflow itself.
 
 ## Create a Crawl Workflow
 
@@ -12,7 +12,7 @@ The first step in creating a new crawl workflow is to choose what you'd like to 
 
 #### Known URLs `URL List`{ .badge-blue }
 
-Crawl a single page, or choose this option if you already know the URL of every page you'd like to crawl. The crawler will visit every URL specified in a list, and optionally every URL linked on those pages.
+Choose this option if you already know the URL of every page you'd like to crawl. The crawler will visit every URL specified in a list, and optionally every URL linked on those pages.
 
 A URL list is simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
 
@@ -22,7 +22,7 @@ Let the crawler automatically discover pages based on a domain or start page tha
 
 Seeded crawls are great for advanced use cases where you don't need (or want) to know every single URL of the website that you're archiving.
 
-Upon choosing you can begin to set up your workflow. A detailed breakdown of available settings can be found in the [workflow settings guide](workflow-setup.md).
+After deciding what type of crawl you'd like to run, you can begin to set up your workflow. A detailed breakdown of available settings can be found in the [workflow settings guide](workflow-setup.md).
 
 ## Run Crawl
 
@@ -30,7 +30,7 @@ Run a crawl workflow by clicking _Run Crawl_ in the actions menu of the workflow
 
 While crawling, the **Watch Crawl** section displays a list of queued URLs that will be visited, and streams the current state of the browser windows as they visit pages from the queue. You can [modify the crawl live](./running-crawl.md) by adding URL exclusions or changing the number of crawling instances.
 
-Running a crawl workflow that has successfully run previously can be useful to capture a website as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#scope).
+Re-running a crawl workflow can be useful to capture a website as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#scope).
 
 ## Status
 

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -1,10 +1,14 @@
 # Intro to Crawl Workflows
 
-Crawl workflows enable you to run crawls, which in turn produce [archived items](./archived-items.md). A crawl workflow consists of configuration options that instruct the crawler what it should capture and metadata about the workflow itself.
+Crawl workflows are the bread and butter of automated browser-based crawling. A crawl workflow enables you to specify how and what the crawler should capture on a website.
+
+A finished crawl results in an [archived item](./archived-items.md) that can be downloaded and shared. To easily identify and find archived items within your org, you can automatically name and tag archived items through custom workflow metadata.
+
+You can create, view, search for, and run crawl workflows from the **Crawling** page.
 
 ## Create a Crawl Workflow
 
-You can create new crawl workflows from the **Crawling** page, or the  _Create New ..._ shortcut from **Overview**.
+Create new crawl workflows from the **Crawling** page, or the  _Create New ..._ shortcut from **Overview**.
 
 ### Choose what to crawl
 
@@ -34,4 +38,4 @@ Re-running a crawl workflow can be useful to capture a website as it changes ove
 
 ## Status
 
-Finished crawl workflows inherit the [status of the last archived item they created](archived-items.md#status). Crawl workflows that are in progress maintain their [own statuses](./running-crawl.md#in-progress-status).
+Finished crawl workflows inherit the [status of the last archived item they created](archived-items.md#status). Crawl workflows that are in progress maintain their [own statuses](./running-crawl.md#crawl-workflow-status).

--- a/docs/user-guide/crawl-workflows.md
+++ b/docs/user-guide/crawl-workflows.md
@@ -1,10 +1,28 @@
-# Introduction to crawl workflows
+# Getting started with crawl workflows
 
 Crawl workflows enable you to run crawls, which in turn produces an [archived item](./archived-items.md). A crawl workflow consists of a list of configuration options that instruct the crawler what it should capture and metadata about the workflow itself.
 
 ## Create a Crawl Workflow
 
-You can create new crawl workflows from the Crawling page, or the  _Create New ..._ shortcut from the org overview. A detailed breakdown of available settings can be found in the [workflow configuration guide](workflow-setup.md).
+You can create new crawl workflows from the Crawling page, or the  _Create New ..._ shortcut from the org overview.
+
+### Choose what to crawl
+
+The first step in creating a new [crawl workflow](crawl-workflows.md) is to choose what you'd like to crawl. This determines whether the crawl type will be **URL List** or **Seeded Crawl**. Crawl types can't be changed after the workflow is created—you'll need to create a new crawl workflow.
+
+#### Known URLs `URL List`{ .badge-blue }
+
+Crawl a single page, or choose this option if you already know the URL of every page you'd like to crawl. The crawler will visit every URL specified in a list, and optionally every URL linked on those pages.
+
+A URL list is simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
+
+#### Automated Discovery `Seeded Crawl`{ .badge-orange }
+
+Let the crawler automatically discover pages based on a domain or start page that you specify.
+
+Seeded crawls are great for advanced use cases where you don't need (or want) to know every single URL of the website that you're archiving.
+
+Upon choosing you can begin to set up your workflow. A detailed breakdown of available settings can be found in the [workflow settings guide](workflow-setup.md).
 
 ## Run Crawl
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -6,7 +6,9 @@ We'll walk you through your first crawl. Open up a webpage that you'd like to cr
 
 To start crawling with hosted Browsertrix, you'll need a Browsertrix account. [Sign up for an account](./signup.md) and log in.
 
-If you'd like to try Browsertrix before signing up, or you have specialized hosting requirements, you can host Browsertrix yourself. [Set up Browsertrix](../deploy/index.md) on your system and log in as your admin user.
+!!! note "Self-hosting"
+
+    If you'd like to try Browsertrix before signing up, or you have specialized hosting requirements, you can host Browsertrix yourself. [Set up Browsertrix](../deploy/index.md) on your system and log in as your admin user.
 
 ## Starting the crawl
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -32,4 +32,4 @@ After running your first crawl, check out the following to learn more about Brow
 - Best practices for crawling with [browser profiles](browser-profiles.md) to capture content only available when logged in to a website.
 - Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
 - Organizing and combining archived items with [collections](collections.md) for sharing and export.
-- If you're an admin: [Inviting collaborators to your org](org-members.md).
+- [Invite collaborators](org-members.md) to your org.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,6 +1,6 @@
 # Your first crawl
 
-We'll walk you through your first crawl. Open up a webpage that you'd like to crawl and note the URL for later.
+Let’s crawl your first webpage! Start by opening up a webpage that you'd like to crawl, and note the URL for later.
 
 ## Logging in
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,0 +1,33 @@
+# Your first crawl
+
+We'll walk you through your first crawl. Open up a webpage that you'd like to crawl and note the URL for later.
+
+## Logging in
+
+To start crawling with hosted Browsertrix, you'll need a Browsertrix account. [Sign up for an account](./signup.md) and log in.
+
+If you'd like to try Browsertrix before signing up, or you have specialized hosting requirements, you can host Browsertrix yourself. [Set up Browsertrix](../deploy/index.md) on your system and log in as your admin user.
+
+## Starting the crawl
+
+Once you've logged in you should see your org [overview](overview.md). If you land somewhere else, navigate to **Overview**.
+
+1. Tap the _Create New..._ shortcut and select **Crawl Workflow**.
+2. Choose **Known URLs**. We'll get into the details of the options [later](./crawl-workflows.md), but this is a good starting point for a simple crawl.
+3. Enter the URL of the webpage that you noted earlier in **Crawl URL(s)**.
+4. Tap _Review & Save_.
+5. Tap _Save Workflow_.
+6. You should now see your new crawl workflow. Give the crawler a few moments to warm up, and then watch as it archives the webpage!
+
+---
+
+## Next steps
+
+After running your first crawl, check out the following to learn more about Browsertrix's features:
+
+- A detailed list of [crawl workflow setup](workflow-setup.md) options.
+- Adding [exclusions](workflow-setup.md#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](running-crawl.md#live-exclusion-editing).
+- Best practices for crawling with [browser profiles](browser-profiles.md) to capture content only available when logged in to a website.
+- Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
+- Organizing and combining archived items with [collections](collections.md) for sharing and export.
+- If you're an admin: [Inviting collaborators to your org](org-members.md).

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,4 +1,4 @@
-# Your first crawl
+# Your First Crawl
 
 Let’s crawl your first webpage! Start by opening up a webpage that you'd like to crawl, and note the URL for later.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -4,9 +4,9 @@ Browsertrix is an intuitive, open source, automated web archiving system. Archiv
 
 Browsertrix is built and hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building.
 
-This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized like the web interface for ease of browsing. You can also use the search box up top to search by topic.
+This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide navigation is organized similarly to the Browsertrix web interface for ease of browsing. You can also use the search box up top to search by topic.
 
-If you have any feedback on our documentation [we'd love to hear it](mailto:docs-feedback@webrecorder.net).
+If you have any feedback on our documentation [we'd love to hear it](mailto:docs-feedback@webrecorder.net). We've written the user guide with both seasoned web archivists and new archivists in mind and we value feedback from all levels of archiving experience.
 
 For help with a specific topic, try our [community help forum](https://forum.webrecorder.net/c/help/5).
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -17,7 +17,7 @@ To get started crawling with Browsertrix:
 After running your first crawl, check out the following to learn more about Browsertrix's features:
 
 - A detailed list of [crawl workflow setup](workflow-setup.md) options.
-- Adding [exclusions](workflow-setup.md#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](crawl-workflows.md#live-exclusion-editing).
+- Adding [exclusions](workflow-setup.md#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](running-crawl.md#live-exclusion-editing).
 - Best practices for crawling with [browser profiles](browser-profiles.md) to capture content only available when logged in to a website.
 - Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
 - Organizing and combining archived items with [collections](collections.md) for sharing and export.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,8 +1,8 @@
 # Welcome
 
-Browsertrix is an intuitive, open-source, automated web archiving system. Archive, replay, and share websites exactly as they were at a certain point in time.
+Browsertrix is an intuitive, open source, automated web archiving system. Archive, replay, and share websites exactly as they were at a certain point in time.
 
-Browsertrix is hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open-source tools, easy-to-use interfaces, and community building.
+Browsertrix is hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building.
 
 This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized similarly to the web interface to make it easier to browse. You can also use the search box up top to search by topic.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,29 +1,15 @@
-# Welcome!
+# Welcome
 
-Welcome to the Browsertrix User Guide. This page covers the basics of using Browsertrix, Webrecorder's high-fidelity web archiving system.
+Browsertrix is an intuitive, open-source, automated web archiving system. Archive, replay, and share websites exactly as they were at a certain point in time.
 
-## Getting Started
+Browsertrix is hosted by Webrecorder, a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open-source tools, easy-to-use interfaces, and community building.
 
-To get started crawling with Browsertrix:
+This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized similarly to the web interface to make it easier to browse. You can also use the search box up top to search by topic.
 
-1. Create an account and join an organization [as described here](signup.md).
-2. After being redirected to the organization's [overview page](overview.md), click the _Create New_ button in the top right and select _[Crawl Workflow](crawl-workflows.md)_ to begin configuring your first crawl!
-3. For a simple crawl, choose the _Seeded Crawl_ option, and enter a page url in the _Crawl Start URL_ field. By default, the crawler will archive all pages under the starting path.
-4. Next, click _Review & Save_, and ensure the _Run on Save_ option is selected. Then click _Save Workflow_.
-5. Wait a moment for the crawler to start and watch as it archives the website!
+If you have any feedback on our documentation [we'd love to hear it](mailto:docs-feedback@webrecorder.net).
 
----
+For help with a certain topic, try our [community help forum](https://forum.webrecorder.net/c/help/5).
 
-After running your first crawl, check out the following to learn more about Browsertrix's features:
+For bug reports or feature requests, please open a [GitHub issue](https://github.com/webrecorder/browsertrix/issues/new/choose).
 
-- A detailed list of [crawl workflow setup](workflow-setup.md) options.
-- Adding [exclusions](workflow-setup.md#exclusions) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](running-crawl.md#live-exclusion-editing).
-- Best practices for crawling with [browser profiles](browser-profiles.md) to capture content only available when logged in to a website.
-- Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
-- Organizing and combining archived items with [collections](collections.md) for sharing and export.
-- If you're an admin: [Inviting collaborators to your org](org-members.md).
-
-
-### Have more questions?
-
-While our aim is to create intuitive interfaces, sometimes the complexities of web archiving require a little more explanation. If there's something that you found especially confusing or frustrating [please get in touch](mailto:docs-feedback@webrecorder.net)!
+Thanks for choosing Browsertrix! Ready for [your first crawl](./getting-started.md)?

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -2,7 +2,7 @@
 
 Browsertrix is an intuitive, open-source, automated web archiving system. Archive, replay, and share websites exactly as they were at a certain point in time.
 
-Browsertrix is hosted by Webrecorder, a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open-source tools, easy-to-use interfaces, and community building.
+Browsertrix is hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open-source tools, easy-to-use interfaces, and community building.
 
 This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized similarly to the web interface to make it easier to browse. You can also use the search box up top to search by topic.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -4,7 +4,7 @@ Browsertrix is an intuitive, open source, automated web archiving system. Archiv
 
 Browsertrix is hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building.
 
-This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized similarly to the web interface to make it easier to browse. You can also use the search box up top to search by topic.
+This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized like the web interface for ease of browsing. You can also use the search box up top to search by topic.
 
 If you have any feedback on our documentation [we'd love to hear it](mailto:docs-feedback@webrecorder.net).
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -2,13 +2,13 @@
 
 Browsertrix is an intuitive, open source, automated web archiving system. Archive, replay, and share websites exactly as they were at a certain point in time.
 
-Browsertrix is hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building.
+Browsertrix is built and hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building.
 
 This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide is organized like the web interface for ease of browsing. You can also use the search box up top to search by topic.
 
 If you have any feedback on our documentation [we'd love to hear it](mailto:docs-feedback@webrecorder.net).
 
-For help with a certain topic, try our [community help forum](https://forum.webrecorder.net/c/help/5).
+For help with a specific topic, try our [community help forum](https://forum.webrecorder.net/c/help/5).
 
 For bug reports or feature requests, please open a [GitHub issue](https://github.com/webrecorder/browsertrix/issues/new/choose).
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -21,7 +21,7 @@ After running your first crawl, check out the following to learn more about Brow
 - Best practices for crawling with [browser profiles](browser-profiles.md) to capture content only available when logged in to a website.
 - Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
 - Organizing and combining archived items with [collections](collections.md) for sharing and export.
-- If you're an admin: [Inviting collaborators to your org](org-settings.md#members).
+- If you're an admin: [Inviting collaborators to your org](org-members.md).
 
 
 ### Have more questions?

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,4 +1,4 @@
-# Browsertrix User Guide
+# Welcome!
 
 Welcome to the Browsertrix User Guide. This page covers the basics of using Browsertrix, Webrecorder's high-fidelity web archiving system.
 

--- a/docs/user-guide/join.md
+++ b/docs/user-guide/join.md
@@ -1,1 +1,5 @@
-# Joining an existing org
+# Join an existing org
+
+If you've received an email inviting you to an org, you can join the org by accepting the invitation.
+
+If you don't have a Browsertrix account, you'll be prompted to [create a password and display name](./signup.md#configure-your-user-account).

--- a/docs/user-guide/join.md
+++ b/docs/user-guide/join.md
@@ -1,4 +1,4 @@
-# Join an existing org
+# Join an Existing Org
 
 If you've received an email inviting you to an org, you can join the org by accepting the invitation.
 

--- a/docs/user-guide/join.md
+++ b/docs/user-guide/join.md
@@ -1,0 +1,1 @@
+# Joining an existing org

--- a/docs/user-guide/org-members.md
+++ b/docs/user-guide/org-members.md
@@ -1,4 +1,4 @@
-# Manage org members
+# Manage Org Members
 
 View and manage all current members who have access to the organization, as well as any invited members who have not yet accepted an invitation to join the organization. In the _Active Members_ table, you can change the permission level of all users in the organization, including other admins. An organization must have at least one admin. Admins can also remove members by pressing the trash button.
 

--- a/docs/user-guide/org-members.md
+++ b/docs/user-guide/org-members.md
@@ -1,0 +1,18 @@
+# Manage org members
+
+View and manage all current members who have access to the organization, as well as any invited members who have not yet accepted an invitation to join the organization. In the _Active Members_ table, you can change the permission level of all users in the organization, including other admins. An organization must have at least one admin. Admins can also remove members by pressing the trash button.
+
+You can add new members to the organization by pressing the _Invite New Member_ button. Enter the email address associated with the user, select the appropriate role, and press _Invite_ to send a link to join the organization via email.
+
+Sent invites can be invalidated by pressing the trash button in the relevant _Pending Invites_ table row.
+
+## Permission Levels
+
+`Viewer`
+: Users with the viewer role have read-only access to all material within the organization. They cannot create or edit archived items, crawl workflows, browser profiles, or collections. They also do not have access to any crawl analysis or review tools.
+
+`Crawler`
+: Users with the crawler role can create crawl workflows and collections, but they cannot delete existing archived items that they were not responsible for creating.
+
+`Admin`
+: Users with the administrator role have full access to the organization, including its settings page.

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -1,4 +1,4 @@
-# Org Settings
+# Change org name or URL
 
 The Org Settings page is only available to organization admins. It can be found in the main navigation menu.
 

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -1,6 +1,6 @@
 # Change org settings
 
-Settings that apply to the entire organization are found in the Org Settings page. If you're an org admin, you'll see the link to "Settings" in the org navigation bar.
+Settings that apply to the entire organization are found in the **Settings** page. If you're an org admin, you'll see the link to _Settings_ in the org navigation bar.
 
 ## General
 

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -1,29 +1,20 @@
-# Change org name or URL
+# Change org settings
 
-The Org Settings page is only available to organization admins. It can be found in the main navigation menu.
+Settings that apply to the entire organization are found in the Org Settings page. If you're an org admin, you'll see the link to "Settings" in the org navigation bar.
 
-## Org Information
+## General
 
-This tab lets you change the organization's name. This name must be unique.
+Change your organization's name and URL identifier in this tab. Choose an org name that's unique and memorable, like the name of your company or organization. Org name and URLs are unique to each Browsertrix instance (for example, on browsertrix.com) and you may be asked to change the org name or URL identifier if either are already in use by another org.
 
-## Members
+## Billing
 
-This tab lists all current members who have access to the organization, as well as any invited members who have not yet accepted an invitation to join the organization. In the _Active Members_ table, admins can change the permission level of all users in the organization, including other admins. At least one user must be an admin per-organization. Admins can also remove members by pressing the trash button.
+`Paid Feature`{ .badge-green }
 
-Admins can add new members to the organization by pressing the _Invite New Member_ button. Enter the email address associated with the user, select the appropriate role, and press _Invite_ to send a link to join the organization via email.
+View and manage your org's current payment plan and associated quotas. Usage history statistics for previous months are shown here to better inform your plan and quota requirements.
 
-Sent invites can be invalidated by pressing the trash button in the relevant _Pending Invites_ table row.
+## Crawl Workflows
 
-### Permission Levels
-
-`Viewer`
-:   Users with the viewer role have read-only access to all material within the organization. They cannot create or edit archived items, crawl workflows, browser profiles, or collections. They also do not have access to any crawl analysis or review tools.
-
-`Crawler`
-:   Users with the crawler role can create crawl workflows and collections, but they cannot delete existing archived items that they were not responsible for creating.
-
-`Admin`
-:   Users with the administrator role have full access to the organization, including its settings page.
+Set default suggested settings for all new crawl workflows in this tab. When creating a new workflow, org members will see the form pre-filled with default values. Org members can still change or remove these settings when configuring the workflow. Removing a default setting will revert the setting back to Browsertrix defaults.
 
 <!-- ## Limits
 

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -1,4 +1,4 @@
-# Change org settings
+# Change Org Settings
 
 Settings that apply to the entire organization are found in the **Settings** page. If you're an org admin, you'll see the link to _Settings_ in the org navigation bar.
 

--- a/docs/user-guide/org-settings.md
+++ b/docs/user-guide/org-settings.md
@@ -12,9 +12,9 @@ Change your organization's name and URL identifier in this tab. Choose an org na
 
 View and manage your org's current payment plan and associated quotas. Usage history statistics for previous months are shown here to better inform your plan and quota requirements.
 
-## Crawl Workflows
+<!-- ## Crawl Workflows
 
-Set default suggested settings for all new crawl workflows in this tab. When creating a new workflow, org members will see the form pre-filled with default values. Org members can still change or remove these settings when configuring the workflow. Removing a default setting will revert the setting back to Browsertrix defaults.
+Set default suggested settings for all new crawl workflows in this tab. When creating a new workflow, org members will see the form pre-filled with default values. Org members can still change or remove these settings when configuring the workflow. Removing a default setting will revert the setting back to Browsertrix defaults. -->
 
 <!-- ## Limits
 

--- a/docs/user-guide/org.md
+++ b/docs/user-guide/org.md
@@ -1,0 +1,9 @@
+# Introduction to orgs
+
+A Browsertrix org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.
+
+Every Browsertrix user belongs to one or more orgs. If you sign up for Browsertrix through one of our hosted plans, you'll create an org during sign up.
+
+Billing is managed per-org. Depending on your plan, your org may have monthly quotas for storage and minutes of crawl time. These quotas can be increased by upgrading your plan.
+
+You can change or your name, URL, default workflow settings, and more from the [**Settings**](./org-settings.md) page.

--- a/docs/user-guide/org.md
+++ b/docs/user-guide/org.md
@@ -2,7 +2,7 @@
 
 A Browsertrix org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.
 
-Every Browsertrix user belongs to one or more orgs. If you sign up for Browsertrix through one of our hosted plans, you'll create an org during sign up.
+Every Browsertrix user belongs to one or more orgs. You'll create an org during sign up if you sign up for Browsertrix through one of our hosted plans.
 
 Billing is managed per-org. Depending on your plan, your org may have monthly quotas for storage and minutes of crawl time. These quotas can be increased by upgrading your plan.
 

--- a/docs/user-guide/org.md
+++ b/docs/user-guide/org.md
@@ -1,4 +1,4 @@
-# Introduction to orgs
+# Introduction to Orgs
 
 A Browsertrix org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.
 

--- a/docs/user-guide/org.md
+++ b/docs/user-guide/org.md
@@ -2,8 +2,8 @@
 
 A Browsertrix org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.
 
-Every Browsertrix user belongs to one or more orgs. You'll create an org during sign up if you sign up for Browsertrix through one of our hosted plans.
+Every Browsertrix user belongs to one or more orgs. You'll create an org during sign-up if you sign up for Browsertrix through one of our hosted plans.
 
 Billing is managed per-org. Depending on your plan, your org may have monthly quotas for storage and minutes of crawl time. These quotas can be increased by upgrading your plan.
 
-You can change or your name, URL, default workflow settings, and more from the [**Settings**](./org-settings.md) page.
+You can change your org name, org URL, default workflow settings, and more from the [**Settings**](./org-settings.md) page.

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,4 +1,4 @@
-# Org Overview
+# Usage stats and quotas
 
 The overview page delivers key statistics about the organization's resource usage. It also lets users create crawl workflows, uploaded archived items, collections, and browser profiles through the _Create New ..._ button.
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,4 +1,4 @@
-# View usage stats and quotas
+# View Usage Stats and Quotas
 
 The **Overview** dashboard delivers key statistics about the org's resource usage. You can also create crawl workflows, upload archived items, create collections, and create browser profiles through the _Create New ..._ shortcut.
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,6 +1,6 @@
 # View usage stats and quotas
 
-The overview dashboard delivers key statistics about the org's resource usage. You can also create crawl workflows, upload archived items, create collections, and create browser profiles through the _Create New ..._ shortcut.
+The **Overview** dashboard delivers key statistics about the org's resource usage. You can also create crawl workflows, upload archived items, create collections, and create browser profiles through the _Create New ..._ shortcut.
 
 ## Storage
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,6 +1,6 @@
-# Usage stats and quotas
+# View usage stats and quotas
 
-The overview page delivers key statistics about the organization's resource usage. It also lets users create crawl workflows, uploaded archived items, collections, and browser profiles through the _Create New ..._ button.
+The overview dashboard delivers key statistics about the org's resource usage. You can also create crawl workflows, upload archived items, create collections, and create browser profiles through the _Create New ..._ shortcut.
 
 ## Storage
 

--- a/docs/user-guide/review.md
+++ b/docs/user-guide/review.md
@@ -1,4 +1,4 @@
-# Crawl Review
+# Review crawl quality (QA)
 
 The Crawl Review page provides a streamlined interface for assessing the capture quality of pages within an archived item using the heuristics collected during crawl analysis.
 

--- a/docs/user-guide/review.md
+++ b/docs/user-guide/review.md
@@ -1,6 +1,6 @@
-# Review crawl quality (QA)
+# Review crawl quality
 
-The Crawl Review page provides a streamlined interface for assessing the capture quality of pages within an archived item using the heuristics collected during crawl analysis.
+The crawl **Review** page provides a streamlined interface for quality assurance (QA). Assess and assign a score to the capture quality of an archived item using the heuristics collected during crawl analysis.
 
 Crawls can only be reviewed once [crawl analysis](archived-items.md#crawl-analysis) has been run. If multiple analysis runs have been completed, the page analysis heuristics will be used from the selected analysis run, which are displayed next to the archived item name. The most recent analysis run is selected by default, but you can choose to display data from any other completed or stopped analysis run here as well.
 

--- a/docs/user-guide/review.md
+++ b/docs/user-guide/review.md
@@ -10,7 +10,7 @@ Crawl analysis generates comparisons across three heuristics that can indicate w
 
 ### Screenshot Comparison
 
-Screenshots are compared by measuring the perceived difference between color samples and by the intensity of difference between pixels. These metrics are provided by the open-source tool [Pixelmatch](https://observablehq.com/@mourner/pixelmatch-demo).
+Screenshots are compared by measuring the perceived difference between color samples and by the intensity of difference between pixels. These metrics are provided by the open source tool [Pixelmatch](https://observablehq.com/@mourner/pixelmatch-demo).
 
 Discrepancies between crawl and replay screenshots may occur because resources aren't loaded or rendered properly (usually indicating a replay issue).
 

--- a/docs/user-guide/review.md
+++ b/docs/user-guide/review.md
@@ -1,4 +1,4 @@
-# Review crawl quality
+# Review Crawl Quality
 
 The crawl **Review** page provides a streamlined interface for quality assurance (QA). Assess and assign a score to the capture quality of an archived item using the heuristics collected during crawl analysis.
 

--- a/docs/user-guide/running-crawl.md
+++ b/docs/user-guide/running-crawl.md
@@ -1,0 +1,38 @@
+# Modifying running crawls
+
+Once you click "Run Crawl", a workflow can be in five possible states:
+
+| Status | Description |
+| ---- | ---- |
+| <span class="status-waiting">:bootstrap-hourglass-split: Waiting</span>     | The workflow can't start running yet but it is queued to run when resources are available. |
+| <span class="status-waiting">:btrix-status-dot: Starting</span>       | New resources are starting up. Crawling should begin shortly.|
+| <span class="status-success">:btrix-status-dot: Running</span>        | The crawler is finding and capturing pages! |
+| <span class="status-waiting">:btrix-status-dot: Stopping</span> | A user has instructed this workflow to stop. Finishing capture of the current pages.|
+| <span class="status-waiting">:btrix-status-dot: Finishing Crawl</span> | The workflow has finished crawling and data is being packaged into WACZ files.|
+| <span class="status-waiting">:btrix-status-dot: Uploading WACZ</span> | WACZ files have been created and are being transferred to storage.|
+
+## Live Exclusion Editing
+
+While [exclusions](workflow-setup.md#exclusions) can be set before running a crawl workflow, sometimes while crawling the crawler may find new parts of the site that weren't previously known about and shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
+
+If the crawl queue is filled with URLs that should not be crawled, use the _Edit Exclusions_ button on the Watch Crawl page to instruct the crawler what pages should be excluded from the queue.
+
+Exclusions added while crawling are applied to the same exclusion table saved in the workflow's settings and will be used the next time the crawl workflow is run unless they are manually removed.
+
+## Changing the Number of Crawler Instances
+
+Like exclusions, the [crawler instance](workflow-setup.md#crawler-instances) scale can also be adjusted while crawling. On the Watch Crawl page, press the _Edit Crawler Instances_ button, and set the desired value.
+
+Unlike exclusions, this change will not be applied to future workflow runs.
+
+## End a Crawl
+
+If a crawl workflow is not crawling websites as intended it may be preferable to end crawling operations and update the crawl workflow's settings before trying again. There are two operations to end crawls, available both on the workflow's details page, or as part of the actions menu in the workflow list.
+
+### Stopping
+
+Stopping a crawl will throw away the crawl queue but otherwise gracefully end the process and save anything that has been collected. Stopped crawls show up in the list of Archived Items and can be used like any other item in the app.
+
+### Canceling
+
+Canceling a crawl will throw away all data collected and immediately end the process. Canceled crawls do not show up in the list of Archived Items, though a record of the runtime and workflow settings can be found in the crawl workflow's list of crawls.

--- a/docs/user-guide/running-crawl.md
+++ b/docs/user-guide/running-crawl.md
@@ -1,6 +1,8 @@
 # Modifying running crawls
 
-Once you click "Run Crawl", a workflow can be in five possible states:
+## In Progress Status
+
+A crawl workflow that is in progress can be in one of five possible states:
 
 | Status | Description |
 | ---- | ---- |

--- a/docs/user-guide/running-crawl.md
+++ b/docs/user-guide/running-crawl.md
@@ -1,6 +1,6 @@
-# Modifying running crawls
+# Modifying Running Crawls
 
-## In Progress Status
+## In-Progress Statuses
 
 A crawl workflow that is in progress can be in one of five possible states:
 

--- a/docs/user-guide/running-crawl.md
+++ b/docs/user-guide/running-crawl.md
@@ -33,8 +33,8 @@ If a crawl workflow is not crawling websites as intended it may be preferable to
 
 ### Stopping
 
-Stopping a crawl will throw away the crawl queue but otherwise gracefully end the process and save anything that has been collected. Stopped crawls show up in the list of Archived Items and can be used like any other item in the app.
+Stopping a crawl will throw away the crawl queue but otherwise gracefully end the process and save anything that has been collected. Stopped crawls show up in **Archived Items** and can be used like any other item in the app.
 
 ### Canceling
 
-Canceling a crawl will throw away all data collected and immediately end the process. Canceled crawls do not show up in the list of Archived Items, though a record of the runtime and workflow settings can be found in the crawl workflow's list of crawls.
+Canceling a crawl will throw away all data collected and immediately end the process. Canceled crawls do not show up in **Archived Items**, though a record of the runtime and workflow settings can be found in the crawl workflow's list of crawls.

--- a/docs/user-guide/running-crawl.md
+++ b/docs/user-guide/running-crawl.md
@@ -2,7 +2,7 @@
 
 ## In-Progress Statuses
 
-A crawl workflow that is in progress can be in one of five possible states:
+A crawl workflow that is in progress can be in one of the following states:
 
 | Status | Description |
 | ---- | ---- |

--- a/docs/user-guide/running-crawl.md
+++ b/docs/user-guide/running-crawl.md
@@ -1,6 +1,8 @@
 # Modifying Running Crawls
 
-## In-Progress Statuses
+Running crawls can be modified from the crawl workflow **Watch Crawl** tab. You may want to modify a runnning crawl if you find that the workflow is crawling pages that you didn't intend to archive, or if you want a boost of speed.
+
+## Crawl Workflow Status
 
 A crawl workflow that is in progress can be in one of the following states:
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -1,6 +1,6 @@
 # Register for an account
 
-!!! note
+!!! note "Self-hosting?"
 
     This guide only applies to hosted Browsertrix accounts. If you're self-hosting Browsertrix, [enable open registration](../deploy/customization.md#enable-open-registration) to allow others to sign up for an account on your instance.
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -4,7 +4,7 @@
 
     This guide only applies to hosted Browsertrix accounts. If you're self-hosting Browsertrix, you'll need to [enable open registration](../deploy/customization.md#enable-open-registration).
 
-To use Browsertrix, [choose a plan](https://browsertrix.com/). We offer a variety of plans for individuals, teams, and organizations of all sizes.
+To sign up for Browsertrix, [choose a plan](https://browsertrix.com/). We offer a variety of plans for individuals, teams, and organizations of all sizes.
 
 ## Register your org
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -1,4 +1,4 @@
-# Register for an account
+# Register For an Account
 
 !!! note "Self-hosting?"
 
@@ -6,13 +6,13 @@
 
 To sign up for Browsertrix, [choose a plan](https://browsertrix.com/). We offer a variety of plans for individuals, teams, and organizations of all sizes.
 
-## Register your org
+## Register Your Org
 
 After you finish setting up your subscription, you'll receive an email from us with a link to set up your org (organization.)
 
 Choose an org name that's unique and memorable, like the name of your company or organization. Your org URL identifier will determine the unique URL of the org's home page.
 
-## Configure your user account
+## Configure Your User Account
 
 Create a password and display name. Your display name is the name that is visible to other org members. For example, your display name will be visible in crawl workflows that you create or run.
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -1,9 +1,23 @@
 # Register for an account
 
-## Invite Link
+!!! note
 
-If you have been sent an [invite](org-settings.md#members), enter a name and password to create a new account. Your account will be added to the organization you were invited to by an organization admin.
+    This guide only applies to hosted Browsertrix accounts. If you're self-hosting Browsertrix, you'll need to [enable open registration](../deploy/customization.md#enable-open-registration).
 
-## Open Registration
+To use Browsertrix, [choose a plan](https://browsertrix.com/). We offer a variety of plans for individuals, teams, and organizations of all sizes.
 
-If the server has enabled signups and you have been given a registration link, enter your email address, name, and password to create a new account. Your account will be added to the server's default organization.
+## Register your org
+
+After you finish setting up your subscription, you'll receive an email from us with a link to set up your org. A Browsertrix org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.
+
+Choose an org name that's unique and memorable, like the name of your company or organization. Your org URL identifier will determine the unique URL of the org's home page.
+
+## Configure your user account
+
+Create a password and display name. Your display name is the name that is visible to other org members. For example, your display name will be visible in crawl workflows that you create or run.
+
+Once you've completed this step, you're in! Next, familiarize yourself with the [org overview](./overview.md), head over to [crawl workflows](./crawl-workflows.md), or [invite team members](./org-settings.md).
+
+## Can't complete sign-up or have a question?
+
+Don't hesitate to [reach out to us](mailto:support@webrecorder.org) if you encounter any issues while signing up.

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -8,7 +8,7 @@ To sign up for Browsertrix, [choose a plan](https://browsertrix.com/). We offer 
 
 ## Register your org
 
-After you finish setting up your subscription, you'll receive an email from us with a link to set up your org. A Browsertrix org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.
+After you finish setting up your subscription, you'll receive an email from us with a link to set up your org (organization.)
 
 Choose an org name that's unique and memorable, like the name of your company or organization. Your org URL identifier will determine the unique URL of the org's home page.
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -2,7 +2,7 @@
 
 !!! note
 
-    This guide only applies to hosted Browsertrix accounts. If you're self-hosting Browsertrix, you'll need to [enable open registration](../deploy/customization.md#enable-open-registration).
+    This guide only applies to hosted Browsertrix accounts. If you're self-hosting Browsertrix, [enable open registration](../deploy/customization.md#enable-open-registration) to allow others to sign up for an account on your instance.
 
 To sign up for Browsertrix, [choose a plan](https://browsertrix.com/). We offer a variety of plans for individuals, teams, and organizations of all sizes.
 

--- a/docs/user-guide/signup.md
+++ b/docs/user-guide/signup.md
@@ -1,4 +1,4 @@
-# Signup
+# Register for an account
 
 ## Invite Link
 

--- a/docs/user-guide/user-settings.md
+++ b/docs/user-guide/user-settings.md
@@ -1,4 +1,4 @@
-# Change your name, email, or password
+# Change Your Name, Email, or Password
 
 ## Display Name
 

--- a/docs/user-guide/user-settings.md
+++ b/docs/user-guide/user-settings.md
@@ -1,4 +1,4 @@
-# Configure your user account
+# Change your name, email, or password
 
 ## Display Name
 

--- a/docs/user-guide/user-settings.md
+++ b/docs/user-guide/user-settings.md
@@ -1,4 +1,4 @@
-# Account Settings
+# Configure your user account
 
 ## Display Name
 

--- a/docs/user-guide/user-settings.md
+++ b/docs/user-guide/user-settings.md
@@ -2,12 +2,12 @@
 
 ## Display Name
 
-This is the name that other users will see as yours in the application.
+Specify how you want your name to be shown to other org members. For example, your display name will be shown with the crawl workflows that you run. This display name will be used for all orgs that you're a part of.
 
 ## Email
 
-This is the email that you use to login. It is also what we'll use to contact you.
+Update the email that you use to log in and receive Browsertrix emails from.
 
 ## Password
 
-This is the password that you use to login. Passwords must meet a minimum security check. For more information on how we derive password security levels, see [zxcvbn](https://zxcvbn-ts.github.io/zxcvbn/guide/).
+Update the password that you use to login. For your security, we enforce strong passwords. For more information on we secure your account by enforcing strong passwords, see [zxcvbn](https://zxcvbn-ts.github.io/zxcvbn/guide/).

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -1,8 +1,14 @@
 # Crawl Workflow Settings
 
+One of the key features of Browsertrix is the ability to refine crawler settings to the exact specifications of your crawl and website.
+
+Changes to a setting will only apply to subsequent crawls.
+
+Crawl settings are shown in the crawl workflow detail **Settings** tab and in the archived item **Crawl Settings** tab.
+
 ## Scope
 
-Specify the range and depth of your crawl.
+Specify the range and depth of your crawl. Different settings will be shown depending on whether you chose _Known URLs_ (crawl type of **URL List**) or _Automated Discovery_ (crawl type of **Seeded Crawl**) when creating a new workflow.
 
 ??? example "Crawling with HTTP basic auth"
 
@@ -10,40 +16,32 @@ Specify the range and depth of your crawl.
     
     **These credentials WILL BE WRITTEN into the archive.** We recommend exercising caution and only archiving with dedicated archival accounts, changing your password or deleting the account when finished.
 
-### Crawl URL(s)
+### Crawl Type: URL List
 
-`URL List`{ .badge-blue } `Seeded Crawl`{ .badge-orange }
+#### Crawl URL(s)
 
-This list informs the crawler what pages it should capture as part of a URL List crawl.
+A list of one or more URLs that the crawler should visit and capture.
 
-It is also available under the _Additional URLs_ section for Seeded Crawls where it can accept arbitrary URLs that will be crawled regardless of other scoping rules.
-
-### Include Any Linked Page
-
-`URL List`{ .badge-blue }
+#### Include Any Linked Page
 
 When enabled, the crawler will visit all the links it finds within each page defined in the _Crawl URL(s)_ field.
 
 ??? example "Crawling tags & search queries with URL List crawls"
     This setting can be useful for crawling the content of specific tags or search queries. Specify the tag or search query URL(s) in the _Crawl URL(s)_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
 
-### Fail Crawl on Failed URL
-
-`URL List`{ .badge-blue }
+#### Fail Crawl on Failed URL
 
 When enabled, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Failed".
 
-### Crawl Start URL
+### Crawl Type: Seeded Crawl
 
-`Seeded Crawl`{ .badge-orange }
+#### Crawl Start URL
 
 This is the first page that the crawler will visit. It's important to set _Crawl Start URL_ that accurately represents the scope of the pages you wish to crawl as the _Start URL Scope_ selection will depend on this field's contents.
 
 You must specify the protocol (likely `http://` or `https://`) as a part of the URL entered into this field.
 
-### Start URL Scope
-
-`Seeded Crawl`{ .badge-orange }
+#### Start URL Scope
 
 `Hashtag Links Only`
 :   This scope will ignore links that lead to other addresses such as `example.com/path` and will instead instruct the crawler to visit hashtag links such as `example.com/#linkedsection`.
@@ -62,39 +60,29 @@ You must specify the protocol (likely `http://` or `https://`) as a part of the 
 `Custom Page Prefix`
 :   This scope will crawl all pages that begin with the _Crawl Start URL_ as well as pages from any URL that begin with the URLs listed in `Extra URL Prefixes in Scope`
 
-### Max Depth
-
-`Seeded Crawl`{ .badge-orange }
+#### Max Depth
 
 Only shown with a _Start URL Scope_ of `Pages on This Domain` and above, the _Max Depth_ setting instructs the crawler to stop visiting new links past a specified depth.
 
-### Extra URL Prefixes in Scope
-
-`Seeded Crawl`{ .badge-orange }
+#### Extra URL Prefixes in Scope
 
 Only shown with a _Start URL Scope_ of `Custom Page Prefix`, this field accepts additional URLs or domains that will be crawled if URLs that lead to them are found.
 
 This can be useful for crawling websites that span multiple domains such as `example.org` and `example.net`
 
-### Include Any Linked Page ("one hop out")
-
-`Seeded Crawl`{ .badge-orange }
+#### Include Any Linked Page ("one hop out")
 
 When enabled, the crawler will visit all the links it finds within each page, regardless of the _Start URL Scope_ setting.
 
 This can be useful for capturing links on a page that lead outside the website that is being crawled but should still be included in the archive for context.
 
-### Check For Sitemap
-
-`Seeded Crawl`{ .badge-orange }
+#### Check For Sitemap
 
 When enabled, the crawler will check for a sitemap at /sitemap.xml and use it to discover pages to crawl if found. It will not crawl pages found in the sitemap that do not meet the crawl's scope settings or limits.
 
 This can be useful for discovering and capturing pages on a website that aren't linked to from the seed and which might not otherwise be captured.
 
 ### Exclusions
-
-`URL List`{ .badge-blue } `Seeded Crawl`{ .badge-orange }
 
 The exclusions table will instruct the crawler to ignore links it finds on pages where all or part of the link matches an exclusion found in the table. The table is only available in URL List crawls when _Include Any Linked Page_ is enabled.
 

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -1,4 +1,4 @@
-# Crawl Workflow Setup
+# Create a crawl workflow
 
 ## Crawl Type
 

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -1,20 +1,8 @@
-# Configure a crawl workflow
-
-## Crawl Type
-
-The first step in creating a new [crawl workflow](crawl-workflows.md) is to choose what type of crawl you want to run. Crawl types are fixed and cannot be converted or changed later.
-
-### Known URLs
-
-`URL List`{ .badge-blue }
-:   The crawler visits every URL specified in a list, and optionally every URL linked on those pages.
-
-### Automated Discovery
-
-`Seeded Crawl`{ .badge-orange }
-:   The crawler automatically discovers and archives pages starting from a single seed URL.
+# Crawl workflow settings
 
 ## Scope
+
+Specify the range and depth of your crawl.
 
 ??? example "Crawling with HTTP basic auth"
 
@@ -124,6 +112,8 @@ This can be useful for avoiding crawler traps — sites that may automatically g
 
 ## Limits
 
+Enforce maximum limits on your crawl.
+
 ### Max Pages
 
 Adds a hard limit on the number of pages that will be crawled. The crawl will be gracefully stopped after this limit is reached.
@@ -162,6 +152,8 @@ Waits on the page for a set period of elapsed time after any behaviors have fini
 
 ## Browser Settings
 
+Configure the browser used to visit URLs during the crawl.
+
 ### Browser Profile
 
 Sets the [_Browser Profile_](browser-profiles.md) to be used for this crawl.
@@ -198,6 +190,8 @@ Sets the browser's [user agent](https://developer.mozilla.org/en-US/docs/Web/HTT
 Sets the browser's language setting. Useful for crawling websites that detect the browser's language setting and serve content accordingly.
 
 ## Scheduling
+
+Automatically start crawls at a specific date or periodically.
 
 !!! tip "Tip: Scheduling crawl workflows with logged-in browser profiles"
     Some websites will log users out after a set period of time. When crawling with a custom [browser profile](browser-profiles.md) that is logged into a website, we recommend checking the profile before crawling to ensure it is still logged in.
@@ -237,6 +231,8 @@ When enabled, a crawl will run immediately on save as if the `Run Immediately on
 
 ## Metadata
 
+Describe and organize your crawl workflow and the resulting archived items.
+
 ### Name
 
 Allows a custom name to be set for the workflow. If no name is set, the workflow's name will be set to the _Crawl Start URL_. For URL List crawls, the workflow's name will be set to the first URL present in the _Crawl URL(s)_ field, with an added `(+x)` where `x` represents the total number of URLs in the list.
@@ -251,4 +247,4 @@ Apply tags to the workflow. Tags applied to the workflow will propagate to every
 
 ### Collection Auto-Add
 
-Search for and specify [collections](collections.md) that this crawl workflow should automatically add content to as soon as crawling finishes. Canceled and Failed crawls will not be automatically added to collections.
+Search for and specify [collections](collections.md) that this crawl workflow should automatically add archived items to as soon as crawling finishes. Canceled and Failed crawls will not be added to collections.

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -1,4 +1,4 @@
-# Create a crawl workflow
+# Configure a crawl workflow
 
 ## Crawl Type
 

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -191,7 +191,7 @@ Sets the browser's language setting. Useful for crawling websites that detect th
 
 ## Scheduling
 
-Automatically start crawls at a specific date or periodically.
+Automatically start crawls periodically on a daily, weekly, or monthly schedule.
 
 !!! tip "Tip: Scheduling crawl workflows with logged-in browser profiles"
     Some websites will log users out after a set period of time. When crawling with a custom [browser profile](browser-profiles.md) that is logged into a website, we recommend checking the profile before crawling to ensure it is still logged in.

--- a/docs/user-guide/workflow-setup.md
+++ b/docs/user-guide/workflow-setup.md
@@ -1,4 +1,4 @@
-# Crawl workflow settings
+# Crawl Workflow Settings
 
 ## Scope
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Crawling:
         - user-guide/crawl-workflows.md
         - user-guide/workflow-setup.md
+        - user-guide/running-crawl.md
       - Archived Items:
         - user-guide/archived-items.md
         - user-guide/review.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Getting Started:
         - user-guide/index.md
         - user-guide/signup.md
+        - user-guide/join.md
       - Org Overview:
         - user-guide/overview.md
       - Crawling:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,8 +65,10 @@ nav:
       - Getting Started:
         - user-guide/index.md
         - user-guide/signup.md
+        - user-guide/getting-started.md
+      - Orgs:
+        - user-guide/org.md
         - user-guide/join.md
-      - Org Overview:
         - user-guide/overview.md
       - Crawling:
         - user-guide/crawl-workflows.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,18 +64,25 @@ nav:
       - develop/frontend-dev.md
       - develop/docs.md
   - User Guide:
-      - user-guide/index.md
-      - user-guide/signup.md
+      - Getting Started:
+        - user-guide/index.md
+        - user-guide/signup.md
+      - Org Overview:
+        - user-guide/overview.md
       - Crawling:
         - user-guide/crawl-workflows.md
         - user-guide/workflow-setup.md
+      - Archived Items:
+        - user-guide/archived-items.md
+        - user-guide/review.md
+      - Collections:
+        - user-guide/collections.md
+      - Browser Profiles:
         - user-guide/browser-profiles.md
-      - user-guide/overview.md
-      - user-guide/archived-items.md
-      - user-guide/review.md
-      - user-guide/collections.md
-      - user-guide/org-settings.md
-      - user-guide/user-settings.md
+      - Org Settings:
+        - user-guide/org-settings.md
+      - Account Settings:
+        - user-guide/user-settings.md
 
 markdown_extensions:
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
         - user-guide/org-members.md
       - Account Settings:
         - user-guide/user-settings.md
+      - user-guide/contribute.md
 
 markdown_extensions:
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,12 +77,14 @@ nav:
       - Archived Items:
         - user-guide/archived-items.md
         - user-guide/review.md
-      - Collections:
         - user-guide/collections.md
+      - Collections:
+        - user-guide/collection.md
       - Browser Profiles:
         - user-guide/browser-profiles.md
       - Org Settings:
         - user-guide/org-settings.md
+        - user-guide/org-members.md
       - Account Settings:
         - user-guide/user-settings.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,12 +10,10 @@ theme:
   name: material
   custom_dir: docs/overrides
   features:
-    - navigation.sections
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.instant
     - navigation.tracking
-    - navigation.indexes
     - navigation.footer
     - content.code.copy
     - content.action.edit


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2041

Note: If this is ready to be merged before https://github.com/webrecorder/browsertrix/pull/2020 we'll need to comment out the org settings "Crawl Workflows" section.

Reorganizes user guide to be more solutions based. For the most part, I kept the content the same but moved sections into separate files.

New/overhauled pages:
- Welcome http://localhost:8000/user-guide/
- Registration http://localhost:8000/user-guide/signup/
- Getting started http://localhost:8000/user-guide/getting-started/
- Intro to orgs http://localhost:8000/user-guide/org/
- Join existing org http://localhost:8000/user-guide/join/
- Contribute http://localhost:8000/user-guide/contribute/

Feel free to commit suggestions directly.