### PR TITLE
feat: Breadcrumb navigation

### DIFF
--- a/docs/user-guide/archived-items.md
+++ b/docs/user-guide/archived-items.md
@@ -58,9 +58,9 @@ For more details on navigating web archives within ReplayWeb.page, see the [Repl
 
 While crawling, Browsertrix will output one or more WACZ files — the crawler aims to output files in consistently sized chunks, and each [crawler instance](workflow-setup.md#crawler-instances) will output separate WACZ files.
 
-The files tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status.
+The **WACZ Files** tab lists the individually downloadable WACZ files that make up the archived item as well as their file sizes and backup status.
 
-To download an entire archived item as a single WACZ file, click the _Download Item_ button at the top of the files tab or the _Download Item_ entry in the crawl's _Actions_ menu.
+To download an entire archived item as a single WACZ file, click the _Download Item_ button at the top of the **WACZ Files** tab or the _Download Item_ entry in the crawl's _Actions_ menu.
 
 To combine multiple archived items and download them all as a single WACZ file, add them to a collection and [download the collection](collections.md#downloading-collections).
 

--- a/frontend/src/controllers/navigate.ts
+++ b/frontend/src/controllers/navigate.ts
@@ -19,6 +19,13 @@ const NAVIGATE_EVENT_NAME: keyof NavigateEventMap = "btrix-navigate";
  * Manage app navigation
  */
 export class NavigateController implements ReactiveController {
+  static createNavigateEvent = (detail: NavigateEventDetail) =>
+    new CustomEvent<NavigateEventDetail>(NAVIGATE_EVENT_NAME, {
+      detail,
+      bubbles: true,
+      composed: true,
+    });
+
   private readonly host: ReactiveControllerHost & EventTarget;
 
   get orgBasePath() {
@@ -43,10 +50,11 @@ export class NavigateController implements ReactiveController {
     resetScroll = true,
     replace = false,
   ): void => {
-    const evt = new CustomEvent<NavigateEventDetail>(NAVIGATE_EVENT_NAME, {
-      detail: { url, state, resetScroll, replace },
-      bubbles: true,
-      composed: true,
+    const evt = NavigateController.createNavigateEvent({
+      url,
+      state,
+      resetScroll,
+      replace,
     });
     this.host.dispatchEvent(evt);
   };
@@ -88,13 +96,9 @@ export class NavigateController implements ReactiveController {
       return;
     }
 
-    const evt = new CustomEvent<NavigateEventDetail>(NAVIGATE_EVENT_NAME, {
-      detail: {
-        url: (event.currentTarget as HTMLAnchorElement).href,
-        resetScroll,
-      },
-      bubbles: true,
-      composed: true,
+    const evt = NavigateController.createNavigateEvent({
+      url: (event.currentTarget as HTMLAnchorElement).href,
+      resetScroll,
     });
     this.host.dispatchEvent(evt);
   };

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -1,0 +1,30 @@
+import clsx from "clsx";
+import { html, nothing, type TemplateResult } from "lit";
+
+export function pageTitle(title?: string | TemplateResult) {
+  return html`
+    <h1 class="min-w-0 text-xl font-semibold leading-8">
+      ${title || html`<sl-skeleton class="my-.5 h-5 w-60"></sl-skeleton>`}
+    </h1>
+  `;
+}
+
+export function pageHeader(
+  title?: string | TemplateResult,
+  suffix?: TemplateResult<1>,
+  classNames?: string,
+) {
+  return html`
+    <header
+      class=${clsx(
+        "mt-5 flex items-end flex-wrap justify-between gap-2 border-b pb-3",
+        classNames,
+      )}
+    >
+      ${pageTitle(title)}
+      ${suffix
+        ? html`<div class="ml-auto flex items-center gap-2">${suffix}</div>`
+        : nothing}
+    </header>
+  `;
+}

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -1,5 +1,47 @@
+import type { SlBreadcrumb } from "@shoelace-style/shoelace";
 import clsx from "clsx";
 import { html, nothing, type TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { NavigateController } from "@/controllers/navigate";
+
+export type Breadcrumb = {
+  href?: string;
+  content?: string | TemplateResult;
+};
+
+function navigateBreadcrumb(e: MouseEvent, href: string) {
+  e.preventDefault();
+
+  const el = e.target as SlBreadcrumb;
+  const evt = NavigateController.createNavigateEvent({
+    url: href,
+    resetScroll: true,
+  });
+
+  el.dispatchEvent(evt);
+}
+
+export function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
+  return html`
+    <sl-breadcrumb>
+      ${breadcrumbs.map(({ href, content }) =>
+        content
+          ? html`
+              <sl-breadcrumb-item
+                href=${ifDefined(href)}
+                @click=${href
+                  ? (e: MouseEvent) => navigateBreadcrumb(e, href)
+                  : undefined}
+              >
+                ${content}
+              </sl-breadcrumb-item>
+            `
+          : nothing,
+      )}
+    </sl-breadcrumb>
+  `;
+}
 
 export function pageTitle(title?: string | TemplateResult) {
   return html`

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -24,19 +24,26 @@ function navigateBreadcrumb(e: MouseEvent, href: string) {
 
 export function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
   return html`
-    <sl-breadcrumb>
-      ${breadcrumbs.map(
-        ({ href, content }) => html`
-          <sl-breadcrumb-item
-            href=${ifDefined(href)}
-            @click=${href
-              ? (e: MouseEvent) => navigateBreadcrumb(e, href)
-              : undefined}
-          >
-            ${content || html`<sl-skeleton class="w-48"></sl-skeleton>`}
-          </sl-breadcrumb-item>
-        `,
-      )}
+    <sl-breadcrumb class="part-[base]:h-6">
+      ${breadcrumbs.length
+        ? breadcrumbs.map(
+            ({ href, content }) => html`
+              <sl-breadcrumb-item
+                href=${ifDefined(href)}
+                @click=${href
+                  ? (e: MouseEvent) => navigateBreadcrumb(e, href)
+                  : undefined}
+              >
+                ${content || html`<sl-skeleton class="w-48"></sl-skeleton>`}
+              </sl-breadcrumb-item>
+            `,
+          )
+        : html`<sl-breadcrumb-item>
+              <sl-skeleton class="w-48"></sl-skeleton>
+            </sl-breadcrumb-item>
+            <sl-breadcrumb-item>
+              <sl-skeleton class="w-48"></sl-skeleton>
+            </sl-breadcrumb-item>`}
     </sl-breadcrumb>
   `;
 }

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -25,19 +25,17 @@ function navigateBreadcrumb(e: MouseEvent, href: string) {
 export function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
   return html`
     <sl-breadcrumb>
-      ${breadcrumbs.map(({ href, content }) =>
-        content
-          ? html`
-              <sl-breadcrumb-item
-                href=${ifDefined(href)}
-                @click=${href
-                  ? (e: MouseEvent) => navigateBreadcrumb(e, href)
-                  : undefined}
-              >
-                ${content}
-              </sl-breadcrumb-item>
-            `
-          : nothing,
+      ${breadcrumbs.map(
+        ({ href, content }) => html`
+          <sl-breadcrumb-item
+            href=${ifDefined(href)}
+            @click=${href
+              ? (e: MouseEvent) => navigateBreadcrumb(e, href)
+              : undefined}
+          >
+            ${content || html`<sl-skeleton class="w-48"></sl-skeleton>`}
+          </sl-breadcrumb-item>
+        `,
       )}
     </sl-breadcrumb>
   `;

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -563,7 +563,18 @@ export class ArchivedItemDetail extends BtrixElement {
   }
 
   private renderHeader() {
+    let parentPageLabel: TemplateResult | null = null;
+
+    if (this.workflowId || this.collectionId) {
+      parentPageLabel = html`<div class="mb-1 font-medium text-neutral-400">
+        ${this.workflowId
+          ? msg("Viewing Workflow Crawl")
+          : msg("Viewing Archived Item in Collection")}
+      </div>`;
+    }
+
     return html`
+      ${parentPageLabel}
       <header class="mb-3 flex flex-wrap gap-2 border-b pb-3">
         <btrix-detail-page-title .item=${this.crawl}></btrix-detail-page-title>
         <div class="ml-auto flex flex-wrap justify-end gap-2">

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -123,7 +123,7 @@ export class ArchivedItemDetail extends BtrixElement {
     overview: msg("Overview"),
     qa: msg("Quality Assurance"),
     replay: msg("Replay"),
-    files: msg("Files"),
+    files: msg("WACZ Files"),
     logs: msg("Error Logs"),
     config: msg("Crawl Settings"),
   };
@@ -250,8 +250,7 @@ export class ArchivedItemDetail extends BtrixElement {
         }
         sectionContent = this.renderPanel(
           html`${this.renderTitle(
-              html`${msg("Quality Assurance")}
-                <btrix-beta-badge></btrix-beta-badge>`,
+              html`${this.tabLabels.qa} <btrix-beta-badge></btrix-beta-badge>`,
             )}
             <div class="ml-auto flex flex-wrap justify-end gap-2">
               ${when(this.qaRuns, this.renderQAHeader)}
@@ -271,13 +270,15 @@ export class ArchivedItemDetail extends BtrixElement {
         break;
       }
       case "replay":
-        sectionContent = this.renderPanel(msg("Replay"), this.renderReplay(), [
-          tw`overflow-hidden rounded-lg border`,
-        ]);
+        sectionContent = this.renderPanel(
+          this.tabLabels.replay,
+          this.renderReplay(),
+          [tw`overflow-hidden rounded-lg border`],
+        );
         break;
       case "files":
         sectionContent = this.renderPanel(
-          html` ${this.renderTitle(msg("Files"))}
+          html` ${this.renderTitle(this.tabLabels.files)}
             <sl-tooltip content=${msg("Download all files as a single WACZ")}>
               <sl-button
                 href=${`/api/orgs/${this.orgId}/all-crawls/${this.crawlId}/download?auth_bearer=${authToken}`}
@@ -286,7 +287,7 @@ export class ArchivedItemDetail extends BtrixElement {
                 variant="primary"
               >
                 <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-                ${msg("Download Item")}
+                ${msg("Download as Multi-WACZ")}
               </sl-button>
             </sl-tooltip>`,
           this.renderFiles(),
@@ -294,7 +295,7 @@ export class ArchivedItemDetail extends BtrixElement {
         break;
       case "logs":
         sectionContent = this.renderPanel(
-          html` ${this.renderTitle(msg("Error Logs"))}
+          html` ${this.renderTitle(this.tabLabels.logs)}
             <sl-button
               href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/logs?auth_bearer=${authToken}`}
               download=${`btrix-${this.crawlId}-logs.txt`}
@@ -309,7 +310,7 @@ export class ArchivedItemDetail extends BtrixElement {
         break;
       case "config":
         sectionContent = this.renderPanel(
-          msg("Crawl Settings"),
+          this.tabLabels.config,
           this.renderConfig(),
           [tw`rounded-lg border p-4`],
         );

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -432,23 +432,30 @@ export class ArchivedItemDetail extends BtrixElement {
         </sl-breadcrumb-item>`,
       );
 
-      if (this.workflow) {
+      if (this.crawl) {
+        const collection = this.crawl.collections.find(
+          ({ id }) => id === this.collectionId,
+        );
+
         breadcrumbs.push(
+          html`<sl-breadcrumb-item
+            href="${this.navigate.orgBasePath}/collections/view/${this
+              .collectionId}"
+            @click=${this.navigate.link}
+          >
+            ${collection?.name || msg("Collection")}
+          </sl-breadcrumb-item>`,
           html`<sl-breadcrumb-item
             href="${this.navigate.orgBasePath}/collections/view/${this
               .collectionId}/items"
             @click=${this.navigate.link}
           >
-            <!-- TODO name -->
-            ${msg("Collection Archived Items")}
+            ${msg("Archived Items")}
+          </sl-breadcrumb-item>`,
+          html`<sl-breadcrumb-item>
+            ${renderName(this.crawl)}
           </sl-breadcrumb-item>`,
         );
-
-        if (this.crawl) {
-          breadcrumbs.push(html`
-            <sl-breadcrumb-item> ${renderName(this.crawl)} </sl-breadcrumb-item>
-          `);
-        }
       }
     } else if (this.crawl) {
       breadcrumbs.push(

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -40,12 +40,10 @@ import "./ui/qa";
 const SECTIONS = [
   "overview",
   "qa",
-  "watch",
   "replay",
   "files",
   "logs",
   "config",
-  "exclusions",
 ] as const;
 type SectionName = (typeof SECTIONS)[number];
 
@@ -117,6 +115,18 @@ export class ArchivedItemDetail extends BtrixElement {
 
   @query("#cancelQARunDialog")
   private readonly cancelQARunDialog?: Dialog | null;
+
+  private readonly tabLabels: Omit<
+    Record<SectionName, string>,
+    "watch" | "exclusions"
+  > = {
+    overview: msg("Overview"),
+    qa: msg("Quality Assurance"),
+    replay: msg("Replay"),
+    files: msg("Files"),
+    logs: msg("Error Logs"),
+    config: msg("Crawl Settings"),
+  };
 
   private get listUrl(): string {
     let path = "items";
@@ -455,9 +465,15 @@ export class ArchivedItemDetail extends BtrixElement {
         });
       }
 
-      breadcrumbs.push({
-        content: renderName(this.crawl),
-      });
+      breadcrumbs.push(
+        {
+          href: `${this.navigate.orgBasePath}/items/${this.crawl.type}/${this.crawlId}`,
+          content: renderName(this.crawl),
+        },
+        {
+          content: this.tabLabels[this.activeTab],
+        },
+      );
     }
 
     return pageBreadcrumbs(breadcrumbs);
@@ -466,13 +482,11 @@ export class ArchivedItemDetail extends BtrixElement {
   private renderNav() {
     const renderNavItem = ({
       section,
-      label,
       iconLibrary,
       icon,
       detail,
     }: {
       section: SectionName;
-      label: string;
       iconLibrary: "app" | "default";
       icon: string;
       detail?: TemplateResult<1>;
@@ -493,7 +507,7 @@ export class ArchivedItemDetail extends BtrixElement {
             aria-hidden="true"
             library=${iconLibrary}
           ></sl-icon>
-          ${label}${detail}</btrix-navigation-button
+          ${this.tabLabels[section]}${detail}</btrix-navigation-button
         >
       `;
     };
@@ -506,7 +520,6 @@ export class ArchivedItemDetail extends BtrixElement {
           section: "overview",
           iconLibrary: "default",
           icon: "info-circle-fill",
-          label: msg("Overview"),
         })}
         ${when(
           this.itemType === "crawl" && this.isCrawler,
@@ -515,7 +528,6 @@ export class ArchivedItemDetail extends BtrixElement {
               section: "qa",
               iconLibrary: "default",
               icon: "clipboard2-data-fill",
-              label: msg("Quality Assurance"),
               detail: html`<btrix-beta-icon></btrix-beta-icon>`,
             })}
           `,
@@ -524,13 +536,11 @@ export class ArchivedItemDetail extends BtrixElement {
           section: "replay",
           iconLibrary: "app",
           icon: "replaywebpage",
-          label: msg("Replay"),
         })}
         ${renderNavItem({
           section: "files",
           iconLibrary: "default",
           icon: "folder-fill",
-          label: msg("Files"),
         })}
         ${when(
           this.itemType === "crawl",
@@ -539,13 +549,11 @@ export class ArchivedItemDetail extends BtrixElement {
               section: "logs",
               iconLibrary: "default",
               icon: "terminal-fill",
-              label: msg("Error Logs"),
             })}
             ${renderNavItem({
               section: "config",
               iconLibrary: "default",
               icon: "file-code-fill",
-              label: msg("Crawl Settings"),
             })}
           `,
         )}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -12,6 +12,7 @@ import { type Dialog } from "@/components/ui/dialog";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { RelativeDuration } from "@/components/ui/relative-duration";
 import type { CrawlLog } from "@/features/archived-items/crawl-logs";
+import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
 import type { APIPaginatedList } from "@/types/api";
 import type {
   ArchivedItem,
@@ -375,62 +376,47 @@ export class ArchivedItemDetail extends BtrixElement {
   }
 
   private renderBreadcrumbs() {
-    const breadcrumbs = [];
+    const breadcrumbs: Breadcrumb[] = [];
 
     if (this.workflowId) {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item
-          href="${this.navigate.orgBasePath}/workflows/crawls"
-          @click=${this.navigate.link}
-        >
-          ${msg("Crawl Workflows")}
-        </sl-breadcrumb-item>`,
-      );
+      breadcrumbs.push({
+        href: `${this.navigate.orgBasePath}/workflows/crawls`,
+        content: msg("Crawl Workflows"),
+      });
 
       if (this.workflow) {
         breadcrumbs.push(
-          html`<sl-breadcrumb-item
-            href="${this.navigate.orgBasePath}/workflows/crawl/${this
-              .workflowId}"
-            @click=${this.navigate.link}
-          >
-            ${renderName(this.workflow)}
-          </sl-breadcrumb-item>`,
-          html`<sl-breadcrumb-item
-            href="${this.navigate.orgBasePath}/workflows/crawl/${this
-              .workflowId}#crawls"
-            @click=${this.navigate.link}
-          >
-            ${msg("Crawls")}
-          </sl-breadcrumb-item>`,
+          {
+            href: `${this.navigate.orgBasePath}/workflows/crawl/${this.workflowId}`,
+            content: renderName(this.workflow),
+          },
+          {
+            href: `${this.navigate.orgBasePath}/workflows/crawl/${this.workflowId}#crawls`,
+
+            content: msg("Crawls"),
+          },
         );
 
         if (this.crawl) {
-          breadcrumbs.push(html`
-            <sl-breadcrumb-item>
-              <sl-format-date
-                lang=${getLocale()}
-                date=${`${this.crawl.finished}Z` /** Z for UTC */}
-                month="2-digit"
-                day="2-digit"
-                year="2-digit"
-                hour="numeric"
-                minute="numeric"
-                timeZoneName="short"
-              ></sl-format-date>
-            </sl-breadcrumb-item>
-          `);
+          breadcrumbs.push({
+            content: html`<sl-format-date
+              lang=${getLocale()}
+              date=${`${this.crawl.finished}Z` /** Z for UTC */}
+              month="2-digit"
+              day="2-digit"
+              year="2-digit"
+              hour="numeric"
+              minute="numeric"
+              timeZoneName="short"
+            ></sl-format-date>`,
+          });
         }
       }
     } else if (this.collectionId) {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item
-          href="${this.navigate.orgBasePath}/collections"
-          @click=${this.navigate.link}
-        >
-          ${msg("Collections")}
-        </sl-breadcrumb-item>`,
-      );
+      breadcrumbs.push({
+        href: `${this.navigate.orgBasePath}/collections`,
+        content: msg("Collections"),
+      });
 
       if (this.crawl) {
         const collection = this.crawl.collections.find(
@@ -438,66 +424,43 @@ export class ArchivedItemDetail extends BtrixElement {
         );
 
         breadcrumbs.push(
-          html`<sl-breadcrumb-item
-            href="${this.navigate.orgBasePath}/collections/view/${this
-              .collectionId}"
-            @click=${this.navigate.link}
-          >
-            ${collection?.name || msg("Collection")}
-          </sl-breadcrumb-item>`,
-          html`<sl-breadcrumb-item
-            href="${this.navigate.orgBasePath}/collections/view/${this
-              .collectionId}/items"
-            @click=${this.navigate.link}
-          >
-            ${msg("Archived Items")}
-          </sl-breadcrumb-item>`,
-          html`<sl-breadcrumb-item>
-            ${renderName(this.crawl)}
-          </sl-breadcrumb-item>`,
+          {
+            href: `${this.navigate.orgBasePath}/collections/view/${this.collectionId}`,
+            content: collection?.name || msg("Collection"),
+          },
+          {
+            href: `${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items`,
+            content: msg("Archived Items"),
+          },
+          {
+            content: renderName(this.crawl),
+          },
         );
       }
     } else if (this.crawl) {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item
-          href="${this.navigate.orgBasePath}/items"
-          @click=${this.navigate.link}
-        >
-          ${msg("Archived Items")}
-        </sl-breadcrumb-item>`,
-      );
+      breadcrumbs.push({
+        href: `${this.navigate.orgBasePath}/items`,
+        content: msg("Archived Items"),
+      });
 
       if (this.crawl.type === "upload") {
-        breadcrumbs.push(
-          html`<sl-breadcrumb-item
-            href="${this.navigate.orgBasePath}/items/upload"
-            @click=${this.navigate.link}
-          >
-            ${msg("Uploads")}
-          </sl-breadcrumb-item>`,
-        );
+        breadcrumbs.push({
+          href: `${this.navigate.orgBasePath}/items/upload`,
+          content: msg("Uploads"),
+        });
       } else {
-        breadcrumbs.push(
-          html`<sl-breadcrumb-item
-            href="${this.navigate.orgBasePath}/items/crawl"
-            @click=${this.navigate.link}
-          >
-            ${msg("Crawls")}
-          </sl-breadcrumb-item>`,
-        );
+        breadcrumbs.push({
+          href: `${this.navigate.orgBasePath}/items/crawl`,
+          content: msg("Crawls"),
+        });
       }
 
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item>
-          ${renderName(this.crawl)}
-        </sl-breadcrumb-item>`,
-        // TODO tab
-      );
+      breadcrumbs.push({
+        content: renderName(this.crawl),
+      });
     }
 
-    return html`
-      <sl-breadcrumb>${breadcrumbs.map((bc) => bc)}</sl-breadcrumb>
-    `;
+    return pageBreadcrumbs(breadcrumbs);
   }
 
   private renderNav() {

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -469,7 +469,7 @@ export class ArchivedItemDetail extends BtrixElement {
       breadcrumbs.push(
         {
           href: `${this.navigate.orgBasePath}/items/${this.crawl.type}/${this.crawlId}`,
-          content: renderName(this.crawl),
+          content: renderName(this.crawl, tw`max-w-48`),
         },
         {
           content: this.tabLabels[this.activeTab],

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -364,8 +364,24 @@ export class ArchivedItemQA extends BtrixElement {
     return html`
       ${this.renderHidden()}
 
-      <div class="grid--header pb-3 border-b">
-        ${this.renderBreadcrumbs()}
+      <div class="grid--header pb-3 h-8 border-b flex items-center">
+        ${this.renderBreadcrumbs()} ${when(
+          this.finishedQARuns,
+          (qaRuns) => html`
+            <btrix-qa-run-dropdown
+              slot="suffix"
+              .items=${qaRuns}
+              selectedId=${this.qaRunId || ""}
+              @btrix-select=${(e: CustomEvent<SelectDetail>) => {
+                const params = new URLSearchParams(searchParams);
+                params.set("qaRunId", e.detail.item.id);
+                this.navigate.to(
+                  `${window.location.pathname}?${params.toString()}`,
+                );
+              }}
+            ></btrix-qa-run-dropdown>
+          `,
+        )}
       </div>
 
       <article class="qa-grid min-h-screen grid gap-x-6 gap-y-0 lg:snap-start">
@@ -570,8 +586,6 @@ export class ArchivedItemQA extends BtrixElement {
   }
 
   private renderBreadcrumbs() {
-    const searchParams = new URLSearchParams(window.location.search);
-
     const breadcrumbs = [
       {
         href: `${this.navigate.orgBasePath}/items`,
@@ -586,26 +600,7 @@ export class ArchivedItemQA extends BtrixElement {
         content: msg("Quality Assurance"),
       },
       {
-        content: html`
-          ${msg("Review")}
-          ${when(
-            this.finishedQARuns,
-            (qaRuns) => html`
-              <btrix-qa-run-dropdown
-                slot="suffix"
-                .items=${qaRuns}
-                selectedId=${this.qaRunId || ""}
-                @btrix-select=${(e: CustomEvent<SelectDetail>) => {
-                  const params = new URLSearchParams(searchParams);
-                  params.set("qaRunId", e.detail.item.id);
-                  this.navigate.to(
-                    `${window.location.pathname}?${params.toString()}`,
-                  );
-                }}
-              ></btrix-qa-run-dropdown>
-            `,
-          )}
-        `,
+        content: msg("Review"),
       },
     ];
 

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -30,6 +30,7 @@ import {
 } from "@/features/qa/page-list/page-list";
 import { type UpdatePageApprovalDetail } from "@/features/qa/page-qa-approval";
 import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
+import { pageBreadcrumbs } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -354,7 +355,6 @@ export class ArchivedItemQA extends BtrixElement {
   render() {
     const crawlBaseUrl = `${this.navigate.orgBasePath}/items/crawl/${this.itemId}`;
     const searchParams = new URLSearchParams(window.location.search);
-    const itemName = this.item ? renderName(this.item) : nothing;
     const [prevPage, currentPage, nextPage] = this.getPageListSliceByCurrent();
     const currentQARun = this.finishedQARuns?.find(
       ({ id }) => id === this.qaRunId,
@@ -364,81 +364,13 @@ export class ArchivedItemQA extends BtrixElement {
     return html`
       ${this.renderHidden()}
 
-      <div class="flex items-center gap-2">
-        <a
-          class="font-medium text-neutral-500 hover:text-neutral-600"
-          href=${`${crawlBaseUrl}#qa`}
-          @click=${this.navigate.link}
-        >
-          <sl-icon
-            name="arrow-left"
-            class="inline-block align-middle"
-          ></sl-icon>
-          <span class="inline-block align-middle"> ${msg("Back")} </span>
-        </a>
-        <div class="text-neutral-400" role="separator">/</div>
-        <h1 class="text-neutral-400">
-          ${msg("Review Archived Item")}
-          <btrix-beta-badge placement="right"></btrix-beta-badge>
-        </h1>
+      <div class="grid--header pb-3 border-b">
+        ${this.renderBreadcrumbs()}
       </div>
 
       <article class="qa-grid min-h-screen grid gap-x-6 gap-y-0 lg:snap-start">
-        <header
-          class="grid--header flex flex-wrap items-center justify-between gap-1 border-b py-2"
-        >
-          <div class="flex items-center gap-2 overflow-hidden">
-            <h2
-              class="flex-1 flex-shrink-0 min-w-32 truncate text-base font-semibold leading-tight"
-            >
-              ${itemName}
-            </h2>
-            ${when(
-              this.finishedQARuns,
-              (qaRuns) => html`
-                <btrix-qa-run-dropdown
-                  .items=${qaRuns}
-                  selectedId=${this.qaRunId || ""}
-                  @btrix-select=${(e: CustomEvent<SelectDetail>) => {
-                    const params = new URLSearchParams(searchParams);
-                    params.set("qaRunId", e.detail.item.id);
-                    this.navigate.to(
-                      `${window.location.pathname}?${params.toString()}`,
-                    );
-                  }}
-                ></btrix-qa-run-dropdown>
-              `,
-            )}
-          </div>
-          <div class="ml-auto flex">
-            <sl-button
-              size="small"
-              variant="text"
-              href=${`${crawlBaseUrl}#qa`}
-              @click=${this.navigate.link}
-              >${msg("Exit Review")}</sl-button
-            >
-            <sl-tooltip
-              content=${msg(
-                "Reviews are temporarily disabled during analysis runs.",
-              )}
-              ?disabled=${!disableReview}
-            >
-              <sl-button
-                variant="success"
-                size="small"
-                @click=${() => void this.reviewDialog?.show()}
-                ?disabled=${disableReview}
-              >
-                <sl-icon slot="prefix" name="patch-check"> </sl-icon>
-                ${msg("Finish Review")}
-              </sl-button>
-            </sl-tooltip>
-          </div>
-        </header>
-
         <div
-          class="grid--pageToolbar flex flex-wrap items-center justify-stretch gap-2 overflow-hidden border-b py-2 @container"
+          class="grid--pageToolbar flex flex-wrap items-center justify-stretch gap-2 overflow-hidden border-b py-3 @container"
         >
           <h3
             class="flex-auto flex-shrink-0 flex-grow basis-32 truncate text-base font-semibold text-neutral-700"
@@ -545,11 +477,38 @@ export class ArchivedItemQA extends BtrixElement {
         <section
           class="grid--pageList grid grid-rows-[auto_1fr] *:min-h-0 *:min-w-0"
         >
-          <h3
-            class="my-4 text-base font-semibold leading-none text-neutral-800"
-          >
-            ${msg("Pages")}
-          </h3>
+          <div class="flex justify-between items-center py-3">
+            <h3
+              class="text-base font-semibold leading-none text-neutral-800"
+            >
+              ${msg("Pages")}
+            </h3>
+            <div class="ml-auto flex">
+              <sl-button
+                size="small"
+                variant="text"
+                href=${`${crawlBaseUrl}#qa`}
+                @click=${this.navigate.link}
+                >${msg("Exit Review")}</sl-button
+              >
+              <sl-tooltip
+                content=${msg(
+                  "Reviews are temporarily disabled during analysis runs.",
+                )}
+                ?disabled=${!disableReview}
+              >
+                <sl-button
+                  variant="success"
+                  size="small"
+                  @click=${() => void this.reviewDialog?.show()}
+                  ?disabled=${disableReview}
+                >
+                  <sl-icon slot="prefix" name="patch-check"> </sl-icon>
+                  ${msg("Finish Review")}
+                </sl-button>
+              </sl-tooltip>
+            </div>
+          </div>
           <btrix-qa-page-list
             class="flex flex-col lg:contain-size"
             .qaRunId=${this.qaRunId}
@@ -608,6 +567,49 @@ export class ArchivedItemQA extends BtrixElement {
 
       ${this.renderReviewDialog()}
     `;
+  }
+
+  private renderBreadcrumbs() {
+    const searchParams = new URLSearchParams(window.location.search);
+
+    const breadcrumbs = [
+      {
+        href: `${this.navigate.orgBasePath}/items`,
+        content: msg("Archived Items"),
+      },
+      {
+        href: `${this.navigate.orgBasePath}/items/crawl/${this.itemId}`,
+        content: this.item ? renderName(this.item) : undefined,
+      },
+      {
+        href: `${this.navigate.orgBasePath}/items/crawl/${this.itemId}#qa`,
+        content: msg("Quality Assurance"),
+      },
+      {
+        content: html`
+          ${msg("Review")}
+          ${when(
+            this.finishedQARuns,
+            (qaRuns) => html`
+              <btrix-qa-run-dropdown
+                slot="suffix"
+                .items=${qaRuns}
+                selectedId=${this.qaRunId || ""}
+                @btrix-select=${(e: CustomEvent<SelectDetail>) => {
+                  const params = new URLSearchParams(searchParams);
+                  params.set("qaRunId", e.detail.item.id);
+                  this.navigate.to(
+                    `${window.location.pathname}?${params.toString()}`,
+                  );
+                }}
+              ></btrix-qa-run-dropdown>
+            `,
+          )}
+        `,
+      },
+    ];
+
+    return pageBreadcrumbs(breadcrumbs);
   }
 
   private renderReviewDialog() {

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -256,7 +256,9 @@ export class CrawlsList extends BtrixElement {
     return html`
       <main>
         <header class="contents">
-          <div class="mb-3 flex flex-wrap justify-between gap-2 border-b pb-3">
+          <div
+            class="mb-3 mt-7 flex flex-wrap justify-between gap-2 border-b pb-3"
+          >
             <h1 class="mb-2 text-xl font-semibold leading-8 md:mb-0">
               ${msg("Archived Items")}
             </h1>

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -14,10 +14,12 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
+import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import { finishedCrawlStates, isActive } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
+import { tw } from "@/utils/tailwind";
 
 type ArchivedItems = APIPaginatedList<ArchivedItem>;
 type SearchFields = "name" | "firstSeed";
@@ -255,14 +257,10 @@ export class CrawlsList extends BtrixElement {
 
     return html`
       <main>
-        <header class="contents">
-          <div
-            class="mb-3 mt-7 flex flex-wrap justify-between gap-2 border-b pb-3"
-          >
-            <h1 class="mb-2 text-xl font-semibold leading-8 md:mb-0">
-              ${msg("Archived Items")}
-            </h1>
-            ${when(
+        <div class="contents">
+          ${pageHeader(
+            msg("Archived Items"),
+            when(
               this.isCrawler,
               () => html`
                 <sl-tooltip
@@ -280,8 +278,9 @@ export class CrawlsList extends BtrixElement {
                   </sl-button>
                 </sl-tooltip>
               `,
-            )}
-          </div>
+            ),
+            tw`mb-3`,
+          )}
           <div class="mb-3 flex gap-2">
             ${listTypes.map(({ label, itemType, icon }) => {
               const isSelected = itemType === this.itemType;
@@ -304,7 +303,7 @@ export class CrawlsList extends BtrixElement {
           >
             ${this.renderControls()}
           </div>
-        </header>
+        </div>
 
         ${this.archivedItemsTask.render({
           initial: () => html`

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -11,6 +11,7 @@ import type { Profile, ProfileWorkflow } from "./types";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { BrowserConnectionChange } from "@/features/browser-profiles/profile-browser";
+import { pageBreadcrumbs } from "@/layouts/pageHeader";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 import { formatNumber, getLocale } from "@/utils/localization";
@@ -312,18 +313,16 @@ export class BrowserProfilesDetail extends BtrixElement {
 
   private renderBreadcrumbs() {
     const breadcrumbs = [
-      html`<sl-breadcrumb-item
-        href="${this.navigate.orgBasePath}/browser-profiles"
-        @click=${this.navigate.link}
-      >
-        ${msg("Browser Profiles")}
-      </sl-breadcrumb-item>`,
-      html`<sl-breadcrumb-item>${this.profile?.name}</sl-breadcrumb-item>`,
+      {
+        href: `${this.navigate.orgBasePath}/browser-profiles`,
+        content: msg("Browser Profiles"),
+      },
+      {
+        content: this.profile?.name,
+      },
     ];
 
-    return html`
-      <sl-breadcrumb> ${breadcrumbs.map((bc) => bc)} </sl-breadcrumb>
-    `;
+    return pageBreadcrumbs(breadcrumbs);
   }
 
   private renderCrawlWorkflows() {

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -86,21 +86,7 @@ export class BrowserProfilesDetail extends BtrixElement {
       this.profile.resource.replicas.length > 0;
     const none = html`<span class="text-neutral-400">${msg("None")}</span>`;
 
-    return html`<div class="mb-7">
-        <a
-          class="text-sm font-medium text-neutral-500 hover:text-neutral-600"
-          href=${`${this.navigate.orgBasePath}/browser-profiles`}
-          @click=${this.navigate.link}
-        >
-          <sl-icon
-            name="arrow-left"
-            class="inline-block align-middle"
-          ></sl-icon>
-          <span class="inline-block align-middle"
-            >${msg("Back to Browser Profiles")}</span
-          >
-        </a>
-      </div>
+    return html`<div class="mb-7">${this.renderBreadcrumbs()}</div>
 
       <header class="mb-3 items-center justify-between md:flex">
         <h1 class="min-w-0 flex-1 truncate text-xl font-medium leading-7">
@@ -322,6 +308,22 @@ export class BrowserProfilesDetail extends BtrixElement {
       >
         ${this.isEditDialogContentVisible ? this.renderEditProfile() : nothing}
       </btrix-dialog> `;
+  }
+
+  private renderBreadcrumbs() {
+    const breadcrumbs = [
+      html`<sl-breadcrumb-item
+        href="${this.navigate.orgBasePath}/browser-profiles"
+        @click=${this.navigate.link}
+      >
+        ${msg("Browser Profiles")}
+      </sl-breadcrumb-item>`,
+      html`<sl-breadcrumb-item>${this.profile?.name}</sl-breadcrumb-item>`,
+    ];
+
+    return html`
+      <sl-breadcrumb> ${breadcrumbs.map((bc) => bc)} </sl-breadcrumb>
+    `;
   }
 
   private renderCrawlWorkflows() {

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -15,6 +15,7 @@ import {
   SortDirection,
   type SortValues,
 } from "@/components/ui/table/table-header-cell";
+import { pageHeader } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -94,35 +95,30 @@ export class BrowserProfilesList extends BtrixElement {
   }
 
   render() {
-    return html`<header>
-        <div
-          class="mb-3 mt-7 flex flex-wrap justify-between gap-2 border-b pb-3"
-        >
-          <h1 class="mb-2 text-xl font-semibold leading-8 md:mb-0">
-            ${msg("Browser Profiles")}
-          </h1>
-          ${when(
-            this.isCrawler,
-            () => html`
-              <sl-button
-                variant="primary"
-                size="small"
-                ?disabled=${isArchivingDisabled(this.org)}
-                @click=${() => {
-                  this.dispatchEvent(
-                    new CustomEvent("select-new-dialog", {
-                      detail: "browser-profile",
-                    }) as SelectNewDialogEvent,
-                  );
-                }}
-              >
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("New Browser Profile")}
-              </sl-button>
-            `,
-          )}
-        </div>
-      </header>
+    return html`${pageHeader(
+        msg("Browser Profiles"),
+        when(
+          this.isCrawler,
+          () => html`
+            <sl-button
+              variant="primary"
+              size="small"
+              ?disabled=${isArchivingDisabled(this.org)}
+              @click=${() => {
+                this.dispatchEvent(
+                  new CustomEvent("select-new-dialog", {
+                    detail: "browser-profile",
+                  }) as SelectNewDialogEvent,
+                );
+              }}
+            >
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              ${msg("New Browser Profile")}
+            </sl-button>
+          `,
+        ),
+        tw`mb-3`,
+      )}
       <div class="pb-1">${this.renderTable()}</div>`;
   }
 

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -95,7 +95,9 @@ export class BrowserProfilesList extends BtrixElement {
 
   render() {
     return html`<header>
-        <div class="mb-3 flex flex-wrap justify-between gap-2 border-b pb-3">
+        <div
+          class="mb-3 mt-7 flex flex-wrap justify-between gap-2 border-b pb-3"
+        >
           <h1 class="mb-2 text-xl font-semibold leading-8 md:mb-0">
             ${msg("Browser Profiles")}
           </h1>

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -7,6 +7,7 @@ import queryString from "query-string";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { BrowserConnectionChange } from "@/features/browser-profiles/profile-browser";
+import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
 import { isApiError } from "@/utils/api";
 
 /**
@@ -148,41 +149,32 @@ export class BrowserProfilesNew extends BtrixElement {
   }
 
   private renderBreadcrumbs() {
-    const breadcrumbs = [
-      html`<sl-breadcrumb-item
-        href="${this.navigate.orgBasePath}/browser-profiles"
-        @click=${this.navigate.link}
-      >
-        ${msg("Browser Profiles")}
-      </sl-breadcrumb-item>`,
+    const breadcrumbs: Breadcrumb[] = [
+      {
+        href: `${this.navigate.orgBasePath}/browser-profiles`,
+        content: msg("Browser Profiles"),
+      },
     ];
 
     if (this.browserParams.profileId) {
       breadcrumbs.push(
-        html`<sl-breadcrumb-item
-          href="${this.navigate.orgBasePath}/browser-profiles/profile/${this
-            .browserParams.profileId}"
-          @click=${this.navigate.link}
-        >
-          ${this.browserParams.name
+        {
+          href: `${this.navigate.orgBasePath}/browser-profiles/profile/${this.browserParams.profileId}`,
+          content: this.browserParams.name
             ? this.browserParams.name
-            : msg("Browser Profile")}
-        </sl-breadcrumb-item>`,
-        html`<sl-breadcrumb-item
-          >${msg("Duplicate Profile")}</sl-breadcrumb-item
-        >`,
+            : msg("Browser Profile"),
+        },
+        {
+          content: msg("Duplicate Profile"),
+        },
       );
     } else {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item
-          >${msg("New Browser Profile")}</sl-breadcrumb-item
-        >`,
-      );
+      breadcrumbs.push({
+        content: msg("New Browser Profile"),
+      });
     }
 
-    return html`
-      <sl-breadcrumb>${breadcrumbs.map((bc) => bc)}</sl-breadcrumb>
-    `;
+    return pageBreadcrumbs(breadcrumbs);
   }
 
   private async onBrowserError() {

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -165,7 +165,7 @@ export class BrowserProfilesNew extends BtrixElement {
           @click=${this.navigate.link}
         >
           ${this.browserParams.name
-            ? msg(this.browserParams.name)
+            ? this.browserParams.name
             : msg("Browser Profile")}
         </sl-breadcrumb-item>`,
         html`<sl-breadcrumb-item

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -56,25 +56,7 @@ export class BrowserProfilesNew extends BtrixElement {
 
   render() {
     return html`
-      <div class="mb-7">
-        <a
-          class="text-sm font-medium text-neutral-500 hover:text-neutral-600"
-          href=${this.browserParams.profileId
-            ? `${this.navigate.orgBasePath}/browser-profiles/profile/${this.browserParams.profileId}`
-            : `${this.navigate.orgBasePath}/browser-profiles`}
-          @click=${this.navigate.link}
-        >
-          <sl-icon
-            name="arrow-left"
-            class="inline-block align-middle"
-          ></sl-icon>
-          <span class="inline-block align-middle"
-            >${this.browserParams.profileId
-              ? msg("Back to Profile")
-              : msg("Back to Browser Profiles")}</span
-          >
-        </a>
-      </div>
+      <div class="mb-7">${this.renderBreadcrumbs()}</div>
 
       <header class="mb-3">
         <h1 class="min-w-0 flex-1 truncate text-xl font-medium leading-7">
@@ -162,6 +144,44 @@ export class BrowserProfilesNew extends BtrixElement {
           </sl-button>
         </div>
       </btrix-dialog>
+    `;
+  }
+
+  private renderBreadcrumbs() {
+    const breadcrumbs = [
+      html`<sl-breadcrumb-item
+        href="${this.navigate.orgBasePath}/browser-profiles"
+        @click=${this.navigate.link}
+      >
+        ${msg("Browser Profiles")}
+      </sl-breadcrumb-item>`,
+    ];
+
+    if (this.browserParams.profileId) {
+      breadcrumbs.push(
+        html`<sl-breadcrumb-item
+          href="${this.navigate.orgBasePath}/browser-profiles/profile/${this
+            .browserParams.profileId}"
+          @click=${this.navigate.link}
+        >
+          ${this.browserParams.name
+            ? msg(this.browserParams.name)
+            : msg("Browser Profile")}
+        </sl-breadcrumb-item>`,
+        html`<sl-breadcrumb-item
+          >${msg("Duplicate Profile")}</sl-breadcrumb-item
+        >`,
+      );
+    } else {
+      breadcrumbs.push(
+        html`<sl-breadcrumb-item
+          >${msg("New Browser Profile")}</sl-breadcrumb-item
+        >`,
+      );
+    }
+
+    return html`
+      <sl-breadcrumb>${breadcrumbs.map((bc) => bc)}</sl-breadcrumb>
     `;
   }
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -10,6 +10,7 @@ import queryString from "query-string";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { PageChangeEvent } from "@/components/ui/pagination";
+import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -91,7 +92,7 @@ export class CollectionDetail extends BtrixElement {
   }
 
   render() {
-    return html`${this.renderHeader()}
+    return html` <div class="mb-7">${this.renderBreadcrumbs()}</div>
       <header class="items-center gap-2 pb-3 md:flex">
         <div class="mb-2 flex w-full items-center gap-2 md:mb-0">
           ${this.collection?.isPublic
@@ -351,43 +352,33 @@ export class CollectionDetail extends BtrixElement {
       </section>`;
   };
 
-  private readonly renderHeader = () => {
-    const breadcrumbs = [
-      html`<sl-breadcrumb-item
-        href=${`${this.navigate.orgBasePath}/collections`}
-        @click=${this.navigate.link}
-      >
-        ${msg("Collections")}
-      </sl-breadcrumb-item>`,
+  private readonly renderBreadcrumbs = () => {
+    const breadcrumbs: Breadcrumb[] = [
+      {
+        href: `${this.navigate.orgBasePath}/collections`,
+        content: msg("Collections"),
+      },
     ];
 
     if (this.collection) {
       if (this.collectionTab) {
         breadcrumbs.push(
-          html`<sl-breadcrumb-item
-            href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}`}
-            @click=${this.navigate.link}
-          >
-            ${this.collection.name}
-          </sl-breadcrumb-item>`,
-          html`<sl-breadcrumb-item>
-            ${this.tabLabels[this.collectionTab].text}
-          </sl-breadcrumb-item>`,
+          {
+            href: `${this.navigate.orgBasePath}/collections/view/${this.collectionId}`,
+            content: this.collection.name,
+          },
+          {
+            content: this.tabLabels[this.collectionTab].text,
+          },
         );
       } else {
-        breadcrumbs.push(
-          html`<sl-breadcrumb-item>
-            ${this.collection.name}
-          </sl-breadcrumb-item>`,
-        );
+        breadcrumbs.push({
+          content: this.collection.name,
+        });
       }
     }
 
-    return html`
-      <div class="mb-7">
-        <sl-breadcrumb> ${breadcrumbs.map((bc) => bc)} </sl-breadcrumb>
-      </div>
-    `;
+    return pageBreadcrumbs(breadcrumbs);
   };
 
   private readonly renderTabs = () => {

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -680,7 +680,7 @@ export class CollectionDetail extends BtrixElement {
     idx: number,
   ) => html`
     <btrix-archived-item-list-item
-      href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${item.type}/${item.id}?collName=${window.encodeURIComponent(this.collection?.name || "")}`}
+      href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${item.type}/${item.id}`}
       .item=${item}
     >
       ${this.isCrawler

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -656,7 +656,7 @@ export class CollectionDetail extends BtrixElement {
     idx: number,
   ) => html`
     <btrix-archived-item-list-item
-      href=${`/orgs/${this.orgId}/items/${item.type}/${item.id}?collectionId=${this.collectionId}`}
+      href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${item.type}/${item.id}`}
       .item=${item}
     >
       ${this.isCrawler

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -351,20 +351,44 @@ export class CollectionDetail extends BtrixElement {
       </section>`;
   };
 
-  private readonly renderHeader = () => html`
-    <nav class="mb-7">
-      <a
-        class="text-sm font-medium text-gray-600 hover:text-gray-800"
+  private readonly renderHeader = () => {
+    const breadcrumbs = [
+      html`<sl-breadcrumb-item
         href=${`${this.navigate.orgBasePath}/collections`}
         @click=${this.navigate.link}
       >
-        <sl-icon name="arrow-left" class="inline-block align-middle"></sl-icon>
-        <span class="inline-block align-middle"
-          >${msg("Back to Collections")}</span
-        >
-      </a>
-    </nav>
-  `;
+        ${msg("Collections")}
+      </sl-breadcrumb-item>`,
+    ];
+
+    if (this.collection) {
+      if (this.collectionTab) {
+        breadcrumbs.push(
+          html`<sl-breadcrumb-item
+            href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}`}
+            @click=${this.navigate.link}
+          >
+            ${this.collection.name}
+          </sl-breadcrumb-item>`,
+          html`<sl-breadcrumb-item>
+            ${this.tabLabels[this.collectionTab].text}
+          </sl-breadcrumb-item>`,
+        );
+      } else {
+        breadcrumbs.push(
+          html`<sl-breadcrumb-item>
+            ${this.collection.name}
+          </sl-breadcrumb-item>`,
+        );
+      }
+    }
+
+    return html`
+      <div class="mb-7">
+        <sl-breadcrumb> ${breadcrumbs.map((bc) => bc)} </sl-breadcrumb>
+      </div>
+    `;
+  };
 
   private readonly renderTabs = () => {
     return html`
@@ -656,7 +680,7 @@ export class CollectionDetail extends BtrixElement {
     idx: number,
   ) => html`
     <btrix-archived-item-list-item
-      href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${item.type}/${item.id}`}
+      href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${item.type}/${item.id}?collName=${window.encodeURIComponent(this.collection?.name || "")}`}
       .item=${item}
     >
       ${this.isCrawler

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -119,7 +119,7 @@ export class CollectionsList extends LiteElement {
   render() {
     return html`
       <header class="contents">
-        <div class="mb-4 flex w-full justify-between">
+        <div class="mb-3 mt-7 flex w-full justify-between">
           <h1 class="text-xl font-semibold leading-8">${msg("Collections")}</h1>
           ${when(
             this.isCrawler,

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -12,12 +12,14 @@ import type { SelectNewDialogEvent } from ".";
 
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import type { CollectionSavedEvent } from "@/features/collections/collection-metadata-dialog";
+import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import type { Collection, CollectionSearchValues } from "@/types/collection";
 import type { UnderlyingFunction } from "@/types/utils";
 import { isApiError } from "@/utils/api";
 import LiteElement, { html } from "@/utils/LiteElement";
 import { getLocale } from "@/utils/localization";
+import { tw } from "@/utils/tailwind";
 import noCollectionsImg from "~assets/images/no-collections-found.webp";
 
 type Collections = APIPaginatedList<Collection>;
@@ -118,10 +120,10 @@ export class CollectionsList extends LiteElement {
 
   render() {
     return html`
-      <header class="contents">
-        <div class="mb-3 mt-7 flex w-full justify-between">
-          <h1 class="text-xl font-semibold leading-8">${msg("Collections")}</h1>
-          ${when(
+      <div class="contents">
+        ${pageHeader(
+          msg("Collections"),
+          when(
             this.isCrawler,
             () => html`
               <sl-button
@@ -134,9 +136,10 @@ export class CollectionsList extends LiteElement {
                 ${msg("New Collection")}
               </sl-button>
             `,
-          )}
-        </div>
-      </header>
+          ),
+          tw`border-b-transparent`,
+        )}
+      </div>
 
       <link rel="preload" as="image" href=${noCollectionsImg} />
       ${when(this.fetchErrorStatusCode, this.renderFetchError, () =>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -7,6 +7,7 @@ import { when } from "lit/directives/when.js";
 
 import type { SelectNewDialogEvent } from ".";
 
+import { pageHeader } from "@/layouts/pageHeader";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import LiteElement, { html } from "@/utils/LiteElement";
 
@@ -64,69 +65,69 @@ export class Dashboard extends LiteElement {
       this.metrics.storageQuotaBytes > 0 &&
       this.metrics.storageUsedBytes >= this.metrics.storageQuotaBytes;
 
-    return html`<header
-        class="mb-6 mt-7 flex items-center justify-end gap-2 border-b pb-3"
-      >
-        <h1 class="mr-auto min-w-0 text-xl font-semibold leading-8">
-          ${this.userOrg?.name}
-        </h1>
-        ${when(
-          this.appState.isAdmin,
-          () =>
-            html` <sl-icon-button
-              href=${`${this.orgBasePath}/settings`}
-              class="size-8 text-lg"
-              name="gear"
-              label=${msg("Edit org settings")}
-              @click=${this.navLink}
-            ></sl-icon-button>`,
-        )}
-        ${when(
-          this.isCrawler,
-          () =>
-            html` <sl-dropdown
-              distance="4"
-              placement="bottom-end"
-              @sl-select=${(e: SlSelectEvent) => {
-                this.dispatchEvent(
-                  new CustomEvent("select-new-dialog", {
-                    detail: e.detail.item.value,
-                  }) as SelectNewDialogEvent,
-                );
-              }}
-            >
-              <sl-button
-                slot="trigger"
-                size="small"
-                variant="primary"
-                caret
-                ?disabled=${this.org?.readOnly}
+    return html`
+      ${pageHeader(
+        this.userOrg?.name,
+        html`
+          ${when(
+            this.appState.isAdmin,
+            () =>
+              html` <sl-icon-button
+                href=${`${this.orgBasePath}/settings`}
+                class="size-8 text-base"
+                name="gear"
+                label=${msg("Edit org settings")}
+                @click=${this.navLink}
+              ></sl-icon-button>`,
+          )}
+          ${when(
+            this.isCrawler,
+            () =>
+              html` <sl-dropdown
+                distance="4"
+                placement="bottom-end"
+                @sl-select=${(e: SlSelectEvent) => {
+                  this.dispatchEvent(
+                    new CustomEvent("select-new-dialog", {
+                      detail: e.detail.item.value,
+                    }) as SelectNewDialogEvent,
+                  );
+                }}
               >
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("Create New...")}
-              </sl-button>
-              <sl-menu>
-                <sl-menu-item value="workflow"
-                  >${msg("Crawl Workflow")}</sl-menu-item
+                <sl-button
+                  slot="trigger"
+                  size="small"
+                  variant="primary"
+                  caret
+                  ?disabled=${this.org?.readOnly}
                 >
-                <sl-menu-item
-                  value="upload"
-                  ?disabled=${!this.metrics || quotaReached}
-                  >${msg("Upload")}</sl-menu-item
-                >
-                <sl-menu-item value="collection">
-                  ${msg("Collection")}
-                </sl-menu-item>
-                <sl-menu-item
-                  value="browser-profile"
-                  ?disabled=${!this.metrics || quotaReached}
-                >
-                  ${msg("Browser Profile")}
-                </sl-menu-item>
-              </sl-menu>
-            </sl-dropdown>`,
-        )}
-      </header>
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  ${msg("Create New...")}
+                </sl-button>
+                <sl-menu>
+                  <sl-menu-item value="workflow"
+                    >${msg("Crawl Workflow")}</sl-menu-item
+                  >
+                  <sl-menu-item
+                    value="upload"
+                    ?disabled=${!this.metrics || quotaReached}
+                    >${msg("Upload")}</sl-menu-item
+                  >
+                  <sl-menu-item value="collection">
+                    ${msg("Collection")}
+                  </sl-menu-item>
+                  <sl-menu-item
+                    value="browser-profile"
+                    ?disabled=${!this.metrics || quotaReached}
+                  >
+                    ${msg("Browser Profile")}
+                  </sl-menu-item>
+                </sl-menu>
+              </sl-dropdown>`,
+          )}
+        `,
+        "mb-6",
+      )}
       <main>
         <div class="mb-10 flex flex-col gap-6 md:flex-row">
           ${this.renderCard(
@@ -249,7 +250,8 @@ export class Dashboard extends LiteElement {
             <btrix-usage-history-table></btrix-usage-history-table>
           </btrix-details>
         </section>
-      </main> `;
+      </main>
+    `;
   }
 
   private renderStorageMeter(metrics: Metrics) {

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -65,7 +65,7 @@ export class Dashboard extends LiteElement {
       this.metrics.storageUsedBytes >= this.metrics.storageQuotaBytes;
 
     return html`<header
-        class="mb-7 flex items-center justify-end gap-2 border-b pb-3"
+        class="mb-6 mt-7 flex items-center justify-end gap-2 border-b pb-3"
       >
         <h1 class="mr-auto min-w-0 text-xl font-semibold leading-8">
           ${this.userOrg?.name}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -49,6 +49,7 @@ export type OrgParams = {
   home: Record<string, never>;
   workflows: {
     workflowId?: string;
+    itemId?: string;
     jobType?: JobType;
     new?: ResourceName;
   };
@@ -74,6 +75,8 @@ export type OrgParams = {
   };
   collections: {
     collectionId?: string;
+    itemId?: string;
+    itemType?: string;
     collectionTab?: string;
   };
   settings: {
@@ -475,8 +478,6 @@ export class Org extends LiteElement {
 
       return html`<btrix-archived-item-detail
         crawlId=${params.itemId}
-        collectionId=${params.collectionId || ""}
-        workflowId=${params.workflowId || ""}
         itemType=${params.itemType || "crawl"}
         ?isCrawler=${this.appState.isCrawler}
       ></btrix-archived-item-detail>`;
@@ -497,9 +498,18 @@ export class Org extends LiteElement {
     const workflowId = params.workflowId;
 
     if (workflowId) {
+      if (params.itemId) {
+        return html`<btrix-archived-item-detail
+          crawlId=${params.itemId}
+          workflowId=${workflowId}
+          itemType="crawl"
+          ?isCrawler=${this.appState.isCrawler}
+        ></btrix-archived-item-detail>`;
+      }
+
       return html`
         <btrix-workflow-detail
-          class="col-span-5 mt-6"
+          class="col-span-5"
           workflowId=${workflowId}
           openDialogName=${this.viewStateData?.dialog}
           ?isEditing=${isEditing}
@@ -561,6 +571,14 @@ export class Org extends LiteElement {
     const params = this.params as OrgParams["collections"];
 
     if (params.collectionId) {
+      if (params.itemId) {
+        return html`<btrix-archived-item-detail
+          crawlId=${params.itemId}
+          collectionId=${params.collectionId}
+          itemType=${params.itemType}
+          ?isCrawler=${this.appState.isCrawler}
+        ></btrix-archived-item-detail>`;
+      }
       return html`<btrix-collection-detail
         collectionId=${params.collectionId}
         collectionTab=${(params.collectionTab as CollectionTab | undefined) ||

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -476,8 +476,10 @@ export class Org extends LiteElement {
         ></btrix-archived-item-qa>`;
       }
 
-      return html`<btrix-archived-item-detail
+      return html` <btrix-archived-item-detail
         crawlId=${params.itemId}
+        collectionId=${params.collectionId || ""}
+        workflowId=${params.workflowId || ""}
         itemType=${params.itemType || "crawl"}
         ?isCrawler=${this.appState.isCrawler}
       ></btrix-archived-item-detail>`;

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -242,7 +242,7 @@ export class Org extends LiteElement {
         <main
           class="${noMaxWidth
             ? "w-full"
-            : "w-full max-w-screen-desktop pt-7"} mx-auto box-border flex flex-1 flex-col p-3"
+            : "w-full max-w-screen-desktop"} mx-auto box-border flex flex-1 flex-col p-3"
           aria-labelledby="${this.orgTab}-tab"
         >
           ${when(this.userOrg, (userOrg) =>

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -575,7 +575,7 @@ export class Org extends LiteElement {
         return html`<btrix-archived-item-detail
           crawlId=${params.itemId}
           collectionId=${params.collectionId}
-          itemType=${params.itemType}
+          itemType=${ifDefined(params.itemType)}
           ?isCrawler=${this.appState.isCrawler}
         ></btrix-archived-item-detail>`;
       }

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -1,7 +1,7 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlInput } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
-import { html, unsafeCSS, type PropertyValues } from "lit";
+import { html, nothing, unsafeCSS, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -107,8 +107,20 @@ export class OrgSettings extends BtrixElement {
   }
 
   render() {
-    return html`<header class="mb-3 mt-7">
+    return html`<header
+        class="mb-5 mt-7 flex items-end justify-between border-b pb-3"
+      >
         <h1 class="text-xl font-semibold leading-8">${msg("Org Settings")}</h1>
+        ${this.userInfo?.orgs && this.userInfo.orgs.length > 1 && this.userOrg
+          ? html`
+              <div class="text-neutral-400">
+                ${msg(
+                  html`Viewing
+                    <strong class="font-medium">${this.userOrg.name}</strong>`,
+                )}
+              </div>
+            `
+          : nothing}
       </header>
 
       <btrix-tab-list activePanel=${this.activePanel} hideIndicator>

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -1,7 +1,7 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlInput } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
-import { html, nothing, unsafeCSS, type PropertyValues } from "lit";
+import { html, unsafeCSS, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -12,12 +12,14 @@ import stylesheet from "./settings.stylesheet.css";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { APIUser } from "@/index";
 import { columns } from "@/layouts/columns";
+import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 import { AccessCode, isAdmin, isCrawler } from "@/utils/orgs";
 import slugifyStrict from "@/utils/slugify";
 import { AppStateService } from "@/utils/state";
+import { tw } from "@/utils/tailwind";
 import { formatAPIUser } from "@/utils/user";
 
 import "./components/billing";
@@ -107,21 +109,21 @@ export class OrgSettings extends BtrixElement {
   }
 
   render() {
-    return html`<header
-        class="mb-5 mt-7 flex items-end justify-between border-b pb-3"
-      >
-        <h1 class="text-xl font-semibold leading-8">${msg("Org Settings")}</h1>
-        ${this.userInfo?.orgs && this.userInfo.orgs.length > 1 && this.userOrg
-          ? html`
-              <div class="text-neutral-400">
-                ${msg(
-                  html`Viewing
-                    <strong class="font-medium">${this.userOrg.name}</strong>`,
-                )}
-              </div>
-            `
-          : nothing}
-      </header>
+    return html` ${pageHeader(
+        msg("Org Settings"),
+        when(
+          this.userInfo?.orgs && this.userInfo.orgs.length > 1 && this.userOrg,
+          (userOrg) => html`
+            <div class="text-neutral-400">
+              ${msg(
+                html`Viewing
+                  <strong class="font-medium">${userOrg.name}</strong>`,
+              )}
+            </div>
+          `,
+        ),
+        tw`mb-3 lg:mb-5`,
+      )}
 
       <btrix-tab-list activePanel=${this.activePanel} hideIndicator>
         <header slot="header" class="flex h-7 items-end justify-between">

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -107,7 +107,7 @@ export class OrgSettings extends BtrixElement {
   }
 
   render() {
-    return html`<header class="mb-5">
+    return html`<header class="mb-3 mt-7">
         <h1 class="text-xl font-semibold leading-8">${msg("Org Settings")}</h1>
       </header>
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_MAX_SCALE,
   inactiveCrawlStates,
   isActive,
+  renderName,
 } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import LiteElement, { html } from "@/utils/LiteElement";
@@ -406,7 +407,7 @@ export class WorkflowDetail extends LiteElement {
               href="${this.orgBasePath}/workflows/crawl/${workflowId}"
               @click=${this.navLink}
             >
-              ${this.renderName()}
+              ${renderName(this.workflow)}
             </sl-breadcrumb-item>`
           : html`<sl-breadcrumb-item>
               ${this.renderName()}
@@ -417,7 +418,13 @@ export class WorkflowDetail extends LiteElement {
     if (this.isEditing) {
       breadcrumbs.push(
         html`<sl-breadcrumb-item>
-          ${msg("Edit Workflow Settings")}
+          ${msg("Edit Settings")}
+        </sl-breadcrumb-item>`,
+      );
+    } else if (this.activePanel) {
+      breadcrumbs.push(
+        html`<sl-breadcrumb-item>
+          ${this.tabLabels[this.activePanel]}
         </sl-breadcrumb-item>`,
       );
     }
@@ -875,7 +882,7 @@ export class WorkflowDetail extends LiteElement {
                 this.crawls!.items.map(
                   (crawl: Crawl) =>
                     html` <btrix-crawl-list-item
-                      href=${`/orgs/${this.appState.orgSlug}/items/crawl/${crawl.id}?workflowId=${this.workflowId}`}
+                      href=${`${this.orgBasePath}/workflows/crawl/${this.workflowId}/items/${crawl.id}`}
                       .crawl=${crawl}
                     >
                       ${when(

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -22,13 +22,13 @@ import { type IntersectEvent } from "@/components/utils/observable";
 import type { CrawlLog } from "@/features/archived-items/crawl-logs";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
+import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
 import type { APIPaginatedList } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import {
   DEFAULT_MAX_SCALE,
   inactiveCrawlStates,
   isActive,
-  renderName,
 } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import LiteElement, { html } from "@/utils/LiteElement";
@@ -269,7 +269,7 @@ export class WorkflowDetail extends LiteElement {
 
     return html`
       <div class="grid grid-cols-1 gap-7">
-        ${this.renderHeader()}
+        <div class="col-span-1">${this.renderBreadcrumbs()}</div>
 
         <header class="col-span-1 flex flex-wrap gap-2">
           <btrix-detail-page-title
@@ -390,50 +390,38 @@ export class WorkflowDetail extends LiteElement {
     `;
   }
 
-  private renderHeader(workflowId?: string) {
-    const breadcrumbs = [
-      html`<sl-breadcrumb-item
-        href="${this.orgBasePath}/workflows/crawls"
-        @click=${this.navLink}
-      >
-        ${msg("Crawl Workflows")}
-      </sl-breadcrumb-item>`,
+  private renderBreadcrumbs() {
+    const breadcrumbs: Breadcrumb[] = [
+      {
+        href: `${this.orgBasePath}/workflows/crawls`,
+        content: msg("Crawl Workflows"),
+      },
     ];
 
     if (this.workflow) {
       breadcrumbs.push(
         this.isEditing
-          ? html`<sl-breadcrumb-item
-              href="${this.orgBasePath}/workflows/crawl/${workflowId}"
-              @click=${this.navLink}
-            >
-              ${renderName(this.workflow)}
-            </sl-breadcrumb-item>`
-          : html`<sl-breadcrumb-item>
-              ${this.renderName()}
-            </sl-breadcrumb-item>`,
+          ? {
+              href: `${this.orgBasePath}/workflows/crawl/${this.workflowId}`,
+              content: this.renderName(),
+            }
+          : {
+              content: this.renderName(),
+            },
       );
     }
 
     if (this.isEditing) {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item>
-          ${msg("Edit Settings")}
-        </sl-breadcrumb-item>`,
-      );
+      breadcrumbs.push({
+        content: msg("Edit Settings"),
+      });
     } else if (this.activePanel) {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item>
-          ${this.tabLabels[this.activePanel]}
-        </sl-breadcrumb-item>`,
-      );
+      breadcrumbs.push({
+        content: this.tabLabels[this.activePanel],
+      });
     }
 
-    return html`
-      <sl-breadcrumb class="col-span-1">
-        ${breadcrumbs.map((bc) => bc)}
-      </sl-breadcrumb>
-    `;
+    return pageBreadcrumbs(breadcrumbs);
   }
 
   private readonly renderTabList = () => html`
@@ -565,7 +553,7 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private readonly renderEditor = () => html`
-    ${this.renderHeader(this.workflow!.id)}
+    <div class="col-span-1">${this.renderBreadcrumbs()}</div>
 
     <header>
       <h2 class="break-all text-xl font-semibold leading-10">

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -271,30 +271,32 @@ export class WorkflowDetail extends LiteElement {
       <div class="grid grid-cols-1 gap-7">
         <div class="col-span-1">${this.renderBreadcrumbs()}</div>
 
-        <header class="col-span-1 flex flex-wrap gap-2">
-          <btrix-detail-page-title
-            .item=${this.workflow}
-          ></btrix-detail-page-title>
-          ${when(
-            this.workflow?.inactive,
-            () => html`
-              <btrix-badge class="inline-block align-middle" variant="warning"
-                >${msg("Inactive")}</btrix-badge
-              >
-            `,
-          )}
-
-          <div class="flex-0 ml-auto flex flex-wrap justify-end gap-2">
+        <div>
+          <header class="col-span-1 mb-3 flex flex-wrap gap-2">
+            <btrix-detail-page-title
+              .item=${this.workflow}
+            ></btrix-detail-page-title>
             ${when(
-              this.isCrawler && this.workflow && !this.workflow.inactive,
-              this.renderActions,
+              this.workflow?.inactive,
+              () => html`
+                <btrix-badge class="inline-block align-middle" variant="warning"
+                  >${msg("Inactive")}</btrix-badge
+                >
+              `,
             )}
-          </div>
-        </header>
 
-        <section class="col-span-1 rounded-lg border px-4 py-2">
-          ${this.renderDetails()}
-        </section>
+            <div class="flex-0 ml-auto flex flex-wrap justify-end gap-2">
+              ${when(
+                this.isCrawler && this.workflow && !this.workflow.inactive,
+                this.renderActions,
+              )}
+            </div>
+          </header>
+
+          <section class="col-span-1 rounded-lg border px-4 py-2">
+            ${this.renderDetails()}
+          </section>
+        </div>
 
         ${when(this.workflow, this.renderTabList, this.renderLoading)}
       </div>
@@ -399,26 +401,20 @@ export class WorkflowDetail extends LiteElement {
     ];
 
     if (this.workflow) {
-      breadcrumbs.push(
-        this.isEditing
-          ? {
-              href: `${this.orgBasePath}/workflows/crawl/${this.workflowId}`,
-              content: this.renderName(),
-            }
-          : {
-              content: this.renderName(),
-            },
-      );
-    }
+      breadcrumbs.push({
+        href: `${this.orgBasePath}/workflows/crawl/${this.workflowId}`,
+        content: this.renderName(),
+      });
 
-    if (this.isEditing) {
-      breadcrumbs.push({
-        content: msg("Edit Settings"),
-      });
-    } else if (this.activePanel) {
-      breadcrumbs.push({
-        content: this.tabLabels[this.activePanel],
-      });
+      if (this.isEditing) {
+        breadcrumbs.push({
+          content: msg("Edit Settings"),
+        });
+      } else if (this.activePanel) {
+        breadcrumbs.push({
+          content: this.tabLabels[this.activePanel],
+        });
+      }
     }
 
     return pageBreadcrumbs(breadcrumbs);

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1,6 +1,6 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlSelect } from "@shoelace-style/shoelace";
-import type { PropertyValues, TemplateResult } from "lit";
+import { type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
@@ -390,26 +390,42 @@ export class WorkflowDetail extends LiteElement {
   }
 
   private renderHeader(workflowId?: string) {
+    const breadcrumbs = [
+      html`<sl-breadcrumb-item
+        href="${this.orgBasePath}/workflows/crawls"
+        @click=${this.navLink}
+      >
+        ${msg("Crawl Workflows")}
+      </sl-breadcrumb-item>`,
+    ];
+
+    if (this.workflow) {
+      breadcrumbs.push(
+        this.isEditing
+          ? html`<sl-breadcrumb-item
+              href="${this.orgBasePath}/workflows/crawl/${workflowId}"
+              @click=${this.navLink}
+            >
+              ${this.renderName()}
+            </sl-breadcrumb-item>`
+          : html`<sl-breadcrumb-item>
+              ${this.renderName()}
+            </sl-breadcrumb-item>`,
+      );
+    }
+
+    if (this.isEditing) {
+      breadcrumbs.push(
+        html`<sl-breadcrumb-item>
+          ${msg("Edit Workflow Settings")}
+        </sl-breadcrumb-item>`,
+      );
+    }
+
     return html`
-      <nav class="col-span-1">
-        <a
-          class="text-sm font-medium text-gray-600 hover:text-gray-800"
-          href=${`${this.orgBasePath}/workflows${
-            workflowId ? `/crawl/${workflowId}` : "/crawls"
-          }`}
-          @click=${this.navLink}
-        >
-          <sl-icon
-            name="arrow-left"
-            class="inline-block align-middle"
-          ></sl-icon>
-          <span class="inline-block align-middle"
-            >${workflowId
-              ? msg(html`Back to ${this.renderName()}`)
-              : msg("Back to Crawl Workflows")}</span
-          >
-        </a>
-      </nav>
+      <sl-breadcrumb class="col-span-1">
+        ${breadcrumbs.map((bc) => bc)}
+      </sl-breadcrumb>
     `;
   }
 

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -13,10 +13,12 @@ import type { SelectNewDialogEvent } from ".";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { type SelectEvent } from "@/components/ui/search-combobox";
+import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import LiteElement, { html } from "@/utils/LiteElement";
 import { isArchivingDisabled } from "@/utils/orgs";
+import { tw } from "@/utils/tailwind";
 
 type SearchFields = "name" | "firstSeed";
 type SortField = "lastRun" | "name" | "firstSeed" | "created" | "modified";
@@ -186,48 +188,48 @@ export class WorkflowsList extends LiteElement {
 
   render() {
     return html`
-      <header class="contents">
-        <div class="mb-3 mt-7 flex w-full justify-end gap-2">
-          <h1 class="mr-auto text-xl font-semibold leading-8">
-            ${msg("Crawl Workflows")}
-          </h1>
-
-          ${when(
-            this.appState.isAdmin,
-            () =>
-              html` <sl-icon-button
-                href=${`${this.orgBasePath}/settings/crawling-defaults`}
-                class="size-8 text-lg"
-                name="gear"
-                label=${msg("Edit org crawling settings")}
-                @click=${this.navLink}
-              ></sl-icon-button>`,
-          )}
-          ${when(
-            this.appState.isCrawler,
-            () => html`
-              <sl-button
-                variant="primary"
-                size="small"
-                ?disabled=${this.org?.readOnly}
-                @click=${() => {
-                  this.dispatchEvent(
-                    new CustomEvent("select-new-dialog", {
-                      detail: "workflow",
-                    }) as SelectNewDialogEvent,
-                  );
-                }}
-              >
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("New Workflow")}
-              </sl-button>
-            `,
-          )}
-        </div>
+      <div class="contents">
+        ${pageHeader(
+          msg("Crawl Workflows"),
+          html`
+            ${when(
+              this.appState.isAdmin,
+              () =>
+                html` <sl-icon-button
+                  href=${`${this.orgBasePath}/settings/crawling-defaults`}
+                  class="size-8 text-lg"
+                  name="gear"
+                  label=${msg("Edit org crawling settings")}
+                  @click=${this.navLink}
+                ></sl-icon-button>`,
+            )}
+            ${when(
+              this.appState.isCrawler,
+              () => html`
+                <sl-button
+                  variant="primary"
+                  size="small"
+                  ?disabled=${this.org?.readOnly}
+                  @click=${() => {
+                    this.dispatchEvent(
+                      new CustomEvent("select-new-dialog", {
+                        detail: "workflow",
+                      }) as SelectNewDialogEvent,
+                    );
+                  }}
+                >
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  ${msg("New Workflow")}
+                </sl-button>
+              `,
+            )}
+          `,
+          tw`border-b-transparent`,
+        )}
         <div class="sticky top-2 z-10 mb-3 rounded-lg border bg-neutral-50 p-4">
           ${this.renderControls()}
         </div>
-      </header>
+      </div>
 
       ${when(
         this.fetchErrorStatusCode,

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -187,7 +187,7 @@ export class WorkflowsList extends LiteElement {
   render() {
     return html`
       <header class="contents">
-        <div class="mb-4 flex w-full justify-end gap-2">
+        <div class="mb-3 mt-7 flex w-full justify-end gap-2">
           <h1 class="mr-auto text-xl font-semibold leading-8">
             ${msg("Crawl Workflows")}
           </h1>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -195,13 +195,15 @@ export class WorkflowsList extends LiteElement {
             ${when(
               this.appState.isAdmin,
               () =>
-                html` <sl-icon-button
-                  href=${`${this.orgBasePath}/settings/crawling-defaults`}
-                  class="size-8 text-lg"
-                  name="gear"
-                  label=${msg("Edit org crawling settings")}
-                  @click=${this.navLink}
-                ></sl-icon-button>`,
+                html`<sl-tooltip content=${msg("Configure crawling defaults")}>
+                  <sl-icon-button
+                    href=${`${this.orgBasePath}/settings/crawling-defaults`}
+                    class="size-8 text-lg"
+                    name="gear"
+                    label=${msg("Edit org crawling settings")}
+                    @click=${this.navLink}
+                  ></sl-icon-button>
+                </sl-tooltip>`,
             )}
             ${when(
               this.appState.isCrawler,

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -76,7 +76,7 @@ export class WorkflowsNew extends LiteElement {
       },
     ];
 
-    const jobType = this.initialWorkflow.jobType || this.jobType;
+    const jobType = this.initialWorkflow?.jobType || this.jobType;
 
     if (jobType) {
       breadcrumbs.push({

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -57,37 +57,44 @@ export class WorkflowsNew extends LiteElement {
   @property({ type: Object })
   initialWorkflow?: WorkflowParams;
 
+  private readonly jobTypeLabels: Record<JobType, string> = {
+    "url-list": msg("URL List"),
+    "seed-crawl": msg("Seeded Crawl"),
+    custom: msg("Custom"),
+  };
+
   private renderHeader() {
-    const href = `${this.orgBasePath}/workflows/crawls`;
-    const label = msg("Back to Crawl Workflows");
+    const breadcrumbs = [
+      html`<sl-breadcrumb-item
+        href="${this.orgBasePath}/workflows"
+        @click=${this.navLink}
+      >
+        ${msg("Crawl Workflows")}
+      </sl-breadcrumb-item>`,
+      html`<sl-breadcrumb-item
+        href="${this.orgBasePath}/workflows?new=workflow"
+        @click=${this.navLink}
+      >
+        ${msg("New Workflow")}
+      </sl-breadcrumb-item>`,
+    ];
+
+    const jobType = this.initialWorkflow.jobType || this.jobType;
+
+    if (jobType) {
+      breadcrumbs.push(
+        html`<sl-breadcrumb-item>
+          ${this.jobTypeLabels[jobType]}
+        </sl-breadcrumb-item>`,
+      );
+    }
 
     return html`
-      <nav class="mb-5">
-        <a
-          class="text-sm font-medium text-gray-600 hover:text-gray-800"
-          href=${href}
-          @click=${(e: MouseEvent) => {
-            this.navLink(e);
-            this.jobType = undefined;
-          }}
-        >
-          <sl-icon
-            name="arrow-left"
-            class="inline-block align-middle"
-          ></sl-icon>
-          <span class="inline-block align-middle">${label}</span>
-        </a>
-      </nav>
+      <sl-breadcrumb> ${breadcrumbs.map((bc) => bc)} </sl-breadcrumb>
     `;
   }
 
   render() {
-    const jobTypeLabels: Record<JobType, string> = {
-      "url-list": msg("URL List"),
-      "seed-crawl": msg("Seeded Crawl"),
-      custom: msg("Custom"),
-    };
-
     const jobType = this.initialWorkflow?.jobType || this.jobType;
 
     if (!this.isCrawler) {
@@ -96,9 +103,9 @@ export class WorkflowsNew extends LiteElement {
 
     if (jobType) {
       return html`
-        ${this.renderHeader()}
+        <div class="mb-5">${this.renderHeader()}</div>
         <h2 class="mb-6 text-xl font-semibold">
-          ${msg(html`New Crawl Workflow &mdash; ${jobTypeLabels[jobType]}`)}
+          ${msg("New")} ${this.jobTypeLabels[jobType]}
         </h2>
         ${when(this.org, (org) => {
           const initialWorkflow = mergeDeep(

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -8,6 +8,7 @@ import type { JobType, Seed, WorkflowParams } from "./types";
 
 import type { SelectNewDialogEvent } from ".";
 
+import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
 import LiteElement, { html } from "@/utils/LiteElement";
 
 const defaultValue = {
@@ -63,35 +64,27 @@ export class WorkflowsNew extends LiteElement {
     custom: msg("Custom"),
   };
 
-  private renderHeader() {
-    const breadcrumbs = [
-      html`<sl-breadcrumb-item
-        href="${this.orgBasePath}/workflows"
-        @click=${this.navLink}
-      >
-        ${msg("Crawl Workflows")}
-      </sl-breadcrumb-item>`,
-      html`<sl-breadcrumb-item
-        href="${this.orgBasePath}/workflows?new=workflow"
-        @click=${this.navLink}
-      >
-        ${msg("New Workflow")}
-      </sl-breadcrumb-item>`,
+  private renderBreadcrumbs() {
+    const breadcrumbs: Breadcrumb[] = [
+      {
+        href: `${this.orgBasePath}/workflows`,
+        content: msg("Crawl Workflows"),
+      },
+      {
+        href: `${this.orgBasePath}/workflows?new=workflow`,
+        content: msg("New Workflow"),
+      },
     ];
 
     const jobType = this.initialWorkflow.jobType || this.jobType;
 
     if (jobType) {
-      breadcrumbs.push(
-        html`<sl-breadcrumb-item>
-          ${this.jobTypeLabels[jobType]}
-        </sl-breadcrumb-item>`,
-      );
+      breadcrumbs.push({
+        content: this.jobTypeLabels[jobType],
+      });
     }
 
-    return html`
-      <sl-breadcrumb> ${breadcrumbs.map((bc) => bc)} </sl-breadcrumb>
-    `;
+    return pageBreadcrumbs(breadcrumbs);
   }
 
   render() {
@@ -103,7 +96,7 @@ export class WorkflowsNew extends LiteElement {
 
     if (jobType) {
       return html`
-        <div class="mb-5">${this.renderHeader()}</div>
+        <div class="mb-5">${this.renderBreadcrumbs()}</div>
         <h2 class="mb-6 text-xl font-semibold">
           ${msg("New")} ${this.jobTypeLabels[jobType]}
         </h2>

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -13,9 +13,9 @@ export const ROUTES = {
   org: [
     "/orgs/:slug",
     // Org sections:
-    "(/workflows(/crawls)(/crawl/:workflowId))",
+    "(/workflows(/crawls)(/crawl/:workflowId)(/items/:itemId))",
     "(/items(/:itemType(/:itemId(/review/:qaTab))))",
-    "(/collections(/new)(/view/:collectionId(/:collectionTab)))",
+    "(/collections(/new)(/view/:collectionId(/:collectionTab(/:itemType/:itemId))))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
     "(/settings(/:settingsTab))",
   ].join(""),

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -30,6 +30,12 @@ import "@shoelace-style/shoelace/dist/components/progress-bar/progress-bar";
 import "@shoelace-style/shoelace/dist/components/progress-ring/progress-ring";
 
 import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/breadcrumb/breadcrumb"
+);
+import(
+  /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/breadcrumb-item/breadcrumb-item"
+);
+import(
   /* webpackChunkName: "shoelace" */ "@shoelace-style/shoelace/dist/components/dialog/dialog"
 );
 import(

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -1,7 +1,6 @@
 import { msg, str } from "@lit/localize";
+import clsx from "clsx";
 import { html, type TemplateResult } from "lit";
-
-import { tw } from "./tailwind";
 
 import type { ArchivedItem, CrawlState, Workflow } from "@/types/crawler";
 
@@ -46,31 +45,34 @@ export function isActive(state: CrawlState | null) {
   return state && activeCrawlStates.includes(state);
 }
 
-export function renderName(item: ArchivedItem | Workflow) {
-  if (item.name) return html`<div class=${tw`truncate`}>${item.name}</div>`;
+export function renderName(item: ArchivedItem | Workflow, className?: string) {
+  if (item.name)
+    return html`<div class=${clsx("truncate", className)}>${item.name}</div>`;
   if (item.firstSeed && item.seedCount) {
     const remainder = item.seedCount - 1;
     let nameSuffix: string | TemplateResult<1> = "";
     if (remainder) {
       if (remainder === 1) {
-        nameSuffix = html`<div class=${tw`ml-1`}>
+        nameSuffix = html`<div class="ml-1">
           ${msg(str`+${remainder} URL`)}
         </div>`;
       } else {
-        nameSuffix = html`<div class=${tw`ml-1`}>
+        nameSuffix = html`<div class="ml-1">
           ${msg(str`+${remainder} URLs`)}
         </div>`;
       }
     }
     return html`
-      <div class=${tw`inline-flex w-full overflow-hidden whitespace-nowrap`}>
-        <div class=${tw`min-w-0 truncate`}>${item.firstSeed}</div>
+      <div class="inline-flex w-full overflow-hidden whitespace-nowrap">
+        <div class=${clsx("min-w-0 truncate", className)}>
+          ${item.firstSeed}
+        </div>
         ${nameSuffix}
       </div>
     `;
   }
 
-  return html`<div class=${tw`truncate text-neutral-500`}>
+  return html`<div class=${clsx("truncate text-neutral-500", className)}>
     ${msg("(unnamed item)")}
   </div>`;
 }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/641

<!-- Fixes #issue_number -->

### Changes

- Adds breadcrumb navigation to all detail views, returning to correct origin for workflow and collection items
- Refactors list page headers into layout utility
- Refactors crawl tab labels and renames "Files" tab to "WACZ Files"

Note: In this implementation archived time QA breadcrumbs always return to the archived item, even if it originates from a collection or workflow. This is so that breadcrumbs aren't too long and assuming that in most cases, users are reviewing crawls before adding them to a collection.

## Screenshots

### Workflow detail
<img width="734" alt="Screenshot 2024-08-28 at 12 07 14 PM" src="https://github.com/user-attachments/assets/8c11c7ff-da85-4187-8d62-a5ef6dd7a135">

### Workflow crawl
<img width="726" alt="Screenshot 2024-08-28 at 12 07 22 PM" src="https://github.com/user-attachments/assets/89fe1078-9740-4165-815f-a76b35b46014">

### Archived item detail
<img width="734" alt="Screenshot 2024-08-28 at 12 08 21 PM" src="https://github.com/user-attachments/assets/e2906190-43e4-48f5-a02b-9ded367f3fde">

### Archived item review
<img width="835" alt="Screenshot 2024-08-28 at 12 08 54 PM" src="https://github.com/user-attachments/assets/94b103d3-1606-4e6d-96b0-0285741a348d">

### Collection archived item
<img width="639" alt="Screenshot 2024-08-28 at 12 09 53 PM" src="https://github.com/user-attachments/assets/098ca373-6335-4590-99b5-801708462fd8">

### Browser profile detail
<img width="628" alt="Screenshot 2024-08-28 at 12 10 07 PM" src="https://github.com/user-attachments/assets/a42d7d57-fd24-4b63-80bf-0b81f39ed78a">

### Duplicate browser profile
<img width="660" alt="Screenshot 2024-08-28 at 12 10 18 PM" src="https://github.com/user-attachments/assets/7064a799-1b0b-47bc-bd9f-52bf44a4664c">

### New browser profile
<img width="607" alt="Screenshot 2024-08-28 at 12 10 28 PM" src="https://github.com/user-attachments/assets/c6fc5abb-6ebe-4eb0-ade1-375968ec5d6d">

 ### Follow-ups

https://github.com/webrecorder/browsertrix/issues/2056