### PR TITLE
fix: create new profile link in the workflow form

### DIFF
--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -168,7 +168,7 @@ export class SelectBrowserProfile extends BtrixElement {
           >${msg("This org doesn't have any custom profiles yet.")}</span
         >
         <a
-          href=${`${this.navigate.orgBasePath}/browser-profiles?new`}
+          href=${`${this.navigate.orgBasePath}/browser-profiles?new=browser-profile`}
           class="font-medium text-primary hover:text-primary-500"
           target="_blank"
           @click=${(e: Event) => {


### PR DESCRIPTION
Closes #2372

[Original bug report on the forum](https://forum.webrecorder.net/t/new-browser-profile-button-is-disabled/776)

### Changes
- Fixes broken link, `?new` → `?new=browser-profile`