### PR TITLE
fix: Collection deletion dialog visibility

### DIFF
--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -160,8 +160,12 @@ export class CollectionsList extends BtrixElement {
       <btrix-dialog
         .label=${msg("Delete Collection?")}
         ?open=${this.openDialogName === "delete"}
+        @sl-show=${() => (this.isDialogVisible = true)}
         @sl-hide=${() => (this.openDialogName = undefined)}
-        @sl-after-hide=${() => (this.isDialogVisible = false)}
+        @sl-after-hide=${() => {
+          this.isDialogVisible = false;
+          this.selectedCollection = undefined;
+        }}
       >
         ${when(
           this.isDialogVisible,
@@ -678,7 +682,6 @@ export class CollectionsList extends BtrixElement {
         },
       );
 
-      this.selectedCollection = undefined;
       void this.fetchCollections();
 
       this.notify.toast({


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2150

## Changes

Fixes collection deletion dialog rendering empty content.

## Manual testing

1. Log in and crawler
2. Go to "Collections"
3. Click action. menu for collection and choose "Delete Collection". Verify dialog is shown with correct content

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collections | <img width="520" alt="Screenshot 2024-11-12 at 3 58 21 PM" src="https://github.com/user-attachments/assets/5006027f-25d0-419d-99b1-95ae16308203"> |


<!-- ## Follow-ups -->
