### PR TITLE
fix: Fix app not loading for browsers without `adoptedStyleSheets` support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "broadcastchannel-polyfill": "^1.0.1",
     "clsx": "^2.1.0",
     "color": "^4.0.1",
+    "construct-style-sheets-polyfill": "^3.1.0",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.3.0",
     "date-fns": "^3.6.0",

--- a/frontend/src/classes/TailwindElement.ts
+++ b/frontend/src/classes/TailwindElement.ts
@@ -14,6 +14,11 @@ export class TailwindElement extends LitElement {
     // thanks to `postcss-lit`.
     //
     // [^1]: (see https://tailwindcss.com/docs/adding-custom-styles#using-css-and-layer),
-    this.shadowRoot?.adoptedStyleSheets.push(theme);
+    if (this.shadowRoot) {
+      this.shadowRoot.adoptedStyleSheets = [
+        ...this.shadowRoot.adoptedStyleSheets,
+        theme,
+      ];
+    }
   }
 }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -10,6 +10,7 @@ import { when } from "lit/directives/when.js";
 import isEqual from "lodash/fp/isEqual";
 
 import "broadcastchannel-polyfill";
+import "construct-style-sheets-polyfill";
 import "./utils/polyfills";
 
 import type { OrgTab } from "./pages/org";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3557,6 +3557,11 @@ connect-history-api-fallback@^2.0.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
 
+construct-style-sheets-polyfill@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz#c490abd79efdb359fafa62ec14ea55232be0eecf"
+  integrity sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==
+
 content-disposition@0.5.4, content-disposition@~0.5.2:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2149

## Changes

Adds polyfill for `replaceSync` and `adoptedStyleSheets` support.

## Manual testing

Open app in browser emulator that's older than a browser/version listed in the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets#browser_compatibility) and very it loads. I tested with a Safari 16.2 emulator on my macbook.