### PR TITLE
Save new workflow scope type preference

### DIFF
--- a/frontend/src/features/crawl-workflows/new-workflow-dialog.ts
+++ b/frontend/src/features/crawl-workflows/new-workflow-dialog.ts
@@ -3,11 +3,13 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import type { FormState as WorkflowFormState } from "@/utils/workflow";
+import { WorkflowScopeType } from "@/types/workflow";
 import seededCrawlSvg from "~assets/images/new-crawl-config_Seeded-Crawl.svg";
 import urlListSvg from "~assets/images/new-crawl-config_URL-List.svg";
 
-export type SelectJobTypeEvent = CustomEvent<WorkflowFormState["scopeType"]>;
+export type SelectJobTypeEvent = CustomEvent<
+  (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType]
+>;
 
 /**
  * @event select-job-type SelectJobTypeEvent
@@ -33,8 +35,8 @@ export class NewWorkflowDialog extends TailwindElement {
             @click=${() => {
               this.dispatchEvent(
                 new CustomEvent("select-job-type", {
-                  detail: "page-list",
-                }) as SelectJobTypeEvent,
+                  detail: WorkflowScopeType.PageList,
+                }),
               );
             }}
           >
@@ -63,7 +65,7 @@ export class NewWorkflowDialog extends TailwindElement {
             @click=${() => {
               this.dispatchEvent(
                 new CustomEvent("select-job-type", {
-                  detail: "prefix",
+                  detail: WorkflowScopeType.Prefix,
                 }) as SelectJobTypeEvent,
               );
             }}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -67,6 +67,7 @@ import {
 import { maxLengthValidator } from "@/utils/form";
 import { getLocale } from "@/utils/localization";
 import { isArchivingDisabled } from "@/utils/orgs";
+import { AppStateService } from "@/utils/state";
 import { regexEscape } from "@/utils/string";
 import { tw } from "@/utils/tailwind";
 import {
@@ -1710,6 +1711,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
       } else if (isPageScope) {
         formState.urlList = [this.formState.primarySeedUrl, ...urls].join("\n");
       }
+    }
+
+    if (!this.configId) {
+      // Remember scope type for new workflows
+      AppStateService.partialUpdateUserPreferences({
+        newWorkflowScopeType: value,
+      });
     }
 
     this.updateFormState(formState);

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -540,8 +540,6 @@ export class Org extends LiteElement {
       @select-job-type=${(e: SelectJobTypeEvent) => {
         this.openDialogName = undefined;
 
-        console.log("e.detail:", e.detail);
-
         if (e.detail !== this.appState.userPreferences?.newWorkflowScopeType) {
           AppStateService.partialUpdateUserPreferences({
             newWorkflowScopeType: e.detail,

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -539,6 +539,15 @@ export class Org extends LiteElement {
       @select-new-dialog=${this.onSelectNewDialog}
       @select-job-type=${(e: SelectJobTypeEvent) => {
         this.openDialogName = undefined;
+
+        console.log("e.detail:", e.detail);
+
+        if (e.detail !== this.appState.userPreferences?.newWorkflowScopeType) {
+          AppStateService.partialUpdateUserPreferences({
+            newWorkflowScopeType: e.detail,
+          });
+        }
+
         this.navTo(`${this.orgBasePath}/workflows/new`, {
           scopeType: e.detail,
         });

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -219,9 +219,12 @@ export class WorkflowsList extends LiteElement {
                   <sl-button
                     variant="primary"
                     size="small"
-                    href="${this.orgBasePath}/workflows/new"
                     ?disabled=${this.org?.readOnly}
-                    @click=${this.navLink}
+                    @click=${() =>
+                      this.navTo(`${this.orgBasePath}/workflows/new`, {
+                        scopeType:
+                          this.appState.userPreferences?.newWorkflowScopeType,
+                      })}
                   >
                     <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                     ${msg("New Workflow")}</sl-button

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -8,35 +8,9 @@ import { ScopeType, type Seed, type WorkflowParams } from "./types";
 
 import type { UserGuideEventMap } from "@/index";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
+import { WorkflowScopeType } from "@/types/workflow";
 import LiteElement, { html } from "@/utils/LiteElement";
 import type { FormState as WorkflowFormState } from "@/utils/workflow";
-
-const defaultValue = {
-  name: "",
-  description: null,
-  profileid: null,
-  schedule: "",
-  config: {
-    seeds: [],
-    scopeType: ScopeType.Page,
-    exclude: [],
-    behaviorTimeout: null,
-    pageLoadTimeout: null,
-    pageExtraDelay: null,
-    postLoadDelay: null,
-    useSitemap: false,
-    failOnFailedSeed: false,
-    userAgent: null,
-  },
-  tags: [],
-  crawlTimeout: null,
-  maxCrawlSize: null,
-  jobType: "custom",
-  scale: 1,
-  autoAddCollections: [],
-  crawlerChannel: "default",
-  proxyId: null,
-} as WorkflowParams;
 
 /**
  * Usage:
@@ -58,6 +32,35 @@ export class WorkflowsNew extends LiteElement {
 
   @property({ type: Object })
   initialWorkflow?: WorkflowParams;
+
+  private get defaultNewWorkflow(): WorkflowParams {
+    return {
+      name: "",
+      description: null,
+      profileid: null,
+      schedule: "",
+      config: {
+        scopeType: (this.appState.userPreferences?.newWorkflowScopeType ||
+          WorkflowScopeType.Page) as ScopeType,
+        exclude: [],
+        behaviorTimeout: null,
+        pageLoadTimeout: null,
+        pageExtraDelay: null,
+        postLoadDelay: null,
+        useSitemap: false,
+        failOnFailedSeed: false,
+        userAgent: null,
+      },
+      tags: [],
+      crawlTimeout: null,
+      maxCrawlSize: null,
+      jobType: "custom",
+      scale: 1,
+      autoAddCollections: [],
+      crawlerChannel: "default",
+      proxyId: null,
+    };
+  }
 
   private renderBreadcrumbs() {
     const breadcrumbs: Breadcrumb[] = [
@@ -103,7 +106,7 @@ export class WorkflowsNew extends LiteElement {
       </header>
       ${when(this.org, (org) => {
         const initialWorkflow = mergeDeep(
-          defaultValue,
+          this.defaultNewWorkflow,
           {
             profileid: org.crawlingDefaults?.profileid,
             config: {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { accessCodeSchema } from "./org";
-import { NewWorkflowOnlyScopeType } from "./workflow";
+import { WorkflowScopeType } from "./workflow";
 
 export const userOrgSchema = z.object({
   default: z.boolean().optional(),
@@ -47,6 +47,6 @@ export const userInfoSchema = z.object({
 export type UserInfo = z.infer<typeof userInfoSchema>;
 
 export const userPreferencesSchema = z.object({
-  newWorkflowScopeType: z.nativeEnum(NewWorkflowOnlyScopeType),
+  newWorkflowScopeType: z.nativeEnum(WorkflowScopeType).optional(),
 });
 export type UserPreferences = z.infer<typeof userPreferencesSchema>;

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { accessCodeSchema } from "./org";
+import { NewWorkflowOnlyScopeType } from "./workflow";
 
 export const userOrgSchema = z.object({
   default: z.boolean().optional(),
@@ -44,3 +45,8 @@ export const userInfoSchema = z.object({
   orgs: z.array(userOrgSchema),
 });
 export type UserInfo = z.infer<typeof userInfoSchema>;
+
+export const userPreferencesSchema = z.object({
+  newWorkflowScopeType: z.nativeEnum(NewWorkflowOnlyScopeType),
+});
+export type UserPreferences = z.infer<typeof userPreferencesSchema>;

--- a/frontend/src/utils/state.ts
+++ b/frontend/src/utils/state.ts
@@ -1,6 +1,7 @@
 /**
  * Store and access application-wide state
  */
+import { mergeDeep } from "immutable";
 import { locked, options, transaction, use } from "lit-shared-state";
 
 import { persist } from "./persist";
@@ -125,10 +126,21 @@ export function makeAppStateService() {
 
     @transaction()
     @unlock()
-    updateUserPreferences(userPreferences: AppState["userPreferences"]) {
+    partialUpdateUserPreferences(
+      userPreferences: Partial<AppState["userPreferences"]>,
+    ) {
       userPreferencesSchema.nullable().parse(userPreferences);
 
-      appState.userPreferences = userPreferences;
+      if (appState.userPreferences && userPreferences) {
+        appState.userPreferences = mergeDeep(
+          appState.userPreferences,
+          userPreferences,
+        );
+      } else {
+        appState.userPreferences = userPreferences;
+      }
+
+      console.log("appState.userPreferences:", appState.userPreferences);
     }
 
     @transaction()
@@ -170,6 +182,7 @@ export function makeAppStateService() {
     private _resetUser() {
       appState.auth = null;
       appState.userInfo = null;
+      appState.userPreferences = null;
       appState.orgSlug = null;
       appState.org = undefined;
     }

--- a/frontend/src/utils/state.ts
+++ b/frontend/src/utils/state.ts
@@ -7,7 +7,13 @@ import { persist } from "./persist";
 
 import { authSchema, type Auth } from "@/types/auth";
 import type { OrgData } from "@/types/org";
-import { userInfoSchema, type UserInfo, type UserOrg } from "@/types/user";
+import {
+  userInfoSchema,
+  userPreferencesSchema,
+  type UserInfo,
+  type UserOrg,
+  type UserPreferences,
+} from "@/types/user";
 import type { AppSettings } from "@/utils/app";
 import { isAdmin, isCrawler } from "@/utils/orgs";
 
@@ -28,11 +34,15 @@ export function makeAppStateService() {
     @options(persist(window.sessionStorage))
     userInfo: UserInfo | null = null;
 
+    @options(persist(window.localStorage))
+    userPreferences: UserPreferences | null = null;
+
     // TODO persist here
     auth: Auth | null = null;
 
     // Store org slug in local storage in order to redirect
     // to the most recently visited org on next log in
+    // TODO move to `userPreferences`
     @options(persist(window.localStorage))
     orgSlug: string | null = null;
 
@@ -111,6 +121,14 @@ export function makeAppStateService() {
       ) {
         appState.orgSlug = userInfo.orgs[0].slug;
       }
+    }
+
+    @transaction()
+    @unlock()
+    updateUserPreferences(userPreferences: AppState["userPreferences"]) {
+      userPreferencesSchema.nullable().parse(userPreferences);
+
+      appState.userPreferences = userPreferences;
     }
 
     @transaction()

--- a/frontend/src/utils/state.ts
+++ b/frontend/src/utils/state.ts
@@ -63,7 +63,7 @@ export function makeAppStateService() {
           )) ||
         null;
 
-      if (!userOrg) {
+      if (appState.userInfo && !userOrg) {
         console.debug("no user org matching slug in state");
       }
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2091

<!-- Fixes #issue_number -->

### Changes

Saves scope type chosen from "+ New Workflow" dropdown to local storage.

### Manual testing

1. Log in as crawler
2. Go to "Crawling"
3. Select scope type from "+ New Workflow" dropdown
4. Refresh page. Verify scope type selection persists
5. Change scope type. Refresh. Verify scope type selection persists
6. Go back to "Crawling" and click "+ New Workflow". Verify last scope type is selected
7. Close all browser tabs
8. Log back in
9. Repeat and verify step 6
10. Log out and log back in
11. Verify scope type selection is reset to "Single Page"