### PR TITLE
optimize public collection loading:

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -498,6 +498,8 @@ class CollectionOps:
                         org, self.storage_ops
                     )
 
+            res["orgName"] = org.name
+
             if public_colls_out:
                 collections.append(PublicCollOut.from_dict(res))
             else:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -377,6 +377,8 @@ class CollectionOps:
         """Get PublicCollOut by id"""
         result = await self.get_collection_raw(coll_id)
 
+        result["orgName"] = org.name
+
         allowed_access = [CollAccessType.PUBLIC]
         if allow_unlisted:
             allowed_access.append(CollAccessType.UNLISTED)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1525,6 +1525,7 @@ class PublicCollOut(BaseMongoModel):
     name: str
     slug: str
     oid: UUID
+    orgName: str
     description: Optional[str] = None
     caption: Optional[str] = None
     created: Optional[datetime] = None

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -20,6 +20,7 @@ export const publicCollectionSchema = z.object({
   id: z.string(),
   slug: z.string(),
   oid: z.string(),
+  orgName: z.string(),
   name: z.string(),
   created: z.string().datetime(),
   modified: z.string().datetime(),


### PR DESCRIPTION
- remove query for /collections endpoint just to get the org name
- add orgName to single /collection endpoint, where it is already available on the backend