### PR TITLE
Add missing navigation button icons

### DIFF
--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -206,6 +206,18 @@ export class OrgSettings extends BtrixElement {
         @click=${this.navigate.link}
         aria-selected=${isActive}
       >
+        ${choose(name, [
+          [
+            "information",
+            () => html`<sl-icon name="info-circle-fill"></sl-icon>`,
+          ],
+          ["members", () => html`<sl-icon name="people-fill"></sl-icon>`],
+          ["billing", () => html`<sl-icon name="credit-card-fill"></sl-icon>`],
+          [
+            "crawling-defaults",
+            () => html`<sl-icon name="file-code-fill"></sl-icon>`,
+          ],
+        ])}
         ${this.tabLabels[name]}
       </btrix-navigation-button>
     `;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -2,6 +2,7 @@ import { localized, msg, str } from "@lit/localize";
 import type { SlSelect } from "@shoelace-style/shoelace";
 import { type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
@@ -566,6 +567,15 @@ export class WorkflowDetail extends LiteElement {
           if (disabled) e.preventDefault();
         }}
       >
+        ${choose(tabName, [
+          [
+            "crawls",
+            () => html`<sl-icon name="gear-wide-connected"></sl-icon>`,
+          ],
+          ["watch", () => html`<sl-icon name="eye-fill"></sl-icon>`],
+          ["logs", () => html`<sl-icon name="terminal-fill"></sl-icon>`],
+          ["settings", () => html`<sl-icon name="file-code-fill"></sl-icon>`],
+        ])}
         ${this.tabLabels[tabName]}
       </btrix-navigation-button>
     `;


### PR DESCRIPTION
### Changes
- Adds navigation button icons to the workflow details and org settings pages

### Screenshots

<img width="514" alt="Screenshot 2024-11-12 at 2 27 05 AM" src="https://github.com/user-attachments/assets/e303e85a-a2d1-4513-8fdd-4578028ebb6f">

<img width="612" alt="Screenshot 2024-11-12 at 2 44 49 AM" src="https://github.com/user-attachments/assets/97f65b48-5aca-40e7-921c-71687f554960">
