### PR TITLE
ingress: only set ssl-redirect if using tls

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -15,9 +15,9 @@ metadata:
     # for larger uploads to not timeout
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/upstream-vhost: "{{ .Values.ingress.host }}"
     {{- if .Values.ingress.tls }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.custom_cluster_issuer | default "cert-main" }}
-    nginx.ingress.kubernetes.io/upstream-vhost: "{{ .Values.ingress.host }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Forwarded-Proto {{ .Values.ingress.tls | ternary "https" "http" }};
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     {{- if .Values.ingress.useOldClassAnnotation }}
     kubernetes.io/ingress.class: {{ .Values.ingress_class | default "nginx" }}
     {{- end }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     # for larger uploads to not timeout
@@ -18,10 +17,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     {{- if .Values.ingress.tls }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.custom_cluster_issuer | default "cert-main" }}
-    {{- end }}
     nginx.ingress.kubernetes.io/upstream-vhost: "{{ .Values.ingress.host }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Forwarded-Proto {{ .Values.ingress.tls | ternary "https" "http" }};
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- else }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
 
 spec:
   {{- if not .Values.ingress.useOldClassAnnotation }}


### PR DESCRIPTION
otherwise, http path should be accessible. Can be used when TLS termination handled outside of ingress.