### PR TITLE
Update screencast aspect ratio to what's being used in prod currently

### DIFF
--- a/frontend/src/components/screencast.ts
+++ b/frontend/src/components/screencast.ts
@@ -145,7 +145,7 @@ export class Screencast extends BtrixElement {
   // Multiply by scale to get available browser window count
   private browsersCount = 1;
   private screenWidth = 640;
-  private screenHeight = 480;
+  private screenHeight = 360;
   private readonly timerIds: number[] = [];
 
   protected firstUpdated() {


### PR DESCRIPTION
Unsure if this is _totally_ done, https://github.com/webrecorder/browsertrix-crawler/issues/733 is still open, but in prod the screencasts are 16:9, so this updates the aspect ratio to match that

<img alt="Screenshot_2025-03-03_at_1.59.45_PM.png" src="https://github.com/user-attachments/assets/15c69e44-990f-4edf-a3e6-f7806115731c" width="489" height="395">