### PR TITLE
fix: Prevent submitting invalid regex with keyboard enter

### DIFF
--- a/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
@@ -178,7 +178,7 @@ export class QueueExclusionForm extends LiteElement {
 
   private readonly onKeyDown = (e: KeyboardEvent) => {
     e.stopPropagation();
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !this.isRegexInvalid) {
       void this.handleAdd();
     }
   };
@@ -217,7 +217,7 @@ export class QueueExclusionForm extends LiteElement {
   private async handleAdd() {
     this.onInput.flush();
     await this.updateComplete;
-    if (!this.regex) return;
+    if (!this.regex || this.isRegexInvalid) return;
 
     if (this.input) {
       this.input.value = "";


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2227

## Manual testing

1. Log in as crawler
2. Start a crawl
3. Go to watch crawl
4. Open exclusion editor
5. Choose "Regex" type
6. Type in invalid regex like `**`
7. Hit "Enter" on keyboard. Verify regex is not submitted