### PR TITLE
fix: Re-enable workflow setup guide button

### DIFF
--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -130,6 +130,7 @@ export class WorkflowsNew extends LiteElement {
                   path: `user-guide/workflow-setup/#${this.userGuideHashLink}`,
                 },
                 bubbles: true,
+                composed: true,
               }),
             );
           }}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2335

## Changes

Fixes workflow setup guide not showing when button is clicked

## Manual testing

1. Log in as crawler
2. Go to New Workflow
3. Click "Setup Guide". Verify side panel opens with user guide