### PR TITLE
feat: Update collection sorting & metadata

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -409,7 +409,9 @@ class CollectionOps:
         elif access:
             match_query["access"] = access
 
-        aggregate = [{"$match": match_query}]
+        aggregate: List[Dict[str, Dict[str, Union[int, object]]]] = [
+            {"$match": match_query}
+        ]
 
         if sort_by:
             if sort_by not in (

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -396,7 +396,7 @@ class CollectionOps:
         page = page - 1
         skip = page * page_size
 
-        match_query: dict[str, Union[str, UUID, int, object]] = {"oid": org.id}
+        match_query: Dict[str, Union[str, UUID, int, object]] = {"oid": org.id}
 
         if name:
             match_query["name"] = name
@@ -409,7 +409,9 @@ class CollectionOps:
         elif access:
             match_query["access"] = access
 
-        aggregate = [{"$match": match_query}]
+        aggregate: List[Dict[str, Union[str, UUID, int, object]]] = [
+            {"$match": match_query}
+        ]
 
         if sort_by:
             if sort_by not in (

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -409,7 +409,9 @@ class CollectionOps:
         elif access:
             match_query["access"] = access
 
-        aggregate: List[Dict[str, Dict[str, object]]] = [{"$match": match_query}]
+        aggregate: List[Dict[str, Dict[str, Union[int, object]]]] = [
+            {"$match": match_query}
+        ]
 
         if sort_by:
             if sort_by not in (

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -415,17 +415,23 @@ class CollectionOps:
             if sort_by not in (
                 "created",
                 "modified",
-                "dateEarliest",
                 "dateLatest",
                 "name",
-                "description",
+                "crawlCount",
+                "pageCount",
                 "totalSize",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
 
-            aggregate.extend([{"$sort": {sort_by: sort_direction}}])
+            sort_query = {sort_by: sort_direction}
+
+            # add secondary sort keys:
+            if sort_by == "dateLatest":
+                sort_query["dateEarliest"] = sort_direction
+
+            aggregate.extend([{"$sort": sort_query}])
 
         aggregate.extend(
             [

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -396,7 +396,7 @@ class CollectionOps:
         page = page - 1
         skip = page * page_size
 
-        match_query: dict[str, object] = {"oid": org.id}
+        match_query: dict[str, Union[str, UUID, int, object]] = {"oid": org.id}
 
         if name:
             match_query["name"] = name
@@ -409,9 +409,7 @@ class CollectionOps:
         elif access:
             match_query["access"] = access
 
-        aggregate: List[Dict[str, Dict[str, Union[int, object]]]] = [
-            {"$match": match_query}
-        ]
+        aggregate = [{"$match": match_query}]
 
         if sort_by:
             if sort_by not in (
@@ -429,7 +427,7 @@ class CollectionOps:
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
 
-            sort_query: Dict[str, int] = {sort_by: sort_direction}
+            sort_query = {sort_by: sort_direction}
 
             # add secondary sort keys:
             if sort_by == "dateLatest":

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -422,6 +422,8 @@ class CollectionOps:
                 "crawlCount",
                 "pageCount",
                 "totalSize",
+                "description",
+                "caption",
             ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -412,7 +412,15 @@ class CollectionOps:
         aggregate = [{"$match": match_query}]
 
         if sort_by:
-            if sort_by not in ("modified", "name", "description", "totalSize"):
+            if sort_by not in (
+                "created",
+                "modified",
+                "dateEarliest",
+                "dateLatest",
+                "name",
+                "description",
+                "totalSize",
+            ):
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -409,9 +409,7 @@ class CollectionOps:
         elif access:
             match_query["access"] = access
 
-        aggregate: List[Dict[str, Dict[str, Union[int, object]]]] = [
-            {"$match": match_query}
-        ]
+        aggregate: List[Dict[str, Dict[str, object]]] = [{"$match": match_query}]
 
         if sort_by:
             if sort_by not in (
@@ -429,7 +427,7 @@ class CollectionOps:
             if sort_direction not in (1, -1):
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
 
-            sort_query = {sort_by: sort_direction}
+            sort_query: Dict[str, int] = {sort_by: sort_direction}
 
             # add secondary sort keys:
             if sort_by == "dateLatest":

--- a/frontend/src/features/collections/collection-metadata-dialog.ts
+++ b/frontend/src/features/collections/collection-metadata-dialog.ts
@@ -135,12 +135,13 @@ export class CollectionMetadataDialog extends BtrixElement {
             <sl-tooltip>
               <span slot="content">
                 ${msg(
-                  "Write a short description that summarizes this collection. If the collection is public, this description will be visible next to the collection name.",
+                  "Write a short description that summarizes this collection. If the collection is shareable, this will appear next to the collection name.",
                 )}
                 ${this.collection
                   ? nothing
                   : msg(
-                      "You can write a longer description in the 'About' section after creating the collection.",
+                      html`You can add a longer description in the “About”
+                      section after creating the collection.`,
                     )}
               </span>
               <sl-icon

--- a/frontend/src/layouts/collections/metadataColumn.ts
+++ b/frontend/src/layouts/collections/metadataColumn.ts
@@ -1,0 +1,57 @@
+import { msg } from "@lit/localize";
+import { html, type TemplateResult } from "lit";
+import { when } from "lit/directives/when.js";
+
+import { monthYearDateRange } from "@/strings/utils";
+import type { Collection, PublicCollection } from "@/types/collection";
+import localize from "@/utils/localize";
+import { pluralOf } from "@/utils/pluralize";
+
+export function metadataItemWithCollection(
+  collection?: Collection | PublicCollection,
+) {
+  return function metadataItem({
+    label,
+    render,
+  }: {
+    label: string | TemplateResult;
+    render: (c: PublicCollection) => TemplateResult | string;
+  }) {
+    return html`
+      <btrix-desc-list-item label=${label}>
+        ${when(
+          collection,
+          render,
+          () => html`<sl-skeleton class="w-full"></sl-skeleton>`,
+        )}
+      </btrix-desc-list-item>
+    `;
+  };
+}
+
+export function metadataColumn(collection?: Collection | PublicCollection) {
+  const metadataItem = metadataItemWithCollection(collection);
+
+  return html`
+    <btrix-desc-list>
+      ${metadataItem({
+        label: msg("Collection Period"),
+        render: (col) => html`
+          <span class="font-sans">
+            ${monthYearDateRange(col.dateEarliest, col.dateLatest)}
+          </span>
+        `,
+      })}
+      ${metadataItem({
+        label: msg("Pages in Collection"),
+        render: (col) =>
+          `${localize.number(col.pageCount)} ${pluralOf("pages", col.pageCount)}`,
+      })}
+      ${metadataItem({
+        label: msg("Total Page Snapshots"),
+        render: (col) =>
+          `${localize.number(col.snapshotCount)} ${pluralOf("snapshots", col.snapshotCount)}`,
+      })}
+    </btrix-desc-list>
+  `;
+}

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -6,9 +6,9 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import { metadataColumn } from "@/layouts/collections/metadataColumn";
 import { page } from "@/layouts/page";
 import { RouteNamespace } from "@/routes";
-import { monthYearDateRange } from "@/strings/utils";
 import type { PublicCollection } from "@/types/collection";
 import type { PublicOrgCollections } from "@/types/org";
 import { formatRwpTimestamp } from "@/utils/replay";
@@ -213,24 +213,7 @@ export class Collection extends BtrixElement {
   }
 
   private renderAbout(collection: PublicCollection) {
-    const metadata = html`
-      <btrix-desc-list>
-        <btrix-desc-list-item label=${msg("Collection Period")}>
-          <span class="font-sans">
-            ${monthYearDateRange(
-              collection.dateEarliest,
-              collection.dateLatest,
-            )}
-          </span>
-        </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Total Pages")}>
-          ${this.localize.number(collection.pageCount)}
-        </btrix-desc-list-item>
-        <btrix-desc-list-item label=${msg("Collection Size")}>
-          ${this.localize.bytes(collection.totalSize)}
-        </btrix-desc-list-item>
-      </btrix-desc-list>
-    `;
+    const metadata = metadataColumn(collection);
 
     if (collection.description) {
       return html`

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -1,4 +1,4 @@
-import { localized, msg, str } from "@lit/localize";
+import { localized, msg } from "@lit/localize";
 import { Task, TaskStatus } from "@lit/task";
 import { html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -8,6 +8,7 @@ import { when } from "lit/directives/when.js";
 import { BtrixElement } from "@/classes/BtrixElement";
 import { page } from "@/layouts/page";
 import { RouteNamespace } from "@/routes";
+import { monthYearDateRange } from "@/strings/utils";
 import type { PublicCollection } from "@/types/collection";
 import type { PublicOrgCollections } from "@/types/org";
 import { formatRwpTimestamp } from "@/utils/replay";
@@ -211,30 +212,16 @@ export class Collection extends BtrixElement {
     `;
   }
 
-  // TODO Consolidate with collection-detail.ts
   private renderAbout(collection: PublicCollection) {
-    const dateRange = () => {
-      if (!collection.dateEarliest || !collection.dateLatest) {
-        return msg("n/a");
-      }
-      const format: Intl.DateTimeFormatOptions = {
-        month: "long",
-        year: "numeric",
-      };
-      const dateEarliest = this.localize.date(collection.dateEarliest, format);
-      const dateLatest = this.localize.date(collection.dateLatest, format);
-
-      if (dateEarliest === dateLatest) return dateLatest;
-
-      return msg(str`${dateEarliest} to ${dateLatest}`, {
-        desc: "Date range formatted to show full month name and year",
-      });
-    };
-
     const metadata = html`
       <btrix-desc-list>
         <btrix-desc-list-item label=${msg("Collection Period")}>
-          <span class="font-sans">${dateRange()}</span>
+          <span class="font-sans">
+            ${monthYearDateRange(
+              collection.dateEarliest,
+              collection.dateLatest,
+            )}
+          </span>
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Total Pages")}>
           ${this.localize.number(collection.pageCount)}

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -38,6 +38,7 @@ import type {
 } from "@/types/api";
 import type { ArchivedItem, ArchivedItemPageComment } from "@/types/crawler";
 import type { ArchivedItemQAPage, QARun } from "@/types/qa";
+import { SortDirection as APISortDirection } from "@/types/utils";
 import {
   isActive,
   isSuccessfullyFinished,
@@ -553,7 +554,8 @@ export class ArchivedItemQA extends BtrixElement {
             .pages=${this.pages}
             .orderBy=${{
               field: this.sortPagesBy.sortBy,
-              direction: (this.sortPagesBy.sortDirection === -1
+              direction: (this.sortPagesBy.sortDirection ===
+              APISortDirection.Descending
                 ? "desc"
                 : "asc") as SortDirection,
             }}

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -15,6 +15,7 @@ import type { PageChangeEvent } from "@/components/ui/pagination";
 import { SelectCollectionAccess } from "@/features/collections/select-collection-access";
 import type { ShareCollection } from "@/features/collections/share-collection";
 import { pageHeader, pageNav, type Breadcrumb } from "@/layouts/pageHeader";
+import { monthYearDateRange } from "@/strings/utils";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -509,6 +510,7 @@ export class CollectionDetail extends BtrixElement {
               year="numeric"
               hour="numeric"
               minute="numeric"
+              time-zone-name="short"
             ></btrix-format-date>`,
         )}
       </btrix-desc-list>
@@ -530,32 +532,19 @@ export class CollectionDetail extends BtrixElement {
     `;
   }
 
-  // TODO Consolidate with collection.ts
   private renderAbout() {
-    const dateRange = (collection: Collection) => {
-      if (!collection.dateEarliest || !collection.dateLatest) {
-        return msg("n/a");
-      }
-      const format: Intl.DateTimeFormatOptions = {
-        month: "long",
-        year: "numeric",
-      };
-      const dateEarliest = this.localize.date(collection.dateEarliest, format);
-      const dateLatest = this.localize.date(collection.dateLatest, format);
-
-      if (dateEarliest === dateLatest) return dateLatest;
-
-      return msg(str`${dateEarliest} to ${dateLatest}`, {
-        desc: "Date range formatted to show full month name and year",
-      });
-    };
     const skeleton = html`<sl-skeleton class="w-24"></sl-skeleton>`;
 
     const metadata = html`
       <btrix-desc-list>
         <btrix-desc-list-item label=${msg("Collection Period")}>
           <span class="font-sans"
-            >${this.collection ? dateRange(this.collection) : skeleton}</span
+            >${this.collection
+              ? monthYearDateRange(
+                  this.collection.dateEarliest,
+                  this.collection.dateLatest,
+                )
+              : skeleton}</span
           >
         </btrix-desc-list-item>
       </btrix-desc-list>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -14,14 +14,21 @@ import type { MarkdownEditor } from "@/components/ui/markdown-editor";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { SelectCollectionAccess } from "@/features/collections/select-collection-access";
 import type { ShareCollection } from "@/features/collections/share-collection";
+import {
+  metadataColumn,
+  metadataItemWithCollection,
+} from "@/layouts/collections/metadataColumn";
 import { pageHeader, pageNav, type Breadcrumb } from "@/layouts/pageHeader";
-import { monthYearDateRange } from "@/strings/utils";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
   APISortQuery,
 } from "@/types/api";
-import { CollectionAccess, type Collection } from "@/types/collection";
+import {
+  CollectionAccess,
+  type Collection,
+  type PublicCollection,
+} from "@/types/collection";
 import type { ArchivedItem, Crawl, Upload } from "@/types/crawler";
 import type { CrawlState } from "@/types/crawlState";
 import { pluralOf } from "@/utils/pluralize";
@@ -473,16 +480,6 @@ export class CollectionDetail extends BtrixElement {
           (col) =>
             `${this.localize.number(col.crawlCount)} ${pluralOf("items", col.crawlCount)}`,
         )}
-        ${this.renderDetailItem(msg("Total Size"), (col) =>
-          this.localize.bytes(col.totalSize || 0, {
-            unitDisplay: "narrow",
-          }),
-        )}
-        ${this.renderDetailItem(
-          msg("Total Pages"),
-          (col) =>
-            `${this.localize.number(col.pageCount)} ${pluralOf("pages", col.pageCount)}`,
-        )}
         ${when(this.collection?.created, (created) =>
           // Collections created before 49516bc4 is released may not have date in db
           created
@@ -496,6 +493,7 @@ export class CollectionDetail extends BtrixElement {
                     year="numeric"
                     hour="numeric"
                     minute="numeric"
+                    time-zone-name="short"
                   ></btrix-format-date>`,
               )
             : nothing,
@@ -519,54 +517,58 @@ export class CollectionDetail extends BtrixElement {
 
   private renderDetailItem(
     label: string | TemplateResult,
-    renderContent: (collection: Collection) => TemplateResult | string,
+    renderContent: (collection: PublicCollection) => TemplateResult | string,
   ) {
-    return html`
-      <btrix-desc-list-item label=${label}>
-        ${when(
-          this.collection,
-          () => renderContent(this.collection!),
-          () => html`<sl-skeleton class="w-full"></sl-skeleton>`,
-        )}
-      </btrix-desc-list-item>
-    `;
+    return metadataItemWithCollection(this.collection)({
+      label,
+      render: renderContent,
+    });
   }
 
   private renderAbout() {
-    const skeleton = html`<sl-skeleton class="w-24"></sl-skeleton>`;
-
-    const metadata = html`
-      <btrix-desc-list>
-        <btrix-desc-list-item label=${msg("Collection Period")}>
-          <span class="font-sans"
-            >${this.collection
-              ? monthYearDateRange(
-                  this.collection.dateEarliest,
-                  this.collection.dateLatest,
-                )
-              : skeleton}</span
-          >
-        </btrix-desc-list-item>
-      </btrix-desc-list>
-    `;
+    const metadata = metadataColumn(this.collection);
 
     return html`
       <div class="flex flex-1 flex-col gap-10 lg:flex-row">
         <section class="flex w-full max-w-4xl flex-col leading-relaxed">
-          <header class="mb-3 flex min-h-8 items-end justify-between">
-            <h2 class="text-base font-semibold leading-none">
-              ${msg("Description")}
-            </h2>
+          <header class="mb-2 flex min-h-8 items-center justify-between">
+            <div class="flex items-center gap-2">
+              <h2 class="text-base font-medium">
+                ${msg("About This Collection")}
+              </h2>
+              <sl-tooltip>
+                <div slot="content">
+                  <p class="mb-3">
+                    ${msg(
+                      html`Describe your collection in long-form rich text (e.g.
+                        <strong>bold</strong> and <em>italicized</em> text.)`,
+                    )}
+                  </p>
+                  <p>
+                    ${msg(
+                      html`If this collection is shareable, this will appear in
+                      the “About This Collection” section of the shared
+                      collection.`,
+                    )}
+                  </p>
+                </div>
+                <sl-icon
+                  name="info-circle"
+                  class="size-4 text-base text-neutral-500 [vertical-align:-.175em]"
+                ></sl-icon>
+              </sl-tooltip>
+            </div>
             ${when(
               this.collection?.description && !this.isEditingDescription,
               () => html`
-                <sl-button
-                  size="small"
-                  @click=${() => (this.isEditingDescription = true)}
-                >
-                  <sl-icon name="pencil" slot="prefix"></sl-icon>
-                  ${msg("Edit Description")}
-                </sl-button>
+                <sl-tooltip content=${msg("Edit description")}>
+                  <sl-icon-button
+                    class="text-base"
+                    name="pencil"
+                    @click=${() => (this.isEditingDescription = true)}
+                  >
+                  </sl-icon-button>
+                </sl-tooltip>
               `,
             )}
           </header>
@@ -591,7 +593,7 @@ export class CollectionDetail extends BtrixElement {
                           `
                         : html`
                             <div class="text-center text-neutral-500">
-                              <p class="mb-3">
+                              <p class="mb-3 max-w-prose">
                                 ${msg("No description provided.")}
                               </p>
                               <sl-button

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -51,7 +51,7 @@ export class CollectionDetail extends BtrixElement {
   collectionId!: string;
 
   @property({ type: String })
-  collectionTab: Tab = Tab.Replay;
+  collectionTab: Tab | null = Tab.Replay;
 
   @state()
   private collection?: Collection;
@@ -112,6 +112,9 @@ export class CollectionDetail extends BtrixElement {
     if (changedProperties.has("collectionId")) {
       void this.fetchCollection();
       void this.fetchArchivedItems({ page: 1 });
+    }
+    if (changedProperties.has("collectionTab") && this.collectionTab === null) {
+      this.collectionTab = Tab.Replay;
     }
   }
 

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -500,7 +500,7 @@ export class CollectionDetail extends BtrixElement {
             : nothing,
         )}
         ${this.renderDetailItem(
-          msg("Last Updated"),
+          msg("Last Modified"),
           (col) =>
             html`<btrix-format-date
               date=${col.modified}

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -381,7 +381,7 @@ export class CollectionsList extends BtrixElement {
       return html`
         <btrix-table
           class="[--btrix-column-gap:var(--sl-spacing-small)]"
-          style="grid-template-columns: min-content [clickable-start] 48em repeat(4, 1fr) [clickable-end] min-content"
+          style="grid-template-columns: min-content [clickable-start] 45em repeat(4, 1fr) [clickable-end] min-content"
         >
           <btrix-table-head class="mb-2 whitespace-nowrap">
             <btrix-table-header-cell>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -39,7 +39,7 @@ type SearchResult = {
     value: string;
   };
 };
-type SortField = "modified" | "dateLatest" | "name" | "totalSize";
+type SortField = "modified" | "dateLatest" | "name" | "totalSize" | "pageCount";
 const INITIAL_PAGE_SIZE = 20;
 const sortableFields: Record<
   SortField,
@@ -59,6 +59,10 @@ const sortableFields: Record<
   },
   totalSize: {
     label: msg("Size"),
+    defaultDirection: SortDirection.Descending,
+  },
+  pageCount: {
+    label: msg("Pages"),
     defaultDirection: SortDirection.Descending,
   },
 };

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -39,7 +39,13 @@ type SearchResult = {
     value: string;
   };
 };
-type SortField = "modified" | "dateLatest" | "name" | "totalSize" | "pageCount";
+type SortField =
+  | "modified"
+  | "dateLatest"
+  | "name"
+  | "totalSize"
+  | "pageCount"
+  | "crawlCount";
 const INITIAL_PAGE_SIZE = 20;
 const sortableFields: Record<
   SortField,
@@ -49,16 +55,20 @@ const sortableFields: Record<
     label: msg("Name"),
     defaultDirection: SortDirection.Ascending,
   },
-  totalSize: {
-    label: msg("Size"),
+  dateLatest: {
+    label: msg("Collection Period"),
+    defaultDirection: SortDirection.Descending,
+  },
+  crawlCount: {
+    label: msg("Archived Items"),
     defaultDirection: SortDirection.Descending,
   },
   pageCount: {
     label: msg("Pages"),
     defaultDirection: SortDirection.Descending,
   },
-  dateLatest: {
-    label: msg("Collection Period"),
+  totalSize: {
+    label: msg("Size"),
     defaultDirection: SortDirection.Descending,
   },
   modified: {
@@ -371,25 +381,20 @@ export class CollectionsList extends BtrixElement {
       return html`
         <btrix-table
           class="[--btrix-column-gap:var(--sl-spacing-small)]"
-          style="grid-template-columns: min-content [clickable-start] 50ch repeat(5, 1fr) [clickable-end] min-content"
+          style="grid-template-columns: min-content [clickable-start] 48em repeat(4, 1fr) [clickable-end] min-content"
         >
           <btrix-table-head class="mb-2 whitespace-nowrap">
             <btrix-table-header-cell>
               <span class="sr-only">${msg("Collection Access")}</span>
             </btrix-table-header-cell>
-            <btrix-table-header-cell>${msg("Name")}</btrix-table-header-cell>
+            <btrix-table-header-cell>
+              ${msg(html`Name & Collection Period`)}
+            </btrix-table-header-cell>
             <btrix-table-header-cell>
               ${msg("Archived Items")}
             </btrix-table-header-cell>
-            <btrix-table-header-cell>
-              ${msg("Total Size")}
-            </btrix-table-header-cell>
-            <btrix-table-header-cell>
-              ${msg("Total Pages")}
-            </btrix-table-header-cell>
-            <btrix-table-header-cell>
-              ${msg("Collection Period")}
-            </btrix-table-header-cell>
+            <btrix-table-header-cell>${msg("Pages")}</btrix-table-header-cell>
+            <btrix-table-header-cell>${msg("Size")}</btrix-table-header-cell>
             <btrix-table-header-cell>
               ${msg("Last Modified")}
             </btrix-table-header-cell>
@@ -525,7 +530,10 @@ export class CollectionsList extends BtrixElement {
           href=${`${this.navigate.orgBasePath}/collections/view/${col.id}`}
           @click=${this.navigate.link}
         >
-          ${col.name}
+          <div class="mb-0.5 truncate">${col.name}</div>
+          <div class="text-xs leading-4 text-neutral-500">
+            ${monthYearDateRange(col.dateEarliest, col.dateLatest)}
+          </div>
         </a>
       </btrix-table-cell>
       <btrix-table-cell>
@@ -533,16 +541,13 @@ export class CollectionsList extends BtrixElement {
         ${pluralOf("items", col.crawlCount)}
       </btrix-table-cell>
       <btrix-table-cell>
-        ${this.localize.bytes(col.totalSize || 0, {
-          unitDisplay: "narrow",
-        })}
-      </btrix-table-cell>
-      <btrix-table-cell>
         ${this.localize.number(col.pageCount, { notation: "compact" })}
         ${pluralOf("pages", col.pageCount)}
       </btrix-table-cell>
       <btrix-table-cell>
-        ${monthYearDateRange(col.dateEarliest, col.dateLatest)}
+        ${this.localize.bytes(col.totalSize || 0, {
+          unitDisplay: "narrow",
+        })}
       </btrix-table-cell>
       <btrix-table-cell>
         <btrix-format-date

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -45,14 +45,6 @@ const sortableFields: Record<
   SortField,
   { label: string; defaultDirection?: SortDirection }
 > = {
-  modified: {
-    label: msg("Last Modified"),
-    defaultDirection: SortDirection.Descending,
-  },
-  dateLatest: {
-    label: msg("Collection Period"),
-    defaultDirection: SortDirection.Descending,
-  },
   name: {
     label: msg("Name"),
     defaultDirection: SortDirection.Ascending,
@@ -63,6 +55,14 @@ const sortableFields: Record<
   },
   pageCount: {
     label: msg("Pages"),
+    defaultDirection: SortDirection.Descending,
+  },
+  dateLatest: {
+    label: msg("Collection Period"),
+    defaultDirection: SortDirection.Descending,
+  },
+  modified: {
+    label: msg("Last Modified"),
     defaultDirection: SortDirection.Descending,
   },
 };
@@ -379,9 +379,6 @@ export class CollectionsList extends BtrixElement {
             </btrix-table-header-cell>
             <btrix-table-header-cell>${msg("Name")}</btrix-table-header-cell>
             <btrix-table-header-cell>
-              ${msg("Collection Period")}
-            </btrix-table-header-cell>
-            <btrix-table-header-cell>
               ${msg("Archived Items")}
             </btrix-table-header-cell>
             <btrix-table-header-cell>
@@ -389,6 +386,9 @@ export class CollectionsList extends BtrixElement {
             </btrix-table-header-cell>
             <btrix-table-header-cell>
               ${msg("Total Pages")}
+            </btrix-table-header-cell>
+            <btrix-table-header-cell>
+              ${msg("Collection Period")}
             </btrix-table-header-cell>
             <btrix-table-header-cell>
               ${msg("Last Modified")}
@@ -529,9 +529,6 @@ export class CollectionsList extends BtrixElement {
         </a>
       </btrix-table-cell>
       <btrix-table-cell>
-        ${monthYearDateRange(col.dateEarliest, col.dateLatest)}
-      </btrix-table-cell>
-      <btrix-table-cell>
         ${this.localize.number(col.crawlCount, { notation: "compact" })}
         ${pluralOf("items", col.crawlCount)}
       </btrix-table-cell>
@@ -543,6 +540,9 @@ export class CollectionsList extends BtrixElement {
       <btrix-table-cell>
         ${this.localize.number(col.pageCount, { notation: "compact" })}
         ${pluralOf("pages", col.pageCount)}
+      </btrix-table-cell>
+      <btrix-table-cell>
+        ${monthYearDateRange(col.dateEarliest, col.dateLatest)}
       </btrix-table-cell>
       <btrix-table-cell>
         <btrix-format-date

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -19,6 +19,7 @@ import { SelectCollectionAccess } from "@/features/collections/select-collection
 import { emptyMessage } from "@/layouts/emptyMessage";
 import { pageHeader } from "@/layouts/pageHeader";
 import { RouteNamespace } from "@/routes";
+import { monthYearDateRange } from "@/strings/utils";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import {
   CollectionAccess,
@@ -366,13 +367,16 @@ export class CollectionsList extends BtrixElement {
       return html`
         <btrix-table
           class="[--btrix-column-gap:var(--sl-spacing-small)]"
-          style="grid-template-columns: min-content [clickable-start] 50ch repeat(4, 1fr) [clickable-end] min-content"
+          style="grid-template-columns: min-content [clickable-start] 50ch repeat(5, 1fr) [clickable-end] min-content"
         >
           <btrix-table-head class="mb-2 whitespace-nowrap">
             <btrix-table-header-cell>
               <span class="sr-only">${msg("Collection Access")}</span>
             </btrix-table-header-cell>
             <btrix-table-header-cell>${msg("Name")}</btrix-table-header-cell>
+            <btrix-table-header-cell>
+              ${msg("Collection Period")}
+            </btrix-table-header-cell>
             <btrix-table-header-cell>
               ${msg("Archived Items")}
             </btrix-table-header-cell>
@@ -521,6 +525,9 @@ export class CollectionsList extends BtrixElement {
         </a>
       </btrix-table-cell>
       <btrix-table-cell>
+        ${monthYearDateRange(col.dateEarliest, col.dateLatest)}
+      </btrix-table-cell>
+      <btrix-table-cell>
         ${this.localize.number(col.crawlCount, { notation: "compact" })}
         ${pluralOf("items", col.crawlCount)}
       </btrix-table-cell>
@@ -539,8 +546,6 @@ export class CollectionsList extends BtrixElement {
           month="2-digit"
           day="2-digit"
           year="2-digit"
-          hour="2-digit"
-          minute="2-digit"
         ></btrix-format-date>
       </btrix-table-cell>
       <btrix-table-cell class="p-0">

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -25,7 +25,7 @@ import {
   type Collection,
   type CollectionSearchValues,
 } from "@/types/collection";
-import type { UnderlyingFunction } from "@/types/utils";
+import { SortDirection, type UnderlyingFunction } from "@/types/utils";
 import { isApiError } from "@/utils/api";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
@@ -38,24 +38,27 @@ type SearchResult = {
     value: string;
   };
 };
-type SortField = "modified" | "name" | "totalSize";
-type SortDirection = "asc" | "desc";
+type SortField = "modified" | "dateLatest" | "name" | "totalSize";
 const INITIAL_PAGE_SIZE = 20;
 const sortableFields: Record<
   SortField,
   { label: string; defaultDirection?: SortDirection }
 > = {
   modified: {
-    label: msg("Last Updated"),
-    defaultDirection: "desc",
+    label: msg("Last Modified"),
+    defaultDirection: SortDirection.Descending,
+  },
+  dateLatest: {
+    label: msg("Collection Period"),
+    defaultDirection: SortDirection.Descending,
   },
   name: {
     label: msg("Name"),
-    defaultDirection: "asc",
+    defaultDirection: SortDirection.Ascending,
   },
   totalSize: {
     label: msg("Size"),
-    defaultDirection: "desc",
+    defaultDirection: SortDirection.Descending,
   },
 };
 const MIN_SEARCH_LENGTH = 2;
@@ -269,7 +272,7 @@ export class CollectionsList extends BtrixElement {
               @click=${() => {
                 this.orderBy = {
                   ...this.orderBy,
-                  direction: this.orderBy.direction === "asc" ? "desc" : "asc",
+                  direction: -1 * this.orderBy.direction,
                 };
               }}
             ></sl-icon-button>
@@ -380,7 +383,7 @@ export class CollectionsList extends BtrixElement {
               ${msg("Total Pages")}
             </btrix-table-header-cell>
             <btrix-table-header-cell>
-              ${msg("Last Updated")}
+              ${msg("Last Modified")}
             </btrix-table-header-cell>
             <btrix-table-header-cell>
               <span class="sr-only">${msg("Row Actions")}</span>
@@ -783,7 +786,7 @@ export class CollectionsList extends BtrixElement {
           this.collections?.pageSize ||
           INITIAL_PAGE_SIZE,
         sortBy: this.orderBy.field,
-        sortDirection: this.orderBy.direction === "desc" ? -1 : 1,
+        sortDirection: this.orderBy.direction,
       },
       {
         arrayFormat: "comma",

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -5,6 +5,7 @@ import { html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
+import queryString from "query-string";
 
 import type { SelectNewDialogEvent } from ".";
 
@@ -13,8 +14,9 @@ import { ClipboardController } from "@/controllers/clipboard";
 import { pageHeading } from "@/layouts/page";
 import { pageHeader } from "@/layouts/pageHeader";
 import { RouteNamespace } from "@/routes";
-import type { PublicCollection } from "@/types/collection";
-import type { PublicOrgCollections } from "@/types/org";
+import type { APIPaginatedList, APISortQuery } from "@/types/api";
+import { CollectionAccess, type Collection } from "@/types/collection";
+import { SortDirection } from "@/types/utils";
 import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { tw } from "@/utils/tailwind";
 
@@ -56,16 +58,13 @@ export class Dashboard extends BtrixElement {
   };
 
   private readonly publicCollections = new Task(this, {
-    task: async ([slug, metrics]) => {
-      if (!slug) throw new Error("slug required");
+    task: async ([orgId]) => {
+      if (!orgId) throw new Error("orgId required");
 
-      if (!metrics) return undefined;
-      if (!metrics.publicCollectionsCount) return [];
-
-      const collections = await this.fetchCollections({ slug });
+      const collections = await this.getPublicCollections({ orgId });
       return collections;
     },
-    args: () => [this.orgSlugState, this.metrics] as const,
+    args: () => [this.orgId] as const,
   });
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
@@ -368,29 +367,16 @@ export class Dashboard extends BtrixElement {
     let button: TemplateResult;
 
     if (this.metrics.collectionsCount) {
-      if (this.org.enablePublicProfile) {
-        button = html`
-          <sl-button
-            @click=${() => {
-              this.navigate.to(`${this.navigate.orgBasePath}/collections`);
-            }}
-          >
-            <sl-icon slot="prefix" name="collection-fill"></sl-icon>
-            ${msg("Manage Collections")}
-          </sl-button>
-        `;
-      } else {
-        button = html`
-          <sl-button
-            @click=${() => {
-              this.navigate.to(`${this.navigate.orgBasePath}/settings`);
-            }}
-          >
-            <sl-icon slot="prefix" name="gear"></sl-icon>
-            ${msg("Update Org Visibility")}
-          </sl-button>
-        `;
-      }
+      button = html`
+        <sl-button
+          @click=${() => {
+            this.navigate.to(`${this.navigate.orgBasePath}/collections`);
+          }}
+        >
+          <sl-icon slot="prefix" name="collection-fill"></sl-icon>
+          ${msg("Manage Collections")}
+        </sl-button>
+      `;
     } else {
       button = html`
         <sl-button
@@ -846,22 +832,20 @@ export class Dashboard extends BtrixElement {
     }
   }
 
-  private async fetchCollections({
-    slug,
-  }: {
-    slug: string;
-  }): Promise<PublicCollection[]> {
-    const resp = await fetch(`/api/public/orgs/${slug}/collections`, {
-      headers: { "Content-Type": "application/json" },
-    });
+  private async getPublicCollections({ orgId }: { orgId: string }) {
+    const params: APISortQuery<Collection> & {
+      access: CollectionAccess;
+    } = {
+      sortBy: "dateLatest",
+      sortDirection: SortDirection.Descending,
+      access: CollectionAccess.Public,
+    };
+    const query = queryString.stringify(params);
 
-    switch (resp.status) {
-      case 200:
-        return ((await resp.json()) as PublicOrgCollections).collections;
-      case 404:
-        return [];
-      default:
-        throw resp.status;
-    }
+    const data = await this.api.fetch<APIPaginatedList<Collection>>(
+      `/orgs/${orgId}/collections?${query}`,
+    );
+
+    return data.items;
   }
 }

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -1,7 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import { Task } from "@lit/task";
 import type { SlSelectEvent } from "@shoelace-style/shoelace";
-import { html, type PropertyValues, type TemplateResult } from "lit";
+import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
@@ -333,15 +333,17 @@ export class Dashboard extends BtrixElement {
                               ${msg("Copy Link to Profile")}
                             </sl-menu-item>
                           `
-                        : html`
-                            <sl-divider></sl-divider>
-                            <btrix-menu-item-link
-                              href=${`${this.navigate.orgBasePath}/settings`}
-                            >
-                              <sl-icon slot="prefix" name="gear"></sl-icon>
-                              ${msg("Update Org Visibility")}
-                            </btrix-menu-item-link>
-                          `,
+                        : this.appState.isAdmin
+                          ? html`
+                              <sl-divider></sl-divider>
+                              <btrix-menu-item-link
+                                href=${`${this.navigate.orgBasePath}/settings`}
+                              >
+                                <sl-icon slot="prefix" name="gear"></sl-icon>
+                                ${msg("Update Org Profile")}
+                              </btrix-menu-item-link>
+                            `
+                          : nothing,
                     )}
                   </sl-menu>
                 </btrix-overflow-dropdown>

--- a/frontend/src/pages/org/profile.ts
+++ b/frontend/src/pages/org/profile.ts
@@ -246,7 +246,13 @@ export class OrgProfile extends BtrixElement {
   }: {
     slug: string;
   }): Promise<PublicOrgCollections | void> {
-    const resp = await fetch(`/api/public/orgs/${slug}/collections`, {
+    const params: APISortQuery<Collection> = {
+      sortBy: "dateLatest",
+      sortDirection: SortDirection.Descending,
+    };
+    const query = queryString.stringify(params);
+
+    const resp = await fetch(`/api/public/orgs/${slug}/collections?${query}`, {
       headers: { "Content-Type": "application/json" },
     });
 
@@ -281,7 +287,7 @@ export class OrgProfile extends BtrixElement {
       }
 
       const org = await this.api.fetch<OrgData>(`/orgs/${userOrg.id}`);
-      const collections = await this.getPublicCollections({
+      const collections = await this.getUserPublicCollections({
         orgId: this.orgId,
       });
 
@@ -299,7 +305,7 @@ export class OrgProfile extends BtrixElement {
     }
   }
 
-  private async getPublicCollections({ orgId }: { orgId: string }) {
+  private async getUserPublicCollections({ orgId }: { orgId: string }) {
     const params: APISortQuery<Collection> & {
       access: CollectionAccess;
     } = {

--- a/frontend/src/strings/ui.ts
+++ b/frontend/src/strings/ui.ts
@@ -1,6 +1,9 @@
 import { msg } from "@lit/localize";
 import { html, type TemplateResult } from "lit";
 
+export const noData = "--";
+export const notApplicable = msg("n/a");
+
 // TODO Refactor all generic confirmation messages to use utility
 export const deleteConfirmation = (name: string | TemplateResult) =>
   msg(html`

--- a/frontend/src/strings/utils.ts
+++ b/frontend/src/strings/utils.ts
@@ -1,0 +1,25 @@
+import { msg, str } from "@lit/localize";
+
+import { noData } from "@/strings/ui";
+import localize from "@/utils/localize";
+
+export const monthYearDateRange = (
+  startDate?: string | null,
+  endDate?: string | null,
+): string => {
+  if (!startDate || !endDate) {
+    return noData;
+  }
+  const format: Intl.DateTimeFormatOptions = {
+    month: "long",
+    year: "numeric",
+  };
+  const startMonthYear = localize.date(startDate, format);
+  const endMonthYear = localize.date(endDate, format);
+
+  if (startMonthYear === endMonthYear) return endMonthYear;
+
+  return msg(str`${startMonthYear} to ${endMonthYear}`, {
+    desc: "Date range formatted to show full month name and year",
+  });
+};

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -30,7 +30,7 @@ export type APIPaginationQuery = {
   pageSize?: number;
 };
 
-export type APISortQuery = {
-  sortBy?: string;
+export type APISortQuery<T = Record<string, unknown>> = {
+  sortBy?: keyof T;
   sortDirection?: SortDirection;
 };

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -11,6 +11,8 @@ export const publicCollectionSchema = z.object({
   slug: z.string(),
   oid: z.string(),
   name: z.string(),
+  created: z.string().datetime(),
+  modified: z.string().datetime(),
   caption: z.string().nullable(),
   description: z.string().nullable(),
   resources: z.array(z.string()),
@@ -25,6 +27,7 @@ export const publicCollectionSchema = z.object({
   defaultThumbnailName: z.string().nullable(),
   crawlCount: z.number(),
   pageCount: z.number(),
+  snapshotCount: z.number(),
   totalSize: z.number(),
   allowPublicDownload: z.boolean(),
   homeUrl: z.string().url().nullable(),
@@ -34,9 +37,6 @@ export const publicCollectionSchema = z.object({
 export type PublicCollection = z.infer<typeof publicCollectionSchema>;
 
 export const collectionSchema = publicCollectionSchema.extend({
-  id: z.string(),
-  created: z.string().datetime(),
-  modified: z.string().datetime(),
   tags: z.array(z.string()),
   access: z.nativeEnum(CollectionAccess),
 });

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -22,5 +22,7 @@ export type Range<F extends number, T extends number> = Exclude<
   Enumerate<F>
 >;
 
-/** 1 or -1, but will accept any number for easier typing where this is used **/
-export type SortDirection = -1 | 1 | (number & {});
+export enum SortDirection {
+  Descending = -1,
+  Ascending = 1,
+}

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -91,6 +91,32 @@ const plurals = {
       id: "pages.plural.other",
     }),
   },
+  snapshots: {
+    zero: msg("snapshots", {
+      desc: 'plural form of "snapshot" for zero snapshots',
+      id: "snapshots.plural.zero",
+    }),
+    one: msg("snapshot", {
+      desc: 'singular form for "snapshot"',
+      id: "snapshots.plural.one",
+    }),
+    two: msg("snapshots", {
+      desc: 'plural form of "snapshot" for two snapshots',
+      id: "snapshots.plural.two",
+    }),
+    few: msg("snapshots", {
+      desc: 'plural form of "snapshot" for few snapshots',
+      id: "snapshots.plural.few",
+    }),
+    many: msg("snapshots", {
+      desc: 'plural form of "snapshot" for many snapshots',
+      id: "snapshots.plural.many",
+    }),
+    other: msg("snapshots", {
+      desc: 'plural form of "snapshot" for multiple/other snapshots',
+      id: "snapshots.plural.other",
+    }),
+  },
   comments: {
     zero: msg("comments", {
       desc: 'plural form of "comment" for zero comments',


### PR DESCRIPTION
- Fixes https://github.com/webrecorder/browsertrix/issues/2321
- Resolves https://github.com/webrecorder/browsertrix/issues/2323

Follows https://github.com/webrecorder/browsertrix/pull/2327, should be rebased and merged afterwards

## Changes

- Refactors dashboard and org profile preview to use private API endpoint, to fix public collections not showing the org visibility is hidden
- Enables sorting collections by `dateLatest`, sorts public collections by `dateLatest` by default
- Enables sorting collections by page count
- Shows collection period (i.e. `dateEarliest` to `dateLatest`) in collections list
- Shows same collection metadata in private and public views, updates private view info bar
- Fixes "Update Org Profile" action item showing for crawler roles

## Manual testing

Requires running both backend and frontend locally.

1. Log in to org with public collections as an org admin
2. Go to org settings
3. Make org visibility private
4. Go to org dashboard. Verify public collections are shown in "Public Collections" section
5. Click "Public Collections" section action overflow button -> "Preview Public Profile". Verify public collections are shown
6. Click "Go to Settings"
7. Update org visibility to be visible
8. Click "Preview public profile page". Verify collections are ordered by collection period year

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collections | <img width="1299" alt="Screenshot 2025-01-21 at 3 53 30 PM" src="https://github.com/user-attachments/assets/70d4671f-9de2-4ee6-b016-6906b49175a4" /> |
| Collections | <img width="338" alt="Screenshot 2025-01-21 at 3 53 33 PM" src="https://github.com/user-attachments/assets/3e6ec844-7b37-4575-b388-8bfaea2b123e" /> |
| Collection (private) | <img width="1324" alt="Screenshot 2025-01-21 at 3 47 17 PM" src="https://github.com/user-attachments/assets/23d3a425-47be-497b-bc9a-c3c570a5f33c" /> |
| Collection (private & public ) | <img width="407" alt="Screenshot 2025-01-21 at 3 47 01 PM" src="https://github.com/user-attachments/assets/dbfb8f93-f64d-45c2-b3d0-c17ace5dec7d" /> |






<!-- ## Follow-ups -->
