### PR TITLE
feat: Show collection created date

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,10 +2,10 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint",
     "runem.lit-plugin",
     "bradlc.vscode-tailwindcss",
     "redhat.vscode-yaml",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "ms-python.black-formatter"
   ]
 }

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -110,6 +110,7 @@ class CollectionOps:
         """Add new collection"""
         crawl_ids = coll_in.crawlIds if coll_in.crawlIds else []
         coll_id = uuid4()
+        created = dt_now()
         modified = dt_now()
 
         coll = Collection(
@@ -118,6 +119,7 @@ class CollectionOps:
             name=coll_in.name,
             description=coll_in.description,
             caption=coll_in.caption,
+            created=created,
             modified=modified,
             access=coll_in.access,
             defaultThumbnailName=coll_in.defaultThumbnailName,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1239,6 +1239,8 @@ class Collection(BaseMongoModel):
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
+
+    created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
@@ -2168,27 +2170,27 @@ class BaseCollectionItemBody(WebhookNotificationBody):
 class CollectionItemAddedBody(BaseCollectionItemBody):
     """Webhook notification POST body for collection additions"""
 
-    event: Literal[WebhookEventType.ADDED_TO_COLLECTION] = (
+    event: Literal[
         WebhookEventType.ADDED_TO_COLLECTION
-    )
+    ] = WebhookEventType.ADDED_TO_COLLECTION
 
 
 # ============================================================================
 class CollectionItemRemovedBody(BaseCollectionItemBody):
     """Webhook notification POST body for collection removals"""
 
-    event: Literal[WebhookEventType.REMOVED_FROM_COLLECTION] = (
+    event: Literal[
         WebhookEventType.REMOVED_FROM_COLLECTION
-    )
+    ] = WebhookEventType.REMOVED_FROM_COLLECTION
 
 
 # ============================================================================
 class CollectionDeletedBody(WebhookNotificationBody):
     """Webhook notification base POST body for collection changes"""
 
-    event: Literal[WebhookEventType.COLLECTION_DELETED] = (
+    event: Literal[
         WebhookEventType.COLLECTION_DELETED
-    )
+    ] = WebhookEventType.COLLECTION_DELETED
     collectionId: str
 
 
@@ -2247,9 +2249,9 @@ class UploadDeletedBody(BaseArchivedItemBody):
 class QaAnalysisStartedBody(BaseArchivedItemBody):
     """Webhook notification POST body for when qa analysis run starts"""
 
-    event: Literal[WebhookEventType.QA_ANALYSIS_STARTED] = (
+    event: Literal[
         WebhookEventType.QA_ANALYSIS_STARTED
-    )
+    ] = WebhookEventType.QA_ANALYSIS_STARTED
 
     qaRunId: str
 
@@ -2258,9 +2260,9 @@ class QaAnalysisStartedBody(BaseArchivedItemBody):
 class QaAnalysisFinishedBody(BaseArchivedItemFinishedBody):
     """Webhook notification POST body for when qa analysis run finishes"""
 
-    event: Literal[WebhookEventType.QA_ANALYSIS_FINISHED] = (
+    event: Literal[
         WebhookEventType.QA_ANALYSIS_FINISHED
-    )
+    ] = WebhookEventType.QA_ANALYSIS_FINISHED
 
     qaRunId: str
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1288,6 +1288,7 @@ class CollOut(BaseMongoModel):
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
+    created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
@@ -1321,6 +1322,8 @@ class PublicCollOut(BaseMongoModel):
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
+    created: Optional[datetime] = None
+    modified: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0
@@ -2170,27 +2173,27 @@ class BaseCollectionItemBody(WebhookNotificationBody):
 class CollectionItemAddedBody(BaseCollectionItemBody):
     """Webhook notification POST body for collection additions"""
 
-    event: Literal[
+    event: Literal[WebhookEventType.ADDED_TO_COLLECTION] = (
         WebhookEventType.ADDED_TO_COLLECTION
-    ] = WebhookEventType.ADDED_TO_COLLECTION
+    )
 
 
 # ============================================================================
 class CollectionItemRemovedBody(BaseCollectionItemBody):
     """Webhook notification POST body for collection removals"""
 
-    event: Literal[
+    event: Literal[WebhookEventType.REMOVED_FROM_COLLECTION] = (
         WebhookEventType.REMOVED_FROM_COLLECTION
-    ] = WebhookEventType.REMOVED_FROM_COLLECTION
+    )
 
 
 # ============================================================================
 class CollectionDeletedBody(WebhookNotificationBody):
     """Webhook notification base POST body for collection changes"""
 
-    event: Literal[
+    event: Literal[WebhookEventType.COLLECTION_DELETED] = (
         WebhookEventType.COLLECTION_DELETED
-    ] = WebhookEventType.COLLECTION_DELETED
+    )
     collectionId: str
 
 
@@ -2249,9 +2252,9 @@ class UploadDeletedBody(BaseArchivedItemBody):
 class QaAnalysisStartedBody(BaseArchivedItemBody):
     """Webhook notification POST body for when qa analysis run starts"""
 
-    event: Literal[
+    event: Literal[WebhookEventType.QA_ANALYSIS_STARTED] = (
         WebhookEventType.QA_ANALYSIS_STARTED
-    ] = WebhookEventType.QA_ANALYSIS_STARTED
+    )
 
     qaRunId: str
 
@@ -2260,9 +2263,9 @@ class QaAnalysisStartedBody(BaseArchivedItemBody):
 class QaAnalysisFinishedBody(BaseArchivedItemFinishedBody):
     """Webhook notification POST body for when qa analysis run finishes"""
 
-    event: Literal[
+    event: Literal[WebhookEventType.QA_ANALYSIS_FINISHED] = (
         WebhookEventType.QA_ANALYSIS_FINISHED
-    ] = WebhookEventType.QA_ANALYSIS_FINISHED
+    )
 
     qaRunId: str
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -17,7 +17,6 @@ CAPTION = "Short caption"
 UPDATED_CAPTION = "Updated caption"
 
 NON_PUBLIC_COLL_FIELDS = (
-    "modified",
     "tags",
     "homeUrlPageId",
 )
@@ -887,6 +886,8 @@ def test_list_public_collections(
         assert collection["oid"]
         assert collection["access"] == "public"
         assert collection["name"]
+        assert collection["created"]
+        assert collection["modified"]
         assert collection["dateEarliest"]
         assert collection["dateLatest"]
         assert collection["crawlCount"] > 0
@@ -1070,6 +1071,8 @@ def test_list_public_colls_home_url_thumbnail():
         assert coll["oid"]
         assert coll["access"] == "public"
         assert coll["name"]
+        assert coll["created"]
+        assert coll["modified"]
         assert coll["resources"]
         assert coll["dateEarliest"]
         assert coll["dateLatest"]
@@ -1117,6 +1120,8 @@ def test_get_public_collection(default_org_id):
     assert coll["oid"] == default_org_id
     assert coll["access"] == "public"
     assert coll["name"]
+    assert coll["created"]
+    assert coll["modified"]
     assert coll["resources"]
     assert coll["dateEarliest"]
     assert coll["dateLatest"]
@@ -1193,6 +1198,8 @@ def test_get_public_collection_unlisted(crawler_auth_headers, default_org_id):
     assert coll["oid"] == default_org_id
     assert coll["access"] == "unlisted"
     assert coll["name"]
+    assert coll["created"]
+    assert coll["modified"]
     assert coll["resources"]
     assert coll["dateEarliest"]
     assert coll["dateLatest"]
@@ -1231,6 +1238,8 @@ def test_get_public_collection_unlisted_org_profile_disabled(
     assert coll["oid"] == default_org_id
     assert coll["access"] == "unlisted"
     assert coll["name"]
+    assert coll["created"]
+    assert coll["modified"]
     assert coll["resources"]
     assert coll["dateEarliest"]
     assert coll["dateLatest"]

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -479,16 +479,33 @@ export class CollectionDetail extends BtrixElement {
           (col) =>
             `${this.localize.number(col.pageCount)} ${pluralOf("pages", col.pageCount)}`,
         )}
+        ${when(this.collection?.created, (created) =>
+          // Collections created before 49516bc4 is released may not have date in db
+          created
+            ? this.renderDetailItem(
+                msg("Date Created"),
+                () =>
+                  html`<btrix-format-date
+                    date=${created}
+                    month="long"
+                    day="numeric"
+                    year="numeric"
+                    hour="numeric"
+                    minute="numeric"
+                  ></btrix-format-date>`,
+              )
+            : nothing,
+        )}
         ${this.renderDetailItem(
           msg("Last Updated"),
           (col) =>
             html`<btrix-format-date
               date=${col.modified}
-              month="2-digit"
-              day="2-digit"
-              year="2-digit"
-              hour="2-digit"
-              minute="2-digit"
+              month="long"
+              day="numeric"
+              year="numeric"
+              hour="numeric"
+              minute="numeric"
             ></btrix-format-date>`,
         )}
       </btrix-desc-list>

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -34,6 +34,7 @@ export type PublicCollection = z.infer<typeof publicCollectionSchema>;
 
 export const collectionSchema = publicCollectionSchema.extend({
   id: z.string(),
+  created: z.string().datetime(),
   modified: z.string().datetime(),
   tags: z.array(z.string()),
   access: z.nativeEnum(CollectionAccess),


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2299

## Changes

- Shows collection created date in detail view (if present)
- Adds `black` formatter to vscode extension recommendations

## Manual testing

Tested by building and running backend locally.

1. Log in as crawler
2. Go to collection detail. Verify created date is not shown
3. Create new collection. Verify created date is shown in detail page

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection detail (new) | <img width="1320" alt="Screenshot 2025-01-13 at 3 40 20 PM" src="https://github.com/user-attachments/assets/a13b09e1-15c8-4a5b-8239-8b821eddeff5" /> |
| Collection detail (old) | <img width="1309" alt="Screenshot 2025-01-13 at 3 40 30 PM" src="https://github.com/user-attachments/assets/7683a470-c50b-44fa-ad30-320f513f6094" /> |


<!-- ## Follow-ups -->
