### PR TITLE
Allow replaying WACZ files from replica storage

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -449,7 +449,12 @@ class StorageOps:
     ) -> str:
         """generate pre-signed url for crawl file"""
 
-        s3storage = self.get_org_storage_by_ref(org, crawlfile.storage)
+        if crawlfile.replicas:
+            storage_ref = crawlfile.replicas[0]
+        else:
+            storage_ref = crawlfile.storage
+
+        s3storage = self.get_org_storage_by_ref(org, storage_ref)
 
         async with self.get_s3_client(
             s3storage,

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -52,7 +52,7 @@ from .models import (
     AddedResponseName,
 )
 
-from .utils import slug_from_name
+from .utils import slug_from_name, is_bool
 from .version import __version__
 
 
@@ -81,6 +81,8 @@ class StorageOps:
 
     frontend_origin: str
 
+    replay_from_replica: bool
+
     def __init__(self, org_ops, crawl_manager) -> None:
         self.org_ops = org_ops
         self.crawl_manager = crawl_manager
@@ -90,6 +92,8 @@ class StorageOps:
         )
         default_namespace = os.environ.get("DEFAULT_NAMESPACE", "default")
         self.frontend_origin = f"{frontend_origin}.{default_namespace}"
+
+        self.replay_from_replica = is_bool(os.environ.get("REPLAY_FROM_REPLICA", "0"))
 
         with open(os.environ["STORAGES_JSON"], encoding="utf-8") as fh:
             storage_list = json.loads(fh.read())
@@ -449,7 +453,7 @@ class StorageOps:
     ) -> str:
         """generate pre-signed url for crawl file"""
 
-        if crawlfile.replicas:
+        if self.replay_from_replica and crawlfile.replicas:
             storage_ref = crawlfile.replicas[0]
         else:
             storage_ref = crawlfile.storage

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -90,6 +90,7 @@ data:
 
   REPLICA_DELETION_DELAY_DAYS: "{{ .Values.replica_deletion_delay_days | default 0 }}"
 
+  REPLAY_FROM_REPLICA: "{{ .Values.replay_from_replica | default 0 }}"
 
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -423,8 +423,8 @@ storages:
 # max value = 10079 (one week minus one minute)
 # storage_presign_duration_minutes: 10079
 
-# if truthy, will attempt to replay from first replica
-# replay_from_replica: true
+# if set, will replay from particular replica, instead of default storage
+# replay_from_replica: default
 
 # Email Options
 # =========================================

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -423,6 +423,8 @@ storages:
 # max value = 10079 (one week minus one minute)
 # storage_presign_duration_minutes: 10079
 
+# if truthy, will attempt to replay from first replica
+# replay_from_replica: true
 
 # Email Options
 # =========================================


### PR DESCRIPTION
Add `replay_from_replica` helm chart value, which, if set, will use the first replica (when available) for replay instead of the primary storage.