### PR TITLE
fix: Crawler proxy selection fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@formatjs/intl-durationformat": "^0.6.4",
     "@formatjs/intl-localematcher": "^0.5.9",
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
+    "@lit/context": "^1.1.3",
     "@lit/localize": "^0.12.1",
     "@lit/task": "^1.0.0",
     "@novnc/novnc": "^1.4.0-beta",

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -27,12 +27,12 @@ export type SelectCrawlerProxyUpdateEvent =
  * Usage example:
  * ```ts
  * <btrix-select-crawler-proxy
- *   orgId=${orgId}
- *   on-change=${({value}) => selectedcrawlerProxy = value}
+ *   .proxyServers=${proxyServers}
+ *   btrix-change=${({value}) => selectedcrawlerProxy = value}
  * ></btrix-select-crawler-proxy>
  * ```
  *
- * @event on-change
+ * @fires btrix-change
  */
 @customElement("btrix-select-crawler-proxy")
 @localized()
@@ -55,8 +55,12 @@ export class SelectCrawlerProxy extends BtrixElement {
   @state()
   private defaultProxy?: Proxy;
 
+  public get value() {
+    return this.selectedProxy?.id || "";
+  }
+
   protected firstUpdated() {
-    void this.fetchOrgProxies();
+    void this.initProxies();
   }
   // credit: https://dev.to/jorik/country-code-to-flag-emoji-a21
   private countryCodeToFlagEmoji(countryCode: String): String {
@@ -68,10 +72,6 @@ export class SelectCrawlerProxy extends BtrixElement {
   }
 
   render() {
-    /*if (this.crawlerProxys && this.crawlerProxys.length < 2) {
-      return html``;
-    }*/
-
     return html`
       <sl-select
         name="proxyId"
@@ -84,10 +84,6 @@ export class SelectCrawlerProxy extends BtrixElement {
         clearable
         size=${ifDefined(this.size)}
         @sl-change=${this.onChange}
-        @sl-focus=${() => {
-          // Refetch to keep list up to date
-          void this.fetchOrgProxies();
-        }}
         @sl-hide=${this.stopProp}
         @sl-after-hide=${this.stopProp}
       >
@@ -138,7 +134,7 @@ export class SelectCrawlerProxy extends BtrixElement {
     }
 
     this.dispatchEvent(
-      new CustomEvent<SelectCrawlerProxyChangeDetail>("on-change", {
+      new CustomEvent<SelectCrawlerProxyChangeDetail>("btrix-change", {
         detail: {
           value: this.selectedProxy ? this.selectedProxy.id : null,
         },
@@ -146,50 +142,23 @@ export class SelectCrawlerProxy extends BtrixElement {
     );
   }
 
-  private async fetchOrgProxies(): Promise<void> {
-    try {
-      const defaultProxyId = this.defaultProxyId;
+  private async initProxies(): Promise<void> {
+    const defaultProxyId = this.defaultProxyId;
 
-      if (!this.defaultProxy) {
-        this.defaultProxy = this.proxyServers.find(
-          ({ id }) => id === defaultProxyId,
-        );
-      }
-
-      if (this.proxyId && !this.selectedProxy?.id) {
-        this.selectedProxy = this.proxyServers.find(
-          ({ id }) => id === this.proxyId,
-        );
-      }
-
-      if (!this.selectedProxy) {
-        this.proxyId = null;
-        this.dispatchEvent(
-          new CustomEvent("on-change", {
-            detail: {
-              value: null,
-            },
-          }),
-        );
-        this.selectedProxy = this.proxyServers.find(
-          ({ id }) => id === this.proxyId,
-        );
-      }
-
-      this.dispatchEvent(
-        new CustomEvent<SelectCrawlerProxyUpdateDetail>("on-update", {
-          detail: {
-            show: this.proxyServers.length > 1,
-          },
-        }),
+    if (!this.defaultProxy) {
+      this.defaultProxy = this.proxyServers.find(
+        ({ id }) => id === defaultProxyId,
       );
-    } catch (e) {
-      this.notify.toast({
-        message: msg("Sorry, couldn't retrieve proxies at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-        id: "proxy-retrieve-status",
-      });
+    }
+
+    if (this.proxyId && !this.selectedProxy) {
+      this.selectedProxy = this.proxyServers.find(
+        ({ id }) => id === this.proxyId,
+      );
+    }
+
+    if (!this.selectedProxy) {
+      this.proxyId = null;
     }
   }
 

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -3,8 +3,8 @@ import { type SlSelect } from "@shoelace-style/shoelace";
 import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
+import { BtrixElement } from "@/classes/BtrixElement";
 import type { ProxiesAPIResponse, Proxy } from "@/pages/org/types";
-import LiteElement from "@/utils/LiteElement";
 
 type SelectCrawlerProxyChangeDetail = {
   value: string | null;
@@ -35,7 +35,7 @@ export type SelectCrawlerProxyUpdateEvent =
  */
 @customElement("btrix-select-crawler-proxy")
 @localized()
-export class SelectCrawlerProxy extends LiteElement {
+export class SelectCrawlerProxy extends BtrixElement {
   @property({ type: String })
   proxyId: string | null = null;
 
@@ -182,7 +182,7 @@ export class SelectCrawlerProxy extends LiteElement {
         }),
       );
     } catch (e) {
-      this.notify({
+      this.notify.toast({
         message: msg("Sorry, couldn't retrieve proxies at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
@@ -192,7 +192,7 @@ export class SelectCrawlerProxy extends LiteElement {
   }
 
   private async getOrgProxies(): Promise<ProxiesAPIResponse> {
-    return this.apiFetch<ProxiesAPIResponse>(
+    return this.api.fetch<ProxiesAPIResponse>(
       `/orgs/${this.orgId}/crawlconfigs/crawler-proxies`,
     );
   }

--- a/frontend/src/context/org.ts
+++ b/frontend/src/context/org.ts
@@ -1,0 +1,7 @@
+import { createContext } from "@lit/context";
+
+import type { ProxiesAPIResponse } from "@/types/crawler";
+
+export type ProxiesContext = ProxiesAPIResponse | null;
+
+export const proxiesContext = createContext<ProxiesContext>("proxies");

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -1,5 +1,7 @@
+import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import { type SlInput } from "@shoelace-style/shoelace";
+import { nothing } from "lit";
 import {
   customElement,
   property,
@@ -7,16 +9,21 @@ import {
   queryAsync,
   state,
 } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import queryString from "query-string";
 
 import type { Dialog } from "@/components/ui/dialog";
 import { type SelectCrawlerChangeEvent } from "@/components/ui/select-crawler";
 import { type SelectCrawlerProxyChangeEvent } from "@/components/ui/select-crawler-proxy";
+import { proxiesContext, type ProxiesContext } from "@/context/org";
 import LiteElement, { html } from "@/utils/LiteElement";
 
 @localized()
 @customElement("btrix-new-browser-profile-dialog")
 export class NewBrowserProfileDialog extends LiteElement {
+  @consume({ context: proxiesContext, subscribe: true })
+  private readonly proxies?: ProxiesContext;
+
   @property({ type: Boolean })
   open = false;
 
@@ -83,14 +90,22 @@ export class NewBrowserProfileDialog extends LiteElement {
               (this.crawlerChannel = e.detail.value!)}
           ></btrix-select-crawler>
         </div>
-        <div class="mt-4">
-          <btrix-select-crawler-proxy
-            orgId=${this.orgId}
-            .proxyId="${this.proxyId || ""}"
-            @on-change=${(e: SelectCrawlerProxyChangeEvent) =>
-              (this.proxyId = e.detail.value!)}
-          ></btrix-select-crawler-proxy>
-        </div>
+        ${this.proxies?.servers.length
+          ? html`
+              <div class="mt-4">
+                <btrix-select-crawler-proxy
+                  defaultProxyId=${ifDefined(
+                    this.proxies.default_proxy_id ?? undefined,
+                  )}
+                  .proxyServers=${this.proxies.servers}
+                  .proxyId="${this.proxyId || ""}"
+                  @on-change=${(e: SelectCrawlerProxyChangeEvent) =>
+                    (this.proxyId = e.detail.value!)}
+                ></btrix-select-crawler-proxy>
+              </div>
+            `
+          : nothing}
+
         <input class="invisible size-0" type="submit" />
       </form>
       <div slot="footer" class="flex justify-between">

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -99,8 +99,8 @@ export class NewBrowserProfileDialog extends LiteElement {
                   )}
                   .proxyServers=${this.proxies.servers}
                   .proxyId="${this.proxyId || ""}"
-                  @on-change=${(e: SelectCrawlerProxyChangeEvent) =>
-                    (this.proxyId = e.detail.value!)}
+                  @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
+                    (this.proxyId = e.detail.value)}
                 ></btrix-select-crawler-proxy>
               </div>
             `

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import type {
   SlChangeEvent,
@@ -43,6 +44,7 @@ import type { SelectCrawlerProxyChangeEvent } from "@/components/ui/select-crawl
 import type { Tab } from "@/components/ui/tab-list";
 import type { TagInputEvent, TagsChangeEvent } from "@/components/ui/tag-input";
 import type { TimeInputChangeEvent } from "@/components/ui/time-input";
+import { proxiesContext, type ProxiesContext } from "@/context/org";
 import { type SelectBrowserProfileChangeEvent } from "@/features/browser-profiles/select-browser-profile";
 import type { CollectionsChangeEvent } from "@/features/collections/collections-add";
 import type { QueueExclusionTable } from "@/features/crawl-workflows/queue-exclusion-table";
@@ -188,6 +190,9 @@ type CrawlConfigResponse = {
 @localized()
 @customElement("btrix-workflow-editor")
 export class WorkflowEditor extends BtrixElement {
+  @consume({ context: proxiesContext, subscribe: true })
+  private readonly proxies?: ProxiesContext;
+
   @property({ type: String })
   configId?: string;
 
@@ -1329,17 +1334,24 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ></btrix-select-browser-profile>
       `)}
       ${this.renderHelpTextCol(infoTextStrings["browserProfile"])}
-      ${inputCol(html`
-        <btrix-select-crawler-proxy
-          orgId=${this.orgId}
-          .proxyId="${this.formState.proxyId || ""}"
-          @on-change=${(e: SelectCrawlerProxyChangeEvent) =>
-            this.updateFormState({
-              proxyId: e.detail.value,
-            })}
-        ></btrix-select-crawler-proxy>
-      `)}
-      ${this.renderHelpTextCol(infoTextStrings["proxyId"])}
+      ${this.proxies?.servers.length
+        ? [
+            inputCol(html`
+              <btrix-select-crawler-proxy
+                defaultProxyId=${ifDefined(
+                  this.proxies.default_proxy_id ?? undefined,
+                )}
+                .proxyServers=${this.proxies.servers}
+                .proxyId="${this.formState.proxyId || ""}"
+                @on-change=${(e: SelectCrawlerProxyChangeEvent) =>
+                  this.updateFormState({
+                    proxyId: e.detail.value,
+                  })}
+              ></btrix-select-crawler-proxy>
+            `),
+            this.renderHelpTextCol(infoTextStrings["proxyId"]),
+          ]
+        : nothing}
       ${inputCol(html`
         <sl-radio-group
           name="scale"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1343,7 +1343,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
                 )}
                 .proxyServers=${this.proxies.servers}
                 .proxyId="${this.formState.proxyId || ""}"
-                @on-change=${(e: SelectCrawlerProxyChangeEvent) =>
+                @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                   this.updateFormState({
                     proxyId: e.detail.value,
                   })}

--- a/frontend/src/pages/org/context.ts
+++ b/frontend/src/pages/org/context.ts
@@ -1,0 +1,7 @@
+import { createContext } from "@lit/context";
+
+import type { ProxiesAPIResponse } from "@/types/crawler";
+
+export const proxiesContext = createContext<ProxiesAPIResponse | null>(
+  "proxies",
+);

--- a/frontend/src/pages/org/context.ts
+++ b/frontend/src/pages/org/context.ts
@@ -1,7 +1,0 @@
-import { createContext } from "@lit/context";
-
-import type { ProxiesAPIResponse } from "@/types/crawler";
-
-export const proxiesContext = createContext<ProxiesAPIResponse | null>(
-  "proxies",
-);

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -10,6 +10,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { LanguageSelect } from "@/components/ui/language-select";
+import type { SelectCrawlerProxy } from "@/components/ui/select-crawler-proxy";
 import { proxiesContext, type ProxiesContext } from "@/context/org";
 import type { QueueExclusionTable } from "@/features/crawl-workflows/queue-exclusion-table";
 import { columns, type Cols } from "@/layouts/columns";
@@ -65,6 +66,9 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
   @query("btrix-language-select")
   languageSelect?: LanguageSelect | null;
 
+  @query("btrix-select-crawler-proxy")
+  proxySelect?: SelectCrawlerProxy | null;
+
   @query('sl-button[type="submit"]')
   submitButton?: SlButton | null;
 
@@ -75,7 +79,6 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
   }
 
   render() {
-    console.log("crawling defaults:", this.proxies);
     return html` ${this.renderWorkflowDefaults()} `;
   }
 
@@ -305,7 +308,7 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
       blockAds: values.blockAds === "on",
       profileid: values.profileid,
       crawlerChannel: values.crawlerChannel,
-      proxyId: values.proxyId,
+      proxyId: this.proxySelect?.value || undefined,
       userAgent: values.userAgent,
       lang: this.languageSelect?.value || undefined,
       exclude: this.exclusionTable?.exclusions?.filter((v) => v) || [],

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit/context";
 import { localized, msg } from "@lit/localize";
 import type { SlButton } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1161,6 +1161,13 @@
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz#353ce4a76c83fadec272ea5674ede767650762fd"
   integrity sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==
 
+"@lit/context@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@lit/context/-/context-1.1.3.tgz#66f8832e57f760f51f39c9d658ca6bd78f809e19"
+  integrity sha512-Auh37F4S0PZM93HTDfZWs97mmzaQ7M3vnTc9YvxAGyP3UItSK/8Fs0vTOGT+njuvOwbKio/l8Cx/zWL4vkutpQ==
+  dependencies:
+    "@lit/reactive-element" "^1.6.2 || ^2.0.0"
+
 "@lit/localize-tools@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@lit/localize-tools/-/localize-tools-0.8.0.tgz#8a14b3961aa63ef801c9f63274cb1d58821a3552"
@@ -1197,7 +1204,7 @@
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.0.0"
 
-"@lit/reactive-element@^1.0.0 || ^2.0.0":
+"@lit/reactive-element@^1.0.0 || ^2.0.0", "@lit/reactive-element@^1.6.2 || ^2.0.0":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.4.tgz#8f2ed950a848016383894a26180ff06c56ae001b"
   integrity sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2168

## Changes

- Hides proxy form control if there are no proxy servers available
- Fixes org default proxy value not being saved

## Manual testing

1. Log in as superadmin
2. Select org with proxies
3. Go to Settings -> Crawling Defaults. Verify "Crawler Proxy Server" is available
4. Update "Crawler Proxy Server" and save
5. Go to Crawling -> New Workflow -> Crawling Settings. Verify correct default proxy is shown
6. Go to Browser Profiles -> New Browser Profile. Verify "Crawler Proxy Server" is available
7. Select different org without proxies
8. Repeat 3-6, only verify that "Crawler Proxy Server" is not visible and forms save as expected

## Follow-ups

Browser profile proxies need some updates, see https://github.com/webrecorder/browsertrix/issues/2281