### PR TITLE
Prevent btrix helper from doing anything to k8s contexts other than docker-desktop

### DIFF
--- a/btrix
+++ b/btrix
@@ -120,6 +120,11 @@ CONTEXT=$(cat ~/.kube/config | grep "current-context:" | sed "s/current-context:
 MICROK8S="-microk8s"
 WAIT="-wait"
 
+if [ $CONTEXT != "docker-desktop" ]; then
+    echo "Attempting to modify context other than docker-desktop not supported. Quitting."
+    exit 1
+fi
+
 if [[ $1 = "setup" ]]; then
     setupLocalConfig
 fi


### PR DESCRIPTION
The `./btrix` development helper shouldn't be used for anything other than local dev, which this commit helps to enforce.

When running any command, if the k8s context is anything other than `docker-desktop` the script will now shut down immediately without doing anything and print the message: "Attempting to modify context other than docker-desktop not supported. Quitting."

## Testing

- Set k8s context to "docker-desktop"
- Attempt running a command, e.g. `./btrix bootstrap`, and verify it works
- Set k8s context to dev
- Attempt running a non-existent command (to be safe), e.g. `./btrix notarealcommand`, and verify that the message is printed and the script exits immediately without doing anything