### PR TITLE
Make changes to collections to support publicly listed collections

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -89,7 +89,7 @@ class CollectionOps:
             name=coll_in.name,
             description=coll_in.description,
             modified=modified,
-            isPublic=coll_in.isPublic,
+            visibility=coll_in.visibility,
         )
         try:
             await self.collections.insert_one(coll.to_dict())
@@ -189,7 +189,7 @@ class CollectionOps:
         """Get collection by id"""
         query: dict[str, object] = {"_id": coll_id}
         if public_only:
-            query["isPublic"] = True
+            query["visibility"] = {"$in": ["public", "unlisted"]}
 
         result = await self.collections.find_one(query)
         if not result:
@@ -210,6 +210,7 @@ class CollectionOps:
         sort_direction: int = 1,
         name: Optional[str] = None,
         name_prefix: Optional[str] = None,
+        visibility: Optional[str] = None,
     ):
         """List all collections for org"""
         # pylint: disable=too-many-locals, duplicate-code
@@ -225,6 +226,9 @@ class CollectionOps:
         elif name_prefix:
             regex_pattern = f"^{name_prefix}"
             match_query["name"] = {"$regex": regex_pattern, "$options": "i"}
+
+        if visibility:
+            match_query["visibility"] = visibility
 
         aggregate = [{"$match": match_query}]
 
@@ -427,6 +431,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
         sortDirection: int = 1,
         name: Optional[str] = None,
         namePrefix: Optional[str] = None,
+        visibility: Optional[str] = None,
     ):
         collections, total = await colls.list_collections(
             org.id,
@@ -436,6 +441,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
             sort_direction=sortDirection,
             name=name,
             name_prefix=namePrefix,
+            visibility=visibility,
         )
         return paginated_format(collections, total, page, pageSize)
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -89,7 +89,7 @@ class CollectionOps:
             name=coll_in.name,
             description=coll_in.description,
             modified=modified,
-            visibility=coll_in.visibility,
+            access=coll_in.access,
         )
         try:
             await self.collections.insert_one(coll.to_dict())
@@ -189,7 +189,7 @@ class CollectionOps:
         """Get collection by id"""
         query: dict[str, object] = {"_id": coll_id}
         if public_only:
-            query["visibility"] = {"$in": ["public", "unlisted"]}
+            query["access"] = {"$in": ["public", "unlisted"]}
 
         result = await self.collections.find_one(query)
         if not result:
@@ -210,7 +210,7 @@ class CollectionOps:
         sort_direction: int = 1,
         name: Optional[str] = None,
         name_prefix: Optional[str] = None,
-        visibility: Optional[str] = None,
+        access: Optional[str] = None,
     ):
         """List all collections for org"""
         # pylint: disable=too-many-locals, duplicate-code
@@ -227,8 +227,8 @@ class CollectionOps:
             regex_pattern = f"^{name_prefix}"
             match_query["name"] = {"$regex": regex_pattern, "$options": "i"}
 
-        if visibility:
-            match_query["visibility"] = visibility
+        if access:
+            match_query["access"] = access
 
         aggregate = [{"$match": match_query}]
 
@@ -431,7 +431,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
         sortDirection: int = 1,
         name: Optional[str] = None,
         namePrefix: Optional[str] = None,
-        visibility: Optional[str] = None,
+        access: Optional[str] = None,
     ):
         collections, total = await colls.list_collections(
             org.id,
@@ -441,7 +441,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
             sort_direction=sortDirection,
             name=name,
             name_prefix=namePrefix,
-            visibility=visibility,
+            access=access,
         )
         return paginated_format(collections, total, page, pageSize)
 

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -17,7 +17,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0035"
+CURR_DB_VERSION = "0036"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
+++ b/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
@@ -1,0 +1,49 @@
+"""
+Migration 0036 -- collection visibility
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0036"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Move from Collection.isPublic cool to Collection.visibility enum
+        """
+        colls_mdb = self.mdb["collections"]
+
+        # Set non-public collections to private
+        try:
+            await colls_mdb.update_many(
+                {"isPublic": False},
+                [{"$set": {"visibility": "private"}, "$unset": {"isPublic": 1}}],
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error migrating private collections: {err}",
+                flush=True,
+            )
+
+        # Set public collections to unlisted
+        try:
+            await colls_mdb.update_many(
+                {"isPublic": True},
+                [{"$set": {"visibility": "unlisted"}, "$unset": {"isPublic": 1}}],
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error migrating public unlisted collections: {err}",
+                flush=True,
+            )

--- a/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
+++ b/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
@@ -1,5 +1,5 @@
 """
-Migration 0036 -- collection visibility
+Migration 0036 -- collection access
 """
 
 from btrixcloud.migrations import BaseMigration
@@ -18,7 +18,7 @@ class Migration(BaseMigration):
     async def migrate_up(self):
         """Perform migration up.
 
-        Move from Collection.isPublic cool to Collection.visibility enum
+        Move from Collection.isPublic cool to Collection.access enum
         """
         colls_mdb = self.mdb["collections"]
 
@@ -26,7 +26,7 @@ class Migration(BaseMigration):
         try:
             await colls_mdb.update_many(
                 {"isPublic": False},
-                [{"$set": {"visibility": "private"}, "$unset": {"isPublic": 1}}],
+                [{"$set": {"access": "private"}, "$unset": {"isPublic": 1}}],
             )
         # pylint: disable=broad-exception-caught
         except Exception as err:
@@ -39,7 +39,7 @@ class Migration(BaseMigration):
         try:
             await colls_mdb.update_many(
                 {"isPublic": True},
-                [{"$set": {"visibility": "unlisted"}, "$unset": {"isPublic": 1}}],
+                [{"$set": {"access": "unlisted"}, "$unset": {"isPublic": 1}}],
             )
         # pylint: disable=broad-exception-caught
         except Exception as err:

--- a/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
+++ b/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
@@ -26,7 +26,7 @@ class Migration(BaseMigration):
         try:
             await colls_mdb.update_many(
                 {"isPublic": False},
-                [{"$set": {"access": "private"}, "$unset": {"isPublic": 1}}],
+                {"$set": {"access": "private"}, "$unset": {"isPublic": 1}},
             )
         # pylint: disable=broad-exception-caught
         except Exception as err:
@@ -39,7 +39,7 @@ class Migration(BaseMigration):
         try:
             await colls_mdb.update_many(
                 {"isPublic": True},
-                [{"$set": {"access": "unlisted"}, "$unset": {"isPublic": 1}}],
+                {"$set": {"access": "unlisted"}, "$unset": {"isPublic": 1}},
             )
         # pylint: disable=broad-exception-caught
         except Exception as err:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1048,6 +1048,15 @@ class UpdateUpload(UpdateCrawl):
 
 
 # ============================================================================
+class CollVisibilityType(str, Enum):
+    """Collection visibility types"""
+
+    PRIVATE = "private"
+    UNLISTED = "unlisted"
+    PUBLIC = "public"
+
+
+# ============================================================================
 class Collection(BaseMongoModel):
     """Org collection structure"""
 
@@ -1063,7 +1072,7 @@ class Collection(BaseMongoModel):
     # Sorted by count, descending
     tags: Optional[List[str]] = []
 
-    isPublic: Optional[bool] = False
+    visibility: CollVisibilityType = CollVisibilityType.PRIVATE
 
 
 # ============================================================================
@@ -1074,7 +1083,7 @@ class CollIn(BaseModel):
     description: Optional[str] = None
     crawlIds: Optional[List[str]] = []
 
-    isPublic: bool = False
+    visibility: CollVisibilityType = CollVisibilityType.PRIVATE
 
 
 # ============================================================================
@@ -1090,7 +1099,7 @@ class UpdateColl(BaseModel):
 
     name: Optional[str] = None
     description: Optional[str] = None
-    isPublic: Optional[bool] = None
+    visibility: Optional[CollVisibilityType] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1048,8 +1048,8 @@ class UpdateUpload(UpdateCrawl):
 
 
 # ============================================================================
-class CollVisibilityType(str, Enum):
-    """Collection visibility types"""
+class CollAccessType(str, Enum):
+    """Collection access types"""
 
     PRIVATE = "private"
     UNLISTED = "unlisted"
@@ -1072,7 +1072,7 @@ class Collection(BaseMongoModel):
     # Sorted by count, descending
     tags: Optional[List[str]] = []
 
-    visibility: CollVisibilityType = CollVisibilityType.PRIVATE
+    access: CollAccessType = CollAccessType.PRIVATE
 
 
 # ============================================================================
@@ -1083,7 +1083,7 @@ class CollIn(BaseModel):
     description: Optional[str] = None
     crawlIds: Optional[List[str]] = []
 
-    visibility: CollVisibilityType = CollVisibilityType.PRIVATE
+    access: CollAccessType = CollAccessType.PRIVATE
 
 
 # ============================================================================
@@ -1099,7 +1099,7 @@ class UpdateColl(BaseModel):
 
     name: Optional[str] = None
     description: Optional[str] = None
-    visibility: Optional[CollVisibilityType] = None
+    access: Optional[CollAccessType] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1365,6 +1365,13 @@ class OrgReadOnlyUpdate(BaseModel):
 
 
 # ============================================================================
+class OrgListPublicCollectionsUpdate(BaseModel):
+    """Organization listPublicCollections update"""
+
+    listPublicCollections: bool
+
+
+# ============================================================================
 class OrgWebhookUrls(BaseModel):
     """Organization webhook URLs"""
 
@@ -1432,6 +1439,8 @@ class OrgOut(BaseMongoModel):
     allowedProxies: list[str] = []
     crawlingDefaults: Optional[CrawlConfigDefaults] = None
 
+    listPublicCollections: bool = False
+
 
 # ============================================================================
 class Organization(BaseMongoModel):
@@ -1486,6 +1495,8 @@ class Organization(BaseMongoModel):
     allowSharedProxies: bool = False
     allowedProxies: list[str] = []
     crawlingDefaults: Optional[CrawlConfigDefaults] = None
+
+    listPublicCollections: bool = False
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -930,7 +930,7 @@ class OrgOps:
         )
         collections_count = await self.colls_db.count_documents({"oid": org.id})
         public_collections_count = await self.colls_db.count_documents(
-            {"oid": org.id, "visibility": {"$in": ["public", "unlisted"]}}
+            {"oid": org.id, "access": {"$in": ["public", "unlisted"]}}
         )
 
         return {

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -930,7 +930,7 @@ class OrgOps:
         )
         collections_count = await self.colls_db.count_documents({"oid": org.id})
         public_collections_count = await self.colls_db.count_documents(
-            {"oid": org.id, "isPublic": True}
+            {"oid": org.id, "visibility": {"$in": ["public", "unlisted"]}}
         )
 
         return {

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -78,6 +78,7 @@ from .models import (
     RemovedResponse,
     OrgSlugsResponse,
     OrgImportResponse,
+    OrgListPublicCollectionsUpdate,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import (
@@ -986,6 +987,16 @@ class OrgOps:
         )
         return res is not None
 
+    async def update_list_public_collections(
+        self, org: Organization, list_public_collections: bool
+    ):
+        """Update listPublicCollections field on organization"""
+        res = await self.orgs.find_one_and_update(
+            {"_id": org.id},
+            {"$set": {"listPublicCollections": list_public_collections}},
+        )
+        return res is not None
+
     async def export_org(
         self, org: Organization, user_manager: UserManager
     ) -> StreamingResponse:
@@ -1539,6 +1550,19 @@ def init_orgs_api(
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         await ops.update_read_only_on_cancel(org, update)
+
+        return {"updated": True}
+
+    @router.post(
+        "/list-public-collections",
+        tags=["organizations", "collections"],
+        response_model=UpdatedResponse,
+    )
+    async def update_list_public_collections(
+        update: OrgListPublicCollectionsUpdate,
+        org: Organization = Depends(org_owner_dep),
+    ):
+        await ops.update_list_public_collections(org, update.listPublicCollections)
 
         return {"updated": True}
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -365,6 +365,24 @@ def test_collection_public(crawler_auth_headers, default_org_id):
     assert r.status_code == 404
 
 
+def test_collection_access_invalid_value(crawler_auth_headers, default_org_id):
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+        headers=crawler_auth_headers,
+        json={
+            "access": "invalid",
+        },
+    )
+    assert r.status_code == 400
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["access"] == "private"
+
+
 def test_add_upload_to_collection(crawler_auth_headers, default_org_id):
     with open(os.path.join(curr_dir, "data", "example.wacz"), "rb") as fh:
         r = requests.put(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -58,7 +58,7 @@ def test_create_public_collection(
         json={
             "crawlIds": [crawler_crawl_id],
             "name": PUBLIC_COLLECTION_NAME,
-            "visibility": "public",
+            "access": "public",
         },
     )
     assert r.status_code == 200
@@ -73,7 +73,7 @@ def test_create_public_collection(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
         headers=crawler_auth_headers,
     )
-    assert r.json()["visibility"] == "public"
+    assert r.json()["access"] == "public"
 
 
 def test_create_collection_taken_name(
@@ -316,7 +316,7 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
         headers=crawler_auth_headers,
         json={
-            "visibility": "public",
+            "access": "public",
         },
     )
     assert r.status_code == 200
@@ -335,7 +335,7 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
         headers=crawler_auth_headers,
         json={
-            "visibility": "unlisted",
+            "access": "unlisted",
         },
     )
     assert r.status_code == 200
@@ -354,7 +354,7 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
         headers=crawler_auth_headers,
         json={
-            "visibility": "private",
+            "access": "private",
         },
     )
 
@@ -448,7 +448,7 @@ def test_list_collections(
     assert first_coll["totalSize"] > 0
     assert first_coll["modified"]
     assert first_coll["tags"] == ["wr-test-2", "wr-test-1"]
-    assert first_coll["visibility"] == "private"
+    assert first_coll["access"] == "private"
 
     second_coll = [coll for coll in items if coll["name"] == SECOND_COLLECTION_NAME][0]
     assert second_coll["id"]
@@ -460,7 +460,7 @@ def test_list_collections(
     assert second_coll["totalSize"] > 0
     assert second_coll["modified"]
     assert second_coll["tags"] == ["wr-test-2"]
-    assert second_coll["visibility"] == "private"
+    assert second_coll["access"] == "private"
 
 
 def test_remove_upload_from_collection(crawler_auth_headers, default_org_id):
@@ -546,10 +546,10 @@ def test_filter_sort_collections(
     assert coll["oid"] == default_org_id
     assert coll.get("description") is None
 
-    # Test filtering by visibility
+    # Test filtering by access
     name_prefix = name_prefix.upper()
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections?visibility=public",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections?access=public",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -564,7 +564,7 @@ def test_filter_sort_collections(
     assert coll["name"] == PUBLIC_COLLECTION_NAME
     assert coll["oid"] == default_org_id
     assert coll.get("description") is None
-    assert coll["visibility"] == "public"
+    assert coll["access"] == "public"
 
     # Test sorting by name, ascending (default)
     r = requests.get(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -373,7 +373,7 @@ def test_collection_access_invalid_value(crawler_auth_headers, default_org_id):
             "access": "invalid",
         },
     )
-    assert r.status_code == 400
+    assert r.status_code == 422
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -697,6 +697,24 @@ def test_update_read_only(admin_auth_headers, default_org_id):
     assert data["readOnlyReason"] == ""
 
 
+def test_update_list_public_collections(admin_auth_headers, default_org_id):
+    # Test that default is false
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.json()["listPublicCollections"] is False
+
+    # Update
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/list-public-collections",
+        headers=admin_auth_headers,
+        json={"listPublicCollections": True},
+    )
+    assert r.json()["updated"]
+
+    # Test update is reflected in GET response
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    assert r.json()["listPublicCollections"]
+
+
 def test_sort_orgs(admin_auth_headers):
     # Create a few new orgs for testing
     r = requests.post(

--- a/frontend/src/features/collections/collection-metadata-dialog.ts
+++ b/frontend/src/features/collections/collection-metadata-dialog.ts
@@ -180,7 +180,7 @@ export class CollectionMetadataDialog extends BtrixElement {
       const body = JSON.stringify({
         name,
         description,
-        isPublic: Boolean(isPublic),
+        visibility: !isPublic ? "private" : "unlisted",
       });
       let path = `/orgs/${this.orgId}/collections`;
       let method = "POST";

--- a/frontend/src/features/collections/collection-metadata-dialog.ts
+++ b/frontend/src/features/collections/collection-metadata-dialog.ts
@@ -14,7 +14,7 @@ import { when } from "lit/directives/when.js";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { MarkdownEditor } from "@/components/ui/markdown-editor";
-import type { Collection } from "@/types/collection";
+import { CollectionVisibility, type Collection } from "@/types/collection";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 
@@ -180,7 +180,9 @@ export class CollectionMetadataDialog extends BtrixElement {
       const body = JSON.stringify({
         name,
         description,
-        visibility: !isPublic ? "private" : "unlisted",
+        visibility: !isPublic
+          ? CollectionVisibility.Private
+          : CollectionVisibility.Unlisted,
       });
       let path = `/orgs/${this.orgId}/collections`;
       let method = "POST";

--- a/frontend/src/features/collections/collection-metadata-dialog.ts
+++ b/frontend/src/features/collections/collection-metadata-dialog.ts
@@ -14,7 +14,7 @@ import { when } from "lit/directives/when.js";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { MarkdownEditor } from "@/components/ui/markdown-editor";
-import { CollectionVisibility, type Collection } from "@/types/collection";
+import { CollectionAccess, type Collection } from "@/types/collection";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 
@@ -180,9 +180,9 @@ export class CollectionMetadataDialog extends BtrixElement {
       const body = JSON.stringify({
         name,
         description,
-        visibility: !isPublic
-          ? CollectionVisibility.Private
-          : CollectionVisibility.Unlisted,
+        access: !isPublic
+          ? CollectionAccess.Private
+          : CollectionAccess.Unlisted,
       });
       let path = `/orgs/${this.orgId}/collections`;
       let method = "POST";

--- a/frontend/src/features/collections/collections-add.ts
+++ b/frontend/src/features/collections/collections-add.ts
@@ -117,7 +117,7 @@ export class CollectionsAdd extends BtrixElement {
           : this.emptyText
             ? html`
                 <div class="mb-2">
-                  <p class="text-center text-0-500">${this.emptyText}</p>
+                  <p class="text-0-500 text-center">${this.emptyText}</p>
                 </div>
               `
             : "",

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -228,7 +228,7 @@ export class BrowserProfilesList extends BtrixElement {
             `
           : html`
               <div class="border-b border-t py-5">
-                <p class="text-center text-0-500">
+                <p class="text-0-500 text-center">
                   ${msg("No browser profiles yet.")}
                 </p>
               </div>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -16,7 +16,7 @@ import type {
   APIPaginationQuery,
   APISortQuery,
 } from "@/types/api";
-import { CollectionVisibility, type Collection } from "@/types/collection";
+import { CollectionAccess, type Collection } from "@/types/collection";
 import type { ArchivedItem, Crawl, Upload } from "@/types/crawler";
 import type { CrawlState } from "@/types/crawlState";
 import { formatNumber, getLocale } from "@/utils/localization";
@@ -100,7 +100,7 @@ export class CollectionDetail extends BtrixElement {
       <header class="items-center gap-2 pb-3 md:flex">
         <div class="mb-2 flex w-full items-center gap-2 md:mb-0">
           <div class="flex size-8 items-center justify-center">
-            ${this.collection?.visibility === CollectionVisibility.Unlisted
+            ${this.collection?.access === CollectionAccess.Unlisted
               ? html`
                   <sl-tooltip content=${msg("Shareable")}>
                     <sl-icon
@@ -122,7 +122,7 @@ export class CollectionDetail extends BtrixElement {
         </div>
         ${when(
           this.isCrawler ||
-            this.collection?.visibility !== CollectionVisibility.Private,
+            this.collection?.access !== CollectionAccess.Private,
           () => html`
             <sl-button
               variant=${this.collection?.crawlCount ? "primary" : "default"}
@@ -241,7 +241,7 @@ export class CollectionDetail extends BtrixElement {
         style="--width: 32rem;"
       >
         ${
-          this.collection?.visibility === CollectionVisibility.Unlisted
+          this.collection?.access === CollectionAccess.Unlisted
             ? ""
             : html`<p class="mb-3">
                 ${msg(
@@ -254,8 +254,8 @@ export class CollectionDetail extends BtrixElement {
           () => html`
             <div class="mb-5">
               <sl-switch
-                ?checked=${this.collection?.visibility ===
-                CollectionVisibility.Unlisted}
+                ?checked=${this.collection?.access ===
+                CollectionAccess.Unlisted}
                 @sl-change=${(e: CustomEvent) =>
                   void this.onTogglePublic((e.target as SlCheckbox).checked)}
                 >${msg("Collection is Shareable")}</sl-switch
@@ -264,7 +264,7 @@ export class CollectionDetail extends BtrixElement {
           `,
         )}
         </div>
-        ${when(this.collection?.visibility === CollectionVisibility.Unlisted, this.renderShareInfo)}
+        ${when(this.collection?.access === CollectionAccess.Unlisted, this.renderShareInfo)}
         <div slot="footer" class="flex justify-end">
           <sl-button size="small" @click=${() => (this.showShareInfo = false)}
             >${msg("Done")}</sl-button
@@ -416,7 +416,7 @@ export class CollectionDetail extends BtrixElement {
             ${msg("Select Archived Items")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-          ${this.collection?.visibility === CollectionVisibility.Private
+          ${this.collection?.access === CollectionAccess.Private
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -748,19 +748,19 @@ export class CollectionDetail extends BtrixElement {
   };
 
   private async onTogglePublic(isPublic: boolean) {
-    const visibility = !isPublic
-      ? CollectionVisibility.Private
-      : CollectionVisibility.Unlisted;
+    const access = !isPublic
+      ? CollectionAccess.Private
+      : CollectionAccess.Unlisted;
     const res = await this.api.fetch<{ updated: boolean }>(
       `/orgs/${this.orgId}/collections/${this.collectionId}`,
       {
         method: "PATCH",
-        body: JSON.stringify({ visibility }),
+        body: JSON.stringify({ access }),
       },
     );
 
     if (res.updated && this.collection) {
-      this.collection = { ...this.collection, visibility };
+      this.collection = { ...this.collection, access };
     }
   }
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -100,7 +100,7 @@ export class CollectionDetail extends BtrixElement {
       <header class="items-center gap-2 pb-3 md:flex">
         <div class="mb-2 flex w-full items-center gap-2 md:mb-0">
           <div class="flex size-8 items-center justify-center">
-            ${this.collection?.isPublic
+            ${this.collection?.visibility === "unlisted"
               ? html`
                   <sl-tooltip content=${msg("Shareable")}>
                     <sl-icon
@@ -121,7 +121,7 @@ export class CollectionDetail extends BtrixElement {
           </h1>
         </div>
         ${when(
-          this.isCrawler || this.collection?.isPublic,
+          this.isCrawler || this.collection?.visibility !== "private",
           () => html`
             <sl-button
               variant=${this.collection?.crawlCount ? "primary" : "default"}
@@ -240,7 +240,7 @@ export class CollectionDetail extends BtrixElement {
         style="--width: 32rem;"
       >
         ${
-          this.collection?.isPublic
+          this.collection?.visibility === "unlisted"
             ? ""
             : html`<p class="mb-3">
                 ${msg(
@@ -253,7 +253,7 @@ export class CollectionDetail extends BtrixElement {
           () => html`
             <div class="mb-5">
               <sl-switch
-                ?checked=${this.collection?.isPublic}
+                ?checked=${this.collection?.visibility === "unlisted"}
                 @sl-change=${(e: CustomEvent) =>
                   void this.onTogglePublic((e.target as SlCheckbox).checked)}
                 >${msg("Collection is Shareable")}</sl-switch
@@ -262,7 +262,7 @@ export class CollectionDetail extends BtrixElement {
           `,
         )}
         </div>
-        ${when(this.collection?.isPublic, this.renderShareInfo)}
+        ${when(this.collection?.visibility === "unlisted", this.renderShareInfo)}
         <div slot="footer" class="flex justify-end">
           <sl-button size="small" @click=${() => (this.showShareInfo = false)}
             >${msg("Done")}</sl-button
@@ -414,7 +414,7 @@ export class CollectionDetail extends BtrixElement {
             ${msg("Select Archived Items")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-          ${!this.collection?.isPublic
+          ${this.collection?.visibility === "private"
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -746,16 +746,17 @@ export class CollectionDetail extends BtrixElement {
   };
 
   private async onTogglePublic(isPublic: boolean) {
+    const visibility = !isPublic ? "private" : "unlisted";
     const res = await this.api.fetch<{ updated: boolean }>(
       `/orgs/${this.orgId}/collections/${this.collectionId}`,
       {
         method: "PATCH",
-        body: JSON.stringify({ isPublic }),
+        body: JSON.stringify({ visibility }),
       },
     );
 
     if (res.updated && this.collection) {
-      this.collection = { ...this.collection, isPublic };
+      this.collection = { ...this.collection, visibility };
     }
   }
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -16,7 +16,7 @@ import type {
   APIPaginationQuery,
   APISortQuery,
 } from "@/types/api";
-import type { Collection } from "@/types/collection";
+import { CollectionVisibility, type Collection } from "@/types/collection";
 import type { ArchivedItem, Crawl, Upload } from "@/types/crawler";
 import type { CrawlState } from "@/types/crawlState";
 import { formatNumber, getLocale } from "@/utils/localization";
@@ -100,7 +100,7 @@ export class CollectionDetail extends BtrixElement {
       <header class="items-center gap-2 pb-3 md:flex">
         <div class="mb-2 flex w-full items-center gap-2 md:mb-0">
           <div class="flex size-8 items-center justify-center">
-            ${this.collection?.visibility === "unlisted"
+            ${this.collection?.visibility === CollectionVisibility.Unlisted
               ? html`
                   <sl-tooltip content=${msg("Shareable")}>
                     <sl-icon
@@ -121,7 +121,8 @@ export class CollectionDetail extends BtrixElement {
           </h1>
         </div>
         ${when(
-          this.isCrawler || this.collection?.visibility !== "private",
+          this.isCrawler ||
+            this.collection?.visibility !== CollectionVisibility.Private,
           () => html`
             <sl-button
               variant=${this.collection?.crawlCount ? "primary" : "default"}
@@ -240,7 +241,7 @@ export class CollectionDetail extends BtrixElement {
         style="--width: 32rem;"
       >
         ${
-          this.collection?.visibility === "unlisted"
+          this.collection?.visibility === CollectionVisibility.Unlisted
             ? ""
             : html`<p class="mb-3">
                 ${msg(
@@ -253,7 +254,8 @@ export class CollectionDetail extends BtrixElement {
           () => html`
             <div class="mb-5">
               <sl-switch
-                ?checked=${this.collection?.visibility === "unlisted"}
+                ?checked=${this.collection?.visibility ===
+                CollectionVisibility.Unlisted}
                 @sl-change=${(e: CustomEvent) =>
                   void this.onTogglePublic((e.target as SlCheckbox).checked)}
                 >${msg("Collection is Shareable")}</sl-switch
@@ -262,7 +264,7 @@ export class CollectionDetail extends BtrixElement {
           `,
         )}
         </div>
-        ${when(this.collection?.visibility === "unlisted", this.renderShareInfo)}
+        ${when(this.collection?.visibility === CollectionVisibility.Unlisted, this.renderShareInfo)}
         <div slot="footer" class="flex justify-end">
           <sl-button size="small" @click=${() => (this.showShareInfo = false)}
             >${msg("Done")}</sl-button
@@ -414,7 +416,7 @@ export class CollectionDetail extends BtrixElement {
             ${msg("Select Archived Items")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-          ${this.collection?.visibility === "private"
+          ${this.collection?.visibility === CollectionVisibility.Private
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -746,7 +748,9 @@ export class CollectionDetail extends BtrixElement {
   };
 
   private async onTogglePublic(isPublic: boolean) {
-    const visibility = !isPublic ? "private" : "unlisted";
+    const visibility = !isPublic
+      ? CollectionVisibility.Private
+      : CollectionVisibility.Unlisted;
     const res = await this.api.fetch<{ updated: boolean }>(
       `/orgs/${this.orgId}/collections/${this.collectionId}`,
       {

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -500,7 +500,7 @@ export class CollectionsList extends BtrixElement {
       class="cursor-pointer select-none rounded border shadow transition-all focus-within:bg-neutral-50 hover:bg-neutral-50 hover:shadow-none"
     >
       <btrix-table-cell class="p-3">
-        ${col.isPublic
+        ${col.visibility === "unlisted"
           ? html`
               <sl-tooltip content=${msg("Shareable")}>
                 <sl-icon
@@ -572,7 +572,7 @@ export class CollectionsList extends BtrixElement {
             ${msg("Edit Metadata")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-          ${!col.isPublic
+          ${col.visibility === "private"
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -647,9 +647,10 @@ export class CollectionsList extends BtrixElement {
   });
 
   private async onTogglePublic(coll: Collection, isPublic: boolean) {
+    const visibility = !isPublic ? "private" : "unlisted";
     await this.api.fetch(`/orgs/${this.orgId}/collections/${coll.id}`, {
       method: "PATCH",
-      body: JSON.stringify({ isPublic }),
+      body: JSON.stringify({ visibility }),
     });
 
     void this.fetchCollections();

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -16,7 +16,7 @@ import type { CollectionSavedEvent } from "@/features/collections/collection-met
 import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import {
-  CollectionVisibility,
+  CollectionAccess,
   type Collection,
   type CollectionSearchValues,
 } from "@/types/collection";
@@ -504,7 +504,7 @@ export class CollectionsList extends BtrixElement {
       class="cursor-pointer select-none rounded border shadow transition-all focus-within:bg-neutral-50 hover:bg-neutral-50 hover:shadow-none"
     >
       <btrix-table-cell class="p-3">
-        ${col.visibility === CollectionVisibility.Unlisted
+        ${col.access === CollectionAccess.Unlisted
           ? html`
               <sl-tooltip content=${msg("Shareable")}>
                 <sl-icon
@@ -576,7 +576,7 @@ export class CollectionsList extends BtrixElement {
             ${msg("Edit Metadata")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-          ${col.visibility === CollectionVisibility.Private
+          ${col.access === CollectionAccess.Private
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -651,12 +651,12 @@ export class CollectionsList extends BtrixElement {
   });
 
   private async onTogglePublic(coll: Collection, isPublic: boolean) {
-    const visibility = !isPublic
-      ? CollectionVisibility.Private
-      : CollectionVisibility.Unlisted;
+    const access = !isPublic
+      ? CollectionAccess.Private
+      : CollectionAccess.Unlisted;
     await this.api.fetch(`/orgs/${this.orgId}/collections/${coll.id}`, {
       method: "PATCH",
-      body: JSON.stringify({ visibility }),
+      body: JSON.stringify({ access }),
     });
 
     void this.fetchCollections();

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -15,7 +15,11 @@ import type { PageChangeEvent } from "@/components/ui/pagination";
 import type { CollectionSavedEvent } from "@/features/collections/collection-metadata-dialog";
 import { pageHeader } from "@/layouts/pageHeader";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
-import type { Collection, CollectionSearchValues } from "@/types/collection";
+import {
+  CollectionVisibility,
+  type Collection,
+  type CollectionSearchValues,
+} from "@/types/collection";
 import type { UnderlyingFunction } from "@/types/utils";
 import { isApiError } from "@/utils/api";
 import { formatNumber, getLocale } from "@/utils/localization";
@@ -500,7 +504,7 @@ export class CollectionsList extends BtrixElement {
       class="cursor-pointer select-none rounded border shadow transition-all focus-within:bg-neutral-50 hover:bg-neutral-50 hover:shadow-none"
     >
       <btrix-table-cell class="p-3">
-        ${col.visibility === "unlisted"
+        ${col.visibility === CollectionVisibility.Unlisted
           ? html`
               <sl-tooltip content=${msg("Shareable")}>
                 <sl-icon
@@ -572,7 +576,7 @@ export class CollectionsList extends BtrixElement {
             ${msg("Edit Metadata")}
           </sl-menu-item>
           <sl-divider></sl-divider>
-          ${col.visibility === "private"
+          ${col.visibility === CollectionVisibility.Private
             ? html`
                 <sl-menu-item
                   style="--sl-color-neutral-700: var(--success)"
@@ -647,7 +651,9 @@ export class CollectionsList extends BtrixElement {
   });
 
   private async onTogglePublic(coll: Collection, isPublic: boolean) {
-    const visibility = !isPublic ? "private" : "unlisted";
+    const visibility = !isPublic
+      ? CollectionVisibility.Private
+      : CollectionVisibility.Unlisted;
     await this.api.fetch(`/orgs/${this.orgId}/collections/${coll.id}`, {
       method: "PATCH",
       body: JSON.stringify({ visibility }),

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -323,7 +323,7 @@ export class WorkflowsList extends LiteElement {
         <div class="grow">${this.renderSearch()}</div>
 
         <div class="flex w-full items-center md:w-fit">
-          <div class="mr-2 whitespace-nowrap text-sm text-0-500">
+          <div class="text-0-500 mr-2 whitespace-nowrap text-sm">
             ${msg("Sort by:")}
           </div>
           <sl-select

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -9,7 +9,7 @@ export type Collection = {
   totalSize: number;
   tags: string[];
   resources: string[];
-  isPublic: boolean;
+  visibility: string;
 };
 
 export type CollectionSearchValues = {

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -1,3 +1,9 @@
+export enum CollectionVisibility {
+  Private = "private",
+  Public = "public",
+  Unlisted = "unlisted",
+}
+
 export type Collection = {
   id: string;
   oid: string;
@@ -9,7 +15,7 @@ export type Collection = {
   totalSize: number;
   tags: string[];
   resources: string[];
-  visibility: string;
+  visibility: CollectionVisibility;
 };
 
 export type CollectionSearchValues = {

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -1,4 +1,4 @@
-export enum CollectionVisibility {
+export enum CollectionAccess {
   Private = "private",
   Public = "public",
   Unlisted = "unlisted",
@@ -15,7 +15,7 @@ export type Collection = {
   totalSize: number;
   tags: string[];
   resources: string[];
-  visibility: CollectionVisibility;
+  access: CollectionAccess;
 };
 
 export type CollectionSearchValues = {


### PR DESCRIPTION
Fixes #2158 

- Adds `Organization.listPublicCollections` field and API endpoint to update it
- Replaces `Collection.isPublic` boolean with `Collection.access` (values: `private`, `unlisted`, `public`) and add database migration
- Update frontend to use `Collection.access` instead of `isPublic`, otherwise not changing current behavior