### PR TITLE
chore: Add pylint to vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "bradlc.vscode-tailwindcss",
     "redhat.vscode-yaml",
     "streetsidesoftware.code-spell-checker",
-    "ms-python.black-formatter"
+    "ms-python.black-formatter",
+    "ms-python.pylint"
   ]
 }


### PR DESCRIPTION
No issue created for this, small devex improvement after I noticed linting errors weren't surfaced in vscode.