### PR TITLE
Fix nightly tests: Add boto3 as test requirement

### DIFF
--- a/backend/test-requirements.txt
+++ b/backend/test-requirements.txt
@@ -2,3 +2,4 @@
 
 pytest
 requests
+boto3


### PR DESCRIPTION
One more for you @ikreymer, looks like we removed `boto3`, which the nightly tests were using, so adding it back to the test requirements only.