### PR TITLE
fix rendering org list if org.created is null:

### DIFF
--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -52,7 +52,7 @@ export type CrawlingDefaults = z.infer<typeof crawlingDefaultsSchema>;
 export const orgDataSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  created: apiDateSchema.optional().nullable(),
+  created: apiDateSchema.nullable(),
   slug: z.string(),
   default: z.boolean(),
   quotas: orgQuotasSchema,

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -52,7 +52,7 @@ export type CrawlingDefaults = z.infer<typeof crawlingDefaultsSchema>;
 export const orgDataSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  created: apiDateSchema,
+  created: apiDateSchema.optional().nullable(),
   slug: z.string(),
   default: z.boolean(),
   quotas: orgQuotasSchema,

--- a/frontend/src/utils/localize.ts
+++ b/frontend/src/utils/localize.ts
@@ -202,7 +202,7 @@ export class Localize {
 
   // Custom date formatter that takes missing `Z` into account
   readonly date = (
-    d: Date | string | null | undefined,
+    d: Date | string | null,
     opts?: Intl.DateTimeFormatOptions,
   ) => {
     if (!d) {

--- a/frontend/src/utils/localize.ts
+++ b/frontend/src/utils/localize.ts
@@ -201,7 +201,13 @@ export class Localize {
   };
 
   // Custom date formatter that takes missing `Z` into account
-  readonly date = (d: Date | string, opts?: Intl.DateTimeFormatOptions) => {
+  readonly date = (
+    d: Date | string | null | undefined,
+    opts?: Intl.DateTimeFormatOptions,
+  ) => {
+    if (!d) {
+      return "";
+    }
     const date = new Date(d instanceof Date || d.endsWith("Z") ? d : `${d}Z`);
 
     const formatter = dateFormatter(


### PR DESCRIPTION
- org.created may be null (for backwards compatibility before it was set)
- fix frontend type to match backend
- update format.date() to accept null/undefined, return empty string