### PR TITLE
move db migrations to initContainers:

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -98,7 +98,6 @@ async def update_and_prepare_db(
     storage_ops: StorageOps,
     page_ops: PageOps,
     background_job_ops: BackgroundJobOps,
-    db_inited: dict[str, bool],
 ) -> None:
     """Prepare database for application.
 
@@ -127,7 +126,6 @@ async def update_and_prepare_db(
     await user_manager.create_super_user()
     await org_ops.create_default_org()
     await org_ops.check_all_org_default_storages(storage_ops)
-    db_inited["inited"] = True
     print("Database updated and ready", flush=True)
 
 

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -16,7 +16,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
 from pydantic import BaseModel
 
-from .db import init_db, await_db_and_migrations, update_and_prepare_db
+from .db import init_db, await_db_and_migrations
 
 from .emailsender import EmailSender
 from .invites import init_invites
@@ -38,7 +38,7 @@ from .pages import init_pages_api
 from .subs import init_subs_api
 
 from .crawlmanager import CrawlManager
-from .utils import run_once_lock, register_exit_handler, is_bool
+from .utils import register_exit_handler, is_bool
 from .version import __version__
 
 API_PREFIX = "/api"

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -272,25 +272,8 @@ def main() -> None:
 
     coll_ops.set_page_ops(page_ops)
 
-    # run only in first worker
-    if run_once_lock("btrix-init-db"):
-        asyncio.create_task(
-            update_and_prepare_db(
-                mdb,
-                user_manager,
-                org_ops,
-                crawls,
-                crawl_config_ops,
-                coll_ops,
-                invites,
-                storage_ops,
-                page_ops,
-                background_job_ops,
-                db_inited,
-            )
-        )
-    else:
-        asyncio.create_task(await_db_and_migrations(mdb, db_inited))
+    # await db init, migrations should have already completed in init containers
+    asyncio.create_task(await_db_and_migrations(mdb, db_inited))
 
     app.include_router(org_ops.router)
 

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -30,7 +30,9 @@ async def main():
         )
         return 1
 
-    (org_ops, _, _, _, _, page_ops, coll_ops, _, _, _, _, user_manager) = init_ops()
+    (org_ops, _, _, _, _, page_ops, coll_ops, _, _, _, _, user_manager, _, _, _) = (
+        init_ops()
+    )
 
     # Run job (generic)
     if job_type == BgJobType.OPTIMIZE_PAGES:

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -10,7 +10,7 @@ from .db import update_and_prepare_db
 
 # ============================================================================
 # pylint: disable=too-many-function-args, duplicate-code
-async def main() -> None:
+async def main() -> int:
     """init migrations"""
 
     # pylint: disable=import-outside-toplevel
@@ -19,7 +19,7 @@ async def main() -> None:
             "Sorry, the Browsertrix Backend must be run inside a Kubernetes environment.\
              Kubernetes not detected (KUBERNETES_SERVICE_HOST is not set), Exiting"
         )
-        sys.exit(1)
+        return 1
 
     (
         org_ops,
@@ -54,6 +54,7 @@ async def main() -> None:
     )
 
     return 0
+
 
 # # ============================================================================
 if __name__ == "__main__":

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -1,0 +1,61 @@
+"""entrypoint module for init_container, handles db migration"""
+
+import os
+import sys
+import asyncio
+
+from .ops import init_ops
+from .db import update_and_prepare_db
+
+
+# ============================================================================
+# pylint: disable=too-many-function-args, duplicate-code
+async def main() -> None:
+    """init migrations"""
+
+    # pylint: disable=import-outside-toplevel
+    if not os.environ.get("KUBERNETES_SERVICE_HOST"):
+        print(
+            "Sorry, the Browsertrix Backend must be run inside a Kubernetes environment.\
+             Kubernetes not detected (KUBERNETES_SERVICE_HOST is not set), Exiting"
+        )
+        sys.exit(1)
+
+    (
+        org_ops,
+        crawl_config_ops,
+        _,
+        crawl_ops,
+        _,
+        page_ops,
+        coll_ops,
+        _,
+        storage_ops,
+        background_job_ops,
+        _,
+        user_manager,
+        invite_ops,
+        _,
+        mdb,
+    ) = init_ops()
+
+    await update_and_prepare_db(
+        mdb,
+        user_manager,
+        org_ops,
+        crawl_ops,
+        crawl_config_ops,
+        coll_ops,
+        invite_ops,
+        storage_ops,
+        page_ops,
+        background_job_ops,
+        {},
+    )
+
+    return 0
+
+# # ============================================================================
+if __name__ == "__main__":
+    return_code = asyncio.run(main())
+    sys.exit(return_code)

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -50,7 +50,6 @@ async def main() -> int:
         storage_ops,
         page_ops,
         background_job_ops,
-        {},
     )
 
     return 0

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -39,6 +39,9 @@ def main():
         background_job_ops,
         event_webhook_ops,
         _,
+        _,
+        _,
+        _,
     ) = init_ops()
 
     return init_operator_api(

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -1,6 +1,7 @@
 """shared helper to initialize ops classes"""
 
 from typing import Tuple
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 
 from .crawlmanager import CrawlManager
 from .db import init_db
@@ -35,6 +36,9 @@ def init_ops() -> Tuple[
     BackgroundJobOps,
     EventWebhookOps,
     UserManager,
+    InviteOps,
+    AsyncIOMotorClient,
+    AsyncIOMotorDatabase,
 ]:
     """Initialize and return ops classes"""
     email = EmailSender()
@@ -122,4 +126,7 @@ def init_ops() -> Tuple[
         background_job_ops,
         event_webhook_ops,
         user_manager,
+        invite_ops,
+        dbclient,
+        mdb,
     )

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -1,7 +1,6 @@
 """k8s utils"""
 
 import asyncio
-import atexit
 import csv
 import io
 import json
@@ -56,26 +55,6 @@ def date_to_str(dt_val: datetime) -> str:
 def dt_now() -> datetime:
     """get current ts"""
     return datetime.now(timezone.utc).replace(microsecond=0)
-
-
-def run_once_lock(name) -> bool:
-    """run once lock via temp directory
-    - if dir doesn't exist, return true
-    - if exists, return false"""
-    lock_dir = "/tmp/." + name
-    try:
-        os.mkdir(lock_dir)
-    # pylint: disable=bare-except
-    except:
-        return False
-
-    # just in case, delete dir on exit
-    def del_dir():
-        print("release lock: " + lock_dir, flush=True)
-        os.rmdir(lock_dir)
-
-    atexit.register(del_dir)
-    return True
 
 
 def register_exit_handler() -> None:

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -56,6 +56,48 @@ spec:
           configMap:
             name: email-templates
 
+      initContainers:
+        - name: migrations
+          image: {{ .Values.backend_image }}
+          imagePullPolicy: {{ .Values.backend_pull_policy }}
+          command: ["python3", "-m", "btrixcloud.main_migrations"]
+
+          envFrom:
+            - configMapRef:
+                name: backend-env-config
+            - secretRef:
+                name: backend-auth
+            - secretRef:
+                name: mongo-auth
+
+          env:
+            - name: MOTOR_MAX_WORKERS
+              value: "{{ .Values.backend_mongodb_workers | default 1 }}"
+
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+
+            - name: ops-configs
+              mountPath: /ops-configs/
+
+            - name: ops-proxy-configs
+              mountPath: /ops-proxy-configs/
+
+            - name: app-templates
+              mountPath: /app/btrixcloud/templates/
+
+            - name: email-templates
+              mountPath: /app/btrixcloud/email-templates/
+
+          resources:
+            limits:
+              memory: {{ .Values.backend_memory }}
+
+            requests:
+              cpu: {{ .Values.backend_cpu }}
+              memory: {{ .Values.backend_memory }}
+
       containers:
         - name: api
           image: {{ .Values.backend_image }}


### PR DESCRIPTION
- should avoid gunicorn worker timeouts for long running migrations, also fixes #2439
- add main_migrations as entrypoint to just run db migrations, using existing init_ops() call
- first run 'migrations' container with same resources as 'app' and 'op'
- additional typing for initializing db
- fixes #2447