### PR TITLE
Adds optional IDs to toasts to replace rather than add to toast stack

### DIFF
--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -486,6 +486,7 @@ export class OrgsList extends BtrixElement {
           : msg(str`Archiving in "${org.name}" is re-enabled.`),
         variant: "success",
         icon: "check2-circle",
+        id: "archiving-enabled-status",
       });
     } catch (e) {
       console.debug(e);
@@ -496,6 +497,7 @@ export class OrgsList extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archiving-ability-status",
       });
     }
   }
@@ -513,6 +515,7 @@ export class OrgsList extends BtrixElement {
         message: msg("Sorry, couldn't get all proxies at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "proxy-retrieve-status",
       });
     }
   }
@@ -528,6 +531,7 @@ export class OrgsList extends BtrixElement {
         message: msg(str`Org "${org.name}" has been deleted.`),
         variant: "success",
         icon: "check2-circle",
+        id: "org-delete-status",
       });
     } catch (e) {
       console.debug(e);
@@ -536,6 +540,7 @@ export class OrgsList extends BtrixElement {
         message: msg("Sorry, couldn't delete org at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "org-delete-status",
       });
     }
   }

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -489,6 +489,7 @@ export class ConfigDetails extends BtrixElement {
                 ),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "collection-fetch-status",
         });
       }
     }

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -186,6 +186,7 @@ export class SelectCrawlerProxy extends LiteElement {
         message: msg("Sorry, couldn't retrieve proxies at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "proxy-retrieve-status",
       });
     }
   }

--- a/frontend/src/components/ui/select-crawler.ts
+++ b/frontend/src/components/ui/select-crawler.ts
@@ -167,6 +167,7 @@ export class SelectCrawler extends LiteElement {
         message: msg("Sorry, couldn't retrieve crawler channels at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawler-channel-retrieve-error",
       });
     }
   }

--- a/frontend/src/controllers/notify.ts
+++ b/frontend/src/controllers/notify.ts
@@ -30,6 +30,7 @@ export type NotifyEventDetail = {
   icon?: string;
   variant?: "success" | "warning" | "danger" | "primary" | "info";
   duration?: number;
+  id?: string | number | symbol;
 };
 
 export interface NotifyEventMap {

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -259,6 +259,7 @@ export class CrawlQueue extends BtrixElement {
           message: msg("Sorry, couldn't fetch crawl queue at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "crawl-queue-status",
         });
       }
     }

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -457,6 +457,7 @@ export class FileUploader extends BtrixElement {
           ),
           variant: "success",
           icon: "check2-circle",
+          id: "file-upload-status",
         });
       } else {
         throw data;
@@ -482,6 +483,7 @@ export class FileUploader extends BtrixElement {
           message: message,
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "file-upload-status",
         });
       }
     }

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -235,6 +235,7 @@ export class CrawlMetadataEditor extends LiteElement {
         message: msg("Successfully saved crawl details."),
         variant: "success",
         icon: "check2-circle",
+        id: "crawl-details-update-status",
       });
       this.requestClose();
     } catch (e) {
@@ -242,6 +243,7 @@ export class CrawlMetadataEditor extends LiteElement {
         message: msg("Sorry, couldn't save crawl details at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawl-details-update-status",
       });
     }
 

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -145,6 +145,7 @@ export class NewBrowserProfileDialog extends LiteElement {
         message: msg("Starting up browser for new profile..."),
         variant: "success",
         icon: "check2-circle",
+        id: "browser-profile-update-status",
       });
       await this.hideDialog();
       this.navTo(
@@ -162,6 +163,7 @@ export class NewBrowserProfileDialog extends LiteElement {
         message: msg("Sorry, couldn't create browser profile at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-update-status",
       });
     }
     this.isSubmitting = false;

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -236,6 +236,7 @@ export class SelectBrowserProfile extends BtrixElement {
         message: msg("Sorry, couldn't retrieve browser profiles at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-status",
       });
     }
   }

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -677,6 +677,7 @@ export class CollectionItemsDialog extends BtrixElement {
         message: msg(str`Successfully saved archived item selection.`),
         variant: "success",
         icon: "check2-circle",
+        id: "archived-item-selection-status",
       });
     } catch (e) {
       this.notify.toast({
@@ -685,6 +686,7 @@ export class CollectionItemsDialog extends BtrixElement {
           : msg("Something unexpected went wrong"),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-selection-status",
       });
     }
 
@@ -871,6 +873,7 @@ export class CollectionItemsDialog extends BtrixElement {
         variant: "success",
         icon: "check2-circle",
         duration: 1000,
+        id: "auto-add-status",
       });
     } catch (e: unknown) {
       console.debug(e);
@@ -880,6 +883,7 @@ export class CollectionItemsDialog extends BtrixElement {
         ),
         variant: "warning",
         icon: "exclamation-circle",
+        id: "auto-add-status",
       });
     }
   }

--- a/frontend/src/features/collections/collection-metadata-dialog.ts
+++ b/frontend/src/features/collections/collection-metadata-dialog.ts
@@ -206,6 +206,7 @@ export class CollectionMetadataDialog extends BtrixElement {
         ),
         variant: "success",
         icon: "check2-circle",
+        id: "collection-metadata-status",
       });
       void this.hideDialog();
     } catch (e) {
@@ -217,6 +218,7 @@ export class CollectionMetadataDialog extends BtrixElement {
         message: message || msg("Something unexpected went wrong"),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "collection-metadata-status",
       });
     }
 

--- a/frontend/src/features/collections/collections-add.ts
+++ b/frontend/src/features/collections/collections-add.ts
@@ -299,6 +299,7 @@ export class CollectionsAdd extends BtrixElement {
           message: msg("Sorry, couldn't retrieve Collections at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "collection-fetch-throttled",
         });
       }
     }

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -165,6 +165,7 @@ export class ExclusionEditor extends LiteElement {
           message: msg(html`Removed exclusion: <code>${regex}</code>`),
           variant: "success",
           icon: "check2-circle",
+          id: "exclusion-edit-status",
         });
 
         this.dispatchEvent(new CustomEvent("on-success"));
@@ -179,6 +180,7 @@ export class ExclusionEditor extends LiteElement {
             : msg("Sorry, couldn't remove exclusion at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "exclusion-edit-status",
       });
     }
   }
@@ -204,6 +206,7 @@ export class ExclusionEditor extends LiteElement {
           ),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "exclusion-edit-status",
         });
       }
     }
@@ -255,6 +258,7 @@ export class ExclusionEditor extends LiteElement {
           message: msg("Exclusion added."),
           variant: "success",
           icon: "check2-circle",
+          id: "exclusion-edit-status",
         });
 
         this.regex = "";
@@ -280,6 +284,7 @@ export class ExclusionEditor extends LiteElement {
           message: msg("Sorry, couldn't add exclusion at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "exclusion-edit-status",
         });
       }
     }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1983,6 +1983,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         message,
         variant: "success",
         icon: "check2-circle",
+        id: "workflow-created-status",
       });
 
       this.navigate.to(
@@ -2003,6 +2004,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             variant: "warning",
             icon: "exclamation-circle",
             duration: 12000,
+            id: "workflow-created-status",
           });
         } else {
           const isConfigError = ({ loc }: Detail) =>

--- a/frontend/src/features/qa/page-qa-approval.ts
+++ b/frontend/src/features/qa/page-qa-approval.ts
@@ -263,6 +263,7 @@ export class PageQAToolbar extends BtrixElement {
         message: msg("Sorry, couldn't submit page approval at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-page-approval-status",
       });
     }
   }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -946,6 +946,7 @@ export class App extends BtrixElement {
         message: msg("Please log in to continue."),
         variant: "warning",
         icon: "exclamation-triangle",
+        id: "log-in",
       });
     }
   };

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,17 +1,25 @@
+import "./utils/polyfills";
+
 import { localized, msg, str } from "@lit/localize";
 import type {
   SlDialog,
   SlDrawer,
   SlSelectEvent,
 } from "@shoelace-style/shoelace";
-import { html, nothing, render, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import isEqual from "lodash/fp/isEqual";
 
 import "broadcastchannel-polyfill";
 import "construct-style-sheets-polyfill";
-import "./utils/polyfills";
+import "./shoelace";
+import "./components";
+import "./features";
+import "./pages";
+import "./assets/fonts/Inter/inter.css";
+import "./assets/fonts/Recursive/recursive.css";
+import "./styles.css";
 
 import type { OrgTab } from "./pages/org";
 import { ROUTES } from "./routes";
@@ -22,9 +30,6 @@ import AuthService, {
   type LoggedInEventDetail,
   type NeedLoginEventDetail,
 } from "./utils/AuthService";
-import { DEFAULT_MAX_SCALE } from "./utils/crawler";
-import { AppStateService } from "./utils/state";
-import { formatAPIUser } from "./utils/user";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { NavigateEventDetail } from "@/controllers/navigate";
@@ -36,16 +41,12 @@ import {
   type TranslatedLocaleEnum,
 } from "@/types/localization";
 import { type AppSettings } from "@/utils/app";
+import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
 import localize from "@/utils/localize";
+import { toast } from "@/utils/notify";
+import { AppStateService } from "@/utils/state";
+import { formatAPIUser } from "@/utils/user";
 import brandLockupColor from "~assets/brand/browsertrix-lockup-color.svg";
-
-import "./shoelace";
-import "./components";
-import "./features";
-import "./pages";
-import "./assets/fonts/Inter/inter.css";
-import "./assets/fonts/Recursive/recursive.css";
-import "./styles.css";
 
 // Make theme CSS available in document
 document.adoptedStyleSheets = [theme];
@@ -975,37 +976,7 @@ export class App extends BtrixElement {
   onNotify = (event: CustomEvent<NotifyEventDetail>) => {
     event.stopPropagation();
 
-    const {
-      title,
-      message,
-      variant = "primary",
-      icon = "info-circle",
-      duration = 5000,
-    } = event.detail;
-
-    const container = document.createElement("sl-alert");
-    const alert = Object.assign(container, {
-      variant,
-      closable: true,
-      duration: duration,
-      style: [
-        "--sl-panel-background-color: var(--sl-color-neutral-1000)",
-        "--sl-color-neutral-700: var(--sl-color-neutral-0)",
-        // "--sl-panel-border-width: 0px",
-        "--sl-spacing-large: var(--sl-spacing-medium)",
-      ].join(";"),
-    });
-
-    render(
-      html`
-        <sl-icon name="${icon}" slot="icon"></sl-icon>
-        ${title ? html`<strong>${title}</strong>` : ""}
-        ${message ? html`<div>${message}</div>` : ""}
-      `,
-      container,
-    );
-    document.body.append(alert);
-    void alert.toast();
+    void toast(event.detail);
   };
 
   async getUserInfo(): Promise<APIUser> {

--- a/frontend/src/pages/account-settings.ts
+++ b/frontend/src/pages/account-settings.ts
@@ -424,12 +424,14 @@ export class AccountSettings extends BtrixElement {
         message: msg("Your name has been updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "name-update-status",
       });
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't update name at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "name-update-status",
       });
     }
 
@@ -468,12 +470,14 @@ export class AccountSettings extends BtrixElement {
         message: msg("Your email has been updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "email-update-status",
       });
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't update email at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "email-update-status",
       });
     }
 
@@ -506,6 +510,7 @@ export class AccountSettings extends BtrixElement {
         message: msg("Your password has been updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "password-update-status",
       });
     } catch (e) {
       if (isApiError(e) && e.details === "invalid_current_password") {
@@ -513,12 +518,14 @@ export class AccountSettings extends BtrixElement {
           message: msg("Please correct your current password and try again."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "password-update-status",
         });
       } else {
         this.notify.toast({
           message: msg("Sorry, couldn't update password at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "password-update-status",
         });
       }
     }
@@ -540,6 +547,7 @@ export class AccountSettings extends BtrixElement {
       message: msg("Your language preference has been updated."),
       variant: "success",
       icon: "check2-circle",
+      id: "language-update-status",
     });
   };
 }

--- a/frontend/src/pages/admin.ts
+++ b/frontend/src/pages/admin.ts
@@ -306,6 +306,7 @@ export class Admin extends BtrixElement {
             `,
             variant: "success",
             icon: "check2-circle",
+            id: "user-updated-status",
           });
         }}
       ></btrix-invite-form>
@@ -396,6 +397,7 @@ export class Admin extends BtrixElement {
         message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "org-invalid",
       });
     }
 

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -328,6 +328,7 @@ export class Crawls extends BtrixElement {
           message: msg("Sorry, couldn't retrieve crawls at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "fetch-crawls-throttled",
         });
       }
     }

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -139,6 +139,7 @@ export class OrgForm extends BtrixElement {
         message: msg("Org successfully updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "org-update-status",
       });
 
       await this.onRenameSuccess(payload);
@@ -183,6 +184,7 @@ export class OrgForm extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "org-update-status",
       });
     }
   }

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1213,6 +1213,7 @@ ${this.item?.description}
         message: msg("Sorry, couldn't retrieve crawl at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-retrieve-error",
       });
     }
   }
@@ -1227,6 +1228,7 @@ ${this.item?.description}
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-retrieve-error",
       });
     }
   }
@@ -1244,6 +1246,7 @@ ${this.item?.description}
         message: msg("Sorry, couldn't load all crawl settings."),
         variant: "warning",
         icon: "exclamation-circle",
+        id: "archived-item-retrieve-error",
       });
     }
   }
@@ -1282,6 +1285,7 @@ ${this.item?.description}
         message: msg("Sorry, couldn't retrieve crawl logs at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-retrieve-error",
       });
     }
   }
@@ -1313,6 +1317,7 @@ ${this.item?.description}
           message: msg("Sorry, couldn't cancel crawl at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "crawl-stop-error",
         });
       }
     }
@@ -1334,6 +1339,7 @@ ${this.item?.description}
           message: msg("Sorry, couldn't stop crawl at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "crawl-stop-error",
         });
       }
     }
@@ -1373,6 +1379,7 @@ ${this.item?.description}
         message: msg(`Successfully deleted crawl`),
         variant: "success",
         icon: "check2-circle",
+        id: "crawl-stop-error",
       });
     } catch (e) {
       let message = msg(
@@ -1391,6 +1398,7 @@ ${this.item?.description}
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-delete-status",
       });
     }
   }
@@ -1411,6 +1419,7 @@ ${this.item?.description}
         message: msg("Starting QA analysis..."),
         variant: "success",
         icon: "check2-circle",
+        id: "qa-start-status",
       });
     } catch (e: unknown) {
       let message = msg("Sorry, couldn't start QA run at this time.");
@@ -1425,6 +1434,7 @@ ${this.item?.description}
         message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-start-status",
       });
     }
   }
@@ -1447,6 +1457,7 @@ ${this.item?.description}
         message: msg(`Stopping QA analysis...`),
         variant: "success",
         icon: "check2-circle",
+        id: "qa-stop-status",
       });
     } catch (e: unknown) {
       this.notify.toast({
@@ -1456,6 +1467,7 @@ ${this.item?.description}
             : msg("Sorry, couldn't stop crawl at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-stop-status",
       });
     }
   }
@@ -1478,6 +1490,7 @@ ${this.item?.description}
         message: msg(`Canceling QA analysis...`),
         variant: "success",
         icon: "check2-circle",
+        id: "qa-stop-status",
       });
     } catch (e: unknown) {
       this.notify.toast({
@@ -1487,6 +1500,7 @@ ${this.item?.description}
             : msg("Sorry, couldn't cancel crawl at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-stop-status",
       });
     }
   }
@@ -1499,6 +1513,7 @@ ${this.item?.description}
         message: msg("Sorry, couldn't retrieve archived item at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-retrieve-error",
       });
     }
 

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -874,6 +874,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
         message: msg("Sorry, couldn't retrieve archived item at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -1086,6 +1086,7 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Sorry, couldn't retrieve archived item at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }
@@ -1150,6 +1151,7 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Sorry, couldn't add comment at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }
@@ -1178,6 +1180,7 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Sorry, couldn't delete comment at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }
@@ -1192,6 +1195,7 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Sorry, couldn't retrieve analysis runs at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }
@@ -1218,6 +1222,7 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Sorry, couldn't retrieve page at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }
@@ -1449,6 +1454,7 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Sorry, couldn't retrieve pages at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-error",
       });
     }
   }
@@ -1505,12 +1511,14 @@ export class ArchivedItemQA extends BtrixElement {
         message: msg("Saved QA review."),
         variant: "success",
         icon: "check2-circle",
+        id: "qa-review-status",
       });
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't submit QA review at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "qa-review-status",
       });
     }
   }

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -165,6 +165,7 @@ export class CrawlsList extends BtrixElement {
             ),
             variant: "danger",
             icon: "exclamation-octagon",
+            id: "archived-item-fetch-error",
           });
         }
         throw e;

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -537,6 +537,7 @@ export class BrowserProfilesDetail extends BtrixElement {
         message: msg("Sorry, couldn't preview browser profile at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-error",
       });
     }
   }
@@ -592,6 +593,7 @@ export class BrowserProfilesDetail extends BtrixElement {
         message: msg("Sorry, couldn't create browser profile at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-error",
       });
     }
   }
@@ -633,6 +635,7 @@ export class BrowserProfilesDetail extends BtrixElement {
         message: msg("Sorry, couldn't delete browser profile at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-error",
       });
     }
   }
@@ -671,6 +674,7 @@ export class BrowserProfilesDetail extends BtrixElement {
         message: msg("Sorry, couldn't retrieve browser profiles at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-error",
       });
     }
   }
@@ -707,6 +711,7 @@ export class BrowserProfilesDetail extends BtrixElement {
           message: msg("Successfully saved browser profile."),
           variant: "success",
           icon: "check2-circle",
+          id: "browser-profile-save-status",
         });
 
         this.browserId = undefined;
@@ -718,6 +723,7 @@ export class BrowserProfilesDetail extends BtrixElement {
         message: msg("Sorry, couldn't save browser profile at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-save-status",
       });
     }
 
@@ -755,6 +761,7 @@ export class BrowserProfilesDetail extends BtrixElement {
           message: msg("Successfully saved browser profile."),
           variant: "success",
           icon: "check2-circle",
+          id: "browser-profile-save-status",
         });
 
         this.profile = {
@@ -782,6 +789,7 @@ export class BrowserProfilesDetail extends BtrixElement {
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-save-status",
       });
     }
 

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -398,6 +398,7 @@ export class BrowserProfilesList extends BtrixElement {
           message: msg(html`Deleted <strong>${profile.name}</strong>.`),
           variant: "success",
           icon: "check2-circle",
+          id: "browser-profile-deleted-status",
         });
 
         void this.fetchBrowserProfiles();
@@ -407,6 +408,7 @@ export class BrowserProfilesList extends BtrixElement {
         message: msg("Sorry, couldn't delete browser profile at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-deleted-status",
       });
     }
   }
@@ -444,6 +446,7 @@ export class BrowserProfilesList extends BtrixElement {
         message: msg("Sorry, couldn't retrieve browser profiles at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-status",
       });
     } finally {
       this.isLoading = false;

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -325,6 +325,7 @@ export class BrowserProfilesNew extends BtrixElement {
         message: msg("Successfully created browser profile."),
         variant: "success",
         icon: "check2-circle",
+        id: "browser-profile-save-status",
       });
 
       this.navigate.to(
@@ -351,6 +352,7 @@ export class BrowserProfilesNew extends BtrixElement {
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-profile-save-status",
       });
     }
   }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -796,12 +796,14 @@ export class CollectionDetail extends BtrixElement {
         message: msg(html`Deleted <strong>${name}</strong> Collection.`),
         variant: "success",
         icon: "check2-circle",
+        id: "collection-delete-status",
       });
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't delete Collection at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "collection-delete-status",
       });
     }
   }
@@ -814,6 +816,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg("Sorry, couldn't retrieve Collection at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "collection-retrieve-status",
       });
     }
   }
@@ -841,6 +844,7 @@ export class CollectionDetail extends BtrixElement {
           message: msg("Sorry, couldn't retrieve web captures at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "collection-retrieve-status",
         });
       }
     }
@@ -896,6 +900,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg(str`Successfully removed item from Collection.`),
         variant: "success",
         icon: "check2-circle",
+        id: "collection-item-remove-status",
       });
       void this.fetchCollection();
       void this.fetchArchivedItems({
@@ -910,6 +915,7 @@ export class CollectionDetail extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "collection-item-remove-status",
       });
     }
   }

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -686,12 +686,14 @@ export class CollectionsList extends BtrixElement {
         message: msg(html`Deleted <strong>${name}</strong> Collection.`),
         variant: "success",
         icon: "check2-circle",
+        id: "collection-delete-status",
       });
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't delete Collection at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "collection-delete-status",
       });
     }
   }
@@ -729,6 +731,7 @@ export class CollectionsList extends BtrixElement {
           message: msg("Sorry, couldn't retrieve Collections at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "collection-retrieve-status",
         });
       }
     }

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -691,6 +691,7 @@ export class Dashboard extends BtrixElement {
         message: msg("Sorry, couldn't retrieve org metrics at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "metrics-retrieve-error",
       });
     }
   }

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -206,6 +206,7 @@ export class Org extends BtrixElement {
         message: msg("Sorry, couldn't retrieve organization at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "org-retrieve-error",
       });
     }
   }
@@ -679,6 +680,7 @@ export class Org extends BtrixElement {
         ),
         variant: "success",
         icon: "check2-circle",
+        id: "user-updated-status",
       });
       const org = await this.getOrg(this.orgId);
 
@@ -696,6 +698,7 @@ export class Org extends BtrixElement {
             ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "user-updated-status",
       });
     }
   }
@@ -731,6 +734,7 @@ export class Org extends BtrixElement {
         ),
         variant: "success",
         icon: "check2-circle",
+        id: "user-updated-status",
       });
       if (isSelf) {
         // FIXME better UX, this is the only page currently that doesn't require org...
@@ -753,6 +757,7 @@ export class Org extends BtrixElement {
             ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "user-updated-status",
       });
     }
   }

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -321,6 +321,7 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
         message: msg("Crawl defaults have been updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "crawl-defaults-update-status",
       });
     } catch (e) {
       console.debug(e);
@@ -329,6 +330,7 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
         message: msg("Sorry, couldn't update crawl defaults at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawl-defaults-update-status",
       });
     }
 

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -605,6 +605,7 @@ export class OrgSettings extends BtrixElement {
         message: msg("Sorry, couldn't retrieve pending invites at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "pending-invites-retrieve-error",
       });
     }
   }
@@ -667,6 +668,7 @@ export class OrgSettings extends BtrixElement {
         message: msg(str`Successfully invited ${inviteEmail}.`),
         variant: "success",
         icon: "check2-circle",
+        id: "user-updated-status",
       });
 
       void this.fetchPendingInvites();
@@ -678,6 +680,7 @@ export class OrgSettings extends BtrixElement {
           : msg("Sorry, couldn't invite user at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "user-updated-status",
       });
     }
 
@@ -699,6 +702,7 @@ export class OrgSettings extends BtrixElement {
         ),
         variant: "success",
         icon: "check2-circle",
+        id: "user-updated-status",
       });
 
       this.pendingInvites = this.pendingInvites.filter(
@@ -713,6 +717,7 @@ export class OrgSettings extends BtrixElement {
           : msg(str`Sorry, couldn't remove ${invite.email} at this time.`),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "user-updated-status",
       });
     }
   }
@@ -734,6 +739,7 @@ export class OrgSettings extends BtrixElement {
         message: msg("Org successfully updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "org-update-status",
       });
     } catch (e) {
       console.debug(e);
@@ -760,6 +766,7 @@ export class OrgSettings extends BtrixElement {
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "org-update-status",
       });
     }
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -238,6 +238,7 @@ export class WorkflowDetail extends BtrixElement {
             : msg("Sorry, couldn't retrieve Workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "workflow-retrieve-error",
       });
     }
 
@@ -1365,6 +1366,7 @@ export class WorkflowDetail extends BtrixElement {
           message: msg("Updated number of browser windows."),
           variant: "success",
           icon: "check2-circle",
+          id: "browser-windows-update-status",
         });
       } else {
         throw new Error("unhandled API response");
@@ -1376,6 +1378,7 @@ export class WorkflowDetail extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "browser-windows-update-status",
       });
     }
 
@@ -1408,6 +1411,7 @@ export class WorkflowDetail extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-retrieve-error",
       });
     }
   }
@@ -1427,6 +1431,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Sorry, couldn't get crawls at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-retrieve-error",
       });
     }
   }
@@ -1497,6 +1502,7 @@ export class WorkflowDetail extends BtrixElement {
       message: msg(str`Copied Workflow to new template.`),
       variant: "success",
       icon: "check2-circle",
+      id: "workflow-copied-success",
     });
   }
 
@@ -1519,12 +1525,14 @@ export class WorkflowDetail extends BtrixElement {
         ),
         variant: "success",
         icon: "check2-circle",
+        id: "workflow-delete-status",
       });
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't delete Workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "workflow-delete-status",
       });
     }
   }
@@ -1551,6 +1559,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Something went wrong, couldn't cancel crawl."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawl-stop-error",
       });
     }
 
@@ -1579,6 +1588,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Something went wrong, couldn't stop crawl."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawl-stop-error",
       });
     }
 
@@ -1603,6 +1613,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Starting crawl."),
         variant: "success",
         icon: "check2-circle",
+        id: "crawl-start-status",
       });
     } catch (e) {
       let message = msg("Sorry, couldn't run crawl at this time.");
@@ -1625,6 +1636,7 @@ export class WorkflowDetail extends BtrixElement {
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawl-start-status",
       });
     }
   }
@@ -1651,6 +1663,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg(`Successfully deleted crawl`),
         variant: "success",
         icon: "check2-circle",
+        id: "archived-item-delete-status",
       });
       void this.fetchCrawls();
     } catch (e) {
@@ -1674,6 +1687,7 @@ export class WorkflowDetail extends BtrixElement {
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "archived-item-delete-status",
       });
     }
   }
@@ -1693,6 +1707,7 @@ export class WorkflowDetail extends BtrixElement {
           ),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "archived-item-retrieve-error",
         });
       }
     }

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -742,14 +742,14 @@ export class WorkflowsList extends BtrixElement {
         ),
         variant: "warning",
         icon: "exclamation-triangle",
-        id: "workflow-coped-status",
+        id: "workflow-copied-status",
       });
     } else {
       this.notify.toast({
         message: msg(str`Copied Workflow to new template.`),
         variant: "success",
         icon: "check2-circle",
-        id: "workflow-coped-status",
+        id: "workflow-copied-status",
       });
     }
   }

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -174,6 +174,7 @@ export class WorkflowsList extends BtrixElement {
           message: msg("Sorry, couldn't retrieve Workflows at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "workflow-retrieve-error",
         });
       }
     }
@@ -741,12 +742,14 @@ export class WorkflowsList extends BtrixElement {
         ),
         variant: "warning",
         icon: "exclamation-triangle",
+        id: "workflow-coped-status",
       });
     } else {
       this.notify.toast({
         message: msg(str`Copied Workflow to new template.`),
         variant: "success",
         icon: "check2-circle",
+        id: "workflow-coped-status",
       });
     }
   }
@@ -764,12 +767,14 @@ export class WorkflowsList extends BtrixElement {
         ),
         variant: "success",
         icon: "check2-circle",
+        id: "workflow-delete-status",
       });
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't delete Workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "workflow-delete-status",
       });
     }
   }
@@ -790,6 +795,7 @@ export class WorkflowsList extends BtrixElement {
           message: msg("Something went wrong, couldn't cancel crawl."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "crawl-stop-error",
         });
       }
     }
@@ -811,6 +817,7 @@ export class WorkflowsList extends BtrixElement {
           message: msg("Something went wrong, couldn't stop crawl."),
           variant: "danger",
           icon: "exclamation-octagon",
+          id: "crawl-stop-error",
         });
       }
     }
@@ -865,6 +872,7 @@ export class WorkflowsList extends BtrixElement {
         message: message,
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "crawl-start-error",
       });
     }
   }

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -1,0 +1,50 @@
+import type SlAlert from "@shoelace-style/shoelace/dist/components/alert/alert";
+import { html, render } from "lit";
+
+import { type NotifyEventDetail } from "@/controllers/notify";
+
+const toastsWithIds = new Map<string | number | symbol, SlAlert>();
+
+export const toast = async (detail: NotifyEventDetail) => {
+  const {
+    title,
+    message,
+    variant = "primary",
+    icon = "info-circle",
+    duration = 5000,
+    id,
+  } = detail;
+
+  if (id && toastsWithIds.has(id)) {
+    const oldToast = toastsWithIds.get(id)!;
+    await oldToast.hide();
+  }
+  const container = document.createElement("sl-alert");
+  const alert = Object.assign(container, {
+    variant,
+    closable: true,
+    duration: duration,
+    style: [
+      "--sl-panel-background-color: var(--sl-color-neutral-1000)",
+      "--sl-color-neutral-700: var(--sl-color-neutral-0)",
+      // "--sl-panel-border-width: 0px",
+      "--sl-spacing-large: var(--sl-spacing-medium)",
+    ].join(";"),
+  });
+  if (id) {
+    toastsWithIds.set(id, container);
+    container.addEventListener("sl-after-hide", () => {
+      toastsWithIds.delete(id);
+    });
+  }
+  render(
+    html`
+      <sl-icon name="${icon}" slot="icon"></sl-icon>
+      ${title ? html`<strong>${title}</strong>` : ""}
+      ${message ? html`<div>${message}</div>` : ""}
+    `,
+    container,
+  );
+  document.body.append(alert);
+  await alert.toast();
+};


### PR DESCRIPTION
This has been bugging me for a while — any type of repetitive action that shows a toast will quickly cause a big stack of toasts to build up. This fixes that by allowing different categories of toasts to exist, where each category can only have one active toast. _Different_ categories of toast can coexist just fine, but toasts with the same `id` will replace any existing toast with that same `id`.

It's been a pet peeve for a while, and it should make any sort of "power user" use of Browsertrix a lot nicer :)

I've gone over all the existing toasts and applied what feel like decent differentiations, but I'm not set on any of them — open to suggestions!

https://github.com/user-attachments/assets/dbe39141-9e56-427d-b702-124c45ef2b9a

