### PR TITLE
fix: Update superadmin orgs list after create

### DIFF
--- a/frontend/src/pages/admin.ts
+++ b/frontend/src/pages/admin.ts
@@ -366,6 +366,7 @@ export class Admin extends BtrixElement {
         method: "POST",
         body: JSON.stringify(params),
       });
+      await this.fetchOrgs();
       const userInfo = await this.getUserInfo();
       AppStateService.updateUser(formatAPIUser(userInfo));
 


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2235

## Changes

Fixes newly created org not showing in list

## Manual testing

1. Log in as superadmin
2. Create new org. Verify new org is shown in list after dialog closes