### PR TITLE
chore: Revert frontend build check trigger

### DIFF
--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -1,14 +1,5 @@
 name: Frontend Build Check
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'frontend/src/**'
-      - 'frontend/*.json'
-      - 'frontend/*.js'
-      - 'frontend/*.ts'
-      - '.github/workflows/frontend-build-check.yaml'
   pull_request:
     paths:
       - 'frontend/src/**'


### PR DESCRIPTION
Reverts `push` trigger added to frontend build check in https://github.com/webrecorder/browsertrix/commit/99ed08656a3dce5785a385cc2173c2a973f64b5f now that we require PRs to merge.