### PR TITLE
fix: Open and highlight correct workflow form section on tab click

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -355,6 +355,7 @@ export class WorkflowEditor extends BtrixElement {
 
     if (this.progressState?.activeTab !== STEPS[0]) {
       void this.scrollToActivePanel();
+      void (await this.activeTabPanel)?.querySelector("sl-details")?.show();
     }
   }
 
@@ -1686,8 +1687,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
       .find((panel) => this.visiblePanels.has(panel.id))
       ?.id.split(panelSuffix)[0] as StepName | undefined;
 
-    if (!STEPS.includes(activeTab!)) {
-      console.debug("tab not in steps:", activeTab, this.visiblePanels);
+    if (!activeTab || !STEPS.includes(activeTab)) {
+      if (activeTab) {
+        console.debug("tab not in steps:", activeTab, this.visiblePanels);
+      }
+
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2461

## Changes

Opens workflow form section when clicking on section navigation link, fixing issue with scroll position impacting unopened panels.

## Manual testing

1. Log in as crawler
2. Go to New Workflow
3. Click section in side navigation. Verify section is scrolled to expands
4. Scroll and interact with the page. Verify scroll indicator works as expected