### PR TITLE
Move org storage recalculation into background job

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -118,7 +118,7 @@ class CrawlManager(K8sAPI):
         backend_image: str,
         pull_policy: str,
         existing_job_id: Optional[str] = None,
-    ):
+    ) -> str:
         """run job to delete org and all of its data"""
 
         if existing_job_id:
@@ -126,10 +126,46 @@ class CrawlManager(K8sAPI):
         else:
             job_id = f"delete-org-{oid}-{secrets.token_hex(5)}"
 
+        return await self._run_bg_job_with_ops_classes(
+            oid, backend_image, pull_policy, job_id, job_type=BgJobType.DELETE_ORG.value
+        )
+
+    async def run_recalculate_org_stats_job(
+        self,
+        oid: str,
+        backend_image: str,
+        pull_policy: str,
+        existing_job_id: Optional[str] = None,
+    ) -> str:
+        """run job to delete org and all of its data"""
+
+        if existing_job_id:
+            job_id = existing_job_id
+        else:
+            job_id = f"org-stats-{oid}-{secrets.token_hex(5)}"
+
+        return await self._run_bg_job_with_ops_classes(
+            oid,
+            backend_image,
+            pull_policy,
+            job_id,
+            job_type=BgJobType.RECALCULATE_ORG_STATS.value,
+        )
+
+    async def _run_bg_job_with_ops_classes(
+        self,
+        oid: str,
+        backend_image: str,
+        pull_policy: str,
+        job_id: str,
+        job_type: str,
+    ) -> str:
+        """run background job with access to ops classes"""
+
         params = {
             "id": job_id,
             "oid": oid,
-            "job_type": BgJobType.DELETE_ORG.value,
+            "job_type": job_type,
             "backend_image": backend_image,
             "pull_policy": pull_policy,
         }

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -137,7 +137,7 @@ class CrawlManager(K8sAPI):
         pull_policy: str,
         existing_job_id: Optional[str] = None,
     ) -> str:
-        """run job to delete org and all of its data"""
+        """run job to recalculate storage stats for the org"""
 
         if existing_job_id:
             job_id = existing_job_id

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2014,6 +2014,7 @@ class BgJobType(str, Enum):
     CREATE_REPLICA = "create-replica"
     DELETE_REPLICA = "delete-replica"
     DELETE_ORG = "delete-org"
+    RECALCULATE_ORG_STATS = "recalculate-org-stats"
 
 
 # ============================================================================
@@ -2060,10 +2061,23 @@ class DeleteOrgJob(BackgroundJob):
 
 
 # ============================================================================
+class RecalculateOrgStatsJob(BackgroundJob):
+    """Model for tracking jobs to recalculate org stats"""
+
+    type: Literal[BgJobType.RECALCULATE_ORG_STATS] = BgJobType.RECALCULATE_ORG_STATS
+
+
+# ============================================================================
 # Union of all job types, for response model
 
 AnyJob = RootModel[
-    Union[CreateReplicaJob, DeleteReplicaJob, BackgroundJob, DeleteOrgJob]
+    Union[
+        CreateReplicaJob,
+        DeleteReplicaJob,
+        BackgroundJob,
+        DeleteOrgJob,
+        RecalculateOrgStatsJob,
+    ]
 ]
 
 
@@ -2217,6 +2231,13 @@ class SuccessResponse(BaseModel):
     """Response for API endpoints that return success"""
 
     success: bool
+
+
+# ============================================================================
+class SuccessResponseId(SuccessResponse):
+    """Response for API endpoints that return success and a background job id"""
+
+    id: Optional[str] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -71,7 +71,7 @@ from .models import (
     UpdatedResponse,
     AddedResponse,
     AddedResponseId,
-    SuccessResponse,
+    SuccessResponseId,
     OrgInviteResponse,
     OrgAcceptInviteResponse,
     OrgDeleteInviteResponse,
@@ -1588,10 +1588,13 @@ def init_orgs_api(
         return {"updated": True}
 
     @router.post(
-        "/recalculate-storage", tags=["organizations"], response_model=SuccessResponse
+        "/recalculate-storage",
+        tags=["organizations"],
+        response_model=SuccessResponseId,
     )
     async def recalculate_org_storage(org: Organization = Depends(org_owner_dep)):
-        return await ops.recalculate_storage(org)
+        job_id = await ops.background_job_ops.create_recalculate_org_stats_job(org)
+        return {"success": True, "id": job_id}
 
     @router.post("/invite", tags=["invites"], response_model=OrgInviteResponse)
     async def invite_user_to_org(

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -11,9 +11,9 @@ MAX_ATTEMPTS = 24
 
 
 @pytest.fixture(scope="module")
-def qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
+def qa_run_id(qa_crawl_id, crawler_auth_headers, default_org_id):
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/start",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/start",
         headers=crawler_auth_headers,
     )
 
@@ -26,14 +26,12 @@ def qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
 
 
 @pytest.fixture(scope="module")
-def qa_run_pages_ready(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_id
-):
+def qa_run_pages_ready(qa_crawl_id, crawler_auth_headers, default_org_id, qa_run_id):
     # Wait until activeQA is finished
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/activeQA",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/activeQA",
             headers=crawler_auth_headers,
         )
 
@@ -51,7 +49,7 @@ def qa_run_pages_ready(
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/pages",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/pages",
             headers=crawler_auth_headers,
         )
         if len(r.json()["items"]) > 0:
@@ -65,9 +63,9 @@ def qa_run_pages_ready(
 
 
 @pytest.fixture(scope="module")
-def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
+def failed_qa_run_id(qa_crawl_id, crawler_auth_headers, default_org_id):
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/start",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/start",
         headers=crawler_auth_headers,
     )
 
@@ -81,7 +79,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/activeQA",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/activeQA",
             headers=crawler_auth_headers,
         )
 
@@ -97,7 +95,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
 
     # Ensure can't start another QA job while this one's running
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/start",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/start",
         headers=crawler_auth_headers,
     )
 
@@ -106,7 +104,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
 
     # Ensure activeQA responds as expected
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/activeQA",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/activeQA",
         headers=crawler_auth_headers,
     )
 
@@ -125,7 +123,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
-    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["id"] == qa_crawl_id
     assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
     assert crawls[0]["lastQAStarted"]
@@ -137,7 +135,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
-    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["id"] == qa_crawl_id
     assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
     assert crawls[0]["lastQAStarted"]
@@ -149,7 +147,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
-    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["id"] == qa_crawl_id
     assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
     assert crawls[0]["lastQAStarted"]
@@ -161,14 +159,14 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     crawls = r.json()["items"]
-    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["id"] == qa_crawl_id
     assert crawls[0]["activeQAStats"]
     assert crawls[0]["lastQAState"]
     assert crawls[0]["lastQAStarted"]
 
     # Cancel crawl
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/cancel",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/cancel",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -178,7 +176,7 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa",
             headers=crawler_auth_headers,
         )
         assert r.status_code == 200
@@ -202,10 +200,10 @@ def failed_qa_run_id(crawler_crawl_id, crawler_auth_headers, default_org_id):
 
 
 def test_qa_completed(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_pages_ready
+    qa_crawl_id, crawler_auth_headers, default_org_id, qa_run_pages_ready
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa",
         headers=crawler_auth_headers,
     )
 
@@ -224,10 +222,10 @@ def test_qa_completed(
 
 
 def test_qa_org_stats(
-    crawler_crawl_id, crawler_auth_headers, default_org_id, qa_run_pages_ready
+    qa_crawl_id, crawler_auth_headers, default_org_id, qa_run_pages_ready
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}",
         headers=crawler_auth_headers,
     )
     crawl_stats = r.json()
@@ -245,14 +243,14 @@ def test_qa_org_stats(
 
 
 def test_qa_page_data(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     qa_run_id,
     qa_run_pages_ready,
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/pages",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/pages",
         headers=crawler_auth_headers,
     )
     data = r.json()
@@ -263,47 +261,47 @@ def test_qa_page_data(
     assert page_id
 
     assert page["title"] == "Webrecorder"
-    assert page["url"] == "https://webrecorder.net/"
+    assert page["url"] == "https://old.webrecorder.net/"
     assert page["mime"] == "text/html"
     assert page["status"] == 200
     assert page["qa"]["textMatch"] == 1.0
     assert page["qa"]["screenshotMatch"] == 1.0
     assert page["qa"]["resourceCounts"] == {
-        "crawlGood": 16,
+        "crawlGood": 14,
         "crawlBad": 0,
-        "replayGood": 15,
+        "replayGood": 13,
         "replayBad": 1,
     }
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/pages/{page_id}",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/pages/{page_id}",
         headers=crawler_auth_headers,
     )
     page = r.json()
     assert page["id"]
     assert page["title"] == "Webrecorder"
-    assert page["url"] == "https://webrecorder.net/"
+    assert page["url"] == "https://old.webrecorder.net/"
     assert page["mime"] == "text/html"
     assert page["status"] == 200
     assert page["qa"]["textMatch"] == 1.0
     assert page["qa"]["screenshotMatch"] == 1.0
     assert page["qa"]["resourceCounts"] == {
-        "crawlGood": 16,
+        "crawlGood": 14,
         "crawlBad": 0,
-        "replayGood": 15,
+        "replayGood": 13,
         "replayBad": 1,
     }
 
 
 def test_qa_replay(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     qa_run_id,
     qa_run_pages_ready,
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/replay.json",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/replay.json",
         headers=crawler_auth_headers,
     )
     data = r.json()
@@ -312,7 +310,7 @@ def test_qa_replay(
 
 
 def test_qa_stats(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     qa_run_id,
@@ -321,7 +319,7 @@ def test_qa_stats(
     # We'll want to improve this test by having more pages to test
     # if we can figure out stable page scores to test against
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0.7,0.9&textThresholds=0.7,0.9",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0.7,0.9&textThresholds=0.7,0.9",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -340,7 +338,7 @@ def test_qa_stats(
 
     # Test we get expected results with explicit 0 boundary
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0,0.7,0.9&textThresholds=0,0.7,0.9",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0,0.7,0.9&textThresholds=0,0.7,0.9",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -359,7 +357,7 @@ def test_qa_stats(
 
     # Test that missing threshold values result in 422 HTTPException
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0.7",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0.7",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 422
@@ -367,7 +365,7 @@ def test_qa_stats(
 
     # Test that invalid threshold values result in 400 HTTPException
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0.7&textThresholds=null",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/stats?screenshotThresholds=0.7&textThresholds=null",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 400
@@ -375,7 +373,7 @@ def test_qa_stats(
 
 
 def test_run_qa_not_running(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     failed_qa_run_id,
@@ -385,7 +383,7 @@ def test_run_qa_not_running(
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/activeQA",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/activeQA",
             headers=crawler_auth_headers,
         )
         data = r.json()
@@ -400,7 +398,7 @@ def test_run_qa_not_running(
 
     # Try to stop when there's no running QA run
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/stop",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/stop",
         headers=crawler_auth_headers,
     )
 
@@ -409,7 +407,7 @@ def test_run_qa_not_running(
 
 
 def test_failed_qa_run(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     failed_qa_run_id,
@@ -417,7 +415,7 @@ def test_failed_qa_run(
 ):
     # Ensure failed QA run is included in list endpoint
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa",
         headers=crawler_auth_headers,
     )
 
@@ -435,7 +433,7 @@ def test_failed_qa_run(
 
     # Ensure failed QA run not included in list endpoint with skipFailed param
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa?skipFailed=true",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa?skipFailed=true",
         headers=crawler_auth_headers,
     )
 
@@ -454,7 +452,7 @@ def test_failed_qa_run(
 
 
 def test_sort_crawls_by_qa_runs(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     failed_qa_run_id,
@@ -468,13 +466,13 @@ def test_sort_crawls_by_qa_runs(
     assert r.status_code == 200
     crawls = r.json()["items"]
 
-    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["id"] == qa_crawl_id
     qa_run_count = crawls[0]["qaRunCount"]
     assert qa_run_count > 0
 
     last_count = qa_run_count
     for crawl in crawls:
-        if crawl["id"] == crawler_crawl_id:
+        if crawl["id"] == qa_crawl_id:
             continue
         crawl_qa_count = crawl["qaRunCount"]
         assert isinstance(crawl_qa_count, int)
@@ -489,12 +487,12 @@ def test_sort_crawls_by_qa_runs(
     assert r.status_code == 200
     crawls = r.json()["items"]
 
-    assert crawls[-1]["id"] == crawler_crawl_id
+    assert crawls[-1]["id"] == qa_crawl_id
     assert crawls[-1]["qaRunCount"] > 0
 
     last_count = 0
     for crawl in crawls:
-        if crawl["id"] == crawler_crawl_id:
+        if crawl["id"] == qa_crawl_id:
             continue
         crawl_qa_count = crawl["qaRunCount"]
         assert isinstance(crawl_qa_count, int)
@@ -509,13 +507,13 @@ def test_sort_crawls_by_qa_runs(
     assert r.status_code == 200
     crawls = r.json()["items"]
 
-    assert crawls[0]["id"] == crawler_crawl_id
+    assert crawls[0]["id"] == qa_crawl_id
     qa_run_count = crawls[0]["qaRunCount"]
     assert qa_run_count > 0
 
     last_count = qa_run_count
     for crawl in crawls:
-        if crawl["id"] == crawler_crawl_id:
+        if crawl["id"] == qa_crawl_id:
             continue
         crawl_qa_count = crawl["qaRunCount"]
         assert isinstance(crawl_qa_count, int)
@@ -530,12 +528,12 @@ def test_sort_crawls_by_qa_runs(
     assert r.status_code == 200
     crawls = r.json()["items"]
 
-    assert crawls[-1]["id"] == crawler_crawl_id
+    assert crawls[-1]["id"] == qa_crawl_id
     assert crawls[-1]["qaRunCount"] > 0
 
     last_count = 0
     for crawl in crawls:
-        if crawl["id"] == crawler_crawl_id:
+        if crawl["id"] == qa_crawl_id:
             continue
         crawl_qa_count = crawl["qaRunCount"]
         assert isinstance(crawl_qa_count, int)
@@ -544,7 +542,7 @@ def test_sort_crawls_by_qa_runs(
 
 
 def test_download_wacz_crawls(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     qa_run_id,
@@ -552,7 +550,7 @@ def test_download_wacz_crawls(
 ):
     with TemporaryFile() as fh:
         with requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/download",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/download",
             headers=crawler_auth_headers,
             stream=True,
         ) as r:
@@ -571,7 +569,7 @@ def test_download_wacz_crawls(
 
 
 def test_delete_qa_runs(
-    crawler_crawl_id,
+    qa_crawl_id,
     crawler_auth_headers,
     default_org_id,
     qa_run_id,
@@ -580,7 +578,7 @@ def test_delete_qa_runs(
 ):
     # Get download links for QA WACZs
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run_id}/replay.json",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run_id}/replay.json",
         headers=crawler_auth_headers,
     )
     data = r.json()
@@ -589,7 +587,7 @@ def test_delete_qa_runs(
 
     # Delete QA runs
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/delete",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/delete",
         json={"qa_run_ids": [qa_run_id, failed_qa_run_id]},
         headers=crawler_auth_headers,
     )
@@ -601,7 +599,7 @@ def test_delete_qa_runs(
     count = 0
     while count < MAX_ATTEMPTS:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa",
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa",
             headers=crawler_auth_headers,
         )
 
@@ -623,7 +621,7 @@ def test_delete_qa_runs(
         count = 0
         while count < MAX_ATTEMPTS:
             r = requests.get(
-                f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/qa/{qa_run}/pages",
+                f"{API_PREFIX}/orgs/{default_org_id}/crawls/{qa_crawl_id}/qa/{qa_run}/pages",
                 headers=crawler_auth_headers,
             )
             data = r.json()

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -46,7 +46,7 @@ def test_create_new_config(admin_auth_headers, default_org_id):
     crawl_data = {
         "runNow": False,
         "name": "Test Crawl",
-        "config": {"seeds": [{"url": "https://webrecorder.net/"}]},
+        "config": {"seeds": [{"url": "https://old.webrecorder.net/"}]},
     }
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
@@ -70,7 +70,7 @@ def test_start_crawl(admin_auth_headers, default_org_id):
         "description": "Admin Test Crawl description",
         "tags": ["wr-test-1", "wr-test-2"],
         "config": {
-            "seeds": [{"url": "https://webrecorder.net/", "depth": 1}],
+            "seeds": [{"url": "https://old.webrecorder.net/", "depth": 1}],
             "exclude": "community",
             # limit now set via 'max_pages_per_crawl' global limit
             # "limit": 1,
@@ -231,7 +231,7 @@ def test_crawls_include_seed_info(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert data["firstSeed"] == "https://webrecorder.net/"
+    assert data["firstSeed"] == "https://old.webrecorder.net/"
     assert data["seedCount"] == 1
 
     r = requests.get(
@@ -266,7 +266,7 @@ def test_crawl_seeds_endpoint(admin_auth_headers, default_org_id):
 
     data = r.json()
     assert data["total"] == 1
-    assert data["items"][0]["url"] == "https://webrecorder.net/"
+    assert data["items"][0]["url"] == "https://old.webrecorder.net/"
     assert data["items"][0]["depth"] == 1
 
 
@@ -363,14 +363,14 @@ def test_verify_wacz():
 
     # 1 seed page
     pages = z.open("pages/pages.jsonl").read().decode("utf-8")
-    assert '"https://webrecorder.net/"' in pages
+    assert '"https://old.webrecorder.net/"' in pages
 
     # 1 seed page + header line
     assert len(pages.strip().split("\n")) == 2
 
     # 1 other page
     pages = z.open("pages/extraPages.jsonl").read().decode("utf-8")
-    assert '"https://webrecorder.net/blog"' in pages
+    assert '"https://old.webrecorder.net/blog"' in pages
 
     # 3 other page + header line
     assert len(pages.strip().split("\n")) == 4

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -512,7 +512,7 @@ def test_get_all_crawls_by_first_seed(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 4
+    assert data["total"] == 3
     for item in data["items"]:
         assert item["firstSeed"] == first_seed
 
@@ -527,7 +527,7 @@ def test_get_all_crawls_by_type(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 4
+    assert data["total"] == 5
     for item in data["items"]:
         assert item["type"] == "crawl"
 
@@ -559,7 +559,7 @@ def test_get_all_crawls_by_user(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 4
+    assert data["total"] == 5
     for item in data["items"]:
         assert item["userid"] == crawler_userid
 
@@ -631,9 +631,9 @@ def test_sort_all_crawls(
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 8
+    assert data["total"] >= 9
     items = data["items"]
-    assert len(items) == 8
+    assert len(items) >= 9
 
     last_created = None
     for crawl in items:
@@ -743,18 +743,22 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 6
+    assert len(data["names"]) == 7
     expected_names = [
         "Crawler User Test Crawl",
         "My Upload Updated",
         "test2.wacz",
         "All Crawls Test Crawl",
+        "Crawler User Crawl for Testing QA",
     ]
     for expected_name in expected_names:
         assert expected_name in data["names"]
 
     assert sorted(data["descriptions"]) == ["Lorem ipsum"]
-    assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
+    assert sorted(data["firstSeeds"]) == [
+        "https://old.webrecorder.net/",
+        "https://webrecorder.net/",
+    ]
 
     # Test filtering by crawls
     r = requests.get(
@@ -764,16 +768,21 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 3
+    assert len(data["names"]) == 4
     expected_names = [
-        "Crawler User Test Crawl",
+        "Admin Test Crawl",
         "All Crawls Test Crawl",
+        "Crawler User Crawl for Testing QA",
+        "Crawler User Test Crawl",
     ]
     for expected_name in expected_names:
         assert expected_name in data["names"]
 
     assert sorted(data["descriptions"]) == ["Lorem ipsum"]
-    assert sorted(data["firstSeeds"]) == ["https://webrecorder.net/"]
+    assert sorted(data["firstSeeds"]) == [
+        "https://old.webrecorder.net/",
+        "https://webrecorder.net/",
+    ]
 
     # Test filtering by uploads
     r = requests.get(

--- a/backend/test/test_z_delete_org.py
+++ b/backend/test/test_z_delete_org.py
@@ -88,6 +88,7 @@ def test_delete_org_superadmin(admin_auth_headers, default_org_id):
     assert data["deleted"]
 
     job_id = data["id"]
+    assert job_id
 
     # Check that background job is launched and eventually succeeds
     max_attempts = 18

--- a/backend/test/test_z_delete_org.py
+++ b/backend/test/test_z_delete_org.py
@@ -11,7 +11,37 @@ def test_recalculate_org_storage(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["success"]
+    data = r.json()
+    assert data["success"]
+
+    job_id = data["id"]
+    assert job_id
+
+    # Check that background job is launched and eventually succeeds
+    max_attempts = 18
+    attempts = 1
+    while True:
+        try:
+            r = requests.get(
+                f"{API_PREFIX}/orgs/all/jobs/{job_id}", headers=admin_auth_headers
+            )
+            assert r.status_code == 200
+            success = r.json()["success"]
+
+            if success:
+                break
+
+            if success is False:
+                assert False
+
+            if attempts >= max_attempts:
+                assert False
+
+            time.sleep(10)
+        except:
+            pass
+
+        attempts += 1
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}",


### PR DESCRIPTION
Fixes #2112 

- Moves org storage recalculation to background job, modify endpoint to return job id as part of response
- Updates crawl + QA backend tests that broke due to https://webrecorder.net website changes

Not moving org import over to a background job yet as we hadn't firmly decided to do that and it seems likely to take more time to figure out mounting the JSON to import into the background job container than I wanted to spend on this for this sprint.
