### PR TITLE
Add WACZ filename, depth, favIconUrl, isSeed to pages

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -17,7 +17,7 @@ from pymongo.errors import InvalidName
 from .migrations import BaseMigration
 
 
-CURR_DB_VERSION = "0041"
+CURR_DB_VERSION = "0042"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0042_page_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0042_page_filenames.py
@@ -27,18 +27,24 @@ class Migration(BaseMigration):
 
         if self.page_ops is None:
             print(
-                "Unable to add filename to pages, missing page_ops",
+                "Unable to add filename and other fields to pages, missing page_ops",
                 flush=True,
             )
             return
 
         crawl_ids_to_update = await pages_mdb.distinct("crawl_id", {"filename": None})
+
+        crawl_count = len(crawl_ids_to_update)
+        current_index = 1
+
         for crawl_id in crawl_ids_to_update:
+            print(f"Migrating archived item {current_index}/{crawl_count}", flush=True)
             try:
                 await self.page_ops.add_crawl_wacz_filename_to_pages(crawl_id)
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(
-                    f"Error adding filename to pages in item {crawl_id}: {err}",
+                    f"Error adding filename and other fields to pages in item {crawl_id}: {err}",
                     flush=True,
                 )
+            current_index += 1

--- a/backend/btrixcloud/migrations/migration_0042_page_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0042_page_filenames.py
@@ -1,0 +1,50 @@
+"""
+Migration 0042 - Add filename to pages
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0042"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+        self.page_ops = kwargs.get("page_ops")
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Add filename to all pages that don't currently have it stored,
+        iterating through each archived item and its WACZ files as necessary
+        """
+        pages_mdb = self.mdb["pages"]
+
+        crawl_ids_to_update = set()
+
+        if self.page_ops is None:
+            print(
+                "Unable to add filename to pages, missing page_ops",
+                flush=True,
+            )
+            return
+
+        async for page_raw in pages_mdb.find({"filename": None}):
+            crawl_id = page_raw.get("crawl_id")
+            if crawl_id:
+                crawl_ids_to_update.add(crawl_id)
+
+        for crawl_id in crawl_ids_to_update:
+            try:
+                await self.page_ops.add_crawl_wacz_filename_to_pages(crawl_id)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error adding filename to pages in item {crawl_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/migrations/migration_0042_page_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0042_page_filenames.py
@@ -25,8 +25,6 @@ class Migration(BaseMigration):
         """
         pages_mdb = self.mdb["pages"]
 
-        crawl_ids_to_update = set()
-
         if self.page_ops is None:
             print(
                 "Unable to add filename to pages, missing page_ops",
@@ -34,11 +32,7 @@ class Migration(BaseMigration):
             )
             return
 
-        async for page_raw in pages_mdb.find({"filename": None}):
-            crawl_id = page_raw.get("crawl_id")
-            if crawl_id:
-                crawl_ids_to_update.add(crawl_id)
-
+        crawl_ids_to_update = await pages_mdb.distinct("crawl_id", {"filename": None})
         for crawl_id in crawl_ids_to_update:
             try:
                 await self.page_ops.add_crawl_wacz_filename_to_pages(crawl_id)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2494,6 +2494,7 @@ class Page(BaseMongoModel):
     status: Optional[int] = None
     mime: Optional[str] = None
     filename: Optional[str] = None
+    depth: Optional[int] = None
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2493,6 +2493,7 @@ class Page(BaseMongoModel):
     loadState: Optional[int] = None
     status: Optional[int] = None
     mime: Optional[str] = None
+    filename: Optional[str] = None
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2495,7 +2495,7 @@ class Page(BaseMongoModel):
     mime: Optional[str] = None
     filename: Optional[str] = None
     depth: Optional[int] = None
-    faviconUrl: Optional[AnyHttpUrl] = None
+    favIconUrl: Optional[AnyHttpUrl] = None
     seed: Optional[bool] = None
 
     # manual review

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2496,7 +2496,7 @@ class Page(BaseMongoModel):
     filename: Optional[str] = None
     depth: Optional[int] = None
     favIconUrl: Optional[AnyHttpUrl] = None
-    seed: Optional[bool] = None
+    isSeed: Optional[bool] = False
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2495,6 +2495,8 @@ class Page(BaseMongoModel):
     mime: Optional[str] = None
     filename: Optional[str] = None
     depth: Optional[int] = None
+    faviconUrl: Optional[AnyHttpUrl] = None
+    seed: Optional[bool] = None
 
     # manual review
     userid: Optional[UUID] = None

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -137,7 +137,7 @@ class PageOps:
                                 "filename": filename,
                                 "depth": page_dict.get("depth"),
                                 "isSeed": page_dict.get("seed", False),
-                                "faviconUrl": page_dict.get("faviconUrl"),
+                                "favIconUrl": page_dict.get("favIconUrl"),
                             }
                         },
                     )

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -106,7 +106,12 @@ class PageOps:
         try:
             crawl = await self.crawl_ops.get_crawl_out(crawl_id)
             for wacz_file in crawl.resources:
-                wacz_filename = wacz_file.name
+
+                filename = wacz_file.name
+                name_parts = wacz_file.name.split("/")
+                if name_parts and len(name_parts) > 1:
+                    filename = name_parts[-1]
+
                 wacz_page_ids = []
 
                 stream = await self.storage_ops.sync_stream_wacz_pages([wacz_file])
@@ -123,7 +128,7 @@ class PageOps:
                 # Update pages in batch per-filename
                 await self.pages.update_many(
                     {"_id": {"$in": wacz_page_ids}},
-                    {"$set": {"filename": wacz_filename}},
+                    {"$set": {"filename": filename}},
                 )
         # pylint: disable=broad-exception-caught, raise-missing-from
         except Exception as err:

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -127,6 +127,7 @@ class PageOps:
             loadState=page_dict.get("loadState"),
             status=status,
             mime=page_dict.get("mime", "text/html"),
+            filename=page_dict.get("filename"),
             ts=(str_to_date(ts) if ts else dt_now()),
         )
         p.compute_page_type()

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -1,6 +1,7 @@
 """crawl pages"""
 
 import asyncio
+import os
 import traceback
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Tuple, List, Dict, Any, Union
@@ -110,11 +111,7 @@ class PageOps:
 
             for wacz_file in crawl.resources:
                 # Strip oid directory from filename
-                filename = wacz_file.name
-                name_parts = wacz_file.name.split("/")
-                if name_parts and len(name_parts) > 1:
-                    filename = name_parts[-1]
-
+                filename = os.path.basename(wacz_file.name)
                 page_ids_to_update = []
 
                 stream = await self.storage_ops.sync_stream_wacz_pages([wacz_file])

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -136,7 +136,7 @@ class PageOps:
                             "$set": {
                                 "filename": filename,
                                 "depth": page_dict.get("depth"),
-                                "seed": page_dict.get("seed"),
+                                "isSeed": page_dict.get("seed", False),
                                 "faviconUrl": page_dict.get("faviconUrl"),
                             }
                         },
@@ -178,7 +178,7 @@ class PageOps:
             mime=page_dict.get("mime", "text/html"),
             filename=page_dict.get("filename"),
             depth=page_dict.get("depth"),
-            seed=page_dict.get("seed"),
+            isSeed=page_dict.get("seed", False),
             favIconUrl=page_dict.get("favIconUrl"),
             ts=(str_to_date(ts) if ts else dt_now()),
         )

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -103,7 +103,7 @@ class PageOps:
             print(f"Error adding pages for crawl {crawl_id} to db: {err}", flush=True)
 
     async def add_crawl_wacz_filename_to_pages(self, crawl_id: str):
-        """Add WACZ filename to existing pages in crawl if not already set"""
+        """Add WACZ filename (and depth) to existing pages in crawl if not already set"""
         try:
             crawl = await self.crawl_ops.get_crawl_out(crawl_id)
             if not crawl.resources:
@@ -120,6 +120,7 @@ class PageOps:
                         continue
 
                     page_id = page_dict.get("id")
+                    depth = page_dict.get("depth")
                     if page_id:
                         try:
                             page_ids_to_update.append(UUID(page_id))
@@ -130,7 +131,7 @@ class PageOps:
                 # Update pages in batch per-filename
                 await self.pages.update_many(
                     {"_id": {"$in": page_ids_to_update}},
-                    {"$set": {"filename": filename}},
+                    {"$set": {"filename": filename, "depth": depth}},
                 )
         # pylint: disable=broad-exception-caught, raise-missing-from
         except Exception as err:
@@ -168,6 +169,7 @@ class PageOps:
             status=status,
             mime=page_dict.get("mime", "text/html"),
             filename=page_dict.get("filename"),
+            depth=page_dict.get("depth"),
             ts=(str_to_date(ts) if ts else dt_now()),
         )
         p.compute_page_type()

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -178,6 +178,8 @@ class PageOps:
             mime=page_dict.get("mime", "text/html"),
             filename=page_dict.get("filename"),
             depth=page_dict.get("depth"),
+            seed=page_dict.get("seed"),
+            favIconUrl=page_dict.get("favIconUrl"),
             ts=(str_to_date(ts) if ts else dt_now()),
         )
         p.compute_page_type()

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -619,7 +619,9 @@ class StorageOps:
 
             line_iter: Iterator[bytes] = self._sync_get_filestream(wacz_url, filename)
             for line in line_iter:
-                yield _parse_json(line.decode("utf-8", errors="ignore"))
+                page_json = _parse_json(line.decode("utf-8", errors="ignore"))
+                page_json["filename"] = wacz_filename
+                yield page_json
 
         page_generators: List[Iterator[Dict[Any, Any]]] = []
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -620,7 +620,7 @@ class StorageOps:
             line_iter: Iterator[bytes] = self._sync_get_filestream(wacz_url, filename)
             for line in line_iter:
                 page_json = _parse_json(line.decode("utf-8", errors="ignore"))
-                page_json["filename"] = wacz_filename
+                page_json["filename"] = os.path.basename(wacz_filename)
                 yield page_json
 
         page_generators: List[Iterator[Dict[Any, Any]]] = []

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -674,6 +674,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["status"]
         assert page["mime"]
         assert page["filename"]
+        assert page["depth"] is not None
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 
@@ -696,6 +697,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["loadState"]
     assert page["mime"]
     assert page["filename"]
+    assert page["depth"] is not None
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -797,6 +799,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["loadState"]
     assert page["mime"]
     assert page["filename"]
+    assert page["depth"] is not None
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -880,6 +883,7 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         assert page["status"]
         assert page["mime"]
         assert page["filename"]
+        assert page["depth"] is not None
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -675,6 +675,8 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["mime"]
         assert page["filename"]
         assert page["depth"] is not None
+        assert page["faviconUrl"]
+        assert page["seed"] in (True, False)
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 
@@ -698,6 +700,8 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["mime"]
     assert page["filename"]
     assert page["depth"] is not None
+    assert page["faviconUrl"]
+    assert page["seed"] in (True, False)
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -800,6 +804,8 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["mime"]
     assert page["filename"]
     assert page["depth"] is not None
+    assert page["faviconUrl"]
+    assert page["seed"] in (True, False)
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -884,6 +890,8 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         assert page["mime"]
         assert page["filename"]
         assert page["depth"] is not None
+        assert page["faviconUrl"]
+        assert page["seed"] in (True, False)
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -673,6 +673,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["loadState"]
         assert page["status"]
         assert page["mime"]
+        assert page["filename"]
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 
@@ -694,6 +695,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page.get("title") or page.get("title") is None
     assert page["loadState"]
     assert page["mime"]
+    assert page["filename"]
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -794,6 +796,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page.get("title") or page.get("title") is None
     assert page["loadState"]
     assert page["mime"]
+    assert page["filename"]
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -876,6 +879,7 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         assert page["loadState"]
         assert page["status"]
         assert page["mime"]
+        assert page["filename"]
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -676,7 +676,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["filename"]
         assert page["depth"] is not None
         assert page["favIconUrl"]
-        assert page["seed"] in (True, False)
+        assert page["isSeed"] in (True, False)
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 
@@ -701,7 +701,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["filename"]
     assert page["depth"] is not None
     assert page["favIconUrl"]
-    assert page["seed"] in (True, False)
+    assert page["isSeed"] in (True, False)
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -805,7 +805,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["filename"]
     assert page["depth"] is not None
     assert page["favIconUrl"]
-    assert page["seed"] in (True, False)
+    assert page["isSeed"] in (True, False)
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
 
@@ -891,7 +891,7 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         assert page["filename"]
         assert page["depth"] is not None
         assert page["favIconUrl"]
-        assert page["seed"] in (True, False)
+        assert page["isSeed"] in (True, False)
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -675,7 +675,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["mime"]
         assert page["filename"]
         assert page["depth"] is not None
-        assert page["faviconUrl"]
+        assert page["favIconUrl"]
         assert page["seed"] in (True, False)
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)
@@ -700,7 +700,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["mime"]
     assert page["filename"]
     assert page["depth"] is not None
-    assert page["faviconUrl"]
+    assert page["favIconUrl"]
     assert page["seed"] in (True, False)
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
@@ -804,7 +804,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert page["mime"]
     assert page["filename"]
     assert page["depth"] is not None
-    assert page["faviconUrl"]
+    assert page["favIconUrl"]
     assert page["seed"] in (True, False)
     assert page["isError"] in (True, False)
     assert page["isFile"] in (True, False)
@@ -890,7 +890,7 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         assert page["mime"]
         assert page["filename"]
         assert page["depth"] is not None
-        assert page["faviconUrl"]
+        assert page["favIconUrl"]
         assert page["seed"] in (True, False)
         assert page["isError"] in (True, False)
         assert page["isFile"] in (True, False)

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -253,7 +253,6 @@ def test_get_upload_pages(admin_auth_headers, default_org_id, upload_id):
         assert page["url"]
         assert page["ts"]
         assert page["filename"]
-        assert page["depth"] is not None
         assert page.get("title") or page.get("title") is None
 
     page_id = pages[0]["id"]
@@ -270,7 +269,6 @@ def test_get_upload_pages(admin_auth_headers, default_org_id, upload_id):
     assert page["url"]
     assert page["ts"]
     assert page["filename"]
-    assert page["depth"] is not None
     assert page.get("title") or page.get("title") is None
 
     assert page["notes"] == []

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -252,6 +252,7 @@ def test_get_upload_pages(admin_auth_headers, default_org_id, upload_id):
         assert page["crawl_id"] == upload_id
         assert page["url"]
         assert page["ts"]
+        assert page["filename"]
         assert page.get("title") or page.get("title") is None
 
     page_id = pages[0]["id"]
@@ -267,6 +268,7 @@ def test_get_upload_pages(admin_auth_headers, default_org_id, upload_id):
     assert page["crawl_id"]
     assert page["url"]
     assert page["ts"]
+    assert page["filename"]
     assert page.get("title") or page.get("title") is None
 
     assert page["notes"] == []

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -253,6 +253,7 @@ def test_get_upload_pages(admin_auth_headers, default_org_id, upload_id):
         assert page["url"]
         assert page["ts"]
         assert page["filename"]
+        assert page["depth"] is not None
         assert page.get("title") or page.get("title") is None
 
     page_id = pages[0]["id"]
@@ -269,6 +270,7 @@ def test_get_upload_pages(admin_auth_headers, default_org_id, upload_id):
     assert page["url"]
     assert page["ts"]
     assert page["filename"]
+    assert page["depth"] is not None
     assert page.get("title") or page.get("title") is None
 
     assert page["notes"] == []

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -124,7 +124,7 @@ spec:
               path: /healthzStartup
               port: 8000
             periodSeconds: 10
-            failureThreshold: 360
+            failureThreshold: 8640
             successThreshold: 1
 
           readinessProbe:

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -123,8 +123,8 @@ spec:
             httpGet:
               path: /healthzStartup
               port: 8000
-            periodSeconds: 5
-            failureThreshold: 60
+            periodSeconds: 10
+            failureThreshold: 360
             successThreshold: 1
 
           readinessProbe:


### PR DESCRIPTION
Fixes #2348 

Adds `filename` to pages, pointed to the WACZ file those files come from.

Also adds idempotent migration to backfill this information for existing pages.

Update: Now also adding `depth`, `isSeed`, and `favIconUrl` to pages as well, both for crawls moving forward and in the backfill migration.

## Manual testing

1. Spin up a local environment off of latest main
2. Create some crawls, verify pages are added to database
3. Re-deploy from this branch
4. Verify migration ran successfully in backend logs, didn't raise errors
5. Verify `filename` and other fields have been added for pages in older crawls
6. Create a new crawl, verify `filename` is present and matches values in backfilled pages (namely, that it's just the WACZ filename, with no oid directory prefix)