### PR TITLE
Add superadmin API endpoint to clear all presigned URLs

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -912,6 +912,8 @@ class BaseCrawlOps:
         match_query = {"type": "crawl", "qaFinished": {"$nin": [None, {}]}}
         async for crawl_with_qa in self.crawls.find(match_query):
             crawl = Crawl.from_dict(crawl_with_qa)
+            if not crawl.qaFinished:
+                continue
             for qa_run_id in crawl.qaFinished:
                 await self.crawls.find_one_and_update(
                     {"_id": crawl.id},

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -898,12 +898,12 @@ class BaseCrawlOps:
     async def clear_presigned_urls(self, org: Optional[Organization] = None):
         """Clear presigned URLs for all crawl/upload files"""
         # Clear presign for crawl files
-        match_query = {}
+        crawl_query = {}
         if org:
-            match_query["oid"] = org.id
+            crawl_query["oid"] = org.id
 
         await self.crawls.update_many(
-            match_query,
+            crawl_query,
             {
                 "$set": {
                     "files.$[].presignedUrl": None,
@@ -913,14 +913,14 @@ class BaseCrawlOps:
         )
 
         # Clear presign for QA crawl files
-        match_query: Dict[str, Union[object, str, UUID]] = {
+        qa_query: Dict[str, Union[object, str, UUID]] = {
             "type": "crawl",
             "qaFinished": {"$nin": [None, {}]},
         }
         if org:
-            match_query["oid"] = org.id
+            qa_query["oid"] = org.id
 
-        async for crawl_with_qa in self.crawls.find(match_query):
+        async for crawl_with_qa in self.crawls.find(qa_query):
             crawl = Crawl.from_dict(crawl_with_qa)
             if not crawl.qaFinished:
                 continue

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -912,7 +912,7 @@ class BaseCrawlOps:
         match_query = {"type": "crawl", "qaFinished": {"$nin": [None, {}]}}
         async for crawl_with_qa in self.crawls.find(match_query):
             crawl = Crawl.from_dict(crawl_with_qa)
-            for qa_run_id in crawl.qaFinished.keys():
+            for qa_run_id in crawl.qaFinished:
                 await self.crawls.find_one_and_update(
                     {"_id": crawl.id},
                     {

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -913,7 +913,10 @@ class BaseCrawlOps:
         )
 
         # Clear presign for QA crawl files
-        match_query = {"type": "crawl", "qaFinished": {"$nin": [None, {}]}}
+        match_query: Dict[str, Union[object, str, UUID]] = {
+            "type": "crawl",
+            "qaFinished": {"$nin": [None, {}]},
+        }
         if org:
             match_query["oid"] = org.id
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -1071,6 +1071,18 @@ def init_base_crawls_api(app, user_dep, *args):
         return await ops.delete_crawls_all_types(delete_list, org, user)
 
     @app.post(
+        "/orgs/all/all-crawls/clear-presigned-urls",
+        tags=["all-crawls"],
+        response_model=SuccessResponse,
+    )
+    async def clear_all_presigned_urls(user: User = Depends(user_dep)):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
+        asyncio.create_task(ops.clear_presigned_urls(org=None))
+        return {"success": True}
+
+    @app.post(
         "/orgs/{oid}/all-crawls/clear-presigned-urls",
         tags=["all-crawls"],
         response_model=SuccessResponse,
@@ -1082,18 +1094,6 @@ def init_base_crawls_api(app, user_dep, *args):
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         asyncio.create_task(ops.clear_presigned_urls(org=org))
-        return {"success": True}
-
-    @app.post(
-        "/orgs/all/all-crawls/clear-presigned-urls",
-        tags=["all-crawls"],
-        response_model=SuccessResponse,
-    )
-    async def clear_all_presigned_urls(user: User = Depends(user_dep)):
-        if not user.is_superuser:
-            raise HTTPException(status_code=403, detail="Not Allowed")
-
-        asyncio.create_task(ops.clear_presigned_urls(org=None))
         return {"success": True}
 
     return ops

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -1030,6 +1030,22 @@ def test_update_upload_metadata_all_crawls(
     assert data["collectionIds"] == []
 
 
+def test_clear_all_presigned_urls(admin_auth_headers, crawler_auth_headers):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/all/all-crawls/clear-presigned-urls",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Not Allowed"
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/all/all-crawls/clear-presigned-urls",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+
 def test_delete_form_upload_and_crawls_from_all_crawls(
     admin_auth_headers,
     crawler_auth_headers,

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -1030,7 +1030,10 @@ def test_update_upload_metadata_all_crawls(
     assert data["collectionIds"] == []
 
 
-def test_clear_all_presigned_urls(admin_auth_headers, crawler_auth_headers):
+def test_clear_all_presigned_urls(
+    admin_auth_headers, crawler_auth_headers, default_org_id
+):
+    # All orgs
     r = requests.post(
         f"{API_PREFIX}/orgs/all/all-crawls/clear-presigned-urls",
         headers=crawler_auth_headers,
@@ -1040,6 +1043,21 @@ def test_clear_all_presigned_urls(admin_auth_headers, crawler_auth_headers):
 
     r = requests.post(
         f"{API_PREFIX}/orgs/all/all-crawls/clear-presigned-urls",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+    # Per-org
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/clear-presigned-urls",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Not Allowed"
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/clear-presigned-urls",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200


### PR DESCRIPTION
Fixes #2437 

Adds two new superadmin-only API endpoint to clear presigned URLs for all crawl/upload WACZs as well as all QA analysis run WACZs:
- One for all orgs
- One limited to specific org