### PR TITLE
Add grid view to collection list

### DIFF
--- a/frontend/src/components/ui/overflow-dropdown.ts
+++ b/frontend/src/components/ui/overflow-dropdown.ts
@@ -31,6 +31,9 @@ export class OverflowDropdown extends TailwindElement {
   @property({ type: Boolean })
   raised = false;
 
+  @property({ type: String })
+  size?: "x-small" | "small" | "medium";
+
   @state()
   private hasMenuItems?: boolean;
 
@@ -47,7 +50,7 @@ export class OverflowDropdown extends TailwindElement {
         hoist
         distance=${ifDefined(this.raised ? "4" : undefined)}
       >
-        <btrix-button slot="trigger" ?raised=${this.raised}>
+        <btrix-button slot="trigger" ?raised=${this.raised} size=${this.size}>
           <sl-icon
             label=${msg("Actions")}
             name="three-dots-vertical"

--- a/frontend/src/features/collections/collections-grid-with-edit-dialog.ts
+++ b/frontend/src/features/collections/collections-grid-with-edit-dialog.ts
@@ -1,0 +1,52 @@
+import { localized } from "@lit/localize";
+import { html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import { type PublicCollection } from "@/types/collection";
+
+@customElement("btrix-collections-grid-with-edit-dialog")
+@localized()
+export class CollectionsGridWithEditDialog extends BtrixElement {
+  @property({ type: Array })
+  collections?: PublicCollection[];
+
+  @state()
+  collectionBeingEdited: string | null = null;
+
+  @property({ type: String })
+  collectionRefreshing: string | null = null;
+
+  @property({ type: Boolean })
+  showVisibility = false;
+
+  render() {
+    const showActions = !this.navigate.isPublicPage && this.appState.isCrawler;
+    return html`
+      <btrix-collections-grid
+        slug=${this.orgSlugState || ""}
+        .collections=${this.collections}
+        .collectionRefreshing=${this.collectionRefreshing}
+        ?showVisibility=${this.showVisibility}
+        @btrix-edit-collection=${(e: CustomEvent<string>) => {
+          this.collectionBeingEdited = e.detail;
+        }}
+      >
+        <slot name="empty-actions" slot="empty-actions"></slot>
+        <slot name="pagination" slot="pagination"></slot>
+      </btrix-collections-grid>
+      ${when(
+        showActions,
+        () =>
+          html`<btrix-collection-edit-dialog
+            .collectionId=${this.collectionBeingEdited ?? undefined}
+            ?open=${!!this.collectionBeingEdited}
+            @sl-after-hide=${() => {
+              this.collectionBeingEdited = null;
+            }}
+          ></btrix-collection-edit-dialog>`,
+      )}
+    `;
+  }
+}

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -1,12 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, nothing } from "lit";
-import {
-  customElement,
-  property,
-  queryAssignedNodes,
-  state,
-} from "lit/decorators.js";
+import { customElement, property, queryAssignedNodes } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
@@ -34,9 +29,6 @@ export class CollectionsGrid extends BtrixElement {
 
   @property({ type: Array })
   collections?: PublicCollection[];
-
-  @state()
-  collectionBeingEdited: string | null = null;
 
   @property({ type: String })
   collectionRefreshing: string | null = null;
@@ -212,18 +204,6 @@ export class CollectionsGrid extends BtrixElement {
         class=${clsx("justify-center flex", this.pagination.length && "mt-10")}
         name="pagination"
       ></slot>
-
-      ${when(
-        showActions,
-        () =>
-          html`<btrix-collection-edit-dialog
-            .collectionId=${this.collectionBeingEdited ?? undefined}
-            ?open=${!!this.collectionBeingEdited}
-            @sl-after-hide=${() => {
-              this.collectionBeingEdited = null;
-            }}
-          ></btrix-collection-edit-dialog>`,
-      )}
     `;
   }
 
@@ -235,7 +215,11 @@ export class CollectionsGrid extends BtrixElement {
             raised
             size="small"
             @click=${() => {
-              this.collectionBeingEdited = collection.id;
+              this.dispatchEvent(
+                new CustomEvent<string>("btrix-edit-collection", {
+                  detail: collection.id,
+                }),
+              );
             }}
           >
             <sl-icon name="pencil"></sl-icon>

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { customElement, property, queryAssignedNodes } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -36,6 +36,9 @@ export class CollectionsGrid extends BtrixElement {
 
   @property({ type: Boolean })
   showVisibility = false;
+
+  @property()
+  renderActions?: (collection: PublicCollection) => TemplateResult;
 
   @queryAssignedNodes({ slot: "pagination" })
   pagination!: Node[];
@@ -196,7 +199,7 @@ export class CollectionsGrid extends BtrixElement {
                   `}
                 </div>
               </a>
-              ${when(showActions, () => this.renderActions(collection))}
+              ${when(showActions, () => this._renderActions(collection))}
               ${when(
                 this.collectionRefreshing === collection.id,
                 () =>
@@ -218,24 +221,26 @@ export class CollectionsGrid extends BtrixElement {
     `;
   }
 
-  private readonly renderActions = (collection: PublicCollection) => html`
+  private readonly _renderActions = (collection: PublicCollection) => html`
     <div class="pointer-events-none absolute left-0 right-0 top-0 aspect-video">
       <div class="pointer-events-auto absolute bottom-2 right-2">
-        <sl-tooltip content=${msg("Edit Collection Settings")}>
-          <btrix-button
-            raised
-            size="small"
-            @click=${() => {
-              this.dispatchEvent(
-                new CustomEvent<string>("btrix-edit-collection", {
-                  detail: collection.id,
-                }),
-              );
-            }}
-          >
-            <sl-icon name="pencil"></sl-icon>
-          </btrix-button>
-        </sl-tooltip>
+        ${this.renderActions
+          ? this.renderActions(collection)
+          : html`<sl-tooltip content=${msg("Edit Collection Settings")}>
+              <btrix-button
+                raised
+                size="small"
+                @click=${() => {
+                  this.dispatchEvent(
+                    new CustomEvent<string>("btrix-edit-collection", {
+                      detail: collection.id,
+                    }),
+                  );
+                }}
+              >
+                <sl-icon name="pencil"></sl-icon>
+              </btrix-button>
+            </sl-tooltip>`}
       </div>
     </div>
   `;

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -2,7 +2,6 @@ import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, nothing, type TemplateResult } from "lit";
 import { customElement, property, queryAssignedNodes } from "lit/decorators.js";
-import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { keyed } from "lit/directives/keyed.js";
 import { when } from "lit/directives/when.js";
@@ -114,68 +113,24 @@ export class CollectionsGrid extends BtrixElement {
                 </div>
                 <div class="${showActions ? "mr-9" : ""} min-h-9 leading-tight">
                   ${this.showVisibility
-                    ? choose(collection.access, [
-                        [
-                          CollectionAccess.Private,
-                          () => html`
-                            <sl-tooltip
-                              content=${SelectCollectionAccess.Options[
-                                CollectionAccess.Private
-                              ].label}
-                            >
-                              <sl-icon
-                                class="mr-[5px] inline-block align-[-1px] text-neutral-600"
-                                name=${SelectCollectionAccess.Options[
-                                  CollectionAccess.Private
-                                ].icon}
-                              ></sl-icon>
-                            </sl-tooltip>
-                          `,
-                        ],
-                        [
-                          CollectionAccess.Unlisted,
-                          () => html`
-                            <sl-tooltip
-                              content=${SelectCollectionAccess.Options[
-                                CollectionAccess.Unlisted
-                              ].label}
-                            >
-                              <sl-icon
-                                class="mr-[5px] inline-block align-[-1px] text-neutral-600"
-                                name=${SelectCollectionAccess.Options[
-                                  CollectionAccess.Unlisted
-                                ].icon}
-                              ></sl-icon>
-                            </sl-tooltip>
-                          `,
-                        ],
-                        [
-                          CollectionAccess.Public,
-                          () => html`
-                            <sl-tooltip
-                              content=${SelectCollectionAccess.Options[
-                                CollectionAccess.Public
-                              ].label}
-                            >
-                              <sl-icon
-                                class="mr-[5px] inline-block align-[-1px] text-success-600"
-                                name=${SelectCollectionAccess.Options[
-                                  CollectionAccess.Public
-                                ].icon}
-                              ></sl-icon>
-                            </sl-tooltip>
-                          `,
-                        ],
-                      ])
-                    : // ? html`<sl-icon
-                      //     class="mr-[5px] align-[-1px] text-sm"
-                      //     name=${SelectCollectionAccess.Options[collection.access]
-                      //       .icon}
-                      //     label=${SelectCollectionAccess.Options[
-                      //       collection.access
-                      //     ].label}
-                      //   ></sl-icon>`
-                      nothing}
+                    ? html`<sl-tooltip
+                        content=${SelectCollectionAccess.Options[
+                          collection.access
+                        ].label}
+                      >
+                        <sl-icon
+                          class=${clsx(
+                            "mr-[5px] inline-block align-[-1px]",
+                            collection.access === CollectionAccess.Public
+                              ? "text-success-600"
+                              : "text-neutral-600",
+                          )}
+                          name=${SelectCollectionAccess.Options[
+                            collection.access
+                          ].icon}
+                        ></sl-icon>
+                      </sl-tooltip>`
+                    : nothing}
                   <strong
                     class="text-base font-medium leading-tight text-stone-800 transition-colors group-hover:text-cyan-600"
                   >

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -4,6 +4,7 @@ import { html, nothing } from "lit";
 import { customElement, property, queryAssignedNodes } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { keyed } from "lit/directives/keyed.js";
 import { when } from "lit/directives/when.js";
 
 import { CollectionThumbnail } from "./collection-thumbnail";
@@ -88,14 +89,24 @@ export class CollectionsGrid extends BtrixElement {
                 <div
                   class="relative mb-4 rounded-lg shadow-md shadow-stone-600/10 ring-1 ring-stone-600/10 transition group-hover:shadow-stone-800/20 group-hover:ring-stone-800/20"
                 >
-                  <btrix-collection-thumbnail
-                    src=${ifDefined(
-                      Object.entries(CollectionThumbnail.Variants).find(
-                        ([name]) => name === collection.defaultThumbnailName,
-                      )?.[1].path || collection.thumbnail?.path,
-                    )}
-                    collectionName=${collection.name}
-                  ></btrix-collection-thumbnail>
+                  ${
+                    // When swapping images, the previous image is retained until the new one is loaded,
+                    // which leads to the wrong image briefly being displayed when switching pages.
+                    // This removes and replaces the image instead, which prevents this at the cost of the
+                    // occasional flash of white while loading, but overall this feels more responsive.
+                    keyed(
+                      collection.id,
+                      html` <btrix-collection-thumbnail
+                        src=${ifDefined(
+                          Object.entries(CollectionThumbnail.Variants).find(
+                            ([name]) =>
+                              name === collection.defaultThumbnailName,
+                          )?.[1].path || collection.thumbnail?.path,
+                        )}
+                        collectionName=${collection.name}
+                      ></btrix-collection-thumbnail>`,
+                    )
+                  }
                   ${this.renderDateBadge(collection)}
                 </div>
                 <div class="${showActions ? "mr-9" : ""} min-h-9 leading-tight">

--- a/frontend/src/features/collections/collections-grid.ts
+++ b/frontend/src/features/collections/collections-grid.ts
@@ -7,6 +7,7 @@ import {
   queryAssignedNodes,
   state,
 } from "lit/decorators.js";
+import { choose } from "lit/directives/choose.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
@@ -16,7 +17,7 @@ import { SelectCollectionAccess } from "./select-collection-access";
 import { BtrixElement } from "@/classes/BtrixElement";
 import { textSeparator } from "@/layouts/separator";
 import { RouteNamespace } from "@/routes";
-import type { PublicCollection } from "@/types/collection";
+import { CollectionAccess, type PublicCollection } from "@/types/collection";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
 
@@ -107,15 +108,68 @@ export class CollectionsGrid extends BtrixElement {
                 </div>
                 <div class="${showActions ? "mr-9" : ""} min-h-9 leading-tight">
                   ${this.showVisibility
-                    ? html`<sl-icon
-                        class="mr-[5px] align-[-1px] text-sm"
-                        name=${SelectCollectionAccess.Options[collection.access]
-                          .icon}
-                        label=${SelectCollectionAccess.Options[
-                          collection.access
-                        ].label}
-                      ></sl-icon>`
-                    : nothing}
+                    ? choose(collection.access, [
+                        [
+                          CollectionAccess.Private,
+                          () => html`
+                            <sl-tooltip
+                              content=${SelectCollectionAccess.Options[
+                                CollectionAccess.Private
+                              ].label}
+                            >
+                              <sl-icon
+                                class="mr-[5px] inline-block align-[-1px] text-neutral-600"
+                                name=${SelectCollectionAccess.Options[
+                                  CollectionAccess.Private
+                                ].icon}
+                              ></sl-icon>
+                            </sl-tooltip>
+                          `,
+                        ],
+                        [
+                          CollectionAccess.Unlisted,
+                          () => html`
+                            <sl-tooltip
+                              content=${SelectCollectionAccess.Options[
+                                CollectionAccess.Unlisted
+                              ].label}
+                            >
+                              <sl-icon
+                                class="mr-[5px] inline-block align-[-1px] text-neutral-600"
+                                name=${SelectCollectionAccess.Options[
+                                  CollectionAccess.Unlisted
+                                ].icon}
+                              ></sl-icon>
+                            </sl-tooltip>
+                          `,
+                        ],
+                        [
+                          CollectionAccess.Public,
+                          () => html`
+                            <sl-tooltip
+                              content=${SelectCollectionAccess.Options[
+                                CollectionAccess.Public
+                              ].label}
+                            >
+                              <sl-icon
+                                class="mr-[5px] inline-block align-[-1px] text-success-600"
+                                name=${SelectCollectionAccess.Options[
+                                  CollectionAccess.Public
+                                ].icon}
+                              ></sl-icon>
+                            </sl-tooltip>
+                          `,
+                        ],
+                      ])
+                    : // ? html`<sl-icon
+                      //     class="mr-[5px] align-[-1px] text-sm"
+                      //     name=${SelectCollectionAccess.Options[collection.access]
+                      //       .icon}
+                      //     label=${SelectCollectionAccess.Options[
+                      //       collection.access
+                      //     ].label}
+                      //   ></sl-icon>`
+                      nothing}
                   <strong
                     class="text-base font-medium leading-tight text-stone-800 transition-colors group-hover:text-cyan-600"
                   >

--- a/frontend/src/features/collections/index.ts
+++ b/frontend/src/features/collections/index.ts
@@ -1,5 +1,6 @@
 import("./collections-add");
 import("./collections-grid");
+import("./collections-grid-with-edit-dialog");
 import("./collection-items-dialog");
 import("./collection-edit-dialog");
 import("./collection-create-dialog");

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -129,6 +129,9 @@ export class CollectionsList extends BtrixElement {
   private selectedCollection?: Collection;
 
   @state()
+  collectionRefreshing: string | null = null;
+
+  @state()
   private fetchErrorStatusCode?: number;
 
   @query("sl-input")
@@ -193,7 +196,7 @@ export class CollectionsList extends BtrixElement {
               </div>
               <div class="-mx-3 overflow-auto px-3 pb-1">
                 ${guard(
-                  [this.collections, this.listView],
+                  [this.collections, this.listView, this.collectionRefreshing],
                   this.listView === ListView.List
                     ? this.renderList
                     : this.renderGrid,
@@ -436,6 +439,14 @@ export class CollectionsList extends BtrixElement {
     return html`<btrix-collections-grid
       slug=${this.orgSlugState || ""}
       .collections=${this.collections?.items}
+      .collectionRefreshing=${this.collectionRefreshing}
+      showVisibility
+      class="mt-8 block"
+      @btrix-collection-saved=${async ({ detail }: CollectionSavedEvent) => {
+        this.collectionRefreshing = detail.id;
+        await this.fetchCollections();
+        this.collectionRefreshing = null;
+      }}
     >
       ${this.collections &&
       this.collections.total > this.collections.items.length
@@ -468,7 +479,7 @@ export class CollectionsList extends BtrixElement {
           class="[--btrix-column-gap:var(--sl-spacing-small)]"
           style="grid-template-columns: min-content [clickable-start] 45em repeat(4, 1fr) [clickable-end] min-content"
         >
-          <btrix-table-head class="mb-2 whitespace-nowrap">
+          <btrix-table-head class="mb-2 mt-1 whitespace-nowrap">
             <btrix-table-header-cell>
               <span class="sr-only">${msg("Collection Access")}</span>
             </btrix-table-header-cell>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -440,6 +440,8 @@ export class CollectionsList extends BtrixElement {
       slug=${this.orgSlugState || ""}
       .collections=${this.collections?.items}
       .collectionRefreshing=${this.collectionRefreshing}
+      .renderActions=${(col: Collection) =>
+        this.renderActions(col, { renderOnGridItem: true })}
       showVisibility
       class="mt-8 block"
       @btrix-collection-saved=${async ({ detail }: CollectionSavedEvent) => {
@@ -661,11 +663,17 @@ export class CollectionsList extends BtrixElement {
     </btrix-table-row>
   `;
 
-  private readonly renderActions = (col: Collection) => {
+  private readonly renderActions = (
+    col: Collection,
+    { renderOnGridItem } = { renderOnGridItem: false },
+  ) => {
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
 
     return html`
-      <btrix-overflow-dropdown>
+      <btrix-overflow-dropdown
+        ?raised=${renderOnGridItem}
+        size=${renderOnGridItem ? "small" : "medium"}
+      >
         <sl-menu>
           <sl-menu-item @click=${() => void this.manageCollection(col, "edit")}>
             <sl-icon name="gear" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -128,8 +128,9 @@ export class CollectionsList extends BtrixElement {
   @state()
   private selectedCollection?: Collection;
 
+  /** ID of the collection currently being refreshed */
   @state()
-  collectionRefreshing: string | null = null;
+  private collectionRefreshing: string | null = null;
 
   @state()
   private fetchErrorStatusCode?: number;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -376,33 +376,35 @@ export class Dashboard extends BtrixElement {
                     ? msg("Public Collections")
                     : msg("All Collections"),
               })}
-              ${this.collectionsView === CollectionGridView.Public
-                ? html` <span class="text-sm text-neutral-400"
-                    >—
-                    <a
-                      href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
-                      class="inline-flex h-8 items-center text-sm font-medium text-primary-500 transition hover:text-primary-600"
-                      @click=${this.navigate.link}
-                    >
+              ${
+                this.collectionsView === CollectionGridView.Public
+                  ? html` <span class="text-sm text-neutral-400"
+                      >—
+                      <a
+                        href=${`/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`}
+                        class="inline-flex h-8 items-center text-sm font-medium text-primary-500 transition hover:text-primary-600"
+                        @click=${this.navigate.link}
+                      >
+                        ${this.org?.enablePublicProfile
+                          ? msg("Visit public collections gallery")
+                          : msg("Preview public collections gallery")}
+                      </a>
+                      <!-- TODO Refactor clipboard code, get URL in a nicer way? -->
                       ${this.org?.enablePublicProfile
-                        ? msg("Visit public collections gallery")
-                        : msg("Preview public collections gallery")}
-                    </a>
-                    <!-- TODO Refactor clipboard code, get URL in a nicer way? -->
-                    ${this.org?.enablePublicProfile
-                      ? html`<btrix-copy-button
-                          value=${new URL(
-                            `/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`,
-                            window.location.toString(),
-                          ).toString()}
-                          content=${msg(
-                            "Copy Link to Public Collections Gallery",
-                          )}
-                          class="inline-block"
-                        ></btrix-copy-button>`
-                      : nothing}
-                  </span>`
-                : nothing}
+                        ? html`<btrix-copy-button
+                            value=${new URL(
+                              `/${RouteNamespace.PublicOrgs}/${this.orgSlugState}`,
+                              window.location.toString(),
+                            ).toString()}
+                            content=${msg(
+                              "Copy Link to Public Collections Gallery",
+                            )}
+                            class="inline-block"
+                          ></btrix-copy-button>`
+                        : nothing}
+                    </span>`
+                  : nothing
+              }
             </div>
             <div class="flex items-center gap-2">
               ${when(
@@ -446,8 +448,7 @@ export class Dashboard extends BtrixElement {
             </div>
           </header>
           <div class="relative rounded-lg border p-10">
-            <btrix-collections-grid
-              slug=${this.orgSlugState || ""}
+            <btrix-collections-grid-with-edit-dialog
               .collections=${this.collections.value?.items}
               .collectionRefreshing=${this.collectionRefreshing}
               ?showVisibility=${this.collectionsView === CollectionGridView.All}
@@ -463,34 +464,41 @@ export class Dashboard extends BtrixElement {
             >
               ${this.renderNoPublicCollections()}
               <span slot="empty-text"
-                >${this.collectionsView === CollectionGridView.Public
-                  ? msg("No public collections yet.")
-                  : msg("No collections yet.")}</span
+                >${
+                  this.collectionsView === CollectionGridView.Public
+                    ? msg("No public collections yet.")
+                    : msg("No collections yet.")
+                }</span
               >
-              ${this.collections.value &&
-              this.collections.value.total > this.collections.value.items.length
-                ? html`
-                    <btrix-pagination
-                      page=${this.collectionPage}
-                      size=${PAGE_SIZE}
-                      totalCount=${this.collections.value.total}
-                      @page-change=${(e: PageChangeEvent) => {
-                        this.collectionPage = e.detail.page;
-                      }}
-                      slot="pagination"
-                    >
-                    </btrix-pagination>
-                  `
-                : nothing}
+              ${
+                this.collections.value &&
+                this.collections.value.total >
+                  this.collections.value.items.length
+                  ? html`
+                      <btrix-pagination
+                        page=${this.collectionPage}
+                        size=${PAGE_SIZE}
+                        totalCount=${this.collections.value.total}
+                        @page-change=${(e: PageChangeEvent) => {
+                          this.collectionPage = e.detail.page;
+                        }}
+                        slot="pagination"
+                      >
+                      </btrix-pagination>
+                    `
+                  : nothing
+              }
             </btrix-collections-grid>
-            ${this.collections.status === TaskStatus.PENDING &&
-            this.collections.value
-              ? html`<div
-                  class="absolute inset-0 rounded-lg bg-stone-50/75 p-24 text-center text-4xl"
-                >
-                  <sl-spinner></sl-spinner>
-                </div>`
-              : nothing}
+            ${
+              this.collections.status === TaskStatus.PENDING &&
+              this.collections.value
+                ? html`<div
+                    class="absolute inset-0 rounded-lg bg-stone-50/75 p-24 text-center text-4xl"
+                  >
+                    <sl-spinner></sl-spinner>
+                  </div>`
+                : nothing
+            }
           </div>
         </section>
       </main>


### PR DESCRIPTION
Closes #2498 

Yay for consistency!

## Changes

Adds a grid view to the collections list, alongside the default list view.

- Refactors edit dialog into `collections-grid-with-edit-dialog` component for dashboard — collections list already has its own edit dialog, so no need for this to be duplicated in the grid component
- Adds getter/setter for `page` property of pagination component, which fixes the dashboard not switching back to page 1 when switching between "Public" and "All" collection views

## Manual testing

1. On the collections list page, click between "View as Grid" and "View as List" in the toolbar
2. Verify that pagination, the collection editing dialog, and the action menu works in grid view
3. On the dashboard in an org with multiple pages of collections, switch to the second page of "All" collections, then switch back to "Public" collections. Verify that the page search param disappears when switching between views.

## Screenshots

| Page | Screenshot |
|--------|--------|
| Collection list | <img width="1282" alt="Screenshot 2025-04-17 at 3 46 55 PM" src="https://github.com/user-attachments/assets/f6dff74f-d56e-48f6-8d44-11b84bacbafb" /> |
| Collection list (detail) | <img width="165" alt="Screenshot 2025-04-17 at 3 46 29 PM" src="https://github.com/user-attachments/assets/3442c5e4-a67f-46a2-b475-ee4d3d1e0259" /> | 

---



Remaining things to do:
- [x] Add full actions menu from list view to grid view, instead of just having pencil icon
- [x] Reuse collection editing dialog from existing list view, instead of the grid view having its own separate dialog instance