### PR TITLE
docs: Publish only on release

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,10 +1,5 @@
 name: docs-publish
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
   release:
     types: [published]
 

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,5 +1,7 @@
-name: docs-publish
+name: Publish Docs
 on:
+  workflow_dispatch:
+  
   release:
     types: [published]
 


### PR DESCRIPTION
No issue created, see [Discord channel](https://discord.com/channels/895426029194207262/1082417383123210281/1278457553482678334).

The prod docs (docs.browsertrix.com) gets updated on pushes to `main`. This isn't in line with our git flow where main can contain features that we don't want to release to prod yet.