### PR TITLE
Fix issue with failed background job emails not being sent

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2354,7 +2354,7 @@ class EmptyResponse(BaseModel):
 class PaginatedBackgroundJobResponse(PaginatedResponse):
     """Response model for paginated background jobs"""
 
-    items: List[Union[CreateReplicaJob, DeleteReplicaJob]]
+    items: List[AnyJob]
 
 
 # ============================================================================

--- a/chart/email-templates/failed_bg_job
+++ b/chart/email-templates/failed_bg_job
@@ -10,7 +10,18 @@ Job ID: {{ job.id }}
 Started: {{ job.started.isoformat(sep=" ", timespec="seconds") }}Z
 Finished: {{ finished.isoformat(sep=" ", timespec="seconds") }}Z
 
+{% if job.object_type %}
 Object type: {{ job.object_type }}
+{% endif %}
+
+{% if job.object_id %}
 Object ID: {{ job.object_id }}
+{% endif %}
+
+{% if job.file_path %}
 File path: {{ job.file_path }}
+{% endif %}
+
+{% if job.replica_storage %}
 Replica storage name: {{ job.replica_storage.name }}
+{% endif %}


### PR DESCRIPTION
Fixes #2186 

Background job emails will no longer fail to send for jobs unrelated to file replication or replica deletion.

Also uses `AnyJob` for paginated background job response model, to fix typing being out of data following addition of other types of background jobs and lower overhead for adding new ones moving forward.