### PR TITLE
Unsuspend Job when CrawlJob is finished

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -281,7 +281,7 @@ class K8sAPI:
             return {"error": str(exc)}
 
     async def unsuspend_k8s_job(self, name) -> dict:
-        """ unsuspend k8s Job """
+        """unsuspend k8s Job"""
         try:
             await self.batch_api.patch_namespaced_job(
                 name=name, namespace=self.namespace, body={"spec": {"suspend": False}}

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -281,6 +281,7 @@ class K8sAPI:
             return {"error": str(exc)}
 
     async def unsuspend_k8s_job(self, name) -> dict:
+        """ unsuspend k8s Job """
         try:
             await self.batch_api.patch_namespaced_job(
                 name=name, namespace=self.namespace, body={"spec": {"suspend": False}}

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -280,6 +280,17 @@ class K8sAPI:
             traceback.print_exc()
             return {"error": str(exc)}
 
+    async def unsuspend_k8s_job(self, name) -> dict:
+        try:
+            await self.batch_api.patch_namespaced_job(
+                name=name, namespace=self.namespace, body={"spec": {"suspend": False}}
+            )
+            return {"success": True}
+        # pylint: disable=broad-except
+        except Exception as exc:
+            traceback.print_exc()
+            return {"error": str(exc)}
+
     async def print_pod_logs(self, pod_names, lines=100):
         """print pod logs"""
         for pod in pod_names:

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -42,6 +42,8 @@ class CronJobOperator(BaseOperator):
                 "completionTime": finished,
             }
 
+        self.run_task(self.k8s.unsuspend_k8s_job(metadata.get("name")))
+
         return MCDecoratorSyncResponse(
             attachments=[],
             # set on job to match default behavior when job finishes

--- a/chart/app-templates/crawl_cron_job.yaml
+++ b/chart/app-templates/crawl_cron_job.yaml
@@ -24,7 +24,7 @@ spec:
         role: "scheduled-crawljob"
 
     spec:
-      suspend: True
+      suspend: true
       template:
         spec:
           restartPolicy: Never

--- a/chart/app-templates/crawl_cron_job.yaml
+++ b/chart/app-templates/crawl_cron_job.yaml
@@ -24,7 +24,7 @@ spec:
         role: "scheduled-crawljob"
 
     spec:
-      suspend: true
+      suspend: True
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
Fixes #2488 

Adds a k8s api cal to set `suspend=False` on Job when associated CrawlJob is finished.