### PR TITLE
fix: More accurate rounded days in subscription end message

### DIFF
--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -1,5 +1,5 @@
 import { localized, msg, str } from "@lit/localize";
-import { differenceInDays } from "date-fns/fp";
+import { differenceInHours } from "date-fns/fp";
 import { html, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
@@ -62,18 +62,21 @@ export class OrgStatusBanner extends BtrixElement {
       execMinutesQuotaReached,
     } = this.org;
 
+    let hoursDiff = 0;
     let daysDiff = 0;
     let dateStr = "";
     const futureCancelDate = subscription?.futureCancelDate || null;
 
     if (futureCancelDate) {
-      daysDiff = differenceInDays(new Date(), new Date(futureCancelDate));
+      hoursDiff = differenceInHours(new Date(), new Date(futureCancelDate));
+      daysDiff = Math.trunc(hoursDiff / 24);
 
       dateStr = this.localize.date(futureCancelDate, {
         month: "long",
         day: "numeric",
         year: "numeric",
         hour: "numeric",
+        timeZoneName: "short",
       });
     }
 
@@ -90,12 +93,11 @@ export class OrgStatusBanner extends BtrixElement {
         content: () => {
           return {
             title:
-              daysDiff > 1
-                ? msg(
-                    str`Your org will be deleted in
-              ${daysDiff} days`,
-                  )
-                : `Your org will be deleted within one day`,
+              hoursDiff < 24
+                ? msg("Your org will be deleted within one day")
+                : daysDiff === 1
+                  ? msg("Your org will be deleted in one day.")
+                  : msg(str`Your org will be deleted in ${daysDiff} days`),
             detail: html`
               <p>
                 ${msg(
@@ -124,11 +126,13 @@ export class OrgStatusBanner extends BtrixElement {
         content: () => {
           return {
             title:
-              daysDiff > 1
-                ? msg(
-                    str`You have ${daysDiff} days left of your Browsertrix trial`,
-                  )
-                : msg(`Your trial ends within one day`),
+              hoursDiff < 24
+                ? msg("Your trial ends within one day")
+                : daysDiff === 1
+                  ? msg("You have one day left of your Browsertrix trial")
+                  : msg(
+                      str`You have ${daysDiff} days left of your Browsertrix trial`,
+                    ),
 
             detail: html`
               <p>

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -404,9 +404,6 @@
         <source>Choose a custom profile to make use of saved cookies and logged-in
   accounts. Note that websites may log profiles out after a period of time.</source>
       </trans-unit>
-      <trans-unit id="scd15181280405de6">
-        <source>Choose a Browsertrix Crawler Release Channel. If available, other versions may provide new/experimental crawling features.</source>
-      </trans-unit>
       <trans-unit id="h1a88ca035802fcd0">
         <source>Blocks advertising content from being loaded. Uses
       <x equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>Steven Black’s Hosts file<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
@@ -2938,10 +2935,6 @@
       <trans-unit id="sc154fb69dffcdef9">
         <source>billing settings</source>
       </trans-unit>
-      <trans-unit id="s71c5c2d34bb2c4c2">
-        <source>Your org will be deleted in
-              <x equiv-text="${daysDiff}" id="0"/> days</source>
-      </trans-unit>
       <trans-unit id="s7fa0d24b94690373">
         <source>Your subscription ends on <x equiv-text="${dateStr}" id="0"/>. Your user account, org, and all associated data will be deleted.</source>
       </trans-unit>
@@ -3849,17 +3842,19 @@
       </trans-unit>
       <trans-unit id="se1037ae4d9adb08a">
         <source>You have one day left of your Browsertrix trial</source>
-      <trans-unit id="saecba9c0445090e6">
-        <source>Choose a Browsertrix Crawler release channel. If available, other versions may provide new/experimental crawling features.</source>
-      </trans-unit>
-      <trans-unit id="s22cec6a3e464a4e9">
-        <source>Gracefully stop archiving after the specified amount of time has elapsed.</source>
-      </trans-unit>
-      <trans-unit id="s2823887bf8a836da">
-        <source>Gracefully stop archiving after the specified amount of data has been captured.</source>
-      </trans-unit>
-      <trans-unit id="s9aa0dfb832cb7f69">
-        <source>View error logs</source>
+        <trans-unit id="saecba9c0445090e6">
+          <source>Choose a Browsertrix Crawler release channel. If available, other versions may provide new/experimental crawling features.</source>
+        </trans-unit>
+        <trans-unit id="s22cec6a3e464a4e9">
+          <source>Gracefully stop archiving after the specified amount of time has elapsed.</source>
+        </trans-unit>
+        <trans-unit id="s2823887bf8a836da">
+          <source>Gracefully stop archiving after the specified amount of data has been captured.</source>
+        </trans-unit>
+        <trans-unit id="s9aa0dfb832cb7f69">
+          <source>View error logs</source>
+        </trans-unit>
+        <source>You have one day left of your Browsertrix trial</source>
       </trans-unit>
     </body>
   </file>

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -2939,10 +2939,6 @@
       <trans-unit id="sc154fb69dffcdef9">
         <source>billing settings</source>
       </trans-unit>
-      <trans-unit id="s71c5c2d34bb2c4c2">
-        <source>Your org will be deleted in
-              <x equiv-text="${daysDiff}" id="0"/> days</source>
-      </trans-unit>
       <trans-unit id="s7fa0d24b94690373">
         <source>Your subscription ends on <x equiv-text="${dateStr}" id="0"/>. Your user account, org, and all associated data will be deleted.</source>
       </trans-unit>
@@ -3838,6 +3834,18 @@
       </trans-unit>
       <trans-unit id="sab5061cf8c519285">
         <source><x equiv-text="${storageBytesText}" id="0"/> of disk space</source>
+      </trans-unit>
+      <trans-unit id="s8be75efeafa7ffe1">
+        <source>Your org will be deleted within one day</source>
+      </trans-unit>
+      <trans-unit id="sfa1778ba000b56f5">
+        <source>Your org will be deleted in one day.</source>
+      </trans-unit>
+      <trans-unit id="se392e1f811076a30">
+        <source>Your org will be deleted in <x equiv-text="${daysDiff}" id="0"/> days</source>
+      </trans-unit>
+      <trans-unit id="se1037ae4d9adb08a">
+        <source>You have one day left of your Browsertrix trial</source>
       </trans-unit>
     </body>
   </file>

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -31,12 +31,12 @@
         <target state="translated">Siguiente página</target>
       </trans-unit>
       <trans-unit xml:space="preserve" id="h7ee8a6e551e702ba">
-        <source><x equiv-text="${this.renderInput()}" id="0"></x> of <x equiv-text="${this.pages} " id="1"></x></source>
-        <target state="translated"><x equiv-text="${this.renderInput()}" id="0"></x> de <x equiv-text="${this.pages} " id="1"></x></target>
+        <source> <x equiv-text="${this.renderInput()}" id="0"/> of <x equiv-text="${this.pages} " id="1"/></source>
+        <target state="translated"><x equiv-text="${this.renderInput()}" id="0"/> de <x equiv-text="${this.pages} " id="1"/></target>
       </trans-unit>
       <trans-unit xml:space="preserve" id="s5697808ce744d508">
-        <source>Current page, page <x equiv-text="${this.page}" id="0"></x></source>
-        <target state="translated">Página actual, página <x equiv-text="${this.page}" id="0"></x></target>
+        <source>Current page, page <x equiv-text="${this.page}" id="0"/></source>
+        <target state="translated">Página actual, página <x equiv-text="${this.page}" id="0"/></target>
       </trans-unit>
       <trans-unit xml:space="preserve" id="s81a19821f3e4a3d2">
         <source>Replay</source>
@@ -67,8 +67,9 @@
         <target state="translated">¿Eliminar colección?</target>
       </trans-unit>
       <trans-unit xml:space="preserve" id="h05165b87bf66fe02">
-        <source>Are you sure you want to delete <x equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;" id="0"></x>?</source>
-        <target state="translated">¿Estás seguro de que deseas eliminar <x equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;" id="0"></x>?</target>
+        <source>Are you sure you want to delete
+            <x equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;" id="0"/>?</source>
+        <target state="translated">¿Estás seguro de que deseas eliminar <x equiv-text="&lt;strong&gt;${this.collection?.name}&lt;/strong&gt;" id="0"/>?</target>
       </trans-unit>
       <trans-unit id="s2ceb11be2290bb1b">
         <source>Cancel</source>
@@ -85,7 +86,7 @@
       <trans-unit id="seeb6295e19bc1400">
         <source>Collection is Shareable</source>
       </trans-unit>
-      <trans-unit id="s0379fc73608ab971" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="s0379fc73608ab971">
         <source>Done</source>
         <target state="translated">hecho</target>
       </trans-unit>
@@ -111,13 +112,17 @@
         <source>Copy Embed Code</source>
       </trans-unit>
       <trans-unit id="h648aaa4b436a5970">
-        <source>Add the following JavaScript to your <x equiv-text="&lt;code class=&quot;text-[0.9em]&quot;&gt;" id="0"></x>/replay/sw.js<x equiv-text="&lt;/code&gt;" id="1"></x>:</source>
+        <source>Add the following JavaScript to your
+              <x equiv-text="&lt;code class=&quot;text-[0.9em]&quot;&gt;" id="0"/>/replay/sw.js<x equiv-text="&lt;/code&gt;" id="1"/>:</source>
       </trans-unit>
       <trans-unit id="s4f0cf5a844f978f3">
         <source>Copy JS</source>
       </trans-unit>
       <trans-unit id="hf56186ec17103fb3">
-        <source>See <x equiv-text="&lt;a class=&quot;text-primary&quot; href=&quot;https://replayweb.page/docs/embedding&quot; target=&quot;_blank&quot;&gt;" id="0"></x> our embedding guide<x equiv-text="&lt;/a&gt;" id="1"></x> for more details.</source>
+        <source>See
+              <x equiv-text="&lt;a class=&quot;text-primary&quot; href=&quot;https://replayweb.page/docs/embedding&quot; target=&quot;_blank&quot;&gt;" id="0"/>
+                our embedding guide<x equiv-text="&lt;/a&gt;" id="1"/>
+              for more details.</source>
       </trans-unit>
       <trans-unit id="s3f5390ecd7d14626">
         <source>Collections</source>
@@ -141,7 +146,7 @@
         <source>Download Collection</source>
       </trans-unit>
       <trans-unit id="s125a86b2f45bbb25">
-        <source><x equiv-text="${item.crawlCount}" id="0"></x> items</source>
+        <source><x equiv-text="${item.crawlCount}" id="0"/> items</source>
       </trans-unit>
       <trans-unit id="s88f9e7f4ecc07ede">
         <source>Total Size</source>
@@ -150,7 +155,7 @@
         <source>Total Pages</source>
       </trans-unit>
       <trans-unit id="s279de934d8a18e21">
-        <source><x equiv-text="${this.localize.number(pageCount)}" id="0"></x> pages</source>
+        <source><x equiv-text="${this.localize.number(pageCount)}" id="0"/> pages</source>
       </trans-unit>
       <trans-unit id="s3512b3c95c7a5c3a">
         <source>Last Updated</source>
@@ -183,7 +188,7 @@
         <source>Remove from Collection</source>
       </trans-unit>
       <trans-unit id="h2962269031cae049">
-        <source>Deleted <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"></x> Collection.</source>
+        <source>Deleted <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"/> Collection.</source>
       </trans-unit>
       <trans-unit id="s1a223f3372970867">
         <source>Sorry, couldn't delete Collection at this time.</source>
@@ -201,16 +206,16 @@
         <source>Sorry, couldn't remove item from Collection at this time.</source>
       </trans-unit>
       <trans-unit id="sd77c5f8da91d0729">
-        <source>Maximum <x equiv-text="${localize.number(maxLength)}" id="0"></x> characters</source>
+        <source>Maximum <x equiv-text="${localize.number(maxLength)}" id="0"/> characters</source>
       </trans-unit>
       <trans-unit id="sa1c466807a6fdfb7">
-        <source><x equiv-text="${localize.number(overMax)}" id="0"></x> character over limit</source>
+        <source><x equiv-text="${localize.number(overMax)}" id="0"/> character over limit</source>
       </trans-unit>
       <trans-unit id="s8b6894f4bfec27c0">
-        <source><x equiv-text="${localize.number(overMax)}" id="0"></x> characters over limit</source>
+        <source><x equiv-text="${localize.number(overMax)}" id="0"/> characters over limit</source>
       </trans-unit>
       <trans-unit id="se1f5b61904654dba">
-        <source>Please shorten this text to <x equiv-text="${maxLength}" id="0"></x> or fewer characters.</source>
+        <source>Please shorten this text to <x equiv-text="${maxLength}" id="0"/> or fewer characters.</source>
       </trans-unit>
       <trans-unit id="s9f8c17b4d595bb2d">
         <source>Manage Billing</source>
@@ -231,16 +236,17 @@
         <source>Subscription status, features, and add-ons, if applicable.</source>
       </trans-unit>
       <trans-unit id="sc93b55ebdda10016">
-        <source>You can view plan details, update payment methods, and update billing information by clicking “<x equiv-text="${this.portalUrlLabel}" id="0"></x>”.</source>
+        <source>You can view plan details, update payment methods, and update billing information by clicking “<x equiv-text="${this.portalUrlLabel}" id="0"/>”.</source>
       </trans-unit>
       <trans-unit id="h1abcffb9335ebc6d">
-        <source>To upgrade to Pro, contact us at <x equiv-text="&lt;a class=&quot;${linkClassList}&quot; href=&quot;${`mailto:${this.salesEmail}?subject=${msg(str `Upgrade Browsertrix plan (${this.userOrg?.name})`)}`}&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;${this.salesEmail}&lt;/a&gt;" id="0"></x>.</source>
+        <source>To upgrade to Pro, contact us at
+                                <x equiv-text="&lt;a class=&quot;${linkClassList}&quot; href=&quot;${`mailto:${this.salesEmail}?subject=${msg(str `Upgrade Browsertrix plan (${this.userOrg?.name})`)}`}&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;${this.salesEmail}&lt;/a&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s7ec899c7c6213c52">
-        <source>Upgrade Browsertrix plan (<x equiv-text="${this.userOrg?.name}" id="0"></x>)</source>
+        <source>Upgrade Browsertrix plan (<x equiv-text="${this.userOrg?.name}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s00341480baa290eb">
-        <source>Contact us at <x equiv-text="${this.salesEmail}" id="0"></x> to make changes to your plan.</source>
+        <source>Contact us at <x equiv-text="${this.salesEmail}" id="0"/> to make changes to your plan.</source>
       </trans-unit>
       <trans-unit id="s1d04dbb2d7ee4b9b">
         <source>Contact your Browsertrix host administrator to make changes to your plan.</source>
@@ -276,10 +282,10 @@
         <source>Unlimited</source>
       </trans-unit>
       <trans-unit id="s8e49ef99717ff3d4">
-        <source><x equiv-text="${this.localize.number(quotas.maxConcurrentCrawls)}" id="0"></x> concurrent <x equiv-text="${pluralOf(&quot;crawls&quot;, quotas.maxConcurrentCrawls)}" id="1"></x></source>
+        <source><x equiv-text="${this.localize.number(quotas.maxConcurrentCrawls)}" id="0"/> concurrent <x equiv-text="${pluralOf(&quot;crawls&quot;, quotas.maxConcurrentCrawls)}" id="1"/></source>
       </trans-unit>
       <trans-unit id="sc27403512c49c425">
-        <source>Pro plan change request (<x equiv-text="${this.userOrg?.name}" id="0"></x>)</source>
+        <source>Pro plan change request (<x equiv-text="${this.userOrg?.name}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="sc2a7f6d40341e683">
         <source>Contact Sales</source>
@@ -300,10 +306,13 @@
         <source>Regex</source>
       </trans-unit>
       <trans-unit id="h8c21d04827e5cb19">
-        <source>Regular Expression syntax error: <x equiv-text="&lt;code&gt;${this.fieldErrorMessage}&lt;/code&gt;" id="0"></x></source>
+        <source>Regular Expression syntax error:
+                                    <x equiv-text="&lt;code&gt;${this.fieldErrorMessage}&lt;/code&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="h1a1f28e6632c15d0">
-        <source>Please enter a valid constructor string pattern. See <x equiv-text="&lt;a class=&quot;underline hover:no-underline&quot; href=&quot;https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;&lt;code&gt;" id="0"></x>RegExp<x equiv-text="&lt;/code&gt;" id="1"></x> docs<x equiv-text="&lt;/a&gt;" id="2"></x>.</source>
+        <source>Please enter a valid constructor string
+                                    pattern. See
+                                    <x equiv-text="&lt;a class=&quot;underline hover:no-underline&quot; href=&quot;https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;&lt;code&gt;" id="0"/>RegExp<x equiv-text="&lt;/code&gt;" id="1"/> docs<x equiv-text="&lt;/a&gt;" id="2"/>.</source>
       </trans-unit>
       <trans-unit id="s312a6fda81078718">
         <source>Exclusions</source>
@@ -327,7 +336,7 @@
         <source>Exclusion already exists. Please edit or remove to continue</source>
       </trans-unit>
       <trans-unit id="sbe7425a3b5445ba7">
-        <source>Please enter <x equiv-text="${MIN_LENGTH}" id="0"></x> or more characters</source>
+        <source>Please enter <x equiv-text="${MIN_LENGTH}" id="0"/> or more characters</source>
       </trans-unit>
       <trans-unit id="s74abf58e08f32710">
         <source>Please enter a valid Regular Expression constructor pattern</source>
@@ -339,40 +348,42 @@
         <source>Tags</source>
       </trans-unit>
       <trans-unit id="s0e3006648a1a80a5">
-        <source>Add “<x equiv-text="${this.inputValue.toLocaleLowerCase()}" id="0"></x>”</source>
+        <source>Add “<x equiv-text="${this.inputValue.toLocaleLowerCase()}" id="0"/>”</source>
       </trans-unit>
       <trans-unit id="s1eee55ca9401677a">
-        <source>+<x equiv-text="${this.localize.number(this.total)}" id="0"></x> URLs</source>
+        <source>+<x equiv-text="${this.localize.number(this.total)}" id="0"/> URLs</source>
       </trans-unit>
       <trans-unit id="sfff90c46fdba31db">
         <source>(unnamed item)</source>
       </trans-unit>
       <trans-unit id="s8265788524ca2260">
-        <source><x equiv-text="${formattedTime}" id="0"></x> daily</source>
+        <source><x equiv-text="${formattedTime}" id="0"/> daily</source>
       </trans-unit>
       <trans-unit id="s2acb3777ed86adb6">
-        <source>Every <x equiv-text="${formattedWeekDay}" id="0"></x></source>
+        <source>Every <x equiv-text="${formattedWeekDay}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s37a3a294775e081a">
-        <source>Monthly on the <x equiv-text="${localize.number(days[0], { ordinal: true })}" id="0"></x></source>
+        <source>Monthly on the <x equiv-text="${localize.number(days[0], { ordinal: true })}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s2bc963c5c7bac2e1">
-        <source>Every day at <x equiv-text="${formattedTime}" id="0"></x></source>
+        <source>Every day at <x equiv-text="${formattedTime}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s3fc21c0b1ae61eb7">
-        <source>Every <x equiv-text="${formattedWeekDay}" id="0"></x> at <x equiv-text="${formattedTime}" id="1"></x></source>
+        <source>Every <x equiv-text="${formattedWeekDay}" id="0"/>
+            at <x equiv-text="${formattedTime}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s478f33dea36e1d3f">
-        <source>On day <x equiv-text="${nextDate.getDate()}" id="0"></x> of the month at <x equiv-text="${formattedTime}" id="1"></x></source>
+        <source>On day <x equiv-text="${nextDate.getDate()}" id="0"/> of the month at <x equiv-text="${formattedTime}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s44f6ab2c6b3cff23">
         <source>Default: Unlimited</source>
       </trans-unit>
       <trans-unit id="sf21761e7f8e0550e">
-        <source>Default: <x equiv-text="${localize.number(value)}" id="0"></x></source>
+        <source>Default: <x equiv-text="${localize.number(value)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s5ae0226079b4d5fc">
-        <source>Specify exclusion rules for what pages should not be visited. Exclusions apply to all URLs.</source>
+        <source>Specify exclusion rules for what pages should not be visited.
+  Exclusions apply to all URLs.</source>
       </trans-unit>
       <trans-unit id="sa663117885b91a78">
         <source>Adds a hard limit on the number of pages that will be crawled.</source>
@@ -396,19 +407,24 @@
         <source>Waits on the page after behaviors are complete before moving onto the next page. Can be helpful for rate limiting.</source>
       </trans-unit>
       <trans-unit id="s750a2fea733037cb">
-        <source>Choose a custom profile to make use of saved cookies and logged-in accounts. Note that websites may log profiles out after a period of time.</source>
+        <source>Choose a custom profile to make use of saved cookies and logged-in
+  accounts. Note that websites may log profiles out after a period of time.</source>
       </trans-unit>
       <trans-unit id="scd15181280405de6">
         <source>Choose a Browsertrix Crawler Release Channel. If available, other versions may provide new/experimental crawling features.</source>
       </trans-unit>
       <trans-unit id="h1a88ca035802fcd0">
-        <source>Blocks advertising content from being loaded. Uses <x equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"></x>Steven Black’s Hosts file<x equiv-text="&lt;/a&gt;" id="1"></x>.</source>
+        <source>Blocks advertising content from being loaded. Uses
+      <x equiv-text="&lt;a href=&quot;https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>Steven Black’s Hosts file<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="h63182e63349f17de">
-        <source>Set custom user agent for crawler browsers to use in requests. For common user agents see <x equiv-text="&lt;a href=&quot;https://www.useragents.me/&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"></x>Useragents.me<x equiv-text="&lt;/a&gt;" id="1"></x>.</source>
+        <source>Set custom user agent for crawler browsers to use in requests. For
+      common user agents see
+      <x equiv-text="&lt;a href=&quot;https://www.useragents.me/&quot; class=&quot;text-blue-600 hover:text-blue-500&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>Useragents.me<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="s49e094325ac57142">
-        <source>Websites that observe the browser’s language setting may serve content in that language if available.</source>
+        <source>Websites that observe the browser’s language setting may serve
+  content in that language if available.</source>
       </trans-unit>
       <trans-unit id="s68eac1025cee6964">
         <source>Crawl Scope</source>
@@ -486,7 +502,8 @@
         <source>Org Settings</source>
       </trans-unit>
       <trans-unit id="h9c83f117a7e3a93f">
-        <source>Viewing <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${userOrg.name}&lt;/strong&gt;" id="0"></x></source>
+        <source>Viewing
+                  <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${userOrg.name}&lt;/strong&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s52d61e7db1ece998">
         <source>Active Members</source>
@@ -513,7 +530,7 @@
         <source>Custom URL Identifier</source>
       </trans-unit>
       <trans-unit id="s736e0de127d6aba2">
-        <source>Org home page: <x equiv-text="${window.location.protocol}" id="0"></x>//<x equiv-text="${window.location.hostname}" id="1"></x>/orgs/<x equiv-text="${this.slugValue&#10;    ? slugifyStrict(this.slugValue)&#10;    : this.orgSlug}" id="2"></x></source>
+        <source>Org home page: <x equiv-text="${window.location.protocol}" id="0"/>//<x equiv-text="${window.location.hostname}" id="1"/>/orgs/<x equiv-text="${this.slugValue&#10;    ? slugifyStrict(this.slugValue)&#10;    : this.orgSlug}" id="2"/></source>
       </trans-unit>
       <trans-unit id="s0559157886d79c76">
         <source>Customize your organization's web address for accessing Browsertrix.</source>
@@ -636,16 +653,16 @@
         <source>Sorry, couldn't retrieve pending invites at this time.</source>
       </trans-unit>
       <trans-unit id="s7cfdd7b9b1ce6231">
-        <source>Successfully invited <x equiv-text="${inviteEmail}" id="0"></x>.</source>
+        <source>Successfully invited <x equiv-text="${inviteEmail}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s53846234c681dace">
         <source>Sorry, couldn't invite user at this time.</source>
       </trans-unit>
       <trans-unit id="s63ca31a1df9116e2">
-        <source>Successfully removed <x equiv-text="${invite.email}" id="0"></x> from <x equiv-text="${this.userOrg?.name}" id="1"></x>.</source>
+        <source>Successfully removed <x equiv-text="${invite.email}" id="0"/> from <x equiv-text="${this.userOrg?.name}" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="s667558910cf30318">
-        <source>Sorry, couldn't remove <x equiv-text="${invite.email}" id="0"></x> at this time.</source>
+        <source>Sorry, couldn't remove <x equiv-text="${invite.email}" id="0"/> at this time.</source>
       </trans-unit>
       <trans-unit id="s0cac3669c233a0ad">
         <source>Org successfully updated.</source>
@@ -663,10 +680,11 @@
         <source>This org URL identifier is invalid. Please use alphanumeric characters and dashes (-) only.</source>
       </trans-unit>
       <trans-unit id="h58a74834f0ef0fcb">
-        <source>Supports <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"></x>GitHub Flavored Markdown<x equiv-text="&lt;/a&gt;" id="1"></x>.</source>
+        <source>Supports
+                <x equiv-text="&lt;a class=&quot;text-blue-500 hover:text-blue-600&quot; href=&quot;https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot;&gt;" id="0"/>GitHub Flavored Markdown<x equiv-text="&lt;/a&gt;" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="s7a89a316efd4e9c0">
-        <source>Please shorten the description to <x equiv-text="${this.localize.number(this.maxlength)}" id="0"></x> or fewer characters.</source>
+        <source>Please shorten the description to <x equiv-text="${this.localize.number(this.maxlength)}" id="0"/> or fewer characters.</source>
       </trans-unit>
       <trans-unit id="s6ee5d5975cae2ed4">
         <source>Edit Collection Metadata</source>
@@ -696,7 +714,7 @@
         <source>Enable public access to make Collections shareable. Only people with the shared link can view your Collection.</source>
       </trans-unit>
       <trans-unit id="s77001a56d74ac617">
-        <source>Successfully saved "<x equiv-text="${data.name || name}" id="0"></x>" Collection.</source>
+        <source>Successfully saved "<x equiv-text="${data.name || name}" id="0"/>" Collection.</source>
       </trans-unit>
       <trans-unit id="s0014ed029ed0ef6f">
         <source>This name is already taken.</source>
@@ -786,7 +804,7 @@
         <source>Stopped: Crawling Disabled</source>
       </trans-unit>
       <trans-unit id="h98fd4ace98188324">
-        <source>Removed exclusion: <x equiv-text="&lt;code&gt;${regex}&lt;/code&gt;" id="0"></x></source>
+        <source>Removed exclusion: <x equiv-text="&lt;code&gt;${regex}&lt;/code&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s13acc5f8f152f1b6">
         <source>Cannot remove exclusion when crawl is no longer running.</source>
@@ -924,13 +942,13 @@
         <source>Created By</source>
       </trans-unit>
       <trans-unit id="sf72695e8cd91f93c">
-        <source><x equiv-text="${workflow.createdByName}" id="0"></x> on <x equiv-text="${this.localize.date(new Date(workflow.created), {&#10;    year: &quot;numeric&quot;,&#10;    month: &quot;numeric&quot;,&#10;    day: &quot;numeric&quot;,&#10;})}" id="1"></x></source>
+        <source><x equiv-text="${workflow.createdByName}" id="0"/> on <x equiv-text="${this.localize.date(new Date(workflow.created), {&#10;    year: &quot;numeric&quot;,&#10;    month: &quot;numeric&quot;,&#10;    day: &quot;numeric&quot;,&#10;})}" id="1"/></source>
       </trans-unit>
       <trans-unit id="hcb76d3d062f4fe97">
-        <source><x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;          &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URL<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source> <x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;          &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URL<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="h0f472740ba5c3c86">
-        <source><x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;        &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URLs<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source> <x equiv-text="&lt;span class=&quot;truncate&quot;&gt;${firstSeed}&lt;/span&gt;&#10;        &lt;span class=&quot;whitespace-nowrap text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URLs<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="s900a5e61e7ade066">
         <source>View:</source>
@@ -939,7 +957,8 @@
         <source>All Crawls</source>
       </trans-unit>
       <trans-unit id="he775de5878ab0942">
-        <source>Crawl is currently running. <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"></x>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"></x></source>
+        <source>Crawl is currently running.
+                    <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"/>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="s76d9944af031bdb3">
         <source>No matching crawls found.</source>
@@ -984,7 +1003,8 @@
         <source>Crawl is not running.</source>
       </trans-unit>
       <trans-unit id="h27573a6e2ed7211d">
-        <source>Viewing error logs for currently running crawl. <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"></x>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"></x></source>
+        <source>Viewing error logs for currently running crawl.
+                    <x equiv-text="&lt;a href=&quot;${`${window.location.pathname}#watch`}&quot; class=&quot;underline hover:no-underline&quot;&gt;" id="0"/>Watch Crawl Progress<x equiv-text="&lt;/a&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="s31b57d50c6a992ba">
         <source>Error logs currently not available.</source>
@@ -996,7 +1016,7 @@
         <source>Logs will show here after you run a crawl.</source>
       </trans-unit>
       <trans-unit id="sa641ef4b0f2af2b4">
-        <source>Displaying latest <x equiv-text="${this.localize.number(LOGS_PAGE_SIZE)}" id="0"></x> errors of <x equiv-text="${this.localize.number(this.logs!.total)}" id="1"></x>.</source>
+        <source>Displaying latest <x equiv-text="${this.localize.number(LOGS_PAGE_SIZE)}" id="0"/> errors of <x equiv-text="${this.localize.number(this.logs!.total)}" id="1"/>.</source>
       </trans-unit>
       <trans-unit id="sa7bc374e662a4beb">
         <source>Upcoming Pages</source>
@@ -1023,13 +1043,13 @@
         <source>Sorry, couldn't get crawls at this time.</source>
       </trans-unit>
       <trans-unit id="s1a20a47c9bf221da">
-        <source><x equiv-text="${this.workflow.name}" id="0"></x> Copy</source>
+        <source><x equiv-text="${this.workflow.name}" id="0"/> Copy</source>
       </trans-unit>
       <trans-unit id="sb751de28d615caad">
         <source>Copied Workflow to new template.</source>
       </trans-unit>
       <trans-unit id="h0e60bb54fe15e7b6">
-        <source>Deleted <x equiv-text="&lt;strong&gt;${this.renderName()}&lt;/strong&gt;" id="0"></x> Workflow.</source>
+        <source>Deleted <x equiv-text="&lt;strong&gt;${this.renderName()}&lt;/strong&gt;" id="0"/> Workflow.</source>
       </trans-unit>
       <trans-unit id="s6ec009ac55d85d6a">
         <source>Sorry, couldn't delete Workflow at this time.</source>
@@ -1125,10 +1145,10 @@
         <source>Search all Workflows by name or Crawl Start URL</source>
       </trans-unit>
       <trans-unit id="hc226df43ef96e720">
-        <source><x equiv-text="${firstSeed}&#10;          &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URL<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source><x equiv-text="${firstSeed}&#10;          &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URL<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="h649ef1ec13735ee9">
-        <source><x equiv-text="${firstSeed}&#10;        &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"></x>+<x equiv-text="${remainderCount}" id="1"></x> URLs<x equiv-text="&lt;/span&gt;" id="2"></x></source>
+        <source><x equiv-text="${firstSeed}&#10;        &lt;span class=&quot;text-neutral-500&quot;&gt;" id="0"/>+<x equiv-text="${remainderCount}" id="1"/> URLs<x equiv-text="&lt;/span&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="s442425cd7d61051f">
         <source>No matching Workflows found.</source>
@@ -1146,7 +1166,7 @@
         <source>Partially copied Workflow</source>
       </trans-unit>
       <trans-unit id="sebba8356f42b6eaa">
-        <source>Only first <x equiv-text="${this.localize.number(SEEDS_MAX)}" id="0"></x> URLs were copied.</source>
+        <source>Only first <x equiv-text="${this.localize.number(SEEDS_MAX)}" id="0"/> URLs were copied.</source>
       </trans-unit>
       <trans-unit id="s8745d54f3284f080">
         <source>Are you sure you want to cancel the crawl?</source>
@@ -1191,7 +1211,9 @@
         <source>Analysis Progress</source>
       </trans-unit>
       <trans-unit id="s984a5e18d85b6d57">
-        <source><x equiv-text="${this.mostRecentNonFailedQARun.stats.found === 0&#10;    ? msg(&quot;Loading&quot;)&#10;    : `${this.mostRecentNonFailedQARun.stats.done}/${this.mostRecentNonFailedQARun.stats.found}`} ${pluralOf(&quot;pages&quot;, this.mostRecentNonFailedQARun.stats.found)}" id="0"></x> </source>
+        <source>
+          <x equiv-text="${this.mostRecentNonFailedQARun.stats.found === 0&#10;    ? msg(&quot;Loading&quot;)&#10;    : `${this.mostRecentNonFailedQARun.stats.done}/${this.mostRecentNonFailedQARun.stats.found}`} ${pluralOf(&quot;pages&quot;, this.mostRecentNonFailedQARun.stats.found)}" id="0"/>
+        </source>
       </trans-unit>
       <trans-unit id="sb59d68ed12d46377">
         <source>Loading</source>
@@ -1215,13 +1237,19 @@
         <source>Non-HTML files captured as pages are known good files that the crawler found as clickable links on a page and don't need to be analyzed. Failed pages did not respond when the crawler tried to visit them.</source>
       </trans-unit>
       <trans-unit id="h8309b5706a9a85ba">
-        <source><x equiv-text="&lt;span class=&quot;text-primary&quot;&gt;${htmlCount}&lt;/span&gt;" id="0"></x> HTML <x equiv-text="${pluralOf(&quot;pages&quot;, htmlCount)}&#10;                    " id="1"></x></source>
+        <source>
+                      <x equiv-text="&lt;span class=&quot;text-primary&quot;&gt;${htmlCount}&lt;/span&gt;" id="0"/>
+                      HTML <x equiv-text="${pluralOf(&quot;pages&quot;, htmlCount)}&#10;                    " id="1"/></source>
       </trans-unit>
       <trans-unit id="h7d8f1533bbc700e1">
-        <source><x equiv-text="&lt;span class=&quot;text-neutral-600&quot;&gt;${fileCount}&lt;/span&gt;" id="0"></x> Non-HTML files captured as <x equiv-text="${pluralOf(&quot;pages&quot;, fileCount)}&#10;                    " id="1"></x></source>
+        <source>
+                      <x equiv-text="&lt;span class=&quot;text-neutral-600&quot;&gt;${fileCount}&lt;/span&gt;" id="0"/>
+                      Non-HTML files captured as <x equiv-text="${pluralOf(&quot;pages&quot;, fileCount)}&#10;                    " id="1"/></source>
       </trans-unit>
       <trans-unit id="ha312818a16d5146b">
-        <source><x equiv-text="&lt;span class=&quot;text-danger&quot;&gt;${errorCount}&lt;/span&gt;" id="0"></x> Failed <x equiv-text="${pluralOf(&quot;pages&quot;, errorCount)}&#10;                    " id="1"></x></source>
+        <source>
+                      <x equiv-text="&lt;span class=&quot;text-danger&quot;&gt;${errorCount}&lt;/span&gt;" id="0"/>
+                      Failed <x equiv-text="${pluralOf(&quot;pages&quot;, errorCount)}&#10;                    " id="1"/></source>
       </trans-unit>
       <trans-unit id="s3fd6bd99e3f6a5be">
         <source>Started</source>
@@ -1248,7 +1276,7 @@
         <source>All of the data included in this analysis run will be deleted.</source>
       </trans-unit>
       <trans-unit id="sc2007e562d105da2">
-        <source>This analysis run includes data for <x equiv-text="${runToBeDeleted.stats.done} ${pluralOf(&quot;pages&quot;, runToBeDeleted.stats.done)}" id="0"></x> and was started on </source>
+        <source>This analysis run includes data for <x equiv-text="${runToBeDeleted.stats.done} ${pluralOf(&quot;pages&quot;, runToBeDeleted.stats.done)}" id="0"/> and was started on </source>
       </trans-unit>
       <trans-unit id="s08a64b07b54df8d4">
         <source>by</source>
@@ -1332,7 +1360,7 @@
         <source>Comments</source>
       </trans-unit>
       <trans-unit id="s4d3c92a1a881dc5f">
-        <source>Review "<x equiv-text="${page.title ?? page.url}" id="0"></x>"</source>
+        <source>Review "<x equiv-text="${page.title ?? page.url}" id="0"/>"</source>
       </trans-unit>
       <trans-unit id="s7282886335497d58">
         <source>Newest comment:</source>
@@ -1407,7 +1435,8 @@
         <source>Initiator</source>
       </trans-unit>
       <trans-unit id="h1dc2f6235d169989">
-        <source>Manual start by <x equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;" id="0"></x></source>
+        <source>Manual start by
+                          <x equiv-text="&lt;span&gt;${this.item!.userName || this.item!.userid}&lt;/span&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="hdfcda45e7d5c5ab4">
         <source>Scheduled start</source>
@@ -1536,7 +1565,7 @@
         <source>All files and logs associated with this item will also be deleted, and the crawl will no longer be visible in its associated Workflow.</source>
       </trans-unit>
       <trans-unit id="s039b6434e8a75560">
-        <source>Delete <x equiv-text="${this.itemToDelete?.type === &quot;upload&quot;&#10;    ? msg(&quot;Upload&quot;)&#10;    : msg(&quot;Crawl&quot;)}" id="0"></x></source>
+        <source>Delete <x equiv-text="${this.itemToDelete?.type === &quot;upload&quot;&#10;    ? msg(&quot;Upload&quot;)&#10;    : msg(&quot;Crawl&quot;)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s96668830629e0dfc">
         <source>Upload</source>
@@ -1575,7 +1604,8 @@
         <source>New Collection</source>
       </trans-unit>
       <trans-unit id="h21e623f674123fc2">
-        <source>Are you sure you want to delete <x equiv-text="&lt;strong&gt;${this.selectedCollection?.name}&lt;/strong&gt;" id="0"></x>?</source>
+        <source>Are you sure you want to delete
+                <x equiv-text="&lt;strong&gt;${this.selectedCollection?.name}&lt;/strong&gt;" id="0"/>?</source>
       </trans-unit>
       <trans-unit id="s777098c61f6b518a">
         <source>Start building your Collection.</source>
@@ -1656,7 +1686,7 @@
         <source>Websites that are not in the browser profile yet. Finish editing and save to add these websites to the profile.</source>
       </trans-unit>
       <trans-unit id="sf4d539e610f3a2aa">
-        <source>Go to <x equiv-text="${url}" id="0"></x></source>
+        <source>Go to <x equiv-text="${url}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sb07ea0d5070f719d">
         <source>Crawler Release Channel</source>
@@ -1719,10 +1749,11 @@
         <source>Sorry, couldn't create browser profile at this time.</source>
       </trans-unit>
       <trans-unit id="h132d0ccd2402fb33">
-        <source>Could not delete <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"></x>, in use by <x equiv-text="&lt;strong&gt;${data.crawlconfigs.map(({ name }) =&gt; name).join(&quot;, &quot;)}&lt;/strong&gt;" id="1"></x>. Please remove browser profile from Workflow to continue.</source>
+        <source>Could not delete <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"/>, in use by
+              <x equiv-text="&lt;strong&gt;${data.crawlconfigs.map(({ name }) =&gt; name).join(&quot;, &quot;)}&lt;/strong&gt;" id="1"/>. Please remove browser profile from Workflow to continue.</source>
       </trans-unit>
       <trans-unit id="ha6f8533fba325287">
-        <source>Deleted <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"></x>.</source>
+        <source>Deleted <x equiv-text="&lt;strong&gt;${profileName}&lt;/strong&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s6a43c0c6daea3998">
         <source>Sorry, couldn't delete browser profile at this time.</source>
@@ -1761,10 +1792,10 @@
         <source>No browser profiles yet.</source>
       </trans-unit>
       <trans-unit id="s07e46807b4a9183c">
-        <source>+<x equiv-text="${data.origins.length - 1}" id="0"></x></source>
+        <source>+<x equiv-text="${data.origins.length - 1}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s922123a81f238186">
-        <source>By <x equiv-text="${data.createdByName}" id="0"></x></source>
+        <source>By <x equiv-text="${data.createdByName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s0d2b97026d57ffd0">
         <source>Starting up browser with selected profile...</source>
@@ -1817,7 +1848,7 @@
       <trans-unit id="sd158a5fc0f062f18">
         <source>Available</source>
       </trans-unit>
-      <trans-unit id="sa17899510bcc6527" xml:space="preserve">
+      <trans-unit xml:space="preserve" id="sa17899510bcc6527">
         <source>gigabyte</source>
         <target state="translated">gigabyte</target>
       </trans-unit>
@@ -1939,10 +1970,10 @@
         <source>Text Match</source>
       </trans-unit>
       <trans-unit id="s2344bb018c2ade99">
-        <source>Showing all <x equiv-text="${this.localize.number(this.totalPages)}" id="0"></x> pages</source>
+        <source>Showing all <x equiv-text="${this.localize.number(this.totalPages)}" id="0"/> pages</source>
       </trans-unit>
       <trans-unit id="sd2afbd920020fe6d">
-        <source>Showing <x equiv-text="${this.localize.number(total)}" id="0"></x> of <x equiv-text="${this.localize.number(this.totalPages)}" id="1"></x> pages</source>
+        <source>Showing <x equiv-text="${this.localize.number(total)}" id="0"/> of <x equiv-text="${this.localize.number(this.totalPages)}" id="1"/> pages</source>
       </trans-unit>
       <trans-unit id="sd7c439303c5c7045">
         <source>No matching pages found</source>
@@ -2062,10 +2093,10 @@
         <source>Submit Review</source>
       </trans-unit>
       <trans-unit id="s6d7c9c2bb994f236">
-        <source>Comments (<x equiv-text="${this.localize.number(commentCount)}" id="0"></x>)</source>
+        <source>Comments (<x equiv-text="${this.localize.number(commentCount)}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s3732b439b691ea10">
-        <source><x equiv-text="${comment.userName}" id="0"></x> commented on <x equiv-text="${this.localize.date(comment.created, {&#10;    year: &quot;numeric&quot;,&#10;    month: &quot;numeric&quot;,&#10;    day: &quot;numeric&quot;,&#10;})}" id="1"></x></source>
+        <source><x equiv-text="${comment.userName}" id="0"/> commented on <x equiv-text="${this.localize.date(comment.created, {&#10;    year: &quot;numeric&quot;,&#10;    month: &quot;numeric&quot;,&#10;    day: &quot;numeric&quot;,&#10;})}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s36012a8db93560f3">
         <source>Delete comment</source>
@@ -2125,7 +2156,7 @@
         <source>browser profile best practices</source>
       </trans-unit>
       <trans-unit id="h6c440abb1e1a7d78">
-        <source>Extending <x equiv-text="&lt;strong&gt;${this.browserParams.name}&lt;/strong&gt;" id="0"></x></source>
+        <source>Extending <x equiv-text="&lt;strong&gt;${this.browserParams.name}&lt;/strong&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s3b397808715b71d8">
         <source>Cancel Profile Creation?</source>
@@ -2164,13 +2195,13 @@
         <source>Sorry, couldn't retrieve organization at this time.</source>
       </trans-unit>
       <trans-unit id="s0726c5784ccf9222">
-        <source>Successfully updated role for <x equiv-text="${user.name || user.email}" id="0"></x>.</source>
+        <source>Successfully updated role for <x equiv-text="${user.name || user.email}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="scc21a97f5f1b13b0">
-        <source>Sorry, couldn't update role for <x equiv-text="${user.name || user.email}" id="0"></x> at this time.</source>
+        <source>Sorry, couldn't update role for <x equiv-text="${user.name || user.email}" id="0"/> at this time.</source>
       </trans-unit>
       <trans-unit id="saafb6030ac4b40dd">
-        <source>Are you sure you want to remove yourself from <x equiv-text="${this.userOrg.name}" id="0"></x>?</source>
+        <source>Are you sure you want to remove yourself from <x equiv-text="${this.userOrg.name}" id="0"/>?</source>
       </trans-unit>
       <trans-unit id="s1ae7988ed93b0a32">
         <source>0 seconds</source>
@@ -2209,7 +2240,7 @@
         <source>Extra URL Prefixes in Scope</source>
       </trans-unit>
       <trans-unit id="s00952de51c229a2e">
-        <source><x equiv-text="${primarySeedConfig.depth}" id="0"></x> hop(s)</source>
+        <source><x equiv-text="${primarySeedConfig.depth}" id="0"/> hop(s)</source>
       </trans-unit>
       <trans-unit id="s9ecb6da2267389f4">
         <source>Unlimited (default)</source>
@@ -2281,7 +2312,7 @@
         <source>Bytes Stored</source>
       </trans-unit>
       <trans-unit id="sd805db60d62be7a1">
-        <source>Quotas for: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"></x></source>
+        <source>Quotas for: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sfba7b662681a9f92">
         <source>Max Concurrent Crawls</source>
@@ -2311,7 +2342,10 @@
         <source>Disable Archiving?</source>
       </trans-unit>
       <trans-unit id="h66cb67cd841f4beb">
-        <source>Are you sure you want to disable archiving in <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"></x> org? Members will no longer be able to crawl, upload files, create browser profiles, or create collections.</source>
+        <source>Are you sure you want to disable archiving in
+                  <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"/> org?
+                  Members will no longer be able to crawl, upload files, create
+                  browser profiles, or create collections.</source>
       </trans-unit>
       <trans-unit id="sdc8e0ecdba53dccc">
         <source>Slug:</source>
@@ -2329,40 +2363,42 @@
         <source>Disable Archiving</source>
       </trans-unit>
       <trans-unit id="s2f2866981870fee3">
-        <source>Confirm Org Deletion: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"></x></source>
+        <source>Confirm Org Deletion: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"/></source>
       </trans-unit>
       <trans-unit id="hbc605ddee9667ea5">
-        <source>Are you sure you want to delete <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"></x>? This cannot be undone.</source>
+        <source>Are you sure you want to delete
+                  <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;${org.name}&lt;/strong&gt;" id="0"/>? This
+                  cannot be undone.</source>
       </trans-unit>
       <trans-unit id="h88cfbf4cb1b57616">
-        <source>Deleting an org will delete all <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;" id="0"></x> of data associated with the org.</source>
+        <source>Deleting an org will delete all <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;" id="0"/> of data associated with the org.</source>
       </trans-unit>
       <trans-unit id="hc95f75343ebc2ce0">
-        <source>Crawls: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Crawls: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="h9e8c0254131f987c">
-        <source>Uploads: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Uploads: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="hc4433ba5eba156e2">
-        <source>Profiles: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Profiles: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="se49bbaeabfd85d48">
-        <source>Type "<x equiv-text="${confirmationStr}" id="0"></x>" to confirm</source>
+        <source>Type "<x equiv-text="${confirmationStr}" id="0"/>" to confirm</source>
       </trans-unit>
       <trans-unit id="s91622815dce6a0ec">
         <source>Delete Org</source>
       </trans-unit>
       <trans-unit id="s3eab2ed27de13f27">
-        <source>Archiving in "<x equiv-text="${org.name}" id="0"></x>" is disabled.</source>
+        <source>Archiving in "<x equiv-text="${org.name}" id="0"/>" is disabled.</source>
       </trans-unit>
       <trans-unit id="s2da2e2eba00d0f28">
-        <source>Archiving in "<x equiv-text="${org.name}" id="0"></x>" is re-enabled.</source>
+        <source>Archiving in "<x equiv-text="${org.name}" id="0"/>" is re-enabled.</source>
       </trans-unit>
       <trans-unit id="s42dfcfdcb5aee47e">
         <source>Sorry, couldn't update org archiving ability at this time.</source>
       </trans-unit>
       <trans-unit id="s081029829332df74">
-        <source>Org "<x equiv-text="${org.name}" id="0"></x>" has been deleted.</source>
+        <source>Org "<x equiv-text="${org.name}" id="0"/>" has been deleted.</source>
       </trans-unit>
       <trans-unit id="s4de74a2a08a74bff">
         <source>Sorry, couldn't delete org at this time.</source>
@@ -2428,7 +2464,7 @@
         <source>Password</source>
       </trans-unit>
       <trans-unit id="se7e0859bf0c563fe">
-        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"></x>–<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"></x> characters.</source>
+        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"/>–<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"/> characters.</source>
       </trans-unit>
       <trans-unit id="sa9d1dd5d6142477d">
         <source>Your name</source>
@@ -2452,22 +2488,22 @@
         <source>Not applicable</source>
       </trans-unit>
       <trans-unit id="s0382d73823585617">
-        <source><x equiv-text="${typeLabel}" id="0"></x>: <x equiv-text="${crawlStatus.label}" id="1"></x></source>
+        <source><x equiv-text="${typeLabel}" id="0"/>: <x equiv-text="${crawlStatus.label}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s9fdb0be4e08e3609">
-        <source>QA Analysis: <x equiv-text="${qaStatus.label}" id="0"></x> (<x equiv-text="${activeProgress}" id="1"></x>% finished)</source>
+        <source>QA Analysis: <x equiv-text="${qaStatus.label}" id="0"/> (<x equiv-text="${activeProgress}" id="1"/>% finished)</source>
       </trans-unit>
       <trans-unit id="s9087c0239aa5bd6d">
-        <source>QA Analysis: <x equiv-text="${isUpload ? &quot;Not Applicable&quot; : qaStatus.label || msg(&quot;None&quot;)}" id="0"></x></source>
+        <source>QA Analysis: <x equiv-text="${isUpload ? &quot;Not Applicable&quot; : qaStatus.label || msg(&quot;None&quot;)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s2fb39b9ba9441537">
-        <source><x equiv-text="${this.localize.number(this.item.stats?.done ? +this.item.stats.done : 0)}" id="0"></x> crawled, <x equiv-text="${this.localize.number(this.item.stats?.found ? +this.item.stats.found : 0)}" id="1"></x> found</source>
+        <source><x equiv-text="${this.localize.number(this.item.stats?.done ? +this.item.stats.done : 0)}" id="0"/> crawled, <x equiv-text="${this.localize.number(this.item.stats?.found ? +this.item.stats.found : 0)}" id="1"/> found</source>
       </trans-unit>
       <trans-unit id="s1a8b76905717bc34">
-        <source>Last run started on <x equiv-text="${localize.date(lastQAStarted)}" id="0"></x></source>
+        <source>Last run started on <x equiv-text="${localize.date(lastQAStarted)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sa0ffc3feac61fcc4">
-        <source>Rated <x equiv-text="${this.item.reviewStatus}" id="0"></x> / <x equiv-text="${ReviewStatus.Excellent}" id="1"></x></source>
+        <source>Rated <x equiv-text="${this.item.reviewStatus}" id="0"/> / <x equiv-text="${ReviewStatus.Excellent}" id="1"/></source>
       </trans-unit>
       <trans-unit id="s4e31ba44d4056425">
         <source>No QA review submitted</source>
@@ -2476,7 +2512,7 @@
         <source>QA Analysis Runs</source>
       </trans-unit>
       <trans-unit id="s1b210718400e7ea8">
-        <source><x equiv-text="${this.localize.number(pageCount)}" id="0"></x> page</source>
+        <source><x equiv-text="${this.localize.number(pageCount)}" id="0"/> page</source>
       </trans-unit>
       <trans-unit id="s92921878e886e36d">
         <source>Duration</source>
@@ -2524,10 +2560,14 @@
         <source>Queued URLs</source>
       </trans-unit>
       <trans-unit id="se7f351ae6cbb41f0">
-        <source>Queued URLs from 1 to <x equiv-text="${this.localize.number(this.queue.total)}" id="0"></x></source>
+        <source>Queued URLs from 1 to <x equiv-text="${this.localize.number(this.queue.total)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="h077c8fe82a78c616">
-        <source>Queued URLs from <x equiv-text="&lt;btrix-inline-input class=&quot;mx-1 inline-block&quot; style=&quot;width: ${Math.max(offsetValue.toString().length, 2) + 2}ch&quot; value=&quot;1&quot; inputmode=&quot;numeric&quot; size=&quot;small&quot; autocomplete=&quot;off&quot; @sl-input=&quot;${(e: SlInputEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    input.style.width = getInputWidth(input.value);&#10;}}&quot; @sl-change=&quot;${async (e: SlChangeEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    const int = +input.value.replace(/\D/g, &quot;&quot;);&#10;    await this.updateComplete;&#10;    const value = Math.max(1, Math.min(int, this.queue!.total - 1));&#10;    input.value = value.toString();&#10;    this.pageOffset = value - 1;&#10;}}&quot;&gt;&lt;/btrix-inline-input&gt;" id="0"></x> to <x equiv-text="${this.localize.number(countMax)}" id="1"></x> of <x equiv-text="${this.localize.number(this.queue.total)}&#10;        " id="2"></x></source>
+        <source>
+          Queued URLs from
+          <x equiv-text="&lt;btrix-inline-input class=&quot;mx-1 inline-block&quot; style=&quot;width: ${Math.max(offsetValue.toString().length, 2) + 2}ch&quot; value=&quot;1&quot; inputmode=&quot;numeric&quot; size=&quot;small&quot; autocomplete=&quot;off&quot; @sl-input=&quot;${(e: SlInputEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    input.style.width = getInputWidth(input.value);&#10;}}&quot; @sl-change=&quot;${async (e: SlChangeEvent) =&gt; {&#10;    const input = e.target as SlInput;&#10;    const int = +input.value.replace(/\D/g, &quot;&quot;);&#10;    await this.updateComplete;&#10;    const value = Math.max(1, Math.min(int, this.queue!.total - 1));&#10;    input.value = value.toString();&#10;    this.pageOffset = value - 1;&#10;}}&quot;&gt;&lt;/btrix-inline-input&gt;" id="0"/>
+          to <x equiv-text="${this.localize.number(countMax)}" id="1"/> of
+          <x equiv-text="${this.localize.number(this.queue.total)}&#10;        " id="2"/></source>
       </trans-unit>
       <trans-unit id="s4dfaf5cfc90f8493">
         <source>No pages queued.</source>
@@ -2539,7 +2579,7 @@
         <source>Load more</source>
       </trans-unit>
       <trans-unit id="s813262fab638bbfc">
-        <source>-<x equiv-text="${this.localize.number(this.matchedTotal)}" id="0"></x> URLs</source>
+        <source>-<x equiv-text="${this.localize.number(this.matchedTotal)}" id="0"/> URLs</source>
       </trans-unit>
       <trans-unit id="s6c4a20fdba7af262">
         <source>-1 URL</source>
@@ -2569,7 +2609,7 @@
         <source>Keep this window open until your upload finishes.</source>
       </trans-unit>
       <trans-unit id="hb8ae169d4ea6d7a3">
-        <source>Successfully uploaded <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"></x>.<x equiv-text="&lt;br&gt;&#10;              &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/items/upload/${data.id}&quot; @click=&quot;${this.navigate.link}&quot;&gt;" id="1"></x>View Item<x equiv-text="&lt;/a&gt; " id="2"></x></source>
+        <source>Successfully uploaded <x equiv-text="&lt;strong&gt;${name}&lt;/strong&gt;" id="0"/>.<x equiv-text="&lt;br&gt;&#10;              &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/items/upload/${data.id}&quot; @click=&quot;${this.navigate.link}&quot;&gt;" id="1"/>View Item<x equiv-text="&lt;/a&gt; " id="2"/></source>
       </trans-unit>
       <trans-unit id="scccaadc44687f6bf">
         <source>Sorry, couldn't upload file at this time.</source>
@@ -2611,10 +2651,10 @@
         <source>Create profile</source>
       </trans-unit>
       <trans-unit id="sfd20092783b9309d">
-        <source><x equiv-text="${this.localize.number(selected)}" id="0"></x> / <x equiv-text="${this.localize.number(total)}" id="1"></x> crawl</source>
+        <source><x equiv-text="${this.localize.number(selected)}" id="0"/> / <x equiv-text="${this.localize.number(total)}" id="1"/> crawl</source>
       </trans-unit>
       <trans-unit id="sd6a07c24d3ae246a">
-        <source><x equiv-text="${this.localize.number(selected)}" id="0"></x> / <x equiv-text="${this.localize.number(total)}" id="1"></x> crawls</source>
+        <source><x equiv-text="${this.localize.number(selected)}" id="0"/> / <x equiv-text="${this.localize.number(total)}" id="1"/> crawls</source>
       </trans-unit>
       <trans-unit id="sea0ac3af5d7a3071">
         <source>0 crawls</source>
@@ -2623,7 +2663,7 @@
         <source>Auto-Add</source>
       </trans-unit>
       <trans-unit id="s514cde9d19a9adc5">
-        <source>Started by <x equiv-text="${crawl.userName}" id="0"></x></source>
+        <source>Started by <x equiv-text="${crawl.userName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s9b31004ff434426e">
         <source>Crawl Finished</source>
@@ -2632,22 +2672,22 @@
         <source>File Size</source>
       </trans-unit>
       <trans-unit id="sf51117c57a1110ec">
-        <source>in <x equiv-text="${this.collectionName}" id="0"></x></source>
+        <source>in <x equiv-text="${this.collectionName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sf27239dda9b1416d">
-        <source>Crawls in Collection (<x equiv-text="${this.localize.number(data!.total)}" id="0"></x>)</source>
+        <source>Crawls in Collection (<x equiv-text="${this.localize.number(data!.total)}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="sa3d5a7186b818303">
-        <source>All Workflows (<x equiv-text="${this.localize.number(data!.total)}" id="0"></x>)</source>
+        <source>All Workflows (<x equiv-text="${this.localize.number(data!.total)}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s49730f3d5751a433">
         <source>Loading...</source>
       </trans-unit>
       <trans-unit id="sd7d35ab49e07fe79">
-        <source>Uploads in Collection (<x equiv-text="${this.localize.number(this.uploads!.total)}" id="0"></x>)</source>
+        <source>Uploads in Collection (<x equiv-text="${this.localize.number(this.uploads!.total)}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s84c2e4081c2bf6d7">
-        <source>All Uploads (<x equiv-text="${this.localize.number(this.uploads!.total)}" id="0"></x>)</source>
+        <source>All Uploads (<x equiv-text="${this.localize.number(this.uploads!.total)}" id="0"/>)</source>
       </trans-unit>
       <trans-unit id="s1e2b42118528e92f">
         <source>In Collection?</source>
@@ -2701,7 +2741,9 @@
         <source>Review Settings</source>
       </trans-unit>
       <trans-unit id="hf77ba6b1d74e2cdb">
-        <source>Fields marked with <x equiv-text="&lt;span style=&quot;color:var(--sl-input-required-content-color)&quot;&gt;" id="0"></x>*<x equiv-text="&lt;/span&gt;" id="1"></x> are required</source>
+        <source>Fields marked with
+                  <x equiv-text="&lt;span style=&quot;color:var(--sl-input-required-content-color)&quot;&gt;" id="0"/>*<x equiv-text="&lt;/span&gt;" id="1"/>
+                  are required</source>
       </trans-unit>
       <trans-unit id="s5f94c84437a8594c">
         <source>Form section contains errors</source>
@@ -2731,16 +2773,24 @@
         <source>Tells the crawler which pages it can visit.</source>
       </trans-unit>
       <trans-unit id="hef8020bab2159211">
-        <source>Will crawl all pages and paths in the same directory, e.g. <x equiv-text="&lt;span class=&quot;break-word break-word text-blue-500&quot;&gt;${exampleDomain}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;${examplePathname.slice(0, examplePathname.lastIndexOf(&quot;/&quot;))}" id="0"></x>/<x equiv-text="&lt;/span&gt;" id="1"></x></source>
+        <source>Will crawl all pages and paths in the same directory, e.g.
+            <x equiv-text="&lt;span class=&quot;break-word break-word text-blue-500&quot;&gt;${exampleDomain}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;${examplePathname.slice(0, examplePathname.lastIndexOf(&quot;/&quot;))}" id="0"/>/<x equiv-text="&lt;/span&gt;" id="1"/></source>
       </trans-unit>
       <trans-unit id="hed4c39f98af5c58f">
-        <source>Will crawl all pages on <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"></x> and ignore pages on any subdomains.</source>
+        <source>Will crawl all pages on
+            <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"/> and ignore pages
+            on any subdomains.</source>
       </trans-unit>
       <trans-unit id="ha8f0ffdb034da2d1">
-        <source>Will crawl all pages on <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"></x> and <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;" id="1"></x>subdomain.<x equiv-text="${exampleHost}&lt;/span&gt;" id="2"></x>.</source>
+        <source>Will crawl all pages on
+            <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${exampleHost}&lt;/span&gt;" id="0"/> and
+            <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;" id="1"/>subdomain.<x equiv-text="${exampleHost}&lt;/span&gt;" id="2"/>.</source>
       </trans-unit>
       <trans-unit id="h2303b42f0dff5ee4">
-        <source>Will crawl all page URLs that begin with <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;" id="0"></x> or any URL that begins with those specified in <x equiv-text="&lt;em&gt;" id="1"></x>Extra URL Prefixes in Scope<x equiv-text="&lt;/em&gt;" id="2"></x></source>
+        <source>Will crawl all page URLs that begin with
+            <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;" id="0"/>
+            or any URL that begins with those specified in
+            <x equiv-text="&lt;em&gt;" id="1"/>Extra URL Prefixes in Scope<x equiv-text="&lt;/em&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="s262c31c801cfbcd9">
         <source>Please enter a valid URL.</source>
@@ -2764,10 +2814,10 @@
         <source>Specify exclusion rules for what pages should not be visited.</source>
       </trans-unit>
       <trans-unit id="sdd5dbd4b0fef8660">
-        <source>Must be more than minimum of <x equiv-text="${this.localize.number(+min)}" id="0"></x></source>
+        <source>Must be more than minimum of <x equiv-text="${this.localize.number(+min)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sa4f9d4099c408ae6">
-        <source>Must be less than maximum of <x equiv-text="${this.localize.number(+max)}" id="0"></x></source>
+        <source>Must be less than maximum of <x equiv-text="${this.localize.number(+max)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s9d84cf47af31a3ba">
         <source>Auto-scroll behavior</source>
@@ -2806,31 +2856,37 @@
         <source>What day of the month should a crawl run on?</source>
       </trans-unit>
       <trans-unit id="h8c7c3a6e07d7c512">
-        <source>Schedule: <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${utcSchedule&#10;    ? humanizeSchedule(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"></x>.</source>
+        <source>Schedule:
+                <x equiv-text="&lt;span class=&quot;text-blue-500&quot;&gt;${utcSchedule&#10;    ? humanizeSchedule(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="se0baa9b7fb0768e4">
         <source>Invalid date</source>
       </trans-unit>
       <trans-unit id="h30728ea4302f7fe9">
-        <source>Next scheduled run: <x equiv-text="&lt;span&gt;${utcSchedule&#10;    ? humanizeNextDate(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"></x>.</source>
+        <source>Next scheduled run:
+                <x equiv-text="&lt;span&gt;${utcSchedule&#10;    ? humanizeNextDate(utcSchedule)&#10;    : msg(&quot;Invalid date&quot;)}&lt;/span&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s4174899261b8b308">
         <source>A crawl will run at this time in your current timezone.</source>
       </trans-unit>
       <trans-unit id="s0d56a24ca72b8e48">
-        <source>Customize this Workflow's name. Workflows are named after the first Crawl URL by default.</source>
+        <source>Customize this Workflow's name. Workflows are named after
+        the first Crawl URL by default.</source>
       </trans-unit>
       <trans-unit id="sa8e78592c1db6c3a">
         <source>Provide details about this Workflow.</source>
       </trans-unit>
       <trans-unit id="s163480f4b18e39c0">
-        <source>Create or assign this crawl (and its outputs) to one or more tags to help organize your archived items.</source>
+        <source>Create or assign this crawl (and its outputs) to one or more tags
+        to help organize your archived items.</source>
       </trans-unit>
       <trans-unit id="s68f29315fcc19b3b">
         <source>Search for a Collection to auto-add crawls</source>
       </trans-unit>
       <trans-unit id="s54100e0807a1e40d">
-        <source>Automatically add crawls from this workflow to one or more collections as soon as they complete. Individual crawls can be selected from within the collection later.</source>
+        <source>Automatically add crawls from this workflow to one or more collections
+          as soon as they complete.
+          Individual crawls can be selected from within the collection later.</source>
       </trans-unit>
       <trans-unit id="s0e598010b73d1398">
         <source>There are issues with this Workflow. Please go through previous steps and fix all issues to continue.</source>
@@ -2851,34 +2907,36 @@
         <source>Could not run crawl with new workflow settings due to already running crawl.</source>
       </trans-unit>
       <trans-unit id="s286331d9358fc509">
-        <source>Seed URL <x equiv-text="${loc[loc.length - 1] + 1}" id="0"></x>: </source>
+        <source>Seed URL <x equiv-text="${loc[loc.length - 1] + 1}" id="0"/>: </source>
       </trans-unit>
       <trans-unit id="s08dd397493a013b1">
         <source>Couldn't save Workflow. Please fix the following Workflow issues:</source>
       </trans-unit>
       <trans-unit id="sea5eee53e296f33b">
-        <source><x equiv-text="${this.localize.number(urlList.length)}" id="0"></x> URL entered</source>
+        <source><x equiv-text="${this.localize.number(urlList.length)}" id="0"/> URL entered</source>
       </trans-unit>
       <trans-unit id="sfa75e464c2da4bba">
-        <source><x equiv-text="${this.localize.number(urlList.length)}" id="0"></x> URLs entered</source>
+        <source><x equiv-text="${this.localize.number(urlList.length)}" id="0"/> URLs entered</source>
       </trans-unit>
       <trans-unit id="s960e671fe5f2559b">
-        <source>Please shorten list to <x equiv-text="${this.localize.number(max)}" id="0"></x> or fewer URLs.</source>
+        <source>Please shorten list to <x equiv-text="${this.localize.number(max)}" id="0"/> or fewer URLs.</source>
       </trans-unit>
       <trans-unit id="s40b5b363fefc9199">
-        <source>Please remove or fix the following invalid URL: <x equiv-text="${invalidUrl}" id="0"></x></source>
+        <source>Please remove or fix the following invalid URL: <x equiv-text="${invalidUrl}" id="0"/></source>
       </trans-unit>
       <trans-unit id="saf63d34c8601dd41">
-        <source><x equiv-text="${humanizeSchedule(workflow.schedule, {&#10;    length: &quot;short&quot;,&#10;})}" id="0"></x> </source>
+        <source>
+          <x equiv-text="${humanizeSchedule(workflow.schedule, {&#10;    length: &quot;short&quot;,&#10;})}" id="0"/>
+        </source>
       </trans-unit>
       <trans-unit id="s136b21dec9a221bd">
-        <source>Manual run by <x equiv-text="${workflow.lastStartedByName}" id="0"></x></source>
+        <source>Manual run by <x equiv-text="${workflow.lastStartedByName}" id="0"/></source>
       </trans-unit>
       <trans-unit id="sde7cc417de1b3246">
         <source>---</source>
       </trans-unit>
       <trans-unit id="sa84bc532c73403ed">
-        <source>Running for <x equiv-text="${this.localize.humanizeDuration(diff, {&#10;    compact: true,&#10;})}" id="0"></x></source>
+        <source>Running for <x equiv-text="${this.localize.humanizeDuration(diff, {&#10;    compact: true,&#10;})}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s8eb4021572d41d99">
         <source>Name &amp; Schedule</source>
@@ -2886,29 +2944,29 @@
       <trans-unit id="sc154fb69dffcdef9">
         <source>billing settings</source>
       </trans-unit>
-      <trans-unit id="s71c5c2d34bb2c4c2">
-        <source>Your org will be deleted in <x equiv-text="${daysDiff}" id="0"></x> days</source>
-      </trans-unit>
       <trans-unit id="s7fa0d24b94690373">
-        <source>Your subscription ends on <x equiv-text="${dateStr}" id="0"></x>. Your user account, org, and all associated data will be deleted.</source>
+        <source>Your subscription ends on <x equiv-text="${dateStr}" id="0"/>. Your user account, org, and all associated data will be deleted.</source>
       </trans-unit>
       <trans-unit id="h16be212de6638b6c">
-        <source>We suggest downloading your archived items before they are deleted. To keep your plan and data, see <x equiv-text="${billingTabLink}" id="0"></x>.</source>
+        <source>We suggest downloading your archived items before they
+                  are deleted. To keep your plan and data, see
+                  <x equiv-text="${billingTabLink}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sc3e0d8cbe688ccd5">
-        <source>Archiving will be disabled in <x equiv-text="${daysDiff}" id="0"></x> days</source>
+        <source>Archiving will be disabled in <x equiv-text="${daysDiff}" id="0"/> days</source>
       </trans-unit>
       <trans-unit id="sda57befc109a45f6">
         <source>Archiving will be disabled within one day</source>
       </trans-unit>
       <trans-unit id="s618b35a93b6fd392">
-        <source>Your subscription ends on <x equiv-text="${dateStr}" id="0"></x>. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.</source>
+        <source>Your subscription ends on <x equiv-text="${dateStr}" id="0"/>. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.</source>
       </trans-unit>
       <trans-unit id="sfb85ab2a166e4c99">
         <source>Archiving is disabled for this org</source>
       </trans-unit>
       <trans-unit id="habd962339c5b3e55">
-        <source>Your subscription has been paused due to payment failure. Please go to <x equiv-text="${billingTabLink}" id="0"></x> to update your payment method.</source>
+        <source>Your subscription has been paused due to payment failure.
+            Please go to <x equiv-text="${billingTabLink}" id="0"/> to update your payment method.</source>
       </trans-unit>
       <trans-unit id="s4e6c7f0a1e774fea">
         <source>Your subscription has been canceled. Please contact Browsertrix support to renew your plan.</source>
@@ -2920,7 +2978,7 @@
         <source>Your org has reached its storage limit</source>
       </trans-unit>
       <trans-unit id="s7b663782f7f35eb8">
-        <source>To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"></x> to upgrade your storage plan.</source>
+        <source>To add archived items again, delete unneeded items and unused browser profiles to free up space, or contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"/> to upgrade your storage plan.</source>
       </trans-unit>
       <trans-unit id="sf3a7cc6ecc194453">
         <source>Browsertrix host administrator</source>
@@ -2929,7 +2987,7 @@
         <source>Your org has reached its monthly execution minutes limit</source>
       </trans-unit>
       <trans-unit id="s10a8d7c57c09ca1b">
-        <source>Contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"></x> to purchase additional monthly execution minutes or upgrade your plan.</source>
+        <source>Contact <x equiv-text="${this.appState.settings?.salesEmail || msg(&quot;Browsertrix host administrator&quot;)}" id="0"/> to purchase additional monthly execution minutes or upgrade your plan.</source>
       </trans-unit>
       <trans-unit id="seb2d088a92660d77">
         <source>No usage history to show.</source>
@@ -3010,7 +3068,7 @@
         <source>This org name is already taken.</source>
       </trans-unit>
       <trans-unit id="s1184d1f63618dc4e">
-        <source>Created new org named "<x equiv-text="${params.name}" id="0"></x>".</source>
+        <source>Created new org named "<x equiv-text="${params.name}" id="0"/>".</source>
       </trans-unit>
       <trans-unit id="sf1c2a4776e202435">
         <source>Sorry, couldn't create organization at this time.</source>
@@ -3083,10 +3141,16 @@
         <source>Finish setting up your Browsertrix account to start crawling.</source>
       </trans-unit>
       <trans-unit id="h22769969c5066f85">
-        <source>You’ve been invited by <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${inviterName}&lt;/strong&gt;" id="0"></x> to join the organization <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="1"></x> on Browsertrix.</source>
+        <source>You’ve been invited by
+          <x equiv-text="&lt;strong class=&quot;font-medium&quot;&gt;${inviterName}&lt;/strong&gt;" id="0"/>
+          to join the organization
+          <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="1"/>
+          on Browsertrix.</source>
       </trans-unit>
       <trans-unit id="h406ea2eff53edcfb">
-        <source>You’ve been invited to join the organization <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="0"></x> on Browsertrix.</source>
+        <source>You’ve been invited to join the organization
+          <x equiv-text="&lt;span class=&quot;font-medium text-primary&quot;&gt;${orgName}&lt;/span&gt;" id="0"/>
+          on Browsertrix.</source>
       </trans-unit>
       <trans-unit id="s07cee0cdf942df03">
         <source>Step 1 complete</source>
@@ -3113,7 +3177,8 @@
         <source>An org, or organization, is your workspace for web archiving. If you’re archiving collaboratively, an org workspace can be shared between team members.</source>
       </trans-unit>
       <trans-unit id="s8ae1873b610b92d6">
-        <source>Your org dashboard will be <x equiv-text="${window.location.protocol}" id="0"></x>//<x equiv-text="${window.location.hostname}" id="1"></x>/orgs/<x equiv-text="${slug || &quot;&quot;}" id="2"></x></source>
+        <source>Your org dashboard will be
+        <x equiv-text="${window.location.protocol}" id="0"/>//<x equiv-text="${window.location.hostname}" id="1"/>/orgs/<x equiv-text="${slug || &quot;&quot;}" id="2"/></source>
       </trans-unit>
       <trans-unit id="s0d5ee4ffcb9c2c65">
         <source>You can change this in your org settings later.</source>
@@ -3122,13 +3187,13 @@
         <source>Go to Dashboard</source>
       </trans-unit>
       <trans-unit id="s033b7f18e2a1b86e">
-        <source>The org name "<x equiv-text="${name}" id="0"></x>" is already taken, try another one.</source>
+        <source>The org name "<x equiv-text="${name}" id="0"/>" is already taken, try another one.</source>
       </trans-unit>
       <trans-unit id="s6d0192d253b870f7">
-        <source>The org URL identifier "<x equiv-text="${slug}" id="0"></x>" is already taken, try another one.</source>
+        <source>The org URL identifier "<x equiv-text="${slug}" id="0"/>" is already taken, try another one.</source>
       </trans-unit>
       <trans-unit id="s692207ce67c91506">
-        <source>The org URL identifier "<x equiv-text="${slug}" id="0"></x>" is not a valid URL. Please use alphanumeric characters and dashes (-) only</source>
+        <source>The org URL identifier "<x equiv-text="${slug}" id="0"/>" is not a valid URL. Please use alphanumeric characters and dashes (-) only</source>
       </trans-unit>
       <trans-unit id="s5df133e1b1fd43c3">
         <source>Welcome to Browsertrix</source>
@@ -3140,13 +3205,13 @@
         <source>This invite doesn't exist or has expired. Please ask the organization administrator to resend an invitation.</source>
       </trans-unit>
       <trans-unit id="s1952dc02aa41f1c9">
-        <source>This is not a valid invite, or it may have expired. If you believe this is an error, please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"></x> for help.</source>
+        <source>This is not a valid invite, or it may have expired. If you believe this is an error, please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"/> for help.</source>
       </trans-unit>
       <trans-unit id="s0235065054efe3a8">
         <source>your Browsertrix administrator</source>
       </trans-unit>
       <trans-unit id="s4a7fb6e66ba564d7">
-        <source>Something unexpected went wrong retrieving this invite. Please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"></x> for help.</source>
+        <source>Something unexpected went wrong retrieving this invite. Please contact <x equiv-text="${this.appState.settings?.supportEmail || msg(&quot;your Browsertrix administrator&quot;)}" id="0"/> for help.</source>
       </trans-unit>
       <trans-unit id="s7ebc4f216d73836f">
         <source>This verification email is not valid.</source>
@@ -3161,7 +3226,7 @@
         <source>Enter new password</source>
       </trans-unit>
       <trans-unit id="s8daf047a917f4cc4">
-        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"></x>-<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"></x> characters.</source>
+        <source>Choose a strong password between <x equiv-text="${PASSWORD_MINLENGTH}" id="0"/>-<x equiv-text="${PASSWORD_MAXLENGTH}" id="1"/> characters.</source>
       </trans-unit>
       <trans-unit id="s16ba889483d4940e">
         <source>Change Password</source>
@@ -3173,7 +3238,7 @@
         <source>Password reset email is not valid. Request a new password reset email</source>
       </trans-unit>
       <trans-unit id="s7d90fb0e2d1684a7">
-        <source>Sent invite to <x equiv-text="${this.invitedEmail}" id="0"></x></source>
+        <source>Sent invite to <x equiv-text="${this.invitedEmail}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s586d6bd2eca2da93">
         <source>Users</source>
@@ -3200,10 +3265,10 @@
         <source>Decline</source>
       </trans-unit>
       <trans-unit id="s84922e45c0957371">
-        <source>This invitation is for <x equiv-text="${this.email}" id="0"></x>. You are currently logged in as <x equiv-text="${this.authState?.username}" id="1"></x>. Please log in with the correct email to access this invite.</source>
+        <source>This invitation is for <x equiv-text="${this.email}" id="0"/>. You are currently logged in as <x equiv-text="${this.authState?.username}" id="1"/>. Please log in with the correct email to access this invite.</source>
       </trans-unit>
       <trans-unit id="sc9a2484754aae7bb">
-        <source>You've joined <x equiv-text="${org.name || inviteInfo.orgName || msg(&quot;Browsertrix&quot;)}" id="0"></x>.</source>
+        <source>You've joined <x equiv-text="${org.name || inviteInfo.orgName || msg(&quot;Browsertrix&quot;)}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sdb8ec1b3a5726c88">
         <source>Browsertrix</source>
@@ -3212,7 +3277,7 @@
         <source>This invitation is not valid</source>
       </trans-unit>
       <trans-unit id="s4b97257cf024d907">
-        <source>You've declined to join <x equiv-text="${orgName || msg(&quot;Browsertrix&quot;)}" id="0"></x>.</source>
+        <source>You've declined to join <x equiv-text="${orgName || msg(&quot;Browsertrix&quot;)}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s686306cdb839fb8d">
         <source>Sending...</source>
@@ -3284,7 +3349,7 @@
         <source>You must belong to at least one org in order to access Browsertrix features.</source>
       </trans-unit>
       <trans-unit id="s273f0ee82bf2b922">
-        <source>If you haven't received an invitation to an org, please contact us at <x equiv-text="${this.appState.settings.salesEmail}" id="0"></x>.</source>
+        <source>If you haven't received an invitation to an org, please contact us at <x equiv-text="${this.appState.settings.salesEmail}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s95aeb2828c01b0de">
         <source>If you haven't received an invitation to an org, please contact your Browsertrix administrator.</source>
@@ -3323,7 +3388,7 @@
         <source>Welcome to Browsertrix!</source>
       </trans-unit>
       <trans-unit id="h702a7337c08bf73f">
-        <source>A confirmation email was sent to: <x equiv-text="&lt;br&gt;&#10;                &lt;strong&gt;${email}&lt;/strong&gt;" id="0"></x>.</source>
+        <source>A confirmation email was sent to: <x equiv-text="&lt;br&gt;&#10;                &lt;strong&gt;${email}&lt;/strong&gt;" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="sd11e60711d79e788">
         <source>Click the link in your email to confirm your email address.</source>
@@ -3466,7 +3531,7 @@
         <note from="lit-localize">Time AM/PM</note>
       </trans-unit>
       <trans-unit id="s1d6a13ef53c51ee9">
-        <source><x equiv-text="${maxPagesPerCrawl || msg(&quot;Unlimited pages&quot;)}" id="0"></x> per crawl</source>
+        <source><x equiv-text="${maxPagesPerCrawl || msg(&quot;Unlimited pages&quot;)}" id="0"/> per crawl</source>
       </trans-unit>
       <trans-unit id="s41de0883966c23c8">
         <source>Unlimited pages</source>
@@ -3475,7 +3540,7 @@
         <source>Unlimited concurrent crawls</source>
       </trans-unit>
       <trans-unit id="s8ad4a17ab2b75854">
-        <source>Adding <x equiv-text="${this.localize.number(addCount)} ${pluralOf(&quot;items&quot;, addCount)}" id="0"></x></source>
+        <source>Adding <x equiv-text="${this.localize.number(addCount)} ${pluralOf(&quot;items&quot;, addCount)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="items.plural.few">
         <source>items</source>
@@ -3520,7 +3585,8 @@
         <source>Crawl finishing...</source>
       </trans-unit>
       <trans-unit id="ha60886587b96e32c">
-        <source>Started crawl from <x equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;" id="0"></x>. <x equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navigate.link.bind(this)}&quot;&gt;" id="1"></x>Watch crawl<x equiv-text="&lt;/a&gt;" id="2"></x></source>
+        <source>Started crawl from <x equiv-text="&lt;strong&gt;${this.renderName(workflow)}&lt;/strong&gt;" id="0"/>.
+            <x equiv-text="&lt;br&gt;&#10;            &lt;a class=&quot;underline hover:no-underline&quot; href=&quot;${this.navigate.orgBasePath}/workflows/${workflow.id}#watch&quot; @click=&quot;${this.navigate.link.bind(this)}&quot;&gt;" id="1"/>Watch crawl<x equiv-text="&lt;/a&gt;" id="2"/></source>
       </trans-unit>
       <trans-unit id="sb32ae1652df8c7ad">
         <source>Workflow settings used to run this crawl</source>
@@ -3535,10 +3601,10 @@
         <source>Page URL(s)</source>
       </trans-unit>
       <trans-unit id="s4201222224dff23c">
-        <source>Crawl: <x equiv-text="${crawlStatus.label}" id="0"></x></source>
+        <source>Crawl: <x equiv-text="${crawlStatus.label}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s0eb7c300368b2a58">
-        <source>Upload: <x equiv-text="${crawlStatus.label}" id="0"></x></source>
+        <source>Upload: <x equiv-text="${crawlStatus.label}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s7d61376257220dab">
         <source>Scope</source>
@@ -3595,22 +3661,26 @@
         <source>The URL of the page to crawl.</source>
       </trans-unit>
       <trans-unit id="s41d2278219615589">
-        <source>The crawler will visit and record each URL listed here. You can enter up to <x equiv-text="${this.localize.number(URL_LIST_MAX_URLS)}" id="0"></x> URLs.</source>
+        <source>The crawler will visit and record each URL listed here. You can enter up to <x equiv-text="${this.localize.number(URL_LIST_MAX_URLS)}" id="0"/> URLs.</source>
       </trans-unit>
       <trans-unit id="sfc5e402f8b21ef5f">
         <source>If checked, the crawler will visit pages one link away.</source>
       </trans-unit>
       <trans-unit id="hba1eb91e4626e056">
-        <source>Will crawl hash anchor links as pages. For example, <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;" id="0"></x>#example-page<x equiv-text="&lt;/span&gt;" id="1"></x> will be treated as a separate page.</source>
+        <source>Will crawl hash anchor links as pages. For example,
+            <x equiv-text="&lt;span class=&quot;break-word text-blue-500&quot;&gt;${exampleDomain}${examplePathname}&lt;/span&gt;&lt;span class=&quot;break-word font-medium text-blue-500&quot;&gt;" id="0"/>#example-page<x equiv-text="&lt;/span&gt;" id="1"/>
+            will be treated as a separate page.</source>
       </trans-unit>
       <trans-unit id="s09a8c053783eafa0">
-        <source>If the crawler finds pages outside of the Crawl Scope they will only be saved if they begin with URLs listed here.</source>
+        <source>If the crawler finds pages outside of the Crawl Scope they
+            will only be saved if they begin with URLs listed here.</source>
       </trans-unit>
       <trans-unit id="sb43ce2ffe2a4857f">
         <source>Limits how many hops away the crawler can visit while staying within the Crawl Scope.</source>
       </trans-unit>
       <trans-unit id="sba156796788dc6c2">
-        <source>If checked, the crawler will visit pages one link away outside of Crawl Scope.</source>
+        <source>If checked, the crawler will visit pages one link away outside of
+        Crawl Scope.</source>
       </trans-unit>
       <trans-unit id="s2279075e18f7dd74">
         <source>Additional Pages</source>
@@ -3619,7 +3689,9 @@
         <source>There is an issue with this Crawl Workflow:</source>
       </trans-unit>
       <trans-unit id="h94a6d35ca79705c4">
-        <source><x equiv-text="${pageScope ? msg(&quot;Page URL(s)&quot;) : msg(&quot;Crawl Start URL&quot;)}" id="0"></x> required in <x equiv-text="&lt;a href=&quot;${crawlSetupUrl}&quot; class=&quot;bold underline hover:no-underline&quot;&gt;" id="1"></x>Scope<x equiv-text="&lt;/a&gt;" id="2"></x>. </source>
+        <source><x equiv-text="${pageScope ? msg(&quot;Page URL(s)&quot;) : msg(&quot;Crawl Start URL&quot;)}" id="0"/>
+                required in
+                <x equiv-text="&lt;a href=&quot;${crawlSetupUrl}&quot; class=&quot;bold underline hover:no-underline&quot;&gt;" id="1"/>Scope<x equiv-text="&lt;/a&gt;" id="2"/>. </source>
       </trans-unit>
       <trans-unit id="s67b76d03e88b5990">
         <source>Please fix to continue.</source>
@@ -3652,7 +3724,7 @@
         <source>Sorry, couldn't retrieve proxies at this time.</source>
       </trans-unit>
       <trans-unit id="s438a40049bb04715">
-        <source>Proxy Settings for: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"></x></source>
+        <source>Proxy Settings for: <x equiv-text="${this.currOrg?.name || &quot;&quot;}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s234e4c06c8c1aada">
         <source>Enable all shared proxies</source>
@@ -3667,10 +3739,12 @@
         <source>Edit Proxies</source>
       </trans-unit>
       <trans-unit id="sadfb54de733655c9">
-        <source>Using proxy:</source>
+        <source>Using proxy: </source>
       </trans-unit>
       <trans-unit id="hda7aa624404fc0ed">
-        <source>Refer to our user guide on <x equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;/docs/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;" id="0"></x>org settings<x equiv-text="&lt;/a&gt;" id="1"></x> for details.</source>
+        <source>Refer to our user guide on
+                <x equiv-text="&lt;a class=&quot;text-neutral-500 underline hover:text-primary&quot; href=&quot;/docs/user-guide/org-settings/&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot;&gt;" id="0"/>org settings<x equiv-text="&lt;/a&gt;" id="1"/>
+                for details.</source>
       </trans-unit>
       <trans-unit id="sb061ff5a347a296e">
         <source>Profile</source>
@@ -3682,7 +3756,11 @@
         <source>Your language preference has been updated.</source>
       </trans-unit>
       <trans-unit id="h594aac845e847983">
-        <source>It is highly recommended to create dedicated accounts to use when crawling. For details, refer to <x equiv-text="&lt;a class=&quot;text-primary hover:text-primary-400&quot; href=&quot;/docs/user-guide/browser-profiles/&quot; target=&quot;_blank&quot;&gt;&#10;            ${msg(&quot;browser profile best practices&quot;)}&lt;/a&gt;" id="0"></x>. </source>
+        <source>
+          It is highly recommended to create dedicated accounts to use when
+          crawling. For details, refer to
+          <x equiv-text="&lt;a class=&quot;text-primary hover:text-primary-400&quot; href=&quot;/docs/user-guide/browser-profiles/&quot; target=&quot;_blank&quot;&gt;&#10;            ${msg(&quot;browser profile best practices&quot;)}&lt;/a&gt;" id="0"/>.
+        </source>
       </trans-unit>
       <trans-unit id="s5f35a66624e4d770">
         <source>Translations are in beta</source>
@@ -3700,40 +3778,49 @@
         <source>Choose your preferred language for displaying Browsertrix in your browser.</source>
       </trans-unit>
       <trans-unit id="h88cfbf4cb1b57616">
-        <source>Deleting an org will delete all <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;" id="0"></x> of data associated with the org.</source>
+        <source>Deleting an org will delete all
+                  <x equiv-text="&lt;strong class=&quot;font-semibold&quot;&gt;&#10;                    &lt;sl-format-bytes value=&quot;${org.bytesStored}&quot;&gt;&lt;/sl-format-bytes&gt;&#10;                  &lt;/strong&gt;" id="0"/>
+                  of data associated with the org.</source>
       </trans-unit>
       <trans-unit id="hc95f75343ebc2ce0">
-        <source>Crawls: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Crawls:
+                    <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredCrawls}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="h9e8c0254131f987c">
-        <source>Uploads: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Uploads:
+                    <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredUploads}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="hc4433ba5eba156e2">
-        <source>Profiles: <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"></x></source>
+        <source>Profiles:
+                    <x equiv-text="&lt;sl-format-bytes value=&quot;${org.bytesStoredProfiles}&quot;&gt;&lt;/sl-format-bytes&gt;" id="0"/></source>
       </trans-unit>
       <trans-unit id="s582e36ff4a424786">
-        <source>Removing <x equiv-text="${this.localize.number(removeCount)} ${pluralOf(&quot;items&quot;, removeCount)}" id="0"></x></source>
+        <source>Removing <x equiv-text="${this.localize.number(removeCount)} ${pluralOf(&quot;items&quot;, removeCount)}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s1f1b3cea8b3a20f3">
-        <source>You have <x equiv-text="${daysDiff}" id="0"></x> days left of your Browsertrix trial</source>
+        <source>You have <x equiv-text="${daysDiff}" id="0"/> days left of your Browsertrix trial</source>
       </trans-unit>
       <trans-unit id="se4dfda71fd51327d">
         <source>Your trial ends within one day</source>
       </trans-unit>
       <trans-unit id="he8a019fc239da9d2">
-        <source>Your free trial ends on <x equiv-text="${dateStr}" id="0"></x>. To continue using Browsertrix, select <x equiv-text="&lt;strong&gt;" id="1"></x>Choose Plan<x equiv-text="&lt;/strong&gt;" id="2"></x> in <x equiv-text="${billingTabLink}" id="3"></x>.</source>
+        <source>Your free trial ends on <x equiv-text="${dateStr}" id="0"/>. To continue using
+                    Browsertrix, select <x equiv-text="&lt;strong&gt;" id="1"/>Choose Plan<x equiv-text="&lt;/strong&gt;" id="2"/> in
+                    <x equiv-text="${billingTabLink}" id="3"/>.</source>
       </trans-unit>
       <trans-unit id="se5578c14db3c7b2b">
-        <source>Your web archives are always yours — you can download any archived items you'd like to keep before the trial ends!</source>
+        <source>Your web archives are always yours — you can download any archived items you'd like to keep
+                  before the trial ends!</source>
       </trans-unit>
       <trans-unit id="hc4152410e53b56c9">
-        <source>To choose a plan and continue using Browsertrix, see <x equiv-text="${billingTabLink}" id="0"></x>.</source>
+        <source>To choose a plan and continue using Browsertrix, see
+                  <x equiv-text="${billingTabLink}" id="0"/>.</source>
       </trans-unit>
       <trans-unit id="s17658c5f9a5e8a52">
-        <source>Your trial will end on <x equiv-text="${futureCancelDate}" id="0"></x></source>
+        <source>Your trial will end on <x equiv-text="${futureCancelDate}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s5f5b3049f319a00a">
-        <source>Your plan will be canceled on <x equiv-text="${futureCancelDate}" id="0"></x></source>
+        <source>Your plan will be canceled on <x equiv-text="${futureCancelDate}" id="0"/></source>
       </trans-unit>
       <trans-unit id="s02e734a81b23d11b">
         <source>Subscribe Now</source>
@@ -3742,16 +3829,16 @@
         <source>subscribe to keep your account</source>
       </trans-unit>
       <trans-unit id="s2ab646dc4c6667ec">
-        <source>To continue using Browsertrix at the end of your trial, click “<x equiv-text="${this.portalUrlLabel}" id="0"></x>”.</source>
+        <source>To continue using Browsertrix at the end of your trial, click “<x equiv-text="${this.portalUrlLabel}" id="0"/>”.</source>
       </trans-unit>
       <trans-unit id="sd95c2c71d3eaada7">
         <source>Free Trial</source>
       </trans-unit>
       <trans-unit id="sdf3aa31f524a7300">
-        <source><x equiv-text="${maxExecMinutesPerMonth || msg(&quot;Unlimited minutes&quot;)}" id="0"></x> of crawling time</source>
+        <source><x equiv-text="${maxExecMinutesPerMonth || msg(&quot;Unlimited minutes&quot;)}" id="0"/> of crawling time</source>
       </trans-unit>
       <trans-unit id="sab5061cf8c519285">
-        <source><x equiv-text="${storageBytesText}" id="0"></x> of disk space</source>
+        <source><x equiv-text="${storageBytesText}" id="0"/> of disk space</source>
       </trans-unit>
       <trans-unit id="s8be75efeafa7ffe1">
         <source>Your org will be deleted within one day</source>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2192

## Changes

- Displays more accurate subscription/trial end message when subscription ends between 1-2 days
- Shows timezone for end date

## Screenshots

Taken on December 2nd, 11 am:

Before:
<img width="355" alt="Screenshot 2024-12-02 at 11 48 17 AM" src="https://github.com/user-attachments/assets/50f681ab-57ff-4c3b-82a9-d81affff1ccd">

After:
<img width="374" alt="Screenshot 2024-12-02 at 12 32 49 PM" src="https://github.com/user-attachments/assets/cfd677b6-3d80-4044-a9ec-9131b1c7e7b3">
