### PR TITLE
ui: fix missing click handler on QA review 'cancel' button

### DIFF
--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -688,7 +688,9 @@ export class ArchivedItemQA extends BtrixElement {
         </form>
 
         <div slot="footer" class="flex justify-between">
-          <sl-button size="small">${msg("Cancel")}</sl-button>
+          <sl-button size="small" @click=${() => void this.reviewDialog?.hide()}
+            >${msg("Cancel")}</sl-button
+          >
           <sl-button
             variant="primary"
             size="small"


### PR DESCRIPTION
quick fix: add a handler to close the dialog as expected