### PR TITLE
feat: Add slug to collections and use it in public collection URLs

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1109,7 +1109,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops, user_de
         coll, redirect = await colls.get_collection_by_slug(coll_slug)
 
         return await colls.get_public_collection_out(
-            cast(UUID, coll.id), org, redirect=redirect, allow_unlisted=True
+            coll.id, org, redirect=redirect, allow_unlisted=True
         )
 
     @app.get(
@@ -1136,7 +1136,7 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops, user_de
         if coll.allowPublicDownload is False:
             raise HTTPException(status_code=403, detail="not_allowed")
 
-        return await colls.download_collection(cast(UUID, coll.id), org)
+        return await colls.download_collection(coll.id, org)
 
     @app.get(
         "/orgs/{oid}/collections/{coll_id}/urls",

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -17,7 +17,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0038"
+CURR_DB_VERSION = "0039"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0038_coll_slugs.py
+++ b/backend/btrixcloud/migrations/migration_0038_coll_slugs.py
@@ -1,0 +1,38 @@
+"""
+Migration 0038 -- collection access
+"""
+
+from btrixcloud.migrations import BaseMigration
+from btrixcloud.utils import slug_from_name
+
+
+MIGRATION_VERSION = "0038"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Add slug to collections that don't have one yet, based on name
+        """
+        colls_mdb = self.mdb["collections"]
+
+        async for coll_raw in colls_mdb.find({"slug": None}):
+            coll_id = coll_raw["_id"]
+            try:
+                await colls_mdb.find_one_and_update(
+                    {"_id": coll_id},
+                    {"$set": {"slug": slug_from_name(coll_raw.get("name", ""))}},
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error saving slug for collection {coll_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/migrations/migration_0039_coll_slugs.py
+++ b/backend/btrixcloud/migrations/migration_0039_coll_slugs.py
@@ -1,12 +1,12 @@
 """
-Migration 0038 -- collection access
+Migration 0039 -- collection slugs
 """
 
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.utils import slug_from_name
 
 
-MIGRATION_VERSION = "0038"
+MIGRATION_VERSION = "0039"
 
 
 class Migration(BaseMigration):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1236,6 +1236,7 @@ class Collection(BaseMongoModel):
     """Org collection structure"""
 
     name: str = Field(..., min_length=1)
+    slug: str = Field(..., min_length=1)
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
@@ -1264,12 +1265,15 @@ class Collection(BaseMongoModel):
 
     allowPublicDownload: Optional[bool] = True
 
+    previousSlugs: List[str] = []
+
 
 # ============================================================================
 class CollIn(BaseModel):
     """Collection Passed in By User"""
 
     name: str = Field(..., min_length=1)
+    slug: Optional[str] = None
     description: Optional[str] = None
     caption: Optional[str] = None
     crawlIds: Optional[List[str]] = []
@@ -1285,6 +1289,7 @@ class CollOut(BaseMongoModel):
     """Collection output model with annotations."""
 
     name: str
+    slug: str
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
@@ -1319,6 +1324,7 @@ class PublicCollOut(BaseMongoModel):
     """Collection output model with annotations."""
 
     name: str
+    slug: str
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
@@ -1349,6 +1355,7 @@ class UpdateColl(BaseModel):
     """Update collection"""
 
     name: Optional[str] = None
+    slug: Optional[str] = None
     description: Optional[str] = None
     caption: Optional[str] = None
     access: Optional[CollAccessType] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1351,7 +1351,6 @@ class PublicCollOut(BaseMongoModel):
     defaultThumbnailName: Optional[str] = None
 
     allowPublicDownload: bool = True
-    redirectToSlug: Optional[str] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1348,6 +1348,7 @@ class PublicCollOut(BaseMongoModel):
     defaultThumbnailName: Optional[str] = None
 
     allowPublicDownload: bool = True
+    redirectToSlug: Optional[str] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1235,6 +1235,7 @@ class CollAccessType(str, Enum):
 class Collection(BaseMongoModel):
     """Org collection structure"""
 
+    id: UUID
     name: str = Field(..., min_length=1)
     slug: str = Field(..., min_length=1)
     oid: UUID
@@ -1288,6 +1289,7 @@ class CollIn(BaseModel):
 class CollOut(BaseMongoModel):
     """Collection output model with annotations."""
 
+    id: UUID
     name: str
     slug: str
     oid: UUID
@@ -1323,6 +1325,7 @@ class CollOut(BaseMongoModel):
 class PublicCollOut(BaseMongoModel):
     """Collection output model with annotations."""
 
+    id: UUID
     name: str
     slug: str
     oid: UUID

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1306,6 +1306,8 @@ class OrgOps:
         # collections
         for collection in org_data.get("collections", []):
             collection = json_stream.to_standard_types(collection)
+            if not collection.get("slug"):
+                collection["slug"] = slug_from_name(collection["name"])
             await self.colls_db.insert_one(Collection.from_dict(collection).to_dict())
 
     async def delete_org_and_data(

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -171,15 +171,13 @@ def stream_dict_list_as_csv(
 
 def get_duplicate_key_error_field(err: DuplicateKeyError) -> str:
     """Get name of duplicate field from pymongo DuplicateKeyError"""
-    dupe_field = "name"
     if err.details:
         key_value = err.details.get("keyValue")
         if key_value:
-            try:
-                dupe_field = list(key_value.keys())[0]
-            except IndexError:
-                pass
-    return dupe_field
+            for field in key_value.keys():
+                if field in ("name", "slug"):
+                    return field
+    return "name"
 
 
 def get_origin(headers) -> str:

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -171,12 +171,15 @@ def stream_dict_list_as_csv(
 
 def get_duplicate_key_error_field(err: DuplicateKeyError) -> str:
     """Get name of duplicate field from pymongo DuplicateKeyError"""
+    allowed_fields = ("name", "slug", "subscription.subId")
+
     if err.details:
         key_value = err.details.get("keyValue")
         if key_value:
             for field in key_value.keys():
-                if field in ("name", "slug"):
+                if field in allowed_fields:
                     return field
+
     return "name"
 
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1151,7 +1151,6 @@ def test_get_public_collection(default_org_id):
     assert coll["crawlCount"] > 0
     assert coll["pageCount"] > 0
     assert coll["totalSize"] > 0
-    assert coll.get("redirectToSlug") is None
 
     for field in NON_PUBLIC_COLL_FIELDS:
         assert field not in coll
@@ -1432,7 +1431,6 @@ def test_get_public_collection_slug_redirect(admin_auth_headers, default_org_id)
     assert coll["id"] == _public_coll_id
     assert coll["oid"] == default_org_id
     assert coll["slug"] == new_slug
-    assert coll["redirectToSlug"] == new_slug
 
     # Rename second public collection slug to now-unused PUBLIC_COLLECTION_SLUG
     r = requests.patch(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1193,7 +1193,7 @@ def test_get_public_collection(default_org_id):
 
     # Collection isn't public
     r = requests.get(
-        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections/{PUBLIC_COLLECTION_SLUG}"
+        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections/{UPDATED_SLUG}"
     )
     assert r.status_code == 404
     assert r.json()["detail"] == "collection_not_found"

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -238,8 +238,7 @@ type btrixEvent = (
   extra?: {
     props?: {
       org_slug: string | null;
-      collection_id?: string | null;
-      collection_name?: string | null;
+      collection_slug?: string | null;
       logged_in?: boolean;
     };
   },

--- a/frontend/src/classes/BtrixElement.ts
+++ b/frontend/src/classes/BtrixElement.ts
@@ -32,7 +32,7 @@ export class BtrixElement extends TailwindElement {
     return this.appState.orgId;
   }
 
-  protected get orgSlug() {
+  protected get orgSlugState() {
     return this.appState.orgSlug;
   }
 

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -61,7 +61,7 @@ export class CollectionsGrid extends BtrixElement {
             <li class="relative col-span-1">
               <a
                 href=${this.navigate.isPublicPage
-                  ? `/${RouteNamespace.PublicOrgs}/${this.slug}/collections/${collection.id}`
+                  ? `/${RouteNamespace.PublicOrgs}/${this.slug}/collections/${collection.slug}`
                   : `/${RouteNamespace.PrivateOrgs}/${this.slug}/collections/view/${collection.id}`}
                 class="group block h-full rounded-lg"
                 @click=${this.navigate.link}
@@ -109,7 +109,7 @@ export class CollectionsGrid extends BtrixElement {
         <btrix-overflow-dropdown raised>
           <sl-menu>
             <btrix-menu-item-link
-              href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections/${collection.id}`}
+              href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections/${collection.slug}`}
             >
               <sl-icon slot="prefix" name="globe2"></sl-icon>
               ${msg("Visit Public Page")}

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -109,7 +109,7 @@ export class CollectionsGrid extends BtrixElement {
         <btrix-overflow-dropdown raised>
           <sl-menu>
             <btrix-menu-item-link
-              href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${collection.id}`}
+              href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections/${collection.id}`}
             >
               <sl-icon slot="prefix" name="globe2"></sl-icon>
               ${msg("Visit Public Page")}

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -59,7 +59,7 @@ export class ShareCollection extends BtrixElement {
   private get shareLink() {
     const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;
     if (this.collection) {
-      return `${baseUrl}/${this.collection.access === CollectionAccess.Private ? `${RouteNamespace.PrivateOrgs}/${this.orgSlug}/collections/view` : `${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections`}/${this.collectionId}`;
+      return `${baseUrl}/${this.collection.access === CollectionAccess.Private ? `${RouteNamespace.PrivateOrgs}/${this.orgSlugState}/collections/view` : `${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections`}/${this.collectionId}`;
     }
     return "";
   }

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -120,12 +120,13 @@ export class ShareCollection extends BtrixElement {
             @click=${() => {
               void this.clipboardController.copy(this.shareLink);
 
-              track(AnalyticsTrackEvent.CopyShareCollectionLink, {
-                org_slug: this.orgSlug,
-                collection_id: this.collectionId,
-                collection_name: this.collection?.name,
-                logged_in: !!this.authState,
-              });
+              if (this.collection?.access === CollectionAccess.Public) {
+                track(AnalyticsTrackEvent.CopyShareCollectionLink, {
+                  org_slug: this.orgSlug,
+                  collection_slug: this.collection.slug,
+                  logged_in: !!this.authState,
+                });
+              }
             }}
           >
             <sl-icon
@@ -204,8 +205,7 @@ export class ShareCollection extends BtrixElement {
                       @click=${() => {
                         track(AnalyticsTrackEvent.DownloadPublicCollection, {
                           org_slug: this.orgSlug,
-                          collection_id: this.collectionId,
-                          collection_name: this.collection?.name,
+                          collection_slug: this.collection?.slug,
                         });
                       }}
                     >

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -62,7 +62,7 @@ export class ShareCollection extends BtrixElement {
       return `${baseUrl}/${
         this.collection.access === CollectionAccess.Private
           ? `${RouteNamespace.PrivateOrgs}/${this.orgSlugState}/collections/view/${this.collectionId}`
-          : `${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections/${this.collection.slug}`
+          : `${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${this.collection.slug}`
       }`;
     }
     return "";

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -220,7 +220,7 @@ export class WorkflowListItem extends BtrixElement {
         }
         e.preventDefault();
         await this.updateComplete;
-        const href = `/orgs/${this.orgSlug}/workflows/${
+        const href = `/orgs/${this.orgSlugState}/workflows/${
           this.workflow?.id
         }#${this.workflow?.isCrawlRunning ? "watch" : "crawls"}`;
         this.navigate.to(href);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -820,20 +820,20 @@ export class App extends BtrixElement {
       case "publicOrgProfile":
         return html`<btrix-org-profile
           class="w-full"
-          slug=${this.viewState.params.slug}
+          orgSlug=${this.viewState.params.slug}
         ></btrix-org-profile>`;
 
       case "publicCollection": {
-        const { collectionId, collectionTab } = this.viewState.params;
+        const { collectionSlug, collectionTab } = this.viewState.params;
 
-        if (!collectionId) {
+        if (!collectionSlug) {
           break;
         }
 
         return html`<btrix-collection
           class="w-full"
-          slug=${this.viewState.params.slug}
-          collectionId=${collectionId}
+          orgSlug=${this.viewState.params.slug}
+          collectionSlug=${collectionSlug}
           tab=${ifDefined(collectionTab || undefined)}
         ></btrix-collection>`;
       }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -113,8 +113,12 @@ export class App extends BtrixElement {
   @query("#userGuideDrawer")
   private readonly userGuideDrawer!: SlDrawer;
 
+  get orgSlugInPath() {
+    return this.viewState.params.slug || "";
+  }
+
   get isUserInCurrentOrg(): boolean {
-    const { slug } = this.viewState.params;
+    const slug = this.orgSlugInPath;
     if (!this.userInfo || !slug) return false;
     return Boolean(this.userInfo.orgs.some((org) => org.slug === slug));
   }
@@ -567,12 +571,12 @@ export class App extends BtrixElement {
     const orgs = this.userInfo?.orgs;
     if (!orgs) return;
 
-    const selectedOption = this.orgSlug
-      ? orgs.find(({ slug }) => slug === this.orgSlug)
+    const selectedOption = this.orgSlugInPath
+      ? orgs.find(({ slug }) => slug === this.orgSlugInPath)
       : { slug: "", name: msg("All Organizations") };
     if (!selectedOption) {
       console.debug(
-        `Couldn't find organization with slug ${this.orgSlug}`,
+        `Couldn't find organization with slug ${this.orgSlugInPath}`,
         orgs,
       );
       return;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -310,14 +310,14 @@ export class App extends BtrixElement {
   }
 
   trackPageView() {
-    const { slug, collectionId } = this.viewState.params;
+    const { slug, collectionSlug } = this.viewState.params;
     const pageViewProps: AnalyticsTrackProps = {
       org_slug: slug || null,
       logged_in: !!this.authState,
     };
 
-    if (collectionId) {
-      pageViewProps.collection_id = collectionId;
+    if (collectionSlug) {
+      pageViewProps.collection_slug = collectionSlug;
     }
 
     pageView(pageViewProps);

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -69,6 +69,13 @@ export class Collection extends BtrixElement {
         this.tab = Tab.About;
       }
 
+      if (collection.slug !== this.collectionSlug) {
+        // Redirect to newest slug
+        this.navigate.to(
+          `/${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${collection.slug}`,
+        );
+      }
+
       return collection;
     },
     args: () => [this.orgSlug, this.collectionSlug] as const,

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -183,7 +183,7 @@ export class Collection extends BtrixElement {
 
   private renderReplay(collection: PublicCollection) {
     const replaySource = new URL(
-      `/api/orgs/${collection.oid}/collections/${this.collectionSlug}/public/replay.json`,
+      `/api/orgs/${collection.oid}/collections/${collection.id}/public/replay.json`,
       window.location.href,
     ).href;
 

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -65,9 +65,9 @@ export class Collection extends BtrixElement {
         collectionSlug,
       });
 
-      if (collection.redirectToSlug) {
+      if (collection.slug !== collectionSlug) {
         this.navigate.to(
-          `/${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${collection.redirectToSlug}`,
+          `/${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${collection.slug}`,
         );
       }
 
@@ -291,7 +291,7 @@ export class Collection extends BtrixElement {
   }: {
     orgSlug: string;
     collectionSlug: string;
-  }): Promise<PublicCollection & { redirectToSlug?: string | null }> {
+  }): Promise<PublicCollection> {
     const resp = await fetch(
       `/api/public/orgs/${orgSlug}/collections/${collectionSlug}`,
       {

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -65,15 +65,14 @@ export class Collection extends BtrixElement {
         collectionSlug,
       });
 
-      if (!collection.crawlCount && (this.tab as unknown) === Tab.Replay) {
-        this.tab = Tab.About;
+      if (collection.redirectToSlug) {
+        this.navigate.to(
+          `/${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${collection.redirectToSlug}`,
+        );
       }
 
-      if (collection.slug !== this.collectionSlug) {
-        // Redirect to newest slug
-        this.navigate.to(
-          `/${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections/${collection.slug}`,
-        );
+      if (!collection.crawlCount && (this.tab as unknown) === Tab.Replay) {
+        this.tab = Tab.About;
       }
 
       return collection;
@@ -292,7 +291,7 @@ export class Collection extends BtrixElement {
   }: {
     orgSlug: string;
     collectionSlug: string;
-  }): Promise<PublicCollection> {
+  }): Promise<PublicCollection & { redirectToSlug?: string | null }> {
     const resp = await fetch(
       `/api/public/orgs/${orgSlug}/collections/${collectionSlug}`,
       {

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -30,7 +30,7 @@ export class Collection extends BtrixElement {
   tab: Tab | string = Tab.Replay;
 
   get canEditCollection() {
-    return this.slug === this.orgSlug && this.appState.isCrawler;
+    return this.slug === this.orgSlugState && this.appState.isCrawler;
   }
 
   private readonly tabLabels: Record<

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -1,5 +1,5 @@
 import { localized, msg, str } from "@lit/localize";
-import { Task } from "@lit/task";
+import { Task, TaskStatus } from "@lit/task";
 import { html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -84,21 +84,17 @@ export class Collection extends BtrixElement {
   private readonly renderComplete = (collection: PublicCollection) => {
     const org = this.orgCollections.value?.org;
     const header: Parameters<typeof page>[0] = {
-      breadcrumbs: org
-        ? [
-            {
-              href: `/${RouteNamespace.PublicOrgs}/${this.orgSlug}`,
-              content: org.name,
-            },
-            {
-              href: `/${RouteNamespace.PublicOrgs}/${this.orgSlug}`,
-              content: msg("Collections"),
-            },
-            {
-              content: collection.name,
-            },
-          ]
-        : [],
+      breadcrumbs:
+        this.orgCollections.status > TaskStatus.PENDING
+          ? org
+            ? [
+                {
+                  href: `/${RouteNamespace.PublicOrgs}/${this.orgSlug}`,
+                  content: org.name,
+                },
+              ]
+            : undefined
+          : [],
       title: collection.name || "",
       actions: html`
         ${when(

--- a/frontend/src/pages/log-in.ts
+++ b/frontend/src/pages/log-in.ts
@@ -389,8 +389,9 @@ export class LogInPage extends BtrixElement {
 
       // Check if org slug in app state matches newly logged in user
       const slug =
-        this.orgSlug && data.user.orgs.some((org) => org.slug === this.orgSlug)
-          ? this.orgSlug
+        this.orgSlugState &&
+        data.user.orgs.some((org) => org.slug === this.orgSlugState)
+          ? this.orgSlugState
           : data.user.orgs[0].slug;
 
       AppStateService.updateUser(formatAPIUser(data.user), slug);

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -269,7 +269,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
                       ? html`—
                           <a
                             class="text-primary"
-                            href=${`/orgs/${this.orgSlug}/workflows/${this.workflowId}/crawls/${this.crawlId}#logs`}
+                            href=${`/orgs/${this.orgSlugState}/workflows/${this.workflowId}/crawls/${this.crawlId}#logs`}
                             >${msg("View error logs")}</a
                           >`
                       : ""}

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -136,6 +136,7 @@ export class CollectionDetail extends BtrixElement {
           : nothing,
         actions: html`
           <btrix-share-collection
+            orgSlug=${this.orgSlugState || ""}
             collectionId=${this.collectionId}
             .collection=${this.collection}
             @btrix-change=${(e: CustomEvent) => {

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -110,7 +110,7 @@ export class CollectionsList extends BtrixElement {
   });
 
   private getShareLink(collection: Collection) {
-    return `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${collection.access === CollectionAccess.Private ? `${RouteNamespace.PrivateOrgs}/${this.orgSlugState}/collections/view` : `${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections`}/${collection.id}`;
+    return `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${collection.access === CollectionAccess.Private ? `${RouteNamespace.PrivateOrgs}/${this.orgSlugState}/collections/view` : `${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections`}/${collection.slug}`;
   }
 
   private get hasSearchStr() {

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -110,7 +110,7 @@ export class CollectionsList extends BtrixElement {
   });
 
   private getShareLink(collection: Collection) {
-    return `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${collection.access === CollectionAccess.Private ? `${RouteNamespace.PrivateOrgs}/${this.orgSlug}/collections/view` : `${RouteNamespace.PublicOrgs}/${this.orgSlug}/collections`}/${collection.id}`;
+    return `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${collection.access === CollectionAccess.Private ? `${RouteNamespace.PrivateOrgs}/${this.orgSlugState}/collections/view` : `${RouteNamespace.PublicOrgs}/${this.orgSlugState}/collections`}/${collection.id}`;
   }
 
   private get hasSearchStr() {

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,7 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import { Task } from "@lit/task";
 import type { SlSelectEvent } from "@shoelace-style/shoelace";
-import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
+import { html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
@@ -9,6 +9,7 @@ import { when } from "lit/directives/when.js";
 import type { SelectNewDialogEvent } from ".";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import { ClipboardController } from "@/controllers/clipboard";
 import { pageHeading } from "@/layouts/page";
 import { pageHeader } from "@/layouts/pageHeader";
 import { RouteNamespace } from "@/routes";
@@ -289,17 +290,37 @@ export class Dashboard extends BtrixElement {
                         ? msg("Visit Public Profile")
                         : msg("Preview Public Profile")}
                     </btrix-menu-item-link>
-                    ${this.org && !this.org.enablePublicProfile
-                      ? html`
-                          <sl-divider></sl-divider>
-                          <btrix-menu-item-link
-                            href=${`${this.navigate.orgBasePath}/settings`}
-                          >
-                            <sl-icon slot="prefix" name="gear"></sl-icon>
-                            ${msg("Update Org Visibility")}
-                          </btrix-menu-item-link>
-                        `
-                      : nothing}
+                    ${when(this.org, (org) =>
+                      org.enablePublicProfile
+                        ? html`
+                            <sl-menu-item
+                              @click=${() => {
+                                ClipboardController.copyToClipboard(
+                                  `${window.location.protocol}//${window.location.hostname}${
+                                    window.location.port
+                                      ? `:${window.location.port}`
+                                      : ""
+                                  }/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`,
+                                );
+                                this.notify.toast({
+                                  message: msg("Link copied"),
+                                });
+                              }}
+                            >
+                              <sl-icon name="copy" slot="prefix"></sl-icon>
+                              ${msg("Copy Link to Profile")}
+                            </sl-menu-item>
+                          `
+                        : html`
+                            <sl-divider></sl-divider>
+                            <btrix-menu-item-link
+                              href=${`${this.navigate.orgBasePath}/settings`}
+                            >
+                              <sl-icon slot="prefix" name="gear"></sl-icon>
+                              ${msg("Update Org Visibility")}
+                            </btrix-menu-item-link>
+                          `,
+                    )}
                   </sl-menu>
                 </btrix-overflow-dropdown>
               `,

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -62,7 +62,7 @@ export class Dashboard extends BtrixElement {
       const collections = await this.fetchCollections({ slug });
       return collections;
     },
-    args: () => [this.orgSlug, this.metrics] as const,
+    args: () => [this.orgSlugState, this.metrics] as const,
   });
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
@@ -282,7 +282,7 @@ export class Dashboard extends BtrixElement {
                       ${msg("Manage Collections")}
                     </btrix-menu-item-link>
                     <btrix-menu-item-link
-                      href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlug}`}
+                      href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
                     >
                       <sl-icon slot="prefix" name="globe2"></sl-icon>
                       ${this.org?.enablePublicProfile
@@ -307,7 +307,7 @@ export class Dashboard extends BtrixElement {
           </header>
           <div class="rounded-lg border p-10">
             <btrix-collections-grid
-              slug=${this.orgSlug || ""}
+              slug=${this.orgSlugState || ""}
               .collections=${this.publicCollections.value}
             >
               ${this.renderNoPublicCollections()}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -154,7 +154,7 @@ export class Org extends BtrixElement {
     if (
       changedProperties.has("appState.orgSlug") &&
       this.userInfo &&
-      this.orgSlug
+      this.orgSlugState
     ) {
       if (this.userOrg) {
         void this.updateOrg();
@@ -236,14 +236,14 @@ export class Org extends BtrixElement {
   async firstUpdated() {
     // if slug is actually an orgId (UUID), attempt to lookup the slug
     // and redirect to the slug url
-    if (this.orgSlug && UUID_REGEX.test(this.orgSlug)) {
-      const org = await this.getOrg(this.orgSlug);
+    if (this.orgSlugState && UUID_REGEX.test(this.orgSlugState)) {
+      const org = await this.getOrg(this.orgSlugState);
       const actualSlug = org?.slug;
       if (actualSlug) {
         this.navigate.to(
           window.location.href
             .slice(window.location.origin.length)
-            .replace(this.orgSlug, actualSlug),
+            .replace(this.orgSlugState, actualSlug),
         );
         return;
       }

--- a/frontend/src/pages/org/profile.ts
+++ b/frontend/src/pages/org/profile.ts
@@ -18,7 +18,7 @@ export class OrgProfile extends BtrixElement {
   private isPrivatePreview = false;
 
   get canEditOrg() {
-    return this.slug === this.orgSlug && this.appState.isAdmin;
+    return this.slug === this.orgSlugState && this.appState.isAdmin;
   }
 
   private readonly orgCollections = new Task(this, {

--- a/frontend/src/pages/org/profile.ts
+++ b/frontend/src/pages/org/profile.ts
@@ -12,13 +12,13 @@ import type { OrgData, PublicOrgCollections } from "@/types/org";
 @customElement("btrix-org-profile")
 export class OrgProfile extends BtrixElement {
   @property({ type: String })
-  slug?: string;
+  orgSlug?: string;
 
   @state()
   private isPrivatePreview = false;
 
   get canEditOrg() {
-    return this.slug === this.orgSlugState && this.appState.isAdmin;
+    return this.orgSlug === this.orgSlugState && this.appState.isAdmin;
   }
 
   private readonly orgCollections = new Task(this, {
@@ -27,11 +27,11 @@ export class OrgProfile extends BtrixElement {
       const org = await this.fetchCollections({ slug });
       return org;
     },
-    args: () => [this.slug] as const,
+    args: () => [this.orgSlug] as const,
   });
 
   render() {
-    if (!this.slug) {
+    if (!this.orgSlug) {
       return this.renderError();
     }
 
@@ -196,7 +196,7 @@ export class OrgProfile extends BtrixElement {
       </header>
       <div class="flex-1 pb-16">
         <btrix-collections-grid
-          slug=${this.slug || ""}
+          slug=${this.orgSlug || ""}
           .collections=${collections}
         ></btrix-collections-grid>
       </div>
@@ -270,7 +270,7 @@ export class OrgProfile extends BtrixElement {
   private async getUserOrg(): Promise<PublicOrgCollections | null> {
     try {
       const userInfo = this.userInfo || (await this.api.fetch("/users/me"));
-      const userOrg = userInfo?.orgs.find((org) => org.slug === this.slug);
+      const userOrg = userInfo?.orgs.find((org) => org.slug === this.orgSlug);
 
       if (!userOrg) {
         return null;

--- a/frontend/src/pages/org/settings/components/profile.ts
+++ b/frontend/src/pages/org/settings/components/profile.ts
@@ -71,7 +71,7 @@ export class OrgSettingsProfile extends BtrixElement {
           <div class="mb-2">
             <btrix-copy-field
               label=${msg("Profile Page")}
-              value=${`${orgBaseUrl}/${RouteNamespace.PublicOrgs}/${this.orgSlug}`}
+              value=${`${orgBaseUrl}/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
               .monostyle=${false}
             ></btrix-copy-field>
           </div>
@@ -97,7 +97,7 @@ export class OrgSettingsProfile extends BtrixElement {
           <div class="p-5">${columns(cols)}</div>
           <footer class="flex items-center justify-between border-t px-4 py-3">
             <btrix-link
-              href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlug}`}
+              href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
               target="_blank"
             >
               ${msg("Preview public profile page")}

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -300,7 +300,7 @@ export class OrgSettings extends BtrixElement {
                   label=${msg("Org URL")}
                   placeholder="my-organization"
                   autocomplete="off"
-                  value=${this.orgSlug || ""}
+                  value=${this.orgSlugState || ""}
                   minlength="2"
                   maxlength="30"
                   required
@@ -674,7 +674,7 @@ export class OrgSettings extends BtrixElement {
 
     const params = {
       name: orgName,
-      slug: this.orgSlug!,
+      slug: this.orgSlugState!,
     };
 
     if (this.slugValue) {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -36,7 +36,7 @@ export const ROUTES = {
   ].join(""),
   publicOrgs: `/${RouteNamespace.PublicOrgs}(/)`,
   publicOrgProfile: `/${RouteNamespace.PublicOrgs}/:slug(/)`,
-  publicCollection: `/${RouteNamespace.PublicOrgs}/:slug/collections/:collectionId(/:collectionTab)`,
+  publicCollection: `/${RouteNamespace.PublicOrgs}/:slug/collections/:collectionSlug(/:collectionTab)`,
   users: "/users",
   usersInvite: "/users/invite",
   crawls: "/crawls",

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -8,6 +8,7 @@ export enum CollectionAccess {
 
 export const publicCollectionSchema = z.object({
   id: z.string(),
+  slug: z.string(),
   oid: z.string(),
   name: z.string(),
   caption: z.string().nullable(),

--- a/frontend/src/utils/LiteElement.ts
+++ b/frontend/src/utils/LiteElement.ts
@@ -37,7 +37,7 @@ export default class LiteElement extends LitElement {
     return this.appState.orgId;
   }
 
-  protected get orgSlug() {
+  protected get orgSlugState() {
     return this.appState.orgSlug;
   }
 

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -9,8 +9,7 @@ import { AnalyticsTrackEvent } from "../trackEvents";
 
 export type AnalyticsTrackProps = {
   org_slug: string | null;
-  collection_id?: string | null;
-  collection_name?: string | null;
+  collection_slug?: string | null;
   logged_in?: boolean;
 };
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2298

## Changes

- Slugs added to collections, can be specified separately when creating or updating collections or else is based off of supplied collection name
- Migration added to backfill slugs for existing collections
- Redirect collection to newest slug if changed
- Adds option to copy public profile link to "Public Collections" action menu
- Show "Back to <Org>" link instead of breadcrumbs

## Manual testing

1. Log in as crawler
2. Create or go to a public collection
3. Click "Copy Link"
4. Paste link into new tab. Verify collection loads as expected
5. Click "< Back to <org name>". Verify org profile loads as expected
6. Click collection from org profile. Verify collection loads as expected
7. Click pencil icon to edit collection
8. Update and save new collection name
9. Repeat 3-4. Verify collection loads with new slug
10. Go back to previous tab and copy link with old slug
11. Open new incognito window and paste link with old slug. Verify you're redirected to the newest slug
12. Go to logged in tab and create a new public collection using the old slug. Verify collection can be created and public view loads as expected

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Dashboard | <img width="232" alt="Screenshot 2025-01-13 at 8 33 25 PM" src="https://github.com/user-attachments/assets/a88144d5-46cf-40f0-80c5-c5678d51931b" /> |
| Public collection | <img width="507" alt="Screenshot 2025-01-13 at 8 33 43 PM" src="https://github.com/user-attachments/assets/b81797b2-a349-405e-824b-5baf6747a9f0" /> |
