### PR TITLE
Show download button on public collection pages regardless of collection access

### DIFF
--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -97,9 +97,7 @@ export class ShareCollection extends BtrixElement {
           </sl-icon-button>
         </sl-tooltip>
         ${when(this.orgSlug && this.collection, (collection) =>
-          this.context === "public" &&
-          collection.access === CollectionAccess.Public &&
-          collection.allowPublicDownload
+          this.context === "public" && collection.allowPublicDownload
             ? html`
                 <sl-tooltip
                   content=${msg("Download Collection: ") +


### PR DESCRIPTION
Reported here https://discord.com/channels/895426029194207262/1011678975636013066/1345095899008860224

Public-facing collections (whether public or unlisted) should have the download button visible if "show download button" is enabled.