### PR TITLE
Fix max pages quota setting and display

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -707,8 +707,6 @@ class CrawlConfigOps:
 
         crawlconfig.config.seeds = None
 
-        self.ensure_quota_page_limit(crawlconfig, org)
-
         return crawlconfig
 
     async def get_crawl_config_seed_count(self, cid: UUID, org: Organization):

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -251,11 +251,6 @@ class CrawlConfigOps:
             crawlconfig.lastStartedBy = user.id
             crawlconfig.lastStartedByName = user.name
 
-        # Ensure page limit is below org maxPagesPerCall if set
-        max_pages = org.quotas.maxPagesPerCrawl or 0
-        if max_pages > 0:
-            crawlconfig.config.limit = max_pages
-
         # add  CrawlConfig to DB here
         result = await self.crawl_configs.insert_one(crawlconfig.to_dict())
 
@@ -286,12 +281,29 @@ class CrawlConfigOps:
             execMinutesQuotaReached=exec_mins_quota_reached,
         )
 
+    def ensure_quota_page_limit(self, crawlconfig: CrawlConfig, org: Organization):
+        """ensure page limit is set to smaller or existing limit or quota limit"""
+        if org.quotas.maxPagesPerCrawl and org.quotas.maxPagesPerCrawl > 0:
+            if crawlconfig.config.limit and crawlconfig.config.limit > 0:
+                crawlconfig.config.limit = min(
+                    org.quotas.maxPagesPerCrawl, crawlconfig.config.limit
+                )
+            else:
+                crawlconfig.config.limit = org.quotas.maxPagesPerCrawl
+
     async def add_new_crawl(
-        self, crawl_id: str, crawlconfig: CrawlConfig, user: User, manual: bool
+        self,
+        crawl_id: str,
+        crawlconfig: CrawlConfig,
+        user: User,
+        org: Organization,
+        manual: bool,
     ) -> None:
         """increments crawl count for this config and adds new crawl"""
 
         started = dt_now()
+
+        self.ensure_quota_page_limit(crawlconfig, org)
 
         inc = self.inc_crawl_count(crawlconfig.id)
         add = self.crawl_ops.add_new_crawl(
@@ -695,6 +707,8 @@ class CrawlConfigOps:
 
         crawlconfig.config.seeds = None
 
+        self.ensure_quota_page_limit(crawlconfig, org)
+
         return crawlconfig
 
     async def get_crawl_config_seed_count(self, cid: UUID, org: Organization):
@@ -892,7 +906,7 @@ class CrawlConfigOps:
                 storage_filename=storage_filename,
                 profile_filename=profile_filename or "",
             )
-            await self.add_new_crawl(crawl_id, crawlconfig, user, manual=True)
+            await self.add_new_crawl(crawl_id, crawlconfig, user, org, manual=True)
             return crawl_id
 
         except Exception as exc:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -282,7 +282,7 @@ class CrawlConfigOps:
         )
 
     def ensure_quota_page_limit(self, crawlconfig: CrawlConfig, org: Organization):
-        """ensure page limit is set to smaller or existing limit or quota limit"""
+        """ensure page limit is set to no greater than quota page limit, if any"""
         if org.quotas.maxPagesPerCrawl and org.quotas.maxPagesPerCrawl > 0:
             if crawlconfig.config.limit and crawlconfig.config.limit > 0:
                 crawlconfig.config.limit = min(

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -112,6 +112,7 @@ class CronJobOperator(BaseOperator):
                 crawl_id,
                 crawlconfig,
                 user,
+                org,
                 manual=False,
             )
             print("Scheduled Crawl Created: " + crawl_id)

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from typing import Optional, DefaultDict, Literal, Annotated, Any
 from pydantic import BaseModel, Field
 from kubernetes.utils import parse_quantity
-from btrixcloud.models import StorageRef, TYPE_ALL_CRAWL_STATES
+from btrixcloud.models import StorageRef, TYPE_ALL_CRAWL_STATES, Organization
 
 
 BTRIX_API = "btrix.cloud/v1"
@@ -70,6 +70,7 @@ class CrawlSpec(BaseModel):
     id: str
     cid: UUID
     oid: UUID
+    org: Organization
     scale: int = 1
     storage: StorageRef
     started: str

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -14,10 +14,10 @@ import sectionStrings from "@/strings/crawl-workflows/section";
 import type { Collection } from "@/types/collection";
 import { WorkflowScopeType } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
-import { getAppSettings } from "@/utils/app";
 import { DEPTH_SUPPORTED_SCOPES, isPageScopeType } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import { pluralOf } from "@/utils/pluralize";
+import { getServerDefaults } from "@/utils/workflow";
 
 /**
  * Usage:
@@ -55,7 +55,7 @@ export class ConfigDetails extends BtrixElement {
 
   async connectedCallback() {
     super.connectedCallback();
-    void this.fetchAPIDefaults();
+    void this.fetchOrgDefaults();
     await this.fetchCollections();
   }
 
@@ -137,7 +137,9 @@ export class ConfigDetails extends BtrixElement {
 
               if (this.orgDefaults?.maxPagesPerCrawl) {
                 return html`<span class="text-neutral-400">
-                  ${this.localize.number(this.orgDefaults.maxPagesPerCrawl)}
+                  ${this.orgDefaults.maxPagesPerCrawl === Infinity
+                    ? msg("Unlimited")
+                    : this.localize.number(this.orgDefaults.maxPagesPerCrawl)}
                   ${pluralOf("pages", this.orgDefaults.maxPagesPerCrawl)}
                   ${msg("(default)")}</span
                 >`;
@@ -510,25 +512,29 @@ export class ConfigDetails extends BtrixElement {
     this.requestUpdate();
   }
 
-  private async fetchAPIDefaults() {
+  // TODO Consolidate with workflow-editor
+  private async fetchOrgDefaults() {
     try {
-      const settings = await getAppSettings();
-      const orgDefaults = {
+      const [serverDefaults, { quotas }] = await Promise.all([
+        getServerDefaults(),
+        this.api.fetch<{
+          quotas: { maxPagesPerCrawl?: number };
+        }>(`/orgs/${this.orgId}`),
+      ]);
+
+      const defaults = {
         ...this.orgDefaults,
+        ...serverDefaults,
       };
 
-      if (settings.defaultBehaviorTimeSeconds > 0) {
-        orgDefaults.behaviorTimeoutSeconds =
-          settings.defaultBehaviorTimeSeconds;
+      if (defaults.maxPagesPerCrawl && quotas.maxPagesPerCrawl) {
+        defaults.maxPagesPerCrawl = Math.min(
+          defaults.maxPagesPerCrawl,
+          quotas.maxPagesPerCrawl,
+        );
       }
-      if (settings.defaultPageLoadTimeSeconds > 0) {
-        orgDefaults.pageLoadTimeoutSeconds =
-          settings.defaultPageLoadTimeSeconds;
-      }
-      if (settings.maxPagesPerCrawl > 0) {
-        orgDefaults.maxPagesPerCrawl = settings.maxPagesPerCrawl;
-      }
-      this.orgDefaults = orgDefaults;
+
+      this.orgDefaults = defaults;
     } catch (e) {
       console.debug(e);
     }


### PR DESCRIPTION
- add ensure_page_limit_quotas() which sets the config limit to the max pages quota, if any
- set the page limit on the config when: creating new crawl, creating configmap
- don't set the quota page limit on new or existing crawl workflows (remove setting it on new workflows) to allow updated quotas to take affect for next crawl
- frontend: correctly display page limit on workflow settings page from org quotas, if set.
- operator: get org on each sync in one place
- fixes #2369