### PR TITLE
Verified badges

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -7,3 +7,4 @@ import("./not-found");
 import("./screencast");
 import("./beta-badges");
 import("./detail-page-title");
+import("./verified-badge");

--- a/frontend/src/components/verified-badge.ts
+++ b/frontend/src/components/verified-badge.ts
@@ -1,0 +1,26 @@
+import { localized, msg } from "@lit/localize";
+import { html } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+
+@localized()
+@customElement("btrix-verified-badge")
+export class Component extends BtrixElement {
+  render() {
+    return html`
+      <sl-tooltip
+        class="part-[body]:max-w-48 part-[body]:text-xs"
+        content=${msg(
+          "This organization has been verified by Webrecorder to be who they say they are.",
+        )}
+      >
+        <btrix-tag
+          ><sl-icon name="check-circle-fill" class="-ml-1 mr-1"></sl-icon>${msg(
+            "Verified",
+          )}</btrix-tag
+        >
+      </sl-tooltip>
+    `;
+  }
+}

--- a/frontend/src/pages/org/profile.ts
+++ b/frontend/src/pages/org/profile.ts
@@ -317,7 +317,7 @@ export class OrgProfile extends BtrixElement {
           name: org.name,
           description: org.publicDescription || "",
           url: org.publicUrl || "",
-          verified: true, // TODO
+          verified: false, // TODO
         },
         collections: [],
       };

--- a/frontend/src/pages/org/profile.ts
+++ b/frontend/src/pages/org/profile.ts
@@ -14,6 +14,7 @@ type OrgProfileData = {
     name: string;
     description: string;
     url: string;
+    verified: boolean;
   };
   collections: unknown[];
 };
@@ -119,6 +120,8 @@ export class OrgProfile extends BtrixElement {
         <header class="mt-5 border-b pb-3">
           <div class="flex flex-wrap items-end justify-between gap-2">
             ${pageTitle(org.name)}
+            ${org.verified &&
+            html`<btrix-verified-badge class="mb-0.5"></btrix-verified-badge>`}
             ${when(
               this.appState.isAdmin,
               () =>
@@ -314,6 +317,7 @@ export class OrgProfile extends BtrixElement {
           name: org.name,
           description: org.publicDescription || "",
           url: org.publicUrl || "",
+          verified: true, // TODO
         },
         collections: [],
       };

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -3923,6 +3923,9 @@
       <trans-unit id="s213ea1039161ce68">
         <source>If enabled, anyone will be able to view your org's profile page and public collections.</source>
       </trans-unit>
+      <trans-unit id="s6590981742c5b548">
+        <source>This organization has been verified by Webrecorder to be who they say they are.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Adds a simple verified badge to public pages (off by default currently until there's a corresponding backend change).

To be merged after #2172 (& once corresponding backend changes are done).

<img width="1057" alt="Screenshot_2024-12-02_at_3 12 57_PM" src="https://github.com/user-attachments/assets/4a70b7c8-9c88-42c3-ae78-59a12228f277">
<img width="318" alt="Screenshot_2024-12-02_at_3 13 54_PM" src="https://github.com/user-attachments/assets/15985c2e-9ac7-4d65-a668-578807487766">
