### PR TITLE
Hide breadcrumbs for private orgs

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -342,9 +342,11 @@ class CollectionOps:
         result = await self.get_collection_raw(coll_id, public_or_unlisted_only)
 
         if resources:
-            result["resources"], crawl_ids, pages_optimized = (
-                await self.get_collection_crawl_resources(coll_id)
-            )
+            (
+                result["resources"],
+                crawl_ids,
+                pages_optimized,
+            ) = await self.get_collection_crawl_resources(coll_id)
 
             initial_pages, _ = await self.page_ops.list_pages(
                 crawl_ids=crawl_ids,
@@ -389,6 +391,7 @@ class CollectionOps:
         result = await self.get_collection_raw(coll_id)
 
         result["orgName"] = org.name
+        result["orgPublicProfile"] = org.enablePublicProfile
 
         allowed_access = [CollAccessType.PUBLIC]
         if allow_unlisted:
@@ -542,6 +545,7 @@ class CollectionOps:
                     )
 
             res["orgName"] = org.name
+            res["orgPublicProfile"] = org.enablePublicProfile
 
             if public_colls_out:
                 collections.append(PublicCollOut.from_dict(res))
@@ -1009,9 +1013,11 @@ def init_collections_api(
         try:
             all_collections, _ = await colls.list_collections(org, page_size=10_000)
             for collection in all_collections:
-                results[collection.name], _, _ = (
-                    await colls.get_collection_crawl_resources(collection.id)
-                )
+                (
+                    results[collection.name],
+                    _,
+                    _,
+                ) = await colls.get_collection_crawl_resources(collection.id)
         except Exception as exc:
             # pylint: disable=raise-missing-from
             raise HTTPException(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1531,6 +1531,7 @@ class PublicCollOut(BaseMongoModel):
     slug: str
     oid: UUID
     orgName: str
+    orgPublicProfile: bool
     description: Optional[str] = None
     caption: Optional[str] = None
     created: Optional[datetime] = None

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -80,12 +80,15 @@ export class Collection extends BtrixElement {
 
   private readonly renderComplete = (collection: PublicCollection) => {
     const header: Parameters<typeof page>[0] = {
-      breadcrumbs: [
-        {
-          href: `/${RouteNamespace.PublicOrgs}/${this.orgSlug}`,
-          content: collection.orgName,
-        },
-      ],
+      breadcrumbs:
+        collection.orgPublicProfile || collection.oid === this.orgId
+          ? [
+              {
+                href: `/${RouteNamespace.PublicOrgs}/${this.orgSlug}`,
+                content: collection.orgName,
+              },
+            ]
+          : undefined,
       title: collection.name || "",
       actions: html`
         <btrix-share-collection

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -21,6 +21,7 @@ export const publicCollectionSchema = z.object({
   slug: z.string(),
   oid: z.string(),
   orgName: z.string(),
+  orgPublicProfile: z.boolean(),
   name: z.string(),
   created: z.string().datetime(),
   modified: z.string().datetime(),


### PR DESCRIPTION
Hides "Back to [org name]" breadcrumb when viewing a public/unlisted collection when the public gallery isn't enabled for the org (except when logged into that org).