### PR TITLE
feat: Enable viewing all workflow form sections at once

### DIFF
--- a/frontend/src/components/ui/tab-group/tab-group.ts
+++ b/frontend/src/components/ui/tab-group/tab-group.ts
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import {
   customElement,
@@ -10,7 +9,7 @@ import type { TabClickDetail, TabGroupTab } from "./tab";
 import { type TabGroupPanel } from "./tab-panel";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import { tw } from "@/utils/tailwind";
+import { pageSectionsWithNav } from "@/layouts/pageSectionsWithNav";
 
 /**
  * @example Usage:
@@ -32,6 +31,10 @@ export class TabGroup extends TailwindElement {
   /* Nav placement */
   @property({ type: String })
   placement: "top" | "start" = "top";
+
+  /* Nav sticky */
+  @property({ type: Boolean })
+  sticky = true;
 
   @property({ type: String, noAccessor: true, reflect: true })
   role = "tablist";
@@ -61,29 +64,16 @@ export class TabGroup extends TailwindElement {
   }
 
   render() {
-    return html`
-      <div
-        class=${clsx(
-          tw`flex flex-col`,
-          this.placement === "start" && tw`gap-8 lg:flex-row`,
-        )}
-      >
-        <div
-          class=${clsx(
-            tw`flex flex-1 flex-col gap-2`,
-            this.placement === "start"
-              ? tw`lg:sticky lg:top-2 lg:max-w-[16.5rem] lg:self-start`
-              : tw`lg:flex-row`,
-          )}
-          @keydown=${this.onKeyDown}
-        >
-          <slot name="nav" @btrix-select-tab=${this.onSelectTab}></slot>
-        </div>
-        <div class="flex-1">
-          <slot></slot>
-        </div>
-      </div>
-    `;
+    return pageSectionsWithNav({
+      nav: html`<slot
+        name="nav"
+        @btrix-select-tab=${this.onSelectTab}
+        @keydown=${this.onKeyDown}
+      ></slot>`,
+      main: html`<slot></slot>`,
+      placement: this.placement,
+      sticky: this.sticky,
+    });
   }
 
   private handleActiveChange() {

--- a/frontend/src/components/utils/observable.ts
+++ b/frontend/src/components/utils/observable.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement, query } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 
 type IntersectionEventDetail = {
   entry: IntersectionObserverEntry;
@@ -11,23 +11,26 @@ export type IntersectEvent = CustomEvent<IntersectionEventDetail>;
  *
  * @example Usage:
  * ```
- * <btrix-observable @intersect=${console.log}>
+ * <btrix-observable @btrix-intersect=${console.log}>
  *   Observe me!
  * </btrix-observable>
  * ```
  *
- * @event intersect { entry: IntersectionObserverEntry }
+ * @fires btrix-intersect { entry: IntersectionObserverEntry }
  */
 @customElement("btrix-observable")
 export class Observable extends LitElement {
-  @query(".target")
-  private readonly target?: HTMLElement;
+  @property({ type: Object })
+  options?: IntersectionObserverInit;
 
   private observer?: IntersectionObserver;
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.observer = new IntersectionObserver(this.handleIntersect);
+    this.observer = new IntersectionObserver(
+      this.handleIntersect,
+      this.options,
+    );
   }
 
   disconnectedCallback(): void {
@@ -36,18 +39,18 @@ export class Observable extends LitElement {
   }
 
   firstUpdated() {
-    this.observer?.observe(this.target!);
+    this.observer?.observe(this);
   }
 
   private readonly handleIntersect = ([entry]: IntersectionObserverEntry[]) => {
     this.dispatchEvent(
-      new CustomEvent<IntersectionEventDetail>("intersect", {
+      new CustomEvent<IntersectionEventDetail>("btrix-intersect", {
         detail: { entry },
       }),
     );
   };
 
   render() {
-    return html`<div class="target"><slot></slot></div>`;
+    return html`<slot></slot>`;
   }
 }

--- a/frontend/src/components/utils/observable.ts
+++ b/frontend/src/components/utils/observable.ts
@@ -1,10 +1,7 @@
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-type IntersectionEventDetail = {
-  entry: IntersectionObserverEntry;
-};
-export type IntersectEvent = CustomEvent<IntersectionEventDetail>;
+import { ObservableController } from "@/controllers/observable";
 
 /**
  * Observe element with Intersection Observer API.
@@ -16,39 +13,18 @@ export type IntersectEvent = CustomEvent<IntersectionEventDetail>;
  * </btrix-observable>
  * ```
  *
- * @fires btrix-intersect { entry: IntersectionObserverEntry }
+ * @fires btrix-intersect IntersectionEventDetail
  */
 @customElement("btrix-observable")
 export class Observable extends LitElement {
   @property({ type: Object })
   options?: IntersectionObserverInit;
 
-  private observer?: IntersectionObserver;
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    this.observer = new IntersectionObserver(
-      this.handleIntersect,
-      this.options,
-    );
-  }
-
-  disconnectedCallback(): void {
-    this.observer?.disconnect();
-    super.disconnectedCallback();
-  }
+  private readonly observable = new ObservableController(this);
 
   firstUpdated() {
-    this.observer?.observe(this);
+    this.observable.observe(this);
   }
-
-  private readonly handleIntersect = ([entry]: IntersectionObserverEntry[]) => {
-    this.dispatchEvent(
-      new CustomEvent<IntersectionEventDetail>("btrix-intersect", {
-        detail: { entry },
-      }),
-    );
-  };
 
   render() {
     return html`<slot></slot>`;

--- a/frontend/src/controllers/observable.ts
+++ b/frontend/src/controllers/observable.ts
@@ -1,0 +1,50 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+type IntersectionEventDetail = {
+  entries: IntersectionObserverEntry[];
+};
+export type IntersectEvent = CustomEvent<IntersectionEventDetail>;
+
+/**
+ * Observe one or more elements with Intersection Observer API.
+ *
+ * @fires btrix-intersect IntersectionEventDetail
+ */
+export class ObservableController implements ReactiveController {
+  private readonly host: ReactiveControllerHost & EventTarget;
+
+  private observer?: IntersectionObserver;
+  private readonly observerOptions?: IntersectionObserverInit;
+
+  constructor(
+    host: ObservableController["host"],
+    options?: IntersectionObserverInit,
+  ) {
+    this.host = host;
+    this.observerOptions = options;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    this.observer = new IntersectionObserver(
+      this.handleIntersect,
+      this.observerOptions,
+    );
+  }
+
+  hostDisconnected() {
+    this.observer?.disconnect();
+  }
+
+  public observe(target: Element) {
+    this.observer?.observe(target);
+  }
+
+  private readonly handleIntersect = (entries: IntersectionObserverEntry[]) => {
+    this.host.dispatchEvent(
+      new CustomEvent<IntersectionEventDetail>("btrix-intersect", {
+        detail: { entries },
+      }),
+    );
+  };
+}

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -10,6 +10,7 @@ import { when } from "lit/directives/when.js";
 import throttle from "lodash/fp/throttle";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import type { IntersectEvent } from "@/controllers/observable";
 
 type Pages = string[];
 type ResponseData = {
@@ -232,8 +233,8 @@ export class CrawlQueue extends BtrixElement {
     `;
   }
 
-  private readonly onLoadMoreIntersect = throttle(50)((e: CustomEvent) => {
-    if (!e.detail.entry.isIntersecting) return;
+  private readonly onLoadMoreIntersect = throttle(50)((e: IntersectEvent) => {
+    if (!e.detail.entries[0].isIntersecting) return;
     this.loadMore();
   }) as (e: CustomEvent) => void;
 

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -201,7 +201,7 @@ export class CrawlQueue extends BtrixElement {
               ${msg("End of queue")}
             </div>`,
           () => html`
-            <btrix-observable @intersect=${this.onLoadMoreIntersect}>
+            <btrix-observable @btrix-intersect=${this.onLoadMoreIntersect}>
               <div class="py-3">
                 <sl-icon-button
                   name="three-dots"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1715,9 +1715,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
       });
     } else {
       console.debug("summary not found in sl-details");
-
-      activeTabPanel.scrollIntoView();
     }
+    activeTabPanel.scrollIntoView({ block: "start" });
   }
 
   private async handleRemoveRegex(e: CustomEvent) {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -541,8 +541,6 @@ export class WorkflowEditor extends BtrixElement {
       <div class="mb-10 flex flex-col gap-12 px-2">
         ${this.formSections.map(formSection)}
       </div>
-
-      ${when(this.serverError, (error) => this.renderErrorAlert(error))}
     `;
   }
 
@@ -551,7 +549,7 @@ export class WorkflowEditor extends BtrixElement {
       <footer
         class=${clsx(
           "flex items-center justify-end gap-2 rounded-lg border bg-white px-6 py-4 mb-7 shadow",
-          this.configId && tw`sticky bottom-2 z-50`,
+          (this.configId || this.serverError) && tw`sticky bottom-2 z-50`,
         )}
       >
         ${this.configId
@@ -561,6 +559,8 @@ export class WorkflowEditor extends BtrixElement {
               </sl-button>
             `
           : nothing}
+        ${when(this.serverError, (error) => this.renderErrorAlert(error))}
+
         <sl-button
           size="small"
           variant="primary"
@@ -1560,11 +1560,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private renderErrorAlert(errorMessage: string | TemplateResult) {
-    return html`
-      <div class="mb-5">
-        <btrix-alert variant="danger">${errorMessage}</btrix-alert>
-      </div>
-    `;
+    return html` <div class="px-2 text-danger">${errorMessage}</div> `;
   }
 
   private readonly formSections: {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -441,6 +441,11 @@ export class WorkflowEditor extends BtrixElement {
             "part-[summary-icon]:text-neutral-400 part-[header]:cursor-default part-[summary-icon]:cursor-not-allowed",
         )}
         ?open=${required || hasError || tabProgress?.completed}
+        @sl-focus=${() => {
+          this.updateProgressState({
+            activeTab: name,
+          });
+        }}
         @sl-show=${() => {
           this.skipIntersectUpdate = true;
           this.updateProgressState({
@@ -468,6 +473,9 @@ export class WorkflowEditor extends BtrixElement {
           }
 
           this.skipIntersectUpdate = true;
+          this.updateProgressState({
+            activeTab: name,
+          });
         }}
         @sl-after-show=${() => {
           this.skipIntersectUpdate = false;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -468,11 +468,6 @@ export class WorkflowEditor extends BtrixElement {
             invalidEl.focus();
             invalidEl.checkValidity();
           }
-
-          this.pauseObserve();
-          this.updateProgressState({
-            activeTab: name,
-          });
         }}
         @sl-after-show=${this.resumeObserve}
         @sl-after-hide=${this.resumeObserve}

--- a/frontend/src/layouts/pageSectionsWithNav.ts
+++ b/frontend/src/layouts/pageSectionsWithNav.ts
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import { html, type TemplateResult } from "lit";
+
+import { tw } from "@/utils/tailwind";
+
+export function pageSectionsWithNav({
+  nav,
+  main,
+  placement = "start",
+  sticky = false,
+}: {
+  nav: TemplateResult;
+  main: TemplateResult;
+  placement?: "start" | "top";
+  sticky?: boolean;
+}) {
+  return html`
+    <div
+      class=${clsx(
+        tw`flex flex-col`,
+        placement === "start" && tw`gap-8 lg:flex-row`,
+      )}
+    >
+      <div
+        class=${clsx(
+          tw`flex flex-1 flex-col gap-2`,
+          sticky && tw`lg:sticky lg:top-2 lg:self-start`,
+          placement === "start" ? tw`lg:max-w-[16.5rem]` : tw`lg:flex-row`,
+        )}
+      >
+        ${nav}
+      </div>
+      <div class="flex-1">${main}</div>
+    </div>
+  `;
+}

--- a/frontend/src/layouts/panel.ts
+++ b/frontend/src/layouts/panel.ts
@@ -1,4 +1,5 @@
 import { html, type TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { pageHeading } from "./page";
 
@@ -30,10 +31,14 @@ export function panel({
   content,
   heading,
   actions,
+  id,
+  className,
 }: {
   content: TemplateResult;
+  id?: string;
+  className?: string;
 } & Parameters<typeof panelHeader>[0]) {
-  return html`<section>
+  return html`<section id=${ifDefined(id)} class=${ifDefined(className)}>
     ${panelHeader({ heading, actions })} ${content}
   </section>`;
 }

--- a/frontend/src/layouts/panel.ts
+++ b/frontend/src/layouts/panel.ts
@@ -28,17 +28,17 @@ export function panelBody({ content }: { content: TemplateResult }) {
  * @TODO Refactor components to use panel
  */
 export function panel({
-  content,
   heading,
   actions,
+  body,
   id,
   className,
 }: {
-  content: TemplateResult;
+  body: TemplateResult;
   id?: string;
   className?: string;
 } & Parameters<typeof panelHeader>[0]) {
   return html`<section id=${ifDefined(id)} class=${ifDefined(className)}>
-    ${panelHeader({ heading, actions })} ${content}
+    ${panelHeader({ heading, actions })} ${body}
   </section>`;
 }

--- a/frontend/src/layouts/panel.ts
+++ b/frontend/src/layouts/panel.ts
@@ -1,0 +1,39 @@
+import { html, type TemplateResult } from "lit";
+
+import { pageHeading } from "./page";
+
+export function panelHeader({
+  heading,
+  actions,
+}: {
+  heading: string | Parameters<typeof pageHeading>[0];
+  actions?: TemplateResult;
+}) {
+  return html`
+    <header class="mb-3 flex min-h-8 items-baseline justify-between">
+      ${typeof heading === "string"
+        ? pageHeading({ content: heading })
+        : pageHeading(heading)}
+      ${actions}
+    </header>
+  `;
+}
+
+export function panelBody({ content }: { content: TemplateResult }) {
+  return html`<div class="lg:rounded-lg lg:border lg:p-4">${content}</div>`;
+}
+
+/**
+ * @TODO Refactor components to use panel
+ */
+export function panel({
+  content,
+  heading,
+  actions,
+}: {
+  content: TemplateResult;
+} & Parameters<typeof panelHeader>[0]) {
+  return html`<section>
+    ${panelHeader({ heading, actions })} ${content}
+  </section>`;
+}

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -6,8 +6,9 @@ import { type FormState } from "@/utils/workflow";
 type Field = keyof FormState;
 
 const infoText: Partial<Record<Field, string | TemplateResult>> = {
-  exclusions: msg(`Specify exclusion rules for what pages should not be visited.
-  Exclusions apply to all URLs.`),
+  exclusions: msg(
+    "Specify exclusion rules for what pages should not be visited.",
+  ),
   pageLimit: msg(
     "Adds a hard limit on the number of pages that will be crawled.",
   ),

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -183,11 +183,13 @@
   }
 
   /* Validation styles */
-  [data-user-invalid]:not([disabled])::part(base) {
+  sl-input[data-user-invalid]:not([disabled])::part(base),
+  sl-textarea[data-user-invalid]:not([disabled])::part(base) {
     border-color: var(--sl-color-danger-400);
   }
 
-  [data-user-invalid]:focus-within::part(base) {
+  sl-input[data-user-invalid]:focus-within::part(base),
+  sl-textarea[data-user-invalid]:focus-within::part(base) {
     box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-color-danger-100);
   }
 

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -155,9 +155,6 @@ export function getInitialFormState(params: {
   org?: OrgData | null;
 }): FormState {
   const defaultFormState = getDefaultFormState();
-  if (!params.configId) {
-    defaultFormState.runNow = true;
-  }
   if (!params.initialWorkflow) return defaultFormState;
   const formState: Partial<FormState> = {};
   const seedsConfig = params.initialWorkflow.config;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2169

## Changes

- Displays workflow form as collapsible sections
- Combines run now toggle into submit
- Fixes exclusion field errors not preventing form submission
- Refactors `<btrix-observable>` into new `Observable` controller

## Manual testing

1. Log in as crawler
2. Go to New Workflow. Verify scope section is the only section expanded
3. Interact with side navigation and form sections open/close button. Verify sections update as expected
4. Enter invalid fields (like regular expression of `**`.) Verify form submission is prevent and form is scrolled to the errored field
5. Click "Save". Verify workflow is saved without running
6. Go to New Workflow again
7. Fill required fields and click "Run Crawl". Verify workflow is saved and crawl immediately runs
8. Go to existing workflow. Verify all sections are open and save buttons are always visible
9. Repeat steps 5 and 7 to test saving existing workflow

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Workflow | <img width="1319" alt="Screenshot 2025-02-03 at 3 39 00 PM" src="https://github.com/user-attachments/assets/0b227d07-6b34-4d53-9ce0-406dbc3b4de2" /> |
| New Workflow | <img width="274" alt="Screenshot 2025-02-03 at 3 39 06 PM" src="https://github.com/user-attachments/assets/e3fba9b9-ad8d-4447-b267-c18badf3ad7c" /><br/><img width="278" alt="Screenshot 2025-02-03 at 3 39 09 PM" src="https://github.com/user-attachments/assets/bc13da77-4ed4-4e5b-9f4a-f3a4e354cf91" /> |
| Edit Workflow | <img width="1326" alt="Screenshot 2025-02-03 at 3 39 44 PM" src="https://github.com/user-attachments/assets/00dddd5b-1e3e-44d3-ac02-4917645d5689" /> |
| Workflow (field errors) | <img width="1125" alt="Screenshot 2025-02-03 at 3 29 39 PM" src="https://github.com/user-attachments/assets/fc0117f7-6abc-4ce5-afd2-b0511c51d0a2" /><br/><img width="578" alt="Screenshot 2025-02-03 at 10 30 56 AM" src="https://github.com/user-attachments/assets/731d7d9a-5416-4e90-9226-2280bc1ce44d" /> |





<!-- ## Follow-ups -->
