### PR TITLE
Add public API endpoint for public collections

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -415,7 +415,9 @@ class CollectionOps:
         )
 
         public_org_details = PublicOrgDetails(
-            name=org.name, description=org.publicDescription, url=org.publicUrl
+            name=org.name,
+            description=org.publicDescription or "",
+            url=org.publicUrl or "",
         )
 
         return OrgPublicCollections(org=public_org_details, collections=collections)

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -31,6 +31,7 @@ from .models import (
     SuccessResponse,
     CollectionSearchValuesResponse,
     OrgPublicCollections,
+    PublicOrgDetails,
     CollAccessType,
 )
 from .utils import dt_now
@@ -416,7 +417,9 @@ class CollectionOps:
         if not collections:
             raise HTTPException(status_code=404, detail="public_collections_not_found")
 
-        return OrgPublicCollections(orgName=org.name, collections=collections)
+        public_org_details = PublicOrgDetails(name=org.name)
+
+        return OrgPublicCollections(org=public_org_details, collections=collections)
 
 
 # ============================================================================

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -417,7 +417,7 @@ class CollectionOps:
         if not collections:
             raise HTTPException(status_code=404, detail="public_collections_not_found")
 
-        public_org_details = PublicOrgDetails(name=org.name)
+        public_org_details = PublicOrgDetails(name=org.name, description=org.publicDescription)
 
         return OrgPublicCollections(org=public_org_details, collections=collections)
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -417,7 +417,9 @@ class CollectionOps:
         if not collections:
             raise HTTPException(status_code=404, detail="public_collections_not_found")
 
-        public_org_details = PublicOrgDetails(name=org.name, description=org.publicDescription)
+        public_org_details = PublicOrgDetails(
+            name=org.name, description=org.publicDescription
+        )
 
         return OrgPublicCollections(org=public_org_details, collections=collections)
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -406,9 +406,13 @@ class CollectionOps:
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=404, detail="public_collections_not_found")
 
-        collections, _ = await self.list_collections(
-            org.id, access=CollAccessType.PUBLIC
-        )
+        collections: List[CollOut] = []
+
+        if org.enablePublicProfile:
+            collections, _ = await self.list_collections(
+                org.id, access=CollAccessType.PUBLIC
+            )
+
         if not collections:
             raise HTTPException(status_code=404, detail="public_collections_not_found")
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -405,17 +405,14 @@ class CollectionOps:
         # pylint: disable=broad-exception-caught
         except Exception:
             # pylint: disable=raise-missing-from
-            raise HTTPException(status_code=404, detail="public_collections_not_found")
+            raise HTTPException(status_code=404, detail="public_profile_not_found")
 
-        collections: List[CollOut] = []
+        if not org.enablePublicProfile:
+            raise HTTPException(status_code=404, detail="public_profile_not_found")
 
-        if org.enablePublicProfile:
-            collections, _ = await self.list_collections(
-                org.id, access=CollAccessType.PUBLIC
-            )
-
-        if not collections:
-            raise HTTPException(status_code=404, detail="public_collections_not_found")
+        collections, _ = await self.list_collections(
+            org.id, access=CollAccessType.PUBLIC
+        )
 
         public_org_details = PublicOrgDetails(
             name=org.name, description=org.publicDescription

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -415,7 +415,7 @@ class CollectionOps:
         )
 
         public_org_details = PublicOrgDetails(
-            name=org.name, description=org.publicDescription
+            name=org.name, description=org.publicDescription, url=org.publicUrl
         )
 
         return OrgPublicCollections(org=public_org_details, collections=collections)

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -30,6 +30,8 @@ from .models import (
     UpdatedResponse,
     SuccessResponse,
     CollectionSearchValuesResponse,
+    OrgPublicCollections,
+    CollAccessType,
 )
 from .utils import dt_now
 
@@ -395,6 +397,23 @@ class CollectionOps:
             )
             await self.update_crawl_collections(crawl_id)
 
+    async def get_org_public_collections(self, org_slug: str):
+        """List public collections for org"""
+        try:
+            org = await self.orgs.get_org_by_slug(org_slug)
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            # pylint: disable=raise-missing-from
+            raise HTTPException(status_code=404, detail="public_collections_not_found")
+
+        collections, _ = await self.list_collections(
+            org.id, access=CollAccessType.PUBLIC
+        )
+        if not collections:
+            raise HTTPException(status_code=404, detail="public_collections_not_found")
+
+        return OrgPublicCollections(orgName=org.name, collections=collections)
+
 
 # ============================================================================
 # pylint: disable=too-many-locals
@@ -581,5 +600,13 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops):
         coll_id: UUID, org: Organization = Depends(org_viewer_dep)
     ):
         return await colls.download_collection(coll_id, org)
+
+    @app.get(
+        "/public-collections/{org_slug}",
+        tags=["collections"],
+        response_model=OrgPublicCollections,
+    )
+    async def get_org_public_collections(org_slug: str):
+        return await colls.get_org_public_collections(org_slug)
 
     return colls

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1149,6 +1149,7 @@ class PublicOrgDetails(BaseModel):
     """Model for org details that are available in public profile"""
 
     name: str
+    description: str = ""
 
 
 # ============================================================================
@@ -1390,10 +1391,11 @@ class OrgReadOnlyUpdate(BaseModel):
 
 
 # ============================================================================
-class OrgEnablePublicProfileUpdate(BaseModel):
+class OrgPublicProfileUpdate(BaseModel):
     """Organization enablePublicProfile update"""
 
-    enablePublicProfile: bool
+    enablePublicProfile: Optional[bool] = None
+    publicDescription: Optional[str] = None
 
 
 # ============================================================================
@@ -1465,6 +1467,7 @@ class OrgOut(BaseMongoModel):
     crawlingDefaults: Optional[CrawlConfigDefaults] = None
 
     enablePublicProfile: bool = False
+    publicDescription: str = ""
 
 
 # ============================================================================
@@ -1522,6 +1525,7 @@ class Organization(BaseMongoModel):
     crawlingDefaults: Optional[CrawlConfigDefaults] = None
 
     enablePublicProfile: bool = False
+    publicDescription: Optional[str] = None
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1150,6 +1150,7 @@ class PublicOrgDetails(BaseModel):
 
     name: str
     description: str = ""
+    url: str = ""
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1145,6 +1145,15 @@ class RenameOrg(BaseModel):
 
 
 # ============================================================================
+class OrgPublicCollections(BaseModel):
+    """Model for listing public collections in org"""
+
+    orgName: str
+
+    collections: List[CollOut]
+
+
+# ============================================================================
 class OrgStorageRefs(BaseModel):
     """Input model for setting primary storage + optional replicas"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1145,12 +1145,19 @@ class RenameOrg(BaseModel):
 
 
 # ============================================================================
+class PublicOrgDetails(BaseModel):
+    """Model for org details that are available in public profile"""
+
+    name: str
+
+
+# ============================================================================
 class OrgPublicCollections(BaseModel):
     """Model for listing public collections in org"""
 
-    orgName: str
+    org: PublicOrgDetails
 
-    collections: List[CollOut]
+    collections: List[CollOut] = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1383,10 +1383,10 @@ class OrgReadOnlyUpdate(BaseModel):
 
 
 # ============================================================================
-class OrgListPublicCollectionsUpdate(BaseModel):
-    """Organization listPublicCollections update"""
+class OrgEnablePublicProfileUpdate(BaseModel):
+    """Organization enablePublicProfile update"""
 
-    listPublicCollections: bool
+    enablePublicProfile: bool
 
 
 # ============================================================================
@@ -1457,7 +1457,7 @@ class OrgOut(BaseMongoModel):
     allowedProxies: list[str] = []
     crawlingDefaults: Optional[CrawlConfigDefaults] = None
 
-    listPublicCollections: bool = False
+    enablePublicProfile: bool = False
 
 
 # ============================================================================
@@ -1514,7 +1514,7 @@ class Organization(BaseMongoModel):
     allowedProxies: list[str] = []
     crawlingDefaults: Optional[CrawlConfigDefaults] = None
 
-    listPublicCollections: bool = False
+    enablePublicProfile: bool = False
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1396,6 +1396,7 @@ class OrgPublicProfileUpdate(BaseModel):
 
     enablePublicProfile: Optional[bool] = None
     publicDescription: Optional[str] = None
+    publicUrl: Optional[str] = None
 
 
 # ============================================================================
@@ -1468,6 +1469,7 @@ class OrgOut(BaseMongoModel):
 
     enablePublicProfile: bool = False
     publicDescription: str = ""
+    publicUrl: str = ""
 
 
 # ============================================================================
@@ -1526,6 +1528,7 @@ class Organization(BaseMongoModel):
 
     enablePublicProfile: bool = False
     publicDescription: Optional[str] = None
+    publicUrl: Optional[str] = None
 
     def is_owner(self, user):
         """Check if user is owner"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -284,6 +284,14 @@ class OrgOps:
 
         return Organization.from_dict(res)
 
+    async def get_org_by_slug(self, slug: str) -> Organization:
+        """Get an org by id"""
+        res = await self.orgs.find_one({"slug": slug})
+        if not res:
+            raise HTTPException(status_code=400, detail="invalid_org_slug")
+
+        return Organization.from_dict(res)
+
     async def get_default_org(self) -> Organization:
         """Get default organization"""
         res = await self.orgs.find_one({"default": True})

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -78,7 +78,7 @@ from .models import (
     RemovedResponse,
     OrgSlugsResponse,
     OrgImportResponse,
-    OrgListPublicCollectionsUpdate,
+    OrgEnablePublicProfileUpdate,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import (
@@ -995,13 +995,13 @@ class OrgOps:
         )
         return res is not None
 
-    async def update_list_public_collections(
-        self, org: Organization, list_public_collections: bool
+    async def update_public_profile(
+        self, org: Organization, enable_public_profile: bool
     ):
-        """Update listPublicCollections field on organization"""
+        """Update enablePublicProfile field on organization"""
         res = await self.orgs.find_one_and_update(
             {"_id": org.id},
-            {"$set": {"listPublicCollections": list_public_collections}},
+            {"$set": {"enablePublicProfile": enable_public_profile}},
         )
         return res is not None
 
@@ -1562,15 +1562,15 @@ def init_orgs_api(
         return {"updated": True}
 
     @router.post(
-        "/list-public-collections",
+        "/public-profile",
         tags=["organizations", "collections"],
         response_model=UpdatedResponse,
     )
-    async def update_list_public_collections(
-        update: OrgListPublicCollectionsUpdate,
+    async def update_public_profile(
+        update: OrgEnablePublicProfileUpdate,
         org: Organization = Depends(org_owner_dep),
     ):
-        await ops.update_list_public_collections(org, update.listPublicCollections)
+        await ops.update_public_profile(org, update.enablePublicProfile)
 
         return {"updated": True}
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -789,7 +789,7 @@ def test_list_public_collections(
 
     org_data = data["org"]
     assert org_data["name"] == org_name
-    assert org_data["publicDescription"] == public_description
+    assert org_data["description"] == public_description
 
     collections = data["collections"]
     assert len(collections) == 2

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -766,7 +766,7 @@ def test_list_public_collections(
     # Try listing public collections without org public profile enabled
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")
     assert r.status_code == 404
-    assert r.json()["detail"] == "public_collections_not_found"
+    assert r.json()["detail"] == "public_profile_not_found"
 
     # Enable public profile on org
     public_description = "This is a test public org!"

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -781,7 +781,7 @@ def test_list_public_collections(
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")
     assert r.status_code == 200
     data = r.json()
-    assert data["orgName"] == org_name
+    assert data["org"]["name"] == org_name
 
     collections = data["collections"]
     assert len(collections) == 2

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -755,6 +755,7 @@ def test_list_public_collections(
 
     # Verify that public profile isn't enabled
     assert data["enablePublicProfile"] is False
+    assert data["publicDescription"] == ""
 
     # Try listing public collections without org public profile enabled
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")
@@ -762,10 +763,12 @@ def test_list_public_collections(
     assert r.json()["detail"] == "public_collections_not_found"
 
     # Enable public profile on org
+    public_description = "This is a test public org!"
+
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/public-profile",
         headers=admin_auth_headers,
-        json={"enablePublicProfile": True}
+        json={"enablePublicProfile": True, "publicDescription": public_description}
     )
     assert r.status_code == 200
     assert r.json()["updated"]
@@ -775,13 +778,18 @@ def test_list_public_collections(
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["enablePublicProfile"]
+    data = r.json()
+    assert data["enablePublicProfile"]
+    assert data["publicDesciprtion"] == public_description
 
     # List public collections with no auth (no public profile)
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")
     assert r.status_code == 200
     data = r.json()
-    assert data["org"]["name"] == org_name
+
+    org_data = data["org"]
+    assert org_data["name"] == org_name
+    assert org_data["publicDescription"] == public_description
 
     collections = data["collections"]
     assert len(collections) == 2

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -760,6 +760,7 @@ def test_list_public_collections(
     # Verify that public profile isn't enabled
     assert data["enablePublicProfile"] is False
     assert data["publicDescription"] == ""
+    assert data["publicUrl"] == ""
 
     # Try listing public collections without org public profile enabled
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")
@@ -768,11 +769,16 @@ def test_list_public_collections(
 
     # Enable public profile on org
     public_description = "This is a test public org!"
+    public_url = "https://example.com"
 
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/public-profile",
         headers=admin_auth_headers,
-        json={"enablePublicProfile": True, "publicDescription": public_description},
+        json={
+            "enablePublicProfile": True,
+            "publicDescription": public_description,
+            "publicUrl": public_url,
+        },
     )
     assert r.status_code == 200
     assert r.json()["updated"]
@@ -785,6 +791,7 @@ def test_list_public_collections(
     data = r.json()
     assert data["enablePublicProfile"]
     assert data["publicDescription"] == public_description
+    assert data["publicUrl"] == public_url
 
     # List public collections with no auth (no public profile)
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")
@@ -794,6 +801,7 @@ def test_list_public_collections(
     org_data = data["org"]
     assert org_data["name"] == org_name
     assert org_data["description"] == public_description
+    assert org_data["url"] == public_url
 
     collections = data["collections"]
     assert len(collections) == 2
@@ -806,7 +814,7 @@ def test_list_public_collections(
     # an org exists with that slug
     r = requests.get(f"{API_PREFIX}/public-collections/nonexistentslug")
     assert r.status_code == 404
-    assert r.json()["detail"] == "public_collections_not_found"
+    assert r.json()["detail"] == "public_profile_not_found"
 
 
 def test_delete_collection(crawler_auth_headers, default_org_id, crawler_crawl_id):

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -728,7 +728,11 @@ def test_filter_sort_collections(
 
 
 def test_list_public_collections(
-    crawler_auth_headers, admin_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+    crawler_auth_headers,
+    admin_auth_headers,
+    default_org_id,
+    crawler_crawl_id,
+    admin_crawl_id,
 ):
     # Create new public collection
     r = requests.post(
@@ -768,7 +772,7 @@ def test_list_public_collections(
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/public-profile",
         headers=admin_auth_headers,
-        json={"enablePublicProfile": True, "publicDescription": public_description}
+        json={"enablePublicProfile": True, "publicDescription": public_description},
     )
     assert r.status_code == 200
     assert r.json()["updated"]
@@ -780,7 +784,7 @@ def test_list_public_collections(
     assert r.status_code == 200
     data = r.json()
     assert data["enablePublicProfile"]
-    assert data["publicDesciprtion"] == public_description
+    assert data["publicDescription"] == public_description
 
     # List public collections with no auth (no public profile)
     r = requests.get(f"{API_PREFIX}/public-collections/{org_slug}")

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -17,7 +17,7 @@ invite_email = "test-user@example.com"
 def test_ensure_only_one_default_org(admin_auth_headers):
     r = requests.get(f"{API_PREFIX}/orgs", headers=admin_auth_headers)
     data = r.json()
-    assert data["total"] == 1
+    assert data["total"] == 2
 
     orgs = data["items"]
     default_orgs = [org for org in orgs if org["default"]]

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -697,24 +697,6 @@ def test_update_read_only(admin_auth_headers, default_org_id):
     assert data["readOnlyReason"] == ""
 
 
-def test_update_list_public_collections(admin_auth_headers, default_org_id):
-    # Test that default is false
-    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
-    assert r.json()["enablePublicProfile"] is False
-
-    # Update
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/list-public-collections",
-        headers=admin_auth_headers,
-        json={"enablePublicProfile": True},
-    )
-    assert r.json()["updated"]
-
-    # Test update is reflected in GET response
-    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
-    assert r.json()["enablePublicProfile"]
-
-
 def test_sort_orgs(admin_auth_headers):
     # Create a few new orgs for testing
     r = requests.post(

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -700,19 +700,19 @@ def test_update_read_only(admin_auth_headers, default_org_id):
 def test_update_list_public_collections(admin_auth_headers, default_org_id):
     # Test that default is false
     r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
-    assert r.json()["listPublicCollections"] is False
+    assert r.json()["enablePublicProfile"] is False
 
     # Update
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/list-public-collections",
         headers=admin_auth_headers,
-        json={"listPublicCollections": True},
+        json={"enablePublicProfile": True},
     )
     assert r.json()["updated"]
 
     # Test update is reflected in GET response
     r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
-    assert r.json()["listPublicCollections"]
+    assert r.json()["enablePublicProfile"]
 
 
 def test_sort_orgs(admin_auth_headers):


### PR DESCRIPTION
Fixes #1051 

If org with provided slug doesn't exist or no public collections exist for that org, return same 404 response with a detail of "public_profile_not_found" to prevent people from using public endpoint to determine whether an org exists.

Endpoint is `GET /api/public-collections/<org-slug>` (no auth needed) to avoid collisions with existing org and collection endpoints.

@SuaYoo happy to make any changes needed for the frontend, just lmk!