### PR TITLE
Adding secret into ingress template

### DIFF
--- a/chart/examples/microk8s-hosted.yaml
+++ b/chart/examples/microk8s-hosted.yaml
@@ -37,6 +37,10 @@ ingress:
 
   scheme: "https"
   tls: true
+  # Optional for Certificate from other authority already added to microk8s as secret
+  # Secret must be added like, assumed command is executed in the path of my-key.key and my-cert.crt 
+  # microk8s kubectl create secret tls onb-tls --namespace default --key=my-key.key --cert=my-cert.crt -o yaml
+  # secretName: my-secret
 
 ingress_class: "public"
 

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   tls:
     - hosts:
       - {{ .Values.ingress.host }}
-      secretName: cert-main
+      secretName: {{ .Values.ingress.secretName | default "cert-main" }}
   {{- end }}
 
   rules:


### PR DESCRIPTION
For manually adding a secret for a tls of another authority then Let's Encrypt
See https://github.com/webrecorder/browsertrix/issues/2077
Fix for frontend&backend ingress
Still open: auth-signer is not using the same secret