### PR TITLE
Add initial pages + pagesQuery endpoint to /replay.json APIs

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -502,7 +502,7 @@ class BaseCrawlOps:
                     path=presigned_url or "",
                     hash=file_.hash,
                     size=file_.size,
-                    itemId=crawl_id,
+                    crawlId=crawl_id,
                     numReplicas=len(file_.replicas) if file_.replicas else 0,
                     expireAt=expire_at_str,
                 )

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 from typing import Optional, List, Union, Dict, Any, Type, TYPE_CHECKING, cast, Tuple
 from uuid import UUID
+import os
 import urllib.parse
 
 import asyncio
@@ -497,11 +498,11 @@ class BaseCrawlOps:
 
             out_files.append(
                 CrawlFileOut(
-                    name=file_.filename,
+                    name=os.path.basename(file_.filename),
                     path=presigned_url or "",
                     hash=file_.hash,
                     size=file_.size,
-                    crawlId=crawl_id,
+                    itemId=crawl_id,
                     numReplicas=len(file_.replicas) if file_.replicas else 0,
                     expireAt=expire_at_str,
                 )

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -32,7 +32,7 @@ from .models import (
     PRESIGN_DURATION_SECONDS,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
-from .utils import dt_now, date_to_str
+from .utils import dt_now, date_to_str, get_origin
 
 if TYPE_CHECKING:
     from .crawlconfigs import CrawlConfigOps
@@ -157,6 +157,7 @@ class BaseCrawlOps:
         org: Optional[Organization] = None,
         type_: Optional[str] = None,
         skip_resources=False,
+        headers: Optional[dict] = None,
     ) -> CrawlOutWithResources:
         """Get crawl data for api output"""
         res = await self.get_crawl_raw(crawlid, org, type_)
@@ -168,6 +169,16 @@ class BaseCrawlOps:
             coll_ids = res.get("collectionIds")
             if coll_ids:
                 res["collections"] = await self.colls.get_collection_names(coll_ids)
+
+            res["seedPages"], _ = await self.page_ops.list_pages(
+                crawlid, is_seed=True, page_size=25
+            )
+
+            oid = res.get("oid")
+            if oid:
+                res["pagesQueryUrl"] = (
+                    get_origin(headers) + f"/api/orgs/{oid}/crawls/{crawlid}/pages"
+                )
 
         crawl = CrawlOutWithResources.from_dict(res)
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -170,7 +170,7 @@ class BaseCrawlOps:
             if coll_ids:
                 res["collections"] = await self.colls.get_collection_names(coll_ids)
 
-            res["seedPages"], _ = await self.page_ops.list_pages(
+            res["initialPages"], _ = await self.page_ops.list_pages(
                 crawlid, is_seed=True, page_size=25
             )
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -343,24 +343,23 @@ class CollectionOps:
     ) -> CollOut:
         """Get CollOut by id"""
         result = await self.get_collection_raw(coll_id, public_or_unlisted_only)
-        coll = CollOut.from_dict(result)
 
         if resources:
-            coll.resources = await self.get_collection_crawl_resources(coll_id)
+            result["resources"] = await self.get_collection_crawl_resources(coll_id)
 
             pages, _ = await self.page_ops.list_collection_pages(
                 coll_id, is_seed=True, page_size=25
             )
-            coll.pages = cast(List[PageOut], pages)
+            result["pages"] = pages
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
             image_file = ImageFile(**thumbnail)
-            coll.thumbnail = await image_file.get_image_file_out(
+            result["thumbnail"] = await image_file.get_image_file_out(
                 org, self.storage_ops
             )
 
-        return coll
+        return CollOut.from_dict(result)
 
     async def get_public_collection_out(
         self,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -367,7 +367,7 @@ class CollectionOps:
                     seed_wacz_filenames.add(page.filename)
                     always_load.append(
                         AlwaysLoadResource(
-                            wacz=page.filename, itemId=page.crawl_id, hasPages=True
+                            wacz=page.filename, crawlId=page.crawl_id, hasPages=True
                         )
                     )
 
@@ -562,7 +562,7 @@ class CollectionOps:
                     resources_no_pages.append(
                         AlwaysLoadResource(
                             wacz=os.path.basename(resource.name),
-                            itemId=crawl.id,
+                            crawlId=crawl.id,
                             hasPages=False,
                         )
                     )

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -353,8 +353,8 @@ class CollectionOps:
                 )
             )
 
-            result["seedPages"], _ = await self.page_ops.list_collection_pages(
-                coll_id, is_seed=True, page_size=25
+            result["initialPages"], result["totalPages"] = (
+                await self.page_ops.list_collection_pages(coll_id, page_size=25)
             )
 
             public = "public/" if public_or_unlisted_only else ""

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -343,6 +343,7 @@ class CollectionOps:
         headers: Optional[dict] = None,
     ) -> CollOut:
         """Get CollOut by id"""
+        # pylint: disable=too-many-locals
         result = await self.get_collection_raw(coll_id, public_or_unlisted_only)
 
         if resources:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -53,7 +53,7 @@ from .models import (
     ImageFilePreparer,
     MIN_UPLOAD_PART_SIZE,
     PublicCollOut,
-    AlwaysLoadResource,
+    PreloadResource,
 )
 from .utils import dt_now, slug_from_name, get_duplicate_key_error_field, get_origin
 
@@ -347,35 +347,19 @@ class CollectionOps:
         result = await self.get_collection_raw(coll_id, public_or_unlisted_only)
 
         if resources:
-            result["resources"] = await self.get_collection_crawl_resources(coll_id)
+            result["resources"], result["preloadResources"] = (
+                await self.get_collection_crawl_resources(coll_id)
+            )
 
-            pages, _ = await self.page_ops.list_collection_pages(
+            result["seedPages"], _ = await self.page_ops.list_collection_pages(
                 coll_id, is_seed=True, page_size=25
             )
-            result["pages"] = pages
+
             public = "public/" if public_or_unlisted_only else ""
-            result["pagesQuery"] = (
+            result["pagesQueryUrl"] = (
                 get_origin(headers)
                 + f"/api/orgs/{org.id}/collections/{coll_id}/{public}pages"
             )
-
-            always_load: List[AlwaysLoadResource] = []
-
-            seed_wacz_filenames = set()
-            for page in pages:
-                if page.isSeed and page.filename not in seed_wacz_filenames:
-                    seed_wacz_filenames.add(page.filename)
-                    always_load.append(
-                        AlwaysLoadResource(
-                            wacz=page.filename, crawlId=page.crawl_id, hasPages=True
-                        )
-                    )
-
-            no_page_items = await self.get_collection_resources_with_no_pages(coll_id)
-            for item in no_page_items:
-                always_load.append(item)
-
-            result["alwaysLoad"] = always_load
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
@@ -402,7 +386,9 @@ class CollectionOps:
         if result.get("access") not in allowed_access:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
-        result["resources"] = await self.get_collection_crawl_resources(coll_id)
+        result["resources"], result["preloadResources"] = (
+            await self.get_collection_crawl_resources(coll_id)
+        )
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
@@ -501,7 +487,9 @@ class CollectionOps:
         collections: List[Union[CollOut, PublicCollOut]] = []
 
         for res in items:
-            res["resources"] = await self.get_collection_crawl_resources(res["_id"])
+            res["resources"], res["preloadResources"] = (
+                await self.get_collection_crawl_resources(res["_id"])
+            )
 
             thumbnail = res.get("thumbnail")
             if thumbnail:
@@ -528,7 +516,7 @@ class CollectionOps:
         # Ensure collection exists
         _ = await self.get_collection_raw(coll_id)
 
-        all_files = []
+        resources = []
 
         crawls, _ = await self.crawl_ops.list_all_base_crawls(
             collection_id=coll_id,
@@ -539,29 +527,29 @@ class CollectionOps:
 
         for crawl in crawls:
             if crawl.resources:
-                all_files.extend(crawl.resources)
+                resources.extend(crawl.resources)
 
-        return all_files
+        preload_resources: List[PreloadResource] = []
+
+        no_page_items = await self.get_collection_resources_with_no_pages(crawls)
+        for item in no_page_items:
+            preload_resources.append(item)
+
+        return resources, preload_resources
 
     async def get_collection_resources_with_no_pages(
-        self, coll_id: UUID
-    ) -> List[AlwaysLoadResource]:
+        self, crawls: List[CrawlOutWithResources]
+    ) -> List[PreloadResource]:
         """Return wacz files in collection that have no pages"""
-        resources_no_pages: List[AlwaysLoadResource] = []
+        resources_no_pages: List[PreloadResource] = []
 
-        crawls, _ = await self.crawl_ops.list_all_base_crawls(
-            collection_id=coll_id,
-            states=list(SUCCESSFUL_STATES),
-            page_size=10_000,
-            cls_type=CrawlOutWithResources,
-        )
         for crawl in crawls:
             _, page_count = await self.page_ops.list_pages(crawl.id)
             if page_count == 0 and crawl.resources:
                 for resource in crawl.resources:
                     resources_no_pages.append(
-                        AlwaysLoadResource(
-                            wacz=os.path.basename(resource.name),
+                        PreloadResource(
+                            name=os.path.basename(resource.name),
                             crawlId=crawl.id,
                             hasPages=False,
                         )
@@ -1075,8 +1063,8 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops, user_de
         try:
             all_collections, _ = await colls.list_collections(org, page_size=10_000)
             for collection in all_collections:
-                results[collection.name] = await colls.get_collection_crawl_resources(
-                    collection.id
+                results[collection.name], _ = (
+                    await colls.get_collection_crawl_resources(collection.id)
                 )
         except Exception as exc:
             # pylint: disable=raise-missing-from

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -580,11 +580,9 @@ class CollectionOps:
     ) -> List[str]:
         """Return list of crawl ids in collection, including only public collections"""
         crawl_ids = []
+        # ensure collection is public or unlisted, else throw here
         if public_or_unlisted_only:
-            try:
-                await self.get_collection_raw(coll_id, public_or_unlisted_only)
-            except HTTPException:
-                return []
+            await self.get_collection_raw(coll_id, public_or_unlisted_only)
 
         async for crawl_raw in self.crawls.find(
             {"collectionIds": coll_id}, projection=["_id"]

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -46,6 +46,7 @@ from .models import (
     CollAccessType,
     PageUrlCount,
     PageIdTimestamp,
+    PageOut,
     PaginatedPageUrlCountResponse,
     UpdateCollHomeUrl,
     User,
@@ -61,8 +62,9 @@ if TYPE_CHECKING:
     from .storages import StorageOps
     from .webhooks import EventWebhookOps
     from .crawls import CrawlOps
+    from .pages import PageOps
 else:
-    OrgOps = StorageOps = EventWebhookOps = CrawlOps = object
+    OrgOps = StorageOps = EventWebhookOps = CrawlOps = PageOps = object
 
 
 THUMBNAIL_MAX_SIZE = 2_000_000
@@ -78,6 +80,7 @@ class CollectionOps:
     storage_ops: StorageOps
     event_webhook_ops: EventWebhookOps
     crawl_ops: CrawlOps
+    page_ops: PageOps
 
     def __init__(self, mdb, storage_ops, orgs, event_webhook_ops):
         self.collections = mdb["collections"]
@@ -340,18 +343,24 @@ class CollectionOps:
     ) -> CollOut:
         """Get CollOut by id"""
         result = await self.get_collection_raw(coll_id, public_or_unlisted_only)
+        coll = CollOut.from_dict(result)
 
         if resources:
-            result["resources"] = await self.get_collection_crawl_resources(coll_id)
+            coll.resources = await self.get_collection_crawl_resources(coll_id)
+
+            pages, _ = await self.page_ops.list_collection_pages(
+                coll_id, is_seed=True, page_size=25
+            )
+            coll.pages = cast(List[PageOut], pages)
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
             image_file = ImageFile(**thumbnail)
-            result["thumbnail"] = await image_file.get_image_file_out(
+            coll.thumbnail = await image_file.get_image_file_out(
                 org, self.storage_ops
             )
 
-        return CollOut.from_dict(result)
+        return coll
 
     async def get_public_collection_out(
         self,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -46,7 +46,6 @@ from .models import (
     CollAccessType,
     PageUrlCount,
     PageIdTimestamp,
-    PageOut,
     PaginatedPageUrlCountResponse,
     UpdateCollHomeUrl,
     User,
@@ -55,7 +54,7 @@ from .models import (
     MIN_UPLOAD_PART_SIZE,
     PublicCollOut,
 )
-from .utils import dt_now, slug_from_name, get_duplicate_key_error_field
+from .utils import dt_now, slug_from_name, get_duplicate_key_error_field, get_origin
 
 if TYPE_CHECKING:
     from .orgs import OrgOps
@@ -340,6 +339,7 @@ class CollectionOps:
         org: Organization,
         resources=False,
         public_or_unlisted_only=False,
+        headers: Optional[dict] = None,
     ) -> CollOut:
         """Get CollOut by id"""
         result = await self.get_collection_raw(coll_id, public_or_unlisted_only)
@@ -351,6 +351,9 @@ class CollectionOps:
                 coll_id, is_seed=True, page_size=25
             )
             result["pages"] = pages
+            result["pagesQuery"] = (
+                get_origin(headers) + f"/api/orgs/{org.id}/collections/{coll_id}/pages"
+            )
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
@@ -1053,9 +1056,11 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops, user_de
         response_model=CollOut,
     )
     async def get_collection_replay(
-        coll_id: UUID, org: Organization = Depends(org_viewer_dep)
+        request: Request, coll_id: UUID, org: Organization = Depends(org_viewer_dep)
     ):
-        return await colls.get_collection_out(coll_id, org, resources=True)
+        return await colls.get_collection_out(
+            coll_id, org, resources=True, headers=dict(request.headers)
+        )
 
     @app.get(
         "/orgs/{oid}/collections/{coll_id}/public/replay.json",
@@ -1063,12 +1068,17 @@ def init_collections_api(app, mdb, orgs, storage_ops, event_webhook_ops, user_de
         response_model=CollOut,
     )
     async def get_collection_public_replay(
+        request: Request,
         response: Response,
         coll_id: UUID,
         org: Organization = Depends(org_public),
     ):
         coll = await colls.get_collection_out(
-            coll_id, org, resources=True, public_or_unlisted_only=True
+            coll_id,
+            org,
+            resources=True,
+            public_or_unlisted_only=True,
+            headers=dict(request.headers),
         )
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["Access-Control-Allow-Headers"] = "*"

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -735,7 +735,7 @@ class CrawlFileOut(BaseModel):
     hash: str
     size: int
 
-    itemId: Optional[str] = None
+    crawlId: Optional[str] = None
     numReplicas: int = 0
     expireAt: Optional[str] = None
 
@@ -1405,7 +1405,7 @@ class AlwaysLoadResource(BaseModel):
     """Resources to always load in RWP"""
 
     wacz: str
-    itemId: str
+    crawlId: str
     hasPages: bool
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1401,6 +1401,15 @@ class CollectionThumbnailSource(BaseModel):
 
 
 # ============================================================================
+class AlwaysLoadResource(BaseModel):
+    """Resources to always load in RWP"""
+
+    wacz: str
+    itemId: str
+    hasPages: bool
+
+
+# ============================================================================
 class Collection(BaseMongoModel):
     """Org collection structure"""
 
@@ -1495,6 +1504,7 @@ class CollOut(BaseMongoModel):
 
     pages: List[PageOut] = []
     pagesQuery: str = ""
+    alwaysLoad: List[AlwaysLoadResource] = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1494,6 +1494,7 @@ class CollOut(BaseMongoModel):
     allowPublicDownload: bool = True
 
     pages: List[PageOut] = []
+    pagesQuery: str = ""
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1226,6 +1226,7 @@ class ImageFilePreparer(FilePreparer):
 
 ### PAGES ###
 
+
 # ============================================================================
 class PageReviewUpdate(BaseModel):
     """Update model for page manual review/approval"""
@@ -1374,9 +1375,12 @@ class PageUrlCount(BaseModel):
     url: AnyHttpUrl
     count: int = 0
     snapshots: List[PageIdTimestamp] = []
+
+
 # ============================================================================
 
 ### COLLECTIONS ###
+
 
 # ============================================================================
 class CollAccessType(str, Enum):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1401,10 +1401,10 @@ class CollectionThumbnailSource(BaseModel):
 
 
 # ============================================================================
-class AlwaysLoadResource(BaseModel):
-    """Resources to always load in RWP"""
+class PreloadResource(BaseModel):
+    """Resources that will preloaded in RWP"""
 
-    wacz: str
+    name: str
     crawlId: str
     hasPages: bool
 
@@ -1502,9 +1502,9 @@ class CollOut(BaseMongoModel):
 
     allowPublicDownload: bool = True
 
-    pages: List[PageOut] = []
-    pagesQuery: str = ""
-    alwaysLoad: List[AlwaysLoadResource] = []
+    seedPages: List[PageOut] = []
+    preloadResources: List[PreloadResource] = []
+    pagesQueryUrl: str = ""
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -882,14 +882,6 @@ class CrawlOut(BaseMongoModel):
 
 
 # ============================================================================
-class CrawlOutWithResources(CrawlOut):
-    """Crawl output model including resources"""
-
-    resources: Optional[List[CrawlFileOut]] = []
-    collections: Optional[List[CollIdName]] = []
-
-
-# ============================================================================
 class UpdateCrawl(BaseModel):
     """Update crawl"""
 
@@ -1375,6 +1367,17 @@ class PageUrlCount(BaseModel):
     url: AnyHttpUrl
     count: int = 0
     snapshots: List[PageIdTimestamp] = []
+
+
+# ============================================================================
+class CrawlOutWithResources(CrawlOut):
+    """Crawl output model including resources"""
+
+    resources: Optional[List[CrawlFileOut]] = []
+    collections: Optional[List[CollIdName]] = []
+
+    seedPages: List[PageOut] = []
+    pagesQueryUrl: str = ""
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1376,7 +1376,8 @@ class CrawlOutWithResources(CrawlOut):
     resources: Optional[List[CrawlFileOut]] = []
     collections: Optional[List[CollIdName]] = []
 
-    seedPages: List[PageOut] = []
+    initialPages: List[PageOut] = []
+    totalPages: Optional[int] = None
     pagesQueryUrl: str = ""
 
 
@@ -1505,7 +1506,8 @@ class CollOut(BaseMongoModel):
 
     allowPublicDownload: bool = True
 
-    seedPages: List[PageOut] = []
+    initialPages: List[PageOut] = []
+    totalPages: Optional[int] = None
     preloadResources: List[PreloadResource] = []
     pagesQueryUrl: str = ""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -735,7 +735,7 @@ class CrawlFileOut(BaseModel):
     hash: str
     size: int
 
-    crawlId: Optional[str] = None
+    itemId: Optional[str] = None
     numReplicas: int = 0
     expireAt: Optional[str] = None
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1224,8 +1224,159 @@ class ImageFilePreparer(FilePreparer):
 
 # ============================================================================
 
-### COLLECTIONS ###
+### PAGES ###
 
+# ============================================================================
+class PageReviewUpdate(BaseModel):
+    """Update model for page manual review/approval"""
+
+    approved: Optional[bool] = None
+
+
+# ============================================================================
+class PageNoteIn(BaseModel):
+    """Input model for adding page notes"""
+
+    text: str
+
+
+# ============================================================================
+class PageNoteEdit(BaseModel):
+    """Input model for editing page notes"""
+
+    id: UUID
+    text: str
+
+
+# ============================================================================
+class PageNoteDelete(BaseModel):
+    """Delete model for page notes"""
+
+    delete_list: List[UUID] = []
+
+
+# ============================================================================
+class PageNote(BaseModel):
+    """Model for page notes, tracking user and time"""
+
+    id: UUID
+    text: str
+    created: datetime
+    userid: UUID
+    userName: str
+
+
+# ============================================================================
+class PageQACompare(BaseModel):
+    """Model for updating pages from QA run"""
+
+    screenshotMatch: Optional[float] = None
+    textMatch: Optional[float] = None
+    resourceCounts: Optional[Dict[str, int]] = None
+
+
+# ============================================================================
+class Page(BaseMongoModel):
+    """Core page data, no QA"""
+
+    id: UUID
+
+    oid: UUID
+    crawl_id: str
+
+    # core page data
+    url: AnyHttpUrl
+    title: Optional[str] = None
+    ts: Optional[datetime] = None
+    loadState: Optional[int] = None
+    status: Optional[int] = None
+    mime: Optional[str] = None
+    filename: Optional[str] = None
+    depth: Optional[int] = None
+    favIconUrl: Optional[AnyHttpUrl] = None
+    isSeed: Optional[bool] = False
+
+    # manual review
+    userid: Optional[UUID] = None
+    modified: Optional[datetime] = None
+    approved: Optional[bool] = None
+    notes: List[PageNote] = []
+
+    isFile: Optional[bool] = False
+    isError: Optional[bool] = False
+
+    def compute_page_type(self):
+        """sets self.isFile or self.isError flags"""
+        self.isFile = False
+        self.isError = False
+        if self.loadState == 2:
+            # pylint: disable=unsupported-membership-test
+            if self.mime and "html" not in self.mime:
+                self.isFile = True
+            elif self.title is None and self.status == 200:
+                self.isFile = True
+
+        elif self.loadState == 0:
+            self.isError = True
+
+
+# ============================================================================
+class PageWithAllQA(Page):
+    """Model for core page data + qa"""
+
+    # automated heuristics, keyed by QA run id
+    qa: Optional[Dict[str, PageQACompare]] = {}
+
+
+# ============================================================================
+class PageOut(Page):
+    """Model for pages output, no QA"""
+
+    status: int = 200
+
+
+# ============================================================================
+class PageOutWithSingleQA(Page):
+    """Page out with single QA entry"""
+
+    qa: Optional[PageQACompare] = None
+
+
+# ============================================================================
+class PageNoteAddedResponse(BaseModel):
+    """Model for response to adding page"""
+
+    added: bool
+    data: PageNote
+
+
+# ============================================================================
+class PageNoteUpdatedResponse(BaseModel):
+    """Model for response to updating page"""
+
+    updated: bool
+    data: PageNote
+
+
+# ============================================================================
+class PageIdTimestamp(BaseModel):
+    """Simplified model for page info to include in PageUrlCount"""
+
+    pageId: UUID
+    ts: Optional[datetime] = None
+    status: int = 200
+
+
+# ============================================================================
+class PageUrlCount(BaseModel):
+    """Model for counting pages by URL"""
+
+    url: AnyHttpUrl
+    count: int = 0
+    snapshots: List[PageIdTimestamp] = []
+# ============================================================================
+
+### COLLECTIONS ###
 
 # ============================================================================
 class CollAccessType(str, Enum):
@@ -1337,6 +1488,8 @@ class CollOut(BaseMongoModel):
     defaultThumbnailName: Optional[str] = None
 
     allowPublicDownload: bool = True
+
+    pages: List[PageOut] = []
 
 
 # ============================================================================
@@ -2433,161 +2586,6 @@ AnyJob = RootModel[
         ReAddOrgPagesJob,
     ]
 ]
-
-
-# ============================================================================
-
-### PAGES ###
-
-
-# ============================================================================
-class PageReviewUpdate(BaseModel):
-    """Update model for page manual review/approval"""
-
-    approved: Optional[bool] = None
-
-
-# ============================================================================
-class PageNoteIn(BaseModel):
-    """Input model for adding page notes"""
-
-    text: str
-
-
-# ============================================================================
-class PageNoteEdit(BaseModel):
-    """Input model for editing page notes"""
-
-    id: UUID
-    text: str
-
-
-# ============================================================================
-class PageNoteDelete(BaseModel):
-    """Delete model for page notes"""
-
-    delete_list: List[UUID] = []
-
-
-# ============================================================================
-class PageNote(BaseModel):
-    """Model for page notes, tracking user and time"""
-
-    id: UUID
-    text: str
-    created: datetime
-    userid: UUID
-    userName: str
-
-
-# ============================================================================
-class PageQACompare(BaseModel):
-    """Model for updating pages from QA run"""
-
-    screenshotMatch: Optional[float] = None
-    textMatch: Optional[float] = None
-    resourceCounts: Optional[Dict[str, int]] = None
-
-
-# ============================================================================
-class Page(BaseMongoModel):
-    """Core page data, no QA"""
-
-    id: UUID
-
-    oid: UUID
-    crawl_id: str
-
-    # core page data
-    url: AnyHttpUrl
-    title: Optional[str] = None
-    ts: Optional[datetime] = None
-    loadState: Optional[int] = None
-    status: Optional[int] = None
-    mime: Optional[str] = None
-    filename: Optional[str] = None
-    depth: Optional[int] = None
-    favIconUrl: Optional[AnyHttpUrl] = None
-    isSeed: Optional[bool] = False
-
-    # manual review
-    userid: Optional[UUID] = None
-    modified: Optional[datetime] = None
-    approved: Optional[bool] = None
-    notes: List[PageNote] = []
-
-    isFile: Optional[bool] = False
-    isError: Optional[bool] = False
-
-    def compute_page_type(self):
-        """sets self.isFile or self.isError flags"""
-        self.isFile = False
-        self.isError = False
-        if self.loadState == 2:
-            # pylint: disable=unsupported-membership-test
-            if self.mime and "html" not in self.mime:
-                self.isFile = True
-            elif self.title is None and self.status == 200:
-                self.isFile = True
-
-        elif self.loadState == 0:
-            self.isError = True
-
-
-# ============================================================================
-class PageWithAllQA(Page):
-    """Model for core page data + qa"""
-
-    # automated heuristics, keyed by QA run id
-    qa: Optional[Dict[str, PageQACompare]] = {}
-
-
-# ============================================================================
-class PageOut(Page):
-    """Model for pages output, no QA"""
-
-    status: int = 200
-
-
-# ============================================================================
-class PageOutWithSingleQA(Page):
-    """Page out with single QA entry"""
-
-    qa: Optional[PageQACompare] = None
-
-
-# ============================================================================
-class PageNoteAddedResponse(BaseModel):
-    """Model for response to adding page"""
-
-    added: bool
-    data: PageNote
-
-
-# ============================================================================
-class PageNoteUpdatedResponse(BaseModel):
-    """Model for response to updating page"""
-
-    updated: bool
-    data: PageNote
-
-
-# ============================================================================
-class PageIdTimestamp(BaseModel):
-    """Simplified model for page info to include in PageUrlCount"""
-
-    pageId: UUID
-    ts: Optional[datetime] = None
-    status: int = 200
-
-
-# ============================================================================
-class PageUrlCount(BaseModel):
-    """Model for counting pages by URL"""
-
-    url: AnyHttpUrl
-    count: int = 0
-    snapshots: List[PageIdTimestamp] = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -744,6 +744,9 @@ class PageOps:
                 raise HTTPException(status_code=400, detail="invalid_sort_direction")
 
             aggregate.extend([{"$sort": {sort_by: sort_direction}}])
+        else:
+            # default sort: seeds first, then by timestamp
+            aggregate.extend([{"$sort": {"isSeed": -1, "ts": 1}}])
 
         aggregate.extend(
             [

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -661,6 +661,7 @@ class PageOps:
         self,
         coll_id: UUID,
         org: Optional[Organization] = None,
+        search: Optional[str] = None,
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
         ts: Optional[datetime] = None,
@@ -688,7 +689,14 @@ class PageOps:
         if org:
             query["oid"] = org.id
 
-        if url_prefix:
+        if search:
+            search_regex = re.escape(urllib.parse.unquote(search))
+            query["$or"] = [
+                {"url": {"$regex": search_regex, "$options": "i"}},
+                {"title": {"$regex": search_regex, "$options": "i"}},
+            ]
+
+        elif url_prefix:
             url_prefix = urllib.parse.unquote(url_prefix)
             regex_pattern = f"^{re.escape(url_prefix)}"
             query["url"] = {"$regex": regex_pattern, "$options": "i"}
@@ -1104,6 +1112,7 @@ def init_pages_api(
     async def get_public_collection_pages_list(
         coll_id: UUID,
         org: Organization = Depends(org_public),
+        search: Optional[str] = None,
         url: Optional[str] = None,
         urlPrefix: Optional[str] = None,
         ts: Optional[datetime] = None,
@@ -1118,6 +1127,7 @@ def init_pages_api(
         pages, total = await ops.list_collection_pages(
             coll_id=coll_id,
             org=org,
+            search=search,
             url=url,
             url_prefix=urlPrefix,
             ts=ts,
@@ -1139,6 +1149,7 @@ def init_pages_api(
     async def get_collection_pages_list(
         coll_id: UUID,
         org: Organization = Depends(org_viewer_dep),
+        search: Optional[str] = None,
         url: Optional[str] = None,
         urlPrefix: Optional[str] = None,
         ts: Optional[datetime] = None,
@@ -1153,6 +1164,7 @@ def init_pages_api(
         pages, total = await ops.list_collection_pages(
             coll_id=coll_id,
             org=org,
+            search=search,
             url=url,
             url_prefix=urlPrefix,
             ts=ts,

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -35,6 +35,7 @@ from .models import (
     DeletedResponse,
     PageNoteAddedResponse,
     PageNoteUpdatedResponse,
+    EmptyResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import str_to_date, str_list_to_bools, dt_now

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Tuple, List, Dict, Any, Union
 from uuid import UUID, uuid4
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request, Response
 import pymongo
 
 from .models import (
@@ -1111,6 +1111,7 @@ def init_pages_api(
     )
     async def get_public_collection_pages_list(
         coll_id: UUID,
+        response: Response,
         org: Organization = Depends(org_public),
         search: Optional[str] = None,
         url: Optional[str] = None,
@@ -1139,7 +1140,21 @@ def init_pages_api(
             sort_direction=sortDirection,
             public_or_unlisted_only=True,
         )
+
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Allow-Headers"] = "*"
         return paginated_format(pages, total, page, pageSize)
+
+    @app.options(
+        "/orgs/{oid}/collections/{coll_id}/public/pages",
+        tags=["pages", "collections"],
+        response_model=EmptyResponse,
+    )
+    async def get_replay_preflight(response: Response):
+        response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Allow-Headers"] = "*"
+        return {}
 
     @app.get(
         "/orgs/{oid}/collections/{coll_id}/pages",

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -504,6 +504,7 @@ class PageOps:
         self,
         crawl_id: str,
         org: Optional[Organization] = None,
+        search: Optional[str] = None,
         url: Optional[str] = None,
         url_prefix: Optional[str] = None,
         ts: Optional[datetime] = None,
@@ -534,6 +535,13 @@ class PageOps:
         }
         if org:
             query["oid"] = org.id
+
+        if search:
+            search_regex = re.escape(urllib.parse.unquote(search))
+            query["$or"] = [
+                {"url": {"$regex": search_regex, "$options": "i"}},
+                {"title": {"$regex": search_regex, "$options": "i"}},
+            ]
 
         if url_prefix:
             url_prefix = urllib.parse.unquote(url_prefix)
@@ -1069,6 +1077,7 @@ def init_pages_api(
     async def get_crawl_pages_list(
         crawl_id: str,
         org: Organization = Depends(org_crawl_dep),
+        search: Optional[str] = None,
         url: Optional[str] = None,
         urlPrefix: Optional[str] = None,
         ts: Optional[datetime] = None,
@@ -1090,6 +1099,7 @@ def init_pages_api(
         pages, total = await ops.list_pages(
             crawl_id=crawl_id,
             org=org,
+            search=search,
             url=url,
             url_prefix=urlPrefix,
             ts=ts,

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -382,7 +382,7 @@ def test_get_collection_replay(crawler_auth_headers, default_org_id):
     assert data["dateEarliest"]
     assert data["dateLatest"]
     assert data["defaultThumbnailName"]
-    assert data["seedPages"]
+    assert data["initialPages"]
     assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/pages"
     )
@@ -419,7 +419,7 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["seedPages"]
+    assert data["initialPages"]
     assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
     )

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -416,7 +416,7 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/replay.json",
         headers=crawler_auth_headers,
     )
-    assert data["pagesQuery"].endswith(
+    assert r.json()["pagesQuery"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
     )
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -642,6 +642,39 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     coll_page_id = coll_page["id"]
     coll_page_url = coll_page["url"]
     coll_page_ts = coll_page["ts"]
+    coll_page_title = coll_page["title"]
+
+    # Test search filter
+    partial_title = coll_page_title[:5]
+    partial_url = coll_page_url[:8]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?search={partial_title}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["total"] >= 1
+    for matching_page in data["items"]:
+        assert (
+            partial_title in matching_page["title"]
+            or partial_url in matching_page["url"]
+        )
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?search={partial_url}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["total"] >= 1
+    for matching_page in data["items"]:
+        assert (
+            partial_title in matching_page["title"]
+            or partial_url in matching_page["url"]
+        )
 
     # Test exact url filter
     r = requests.get(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -386,7 +386,7 @@ def test_get_collection_replay(crawler_auth_headers, default_org_id):
     assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/pages"
     )
-    assert data["preloadResources"]
+    assert "preloadResources" in data
 
     resources = data["resources"]
     assert resources
@@ -423,7 +423,7 @@ def test_collection_public(crawler_auth_headers, default_org_id):
     assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
     )
-    assert data["preloadResources"]
+    assert "preloadResources" in data
 
     assert r.status_code == 200
     assert r.headers["Access-Control-Allow-Origin"] == "*"

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -84,10 +84,6 @@ def test_create_collection(
     assert data["pageCount"] > 0
     assert data["uniquePageCount"] > 0
     assert data["totalSize"] > 0
-    assert (
-        data["pagesQuery"]
-        == f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages"
-    )
     modified = data["modified"]
     assert modified
     assert modified.endswith("Z")
@@ -386,6 +382,9 @@ def test_get_collection_replay(crawler_auth_headers, default_org_id):
     assert data["dateEarliest"]
     assert data["dateLatest"]
     assert data["defaultThumbnailName"]
+    assert data["pagesQuery"].endswith(
+        f"/orgs/{default_org_id}/collections/{_coll_id}/pages"
+    )
 
     resources = data["resources"]
     assert resources
@@ -417,10 +416,10 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/replay.json",
         headers=crawler_auth_headers,
     )
-    assert (
-        r.json()["pagesQuery"]
-        == f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
+    assert data["pagesQuery"].endswith(
+        f"/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
     )
+
     assert r.status_code == 200
     assert r.headers["Access-Control-Allow-Origin"] == "*"
     assert r.headers["Access-Control-Allow-Headers"] == "*"

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -84,6 +84,10 @@ def test_create_collection(
     assert data["pageCount"] > 0
     assert data["uniquePageCount"] > 0
     assert data["totalSize"] > 0
+    assert (
+        data["pagesQuery"]
+        == f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages"
+    )
     modified = data["modified"]
     assert modified
     assert modified.endswith("Z")
@@ -412,6 +416,10 @@ def test_collection_public(crawler_auth_headers, default_org_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/replay.json",
         headers=crawler_auth_headers,
+    )
+    assert (
+        r.json()["pagesQuery"]
+        == f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
     )
     assert r.status_code == 200
     assert r.headers["Access-Control-Allow-Origin"] == "*"

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -382,9 +382,11 @@ def test_get_collection_replay(crawler_auth_headers, default_org_id):
     assert data["dateEarliest"]
     assert data["dateLatest"]
     assert data["defaultThumbnailName"]
-    assert data["pagesQuery"].endswith(
+    assert data["seedPages"]
+    assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/pages"
     )
+    assert data["preloadResources"]
 
     resources = data["resources"]
     assert resources
@@ -416,13 +418,26 @@ def test_collection_public(crawler_auth_headers, default_org_id):
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/replay.json",
         headers=crawler_auth_headers,
     )
-    assert r.json()["pagesQuery"].endswith(
+    data = r.json()
+    assert data["seedPages"]
+    assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/collections/{_coll_id}/public/pages"
     )
+    assert data["preloadResources"]
 
     assert r.status_code == 200
     assert r.headers["Access-Control-Allow-Origin"] == "*"
     assert r.headers["Access-Control-Allow-Headers"] == "*"
+
+    # test public pages endpoint
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/pages",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] > 0
+    assert data["items"]
 
     # make unlisted and test replay headers
     r = requests.patch(
@@ -454,6 +469,12 @@ def test_collection_public(crawler_auth_headers, default_org_id):
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 404
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/public/pages",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 404

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -184,7 +184,7 @@ def test_wait_for_complete(admin_auth_headers, default_org_id):
     assert len(data["resources"]) == 1
     assert data["resources"][0]["path"]
 
-    assert len(data["seedPages"]) == 1
+    assert len(data["initialPages"]) == 1
     assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/crawls/{admin_crawl_id}/pages"
     )

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -184,6 +184,11 @@ def test_wait_for_complete(admin_auth_headers, default_org_id):
     assert len(data["resources"]) == 1
     assert data["resources"][0]["path"]
 
+    assert len(data["seedPages"]) == 1
+    assert data["pagesQueryUrl"].endswith(
+        "/orgs/{default_org_id}/crawls/{admin_crawl_id}/pages"
+    )
+
     # ensure filename matches specified pattern
     # set in default_crawl_filename_template
     assert re.search("/[\\d]+-testing-[\\w-]+\\.wacz", data["resources"][0]["path"])

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -186,7 +186,7 @@ def test_wait_for_complete(admin_auth_headers, default_org_id):
 
     assert len(data["seedPages"]) == 1
     assert data["pagesQueryUrl"].endswith(
-        "/orgs/{default_org_id}/crawls/{admin_crawl_id}/pages"
+        f"/orgs/{default_org_id}/crawls/{admin_crawl_id}/pages"
     )
 
     # ensure filename matches specified pattern


### PR DESCRIPTION
Fixes #2360 

- Adds `seedPages` to /replay.json response for collections, returning upto 25 seed pages.
- Adds `pagesQueryUrl` to /replay.json
- Adds a public pages search endpoint to support public collections.
- Adds `preloadResources`, including list of WACZ files that should always be loaded, to /replay.json

Draft pending work in wabac.js to ensure this is complete.