### PR TITLE
ensure collection replay is fully reload (cache cleared) when:

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -143,7 +143,7 @@ class StorageOps:
             use_access_for_presign = False
         else:
             access_endpoint_url = storage.get("access_endpoint_url") or endpoint_url
-            use_access_for_presign = storage.get("use_access_for_presign", False)
+            use_access_for_presign = is_bool(storage.get("use_access_for_presign"))
 
         return S3Storage(
             access_key=storage["access_key"],

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -143,7 +143,7 @@ class StorageOps:
             use_access_for_presign = False
         else:
             access_endpoint_url = storage.get("access_endpoint_url") or endpoint_url
-            use_access_for_presign = True
+            use_access_for_presign = storage.get("use_access_for_presign", False)
 
         return S3Storage(
             access_key=storage["access_key"],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,7 +75,7 @@ allow_dupe_invites: "0"
 invite_expire_seconds: 604800
 
 # base url for replayweb.page
-rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@2.1.4/"
+rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@2.2.4/"
 
 superuser:
   # set this to enable a superuser admin

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -554,7 +554,7 @@ export class CollectionItemsDialog extends BtrixElement {
     let selectionMessage = msg("No changes to save");
 
     if (hasChange) {
-      const messages = [];
+      const messages: string[] = [];
       if (addCount) {
         messages.push(
           msg(
@@ -564,7 +564,9 @@ export class CollectionItemsDialog extends BtrixElement {
       }
       if (removeCount) {
         messages.push(
-          str`Adding ${formatNumber(removeCount)} ${pluralOf("items", removeCount)}`,
+          msg(
+            str`Removing ${formatNumber(removeCount)} ${pluralOf("items", removeCount)}`,
+          ),
         );
       }
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -61,6 +61,9 @@ export class CollectionDetail extends BtrixElement {
   @query(".descriptionExpandBtn")
   private readonly descriptionExpandBtn?: HTMLElement | null;
 
+  @query("replay-web-page")
+  private readonly replayEmbed?: HTMLElement | null;
+
   // Use to cancel requests
   private getArchivedItemsController: AbortController | null = null;
 
@@ -204,6 +207,7 @@ export class CollectionDetail extends BtrixElement {
         ?open=${this.openDialogName === "editItems"}
         @sl-hide=${() => (this.openDialogName = undefined)}
         @btrix-collection-saved=${() => {
+          this.refreshReplay();
           void this.fetchCollection();
           void this.fetchArchivedItems();
         }}
@@ -216,12 +220,26 @@ export class CollectionDetail extends BtrixElement {
             .collection=${this.collection!}
             ?open=${this.openDialogName === "editMetadata"}
             @sl-hide=${() => (this.openDialogName = undefined)}
-            @btrix-collection-saved=${() => void this.fetchCollection()}
+            @btrix-collection-saved=${() => {
+              this.refreshReplay();
+              void this.fetchCollection();
+            }}
           >
           </btrix-collection-metadata-dialog>
         `,
       )}
       ${this.renderShareDialog()}`;
+  }
+
+  private refreshReplay() {
+    if (this.replayEmbed) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this.replayEmbed as any).fullReload();
+      } catch (e) {
+        console.warn("Full reload not available in RWP");
+      }
+    }
   }
 
   private getPublicReplayURL() {

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -3780,6 +3780,9 @@
                 <x equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;/docs/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;" id="0"/>org settings<x equiv-text="&lt;/a&gt;" id="1"/>
                 for details.</source>
       </trans-unit>
+      <trans-unit id="s582e36ff4a424786">
+        <source>Removing <x equiv-text="${formatNumber(removeCount)} ${pluralOf(&quot;items&quot;, removeCount)}" id="0"/></source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
- editing collection metadata
- adding / remove collection items
- storages: don't default to 'use_access_for_presign' to true, fixes support for custom CDN on DO
- fixes missing string 'Removing X items from collection', was not wrapped in msg()
- fixes #2175 