### PR TITLE
quickfix: add missing dependency for docs

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material requests pyyaml
+      - run: pip install mkdocs-material mkdocs-redirects requests pyyaml
 
       - name: Generate Helm Chart Index
         run: python ./scripts/generate-helm-index.py > ./frontend/docs/docs/helm-repo/index.yaml

--- a/.github/workflows/frontend-lint-test-build.yaml
+++ b/.github/workflows/frontend-lint-test-build.yaml
@@ -35,7 +35,7 @@ jobs:
               - 'frontend/*.json'
               - 'frontend/*.js'
               - 'frontend/*.ts'
-              - 'fromtend/docs/mkdocs.yml'
+              - 'frontend/docs/mkdocs.yml'
               - '.github/workflows/frontend-lint-test-build.yaml'
 
   unit-tests:

--- a/.github/workflows/frontend-lint-test-build.yaml
+++ b/.github/workflows/frontend-lint-test-build.yaml
@@ -35,6 +35,7 @@ jobs:
               - 'frontend/*.json'
               - 'frontend/*.js'
               - 'frontend/*.ts'
+              - 'fromtend/docs/mkdocs.yml'
               - '.github/workflows/frontend-lint-test-build.yaml'
 
   unit-tests:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -40,7 +40,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/python:3.12-slim as build_docs
 
 WORKDIR /docs
 
-RUN pip install mkdocs-material
+RUN pip install mkdocs-material mkdocs-redirects
 
 COPY --link ./docs/mkdocs.yml .
 COPY --link ./docs/docs ./docs


### PR DESCRIPTION
follow-up to #2368:
- add mkdocs-redirect to frontend Docker, docs build ci
- build frontend when changing mkdocs