### PR TITLE
ensure running crawl configmap is updated when exclusions are added/removed

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -220,6 +220,12 @@ class CrawlManager(K8sAPI):
             proxy_id=crawlconfig.proxyId or DEFAULT_PROXY_ID,
         )
 
+    async def reload_running_crawl_config(self, crawl_id: str):
+        """force reload of configmap for crawl"""
+        return await self._patch_job(
+            crawl_id, {"lastConfigUpdate": date_to_str(dt_now())}
+        )
+
     async def create_qa_crawl_job(
         self,
         crawlconfig: CrawlConfig,

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -544,12 +544,12 @@ class CrawlOps(BaseCrawlOps):
             regex, cid, org, user, add
         )
 
+        await self.crawl_manager.reload_running_crawl_config(crawl.id)
+
         await self.crawls.find_one_and_update(
             {"_id": crawl_id, "type": "crawl", "oid": org.id},
             {"$set": {"config": new_config.dict()}},
         )
-
-        await self.crawl_manager.reload_running_crawl_config(crawl.id)
 
         return {"success": True}
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -549,6 +549,8 @@ class CrawlOps(BaseCrawlOps):
             {"$set": {"config": new_config.dict()}},
         )
 
+        await self.crawl_manager.reload_running_crawl_config(crawl.id)
+
         return {"success": True}
 
     async def update_crawl_state_if_allowed(

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -398,6 +398,9 @@ class CrawlOperator(BaseOperator):
 
         params["config"] = json.dumps(raw_config)
 
+        if config_update_needed:
+            print(f"Updating config for {crawl.id}")
+
         return self.load_from_yaml("crawl_configmap.yaml", params)
 
     async def _load_qa_configmap(self, params, children):

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -209,6 +209,7 @@ class CrawlStatus(BaseModel):
     stopReason: Optional[StopReason] = None
     initRedis: bool = False
     crawlerImage: Optional[str] = None
+    lastConfigUpdate: str = ""
 
     lastActiveTime: str = ""
     podStatus: DefaultDict[str, Annotated[PodInfo, Field(default_factory=PodInfo)]] = (

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -127,7 +127,7 @@ spec:
       command:
         - {{ "crawl" if not qa_source_crawl_id else "qa" }}
         - --config
-        - /tmp/crawl-config.json
+        - /tmp/config/crawl-config.json
         - --workers
         - "{{ workers }}"
         - --redisStoreUrl
@@ -153,8 +153,7 @@ spec:
       {% endif %}
       volumeMounts:
         - name: crawl-config
-          mountPath: /tmp/crawl-config.json
-          subPath: crawl-config.json
+          mountPath: /tmp/config/
           readOnly: True
 
       {% if qa_source_crawl_id %}


### PR DESCRIPTION
exclusions are already updated dynamically if crawler pod is running, but when crawler pod is restarted, this ensures new exclusions are also picked up:
- mount configmap in separate path, avoiding subPath, to allow dynamic updates of mounted volume
- adds a lastConfigUpdate timestamp to CrawlJob - if lastConfigUpdate in spec is different from current, the configmap is recreated by operator
- operator: also update image from channel avoid any issues with updating crawler in channel
- only updates for exclusion add/remove so far, can later be expanded to other crawler settings (see: #2355 for broader running crawl config updates)
- fixes #2408

Testing:
- Start a crawl
- Add / remove exclusion
- Wait a few seconds (just in case)
- Delete crawl pod
- Verify that the /tmp/config/crawl-config.json in the restarted pod contains new exclusions.
Before this PR, it would not.