### PR TITLE
fix: Watch tab crawl state consistency

### DIFF
--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -5,7 +5,7 @@ import { customElement, property } from "lit/decorators.js";
 import startCase from "lodash/fp/startCase";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import type { CrawlState } from "@/types/crawler";
+import type { CrawlState } from "@/types/crawlState";
 import { animatePulse } from "@/utils/css";
 
 type CrawlType = "crawl" | "upload" | "qa";

--- a/frontend/src/features/archived-items/item-list-controls.ts
+++ b/frontend/src/features/archived-items/item-list-controls.ts
@@ -7,8 +7,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { type SelectEvent } from "@/components/ui/search-combobox";
-import { CrawlStatus } from "@/features/archived-items/crawl-status";
-import { finishedCrawlStates } from "@/utils/crawler";
 
 export type FilterBy = Partial<Record<string, string>>;
 export type SearchValues = {
@@ -119,29 +117,6 @@ export class ItemListControls extends TailwindElement {
         }}
       >
       </btrix-search-combobox>
-    `;
-  }
-
-  private renderStatusFilter() {
-    const viewOptions = finishedCrawlStates.map((state) => {
-      const { icon, label } = CrawlStatus.getContent(state);
-      return html`<sl-option value=${state}>${icon}${label}</sl-option>`;
-    });
-
-    return html`
-      <div class="flex items-center gap-2">
-        <div class="text-neutral-500">${msg("Status:")}</div>
-        <sl-select
-          class="flex-1 md:min-w-[15rem]"
-          size="small"
-          pill
-          multiple
-          placeholder=${msg("Any")}
-          @sl-change=${async (_e: CustomEvent) => {}}
-        >
-          ${viewOptions}
-        </sl-select>
-      </div>
     `;
   }
 

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -9,7 +9,8 @@ import type { PageChangeEvent } from "@/components/ui/pagination";
 import needLogin from "@/decorators/needLogin";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
-import type { Crawl, CrawlState } from "@/types/crawler";
+import type { Crawl } from "@/types/crawler";
+import type { CrawlState } from "@/types/crawlState";
 import { activeCrawlStates } from "@/utils/crawler";
 import LiteElement, { html } from "@/utils/LiteElement";
 

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -18,10 +18,10 @@ import type {
   ArchivedItem,
   Crawl,
   CrawlConfig,
-  CrawlState,
   Seed,
   Workflow,
 } from "@/types/crawler";
+import type { CrawlState } from "@/types/crawlState";
 import type { QARun } from "@/types/qa";
 import { isApiError } from "@/utils/api";
 import {
@@ -194,7 +194,9 @@ export class ArchivedItemDetail extends BtrixElement {
     if (changedProperties.has("qaRuns")) {
       // Latest QA run that's either running or finished:
       this.mostRecentNonFailedQARun = this.qaRuns?.find((run) =>
-        [...QA_RUNNING_STATES, ...finishedCrawlStates].includes(run.state),
+        (
+          [...QA_RUNNING_STATES, ...finishedCrawlStates] as readonly string[]
+        ).includes(run.state),
       );
     }
     if (

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -21,13 +21,11 @@ import type {
   Seed,
   Workflow,
 } from "@/types/crawler";
-import type { CrawlState } from "@/types/crawlState";
 import type { QARun } from "@/types/qa";
 import { isApiError } from "@/utils/api";
 import {
-  activeCrawlStates,
-  finishedCrawlStates,
   isActive,
+  isNotFailed,
   isSuccessfullyFinished,
   renderName,
 } from "@/utils/crawler";
@@ -50,10 +48,6 @@ const SECTIONS = [
 type SectionName = (typeof SECTIONS)[number];
 
 const POLL_INTERVAL_SECONDS = 5;
-export const QA_RUNNING_STATES = [
-  "starting",
-  ...activeCrawlStates,
-] as CrawlState[];
 
 /**
  * Usage:
@@ -195,9 +189,7 @@ export class ArchivedItemDetail extends BtrixElement {
     if (changedProperties.has("qaRuns")) {
       // Latest QA run that's either running or finished:
       this.mostRecentNonFailedQARun = this.qaRuns?.find((run) =>
-        (
-          [...QA_RUNNING_STATES, ...finishedCrawlStates] as readonly string[]
-        ).includes(run.state),
+        isNotFailed(run),
       );
     }
     if (
@@ -1487,9 +1479,7 @@ ${this.item?.description}
       });
     }
 
-    this.isQAActive = Boolean(
-      this.qaRuns?.[0] && QA_RUNNING_STATES.includes(this.qaRuns[0].state),
-    );
+    this.isQAActive = Boolean(this.qaRuns?.[0] && isActive(this.qaRuns[0]));
 
     if (this.isQAActive) {
       // Clear current timer, if it exists

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -675,7 +675,8 @@ export class ArchivedItemDetail extends BtrixElement {
             `,
           )}
           ${when(
-            this.isCrawler && !isActive(this.item.state),
+            this.isCrawler &&
+              (this.item.type !== "crawl" || !isActive(this.item)),
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -28,6 +28,7 @@ import {
   activeCrawlStates,
   finishedCrawlStates,
   isActive,
+  isSuccessfullyFinished,
   renderName,
 } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
@@ -146,8 +147,8 @@ export class ArchivedItemDetail extends BtrixElement {
   private timerId?: number;
 
   private get isActive(): boolean | null {
-    if (!this.item) return null;
-    return activeCrawlStates.includes(this.item.state);
+    if (!this.item || this.item.type !== "crawl") return null;
+    return isActive(this.item);
   }
 
   private get hasFiles(): boolean | null {
@@ -664,7 +665,7 @@ export class ArchivedItemDetail extends BtrixElement {
             ${msg("Copy Tags")}
           </sl-menu-item>
           ${when(
-            finishedCrawlStates.includes(this.item.state),
+            isSuccessfullyFinished(this.item),
             () => html`
               <sl-divider></sl-divider>
               <btrix-menu-item-link

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -13,8 +13,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
-import { QA_RUNNING_STATES } from "../archived-item-detail";
-
 import { BtrixElement } from "@/classes/BtrixElement";
 import { type Dialog } from "@/components/ui/dialog";
 import type { PageChangeEvent } from "@/components/ui/pagination";
@@ -28,7 +26,7 @@ import type {
 } from "@/types/api";
 import { type ArchivedItem, type ArchivedItemPage } from "@/types/crawler";
 import type { QARun } from "@/types/qa";
-import { isSuccessfullyFinished } from "@/utils/crawler";
+import { isActive, isSuccessfullyFinished } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { formatNumber, getLocale } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
@@ -465,8 +463,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
 
   private renderAnalysis(qaRuns: QARun[]) {
     const isRunning =
-      this.mostRecentNonFailedQARun &&
-      QA_RUNNING_STATES.includes(this.mostRecentNonFailedQARun.state);
+      this.mostRecentNonFailedQARun && isActive(this.mostRecentNonFailedQARun);
     const qaRun = qaRuns.find(({ id }) => id === this.qaRunId);
 
     if (!qaRun && isRunning) {
@@ -495,9 +492,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
               this.qaRunId === finishedQARuns[0]?.id;
 
             const finishedAndRunningQARuns = qaRuns.filter(
-              (qaRun) =>
-                isSuccessfullyFinished(qaRun) ||
-                QA_RUNNING_STATES.includes(qaRun.state),
+              (qaRun) => isSuccessfullyFinished(qaRun) || isActive(qaRun),
             );
             const mostRecentSelected =
               this.qaRunId === finishedAndRunningQARuns[0]?.id;

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -28,7 +28,7 @@ import type {
 } from "@/types/api";
 import { type ArchivedItem, type ArchivedItemPage } from "@/types/crawler";
 import type { QARun } from "@/types/qa";
-import { finishedCrawlStates } from "@/utils/crawler";
+import { isSuccessfullyFinished } from "@/utils/crawler";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { formatNumber, getLocale } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
@@ -488,16 +488,16 @@ export class ArchivedItemDetailQA extends BtrixElement {
         <div class="flex flex-wrap items-center gap-x-3">
           ${msg("HTML Page Match Analysis")}
           ${when(this.qaRuns, (qaRuns) => {
-            const finishedQARuns = qaRuns.filter(({ state }) =>
-              finishedCrawlStates.includes(state),
+            const finishedQARuns = qaRuns.filter((qaRun) =>
+              isSuccessfullyFinished(qaRun),
             );
             const latestFinishedSelected =
               this.qaRunId === finishedQARuns[0]?.id;
 
             const finishedAndRunningQARuns = qaRuns.filter(
-              ({ state }) =>
-                finishedCrawlStates.includes(state) ||
-                QA_RUNNING_STATES.includes(state),
+              (qaRun) =>
+                isSuccessfullyFinished(qaRun) ||
+                QA_RUNNING_STATES.includes(qaRun.state),
             );
             const mostRecentSelected =
               this.qaRunId === finishedAndRunningQARuns[0]?.id;

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -462,11 +462,11 @@ export class ArchivedItemDetailQA extends BtrixElement {
     html`<div class="min-w-32"><sl-spinner class="size-4"></sl-spinner></div>`;
 
   private renderAnalysis(qaRuns: QARun[]) {
-    const isRunning =
+    const isRunningOrStarting =
       this.mostRecentNonFailedQARun && isActive(this.mostRecentNonFailedQARun);
     const qaRun = qaRuns.find(({ id }) => id === this.qaRunId);
 
-    if (!qaRun && isRunning) {
+    if (!qaRun && isRunningOrStarting) {
       return html`<btrix-alert class="mb-3" variant="success">
         ${msg("Running QA analysis on pages...")}
       </btrix-alert>`;
@@ -560,7 +560,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
                   ? this.renderMeter(
                       qaRun.stats.found,
                       this.qaStats.value.screenshotMatch,
-                      isRunning,
+                      isRunningOrStarting,
                     )
                   : this.renderMeter()}
               </btrix-table-cell>
@@ -574,7 +574,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
                   ? this.renderMeter(
                       qaRun.stats.found,
                       this.qaStats.value.textMatch,
-                      isRunning,
+                      isRunningOrStarting,
                     )
                   : this.renderMeter()}
               </btrix-table-cell>

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -38,7 +38,12 @@ import type {
 } from "@/types/api";
 import type { ArchivedItem, ArchivedItemPageComment } from "@/types/crawler";
 import type { ArchivedItemQAPage, QARun } from "@/types/qa";
-import { finishedCrawlStates, isActive, renderName } from "@/utils/crawler";
+import {
+  isActive,
+  isSuccessfullyFinished,
+  renderName,
+  type finishedCrawlStates,
+} from "@/utils/crawler";
 import { maxLengthValidator } from "@/utils/form";
 import { formatISODateString, getLocale } from "@/utils/localization";
 import { tw } from "@/utils/tailwind";
@@ -1178,9 +1183,9 @@ export class ArchivedItemQA extends BtrixElement {
 
   private async fetchQARuns(): Promise<void> {
     try {
-      this.finishedQARuns = (await this.getQARuns()).filter(({ state }) =>
-        finishedCrawlStates.includes(state),
-      );
+      this.finishedQARuns = (await this.getQARuns()).filter((qaRun) =>
+        isSuccessfullyFinished(qaRun),
+      ) as ArchivedItemQA["finishedQARuns"];
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't retrieve analysis runs at this time."),

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -363,7 +363,7 @@ export class ArchivedItemQA extends BtrixElement {
     const currentQARun = this.finishedQARuns?.find(
       ({ id }) => id === this.qaRunId,
     );
-    const disableReview = !currentQARun || isActive(currentQARun.state);
+    const disableReview = !currentQARun || isActive(currentQARun);
 
     return html`
       ${this.renderHidden()}

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -635,7 +635,7 @@ export class CrawlsList extends BtrixElement {
         `,
       )}
       ${when(
-        this.isCrawler && !isActive(item.state),
+        this.isCrawler && (item.type !== "crawl" || !isActive(item)),
         () => html`
           <sl-divider></sl-divider>
           <sl-menu-item

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -8,7 +8,7 @@ import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
-import type { ArchivedItem, Crawl, CrawlState, Workflow } from "./types";
+import type { ArchivedItem, Crawl, Workflow } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -16,6 +16,7 @@ import type { PageChangeEvent } from "@/components/ui/pagination";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
+import type { CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
 import { finishedCrawlStates, isActive } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -18,7 +18,11 @@ import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import type { CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
-import { finishedCrawlStates, isActive } from "@/utils/crawler";
+import {
+  finishedCrawlStates,
+  isActive,
+  isSuccessfullyFinished,
+} from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { tw } from "@/utils/tailwind";
 
@@ -623,7 +627,7 @@ export class CrawlsList extends BtrixElement {
         ${msg("Copy Tags")}
       </sl-menu-item>
       ${when(
-        finishedCrawlStates.includes(item.state),
+        isSuccessfullyFinished(item),
         () => html`
           <sl-divider></sl-divider>
           <btrix-menu-item-link

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -17,15 +17,10 @@ import type {
   APISortQuery,
 } from "@/types/api";
 import type { Collection } from "@/types/collection";
-<<<<<<< HEAD
-import type { ArchivedItem, Crawl, CrawlState, Upload } from "@/types/crawler";
-import { formatNumber, getLocale } from "@/utils/localization";
-import { pluralOf } from "@/utils/pluralize";
-=======
 import type { ArchivedItem, Crawl, Upload } from "@/types/crawler";
 import type { CrawlState } from "@/types/crawlState";
-import { getLocale } from "@/utils/localization";
->>>>>>> a2d70547 (update crawl state)
+import { formatNumber, getLocale } from "@/utils/localization";
+import { pluralOf } from "@/utils/pluralize";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -17,9 +17,15 @@ import type {
   APISortQuery,
 } from "@/types/api";
 import type { Collection } from "@/types/collection";
+<<<<<<< HEAD
 import type { ArchivedItem, Crawl, CrawlState, Upload } from "@/types/crawler";
 import { formatNumber, getLocale } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
+=======
+import type { ArchivedItem, Crawl, Upload } from "@/types/crawler";
+import type { CrawlState } from "@/types/crawlState";
+import { getLocale } from "@/utils/localization";
+>>>>>>> a2d70547 (update crawl state)
 
 const ABORT_REASON_THROTTLE = "throttled";
 const DESCRIPTION_MAX_HEIGHT_PX = 200;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -18,7 +18,7 @@ import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import type { APIPaginatedList } from "@/types/api";
-import type { CrawlState } from "@/types/crawlState";
+import { type CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
 import {
   DEFAULT_MAX_SCALE,
@@ -118,11 +118,10 @@ export class WorkflowDetail extends LiteElement {
   private getWorkflowPromise?: Promise<Workflow>;
   private getSeedsPromise?: Promise<APIPaginatedList<Seed>>;
 
-  private get isExplicitRunningOrStarting() {
-    if (!this.workflow?.isCrawlRunning) return false;
-
+  private get isExplicitRunning() {
     return (
-      this.workflow.lastCrawlState === "starting" ||
+      this.workflow?.isCrawlRunning &&
+      !this.workflow.lastCrawlStopping &&
       this.workflow.lastCrawlState === "running"
     );
   }
@@ -688,7 +687,7 @@ export class WorkflowDetail extends LiteElement {
               </sl-menu-item>
               <sl-menu-item
                 @click=${() => (this.openDialogName = "exclusions")}
-                ?disabled=${!this.isExplicitRunningOrStarting}
+                ?disabled=${!this.isExplicitRunning}
               >
                 <sl-icon name="table" slot="prefix"></sl-icon>
                 ${msg("Edit Exclusions")}
@@ -965,54 +964,46 @@ export class WorkflowDetail extends LiteElement {
   private readonly renderWatchCrawl = () => {
     if (!this.authState || !this.workflow?.lastCrawlState) return "";
 
-    let waitingMsg = null;
+    // Show custom message if crawl is active but not explicitly running
+    let waitingMsg: string | null = null;
 
-    switch (this.workflow.lastCrawlState) {
-      case "starting":
-        waitingMsg = msg("Crawl starting...");
-        break;
+    if (!this.isExplicitRunning) {
+      switch (this.workflow.lastCrawlState) {
+        case "starting":
+          waitingMsg = msg("Crawl starting...");
+          break;
 
-      case "waiting_capacity":
-        waitingMsg = msg(
-          "Crawl waiting for available resources before it can continue...",
-        );
-        break;
+        case "waiting_capacity":
+          waitingMsg = msg(
+            "Crawl waiting for available resources before it can continue...",
+          );
+          break;
 
-      case "waiting_org_limit":
-        waitingMsg = msg(
-          "Crawl waiting for others to finish, concurrent limit per Organization reached...",
-        );
-        break;
+        case "waiting_org_limit":
+          waitingMsg = msg(
+            "Crawl waiting for others to finish, concurrent limit per Organization reached...",
+          );
+          break;
+
+        case "pending-wait":
+        case "generate-wacz":
+        case "uploading-wacz":
+          waitingMsg = msg("Crawl finishing...");
+          break;
+
+        default:
+          if (this.workflow.lastCrawlStopping) {
+            waitingMsg = msg("Crawl stopping...");
+          }
+          break;
+      }
     }
 
-    const isStopping = this.workflow.lastCrawlStopping;
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`
-      ${waitingMsg
-        ? html`<div class="rounded border p-3">
-            <p class="text-sm text-neutral-600 motion-safe:animate-pulse">
-              ${waitingMsg}
-            </p>
-          </div>`
-        : isActive({
-              state: this.workflow.lastCrawlState,
-              stopping: this.workflow.lastCrawlStopping,
-            })
-          ? html`
-              ${isStopping
-                ? html`
-                    <div class="mb-4">
-                      <btrix-alert variant="warning" class="text-sm">
-                        ${msg("Crawl stopping...")}
-                      </btrix-alert>
-                    </div>
-                  `
-                : ""}
-            `
-          : this.renderInactiveCrawlMessage()}
       ${when(
-        this.isExplicitRunningOrStarting && this.workflow,
+        this.isExplicitRunning && this.workflow,
         (workflow) => html`
           <div id="screencast-crawl">
             <btrix-screencast
@@ -1025,6 +1016,14 @@ export class WorkflowDetail extends LiteElement {
           <section class="mt-4">${this.renderCrawlErrors()}</section>
           <section class="mt-8">${this.renderExclusions()}</section>
         `,
+        () =>
+          waitingMsg
+            ? html`<div class="rounded border p-3">
+                <p class="text-sm text-neutral-600 motion-safe:animate-pulse">
+                  ${waitingMsg}
+                </p>
+              </div>`
+            : this.renderInactiveCrawlMessage(),
       )}
     `;
   };

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -498,19 +498,30 @@ export class WorkflowDetail extends LiteElement {
         </sl-icon-button>`;
     }
     if (this.activePanel === "watch" && this.isCrawler) {
+      const enableEditBrowserWindows =
+        this.workflow?.isCrawlRunning && !this.workflow.lastCrawlStopping;
       return html` <h3>${this.tabLabels[this.activePanel]}</h3>
-        <sl-button
-          size="small"
-          ?disabled=${!this.workflow?.isCrawlRunning}
-          @click=${() => (this.openDialogName = "scale")}
-        >
-          <sl-icon
-            name="plus-slash-minus"
-            slot="prefix"
-            label=${msg("Increase or decrease")}
-          ></sl-icon>
-          <span>${msg("Edit Browser Windows")}</span>
-        </sl-button>`;
+        <div>
+          <sl-tooltip
+            content=${msg(
+              "Browser windows can only be edited while a crawl is starting or running",
+            )}
+            ?disabled=${enableEditBrowserWindows}
+          >
+            <sl-button
+              size="small"
+              ?disabled=${!enableEditBrowserWindows}
+              @click=${() => (this.openDialogName = "scale")}
+            >
+              <sl-icon
+                name="plus-slash-minus"
+                slot="prefix"
+                label=${msg("Increase or decrease")}
+              ></sl-icon>
+              <span>${msg("Edit Browser Windows")}</span>
+            </sl-button>
+          </sl-tooltip>
+        </div>`;
     }
     if (this.activePanel === "logs") {
       const authToken = this.authState?.headers.Authorization.split(" ")[1];
@@ -678,7 +689,7 @@ export class WorkflowDetail extends LiteElement {
             `,
           )}
           ${when(
-            workflow.isCrawlRunning,
+            workflow.isCrawlRunning && !workflow.lastCrawlStopping,
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item @click=${() => (this.openDialogName = "scale")}>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -982,7 +982,10 @@ export class WorkflowDetail extends LiteElement {
               ${waitingMsg}
             </p>
           </div>`
-        : isActive(this.workflow.lastCrawlState)
+        : isActive({
+              state: this.workflow.lastCrawlState,
+              stopping: this.workflow.lastCrawlStopping,
+            })
           ? html`
               ${isStopping
                 ? html`
@@ -1227,7 +1230,12 @@ export class WorkflowDetail extends LiteElement {
           ? html`<btrix-exclusion-editor
               .crawlId=${this.lastCrawlId ?? undefined}
               .config=${this.workflow.config}
-              ?isActiveCrawl=${isActive(this.workflow.lastCrawlState)}
+              ?isActiveCrawl=${this.workflow.lastCrawlState
+                ? isActive({
+                    state: this.workflow.lastCrawlState,
+                    stopping: this.workflow.lastCrawlStopping,
+                  })
+                : false}
               @on-success=${this.handleExclusionChange}
             ></btrix-exclusion-editor>`
           : ""}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -7,13 +7,7 @@ import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
-import type {
-  Crawl,
-  CrawlState,
-  Seed,
-  Workflow,
-  WorkflowParams,
-} from "./types";
+import type { Crawl, Seed, Workflow, WorkflowParams } from "./types";
 
 import { CopyButton } from "@/components/ui/copy-button";
 import type { PageChangeEvent } from "@/components/ui/pagination";
@@ -24,6 +18,7 @@ import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import type { APIPaginatedList } from "@/types/api";
+import type { CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
 import {
   DEFAULT_MAX_SCALE,

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -494,7 +494,9 @@ export class WorkflowsList extends LiteElement {
         `,
       )}
       ${when(
-        workflow.isCrawlRunning && this.appState.isCrawler,
+        this.appState.isCrawler &&
+          workflow.isCrawlRunning &&
+          !workflow.lastCrawlStopping,
         // HACK shoelace doesn't current have a way to override non-hover
         // color without resetting the --sl-color-neutral-700 variable
         () => html`

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -511,6 +511,7 @@ export class WorkflowsList extends LiteElement {
             ${msg("Edit Browser Windows")}
           </sl-menu-item>
           <sl-menu-item
+            ?disabled=${workflow.lastCrawlState !== "running"}
             @click=${() =>
               this.navTo(`${this.orgBasePath}/workflows/${workflow.id}#watch`, {
                 dialog: "exclusions",

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -1,0 +1,48 @@
+// Match backend TYPE_RUNNING_STATES in models.py
+export const RUNNING_STATES = [
+  "running",
+  "pending-wait",
+  "generate-wacz",
+  "uploading-wacz",
+] as const;
+
+// Match backend TYPE_WAITING_STATES in models.py
+export const WAITING_STATES = [
+  "starting",
+  "waiting_capacity",
+  "waiting_org_limit",
+] as const;
+
+// Match backend TYPE_SUCCESSFUL_STATES in models.py
+export const SUCCESSFUL_STATES = [
+  "complete",
+  "stopped_by_user",
+  "stopped_storage_quota_reached",
+  "stopped_time_quota_reached",
+  "stopped_org_readonly",
+] as const;
+
+// Match backend TYPE_FAILED_STATES in models.py
+export const FAILED_STATES = [
+  "canceled",
+  "failed",
+  "skipped_storage_quota_reached",
+  "skipped_time_quota_reached",
+] as const;
+
+export const RUNNING_AND_WAITING_STATES = [
+  ...RUNNING_STATES,
+  ...WAITING_STATES,
+] as const;
+
+export const SUCCESSFUL_AND_FAILED_STATES = [
+  ...SUCCESSFUL_STATES,
+  ...FAILED_STATES,
+] as const;
+
+const CRAWL_STATES = [
+  ...RUNNING_AND_WAITING_STATES,
+  ...SUCCESSFUL_AND_FAILED_STATES,
+] as const;
+
+export type CrawlState = (typeof CRAWL_STATES)[number];

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -1,3 +1,5 @@
+import type { CrawlState } from "./crawlState";
+
 type ScopeType =
   | "prefix"
   | "host"
@@ -122,25 +124,6 @@ export type Profile = {
   };
   crawlerChannel?: string;
 };
-
-export type CrawlState =
-  | "starting"
-  | "waiting_capacity"
-  | "waiting_org_limit"
-  | "running"
-  | "generate-wacz"
-  | "uploading-wacz"
-  | "pending-wait"
-  | "stopping"
-  | "complete"
-  | "failed"
-  | "skipped_storage_quota_reached"
-  | "skipped_time_quota_reached"
-  | "canceled"
-  | "stopped_by_user"
-  | "stopped_storage_quota_reached"
-  | "stopped_time_quota_reached"
-  | "stopped_org_readonly";
 
 // TODO maybe convert this to an enum?
 export enum ReviewStatus {

--- a/frontend/src/types/qa.ts
+++ b/frontend/src/types/qa.ts
@@ -1,4 +1,5 @@
-import type { ArchivedItemPage, CrawlState } from "./crawler";
+import type { ArchivedItemPage } from "@/types/crawler";
+import type { CrawlState } from "@/types/crawlState";
 
 export type QARun = {
   id: string;

--- a/frontend/src/types/qa.ts
+++ b/frontend/src/types/qa.ts
@@ -13,6 +13,7 @@ export type QARun = {
     size: number;
   };
   resources?: { crawlId: string; name: string; path: string }[];
+  stopping?: boolean | null;
 };
 
 export type ArchivedItemQAPage = ArchivedItemPage & {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -7,31 +7,49 @@ import { pluralOf } from "./pluralize";
 
 import type { ArchivedItem, CrawlState, Workflow } from "@/types/crawler";
 
-export const activeCrawlStates: CrawlState[] = [
-  "starting",
-  "waiting_org_limit",
-  "waiting_capacity",
+// Match backend TYPE_RUNNING_STATES in models.py
+const RUNNING_STATES: CrawlState[] = [
   "running",
+  "pending-wait",
   "generate-wacz",
   "uploading-wacz",
-  "pending-wait",
-  "stopping",
-];
+] as const;
 
-export const finishedCrawlStates: CrawlState[] = [
+// Match backend TYPE_WAITING_STATES in models.py
+const WAITING_STATES: CrawlState[] = [
+  "starting",
+  "waiting_capacity",
+  "waiting_org_limit",
+] as const;
+
+// Match backend TYPE_SUCCESSFUL_STATES in models.py
+const SUCCESSFUL_STATES: CrawlState[] = [
   "complete",
   "stopped_by_user",
   "stopped_storage_quota_reached",
   "stopped_time_quota_reached",
   "stopped_org_readonly",
-];
+] as const;
 
-export const inactiveCrawlStates: CrawlState[] = [
-  ...finishedCrawlStates,
+// Match backend TYPE_FAILED_STATES in models.py
+const FAILED_STATES: CrawlState[] = [
   "canceled",
+  "failed",
   "skipped_storage_quota_reached",
   "skipped_time_quota_reached",
-  "failed",
+] as const;
+
+// Match backend TYPE_RUNNING_AND_WAITING_STATES in models.py
+export const activeCrawlStates: CrawlState[] = [
+  ...WAITING_STATES,
+  ...RUNNING_STATES,
+];
+
+export const finishedCrawlStates = SUCCESSFUL_STATES;
+
+export const inactiveCrawlStates: CrawlState[] = [
+  ...SUCCESSFUL_STATES,
+  ...FAILED_STATES,
 ];
 
 export const DEFAULT_MAX_SCALE = 3;

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -4,6 +4,7 @@ import { html, type TemplateResult } from "lit";
 
 import type { ArchivedItem, Crawl, Workflow } from "@/types/crawler";
 import {
+  FAILED_STATES,
   RUNNING_AND_WAITING_STATES,
   SUCCESSFUL_AND_FAILED_STATES,
   SUCCESSFUL_STATES,
@@ -37,6 +38,12 @@ export function isActive({ state, stopping }: Partial<Crawl | QARun>) {
 
 export function isSuccessfullyFinished({ state }: { state: string }) {
   return state && (SUCCESSFUL_STATES as readonly string[]).includes(state);
+}
+
+export function isNotFailed({ state }: { state: string }) {
+  return (
+    state && !(FAILED_STATES as readonly string[]).some((str) => str === state)
+  );
 }
 
 export function renderName(item: ArchivedItem | Workflow, className?: string) {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -3,55 +3,19 @@ import clsx from "clsx";
 import { html, type TemplateResult } from "lit";
 
 import type { ArchivedItem, Crawl, Workflow } from "@/types/crawler";
-import type { CrawlState } from "@/types/crawlState";
+import {
+  RUNNING_AND_WAITING_STATES,
+  SUCCESSFUL_AND_FAILED_STATES,
+  SUCCESSFUL_STATES,
+} from "@/types/crawlState";
 import type { QARun } from "@/types/qa";
 import { formatNumber } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
 
-// Match backend TYPE_RUNNING_STATES in models.py
-const RUNNING_STATES: CrawlState[] = [
-  "running",
-  "pending-wait",
-  "generate-wacz",
-  "uploading-wacz",
-] as const;
-
-// Match backend TYPE_WAITING_STATES in models.py
-const WAITING_STATES: CrawlState[] = [
-  "starting",
-  "waiting_capacity",
-  "waiting_org_limit",
-] as const;
-
-// Match backend TYPE_SUCCESSFUL_STATES in models.py
-const SUCCESSFUL_STATES: CrawlState[] = [
-  "complete",
-  "stopped_by_user",
-  "stopped_storage_quota_reached",
-  "stopped_time_quota_reached",
-  "stopped_org_readonly",
-] as const;
-
-// Match backend TYPE_FAILED_STATES in models.py
-const FAILED_STATES: CrawlState[] = [
-  "canceled",
-  "failed",
-  "skipped_storage_quota_reached",
-  "skipped_time_quota_reached",
-] as const;
-
 // Match backend TYPE_RUNNING_AND_WAITING_STATES in models.py
-export const activeCrawlStates: CrawlState[] = [
-  ...WAITING_STATES,
-  ...RUNNING_STATES,
-];
-
+export const activeCrawlStates = RUNNING_AND_WAITING_STATES;
 export const finishedCrawlStates = SUCCESSFUL_STATES;
-
-export const inactiveCrawlStates: CrawlState[] = [
-  ...SUCCESSFUL_STATES,
-  ...FAILED_STATES,
-];
+export const inactiveCrawlStates = SUCCESSFUL_AND_FAILED_STATES;
 
 export const DEFAULT_MAX_SCALE = 3;
 
@@ -64,7 +28,15 @@ export const DEPTH_SUPPORTED_SCOPES = [
 ];
 
 export function isActive({ state, stopping }: Partial<Crawl | QARun>) {
-  return (state && activeCrawlStates.includes(state)) || stopping === true;
+  return (
+    (state &&
+      (activeCrawlStates as readonly string[]).includes(state as string)) ||
+    stopping === true
+  );
+}
+
+export function isSuccessfullyFinished({ state }: { state: string }) {
+  return state && (SUCCESSFUL_STATES as readonly string[]).includes(state);
 }
 
 export function renderName(item: ArchivedItem | Workflow, className?: string) {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -5,7 +5,13 @@ import { html, type TemplateResult } from "lit";
 import { formatNumber } from "./localization";
 import { pluralOf } from "./pluralize";
 
-import type { ArchivedItem, CrawlState, Workflow } from "@/types/crawler";
+import type {
+  ArchivedItem,
+  Crawl,
+  CrawlState,
+  Workflow,
+} from "@/types/crawler";
+import type { QARun } from "@/types/qa";
 
 // Match backend TYPE_RUNNING_STATES in models.py
 const RUNNING_STATES: CrawlState[] = [
@@ -62,8 +68,8 @@ export const DEPTH_SUPPORTED_SCOPES = [
   "any",
 ];
 
-export function isActive(state: CrawlState | null) {
-  return state && activeCrawlStates.includes(state);
+export function isActive({ state, stopping }: Partial<Crawl | QARun>) {
+  return (state && activeCrawlStates.includes(state)) || stopping === true;
 }
 
 export function renderName(item: ArchivedItem | Workflow, className?: string) {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -2,16 +2,11 @@ import { msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, type TemplateResult } from "lit";
 
-import { formatNumber } from "./localization";
-import { pluralOf } from "./pluralize";
-
-import type {
-  ArchivedItem,
-  Crawl,
-  CrawlState,
-  Workflow,
-} from "@/types/crawler";
+import type { ArchivedItem, Crawl, Workflow } from "@/types/crawler";
+import type { CrawlState } from "@/types/crawlState";
 import type { QARun } from "@/types/qa";
+import { formatNumber } from "@/utils/localization";
+import { pluralOf } from "@/utils/pluralize";
 
 // Match backend TYPE_RUNNING_STATES in models.py
 const RUNNING_STATES: CrawlState[] = [

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -714,42 +714,14 @@
 <trans-unit id="sb62f4eaa41f130ab">
   <source>What would you like to crawl?</source>
 </trans-unit>
-<trans-unit id="s5ffd73b74acb2eaa">
-  <source>Known URLs</source>
-</trans-unit>
-<trans-unit id="sb49c47a3e2f5f21f">
-  <source>Choose this option to crawl a single page, or if you already know the URL of every page you'd like to crawl.</source>
-</trans-unit>
-<trans-unit id="s3c0192cd9205d1e7">
-  <source>Automated Discovery</source>
-</trans-unit>
-<trans-unit id="s6f0073add55cd733">
-  <source>Let the crawler automatically discover pages based on a domain or start page that you specify.</source>
-</trans-unit>
 <trans-unit id="s7a82a346a5c00640">
   <source>Need help deciding?</source>
-</trans-unit>
-<trans-unit id="h5a5d2338204a3ebc">
-  <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Known URLs<x id="1" equiv-text="&lt;/strong&gt;"/> (aka a "URL List" crawl
-                type) if:</source>
 </trans-unit>
 <trans-unit id="sb947597b1af186d4">
   <source>You want to archive a single page on a website</source>
 </trans-unit>
-<trans-unit id="sa40db523badc5c03">
-  <source>You're archiving just a few specific pages on a website</source>
-</trans-unit>
 <trans-unit id="sbf17262f3872712d">
   <source>You have a list of URLs that you can copy-and-paste</source>
-</trans-unit>
-<trans-unit id="hc43a8ccecf3cd55a">
-  <source>A URL list is simpler to configure, since you don't need to
-              worry about configuring the workflow to exclude parts of the
-              website that you may not want to archive.</source>
-</trans-unit>
-<trans-unit id="h6dcd9c533c310297">
-  <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Automated Discovery<x id="1" equiv-text="&lt;/strong&gt;"/> (aka a "Seeded
-                Crawl" crawl type) if:</source>
 </trans-unit>
 <trans-unit id="sf2a0e93879d8ac24">
   <source>You want to archive an entire website</source>
@@ -761,12 +733,6 @@
 <trans-unit id="h5711c8b307827832">
   <source>You're archiving a website <x id="0" equiv-text="&lt;em&gt;"/>and<x id="1" equiv-text="&lt;/em&gt;"/> external pages
                   linked to from the website</source>
-</trans-unit>
-<trans-unit id="hcc59d4214edd7f7d">
-  <source>Seeded crawls are great for advanced use cases where you
-              don't need to know every single URL that you want to archive. You
-              can configure reasonable crawl limits and page limits so that you
-              don't crawl more than you need to.</source>
 </trans-unit>
 <trans-unit id="hc76a9160bbdb615c">
   <source>Once you choose a crawl type, you can't go back and change
@@ -1224,10 +1190,6 @@
 <trans-unit id="s5d966c90d8dc06e6">
   <source>Are you sure you want to stop the crawl?</source>
 </trans-unit>
-<trans-unit id="h7c0f7620f388e9ec">
-  <source>Started crawl from <x id="0" equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;"/>.
-            <x id="1" equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.orgBasePath}/workflows/crawl/${workflow.id}#watch&quot; @click=&quot;${this.navLink.bind(this)}&quot;&gt;"/>Watch crawl<x id="2" equiv-text="&lt;/a&gt;"/></source>
-</trans-unit>
 <trans-unit id="sfecdd5e13f68c9ba">
   <source>Approved</source>
 </trans-unit>
@@ -1453,12 +1415,6 @@
 <trans-unit id="s2e46f937929109fd">
   <source>Uploads</source>
 </trans-unit>
-<trans-unit id="s8a172bf54a0db8da">
-  <source>Viewing Workflow Crawl</source>
-</trans-unit>
-<trans-unit id="scd2ae7722d803b9c">
-  <source>Viewing Archived Item in Collection</source>
-</trans-unit>
 <trans-unit id="sa71de39189a9e9cd">
   <source>Go to Workflow</source>
 </trans-unit>
@@ -1494,7 +1450,7 @@
 </trans-unit>
 <trans-unit id="h1dc2f6235d169989">
   <source>Manual start by
-                          <x id="0" equiv-text="&lt;span&gt;${this.crawl!.userName || this.crawl!.userid}&lt;/span&gt;"/></source>
+                          <x id="0" equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;"/></source>
 </trans-unit>
 <trans-unit id="hdfcda45e7d5c5ab4">
   <source>Scheduled start</source>
@@ -2203,17 +2159,8 @@
 <trans-unit id="s36fd1256980b5f58">
   <source>Sorry, couldn't submit QA review at this time.</source>
 </trans-unit>
-<trans-unit id="s602704084f6c7796">
-  <source>URL List</source>
-</trans-unit>
-<trans-unit id="sf74a7ef270ece7ea">
-  <source>Seeded Crawl</source>
-</trans-unit>
 <trans-unit id="sf0cab2483f66aa2e">
   <source>Custom</source>
-</trans-unit>
-<trans-unit id="s3741f519c32ac391">
-  <source>New</source>
 </trans-unit>
 <trans-unit id="saa63c0c9ca0eac98">
   <source>You don't have permission to create a new Workflow.</source>
@@ -2324,17 +2271,11 @@
 <trans-unit id="s063b2ed6541c9181">
   <source>Run on a Recurring Basis</source>
 </trans-unit>
-<trans-unit id="sd8f69a8563eb74e3">
-  <source>Crawl URL(s)</source>
-</trans-unit>
 <trans-unit id="scd8de6628aaada05">
   <source>Include Any Linked Page</source>
 </trans-unit>
 <trans-unit id="sce646d8060e6c775">
   <source>Fail Crawl On Failed URL</source>
-</trans-unit>
-<trans-unit id="sc578fe08950cbb3b">
-  <source>Primary Seed URL</source>
 </trans-unit>
 <trans-unit id="s00147a7c30a80117">
   <source>Extra URL Prefixes in Scope</source>
@@ -3761,6 +3702,84 @@
 <trans-unit id="items.plural.one">
   <source>item</source>
   <note from="lit-localize">singular form for "item"</note>
+</trans-unit>
+<trans-unit id="s24a06fd949e2d65b">
+  <source>Back to</source>
+</trans-unit>
+<trans-unit id="s7ee7b202edc2481e">
+  <source>Page List</source>
+</trans-unit>
+<trans-unit id="s1e2e5062a253c739">
+  <source>One or more URLs</source>
+</trans-unit>
+<trans-unit id="sc33daa5130000a11">
+  <source>Choose this option if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one hop out.</source>
+</trans-unit>
+<trans-unit id="s008f62e40844e6d5">
+  <source>Site Crawl</source>
+</trans-unit>
+<trans-unit id="s46bd7b046b0ca6d4">
+  <source>Website or directory</source>
+</trans-unit>
+<trans-unit id="sa7264597ca290e44">
+  <source>Specify a domain name, start page URL, or path on a website and let the crawler automatically find pages within that scope.</source>
+</trans-unit>
+<trans-unit id="hb653cf5693a98f6b">
+  <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Page List<x id="1" equiv-text="&lt;/strong&gt;"/> if:</source>
+</trans-unit>
+<trans-unit id="s16addd6732b613fd">
+  <source>You want to include URLs with different domain names in the same crawl</source>
+</trans-unit>
+<trans-unit id="h25ccce1baa96d993">
+  <source>A Page List workflow is simpler to configure, since you don't
+              need to worry about configuring the workflow to exclude parts of
+              the website that you may not want to archive.</source>
+</trans-unit>
+<trans-unit id="hc5b85948ffe0eb76">
+  <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Site Crawl<x id="1" equiv-text="&lt;/strong&gt;"/> if:</source>
+</trans-unit>
+<trans-unit id="hddd64e30f6ade731">
+  <source>Site Crawl workflows are great for advanced use cases where
+              you don't need to know every single URL that you want to archive.
+              You can configure reasonable crawl limits and page limits so that
+              you don't crawl more than you need to.</source>
+</trans-unit>
+<trans-unit id="s33807afa94c15a25">
+  <source>Browser windows can only be edited while a crawl is starting or running</source>
+</trans-unit>
+<trans-unit id="s4cb3d6de6b76708d">
+  <source>Crawl finishing...</source>
+</trans-unit>
+<trans-unit id="sa4808f93f7b11e58">
+  <source>New Workflow...</source>
+</trans-unit>
+<trans-unit id="s73fb3e7a0629951c">
+  <source>Help me decide</source>
+</trans-unit>
+<trans-unit id="ha60886587b96e32c">
+  <source>Started crawl from <x id="0" equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;"/>.
+            <x id="1" equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navLink.bind(this)}&quot;&gt;"/>Watch crawl<x id="2" equiv-text="&lt;/a&gt;"/></source>
+</trans-unit>
+<trans-unit id="sb32ae1652df8c7ad">
+  <source>Workflow settings used to run this crawl</source>
+</trans-unit>
+<trans-unit id="sa74e88ae69ff57ca">
+  <source>Edit Workflow</source>
+</trans-unit>
+<trans-unit id="sd813c96a1d891cdc">
+  <source>Select Analysis Run</source>
+</trans-unit>
+<trans-unit id="sd3c4adf4cc6d1668">
+  <source>New <x id="0" equiv-text="${this.jobTypeLabels[jobType]}"/> Workflow</source>
+</trans-unit>
+<trans-unit id="sdd3e1b91cb27a4d5">
+  <source>Page URL(s)</source>
+</trans-unit>
+<trans-unit id="s4201222224dff23c">
+  <source>Crawl: <x id="0" equiv-text="${crawlStatus.label}"/></source>
+</trans-unit>
+<trans-unit id="s0eb7c300368b2a58">
+  <source>Upload: <x id="0" equiv-text="${crawlStatus.label}"/></source>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2059

<!-- Fixes #issue_number -->

### Changes

- Fixes empty watch tab during some active states
- Disables exclusion and browser window editing while a crawl is stopping
- Refactors frontend crawl states to match backend

### Manual testing

Verify with repro steps in https://github.com/webrecorder/browsertrix/issues/2059

The following should be true:
- Browser Window editing is enabled when a crawl is in any active state that is not stopping
- Exclusions editing and screencast is enabled only when a crawl is in a `running` state