### PR TITLE
fixes token lifetime bug / improve security

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -28,7 +28,7 @@ from .utils import dt_now
 # ============================================================================
 PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", uuid4().hex)
 
-JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME_MINUTES", 60)) * 60
+JWT_TOKEN_LIFETIME = int(os.environ.get("JWT_TOKEN_LIFETIME_MINUTES", 60))
 
 BTRIX_SUBS_APP_API_KEY = os.environ.get("BTRIX_SUBS_APP_API_KEY", "")
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1899,7 +1899,7 @@ class OrgOut(BaseMongoModel):
     id: UUID
     name: str
     slug: str
-    users: Dict[str, Any] = {}
+    users: Dict[str, str | int] = {}
 
     created: Optional[datetime] = None
 
@@ -2063,10 +2063,14 @@ class Organization(BaseMongoModel):
                 if not role:
                     continue
 
-                result["users"][id_] = {
+                email = org_user.get("email")
+                if not email:
+                    continue
+
+                result["users"][email] = {
                     "role": role,
                     "name": org_user.get("name", ""),
-                    "email": org_user.get("email", ""),
+                    "email": email,
                 }
 
         return OrgOut.from_dict(result)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1899,7 +1899,7 @@ class OrgOut(BaseMongoModel):
     id: UUID
     name: str
     slug: str
-    users: Dict[str, str | int] = {}
+    users: Dict[str, Any] = {}
 
     created: Optional[datetime] = None
 

--- a/backend/test/test_api.py
+++ b/backend/test/test_api.py
@@ -40,7 +40,7 @@ def test_api_settings():
 
     assert data == {
         "registrationEnabled": False,
-        "jwtTokenLifetime": 86400,
+        "jwtTokenLifetime": 1440,
         "defaultBehaviorTimeSeconds": 300,
         "maxPagesPerCrawl": 4,
         "numBrowsers": 2,


### PR DESCRIPTION
- fix jwt_token_lifetime being in hours, not minutes, remove extra * 60
- don't return userids in user list for org admins, instead just key users by email, which is already unique