### PR TITLE
fix: Use default collection thumbnail if selected

### DIFF
--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -71,10 +71,9 @@ export class CollectionsGrid extends BtrixElement {
                 >
                   <btrix-collection-thumbnail
                     src=${ifDefined(
-                      collection.thumbnail?.path ||
-                        Object.entries(CollectionThumbnail.Variants).find(
-                          ([name]) => name === collection.defaultThumbnailName,
-                        )?.[1].path,
+                      Object.entries(CollectionThumbnail.Variants).find(
+                        ([name]) => name === collection.defaultThumbnailName,
+                      )?.[1].path || collection.thumbnail?.path,
                     )}
                   ></btrix-collection-thumbnail>
                   ${this.renderDateBadge(collection)}


### PR DESCRIPTION
No issue, reported by @emma-sg [in Discord](https://discord.com/channels/895426029194207262/910966759165657161/1331424940687364260)

## Changes

Fixes issue where collection thumbnail is always the screenshot, even if a Browsertrix provided default thumbnail is selected after choosing the screenshot.