### PR TITLE
Allow showing all collections as well as just public ones in org dashboard

### DIFF
--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -118,6 +118,9 @@ export class CollectionsGrid extends BtrixElement {
           `,
         )}
       </ul>
+      <div class="mt-10 flex justify-center">
+        <slot name="pagination"></slot>
+      </div>
       ${when(
         showActions,
         () =>

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -6,6 +6,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
 import { CollectionThumbnail } from "./collection-thumbnail";
+import { SelectCollectionAccess } from "./select-collection-access";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { RouteNamespace } from "@/routes";
@@ -31,6 +32,9 @@ export class CollectionsGrid extends BtrixElement {
 
   @property({ type: String })
   collectionRefreshing: string | null = null;
+
+  @property({ type: Boolean })
+  showVisibility = false;
 
   render() {
     const gridClassNames = tw`grid flex-1 grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`;
@@ -89,6 +93,16 @@ export class CollectionsGrid extends BtrixElement {
                   ${this.renderDateBadge(collection)}
                 </div>
                 <div class="${showActions ? "mr-9" : ""} min-h-9 leading-tight">
+                  ${this.showVisibility
+                    ? html`<sl-icon
+                        class="mr-[5px] align-[-1px] text-sm"
+                        name=${SelectCollectionAccess.Options[collection.access]
+                          .icon}
+                        label=${SelectCollectionAccess.Options[
+                          collection.access
+                        ].label}
+                      ></sl-icon>`
+                    : nothing}
                   <strong
                     class="text-base font-medium leading-tight text-stone-700 transition-colors group-hover:text-cyan-600"
                   >

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -1,7 +1,12 @@
 import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import {
+  customElement,
+  property,
+  queryAssignedNodes,
+  state,
+} from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
@@ -35,6 +40,9 @@ export class CollectionsGrid extends BtrixElement {
 
   @property({ type: Boolean })
   showVisibility = false;
+
+  @queryAssignedNodes({ slot: "pagination" })
+  pagination!: Node[];
 
   render() {
     const gridClassNames = tw`grid flex-1 grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`;
@@ -132,9 +140,12 @@ export class CollectionsGrid extends BtrixElement {
           `,
         )}
       </ul>
-      <div class="mt-10 flex justify-center">
-        <slot name="pagination"></slot>
-      </div>
+
+      <slot
+        class=${clsx("justify-center flex", this.pagination.length && "mt-10")}
+        name="pagination"
+      ></slot>
+
       ${when(
         showActions,
         () =>

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -254,10 +254,7 @@ export class CollectionDetail extends BtrixElement {
                     ${!this.collection ||
                     Boolean(this.collection.crawlCount && !this.isRwpLoaded)
                       ? html`<sl-spinner slot="prefix"></sl-spinner>`
-                      : html`<sl-icon
-                          name="house-fill"
-                          slot="prefix"
-                        ></sl-icon>`}
+                      : html`<sl-icon name="house" slot="prefix"></sl-icon>`}
                     ${msg("Set Initial View")}
                   </sl-button>
                 </sl-tooltip>
@@ -517,7 +514,7 @@ export class CollectionDetail extends BtrixElement {
               ${!this.collection ||
               Boolean(this.collection.crawlCount && !this.isRwpLoaded)
                 ? html`<sl-spinner slot="prefix"></sl-spinner>`
-                : html`<sl-icon name="house-fill" slot="prefix"></sl-icon>`}
+                : html`<sl-icon name="house" slot="prefix"></sl-icon>`}
               ${msg("Set Initial View")}
             </sl-menu-item>
           </sl-tooltip>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -361,32 +361,28 @@ export class Dashboard extends BtrixElement {
 
         <section class="mb-16">
           <header class="mb-1.5 flex items-center justify-between">
-            ${pageHeading({
-              content:
-                this.collectionsView === CollectionGridView.Public
-                  ? msg("Public Collections")
-                  : msg("All Collections"),
-            })}
             <div class="flex items-center gap-2">
-              <sl-tooltip
-                content=${this.org?.enablePublicProfile
-                  ? msg("Visit Public Collections Gallery")
-                  : msg("Preview Public Collections Gallery")}
-              >
-                <sl-icon-button
-                  href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
-                  class="size-8 text-base"
-                  name="globe2"
-                  @click=${this.navigate.link}
-                ></sl-icon-button>
-              </sl-tooltip>
-              ${when(
-                this.appState.isCrawler,
-                () => html`
-                  <!-- TODO Refactor clipboard code, get URL in a nicer way? -->
-                  ${when(this.org, (org) =>
-                    org.enablePublicProfile
-                      ? html` <btrix-copy-button
+              ${pageHeading({
+                content:
+                  this.collectionsView === CollectionGridView.Public
+                    ? msg("Public Collections")
+                    : msg("All Collections"),
+              })}
+              ${this.collectionsView === CollectionGridView.Public
+                ? html` <span class="text-sm text-neutral-400"
+                    >—
+                    <a
+                      href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
+                      class="inline-flex h-8 items-center text-sm font-medium text-primary-500 transition hover:text-primary-600"
+                      @click=${this.navigate.link}
+                    >
+                      ${this.org?.enablePublicProfile
+                        ? msg("Visit public collections gallery")
+                        : msg("Preview public collections gallery")}
+                    </a>
+                    <!-- TODO Refactor clipboard code, get URL in a nicer way? -->
+                    ${this.org?.enablePublicProfile
+                      ? html`<btrix-copy-button
                           value=${new URL(
                             `/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`,
                             window.location.toString(),
@@ -394,9 +390,16 @@ export class Dashboard extends BtrixElement {
                           content=${msg(
                             "Copy Link to Public Collections Gallery",
                           )}
+                          class="inline-block"
                         ></btrix-copy-button>`
-                      : nothing,
-                  )}
+                      : nothing}
+                  </span>`
+                : nothing}
+            </div>
+            <div class="flex items-center gap-2">
+              ${when(
+                this.appState.isCrawler,
+                () => html`
                   <sl-tooltip content=${msg("Manage Collections")}>
                     <sl-icon-button
                       href=${`${this.navigate.orgBasePath}/collections`}
@@ -439,6 +442,7 @@ export class Dashboard extends BtrixElement {
               slug=${this.orgSlugState || ""}
               .collections=${this.collections.value?.items}
               .collectionRefreshing=${this.collectionRefreshing}
+              ?showVisibility=${this.collectionsView === CollectionGridView.All}
               @btrix-collection-saved=${async (e: CollectionSavedEvent) => {
                 this.collectionRefreshing = e.detail.id;
                 void this.collections.run([

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -72,6 +72,9 @@ export class Dashboard extends BtrixElement {
   @state()
   collectionPage = 1;
 
+  // Used for busting cache when updating visible collection
+  cacheBust = 0;
+
   private readonly colors = {
     default: "neutral",
     crawls: "green",
@@ -99,7 +102,12 @@ export class Dashboard extends BtrixElement {
       { cacheConstructor: timeoutCache(300) },
     ),
     args: () =>
-      [this.orgId, this.collectionsView, this.collectionPage] as const,
+      [
+        this.orgId,
+        this.collectionsView,
+        this.collectionPage,
+        this.cacheBust,
+      ] as const,
   });
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
@@ -449,6 +457,7 @@ export class Dashboard extends BtrixElement {
                   this.orgId,
                   this.collectionsView,
                   this.collectionPage,
+                  ++this.cacheBust,
                 ]);
               }}
             >

--- a/frontend/src/utils/timeoutCache.ts
+++ b/frontend/src/utils/timeoutCache.ts
@@ -1,0 +1,39 @@
+import { type Cache } from "./weakCache";
+
+export function timeoutCache(seconds: number) {
+  return class<K, V> implements Cache<K, V> {
+    private readonly cache: { [key: string]: V } = Object.create(null);
+    set(key: K | string, value: V) {
+      if (typeof key !== "string") {
+        key = JSON.stringify(key);
+      }
+      this.cache[key] = value;
+      setTimeout(() => {
+        try {
+          delete this.cache[key as string];
+        } catch (_) {
+          /* empty */
+          console.debug("missing key", key);
+        }
+      }, seconds * 1000);
+      return this;
+    }
+    get(key: K | string) {
+      if (typeof key !== "string") {
+        key = JSON.stringify(key);
+      }
+      try {
+        return this.cache[key];
+      } catch (_) {
+        console.debug("missing key", key);
+        /* empty */
+      }
+    }
+    has(key: K | string) {
+      if (typeof key !== "string") {
+        key = JSON.stringify(key);
+      }
+      return Object.prototype.hasOwnProperty.call(this.cache, key);
+    }
+  };
+}

--- a/frontend/src/utils/weakCache.ts
+++ b/frontend/src/utils/weakCache.ts
@@ -1,3 +1,14 @@
+export interface Cache<K, V> {
+  set: (key: K, value: V) => this;
+  get: (key: K) => V | undefined;
+  has: (key: K) => boolean;
+}
+
+export interface CacheConstructor {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new <K, V>(...args: any[]): Cache<K, V>;
+}
+
 export const WeakRefMapInnerValue = Symbol("inner value");
 
 type WeakRefValue<T> = T extends object
@@ -28,16 +39,16 @@ const unwrapValue = <V>(val: WeakRef<WeakRefValue<V>> | undefined) => {
  *
  * Adapted from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_management#weakrefs_and_finalizationregistry and https://stackoverflow.com/a/72896692
  */
-export class WeakRefMap<K, V> {
+export class WeakRefMap<K, V> implements Cache<K, V> {
   readonly cacheMap = new Map<K, WeakRef<WeakRefValue<V>>>();
   private readonly finalizer = new FinalizationRegistry((key: K) => {
     this.cacheMap.delete(key);
   });
 
-  set(key: K, value: V): V {
+  set(key: K, value: V): this {
     const cache = this.get(key);
     if (cache) {
-      if (cache === value) return value;
+      if (cache === value) return this;
       if (typeof cache === "object") {
         this.finalizer.unregister(cache);
       }
@@ -47,14 +58,14 @@ export class WeakRefMap<K, V> {
     this.cacheMap.set(key, ref);
     this.finalizer.register(objVal, key, objVal);
 
-    return isWrapped(objVal) ? objVal[WeakRefMapInnerValue] : (objVal as V);
+    return this;
   }
 
-  get(key: K): V | undefined {
+  get(key: K) {
     return unwrapValue(this.cacheMap.get(key));
   }
 
-  has(key: K): boolean {
+  has(key: K) {
     return this.cacheMap.has(key);
   }
 }
@@ -67,13 +78,20 @@ export function cached<
   Serializer extends (args: Args) => unknown = (args: Args) => string,
 >(
   fn: (...args: Args) => Result,
-  serializer: Serializer = JSON.stringify as Serializer,
+  options: {
+    cacheConstructor?: CacheConstructor;
+    serializer?: Serializer;
+  } = {},
 ) {
+  const {
+    serializer = JSON.stringify as Serializer,
+    cacheConstructor = WeakRefMap,
+  } = options;
   type Key = ReturnType<Serializer>;
-  const cache = new WeakRefMap<Key, Result>();
+  const cache = new cacheConstructor<Key, Result>();
   const cachedFn: {
     (...args: Args): Result;
-    [InnerCache]: WeakRefMap<Key, Result>;
+    [InnerCache]: Cache<Key, Result>;
   } = (...args: Args) => {
     let k;
     try {
@@ -83,7 +101,13 @@ export function cached<
         "Unable to serialize function arguments successfully - ensure your serializer function is able to handle the args you're passing in",
       );
     }
-    return cache.get(k) ?? cache.set(k, fn(...args));
+    if (cache.has(k)) {
+      return cache.get(k)!;
+    } else {
+      const v = fn(...args);
+      cache.set(k, v);
+      return v;
+    }
   };
   cachedFn[InnerCache] = cache;
   return cachedFn;


### PR DESCRIPTION
Adds a switch to switch between viewing public collections only (default) and all collections on org dashboard.

<img width="1278" alt="Screenshot 2025-02-13 at 10 18 09 AM" src="https://github.com/user-attachments/assets/8a388e96-e082-44e5-be33-564acce7b27e" />

Also updates the `house-fill` icon to `house` in a couple places (@Shrinks99)