### PR TITLE
Support Presigning for use with custom domain

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1179,7 +1179,7 @@ class S3Storage(BaseModel):
     access_key: str
     secret_key: str
     access_endpoint_url: str
-    presign_endpoint_url: str
+    presign_endpoint_url: str = Field(default_factory=lambda data: data["endpoint_url"])  # type: ignore
     region: str = ""
     use_access_for_presign: bool = True
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1165,7 +1165,6 @@ class S3StorageIn(BaseModel):
     endpoint_url: str
     bucket: str
     access_endpoint_url: Optional[str] = None
-    presign_endpoint_url: Optional[str] = None
     region: str = ""
 
 
@@ -1180,7 +1179,6 @@ class S3Storage(BaseModel):
     access_key: str
     secret_key: str
     access_endpoint_url: str
-    presign_endpoint_url: str = ""
     region: str = ""
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1165,6 +1165,7 @@ class S3StorageIn(BaseModel):
     endpoint_url: str
     bucket: str
     access_endpoint_url: Optional[str] = None
+    presign_endpoint_url: Optional[str] = None
     region: str = ""
 
 
@@ -1179,7 +1180,7 @@ class S3Storage(BaseModel):
     access_key: str
     secret_key: str
     access_endpoint_url: str
-    presign_endpoint_url: str = Field(default_factory=lambda data: data["endpoint_url"])  # type: ignore
+    presign_endpoint_url: str = ""
     region: str = ""
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1181,7 +1181,6 @@ class S3Storage(BaseModel):
     access_endpoint_url: str
     presign_endpoint_url: str = Field(default_factory=lambda data: data["endpoint_url"])  # type: ignore
     region: str = ""
-    use_access_for_presign: bool = True
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1179,6 +1179,7 @@ class S3Storage(BaseModel):
     access_key: str
     secret_key: str
     access_endpoint_url: str
+    presign_endpoint_url: str
     region: str = ""
     use_access_for_presign: bool = True
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -277,8 +277,10 @@ class StorageOps:
         bucket, key = parts.path[1:].split("/", 1)
 
         # use presign_endpoint for actual connection here
+        # split key into bucket, key, as actual bucket in domain
         if use_presign_url and storage.presign_endpoint_url:
             parts = urlsplit(storage.presign_endpoint_url)
+            bucket, key = key.split("/", 1)
 
         endpoint_url = parts.scheme + "://" + parts.netloc
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -277,7 +277,7 @@ class StorageOps:
 
         async with session.create_client(
             "s3",
-            region_name=storage.region or "us-east-1",
+            region_name=storage.region or "any",
             endpoint_url=endpoint_url,
             aws_access_key_id=storage.access_key,
             aws_secret_access_key=storage.secret_key,
@@ -452,7 +452,7 @@ class StorageOps:
 
         async with self.get_s3_client(
             s3storage,
-            True,
+            for_presign=True,
         ) as (client, bucket, key):
             orig_key = key
             key += crawlfile.filename

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -141,10 +141,8 @@ class StorageOps:
 
         if self.is_local_minio:
             access_endpoint_url = "/data/"
-            use_access_for_presign = False
         else:
             access_endpoint_url = storage.get("access_endpoint_url") or endpoint_url
-            use_access_for_presign = is_bool(storage.get("use_access_for_presign"))
             presign_endpoint_url = storage.get("presign_endpoint_url") or endpoint_url
 
         return S3Storage(
@@ -154,7 +152,6 @@ class StorageOps:
             endpoint_url=endpoint_url,
             endpoint_no_bucket_url=endpoint_no_bucket_url,
             access_endpoint_url=access_endpoint_url,
-            use_access_for_presign=use_access_for_presign,
             presign_endpoint_url=presign_endpoint_url,
         )
 
@@ -181,7 +178,6 @@ class StorageOps:
             endpoint_no_bucket_url=endpoint_no_bucket_url,
             access_endpoint_url=storagein.access_endpoint_url or storagein.endpoint_url,
             presign_endpoint_url=storagein.endpoint_url,
-            use_access_for_presign=True,
         )
 
         try:
@@ -273,8 +269,6 @@ class StorageOps:
         """context manager for s3 client"""
         if use_presign_url:
             endpoint_url = storage.presign_endpoint_url
-        elif storage.use_access_for_presign:
-            endpoint_url = storage.access_endpoint_url
         else:
             endpoint_url = storage.endpoint_url
 
@@ -477,8 +471,7 @@ class StorageOps:
             )
 
             if (
-                not s3storage.use_access_for_presign
-                and s3storage.access_endpoint_url
+                s3storage.access_endpoint_url
                 and s3storage.access_endpoint_url != s3storage.presign_endpoint_url
             ):
                 presigned_url = presigned_url.replace(

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -278,7 +278,7 @@ class StorageOps:
 
         # use presign_endpoint for actual connection here
         if use_presign_url and storage.presign_endpoint_url:
-            endpoint_url = storage.presign_endpoint_url
+            parts = urlsplit(storage.presign_endpoint_url)
 
         endpoint_url = parts.scheme + "://" + parts.netloc
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -267,16 +267,18 @@ class StorageOps:
         self, storage: S3Storage, use_presign_url=False
     ) -> AsyncIterator[tuple[AIOS3Client, str, str]]:
         """context manager for s3 client"""
-        if use_presign_url:
-            endpoint_url = storage.presign_endpoint_url or storage.endpoint_url
-        else:
-            endpoint_url = storage.endpoint_url
+        # parse bucket and key from standard endpoint_url
+        endpoint_url = storage.endpoint_url
 
         if not endpoint_url.endswith("/"):
             endpoint_url += "/"
 
         parts = urlsplit(endpoint_url)
         bucket, key = parts.path[1:].split("/", 1)
+
+        # use presign_endpoint for actual connection here
+        if use_presign_url and storage.presign_endpoint_url:
+            endpoint_url = storage.presign_endpoint_url
 
         endpoint_url = parts.scheme + "://" + parts.netloc
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -177,7 +177,7 @@ class StorageOps:
             endpoint_url=endpoint_url,
             endpoint_no_bucket_url=endpoint_no_bucket_url,
             access_endpoint_url=storagein.access_endpoint_url or storagein.endpoint_url,
-            presign_endpoint_url=storagein.endpoint_url,
+            presign_endpoint_url=storagein.presign_endpoint_url,
         )
 
         try:
@@ -268,7 +268,7 @@ class StorageOps:
     ) -> AsyncIterator[tuple[AIOS3Client, str, str]]:
         """context manager for s3 client"""
         if use_presign_url:
-            endpoint_url = storage.presign_endpoint_url
+            endpoint_url = storage.presign_endpoint_url or storage.endpoint_url
         else:
             endpoint_url = storage.endpoint_url
 
@@ -470,12 +470,16 @@ class StorageOps:
                 "get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=duration
             )
 
+            presign_endpoint_url = (
+                s3storage.presign_endpoint_url or s3storage.endpoint_url
+            )
+
             if (
                 s3storage.access_endpoint_url
-                and s3storage.access_endpoint_url != s3storage.presign_endpoint_url
+                and s3storage.access_endpoint_url != presign_endpoint_url
             ):
                 presigned_url = presigned_url.replace(
-                    s3storage.presign_endpoint_url, s3storage.access_endpoint_url
+                    presign_endpoint_url, s3storage.access_endpoint_url
                 )
 
         return presigned_url

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -51,7 +51,7 @@ from .models import (
     AddedResponseName,
 )
 
-from .utils import is_bool, slug_from_name
+from .utils import slug_from_name
 from .version import __version__
 
 
@@ -78,14 +78,11 @@ class StorageOps:
     org_ops: OrgOps
     crawl_manager: CrawlManager
 
-    is_local_minio: bool
     frontend_origin: str
 
     def __init__(self, org_ops, crawl_manager) -> None:
         self.org_ops = org_ops
         self.crawl_manager = crawl_manager
-
-        self.is_local_minio = is_bool(os.environ.get("IS_LOCAL_MINIO"))
 
         frontend_origin = os.environ.get(
             "FRONTEND_ORIGIN", "http://browsertrix-cloud-frontend"
@@ -139,10 +136,7 @@ class StorageOps:
         if bucket_name:
             endpoint_url += bucket_name + "/"
 
-        if self.is_local_minio:
-            access_endpoint_url = "/data/"
-        else:
-            access_endpoint_url = storage.get("access_endpoint_url") or endpoint_url
+        access_endpoint_url = storage.get("access_endpoint_url") or endpoint_url
 
         return S3Storage(
             access_key=storage["access_key"],

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -280,6 +280,8 @@ class StorageOps:
         # split key into bucket, key, as actual bucket in domain
         if use_presign_url and storage.presign_endpoint_url:
             parts = urlsplit(storage.presign_endpoint_url)
+            if not key.endswith("/"):
+                key += "/"
             bucket, key = key.split("/", 1)
 
         endpoint_url = parts.scheme + "://" + parts.netloc

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -277,7 +277,7 @@ class StorageOps:
 
         async with session.create_client(
             "s3",
-            region_name=storage.region or "any",
+            region_name=storage.region or "us-east-1",
             endpoint_url=endpoint_url,
             aws_access_key_id=storage.access_key,
             aws_secret_access_key=storage.secret_key,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -405,6 +405,7 @@ storages:
     bucket_name: *local_bucket_name
 
     endpoint_url: "http://local-minio.default:9000/"
+    access_endpoint_url: "/data/"
 
 
 # optional: duration in minutes for WACZ download links to be valid

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -46,9 +46,12 @@ storages:
     access_endpoint_url: /data/
 ```
 
+This configuration uses the locally deployed Minio service, which is available when `minio_local: true` is set (enabled default).
+
+
 ### Using External S3 Storage Providers
 
-The following is an example storage configuration using an external provider instead of local minio:
+Browsertrix can also be used with external S3 storage providers, which can be configured as follows:
 
 ```yaml
 storages:
@@ -70,6 +73,8 @@ The `endpoint_url` should be provided in 'path prefix' form (with the bucket aft
 `https://s3provider.example.com/bucket/path/`.
 
 Browsertrix will handle presigning S3 URLs so that WACZ files (and other data) can be accessed directly, using URLSs of the form: `https://s3provider.example.com/bucket/path/to/files/crawl.wacz?signature...`
+
+Since the local Minio service is not used, `minio_local: false` can be set to save resource in not deploying Minio.
 
 
 ### Custom Access Endpoint URL

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -32,7 +32,14 @@ crawler_channels:
 
 ## Storage
 
-The `storage` setting is used to specify primary and replica storage for a Browsertrix deployment. All configured storage options must be S3-compatible buckets. At minimum, there must be one configured storage option, as can be seen in the default configuration:
+The `storage` setting is used to specify primary and replica storage for a Browsertrix deployment. All configured storage options must be S3-compatible buckets. At minimum, there must be one configured storage option, which includes a `is_default_primary: true`.
+
+### Using Local Minio Storage
+
+Browsertrix includes a built-in Minio storage service, which is enabled by default (`minio_local: true` is set).
+
+The configuration for this is as follows:
+
 
 ```yaml
 storages:
@@ -46,7 +53,9 @@ storages:
     access_endpoint_url: /data/
 ```
 
-This configuration uses the locally deployed Minio service, which is available when `minio_local: true` is set (enabled default).
+The `access_key` and `secret_key` should be changed, otherwise no additional changes are needed, and all local data will be stored in this Minio instance by default.
+
+The S3 bucket is accessible via `/data/` path on the same host Browsertrix is running on, eg. `http://localhost:30870/data/`.
 
 
 ### Using External S3 Storage Providers
@@ -72,7 +81,7 @@ This URL is used for direct access to WACZ files, and can be used to specify a c
 The `endpoint_url` should be provided in 'path prefix' form (with the bucket after the path), eg:
 `https://s3provider.example.com/bucket/path/`.
 
-Browsertrix will handle presigning S3 URLs so that WACZ files (and other data) can be accessed directly, using URLSs of the form: `https://s3provider.example.com/bucket/path/to/files/crawl.wacz?signature...`
+Browsertrix will handle presigning S3 URLs so that WACZ files (and other data) can be accessed directly, using URLs of the form: `https://s3provider.example.com/bucket/path/to/files/crawl.wacz?signature...`
 
 Since the local Minio service is not used, `minio_local: false` can be set to save resource in not deploying Minio.
 
@@ -86,14 +95,12 @@ The host portion of the URL is then replaced with the `access_endpoint_url`. For
 
 The `https://bucket.s3provider.example.com/path/` is then replaced with the `https://my-custom-domain.example.com/path/`, and the final URL becomes `https://my-custom-domain.example.com/path/to/files/crawl.wacz?signature...`.
 
-When using default local Minio storage, the `access_endpoint_url` should be `/data/` to use built-in routing to the local Minio instance.
-
 
 ### Storage Replicas
 
-It is possible to add one or more replica storage locations. If replica locations are enabled, all stored content in the application will be automatically replicated to each configured replica storage location in background jobs after being stored in the default primary storage. If replica locations are enabled, at least one must be set as the default replica location for primary backups. This is indicated with `is_default_replica: True`. If more than one storage location is configured, the primary storage must also be indicated with `is_default_primary: True`.
+It is possible to add one or more replica storage locations. If replica locations are enabled, all stored content in the application will be automatically replicated to each configured replica storage location in background jobs after being stored in the default primary storage. If replica locations are enabled, at least one must be set as the default replica location for primary backups. This is indicated with `is_default_replica: true`. If more than one storage location is configured, the primary storage must also be indicated with `is_default_primary: true`.
 
-For example, here is what a storage configuration with two replica locations, one in another bucket on the same Minio S3 service as primary storage as well as another in an external S3 provider:
+For example, here is what a storage configuration with two replica locations, one in another bucket on the same local Minio S3 service as primary storage as well as another in an external S3 provider:
 
 ```yaml
 storages:
@@ -105,7 +112,7 @@ storages:
     access_endpoint_url: /data/
 
     endpoint_url: "http://local-minio.default:9000/"
-    is_default_primary: True
+    is_default_primary: true
 
   - name: "replica-0"
     type: "s3"
@@ -114,7 +121,7 @@ storages:
     bucket_name: "replica-0"
 
     endpoint_url: "http://local-minio.default:9000/"
-    is_default_replica: True
+    is_default_replica: true
 
   - name: "replica-1"
     type: "s3"

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -40,9 +40,10 @@ storages:
     type: "s3"
     access_key: "ADMIN"
     secret_key: "PASSW0RD"
-    bucket_name: *local_bucket_name
+    bucket_name: btrix-data
 
     endpoint_url: "http://local-minio.default:9000/"
+    access_endpoint_url: /data/
 ```
 
 It is possible to add one or more replica storage locations. If replica locations are enabled, all stored content in the application will be automatically replicated to each configured replica storage location in background jobs after being stored in the default primary storage. If replica locations are enabled, at least one must be set as the default replica location for primary backups. This is indicated with `is_default_replica: True`. If more than one storage location is configured, the primary storage must also be indicated with `is_default_primary: True`.
@@ -55,7 +56,7 @@ storages:
     type: "s3"
     access_key: "ADMIN"
     secret_key: "PASSW0RD"
-    bucket_name: *local_bucket_name
+    bucket_name: btrix-data
 
     endpoint_url: "http://local-minio.default:9000/"
     is_default_primary: True
@@ -75,8 +76,31 @@ storages:
     secret_key: "secret"
     bucket_name: "replica-1"
 
-    endpoint_url: "http://s3provider.example.com"
+    endpoint_url: "https://s3provider.example.com/bucket/path/"
+    access_endpoint_url: "https://my-custom-domain.example.com/path/"
 ```
+
+
+### Using External S3 Storage Providers
+
+When using an external S3 provider, a custom `access_endpoint_url` can be provided.
+This URL is used for direct access to WACZ files, and can be used to specify a custom domain to access the bucket.
+
+The `endpoint_url` should be provided in 'path prefix' form (with the bucket after the path), eg:
+`https://s3provider.example.com/bucket/path/`.
+
+Browsertrix will handle presigning S3 URLs so that WACZ files (and other data) can be accessed directly, using URLSs of the form: `https://s3provider.example.com/bucket/path/to/files/crawl.wacz?signature...`
+
+
+### Custom Access Endpoint URL
+
+It may be useful to provide a custom access endpoint for accessing WACZ files and other data. if the `access_endpoint_url` is provided,
+it should be in 'virtual host' form (the bucket is not added to the path, but is assumed to be the in the host).
+
+The host portion of the URL is then replaced with the `access_endpoint_url`. For example, given `endpoint_url: https://s3provider.example.com/bucket/path/` and `access_endpoint_url: https://my-custom-domain.example.com/path/`, a URL to a WACZ files may be `https://bucket.s3provider.example.com/path/to/files/crawl.wacz?signature...`.
+
+The `https://bucket.s3provider.example.com/path/` is then replaced with the `https://my-custom-domain.example.com/path/`, and the final URL becomes `https://my-custom-domain.example.com/path/to/files/crawl.wacz?signature...`.
+
 
 ## Horizontal Autoscaling
 

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -46,6 +46,46 @@ storages:
     access_endpoint_url: /data/
 ```
 
+### Using External S3 Storage Providers
+
+The following is an example storage configuration using an external provider instead of local minio:
+
+```yaml
+storages:
+  - name: default
+    type: "s3"
+    access_key: "accesskey"
+    secret_key: "secret"
+
+    endpoint_url: "https://s3provider.example.com/bucket/path/"
+    access_endpoint_url: "https://my-custom-domain.example.com/path/" #optional
+    is_default_primary: true
+```
+
+
+When using an external S3 provider, a custom `access_endpoint_url` can be provided, and the `bucket_name` need to be specified separately.
+This URL is used for direct access to WACZ files, and can be used to specify a custom domain to access the bucket.
+
+The `endpoint_url` should be provided in 'path prefix' form (with the bucket after the path), eg:
+`https://s3provider.example.com/bucket/path/`.
+
+Browsertrix will handle presigning S3 URLs so that WACZ files (and other data) can be accessed directly, using URLSs of the form: `https://s3provider.example.com/bucket/path/to/files/crawl.wacz?signature...`
+
+
+### Custom Access Endpoint URL
+
+It may be useful to provide a custom access endpoint for accessing WACZ files and other data. if the `access_endpoint_url` is provided,
+it should be in 'virtual host' form (the bucket is not added to the path, but is assumed to be the in the host).
+
+The host portion of the URL is then replaced with the `access_endpoint_url`. For example, given `endpoint_url: https://s3provider.example.com/bucket/path/` and `access_endpoint_url: https://my-custom-domain.example.com/path/`, a URL to a WACZ files in 'virtual host' form may be `https://bucket.s3provider.example.com/path/to/files/crawl.wacz?signature...`.
+
+The `https://bucket.s3provider.example.com/path/` is then replaced with the `https://my-custom-domain.example.com/path/`, and the final URL becomes `https://my-custom-domain.example.com/path/to/files/crawl.wacz?signature...`.
+
+When using default local Minio storage, the `access_endpoint_url` should be `/data/` to use built-in routing to the local Minio instance.
+
+
+### Storage Replicas
+
 It is possible to add one or more replica storage locations. If replica locations are enabled, all stored content in the application will be automatically replicated to each configured replica storage location in background jobs after being stored in the default primary storage. If replica locations are enabled, at least one must be set as the default replica location for primary backups. This is indicated with `is_default_replica: True`. If more than one storage location is configured, the primary storage must also be indicated with `is_default_primary: True`.
 
 For example, here is what a storage configuration with two replica locations, one in another bucket on the same Minio S3 service as primary storage as well as another in an external S3 provider:
@@ -57,6 +97,7 @@ storages:
     access_key: "ADMIN"
     secret_key: "PASSW0RD"
     bucket_name: btrix-data
+    access_endpoint_url: /data/
 
     endpoint_url: "http://local-minio.default:9000/"
     is_default_primary: True
@@ -79,28 +120,6 @@ storages:
     endpoint_url: "https://s3provider.example.com/bucket/path/"
     access_endpoint_url: "https://my-custom-domain.example.com/path/"
 ```
-
-
-### Using External S3 Storage Providers
-
-When using an external S3 provider, a custom `access_endpoint_url` can be provided.
-This URL is used for direct access to WACZ files, and can be used to specify a custom domain to access the bucket.
-
-The `endpoint_url` should be provided in 'path prefix' form (with the bucket after the path), eg:
-`https://s3provider.example.com/bucket/path/`.
-
-Browsertrix will handle presigning S3 URLs so that WACZ files (and other data) can be accessed directly, using URLSs of the form: `https://s3provider.example.com/bucket/path/to/files/crawl.wacz?signature...`
-
-
-### Custom Access Endpoint URL
-
-It may be useful to provide a custom access endpoint for accessing WACZ files and other data. if the `access_endpoint_url` is provided,
-it should be in 'virtual host' form (the bucket is not added to the path, but is assumed to be the in the host).
-
-The host portion of the URL is then replaced with the `access_endpoint_url`. For example, given `endpoint_url: https://s3provider.example.com/bucket/path/` and `access_endpoint_url: https://my-custom-domain.example.com/path/`, a URL to a WACZ files may be `https://bucket.s3provider.example.com/path/to/files/crawl.wacz?signature...`.
-
-The `https://bucket.s3provider.example.com/path/` is then replaced with the `https://my-custom-domain.example.com/path/`, and the final URL becomes `https://my-custom-domain.example.com/path/to/files/crawl.wacz?signature...`.
-
 
 ## Horizontal Autoscaling
 


### PR DESCRIPTION
If access_endpoint_url is provided:
- Use virtual host addressing style, so presigned URLs are of the form `https://bucket.s3-host.example.com/path/` instead of `https://s3-host.example.com/bucket/path/`
- Allow for replacing `https://bucket.s3-host.example.com/path/` -> `https://my-custom-domain.example.com/path/`, where `https://my-custom-domain.example.com/path/` is the access_endpoint_url
- Remove old `use_access_for_presign` which is no longer used
- Fixes #2248 