### PR TITLE
Add collection page list/search endpoint

### DIFF
--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -248,7 +248,14 @@ def main() -> None:
     upload_ops = init_uploads_api(*base_crawl_init)
 
     page_ops = init_pages_api(
-        app, mdb, crawls, org_ops, storage_ops, background_job_ops, current_active_user
+        app,
+        mdb,
+        crawls,
+        org_ops,
+        storage_ops,
+        background_job_ops,
+        coll_ops,
+        current_active_user,
     )
 
     base_crawl_ops.set_page_ops(page_ops)

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -89,7 +89,9 @@ def init_ops() -> Tuple[
 
     upload_ops = UploadOps(*base_crawl_init)
 
-    page_ops = PageOps(mdb, crawl_ops, org_ops, storage_ops, background_job_ops)
+    page_ops = PageOps(
+        mdb, crawl_ops, org_ops, storage_ops, background_job_ops, coll_ops
+    )
 
     base_crawl_ops.set_page_ops(page_ops)
     crawl_ops.set_page_ops(page_ops)

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -546,8 +546,10 @@ class PageOps:
         if is_seed in (True, False):
             query["isSeed"] = is_seed
 
+        # Check that field matches and value is an int to avoid 0
+        # from returning null results
         if depth:
-            query["depth"] = depth
+            query["$and"] = {"field": depth, "type": 16}
 
         if reviewed:
             query["$or"] = [
@@ -697,8 +699,10 @@ class PageOps:
         if is_seed in (True, False):
             query["isSeed"] = is_seed
 
+        # Check that field matches and value is an int to avoid 0
+        # from returning null results
         if depth:
-            query["depth"] = depth
+            query["$and"] = {"field": depth, "type": 16}
 
         aggregate = [{"$match": query}]
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -628,6 +628,7 @@ class PageOps:
         org: Optional[Organization] = None,
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
+        ts: Optional[datetime] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: Optional[str] = None,
@@ -654,6 +655,9 @@ class PageOps:
 
         elif url:
             query["url"] = urllib.parse.unquote(url)
+
+        if ts:
+            query["ts"] = ts
 
         aggregate = [{"$match": query}]
 
@@ -1036,6 +1040,7 @@ def init_pages_api(
         org: Organization = Depends(org_viewer_dep),
         url: Optional[str] = None,
         urlPrefix: Optional[str] = None,
+        ts: Optional[datetime] = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sortBy: Optional[str] = None,
@@ -1047,6 +1052,7 @@ def init_pages_api(
             org=org,
             url=url,
             url_prefix=urlPrefix,
+            ts=ts,
             page_size=pageSize,
             page=page,
             sort_by=sortBy,

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -546,10 +546,8 @@ class PageOps:
         if is_seed in (True, False):
             query["isSeed"] = is_seed
 
-        # Check that field matches and value is an int to avoid 0
-        # from returning null results
-        if depth:
-            query["$and"] = [{"depth": depth}, {"depth": {"type": 16}}]
+        if isinstance(depth, int):
+            query["depth"] = depth
 
         if reviewed:
             query["$or"] = [
@@ -699,10 +697,8 @@ class PageOps:
         if is_seed in (True, False):
             query["isSeed"] = is_seed
 
-        # Check that field matches and value is an int to avoid 0
-        # from returning null results
-        if depth:
-            query["$and"] = [{"depth": depth}, {"depth": {"type": 16}}]
+        if isinstance(depth, int):
+            query["depth"] = depth
 
         aggregate = [{"$match": query}]
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -1,5 +1,7 @@
 """crawl pages"""
 
+# pylint: disable=too-many-lines
+
 import asyncio
 import os
 import re
@@ -651,7 +653,7 @@ class PageOps:
             query["url"] = {"$regex": regex_pattern, "$options": "i"}
 
         elif url:
-            query["url"] = url
+            query["url"] = urllib.parse.unquote(url)
 
         aggregate = [{"$match": query}]
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -504,7 +504,7 @@ class PageOps:
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
         ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
+        is_seed: Optional[bool] = None,
         depth: Optional[int] = None,
         qa_run_id: Optional[str] = None,
         qa_filter_by: Optional[str] = None,
@@ -543,8 +543,8 @@ class PageOps:
         if ts:
             query["ts"] = ts
 
-        if isSeed in (True, False):
-            query["isSeed"] = isSeed
+        if is_seed in (True, False):
+            query["isSeed"] = is_seed
 
         if depth:
             query["depth"] = depth
@@ -662,7 +662,7 @@ class PageOps:
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
         ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
+        is_seed: Optional[bool] = None,
         depth: Optional[int] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
@@ -694,8 +694,8 @@ class PageOps:
         if ts:
             query["ts"] = ts
 
-        if isSeed in (True, False):
-            query["isSeed"] = isSeed
+        if is_seed in (True, False):
+            query["isSeed"] = is_seed
 
         if depth:
             query["depth"] = depth

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -549,7 +549,7 @@ class PageOps:
         # Check that field matches and value is an int to avoid 0
         # from returning null results
         if depth:
-            query["$and"] = {"field": depth, "type": 16}
+            query["$and"] = [{"depth": depth}, {"depth": {"type": 16}}]
 
         if reviewed:
             query["$or"] = [
@@ -702,7 +702,7 @@ class PageOps:
         # Check that field matches and value is an int to avoid 0
         # from returning null results
         if depth:
-            query["$and"] = {"field": depth, "type": 16}
+            query["$and"] = [{"depth": depth}, {"depth": {"type": 16}}]
 
         aggregate = [{"$match": query}]
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -504,6 +504,8 @@ class PageOps:
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
         ts: Optional[datetime] = None,
+        isSeed: Optional[bool] = None,
+        depth: Optional[int] = None,
         qa_run_id: Optional[str] = None,
         qa_filter_by: Optional[str] = None,
         qa_gte: Optional[float] = None,
@@ -540,6 +542,12 @@ class PageOps:
 
         if ts:
             query["ts"] = ts
+
+        if isSeed in (True, False):
+            query["isSeed"] = isSeed
+
+        if depth:
+            query["depth"] = depth
 
         if reviewed:
             query["$or"] = [
@@ -594,6 +602,8 @@ class PageOps:
                 "status",
                 "mime",
                 "filename",
+                "depth",
+                "isSeed",
             )
             qa_sort_fields = ("screenshotMatch", "textMatch")
             if sort_by not in sort_fields and sort_by not in qa_sort_fields:
@@ -652,6 +662,8 @@ class PageOps:
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
         ts: Optional[datetime] = None,
+        isSeed: Optional[bool] = None,
+        depth: Optional[int] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: Optional[str] = None,
@@ -682,13 +694,28 @@ class PageOps:
         if ts:
             query["ts"] = ts
 
+        if isSeed in (True, False):
+            query["isSeed"] = isSeed
+
+        if depth:
+            query["depth"] = depth
+
         aggregate = [{"$match": query}]
 
         if sort_by:
             # Sorting options to add:
             # - automated heuristics like screenshot_comparison (dict keyed by QA run id)
             # - Ensure notes sorting works okay with notes in list
-            sort_fields = ("url", "crawl_id", "ts", "status", "mime", "filename")
+            sort_fields = (
+                "url",
+                "crawl_id",
+                "ts",
+                "status",
+                "mime",
+                "filename",
+                "depth",
+                "isSeed",
+            )
             if sort_by not in sort_fields:
                 raise HTTPException(status_code=400, detail="invalid_sort_by")
             if sort_direction not in (1, -1):
@@ -1030,6 +1057,8 @@ def init_pages_api(
         url: Optional[str] = None,
         urlPrefix: Optional[str] = None,
         ts: Optional[datetime] = None,
+        isSeed: Optional[bool] = None,
+        depth: Optional[int] = None,
         reviewed: Optional[bool] = None,
         approved: Optional[str] = None,
         hasNotes: Optional[bool] = None,
@@ -1049,6 +1078,8 @@ def init_pages_api(
             url=url,
             url_prefix=urlPrefix,
             ts=ts,
+            is_seed=isSeed,
+            depth=depth,
             reviewed=reviewed,
             approved=formatted_approved,
             has_notes=hasNotes,
@@ -1070,6 +1101,8 @@ def init_pages_api(
         url: Optional[str] = None,
         urlPrefix: Optional[str] = None,
         ts: Optional[datetime] = None,
+        isSeed: Optional[bool] = None,
+        depth: Optional[int] = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sortBy: Optional[str] = None,
@@ -1082,6 +1115,8 @@ def init_pages_api(
             url=url,
             url_prefix=urlPrefix,
             ts=ts,
+            is_seed=isSeed,
+            depth=depth,
             page_size=pageSize,
             page=page,
             sort_by=sortBy,

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -91,6 +91,9 @@ class PageOps:
                 if not page_dict.get("url"):
                     continue
 
+                if not page_dict.get("isSeed"):
+                    page_dict["isSeed"] = False
+
                 if len(pages_buffer) > batch_size:
                     await self._add_pages_to_db(crawl_id, pages_buffer)
                     pages_buffer = []
@@ -219,9 +222,8 @@ class PageOps:
     ):
         """Add page to database"""
         page = self._get_page_from_dict(page_dict, crawl_id, oid)
-        page_to_insert = page.to_dict(
-            exclude_unset=True, exclude_none=True, exclude_defaults=True
-        )
+
+        page_to_insert = page.to_dict(exclude_unset=True, exclude_none=True)
 
         try:
             await self.pages.insert_one(page_to_insert)

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -232,7 +232,7 @@ def crawler_crawl_id(crawler_auth_headers, default_org_id):
         "name": "Crawler User Test Crawl",
         "description": "crawler test crawl",
         "tags": ["wr-test-2"],
-        "config": {"seeds": [{"url": "https://webrecorder.net/"}], "limit": 1},
+        "config": {"seeds": [{"url": "https://webrecorder.net/"}], "limit": 3},
         "crawlerChannel": "test",
     }
     r = requests.post(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -613,6 +613,7 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     coll_page = pages[0]
     coll_page_id = coll_page["id"]
     coll_page_url = coll_page["url"]
+    coll_page_ts = coll_page["ts"]
 
     # Test exact url filter
     r = requests.get(
@@ -622,10 +623,22 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
 
-    assert data["total"] == 1
-    matching_page = data["items"][0]
-    assert matching_page["id"] == coll_page_id
-    assert matching_page["url"] == coll_page_url
+    assert data["total"] >= 1
+    for matching_page in data["items"]:
+        assert matching_page["url"] == coll_page_url
+
+    # Test exact url and ts filters together
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?url={coll_page_url}&ts={coll_page_ts}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["total"] >= 1
+    for matching_page in data["items"]:
+        assert matching_page["url"] == coll_page_url
+        assert matching_page["ts"] == coll_page_ts
 
     # Test urlPrefix filter
     url_prefix = coll_page_url[:8]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -582,6 +582,33 @@ def test_list_collections(
     assert second_coll["dateLatest"]
 
 
+def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["total"] >= 0
+
+    pages = data["items"]
+    assert pages
+
+    for page in pages:
+        assert page["id"]
+        assert page["oid"]
+        assert page["crawl_id"]
+        assert page["url"]
+        assert page["ts"]
+        assert page.get("title") or page.get("title") is None
+        assert page["loadState"]
+        assert page["status"]
+        assert page["mime"]
+        assert page["isError"] in (True, False)
+        assert page["isFile"] in (True, False)
+
+
 def test_remove_upload_from_collection(crawler_auth_headers, default_org_id):
     # Remove upload
     r = requests.post(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -688,7 +688,7 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
         assert page["depth"] == 0
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?depth=1",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?depth=1",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -667,7 +667,6 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     data = r.json()
     for page in data["items"]:
         assert page["isSeed"]
-        assert page["depth"] == 0
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?isSeed=false",
@@ -677,7 +676,6 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     data = r.json()
     for page in data["items"]:
         assert page["isSeed"] is False
-        assert page["depth"] > 0
 
     # Test depth filter
     r = requests.get(
@@ -687,7 +685,6 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     for page in data["items"]:
-        assert page["isSeed"]
         assert page["depth"] == 0
 
     r = requests.get(
@@ -697,7 +694,6 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
     data = r.json()
     for page in data["items"]:
-        assert page["isSeed"] is False
         assert page["depth"] == 1
 
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -603,11 +603,11 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
         assert page["url"]
         assert page["ts"]
         assert page.get("title") or page.get("title") is None
-        assert page["loadState"]
-        assert page["status"]
-        assert page["mime"]
-        assert page["isError"] in (True, False)
-        assert page["isFile"] in (True, False)
+        assert page.get("loadState") or page.get("loadState") is None
+        assert page.get("status") or page.get("status") is None
+        assert page.get("mime") or page.get("mime") is None
+        assert page["isError"] in (None, True, False)
+        assert page["isFile"] in (None, True, False)
 
     # Save info for page to test url and urlPrefix filters
     coll_page = pages[0]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -658,6 +658,48 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
 
     assert found_matching_page
 
+    # Test isSeed filter
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?isSeed=true",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    for page in data["items"]:
+        assert page["isSeed"]
+        assert page["depth"] == 0
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?isSeed=false",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    for page in data["items"]:
+        assert page["isSeed"] is False
+        assert page["depth"] > 0
+
+    # Test depth filter
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?depth=0",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    for page in data["items"]:
+        assert page["isSeed"]
+        assert page["depth"] == 0
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?depth=1",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    for page in data["items"]:
+        assert page["isSeed"] is False
+        assert page["depth"] == 1
+
 
 def test_remove_upload_from_collection(crawler_auth_headers, default_org_id):
     # Remove upload

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -800,13 +800,6 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     for page in data["items"]:
         assert page["depth"] == 1
 
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?depth=2",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    assert data["total"] == 0
-
 
 def test_crawl_pages_qa_filters(crawler_auth_headers, default_org_id, crawler_crawl_id):
     # Test reviewed filter (page has no notes or approved so should show up in false)

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -872,13 +872,13 @@ def test_crawl_pages_qa_filters(crawler_auth_headers, default_org_id, crawler_cr
     assert r.status_code == 200
     assert r.json()["total"] == 2
 
-    # Test reviewed filter (page now approved so should show up in True)
+    # Test reviewed filter (page now approved so should show up in True, other pages show here)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?reviewed=False",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 0
+    assert r.json()["total"] == 2
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?reviewed=True",

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -761,7 +761,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
 
     # Test isSeed filter
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?isSeed=true",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?isSeed=True",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -772,12 +772,12 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
         assert page["depth"] == 0
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?isSeed=false",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?isSeed=False",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == total_pages - 1
+    assert data["total"] == 2
     for page in data["items"]:
         assert page["isSeed"] is False
         assert page["depth"] > 0
@@ -820,7 +820,7 @@ def test_crawl_pages_qa_filters(crawler_auth_headers, default_org_id, crawler_cr
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 1
+    assert r.json()["total"] == 3
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?reviewed=True",
@@ -1089,14 +1089,14 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 1
+    assert r.json()["total"] == 3
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?approved=true,false,none",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 1
+    assert r.json()["total"] == 3
 
     # Test reviewed filter (page now has notes so should show up in True)
     r = requests.get(

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -953,7 +953,7 @@ def test_crawl_pages_qa_filters(crawler_auth_headers, default_org_id, crawler_cr
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 0
+    assert r.json()["total"] == 2
 
 
 def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -660,7 +660,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     data = r.json()
 
     total_pages = data["total"]
-    assert total_pages >= 1
+    assert total_pages == 3
 
     pages = data["items"]
     assert pages
@@ -769,7 +769,6 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert data["total"] == 1
     for page in data["items"]:
         assert page["isSeed"]
-        assert page["depth"] == 0
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?isSeed=False",
@@ -780,7 +779,6 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert data["total"] == 2
     for page in data["items"]:
         assert page["isSeed"] is False
-        assert page["depth"] > 0
 
     # Test depth filter
     r = requests.get(
@@ -791,7 +789,6 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     data = r.json()
     assert data["total"] == 1
     for page in data["items"]:
-        assert page["isSeed"]
         assert page["depth"] == 0
 
     r = requests.get(
@@ -802,7 +799,6 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     data = r.json()
     assert data["total"] == total_pages - 1
     for page in data["items"]:
-        assert page["isSeed"] is False
         assert page["depth"] == 1
 
     r = requests.get(
@@ -874,7 +870,7 @@ def test_crawl_pages_qa_filters(crawler_auth_headers, default_org_id, crawler_cr
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 0
+    assert r.json()["total"] == 2
 
     # Test reviewed filter (page now approved so should show up in True)
     r = requests.get(
@@ -1104,7 +1100,7 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 0
+    assert r.json()["total"] == 2
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?reviewed=True",
@@ -1119,7 +1115,7 @@ def test_crawl_page_notes(crawler_auth_headers, default_org_id, crawler_crawl_id
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["total"] == 0
+    assert r.json()["total"] == 2
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/pages?hasNotes=True",

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -659,8 +659,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     assert r.status_code == 200
     data = r.json()
 
-    total_pages = data["total"]
-    assert total_pages == 3
+    assert data["total"] == 3
 
     pages = data["items"]
     assert pages
@@ -797,7 +796,7 @@ def test_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == total_pages - 1
+    assert data["total"] == 2
     for page in data["items"]:
         assert page["depth"] == 1
 


### PR DESCRIPTION
Fixes #2353

Adds a new endpoint to list pages in a collection, with filtering available on `url` (exact match), `ts`, `urlPrefix`, `isSeed`, and `depth`, as well as accompanying tests. Additional sort options have been added as well.

These same filters and sort options have also been added to the crawl pages endpoint.

Also fixes an issue where `isSeed` wasn't being set in the database when false but only added on serialization, which was preventing filtering from working as expected.