### PR TITLE
ui: Public Collections UI Nitpicks

### DIFF
--- a/frontend/src/components/ui/markdown-editor.ts
+++ b/frontend/src/components/ui/markdown-editor.ts
@@ -27,6 +27,14 @@ export class MarkdownEditor extends BtrixElement {
       --ink-block-padding: var(--sl-input-spacing-small);
     }
 
+    .ink-mde-textarea {
+      flex-grow: 1;
+    }
+
+    .ink-mde {
+      height: 100%;
+    }
+
     .ink-mde {
       border: solid var(--sl-input-border-width) var(--sl-input-border-color);
     }
@@ -56,7 +64,8 @@ export class MarkdownEditor extends BtrixElement {
     }
 
     .cm-line:only-child {
-      min-height: 8em;
+      height: 100%;
+      min-height: 20em;
     }
   `;
 
@@ -111,7 +120,11 @@ export class MarkdownEditor extends BtrixElement {
   render() {
     const isInvalid = this.maxlength && this.value.length > this.maxlength;
     return html`
-      <fieldset ?data-invalid=${isInvalid} ?data-user-invalid=${isInvalid}>
+      <fieldset
+        ?data-invalid=${isInvalid}
+        ?data-user-invalid=${isInvalid}
+        class="flex h-full flex-col"
+      >
         ${this.label && html`<label class="form-label">${this.label}</label>`}
         <textarea id="editor-textarea"></textarea>
         <div class="helpText flex items-baseline justify-between">

--- a/frontend/src/features/collections/collection-replay-dialog.ts
+++ b/frontend/src/features/collections/collection-replay-dialog.ts
@@ -25,14 +25,14 @@ export class CollectionStartPageDialog extends BtrixElement {
     { label: string; icon: NonNullable<SlIcon["name"]>; detail: string }
   > = {
     [HomeView.Pages]: {
-      label: msg("Default"),
+      label: msg("List of Pages"),
       icon: "list-ul",
       detail: `${msg("ReplayWeb.Page default view")}`,
     },
     [HomeView.URL]: {
-      label: msg("Page"),
-      icon: "file-earmark",
-      detail: msg("Load a single page URL"),
+      label: msg("Start Page"),
+      icon: "file-earmark-richtext",
+      detail: msg("Show a single URL snapshot"),
     },
   };
 
@@ -188,7 +188,7 @@ export class CollectionStartPageDialog extends BtrixElement {
       <form @submit=${this.onSubmit}>
         <sl-select
           name="homeView"
-          label=${msg("Select View")}
+          label=${msg("Select Initial View")}
           value=${this.homeView}
           hoist
           ?disabled=${!this.replayLoaded}

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -63,11 +63,11 @@ export class CollectionsGrid extends BtrixElement {
                 href=${this.navigate.isPublicPage
                   ? `/${RouteNamespace.PublicOrgs}/${this.slug}/collections/${collection.id}`
                   : `/${RouteNamespace.PrivateOrgs}/${this.slug}/collections/view/${collection.id}`}
-                class="group block h-full rounded-lg transition-all hover:scale-[102%]"
+                class="group block h-full rounded-lg"
                 @click=${this.navigate.link}
               >
                 <div
-                  class="relative mb-4 rounded-lg shadow-md shadow-stone-600/10 ring-1 ring-stone-600/10 transition-shadow group-hover:shadow-sm"
+                  class="relative mb-4 rounded-lg shadow-md shadow-stone-600/10 ring-1 ring-stone-600/10 transition group-hover:shadow-stone-800/20 group-hover:ring-stone-800/20"
                 >
                   <btrix-collection-thumbnail
                     src=${ifDefined(

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -252,11 +252,7 @@ export class ShareCollection extends BtrixElement {
 
           <sl-tab-panel name=${Tab.Link}>
             <div class="px-4 pb-4">
-              ${when(
-                showSettings && this.collection,
-                this.renderSettings,
-                this.renderShareLink,
-              )}
+              ${when(showSettings && this.collection, this.renderSettings)}
             </div>
           </sl-tab-panel>
 
@@ -266,7 +262,6 @@ export class ShareCollection extends BtrixElement {
         </sl-tab-group>
 
         <div slot="footer">
-          ${when(showSettings, this.renderShareLink)}
           <sl-button size="small" @click=${() => (this.showDialog = false)}>
             ${msg("Done")}
           </sl-button>
@@ -287,6 +282,10 @@ export class ShareCollection extends BtrixElement {
             );
           }}
         ></btrix-select-collection-access>
+        ${when(
+          this.collection?.access != CollectionAccess.Private,
+          this.renderShareLink,
+        )}
         ${when(
           this.org &&
             !this.org.enablePublicProfile &&
@@ -410,7 +409,7 @@ export class ShareCollection extends BtrixElement {
 
   private readonly renderShareLink = () => {
     return html`
-      <div class="text-left">
+      <div class="mt-4 text-left">
         <div class="form-label">${msg("Link to Share")}</div>
         <btrix-copy-field
           class="mb-3"

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -388,7 +388,7 @@ export class ShareCollection extends BtrixElement {
             >
               ${isSelected
                 ? html`<sl-icon
-                    class="size-10 text-white drop-shadow-md"
+                    class="size-10 stroke-black/50 text-white drop-shadow-md [paint-order:stroke]"
                     name="check-lg"
                   ></sl-icon>`
                 : nothing}

--- a/frontend/src/features/qa/page-list/helpers/iconFor.ts
+++ b/frontend/src/features/qa/page-list/helpers/iconFor.ts
@@ -15,12 +15,12 @@ export const iconFor = cached(
       case "severe":
         return html`<sl-icon
           name="exclamation-triangle-fill"
-          class=${clsx("text-red-600", baseClasses, classList)}
+          class=${clsx("text-red-500", baseClasses, classList)}
         ></sl-icon>`;
       case "moderate":
         return html`<sl-icon
           name="dash-square-fill"
-          class=${clsx("text-yellow-600", baseClasses, classList)}
+          class=${clsx("text-yellow-500", baseClasses, classList)}
         ></sl-icon>`;
       case "good":
         return html`<sl-icon
@@ -37,7 +37,7 @@ export const iconFor = cached(
       case "rejected":
         return html`<sl-icon
           name="hand-thumbs-down-fill"
-          class=${clsx("text-red-600", baseClasses, classList)}
+          class=${clsx("text-red-500", baseClasses, classList)}
         ></sl-icon>`;
       case "commentOnly":
         // Comment icons are rendered separately

--- a/frontend/src/features/qa/page-list/helpers/severity.ts
+++ b/frontend/src/features/qa/page-list/helpers/severity.ts
@@ -29,9 +29,9 @@ export const textColorFromSeverity = cached((severity: Severity) => {
     case "good":
       return tw`text-green-600`;
     case "moderate":
-      return tw`text-yellow-600`;
+      return tw`text-yellow-500`;
     case "severe":
-      return tw`text-red-600`;
+      return tw`text-red-500`;
     default:
       return "";
   }

--- a/frontend/src/layouts/page.ts
+++ b/frontend/src/layouts/page.ts
@@ -39,7 +39,7 @@ export function page(
     ></btrix-document-title>
 
     <div
-      class="mx-auto box-border flex min-h-full w-full max-w-screen-desktop flex-1 flex-col gap-3 p-3 lg:px-10"
+      class="mx-auto box-border flex min-h-full w-full max-w-screen-desktop flex-1 flex-col gap-3 p-3 lg:px-10 lg:pb-10"
     >
       ${header.breadcrumbs ? html` ${pageNav(header.breadcrumbs)} ` : nothing}
       ${pageHeader(header)}

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -206,6 +206,7 @@ export class Collection extends BtrixElement {
     `;
   }
 
+  // TODO Consolidate with collection-detail.ts
   private renderAbout(collection: PublicCollection) {
     const dateRange = () => {
       if (!collection.dateEarliest || !collection.dateLatest) {
@@ -243,13 +244,13 @@ export class Collection extends BtrixElement {
       return html`
         <div class="flex flex-1 flex-col gap-10 lg:flex-row">
           <section
-            class="flex-1 py-3 leading-relaxed lg:rounded-lg lg:border lg:p-6"
+            class="w-full max-w-4xl py-3 leading-relaxed lg:rounded-lg lg:border lg:p-6"
           >
             <btrix-markdown-viewer
               value=${collection.description}
             ></btrix-markdown-viewer>
           </section>
-          <section class="min-w-60 lg:-mt-8">
+          <section class="flex-1 lg:-mt-8">
             <btrix-section-heading>
               <h3>${msg("Metadata")}</h3>
             </btrix-section-heading>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -148,9 +148,7 @@ export class CollectionDetail extends BtrixElement {
       <div class="mt-3 rounded-lg border px-4 py-2">
         ${this.renderInfoBar()}
       </div>
-      <div
-        class="sticky top-0 z-50 -mx-3 mb-3 flex items-center justify-between bg-white px-3 pt-3 shadow-lg shadow-white"
-      >
+      <div class="flex items-center justify-between p-3">
         ${this.renderTabs()}
         ${when(this.isCrawler, () =>
           choose(this.collectionTab, [
@@ -719,26 +717,25 @@ export class CollectionDetail extends BtrixElement {
     const headers = this.authState?.headers;
     const config = JSON.stringify({ headers });
 
-    return html`<section>
-      <div class="aspect-4/3 overflow-hidden rounded-lg border">
-        <replay-web-page
-          source=${replaySource}
-          config="${config}"
-          coll=${this.collectionId}
-          url=${this.collection.homeUrl ||
-          /* must be empty string to reset the attribute: */ ""}
-          ts=${formatRwpTimestamp(this.collection.homeUrlTs) ||
-          /* must be empty string to reset the attribute: */ ""}
-          replayBase="/replay/"
-          noSandbox="true"
-          noCache="true"
-          @rwp-url-change=${() => {
-            if (!this.isRwpLoaded) {
-              this.isRwpLoaded = true;
-            }
-          }}
-        ></replay-web-page>
-      </div>
+    return html` <section class="overflow-hidden rounded-lg border">
+      <replay-web-page
+        class="h-[calc(100vh-6.5rem)]"
+        source=${replaySource}
+        config="${config}"
+        coll=${this.collectionId}
+        url=${this.collection.homeUrl ||
+        /* must be empty string to reset the attribute: */ ""}
+        ts=${formatRwpTimestamp(this.collection.homeUrlTs) ||
+        /* must be empty string to reset the attribute: */ ""}
+        replayBase="/replay/"
+        noSandbox="true"
+        noCache="true"
+        @rwp-url-change=${() => {
+          if (!this.isRwpLoaded) {
+            this.isRwpLoaded = true;
+          }
+        }}
+      ></replay-web-page>
     </section>`;
   };
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -177,36 +177,19 @@ export class CollectionDetail extends BtrixElement {
             [
               Tab.About,
               () =>
-                this.isEditingDescription
-                  ? html`
-                      <div>
-                        <sl-button
-                          variant="primary"
-                          size="small"
-                          @click=${() => void this.saveDescription()}
-                          ?disabled=${!this.collection}
-                        >
-                          <sl-icon name="check-lg" slot="prefix"></sl-icon>
-                          ${msg("Save")}
-                        </sl-button>
-                        <sl-button
-                          size="small"
-                          @click=${() => (this.isEditingDescription = false)}
-                        >
-                          ${msg("Cancel")}
-                        </sl-button>
-                      </div>
-                    `
-                  : html`
-                      <sl-button
-                        size="small"
-                        @click=${() => (this.isEditingDescription = true)}
-                        ?disabled=${!this.collection}
-                      >
-                        <sl-icon name="pencil" slot="prefix"></sl-icon>
-                        ${msg("Edit")}
-                      </sl-button>
-                    `,
+                when(
+                  !this.isEditingDescription,
+                  () => html`
+                    <sl-button
+                      size="small"
+                      @click=${() => (this.isEditingDescription = true)}
+                      ?disabled=${!this.collection}
+                    >
+                      <sl-icon name="pencil" slot="prefix"></sl-icon>
+                      ${msg("Edit")}
+                    </sl-button>
+                  `,
+                ),
             ],
             [
               Tab.Items,
@@ -559,6 +542,24 @@ export class CollectionDetail extends BtrixElement {
                         placeholder=${msg("Tell viewers about this collection")}
                         maxlength=${4000}
                       ></btrix-markdown-editor>
+                      <div
+                        class="flex-column mt-4 flex justify-between border-t pt-4"
+                      >
+                        <sl-button
+                          size="small"
+                          @click=${() => (this.isEditingDescription = false)}
+                        >
+                          ${msg("Cancel")}
+                        </sl-button>
+                        <sl-button
+                          variant="primary"
+                          size="small"
+                          @click=${() => void this.saveDescription()}
+                          ?disabled=${!this.collection}
+                        >
+                          ${msg("Update Description")}
+                        </sl-button>
+                      </div>
                     </div>
                   </div>
                 `

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -115,7 +115,7 @@ export class CollectionDetail extends BtrixElement {
       if (this.descriptionEditor) {
         // FIXME Focus on editor ready instead of timeout
         window.setTimeout(() => {
-          void this.descriptionEditor?.focus();
+          this.descriptionEditor && void this.descriptionEditor.focus();
         }, 200);
       }
     }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -552,19 +552,29 @@ export class CollectionDetail extends BtrixElement {
           (collection) =>
             this.isEditingDescription
               ? html`
-                  <btrix-markdown-editor
-                    initialValue=${collection.description || ""}
-                    placeholder=${msg("Tell viewers about this collection")}
-                    maxlength=${4000}
-                  ></btrix-markdown-editor>
+                  <div class="flex justify-center leading-relaxed">
+                    <div class="w-full md:max-w-[783px]">
+                      <btrix-markdown-editor
+                        initialValue=${collection.description || ""}
+                        placeholder=${msg("Tell viewers about this collection")}
+                        maxlength=${4000}
+                      ></btrix-markdown-editor>
+                    </div>
+                  </div>
                 `
               : html`
-                  <div class="rounded-lg border p-4 leading-relaxed">
+                  <div
+                    class="flex justify-center rounded-lg border leading-relaxed"
+                  >
                     ${collection.description
                       ? html`
-                          <btrix-markdown-viewer
-                            value=${collection.description}
-                          ></btrix-markdown-viewer>
+                          <div
+                            class="min-h-full w-full px-8 py-12 md:max-w-[783px]"
+                          >
+                            <btrix-markdown-viewer
+                              value=${collection.description}
+                            ></btrix-markdown-viewer>
+                          </div>
                         `
                       : html`
                           <p class="py-10 text-center text-neutral-500">

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -585,6 +585,7 @@ export class Org extends BtrixElement {
 
     if (params.collectionId) {
       return html`<btrix-collection-detail
+        class="flex min-h-screen flex-1 flex-col pb-7"
         collectionId=${params.collectionId}
         collectionTab=${ifDefined(
           params.collectionTab as CollectionTab | undefined,


### PR DESCRIPTION
Fixes #2283

Public collections are looking great!  This PR covers the few little things I found when exploring the feature.

### Changes

- Removes share link from the dialogue footer
  - I would rather keep that space exclusively reserved for dialogue buttons, moved below the visibility selector so that it adds an extra indicator of what can and cannot be done when a collection is not publicly visible.
- Removes stickied collection navigation, replaces with improved viewport-based scaling!
- Adds a max-width for the collection description in the logged in view.
  - No more full page width text!
- Moves the markdown editor buttons to below the editor
  - Controls are now In-line with how we handle dialogue options elsewhere, fixes a minor responsive design issue.
- Minor copy changes

### Screenshots

**Moved share link (not visible because it's private)**
<img width="739" alt="Screenshot 2025-01-07 at 11 10 52 PM" src="https://github.com/user-attachments/assets/c6b6dfa8-0298-4cc3-b38d-ca1a749e1e61" />

**Moved share link (visible)**
<img width="728" alt="Screenshot 2025-01-07 at 11 10 13 PM" src="https://github.com/user-attachments/assets/f4085864-679a-4463-96df-9d33f7d02f5c" />

**Copy updates**

<img width="474" alt="Screenshot 2025-01-07 at 11 38 30 PM" src="https://github.com/user-attachments/assets/102a5969-9913-486d-988a-402c22a53a50" />

**Line length change**

<img width="1468" alt="Screenshot 2025-01-07 at 11 35 06 PM" src="https://github.com/user-attachments/assets/9d304fe3-94ff-41a0-99ad-e10c476c5841" />

**Composer Button Relocation**

<img width="1404" alt="Screenshot 2025-01-07 at 11 35 16 PM" src="https://github.com/user-attachments/assets/83b08c3c-df88-43cc-8f13-0dd725be2b57" />

### Caveats

- I did not address the lack of error state in the configure home dialogue.  See issue #2286
- The checkmark certain thumbnail backgrounds isn't as visible as I'd like it to be...  We still indicate it with a ring around the box so not the end of the world!