### PR TITLE
fix: Fully load thumbnail before save

### DIFF
--- a/frontend/src/features/collections/collection-replay-dialog.ts
+++ b/frontend/src/features/collections/collection-replay-dialog.ts
@@ -89,7 +89,7 @@ export class CollectionStartPageDialog extends BtrixElement {
       this.homeView === HomeView.URL && !this.selectedSnapshot;
     return html`
       <btrix-dialog
-        .label=${msg("Configure Replay Home")}
+        .label=${msg("Configure Replay View")}
         .open=${this.open}
         class="[--width:60rem]"
         @sl-show=${() => (this.showContent = true)}

--- a/frontend/src/features/collections/collection-replay-dialog.ts
+++ b/frontend/src/features/collections/collection-replay-dialog.ts
@@ -6,11 +6,13 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
+import "./collection-snapshot-preview";
+
+import { type CollectionSnapshotPreview } from "./collection-snapshot-preview";
 import type { SelectSnapshotDetail } from "./select-collection-start-page";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
-import { formatRwpTimestamp } from "@/utils/replay";
 
 enum HomeView {
   Pages = "pages",
@@ -76,7 +78,7 @@ export class CollectionStartPageDialog extends BtrixElement {
   private readonly form?: HTMLFormElement | null;
 
   @query("#thumbnailPreview")
-  private readonly thumbnailPreview?: HTMLIFrameElement | null;
+  private readonly thumbnailPreview?: CollectionSnapshotPreview | null;
 
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("homeUrl") && this.homeUrl) {
@@ -159,15 +161,14 @@ export class CollectionStartPageDialog extends BtrixElement {
 
     if (snapshot) {
       urlPreview = html`
-        <sl-tooltip hoist>
-          <iframe
-            class="inline-block size-full"
-            id="thumbnailPreview"
-            src=${`/replay/w/${this.collectionId}/${formatRwpTimestamp(snapshot.ts)}id_/urn:thumbnail:${snapshot.url}`}
-          >
-          </iframe>
-          <span slot="content" class="break-all">${snapshot.url}</span>
-        </sl-tooltip>
+        <btrix-collection-snapshot-preview
+          class="contents"
+          id="thumbnailPreview"
+          collectionId=${this.collectionId || ""}
+          url=${snapshot.url || ""}
+          timestamp=${snapshot.ts || ""}
+        >
+        </btrix-collection-snapshot-preview>
       `;
     }
 
@@ -338,7 +339,7 @@ export class CollectionStartPageDialog extends BtrixElement {
 
         // Wait to get the thumbnail image before closing the dialog
         try {
-          const resp = await this.thumbnailPreview.contentWindow!.fetch(src);
+          const resp = await this.thumbnailPreview.fetch(src);
           const blob = await resp.blob();
 
           file = new File([blob], fileName, {

--- a/frontend/src/features/collections/collection-snapshot-preview.ts
+++ b/frontend/src/features/collections/collection-snapshot-preview.ts
@@ -1,10 +1,25 @@
-import { localized } from "@lit/localize";
-import { html } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { localized, msg } from "@lit/localize";
+import { Task } from "@lit/task";
+import clsx from "clsx";
+import { html, type PropertyValues } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+
+import type { SelectSnapshotDetail } from "./select-collection-start-page";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { formatRwpTimestamp } from "@/utils/replay";
+import { tw } from "@/utils/tailwind";
 
+export enum HomeView {
+  Pages = "pages",
+  URL = "url",
+}
+
+/**
+ * Display preview of page snapshot.
+ *
+ * A previously loaded `replay-web-page` embed is required in order for preview to work.
+ */
 @customElement("btrix-collection-snapshot-preview")
 @localized()
 export class CollectionSnapshotPreview extends TailwindElement {
@@ -12,32 +27,146 @@ export class CollectionSnapshotPreview extends TailwindElement {
   collectionId = "";
 
   @property({ type: String })
-  timestamp = "";
+  replaySrc = "";
 
   @property({ type: String })
-  url = "";
+  view?: HomeView;
+
+  @property({ type: Object })
+  snapshot?: SelectSnapshotDetail["item"];
 
   @query("iframe")
-  private readonly iframe!: HTMLIFrameElement;
+  private readonly iframe?: HTMLIFrameElement | null;
 
-  public get src() {
-    return this.iframe.src;
+  @state()
+  private iframeLoaded = false;
+
+  public get thumbnailBlob() {
+    return this.blobTask.taskComplete.finally(() => this.blobTask.value);
   }
 
-  public get fetch() {
-    return this.iframe.contentWindow!.fetch;
+  private readonly blobTask = new Task(this, {
+    task: async ([collectionId, snapshot, iframeLoaded]) => {
+      if (
+        !collectionId ||
+        !snapshot ||
+        !iframeLoaded ||
+        !this.iframe?.contentWindow
+      ) {
+        return;
+      }
+
+      const resp = await this.iframe.contentWindow.fetch(
+        `/replay/w/${this.collectionId}/${formatRwpTimestamp(snapshot.ts)}id_/urn:thumbnail:${snapshot.url}`,
+      );
+
+      if (resp.status === 200) {
+        return await resp.blob();
+      }
+
+      throw new Error(`couldn't get thumbnail`);
+    },
+    args: () => [this.collectionId, this.snapshot, this.iframeLoaded] as const,
+  });
+
+  private readonly objectUrlTask = new Task(this, {
+    task: ([blob]) => {
+      if (!blob) return "";
+
+      const url = URL.createObjectURL(blob);
+
+      if (url) return url;
+
+      throw new Error("no object url");
+    },
+    args: () => [this.blobTask.value] as const,
+  });
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    if (this.objectUrlTask.value) {
+      URL.revokeObjectURL(this.objectUrlTask.value);
+    }
+  }
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (
+      changedProperties.has("collectionId") ||
+      changedProperties.has("snapshot")
+    ) {
+      if (this.objectUrlTask.value) {
+        URL.revokeObjectURL(this.objectUrlTask.value);
+      }
+    }
   }
 
   render() {
-    return html`
-      <sl-tooltip hoist>
-        <iframe
-          class="inline-block size-full"
-          src=${`/replay/w/${this.collectionId}/${formatRwpTimestamp(this.timestamp)}id_/urn:thumbnail:${this.url}`}
-        >
-        </iframe>
-        <span slot="content" class="break-all">${this.url}</span>
-      </sl-tooltip>
-    `;
+    return html` ${this.renderSnapshot()} ${this.renderReplay()} `;
   }
+
+  private renderSnapshot() {
+    if (this.view === HomeView.Pages) return;
+
+    return this.blobTask.render({
+      complete: this.renderImage,
+      pending: this.renderSpinner,
+      error: this.renderError,
+    });
+  }
+
+  private readonly renderImage = () => {
+    if (!this.snapshot) {
+      return html`
+        <p class="m-3 text-pretty text-neutral-500">
+          ${msg("Enter a Page URL to preview it")}
+        </p>
+      `;
+    }
+
+    return html`
+      <div class="size-full">
+        <sl-tooltip hoist>
+          ${this.objectUrlTask.render({
+            complete: (value) =>
+              value
+                ? html`<img class="size-full" src=${value} />`
+                : this.renderSpinner(),
+            pending: () => "pending",
+          })}
+          <span slot="content" class="break-all">${this.snapshot.url}</span>
+        </sl-tooltip>
+      </div>
+    `;
+  };
+
+  private renderReplay() {
+    return html`<div
+      class=${clsx(tw`size-full`, this.view === HomeView.URL && tw`offscreen`)}
+    >
+      <div class="aspect-video w-[200%]">
+        <div class="pointer-events-none aspect-video origin-top-left scale-50">
+          <iframe
+            class="inline-block size-full"
+            src=${this.replaySrc}
+            @load=${() => {
+              this.iframeLoaded = true;
+            }}
+          ></iframe>
+        </div>
+      </div>
+    </div>`;
+  }
+
+  private readonly renderError = () => html`
+    <p class="m-3 text-pretty text-danger">
+      ${msg("Couldn't load preview. Try another snapshot")}
+    </p>
+  `;
+
+  private readonly renderSpinner = () => html`
+    <div class="flex size-full items-center justify-center text-2xl">
+      <sl-spinner></sl-spinner>
+    </div>
+  `;
 }

--- a/frontend/src/features/collections/collection-snapshot-preview.ts
+++ b/frontend/src/features/collections/collection-snapshot-preview.ts
@@ -1,0 +1,43 @@
+import { localized } from "@lit/localize";
+import { html } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import { formatRwpTimestamp } from "@/utils/replay";
+
+@customElement("btrix-collection-snapshot-preview")
+@localized()
+export class CollectionSnapshotPreview extends TailwindElement {
+  @property({ type: String })
+  collectionId = "";
+
+  @property({ type: String })
+  timestamp = "";
+
+  @property({ type: String })
+  url = "";
+
+  @query("iframe")
+  private readonly iframe!: HTMLIFrameElement;
+
+  public get src() {
+    return this.iframe.src;
+  }
+
+  public get fetch() {
+    return this.iframe.contentWindow!.fetch;
+  }
+
+  render() {
+    return html`
+      <sl-tooltip hoist>
+        <iframe
+          class="inline-block size-full"
+          src=${`/replay/w/${this.collectionId}/${formatRwpTimestamp(this.timestamp)}id_/urn:thumbnail:${this.url}`}
+        >
+        </iframe>
+        <span slot="content" class="break-all">${this.url}</span>
+      </sl-tooltip>
+    `;
+  }
+}

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -242,7 +242,7 @@ export class ShareCollection extends BtrixElement {
         @sl-after-hide=${() => {
           this.tabGroup?.show(Tab.Link);
         }}
-        class="[--width:40rem] [--body-spacing:0]"
+        class="[--body-spacing:0] [--width:40rem]"
       >
         <sl-tab-group>
           <sl-tab slot="nav" panel=${Tab.Link}

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -168,8 +168,8 @@ export class CollectionDetail extends BtrixElement {
                     @click=${() => (this.openDialogName = "editStartPage")}
                     ?disabled=${!this.collection?.crawlCount}
                   >
-                    <sl-icon name="house-gear" slot="prefix"></sl-icon>
-                    ${msg("Configure Home")}
+                    <sl-icon name="gear" slot="prefix"></sl-icon>
+                    ${msg("Configure View")}
                   </sl-button>
                 </sl-tooltip>
               `,
@@ -399,8 +399,8 @@ export class CollectionDetail extends BtrixElement {
             }}
             ?disabled=${!this.collection?.crawlCount}
           >
-            <sl-icon name="house-gear" slot="prefix"></sl-icon>
-            ${msg("Configure Replay Home")}
+            <sl-icon name="gear" slot="prefix"></sl-icon>
+            ${msg("Configure Replay View")}
           </sl-menu-item>
           <sl-menu-item
             @click=${async () => {

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -166,9 +166,13 @@ export class CollectionDetail extends BtrixElement {
                   <sl-button
                     size="small"
                     @click=${() => (this.openDialogName = "editStartPage")}
-                    ?disabled=${!this.collection?.crawlCount}
+                    ?disabled=${!this.collection?.crawlCount ||
+                    !this.isRwpLoaded}
                   >
-                    <sl-icon name="gear" slot="prefix"></sl-icon>
+                    ${!this.collection ||
+                    Boolean(this.collection.crawlCount && !this.isRwpLoaded)
+                      ? html`<sl-spinner slot="prefix"></sl-spinner>`
+                      : html`<sl-icon name="gear" slot="prefix"></sl-icon>`}
                     ${msg("Configure View")}
                   </sl-button>
                 </sl-tooltip>


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2306

## Changes

Refactors collection view configuration to wait for thumbnail preview image (using `URL.createObjectURL`, like in QA screenshots) to be fully loaded from `replay-web-page` before saving.

## Manual testing

1. Log in as crawler
2. Go to collection with archived items
3. Click "Configure View"
4. Update page view and snapshot. Verify preview loads and thumbnail saves as expected.