### PR TITLE
fix: Validate collection page URL

### DIFF
--- a/frontend/src/features/collections/collection-replay-dialog.ts
+++ b/frontend/src/features/collections/collection-replay-dialog.ts
@@ -93,7 +93,12 @@ export class CollectionStartPageDialog extends BtrixElement {
         .open=${this.open}
         class="[--width:60rem]"
         @sl-show=${() => (this.showContent = true)}
-        @sl-after-hide=${() => (this.showContent = false)}
+        @sl-after-hide=${() => {
+          this.homeView = this.homeUrl ? HomeView.URL : HomeView.Pages;
+          this.isSubmitting = false;
+          this.selectedSnapshot = null;
+          this.showContent = false;
+        }}
       >
         ${this.showContent ? this.renderContent() : nothing}
         <div slot="footer" class="flex items-center justify-between gap-3">
@@ -207,6 +212,16 @@ export class CollectionStartPageDialog extends BtrixElement {
           ?disabled=${!this.replayLoaded}
           @sl-change=${(e: SlChangeEvent) => {
             this.homeView = (e.currentTarget as SlSelect).value as HomeView;
+
+            if (this.homeView === HomeView.Pages) {
+              if (
+                !this.homePageId ||
+                this.homePageId !== this.selectedSnapshot?.pageId
+              ) {
+                // Reset unsaved selected snapshot
+                this.selectedSnapshot = null;
+              }
+            }
           }}
         >
           ${this.replayLoaded

--- a/frontend/src/features/collections/collection-replay-dialog.ts
+++ b/frontend/src/features/collections/collection-replay-dialog.ts
@@ -154,12 +154,15 @@ export class CollectionStartPageDialog extends BtrixElement {
 
     if (snapshot) {
       urlPreview = html`
-        <iframe
-          class="inline-block size-full"
-          id="thumbnailPreview"
-          src=${`/replay/w/${this.collectionId}/${formatRwpTimestamp(snapshot.ts)}id_/urn:thumbnail:${snapshot.url}`}
-        >
-        </iframe>
+        <sl-tooltip hoist>
+          <iframe
+            class="inline-block size-full"
+            id="thumbnailPreview"
+            src=${`/replay/w/${this.collectionId}/${formatRwpTimestamp(snapshot.ts)}id_/urn:thumbnail:${snapshot.url}`}
+          >
+          </iframe>
+          <span slot="content" class="break-all">${snapshot.url}</span>
+        </sl-tooltip>
       `;
     }
 

--- a/frontend/src/features/collections/select-collection-start-page.ts
+++ b/frontend/src/features/collections/select-collection-start-page.ts
@@ -217,14 +217,13 @@ export class SelectCollectionStartPage extends BtrixElement {
           <sl-icon name="search" slot="prefix"></sl-icon>
           ${when(
             this.selectedPage,
-            (page) => html`
+            () => html`
               <div slot="suffix" class="flex items-center">
-                <sl-tooltip hoist>
+                <sl-tooltip hoist content=${msg("Page found in collection")}>
                   <sl-icon
                     name="check-lg"
                     class="size-4 text-base text-success"
                   ></sl-icon>
-                  <span slot="content" class="break-all">${page.url}</span>
                 </sl-tooltip>
               </div>
             `,
@@ -233,12 +232,11 @@ export class SelectCollectionStartPage extends BtrixElement {
             this.pageUrlError,
             (error) => html`
               <div slot="suffix" class="flex items-center">
-                <sl-tooltip hoist>
+                <sl-tooltip hoist content=${error}>
                   <sl-icon
                     name="exclamation-lg"
                     class="size-4 text-base text-danger"
                   ></sl-icon>
-                  <div slot="content">${error}</div>
                 </sl-tooltip>
               </div>
             `,
@@ -302,7 +300,7 @@ export class SelectCollectionStartPage extends BtrixElement {
         if (!items.length) {
           return html`
             <sl-menu-item slot="menu-item" disabled>
-              ${msg("No matching pages found.")}
+              ${msg("No matching page found.")}
             </sl-menu-item>
           `;
         }

--- a/frontend/src/features/collections/select-collection-start-page.ts
+++ b/frontend/src/features/collections/select-collection-start-page.ts
@@ -123,7 +123,7 @@ export class SelectCollectionStartPage extends BtrixElement {
         ${this.renderPageSearch()}
         <sl-select
           label=${msg("Snapshot")}
-          placeholder="--"
+          placeholder=${msg("Enter a page URL to choose snapshot")}
           value=${this.selectedSnapshot?.pageId || ""}
           ?disabled=${!this.selectedPage}
           @sl-change=${async (e: SlChangeEvent) => {
@@ -189,6 +189,7 @@ export class SelectCollectionStartPage extends BtrixElement {
           label=${msg("Page URL")}
           placeholder=${msg("Start typing a URL...")}
           clearable
+          required
           @sl-focus=${() => {
             this.combobox?.show();
           }}

--- a/frontend/src/features/collections/select-collection-start-page.ts
+++ b/frontend/src/features/collections/select-collection-start-page.ts
@@ -198,7 +198,6 @@ export class SelectCollectionStartPage extends BtrixElement {
           id="pageUrlInput"
           label=${msg("Page URL")}
           placeholder=${msg("Start typing a URL...")}
-          clearable
           @sl-focus=${() => {
             this.resetInputValidity();
             this.combobox?.show();

--- a/frontend/src/features/collections/select-collection-start-page.ts
+++ b/frontend/src/features/collections/select-collection-start-page.ts
@@ -63,6 +63,9 @@ export class SelectCollectionStartPage extends BtrixElement {
   @state()
   public selectedSnapshot?: Snapshot;
 
+  @state()
+  private pageUrlError?: string;
+
   @query("btrix-combobox")
   private readonly combobox?: Combobox | null;
 
@@ -213,6 +216,34 @@ export class SelectCollectionStartPage extends BtrixElement {
           @sl-blur=${this.pageUrlOnBlur}
         >
           <sl-icon name="search" slot="prefix"></sl-icon>
+          ${when(
+            this.selectedPage,
+            (page) => html`
+              <div slot="suffix" class="flex items-center">
+                <sl-tooltip hoist>
+                  <sl-icon
+                    name="check-lg"
+                    class="size-4 text-base text-success"
+                  ></sl-icon>
+                  <span slot="content" class="break-all">${page.url}</span>
+                </sl-tooltip>
+              </div>
+            `,
+          )}
+          ${when(
+            this.pageUrlError,
+            (error) => html`
+              <div slot="suffix" class="flex items-center">
+                <sl-tooltip hoist>
+                  <sl-icon
+                    name="exclamation-lg"
+                    class="size-4 text-base text-danger"
+                  ></sl-icon>
+                  <div slot="content">${error}</div>
+                </sl-tooltip>
+              </div>
+            `,
+          )}
         </sl-input>
         ${this.renderSearchResults()}
       </btrix-combobox>
@@ -220,10 +251,8 @@ export class SelectCollectionStartPage extends BtrixElement {
   }
 
   private resetInputValidity() {
-    if (!this.input) return;
-
-    this.input.setCustomValidity("");
-    this.input.helpText = "";
+    this.pageUrlError = undefined;
+    this.input?.setCustomValidity("");
   }
 
   private readonly pageUrlOnBlur = async () => {
@@ -247,11 +276,10 @@ export class SelectCollectionStartPage extends BtrixElement {
 
     if (results.total === 0) {
       if (this.input) {
-        const errorMessage = msg(
-          "Page not found in collection. Please check the URL and try again.",
+        this.pageUrlError = msg(
+          "Page not found in collection. Please check the URL and try again",
         );
-        this.input.setCustomValidity(errorMessage);
-        this.input.helpText = errorMessage;
+        this.input.setCustomValidity(this.pageUrlError);
       }
 
       // Clear selection

--- a/frontend/src/features/collections/select-collection-start-page.ts
+++ b/frontend/src/features/collections/select-collection-start-page.ts
@@ -5,6 +5,7 @@ import type {
   SlInput,
   SlSelect,
 } from "@shoelace-style/shoelace";
+import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
@@ -16,6 +17,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { Combobox } from "@/components/ui/combobox";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import type { UnderlyingFunction } from "@/types/utils";
+import { tw } from "@/utils/tailwind";
 
 type Snapshot = {
   pageId: string;
@@ -188,6 +190,29 @@ export class SelectCollectionStartPage extends BtrixElement {
   }
 
   private renderPageSearch() {
+    let prefix: {
+      icon: string;
+      tooltip: string;
+      className?: string;
+    } = {
+      icon: "search",
+      tooltip: msg("Search for a page in this collection"),
+    };
+
+    if (this.pageUrlError) {
+      prefix = {
+        icon: "exclamation-lg",
+        tooltip: this.pageUrlError,
+        className: tw`text-danger`,
+      };
+    } else if (this.selectedPage) {
+      prefix = {
+        icon: "check-lg",
+        tooltip: msg("Page exists in collection"),
+        className: tw`text-success`,
+      };
+    }
+
     return html`
       <btrix-combobox
         @request-close=${() => {
@@ -198,6 +223,7 @@ export class SelectCollectionStartPage extends BtrixElement {
           id="pageUrlInput"
           label=${msg("Page URL")}
           placeholder=${msg("Start typing a URL...")}
+          clearable
           @sl-focus=${() => {
             this.resetInputValidity();
             this.combobox?.show();
@@ -214,33 +240,18 @@ export class SelectCollectionStartPage extends BtrixElement {
           >}
           @sl-blur=${this.pageUrlOnBlur}
         >
-          <sl-icon name="search" slot="prefix"></sl-icon>
-          ${when(
-            this.selectedPage,
-            () => html`
-              <div slot="suffix" class="flex items-center">
-                <sl-tooltip hoist content=${msg("Page found in collection")}>
-                  <sl-icon
-                    name="check-lg"
-                    class="size-4 text-base text-success"
-                  ></sl-icon>
-                </sl-tooltip>
-              </div>
-            `,
-          )}
-          ${when(
-            this.pageUrlError,
-            (error) => html`
-              <div slot="suffix" class="flex items-center">
-                <sl-tooltip hoist content=${error}>
-                  <sl-icon
-                    name="exclamation-lg"
-                    class="size-4 text-base text-danger"
-                  ></sl-icon>
-                </sl-tooltip>
-              </div>
-            `,
-          )}
+          <div slot="prefix" class="inline-flex items-center">
+            <sl-tooltip
+              hoist
+              content=${prefix.tooltip}
+              placement="bottom-start"
+            >
+              <sl-icon
+                name=${prefix.icon}
+                class=${clsx(tw`size-4 text-base`, prefix.className)}
+              ></sl-icon>
+            </sl-tooltip>
+          </div>
         </sl-input>
         ${this.renderSearchResults()}
       </btrix-combobox>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -241,15 +241,13 @@ export class CollectionDetail extends BtrixElement {
 
       <btrix-collection-replay-dialog
         ?open=${this.openDialogName === "editStartPage"}
-        @sl-hide=${async () => {
-          this.openDialogName = undefined;
-
+        @btrix-change=${() => {
           // Don't do full refresh of rwp so that rwp-url-change fires
           this.isRwpLoaded = false;
 
-          await this.fetchCollection();
-          await this.updateComplete;
+          void this.fetchCollection();
         }}
+        @sl-hide=${async () => (this.openDialogName = undefined)}
         collectionId=${this.collectionId}
         .homeUrl=${this.collection?.homeUrl}
         .homePageId=${this.collection?.homeUrlPageId}
@@ -800,6 +798,7 @@ export class CollectionDetail extends BtrixElement {
         noSandbox="true"
         noCache="true"
         @rwp-url-change=${() => {
+          console.log("url change");
           if (!this.isRwpLoaded) {
             this.isRwpLoaded = true;
           }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -798,7 +798,6 @@ export class CollectionDetail extends BtrixElement {
         noSandbox="true"
         noCache="true"
         @rwp-url-change=${() => {
-          console.log("url change");
           if (!this.isRwpLoaded) {
             this.isRwpLoaded = true;
           }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2286

## Changes

- Disables saving collection start page if valid snapshot is not selected
- Shows full URL in page URL status check mark
- Shows error in page URL status exclamation mark
- Fixes pasting in URL

## Manual testing

1. Log in as crawler
2. Go to collection with items
3. Click "Configure Home"
4. Choose "Start Page"
5. Paste in full URL of a page that's in the collection. Verify snapshot is selected by default
6. Hover over success checkmark. Verify full URL is shown
7. Clear page URL input. Verify snapshot is also cleared
8. Enter page URL that isn't in the collection
9. Click outside of page URL input. Verify input is highlighted in danger color and "Save" button is disabled
10. Hover over `!`. Verify error message is shown

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection detail - Initial state | <img width="481" alt="Screenshot 2025-01-08 at 5 09 15 PM" src="https://github.com/user-attachments/assets/b69d4b07-0908-4037-b8b6-24a90e99c9e3" /> |
| Collection detail - page exists | <img width="473" alt="Screenshot 2025-01-14 at 12 12 45 PM" src="https://github.com/user-attachments/assets/768313ca-e278-4be2-9f18-c9249c0b9ff0" /> |
| Collection detail - page preview hover | <img width="483" alt="Screenshot 2025-01-13 at 11 00 25 AM" src="https://github.com/user-attachments/assets/fe2483e6-f39c-498d-996a-0541a8c48a06" /> |
| Collection detail - page not found | <img width="469" alt="Screenshot 2025-01-14 at 12 13 15 PM" src="https://github.com/user-attachments/assets/df02d4f9-7a6f-4a6e-b0fe-aebafa6256ff" /> |





<!-- ## Follow-ups -->
