### PR TITLE
Ensure that CI fails if extracted strings don't match

### DIFF
--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && if ! git diff-index --quiet HEAD -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
+        run: yarn localize:extract && if ! git diff-index --exit-code HEAD -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && yarn prettier --write xliff/*.xlf && if ! git diff --quiet -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
+        run: yarn localize:extract && if ! git diff --quiet -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && git diff-index HEAD --
+        run: yarn localize:extract && git diff-index --quiet HEAD --
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && git diff-index --quiet HEAD -- || echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results." && false
+        run: yarn localize:extract && if ! git diff-index --quiet HEAD -- ; then; echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'yarn'
           cache-dependency-path: frontend/yarn.lock
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: frontend/dist
           key: ${{ runner.os }}-btrix-frontend-build-${{ hashFiles('frontend/dist') }}

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && if ! git diff-index --exit-code HEAD -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
+        run: yarn localize:extract && yarn prettier --write xliff/*.xlf && if ! git diff-index --exit-code HEAD -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && yarn prettier --write xliff/*.xlf && if ! git diff-index --exit-code HEAD -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
+        run: yarn localize:extract && yarn prettier --write xliff/*.xlf && if ! git diff --quiet -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && if ! git diff-index --quiet HEAD -- ; then; echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
+        run: yarn localize:extract && if ! git diff-index --quiet HEAD -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && git diff-index --quiet HEAD --
+        run: yarn localize:extract && git diff-index --quiet HEAD -- || echo "Error extracting strings, please run \`yarn localize:extract\` and commit the results." && false
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/.github/workflows/frontend-build-check.yaml
+++ b/.github/workflows/frontend-build-check.yaml
@@ -44,7 +44,7 @@ jobs:
         run: yarn test
       - name: Check extracted strings
         working-directory: frontend
-        run: yarn localize:extract && git diff-index --quiet HEAD -- || echo "Error extracting strings, please run \`yarn localize:extract\` and commit the results." && false
+        run: yarn localize:extract && git diff-index --quiet HEAD -- || echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results." && false
       - name: Localization build
         working-directory: frontend
         run: yarn localize:build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "lint:lit-analyzer": "lit-analyzer",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "localize:extract": "lit-localize extract",
+    "localize:extract": "lit-localize extract && prettier --write xliff/*.xlf",
     "localize:build": "lit-localize build"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,7 +123,7 @@
     "chromium": "^3.0.3"
   },
   "lint-staged": {
-    "*.{ts,js,html,css,json,webmanifest,xlf}": "prettier --write"
+    "*.{ts,js,html,css,json,webmanifest}": "prettier --write"
   },
   "husky": {
     "hooks": {

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -2,71 +2,71 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file datatype="plaintext" original="lit-localize-inputs" source-language="en" target-language="es">
     <body>
-      <trans-unit id="s598446c4063cc093" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s598446c4063cc093">
         <source>Unknown API error</source>
         <target state="translated">Error desconocido de API</target>
       </trans-unit>
-      <trans-unit id="scbeafb2ef469257c" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="scbeafb2ef469257c">
         <source>Need login</source>
         <target state="translated">Inicio de sesión requerido</target>
       </trans-unit>
-      <trans-unit id="sa3ce85ea4e96897c" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="sa3ce85ea4e96897c">
         <source>Storage quota reached</source>
         <target state="translated">Cuota de almacenamiento alcanzó su capacidad</target>
       </trans-unit>
-      <trans-unit id="s07018373ca29dfcb" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s07018373ca29dfcb">
         <source>Monthly execution minutes quota reached</source>
         <target state="translated">Cuota de minutos mensual alcanzó su capacidad</target>
       </trans-unit>
-      <trans-unit id="s0a11c2ffb8309d1a" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s0a11c2ffb8309d1a">
         <source>Not found</source>
         <target state="translated">Error 404</target>
       </trans-unit>
-      <trans-unit id="sf3ff78cc329d3528" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="sf3ff78cc329d3528">
         <source>Previous</source>
         <target state="translated">Página anterior</target>
       </trans-unit>
-      <trans-unit id="s0fbf6dc6a1966408" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s0fbf6dc6a1966408">
         <source>Next</source>
         <target state="translated">Siguiente página</target>
       </trans-unit>
       <trans-unit id="h7ee8a6e551e702ba">
-        <source> <x id="0" equiv-text="${this.renderInput()}"/> of <x id="1" equiv-text="${this.pages} "/></source>
+        <source> <x equiv-text="${this.renderInput()}" id="0"/> of <x equiv-text="${this.pages} " id="1"/></source>
       </trans-unit>
       <trans-unit id="s5697808ce744d508">
-        <source>Current page, page <x id="0" equiv-text="${this.page}"/></source>
+        <source>Current page, page <x equiv-text="${this.page}" id="0"/></source>
       </trans-unit>
-      <trans-unit id="s81a19821f3e4a3d2" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s81a19821f3e4a3d2">
         <source>Replay</source>
         <target state="translated">Reproducir</target>
       </trans-unit>
-      <trans-unit id="s2099d599ac75e503" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s2099d599ac75e503">
         <source>Archived Items</source>
         <target state="translated">Archivado</target>
       </trans-unit>
-      <trans-unit id="sfa480f50d480c290" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="sfa480f50d480c290">
         <source>Shareable</source>
         <target state="translated">Compartible</target>
       </trans-unit>
-      <trans-unit id="se7bee6e9a9b5394c" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="se7bee6e9a9b5394c">
         <source>Private</source>
         <target state="translated">Privado</target>
       </trans-unit>
-      <trans-unit id="s2df075aface0dab8" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s2df075aface0dab8">
         <source>Share</source>
         <target state="translated">Compartir archivos</target>
       </trans-unit>
-      <trans-unit id="s833f0d71eaa06739" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s833f0d71eaa06739">
         <source>Select Items</source>
         <target state="translated">Elija ítems</target>
       </trans-unit>
-      <trans-unit id="s0e6ebc9cdd39780b" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s0e6ebc9cdd39780b">
         <source>Delete Collection?</source>
         <target state="translated">¿Eliminar colección?</target>
       </trans-unit>
       <trans-unit id="h05165b87bf66fe02">
         <source>Are you sure you want to delete
-            <x id="0" equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;"/>?</source>
+            <x equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;" id="0"/>?</source>
       </trans-unit>
       <trans-unit id="s2ceb11be2290bb1b">
         <source>Cancel</source>
@@ -109,15 +109,15 @@
       </trans-unit>
       <trans-unit id="h648aaa4b436a5970">
         <source>Add the following JavaScript to your
-              <x id="0" equiv-text="&lt;code class=&quot;text-[0.9em]&quot;&gt;"/>/replay/sw.js<x id="1" equiv-text="&lt;/code&gt;"/>:</source>
+              <x equiv-text="&lt;code class=&quot;text-[0.9em]&quot;&gt;" id="0"/>/replay/sw.js<x equiv-text="&lt;/code&gt;" id="1"/>:</source>
       </trans-unit>
       <trans-unit id="s4f0cf5a844f978f3">
         <source>Copy JS</source>
       </trans-unit>
       <trans-unit id="hf56186ec17103fb3">
         <source>See
-              <x id="0" equiv-text="&lt;a class=&quot;text-primary&quot; href=&quot;https://replayweb.page/docs/embedding&quot; target=&quot;_blank&quot;&gt;"/>
-                our embedding guide<x id="1" equiv-text="&lt;/a&gt;"/>
+              <x equiv-text="&lt;a class=&quot;text-primary&quot; href=&quot;https://replayweb.page/docs/embedding&quot; target=&quot;_blank&quot;&gt;" id="0"/>
+                our embedding guide<x equiv-text="&lt;/a&gt;" id="1"/>
               for more details.</source>
       </trans-unit>
       <trans-unit id="s3f5390ecd7d14626">
@@ -142,7 +142,7 @@
         <source>Download Collection</source>
       </trans-unit>
       <trans-unit id="s125a86b2f45bbb25">
-        <source><x id="0" equiv-text="${item.crawlCount}"/> items</source>
+        <source><x equiv-text="${item.crawlCount}" id="0"/> items</source>
       </trans-unit>
       <trans-unit id="s88f9e7f4ecc07ede">
         <source>Total Size</source>
@@ -151,7 +151,7 @@
         <source>Total Pages</source>
       </trans-unit>
       <trans-unit id="s279de934d8a18e21">
-        <source><x id="0" equiv-text="${pageCount.toLocaleString()}"/> pages</source>
+        <source><x equiv-text="${pageCount.toLocaleString()}" id="0"/> pages</source>
       </trans-unit>
       <trans-unit id="s3512b3c95c7a5c3a">
         <source>Last Updated</source>
@@ -184,7 +184,7 @@
         <source>Remove from Collection</source>
       </trans-unit>
       <trans-unit id="h2962269031cae049">
-        <source>Deleted <x id="0" equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;"/> Collection.</source>
+        <source>Deleted <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"/> Collection.</source>
       </trans-unit>
       <trans-unit id="s1a223f3372970867">
         <source>Sorry, couldn't delete Collection at this time.</source>
@@ -202,16 +202,16 @@
         <source>Sorry, couldn't remove item from Collection at this time.</source>
       </trans-unit>
       <trans-unit id="sd77c5f8da91d0729">
-        <source>Maximum <x id="0" equiv-text="${formatNumber(maxLength)}"/> characters</source>
+        <source>Maximum <x equiv-text="${formatNumber(maxLength)}" id="0"/> characters</source>
       </trans-unit>
       <trans-unit id="sa1c466807a6fdfb7">
-        <source><x id="0" equiv-text="${formatNumber(overMax)}"/> character over limit</source>
+        <source><x equiv-text="${formatNumber(overMax)}" id="0"/> character over limit</source>
       </trans-unit>
       <trans-unit id="s8b6894f4bfec27c0">
-        <source><x id="0" equiv-text="${formatNumber(overMax)}"/> characters over limit</source>
+        <source><x equiv-text="${formatNumber(overMax)}" id="0"/> characters over limit</source>
       </trans-unit>
       <trans-unit id="se1f5b61904654dba">
-        <source>Please shorten this text to <x id="0" equiv-text="${maxLength}"/> or fewer characters.</source>
+        <source>Please shorten this text to <x equiv-text="${maxLength}" id="0"/> or fewer characters.</source>
       </trans-unit>
       <trans-unit id="s9f8c17b4d595bb2d">
         <source>Manage Billing</source>
@@ -232,17 +232,17 @@
         <source>Subscription status, features, and add-ons, if applicable.</source>
       </trans-unit>
       <trans-unit id="sc93b55ebdda10016">
-        <source>You can view plan details, update payment methods, and update billing information by clicking “<x id="0" equiv-text="${this.portalUrlLabel}"/>”.</source>
+        <source>You can view plan details, update payment methods, and update billing information by clicking “<x equiv-text="${this.portalUrlLabel}" id="0"/>”.</source>
       </trans-unit>
       <trans-unit id="h1abcffb9335ebc6d">
         <source>To upgrade to Pro, contact us at
-                                <x id="0" equiv-text="&lt;a class=&quot;${linkClassList}&quot; href=&quot;${`mailto:${this.salesEmail}?subject=${msg(str `Upgrade Browsertrix plan (${this.userOrg?.name})`)}`}&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;${this.salesEmail}&lt;/a&gt;"/>.</source>
+                                <x equiv-text="&lt;a class=&quot;${linkClassList}&quot; href=&quot;${`mailto:${this.salesEmail}?subject=${msg(str `Upgrade Browsertrix plan (${this.userOrg?.name})`)}`}&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;${this.salesEmail}&lt;/a&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s7ec899c7c6213c52">
-        <source>Upgrade Browsertrix plan (<x id="0" equiv-text="${this.userOrg?.name}"/>)</source>
+        <source>Upgrade Browsertrix plan (<x equiv-text="${this.userOrg?.name}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s00341480baa290eb">
-        <source>Contact us at <x id="0" equiv-text="${this.salesEmail}"/> to make changes to your plan.</source>
+        <source>Contact us at <x equiv-text="${this.salesEmail}" id="0"/> to make changes to your plan.</source>
       </trans-unit>
       <trans-unit id="s1d04dbb2d7ee4b9b">
         <source>Contact your Browsertrix host administrator to make changes to your plan.</source>
@@ -272,7 +272,7 @@
         <source>Pro</source>
       </trans-unit>
       <trans-unit id="sd069593586fce913">
-        <source><x id="0" equiv-text="${maxExecMinutesPerMonth || msg(&quot;Unlimited minutes&quot;)}"/> of crawl and QA analysis execution time</source>
+        <source><x equiv-text="${maxExecMinutesPerMonth || msg(&quot;Unlimited minutes&quot;)}" id="0"/> of crawl and QA analysis execution time</source>
       </trans-unit>
       <trans-unit id="s1228a18c03355491">
         <source>Unlimited minutes</source>
@@ -281,10 +281,10 @@
         <source>Unlimited</source>
       </trans-unit>
       <trans-unit id="s8e49ef99717ff3d4">
-        <source><x id="0" equiv-text="${formatNumber(quotas.maxConcurrentCrawls)}"/> concurrent <x id="1" equiv-text="${pluralOf(&quot;crawls&quot;, quotas.maxConcurrentCrawls)}"/></source>
+        <source><x equiv-text="${formatNumber(quotas.maxConcurrentCrawls)}" id="0"/> concurrent <x equiv-text="${pluralOf(&quot;crawls&quot;, quotas.maxConcurrentCrawls)}" id="1"/></source>
       </trans-unit>
       <trans-unit id="sc27403512c49c425">
-        <source>Pro plan change request (<x id="0" equiv-text="${this.userOrg?.name}"/>)</source>
+        <source>Pro plan change request (<x equiv-text="${this.userOrg?.name}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="sc2a7f6d40341e683">
         <source>Contact Sales</source>
@@ -306,12 +306,12 @@
       </trans-unit>
       <trans-unit id="h8c21d04827e5cb19">
         <source>Regular Expression syntax error:
-                                    <x id="0" equiv-text="&lt;code&gt;${this.fieldErrorMessage}&lt;/code&gt;"/></source>
+                                    <x equiv-text="&lt;code&gt;${this.fieldErrorMessage}&lt;/code&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="h1a1f28e6632c15d0">
         <source>Please enter a valid constructor string
                                     pattern. See
-                                    <x id="0" equiv-text="&lt;a class=&quot;underline hover:no-underline&quot; href=&quot;https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;&lt;code&gt;"/>RegExp<x id="1" equiv-text="&lt;/code&gt;"/> docs<x id="2" equiv-text="&lt;/a&gt;"/>.</source>
+                                    <x equiv-text="&lt;a class=&quot;underline hover:no-underline&quot; href=&quot;https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;&lt;code&gt;" id="0"/>RegExp<x equiv-text="&lt;/code&gt;" id="1"/> docs<x equiv-text="&lt;/a&gt;" id="2"/>.</source>
       </trans-unit>
       <trans-unit id="s312a6fda81078718">
         <source>Exclusions</source>
@@ -335,7 +335,7 @@
         <source>Exclusion already exists. Please edit or remove to continue</source>
       </trans-unit>
       <trans-unit id="sbe7425a3b5445ba7">
-        <source>Please enter <x id="0" equiv-text="${MIN_LENGTH}"/> or more characters</source>
+        <source>Please enter <x equiv-text="${MIN_LENGTH}" id="0"/> or more characters</source>
       </trans-unit>
       <trans-unit id="s74abf58e08f32710">
         <source>Please enter a valid Regular Expression constructor pattern</source>
@@ -347,38 +347,38 @@
         <source>Tags</source>
       </trans-unit>
       <trans-unit id="s0e3006648a1a80a5">
-        <source>Add “<x id="0" equiv-text="${this.inputValue.toLocaleLowerCase()}"/>”</source>
+        <source>Add “<x equiv-text="${this.inputValue.toLocaleLowerCase()}" id="0"/>”</source>
       </trans-unit>
       <trans-unit id="s1eee55ca9401677a">
-        <source>+<x id="0" equiv-text="${this.total.toLocaleString()}"/> URLs</source>
+        <source>+<x equiv-text="${this.total.toLocaleString()}" id="0"/> URLs</source>
       </trans-unit>
       <trans-unit id="sfff90c46fdba31db">
         <source>(unnamed item)</source>
       </trans-unit>
       <trans-unit id="s8265788524ca2260">
-        <source><x id="0" equiv-text="${formattedTime}"/> daily</source>
+        <source><x equiv-text="${formattedTime}" id="0"/> daily</source>
       </trans-unit>
       <trans-unit id="s2acb3777ed86adb6">
-        <source>Every <x id="0" equiv-text="${formattedWeekDay}"/></source>
+        <source>Every <x equiv-text="${formattedWeekDay}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s37a3a294775e081a">
-        <source>Monthly on the <x id="0" equiv-text="${format(days[0], { ordinal: true })}"/></source>
+        <source>Monthly on the <x equiv-text="${format(days[0], { ordinal: true })}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s2bc963c5c7bac2e1">
-        <source>Every day at <x id="0" equiv-text="${formattedTime}"/></source>
+        <source>Every day at <x equiv-text="${formattedTime}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s3fc21c0b1ae61eb7">
-        <source>Every <x id="0" equiv-text="${formattedWeekDay}"/>
-            at <x id="1" equiv-text="${formattedTime}"/></source>
+        <source>Every <x equiv-text="${formattedWeekDay}" id="0"/>
+            at <x equiv-text="${formattedTime}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s478f33dea36e1d3f">
-        <source>On day <x id="0" equiv-text="${nextDate.getDate()}"/> of the month at <x id="1" equiv-text="${formattedTime}"/></source>
+        <source>On day <x equiv-text="${nextDate.getDate()}" id="0"/> of the month at <x equiv-text="${formattedTime}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s44f6ab2c6b3cff23">
         <source>Default: Unlimited</source>
       </trans-unit>
       <trans-unit id="sf21761e7f8e0550e">
-        <source>Default: <x id="0" equiv-text="${value.toLocaleString()}"/></source>
+        <source>Default: <x equiv-text="${value.toLocaleString()}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s5ae0226079b4d5fc">
         <source>Specify exclusion rules for what pages should not be visited.
@@ -414,12 +414,12 @@
       </trans-unit>
       <trans-unit id="h1a88ca035802fcd0">
         <source>Blocks advertising content from being loaded. Uses
-      <x id="0" equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;"/>Steven Black’s Hosts file<x id="1" equiv-text="&lt;/a&gt;"/>.</source>
+      <x equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>Steven Black’s Hosts file<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="h63182e63349f17de">
         <source>Set custom user agent for crawler browsers to use in requests. For
       common user agents see
-      <x id="0" equiv-text="&lt;a href=&quot;https://www.useragents.me/&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;"/>Useragents.me<x id="1" equiv-text="&lt;/a&gt;"/>.</source>
+      <x equiv-text="&lt;a href=&quot;https://www.useragents.me/&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>Useragents.me<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="s49e094325ac57142">
         <source>Websites that observe the browser’s language setting may serve
@@ -502,7 +502,7 @@
       </trans-unit>
       <trans-unit id="h9c83f117a7e3a93f">
         <source>Viewing
-                  <x id="0" equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${userOrg.name}&lt;/strong&gt;"/></source>
+                  <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${userOrg.name}&lt;/strong&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s52d61e7db1ece998">
         <source>Active Members</source>
@@ -529,7 +529,7 @@
         <source>Custom URL Identifier</source>
       </trans-unit>
       <trans-unit id="s736e0de127d6aba2">
-        <source>Org home page: <x id="0" equiv-text="${window.location.protocol}"/>//<x id="1" equiv-text="${window.location.hostname}"/>/orgs/<x id="2" equiv-text="${this.slugValue&#10;    ? slugifyStrict(this.slugValue)&#10;    : this.orgSlug}"/></source>
+        <source>Org home page: <x equiv-text="${window.location.protocol}" id="0"/>//<x equiv-text="${window.location.hostname}" id="1"/>/orgs/<x equiv-text="${this.slugValue&#10;    ? slugifyStrict(this.slugValue)&#10;    : this.orgSlug}" id="2"/></source>
       </trans-unit>
       <trans-unit id="s0559157886d79c76">
         <source>Customize your organization's web address for accessing Browsertrix.</source>
@@ -652,16 +652,16 @@
         <source>Sorry, couldn't retrieve pending invites at this time.</source>
       </trans-unit>
       <trans-unit id="s7cfdd7b9b1ce6231">
-        <source>Successfully invited <x id="0" equiv-text="${inviteEmail}"/>.</source>
+        <source>Successfully invited <x equiv-text="${inviteEmail}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s53846234c681dace">
         <source>Sorry, couldn't invite user at this time.</source>
       </trans-unit>
       <trans-unit id="s63ca31a1df9116e2">
-        <source>Successfully removed <x id="0" equiv-text="${invite.email}"/> from <x id="1" equiv-text="${this.userOrg?.name}"/>.</source>
+        <source>Successfully removed <x equiv-text="${invite.email}" id="0"/> from <x equiv-text="${this.userOrg?.name}" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="s667558910cf30318">
-        <source>Sorry, couldn't remove <x id="0" equiv-text="${invite.email}"/> at this time.</source>
+        <source>Sorry, couldn't remove <x equiv-text="${invite.email}" id="0"/> at this time.</source>
       </trans-unit>
       <trans-unit id="s0cac3669c233a0ad">
         <source>Org successfully updated.</source>
@@ -680,10 +680,10 @@
       </trans-unit>
       <trans-unit id="h58a74834f0ef0fcb">
         <source>Supports
-                <x id="0" equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;"/>GitHub Flavored Markdown<x id="1" equiv-text="&lt;/a&gt;"/>.</source>
+                <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>GitHub Flavored Markdown<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="s7a89a316efd4e9c0">
-        <source>Please shorten the description to <x id="0" equiv-text="${formatNumber(this.maxlength)}"/> or fewer characters.</source>
+        <source>Please shorten the description to <x equiv-text="${formatNumber(this.maxlength)}" id="0"/> or fewer characters.</source>
       </trans-unit>
       <trans-unit id="s6ee5d5975cae2ed4">
         <source>Edit Collection Metadata</source>
@@ -713,7 +713,7 @@
         <source>Enable public access to make Collections shareable. Only people with the shared link can view your Collection.</source>
       </trans-unit>
       <trans-unit id="s77001a56d74ac617">
-        <source>Successfully saved "<x id="0" equiv-text="${data.name || name}"/>" Collection.</source>
+        <source>Successfully saved "<x equiv-text="${data.name || name}" id="0"/>" Collection.</source>
       </trans-unit>
       <trans-unit id="s0014ed029ed0ef6f">
         <source>This name is already taken.</source>
@@ -738,18 +738,18 @@
       </trans-unit>
       <trans-unit id="h76170f4b851b8171">
         <source>You're archiving a subset of a website, like everything
-                  under <x id="0" equiv-text="&lt;em&gt;"/>website.com/your-username<x id="1" equiv-text="&lt;/em&gt;"/></source>
+                  under <x equiv-text="&lt;em&gt;" id="0"/>website.com/your-username<x equiv-text="&lt;/em&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="h5711c8b307827832">
-        <source>You're archiving a website <x id="0" equiv-text="&lt;em&gt;"/>and<x id="1" equiv-text="&lt;/em&gt;"/> external pages
+        <source>You're archiving a website <x equiv-text="&lt;em&gt;" id="0"/>and<x equiv-text="&lt;/em&gt;" id="1"/> external pages
                   linked to from the website</source>
       </trans-unit>
       <trans-unit id="hc76a9160bbdb615c">
         <source>Once you choose a crawl type, you can't go back and change
                 it. Check out the
-                <x id="0" equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.browsertrix.com/user-guide/workflow-setup/&quot; target=&quot;_blank&quot;&gt;"/>crawl workflow setup guide<x id="1" equiv-text="&lt;/a&gt;"/>
+                <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.browsertrix.com/user-guide/workflow-setup/&quot; target=&quot;_blank&quot;&gt;" id="0"/>crawl workflow setup guide<x equiv-text="&lt;/a&gt;" id="1"/>
                 if you still need help deciding on a crawl type, and try our
-                <x id="2" equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://forum.webrecorder.net/c/help/5&quot; target=&quot;_blank&quot;&gt;"/>community help forum<x id="3" equiv-text="&lt;/a&gt;"/>.</source>
+                <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://forum.webrecorder.net/c/help/5&quot; target=&quot;_blank&quot;&gt;" id="2"/>community help forum<x equiv-text="&lt;/a&gt;" id="3"/>.</source>
       </trans-unit>
       <trans-unit id="s6c98d4e4eff5c8bb">
         <source>Copied to clipboard!</source>
@@ -830,7 +830,7 @@
         <source>Stopped: Crawling Disabled</source>
       </trans-unit>
       <trans-unit id="h98fd4ace98188324">
-        <source>Removed exclusion: <x id="0" equiv-text="&lt;code&gt;${regex}&lt;/code&gt;"/></source>
+        <source>Removed exclusion: <x equiv-text="&lt;code&gt;${regex}&lt;/code&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s13acc5f8f152f1b6">
         <source>Cannot remove exclusion when crawl is no longer running.</source>
@@ -968,13 +968,13 @@
         <source>Created By</source>
       </trans-unit>
       <trans-unit id="sf72695e8cd91f93c">
-        <source><x id="0" equiv-text="${workflow.createdByName}"/> on <x id="1" equiv-text="${this.dateFormatter.format(new Date(workflow.created))}"/></source>
+        <source><x equiv-text="${workflow.createdByName}" id="0"/> on <x equiv-text="${this.dateFormatter.format(new Date(workflow.created))}" id="1"/></source>
       </trans-unit>
       <trans-unit id="hcb76d3d062f4fe97">
-        <source> <x id="0" equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;          &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URL<x id="2" equiv-text="&lt;/span&gt;"/></source>
+        <source> <x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;          &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URL<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="h0f472740ba5c3c86">
-        <source> <x id="0" equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;        &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URLs<x id="2" equiv-text="&lt;/span&gt;"/></source>
+        <source> <x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;        &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URLs<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="s900a5e61e7ade066">
         <source>View:</source>
@@ -984,7 +984,7 @@
       </trans-unit>
       <trans-unit id="he775de5878ab0942">
         <source>Crawl is currently running.
-                    <x id="0" equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;"/>Watch Crawl Progress<x id="1" equiv-text="&lt;/a&gt;"/></source>
+                    <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"/>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="s76d9944af031bdb3">
         <source>No matching crawls found.</source>
@@ -1030,7 +1030,7 @@
       </trans-unit>
       <trans-unit id="h27573a6e2ed7211d">
         <source>Viewing error logs for currently running crawl.
-                    <x id="0" equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;"/>Watch Crawl Progress<x id="1" equiv-text="&lt;/a&gt;"/></source>
+                    <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"/>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="s31b57d50c6a992ba">
         <source>Error logs currently not available.</source>
@@ -1042,7 +1042,7 @@
         <source>Logs will show here after you run a crawl.</source>
       </trans-unit>
       <trans-unit id="sa641ef4b0f2af2b4">
-        <source>Displaying latest <x id="0" equiv-text="${LOGS_PAGE_SIZE.toLocaleString()}"/> errors of <x id="1" equiv-text="${this.logs!.total.toLocaleString()}"/>.</source>
+        <source>Displaying latest <x equiv-text="${LOGS_PAGE_SIZE.toLocaleString()}" id="0"/> errors of <x equiv-text="${this.logs!.total.toLocaleString()}" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="sa7bc374e662a4beb">
         <source>Upcoming Pages</source>
@@ -1069,13 +1069,13 @@
         <source>Sorry, couldn't get crawls at this time.</source>
       </trans-unit>
       <trans-unit id="s1a20a47c9bf221da">
-        <source><x id="0" equiv-text="${this.workflow.name}"/> Copy</source>
+        <source><x equiv-text="${this.workflow.name}" id="0"/> Copy</source>
       </trans-unit>
       <trans-unit id="sb751de28d615caad">
         <source>Copied Workflow to new template.</source>
       </trans-unit>
       <trans-unit id="h0e60bb54fe15e7b6">
-        <source>Deleted <x id="0" equiv-text="&lt;strong&gt;${this.renderName()}&lt;/strong&gt;"/> Workflow.</source>
+        <source>Deleted <x equiv-text="&lt;strong&gt;${this.renderName()}&lt;/strong&gt;" id="0"/> Workflow.</source>
       </trans-unit>
       <trans-unit id="s6ec009ac55d85d6a">
         <source>Sorry, couldn't delete Workflow at this time.</source>
@@ -1171,10 +1171,10 @@
         <source>Search all Workflows by name or Crawl Start URL</source>
       </trans-unit>
       <trans-unit id="hc226df43ef96e720">
-        <source><x id="0" equiv-text="${firstSeed}&#10;          &lt;span class=&quot;text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URL<x id="2" equiv-text="&lt;/span&gt;"/></source>
+        <source><x equiv-text="${firstSeed}&#10;          &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URL<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="h649ef1ec13735ee9">
-        <source><x id="0" equiv-text="${firstSeed}&#10;        &lt;span class=&quot;text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URLs<x id="2" equiv-text="&lt;/span&gt;"/></source>
+        <source><x equiv-text="${firstSeed}&#10;        &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URLs<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="s442425cd7d61051f">
         <source>No matching Workflows found.</source>
@@ -1192,7 +1192,7 @@
         <source>Partially copied Workflow</source>
       </trans-unit>
       <trans-unit id="sebba8356f42b6eaa">
-        <source>Only first <x id="0" equiv-text="${SEEDS_MAX.toLocaleString()}"/> URLs were copied.</source>
+        <source>Only first <x equiv-text="${SEEDS_MAX.toLocaleString()}" id="0"/> URLs were copied.</source>
       </trans-unit>
       <trans-unit id="s8745d54f3284f080">
         <source>Are you sure you want to cancel the crawl?</source>
@@ -1237,7 +1237,9 @@
         <source>Analysis Progress</source>
       </trans-unit>
       <trans-unit id="s984a5e18d85b6d57">
-        <source><x id="0" equiv-text="${this.mostRecentNonFailedQARun.stats.found === 0&#10;    ? msg(&quot;Loading&quot;)&#10;    : `${this.mostRecentNonFailedQARun.stats.done}/${this.mostRecentNonFailedQARun.stats.found}`} ${pluralOf(&quot;pages&quot;, this.mostRecentNonFailedQARun.stats.found)}"/></source>
+        <source>
+          <x equiv-text="${this.mostRecentNonFailedQARun.stats.found === 0&#10;    ? msg(&quot;Loading&quot;)&#10;    : `${this.mostRecentNonFailedQARun.stats.done}/${this.mostRecentNonFailedQARun.stats.found}`} ${pluralOf(&quot;pages&quot;, this.mostRecentNonFailedQARun.stats.found)}" id="0"/>
+        </source>
       </trans-unit>
       <trans-unit id="sb59d68ed12d46377">
         <source>Loading</source>
@@ -1262,18 +1264,18 @@
       </trans-unit>
       <trans-unit id="h8309b5706a9a85ba">
         <source>
-                      <x id="0" equiv-text="&lt;span class=&quot;text-primary&quot;&gt;${htmlCount}&lt;/span&gt;"/>
-                      HTML <x id="1" equiv-text="${pluralOf(&quot;pages&quot;, htmlCount)}&#10;                    "/></source>
+                      <x equiv-text="&lt;span class=&quot;text-primary&quot;&gt;${htmlCount}&lt;/span&gt;" id="0"/>
+                      HTML <x equiv-text="${pluralOf(&quot;pages&quot;, htmlCount)}&#10;                    " id="1"/></source>
       </trans-unit>
       <trans-unit id="h7d8f1533bbc700e1">
         <source>
-                      <x id="0" equiv-text="&lt;span class=&quot;text-neutral-600&quot;&gt;${fileCount}&lt;/span&gt;"/>
-                      Non-HTML files captured as <x id="1" equiv-text="${pluralOf(&quot;pages&quot;, fileCount)}&#10;                    "/></source>
+                      <x equiv-text="&lt;span class=&quot;text-neutral-600&quot;&gt;${fileCount}&lt;/span&gt;" id="0"/>
+                      Non-HTML files captured as <x equiv-text="${pluralOf(&quot;pages&quot;, fileCount)}&#10;                    " id="1"/></source>
       </trans-unit>
       <trans-unit id="ha312818a16d5146b">
         <source>
-                      <x id="0" equiv-text="&lt;span class=&quot;text-danger&quot;&gt;${errorCount}&lt;/span&gt;"/>
-                      Failed <x id="1" equiv-text="${pluralOf(&quot;pages&quot;, errorCount)}&#10;                    "/></source>
+                      <x equiv-text="&lt;span class=&quot;text-danger&quot;&gt;${errorCount}&lt;/span&gt;" id="0"/>
+                      Failed <x equiv-text="${pluralOf(&quot;pages&quot;, errorCount)}&#10;                    " id="1"/></source>
       </trans-unit>
       <trans-unit id="s3fd6bd99e3f6a5be">
         <source>Started</source>
@@ -1300,7 +1302,7 @@
         <source>All of the data included in this analysis run will be deleted.</source>
       </trans-unit>
       <trans-unit id="sc2007e562d105da2">
-        <source>This analysis run includes data for <x id="0" equiv-text="${runToBeDeleted.stats.done} ${pluralOf(&quot;pages&quot;, runToBeDeleted.stats.done)}"/> and was started on </source>
+        <source>This analysis run includes data for <x equiv-text="${runToBeDeleted.stats.done} ${pluralOf(&quot;pages&quot;, runToBeDeleted.stats.done)}" id="0"/> and was started on </source>
       </trans-unit>
       <trans-unit id="s08a64b07b54df8d4">
         <source>by</source>
@@ -1384,7 +1386,7 @@
         <source>Comments</source>
       </trans-unit>
       <trans-unit id="s4d3c92a1a881dc5f">
-        <source>Review "<x id="0" equiv-text="${page.title ?? page.url}"/>"</source>
+        <source>Review "<x equiv-text="${page.title ?? page.url}" id="0"/>"</source>
       </trans-unit>
       <trans-unit id="s7282886335497d58">
         <source>Newest comment:</source>
@@ -1460,7 +1462,7 @@
       </trans-unit>
       <trans-unit id="h1dc2f6235d169989">
         <source>Manual start by
-                          <x id="0" equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;"/></source>
+                          <x equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="hdfcda45e7d5c5ab4">
         <source>Scheduled start</source>
@@ -1589,7 +1591,7 @@
         <source>All files and logs associated with this item will also be deleted, and the crawl will no longer be visible in its associated Workflow.</source>
       </trans-unit>
       <trans-unit id="s039b6434e8a75560">
-        <source>Delete <x id="0" equiv-text="${this.itemToDelete?.type === &quot;upload&quot;&#10;    ? msg(&quot;Upload&quot;)&#10;    : msg(&quot;Crawl&quot;)}"/></source>
+        <source>Delete <x equiv-text="${this.itemToDelete?.type === &quot;upload&quot;&#10;    ? msg(&quot;Upload&quot;)&#10;    : msg(&quot;Crawl&quot;)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s96668830629e0dfc">
         <source>Upload</source>
@@ -1629,7 +1631,7 @@
       </trans-unit>
       <trans-unit id="h21e623f674123fc2">
         <source>Are you sure you want to delete
-                <x id="0" equiv-text="&lt;strong&gt;${this.selectedCollection?.name}&lt;/strong&gt;"/>?</source>
+                <x equiv-text="&lt;strong&gt;${this.selectedCollection?.name}&lt;/strong&gt;" id="0"/>?</source>
       </trans-unit>
       <trans-unit id="s777098c61f6b518a">
         <source>Start building your Collection.</source>
@@ -1710,7 +1712,7 @@
         <source>Websites that are not in the browser profile yet. Finish editing and save to add these websites to the profile.</source>
       </trans-unit>
       <trans-unit id="sf4d539e610f3a2aa">
-        <source>Go to <x id="0" equiv-text="${url}"/></source>
+        <source>Go to <x equiv-text="${url}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sb07ea0d5070f719d">
         <source>Crawler Release Channel</source>
@@ -1773,11 +1775,11 @@
         <source>Sorry, couldn't create browser profile at this time.</source>
       </trans-unit>
       <trans-unit id="h132d0ccd2402fb33">
-        <source>Could not delete <x id="0" equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;"/>, in use by
-              <x id="1" equiv-text="&lt;strong&gt;${data.crawlconfigs.map(({ name }) =&gt; name).join(&quot;, &quot;)}&lt;/strong&gt;"/>. Please remove browser profile from Workflow to continue.</source>
+        <source>Could not delete <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"/>, in use by
+              <x equiv-text="&lt;strong&gt;${data.crawlconfigs.map(({ name }) =&gt; name).join(&quot;, &quot;)}&lt;/strong&gt;" id="1"/>. Please remove browser profile from Workflow to continue.</source>
       </trans-unit>
       <trans-unit id="ha6f8533fba325287">
-        <source>Deleted <x id="0" equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;"/>.</source>
+        <source>Deleted <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s6a43c0c6daea3998">
         <source>Sorry, couldn't delete browser profile at this time.</source>
@@ -1816,10 +1818,10 @@
         <source>No browser profiles yet.</source>
       </trans-unit>
       <trans-unit id="s07e46807b4a9183c">
-        <source>+<x id="0" equiv-text="${data.origins.length - 1}"/></source>
+        <source>+<x equiv-text="${data.origins.length - 1}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s922123a81f238186">
-        <source>By <x id="0" equiv-text="${data.createdByName}"/></source>
+        <source>By <x equiv-text="${data.createdByName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s0d2b97026d57ffd0">
         <source>Starting up browser with selected profile...</source>
@@ -1993,10 +1995,10 @@
         <source>Text Match</source>
       </trans-unit>
       <trans-unit id="s2344bb018c2ade99">
-        <source>Showing all <x id="0" equiv-text="${this.totalPages.toLocaleString()}"/> pages</source>
+        <source>Showing all <x equiv-text="${this.totalPages.toLocaleString()}" id="0"/> pages</source>
       </trans-unit>
       <trans-unit id="sd2afbd920020fe6d">
-        <source>Showing <x id="0" equiv-text="${total.toLocaleString()}"/> of <x id="1" equiv-text="${this.totalPages.toLocaleString()}"/> pages</source>
+        <source>Showing <x equiv-text="${total.toLocaleString()}" id="0"/> of <x equiv-text="${this.totalPages.toLocaleString()}" id="1"/> pages</source>
       </trans-unit>
       <trans-unit id="sd7c439303c5c7045">
         <source>No matching pages found</source>
@@ -2116,10 +2118,10 @@
         <source>Submit Review</source>
       </trans-unit>
       <trans-unit id="s6d7c9c2bb994f236">
-        <source>Comments (<x id="0" equiv-text="${commentCount.toLocaleString()}"/>)</source>
+        <source>Comments (<x equiv-text="${commentCount.toLocaleString()}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s3732b439b691ea10">
-        <source><x id="0" equiv-text="${comment.userName}"/> commented on <x id="1" equiv-text="${formatISODateString(comment.created, {&#10;    hour: undefined,&#10;    minute: undefined,&#10;})}"/></source>
+        <source><x equiv-text="${comment.userName}" id="0"/> commented on <x equiv-text="${formatISODateString(comment.created, {&#10;    hour: undefined,&#10;    minute: undefined,&#10;})}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s36012a8db93560f3">
         <source>Delete comment</source>
@@ -2182,14 +2184,14 @@
         <source>
           It is highly recommended to create dedicated accounts to use when
           crawling. For details, refer to
-          <x id="0" equiv-text="&lt;a class=&quot;text-primary hover:text-indigo-400&quot; href=&quot;https://docs.browsertrix.com/user-guide/browser-profiles/&quot; target=&quot;_blank&quot;&gt;&#10;            ${msg(&quot;browser profile best practices&quot;)}&lt;/a&gt;"/>.
+          <x equiv-text="&lt;a class=&quot;text-primary hover:text-indigo-400&quot; href=&quot;https://docs.browsertrix.com/user-guide/browser-profiles/&quot; target=&quot;_blank&quot;&gt;&#10;            ${msg(&quot;browser profile best practices&quot;)}&lt;/a&gt;" id="0"/>.
         </source>
       </trans-unit>
       <trans-unit id="se058d83e4b3bad9e">
         <source>browser profile best practices</source>
       </trans-unit>
       <trans-unit id="h6c440abb1e1a7d78">
-        <source>Extending <x id="0" equiv-text="&lt;strong&gt;${this.browserParams.name}&lt;/strong&gt;"/></source>
+        <source>Extending <x equiv-text="&lt;strong&gt;${this.browserParams.name}&lt;/strong&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s3b397808715b71d8">
         <source>Cancel Profile Creation?</source>
@@ -2228,13 +2230,13 @@
         <source>Sorry, couldn't retrieve organization at this time.</source>
       </trans-unit>
       <trans-unit id="s0726c5784ccf9222">
-        <source>Successfully updated role for <x id="0" equiv-text="${user.name || user.email}"/>.</source>
+        <source>Successfully updated role for <x equiv-text="${user.name || user.email}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="scc21a97f5f1b13b0">
-        <source>Sorry, couldn't update role for <x id="0" equiv-text="${user.name || user.email}"/> at this time.</source>
+        <source>Sorry, couldn't update role for <x equiv-text="${user.name || user.email}" id="0"/> at this time.</source>
       </trans-unit>
       <trans-unit id="saafb6030ac4b40dd">
-        <source>Are you sure you want to remove yourself from <x id="0" equiv-text="${this.userOrg.name}"/>?</source>
+        <source>Are you sure you want to remove yourself from <x equiv-text="${this.userOrg.name}" id="0"/>?</source>
       </trans-unit>
       <trans-unit id="s1442d0b6e28b30d1">
         <source>Path Begins with This URL</source>
@@ -2294,7 +2296,7 @@
         <source>Max Depth</source>
       </trans-unit>
       <trans-unit id="s00952de51c229a2e">
-        <source><x id="0" equiv-text="${primarySeedConfig.depth}"/> hop(s)</source>
+        <source><x equiv-text="${primarySeedConfig.depth}" id="0"/> hop(s)</source>
       </trans-unit>
       <trans-unit id="s9ecb6da2267389f4">
         <source>Unlimited (default)</source>
@@ -2375,7 +2377,7 @@
         <source>Bytes Stored</source>
       </trans-unit>
       <trans-unit id="sd805db60d62be7a1">
-        <source>Quotas for: <x id="0" equiv-text="${this.currOrg?.name || &quot;&quot;}"/></source>
+        <source>Quotas for: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sfba7b662681a9f92">
         <source>Max Concurrent Crawls</source>
@@ -2406,7 +2408,7 @@
       </trans-unit>
       <trans-unit id="h66cb67cd841f4beb">
         <source>Are you sure you want to disable archiving in
-                  <x id="0" equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;"/> org?
+                  <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"/> org?
                   Members will no longer be able to crawl, upload files, create
                   browser profiles, or create collections.</source>
       </trans-unit>
@@ -2426,47 +2428,47 @@
         <source>Disable Archiving</source>
       </trans-unit>
       <trans-unit id="s2f2866981870fee3">
-        <source>Confirm Org Deletion: <x id="0" equiv-text="${this.currOrg?.name || &quot;&quot;}"/></source>
+        <source>Confirm Org Deletion: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"/></source>
       </trans-unit>
       <trans-unit id="hbc605ddee9667ea5">
         <source>Are you sure you want to delete
-                  <x id="0" equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;"/>? This
+                  <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"/>? This
                   cannot be undone.</source>
       </trans-unit>
       <trans-unit id="h88cfbf4cb1b57616">
         <source>Deleting an org will delete all
-                  <x id="0" equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;"/>
+                  <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;" id="0"/>
                   of data associated with the org.</source>
       </trans-unit>
       <trans-unit id="hc95f75343ebc2ce0">
         <source>Crawls:
-                    <x id="0" equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;"/></source>
+                    <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="h9e8c0254131f987c">
         <source>Uploads:
-                    <x id="0" equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;"/></source>
+                    <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="hc4433ba5eba156e2">
         <source>Profiles:
-                    <x id="0" equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;"/></source>
+                    <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="se49bbaeabfd85d48">
-        <source>Type "<x id="0" equiv-text="${confirmationStr}"/>" to confirm</source>
+        <source>Type "<x equiv-text="${confirmationStr}" id="0"/>" to confirm</source>
       </trans-unit>
       <trans-unit id="s91622815dce6a0ec">
         <source>Delete Org</source>
       </trans-unit>
       <trans-unit id="s3eab2ed27de13f27">
-        <source>Archiving in "<x id="0" equiv-text="${org.name}"/>" is disabled.</source>
+        <source>Archiving in "<x equiv-text="${org.name}" id="0"/>" is disabled.</source>
       </trans-unit>
       <trans-unit id="s2da2e2eba00d0f28">
-        <source>Archiving in "<x id="0" equiv-text="${org.name}"/>" is re-enabled.</source>
+        <source>Archiving in "<x equiv-text="${org.name}" id="0"/>" is re-enabled.</source>
       </trans-unit>
       <trans-unit id="s42dfcfdcb5aee47e">
         <source>Sorry, couldn't update org archiving ability at this time.</source>
       </trans-unit>
       <trans-unit id="s081029829332df74">
-        <source>Org "<x id="0" equiv-text="${org.name}"/>" has been deleted.</source>
+        <source>Org "<x equiv-text="${org.name}" id="0"/>" has been deleted.</source>
       </trans-unit>
       <trans-unit id="s4de74a2a08a74bff">
         <source>Sorry, couldn't delete org at this time.</source>
@@ -2532,7 +2534,7 @@
         <source>Password</source>
       </trans-unit>
       <trans-unit id="se7e0859bf0c563fe">
-        <source>Choose a strong password between <x id="0" equiv-text="${PASSWORD_MINLENGTH}"/>–<x id="1" equiv-text="${PASSWORD_MAXLENGTH}"/> characters.</source>
+        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"/>–<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"/> characters.</source>
       </trans-unit>
       <trans-unit id="sa9d1dd5d6142477d">
         <source>Your name</source>
@@ -2556,22 +2558,22 @@
         <source>Not applicable</source>
       </trans-unit>
       <trans-unit id="s0382d73823585617">
-        <source><x id="0" equiv-text="${typeLabel}"/>: <x id="1" equiv-text="${crawlStatus.label}"/></source>
+        <source><x equiv-text="${typeLabel}" id="0"/>: <x equiv-text="${crawlStatus.label}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s9fdb0be4e08e3609">
-        <source>QA Analysis: <x id="0" equiv-text="${qaStatus.label}"/> (<x id="1" equiv-text="${activeProgress}"/>% finished)</source>
+        <source>QA Analysis: <x equiv-text="${qaStatus.label}" id="0"/> (<x equiv-text="${activeProgress}" id="1"/>% finished)</source>
       </trans-unit>
       <trans-unit id="s9087c0239aa5bd6d">
-        <source>QA Analysis: <x id="0" equiv-text="${isUpload ? &quot;Not Applicable&quot; : qaStatus.label || msg(&quot;None&quot;)}"/></source>
+        <source>QA Analysis: <x equiv-text="${isUpload ? &quot;Not Applicable&quot; : qaStatus.label || msg(&quot;None&quot;)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s2fb39b9ba9441537">
-        <source><x id="0" equiv-text="${formatNumber(this.item.stats?.done ? +this.item.stats.done : 0)}"/> crawled, <x id="1" equiv-text="${formatNumber(this.item.stats?.found ? +this.item.stats.found : 0)}"/> found</source>
+        <source><x equiv-text="${formatNumber(this.item.stats?.done ? +this.item.stats.done : 0)}" id="0"/> crawled, <x equiv-text="${formatNumber(this.item.stats?.found ? +this.item.stats.found : 0)}" id="1"/> found</source>
       </trans-unit>
       <trans-unit id="s1a8b76905717bc34">
-        <source>Last run started on <x id="0" equiv-text="${formatISODateString(lastQAStarted)}"/></source>
+        <source>Last run started on <x equiv-text="${formatISODateString(lastQAStarted)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sa0ffc3feac61fcc4">
-        <source>Rated <x id="0" equiv-text="${this.item.reviewStatus}"/> / <x id="1" equiv-text="${ReviewStatus.Excellent}"/></source>
+        <source>Rated <x equiv-text="${this.item.reviewStatus}" id="0"/> / <x equiv-text="${ReviewStatus.Excellent}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s4e31ba44d4056425">
         <source>No QA review submitted</source>
@@ -2580,7 +2582,7 @@
         <source>QA Analysis Runs</source>
       </trans-unit>
       <trans-unit id="s1b210718400e7ea8">
-        <source><x id="0" equiv-text="${pageCount.toLocaleString()}"/> page</source>
+        <source><x equiv-text="${pageCount.toLocaleString()}" id="0"/> page</source>
       </trans-unit>
       <trans-unit id="s92921878e886e36d">
         <source>Duration</source>
@@ -2628,14 +2630,14 @@
         <source>Queued URLs</source>
       </trans-unit>
       <trans-unit id="se7f351ae6cbb41f0">
-        <source>Queued URLs from 1 to <x id="0" equiv-text="${this.queue.total.toLocaleString()}"/></source>
+        <source>Queued URLs from 1 to <x equiv-text="${this.queue.total.toLocaleString()}" id="0"/></source>
       </trans-unit>
       <trans-unit id="h077c8fe82a78c616">
         <source>
           Queued URLs from
-          <x id="0" equiv-text="&lt;btrix-inline-input class=&quot;mx-1 inline-block&quot; style=&quot;width: ${Math.max(offsetValue.toString().length, 2) + 2}ch&quot; value=&quot;1&quot; inputmode=&quot;numeric&quot; size=&quot;small&quot; autocomplete=&quot;off&quot; @sl-input=&quot;${(e: SlInputEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    input.style.width = getInputWidth(input.value);&#10;}}&quot; @sl-change=&quot;${async (e: SlChangeEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    const int = +input.value.replace(/\D/g, &quot;&quot;);&#10;    await this.updateComplete;&#10;    const value = Math.max(1, Math.min(int, this.queue!.total - 1));&#10;    input.value = value.toString();&#10;    this.pageOffset = value - 1;&#10;}}&quot;&gt;&lt;/btrix-inline-input&gt;"/>
-          to <x id="1" equiv-text="${countMax.toLocaleString()}"/> of
-          <x id="2" equiv-text="${this.queue.total.toLocaleString()}&#10;        "/></source>
+          <x equiv-text="&lt;btrix-inline-input class=&quot;mx-1 inline-block&quot; style=&quot;width: ${Math.max(offsetValue.toString().length, 2) + 2}ch&quot; value=&quot;1&quot; inputmode=&quot;numeric&quot; size=&quot;small&quot; autocomplete=&quot;off&quot; @sl-input=&quot;${(e: SlInputEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    input.style.width = getInputWidth(input.value);&#10;}}&quot; @sl-change=&quot;${async (e: SlChangeEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    const int = +input.value.replace(/\D/g, &quot;&quot;);&#10;    await this.updateComplete;&#10;    const value = Math.max(1, Math.min(int, this.queue!.total - 1));&#10;    input.value = value.toString();&#10;    this.pageOffset = value - 1;&#10;}}&quot;&gt;&lt;/btrix-inline-input&gt;" id="0"/>
+          to <x equiv-text="${countMax.toLocaleString()}" id="1"/> of
+          <x equiv-text="${this.queue.total.toLocaleString()}&#10;        " id="2"/></source>
       </trans-unit>
       <trans-unit id="s4dfaf5cfc90f8493">
         <source>No pages queued.</source>
@@ -2647,7 +2649,7 @@
         <source>Load more</source>
       </trans-unit>
       <trans-unit id="s813262fab638bbfc">
-        <source>-<x id="0" equiv-text="${this.matchedTotal.toLocaleString()}"/> URLs</source>
+        <source>-<x equiv-text="${this.matchedTotal.toLocaleString()}" id="0"/> URLs</source>
       </trans-unit>
       <trans-unit id="s6c4a20fdba7af262">
         <source>-1 URL</source>
@@ -2677,7 +2679,7 @@
         <source>Keep this window open until your upload finishes.</source>
       </trans-unit>
       <trans-unit id="hb8ae169d4ea6d7a3">
-        <source>Successfully uploaded <x id="0" equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;"/>.<x id="1" equiv-text="&lt;br&gt;&#10;              &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/items/upload/${data.id}&quot; @click=&quot;${this.navigate.link}&quot;&gt;"/>View Item<x id="2" equiv-text="&lt;/a&gt; "/></source>
+        <source>Successfully uploaded <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"/>.<x equiv-text="&lt;br&gt;&#10;              &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/items/upload/${data.id}&quot; @click=&quot;${this.navigate.link}&quot;&gt;" id="1"/>View Item<x equiv-text="&lt;/a&gt; " id="2"/></source>
       </trans-unit>
       <trans-unit id="scccaadc44687f6bf">
         <source>Sorry, couldn't upload file at this time.</source>
@@ -2719,10 +2721,10 @@
         <source>Create profile</source>
       </trans-unit>
       <trans-unit id="sfd20092783b9309d">
-        <source><x id="0" equiv-text="${selected.toLocaleString()}"/> / <x id="1" equiv-text="${total.toLocaleString()}"/> crawl</source>
+        <source><x equiv-text="${selected.toLocaleString()}" id="0"/> / <x equiv-text="${total.toLocaleString()}" id="1"/> crawl</source>
       </trans-unit>
       <trans-unit id="sd6a07c24d3ae246a">
-        <source><x id="0" equiv-text="${selected.toLocaleString()}"/> / <x id="1" equiv-text="${total.toLocaleString()}"/> crawls</source>
+        <source><x equiv-text="${selected.toLocaleString()}" id="0"/> / <x equiv-text="${total.toLocaleString()}" id="1"/> crawls</source>
       </trans-unit>
       <trans-unit id="sea0ac3af5d7a3071">
         <source>0 crawls</source>
@@ -2731,7 +2733,7 @@
         <source>Auto-Add</source>
       </trans-unit>
       <trans-unit id="s514cde9d19a9adc5">
-        <source>Started by <x id="0" equiv-text="${crawl.userName}"/></source>
+        <source>Started by <x equiv-text="${crawl.userName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s9b31004ff434426e">
         <source>Crawl Finished</source>
@@ -2740,22 +2742,22 @@
         <source>File Size</source>
       </trans-unit>
       <trans-unit id="sf51117c57a1110ec">
-        <source>in <x id="0" equiv-text="${this.collectionName}"/></source>
+        <source>in <x equiv-text="${this.collectionName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sf27239dda9b1416d">
-        <source>Crawls in Collection (<x id="0" equiv-text="${data!.total.toLocaleString()}"/>)</source>
+        <source>Crawls in Collection (<x equiv-text="${data!.total.toLocaleString()}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="sa3d5a7186b818303">
-        <source>All Workflows (<x id="0" equiv-text="${data!.total.toLocaleString()}"/>)</source>
+        <source>All Workflows (<x equiv-text="${data!.total.toLocaleString()}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s49730f3d5751a433">
         <source>Loading...</source>
       </trans-unit>
       <trans-unit id="sd7d35ab49e07fe79">
-        <source>Uploads in Collection (<x id="0" equiv-text="${this.uploads!.total.toLocaleString()}"/>)</source>
+        <source>Uploads in Collection (<x equiv-text="${this.uploads!.total.toLocaleString()}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s84c2e4081c2bf6d7">
-        <source>All Uploads (<x id="0" equiv-text="${this.uploads!.total.toLocaleString()}"/>)</source>
+        <source>All Uploads (<x equiv-text="${this.uploads!.total.toLocaleString()}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s1e2b42118528e92f">
         <source>In Collection?</source>
@@ -2816,7 +2818,7 @@
       </trans-unit>
       <trans-unit id="hf77ba6b1d74e2cdb">
         <source>Fields marked with
-                  <x id="0" equiv-text="&lt;span style=&quot;color:var(--sl-input-required-content-color)&quot;&gt;"/>*<x id="1" equiv-text="&lt;/span&gt;"/>
+                  <x equiv-text="&lt;span style=&quot;color:var(--sl-input-required-content-color)&quot;&gt;" id="0"/>*<x equiv-text="&lt;/span&gt;" id="1"/>
                   are required</source>
       </trans-unit>
       <trans-unit id="s5f94c84437a8594c">
@@ -2848,7 +2850,7 @@
       </trans-unit>
       <trans-unit id="s6de92df940cdee71">
         <source>The crawler will visit and record each URL listed in the order
-        defined here. You can enter a maximum of <x id="0" equiv-text="${URL_LIST_MAX_URLS.toLocaleString()}"/> URLs, separated by a new line.</source>
+        defined here. You can enter a maximum of <x equiv-text="${URL_LIST_MAX_URLS.toLocaleString()}" id="0"/> URLs, separated by a new line.</source>
       </trans-unit>
       <trans-unit id="s7af85d601db244a7">
         <source>Tells the crawler which pages it can visit.</source>
@@ -2868,29 +2870,29 @@
       </trans-unit>
       <trans-unit id="hef8020bab2159211">
         <source>Will crawl all pages and paths in the same directory, e.g.
-            <x id="0" equiv-text="&lt;span class=&quot;break-word break-word text-blue-500&quot;&gt;${exampleDomain}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;${examplePathname.slice(0, examplePathname.lastIndexOf(&quot;/&quot;))}"/>/<x id="1" equiv-text="&lt;/span&gt;"/></source>
+            <x equiv-text="&lt;span class=&quot;break-word break-word text-blue-500&quot;&gt;${exampleDomain}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;${examplePathname.slice(0, examplePathname.lastIndexOf(&quot;/&quot;))}" id="0"/>/<x equiv-text="&lt;/span&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="hed4c39f98af5c58f">
         <source>Will crawl all pages on
-            <x id="0" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;"/> and ignore pages
+            <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"/> and ignore pages
             on any subdomains.</source>
       </trans-unit>
       <trans-unit id="ha8f0ffdb034da2d1">
         <source>Will crawl all pages on
-            <x id="0" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;"/> and
-            <x id="1" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;"/>subdomain.<x id="2" equiv-text="${exampleHost}&lt;/span&gt;"/>.</source>
+            <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"/> and
+            <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;" id="1"/>subdomain.<x equiv-text="${exampleHost}&lt;/span&gt;" id="2"/>.</source>
       </trans-unit>
       <trans-unit id="h45676fe694fd7de8">
         <source>Will only visit
-            <x id="0" equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;"/>
+            <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;" id="0"/>
             hash anchor links, e.g.
-            <x id="1" equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;"/>#example-page<x id="2" equiv-text="&lt;/span&gt;"/></source>
+            <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;" id="1"/>#example-page<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="h2303b42f0dff5ee4">
         <source>Will crawl all page URLs that begin with
-            <x id="0" equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;"/>
+            <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;" id="0"/>
             or any URL that begins with those specified in
-            <x id="1" equiv-text="&lt;em&gt;"/>Extra URL Prefixes in Scope<x id="2" equiv-text="&lt;/em&gt;"/></source>
+            <x equiv-text="&lt;em&gt;" id="1"/>Extra URL Prefixes in Scope<x equiv-text="&lt;/em&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="s262c31c801cfbcd9">
         <source>Please enter a valid URL.</source>
@@ -2932,13 +2934,13 @@
       </trans-unit>
       <trans-unit id="sdc9e7f186428eec0">
         <source>The crawler will visit and record each URL listed here. Other
-              links on these pages will not be crawled. You can enter up to <x id="0" equiv-text="${maxAdditionalURls.toLocaleString()}"/> URLs.</source>
+              links on these pages will not be crawled. You can enter up to <x equiv-text="${maxAdditionalURls.toLocaleString()}" id="0"/> URLs.</source>
       </trans-unit>
       <trans-unit id="sdd5dbd4b0fef8660">
-        <source>Must be more than minimum of <x id="0" equiv-text="${(+min).toLocaleString()}"/></source>
+        <source>Must be more than minimum of <x equiv-text="${(+min).toLocaleString()}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sa4f9d4099c408ae6">
-        <source>Must be less than maximum of <x id="0" equiv-text="${(+max).toLocaleString()}"/></source>
+        <source>Must be less than maximum of <x equiv-text="${(+max).toLocaleString()}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s9d84cf47af31a3ba">
         <source>Auto-scroll behavior</source>
@@ -2978,14 +2980,14 @@
       </trans-unit>
       <trans-unit id="h8c7c3a6e07d7c512">
         <source>Schedule:
-                <x id="0" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${utcSchedule&#10;    ? humanizeSchedule(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;"/>.</source>
+                <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${utcSchedule&#10;    ? humanizeSchedule(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="se0baa9b7fb0768e4">
         <source>Invalid date</source>
       </trans-unit>
       <trans-unit id="h30728ea4302f7fe9">
         <source>Next scheduled run:
-                <x id="0" equiv-text="&lt;span&gt;${utcSchedule&#10;    ? humanizeNextDate(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;"/>.</source>
+                <x equiv-text="&lt;span&gt;${utcSchedule&#10;    ? humanizeNextDate(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s4174899261b8b308">
         <source>A crawl will run at this time in your current timezone.</source>
@@ -3013,9 +3015,9 @@
         <source>There are issues with this Workflow. Please go through previous steps and fix all issues to continue.</source>
       </trans-unit>
       <trans-unit id="h2e384a6a9366b427">
-        <source>There is an issue with this Crawl Workflow:<x id="0" equiv-text="&lt;br&gt;&lt;br&gt;"/>Crawl
+        <source>There is an issue with this Crawl Workflow:<x equiv-text="&lt;br&gt;&lt;br&gt;" id="0"/>Crawl
               URL(s) required in
-              <x id="1" equiv-text="&lt;a href=&quot;${crawlSetupUrl}&quot; class=&quot;bold underline hover:no-underline&quot;&gt;"/>Crawl Setup<x id="2" equiv-text="&lt;/a&gt;"/>. <x id="3" equiv-text="&lt;br&gt;&lt;br&gt;"/>
+              <x equiv-text="&lt;a href=&quot;${crawlSetupUrl}&quot; class=&quot;bold underline hover:no-underline&quot;&gt;" id="1"/>Crawl Setup<x equiv-text="&lt;/a&gt;" id="2"/>. <x equiv-text="&lt;br&gt;&lt;br&gt;" id="3"/>
               Please fix to continue.</source>
       </trans-unit>
       <trans-unit id="s265a8f6e25a8c5f2">
@@ -3034,34 +3036,36 @@
         <source>Could not run crawl with new workflow settings due to already running crawl.</source>
       </trans-unit>
       <trans-unit id="s286331d9358fc509">
-        <source>Seed URL <x id="0" equiv-text="${loc[loc.length - 1] + 1}"/>: </source>
+        <source>Seed URL <x equiv-text="${loc[loc.length - 1] + 1}" id="0"/>: </source>
       </trans-unit>
       <trans-unit id="s08dd397493a013b1">
         <source>Couldn't save Workflow. Please fix the following Workflow issues:</source>
       </trans-unit>
       <trans-unit id="sea5eee53e296f33b">
-        <source><x id="0" equiv-text="${urlList.length.toLocaleString()}"/> URL entered</source>
+        <source><x equiv-text="${urlList.length.toLocaleString()}" id="0"/> URL entered</source>
       </trans-unit>
       <trans-unit id="sfa75e464c2da4bba">
-        <source><x id="0" equiv-text="${urlList.length.toLocaleString()}"/> URLs entered</source>
+        <source><x equiv-text="${urlList.length.toLocaleString()}" id="0"/> URLs entered</source>
       </trans-unit>
       <trans-unit id="s960e671fe5f2559b">
-        <source>Please shorten list to <x id="0" equiv-text="${max.toLocaleString()}"/> or fewer URLs.</source>
+        <source>Please shorten list to <x equiv-text="${max.toLocaleString()}" id="0"/> or fewer URLs.</source>
       </trans-unit>
       <trans-unit id="s40b5b363fefc9199">
-        <source>Please remove or fix the following invalid URL: <x id="0" equiv-text="${invalidUrl}"/></source>
+        <source>Please remove or fix the following invalid URL: <x equiv-text="${invalidUrl}" id="0"/></source>
       </trans-unit>
       <trans-unit id="saf63d34c8601dd41">
-        <source><x id="0" equiv-text="${humanizeSchedule(workflow.schedule, {&#10;    length: &quot;short&quot;,&#10;}, numberFormatter)}"/></source>
+        <source>
+          <x equiv-text="${humanizeSchedule(workflow.schedule, {&#10;    length: &quot;short&quot;,&#10;}, numberFormatter)}" id="0"/>
+        </source>
       </trans-unit>
       <trans-unit id="s136b21dec9a221bd">
-        <source>Manual run by <x id="0" equiv-text="${workflow.lastStartedByName}"/></source>
+        <source>Manual run by <x equiv-text="${workflow.lastStartedByName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sde7cc417de1b3246">
         <source>---</source>
       </trans-unit>
       <trans-unit id="sa84bc532c73403ed">
-        <source>Running for <x id="0" equiv-text="${RelativeDuration.humanize(diff, {&#10;    compact: true,&#10;})}"/></source>
+        <source>Running for <x equiv-text="${RelativeDuration.humanize(diff, {&#10;    compact: true,&#10;})}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s8eb4021572d41d99">
         <source>Name &amp; Schedule</source>
@@ -3071,35 +3075,35 @@
       </trans-unit>
       <trans-unit id="s71c5c2d34bb2c4c2">
         <source>Your org will be deleted in
-              <x id="0" equiv-text="${daysDiff}"/> days</source>
+              <x equiv-text="${daysDiff}" id="0"/> days</source>
       </trans-unit>
       <trans-unit id="s7fa0d24b94690373">
-        <source>Your subscription ends on <x id="0" equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}"/>. Your user account, org, and all associated data will be deleted.</source>
+        <source>Your subscription ends on <x equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}" id="0"/>. Your user account, org, and all associated data will be deleted.</source>
       </trans-unit>
       <trans-unit id="h16be212de6638b6c">
         <source>We suggest downloading your archived items before they
                   are deleted. To keep your plan and data, see
-                  <x id="0" equiv-text="${billingTabLink}"/>.</source>
+                  <x equiv-text="${billingTabLink}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sc3e0d8cbe688ccd5">
-        <source>Archiving will be disabled in <x id="0" equiv-text="${daysDiff}"/> days</source>
+        <source>Archiving will be disabled in <x equiv-text="${daysDiff}" id="0"/> days</source>
       </trans-unit>
       <trans-unit id="sda57befc109a45f6">
         <source>Archiving will be disabled within one day</source>
       </trans-unit>
       <trans-unit id="s618b35a93b6fd392">
-        <source>Your subscription ends on <x id="0" equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}"/>. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.</source>
+        <source>Your subscription ends on <x equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}" id="0"/>. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.</source>
       </trans-unit>
       <trans-unit id="hf17c5369da37401b">
         <source>To keep your plan and continue crawling, see
-                  <x id="0" equiv-text="${billingTabLink}"/>.</source>
+                  <x equiv-text="${billingTabLink}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sfb85ab2a166e4c99">
         <source>Archiving is disabled for this org</source>
       </trans-unit>
       <trans-unit id="habd962339c5b3e55">
         <source>Your subscription has been paused due to payment failure.
-            Please go to <x id="0" equiv-text="${billingTabLink}"/> to update your payment method.</source>
+            Please go to <x equiv-text="${billingTabLink}" id="0"/> to update your payment method.</source>
       </trans-unit>
       <trans-unit id="s4e6c7f0a1e774fea">
         <source>Your subscription has been canceled. Please contact Browsertrix support to renew your plan.</source>
@@ -3111,7 +3115,7 @@
         <source>Your org has reached its storage limit</source>
       </trans-unit>
       <trans-unit id="s7b663782f7f35eb8">
-        <source>To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact <x id="0" equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}"/> to upgrade your storage plan.</source>
+        <source>To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"/> to upgrade your storage plan.</source>
       </trans-unit>
       <trans-unit id="sf3a7cc6ecc194453">
         <source>Browsertrix host administrator</source>
@@ -3120,7 +3124,7 @@
         <source>Your org has reached its monthly execution minutes limit</source>
       </trans-unit>
       <trans-unit id="s10a8d7c57c09ca1b">
-        <source>Contact <x id="0" equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}"/> to purchase additional monthly execution minutes or upgrade your plan.</source>
+        <source>Contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"/> to purchase additional monthly execution minutes or upgrade your plan.</source>
       </trans-unit>
       <trans-unit id="seb2d088a92660d77">
         <source>No usage history to show.</source>
@@ -3201,7 +3205,7 @@
         <source>This org name is already taken.</source>
       </trans-unit>
       <trans-unit id="s1184d1f63618dc4e">
-        <source>Created new org named "<x id="0" equiv-text="${params.name}"/>".</source>
+        <source>Created new org named "<x equiv-text="${params.name}" id="0"/>".</source>
       </trans-unit>
       <trans-unit id="sf1c2a4776e202435">
         <source>Sorry, couldn't create organization at this time.</source>
@@ -3274,14 +3278,14 @@
       </trans-unit>
       <trans-unit id="h22769969c5066f85">
         <source>You’ve been invited by
-          <x id="0" equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${inviterName}&lt;/strong&gt;"/>
+          <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${inviterName}&lt;/strong&gt;" id="0"/>
           to join the organization
-          <x id="1" equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;"/>
+          <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="1"/>
           on Browsertrix.</source>
       </trans-unit>
       <trans-unit id="h406ea2eff53edcfb">
         <source>You’ve been invited to join the organization
-          <x id="0" equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;"/>
+          <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="0"/>
           on Browsertrix.</source>
       </trans-unit>
       <trans-unit id="s07cee0cdf942df03">
@@ -3310,12 +3314,12 @@
       </trans-unit>
       <trans-unit id="hecef9e5e39351b37">
         <source>Refer to our user guide on
-                <x id="0" equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;https://docs.browsertrix.com/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;"/>org settings<x id="1" equiv-text="&lt;/a&gt;"/>
+                <x equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;https://docs.browsertrix.com/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;" id="0"/>org settings<x equiv-text="&lt;/a&gt;" id="1"/>
                 for details.</source>
       </trans-unit>
       <trans-unit id="s8ae1873b610b92d6">
         <source>Your org dashboard will be
-        <x id="0" equiv-text="${window.location.protocol}"/>//<x id="1" equiv-text="${window.location.hostname}"/>/orgs/<x id="2" equiv-text="${slug || &quot;&quot;}"/></source>
+        <x equiv-text="${window.location.protocol}" id="0"/>//<x equiv-text="${window.location.hostname}" id="1"/>/orgs/<x equiv-text="${slug || &quot;&quot;}" id="2"/></source>
       </trans-unit>
       <trans-unit id="s0d5ee4ffcb9c2c65">
         <source>You can change this in your org settings later.</source>
@@ -3324,13 +3328,13 @@
         <source>Go to Dashboard</source>
       </trans-unit>
       <trans-unit id="s033b7f18e2a1b86e">
-        <source>The org name "<x id="0" equiv-text="${name}"/>" is already taken, try another one.</source>
+        <source>The org name "<x equiv-text="${name}" id="0"/>" is already taken, try another one.</source>
       </trans-unit>
       <trans-unit id="s6d0192d253b870f7">
-        <source>The org URL identifier "<x id="0" equiv-text="${slug}"/>" is already taken, try another one.</source>
+        <source>The org URL identifier "<x equiv-text="${slug}" id="0"/>" is already taken, try another one.</source>
       </trans-unit>
       <trans-unit id="s692207ce67c91506">
-        <source>The org URL identifier "<x id="0" equiv-text="${slug}"/>" is not a valid URL. Please use alphanumeric characters and dashes (-) only</source>
+        <source>The org URL identifier "<x equiv-text="${slug}" id="0"/>" is not a valid URL. Please use alphanumeric characters and dashes (-) only</source>
       </trans-unit>
       <trans-unit id="s5df133e1b1fd43c3">
         <source>Welcome to Browsertrix</source>
@@ -3342,13 +3346,13 @@
         <source>This invite doesn't exist or has expired. Please ask the organization administrator to resend an invitation.</source>
       </trans-unit>
       <trans-unit id="s1952dc02aa41f1c9">
-        <source>This is not a valid invite, or it may have expired. If you believe this is an error, please contact <x id="0" equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}"/> for help.</source>
+        <source>This is not a valid invite, or it may have expired. If you believe this is an error, please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"/> for help.</source>
       </trans-unit>
       <trans-unit id="s0235065054efe3a8">
         <source>your Browsertrix administrator</source>
       </trans-unit>
       <trans-unit id="s4a7fb6e66ba564d7">
-        <source>Something unexpected went wrong retrieving this invite. Please contact <x id="0" equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}"/> for help.</source>
+        <source>Something unexpected went wrong retrieving this invite. Please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"/> for help.</source>
       </trans-unit>
       <trans-unit id="s7ebc4f216d73836f">
         <source>This verification email is not valid.</source>
@@ -3366,7 +3370,7 @@
         <source>Must be between 8-64 characters</source>
       </trans-unit>
       <trans-unit id="s8daf047a917f4cc4">
-        <source>Choose a strong password between <x id="0" equiv-text="${PASSWORD_MINLENGTH}"/>-<x id="1" equiv-text="${PASSWORD_MAXLENGTH}"/> characters.</source>
+        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"/>-<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"/> characters.</source>
       </trans-unit>
       <trans-unit id="s16ba889483d4940e">
         <source>Change Password</source>
@@ -3378,7 +3382,7 @@
         <source>Password reset email is not valid. Request a new password reset email</source>
       </trans-unit>
       <trans-unit id="s7d90fb0e2d1684a7">
-        <source>Sent invite to <x id="0" equiv-text="${this.invitedEmail}"/></source>
+        <source>Sent invite to <x equiv-text="${this.invitedEmail}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s586d6bd2eca2da93">
         <source>Users</source>
@@ -3405,10 +3409,10 @@
         <source>Decline</source>
       </trans-unit>
       <trans-unit id="s84922e45c0957371">
-        <source>This invitation is for <x id="0" equiv-text="${this.email}"/>. You are currently logged in as <x id="1" equiv-text="${this.authState?.username}"/>. Please log in with the correct email to access this invite.</source>
+        <source>This invitation is for <x equiv-text="${this.email}" id="0"/>. You are currently logged in as <x equiv-text="${this.authState?.username}" id="1"/>. Please log in with the correct email to access this invite.</source>
       </trans-unit>
       <trans-unit id="sc9a2484754aae7bb">
-        <source>You've joined <x id="0" equiv-text="${org.name || inviteInfo.orgName || msg(&quot;Browsertrix&quot;)}"/>.</source>
+        <source>You've joined <x equiv-text="${org.name || inviteInfo.orgName || msg(&quot;Browsertrix&quot;)}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sdb8ec1b3a5726c88">
         <source>Browsertrix</source>
@@ -3417,7 +3421,7 @@
         <source>This invitation is not valid</source>
       </trans-unit>
       <trans-unit id="s4b97257cf024d907">
-        <source>You've declined to join <x id="0" equiv-text="${orgName || msg(&quot;Browsertrix&quot;)}"/>.</source>
+        <source>You've declined to join <x equiv-text="${orgName || msg(&quot;Browsertrix&quot;)}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s686306cdb839fb8d">
         <source>Sending...</source>
@@ -3489,7 +3493,7 @@
         <source>You must belong to at least one org in order to access Browsertrix features.</source>
       </trans-unit>
       <trans-unit id="s273f0ee82bf2b922">
-        <source>If you haven't received an invitation to an org, please contact us at <x id="0" equiv-text="${this.appState.settings.salesEmail}"/>.</source>
+        <source>If you haven't received an invitation to an org, please contact us at <x equiv-text="${this.appState.settings.salesEmail}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s95aeb2828c01b0de">
         <source>If you haven't received an invitation to an org, please contact your Browsertrix administrator.</source>
@@ -3528,7 +3532,7 @@
         <source>Welcome to Browsertrix!</source>
       </trans-unit>
       <trans-unit id="h702a7337c08bf73f">
-        <source>A confirmation email was sent to: <x id="0" equiv-text="&lt;br&gt;&#10;                &lt;strong&gt;${email}&lt;/strong&gt;"/>.</source>
+        <source>A confirmation email was sent to: <x equiv-text="&lt;br&gt;&#10;                &lt;strong&gt;${email}&lt;/strong&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sd11e60711d79e788">
         <source>Click the link in your email to confirm your email address.</source>
@@ -3671,11 +3675,11 @@
         <note from="lit-localize">Time AM/PM</note>
       </trans-unit>
       <trans-unit id="h9083eded7901e66a">
-        <source><x id="0" equiv-text="${quotas.storageQuota&#10;    ? html `&lt;sl-format-bytes&#10;                  value=${quotas.storageQuota}&#10;                &gt;&lt;/sl-format-bytes&gt;`&#10;    : msg(&quot;Unlimited&quot;)}"/>
+        <source><x equiv-text="${quotas.storageQuota&#10;    ? html `&lt;sl-format-bytes&#10;                  value=${quotas.storageQuota}&#10;                &gt;&lt;/sl-format-bytes&gt;`&#10;    : msg(&quot;Unlimited&quot;)}" id="0"/>
             storage</source>
       </trans-unit>
       <trans-unit id="s1d6a13ef53c51ee9">
-        <source><x id="0" equiv-text="${maxPagesPerCrawl || msg(&quot;Unlimited pages&quot;)}"/> per crawl</source>
+        <source><x equiv-text="${maxPagesPerCrawl || msg(&quot;Unlimited pages&quot;)}" id="0"/> per crawl</source>
       </trans-unit>
       <trans-unit id="s41de0883966c23c8">
         <source>Unlimited pages</source>
@@ -3684,10 +3688,10 @@
         <source>Unlimited concurrent crawls</source>
       </trans-unit>
       <trans-unit id="s8ad4a17ab2b75854">
-        <source>Adding <x id="0" equiv-text="${formatNumber(addCount)} ${pluralOf(&quot;items&quot;, addCount)}"/></source>
+        <source>Adding <x equiv-text="${formatNumber(addCount)} ${pluralOf(&quot;items&quot;, addCount)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sbea722837f683db1">
-        <source><x id="0" equiv-text="${firstUrl}"/> + <x id="1" equiv-text="${formatNumber(remainder, { notation: &quot;compact&quot; })}"/> more <x id="2" equiv-text="${pluralOf(&quot;URLs&quot;, remainder)}"/></source>
+        <source><x equiv-text="${firstUrl}" id="0"/> + <x equiv-text="${formatNumber(remainder, { notation: &quot;compact&quot; })}" id="1"/> more <x equiv-text="${pluralOf(&quot;URLs&quot;, remainder)}" id="2"/></source>
       </trans-unit>
       <trans-unit id="items.plural.few">
         <source>items</source>
@@ -3735,7 +3739,7 @@
         <source>Specify a domain name, start page URL, or path on a website and let the crawler automatically find pages within that scope.</source>
       </trans-unit>
       <trans-unit id="hb653cf5693a98f6b">
-        <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Page List<x id="1" equiv-text="&lt;/strong&gt;"/> if:</source>
+        <source>Choose <x equiv-text="&lt;strong&gt;" id="0"/>Page List<x equiv-text="&lt;/strong&gt;" id="1"/> if:</source>
       </trans-unit>
       <trans-unit id="s16addd6732b613fd">
         <source>You want to include URLs with different domain names in the same crawl</source>
@@ -3746,7 +3750,7 @@
               the website that you may not want to archive.</source>
       </trans-unit>
       <trans-unit id="hc5b85948ffe0eb76">
-        <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Site Crawl<x id="1" equiv-text="&lt;/strong&gt;"/> if:</source>
+        <source>Choose <x equiv-text="&lt;strong&gt;" id="0"/>Site Crawl<x equiv-text="&lt;/strong&gt;" id="1"/> if:</source>
       </trans-unit>
       <trans-unit id="hddd64e30f6ade731">
         <source>Site Crawl workflows are great for advanced use cases where
@@ -3767,8 +3771,8 @@
         <source>Help me decide</source>
       </trans-unit>
       <trans-unit id="ha60886587b96e32c">
-        <source>Started crawl from <x id="0" equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;"/>.
-            <x id="1" equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navLink.bind(this)}&quot;&gt;"/>Watch crawl<x id="2" equiv-text="&lt;/a&gt;"/></source>
+        <source>Started crawl from <x equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;" id="0"/>.
+            <x equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navLink.bind(this)}&quot;&gt;" id="1"/>Watch crawl<x equiv-text="&lt;/a&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="sb32ae1652df8c7ad">
         <source>Workflow settings used to run this crawl</source>
@@ -3780,21 +3784,21 @@
         <source>Select Analysis Run</source>
       </trans-unit>
       <trans-unit id="sd3c4adf4cc6d1668">
-        <source>New <x id="0" equiv-text="${this.jobTypeLabels[jobType]}"/> Workflow</source>
+        <source>New <x equiv-text="${this.jobTypeLabels[jobType]}" id="0"/> Workflow</source>
       </trans-unit>
       <trans-unit id="sdd3e1b91cb27a4d5">
         <source>Page URL(s)</source>
       </trans-unit>
       <trans-unit id="s4201222224dff23c">
-        <source>Crawl: <x id="0" equiv-text="${crawlStatus.label}"/></source>
+        <source>Crawl: <x equiv-text="${crawlStatus.label}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s0eb7c300368b2a58">
-        <source>Upload: <x id="0" equiv-text="${crawlStatus.label}"/></source>
+        <source>Upload: <x equiv-text="${crawlStatus.label}" id="0"/></source>
       </trans-unit>
-<trans-unit id="hac630f92c94217bc">
-  <source>Your plan will be canceled on
-                                  <x id="0" equiv-text="&lt;sl-format-date lang=&quot;${getLocale()}&quot; class=&quot;truncate&quot; date=&quot;${org.subscription.futureCancelDate}&quot; month=&quot;long&quot; day=&quot;numeric&quot; year=&quot;numeric&quot;&gt;&#10;                                  &lt;/sl-format-date&gt;"/></source>
-</trans-unit>
+      <trans-unit id="hac630f92c94217bc">
+        <source>Your plan will be canceled on
+                                  <x equiv-text="&lt;sl-format-date lang=&quot;${getLocale()}&quot; class=&quot;truncate&quot; date=&quot;${org.subscription.futureCancelDate}&quot; month=&quot;long&quot; day=&quot;numeric&quot; year=&quot;numeric&quot;&gt;&#10;                                  &lt;/sl-format-date&gt;" id="0"/></source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -31,10 +31,10 @@
         <target state="translated">Siguiente página</target>
       </trans-unit>
       <trans-unit id="h7ee8a6e551e702ba">
-        <source><x equiv-text="${this.renderInput()}" id="0"></x> of <x equiv-text="${this.pages} " id="1"></x></source>
+        <source> <x id="0" equiv-text="${this.renderInput()}"/> of <x id="1" equiv-text="${this.pages} "/></source>
       </trans-unit>
       <trans-unit id="s5697808ce744d508">
-        <source>Current page, page <x equiv-text="${this.page}" id="0"></x></source>
+        <source>Current page, page <x id="0" equiv-text="${this.page}"/></source>
       </trans-unit>
       <trans-unit id="s81a19821f3e4a3d2" xml:space="preserve">
         <source>Replay</source>
@@ -65,7 +65,8 @@
         <target state="translated">¿Eliminar colección?</target>
       </trans-unit>
       <trans-unit id="h05165b87bf66fe02">
-        <source>Are you sure you want to delete <x equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;" id="0"></x>?</source>
+        <source>Are you sure you want to delete
+            <x id="0" equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;"/>?</source>
       </trans-unit>
       <trans-unit id="s2ceb11be2290bb1b">
         <source>Cancel</source>
@@ -107,13 +108,17 @@
         <source>Copy Embed Code</source>
       </trans-unit>
       <trans-unit id="h648aaa4b436a5970">
-        <source>Add the following JavaScript to your <x equiv-text="&lt;code class=&quot;text-[0.9em]&quot;&gt;" id="0"></x>/replay/sw.js<x equiv-text="&lt;/code&gt;" id="1"></x>:</source>
+        <source>Add the following JavaScript to your
+              <x id="0" equiv-text="&lt;code class=&quot;text-[0.9em]&quot;&gt;"/>/replay/sw.js<x id="1" equiv-text="&lt;/code&gt;"/>:</source>
       </trans-unit>
       <trans-unit id="s4f0cf5a844f978f3">
         <source>Copy JS</source>
       </trans-unit>
       <trans-unit id="hf56186ec17103fb3">
-        <source>See <x equiv-text="&lt;a class=&quot;text-primary&quot; href=&quot;https://replayweb.page/docs/embedding&quot; target=&quot;_blank&quot;&gt;" id="0"></x> our embedding guide<x equiv-text="&lt;/a&gt;" id="1"></x> for more details.</source>
+        <source>See
+              <x id="0" equiv-text="&lt;a class=&quot;text-primary&quot; href=&quot;https://replayweb.page/docs/embedding&quot; target=&quot;_blank&quot;&gt;"/>
+                our embedding guide<x id="1" equiv-text="&lt;/a&gt;"/>
+              for more details.</source>
       </trans-unit>
       <trans-unit id="s3f5390ecd7d14626">
         <source>Collections</source>
@@ -137,7 +142,7 @@
         <source>Download Collection</source>
       </trans-unit>
       <trans-unit id="s125a86b2f45bbb25">
-        <source><x equiv-text="${item.crawlCount}" id="0"></x> items</source>
+        <source><x id="0" equiv-text="${item.crawlCount}"/> items</source>
       </trans-unit>
       <trans-unit id="s88f9e7f4ecc07ede">
         <source>Total Size</source>
@@ -146,7 +151,7 @@
         <source>Total Pages</source>
       </trans-unit>
       <trans-unit id="s279de934d8a18e21">
-        <source><x equiv-text="${pageCount.toLocaleString()}" id="0"></x> pages</source>
+        <source><x id="0" equiv-text="${pageCount.toLocaleString()}"/> pages</source>
       </trans-unit>
       <trans-unit id="s3512b3c95c7a5c3a">
         <source>Last Updated</source>
@@ -179,7 +184,7 @@
         <source>Remove from Collection</source>
       </trans-unit>
       <trans-unit id="h2962269031cae049">
-        <source>Deleted <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"></x> Collection.</source>
+        <source>Deleted <x id="0" equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;"/> Collection.</source>
       </trans-unit>
       <trans-unit id="s1a223f3372970867">
         <source>Sorry, couldn't delete Collection at this time.</source>
@@ -197,16 +202,16 @@
         <source>Sorry, couldn't remove item from Collection at this time.</source>
       </trans-unit>
       <trans-unit id="sd77c5f8da91d0729">
-        <source>Maximum <x equiv-text="${formatNumber(maxLength)}" id="0"></x> characters</source>
+        <source>Maximum <x id="0" equiv-text="${formatNumber(maxLength)}"/> characters</source>
       </trans-unit>
       <trans-unit id="sa1c466807a6fdfb7">
-        <source><x equiv-text="${formatNumber(overMax)}" id="0"></x> character over limit</source>
+        <source><x id="0" equiv-text="${formatNumber(overMax)}"/> character over limit</source>
       </trans-unit>
       <trans-unit id="s8b6894f4bfec27c0">
-        <source><x equiv-text="${formatNumber(overMax)}" id="0"></x> characters over limit</source>
+        <source><x id="0" equiv-text="${formatNumber(overMax)}"/> characters over limit</source>
       </trans-unit>
       <trans-unit id="se1f5b61904654dba">
-        <source>Please shorten this text to <x equiv-text="${maxLength}" id="0"></x> or fewer characters.</source>
+        <source>Please shorten this text to <x id="0" equiv-text="${maxLength}"/> or fewer characters.</source>
       </trans-unit>
       <trans-unit id="s9f8c17b4d595bb2d">
         <source>Manage Billing</source>
@@ -220,9 +225,6 @@
       <trans-unit id="sbf7e4b6a4db03e2a">
         <source>Sorry, couldn't retrieve current plan at this time.</source>
       </trans-unit>
-      <trans-unit id="hbdcee9d45257750c">
-        <source>Your plan will be canceled on <x equiv-text="&lt;sl-format-date lang=&quot;${getLocale()}&quot; class=&quot;truncate&quot; date=&quot;${org.subscription.futureCancelDate}Z&quot; month=&quot;long&quot; day=&quot;numeric&quot; year=&quot;numeric&quot;&gt;&#10;                                  &lt;/sl-format-date&gt;" id="0"></x></source>
-      </trans-unit>
       <trans-unit id="sc8fa6bd4dc311b6a">
         <source>Monthly quota</source>
       </trans-unit>
@@ -230,16 +232,17 @@
         <source>Subscription status, features, and add-ons, if applicable.</source>
       </trans-unit>
       <trans-unit id="sc93b55ebdda10016">
-        <source>You can view plan details, update payment methods, and update billing information by clicking “<x equiv-text="${this.portalUrlLabel}" id="0"></x>”.</source>
+        <source>You can view plan details, update payment methods, and update billing information by clicking “<x id="0" equiv-text="${this.portalUrlLabel}"/>”.</source>
       </trans-unit>
       <trans-unit id="h1abcffb9335ebc6d">
-        <source>To upgrade to Pro, contact us at <x equiv-text="&lt;a class=&quot;${linkClassList}&quot; href=&quot;${`mailto:${this.salesEmail}?subject=${msg(str `Upgrade Browsertrix plan (${this.userOrg?.name})`)}`}&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;${this.salesEmail}&lt;/a&gt;" id="0"></x>.</source>
+        <source>To upgrade to Pro, contact us at
+                                <x id="0" equiv-text="&lt;a class=&quot;${linkClassList}&quot; href=&quot;${`mailto:${this.salesEmail}?subject=${msg(str `Upgrade Browsertrix plan (${this.userOrg?.name})`)}`}&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;${this.salesEmail}&lt;/a&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s7ec899c7c6213c52">
-        <source>Upgrade Browsertrix plan (<x equiv-text="${this.userOrg?.name}" id="0"></x>)</source>
+        <source>Upgrade Browsertrix plan (<x id="0" equiv-text="${this.userOrg?.name}"/>)</source>
       </trans-unit>
       <trans-unit id="s00341480baa290eb">
-        <source>Contact us at <x equiv-text="${this.salesEmail}" id="0"></x> to make changes to your plan.</source>
+        <source>Contact us at <x id="0" equiv-text="${this.salesEmail}"/> to make changes to your plan.</source>
       </trans-unit>
       <trans-unit id="s1d04dbb2d7ee4b9b">
         <source>Contact your Browsertrix host administrator to make changes to your plan.</source>
@@ -269,7 +272,7 @@
         <source>Pro</source>
       </trans-unit>
       <trans-unit id="sd069593586fce913">
-        <source><x equiv-text="${maxExecMinutesPerMonth || msg(&quot;Unlimited minutes&quot;)}" id="0"></x> of crawl and QA analysis execution time</source>
+        <source><x id="0" equiv-text="${maxExecMinutesPerMonth || msg(&quot;Unlimited minutes&quot;)}"/> of crawl and QA analysis execution time</source>
       </trans-unit>
       <trans-unit id="s1228a18c03355491">
         <source>Unlimited minutes</source>
@@ -278,10 +281,10 @@
         <source>Unlimited</source>
       </trans-unit>
       <trans-unit id="s8e49ef99717ff3d4">
-        <source><x equiv-text="${formatNumber(quotas.maxConcurrentCrawls)}" id="0"></x> concurrent <x equiv-text="${pluralOf(&quot;crawls&quot;, quotas.maxConcurrentCrawls)}" id="1"></x></source>
+        <source><x id="0" equiv-text="${formatNumber(quotas.maxConcurrentCrawls)}"/> concurrent <x id="1" equiv-text="${pluralOf(&quot;crawls&quot;, quotas.maxConcurrentCrawls)}"/></source>
       </trans-unit>
       <trans-unit id="sc27403512c49c425">
-        <source>Pro plan change request (<x equiv-text="${this.userOrg?.name}" id="0"></x>)</source>
+        <source>Pro plan change request (<x id="0" equiv-text="${this.userOrg?.name}"/>)</source>
       </trans-unit>
       <trans-unit id="sc2a7f6d40341e683">
         <source>Contact Sales</source>
@@ -302,10 +305,13 @@
         <source>Regex</source>
       </trans-unit>
       <trans-unit id="h8c21d04827e5cb19">
-        <source>Regular Expression syntax error: <x equiv-text="&lt;code&gt;${this.fieldErrorMessage}&lt;/code&gt;" id="0"></x></source>
+        <source>Regular Expression syntax error:
+                                    <x id="0" equiv-text="&lt;code&gt;${this.fieldErrorMessage}&lt;/code&gt;"/></source>
       </trans-unit>
       <trans-unit id="h1a1f28e6632c15d0">
-        <source>Please enter a valid constructor string pattern. See <x equiv-text="&lt;a class=&quot;underline hover:no-underline&quot; href=&quot;https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;&lt;code&gt;" id="0"></x>RegExp<x equiv-text="&lt;/code&gt;" id="1"></x> docs<x equiv-text="&lt;/a&gt;" id="2"></x>.</source>
+        <source>Please enter a valid constructor string
+                                    pattern. See
+                                    <x id="0" equiv-text="&lt;a class=&quot;underline hover:no-underline&quot; href=&quot;https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;&lt;code&gt;"/>RegExp<x id="1" equiv-text="&lt;/code&gt;"/> docs<x id="2" equiv-text="&lt;/a&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s312a6fda81078718">
         <source>Exclusions</source>
@@ -329,7 +335,7 @@
         <source>Exclusion already exists. Please edit or remove to continue</source>
       </trans-unit>
       <trans-unit id="sbe7425a3b5445ba7">
-        <source>Please enter <x equiv-text="${MIN_LENGTH}" id="0"></x> or more characters</source>
+        <source>Please enter <x id="0" equiv-text="${MIN_LENGTH}"/> or more characters</source>
       </trans-unit>
       <trans-unit id="s74abf58e08f32710">
         <source>Please enter a valid Regular Expression constructor pattern</source>
@@ -341,40 +347,42 @@
         <source>Tags</source>
       </trans-unit>
       <trans-unit id="s0e3006648a1a80a5">
-        <source>Add “<x equiv-text="${this.inputValue.toLocaleLowerCase()}" id="0"></x>”</source>
+        <source>Add “<x id="0" equiv-text="${this.inputValue.toLocaleLowerCase()}"/>”</source>
       </trans-unit>
       <trans-unit id="s1eee55ca9401677a">
-        <source>+<x equiv-text="${this.total.toLocaleString()}" id="0"></x> URLs</source>
+        <source>+<x id="0" equiv-text="${this.total.toLocaleString()}"/> URLs</source>
       </trans-unit>
       <trans-unit id="sfff90c46fdba31db">
         <source>(unnamed item)</source>
       </trans-unit>
       <trans-unit id="s8265788524ca2260">
-        <source><x equiv-text="${formattedTime}" id="0"></x> daily</source>
+        <source><x id="0" equiv-text="${formattedTime}"/> daily</source>
       </trans-unit>
       <trans-unit id="s2acb3777ed86adb6">
-        <source>Every <x equiv-text="${formattedWeekDay}" id="0"></x></source>
+        <source>Every <x id="0" equiv-text="${formattedWeekDay}"/></source>
       </trans-unit>
       <trans-unit id="s37a3a294775e081a">
-        <source>Monthly on the <x equiv-text="${format(days[0], { ordinal: true })}" id="0"></x></source>
+        <source>Monthly on the <x id="0" equiv-text="${format(days[0], { ordinal: true })}"/></source>
       </trans-unit>
       <trans-unit id="s2bc963c5c7bac2e1">
-        <source>Every day at <x equiv-text="${formattedTime}" id="0"></x></source>
+        <source>Every day at <x id="0" equiv-text="${formattedTime}"/></source>
       </trans-unit>
       <trans-unit id="s3fc21c0b1ae61eb7">
-        <source>Every <x equiv-text="${formattedWeekDay}" id="0"></x> at <x equiv-text="${formattedTime}" id="1"></x></source>
+        <source>Every <x id="0" equiv-text="${formattedWeekDay}"/>
+            at <x id="1" equiv-text="${formattedTime}"/></source>
       </trans-unit>
       <trans-unit id="s478f33dea36e1d3f">
-        <source>On day <x equiv-text="${nextDate.getDate()}" id="0"></x> of the month at <x equiv-text="${formattedTime}" id="1"></x></source>
+        <source>On day <x id="0" equiv-text="${nextDate.getDate()}"/> of the month at <x id="1" equiv-text="${formattedTime}"/></source>
       </trans-unit>
       <trans-unit id="s44f6ab2c6b3cff23">
         <source>Default: Unlimited</source>
       </trans-unit>
       <trans-unit id="sf21761e7f8e0550e">
-        <source>Default: <x equiv-text="${value.toLocaleString()}" id="0"></x></source>
+        <source>Default: <x id="0" equiv-text="${value.toLocaleString()}"/></source>
       </trans-unit>
       <trans-unit id="s5ae0226079b4d5fc">
-        <source>Specify exclusion rules for what pages should not be visited. Exclusions apply to all URLs.</source>
+        <source>Specify exclusion rules for what pages should not be visited.
+  Exclusions apply to all URLs.</source>
       </trans-unit>
       <trans-unit id="sa663117885b91a78">
         <source>Adds a hard limit on the number of pages that will be crawled.</source>
@@ -398,19 +406,24 @@
         <source>Waits on the page after behaviors are complete before moving onto the next page. Can be helpful for rate limiting.</source>
       </trans-unit>
       <trans-unit id="s750a2fea733037cb">
-        <source>Choose a custom profile to make use of saved cookies and logged-in accounts. Note that websites may log profiles out after a period of time.</source>
+        <source>Choose a custom profile to make use of saved cookies and logged-in
+  accounts. Note that websites may log profiles out after a period of time.</source>
       </trans-unit>
       <trans-unit id="scd15181280405de6">
         <source>Choose a Browsertrix Crawler Release Channel. If available, other versions may provide new/experimental crawling features.</source>
       </trans-unit>
       <trans-unit id="h1a88ca035802fcd0">
-        <source>Blocks advertising content from being loaded. Uses <x equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"></x>Steven Black’s Hosts file<x equiv-text="&lt;/a&gt;" id="1"></x>.</source>
+        <source>Blocks advertising content from being loaded. Uses
+      <x id="0" equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;"/>Steven Black’s Hosts file<x id="1" equiv-text="&lt;/a&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="h63182e63349f17de">
-        <source>Set custom user agent for crawler browsers to use in requests. For common user agents see <x equiv-text="&lt;a href=&quot;https://www.useragents.me/&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"></x>Useragents.me<x equiv-text="&lt;/a&gt;" id="1"></x>.</source>
+        <source>Set custom user agent for crawler browsers to use in requests. For
+      common user agents see
+      <x id="0" equiv-text="&lt;a href=&quot;https://www.useragents.me/&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;"/>Useragents.me<x id="1" equiv-text="&lt;/a&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s49e094325ac57142">
-        <source>Websites that observe the browser’s language setting may serve content in that language if available.</source>
+        <source>Websites that observe the browser’s language setting may serve
+  content in that language if available.</source>
       </trans-unit>
       <trans-unit id="s68eac1025cee6964">
         <source>Crawl Scope</source>
@@ -488,7 +501,8 @@
         <source>Org Settings</source>
       </trans-unit>
       <trans-unit id="h9c83f117a7e3a93f">
-        <source>Viewing <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${userOrg.name}&lt;/strong&gt;" id="0"></x></source>
+        <source>Viewing
+                  <x id="0" equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${userOrg.name}&lt;/strong&gt;"/></source>
       </trans-unit>
       <trans-unit id="s52d61e7db1ece998">
         <source>Active Members</source>
@@ -515,7 +529,7 @@
         <source>Custom URL Identifier</source>
       </trans-unit>
       <trans-unit id="s736e0de127d6aba2">
-        <source>Org home page: <x equiv-text="${window.location.protocol}" id="0"></x>//<x equiv-text="${window.location.hostname}" id="1"></x>/orgs/<x equiv-text="${this.slugValue&#10;    ? slugifyStrict(this.slugValue)&#10;    : this.orgSlug}" id="2"></x></source>
+        <source>Org home page: <x id="0" equiv-text="${window.location.protocol}"/>//<x id="1" equiv-text="${window.location.hostname}"/>/orgs/<x id="2" equiv-text="${this.slugValue&#10;    ? slugifyStrict(this.slugValue)&#10;    : this.orgSlug}"/></source>
       </trans-unit>
       <trans-unit id="s0559157886d79c76">
         <source>Customize your organization's web address for accessing Browsertrix.</source>
@@ -638,16 +652,16 @@
         <source>Sorry, couldn't retrieve pending invites at this time.</source>
       </trans-unit>
       <trans-unit id="s7cfdd7b9b1ce6231">
-        <source>Successfully invited <x equiv-text="${inviteEmail}" id="0"></x>.</source>
+        <source>Successfully invited <x id="0" equiv-text="${inviteEmail}"/>.</source>
       </trans-unit>
       <trans-unit id="s53846234c681dace">
         <source>Sorry, couldn't invite user at this time.</source>
       </trans-unit>
       <trans-unit id="s63ca31a1df9116e2">
-        <source>Successfully removed <x equiv-text="${invite.email}" id="0"></x> from <x equiv-text="${this.userOrg?.name}" id="1"></x>.</source>
+        <source>Successfully removed <x id="0" equiv-text="${invite.email}"/> from <x id="1" equiv-text="${this.userOrg?.name}"/>.</source>
       </trans-unit>
       <trans-unit id="s667558910cf30318">
-        <source>Sorry, couldn't remove <x equiv-text="${invite.email}" id="0"></x> at this time.</source>
+        <source>Sorry, couldn't remove <x id="0" equiv-text="${invite.email}"/> at this time.</source>
       </trans-unit>
       <trans-unit id="s0cac3669c233a0ad">
         <source>Org successfully updated.</source>
@@ -665,10 +679,11 @@
         <source>This org URL identifier is invalid. Please use alphanumeric characters and dashes (-) only.</source>
       </trans-unit>
       <trans-unit id="h58a74834f0ef0fcb">
-        <source>Supports <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"></x>GitHub Flavored Markdown<x equiv-text="&lt;/a&gt;" id="1"></x>.</source>
+        <source>Supports
+                <x id="0" equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;"/>GitHub Flavored Markdown<x id="1" equiv-text="&lt;/a&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s7a89a316efd4e9c0">
-        <source>Please shorten the description to <x equiv-text="${formatNumber(this.maxlength)}" id="0"></x> or fewer characters.</source>
+        <source>Please shorten the description to <x id="0" equiv-text="${formatNumber(this.maxlength)}"/> or fewer characters.</source>
       </trans-unit>
       <trans-unit id="s6ee5d5975cae2ed4">
         <source>Edit Collection Metadata</source>
@@ -698,7 +713,7 @@
         <source>Enable public access to make Collections shareable. Only people with the shared link can view your Collection.</source>
       </trans-unit>
       <trans-unit id="s77001a56d74ac617">
-        <source>Successfully saved "<x equiv-text="${data.name || name}" id="0"></x>" Collection.</source>
+        <source>Successfully saved "<x id="0" equiv-text="${data.name || name}"/>" Collection.</source>
       </trans-unit>
       <trans-unit id="s0014ed029ed0ef6f">
         <source>This name is already taken.</source>
@@ -722,13 +737,19 @@
         <source>You want to archive an entire website</source>
       </trans-unit>
       <trans-unit id="h76170f4b851b8171">
-        <source>You're archiving a subset of a website, like everything under <x equiv-text="&lt;em&gt;" id="0"></x>website.com/your-username<x equiv-text="&lt;/em&gt;" id="1"></x></source>
+        <source>You're archiving a subset of a website, like everything
+                  under <x id="0" equiv-text="&lt;em&gt;"/>website.com/your-username<x id="1" equiv-text="&lt;/em&gt;"/></source>
       </trans-unit>
       <trans-unit id="h5711c8b307827832">
-        <source>You're archiving a website <x equiv-text="&lt;em&gt;" id="0"></x>and<x equiv-text="&lt;/em&gt;" id="1"></x> external pages linked to from the website</source>
+        <source>You're archiving a website <x id="0" equiv-text="&lt;em&gt;"/>and<x id="1" equiv-text="&lt;/em&gt;"/> external pages
+                  linked to from the website</source>
       </trans-unit>
       <trans-unit id="hc76a9160bbdb615c">
-        <source>Once you choose a crawl type, you can't go back and change it. Check out the <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.browsertrix.com/user-guide/workflow-setup/&quot; target=&quot;_blank&quot;&gt;" id="0"></x>crawl workflow setup guide<x equiv-text="&lt;/a&gt;" id="1"></x> if you still need help deciding on a crawl type, and try our <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://forum.webrecorder.net/c/help/5&quot; target=&quot;_blank&quot;&gt;" id="2"></x>community help forum<x equiv-text="&lt;/a&gt;" id="3"></x>.</source>
+        <source>Once you choose a crawl type, you can't go back and change
+                it. Check out the
+                <x id="0" equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.browsertrix.com/user-guide/workflow-setup/&quot; target=&quot;_blank&quot;&gt;"/>crawl workflow setup guide<x id="1" equiv-text="&lt;/a&gt;"/>
+                if you still need help deciding on a crawl type, and try our
+                <x id="2" equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://forum.webrecorder.net/c/help/5&quot; target=&quot;_blank&quot;&gt;"/>community help forum<x id="3" equiv-text="&lt;/a&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s6c98d4e4eff5c8bb">
         <source>Copied to clipboard!</source>
@@ -809,7 +830,7 @@
         <source>Stopped: Crawling Disabled</source>
       </trans-unit>
       <trans-unit id="h98fd4ace98188324">
-        <source>Removed exclusion: <x equiv-text="&lt;code&gt;${regex}&lt;/code&gt;" id="0"></x></source>
+        <source>Removed exclusion: <x id="0" equiv-text="&lt;code&gt;${regex}&lt;/code&gt;"/></source>
       </trans-unit>
       <trans-unit id="s13acc5f8f152f1b6">
         <source>Cannot remove exclusion when crawl is no longer running.</source>
@@ -947,13 +968,13 @@
         <source>Created By</source>
       </trans-unit>
       <trans-unit id="sf72695e8cd91f93c">
-        <source><x equiv-text="${workflow.createdByName}" id="0"></x> on <x equiv-text="${this.dateFormatter.format(new Date(`${workflow.created}Z`))}" id="1"></x></source>
+        <source><x id="0" equiv-text="${workflow.createdByName}"/> on <x id="1" equiv-text="${this.dateFormatter.format(new Date(workflow.created))}"/></source>
       </trans-unit>
       <trans-unit id="hcb76d3d062f4fe97">
-        <source><x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;          &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URL<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source> <x id="0" equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;          &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URL<x id="2" equiv-text="&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="h0f472740ba5c3c86">
-        <source><x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;        &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URLs<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source> <x id="0" equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;        &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URLs<x id="2" equiv-text="&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="s900a5e61e7ade066">
         <source>View:</source>
@@ -962,7 +983,8 @@
         <source>All Crawls</source>
       </trans-unit>
       <trans-unit id="he775de5878ab0942">
-        <source>Crawl is currently running. <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"></x>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"></x></source>
+        <source>Crawl is currently running.
+                    <x id="0" equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;"/>Watch Crawl Progress<x id="1" equiv-text="&lt;/a&gt;"/></source>
       </trans-unit>
       <trans-unit id="s76d9944af031bdb3">
         <source>No matching crawls found.</source>
@@ -1007,7 +1029,8 @@
         <source>Crawl is not running.</source>
       </trans-unit>
       <trans-unit id="h27573a6e2ed7211d">
-        <source>Viewing error logs for currently running crawl. <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"></x>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"></x></source>
+        <source>Viewing error logs for currently running crawl.
+                    <x id="0" equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;"/>Watch Crawl Progress<x id="1" equiv-text="&lt;/a&gt;"/></source>
       </trans-unit>
       <trans-unit id="s31b57d50c6a992ba">
         <source>Error logs currently not available.</source>
@@ -1019,7 +1042,7 @@
         <source>Logs will show here after you run a crawl.</source>
       </trans-unit>
       <trans-unit id="sa641ef4b0f2af2b4">
-        <source>Displaying latest <x equiv-text="${LOGS_PAGE_SIZE.toLocaleString()}" id="0"></x> errors of <x equiv-text="${this.logs!.total.toLocaleString()}" id="1"></x>.</source>
+        <source>Displaying latest <x id="0" equiv-text="${LOGS_PAGE_SIZE.toLocaleString()}"/> errors of <x id="1" equiv-text="${this.logs!.total.toLocaleString()}"/>.</source>
       </trans-unit>
       <trans-unit id="sa7bc374e662a4beb">
         <source>Upcoming Pages</source>
@@ -1046,13 +1069,13 @@
         <source>Sorry, couldn't get crawls at this time.</source>
       </trans-unit>
       <trans-unit id="s1a20a47c9bf221da">
-        <source><x equiv-text="${this.workflow.name}" id="0"></x> Copy</source>
+        <source><x id="0" equiv-text="${this.workflow.name}"/> Copy</source>
       </trans-unit>
       <trans-unit id="sb751de28d615caad">
         <source>Copied Workflow to new template.</source>
       </trans-unit>
       <trans-unit id="h0e60bb54fe15e7b6">
-        <source>Deleted <x equiv-text="&lt;strong&gt;${this.renderName()}&lt;/strong&gt;" id="0"></x> Workflow.</source>
+        <source>Deleted <x id="0" equiv-text="&lt;strong&gt;${this.renderName()}&lt;/strong&gt;"/> Workflow.</source>
       </trans-unit>
       <trans-unit id="s6ec009ac55d85d6a">
         <source>Sorry, couldn't delete Workflow at this time.</source>
@@ -1148,10 +1171,10 @@
         <source>Search all Workflows by name or Crawl Start URL</source>
       </trans-unit>
       <trans-unit id="hc226df43ef96e720">
-        <source><x equiv-text="${firstSeed}&#10;          &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URL<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source><x id="0" equiv-text="${firstSeed}&#10;          &lt;span class=&quot;text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URL<x id="2" equiv-text="&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="h649ef1ec13735ee9">
-        <source><x equiv-text="${firstSeed}&#10;        &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URLs<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source><x id="0" equiv-text="${firstSeed}&#10;        &lt;span class=&quot;text-neutral-500&quot;&gt;"/>+<x id="1" equiv-text="${remainderCount}"/> URLs<x id="2" equiv-text="&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="s442425cd7d61051f">
         <source>No matching Workflows found.</source>
@@ -1169,7 +1192,7 @@
         <source>Partially copied Workflow</source>
       </trans-unit>
       <trans-unit id="sebba8356f42b6eaa">
-        <source>Only first <x equiv-text="${SEEDS_MAX.toLocaleString()}" id="0"></x> URLs were copied.</source>
+        <source>Only first <x id="0" equiv-text="${SEEDS_MAX.toLocaleString()}"/> URLs were copied.</source>
       </trans-unit>
       <trans-unit id="s8745d54f3284f080">
         <source>Are you sure you want to cancel the crawl?</source>
@@ -1214,7 +1237,7 @@
         <source>Analysis Progress</source>
       </trans-unit>
       <trans-unit id="s984a5e18d85b6d57">
-        <source><x equiv-text="${this.mostRecentNonFailedQARun.stats.found === 0&#10;    ? msg(&quot;Loading&quot;)&#10;    : `${this.mostRecentNonFailedQARun.stats.done}/${this.mostRecentNonFailedQARun.stats.found}`} ${pluralOf(&quot;pages&quot;, this.mostRecentNonFailedQARun.stats.found)}" id="0"></x> </source>
+        <source><x id="0" equiv-text="${this.mostRecentNonFailedQARun.stats.found === 0&#10;    ? msg(&quot;Loading&quot;)&#10;    : `${this.mostRecentNonFailedQARun.stats.done}/${this.mostRecentNonFailedQARun.stats.found}`} ${pluralOf(&quot;pages&quot;, this.mostRecentNonFailedQARun.stats.found)}"/></source>
       </trans-unit>
       <trans-unit id="sb59d68ed12d46377">
         <source>Loading</source>
@@ -1238,13 +1261,19 @@
         <source>Non-HTML files captured as pages are known good files that the crawler found as clickable links on a page and don't need to be analyzed. Failed pages did not respond when the crawler tried to visit them.</source>
       </trans-unit>
       <trans-unit id="h8309b5706a9a85ba">
-        <source><x equiv-text="&lt;span class=&quot;text-primary&quot;&gt;${htmlCount}&lt;/span&gt;" id="0"></x> HTML <x equiv-text="${pluralOf(&quot;pages&quot;, htmlCount)}&#10;                    " id="1"></x></source>
+        <source>
+                      <x id="0" equiv-text="&lt;span class=&quot;text-primary&quot;&gt;${htmlCount}&lt;/span&gt;"/>
+                      HTML <x id="1" equiv-text="${pluralOf(&quot;pages&quot;, htmlCount)}&#10;                    "/></source>
       </trans-unit>
       <trans-unit id="h7d8f1533bbc700e1">
-        <source><x equiv-text="&lt;span class=&quot;text-neutral-600&quot;&gt;${fileCount}&lt;/span&gt;" id="0"></x> Non-HTML files captured as <x equiv-text="${pluralOf(&quot;pages&quot;, fileCount)}&#10;                    " id="1"></x></source>
+        <source>
+                      <x id="0" equiv-text="&lt;span class=&quot;text-neutral-600&quot;&gt;${fileCount}&lt;/span&gt;"/>
+                      Non-HTML files captured as <x id="1" equiv-text="${pluralOf(&quot;pages&quot;, fileCount)}&#10;                    "/></source>
       </trans-unit>
       <trans-unit id="ha312818a16d5146b">
-        <source><x equiv-text="&lt;span class=&quot;text-danger&quot;&gt;${errorCount}&lt;/span&gt;" id="0"></x> Failed <x equiv-text="${pluralOf(&quot;pages&quot;, errorCount)}&#10;                    " id="1"></x></source>
+        <source>
+                      <x id="0" equiv-text="&lt;span class=&quot;text-danger&quot;&gt;${errorCount}&lt;/span&gt;"/>
+                      Failed <x id="1" equiv-text="${pluralOf(&quot;pages&quot;, errorCount)}&#10;                    "/></source>
       </trans-unit>
       <trans-unit id="s3fd6bd99e3f6a5be">
         <source>Started</source>
@@ -1271,7 +1300,7 @@
         <source>All of the data included in this analysis run will be deleted.</source>
       </trans-unit>
       <trans-unit id="sc2007e562d105da2">
-        <source>This analysis run includes data for <x equiv-text="${runToBeDeleted.stats.done} ${pluralOf(&quot;pages&quot;, runToBeDeleted.stats.done)}" id="0"></x> and was started on </source>
+        <source>This analysis run includes data for <x id="0" equiv-text="${runToBeDeleted.stats.done} ${pluralOf(&quot;pages&quot;, runToBeDeleted.stats.done)}"/> and was started on </source>
       </trans-unit>
       <trans-unit id="s08a64b07b54df8d4">
         <source>by</source>
@@ -1355,7 +1384,7 @@
         <source>Comments</source>
       </trans-unit>
       <trans-unit id="s4d3c92a1a881dc5f">
-        <source>Review "<x equiv-text="${page.title ?? page.url}" id="0"></x>"</source>
+        <source>Review "<x id="0" equiv-text="${page.title ?? page.url}"/>"</source>
       </trans-unit>
       <trans-unit id="s7282886335497d58">
         <source>Newest comment:</source>
@@ -1430,7 +1459,8 @@
         <source>Initiator</source>
       </trans-unit>
       <trans-unit id="h1dc2f6235d169989">
-        <source>Manual start by <x equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;" id="0"></x></source>
+        <source>Manual start by
+                          <x id="0" equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="hdfcda45e7d5c5ab4">
         <source>Scheduled start</source>
@@ -1559,7 +1589,7 @@
         <source>All files and logs associated with this item will also be deleted, and the crawl will no longer be visible in its associated Workflow.</source>
       </trans-unit>
       <trans-unit id="s039b6434e8a75560">
-        <source>Delete <x equiv-text="${this.itemToDelete?.type === &quot;upload&quot;&#10;    ? msg(&quot;Upload&quot;)&#10;    : msg(&quot;Crawl&quot;)}" id="0"></x></source>
+        <source>Delete <x id="0" equiv-text="${this.itemToDelete?.type === &quot;upload&quot;&#10;    ? msg(&quot;Upload&quot;)&#10;    : msg(&quot;Crawl&quot;)}"/></source>
       </trans-unit>
       <trans-unit id="s96668830629e0dfc">
         <source>Upload</source>
@@ -1598,7 +1628,8 @@
         <source>New Collection</source>
       </trans-unit>
       <trans-unit id="h21e623f674123fc2">
-        <source>Are you sure you want to delete <x equiv-text="&lt;strong&gt;${this.selectedCollection?.name}&lt;/strong&gt;" id="0"></x>?</source>
+        <source>Are you sure you want to delete
+                <x id="0" equiv-text="&lt;strong&gt;${this.selectedCollection?.name}&lt;/strong&gt;"/>?</source>
       </trans-unit>
       <trans-unit id="s777098c61f6b518a">
         <source>Start building your Collection.</source>
@@ -1679,7 +1710,7 @@
         <source>Websites that are not in the browser profile yet. Finish editing and save to add these websites to the profile.</source>
       </trans-unit>
       <trans-unit id="sf4d539e610f3a2aa">
-        <source>Go to <x equiv-text="${url}" id="0"></x></source>
+        <source>Go to <x id="0" equiv-text="${url}"/></source>
       </trans-unit>
       <trans-unit id="sb07ea0d5070f719d">
         <source>Crawler Release Channel</source>
@@ -1742,10 +1773,11 @@
         <source>Sorry, couldn't create browser profile at this time.</source>
       </trans-unit>
       <trans-unit id="h132d0ccd2402fb33">
-        <source>Could not delete <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"></x>, in use by <x equiv-text="&lt;strong&gt;${data.crawlconfigs.map(({ name }) =&gt; name).join(&quot;, &quot;)}&lt;/strong&gt;" id="1"></x>. Please remove browser profile from Workflow to continue.</source>
+        <source>Could not delete <x id="0" equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;"/>, in use by
+              <x id="1" equiv-text="&lt;strong&gt;${data.crawlconfigs.map(({ name }) =&gt; name).join(&quot;, &quot;)}&lt;/strong&gt;"/>. Please remove browser profile from Workflow to continue.</source>
       </trans-unit>
       <trans-unit id="ha6f8533fba325287">
-        <source>Deleted <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"></x>.</source>
+        <source>Deleted <x id="0" equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s6a43c0c6daea3998">
         <source>Sorry, couldn't delete browser profile at this time.</source>
@@ -1784,10 +1816,10 @@
         <source>No browser profiles yet.</source>
       </trans-unit>
       <trans-unit id="s07e46807b4a9183c">
-        <source>+<x equiv-text="${data.origins.length - 1}" id="0"></x></source>
+        <source>+<x id="0" equiv-text="${data.origins.length - 1}"/></source>
       </trans-unit>
       <trans-unit id="s922123a81f238186">
-        <source>By <x equiv-text="${data.createdByName}" id="0"></x></source>
+        <source>By <x id="0" equiv-text="${data.createdByName}"/></source>
       </trans-unit>
       <trans-unit id="s0d2b97026d57ffd0">
         <source>Starting up browser with selected profile...</source>
@@ -1961,10 +1993,10 @@
         <source>Text Match</source>
       </trans-unit>
       <trans-unit id="s2344bb018c2ade99">
-        <source>Showing all <x equiv-text="${this.totalPages.toLocaleString()}" id="0"></x> pages</source>
+        <source>Showing all <x id="0" equiv-text="${this.totalPages.toLocaleString()}"/> pages</source>
       </trans-unit>
       <trans-unit id="sd2afbd920020fe6d">
-        <source>Showing <x equiv-text="${total.toLocaleString()}" id="0"></x> of <x equiv-text="${this.totalPages.toLocaleString()}" id="1"></x> pages</source>
+        <source>Showing <x id="0" equiv-text="${total.toLocaleString()}"/> of <x id="1" equiv-text="${this.totalPages.toLocaleString()}"/> pages</source>
       </trans-unit>
       <trans-unit id="sd7c439303c5c7045">
         <source>No matching pages found</source>
@@ -2084,10 +2116,10 @@
         <source>Submit Review</source>
       </trans-unit>
       <trans-unit id="s6d7c9c2bb994f236">
-        <source>Comments (<x equiv-text="${commentCount.toLocaleString()}" id="0"></x>)</source>
+        <source>Comments (<x id="0" equiv-text="${commentCount.toLocaleString()}"/>)</source>
       </trans-unit>
       <trans-unit id="s3732b439b691ea10">
-        <source><x equiv-text="${comment.userName}" id="0"></x> commented on <x equiv-text="${formatISODateString(comment.created, {&#10;    hour: undefined,&#10;    minute: undefined,&#10;})}" id="1"></x></source>
+        <source><x id="0" equiv-text="${comment.userName}"/> commented on <x id="1" equiv-text="${formatISODateString(comment.created, {&#10;    hour: undefined,&#10;    minute: undefined,&#10;})}"/></source>
       </trans-unit>
       <trans-unit id="s36012a8db93560f3">
         <source>Delete comment</source>
@@ -2147,13 +2179,17 @@
         <source>Workflows that use this browser profile will behave as if they have logged into the same websites and have the same web cookies.</source>
       </trans-unit>
       <trans-unit id="hd7ee4df8e7d76865">
-        <source>It is highly recommended to create dedicated accounts to use when crawling. For details, refer to <x equiv-text="&lt;a class=&quot;text-primary hover:text-indigo-400&quot; href=&quot;https://docs.browsertrix.com/user-guide/browser-profiles/&quot; target=&quot;_blank&quot;&gt;&#10;            ${msg(&quot;browser profile best practices&quot;)}&lt;/a&gt;" id="0"></x>. </source>
+        <source>
+          It is highly recommended to create dedicated accounts to use when
+          crawling. For details, refer to
+          <x id="0" equiv-text="&lt;a class=&quot;text-primary hover:text-indigo-400&quot; href=&quot;https://docs.browsertrix.com/user-guide/browser-profiles/&quot; target=&quot;_blank&quot;&gt;&#10;            ${msg(&quot;browser profile best practices&quot;)}&lt;/a&gt;"/>.
+        </source>
       </trans-unit>
       <trans-unit id="se058d83e4b3bad9e">
         <source>browser profile best practices</source>
       </trans-unit>
       <trans-unit id="h6c440abb1e1a7d78">
-        <source>Extending <x equiv-text="&lt;strong&gt;${this.browserParams.name}&lt;/strong&gt;" id="0"></x></source>
+        <source>Extending <x id="0" equiv-text="&lt;strong&gt;${this.browserParams.name}&lt;/strong&gt;"/></source>
       </trans-unit>
       <trans-unit id="s3b397808715b71d8">
         <source>Cancel Profile Creation?</source>
@@ -2192,13 +2228,13 @@
         <source>Sorry, couldn't retrieve organization at this time.</source>
       </trans-unit>
       <trans-unit id="s0726c5784ccf9222">
-        <source>Successfully updated role for <x equiv-text="${user.name || user.email}" id="0"></x>.</source>
+        <source>Successfully updated role for <x id="0" equiv-text="${user.name || user.email}"/>.</source>
       </trans-unit>
       <trans-unit id="scc21a97f5f1b13b0">
-        <source>Sorry, couldn't update role for <x equiv-text="${user.name || user.email}" id="0"></x> at this time.</source>
+        <source>Sorry, couldn't update role for <x id="0" equiv-text="${user.name || user.email}"/> at this time.</source>
       </trans-unit>
       <trans-unit id="saafb6030ac4b40dd">
-        <source>Are you sure you want to remove yourself from <x equiv-text="${this.userOrg.name}" id="0"></x>?</source>
+        <source>Are you sure you want to remove yourself from <x id="0" equiv-text="${this.userOrg.name}"/>?</source>
       </trans-unit>
       <trans-unit id="s1442d0b6e28b30d1">
         <source>Path Begins with This URL</source>
@@ -2258,7 +2294,7 @@
         <source>Max Depth</source>
       </trans-unit>
       <trans-unit id="s00952de51c229a2e">
-        <source><x equiv-text="${primarySeedConfig.depth}" id="0"></x> hop(s)</source>
+        <source><x id="0" equiv-text="${primarySeedConfig.depth}"/> hop(s)</source>
       </trans-unit>
       <trans-unit id="s9ecb6da2267389f4">
         <source>Unlimited (default)</source>
@@ -2339,7 +2375,7 @@
         <source>Bytes Stored</source>
       </trans-unit>
       <trans-unit id="sd805db60d62be7a1">
-        <source>Quotas for: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"></x></source>
+        <source>Quotas for: <x id="0" equiv-text="${this.currOrg?.name || &quot;&quot;}"/></source>
       </trans-unit>
       <trans-unit id="sfba7b662681a9f92">
         <source>Max Concurrent Crawls</source>
@@ -2369,7 +2405,10 @@
         <source>Disable Archiving?</source>
       </trans-unit>
       <trans-unit id="h66cb67cd841f4beb">
-        <source>Are you sure you want to disable archiving in <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"></x> org? Members will no longer be able to crawl, upload files, create browser profiles, or create collections.</source>
+        <source>Are you sure you want to disable archiving in
+                  <x id="0" equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;"/> org?
+                  Members will no longer be able to crawl, upload files, create
+                  browser profiles, or create collections.</source>
       </trans-unit>
       <trans-unit id="sdc8e0ecdba53dccc">
         <source>Slug:</source>
@@ -2387,40 +2426,47 @@
         <source>Disable Archiving</source>
       </trans-unit>
       <trans-unit id="s2f2866981870fee3">
-        <source>Confirm Org Deletion: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"></x></source>
+        <source>Confirm Org Deletion: <x id="0" equiv-text="${this.currOrg?.name || &quot;&quot;}"/></source>
       </trans-unit>
       <trans-unit id="hbc605ddee9667ea5">
-        <source>Are you sure you want to delete <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"></x>? This cannot be undone.</source>
+        <source>Are you sure you want to delete
+                  <x id="0" equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;"/>? This
+                  cannot be undone.</source>
       </trans-unit>
       <trans-unit id="h88cfbf4cb1b57616">
-        <source>Deleting an org will delete all <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;" id="0"></x> of data associated with the org.</source>
+        <source>Deleting an org will delete all
+                  <x id="0" equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;"/>
+                  of data associated with the org.</source>
       </trans-unit>
       <trans-unit id="hc95f75343ebc2ce0">
-        <source>Crawls: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Crawls:
+                    <x id="0" equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;"/></source>
       </trans-unit>
       <trans-unit id="h9e8c0254131f987c">
-        <source>Uploads: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Uploads:
+                    <x id="0" equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;"/></source>
       </trans-unit>
       <trans-unit id="hc4433ba5eba156e2">
-        <source>Profiles: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Profiles:
+                    <x id="0" equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;"/></source>
       </trans-unit>
       <trans-unit id="se49bbaeabfd85d48">
-        <source>Type "<x equiv-text="${confirmationStr}" id="0"></x>" to confirm</source>
+        <source>Type "<x id="0" equiv-text="${confirmationStr}"/>" to confirm</source>
       </trans-unit>
       <trans-unit id="s91622815dce6a0ec">
         <source>Delete Org</source>
       </trans-unit>
       <trans-unit id="s3eab2ed27de13f27">
-        <source>Archiving in "<x equiv-text="${org.name}" id="0"></x>" is disabled.</source>
+        <source>Archiving in "<x id="0" equiv-text="${org.name}"/>" is disabled.</source>
       </trans-unit>
       <trans-unit id="s2da2e2eba00d0f28">
-        <source>Archiving in "<x equiv-text="${org.name}" id="0"></x>" is re-enabled.</source>
+        <source>Archiving in "<x id="0" equiv-text="${org.name}"/>" is re-enabled.</source>
       </trans-unit>
       <trans-unit id="s42dfcfdcb5aee47e">
         <source>Sorry, couldn't update org archiving ability at this time.</source>
       </trans-unit>
       <trans-unit id="s081029829332df74">
-        <source>Org "<x equiv-text="${org.name}" id="0"></x>" has been deleted.</source>
+        <source>Org "<x id="0" equiv-text="${org.name}"/>" has been deleted.</source>
       </trans-unit>
       <trans-unit id="s4de74a2a08a74bff">
         <source>Sorry, couldn't delete org at this time.</source>
@@ -2486,7 +2532,7 @@
         <source>Password</source>
       </trans-unit>
       <trans-unit id="se7e0859bf0c563fe">
-        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"></x>–<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"></x> characters.</source>
+        <source>Choose a strong password between <x id="0" equiv-text="${PASSWORD_MINLENGTH}"/>–<x id="1" equiv-text="${PASSWORD_MAXLENGTH}"/> characters.</source>
       </trans-unit>
       <trans-unit id="sa9d1dd5d6142477d">
         <source>Your name</source>
@@ -2510,22 +2556,22 @@
         <source>Not applicable</source>
       </trans-unit>
       <trans-unit id="s0382d73823585617">
-        <source><x equiv-text="${typeLabel}" id="0"></x>: <x equiv-text="${crawlStatus.label}" id="1"></x></source>
+        <source><x id="0" equiv-text="${typeLabel}"/>: <x id="1" equiv-text="${crawlStatus.label}"/></source>
       </trans-unit>
       <trans-unit id="s9fdb0be4e08e3609">
-        <source>QA Analysis: <x equiv-text="${qaStatus.label}" id="0"></x> (<x equiv-text="${activeProgress}" id="1"></x>% finished)</source>
+        <source>QA Analysis: <x id="0" equiv-text="${qaStatus.label}"/> (<x id="1" equiv-text="${activeProgress}"/>% finished)</source>
       </trans-unit>
       <trans-unit id="s9087c0239aa5bd6d">
-        <source>QA Analysis: <x equiv-text="${isUpload ? &quot;Not Applicable&quot; : qaStatus.label || msg(&quot;None&quot;)}" id="0"></x></source>
+        <source>QA Analysis: <x id="0" equiv-text="${isUpload ? &quot;Not Applicable&quot; : qaStatus.label || msg(&quot;None&quot;)}"/></source>
       </trans-unit>
       <trans-unit id="s2fb39b9ba9441537">
-        <source><x equiv-text="${formatNumber(this.item.stats?.done ? +this.item.stats.done : 0)}" id="0"></x> crawled, <x equiv-text="${formatNumber(this.item.stats?.found ? +this.item.stats.found : 0)}" id="1"></x> found</source>
+        <source><x id="0" equiv-text="${formatNumber(this.item.stats?.done ? +this.item.stats.done : 0)}"/> crawled, <x id="1" equiv-text="${formatNumber(this.item.stats?.found ? +this.item.stats.found : 0)}"/> found</source>
       </trans-unit>
       <trans-unit id="s1a8b76905717bc34">
-        <source>Last run started on <x equiv-text="${formatISODateString(lastQAStarted)}" id="0"></x></source>
+        <source>Last run started on <x id="0" equiv-text="${formatISODateString(lastQAStarted)}"/></source>
       </trans-unit>
       <trans-unit id="sa0ffc3feac61fcc4">
-        <source>Rated <x equiv-text="${this.item.reviewStatus}" id="0"></x> / <x equiv-text="${ReviewStatus.Excellent}" id="1"></x></source>
+        <source>Rated <x id="0" equiv-text="${this.item.reviewStatus}"/> / <x id="1" equiv-text="${ReviewStatus.Excellent}"/></source>
       </trans-unit>
       <trans-unit id="s4e31ba44d4056425">
         <source>No QA review submitted</source>
@@ -2534,7 +2580,7 @@
         <source>QA Analysis Runs</source>
       </trans-unit>
       <trans-unit id="s1b210718400e7ea8">
-        <source><x equiv-text="${pageCount.toLocaleString()}" id="0"></x> page</source>
+        <source><x id="0" equiv-text="${pageCount.toLocaleString()}"/> page</source>
       </trans-unit>
       <trans-unit id="s92921878e886e36d">
         <source>Duration</source>
@@ -2582,10 +2628,14 @@
         <source>Queued URLs</source>
       </trans-unit>
       <trans-unit id="se7f351ae6cbb41f0">
-        <source>Queued URLs from 1 to <x equiv-text="${this.queue.total.toLocaleString()}" id="0"></x></source>
+        <source>Queued URLs from 1 to <x id="0" equiv-text="${this.queue.total.toLocaleString()}"/></source>
       </trans-unit>
       <trans-unit id="h077c8fe82a78c616">
-        <source>Queued URLs from <x equiv-text="&lt;btrix-inline-input class=&quot;mx-1 inline-block&quot; style=&quot;width: ${Math.max(offsetValue.toString().length, 2) + 2}ch&quot; value=&quot;1&quot; inputmode=&quot;numeric&quot; size=&quot;small&quot; autocomplete=&quot;off&quot; @sl-input=&quot;${(e: SlInputEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    input.style.width = getInputWidth(input.value);&#10;}}&quot; @sl-change=&quot;${async (e: SlChangeEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    const int = +input.value.replace(/\D/g, &quot;&quot;);&#10;    await this.updateComplete;&#10;    const value = Math.max(1, Math.min(int, this.queue!.total - 1));&#10;    input.value = value.toString();&#10;    this.pageOffset = value - 1;&#10;}}&quot;&gt;&lt;/btrix-inline-input&gt;" id="0"></x> to <x equiv-text="${countMax.toLocaleString()}" id="1"></x> of <x equiv-text="${this.queue.total.toLocaleString()}&#10;        " id="2"></x></source>
+        <source>
+          Queued URLs from
+          <x id="0" equiv-text="&lt;btrix-inline-input class=&quot;mx-1 inline-block&quot; style=&quot;width: ${Math.max(offsetValue.toString().length, 2) + 2}ch&quot; value=&quot;1&quot; inputmode=&quot;numeric&quot; size=&quot;small&quot; autocomplete=&quot;off&quot; @sl-input=&quot;${(e: SlInputEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    input.style.width = getInputWidth(input.value);&#10;}}&quot; @sl-change=&quot;${async (e: SlChangeEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    const int = +input.value.replace(/\D/g, &quot;&quot;);&#10;    await this.updateComplete;&#10;    const value = Math.max(1, Math.min(int, this.queue!.total - 1));&#10;    input.value = value.toString();&#10;    this.pageOffset = value - 1;&#10;}}&quot;&gt;&lt;/btrix-inline-input&gt;"/>
+          to <x id="1" equiv-text="${countMax.toLocaleString()}"/> of
+          <x id="2" equiv-text="${this.queue.total.toLocaleString()}&#10;        "/></source>
       </trans-unit>
       <trans-unit id="s4dfaf5cfc90f8493">
         <source>No pages queued.</source>
@@ -2597,7 +2647,7 @@
         <source>Load more</source>
       </trans-unit>
       <trans-unit id="s813262fab638bbfc">
-        <source>-<x equiv-text="${this.matchedTotal.toLocaleString()}" id="0"></x> URLs</source>
+        <source>-<x id="0" equiv-text="${this.matchedTotal.toLocaleString()}"/> URLs</source>
       </trans-unit>
       <trans-unit id="s6c4a20fdba7af262">
         <source>-1 URL</source>
@@ -2627,7 +2677,7 @@
         <source>Keep this window open until your upload finishes.</source>
       </trans-unit>
       <trans-unit id="hb8ae169d4ea6d7a3">
-        <source>Successfully uploaded <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"></x>.<x equiv-text="&lt;br&gt;&#10;              &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/items/upload/${data.id}&quot; @click=&quot;${this.navigate.link}&quot;&gt;" id="1"></x>View Item<x equiv-text="&lt;/a&gt; " id="2"></x></source>
+        <source>Successfully uploaded <x id="0" equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;"/>.<x id="1" equiv-text="&lt;br&gt;&#10;              &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/items/upload/${data.id}&quot; @click=&quot;${this.navigate.link}&quot;&gt;"/>View Item<x id="2" equiv-text="&lt;/a&gt; "/></source>
       </trans-unit>
       <trans-unit id="scccaadc44687f6bf">
         <source>Sorry, couldn't upload file at this time.</source>
@@ -2669,10 +2719,10 @@
         <source>Create profile</source>
       </trans-unit>
       <trans-unit id="sfd20092783b9309d">
-        <source><x equiv-text="${selected.toLocaleString()}" id="0"></x> / <x equiv-text="${total.toLocaleString()}" id="1"></x> crawl</source>
+        <source><x id="0" equiv-text="${selected.toLocaleString()}"/> / <x id="1" equiv-text="${total.toLocaleString()}"/> crawl</source>
       </trans-unit>
       <trans-unit id="sd6a07c24d3ae246a">
-        <source><x equiv-text="${selected.toLocaleString()}" id="0"></x> / <x equiv-text="${total.toLocaleString()}" id="1"></x> crawls</source>
+        <source><x id="0" equiv-text="${selected.toLocaleString()}"/> / <x id="1" equiv-text="${total.toLocaleString()}"/> crawls</source>
       </trans-unit>
       <trans-unit id="sea0ac3af5d7a3071">
         <source>0 crawls</source>
@@ -2681,7 +2731,7 @@
         <source>Auto-Add</source>
       </trans-unit>
       <trans-unit id="s514cde9d19a9adc5">
-        <source>Started by <x equiv-text="${crawl.userName}" id="0"></x></source>
+        <source>Started by <x id="0" equiv-text="${crawl.userName}"/></source>
       </trans-unit>
       <trans-unit id="s9b31004ff434426e">
         <source>Crawl Finished</source>
@@ -2690,22 +2740,22 @@
         <source>File Size</source>
       </trans-unit>
       <trans-unit id="sf51117c57a1110ec">
-        <source>in <x equiv-text="${this.collectionName}" id="0"></x></source>
+        <source>in <x id="0" equiv-text="${this.collectionName}"/></source>
       </trans-unit>
       <trans-unit id="sf27239dda9b1416d">
-        <source>Crawls in Collection (<x equiv-text="${data!.total.toLocaleString()}" id="0"></x>)</source>
+        <source>Crawls in Collection (<x id="0" equiv-text="${data!.total.toLocaleString()}"/>)</source>
       </trans-unit>
       <trans-unit id="sa3d5a7186b818303">
-        <source>All Workflows (<x equiv-text="${data!.total.toLocaleString()}" id="0"></x>)</source>
+        <source>All Workflows (<x id="0" equiv-text="${data!.total.toLocaleString()}"/>)</source>
       </trans-unit>
       <trans-unit id="s49730f3d5751a433">
         <source>Loading...</source>
       </trans-unit>
       <trans-unit id="sd7d35ab49e07fe79">
-        <source>Uploads in Collection (<x equiv-text="${this.uploads!.total.toLocaleString()}" id="0"></x>)</source>
+        <source>Uploads in Collection (<x id="0" equiv-text="${this.uploads!.total.toLocaleString()}"/>)</source>
       </trans-unit>
       <trans-unit id="s84c2e4081c2bf6d7">
-        <source>All Uploads (<x equiv-text="${this.uploads!.total.toLocaleString()}" id="0"></x>)</source>
+        <source>All Uploads (<x id="0" equiv-text="${this.uploads!.total.toLocaleString()}"/>)</source>
       </trans-unit>
       <trans-unit id="s1e2b42118528e92f">
         <source>In Collection?</source>
@@ -2765,7 +2815,9 @@
         <source>Review Settings</source>
       </trans-unit>
       <trans-unit id="hf77ba6b1d74e2cdb">
-        <source>Fields marked with <x equiv-text="&lt;span style=&quot;color:var(--sl-input-required-content-color)&quot;&gt;" id="0"></x>*<x equiv-text="&lt;/span&gt;" id="1"></x> are required</source>
+        <source>Fields marked with
+                  <x id="0" equiv-text="&lt;span style=&quot;color:var(--sl-input-required-content-color)&quot;&gt;"/>*<x id="1" equiv-text="&lt;/span&gt;"/>
+                  are required</source>
       </trans-unit>
       <trans-unit id="s5f94c84437a8594c">
         <source>Form section contains errors</source>
@@ -2795,7 +2847,8 @@
         <source>At least 1 URL is required.</source>
       </trans-unit>
       <trans-unit id="s6de92df940cdee71">
-        <source>The crawler will visit and record each URL listed in the order defined here. You can enter a maximum of <x equiv-text="${URL_LIST_MAX_URLS.toLocaleString()}" id="0"></x> URLs, separated by a new line.</source>
+        <source>The crawler will visit and record each URL listed in the order
+        defined here. You can enter a maximum of <x id="0" equiv-text="${URL_LIST_MAX_URLS.toLocaleString()}"/> URLs, separated by a new line.</source>
       </trans-unit>
       <trans-unit id="s7af85d601db244a7">
         <source>Tells the crawler which pages it can visit.</source>
@@ -2804,7 +2857,8 @@
         <source>Include any linked page</source>
       </trans-unit>
       <trans-unit id="s5136cba9c3481508">
-        <source>If checked, the crawler will visit pages one link away from a Crawl URL.</source>
+        <source>If checked, the crawler will visit pages one link away from a Crawl
+        URL.</source>
       </trans-unit>
       <trans-unit id="s0b1911029d6e4715">
         <source>Fail crawl on failed URL</source>
@@ -2813,19 +2867,30 @@
         <source>If checked, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled.</source>
       </trans-unit>
       <trans-unit id="hef8020bab2159211">
-        <source>Will crawl all pages and paths in the same directory, e.g. <x equiv-text="&lt;span class=&quot;break-word break-word text-blue-500&quot;&gt;${exampleDomain}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;${examplePathname.slice(0, examplePathname.lastIndexOf(&quot;/&quot;))}" id="0"></x>/<x equiv-text="&lt;/span&gt;" id="1"></x></source>
+        <source>Will crawl all pages and paths in the same directory, e.g.
+            <x id="0" equiv-text="&lt;span class=&quot;break-word break-word text-blue-500&quot;&gt;${exampleDomain}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;${examplePathname.slice(0, examplePathname.lastIndexOf(&quot;/&quot;))}"/>/<x id="1" equiv-text="&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="hed4c39f98af5c58f">
-        <source>Will crawl all pages on <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"></x> and ignore pages on any subdomains.</source>
+        <source>Will crawl all pages on
+            <x id="0" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;"/> and ignore pages
+            on any subdomains.</source>
       </trans-unit>
       <trans-unit id="ha8f0ffdb034da2d1">
-        <source>Will crawl all pages on <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"></x> and <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;" id="1"></x>subdomain.<x equiv-text="${exampleHost}&lt;/span&gt;" id="2"></x>.</source>
+        <source>Will crawl all pages on
+            <x id="0" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;"/> and
+            <x id="1" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;"/>subdomain.<x id="2" equiv-text="${exampleHost}&lt;/span&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="h45676fe694fd7de8">
-        <source>Will only visit <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;" id="0"></x> hash anchor links, e.g. <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;" id="1"></x>#example-page<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source>Will only visit
+            <x id="0" equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;"/>
+            hash anchor links, e.g.
+            <x id="1" equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;"/>#example-page<x id="2" equiv-text="&lt;/span&gt;"/></source>
       </trans-unit>
       <trans-unit id="h2303b42f0dff5ee4">
-        <source>Will crawl all page URLs that begin with <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;" id="0"></x> or any URL that begins with those specified in <x equiv-text="&lt;em&gt;" id="1"></x>Extra URL Prefixes in Scope<x equiv-text="&lt;/em&gt;" id="2"></x></source>
+        <source>Will crawl all page URLs that begin with
+            <x id="0" equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;"/>
+            or any URL that begins with those specified in
+            <x id="1" equiv-text="&lt;em&gt;"/>Extra URL Prefixes in Scope<x id="2" equiv-text="&lt;/em&gt;"/></source>
       </trans-unit>
       <trans-unit id="s262c31c801cfbcd9">
         <source>Please enter a valid URL.</source>
@@ -2843,13 +2908,15 @@
         <source>Limits how many hops away the crawler can visit while staying within the Start URL Scope.</source>
       </trans-unit>
       <trans-unit id="sc8d321269980767e">
-        <source>If the crawler finds pages outside of the Start URL Scope they will only be saved if they begin with URLs listed here.</source>
+        <source>If the crawler finds pages outside of the Start URL Scope they
+            will only be saved if they begin with URLs listed here.</source>
       </trans-unit>
       <trans-unit id="s150f5e42dc1aad38">
         <source>Include any linked page (“one hop out”)</source>
       </trans-unit>
       <trans-unit id="sa148214c2ff359cc">
-        <source>If checked, the crawler will visit pages one link away outside of Start URL Scope.</source>
+        <source>If checked, the crawler will visit pages one link away outside of
+        Start URL Scope.</source>
       </trans-unit>
       <trans-unit id="sf092ad58edfa163b">
         <source>Check for sitemap</source>
@@ -2864,13 +2931,14 @@
         <source>Additional URLs</source>
       </trans-unit>
       <trans-unit id="sdc9e7f186428eec0">
-        <source>The crawler will visit and record each URL listed here. Other links on these pages will not be crawled. You can enter up to <x equiv-text="${maxAdditionalURls.toLocaleString()}" id="0"></x> URLs.</source>
+        <source>The crawler will visit and record each URL listed here. Other
+              links on these pages will not be crawled. You can enter up to <x id="0" equiv-text="${maxAdditionalURls.toLocaleString()}"/> URLs.</source>
       </trans-unit>
       <trans-unit id="sdd5dbd4b0fef8660">
-        <source>Must be more than minimum of <x equiv-text="${(+min).toLocaleString()}" id="0"></x></source>
+        <source>Must be more than minimum of <x id="0" equiv-text="${(+min).toLocaleString()}"/></source>
       </trans-unit>
       <trans-unit id="sa4f9d4099c408ae6">
-        <source>Must be less than maximum of <x equiv-text="${(+max).toLocaleString()}" id="0"></x></source>
+        <source>Must be less than maximum of <x id="0" equiv-text="${(+max).toLocaleString()}"/></source>
       </trans-unit>
       <trans-unit id="s9d84cf47af31a3ba">
         <source>Auto-scroll behavior</source>
@@ -2909,37 +2977,46 @@
         <source>What day of the month should a crawl run on?</source>
       </trans-unit>
       <trans-unit id="h8c7c3a6e07d7c512">
-        <source>Schedule: <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${utcSchedule&#10;    ? humanizeSchedule(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"></x>.</source>
+        <source>Schedule:
+                <x id="0" equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${utcSchedule&#10;    ? humanizeSchedule(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="se0baa9b7fb0768e4">
         <source>Invalid date</source>
       </trans-unit>
       <trans-unit id="h30728ea4302f7fe9">
-        <source>Next scheduled run: <x equiv-text="&lt;span&gt;${utcSchedule&#10;    ? humanizeNextDate(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"></x>.</source>
+        <source>Next scheduled run:
+                <x id="0" equiv-text="&lt;span&gt;${utcSchedule&#10;    ? humanizeNextDate(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="s4174899261b8b308">
         <source>A crawl will run at this time in your current timezone.</source>
       </trans-unit>
       <trans-unit id="s0d56a24ca72b8e48">
-        <source>Customize this Workflow's name. Workflows are named after the first Crawl URL by default.</source>
+        <source>Customize this Workflow's name. Workflows are named after
+        the first Crawl URL by default.</source>
       </trans-unit>
       <trans-unit id="sa8e78592c1db6c3a">
         <source>Provide details about this Workflow.</source>
       </trans-unit>
       <trans-unit id="s163480f4b18e39c0">
-        <source>Create or assign this crawl (and its outputs) to one or more tags to help organize your archived items.</source>
+        <source>Create or assign this crawl (and its outputs) to one or more tags
+        to help organize your archived items.</source>
       </trans-unit>
       <trans-unit id="s68f29315fcc19b3b">
         <source>Search for a Collection to auto-add crawls</source>
       </trans-unit>
       <trans-unit id="s54100e0807a1e40d">
-        <source>Automatically add crawls from this workflow to one or more collections as soon as they complete. Individual crawls can be selected from within the collection later.</source>
+        <source>Automatically add crawls from this workflow to one or more collections
+          as soon as they complete.
+          Individual crawls can be selected from within the collection later.</source>
       </trans-unit>
       <trans-unit id="s0e598010b73d1398">
         <source>There are issues with this Workflow. Please go through previous steps and fix all issues to continue.</source>
       </trans-unit>
       <trans-unit id="h2e384a6a9366b427">
-        <source>There is an issue with this Crawl Workflow:<x equiv-text="&lt;br&gt;&lt;br&gt;" id="0"></x>Crawl URL(s) required in <x equiv-text="&lt;a href=&quot;${crawlSetupUrl}&quot; class=&quot;bold underline hover:no-underline&quot;&gt;" id="1"></x>Crawl Setup<x equiv-text="&lt;/a&gt;" id="2"></x>. <x equiv-text="&lt;br&gt;&lt;br&gt;" id="3"></x> Please fix to continue.</source>
+        <source>There is an issue with this Crawl Workflow:<x id="0" equiv-text="&lt;br&gt;&lt;br&gt;"/>Crawl
+              URL(s) required in
+              <x id="1" equiv-text="&lt;a href=&quot;${crawlSetupUrl}&quot; class=&quot;bold underline hover:no-underline&quot;&gt;"/>Crawl Setup<x id="2" equiv-text="&lt;/a&gt;"/>. <x id="3" equiv-text="&lt;br&gt;&lt;br&gt;"/>
+              Please fix to continue.</source>
       </trans-unit>
       <trans-unit id="s265a8f6e25a8c5f2">
         <source>Workflow created.</source>
@@ -2957,34 +3034,34 @@
         <source>Could not run crawl with new workflow settings due to already running crawl.</source>
       </trans-unit>
       <trans-unit id="s286331d9358fc509">
-        <source>Seed URL <x equiv-text="${loc[loc.length - 1] + 1}" id="0"></x>: </source>
+        <source>Seed URL <x id="0" equiv-text="${loc[loc.length - 1] + 1}"/>: </source>
       </trans-unit>
       <trans-unit id="s08dd397493a013b1">
         <source>Couldn't save Workflow. Please fix the following Workflow issues:</source>
       </trans-unit>
       <trans-unit id="sea5eee53e296f33b">
-        <source><x equiv-text="${urlList.length.toLocaleString()}" id="0"></x> URL entered</source>
+        <source><x id="0" equiv-text="${urlList.length.toLocaleString()}"/> URL entered</source>
       </trans-unit>
       <trans-unit id="sfa75e464c2da4bba">
-        <source><x equiv-text="${urlList.length.toLocaleString()}" id="0"></x> URLs entered</source>
+        <source><x id="0" equiv-text="${urlList.length.toLocaleString()}"/> URLs entered</source>
       </trans-unit>
       <trans-unit id="s960e671fe5f2559b">
-        <source>Please shorten list to <x equiv-text="${max.toLocaleString()}" id="0"></x> or fewer URLs.</source>
+        <source>Please shorten list to <x id="0" equiv-text="${max.toLocaleString()}"/> or fewer URLs.</source>
       </trans-unit>
       <trans-unit id="s40b5b363fefc9199">
-        <source>Please remove or fix the following invalid URL: <x equiv-text="${invalidUrl}" id="0"></x></source>
+        <source>Please remove or fix the following invalid URL: <x id="0" equiv-text="${invalidUrl}"/></source>
       </trans-unit>
       <trans-unit id="saf63d34c8601dd41">
-        <source><x equiv-text="${humanizeSchedule(workflow.schedule, {&#10;    length: &quot;short&quot;,&#10;}, numberFormatter)}" id="0"></x> </source>
+        <source><x id="0" equiv-text="${humanizeSchedule(workflow.schedule, {&#10;    length: &quot;short&quot;,&#10;}, numberFormatter)}"/></source>
       </trans-unit>
       <trans-unit id="s136b21dec9a221bd">
-        <source>Manual run by <x equiv-text="${workflow.lastStartedByName}" id="0"></x></source>
+        <source>Manual run by <x id="0" equiv-text="${workflow.lastStartedByName}"/></source>
       </trans-unit>
       <trans-unit id="sde7cc417de1b3246">
         <source>---</source>
       </trans-unit>
       <trans-unit id="sa84bc532c73403ed">
-        <source>Running for <x equiv-text="${RelativeDuration.humanize(diff, {&#10;    compact: true,&#10;})}" id="0"></x></source>
+        <source>Running for <x id="0" equiv-text="${RelativeDuration.humanize(diff, {&#10;    compact: true,&#10;})}"/></source>
       </trans-unit>
       <trans-unit id="s8eb4021572d41d99">
         <source>Name &amp; Schedule</source>
@@ -2993,31 +3070,36 @@
         <source>billing settings</source>
       </trans-unit>
       <trans-unit id="s71c5c2d34bb2c4c2">
-        <source>Your org will be deleted in <x equiv-text="${daysDiff}" id="0"></x> days</source>
+        <source>Your org will be deleted in
+              <x id="0" equiv-text="${daysDiff}"/> days</source>
       </trans-unit>
       <trans-unit id="s7fa0d24b94690373">
-        <source>Your subscription ends on <x equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}" id="0"></x>. Your user account, org, and all associated data will be deleted.</source>
+        <source>Your subscription ends on <x id="0" equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}"/>. Your user account, org, and all associated data will be deleted.</source>
       </trans-unit>
       <trans-unit id="h16be212de6638b6c">
-        <source>We suggest downloading your archived items before they are deleted. To keep your plan and data, see <x equiv-text="${billingTabLink}" id="0"></x>.</source>
+        <source>We suggest downloading your archived items before they
+                  are deleted. To keep your plan and data, see
+                  <x id="0" equiv-text="${billingTabLink}"/>.</source>
       </trans-unit>
       <trans-unit id="sc3e0d8cbe688ccd5">
-        <source>Archiving will be disabled in <x equiv-text="${daysDiff}" id="0"></x> days</source>
+        <source>Archiving will be disabled in <x id="0" equiv-text="${daysDiff}"/> days</source>
       </trans-unit>
       <trans-unit id="sda57befc109a45f6">
         <source>Archiving will be disabled within one day</source>
       </trans-unit>
       <trans-unit id="s618b35a93b6fd392">
-        <source>Your subscription ends on <x equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}" id="0"></x>. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.</source>
+        <source>Your subscription ends on <x id="0" equiv-text="${formatISODateString(subscription!.futureCancelDate!, {&#10;    month: &quot;long&quot;,&#10;    day: &quot;numeric&quot;,&#10;    year: &quot;numeric&quot;,&#10;    hour: &quot;numeric&quot;,&#10;})}"/>. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.</source>
       </trans-unit>
       <trans-unit id="hf17c5369da37401b">
-        <source>To keep your plan and continue crawling, see <x equiv-text="${billingTabLink}" id="0"></x>.</source>
+        <source>To keep your plan and continue crawling, see
+                  <x id="0" equiv-text="${billingTabLink}"/>.</source>
       </trans-unit>
       <trans-unit id="sfb85ab2a166e4c99">
         <source>Archiving is disabled for this org</source>
       </trans-unit>
       <trans-unit id="habd962339c5b3e55">
-        <source>Your subscription has been paused due to payment failure. Please go to <x equiv-text="${billingTabLink}" id="0"></x> to update your payment method.</source>
+        <source>Your subscription has been paused due to payment failure.
+            Please go to <x id="0" equiv-text="${billingTabLink}"/> to update your payment method.</source>
       </trans-unit>
       <trans-unit id="s4e6c7f0a1e774fea">
         <source>Your subscription has been canceled. Please contact Browsertrix support to renew your plan.</source>
@@ -3029,7 +3111,7 @@
         <source>Your org has reached its storage limit</source>
       </trans-unit>
       <trans-unit id="s7b663782f7f35eb8">
-        <source>To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"></x> to upgrade your storage plan.</source>
+        <source>To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact <x id="0" equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}"/> to upgrade your storage plan.</source>
       </trans-unit>
       <trans-unit id="sf3a7cc6ecc194453">
         <source>Browsertrix host administrator</source>
@@ -3038,7 +3120,7 @@
         <source>Your org has reached its monthly execution minutes limit</source>
       </trans-unit>
       <trans-unit id="s10a8d7c57c09ca1b">
-        <source>Contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"></x> to purchase additional monthly execution minutes or upgrade your plan.</source>
+        <source>Contact <x id="0" equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}"/> to purchase additional monthly execution minutes or upgrade your plan.</source>
       </trans-unit>
       <trans-unit id="seb2d088a92660d77">
         <source>No usage history to show.</source>
@@ -3119,7 +3201,7 @@
         <source>This org name is already taken.</source>
       </trans-unit>
       <trans-unit id="s1184d1f63618dc4e">
-        <source>Created new org named "<x equiv-text="${params.name}" id="0"></x>".</source>
+        <source>Created new org named "<x id="0" equiv-text="${params.name}"/>".</source>
       </trans-unit>
       <trans-unit id="sf1c2a4776e202435">
         <source>Sorry, couldn't create organization at this time.</source>
@@ -3191,10 +3273,16 @@
         <source>Finish setting up your Browsertrix account to start crawling.</source>
       </trans-unit>
       <trans-unit id="h22769969c5066f85">
-        <source>You’ve been invited by <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${inviterName}&lt;/strong&gt;" id="0"></x> to join the organization <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="1"></x> on Browsertrix.</source>
+        <source>You’ve been invited by
+          <x id="0" equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${inviterName}&lt;/strong&gt;"/>
+          to join the organization
+          <x id="1" equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;"/>
+          on Browsertrix.</source>
       </trans-unit>
       <trans-unit id="h406ea2eff53edcfb">
-        <source>You’ve been invited to join the organization <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="0"></x> on Browsertrix.</source>
+        <source>You’ve been invited to join the organization
+          <x id="0" equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;"/>
+          on Browsertrix.</source>
       </trans-unit>
       <trans-unit id="s07cee0cdf942df03">
         <source>Step 1 complete</source>
@@ -3221,10 +3309,13 @@
         <source>An org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.</source>
       </trans-unit>
       <trans-unit id="hecef9e5e39351b37">
-        <source>Refer to our user guide on <x equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;https://docs.browsertrix.com/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;" id="0"></x>org settings<x equiv-text="&lt;/a&gt;" id="1"></x> for details.</source>
+        <source>Refer to our user guide on
+                <x id="0" equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;https://docs.browsertrix.com/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;"/>org settings<x id="1" equiv-text="&lt;/a&gt;"/>
+                for details.</source>
       </trans-unit>
       <trans-unit id="s8ae1873b610b92d6">
-        <source>Your org dashboard will be <x equiv-text="${window.location.protocol}" id="0"></x>//<x equiv-text="${window.location.hostname}" id="1"></x>/orgs/<x equiv-text="${slug || &quot;&quot;}" id="2"></x></source>
+        <source>Your org dashboard will be
+        <x id="0" equiv-text="${window.location.protocol}"/>//<x id="1" equiv-text="${window.location.hostname}"/>/orgs/<x id="2" equiv-text="${slug || &quot;&quot;}"/></source>
       </trans-unit>
       <trans-unit id="s0d5ee4ffcb9c2c65">
         <source>You can change this in your org settings later.</source>
@@ -3233,13 +3324,13 @@
         <source>Go to Dashboard</source>
       </trans-unit>
       <trans-unit id="s033b7f18e2a1b86e">
-        <source>The org name "<x equiv-text="${name}" id="0"></x>" is already taken, try another one.</source>
+        <source>The org name "<x id="0" equiv-text="${name}"/>" is already taken, try another one.</source>
       </trans-unit>
       <trans-unit id="s6d0192d253b870f7">
-        <source>The org URL identifier "<x equiv-text="${slug}" id="0"></x>" is already taken, try another one.</source>
+        <source>The org URL identifier "<x id="0" equiv-text="${slug}"/>" is already taken, try another one.</source>
       </trans-unit>
       <trans-unit id="s692207ce67c91506">
-        <source>The org URL identifier "<x equiv-text="${slug}" id="0"></x>" is not a valid URL. Please use alphanumeric characters and dashes (-) only</source>
+        <source>The org URL identifier "<x id="0" equiv-text="${slug}"/>" is not a valid URL. Please use alphanumeric characters and dashes (-) only</source>
       </trans-unit>
       <trans-unit id="s5df133e1b1fd43c3">
         <source>Welcome to Browsertrix</source>
@@ -3251,13 +3342,13 @@
         <source>This invite doesn't exist or has expired. Please ask the organization administrator to resend an invitation.</source>
       </trans-unit>
       <trans-unit id="s1952dc02aa41f1c9">
-        <source>This is not a valid invite, or it may have expired. If you believe this is an error, please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"></x> for help.</source>
+        <source>This is not a valid invite, or it may have expired. If you believe this is an error, please contact <x id="0" equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}"/> for help.</source>
       </trans-unit>
       <trans-unit id="s0235065054efe3a8">
         <source>your Browsertrix administrator</source>
       </trans-unit>
       <trans-unit id="s4a7fb6e66ba564d7">
-        <source>Something unexpected went wrong retrieving this invite. Please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"></x> for help.</source>
+        <source>Something unexpected went wrong retrieving this invite. Please contact <x id="0" equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}"/> for help.</source>
       </trans-unit>
       <trans-unit id="s7ebc4f216d73836f">
         <source>This verification email is not valid.</source>
@@ -3275,7 +3366,7 @@
         <source>Must be between 8-64 characters</source>
       </trans-unit>
       <trans-unit id="s8daf047a917f4cc4">
-        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"></x>-<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"></x> characters.</source>
+        <source>Choose a strong password between <x id="0" equiv-text="${PASSWORD_MINLENGTH}"/>-<x id="1" equiv-text="${PASSWORD_MAXLENGTH}"/> characters.</source>
       </trans-unit>
       <trans-unit id="s16ba889483d4940e">
         <source>Change Password</source>
@@ -3287,7 +3378,7 @@
         <source>Password reset email is not valid. Request a new password reset email</source>
       </trans-unit>
       <trans-unit id="s7d90fb0e2d1684a7">
-        <source>Sent invite to <x equiv-text="${this.invitedEmail}" id="0"></x></source>
+        <source>Sent invite to <x id="0" equiv-text="${this.invitedEmail}"/></source>
       </trans-unit>
       <trans-unit id="s586d6bd2eca2da93">
         <source>Users</source>
@@ -3314,10 +3405,10 @@
         <source>Decline</source>
       </trans-unit>
       <trans-unit id="s84922e45c0957371">
-        <source>This invitation is for <x equiv-text="${this.email}" id="0"></x>. You are currently logged in as <x equiv-text="${this.authState?.username}" id="1"></x>. Please log in with the correct email to access this invite.</source>
+        <source>This invitation is for <x id="0" equiv-text="${this.email}"/>. You are currently logged in as <x id="1" equiv-text="${this.authState?.username}"/>. Please log in with the correct email to access this invite.</source>
       </trans-unit>
       <trans-unit id="sc9a2484754aae7bb">
-        <source>You've joined <x equiv-text="${org.name || inviteInfo.orgName || msg(&quot;Browsertrix&quot;)}" id="0"></x>.</source>
+        <source>You've joined <x id="0" equiv-text="${org.name || inviteInfo.orgName || msg(&quot;Browsertrix&quot;)}"/>.</source>
       </trans-unit>
       <trans-unit id="sdb8ec1b3a5726c88">
         <source>Browsertrix</source>
@@ -3326,7 +3417,7 @@
         <source>This invitation is not valid</source>
       </trans-unit>
       <trans-unit id="s4b97257cf024d907">
-        <source>You've declined to join <x equiv-text="${orgName || msg(&quot;Browsertrix&quot;)}" id="0"></x>.</source>
+        <source>You've declined to join <x id="0" equiv-text="${orgName || msg(&quot;Browsertrix&quot;)}"/>.</source>
       </trans-unit>
       <trans-unit id="s686306cdb839fb8d">
         <source>Sending...</source>
@@ -3398,7 +3489,7 @@
         <source>You must belong to at least one org in order to access Browsertrix features.</source>
       </trans-unit>
       <trans-unit id="s273f0ee82bf2b922">
-        <source>If you haven't received an invitation to an org, please contact us at <x equiv-text="${this.appState.settings.salesEmail}" id="0"></x>.</source>
+        <source>If you haven't received an invitation to an org, please contact us at <x id="0" equiv-text="${this.appState.settings.salesEmail}"/>.</source>
       </trans-unit>
       <trans-unit id="s95aeb2828c01b0de">
         <source>If you haven't received an invitation to an org, please contact your Browsertrix administrator.</source>
@@ -3437,7 +3528,7 @@
         <source>Welcome to Browsertrix!</source>
       </trans-unit>
       <trans-unit id="h702a7337c08bf73f">
-        <source>A confirmation email was sent to: <x equiv-text="&lt;br&gt;&#10;                &lt;strong&gt;${email}&lt;/strong&gt;" id="0"></x>.</source>
+        <source>A confirmation email was sent to: <x id="0" equiv-text="&lt;br&gt;&#10;                &lt;strong&gt;${email}&lt;/strong&gt;"/>.</source>
       </trans-unit>
       <trans-unit id="sd11e60711d79e788">
         <source>Click the link in your email to confirm your email address.</source>
@@ -3580,10 +3671,11 @@
         <note from="lit-localize">Time AM/PM</note>
       </trans-unit>
       <trans-unit id="h9083eded7901e66a">
-        <source><x equiv-text="${quotas.storageQuota&#10;    ? html `&lt;sl-format-bytes&#10;                  value=${quotas.storageQuota}&#10;                &gt;&lt;/sl-format-bytes&gt;`&#10;    : msg(&quot;Unlimited&quot;)}" id="0"></x> storage</source>
+        <source><x id="0" equiv-text="${quotas.storageQuota&#10;    ? html `&lt;sl-format-bytes&#10;                  value=${quotas.storageQuota}&#10;                &gt;&lt;/sl-format-bytes&gt;`&#10;    : msg(&quot;Unlimited&quot;)}"/>
+            storage</source>
       </trans-unit>
       <trans-unit id="s1d6a13ef53c51ee9">
-        <source><x equiv-text="${maxPagesPerCrawl || msg(&quot;Unlimited pages&quot;)}" id="0"></x> per crawl</source>
+        <source><x id="0" equiv-text="${maxPagesPerCrawl || msg(&quot;Unlimited pages&quot;)}"/> per crawl</source>
       </trans-unit>
       <trans-unit id="s41de0883966c23c8">
         <source>Unlimited pages</source>
@@ -3592,10 +3684,10 @@
         <source>Unlimited concurrent crawls</source>
       </trans-unit>
       <trans-unit id="s8ad4a17ab2b75854">
-        <source>Adding <x equiv-text="${formatNumber(addCount)} ${pluralOf(&quot;items&quot;, addCount)}" id="0"></x></source>
+        <source>Adding <x id="0" equiv-text="${formatNumber(addCount)} ${pluralOf(&quot;items&quot;, addCount)}"/></source>
       </trans-unit>
       <trans-unit id="sbea722837f683db1">
-        <source><x equiv-text="${firstUrl}" id="0"></x> + <x equiv-text="${formatNumber(remainder, { notation: &quot;compact&quot; })}" id="1"></x> more <x equiv-text="${pluralOf(&quot;URLs&quot;, remainder)}" id="2"></x></source>
+        <source><x id="0" equiv-text="${firstUrl}"/> + <x id="1" equiv-text="${formatNumber(remainder, { notation: &quot;compact&quot; })}"/> more <x id="2" equiv-text="${pluralOf(&quot;URLs&quot;, remainder)}"/></source>
       </trans-unit>
       <trans-unit id="items.plural.few">
         <source>items</source>
@@ -3643,19 +3735,24 @@
         <source>Specify a domain name, start page URL, or path on a website and let the crawler automatically find pages within that scope.</source>
       </trans-unit>
       <trans-unit id="hb653cf5693a98f6b">
-        <source>Choose <x equiv-text="&lt;strong&gt;" id="0"></x>Page List<x equiv-text="&lt;/strong&gt;" id="1"></x> if:</source>
+        <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Page List<x id="1" equiv-text="&lt;/strong&gt;"/> if:</source>
       </trans-unit>
       <trans-unit id="s16addd6732b613fd">
         <source>You want to include URLs with different domain names in the same crawl</source>
       </trans-unit>
       <trans-unit id="h25ccce1baa96d993">
-        <source>A Page List workflow is simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.</source>
+        <source>A Page List workflow is simpler to configure, since you don't
+              need to worry about configuring the workflow to exclude parts of
+              the website that you may not want to archive.</source>
       </trans-unit>
       <trans-unit id="hc5b85948ffe0eb76">
-        <source>Choose <x equiv-text="&lt;strong&gt;" id="0"></x>Site Crawl<x equiv-text="&lt;/strong&gt;" id="1"></x> if:</source>
+        <source>Choose <x id="0" equiv-text="&lt;strong&gt;"/>Site Crawl<x id="1" equiv-text="&lt;/strong&gt;"/> if:</source>
       </trans-unit>
       <trans-unit id="hddd64e30f6ade731">
-        <source>Site Crawl workflows are great for advanced use cases where you don't need to know every single URL that you want to archive. You can configure reasonable crawl limits and page limits so that you don't crawl more than you need to.</source>
+        <source>Site Crawl workflows are great for advanced use cases where
+              you don't need to know every single URL that you want to archive.
+              You can configure reasonable crawl limits and page limits so that
+              you don't crawl more than you need to.</source>
       </trans-unit>
       <trans-unit id="s33807afa94c15a25">
         <source>Browser windows can only be edited while a crawl is starting or running</source>
@@ -3670,7 +3767,8 @@
         <source>Help me decide</source>
       </trans-unit>
       <trans-unit id="ha60886587b96e32c">
-        <source>Started crawl from <x equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;" id="0"></x>. <x equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navLink.bind(this)}&quot;&gt;" id="1"></x>Watch crawl<x equiv-text="&lt;/a&gt;" id="2"></x></source>
+        <source>Started crawl from <x id="0" equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;"/>.
+            <x id="1" equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navLink.bind(this)}&quot;&gt;"/>Watch crawl<x id="2" equiv-text="&lt;/a&gt;"/></source>
       </trans-unit>
       <trans-unit id="sb32ae1652df8c7ad">
         <source>Workflow settings used to run this crawl</source>
@@ -3682,17 +3780,21 @@
         <source>Select Analysis Run</source>
       </trans-unit>
       <trans-unit id="sd3c4adf4cc6d1668">
-        <source>New <x equiv-text="${this.jobTypeLabels[jobType]}" id="0"></x> Workflow</source>
+        <source>New <x id="0" equiv-text="${this.jobTypeLabels[jobType]}"/> Workflow</source>
       </trans-unit>
       <trans-unit id="sdd3e1b91cb27a4d5">
         <source>Page URL(s)</source>
       </trans-unit>
       <trans-unit id="s4201222224dff23c">
-        <source>Crawl: <x equiv-text="${crawlStatus.label}" id="0"></x></source>
+        <source>Crawl: <x id="0" equiv-text="${crawlStatus.label}"/></source>
       </trans-unit>
       <trans-unit id="s0eb7c300368b2a58">
-        <source>Upload: <x equiv-text="${crawlStatus.label}" id="0"></x></source>
+        <source>Upload: <x id="0" equiv-text="${crawlStatus.label}"/></source>
       </trans-unit>
+<trans-unit id="hac630f92c94217bc">
+  <source>Your plan will be canceled on
+                                  <x id="0" equiv-text="&lt;sl-format-date lang=&quot;${getLocale()}&quot; class=&quot;truncate&quot; date=&quot;${org.subscription.futureCancelDate}&quot; month=&quot;long&quot; day=&quot;numeric&quot; year=&quot;numeric&quot;&gt;&#10;                                  &lt;/sl-format-date&gt;"/></source>
+</trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
- Ensures extracted strings get formatted before checking against index
- Fixes index check by switching from `git diff-index` to `git diff`, and ensures the proper `--exit-code` flag is present (implicitly turned on by `--quiet`)
- Adds actionable error message when the check fails
- Updates Github's actions versions from v3 to v4 (major version bump is primarily just for default node version updates, but this way we'll get future updates)
- Adds formatting step to npm script for extracting messages
- Runs a string extraction & format against current main