### PR TITLE
Fix nightly tests

### DIFF
--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -4,12 +4,29 @@ on:
   schedule:
     # Run daily at 8am UTC
     - cron:  '0 8 * * *'
+  push:
+    branches:
+      - 'nightly-test-fix'
 
   workflow_dispatch:
 
 jobs:
-  btrix-k3d-nightly-test:
+  collect-test-modules:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(ls ./backend/test_nightly/ | grep -o "^test_.*" | jq -R -s -c 'split("\n")[:-1]')"
+
+  btrix-k3d-nightly-test:
+    name: ${{ matrix.module }}
+    needs: collect-test-modules
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{fromJSON(needs.collect-test-modules.outputs.matrix)}}
     steps:
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2
@@ -82,7 +99,7 @@ jobs:
         run:  kubectl exec -i deployment/local-minio -c minio -- mkdir /data/replica-0
 
       - name: Run Tests
-        run: pytest -vv ./backend/test_nightly/test_*.py
+        run: pytest -vv ./backend/test_nightly/${{ matrix.module }}
 
       - name: Print Backend Logs (API)
         if: ${{ failure() }}

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -4,9 +4,6 @@ on:
   schedule:
     # Run daily at 8am UTC
     - cron:  '0 8 * * *'
-  push:
-    branches:
-      - 'nightly-test-fix'
 
   workflow_dispatch:
 

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       matrix:
         module: ${{fromJSON(needs.collect-test-modules.outputs.matrix)}}
+      fail-fast: false
     steps:
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(ls ./backend/test_nightly/ | grep -o "^test_.*" | jq -R -s -c 'split("\n")[:-1]')"
+        run: |
+          echo matrix="$(ls ./backend/test_nightly/ | grep -o "^test_.*" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   btrix-k3d-nightly-test:
     name: ${{ matrix.module }}

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -10,7 +10,7 @@ from .conftest import API_PREFIX
 job_id = None
 
 
-def test_background_jobs_list(admin_auth_headers, default_org_id):
+def test_background_jobs_list(admin_auth_headers, default_org_id, deleted_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/", headers=admin_auth_headers
     )
@@ -37,7 +37,7 @@ def test_background_jobs_list(admin_auth_headers, default_org_id):
 
 @pytest.mark.parametrize("job_type", [("create-replica"), ("delete-replica")])
 def test_background_jobs_list_filter_by_type(
-    admin_auth_headers, default_org_id, job_type
+    admin_auth_headers, default_org_id, deleted_crawl_id, job_type
 ):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/?jobType={job_type}",
@@ -54,7 +54,9 @@ def test_background_jobs_list_filter_by_type(
         assert item["type"] == job_type
 
 
-def test_background_jobs_list_filter_by_success(admin_auth_headers, default_org_id):
+def test_background_jobs_list_filter_by_success(
+    admin_auth_headers, default_org_id, deleted_crawl_id
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/?success=True",
         headers=admin_auth_headers,
@@ -70,7 +72,9 @@ def test_background_jobs_list_filter_by_success(admin_auth_headers, default_org_
         assert item["success"]
 
 
-def test_background_jobs_no_failures(admin_auth_headers, default_org_id):
+def test_background_jobs_no_failures(
+    admin_auth_headers, default_org_id, deleted_crawl_id
+):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/?success=False",
         headers=admin_auth_headers,
@@ -81,7 +85,7 @@ def test_background_jobs_no_failures(admin_auth_headers, default_org_id):
     assert data["total"] == 0
 
 
-def test_get_background_job(admin_auth_headers, default_org_id):
+def test_get_background_job(admin_auth_headers, default_org_id, deleted_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}", headers=admin_auth_headers
     )
@@ -100,7 +104,7 @@ def test_get_background_job(admin_auth_headers, default_org_id):
     assert data["replica_storage"]
 
 
-def test_retry_all_failed_bg_jobs_not_superuser(crawler_auth_headers):
+def test_retry_all_failed_bg_jobs_not_superuser(crawler_auth_headers, deleted_crawl_id):
     r = requests.post(
         f"{API_PREFIX}/orgs/all/jobs/retryFailed", headers=crawler_auth_headers
     )

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -8,6 +8,8 @@ max_pages_per_crawl: 300
 # enable to allow access to minio directly
 minio_local_access_port: 30090
 
+minio_local_bucket_name: &local_bucket_name "btrix-test-data"
+
 # for checking registration
 registration_enabled: "1"
 
@@ -16,7 +18,7 @@ storages:
     type: "s3"
     access_key: "ADMIN"
     secret_key: "PASSW0RD"
-    bucket_name: "btrix-test-data"
+    bucket_name: *local_bucket_name
 
     endpoint_url: "http://local-minio.default:9000/"
     is_default_primary: true

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -8,8 +8,6 @@ max_pages_per_crawl: 300
 # enable to allow access to minio directly
 minio_local_access_port: 30090
 
-minio_local_bucket_name: &local_bucket_name "btrix-test-data"
-
 # for checking registration
 registration_enabled: "1"
 
@@ -18,10 +16,11 @@ storages:
     type: "s3"
     access_key: "ADMIN"
     secret_key: "PASSW0RD"
-    bucket_name: *local_bucket_name
+    bucket_name: "btrix-test-data"
 
     endpoint_url: "http://local-minio.default:9000/"
-    is_default_primary: True
+    is_default_primary: true
+    access_endpoint_url: "/data/"
 
   - name: "replica-0"
     type: "s3"
@@ -30,6 +29,6 @@ storages:
     bucket_name: "replica-0"
 
     endpoint_url: "http://local-minio.default:9000/"
-    is_default_replica: True
+    is_default_replica: true
 
 


### PR DESCRIPTION
Fixes #2459 

- Set `/data/` as primary storage `access_endpoint_url` in nightly test chart
- Modify nightly test GH Actions workflow to spawn a separate job per nightly test module using dynamic matrix
- Set configuration not to fail other jobs if one job fails
- Modify failing tests:
     - Add fixture to background job nightly test module so it can run alone
     - Add retry loop to crawlconfig stats nightly test so it's less dependent on timing

GitHub limits each workflow to 256 jobs, so this should continue to be able to scale up for us without issue.