### PR TITLE
Add `deepLink` attribute to public collection replay embed

### DIFF
--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -207,6 +207,7 @@ export class Collection extends BtrixElement {
           replayBase="/replay/"
           noSandbox="true"
           noCache="true"
+          deepLink
         ></replay-web-page>
       </section>
     `;


### PR DESCRIPTION
### Changes

- Public collections can now be deeplinked

### Caveats

- When users click the _About this Collection_ tab and then return to the _Browse Collection_ tab, the deeplink is gone until they visit another page.