### PR TITLE
Calculate total for crawl QA page endpoint

### DIFF
--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -1404,6 +1404,7 @@ def init_pages_api(
             page=page,
             sort_by=sortBy,
             sort_direction=sortDirection,
+            include_total=True,
         )
         return paginated_format(pages, total, page, pageSize)
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -254,6 +254,7 @@ def test_qa_page_data(
         headers=crawler_auth_headers,
     )
     data = r.json()
+    assert data["total"] == 1
     assert len(data["items"]) == 1
     page = data["items"][0]
 


### PR DESCRIPTION
Fixes #2434 

Patch fix for a regression in Browsertrix 1.4.0-1.4.1 where total was not being calculated for QA page list endpoint but still being included in response, which led to total always being 0 and pages not loading in the frontend review screen as a result.