### PR TITLE
fix: Sort filtered collection page URLs

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -764,13 +764,13 @@ class CollectionOps:
         crawl_ids = await self.get_collection_crawl_ids(coll_id)
 
         match_query: dict[str, object] = {"oid": oid, "crawl_id": {"$in": crawl_ids}}
-        sort_query: dict[str, int] = {"count": -1, "url": -1}
+        sort_query: dict[str, int] = {"count": -1, "_id": 1}
 
         if url_prefix:
             url_prefix = urllib.parse.unquote(url_prefix)
             regex_pattern = f"^{re.escape(url_prefix)}"
             match_query["url"] = {"$regex": regex_pattern, "$options": "i"}
-            sort_query = {"url": -1}
+            sort_query = {"_id": 1}
 
         aggregate = [{"$match": match_query}]
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -755,7 +755,7 @@ class CollectionOps:
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
     ) -> Tuple[List[PageUrlCount], int]:
-        """List all URLs in collection sorted desc by snapshot count"""
+        """List all URLs in collection sorted desc by snapshot count unless prefix is specified"""
         # pylint: disable=duplicate-code, too-many-locals, too-many-branches, too-many-statements
         # Zero-index page for query
         page = page - 1
@@ -764,11 +764,13 @@ class CollectionOps:
         crawl_ids = await self.get_collection_crawl_ids(coll_id)
 
         match_query: dict[str, object] = {"oid": oid, "crawl_id": {"$in": crawl_ids}}
+        sort_query: dict[str, int] = {"count": -1, "url": -1}
 
         if url_prefix:
             url_prefix = urllib.parse.unquote(url_prefix)
             regex_pattern = f"^{re.escape(url_prefix)}"
             match_query["url"] = {"$regex": regex_pattern, "$options": "i"}
+            sort_query = {"url": -1}
 
         aggregate = [{"$match": match_query}]
 
@@ -781,7 +783,7 @@ class CollectionOps:
                         "count": {"$sum": 1},
                     },
                 },
-                {"$sort": {"count": -1}},
+                {"$sort": sort_query},
                 {"$set": {"url": "$_id"}},
                 {
                     "$facet": {

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -772,7 +772,7 @@ class CollectionOps:
             match_query["url"] = {"$regex": regex_pattern, "$options": "i"}
             sort_query = {"_id": 1}
 
-        aggregate = [{"$match": match_query}]
+        aggregate: List[Dict[str, Union[int, object]]] = [{"$match": match_query}]
 
         aggregate.extend(
             [

--- a/frontend/src/features/collections/select-collection-page.ts
+++ b/frontend/src/features/collections/select-collection-page.ts
@@ -357,44 +357,52 @@ export class SelectCollectionPage extends BtrixElement {
 
   private renderSearchResults() {
     return this.searchResults.render({
-      pending: () => html`
-        <sl-menu-item slot="menu-item" disabled>
-          <sl-spinner></sl-spinner>
-        </sl-menu-item>
-      `,
-      complete: ({ items }) => {
-        if (!items.length) {
-          return html`
-            <sl-menu-item slot="menu-item" disabled>
-              ${msg("No matching page found.")}
-            </sl-menu-item>
-          `;
-        }
-
-        return html`
-          ${items.map((item: Page) => {
-            return html`
-              <sl-menu-item
-                slot="menu-item"
-                @click=${async () => {
-                  if (this.input) {
-                    this.input.value = item.url;
-                  }
-
-                  this.selectedPage = this.formatPage(item);
-
-                  this.combobox?.hide();
-
-                  this.selectedSnapshot = this.selectedPage.snapshots[0];
-                }}
-                >${item.url}
-              </sl-menu-item>
-            `;
-          })}
-        `;
-      },
+      pending: () =>
+        this.renderItems(
+          // Render previous value so that dropdown doesn't shift while typing
+          this.searchResults.value,
+        ),
+      complete: this.renderItems,
     });
   }
+
+  private readonly renderItems = (
+    results: SelectCollectionPage["searchResults"]["value"],
+  ) => {
+    if (!results) return;
+
+    const { items } = results;
+
+    if (!items.length) {
+      return html`
+        <sl-menu-item slot="menu-item" disabled>
+          ${msg("No matching page found.")}
+        </sl-menu-item>
+      `;
+    }
+
+    return html`
+      ${items.map((item: Page) => {
+        return html`
+          <sl-menu-item
+            slot="menu-item"
+            @click=${async () => {
+              if (this.input) {
+                this.input.value = item.url;
+              }
+
+              this.selectedPage = this.formatPage(item);
+
+              this.combobox?.hide();
+
+              this.selectedSnapshot = this.selectedPage.snapshots[0];
+            }}
+            >${item.url}
+          </sl-menu-item>
+        `;
+      })}
+    `;
+  };
 
   private readonly onSearchInput = debounce(400)(() => {
     const value = this.input?.value;


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2383

## Changes

- Fixes unpredictable sort order when typing in collection page URL
- Fixes page URL results flickering in and out while typing

## Manual testing

1. Log in as crawler
2. Go to collection with archived items
3. Click "Set Initial View"
4. Choose "Start Page"
5. Click "Page URL" input. Verify initial options are shown, sorted by snapshot count
6. Start typing. Verify options are shown sorted by page URL

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection detail | <img width="478" alt="Screenshot 2025-02-11 at 5 54 10 PM" src="https://github.com/user-attachments/assets/b1fab10f-d2c0-4c5e-a59a-7936bc4d0c0b" /> |


## Follow-ups

If we support `$text`, we could potentially [sort by match score](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#text-score-metadata-sort).