### PR TITLE
cleanup unused chart values + change mongo default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -198,7 +198,7 @@ frontend_avg_memory_threshold: 95
 # =========================================
 mongo_local: true
 
-mongo_host: "local-mongo.default"
+mongo_host: "local-mongo"
 
 mongo_image: "docker.io/library/mongo:6.0.5"
 mongo_pull_policy: "IfNotPresent"
@@ -219,12 +219,8 @@ mongo_auth:
 
 # Redis Image
 # =========================================
-redis_local: true
-
 redis_image: "redis"
 redis_pull_policy: "IfNotPresent"
-
-redis_url: "redis://local-redis.default:6379/1"
 
 redis_cpu: "10m"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -387,7 +387,7 @@ minio_local: true
 # minio_local_console_port: 30091
 
 minio_scheme: "http"
-minio_host: "local-minio.default:9000"
+minio_host: "local-minio:9000"
 
 minio_image: docker.io/minio/minio:RELEASE.2022-10-24T18-35-07Z
 minio_mc_image: minio/mc


### PR DESCRIPTION
- Removes chart values that are unused
- Also change `local-mongo.default` -> `local-mongo`, `local-minio.default` -> `local-minio` as some users have reported issues with `.default` and it will certainly break if not deploying Browsertrix in the `default `namespace.