### PR TITLE
fix: More accurate workflow and archived item search

### DIFF
--- a/frontend/src/components/ui/search-combobox.ts
+++ b/frontend/src/components/ui/search-combobox.ts
@@ -56,7 +56,6 @@ export class SearchCombobox<T> extends LitElement {
 
   private fuse = new Fuse<T>([], {
     keys: [],
-    shouldSort: false,
     threshold: 0.2, // stricter; default is 0.6
     includeMatches: true,
   });


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2357

## Changes

Sorts workflow and items search results by match score.

## Manual testing

1. Go to Crawl Workflows
2. Start typing to search. Verify results are ordered as expected