### PR TITLE
Fix replay.json 400 response for empty collection

### DIFF
--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -538,11 +538,9 @@ class PageOps:
             crawl_ids = await self.coll_ops.get_collection_crawl_ids(
                 coll_id, public_or_unlisted_only
             )
-        elif not crawl_ids:
-            # neither coll_id nor crawl_id, error
-            raise HTTPException(
-                status_code=400, detail="either crawl_ids or coll_id must be provided"
-            )
+
+        if not crawl_ids:
+            return [], 0
 
         query: dict[str, object] = {
             "crawl_id": {"$in": crawl_ids},

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -166,9 +166,10 @@ def test_create_empty_collection(
         },
     )
     assert r.status_code == 200
+    coll_id = r.json()["id"]
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/replay.json",
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{coll_id}/replay.json",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
@@ -176,6 +177,15 @@ def test_create_empty_collection(
     assert data["crawlCount"] == 0
     assert data["pageCount"] == 0
     assert len(data["resources"]) == 0
+
+    # Delete the empty collection
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{coll_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
 
 def test_update_collection(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
@@ -591,10 +601,10 @@ def test_list_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 4
+    assert data["total"] == 3
 
     items = data["items"]
-    assert len(items) == 4
+    assert len(items) == 3
 
     first_coll = [coll for coll in items if coll["name"] == UPDATED_NAME][0]
     assert first_coll["id"] == _coll_id

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -155,6 +155,28 @@ def test_create_collection_empty_name(
     assert r.status_code == 422
 
 
+def test_create_empty_collection(
+    crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=crawler_auth_headers,
+        json={
+            "name": "Empty Collection",
+        },
+    )
+    assert r.status_code == 200
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["crawlCount"] == 0
+    assert data["pageCount"] == 0
+    assert len(data["resources"]) == 0
+
 def test_update_collection(
     crawler_auth_headers, default_org_id, crawler_crawl_id, admin_crawl_id
 ):
@@ -569,10 +591,10 @@ def test_list_collections(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 3
+    assert data["total"] == 4
 
     items = data["items"]
-    assert len(items) == 3
+    assert len(items) == 4
 
     first_coll = [coll for coll in items if coll["name"] == UPDATED_NAME][0]
     assert first_coll["id"] == _coll_id


### PR DESCRIPTION
- fix #2443 
- don't throw error in list_pages() if no crawls provided, just return empty list
- ensure an empty collection returns 200 on replay.json, add tests