### PR TITLE
Implement custom storage for orgs

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -116,6 +116,11 @@ jobs:
       - name: Wait for all pods to be ready
         run: kubectl wait --for=condition=ready pod --all --timeout=240s
 
+      - name: Create Extra Test Buckets
+        run: |
+          kubectl exec -i deployment/local-minio -c minio -- mkdir /data/custom-primary &&
+          kubectl exec -i deployment/local-minio -c minio -- mkdir /data/custom-replica
+
       - name: Run Tests
         timeout-minutes: 30
         run: pytest -vv ./backend/test/test_*.py

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -68,6 +68,11 @@ jobs:
       - name: Wait for all pods to be ready
         run: sudo microk8s kubectl wait --for=condition=ready pod --all --timeout=240s
 
+      - name: Create Extra Test Buckets
+        run: |
+          kubectl exec -i deployment/local-minio -c minio -- mkdir /data/custom-primary &&
+          kubectl exec -i deployment/local-minio -c minio -- mkdir /data/custom-replica
+
       - name: Run Tests
         run: pytest -vv ./backend/test/test_*.py
 

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -57,7 +57,7 @@ class BackgroundJobOps:
 
     migration_jobs_scale: int
 
-    # pylint: disable=too-many-locals, too-many-arguments, invalid-name
+    # pylint: disable=too-many-locals, too-many-arguments, too-many-positional-arguments, invalid-name
 
     def __init__(self, mdb, email, user_manager, org_ops, crawl_manager, storage_ops):
         self.jobs = mdb["jobs"]

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -31,6 +31,7 @@ from .models import (
     SuccessResponse,
     SuccessResponseId,
     JobProgress,
+    BackgroundJob,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import dt_now
@@ -44,7 +45,7 @@ else:
 
 
 # ============================================================================
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-lines, too-many-return-statements, too-many-public-methods
 class BackgroundJobOps:
     """k8s background job management"""
 
@@ -807,6 +808,7 @@ class BackgroundJobOps:
         self, job: BackgroundJob, org: Organization
     ) -> Dict[str, Union[bool, Optional[str]]]:
         """Retry background job specific to one org"""
+        # pylint: disable=too-many-return-statements
         if job.type == BgJobType.CREATE_REPLICA:
             job = cast(CreateReplicaJob, job)
             file = await self.get_replica_job_file(job, org)
@@ -872,7 +874,7 @@ class BackgroundJobOps:
                 org,
                 job.prev_storage,
                 job.new_storage,
-                existing_job_id=job_id,
+                existing_job_id=job.id,
             )
             return {"success": True}
 

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -870,6 +870,7 @@ class BackgroundJobOps:
             return {"success": True}
 
         if job.type == BgJobType.COPY_BUCKET:
+            job = cast(CopyBucketJob, job)
             await self.create_copy_bucket_job(
                 org,
                 job.prev_storage,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -432,7 +432,7 @@ class BackgroundJobOps:
             return job_id
         # pylint: disable=broad-exception-caught
         except Exception as exc:
-             # pylint: disable=raise-missing-from
+            # pylint: disable=raise-missing-from
             print(f"warning: re-add org pages job could not be started: {exc}")
             return None
 

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -306,8 +306,6 @@ class BackgroundJobOps:
     ) -> str:
         """Create background job to delete org and its data"""
 
-        job_type = BgJobType.DELETE_ORG.value
-
         try:
             job_id = await self.crawl_manager.run_delete_org_job(
                 oid=str(org.id),

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -639,6 +639,7 @@ class BackgroundJobOps:
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         success: Optional[bool] = None,
+        running: Optional[bool] = None,
         job_type: Optional[str] = None,
         sort_by: Optional[str] = None,
         sort_direction: Optional[int] = -1,
@@ -656,6 +657,12 @@ class BackgroundJobOps:
 
         if success in (True, False):
             query["success"] = success
+
+        if running:
+            query["success"] = None
+
+        if running is False:
+            query["success"] = {"$in": [True, False]}
 
         if job_type:
             query["type"] = job_type
@@ -975,6 +982,7 @@ def init_background_jobs_api(
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         success: Optional[bool] = None,
+        running: Optional[bool] = None,
         jobType: Optional[str] = None,
         sortBy: Optional[str] = None,
         sortDirection: Optional[int] = -1,
@@ -985,6 +993,7 @@ def init_background_jobs_api(
             page_size=pageSize,
             page=page,
             success=success,
+            running=running,
             job_type=jobType,
             sort_by=sortBy,
             sort_direction=sortDirection,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -500,7 +500,7 @@ class BackgroundJobOps:
                 new_storage=new_storage_ref,
                 new_endpoint=new_endpoint,
                 new_bucket=new_bucket,
-                job_id_prefix=f"{job_type}-{object_id}",
+                job_id_prefix=job_type,
                 existing_job_id=existing_job_id,
             )
             if existing_job_id:

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -532,7 +532,9 @@ class BackgroundJobOps:
             return job_id
         # pylint: disable=broad-exception-caught
         except Exception as exc:
-            print(f"warning: copy bucket job could not be started for org {org.id}")
+            print(
+                f"warning: copy bucket job could not be started for org {org.id}: {exc}"
+            )
             return ""
 
     async def job_finished(
@@ -850,7 +852,7 @@ class BackgroundJobOps:
 
 
 # ============================================================================
-# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme, too-many-positional-arguments
 def init_background_jobs_api(
     app, mdb, email, user_manager, org_ops, crawl_manager, storage_ops, user_dep
 ):

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -302,8 +302,10 @@ class BackgroundJobOps:
         self,
         org: Organization,
         existing_job_id: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> str:
         """Create background job to delete org and its data"""
+
+        job_type = BgJobType.DELETE_ORG.value
 
         try:
             job_id = await self.crawl_manager.run_delete_org_job(
@@ -339,7 +341,7 @@ class BackgroundJobOps:
         except Exception as exc:
             # pylint: disable=raise-missing-from
             print(f"warning: delete org job could not be started: {exc}")
-            return None
+            return ""
 
     async def create_recalculate_org_stats_job(
         self,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -489,6 +489,10 @@ class BackgroundJobOps:
         new_storage = self.storage_ops.get_org_storage_by_ref(org, new_storage_ref)
         new_endpoint, new_bucket = self.strip_bucket(new_storage.endpoint_url)
 
+        # Ensure buckets terminate with trailing slash
+        prev_bucket = os.path.join(prev_bucket, "")
+        new_bucket = os.path.join(new_bucket, "")
+
         job_type = BgJobType.COPY_BUCKET.value
 
         try:

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -16,7 +16,6 @@ from .crawlmanager import CrawlManager
 from .models import (
     BaseFile,
     Organization,
-    BackgroundJob,
     BgJobType,
     CreateReplicaJob,
     DeleteReplicaJob,
@@ -563,7 +562,7 @@ class BackgroundJobOps:
                     cast(DeleteReplicaJob, job)
                 )
             if job_type == BgJobType.COPY_BUCKET:
-                org = await self.orgs_ops.get_org_by_id(oid)
+                org = await self.org_ops.get_org_by_id(oid)
                 await self.org_ops.update_read_only(org, False)
         else:
             print(

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -567,8 +567,8 @@ class BackgroundJobOps:
                 await self.handle_delete_replica_job_finished(
                     cast(DeleteReplicaJob, job)
                 )
-            if job_type == BgJobType.COPY_BUCKET:
-                org = await self.org_ops.get_org_by_id(oid)
+            if job_type == BgJobType.COPY_BUCKET and job.oid:
+                org = await self.org_ops.get_org_by_id(job.oid)
                 await self.org_ops.update_read_only(org, False)
         else:
             print(

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -681,6 +681,7 @@ class BackgroundJobOps:
                         progress.eta = eta_list[0]
 
                 break
+            # pylint: disable=bare-except
             except:
                 continue
 
@@ -947,6 +948,7 @@ def init_background_jobs_api(
     )
     async def get_job_progress(
         job_id: str,
+        # pylint: disable=unused-argument
         org: Organization = Depends(org_crawl_dep),
     ):
         """Return progress information for background job"""

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -49,7 +49,7 @@ else:
 
 
 # ============================================================================
-# pylint: disable=too-many-instance-attributes, too-many-public-methods, too-many-lines, too-many-branches
+# pylint: disable=too-many-instance-attributes, too-many-public-methods, too-many-lines, too-many-branches, too-many-positional-arguments
 class BaseCrawlOps:
     """operations that apply to all crawls"""
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -66,6 +66,7 @@ THUMBNAIL_MAX_SIZE = 2_000_000
 
 
 # ============================================================================
+# pylint: disable=too-many-positional-arguments
 class CollectionOps:
     """ops for working with named collections of crawls"""
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1265,7 +1265,7 @@ async def stats_recompute_all(crawl_configs, crawls, cid: UUID):
 
 
 # ============================================================================
-# pylint: disable=redefined-builtin,invalid-name,too-many-locals,too-many-arguments
+# pylint: disable=redefined-builtin,invalid-name,too-many-locals,too-many-arguments,too-many-positional-arguments
 def init_crawl_config_api(
     app,
     dbclient,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -76,7 +76,7 @@ DEFAULT_PROXY_ID: str | None = os.environ.get("DEFAULT_PROXY_ID")
 class CrawlConfigOps:
     """Crawl Config Operations"""
 
-    # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods, too-many-positional-arguments
 
     user_manager: UserManager
     org_ops: OrgOps

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -306,6 +306,9 @@ class CrawlManager(K8sAPI):
         storage_secret = storage.get_storage_secret_name(oid)
         storage_label = f"btrix.storage={storage_secret}"
 
+        # TODO: This is causing deletion of custom storage to fail
+        # even when it hasn't been used - why has this label been applied
+        # when no crawls or profiles have been created yet?
         if await self.has_custom_jobs_with_label("crawljobs", storage_label):
             raise HTTPException(status_code=400, detail="storage_in_use")
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -436,6 +436,22 @@ class CrawlManager(K8sAPI):
         """Delete all crawl configs by id"""
         await self._delete_crawl_configs(f"btrix.crawlconfig={cid}")
 
+    async def tail_background_job(self, job_id: str) -> str:
+        """Tail running background job pod"""
+        pods = await self.core_api.list_namespaced_pod(
+            namespace=self.namespace,
+            label_selector=f"batch.kubernetes.io/job-name={job_id}",
+        )
+
+        if not pods.items:
+            return ""
+
+        pod_name = pods.items[0].metadata.name
+
+        return await self.core_api.read_namespaced_pod_log(
+            pod_name, self.namespace, tail_lines=10
+        )
+
     # ========================================================================
     # Internal Methods
     async def _delete_crawl_configs(self, label) -> None:

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -21,7 +21,7 @@ DEFAULT_NAMESPACE: str = os.environ.get("DEFAULT_NAMESPACE", "default")
 
 
 # ============================================================================
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods, too-many-positional-arguments
 class CrawlManager(K8sAPI):
     """abstract crawl manager"""
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -306,9 +306,6 @@ class CrawlManager(K8sAPI):
         storage_secret = storage.get_storage_secret_name(oid)
         storage_label = f"btrix.storage={storage_secret}"
 
-        # TODO: This is causing deletion of custom storage to fail
-        # even when it hasn't been used - why has this label been applied
-        # when no crawls or profiles have been created yet?
         if await self.has_custom_jobs_with_label("crawljobs", storage_label):
             raise HTTPException(status_code=400, detail="storage_in_use")
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -72,7 +72,7 @@ DEFAULT_RANGE_LIMIT = 50
 
 
 # ============================================================================
-# pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods
+# pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods, too-many-positional-arguments
 class CrawlOps(BaseCrawlOps):
     """Crawl Ops"""
 
@@ -1115,7 +1115,7 @@ async def recompute_crawl_file_count_and_size(crawls, crawl_id: str):
 
 
 # ============================================================================
-# pylint: disable=too-many-arguments, too-many-locals, too-many-statements
+# pylint: disable=too-many-arguments, too-many-locals, too-many-statements, too-many-positional-arguments
 def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     """API for crawl management, including crawl done callback"""
     # pylint: disable=invalid-name, duplicate-code

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -87,7 +87,7 @@ async def ping_db(mdb) -> None:
 
 # ============================================================================
 async def update_and_prepare_db(
-    # pylint: disable=R0913
+    # pylint: disable=R0913, too-many-positional-arguments
     mdb: AsyncIOMotorDatabase,
     user_manager: UserManager,
     org_ops: OrgOps,
@@ -223,7 +223,7 @@ async def drop_indexes(mdb):
 
 
 # ============================================================================
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-positional-arguments
 async def create_indexes(
     org_ops,
     crawl_ops,

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -131,7 +131,7 @@ async def update_and_prepare_db(
 
 
 # ============================================================================
-# pylint: disable=too-many-locals, too-many-arguments
+# pylint: disable=too-many-locals, too-many-arguments, too-many-positional-arguments
 async def run_db_migrations(
     mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops
 ):

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -17,7 +17,7 @@ from .models import CreateReplicaJob, DeleteReplicaJob, Organization, InvitePend
 from .utils import is_bool, get_origin
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
+# pylint: disable=too-few-public-methods, too-many-instance-attributes, too-many-positional-arguments
 class EmailSender:
     """SMTP Email Sender"""
 

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -27,6 +27,7 @@ from .utils import is_bool, dt_now
 
 
 # ============================================================================
+# pylint: disable=too-many-positional-arguments
 class InviteOps:
     """invite users (optionally to an org), send emails and delete invites"""
 

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -328,7 +328,7 @@ class K8sAPI:
         """return true/false if any crawljobs or profilejobs
         match given label"""
         try:
-            await self.custom_api.list_namespaced_custom_object(
+            resp = await self.custom_api.list_namespaced_custom_object(
                 group="btrix.cloud",
                 version="v1",
                 namespace=self.namespace,
@@ -336,6 +336,9 @@ class K8sAPI:
                 label_selector=label,
                 limit=1,
             )
+            matching_items = resp.get("items", [])
+            if not matching_items:
+                return False
             return True
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -22,7 +22,7 @@ from .utils import get_templates_dir, dt_now
 
 
 # ============================================================================
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-positional-arguments
 class K8sAPI:
     """K8S API accessors"""
 

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -266,6 +266,8 @@ def main() -> None:
 
     org_ops.set_ops(base_crawl_ops, profiles, coll_ops, background_job_ops, page_ops)
 
+    storage_ops.set_ops(background_job_ops)
+
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)
 
     background_job_ops.set_ops(base_crawl_ops, profiles)

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -25,7 +25,6 @@ def main():
         )
         sys.exit(1)
 
-
     (
         org_ops,
         crawl_config_ops,

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -9,7 +9,6 @@ from .operator import init_operator_api
 from .ops import init_ops
 from .utils import register_exit_handler
 
-
 app_root = FastAPI()
 
 
@@ -25,6 +24,7 @@ def main():
              Kubernetes not detected (KUBERNETES_SERVICE_HOST is not set), Exiting"
         )
         sys.exit(1)
+
 
     (
         org_ops,

--- a/backend/btrixcloud/migrations/migration_0032_dupe_org_names.py
+++ b/backend/btrixcloud/migrations/migration_0032_dupe_org_names.py
@@ -54,7 +54,7 @@ class Migration(BaseMigration):
                     orgs_db, org_name_set, org_slug_set, name, org_dict.get("_id")
                 )
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     async def update_org_name_and_slug(
         self,
         orgs_db,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2692,6 +2692,13 @@ class UpdatedResponse(BaseModel):
 
 
 # ============================================================================
+class UpdatedResponseId(UpdatedResponse):
+    """Response for API endpoints that return updated + id"""
+
+    id: Optional[str] = None
+
+
+# ============================================================================
 class SuccessResponse(BaseModel):
     """Response for API endpoints that return success"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2570,6 +2570,7 @@ class BgJobType(str, Enum):
     RECALCULATE_ORG_STATS = "recalculate-org-stats"
     READD_ORG_PAGES = "readd-org-pages"
     OPTIMIZE_PAGES = "optimize-pages"
+    COPY_BUCKET = "copy-bucket"
 
 
 # ============================================================================
@@ -2588,7 +2589,7 @@ class BackgroundJob(BaseMongoModel):
 
 # ============================================================================
 class CreateReplicaJob(BackgroundJob):
-    """Model for tracking create of replica jobs"""
+    """Model for tracking creation of replica jobs"""
 
     type: Literal[BgJobType.CREATE_REPLICA] = BgJobType.CREATE_REPLICA
     file_path: str
@@ -2640,14 +2641,24 @@ class OptimizePagesJob(BackgroundJob):
 
 
 # ============================================================================
+class CopyBucketJob(BackgroundJob):
+    """Model for tracking job to copy entire s3 bucket"""
+
+    type: Literal[BgJobType.CREATE_REPLICA] = BgJobType.CREATE_REPLICA
+    prev_storage: StorageRef
+    new_storage: StorageRef
+
+
+# ============================================================================
 # Union of all job types, for response model
 
 AnyJob = RootModel[
     Union[
+        BackgroundJob,
         CreateReplicaJob,
         DeleteReplicaJob,
-        BackgroundJob,
         DeleteOrgJob,
+        CopyBucketJob,
         RecalculateOrgStatsJob,
         ReAddOrgPagesJob,
         OptimizePagesJob,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -693,11 +693,8 @@ class StorageRef(BaseModel):
         return f"storage-cs-{self.name}-{oid[:12]}"
 
     def get_storage_extra_path(self, oid: str) -> str:
-        """return extra path added to the endpoint
-        using oid for default storages, no extra path for custom"""
-        if not self.custom:
-            return oid + "/"
-        return ""
+        """return extra oid path added to the endpoint"""
+        return oid + "/"
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2687,6 +2687,14 @@ AnyJob = RootModel[
 
 
 # ============================================================================
+class JobProgress(BaseModel):
+    """Model for reporting background job progress"""
+
+    percentage: float
+    eta: Optional[str] = None
+
+
+# ============================================================================
 
 ### GENERIC RESPONSE MODELS ###
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1653,6 +1653,13 @@ class OrgStorageRefs(BaseModel):
 
 
 # ============================================================================
+class OrgAllStorages(BaseModel):
+    """Response model for listing all available storages"""
+
+    allStorages: List[StorageRef]
+
+
+# ============================================================================
 class S3StorageIn(BaseModel):
     """Custom S3 Storage input model"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1647,6 +1647,15 @@ class OrgStorageReplicaRefs(BaseModel):
 
 
 # ============================================================================
+class OrgStorageRefs(BaseModel):
+    """Model for org storage references"""
+
+    storage: StorageRef
+
+    storageReplicas: List[StorageRef] = []
+
+
+# ============================================================================
 class S3StorageIn(BaseModel):
     """Custom S3 Storage input model"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1633,12 +1633,17 @@ class OrgPublicCollections(BaseModel):
 
 
 # ============================================================================
-class OrgStorageRefs(BaseModel):
-    """Input model for setting primary storage + optional replicas"""
+class OrgStorageRef(BaseModel):
+    """Input model for setting primary storage"""
 
     storage: StorageRef
 
-    storageReplicas: List[StorageRef] = []
+
+# ============================================================================
+class OrgStorageReplicaRefs(BaseModel):
+    """Input model for setting replica storages"""
+
+    storageReplicas: List[StorageRef]
 
 
 # ============================================================================
@@ -2644,7 +2649,7 @@ class OptimizePagesJob(BackgroundJob):
 class CopyBucketJob(BackgroundJob):
     """Model for tracking job to copy entire s3 bucket"""
 
-    type: Literal[BgJobType.CREATE_REPLICA] = BgJobType.CREATE_REPLICA
+    type: Literal[BgJobType.COPY_BUCKET] = BgJobType.COPY_BUCKET
     prev_storage: StorageRef
     new_storage: StorageRef
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1669,6 +1669,7 @@ class S3StorageIn(BaseModel):
     bucket: str
     access_endpoint_url: Optional[str] = None
     region: str = ""
+    provider: str = "Other"
 
 
 # ============================================================================
@@ -1683,6 +1684,7 @@ class S3Storage(BaseModel):
     secret_key: str
     access_endpoint_url: str
     region: str = ""
+    provider: str = "Other"
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -136,7 +136,7 @@ class K8sOpAPI(K8sAPI):
         print("Auto-Resize Enabled", self.enable_auto_resize)
 
 
-# pylint: disable=too-many-instance-attributes, too-many-arguments
+# pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-positional-arguments
 # ============================================================================
 class BaseOperator:
     """BaseOperator"""

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -78,7 +78,7 @@ MEM_LIMIT_PADDING = 1.2
 
 
 # pylint: disable=too-many-public-methods, too-many-locals, too-many-branches, too-many-statements
-# pylint: disable=invalid-name, too-many-lines, too-many-return-statements
+# pylint: disable=invalid-name, too-many-lines, too-many-return-statements, too-many-positional-arguments
 # ============================================================================
 class CrawlOperator(BaseOperator):
     """CrawlOperator Handler"""

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -51,7 +51,7 @@ class CronJobOperator(BaseOperator):
             status=status,
         )
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     async def make_new_crawljob(
         self,
         cid: UUID,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -993,6 +993,15 @@ class OrgOps:
             "publicCollectionsCount": public_collections_count,
         }
 
+    async def is_crawl_running(self, oid: UUID) -> bool:
+        """Return boolean indicating whether any crawls are currently running in org"""
+        workflows_running_count = await self.crawls_db.count_documents(
+            {"oid": org.id, "state": {"$in": RUNNING_STATES}}
+        )
+        if workflows_running_count > 0:
+            return True
+        return False
+
     async def get_all_org_slugs(self) -> dict[str, list[str]]:
         """Return list of all org slugs."""
         slugs = await self.orgs.distinct("slug", {})

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -516,8 +516,8 @@ class OrgOps:
     ) -> None:
         """Update storage refs for all crawl and profile files in given org"""
         await self.crawls_db.update_many(
-            {"oid": org.id, "files.$.storage": dict(previous_storage)},
-            {"$set": {"files.$.storage": dict(new_storage)}},
+            {"oid": org.id},
+            {"$set": {"files.$[].storage": dict(new_storage)}},
         )
 
         await self.profiles_db.update_many(

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -574,7 +574,7 @@ class OrgOps:
     async def unset_file_presigned_urls(self, org: Organization) -> bool:
         """Unset all presigned URLs for files in org"""
         res = await self.crawls_db.update_many(
-            {"_id": org.id}, {"$set": {"files.$.presignedUrl": None}}
+            {"oid": org.id}, {"$set": {"files.$.presignedUrl": None}}
         )
         if not res:
             return False

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -111,7 +111,7 @@ DEL_ITEMS = 1000
 
 
 # ============================================================================
-# pylint: disable=too-many-public-methods, too-many-instance-attributes, too-many-locals, too-many-arguments
+# pylint: disable=too-many-public-methods, too-many-instance-attributes, too-many-locals, too-many-arguments, too-many-positional-arguments
 class OrgOps:
     """Organization API operations"""
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -547,8 +547,8 @@ class OrgOps:
     async def unset_file_presigned_urls(self, org: Organization) -> None:
         """Unset all presigned URLs for files in org"""
         await self.crawls_db.update_many(
-            {"oid": org.id, "files.$.presignedUrl": {"$ne": None}},
-            {"$set": {"files.$.presignedUrl": None}},
+            {"oid": org.id},
+            {"$set": {"files.$[].presignedUrl": None}},
         )
 
     async def update_subscription_data(

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -536,7 +536,7 @@ class OrgOps:
 
         await self.crawls_db.update_many(
             {"oid": org.id},
-            {verb: {"files.$.replicas": dict(storage_ref)}},
+            {verb: {"files.$[].replicas": dict(storage_ref)}},
         )
 
         await self.profiles_db.update_many(

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -516,15 +516,15 @@ class OrgOps:
     ) -> bool:
         """Update storage refs for all crawl and profile files in given org"""
         res = await self.crawls_db.update_many(
-            {"oid": org.id, "files.$.storage": previous_storage},
-            {"$set": {"files.$.storage": new_storage}},
+            {"oid": org.id, "files.$.storage": dict(previous_storage)},
+            {"$set": {"files.$.storage": dict(new_storage)}},
         )
         if not res:
             return False
 
         res = await self.profiles_db.update_many(
-            {"oid": org.id, "resource.storage": previous_storage},
-            {"$set": {"resource.storage": new_storage}},
+            {"oid": org.id, "resource.storage": dict(previous_storage)},
+            {"$set": {"resource.storage": dict(new_storage)}},
         )
         if not res:
             return False
@@ -537,14 +537,14 @@ class OrgOps:
         """Add replica storage ref for all files in given org"""
         res = await self.crawls_db.update_many(
             {"oid": org.id},
-            {"$push": {"files.$.replicas": new_storage}},
+            {"$push": {"files.$.replicas": dict(new_storage)}},
         )
         if not res:
             return False
 
         res = await self.profiles_db.update_many(
             {"oid": org.id},
-            {"$push": {"resource.replicas": new_storage}},
+            {"$push": {"resource.replicas": dict(new_storage)}},
         )
         if not res:
             return False
@@ -557,14 +557,14 @@ class OrgOps:
         """Remove replica storage ref from all files in given org"""
         res = await self.crawls_db.update_many(
             {"oid": org.id},
-            {"$pull": {"files.$.replicas": new_storage}},
+            {"$pull": {"files.$.replicas": dict(new_storage)}},
         )
         if not res:
             return False
 
         res = await self.profiles_db.update_many(
             {"oid": org.id},
-            {"$pull": {"resource.replicas": new_storage}},
+            {"$pull": {"resource.replicas": dict(new_storage)}},
         )
         if not res:
             return False
@@ -574,7 +574,8 @@ class OrgOps:
     async def unset_file_presigned_urls(self, org: Organization) -> bool:
         """Unset all presigned URLs for files in org"""
         res = await self.crawls_db.update_many(
-            {"oid": org.id}, {"$set": {"files.$.presignedUrl": None}}
+            {"oid": org.id, "files.$.presignedUrl": {"$ne": None}},
+            {"$set": {"files.$.presignedUrl": None}},
         )
         if not res:
             return False

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -52,7 +52,7 @@ else:
 
 
 # ============================================================================
-# pylint: disable=too-many-instance-attributes, too-many-arguments,too-many-public-methods
+# pylint: disable=too-many-instance-attributes, too-many-arguments,too-many-public-methods, too-many-positional-arguments
 class PageOps:
     """crawl pages"""
 
@@ -1013,7 +1013,7 @@ class PageOps:
 
 
 # ============================================================================
-# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme, too-many-positional-arguments
 def init_pages_api(
     app, mdb, crawl_ops, org_ops, storage_ops, background_job_ops, coll_ops, user_dep
 ) -> PageOps:

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -49,7 +49,7 @@ BROWSER_EXPIRE = 300
 
 
 # ============================================================================
-# pylint: disable=too-many-instance-attributes, too-many-arguments
+# pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-positional-arguments
 class ProfileOps:
     """Profile management"""
 
@@ -500,7 +500,7 @@ class ProfileOps:
 
 
 # ============================================================================
-# pylint: disable=redefined-builtin,invalid-name,too-many-locals,too-many-arguments
+# pylint: disable=redefined-builtin,invalid-name,too-many-locals,too-many-arguments, too-many-positional-arguments
 def init_profiles_api(
     mdb,
     org_ops: OrgOps,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -266,7 +266,7 @@ class StorageOps:
         except:
             raise HTTPException(status_code=400, detail="invalid_storage_ref")
 
-        if await self.org_ops.is_crawl_running(org.id):
+        if await self.org_ops.is_crawl_running(org):
             raise HTTPException(status_code=400, detail="crawl_running")
 
         prev_storage = org.storage

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -870,12 +870,6 @@ def init_storages_api(
     ):
         return await storage_ops.remove_custom_storage(name, org)
 
-    # TODO: Modify this to make it easier to change just the primary or replica locations
-    # without needing to explicitly pass the secrets for what we're not changing every time
-    # - Maybe make it a PATCH
-    # - Maybe split out into two endpoints
-    # - Add endpoint to reset to default so we don't have to pass secrets in POST request
-    # to remove custom storage?
     @router.post("/storage", tags=["organizations"], response_model=UpdatedResponse)
     async def update_storage_refs(
         storage: OrgStorageRefs,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -72,7 +72,7 @@ CHUNK_SIZE = 1024 * 256
 
 
 # ============================================================================
-# pylint: disable=broad-except,raise-missing-from
+# pylint: disable=broad-except,raise-missing-from,too-many-public-methods
 class StorageOps:
     """All storage handling, download/upload operations"""
 
@@ -106,7 +106,7 @@ class StorageOps:
         default_namespace = os.environ.get("DEFAULT_NAMESPACE", "default")
         self.frontend_origin = f"{frontend_origin}.{default_namespace}"
 
-        self.base_crawl_ops = cast(BackgroundJobOps, None)
+        self.background_job_ops = cast(BackgroundJobOps, None)
 
         with open(os.environ["STORAGES_JSON"], encoding="utf-8") as fh:
             storage_list = json.loads(fh.read())

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -264,16 +264,20 @@ class StorageOps:
         except:
             raise HTTPException(status_code=400, detail="invalid_storage_ref")
 
+        if org.storage == storage_ref:
+            raise HTTPException(status_code=400, detail="identical_storage_ref")
+
         if await self.org_ops.is_crawl_running(org):
             raise HTTPException(status_code=403, detail="crawl_running")
 
         if org.readOnly:
             raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
-        if org.storage == storage_ref:
-            raise HTTPException(status_code=400, detail="identical_storage_ref")
-
-        # TODO: Check that no CreateReplicaJobs are running
+        _, jobs_running_count = await self.background_job_ops.list_background_jobs(
+            org=org, success=None
+        )
+        if jobs_running_count > 0:
+            raise HTTPException(status_code=403, detail="background_jobs_running")
 
         prev_storage = org.storage
         org.storage = storage_ref
@@ -327,16 +331,20 @@ class StorageOps:
         except:
             raise HTTPException(status_code=400, detail="invalid_storage_ref")
 
+        if org.storageReplicas == replicas:
+            raise HTTPException(status_code=400, detail="identical_storage_ref")
+
         if await self.org_ops.is_crawl_running(org):
             raise HTTPException(status_code=403, detail="crawl_running")
 
         if org.readOnly:
             raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
-        if org.storageReplicas == replicas:
-            raise HTTPException(status_code=400, detail="identical_storage_ref")
-
-        # TODO: Check that no CreateReplicaJobs are running
+        _, jobs_running_count = await self.background_job_ops.list_background_jobs(
+            org=org, success=None
+        )
+        if jobs_running_count > 0:
+            raise HTTPException(status_code=403, detail="background_jobs_running")
 
         prev_storage_replicas = org.storageReplicas
         org.storageReplicas = replicas

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -274,7 +274,7 @@ class StorageOps:
             raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
         _, jobs_running_count = await self.background_job_ops.list_background_jobs(
-            org=org, success=None
+            org=org, success=None, finished=None
         )
         if jobs_running_count > 0:
             raise HTTPException(status_code=403, detail="background_jobs_running")
@@ -341,7 +341,7 @@ class StorageOps:
             raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
         _, jobs_running_count = await self.background_job_ops.list_background_jobs(
-            org=org, success=None
+            org=org, success=None, finished=None
         )
         if jobs_running_count > 0:
             raise HTTPException(status_code=403, detail="background_jobs_running")

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -174,6 +174,7 @@ class StorageOps:
             endpoint_url=endpoint_url,
             endpoint_no_bucket_url=endpoint_no_bucket_url,
             access_endpoint_url=access_endpoint_url,
+            provider=storage.get("provider", "Other"),
         )
 
     async def add_custom_storage(
@@ -198,7 +199,7 @@ class StorageOps:
             endpoint_url=endpoint_url,
             endpoint_no_bucket_url=endpoint_no_bucket_url,
             access_endpoint_url=storagein.access_endpoint_url or endpoint_url,
-            use_access_for_presign=True,
+            provider=storagein.provider,
         )
 
         try:
@@ -218,6 +219,7 @@ class StorageOps:
             "STORE_ACCESS_KEY": storage.access_key,
             "STORE_SECRET_KEY": storage.secret_key,
             "STORE_REGION": storage.region,
+            "STORE_PROVIDER": storage.provider,
         }
 
         await self.crawl_manager.add_org_storage(

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -12,6 +12,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     cast,
+    Callable,
 )
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
@@ -931,7 +932,7 @@ def _parse_json(line) -> dict:
 
 # ============================================================================
 def init_storages_api(
-    org_ops: OrgOps, crawl_manager: CrawlManager, app: APIRouter, mdb, user_dep
+    org_ops: OrgOps, crawl_manager: CrawlManager, app: APIRouter, mdb, user_dep: Callable
 ) -> StorageOps:
     """API for updating storage for an org"""
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -933,7 +933,11 @@ def _parse_json(line) -> dict:
 
 # ============================================================================
 def init_storages_api(
-    org_ops: OrgOps, crawl_manager: CrawlManager, app: APIRouter, mdb, user_dep: Callable
+    org_ops: OrgOps,
+    crawl_manager: CrawlManager,
+    app: APIRouter,
+    mdb,
+    user_dep: Callable,
 ) -> StorageOps:
     """API for updating storage for an org"""
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -369,10 +369,6 @@ class StorageOps:
             print("No files stored, no updates to do", flush=True)
             return
 
-        # TODO: Determine if we need to set read-only for replica operations
-        # (likely not?)
-        # await self.org_ops.update_read_only(org, True, "Updating storage replicas")
-
         # Replicate files to any new replica locations
         for replica_storage in new_replica_refs:
             if replica_storage not in prev_replica_refs:

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -72,7 +72,7 @@ CHUNK_SIZE = 1024 * 256
 
 
 # ============================================================================
-# pylint: disable=broad-except,raise-missing-from,too-many-public-methods
+# pylint: disable=broad-except,raise-missing-from,too-many-public-methods, too-many-positional-arguments
 class StorageOps:
     """All storage handling, download/upload operations"""
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -261,6 +261,21 @@ class StorageOps:
         org.storage = storage_refs.storage
         org.storageReplicas = storage_refs.storageReplicas
 
+        # TODO: Account for replication if there's stored content,
+        # we'll need to move it to the new bucket and update paths in the
+        # database accordingly (if any updates are needed, at minimum should
+        # probably re-generate presigned URLs?)
+        # If a replica location is added, we should replicate everything in
+        # primary storage into it
+        # If a replica location is removed, should we wait for content to
+        # be deleted before removing it, or assume that happens manually as
+        # necessary?
+
+        # We'll also need to make sure any running crawl, bg, or profile jobs
+        # that use this storage are completed first
+
+        # We can set the org to read-only while handling these details
+
         await self.org_ops.update_storage_refs(org)
 
         return {"updated": True}

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -952,7 +952,9 @@ def init_storages_api(
     router = org_ops.router
     org_owner_dep = org_ops.org_owner_dep
 
-    @router.get("/storage", tags=["organizations"], response_model=OrgStorageRefs)
+    @router.get(
+        "/storage", tags=["organizations", "storage"], response_model=OrgStorageRefs
+    )
     def get_storage_refs(
         org: Organization = Depends(org_owner_dep),
     ):
@@ -964,7 +966,9 @@ def init_storages_api(
         return OrgStorageRefs(storage=org.storage, storageReplicas=replica_refs)
 
     @router.get(
-        "/all-storages", tags=["organizations"], response_model=List[StorageRef]
+        "/all-storages",
+        tags=["organizations", "storage"],
+        response_model=List[StorageRef],
     )
     def get_available_storages(org: Organization = Depends(org_owner_dep)):
         return storage_ops.get_available_storages(org)
@@ -993,7 +997,9 @@ def init_storages_api(
         return {"success": True}
 
     @router.post(
-        "/custom-storage", tags=["organizations"], response_model=AddedResponseName
+        "/custom-storage",
+        tags=["organizations", "storage"],
+        response_model=AddedResponseName,
     )
     async def add_custom_storage(
         storage: S3StorageIn,
@@ -1006,7 +1012,9 @@ def init_storages_api(
         return await storage_ops.add_custom_storage(storage, org)
 
     @router.delete(
-        "/custom-storage/{name}", tags=["organizations"], response_model=DeletedResponse
+        "/custom-storage/{name}",
+        tags=["organizations", "storage"],
+        response_model=DeletedResponse,
     )
     async def remove_custom_storage(
         name: str,
@@ -1018,7 +1026,9 @@ def init_storages_api(
 
         return await storage_ops.remove_custom_storage(name, org)
 
-    @router.post("/storage", tags=["organizations"], response_model=UpdatedResponseId)
+    @router.post(
+        "/storage", tags=["organizations", "storage"], response_model=UpdatedResponseId
+    )
     async def update_storage_ref(
         storage: OrgStorageRef,
         background_tasks: BackgroundTasks,
@@ -1031,7 +1041,9 @@ def init_storages_api(
         return await storage_ops.update_storage_ref(storage, org, background_tasks)
 
     @router.post(
-        "/storage-replicas", tags=["organizations"], response_model=UpdatedResponse
+        "/storage-replicas",
+        tags=["organizations", "storage"],
+        response_model=UpdatedResponse,
     )
     async def update_storage_replica_refs(
         storage: OrgStorageReplicaRefs,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -412,7 +412,7 @@ class StorageOps:
             try:
                 resp = await client.put_object(Bucket=bucket, Key=key, Body=data)
                 assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
-            except:
+            except Exception:
                 # create bucket if it doesn't yet exist and then try again
                 resp = await client.create_bucket(Bucket=bucket)
                 assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -219,7 +219,7 @@ class StorageOps:
             "STORE_ACCESS_KEY": storage.access_key,
             "STORE_SECRET_KEY": storage.secret_key,
             "STORE_REGION": storage.region,
-            "STORE_PROVIDER": storage.provider,
+            "STORE_S3_PROVIDER": storage.provider,
         }
 
         await self.crawl_manager.add_org_storage(

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -293,7 +293,11 @@ class StorageOps:
         new_storage_refs: OrgStorageRefs,
         org: Organization,
     ):
-        """Handle tasks necessary after changing org storage"""
+        """Handle tasks necessary after changing org storage
+
+        This is a good candidate for a background job with access to ops
+        classes, which may kick off other background jobs as needed.
+        """
         if not await self.org_ops.has_files_stored(org):
             return
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -217,6 +217,7 @@ class StorageOps:
             "STORE_ENDPOINT_NO_BUCKET_URL": storage.endpoint_no_bucket_url,
             "STORE_ACCESS_KEY": storage.access_key,
             "STORE_SECRET_KEY": storage.secret_key,
+            "STORE_REGION": storage.region,
         }
 
         await self.crawl_manager.add_org_storage(
@@ -274,7 +275,7 @@ class StorageOps:
             raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
         _, jobs_running_count = await self.background_job_ops.list_background_jobs(
-            org=org, success=None, finished=None
+            org=org, running=True
         )
         if jobs_running_count > 0:
             raise HTTPException(status_code=403, detail="background_jobs_running")
@@ -341,7 +342,7 @@ class StorageOps:
             raise HTTPException(status_code=403, detail="org_set_to_read_only")
 
         _, jobs_running_count = await self.background_job_ops.list_background_jobs(
-            org=org, success=None, finished=None
+            org=org, running=True
         )
         if jobs_running_count > 0:
             raise HTTPException(status_code=403, detail="background_jobs_running")

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -983,23 +983,37 @@ def init_storages_api(
         "/custom-storage", tags=["organizations"], response_model=AddedResponseName
     )
     async def add_custom_storage(
-        storage: S3StorageIn, org: Organization = Depends(org_owner_dep)
+        storage: S3StorageIn,
+        org: Organization = Depends(org_owner_dep),
+        user: User = Depends(user_dep),
     ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
         return await storage_ops.add_custom_storage(storage, org)
 
     @router.delete(
         "/custom-storage/{name}", tags=["organizations"], response_model=DeletedResponse
     )
     async def remove_custom_storage(
-        name: str, org: Organization = Depends(org_owner_dep)
+        name: str,
+        org: Organization = Depends(org_owner_dep),
+        user: User = Depends(user_dep),
     ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
         return await storage_ops.remove_custom_storage(name, org)
 
     @router.post("/storage", tags=["organizations"], response_model=UpdatedResponse)
     async def update_storage_ref(
         storage: OrgStorageRef,
         org: Organization = Depends(org_owner_dep),
+        user: User = Depends(user_dep),
     ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
         return await storage_ops.update_storage_ref(storage, org)
 
     @router.post(
@@ -1008,7 +1022,11 @@ def init_storages_api(
     async def update_storage_replica_refs(
         storage: OrgStorageReplicaRefs,
         org: Organization = Depends(org_owner_dep),
+        user: User = Depends(user_dep),
     ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
         return await storage_ops.update_storage_replica_refs(storage, org)
 
     return storage_ops

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -236,7 +236,7 @@ class StorageOps:
     async def remove_custom_storage(
         self, name: str, org: Organization
     ) -> dict[str, bool]:
-        """remove custom storage"""
+        """Remove custom storage from org"""
         if org.storage.custom and org.storage.name == name:
             raise HTTPException(status_code=400, detail="storage_in_use")
 
@@ -263,7 +263,7 @@ class StorageOps:
         org: Organization,
         background_tasks: BackgroundTasks,
     ) -> dict[str, Union[bool, Optional[str]]]:
-        """update storage for org"""
+        """Update storage for org"""
         storage_ref = storage_refs.storage
 
         try:
@@ -301,9 +301,6 @@ class StorageOps:
             org, prev_storage_ref, storage_ref
         )
 
-        # This runs only two update_many mongo commands, so should be safe to run
-        # in a FastAPI background task rather than requiring a full Browsertrix
-        # Background job
         background_tasks.add_task(
             self._run_post_storage_update_tasks,
             org,
@@ -332,7 +329,7 @@ class StorageOps:
         org: Organization,
         background_tasks: BackgroundTasks,
     ) -> dict[str, bool]:
-        """update storage for org"""
+        """Update replica storage for org"""
 
         replicas = storage_refs.storageReplicas
 
@@ -362,11 +359,6 @@ class StorageOps:
 
         await self.org_ops.update_storage_refs(org, replicas=True)
 
-        # This only kicks off background jobs and runs a few update_many mongo
-        # commands, so it might be fine to keep as a FastAPI background job.
-        # Consider moving to a Browsertrix background job, but that may make
-        # retrying difficult as the job which would be retried also kicks off
-        # other background jobs which may have been successful already
         background_tasks.add_task(
             self._run_post_storage_replica_update_tasks,
             org,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -279,7 +279,9 @@ class StorageOps:
 
         asyncio.create_task(
             self.run_post_storage_update_tasks(
-                OrgStorageRefs(storage=prev_storage, storageReplicas=prev_storage_refs),
+                OrgStorageRefs(
+                    storage=prev_storage, storageReplicas=prev_storage_replicas
+                ),
                 storage_refs,
                 org,
             )

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -281,7 +281,7 @@ class StorageOps:
         await self.org_ops.update_storage_refs(org)
 
         # TODO: Consider running into asyncio task or background job
-        await self.run_post_storage_update_tasks(
+        await self._run_post_storage_update_tasks(
             prev_storage_ref,
             storage_ref,
             org,
@@ -289,7 +289,7 @@ class StorageOps:
 
         return {"updated": True}
 
-    async def run_post_storage_update_tasks(
+    async def _run_post_storage_update_tasks(
         self,
         prev_storage_ref: StorageRef,
         new_storage_ref: StorageRef,
@@ -344,13 +344,13 @@ class StorageOps:
         await self.org_ops.update_storage_refs(org, replicas=True)
 
         # TODO: Consider running in asyncio task or background job
-        await self.run_post_storage_replica_update_tasks(
+        await self._run_post_storage_replica_update_tasks(
             prev_storage_replicas, replicas, org
         )
 
         return {"updated": True}
 
-    async def run_post_storage_replica_update_tasks(
+    async def _run_post_storage_replica_update_tasks(
         self,
         prev_storage_refs: List[StorageRef],
         new_storage_refs: List[StorageRef],

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -845,10 +845,6 @@ def init_storages_api(
 
         return {"success": True}
 
-    # pylint: disable=unreachable, fixme
-    # todo: enable when ready to support custom storage
-    return storage_ops
-
     @router.post(
         "/customStorage", tags=["organizations"], response_model=AddedResponseName
     )

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -78,6 +78,7 @@ CHUNK_SIZE = 1024 * 256
 
 # ============================================================================
 # pylint: disable=broad-except,raise-missing-from,too-many-public-methods, too-many-positional-arguments
+# pylint: disable=too-many-lines,too-many-instance-attributes
 class StorageOps:
     """All storage handling, download/upload operations"""
 
@@ -932,6 +933,7 @@ def _parse_json(line) -> dict:
 
 
 # ============================================================================
+# pylint: disable=too-many-locals
 def init_storages_api(
     org_ops: OrgOps,
     crawl_manager: CrawlManager,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -381,12 +381,10 @@ class StorageOps:
                 )
                 await self.org_ops.add_file_replica_storage_refs(org, replica_storage)
 
-        # Delete files from previous replica locations that are no longer
-        # being used
+        # Delete no-longer-used replica storage refs from files
+        # TODO: Determine if we want to delete files from the buckets as well
         for replica_storage in prev_replica_refs:
             if replica_storage not in new_replica_refs:
-                # TODO: Background job to delete files with rclone delete?
-
                 await self.org_ops.remove_file_replica_storage_refs(
                     org, replica_storage
                 )

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -314,7 +314,8 @@ class StorageOps:
                 if bg_job.success:
                     break
                 if bg_job.success is False:
-                    # TODO: Handle failure case
+                    # TODO: Handle failure case, including partial failure
+                    # (i.e. some files but not all copied)
                     pass
 
                 time.sleep(5)
@@ -327,16 +328,32 @@ class StorageOps:
             await self.org_ops.update_read_only(org, False)
 
         if new_storage_refs.storageReplicas != prev_storage_refs.storageReplicas:
-            # If replica location added, kick off background jobs to replicate
-            # primary storage to new replica storage location (non-blocking)
+            # TODO: If we changed primary storage in this update, make sure that
+            # are files are successfully copied to new primary before doing
+            # anything with the replicas - this may be simple or complex depending
+            # on final approach taken to handle above
 
-            # If replica location is removed, start jobs to delete files from
-            # removed replica location (non-blocking)
+            # Replicate files to any new replica locations
+            for replica_storage in new_storage_refs.storageReplicas:
+                if replica_storage not in prev_storage_refs.storageReplicas:
+                    # TODO: Kick off background jobs to replicate primary
+                    # storage to new replica location
+                    print(
+                        "Not yet implemented: Replicate files to {replica_storage.name}",
+                        flush=True,
+                    )
 
-            # If we also changed primary storage in this update, we should make
-            # sure all files are successfully copied before doing anything to
-            # the replicas
-            pass
+            # Delete files from previous replica locations that are no longer
+            # being used
+            for replica_storage in prev_storage_refs.storageReplicas:
+                if replica_storage not in new_storage_refs.storageReplicas:
+                    # TODO: Kick off background jobs to delete replicas
+                    # (may be easier to just delete all files from bucket
+                    # in one rclone command)
+                    print(
+                        "Not yet implemented: Delete files from {replica_storage.name}",
+                        flush=True,
+                    )
 
     def get_available_storages(self, org: Organization) -> List[StorageRef]:
         """return a list of available default + custom storages"""

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -861,6 +861,10 @@ def init_storages_api(
     ):
         return await storage_ops.remove_custom_storage(name, org)
 
+    # TODO: Modify this to make it easier to change just the primary or replica locations
+    # without needing to explicitly pass the secrets for what we're not changing every time
+    # - Maybe make it a PATCH
+    # - Maybe split out into two endpoints
     @router.post("/storage", tags=["organizations"], response_model=UpdatedResponse)
     async def update_storage_refs(
         storage: OrgStorageRefs,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -51,6 +51,7 @@ from .models import (
     OrgStorageRefs,
     OrgStorageRef,
     OrgStorageReplicaRefs,
+    OrgAllStorages,
     DeletedResponse,
     UpdatedResponse,
     UpdatedResponseId,
@@ -397,14 +398,14 @@ class StorageOps:
                     org, replica_storage, remove=True
                 )
 
-    def get_available_storages(self, org: Organization) -> List[StorageRef]:
+    def get_available_storages(self, org: Organization) -> Dict[str, List[StorageRef]]:
         """return a list of available default + custom storages"""
         refs: List[StorageRef] = []
         for name in self.default_storages:
             refs.append(StorageRef(name=name, custom=False))
         for name in org.customStorages:
             refs.append(StorageRef(name=name, custom=True))
-        return refs
+        return {"allStorages": refs}
 
     @asynccontextmanager
     async def get_s3_client(
@@ -960,7 +961,7 @@ def init_storages_api(
     @router.get(
         "/all-storages",
         tags=["organizations", "storage"],
-        response_model=List[StorageRef],
+        response_model=OrgAllStorages,
     )
     def get_available_storages(org: Organization = Depends(org_owner_dep)):
         return storage_ops.get_available_storages(org)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -957,7 +957,11 @@ def init_storages_api(
         org: Organization = Depends(org_owner_dep),
     ):
         """get storage refs for an org"""
-        return OrgStorageRefs(storage=org.storage, storageReplicas=org.storageReplicas)
+        if org.storageReplicas:
+            replica_refs = org.storageReplicas
+        else:
+            replica_refs = storage_ops.default_replicas
+        return OrgStorageRefs(storage=org.storage, storageReplicas=replica_refs)
 
     @router.get(
         "/all-storages", tags=["organizations"], response_model=List[StorageRef]

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -56,6 +56,8 @@ external_subs_app_api_key = os.environ.get("BTRIX_SUBS_APP_API_KEY", "")
 class SubOps:
     """API for managing subscriptions. Only enabled if billing is enabled"""
 
+    # pylint: disable=too-many-positional-arguments
+
     org_ops: OrgOps
     user_manager: UserManager
 

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -334,7 +334,7 @@ class SubOps:
         return SubscriptionPortalUrlResponse()
 
 
-# pylint: disable=invalid-name,too-many-arguments
+# pylint: disable=invalid-name,too-many-arguments,too-many-positional-arguments
 def init_subs_api(
     app,
     mdb,

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -247,7 +247,7 @@ class UploadFileReader(BufferedReader):
 
 
 # ============================================================================
-# pylint: disable=too-many-arguments, too-many-locals, invalid-name
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, too-many-positional-arguments
 def init_uploads_api(app, user_dep, *args):
     """uploads api"""
 

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -47,7 +47,7 @@ class UploadOps(BaseCrawlOps):
         return UploadedCrawl.from_dict(res)
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-public-methods, too-many-function-args
-    # pylint: disable=too-many-arguments, too-many-locals, duplicate-code, invalid-name
+    # pylint: disable=too-many-positional-arguments, too-many-locals, duplicate-code, invalid-name
     async def upload_stream(
         self,
         stream,

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -327,7 +327,7 @@ class UserManager:
             user.email, token, dict(request.headers) if request else None
         )
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     async def create_user(
         self,
         name: str,

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -40,7 +40,7 @@ else:
 class EventWebhookOps:
     """Event webhook notification management"""
 
-    # pylint: disable=invalid-name, too-many-arguments, too-many-locals
+    # pylint: disable=invalid-name, too-many-arguments, too-many-locals, too-many-positional-arguments
 
     org_ops: OrgOps
     crawl_ops: CrawlOps
@@ -556,7 +556,7 @@ class EventWebhookOps:
         )
 
 
-# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme, too-many-positional-arguments
 def init_event_webhooks_api(mdb, org_ops, app):
     """init event webhooks system"""
     # pylint: disable=invalid-name

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -268,7 +268,10 @@ def test_add_custom_storage_doesnt_verify(admin_auth_headers):
         },
     )
     assert r.status_code == 400
-    assert r.json()["detail"] == "Could not verify custom storage. Check credentials are valid?"
+    assert (
+        r.json()["detail"]
+        == "Could not verify custom storage. Check credentials are valid?"
+    )
 
 
 def test_add_custom_storage(admin_auth_headers):
@@ -304,6 +307,16 @@ def test_add_custom_storage(admin_auth_headers):
     data = r.json()
     assert data["added"]
     assert data["name"] == CUSTOM_REPLICA_STORAGE_NAME
+
+    # verify custom storages are now available on org
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{new_oid}/all-storages",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    all_storages = r.json()["allStorages"]
+    assert {"name": CUSTOM_PRIMARY_STORAGE_NAME, "custom": True} in all_storages
+    assert {"name": CUSTOM_REPLICA_STORAGE_NAME, "custom": True} in all_storages
 
     # set org to use custom storage moving forward
     r = requests.post(

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -339,7 +339,10 @@ def test_remove_custom_storage(admin_auth_headers):
     r = requests.post(
         f"{API_PREFIX}/orgs/{new_oid}/storage",
         headers=admin_auth_headers,
-        json={"storage": {"name": CUSTOM_PRIMARY_STORAGE_NAME, "custom": True}},
+        json={
+            "storage": {"name": CUSTOM_PRIMARY_STORAGE_NAME, "custom": True},
+            "storageReplicas": [],
+        },
     )
 
     # Delete no longer used replica storage location

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -253,6 +253,24 @@ def test_change_storage_invalid(admin_auth_headers):
     assert r.status_code == 400
 
 
+def test_add_custom_storage_doesnt_verify(admin_auth_headers):
+    # verify that custom storage that can't be verified with
+    # a test file isn't added
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{new_oid}/custom-storage",
+        headers=admin_auth_headers,
+        json={
+            "name": "custom-bucket-doesnt-exist",
+            "access_key": "ADMIN",
+            "secret_key": "PASSW0RD",
+            "bucket": "custom-bucket-doesnt-exist",
+            "endpoint_url": "http://local-minio.default:9000/",
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Could not verify custom storage. Check credentials are valid?"
+
+
 def test_add_custom_storage(admin_auth_headers):
     # add custom storages
     r = requests.post(

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -86,11 +86,11 @@ spec:
         - name: RCLONE_CONFIG_NEW_ENDPOINT
           value: "{{ new_endpoint }}"
 
-        command: ["rclone", "-vv", "--progress", "copy", "--checksum", "prev:{{ prev_bucket }}{{ oid }}", "new:{{ new_bucket }}{{ oid }}"]
+        command: ["rclone", "-vv", "--progress", "copy", "--checksum", "--use-mmap", "--transfers=2", "--checkers=2", "prev:{{ prev_bucket }}{{ oid }}", "new:{{ new_bucket }}{{ oid }}"]
         resources:
           limits:
-            memory: "500Mi"
+            memory: "350Mi"
 
           requests:
-            memory: "500Mi"
+            memory: "350Mi"
             cpu: "50m"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -1,0 +1,96 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ id }}"
+  labels:
+    role: "background-job"
+    job_type: {{ job_type }}
+    btrix.org: {{ oid }}
+
+spec:
+  ttlSecondsAfterFinished: 0
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      priorityClassName: bg-job
+      podFailurePolicy:
+        rules:
+        - action: FailJob
+          onExitCodes:
+            containerName: rclone
+            operator: NotIn
+            values: [0]
+      containers:
+      - name: rclone
+        image: rclone/rclone:latest
+        env:
+
+        - name: RCLONE_CONFIG_PREV_TYPE
+          value: "s3"
+
+        - name: RCLONE_CONFIG_PREV_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ prev_secret_name }}"
+              key: STORE_ACCESS_KEY
+
+        - name: RCLONE_CONFIG_PREV_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ prev_secret_name }}"
+              key: STORE_SECRET_KEY
+
+        - name: RCLONE_CONFIG_PREV_REGION
+          valueFrom:
+            secretKeyRef:
+              name: "{{ prev_secret_name }}"
+              key: STORE_REGION
+
+        - name: RCLONE_CONFIG_PREV_PROVIDER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ prev_secret_name }}"
+              key: STORE_S3_PROVIDER
+
+        - name: RCLONE_CONFIG_PREV_ENDPOINT
+          value: "{{ prev_endpoint }}"
+
+        - name: RCLONE_CONFIG_NEW_TYPE
+          value: "s3"
+
+        - name: RCLONE_CONFIG_NEW_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ new_secret_name }}"
+              key: STORE_ACCESS_KEY
+
+        - name: RCLONE_CONFIG_NEW_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ new_secret_name }}"
+              key: STORE_SECRET_KEY
+
+        - name: RCLONE_CONFIG_NEW_REGION
+          valueFrom:
+            secretKeyRef:
+              name: "{{ new_secret_name }}"
+              key: STORE_REGION
+
+        - name: RCLONE_CONFIG_NEW_PROVIDER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ new_secret_name }}"
+              key: STORE_S3_PROVIDER
+
+        - name: RCLONE_CONFIG_NEW_ENDPOINT
+          value: "{{ new_endpoint }}"
+
+        command: ["rclone", "-vv", "copy", "--checksum", "prev:{{ prev_bucket }}", "new:{{ new_bucket }}"]
+        resources:
+          limits:
+            memory: "200Mi"
+
+          requests:
+            memory: "200Mi"
+            cpu: "50m"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -86,7 +86,7 @@ spec:
         - name: RCLONE_CONFIG_NEW_ENDPOINT
           value: "{{ new_endpoint }}"
 
-        command: ["rclone", "-vv", "--progress", "copy", "--checksum", "prev:{{ prev_bucket }}/{{ oid }}", "new:{{ new_bucket }}/{{ oid }}"]
+        command: ["rclone", "-vv", "--progress", "copy", "--checksum", "prev:{{ prev_bucket }}{{ oid }}", "new:{{ new_bucket }}{{ oid }}"]
         resources:
           limits:
             memory: "200Mi"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -8,7 +8,7 @@ metadata:
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 300
+  ttlSecondsAfterFinished: 60
   backoffLimit: 3
   template:
     spec:

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -86,7 +86,7 @@ spec:
         - name: RCLONE_CONFIG_NEW_ENDPOINT
           value: "{{ new_endpoint }}"
 
-        command: ["rclone", "-vv", "copy", "--checksum", "prev:{{ prev_bucket }}", "new:{{ new_bucket }}"]
+        command: ["rclone", "-vv", "copy", "--checksum", "prev:{{ prev_bucket }}/{{ oid }}", "new:{{ new_bucket }}/{{ oid }}"]
         resources:
           limits:
             memory: "200Mi"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -3,12 +3,13 @@ kind: Job
 metadata:
   name: "{{ id }}"
   labels:
+    job-id: "{{ id }}"
     role: "background-job"
     job_type: {{ job_type }}
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 60
+  ttlSecondsAfterFinished: 30
   backoffLimit: 3
   template:
     spec:
@@ -86,7 +87,7 @@ spec:
         - name: RCLONE_CONFIG_NEW_ENDPOINT
           value: "{{ new_endpoint }}"
 
-        command: ["rclone", "-vv", "--progress", "copy", "--checksum", "--use-mmap", "--transfers=2", "--checkers=2", "prev:{{ prev_bucket }}{{ oid }}", "new:{{ new_bucket }}{{ oid }}"]
+        command: ["rclone", "-v", "--stats-one-line", "--stats", "10s", "copy", "--checksum", "--use-mmap", "--transfers=2", "--checkers=2", "prev:{{ prev_bucket }}{{ oid }}", "new:{{ new_bucket }}{{ oid }}"]
         resources:
           limits:
             memory: "350Mi"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -89,8 +89,8 @@ spec:
         command: ["rclone", "-vv", "--progress", "copy", "--checksum", "prev:{{ prev_bucket }}{{ oid }}", "new:{{ new_bucket }}{{ oid }}"]
         resources:
           limits:
-            memory: "200Mi"
+            memory: "500Mi"
 
           requests:
-            memory: "200Mi"
+            memory: "500Mi"
             cpu: "50m"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -86,7 +86,7 @@ spec:
         - name: RCLONE_CONFIG_NEW_ENDPOINT
           value: "{{ new_endpoint }}"
 
-        command: ["rclone", "-vv", "copy", "--checksum", "prev:{{ prev_bucket }}/{{ oid }}", "new:{{ new_bucket }}/{{ oid }}"]
+        command: ["rclone", "-vv", "--progress", "copy", "--checksum", "prev:{{ prev_bucket }}/{{ oid }}", "new:{{ new_bucket }}/{{ oid }}"]
         resources:
           limits:
             memory: "200Mi"

--- a/chart/app-templates/copy_job.yaml
+++ b/chart/app-templates/copy_job.yaml
@@ -8,7 +8,7 @@ metadata:
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 300
   backoffLimit: 3
   template:
     spec:

--- a/frontend/docs/docs/deploy/admin/org-storage.md
+++ b/frontend/docs/docs/deploy/admin/org-storage.md
@@ -1,0 +1,74 @@
+# Org Storage
+
+This guide covers configuring storage for an organization in Browsertrix.
+
+By default, all organizations will use the default storage and default replica locations (if any are configured) set in the Helm chart.
+
+The Browsertrix API supports adding custom storage locations per organization and configuring the organization to use custom storages for primary and/or replica storage. These endpoints are available to superusers only.
+
+## Adding Custom Storage
+
+The first step to configuring custom storage with an organization is to add the S3 buckets to the organization, e.g.:
+
+```sh
+curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/custom-storage --data '{"name": "new-custom-storage", "access_key": "<access-key>", "secret_key": "<secret-key>", "bucket": "new-custom-storage", "endpoint_url": "https://s3-provider.example.com/"}'
+```
+
+Verify that the custom storage has been added to the organization by checking the `/all-storages` API endpoint:
+
+```sh
+curl -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/all-storages
+```
+
+The storage reference for our new custom storage should be present in the returned JSON, e.g.:
+
+```json
+{
+	"allStorages": [
+		{"name": "default", "custom": false},
+		{"name": "default-replica", "custom": false},
+		{"name": "new-custom-storage", "custom": true},
+	]
+}
+```
+
+The custom storage is now ready to be configured.
+
+
+## Updating Org Storage
+
+Each organization has one primary storage location. It is possible to configure the organization to use any of the storage options listed in the `/all-storages` API endpoint as primary storage, e.g.:
+
+```sh
+curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/storage --data '{"storage": {"name": "new-custom-storage", "custom": true}}'
+```
+
+If any crawls, uploads, or browser profiles have been created on the organization, modifying the primary storage will disable archiving on the organization while files are migrated from the previous to the new storage location. Archiving is re-enabled when the migration completes.
+
+At this time, all files are copied from the prior storage location to the new storage location, and are not automatically deleted from their source location.
+
+
+## Updating Org Replica Storage
+
+Each organization can have any number of replica storage locations. These locations serve as replicas of the content in the primary storage location, and are most commonly used as backups.
+
+It is possible to configure the organization to use any of the storage options listed in the `/all-storages` API endpoint as replica storage, e.g.:
+
+```sh
+curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/storage --data '{"storageReplicas": [{"name": "default-replica", "custom": false}, {"new-custom-storage": true}]}'
+```
+
+If any crawls, uploads, or browser profiles have been created on the organization, adding a new replica location will result in a background job to replicate all of the organization's files from primary storage to the new replica location. Unlike with updating primary storage, this process will not disable archiving on the organization.
+
+If any crawls, uploads, or browser profiles have been created on the organization, removing a previously used replica location will result in database updates to reflect that the prior replica location is no longer available. At this time, no files are automatically deleted from prior replica location.
+
+
+## Removing Custom Storage
+
+It is also possible to remove a custom storage from an organization, referencing the storage to be deleted's name in the API endpoint, e.g.:
+
+```sh
+curl -X DELETE -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/custom-storage/new-custom-storage
+```
+
+The custom storage location to be deleted must not be in use on the organization, or else the endpoint will return `400`. Default storage locations shared between organizations cannot be deleted with this endpoint.

--- a/frontend/docs/docs/deploy/admin/org-storage.md
+++ b/frontend/docs/docs/deploy/admin/org-storage.md
@@ -55,7 +55,7 @@ Each organization can have any number of replica storage locations. These locati
 It is possible to configure the organization to use any of the storage options listed in the `/all-storages` API endpoint as replica storage, e.g.:
 
 ```sh
-curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/storage --data '{"storageReplicas": [{"name": "default-replica", "custom": false}, {"new-custom-storage": true}]}'
+curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/storage-replicas --data '{"storageReplicas": [{"name": "default-replica", "custom": false}, {"new-custom-storage": true}]}'
 ```
 
 If any crawls, uploads, or browser profiles have been created on the organization, adding a new replica location will result in a background job to replicate all of the organization's files from primary storage to the new replica location. Unlike with updating primary storage, this process will not disable archiving on the organization.

--- a/frontend/docs/docs/deploy/admin/org-storage.md
+++ b/frontend/docs/docs/deploy/admin/org-storage.md
@@ -14,7 +14,7 @@ The first step to configuring custom storage with an organization is to add the 
 curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/custom-storage --data '{"name": "new-custom-storage", "access_key": "<access-key>", "secret_key": "<secret-key>", "bucket": "new-custom-storage", "endpoint_url": "https://s3-provider.example.com/"}'
 ```
 
-If desired, the `provider` field can be set to any of the [values supported by rclone for S3 providers](https://rclone.org/s3/#s3-provider). By default, this field is set to "Other", which should work for nearly all S3 storage providers. This value is used solely for migrations from rclone when updating org storage and/or replica locations.
+If desired, the `provider` field can be set to any of the [values supported by rclone for S3 providers](https://rclone.org/s3/#s3-provider). By default, this field is set to "Other", which should work for nearly all S3 storage providers. This value is used solely for migrating existing files with rclone when updating org storage and/or replica locations.
 
 Verify that the custom storage has been added to the organization by checking the `/all-storages` API endpoint:
 

--- a/frontend/docs/docs/deploy/admin/org-storage.md
+++ b/frontend/docs/docs/deploy/admin/org-storage.md
@@ -14,6 +14,8 @@ The first step to configuring custom storage with an organization is to add the 
 curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt token>" https://app.browsertrix.com/api/orgs/<org-id>/custom-storage --data '{"name": "new-custom-storage", "access_key": "<access-key>", "secret_key": "<secret-key>", "bucket": "new-custom-storage", "endpoint_url": "https://s3-provider.example.com/"}'
 ```
 
+If desired, the `provider` field can be set to any of the [values supported by rclone for S3 providers](https://rclone.org/s3/#s3-provider). By default, this field is set to "Other", which should work for nearly all S3 storage providers. This value is used solely for migrations from rclone when updating org storage and/or replica locations.
+
 Verify that the custom storage has been added to the organization by checking the `/all-storages` API endpoint:
 
 ```sh

--- a/frontend/docs/docs/deploy/admin/org-storage.md
+++ b/frontend/docs/docs/deploy/admin/org-storage.md
@@ -45,7 +45,7 @@ curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt 
 
 If any crawls, uploads, or browser profiles have been created on the organization, modifying the primary storage will disable archiving on the organization while files are migrated from the previous to the new storage location. Archiving is re-enabled when the migration completes.
 
-At this time, all files are copied from the prior storage location to the new storage location, and are not automatically deleted from their source location.
+At this time, all files are copied from the previous storage location to the new storage location, and are not automatically deleted from their source location.
 
 
 ## Updating Org Replica Storage
@@ -60,7 +60,7 @@ curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer <jwt 
 
 If any crawls, uploads, or browser profiles have been created on the organization, adding a new replica location will result in a background job to replicate all of the organization's files from primary storage to the new replica location. Unlike with updating primary storage, this process will not disable archiving on the organization.
 
-If any crawls, uploads, or browser profiles have been created on the organization, removing a previously used replica location will result in database updates to reflect that the prior replica location is no longer available. At this time, no files are automatically deleted from prior replica location.
+If any crawls, uploads, or browser profiles have been created on the organization, removing a previously used replica location will result in database updates to reflect that the prior replica location is no longer available. At this time, no files are automatically deleted from the removed replica location.
 
 
 ## Removing Custom Storage

--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Administration:
           - deploy/admin/upgrade-notes.md
           - deploy/admin/org-import-export.md
+          - deploy/admin/org-storage.md
   - Development:
       - develop/index.md
       - develop/local-dev-setup.md


### PR DESCRIPTION
Fixes #578 

## Adds

- API endpoints for adding and deleting custom storages on organizations
- API endpoints for updating primary and/or replica storage for an org
- API endpoint to check on progress of background job (currently, only bucket copy jobs are supported)
- Automated hooks to copy an organization's files from previous s3 bucket to new and update files in database when primary storage is changed
- Automated hooks to replicate content from primary storage to new replica location and update files in the database when a replica location is set on an org
- Admin documentation for adding, removing, and configuring custom storage locations on an organization

## Notes

Currently, no delete operations happen for a a bucket previously used as a primary or replica location that is unset. Files are copied to the new bucket to ensure there are no usability issues moving forward in the app, but the files are not automatically deleted from the source after the copy job. We could add that but I wonder if it's safer, especially in the early days of testing, to perform that cleanup manually as desired.

Once we're comfortable, we can change the rclone command in the `copy_job.yaml` background job template from `copy` to `move` if we want it to automatically clean up files from the source location on completion.

**Since the same template is used for copying files from an old primary storage to a new primary storage as well as to replicate from primary storage to a new replica location, we'd want to make sure the latter still uses `copy` so as not to delete files from the primary storage location, perhaps through use of a conditional.**
