### PR TITLE
Related crawljob filtering by role

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -580,11 +580,13 @@ class CrawlOperator(BaseOperator):
         spec = data.parent.get("spec", {})
         crawl_id = spec["id"]
         oid = spec.get("oid")
+        # filter by role as well (job vs qa-job)
+        role = data.parent.get("metadata", {}).get("labels", {}).get("role")
         related_resources = [
             {
                 "apiVersion": BTRIX_API,
                 "resource": "crawljobs",
-                "labelSelector": {"matchLabels": {"btrix.org": oid}},
+                "labelSelector": {"matchLabels": {"btrix.org": oid, "role": role}},
             },
         ]
 


### PR DESCRIPTION
add filtering by role to related crawljobs query:
- for regular crawls (role 'job'), only count other regular crawls
- for qa runs (role 'qa-job') only count other qa jobs
- ensures that concurrent crawl limits apply separately to regular crawls and qa runs
- fixes #2261


Testing:
- Create an org with max concurrent crawl limit, eg. 1
- Start a crawl
- Start another crawl, observe crawl is waiting for crawl limit
- Start a QA run, it should start while crawl is running
- Start another QA run, observe that it is waiting for first QA run to finish