### PR TITLE
ensure that when crawl workflow is updated for a running crawl, the f…

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -438,10 +438,11 @@ class CrawlConfigOps:
                 status_code=404, detail=f"Crawl Config '{cid}' not found"
             )
 
+        crawlconfig = CrawlConfig.from_dict(result)
+
         # update in crawl manager to change schedule
         if schedule_changed:
             try:
-                crawlconfig = CrawlConfig.from_dict(result)
                 await self.crawl_manager.update_scheduled_job(crawlconfig, str(user.id))
 
             except Exception as exc:
@@ -461,6 +462,13 @@ class CrawlConfigOps:
         if run_now:
             crawl_id = await self.run_now(cid, org, user)
             ret["started"] = crawl_id
+        elif changed:
+            running_crawl = await self.get_running_crawl(cid)
+            if running_crawl:
+                await self.crawl_manager.update_running_crawl_config(
+                    running_crawl.id, crawlconfig
+                )
+
         return ret
 
     async def update_usernames(self, userid: UUID, updated_name: str) -> None:

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -220,6 +220,22 @@ class CrawlManager(K8sAPI):
             proxy_id=crawlconfig.proxyId or DEFAULT_PROXY_ID,
         )
 
+    async def update_running_crawl_config(
+        self, crawl_id: str, crawlconfig: CrawlConfig
+    ):
+        """force update of config for running crawl"""
+        # pylint: disable=use-dict-literal
+        patch = dict(
+            crawlerChannel=crawlconfig.crawlerChannel,
+            scale=crawlconfig.scale,
+            timeout=crawlconfig.crawlTimeout,
+            maxCrawlSize=crawlconfig.maxCrawlSize,
+            proxyId=crawlconfig.proxyId or DEFAULT_PROXY_ID,
+            lastConfigUpdate=date_to_str(dt_now()),
+        )
+
+        return await self._patch_job(crawl_id, patch)
+
     async def create_qa_crawl_job(
         self,
         crawlconfig: CrawlConfig,

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -274,12 +274,7 @@ class CrawlOperator(BaseOperator):
         params["storage_path"] = storage_path
         params["storage_secret"] = storage_secret
 
-        # only resolve if not already set
-        # not automatically updating image for existing crawls
-        if not status.crawlerImage:
-            status.crawlerImage = self.crawl_config_ops.get_channel_crawler_image(
-                crawl.crawler_channel
-            )
+        status.crawlerImage = self.crawl_config_ops.get_channel_crawler_image(crawl.crawler_channel)
 
         params["crawler_image"] = status.crawlerImage
 
@@ -306,7 +301,10 @@ class CrawlOperator(BaseOperator):
         else:
             params["force_restart"] = False
 
-        children.extend(await self._load_crawl_configmap(crawl, data.children, params))
+        config_update_needed = spec.get("lastConfigUpdate", "") != status.lastConfigUpdate
+        status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
+
+        children.extend(await self._load_crawl_configmap(crawl, data.children, params, config_update_needed))
 
         if crawl.qa_source_crawl_id:
             params["qa_source_crawl_id"] = crawl.qa_source_crawl_id
@@ -364,11 +362,11 @@ class CrawlOperator(BaseOperator):
 
         return behaviors
 
-    async def _load_crawl_configmap(self, crawl: CrawlSpec, children, params):
+    async def _load_crawl_configmap(self, crawl: CrawlSpec, children, params, config_update_needed: bool):
         name = f"crawl-config-{crawl.id}"
 
         configmap = children[CMAP].get(name)
-        if configmap:
+        if configmap and not config_update_needed:
             metadata = configmap["metadata"]
             configmap["metadata"] = {
                 "name": metadata["name"],

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -209,6 +209,7 @@ class CrawlStatus(BaseModel):
     stopReason: Optional[StopReason] = None
     initRedis: bool = False
     crawlerImage: Optional[str] = None
+    lastConfigUpdate: str = ""
 
     lastActiveTime: str = ""
     podStatus: DefaultDict[str, Annotated[PodInfo, Field(default_factory=PodInfo)]] = (

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -127,7 +127,7 @@ spec:
       command:
         - {{ "crawl" if not qa_source_crawl_id else "qa" }}
         - --config
-        - /tmp/crawl-config.json
+        - /tmp/config/crawl-config.json
         - --workers
         - "{{ workers }}"
         - --redisStoreUrl
@@ -153,8 +153,7 @@ spec:
       {% endif %}
       volumeMounts:
         - name: crawl-config
-          mountPath: /tmp/crawl-config.json
-          subPath: crawl-config.json
+          mountPath: /tmp/config/
           readOnly: True
 
       {% if qa_source_crawl_id %}


### PR DESCRIPTION
…ull config changes *are* propagated, including:

- ensure configmap is updated for running crawl
- ensure crawler picks up new configmap (remove subPath which prevented dynamic updates)
- configmap recreated if lastConfigUpdate string is different between spec and status
- exclusions changes when adding/removing exclusions
- other raw config changes are applied
- crawler channel, proxy, timeout, and scale settings are all applied to running crawl
- could be first step to pause/resume crawls, but does not require pausing to make changes