### PR TITLE
fix: firstOrgAdmin being set to true even if invite was not for an admin

### DIFF
--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -292,7 +292,7 @@ class InviteOps:
         invite_out.orgName = org.name
         invite_out.orgSlug = org.slug
 
-        if include_first_org_admin:
+        if include_first_org_admin and invite.role >= UserRole.OWNER:
             invite_out.firstOrgAdmin = True
             for role in org.users.values():
                 if role == UserRole.OWNER:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -102,7 +102,7 @@ class InviteOut(BaseModel):
     orgSlug: Optional[str] = None
     role: UserRole = UserRole.VIEWER
     email: Optional[EmailStr] = None
-    firstOrgAdmin: Optional[bool] = None
+    firstOrgAdmin: bool = False
 
 
 # ============================================================================

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -334,6 +334,7 @@ def test_get_pending_org_invites(
     assert invite["oid"] == non_default_org_id
     assert invite["created"]
     assert invite["role"]
+    assert invite["firstOrgAdmin"] == False
 
     # Delete Invites
     r = requests.post(

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -216,7 +216,7 @@ def test_pending_invite_new_user(admin_auth_headers, default_org_id):
         assert invite["oid"] == default_org_id
         assert invite["created"]
         assert invite["role"]
-        assert invite["firstOrgAdmin"] == None
+        assert invite["firstOrgAdmin"] == False
 
 
 def test_new_user_token():
@@ -382,7 +382,7 @@ def test_pending_invite_existing_user(admin_auth_headers, non_default_org_id):
     assert invite["oid"] == non_default_org_id
     assert invite["created"]
     assert invite["role"]
-    assert invite["firstOrgAdmin"] == None
+    assert invite["firstOrgAdmin"] == False
 
 
 def test_pending_invites_crawler(crawler_auth_headers, default_org_id):
@@ -512,6 +512,7 @@ def test_non_superadmin_admin_can_invite(default_org_id):
     assert not data["fromSuperuser"]
     assert data["inviterEmail"] == VALID_USER_EMAIL
     assert data["inviterName"] == "valid"
+    assert data["firstOrgAdmin"] == False
 
 
 def test_forgot_password():


### PR DESCRIPTION
Non-admin users should not be given option to rename org when invited to a new org:
- set firstOrgAdmin to true only when invite is for an admin
- default to false instead of null
- update tests to check