### PR TITLE
fix: Update links to running crawls

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -561,7 +561,6 @@ export class App extends BtrixElement {
                     @click=${this.navigate.link}
                     >${msg("Running Crawls")}</a
                   >
-                  <div class="hidden md:block">${this.renderFindCrawl()}</div>
                 </div>
               `
             : nothing}
@@ -905,57 +904,6 @@ export class App extends BtrixElement {
     return html`<btrix-not-found
       class="flex w-full items-center justify-center md:bg-neutral-50"
     ></btrix-not-found>`;
-  }
-
-  private renderFindCrawl() {
-    return html`
-      <sl-dropdown
-        @sl-after-show=${(e: Event) => {
-          (e.target as HTMLElement).querySelector("sl-input")?.focus();
-        }}
-        @sl-after-hide=${(e: Event) => {
-          (e.target as HTMLElement).querySelector("sl-input")!.value = "";
-        }}
-        hoist
-      >
-        <button
-          slot="trigger"
-          class="font-medium text-primary-700 hover:text-primary"
-        >
-          ${msg("Jump to Crawl")}
-        </button>
-
-        <div class="p-2">
-          <form
-            @submit=${(e: SubmitEvent) => {
-              e.preventDefault();
-              const id = new FormData(e.target as HTMLFormElement).get(
-                "crawlId",
-              ) as string;
-              this.routeTo(`/crawls/crawl/${id}#watch`);
-              void (e.target as HTMLFormElement).closest("sl-dropdown")?.hide();
-            }}
-          >
-            <div class="flex flex-wrap items-center">
-              <div class="w-90 mr-2">
-                <sl-input
-                  size="small"
-                  name="crawlId"
-                  placeholder=${msg("Enter Crawl ID")}
-                  required
-                ></sl-input>
-              </div>
-              <div class="grow-0">
-                <sl-button size="small" variant="neutral" type="submit">
-                  <sl-icon slot="prefix" name="arrow-right-circle"></sl-icon>
-                  ${msg("Go")}</sl-button
-                >
-              </div>
-            </div>
-          </form>
-        </div>
-      </sl-dropdown>
-    `;
   }
 
   private showUserGuide(pathName?: string) {

--- a/frontend/src/pages/admin.ts
+++ b/frontend/src/pages/admin.ts
@@ -132,37 +132,6 @@ export class Admin extends BtrixElement {
 
   private renderAdminOrgs() {
     return html`
-      <section class="mb-5 rounded-lg border bg-white p-4 md:p-6">
-        <form
-          @submit=${(e: SubmitEvent) => {
-            const formData = new FormData(e.target as HTMLFormElement);
-            const id = formData.get("crawlId");
-            this.navigate.to(`/crawls/crawl/${id?.toString()}`);
-          }}
-        >
-          <div class="flex flex-wrap items-center">
-            <div
-              class="mr-8 w-full grow-0 whitespace-nowrap text-lg font-medium md:w-min"
-            >
-              ${msg("Go to Crawl")}
-            </div>
-            <div class="mt-2 grow md:mr-2 md:mt-0">
-              <sl-input
-                name="crawlId"
-                placeholder=${msg("Enter Crawl ID")}
-                required
-              ></sl-input>
-            </div>
-            <div class="mt-2 grow-0 text-right md:mt-0">
-              <sl-button variant="neutral" type="submit">
-                <sl-icon slot="suffix" name="arrow-right"></sl-icon>
-                ${msg("Go")}</sl-button
-              >
-            </div>
-          </div>
-        </form>
-      </section>
-
       <div class="grid grid-cols-3 gap-6">
         <div class="col-span-3 md:col-span-2">
           <section>

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -283,14 +283,14 @@ export class Crawls extends BtrixElement {
   }
 
   private readonly renderCrawlItem = (crawl: Crawl) => {
-    const crawlPath = `/orgs/${this.slugLookup[crawl.oid]}/workflows/${crawl.cid}/crawls/${
-      crawl.id
-    }`;
+    const crawlPath = `/orgs/${this.slugLookup[crawl.oid]}/workflows/${crawl.cid}`;
     return html`
-      <btrix-crawl-list-item href=${crawlPath} .crawl=${crawl}>
+      <btrix-crawl-list-item href=${`${crawlPath}#watch`} .crawl=${crawl}>
         <sl-menu slot="menu">
-          <sl-menu-item @click=${() => this.navigate.to(`${crawlPath}#config`)}>
-            ${msg("View Crawl Settings")}
+          <sl-menu-item
+            @click=${() => this.navigate.to(`${crawlPath}#settings`)}
+          >
+            ${msg("View Workflow Settings")}
           </sl-menu-item>
         </sl-menu>
       </btrix-crawl-list-item>

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -141,11 +141,6 @@ export class ArchivedItemDetail extends BtrixElement {
 
   private timerId?: number;
 
-  private get isActive(): boolean {
-    if (!this.item || this.item.type !== "crawl") return false;
-    return isActive(this.item);
-  }
-
   private get hasFiles(): boolean | null {
     if (!this.item) return null;
     if (!this.item.resources) return false;
@@ -203,28 +198,40 @@ export class ArchivedItemDetail extends BtrixElement {
       }
     }
 
-    // If item is a crawl and workflow id isn't set, redirect to item page with workflow prefix
     if (
-      this.workflowId === "" &&
       this.itemType === "crawl" &&
       changedProperties.has("item") &&
       this.item
     ) {
-      if (this.qaTab) {
-        // QA review open
-        this.navigate.to(
-          `${this.navigate.orgBasePath}/workflows/${this.item.cid}/crawls/${this.item.id}/review/${this.qaTab}${location.search}`,
-          undefined,
-          undefined,
-          true,
-        );
+      if (this.workflowId) {
+        if (this.item.type === "crawl" && isActive(this.item)) {
+          // Items can technically be "running" on the backend, but only
+          // workflows should be considered running by the frontend
+          this.navigate.to(
+            `${this.navigate.orgBasePath}/workflows/${this.item.cid}#watch`,
+            undefined,
+            undefined,
+            true,
+          );
+        }
       } else {
-        this.navigate.to(
-          `${this.navigate.orgBasePath}/workflows/${this.item.cid}/crawls/${this.item.id}#${this.activeTab}`,
-          undefined,
-          undefined,
-          true,
-        );
+        // If item is a crawl and workflow ID isn't set, redirect to item page with workflow prefix
+        if (this.qaTab) {
+          // QA review open
+          this.navigate.to(
+            `${this.navigate.orgBasePath}/workflows/${this.item.cid}/crawls/${this.item.id}/review/${this.qaTab}${location.search}`,
+            undefined,
+            undefined,
+            true,
+          );
+        } else {
+          this.navigate.to(
+            `${this.navigate.orgBasePath}/workflows/${this.item.cid}/crawls/${this.item.id}#${this.activeTab}`,
+            undefined,
+            undefined,
+            true,
+          );
+        }
       }
     }
   }
@@ -387,22 +394,12 @@ export class ArchivedItemDetail extends BtrixElement {
                   ${when(
                     this.isCrawler,
                     () => html`
-                      <sl-tooltip
-                        content=${msg(
-                          "Metadata cannot be edited while crawl is running.",
-                        )}
-                        ?disabled=${!this.isActive}
-                      >
-                        <sl-icon-button
-                          class=${`text-base${
-                            this.isActive ? " cursor-not-allowed" : ""
-                          }`}
-                          name="pencil"
-                          @click=${this.openMetadataEditor}
-                          label=${msg("Edit Metadata")}
-                          ?disabled=${this.isActive}
-                        ></sl-icon-button>
-                      </sl-tooltip>
+                      <sl-icon-button
+                        class="text-base"
+                        name="pencil"
+                        @click=${this.openMetadataEditor}
+                        label=${msg("Edit Metadata")}
+                      ></sl-icon-button>
                     `,
                   )}
                 `,
@@ -596,24 +593,6 @@ export class ArchivedItemDetail extends BtrixElement {
       <header class="mb-3 flex flex-wrap gap-2 border-b pb-3">
         <btrix-detail-page-title .item=${this.item}></btrix-detail-page-title>
         <div class="ml-auto flex flex-wrap justify-end gap-2">
-          ${this.isActive
-            ? html`
-                <sl-button-group>
-                  <sl-button size="small" @click=${this.stop}>
-                    <sl-icon name="dash-square" slot="prefix"></sl-icon>
-                    <span> ${msg("Stop")} </span>
-                  </sl-button>
-                  <sl-button size="small" @click=${this.cancel}>
-                    <sl-icon
-                      class="text-danger"
-                      name="trash3"
-                      slot="prefix"
-                    ></sl-icon>
-                    <span class="text-danger"> ${msg("Cancel")} </span>
-                  </sl-button>
-                </sl-button-group>
-              `
-            : ""}
           ${this.isCrawler
             ? this.item
               ? this.renderMenu()
@@ -634,9 +613,7 @@ export class ArchivedItemDetail extends BtrixElement {
     return html`
       <sl-dropdown placement="bottom-end" distance="4" hoist>
         <sl-button slot="trigger" size="small" caret
-          >${this.isActive
-            ? html`<sl-icon name="three-dots"></sl-icon>`
-            : msg("Actions")}</sl-button
+          >${msg("Actions")}</sl-button
         >
         <sl-menu>
           ${when(
@@ -696,8 +673,7 @@ export class ArchivedItemDetail extends BtrixElement {
             `,
           )}
           ${when(
-            this.isCrawler &&
-              (this.item.type !== "crawl" || !isActive(this.item)),
+            this.isCrawler,
             () => html`
               <sl-divider></sl-divider>
               <sl-menu-item
@@ -768,9 +744,7 @@ export class ArchivedItemDetail extends BtrixElement {
             </div>`
           : html`
               <p class="p-4 text-sm text-neutral-400">
-                ${this.isActive
-                  ? msg("No files yet.")
-                  : msg("No files to replay.")}
+                ${msg("No files to replay.")}
               </p>
             `
       }
@@ -1007,9 +981,7 @@ ${this.item?.description}
           `
         : html`
             <p class="text-sm text-neutral-400">
-              ${this.isActive
-                ? msg("No files yet.")
-                : msg("No files to download.")}
+              ${msg("No files to download.")}
             </p>
           `}
     `;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -918,7 +918,11 @@ export class WorkflowDetail extends BtrixElement {
               this.crawls!.items.map(
                 (crawl: Crawl) =>
                   html` <btrix-crawl-list-item
-                    href=${`${this.navigate.orgBasePath}/workflows/${this.workflowId}/crawls/${crawl.id}`}
+                    href=${ifDefined(
+                      isActive(crawl)
+                        ? undefined
+                        : `${this.navigate.orgBasePath}/workflows/${this.workflowId}/crawls/${crawl.id}`,
+                    )}
                     .crawl=${crawl}
                   >
                     ${when(


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2376

## Changes

- Updates links to running crawls to redirect to workflow "Watch" tab
- Removes unused "Jump to crawl" superadmin widgets
- Refactors archived item component to remove references to active crawls

## Manual testing

1. Log in as superadmin
2. Start a crawl
3. Click "Running Crawls"
4. Click a crawl. Verify you're redirected to the workflow "watch" view
5. Click "Crawls" tab. Verify you're unable to click the currently running crawl in the list

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Superadmin dashboard | <img width="1172" alt="Screenshot 2025-02-10 at 3 45 18 PM" src="https://github.com/user-attachments/assets/9fd1617f-0130-47a8-b70a-2db14a9f5eaf" /> |


<!-- ## Follow-ups -->
