### PR TITLE
Stopped crawls should not show stop/cancel buttons

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -140,8 +140,8 @@ export class ArchivedItemDetail extends BtrixElement {
 
   private timerId?: number;
 
-  private get isActive(): boolean | null {
-    if (!this.item || this.item.type !== "crawl") return null;
+  private get isActive(): boolean {
+    if (!this.item || this.item.type !== "crawl") return false;
     return isActive(this.item);
   }
 

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -29,12 +29,8 @@ export const DEPTH_SUPPORTED_SCOPES = [
   "any",
 ];
 
-export function isActive({ state }: Partial<Crawl | QARun>): boolean {
-  return (
-    (state &&
-      (activeCrawlStates as readonly string[]).includes(state as string)) ||
-    false
-  );
+export function isActive({ state }: Partial<Crawl | QARun>) {
+  return (activeCrawlStates as readonly (typeof state)[]).includes(state);
 }
 
 export function isSuccessfullyFinished({ state }: { state: string }) {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -29,11 +29,11 @@ export const DEPTH_SUPPORTED_SCOPES = [
   "any",
 ];
 
-export function isActive({ state, stopping }: Partial<Crawl | QARun>) {
+export function isActive({ state }: Partial<Crawl | QARun>): boolean {
   return (
     (state &&
       (activeCrawlStates as readonly string[]).includes(state as string)) ||
-    stopping === true
+    false
   );
 }
 


### PR DESCRIPTION
- crawler isActive() should only look at running states, not 'stopping', since stopping may not be reset to false after crawl is stopped (probably should reset, but also a record that the crawl ended as being stopped). crawl is guaranteed to remain in one of the active states while stopping on the backend
- fixes #2100 

Testing:
- Check a stopped crawl, confirm stop/cancel buttons no longer show up.