### PR TITLE
fix: Update collection deletion confirmation buttons

### DIFF
--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -188,7 +188,7 @@ export class CollectionDetail extends BtrixElement {
           >
           <sl-button
             size="small"
-            variant="primary"
+            variant="danger"
             @click=${async () => {
               await this.deleteCollection();
               this.openDialogName = undefined;

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -182,7 +182,7 @@ export class CollectionsList extends BtrixElement {
               >
               <sl-button
                 size="small"
-                variant="primary"
+                variant="danger"
                 @click=${async () => {
                   await this.deleteCollection(this.selectedCollection!);
                   this.openDialogName = undefined;


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2153

## Changes

Sets correct variant for deletion confirmation

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection Detail | <img width="506" alt="Screenshot 2024-11-13 at 2 57 33 PM" src="https://github.com/user-attachments/assets/4cd5b623-d913-4f42-bda5-e448fba1955d"> |


<!-- ## Follow-ups -->
