### PR TITLE
remove recreating page index on migration, later to add as needed

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -81,6 +81,7 @@ async def update_and_prepare_db(
     coll_ops,
     invite_ops,
     storage_ops,
+    page_ops,
     background_job_ops,
     db_inited,
 ):
@@ -95,7 +96,7 @@ async def update_and_prepare_db(
     await ping_db(mdb)
     print("Database setup started", flush=True)
     if await run_db_migrations(
-        mdb, user_manager, org_ops, background_job_ops, coll_ops
+        mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops
     ):
         await drop_indexes(mdb)
 

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -81,7 +81,6 @@ async def update_and_prepare_db(
     coll_ops,
     invite_ops,
     storage_ops,
-    page_ops,
     background_job_ops,
     db_inited,
 ):
@@ -96,7 +95,7 @@ async def update_and_prepare_db(
     await ping_db(mdb)
     print("Database setup started", flush=True)
     if await run_db_migrations(
-        mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops
+        mdb, user_manager, org_ops, background_job_ops, coll_ops
     ):
         await drop_indexes(mdb)
 
@@ -107,7 +106,6 @@ async def update_and_prepare_db(
         coll_ops,
         invite_ops,
         user_manager,
-        page_ops,
     )
     await user_manager.create_super_user()
     await org_ops.create_default_org()
@@ -206,7 +204,7 @@ async def drop_indexes(mdb):
 # ============================================================================
 # pylint: disable=too-many-arguments
 async def create_indexes(
-    org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_ops, user_manager, page_ops
+    org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_ops, user_manager
 ):
     """Create database indexes."""
     print("Creating database indexes", flush=True)
@@ -216,7 +214,6 @@ async def create_indexes(
     await coll_ops.init_index()
     await invite_ops.init_index()
     await user_manager.init_index()
-    await page_ops.init_index()
 
 
 # ============================================================================

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -107,6 +107,7 @@ async def update_and_prepare_db(
         coll_ops,
         invite_ops,
         user_manager,
+        page_ops,
     )
     await user_manager.create_super_user()
     await org_ops.create_default_org()
@@ -194,6 +195,11 @@ async def drop_indexes(mdb):
     print("Dropping database indexes", flush=True)
     collection_names = await mdb.list_collection_names()
     for collection in collection_names:
+        # Don't drop pages automatically, as these are large
+        # indices and slow to recreate
+        if collection == "pages":
+            continue
+
         try:
             current_coll = mdb[collection]
             await current_coll.drop_indexes()
@@ -205,7 +211,7 @@ async def drop_indexes(mdb):
 # ============================================================================
 # pylint: disable=too-many-arguments
 async def create_indexes(
-    org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_ops, user_manager
+    org_ops, crawl_ops, crawl_config_ops, coll_ops, invite_ops, user_manager, page_ops
 ):
     """Create database indexes."""
     print("Creating database indexes", flush=True)
@@ -215,6 +221,7 @@ async def create_indexes(
     await coll_ops.init_index()
     await invite_ops.init_index()
     await user_manager.init_index()
+    await page_ops.init_index()
 
 
 # ============================================================================

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -284,7 +284,6 @@ def main() -> None:
                 coll_ops,
                 invites,
                 storage_ops,
-                page_ops,
                 background_job_ops,
                 db_inited,
             )

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -284,6 +284,7 @@ def main() -> None:
                 coll_ops,
                 invites,
                 storage_ops,
+                page_ops,
                 background_job_ops,
                 db_inited,
             )


### PR DESCRIPTION
Don't need it for now, and this will now be slow due to amount of pages. Can readd in future migrations if we need it..