### PR TITLE
Pages Query: use $text search or prefix search

### DIFF
--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -768,11 +768,6 @@ class PageOps:
             else:
                 query["$text"] = {"$search": search}
                 is_text_search = True
-            # search_regex = re.escape(search)
-            # query["$or"] = [
-            #    {"url": {"$regex": search_regex, "$options": "i"}},
-            #    {"title": {"$regex": search_regex, "$options": "i"}},
-            # ]
 
         elif url_prefix:
             url_prefix = urllib.parse.unquote(url_prefix)

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -643,12 +643,13 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
     coll_page_ts = coll_page["ts"]
     coll_page_title = coll_page["title"]
 
-    # Test search filter
-    partial_title = coll_page_title[:5]
+    # Test search filter, make sure text search isn't case sensitive
+    partial_title = "Archiving"
+    partial_title_lower = lower(partial_title)
     partial_url = coll_page_url[:8]
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?search={partial_title}",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/pages?search={partial_title_lower}",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -645,7 +645,7 @@ def test_list_pages_in_collection(crawler_auth_headers, default_org_id):
 
     # Test search filter, make sure text search isn't case sensitive
     partial_title = "Archiving"
-    partial_title_lower = lower(partial_title)
+    partial_title_lower = partial_title.lower()
     partial_url = coll_page_url[:8]
 
     r = requests.get(


### PR DESCRIPTION
Instead of regex search on url and title:
- If search string starts with https:// or http://, do a prefix search on URL
- Otherwise, do a $text search on title, sort by match score.