### PR TITLE
fix: Archived item navigation improvements

### DIFF
--- a/frontend/src/components/detail-page-title.ts
+++ b/frontend/src/components/detail-page-title.ts
@@ -1,8 +1,9 @@
-import { localized } from "@lit/localize";
+import { localized, msg, str } from "@lit/localize";
 import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
+import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { type ArchivedItem, type Workflow } from "@/types/crawler";
 import { formatNumber } from "@/utils/localization";
 import { pluralOf } from "@/utils/pluralize";
@@ -15,7 +16,7 @@ enum TitleSource {
 
 type Item = Pick<
   ArchivedItem & Workflow,
-  "name" | "firstSeed" | "seedCount" | "id"
+  "name" | "firstSeed" | "seedCount" | "id" | "type" | "state" | "finished"
 >;
 
 @localized()
@@ -53,24 +54,54 @@ export class DetailPageTitle extends TailwindElement {
 
     const remainder = item.seedCount - 1;
 
-    return html`<span class="truncate">${item.firstSeed}</span>${remainder
+    return html`<span class="max-w-[30ch] truncate">${item.firstSeed}</span
+      >${remainder
         ? html` <span class="whitespace-nowrap text-neutral-500"
             >+${formatNumber(remainder)} ${pluralOf("URLs", remainder)}</span
           >`
         : nothing}`;
   }
 
+  private renderIcon() {
+    if (!this.item?.state) return;
+
+    const crawlStatus = CrawlStatus.getContent(this.item.state, this.item.type);
+
+    let icon = html`<sl-tooltip
+      content=${msg(str`Crawl: ${crawlStatus.label}`)}
+    >
+      <sl-icon
+        name="gear-wide-connected"
+        style="color: ${crawlStatus.cssColor}"
+      ></sl-icon>
+    </sl-tooltip>`;
+
+    if (this.item.type === "upload") {
+      icon = html`<sl-tooltip content=${msg(str`Upload: ${crawlStatus.label}`)}>
+        <sl-icon name="upload" style="color: ${crawlStatus.cssColor}"></sl-icon>
+      </sl-tooltip>`;
+    }
+
+    return html`
+      <div class="flex size-8 items-center justify-center text-neutral-500">
+        ${icon}
+      </div>
+    `;
+  }
+
   render() {
     if (!this.item)
       return html`<sl-skeleton class="inline-block h-8 w-60"></sl-skeleton>`;
 
-    return html`<sl-tooltip
-      content="${this.primaryTitle(this.item).title}"
-      hoist
-    >
-      <h1 class="flex min-w-32 text-xl font-semibold leading-8">
-        ${this.renderTitle(this.item)}
+    return html`
+      <h1
+        class="flex min-w-32 items-center gap-2 text-xl font-semibold leading-8"
+      >
+        ${this.renderIcon()}
+        <sl-tooltip content="${this.primaryTitle(this.item).title}" hoist>
+          ${this.renderTitle(this.item)}
+        </sl-tooltip>
       </h1>
-    </sl-tooltip>`;
+    `;
   }
 }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1974,7 +1974,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       });
 
       this.navigate.to(
-        `${this.navigate.orgBasePath}/workflows/crawl/${this.configId || data.id}${
+        `${this.navigate.orgBasePath}/workflows/${this.configId || data.id}${
           crawlId && !storageQuotaReached && !executionMinutesQuotaReached
             ? "#watch"
             : ""

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -231,7 +231,7 @@ export class WorkflowListItem extends LitElement {
         }
         e.preventDefault();
         await this.updateComplete;
-        const href = `/orgs/${this.orgSlug}/workflows/crawl/${
+        const href = `/orgs/${this.orgSlug}/workflows/${
           this.workflow?.id
         }#${this.workflow?.isCrawlRunning ? "watch" : "crawls"}`;
         this.navigate.to(href);

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -35,16 +35,17 @@ export function breadcrumbSeparator() {
 const separator = breadcrumbSeparator();
 const skeleton = html`<sl-skeleton class="w-48"></sl-skeleton>`;
 
-function breadcrumbLink({ href, content }: Breadcrumb) {
+function breadcrumbLink({ href, content }: Breadcrumb, classNames?: string) {
   if (!content) return skeleton;
 
   return html`
     <a
       class=${clsx(
-        tw`flex h-5 max-w-[30ch] items-center gap-2 truncate whitespace-nowrap leading-5`,
+        tw`flex h-5 items-center gap-1 truncate whitespace-nowrap leading-5`,
         href
           ? tw`font-medium text-neutral-400 transition-colors hover:text-neutral-500`
           : null,
+        classNames,
       )}
       href=${ifDefined(href)}
       @click=${href
@@ -62,7 +63,8 @@ function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
       ${breadcrumbs.length
         ? breadcrumbs.map(
             (breadcrumb, i) => html`
-              ${i !== 0 ? separator : nothing} ${breadcrumbLink(breadcrumb)}
+              ${i !== 0 ? separator : nothing}
+              ${breadcrumbLink(breadcrumb, tw`max-w-[30ch]`)}
             `,
           )
         : html`${skeleton} ${separator} ${skeleton}`}

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -26,7 +26,7 @@ function navigateBreadcrumb(e: MouseEvent, href: string) {
 
 export function breadcrumbSeparator() {
   return html`<span
-    class="font-mono font-thin text-neutral-300"
+    class="font-mono font-thin text-neutral-400"
     role="separator"
     >/</span
   > `;
@@ -43,8 +43,8 @@ function breadcrumbLink({ href, content }: Breadcrumb, classNames?: string) {
       class=${clsx(
         tw`flex h-5 items-center gap-1 truncate whitespace-nowrap leading-5`,
         href
-          ? tw`font-medium text-neutral-400 transition-colors hover:text-neutral-500`
-          : null,
+          ? tw`font-medium text-neutral-500 transition-colors hover:text-neutral-700`
+          : tw`font-medium text-primary`,
         classNames,
       )}
       href=${ifDefined(href)}
@@ -59,7 +59,7 @@ function breadcrumbLink({ href, content }: Breadcrumb, classNames?: string) {
 
 function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
   return html`
-    <nav class="flex flex-wrap items-center gap-2 text-neutral-400">
+    <nav class="flex flex-wrap items-center gap-2 text-neutral-500">
       ${breadcrumbs.length
         ? breadcrumbs.map(
             (breadcrumb, i) => html`
@@ -78,7 +78,7 @@ export function pageBack({ href, content }: Breadcrumb) {
   return breadcrumbLink({
     href,
     content: html`
-      <sl-icon name="chevron-left" class="size-4 text-neutral-400"></sl-icon>
+      <sl-icon name="chevron-left" class="size-4 text-neutral-500"></sl-icon>
       ${content ? html` ${msg("Back to")} ${content}` : msg("Back")}
     `,
   });

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -1,3 +1,4 @@
+import { msg } from "@lit/localize";
 import type { SlBreadcrumb } from "@shoelace-style/shoelace";
 import clsx from "clsx";
 import { html, nothing, type TemplateResult } from "lit";
@@ -22,9 +23,16 @@ function navigateBreadcrumb(e: MouseEvent, href: string) {
   el.dispatchEvent(evt);
 }
 
+export function breadcrumbSeparator() {
+  return html`
+    <span slot="separator" class="font-mono font-thin text-neutral-400">/</span>
+  `;
+}
+
 export function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
   return html`
     <sl-breadcrumb class="part-[base]:h-6">
+      ${breadcrumbSeparator()}
       ${breadcrumbs.length
         ? breadcrumbs.map(
             ({ href, content }) => html`
@@ -45,6 +53,24 @@ export function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
               <sl-skeleton class="w-48"></sl-skeleton>
             </sl-breadcrumb-item>`}
     </sl-breadcrumb>
+  `;
+}
+
+export function pageBack(nav: Breadcrumb) {
+  const { href } = nav;
+  if (!href) return;
+
+  return html`
+    <sl-button
+      class="-ml-4"
+      variant="text"
+      size="small"
+      href=${href}
+      @click=${(e: MouseEvent) => navigateBreadcrumb(e, href)}
+    >
+      <sl-icon slot="prefix" name="chevron-left"></sl-icon>
+      ${nav.content ? html` ${msg("Back to")} ${nav.content}` : msg("Back")}
+    </sl-button>
   `;
 }
 

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -280,7 +280,7 @@ export class Crawls extends LiteElement {
   }
 
   private readonly renderCrawlItem = (crawl: Crawl) => {
-    const crawlPath = `/orgs/${this.slugLookup[crawl.oid]}/items/crawl/${
+    const crawlPath = `/orgs/${this.slugLookup[crawl.oid]}/workflows/${crawl.cid}/crawls/${
       crawl.id
     }`;
     return html`

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -562,18 +562,7 @@ export class ArchivedItemDetail extends BtrixElement {
   }
 
   private renderHeader() {
-    let parentPageLabel: TemplateResult | null = null;
-
-    if (this.workflowId || this.collectionId) {
-      parentPageLabel = html`<div class="mb-1 font-medium text-neutral-400">
-        ${this.workflowId
-          ? msg("Viewing Workflow Crawl")
-          : msg("Viewing Archived Item in Collection")}
-      </div>`;
-    }
-
     return html`
-      ${parentPageLabel}
       <header class="mb-3 flex flex-wrap gap-2 border-b pb-3">
         <btrix-detail-page-title .item=${this.crawl}></btrix-detail-page-title>
         <div class="ml-auto flex flex-wrap justify-end gap-2">

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -76,7 +76,7 @@ export class ArchivedItemDetail extends BtrixElement {
   showOrgLink = false;
 
   @property({ type: String })
-  crawlId?: string;
+  itemId?: string;
 
   @property({ type: Boolean })
   isCrawler = false;
@@ -173,7 +173,7 @@ export class ArchivedItemDetail extends BtrixElement {
   }
 
   willUpdate(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has("crawlId") && this.crawlId) {
+    if (changedProperties.has("itemId") && this.itemId) {
       void this.fetchCrawl();
       void this.fetchCrawlLogs();
       if (this.itemType === "crawl") {
@@ -271,7 +271,7 @@ export class ArchivedItemDetail extends BtrixElement {
             </div> `,
           html`
             <btrix-archived-item-detail-qa
-              .crawlId=${this.crawlId}
+              .crawlId=${this.itemId}
               .itemType=${this.itemType}
               .crawl=${this.item}
               .qaRuns=${this.qaRuns}
@@ -295,7 +295,7 @@ export class ArchivedItemDetail extends BtrixElement {
           html` ${this.renderTitle(this.tabLabels.files)}
             <sl-tooltip content=${msg("Download all files as a single WACZ")}>
               <sl-button
-                href=${`/api/orgs/${this.orgId}/all-crawls/${this.crawlId}/download?auth_bearer=${authToken}`}
+                href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}`}
                 download
                 size="small"
                 variant="primary"
@@ -311,8 +311,8 @@ export class ArchivedItemDetail extends BtrixElement {
         sectionContent = this.renderPanel(
           html` ${this.renderTitle(this.tabLabels.logs)}
             <sl-button
-              href=${`/api/orgs/${this.orgId}/crawls/${this.crawlId}/logs?auth_bearer=${authToken}`}
-              download=${`btrix-${this.crawlId}-logs.txt`}
+              href=${`/api/orgs/${this.orgId}/crawls/${this.itemId}/logs?auth_bearer=${authToken}`}
+              download=${`btrix-${this.itemId}-logs.txt`}
               size="small"
               variant="primary"
             >
@@ -339,7 +339,7 @@ export class ArchivedItemDetail extends BtrixElement {
             <sl-button
               size="small"
               variant="primary"
-              href="${this.navigate.orgBasePath}/workflows/crawl/${this.item
+              href="${this.navigate.orgBasePath}/workflows/${this.item
                 ?.cid}?edit"
               ?disabled=${!this.item}
               @click=${this.navigate.link}
@@ -429,15 +429,15 @@ export class ArchivedItemDetail extends BtrixElement {
     if (this.itemType === "crawl") {
       breadcrumbs.push(
         {
-          href: `${this.navigate.orgBasePath}/workflows/crawls`,
+          href: `${this.navigate.orgBasePath}/workflows`,
           content: msg("Crawl Workflows"),
         },
         {
-          href: `${this.navigate.orgBasePath}/workflows/crawl/${this.item?.cid}`,
+          href: `${this.navigate.orgBasePath}/workflows/${this.item?.cid}`,
           content: this.workflow ? renderName(this.workflow) : undefined,
         },
         {
-          href: `${this.navigate.orgBasePath}/workflows/crawl/${this.item?.cid}#crawls`,
+          href: `${this.navigate.orgBasePath}/workflows/${this.item?.cid}#crawls`,
           content: msg("Crawls"),
         },
       );
@@ -639,7 +639,7 @@ export class ArchivedItemDetail extends BtrixElement {
               <sl-menu-item
                 @click=${() =>
                   this.navigate.to(
-                    `${this.navigate.orgBasePath}/workflows/crawl/${this.item?.cid}`,
+                    `${this.navigate.orgBasePath}/workflows/${this.item?.cid}`,
                   )}
               >
                 <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>
@@ -666,7 +666,7 @@ export class ArchivedItemDetail extends BtrixElement {
             () => html`
               <sl-divider></sl-divider>
               <btrix-menu-item-link
-                href=${`/api/orgs/${this.orgId}/all-crawls/${this.crawlId}/download?auth_bearer=${authToken}`}
+                href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}`}
                 download
               >
                 <sl-icon name="cloud-download" slot="prefix"></sl-icon>
@@ -720,7 +720,7 @@ export class ArchivedItemDetail extends BtrixElement {
     if (!this.item) return;
     const replaySource = `/api/orgs/${this.item.oid}/${
       this.item.type === "upload" ? "uploads" : "crawls"
-    }/${this.crawlId}/replay.json`;
+    }/${this.itemId}/replay.json`;
 
     const headers = this.authState?.headers;
 
@@ -1232,14 +1232,14 @@ ${this.item?.description}
   private async getCrawl(): Promise<Crawl> {
     const apiPath = `/orgs/${this.orgId}/${
       this.itemType === "upload" ? "uploads" : "crawls"
-    }/${this.crawlId}/replay.json`;
+    }/${this.itemId}/replay.json`;
     return this.api.fetch<Crawl>(apiPath);
   }
 
   private async getSeeds() {
     // NOTE Returns first 1000 seeds (backend pagination max)
     const data = await this.api.fetch<APIPaginatedList<Seed>>(
-      `/orgs/${this.orgId}/crawls/${this.crawlId}/seeds`,
+      `/orgs/${this.orgId}/crawls/${this.itemId}/seeds`,
     );
     return data;
   }
@@ -1272,7 +1272,7 @@ ${this.item?.description}
     const pageSize = params.pageSize || this.logs?.pageSize || 50;
 
     const data = (await this.api.fetch)<APIPaginatedList<CrawlLog>>(
-      `/orgs/${this.orgId}/crawls/${this.crawlId}/errors?page=${page}&pageSize=${pageSize}`,
+      `/orgs/${this.orgId}/crawls/${this.itemId}/errors?page=${page}&pageSize=${pageSize}`,
     );
 
     return data;
@@ -1281,7 +1281,7 @@ ${this.item?.description}
   private async cancel() {
     if (window.confirm(msg("Are you sure you want to cancel the crawl?"))) {
       const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.item!.oid}/crawls/${this.crawlId}/cancel`,
+        `/orgs/${this.item!.oid}/crawls/${this.itemId}/cancel`,
         {
           method: "POST",
         },
@@ -1302,7 +1302,7 @@ ${this.item?.description}
   private async stop() {
     if (window.confirm(msg("Are you sure you want to stop the crawl?"))) {
       const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.item!.oid}/crawls/${this.crawlId}/stop`,
+        `/orgs/${this.item!.oid}/crawls/${this.itemId}/stop`,
         {
           method: "POST",
         },
@@ -1379,7 +1379,7 @@ ${this.item?.description}
   private async startQARun() {
     try {
       const result = await this.api.fetch<{ started: string }>(
-        `/orgs/${this.orgId}/crawls/${this.crawlId}/qa/start`,
+        `/orgs/${this.orgId}/crawls/${this.itemId}/qa/start`,
         {
           method: "POST",
         },
@@ -1413,7 +1413,7 @@ ${this.item?.description}
   private async stopQARun() {
     try {
       const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.item!.oid}/crawls/${this.crawlId}/qa/stop`,
+        `/orgs/${this.item!.oid}/crawls/${this.itemId}/qa/stop`,
         {
           method: "POST",
         },
@@ -1444,7 +1444,7 @@ ${this.item?.description}
   private async cancelQARun() {
     try {
       const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.item!.oid}/crawls/${this.crawlId}/qa/cancel`,
+        `/orgs/${this.item!.oid}/crawls/${this.itemId}/qa/cancel`,
         {
           method: "POST",
         },
@@ -1505,7 +1505,7 @@ ${this.item?.description}
 
   private async getQARuns(): Promise<QARun[]> {
     return this.api.fetch<QARun[]>(
-      `/orgs/${this.orgId}/crawls/${this.crawlId}/qa`,
+      `/orgs/${this.orgId}/crawls/${this.itemId}/qa`,
     );
   }
 }

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1076,9 +1076,11 @@ ${this.crawl?.description}
     const qaIsRunning = this.isQAActive;
     const qaIsAvailable = !!this.mostRecentNonFailedQARun;
 
+    console.log(new URL(window.location.href).pathname);
+
     const reviewLink =
       qaIsAvailable && this.qaRunId
-        ? `${this.navigate.orgBasePath}/items/crawl/${this.crawlId}/review/screenshots?qaRunId=${this.qaRunId}`
+        ? `${new URL(window.location.href).pathname}/review/screenshots?qaRunId=${this.qaRunId}`
         : undefined;
 
     return html`

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -324,7 +324,30 @@ export class ArchivedItemDetail extends BtrixElement {
         break;
       case "config":
         sectionContent = this.renderPanel(
-          this.tabLabels.config,
+          html`
+            ${this.renderTitle(html`
+              ${this.tabLabels.config}
+              <sl-tooltip
+                content=${msg("Workflow settings used to run this crawl")}
+              >
+                <sl-icon
+                  class="text-base text-neutral-500"
+                  name="info-circle"
+                ></sl-icon>
+              </sl-tooltip>
+            `)}
+            <sl-button
+              size="small"
+              variant="primary"
+              href="${this.navigate.orgBasePath}/workflows/crawl/${this.item
+                ?.cid}?edit"
+              ?disabled=${!this.item}
+              @click=${this.navigate.link}
+            >
+              <sl-icon slot="prefix" name="gear"></sl-icon>
+              ${msg("Edit Workflow")}
+            </sl-button>
+          `,
           this.renderConfig(),
           [tw`rounded-lg border p-4`],
         );
@@ -670,7 +693,11 @@ export class ArchivedItemDetail extends BtrixElement {
   }
 
   private renderTitle(title: string | TemplateResult<1>) {
-    return html`<h2 class="text-lg font-semibold leading-8">${title}</h2>`;
+    return html`<h2
+      class="flex items-center gap-2 text-lg font-semibold leading-8"
+    >
+      ${title}
+    </h2>`;
   }
 
   private renderPanel(

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -272,7 +272,7 @@ export class ArchivedItemDetail extends BtrixElement {
           html`
             <btrix-archived-item-detail-qa
               .crawlId=${this.itemId}
-              .itemType=${this.itemType}
+              .workflowId=${this.workflowId}
               .crawl=${this.item}
               .qaRuns=${this.qaRuns}
               .qaRunId=${this.qaRunId}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -597,7 +597,19 @@ export class ArchivedItemDetail extends BtrixElement {
             : ""}
           ${this.isCrawler
             ? this.crawl
-              ? this.renderMenu()
+              ? html`
+                  ${this.crawl.type === "crawl"
+                    ? html`<sl-button
+                        size="small"
+                        href=${`${this.navigate.orgBasePath}/workflows/crawl/${this.crawl.cid}`}
+                        @click=${this.navigate.link}
+                      >
+                        <sl-icon name="file-code-fill" slot="prefix"></sl-icon>
+                        ${msg("Go to Workflow")}
+                      </sl-button>`
+                    : nothing}
+                  ${this.renderMenu()}
+                `
               : html`<sl-skeleton
                   class="h-8 w-24 [--border-radius:theme(borderRadius.sm)]"
                 ></sl-skeleton>`

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -87,10 +87,10 @@ export class ArchivedItemDetailQA extends BtrixElement {
   `;
 
   @property({ type: String, attribute: false })
-  crawlId?: string;
+  workflowId?: string;
 
   @property({ type: String, attribute: false })
-  itemType: ArchivedItem["type"] = "crawl";
+  crawlId?: string;
 
   @property({ type: Object, attribute: false })
   crawl?: ArchivedItem;
@@ -771,7 +771,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
                   ${this.qaRunId
                     ? html`
                         <a
-                          href=${`${this.navigate.orgBasePath}/items/${this.itemType}/${this.crawlId}/review/screenshots?qaRunId=${this.qaRunId}&itemPageId=${page.id}`}
+                          href=${`${this.navigate.orgBasePath}/workflows/${this.workflowId}/crawls/${this.crawlId}/review/screenshots?qaRunId=${this.qaRunId}&itemPageId=${page.id}`}
                           title=${msg(str`Review "${page.title ?? page.url}"`)}
                           @click=${this.navigate.link}
                         >

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -86,6 +86,9 @@ export class ArchivedItemQA extends BtrixElement {
   static styles = styles;
 
   @property({ type: String })
+  workflowId?: string;
+
+  @property({ type: String })
   itemId?: string;
 
   @property({ type: String })
@@ -353,7 +356,7 @@ export class ArchivedItemQA extends BtrixElement {
   }
 
   render() {
-    const crawlBaseUrl = `${this.navigate.orgBasePath}/items/crawl/${this.itemId}`;
+    const crawlBaseUrl = `${this.navigate.orgBasePath}/workflows/${this.workflowId}/crawls/${this.itemId}`;
     const searchParams = new URLSearchParams(window.location.search);
     const itemName = this.item ? renderName(this.item) : nothing;
     const [prevPage, currentPage, nextPage] = this.getPageListSliceByCurrent();
@@ -600,7 +603,7 @@ export class ArchivedItemQA extends BtrixElement {
 
   private renderBackLink() {
     return pageBack({
-      href: `${this.navigate.orgBasePath}/items/crawl/${this.itemId}?workflowId=${this.item?.cid}#qa`,
+      href: `${this.navigate.orgBasePath}/workflows/${this.workflowId}/crawls/${this.itemId}?workflowId=${this.item?.cid}#qa`,
       content: this.item ? renderName(this.item) : undefined,
     });
   }
@@ -1490,7 +1493,7 @@ export class ArchivedItemQA extends BtrixElement {
       void this.reviewDialog?.hide();
 
       this.navigate.to(
-        `${this.navigate.orgBasePath}/items/crawl/${this.itemId}#qa`,
+        `${this.navigate.orgBasePath}/workflows/${this.workflowId}/crawls/${this.itemId}#qa`,
       );
       this.notify.toast({
         message: msg("Saved QA review."),

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -95,6 +95,12 @@ export class ArchivedItemQA extends BtrixElement {
   qaRunId?: string;
 
   @property({ type: String })
+  workflowId?: string;
+
+  @property({ type: String })
+  collectionId?: string;
+
+  @property({ type: String })
   tab: QATypes.QATab = "screenshots";
 
   @state()

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -30,7 +30,6 @@ import {
 } from "@/features/qa/page-list/page-list";
 import { type UpdatePageApprovalDetail } from "@/features/qa/page-qa-approval";
 import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
-import { pageBreadcrumbs } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -371,7 +370,9 @@ export class ArchivedItemQA extends BtrixElement {
       ${this.renderHidden()}
 
       <div class="grid--header pb-3 h-8 border-b flex items-center">
-        ${this.renderBreadcrumbs()} ${when(
+        ${this.renderBackLink()}
+        <sl-icon name="chevron-right"></sl-icon>
+        ${when(
           this.finishedQARuns,
           (qaRuns) => html`
             <btrix-qa-run-dropdown
@@ -591,26 +592,25 @@ export class ArchivedItemQA extends BtrixElement {
     `;
   }
 
-  private renderBreadcrumbs() {
-    const breadcrumbs = [
-      {
-        href: `${this.navigate.orgBasePath}/items`,
-        content: msg("Archived Items"),
-      },
-      {
-        href: `${this.navigate.orgBasePath}/items/crawl/${this.itemId}`,
-        content: this.item ? renderName(this.item) : undefined,
-      },
-      {
-        href: `${this.navigate.orgBasePath}/items/crawl/${this.itemId}#qa`,
-        content: msg("Quality Assurance"),
-      },
-      {
-        content: msg("Review"),
-      },
-    ];
+  private renderBackLink() {
+    let backLink = `${this.navigate.orgBasePath}/items/${this.item?.type}/${this.itemId}#qa`;
 
-    return pageBreadcrumbs(breadcrumbs);
+    if (this.workflowId) {
+      backLink = `${this.navigate.orgBasePath}/workflows/crawl/${this.workflowId}/items/${this.itemId}#qa`;
+    } else if (this.collectionId) {
+      backLink = `${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${this.item?.type}/${this.itemId}#qa`;
+    }
+
+    return html`
+      <sl-button
+        variant="text"
+        size="small"
+        href=${backLink}
+        @click=${this.navigate.link}
+      >
+        ${this.item ? renderName(this.item) : ""}
+      </sl-button>
+    `;
   }
 
   private renderReviewDialog() {

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -30,7 +30,7 @@ import {
 } from "@/features/qa/page-list/page-list";
 import { type UpdatePageApprovalDetail } from "@/features/qa/page-qa-approval";
 import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
-import { breadcrumbSeparator, pageBack } from "@/layouts/pageHeader";
+import { pageBack } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -93,12 +93,6 @@ export class ArchivedItemQA extends BtrixElement {
 
   @property({ type: String })
   qaRunId?: string;
-
-  @property({ type: String })
-  collectionId?: string;
-
-  @property({ type: String })
-  workflowId?: string;
 
   @property({ type: String })
   tab: QATypes.QATab = "screenshots";
@@ -373,11 +367,6 @@ export class ArchivedItemQA extends BtrixElement {
 
       <div class="flex items-center">
         ${this.renderBackLink()}
-        <div class="mx-2">${breadcrumbSeparator()}</div>
-        <h1 class="text-neutral-500 font-medium">
-          ${msg("Review Crawl")}
-          <btrix-beta-badge placement="right"></btrix-beta-badge>
-        </h1>
       </div>
 
       <article class="qa-grid min-h-screen grid gap-x-6 gap-y-0 lg:snap-start">
@@ -385,25 +374,27 @@ export class ArchivedItemQA extends BtrixElement {
           class="grid--header flex flex-wrap items-center justify-between gap-1 border-b py-2"
         >
           <div class="flex items-center gap-2 overflow-hidden">
-            <h2
-              class="flex-1 flex-shrink-0 min-w-32 truncate text-base font-semibold leading-tight"
+            <h1
+              class="flex gap-1 flex-1 flex-shrink-0 min-w-32 truncate text-base font-semibold leading-tight"
             >
-              ${itemName}
-            </h2>
+              ${msg("Review")} ${itemName}
+            </h1>
             ${when(
               this.finishedQARuns,
               (qaRuns) => html`
-                <btrix-qa-run-dropdown
-                  .items=${qaRuns}
-                  selectedId=${this.qaRunId || ""}
-                  @btrix-select=${(e: CustomEvent<SelectDetail>) => {
-                    const params = new URLSearchParams(searchParams);
-                    params.set("qaRunId", e.detail.item.id);
-                    this.navigate.to(
-                      `${window.location.pathname}?${params.toString()}`,
-                    );
-                  }}
-                ></btrix-qa-run-dropdown>
+                <sl-tooltip content=${msg("Select Analysis Run")}>
+                  <btrix-qa-run-dropdown
+                    .items=${qaRuns}
+                    selectedId=${this.qaRunId || ""}
+                    @btrix-select=${(e: CustomEvent<SelectDetail>) => {
+                      const params = new URLSearchParams(searchParams);
+                      params.set("qaRunId", e.detail.item.id);
+                      this.navigate.to(
+                        `${window.location.pathname}?${params.toString()}`,
+                      );
+                    }}
+                  ></btrix-qa-run-dropdown>
+                </sl-tooltip>
               `,
             )}
           </div>
@@ -542,11 +533,11 @@ export class ArchivedItemQA extends BtrixElement {
         <section
           class="grid--pageList grid grid-rows-[auto_1fr] *:min-h-0 *:min-w-0"
         >
-          <h3
+          <h2
             class="my-4 text-base font-semibold leading-none text-neutral-800"
           >
             ${msg("Pages")}
-          </h3>
+          </h2>
           <btrix-qa-page-list
             class="flex flex-col lg:contain-size"
             .qaRunId=${this.qaRunId}
@@ -608,17 +599,9 @@ export class ArchivedItemQA extends BtrixElement {
   }
 
   private renderBackLink() {
-    let backLink = `${this.navigate.orgBasePath}/items/crawl/${this.itemId}#qa`;
-
-    if (this.workflowId) {
-      backLink = `${this.navigate.orgBasePath}/workflows/crawl/${this.workflowId}/items/${this.itemId}#qa`;
-    } else if (this.collectionId) {
-      backLink = `${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/crawl/${this.itemId}#qa`;
-    }
-
     return pageBack({
-      href: backLink,
-      content: msg("Crawl QA"),
+      href: `${this.navigate.orgBasePath}/workflows/crawl/${this.item?.cid}/items/${this.itemId}#qa`,
+      content: this.item ? renderName(this.item) : undefined,
     });
   }
 

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -373,8 +373,8 @@ export class ArchivedItemQA extends BtrixElement {
 
       <div class="flex items-center">
         ${this.renderBackLink()}
-        <div role="separator">${breadcrumbSeparator()}</div>
-        <h1 class="text-neutral-500 font-medium ml-3">
+        <div class="mx-2">${breadcrumbSeparator()}</div>
+        <h1 class="text-neutral-500 font-medium">
           ${msg("Review Crawl")}
           <btrix-beta-badge placement="right"></btrix-beta-badge>
         </h1>

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -30,6 +30,7 @@ import {
 } from "@/features/qa/page-list/page-list";
 import { type UpdatePageApprovalDetail } from "@/features/qa/page-qa-approval";
 import type { SelectDetail } from "@/features/qa/qa-run-dropdown";
+import { breadcrumbSeparator, pageBack } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -372,9 +373,9 @@ export class ArchivedItemQA extends BtrixElement {
 
       <div class="flex items-center">
         ${this.renderBackLink()}
-        <div class="text-neutral-400" role="separator">/</div>
-        <h1 class="text-neutral-400 ml-3">
-          ${msg("QA Review")}
+        <div role="separator">${breadcrumbSeparator()}</div>
+        <h1 class="text-neutral-500 font-medium ml-3">
+          ${msg("Review Crawl")}
           <btrix-beta-badge placement="right"></btrix-beta-badge>
         </h1>
       </div>
@@ -615,18 +616,10 @@ export class ArchivedItemQA extends BtrixElement {
       backLink = `${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/crawl/${this.itemId}#qa`;
     }
 
-    return html`
-      <sl-button
-        class="-ml-4"
-        variant="text"
-        size="small"
-        href=${backLink}
-        @click=${this.navigate.link}
-      >
-        <sl-icon name="chevron-left"></sl-icon>
-        ${msg("Back to Crawl")}
-      </sl-button>
-    `;
+    return pageBack({
+      href: backLink,
+      content: msg("Crawl QA"),
+    });
   }
 
   private renderReviewDialog() {

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -600,7 +600,7 @@ export class ArchivedItemQA extends BtrixElement {
 
   private renderBackLink() {
     return pageBack({
-      href: `${this.navigate.orgBasePath}/workflows/crawl/${this.item?.cid}/items/${this.itemId}#qa`,
+      href: `${this.navigate.orgBasePath}/items/crawl/${this.itemId}?workflowId=${this.item?.cid}#qa`,
       content: this.item ? renderName(this.item) : undefined,
     });
   }

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -559,7 +559,7 @@ export class CrawlsList extends BtrixElement {
 
   private readonly renderArchivedItem = (item: ArchivedItem) => html`
     <btrix-archived-item-list-item
-      href=${`${this.navigate.orgBasePath}/items/${item.type}/${item.id}`}
+      href=${`${this.navigate.orgBasePath}/${item.type === "crawl" ? `workflows/${item.cid}/crawls` : `items/${item.type}`}/${item.id}`}
       .item=${item}
       ?showStatus=${this.itemType !== null}
     >
@@ -598,7 +598,7 @@ export class CrawlsList extends BtrixElement {
             <sl-menu-item
               @click=${() =>
                 this.navigate.to(
-                  `${this.navigate.orgBasePath}/workflows/crawl/${item.cid}`,
+                  `${this.navigate.orgBasePath}/workflows/${item.cid}`,
                 )}
             >
               <sl-icon name="arrow-return-right" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -11,7 +11,7 @@ import type { Profile, ProfileWorkflow } from "./types";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { BrowserConnectionChange } from "@/features/browser-profiles/profile-browser";
-import { pageBreadcrumbs } from "@/layouts/pageHeader";
+import { pageNav } from "@/layouts/pageHeader";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 import { formatNumber, getLocale } from "@/utils/localization";
@@ -323,7 +323,7 @@ export class BrowserProfilesDetail extends BtrixElement {
       },
     ];
 
-    return pageBreadcrumbs(breadcrumbs);
+    return pageNav(breadcrumbs);
   }
 
   private renderCrawlWorkflows() {

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -336,7 +336,7 @@ export class BrowserProfilesDetail extends BtrixElement {
             >
               <a
                 class="block p-2 transition-colors focus-within:bg-neutral-50 hover:bg-neutral-50"
-                href=${`${this.navigate.orgBasePath}/workflows/crawl/${workflow.id}`}
+                href=${`${this.navigate.orgBasePath}/workflows/${workflow.id}`}
                 @click=${this.navigate.link}
               >
                 ${this.renderWorkflowName(workflow)}

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -7,7 +7,7 @@ import queryString from "query-string";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { BrowserConnectionChange } from "@/features/browser-profiles/profile-browser";
-import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
+import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { isApiError } from "@/utils/api";
 
 /**
@@ -168,13 +168,9 @@ export class BrowserProfilesNew extends BtrixElement {
           content: msg("Duplicate Profile"),
         },
       );
-    } else {
-      breadcrumbs.push({
-        content: msg("New Browser Profile"),
-      });
     }
 
-    return pageBreadcrumbs(breadcrumbs);
+    return pageNav(breadcrumbs);
   }
 
   private async onBrowserError() {

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -661,7 +661,7 @@ export class CollectionDetail extends BtrixElement {
     idx: number,
   ) => html`
     <btrix-archived-item-list-item
-      href=${`${this.navigate.orgBasePath}/items/${item.type}/${item.id}?collectionId=${this.collectionId}`}
+      href=${`${this.navigate.orgBasePath}/${item.type === "crawl" ? `workflows/${item.cid}/crawls` : `items/${item.type}`}/${item.id}?collectionId=${this.collectionId}`}
       .item=${item}
     >
       ${this.isCrawler

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -10,7 +10,7 @@ import queryString from "query-string";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { PageChangeEvent } from "@/components/ui/pagination";
-import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
+import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -98,20 +98,22 @@ export class CollectionDetail extends BtrixElement {
     return html` <div class="mb-7">${this.renderBreadcrumbs()}</div>
       <header class="items-center gap-2 pb-3 md:flex">
         <div class="mb-2 flex w-full items-center gap-2 md:mb-0">
-          ${this.collection?.isPublic
-            ? html`
-                <sl-tooltip content=${msg("Shareable")}>
-                  <sl-icon
-                    class="text-lg text-success-600"
-                    name="people-fill"
-                  ></sl-icon>
-                </sl-tooltip>
-              `
-            : html`
-                <sl-tooltip content=${msg("Private")}>
-                  <sl-icon class="text-lg" name="eye-slash-fill"></sl-icon>
-                </sl-tooltip>
-              `}
+          <div class="flex size-8 items-center justify-center">
+            ${this.collection?.isPublic
+              ? html`
+                  <sl-tooltip content=${msg("Shareable")}>
+                    <sl-icon
+                      class="text-lg text-success-600"
+                      name="people-fill"
+                    ></sl-icon>
+                  </sl-tooltip>
+                `
+              : html`
+                  <sl-tooltip content=${msg("Private")}>
+                    <sl-icon class="text-lg" name="eye-slash-fill"></sl-icon>
+                  </sl-tooltip>
+                `}
+          </div>
           <h1 class="min-w-0 flex-1 truncate text-xl font-semibold leading-7">
             ${this.collection?.name ||
             html`<sl-skeleton class="w-96"></sl-skeleton>`}
@@ -361,27 +363,12 @@ export class CollectionDetail extends BtrixElement {
         href: `${this.navigate.orgBasePath}/collections`,
         content: msg("Collections"),
       },
+      {
+        content: this.collection?.name,
+      },
     ];
 
-    if (this.collection) {
-      if (this.collectionTab) {
-        breadcrumbs.push(
-          {
-            href: `${this.navigate.orgBasePath}/collections/view/${this.collectionId}`,
-            content: this.collection.name,
-          },
-          {
-            content: this.tabLabels[this.collectionTab].text,
-          },
-        );
-      } else {
-        breadcrumbs.push({
-          content: this.collection.name,
-        });
-      }
-    }
-
-    return pageBreadcrumbs(breadcrumbs);
+    return pageNav(breadcrumbs);
   };
 
   private readonly renderTabs = () => {
@@ -674,7 +661,7 @@ export class CollectionDetail extends BtrixElement {
     idx: number,
   ) => html`
     <btrix-archived-item-list-item
-      href=${`${this.navigate.orgBasePath}/collections/view/${this.collectionId}/items/${item.type}/${item.id}`}
+      href=${`${this.navigate.orgBasePath}/items/${item.type}/${item.id}?collectionId=${this.collectionId}`}
       .item=${item}
     >
       ${this.isCrawler

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -18,7 +18,7 @@ import type { QuotaUpdateDetail } from "@/controllers/api";
 import needLogin from "@/decorators/needLogin";
 import type { CollectionSavedEvent } from "@/features/collections/collection-metadata-dialog";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
-import type { Crawl, JobType } from "@/types/crawler";
+import type { JobType } from "@/types/crawler";
 import type { UserOrg } from "@/types/user";
 import { isApiError } from "@/utils/api";
 import type { ViewState } from "@/utils/APIRouter";
@@ -45,23 +45,22 @@ import(/* webpackChunkName: "org" */ "./browser-profiles-new");
 const RESOURCE_NAMES = ["workflow", "collection", "browser-profile", "upload"];
 type ResourceName = (typeof RESOURCE_NAMES)[number];
 export type SelectNewDialogEvent = CustomEvent<ResourceName>;
+type ArchivedItemPageParams = {
+  itemId?: string;
+  itemType?: string;
+  itemPageId?: string;
+  qaTab?: QATab;
+  qaRunId?: string;
+  workflowId?: string;
+  collectionId?: string;
+};
 export type OrgParams = {
   home: Record<string, never>;
-  workflows: {
-    workflowId?: string;
-    itemId?: string;
+  workflows: ArchivedItemPageParams & {
     jobType?: JobType;
     new?: ResourceName;
   };
-  items: {
-    itemType?: Crawl["type"];
-    itemId?: string;
-    itemPageId?: string;
-    qaTab?: QATab;
-    qaRunId?: string;
-    workflowId?: string;
-    collectionId?: string;
-  };
+  items: ArchivedItemPageParams;
   "browser-profiles": {
     browserProfileId?: string;
     browserId?: string;
@@ -73,10 +72,7 @@ export type OrgParams = {
     profileId?: string;
     navigateUrl?: string;
   };
-  collections: {
-    collectionId?: string;
-    itemId?: string;
-    itemType?: string;
+  collections: ArchivedItemPageParams & {
     collectionTab?: string;
   };
   settings: {
@@ -231,8 +227,7 @@ export class Org extends LiteElement {
   }
 
   render() {
-    const noMaxWidth =
-      this.orgTab === "items" && (this.params as OrgParams["items"]).qaTab;
+    const noMaxWidth = (this.params as OrgParams["items"]).qaTab;
 
     return html`
       <btrix-document-title
@@ -501,6 +496,17 @@ export class Org extends LiteElement {
 
     if (workflowId) {
       if (params.itemId) {
+        if (params.qaTab) {
+          return html`<btrix-archived-item-qa
+            class="flex-1"
+            itemId=${params.itemId}
+            workflowId=${workflowId}
+            itemPageId=${ifDefined(params.itemPageId)}
+            qaRunId=${ifDefined(params.qaRunId)}
+            tab=${params.qaTab}
+          ></btrix-archived-item-qa>`;
+        }
+
         return html`<btrix-archived-item-detail
           crawlId=${params.itemId}
           workflowId=${workflowId}
@@ -578,6 +584,16 @@ export class Org extends LiteElement {
 
     if (params.collectionId) {
       if (params.itemId) {
+        if (params.qaTab) {
+          return html`<btrix-archived-item-qa
+            class="flex-1"
+            itemId=${params.itemId}
+            collectionId=${params.collectionId}
+            itemPageId=${ifDefined(params.itemPageId)}
+            qaRunId=${ifDefined(params.qaRunId)}
+            tab=${params.qaTab}
+          ></btrix-archived-item-qa>`;
+        }
         return html`<btrix-archived-item-detail
           crawlId=${params.itemId}
           collectionId=${params.collectionId}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -480,8 +480,6 @@ export class Org extends LiteElement {
           class="flex-1"
           itemId=${params.itemId}
           itemPageId=${ifDefined(params.itemPageId)}
-          collectionId=${params.collectionId || ""}
-          workflowId=${params.workflowId || ""}
           qaRunId=${ifDefined(params.qaRunId)}
           tab=${params.qaTab}
         ></btrix-archived-item-qa>`;

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -46,6 +46,7 @@ const RESOURCE_NAMES = ["workflow", "collection", "browser-profile", "upload"];
 type ResourceName = (typeof RESOURCE_NAMES)[number];
 export type SelectNewDialogEvent = CustomEvent<ResourceName>;
 type ArchivedItemPageParams = {
+  itemId?: string;
   workflowId?: string;
   collectionId?: string;
 };
@@ -54,13 +55,12 @@ export type OrgParams = {
   workflows: ArchivedItemPageParams & {
     jobType?: JobType;
     new?: ResourceName;
-  };
-  items: ArchivedItemPageParams & {
-    itemId?: string;
-    itemType?: string;
     itemPageId?: string;
     qaTab?: QATab;
     qaRunId?: string;
+  };
+  items: ArchivedItemPageParams & {
+    itemType?: string;
   };
   "browser-profiles": {
     browserProfileId?: string;
@@ -241,7 +241,7 @@ export class Org extends LiteElement {
   }
 
   render() {
-    const noMaxWidth = (this.params as OrgParams["items"]).qaTab;
+    const noMaxWidth = (this.params as OrgParams["workflows"]).qaTab;
 
     return html`
       <btrix-document-title
@@ -337,7 +337,7 @@ export class Org extends LiteElement {
           ${this.renderNavTab({
             tabName: "workflows",
             label: msg("Crawling"),
-            path: "workflows/crawls",
+            path: "workflows",
           })}
           ${this.renderNavTab({
             tabName: "items",
@@ -469,24 +469,8 @@ export class Org extends LiteElement {
     const params = this.params as OrgParams["items"];
 
     if (params.itemId) {
-      if (params.qaTab) {
-        if (!this.appState.isCrawler) {
-          return html`<btrix-not-found
-            class="flex items-center justify-center"
-          ></btrix-not-found>`;
-        }
-
-        return html`<btrix-archived-item-qa
-          class="flex-1"
-          itemId=${params.itemId}
-          itemPageId=${ifDefined(params.itemPageId)}
-          qaRunId=${ifDefined(params.qaRunId)}
-          tab=${params.qaTab}
-        ></btrix-archived-item-qa>`;
-      }
-
       return html` <btrix-archived-item-detail
-        crawlId=${params.itemId}
+        itemId=${params.itemId}
         collectionId=${params.collectionId || ""}
         workflowId=${params.workflowId || ""}
         itemType=${params.itemType || "crawl"}
@@ -509,6 +493,33 @@ export class Org extends LiteElement {
     const workflowId = params.workflowId;
 
     if (workflowId) {
+      if (params.itemId) {
+        if (params.qaTab) {
+          if (!this.appState.isCrawler) {
+            return html`<btrix-not-found
+              class="flex items-center justify-center"
+            ></btrix-not-found>`;
+          }
+
+          return html`<btrix-archived-item-qa
+            class="flex-1"
+            workflowId=${workflowId}
+            itemId=${params.itemId}
+            itemPageId=${ifDefined(params.itemPageId)}
+            qaRunId=${ifDefined(params.qaRunId)}
+            tab=${params.qaTab}
+          ></btrix-archived-item-qa>`;
+        }
+
+        return html` <btrix-archived-item-detail
+          itemId=${params.itemId}
+          collectionId=${params.collectionId || ""}
+          workflowId=${workflowId}
+          itemType="crawl"
+          ?isCrawler=${this.appState.isCrawler}
+        ></btrix-archived-item-detail>`;
+      }
+
       return html`
         <btrix-workflow-detail
           class="col-span-5"

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -46,11 +46,6 @@ const RESOURCE_NAMES = ["workflow", "collection", "browser-profile", "upload"];
 type ResourceName = (typeof RESOURCE_NAMES)[number];
 export type SelectNewDialogEvent = CustomEvent<ResourceName>;
 type ArchivedItemPageParams = {
-  itemId?: string;
-  itemType?: string;
-  itemPageId?: string;
-  qaTab?: QATab;
-  qaRunId?: string;
   workflowId?: string;
   collectionId?: string;
 };
@@ -60,7 +55,13 @@ export type OrgParams = {
     jobType?: JobType;
     new?: ResourceName;
   };
-  items: ArchivedItemPageParams;
+  items: ArchivedItemPageParams & {
+    itemId?: string;
+    itemType?: string;
+    itemPageId?: string;
+    qaTab?: QATab;
+    qaRunId?: string;
+  };
   "browser-profiles": {
     browserProfileId?: string;
     browserId?: string;
@@ -177,6 +178,11 @@ export class Org extends LiteElement {
           this.navTo(`${url.pathname}${url.search}`);
         }
       }
+    } else if (changedProperties.has("params")) {
+      const dialogName = this.getDialogName();
+      if (dialogName && !this.openDialogName) {
+        this.openDialog(dialogName);
+      }
     }
   }
 
@@ -218,8 +224,16 @@ export class Org extends LiteElement {
       }
     }
     // Sync URL to create dialog
+    const dialogName = this.getDialogName();
+    if (dialogName) this.openDialog(dialogName);
+  }
+
+  private getDialogName() {
     const url = new URL(window.location.href);
-    const dialogName = url.searchParams.get("new");
+    return url.searchParams.get("new");
+  }
+
+  private openDialog(dialogName: string) {
     if (dialogName && RESOURCE_NAMES.includes(dialogName)) {
       this.openDialogName = dialogName;
       this.isCreateDialogVisible = true;
@@ -466,6 +480,8 @@ export class Org extends LiteElement {
           class="flex-1"
           itemId=${params.itemId}
           itemPageId=${ifDefined(params.itemPageId)}
+          collectionId=${params.collectionId || ""}
+          workflowId=${params.workflowId || ""}
           qaRunId=${ifDefined(params.qaRunId)}
           tab=${params.qaTab}
         ></btrix-archived-item-qa>`;
@@ -495,26 +511,6 @@ export class Org extends LiteElement {
     const workflowId = params.workflowId;
 
     if (workflowId) {
-      if (params.itemId) {
-        if (params.qaTab) {
-          return html`<btrix-archived-item-qa
-            class="flex-1"
-            itemId=${params.itemId}
-            workflowId=${workflowId}
-            itemPageId=${ifDefined(params.itemPageId)}
-            qaRunId=${ifDefined(params.qaRunId)}
-            tab=${params.qaTab}
-          ></btrix-archived-item-qa>`;
-        }
-
-        return html`<btrix-archived-item-detail
-          crawlId=${params.itemId}
-          workflowId=${workflowId}
-          itemType="crawl"
-          ?isCrawler=${this.appState.isCrawler}
-        ></btrix-archived-item-detail>`;
-      }
-
       return html`
         <btrix-workflow-detail
           class="col-span-5"
@@ -531,7 +527,7 @@ export class Org extends LiteElement {
       const { workflow, seeds } = this.viewStateData || {};
 
       return html` <btrix-workflows-new
-        class="col-span-5 mt-6"
+        class="col-span-5"
         ?isCrawler=${this.appState.isCrawler}
         .initialWorkflow=${workflow}
         .initialSeeds=${seeds}
@@ -583,24 +579,6 @@ export class Org extends LiteElement {
     const params = this.params as OrgParams["collections"];
 
     if (params.collectionId) {
-      if (params.itemId) {
-        if (params.qaTab) {
-          return html`<btrix-archived-item-qa
-            class="flex-1"
-            itemId=${params.itemId}
-            collectionId=${params.collectionId}
-            itemPageId=${ifDefined(params.itemPageId)}
-            qaRunId=${ifDefined(params.qaRunId)}
-            tab=${params.qaTab}
-          ></btrix-archived-item-qa>`;
-        }
-        return html`<btrix-archived-item-detail
-          crawlId=${params.itemId}
-          collectionId=${params.collectionId}
-          itemType=${ifDefined(params.itemType)}
-          ?isCrawler=${this.appState.isCrawler}
-        ></btrix-archived-item-detail>`;
-      }
       return html`<btrix-collection-detail
         collectionId=${params.collectionId}
         collectionTab=${(params.collectionTab as CollectionTab | undefined) ||

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -392,7 +392,7 @@ export class WorkflowDetail extends LiteElement {
   private renderBreadcrumbs() {
     const breadcrumbs: Breadcrumb[] = [
       {
-        href: `${this.orgBasePath}/workflows/crawls`,
+        href: `${this.orgBasePath}/workflows`,
         content: msg("Crawl Workflows"),
       },
     ];
@@ -400,7 +400,7 @@ export class WorkflowDetail extends LiteElement {
     if (this.isEditing) {
       breadcrumbs.push(
         {
-          href: `${this.orgBasePath}/workflows/crawl/${this.workflowId}`,
+          href: `${this.orgBasePath}/workflows/${this.workflowId}`,
           content: this.workflow ? this.renderName() : undefined,
         },
         {
@@ -480,7 +480,7 @@ export class WorkflowDetail extends LiteElement {
           label=${msg("Edit workflow settings")}
           @click=${() =>
             this.navTo(
-              `/orgs/${this.appState.orgSlug}/workflows/crawl/${this.workflow?.id}?edit`,
+              `/orgs/${this.appState.orgSlug}/workflows/${this.workflow?.id}?edit`,
             )}
         >
         </sl-icon-button>`;
@@ -564,7 +564,7 @@ export class WorkflowDetail extends LiteElement {
           jobType=${workflow.jobType!}
           configId=${workflow.id}
           @reset=${() =>
-            this.navTo(`${this.orgBasePath}/workflows/crawl/${workflow.id}`)}
+            this.navTo(`${this.orgBasePath}/workflows/${workflow.id}`)}
         ></btrix-workflow-editor>
       `,
       this.renderLoading,
@@ -685,7 +685,7 @@ export class WorkflowDetail extends LiteElement {
           <sl-menu-item
             @click=${() =>
               this.navTo(
-                `/orgs/${this.appState.orgSlug}/workflows/crawl/${workflow.id}?edit`,
+                `/orgs/${this.appState.orgSlug}/workflows/${workflow.id}?edit`,
               )}
           >
             <sl-icon name="gear" slot="prefix"></sl-icon>
@@ -862,7 +862,7 @@ export class WorkflowDetail extends LiteElement {
                 this.crawls!.items.map(
                   (crawl: Crawl) =>
                     html` <btrix-crawl-list-item
-                      href=${`${this.orgBasePath}/items/crawl/${crawl.id}?workflowId=${this.workflowId}`}
+                      href=${`${this.orgBasePath}/workflows/${this.workflowId}/crawls/${crawl.id}`}
                       .crawl=${crawl}
                     >
                       ${when(
@@ -1485,7 +1485,7 @@ export class WorkflowDetail extends LiteElement {
         },
       );
 
-      this.navTo(`${this.orgBasePath}/workflows/crawls`);
+      this.navTo(`${this.orgBasePath}/workflows`);
 
       this.notify({
         message: msg(

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -22,7 +22,7 @@ import { type IntersectEvent } from "@/components/utils/observable";
 import type { CrawlLog } from "@/features/archived-items/crawl-logs";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
-import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
+import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import type { APIPaginatedList } from "@/types/api";
 import { isApiError } from "@/utils/api";
 import {
@@ -397,24 +397,23 @@ export class WorkflowDetail extends LiteElement {
       },
     ];
 
-    if (this.workflow) {
-      breadcrumbs.push({
-        href: `${this.orgBasePath}/workflows/crawl/${this.workflowId}`,
-        content: this.renderName(),
-      });
-
-      if (this.isEditing) {
-        breadcrumbs.push({
+    if (this.isEditing) {
+      breadcrumbs.push(
+        {
+          href: `${this.orgBasePath}/workflows/crawl/${this.workflowId}`,
+          content: this.workflow ? this.renderName() : undefined,
+        },
+        {
           content: msg("Edit Settings"),
-        });
-      } else if (this.activePanel) {
-        breadcrumbs.push({
-          content: this.tabLabels[this.activePanel],
-        });
-      }
+        },
+      );
+    } else {
+      breadcrumbs.push({
+        content: this.workflow ? this.renderName() : undefined,
+      });
     }
 
-    return pageBreadcrumbs(breadcrumbs);
+    return pageNav(breadcrumbs);
   }
 
   private readonly renderTabList = () => html`
@@ -552,10 +551,8 @@ export class WorkflowDetail extends LiteElement {
   private readonly renderEditor = () => html`
     <div class="col-span-1">${this.renderBreadcrumbs()}</div>
 
-    <header>
-      <h2 class="break-all text-xl font-semibold leading-10">
-        ${this.renderName()}
-      </h2>
+    <header class="col-span-1 mb-3 flex flex-wrap gap-2">
+      <btrix-detail-page-title .item=${this.workflow}></btrix-detail-page-title>
     </header>
 
     ${when(
@@ -865,7 +862,7 @@ export class WorkflowDetail extends LiteElement {
                 this.crawls!.items.map(
                   (crawl: Crawl) =>
                     html` <btrix-crawl-list-item
-                      href=${`${this.orgBasePath}/workflows/crawl/${this.workflowId}/items/${crawl.id}`}
+                      href=${`${this.orgBasePath}/items/crawl/${crawl.id}?workflowId=${this.workflowId}`}
                       .crawl=${crawl}
                     >
                       ${when(

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -501,24 +501,18 @@ export class WorkflowsList extends LiteElement {
           <sl-divider></sl-divider>
           <sl-menu-item
             @click=${() =>
-              this.navTo(
-                `${this.orgBasePath}/workflows/crawl/${workflow.id}#watch`,
-                {
-                  dialog: "scale",
-                },
-              )}
+              this.navTo(`${this.orgBasePath}/workflows/${workflow.id}#watch`, {
+                dialog: "scale",
+              })}
           >
             <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
             ${msg("Edit Browser Windows")}
           </sl-menu-item>
           <sl-menu-item
             @click=${() =>
-              this.navTo(
-                `${this.orgBasePath}/workflows/crawl/${workflow.id}#watch`,
-                {
-                  dialog: "exclusions",
-                },
-              )}
+              this.navTo(`${this.orgBasePath}/workflows/${workflow.id}#watch`, {
+                dialog: "exclusions",
+              })}
           >
             <sl-icon name="table" slot="prefix"></sl-icon>
             ${msg("Edit Exclusions")}
@@ -532,9 +526,7 @@ export class WorkflowsList extends LiteElement {
           html` <sl-divider></sl-divider>
             <sl-menu-item
               @click=${() =>
-                this.navTo(
-                  `${this.orgBasePath}/workflows/crawl/${workflow.id}?edit`,
-                )}
+                this.navTo(`${this.orgBasePath}/workflows/${workflow.id}?edit`)}
             >
               <sl-icon name="gear" slot="prefix"></sl-icon>
               ${msg("Edit Workflow Settings")}
@@ -799,7 +791,7 @@ export class WorkflowsList extends LiteElement {
             <br />
             <a
               class="underline hover:no-underline"
-              href="${this.orgBasePath}/workflows/crawl/${workflow.id}#watch"
+              href="${this.orgBasePath}/workflows/${workflow.id}#watch"
               @click=${this.navLink.bind(this)}
               >Watch crawl</a
             >`,

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -8,7 +8,7 @@ import type { JobType, Seed, WorkflowParams } from "./types";
 
 import type { SelectNewDialogEvent } from ".";
 
-import { pageBreadcrumbs, type Breadcrumb } from "@/layouts/pageHeader";
+import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import LiteElement, { html } from "@/utils/LiteElement";
 
 const defaultValue = {
@@ -84,7 +84,7 @@ export class WorkflowsNew extends LiteElement {
       });
     }
 
-    return pageBreadcrumbs(breadcrumbs);
+    return pageNav(breadcrumbs);
   }
 
   render() {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -13,9 +13,9 @@ export const ROUTES = {
   org: [
     "/orgs/:slug",
     // Org sections:
-    "(/workflows(/crawls)(/crawl/:workflowId)(/items/:itemId))",
+    "(/workflows(/crawls)(/crawl/:workflowId)(/items/:itemId(/review/:qaTab)))",
     "(/items(/:itemType(/:itemId(/review/:qaTab))))",
-    "(/collections(/new)(/view/:collectionId(/:collectionTab(/:itemType/:itemId))))",
+    "(/collections(/new)(/view/:collectionId(/:collectionTab(/:itemType/:itemId(/review/:qaTab)))))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
     "(/settings(/:settingsTab))",
   ].join(""),

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -13,8 +13,8 @@ export const ROUTES = {
   org: [
     "/orgs/:slug",
     // Org sections:
-    "(/workflows(/crawls)(/crawl/:workflowId))",
-    "(/items(/:itemType(/:itemId(/review/:qaTab))))",
+    "(/workflows(/:workflowId(/crawls/:itemId(/review/:qaTab))))",
+    "(/items(/:itemType(/:itemId)))",
     "(/collections(/new)(/view/:collectionId(/:collectionTab)))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
     "(/settings(/:settingsTab))",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -13,9 +13,9 @@ export const ROUTES = {
   org: [
     "/orgs/:slug",
     // Org sections:
-    "(/workflows(/crawls)(/crawl/:workflowId)(/items/:itemId(/review/:qaTab)))",
+    "(/workflows(/crawls)(/crawl/:workflowId))",
     "(/items(/:itemType(/:itemId(/review/:qaTab))))",
-    "(/collections(/new)(/view/:collectionId(/:collectionTab(/:itemType/:itemId(/review/:qaTab)))))",
+    "(/collections(/new)(/view/:collectionId(/:collectionTab)))",
     "(/browser-profiles(/profile(/browser/:browserId)(/:browserProfileId)))",
     "(/settings(/:settingsTab))",
   ].join(""),


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2056

<!-- Fixes #issue_number -->

### Changes

- Replaces QA Review breadcrumbs with "Back" button that takes you back to the archived item
- Crawl breadcrumbs always point to workflow
- Shows archived item icon next to item name to differentiate from workflow
- Adds "Edit Workflow" button to "Crawl Settings"

### Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl detail | <img width="629" alt="Screenshot 2024-09-03 at 3 40 33 PM" src="https://github.com/user-attachments/assets/756447a2-dfa8-44d7-bc06-3a47a3e83265"> |
| Crawl detail - Crawl Settings | <img width="628" alt="Screenshot 2024-09-03 at 3 54 28 PM" src="https://github.com/user-attachments/assets/edc4e25b-c441-45c1-8d73-6a19d8f50946"> |
| Upload detail| <img width="615" alt="Screenshot 2024-09-03 at 3 41 41 PM" src="https://github.com/user-attachments/assets/121d3699-b186-450f-bf39-e4bb6186975c"> |
| Crawl detail - From collection | <img width="645" alt="Screenshot 2024-09-03 at 3 41 08 PM" src="https://github.com/user-attachments/assets/bd76033f-d6a2-4f35-b5e7-3756d2c2a8d6"> |



<!-- ### Follow-ups -->
