### PR TITLE
fix: Allow deleting workflows without any crawls

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1666,6 +1666,9 @@ export class WorkflowDetail extends BtrixElement {
         id: "archived-item-delete-status",
       });
       void this.fetchCrawls();
+
+      // Update crawl count
+      void this.fetchWorkflow();
     } catch (e) {
       if (this.crawlToDelete) {
         this.confirmDeleteCrawl(this.crawlToDelete);

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -18,6 +18,7 @@ import type { CrawlLog } from "@/features/archived-items/crawl-logs";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
+import { deleteConfirmation } from "@/strings/ui";
 import type { APIPaginatedList } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
@@ -54,7 +55,13 @@ export class WorkflowDetail extends BtrixElement {
   isCrawler!: boolean;
 
   @property({ type: String })
-  openDialogName?: "scale" | "exclusions" | "cancel" | "stop" | "delete";
+  openDialogName?:
+    | "scale"
+    | "exclusions"
+    | "cancel"
+    | "stop"
+    | "delete"
+    | "deleteCrawl";
 
   @property({ type: String })
   initialActivePanel?: Tab;
@@ -255,14 +262,14 @@ export class WorkflowDetail extends BtrixElement {
   render() {
     if (this.isEditing && this.isCrawler) {
       return html`
-        <div class="grid grid-cols-1 gap-7">
+        <div class="grid grid-cols-1 gap-7 pb-7">
           ${when(this.workflow, this.renderEditor)}
         </div>
       `;
     }
 
     return html`
-      <div class="grid grid-cols-1 gap-7">
+      <div class="grid grid-cols-1 gap-7 pb-7">
         <div class="col-span-1">${this.renderBreadcrumbs()}</div>
 
         <div>
@@ -355,7 +362,7 @@ export class WorkflowDetail extends BtrixElement {
       </btrix-dialog>
       <btrix-dialog
         .label=${msg("Delete Crawl?")}
-        .open=${this.openDialogName === "delete"}
+        .open=${this.openDialogName === "deleteCrawl"}
         @sl-request-close=${() => (this.openDialogName = undefined)}
         @sl-show=${this.showDialog}
         @sl-after-hide=${() => (this.isDialogVisible = false)}
@@ -391,6 +398,32 @@ export class WorkflowDetail extends BtrixElement {
         @sl-after-hide=${() => (this.isDialogVisible = false)}
       >
         ${this.isDialogVisible ? this.renderEditScale() : ""}
+      </btrix-dialog>
+      <btrix-dialog
+        .label=${msg("Delete Workflow?")}
+        .open=${this.openDialogName === "delete"}
+        @sl-request-close=${() => (this.openDialogName = undefined)}
+        @sl-show=${this.showDialog}
+        @sl-after-hide=${() => (this.isDialogVisible = false)}
+      >
+        ${deleteConfirmation(this.renderName())}
+        <div slot="footer" class="flex justify-between">
+          <sl-button
+            size="small"
+            .autofocus=${true}
+            @click=${() => (this.openDialogName = undefined)}
+            >${msg("Cancel")}</sl-button
+          >
+          <sl-button
+            size="small"
+            variant="danger"
+            @click=${async () => {
+              void this.delete();
+              this.openDialogName = undefined;
+            }}
+            >${msg("Delete Workflow")}</sl-button
+          >
+        </div>
       </btrix-dialog>
     `;
   }
@@ -741,7 +774,7 @@ export class WorkflowDetail extends BtrixElement {
               <sl-divider></sl-divider>
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--danger)"
-                @click=${() => void this.delete()}
+                @click=${() => (this.openDialogName = "delete")}
               >
                 <sl-icon name="trash3" slot="prefix"></sl-icon>
                 ${msg("Delete Workflow")}
@@ -842,7 +875,7 @@ export class WorkflowDetail extends BtrixElement {
 
   private renderCrawls() {
     return html`
-      <section>
+      <section class="h-56 min-h-max">
         <div
           class="mb-3 flex items-center justify-end rounded-lg border bg-neutral-50 p-4"
         >
@@ -1643,7 +1676,7 @@ export class WorkflowDetail extends BtrixElement {
 
   private readonly confirmDeleteCrawl = (crawl: Crawl) => {
     this.crawlToDelete = crawl;
-    this.openDialogName = "delete";
+    this.openDialogName = "deleteCrawl";
   };
 
   private async deleteCrawl(crawl: Crawl) {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -736,7 +736,7 @@ export class WorkflowDetail extends BtrixElement {
             ${msg("Duplicate Workflow")}
           </sl-menu-item>
           ${when(
-            !this.lastCrawlId,
+            !workflow.crawlCount,
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -593,7 +593,7 @@ export class WorkflowsList extends BtrixElement {
             ${msg("Duplicate Workflow")}
           </sl-menu-item>
           ${when(
-            !workflow.lastCrawlId,
+            !workflow.crawlCount,
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -1,7 +1,11 @@
 import { localized, msg, str } from "@lit/localize";
-import type { SlCheckbox, SlSelectEvent } from "@shoelace-style/shoelace";
+import type {
+  SlCheckbox,
+  SlDialog,
+  SlSelectEvent,
+} from "@shoelace-style/shoelace";
 import { html, type PropertyValues } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
@@ -21,6 +25,7 @@ import { type SelectEvent } from "@/components/ui/search-combobox";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
 import { pageHeader } from "@/layouts/pageHeader";
 import scopeTypeLabels from "@/strings/crawl-workflows/scopeType";
+import { deleteConfirmation } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { NewWorkflowOnlyScopeType } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
@@ -92,6 +97,9 @@ export class WorkflowsList extends BtrixElement {
   private fetchErrorStatusCode?: number;
 
   @state()
+  private workflowToDelete?: ListWorkflow;
+
+  @state()
   private orderBy: {
     field: SortField;
     direction: SortDirection;
@@ -105,6 +113,9 @@ export class WorkflowsList extends BtrixElement {
 
   @state()
   private filterByCurrentUser = false;
+
+  @query("#deleteDialog")
+  private readonly deleteDialog?: SlDialog | null;
 
   // For fuzzy search:
   private readonly searchKeys = ["name", "firstSeed"];
@@ -311,12 +322,52 @@ export class WorkflowsList extends BtrixElement {
             </btrix-alert>
           </div>
         `,
-        () =>
-          this.workflows
-            ? this.workflows.total
-              ? this.renderWorkflowList()
-              : this.renderEmptyState()
-            : this.renderLoading(),
+        () => html`
+          <div class="pb-10">
+            ${this.workflows
+              ? this.workflows.total
+                ? this.renderWorkflowList()
+                : this.renderEmptyState()
+              : this.renderLoading()}
+          </div>
+        `,
+      )}
+      ${this.renderDialogs()}
+    `;
+  }
+
+  private renderDialogs() {
+    return html`
+      ${when(
+        this.workflowToDelete,
+        (workflow) => html`
+          <btrix-dialog id="deleteDialog" .label=${msg("Delete Workflow?")}>
+            ${deleteConfirmation(this.renderName(workflow))}
+            <div slot="footer" class="flex justify-between">
+              <sl-button
+                size="small"
+                .autofocus=${true}
+                @click=${() => void this.deleteDialog?.hide()}
+                >${msg("Cancel")}</sl-button
+              >
+              <sl-button
+                size="small"
+                variant="danger"
+                @click=${async () => {
+                  void this.deleteDialog?.hide();
+
+                  try {
+                    await this.delete(workflow);
+                    this.workflowToDelete = undefined;
+                  } catch {
+                    void this.deleteDialog?.show();
+                  }
+                }}
+                >${msg("Delete Workflow")}</sl-button
+              >
+            </div>
+          </btrix-dialog>
+        `,
       )}
     `;
   }
@@ -598,7 +649,11 @@ export class WorkflowsList extends BtrixElement {
               <sl-divider></sl-divider>
               <sl-menu-item
                 style="--sl-color-neutral-700: var(--danger)"
-                @click=${() => void this.delete(workflow)}
+                @click=${async () => {
+                  this.workflowToDelete = workflow;
+                  await this.updateComplete;
+                  void this.deleteDialog?.show();
+                }}
               >
                 <sl-icon name="trash3" slot="prefix"></sl-icon>
                 ${msg("Delete Workflow")}

--- a/frontend/src/strings/ui.ts
+++ b/frontend/src/strings/ui.ts
@@ -1,0 +1,9 @@
+import { msg } from "@lit/localize";
+import { html, type TemplateResult } from "lit";
+
+// TODO Refactor all generic confirmation messages to use utility
+export const deleteConfirmation = (name: string | TemplateResult) =>
+  msg(html`
+    Are you sure you want to delete
+    <strong class="font-semibold">${name}</strong>?
+  `);


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2122

## Changes

- Uses crawl count to determine whether workflow can be deleted instead of last crawl ID
- Display delete confirmation dialog when trying to delete a workflow

## Manual testing

1. Log in as crawler
2. Go to workflow with crawls
3. Delete workflow crawls until there are none. Verify "Delete Workflow" item is shown in the action menu
4. Click "Delete Workflow". Verify confirmation dialog is shown
5. Confirm deletion. Verify workflow is removed
6. Repeat 4-5 for deleteable workflow in list

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail | <img width="517" alt="Screenshot 2025-01-07 at 4 00 54 PM" src="https://github.com/user-attachments/assets/3e55a485-3097-42bc-8a86-8ca1d663745a" /> |


<!-- ## Follow-ups -->
