### PR TITLE
Upload Fixes:

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1095,8 +1095,6 @@ class FilePreparer:
         to avoid duplicates"""
         name, ext = os.path.splitext(filename)
         name = slugify(name.rsplit("/", 1)[-1])
-        randstr = base64.b32encode(os.urandom(5)).lower()
-        name += "-" + randstr.decode("utf-8")
         return name + ext
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -24,7 +24,7 @@ from pydantic import (
     BeforeValidator,
     TypeAdapter,
 )
-from slugify import slugify
+from pathvalidate import sanitize_filename
 
 # from fastapi_users import models as fastapi_users_models
 
@@ -1093,7 +1093,7 @@ class FilePreparer:
     def prepare_filename(self, filename):
         """prepare filename by sanitizing and adding extra string
         to avoid duplicates"""
-        name = slugify(filename.rsplit("/", 1)[-1])
+        name = sanitize_filename(filename.rsplit("/", 1)[-1]).replace(" ", "-")
         parts = name.split(".")
         randstr = base64.b32encode(os.urandom(5)).lower()
         parts[0] += "-" + randstr.decode("utf-8")

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -24,7 +24,7 @@ from pydantic import (
     BeforeValidator,
     TypeAdapter,
 )
-from pathvalidate import sanitize_filename
+from slugify import slugify
 
 # from fastapi_users import models as fastapi_users_models
 
@@ -1093,11 +1093,11 @@ class FilePreparer:
     def prepare_filename(self, filename):
         """prepare filename by sanitizing and adding extra string
         to avoid duplicates"""
-        name = sanitize_filename(filename.rsplit("/", 1)[-1]).replace(" ", "-")
-        parts = name.split(".")
+        name, ext = os.path.splitext(filename)
+        name = slugify(filename.rsplit("/", 1)[-1])
         randstr = base64.b32encode(os.urandom(5)).lower()
-        parts[0] += "-" + randstr.decode("utf-8")
-        return ".".join(parts)
+        name += "-" + randstr.decode("utf-8")
+        return name + ext
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -24,7 +24,7 @@ from pydantic import (
     BeforeValidator,
     TypeAdapter,
 )
-from pathvalidate import sanitize_filename
+from slugify import slugify
 
 # from fastapi_users import models as fastapi_users_models
 
@@ -1074,7 +1074,7 @@ class FilePreparer:
     def __init__(self, prefix, filename):
         self.upload_size = 0
         self.upload_hasher = hashlib.sha256()
-        self.upload_name = prefix + self.prepare_filename(filename)
+        self.upload_name = prefix + "-" + self.prepare_filename(filename)
 
     def add_chunk(self, chunk):
         """add chunk for file"""
@@ -1093,7 +1093,7 @@ class FilePreparer:
     def prepare_filename(self, filename):
         """prepare filename by sanitizing and adding extra string
         to avoid duplicates"""
-        name = sanitize_filename(filename.rsplit("/", 1)[-1])
+        name = slugify(filename.rsplit("/", 1)[-1])
         parts = name.split(".")
         randstr = base64.b32encode(os.urandom(5)).lower()
         parts[0] += "-" + randstr.decode("utf-8")

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1094,7 +1094,7 @@ class FilePreparer:
         """prepare filename by sanitizing and adding extra string
         to avoid duplicates"""
         name, ext = os.path.splitext(filename)
-        name = slugify(filename.rsplit("/", 1)[-1])
+        name = slugify(name.rsplit("/", 1)[-1])
         randstr = base64.b32encode(os.urandom(5)).lower()
         name += "-" + randstr.decode("utf-8")
         return name + ext

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -5,6 +5,7 @@ Crawl-related models and types
 from datetime import datetime
 from enum import Enum, IntEnum
 from uuid import UUID
+import base64
 import hashlib
 import mimetypes
 import os
@@ -1094,7 +1095,8 @@ class FilePreparer:
         to avoid duplicates"""
         name, ext = os.path.splitext(filename)
         name = slugify(name.rsplit("/", 1)[-1])
-        return name + ext
+        randstr = base64.b32encode(os.urandom(5)).lower()
+        return name + "-" + randstr.decode("utf-8") + ext
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -5,7 +5,6 @@ Crawl-related models and types
 from datetime import datetime
 from enum import Enum, IntEnum
 from uuid import UUID
-import base64
 import hashlib
 import mimetypes
 import os

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -89,12 +89,18 @@ class PageOps:
                 crawl.resources or []
             )
             new_uuid = crawl.type == "upload"
+            seed_count = 0
+            non_seed_count = 0
             for page_dict in stream:
                 if not page_dict.get("url"):
                     continue
 
-                if not page_dict.get("isSeed") and not page_dict.get("seed"):
-                    page_dict["isSeed"] = False
+                page_dict["isSeed"] = page_dict.get("isSeed") or page_dict.get("seed")
+
+                if page_dict.get("isSeed"):
+                    seed_count += 1
+                else:
+                    non_seed_count += 1
 
                 if len(pages_buffer) > batch_size:
                     await self._add_pages_to_db(crawl_id, pages_buffer)
@@ -110,7 +116,10 @@ class PageOps:
 
             await self.set_archived_item_page_counts(crawl_id)
 
-            print(f"Added pages for crawl {crawl_id} to db", flush=True)
+            print(
+                f"Added pages for crawl {crawl_id}: {seed_count} Seed, {non_seed_count} Non-Seed",
+                flush=True,
+            )
         # pylint: disable=broad-exception-caught, raise-missing-from
         except Exception as err:
             traceback.print_exc()

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -112,8 +112,7 @@ def test_get_stream_upload(
     assert uploads_collection_id in result["collectionIds"]
     assert "files" not in result
     upload_dl_path = result["resources"][0]["path"]
-    assert "test-" in result["resources"][0]["name"]
-    assert result["resources"][0]["name"].endswith(".wacz")
+    assert result["resources"][0]["name"].endswith("-test.wacz")
 
     dl_path = urljoin(API_PREFIX, upload_dl_path)
     wacz_resp = requests.get(dl_path)

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -1120,7 +1120,9 @@ def test_delete_form_upload_and_crawls_from_all_crawls(
             break
 
         if count + 1 == MAX_ATTEMPTS:
-            assert False
+            assert data["storageUsedBytes"] == org_bytes - total_size
+            assert data["storageUsedCrawls"] == org_crawl_bytes - combined_crawl_size
+            assert data["storageUsedUploads"] == org_upload_bytes - upload_size
 
         time.sleep(5)
         count += 1

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -112,7 +112,8 @@ def test_get_stream_upload(
     assert uploads_collection_id in result["collectionIds"]
     assert "files" not in result
     upload_dl_path = result["resources"][0]["path"]
-    assert result["resources"][0]["name"].endswith("-test.wacz")
+    assert "test-" in result["resources"][0]["name"]
+    assert result["resources"][0]["name"].endswith(".wacz")
 
     dl_path = urljoin(API_PREFIX, upload_dl_path)
     wacz_resp = requests.get(dl_path)


### PR DESCRIPTION
- ensure upload pages are always added with a new uuid, to avoid any duplicates with existing uploads, even if upload wacz is actually a crawl from different browsertrix instance, etc..
- cleanup upload names with slugify, which also replaces spaces, fixes uploading wacz filenames with spaces in them
- part of fix for #2396