### PR TITLE
chore: Auto-commit extracted localization strings

### DIFF
--- a/.github/workflows/frontend-build-prepare.yaml
+++ b/.github/workflows/frontend-build-prepare.yaml
@@ -1,4 +1,4 @@
-name: Frontend Build Check
+name: Frontend Prepare Build
 on:
   pull_request:
     paths:
@@ -11,6 +11,8 @@ jobs:
   setup-and-build:
     runs-on: ubuntu-latest
     steps:
+
+      # Setup:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node
@@ -31,6 +33,8 @@ jobs:
         env:
           HUSKY: 0
         run: yarn install --frozen-lockfile
+
+      # Lint and format:
       - name: Lint
         working-directory: frontend
         run: yarn lint:check
@@ -39,21 +43,32 @@ jobs:
         # TODO Reenable when https://github.com/webrecorder/browsertrix-cloud/issues/1618 is addressed
         # run: yarn format:check
         run: echo "yarn format:check disabled"
+
+      # Test:
       - name: Unit tests
         working-directory: frontend
         run: yarn test
-      - name: Check extracted strings
+    
+      # Localize:
+      - name: Extract strings
         working-directory: frontend
         run: yarn localize:extract && if ! git diff --quiet -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
-      - name: Localization build
+      - name: Commit extracted strings
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Apply automatic changes to extracted localization strings
+          file_pattern: '**/*.xlf'
+          skip_fetch: true
+          skip_checkout: true
+      - name: Check localization build
         working-directory: frontend
         run: yarn localize:build
 
+      # Check build:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: network=host
-
       - name: Build Frontend
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/frontend-build-prepare.yaml
+++ b/.github/workflows/frontend-build-prepare.yaml
@@ -40,20 +40,10 @@ jobs:
           HUSKY: 0
         run: yarn install --frozen-lockfile
 
-      # Lint and format:
+      # Lint:
       - name: Lint
         working-directory: frontend
         run: yarn lint:check
-      - name: Format
-        working-directory: frontend
-        # TODO Reenable when https://github.com/webrecorder/browsertrix-cloud/issues/1618 is addressed
-        # run: yarn format:check
-        run: echo "yarn format:check disabled"
-
-      # Test:
-      - name: Unit tests
-        working-directory: frontend
-        run: yarn test
     
       # Localize:
       - name: Extract strings
@@ -62,11 +52,18 @@ jobs:
       - name: Commit extracted strings
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Apply automatic changes to extracted localization strings
+          commit_message: Apply `localize:extract` changes
           file_pattern: '**/*.xlf'
+          skip_fetch: true
+          skip_checkout: true
       - name: Check localization build
         working-directory: frontend
         run: yarn localize:build
+
+      # Test:
+      - name: Unit tests
+        working-directory: frontend
+        run: yarn test
 
       # Check build:
       - name: Set up Docker Buildx

--- a/.github/workflows/frontend-build-prepare.yaml
+++ b/.github/workflows/frontend-build-prepare.yaml
@@ -52,7 +52,7 @@ jobs:
       # Localize:
       - name: Extract strings
         working-directory: frontend
-        run: yarn localize:extract && if ! git diff --quiet -- ; then echo "Error extracting strings, please run \`yarn localize:extract\` from the \`frontend\` directory and commit the results."; false; fi
+        run: yarn localize:extract
       - name: Commit extracted strings
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/frontend-build-prepare.yaml
+++ b/.github/workflows/frontend-build-prepare.yaml
@@ -10,11 +10,17 @@ on:
 jobs:
   setup-and-build:
     runs-on: ubuntu-latest
-    steps:
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
 
+    steps:
       # Setup:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -58,8 +64,6 @@ jobs:
         with:
           commit_message: Apply automatic changes to extracted localization strings
           file_pattern: '**/*.xlf'
-          skip_fetch: true
-          skip_checkout: true
       - name: Check localization build
         working-directory: frontend
         run: yarn localize:build

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -5,8 +5,6 @@
 if git diff --name-only --cached | grep --quiet 'frontend/src/';
   then
     cd frontend
-    yarn localize:extract
-    git add xliff
     npx lint-staged
   else
     echo "(no frontend/src changes - skipping pre-commit hook)"

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -286,7 +286,7 @@ export class App extends LiteElement {
           <sl-alert variant="warning" open>
             <sl-icon slot="icon" name="exclamation-triangle-fill"></sl-icon>
             <strong class="block font-semibold">
-              ${msg("Your account isn't quite set up yet.")}
+              ${msg("Your account isn't quite set up yet")}
             </strong>
             ${msg(
               "You must belong to at least one org in order to access Browsertrix features.",

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -286,7 +286,7 @@ export class App extends LiteElement {
           <sl-alert variant="warning" open>
             <sl-icon slot="icon" name="exclamation-triangle-fill"></sl-icon>
             <strong class="block font-semibold">
-              ${msg("Your account isn't quite set up yet")}
+              ${msg("Your account isn't quite set up yet.")}
             </strong>
             ${msg(
               "You must belong to at least one org in order to access Browsertrix features.",


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/1416

## Changes

Removes `localize:extract` from pre-commit hook and commits changes from `localize:extract` in frontend PR build check.

Example commit: https://github.com/webrecorder/browsertrix/pull/2089/commits/89d04a23b7bd4d8c4dcca419c23e37242fb8b0c9

Also removes the unused format check, it shouldn't be much of an issue since 1. it wasn't working and 2. we're formatting in the pre-commit hook.