### PR TITLE
Workflow editor footer button: ensure `isCrawlRunning` is `false` if editing a new workflow

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -227,7 +227,7 @@ export class WorkflowEditor extends BtrixElement {
   private serverError?: TemplateResult | string;
 
   @state()
-  private isCrawlRunning: boolean | null = null;
+  private isCrawlRunning: boolean | null = this.configId ? null : false;
 
   // For observing panel sections position in viewport
   private readonly observable = new ObservableController(this, {
@@ -330,6 +330,9 @@ export class WorkflowEditor extends BtrixElement {
       } else {
         this.initializeEditor();
       }
+    }
+    if (changedProperties.has("configId")) {
+      this.isCrawlRunning = this.configId ? null : false;
     }
   }
 


### PR DESCRIPTION
Reported by @tw4l 

Quick fix for the bug I introduced in 1bc3c35 in #2481. I didn't properly test on the workflow editor in a "new workflow" state, and didn't realize that the component that fetches the workflow state for an existing workflow wouldn't be rendered for a new workflow, so the update to the loading state never occurred for new workflows. This fix explicitly sets `isCrawlRunning` to `false` instead of `null` for new workflows, so that the loading state isn't displayed.

Tested locally with both new and existing workflows (in both non-running and running states).