### PR TITLE
[Chore] Webpack: Migrate from `onBeforeSetupMiddleware` to `setupMiddlewares`

### DIFF
--- a/frontend/scripts/serve.js
+++ b/frontend/scripts/serve.js
@@ -16,7 +16,7 @@ const app = express();
 
 const { devServer } = devConfig;
 
-devServer.onBeforeSetupMiddleware({ app });
+devServer.setupMiddlewares([], { app });
 
 app.use("/", express.static("dist"));
 Object.keys(devServer.proxy).forEach((path) => {

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -58,8 +58,8 @@ module.exports = [
           },
         },
       },
-      // Serve replay service worker file
-      onBeforeSetupMiddleware: (server) => {
+      setupMiddlewares: (middlewares, server) => {
+        // Serve replay service worker file
         server.app?.get("/replay/sw.js", (req, res) => {
           res.set("Content-Type", "application/javascript");
           res.send(`importScripts("${RWP_BASE_URL}sw.js")`);
@@ -75,6 +75,7 @@ module.exports = [
           res.set("Content-Type", "application/javascript");
           res.status(404).send(`{"error": "placeholder_for_replay"}`);
         });
+        return middlewares;
       },
       port: 9870,
     },


### PR DESCRIPTION
Resolves the big red `[DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.` warnings when starting Webpack.