### PR TITLE
Add backend support for custom behaviors + validation endpoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,13 @@
 FROM docker.io/library/python:3.12-slim
 
-WORKDIR /app
-
-ADD requirements.txt /app
-
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends git \
 	&& apt-get purge -y --auto-remove \
 	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ADD requirements.txt /app
 
 RUN pip install -r requirements.txt
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR /app
 
 ADD requirements.txt /app
 
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends git \
+	&& apt-get purge -y --auto-remove \
+	&& rm -rf /var/lib/apt/lists/*
+
 RUN pip install -r requirements.txt
 
 ADD btrixcloud/ /app/btrixcloud/

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -6,7 +6,6 @@ Crawl Config API handling
 
 from typing import List, Union, Optional, TYPE_CHECKING, cast
 
-import aiohttp
 import asyncio
 import json
 import re
@@ -16,8 +15,9 @@ from datetime import datetime
 from uuid import UUID, uuid4
 import urllib.parse
 
-import pymongo
+import aiohttp
 from fastapi import APIRouter, Depends, HTTPException, Query
+import pymongo
 
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1079,7 +1079,7 @@ class CrawlConfigOps:
                     flush=True,
                 )
 
-    def _validate_behavior_git_repo(self, repo_url: str, branch: str = ""):
+    async def _validate_behavior_git_repo(self, repo_url: str, branch: str = ""):
         """Validate git repository and branch, if specified, exist and are reachable"""
         git_remote_cmd = f"git ls-remote {repo_url} HEAD"
         proc = await asyncio.create_subprocess_shell(cmd)
@@ -1149,7 +1149,7 @@ class CrawlConfigOps:
             raise HTTPException(status_code=400, detail="invalid_custom_behavior")
 
         if is_git_repo:
-            self._validate_behavior_git_repo(url, branch=git_branch)
+            await self._validate_behavior_git_repo(url, branch=git_branch)
         else:
             await self._validate_behavior_url(url)
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -10,7 +10,6 @@ import asyncio
 import json
 import re
 import os
-import time
 import traceback
 from datetime import datetime
 from uuid import UUID, uuid4
@@ -1091,7 +1090,7 @@ class CrawlConfigOps:
             )
 
         if branch:
-            time.sleep(2)
+            await asyncio.sleep(0.5)
             git_remote_cmd = (
                 f"git ls-remote --exit-code --heads {repo_url} refs/heads/{branch}"
             )

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -301,7 +301,8 @@ class CrawlConfigOps:
                 url = url[len(git_prefix) :]
                 url = url.split("?")[0]
 
-            async with aiohttp.ClientSession() as session:
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url) as resp:
                     if resp.status >= 400:
                         raise HTTPException(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1091,7 +1091,9 @@ class CrawlConfigOps:
 
         if branch:
             time.sleep(2)
-            git_remote_cmd = f"git ls-remote --exit-code --heads {repo_url} refs/heads/{branch}"
+            git_remote_cmd = (
+                f"git ls-remote --exit-code --heads {repo_url} refs/heads/{branch}"
+            )
             proc = await asyncio.create_subprocess_shell(git_remote_cmd)
             if await proc.wait() > 0:
                 raise HTTPException(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1081,7 +1081,7 @@ class CrawlConfigOps:
 
     async def _validate_behavior_git_repo(self, repo_url: str, branch: str = ""):
         """Validate git repository and branch, if specified, exist and are reachable"""
-        git_remote_cmd = f"git ls-remote {repo_url} HEAD"
+        cmd = f"git ls-remote {repo_url} HEAD"
         proc = await asyncio.create_subprocess_shell(cmd)
         if await proc.wait() > 0:
             raise HTTPException(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1103,6 +1103,7 @@ class CrawlConfigOps:
             try:
                 subprocess.run(git_remote_cmd, check=True)
             # Raises on non-zero exit code (repo doesn't exist or isn't reachable)
+            # pylint: disable=raise-missing-from
             except subprocess.CalledProcessError:
                 raise HTTPException(
                     status_code=404,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1080,7 +1080,7 @@ class CrawlConfigOps:
                     flush=True,
                 )
 
-    async def _validate_behavior_git_repo(self, repo_url: str, branch: str = ""):
+    def _validate_behavior_git_repo(self, repo_url: str, branch: str = ""):
         """Validate git repository and branch, if specified, exist and are reachable"""
         git_remote_cmd = ["git", "ls-remote", repo_url, "HEAD"]
         try:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1116,14 +1116,21 @@ class CrawlConfigOps:
 
     async def _validate_behavior_url(self, url: str):
         """Validate behavior file exists at url"""
-        timeout = aiohttp.ClientTimeout(total=10)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(url) as resp:
-                if resp.status >= 400:
-                    raise HTTPException(
-                        status_code=404,
-                        detail="custom_behavior_not_found",
-                    )
+        try:
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url) as resp:
+                    if resp.status >= 400:
+                        raise HTTPException(
+                            status_code=404,
+                            detail="custom_behavior_not_found",
+                        )
+        # pylint: disable=raise-missing-from
+        except aiohttp.ClientError:
+            raise HTTPException(
+                status_code=404,
+                detail="custom_behavior_not_found",
+            )
 
     async def validate_custom_behavior(self, url: str) -> Dict[str, bool]:
         """Validate custom behavior URL

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -618,10 +618,10 @@ class CrawlConfigDeletedResponse(BaseModel):
 
 
 # ============================================================================
-class ValidateCustomBehaviors(BaseModel):
-    """Input model for validating custom behaviors"""
+class ValidateCustomBehavior(BaseModel):
+    """Input model for validating custom behavior URL/Git reference"""
 
-    customBehaviors: List[str]
+    customBehavior: str
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -564,6 +564,8 @@ class CrawlConfigDefaults(BaseModel):
 
     exclude: Optional[List[str]] = None
 
+    customBehaviors: List[str] = []
+
 
 # ============================================================================
 class CrawlConfigAddedResponse(BaseModel):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -355,6 +355,7 @@ class RawCrawlConfig(BaseModel):
 
     logging: Optional[str] = None
     behaviors: Optional[str] = "autoscroll,autoplay,autofetch,siteSpecific"
+    customBehaviors: List[str] = []
 
     userAgent: Optional[str] = None
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -618,6 +618,13 @@ class CrawlConfigDeletedResponse(BaseModel):
 
 
 # ============================================================================
+class ValidateCustomBehaviors(BaseModel):
+    """Input model for validating custom behaviors"""
+
+    customBehaviors: List[str]
+
+
+# ============================================================================
 
 ### CRAWLER VERSIONS ###
 

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -11,6 +11,7 @@ import re
 
 from datetime import datetime, timezone
 from typing import Optional, Dict, Union, List, Any
+from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -98,6 +99,15 @@ def is_falsy_bool(stri: Optional[str]) -> bool:
     if stri:
         return stri.lower() in ("false", "0", "no", "off")
     return False
+
+
+def is_url(url: str) -> bool:
+    """Check if string is ad valid URL"""
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
 
 
 def str_list_to_bools(str_list: List[str], allow_none=True) -> List[Union[bool, None]]:

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -102,7 +102,7 @@ def is_falsy_bool(stri: Optional[str]) -> bool:
 
 
 def is_url(url: str) -> bool:
-    """Check if string is ad valid URL"""
+    """Check if string is a valid URL"""
     try:
         result = urlparse(url)
         return all([result.scheme, result.netloc])

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -326,7 +326,7 @@ def crawler_config_id_only(_crawler_create_config_only):
     return _crawler_config_id
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def sample_crawl_data():
     return {
         "runNow": False,

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -662,6 +662,7 @@ def test_add_update_crawl_config_custom_behaviors_git_url(
 
 def test_validate_custom_behaviors(crawler_auth_headers, default_org_id):
     valid_url = "https://raw.githubusercontent.com/webrecorder/custom-behaviors/refs/heads/main/behaviors/fulcrum.js"
+    git_url = "git+https://github.com/webrecorder/custom-behaviors"
     invalid_url_404 = "https://webrecorder.net/nonexistent/behavior.js"
     malformed_url = "http"
 
@@ -691,3 +692,12 @@ def test_validate_custom_behaviors(crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 400
     assert r.json()["detail"] == "Error at list index 1: Invalid URL"
+
+    # No issues
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behaviors",
+        headers=crawler_auth_headers,
+        json={"customBehaviors": [valid_url, git_url]},
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -669,8 +669,15 @@ def test_validate_custom_behavior(crawler_auth_headers, default_org_id):
     invalid_git_url = "git+https://github.com/webrecorder/doesntexist"
     private_git_url = "git+https://github.com/webrecorder/website"
 
+    git_url_with_params = (
+        "git+https://github.com/webrecorder/custom-behaviors?branch=main&path=behaviors"
+    )
+    git_url_invalid_branch = (
+        "git+https://github.com/webrecorder/custom-behaviors?branch=doesntexist"
+    )
+
     # Success
-    for url in (valid_url, git_url):
+    for url in (valid_url, git_url, git_url_with_params):
         r = requests.post(
             f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behavior",
             headers=crawler_auth_headers,
@@ -714,3 +721,12 @@ def test_validate_custom_behavior(crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 404
     assert r.json()["detail"] == "custom_behavior_not_found"
+
+    # Git branch doesn't exist
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behavior",
+        headers=crawler_auth_headers,
+        json={"customBehavior": git_url_invalid_branch},
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "custom_behavior_branch_not_found"

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -687,7 +687,7 @@ def test_validate_custom_behavior(crawler_auth_headers, default_org_id):
 
     # Malformed url
     r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behaviors",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behavior",
         headers=crawler_auth_headers,
         json={"customBehavior": malformed_url},
     )

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -10,7 +10,7 @@ UPDATED_NAME = "Updated name"
 UPDATED_DESCRIPTION = "Updated description"
 UPDATED_TAGS = ["tag3", "tag4"]
 
-INVALID_BEHAVIOR_URL = "https://example.com/path/to/nonexistent/behavior.js"
+INVALID_BEHAVIOR_URL = "https://webrecorder.net/nonexistent/behavior.js"
 
 _coll_id = None
 _admin_crawl_cid = None

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -663,6 +663,7 @@ def test_add_update_crawl_config_custom_behaviors_git_url(
 def test_validate_custom_behavior(crawler_auth_headers, default_org_id):
     valid_url = "https://raw.githubusercontent.com/webrecorder/custom-behaviors/refs/heads/main/behaviors/fulcrum.js"
     invalid_url_404 = "https://webrecorder.net/nonexistent/behavior.js"
+    doesnt_resolve_url = "https://nonexistenturl-for-testing-browsertrix.com"
     malformed_url = "http"
 
     git_url = "git+https://github.com/webrecorder/custom-behaviors"
@@ -687,13 +688,14 @@ def test_validate_custom_behavior(crawler_auth_headers, default_org_id):
         assert r.json()["success"]
 
     # Behavior 404s
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behavior",
-        headers=crawler_auth_headers,
-        json={"customBehavior": invalid_url_404},
-    )
-    assert r.status_code == 404
-    assert r.json()["detail"] == "custom_behavior_not_found"
+    for url in (invalid_url_404, doesnt_resolve_url):
+        r = requests.post(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/validate/custom-behavior",
+            headers=crawler_auth_headers,
+            json={"customBehavior": url},
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"] == "custom_behavior_not_found"
 
     # Malformed url
     r = requests.post(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -12,7 +12,7 @@ def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_
         headers=crawler_auth_headers,
     )
     assert len(r.json()["items"]) == 3
-    assert r.json()["total"] == 3
+    assert r.json()["total"] == 5
 
 
 def test_get_config_by_modified_by(
@@ -24,7 +24,7 @@ def test_get_config_by_modified_by(
         headers=crawler_auth_headers,
     )
     assert len(r.json()["items"]) == 3
-    assert r.json()["total"] == 3
+    assert r.json()["total"] == 5
 
 
 def test_get_configs_by_first_seed(
@@ -362,9 +362,9 @@ def test_sort_crawl_configs(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 9
+    assert data["total"] == 11
     items = data["items"]
-    assert len(items) == 9
+    assert len(items) == 11
 
     last_created = None
     for config in items:

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -11,7 +11,7 @@ def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 3
+    assert len(r.json()["items"]) == 5
     assert r.json()["total"] == 5
 
 
@@ -23,7 +23,7 @@ def test_get_config_by_modified_by(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?modifiedBy={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 3
+    assert len(r.json()["items"]) == 5
     assert r.json()["total"] == 5
 
 

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -60,7 +60,11 @@ def test_update_org_crawling_defaults(admin_auth_headers, default_org_id):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/defaults/crawling",
         headers=admin_auth_headers,
-        json={"maxCrawlSize": 200000, "lang": "fr"},
+        json={
+            "maxCrawlSize": 200000,
+            "lang": "fr",
+            "customBehaviors": ["git+https://github.com/webrecorder/custom-behaviors"],
+        },
     )
 
     assert r.status_code == 200
@@ -72,6 +76,9 @@ def test_update_org_crawling_defaults(admin_auth_headers, default_org_id):
     assert data["crawlingDefaults"]
     assert data["crawlingDefaults"]["maxCrawlSize"] == 200000
     assert data["crawlingDefaults"]["lang"] == "fr"
+    assert data["crawlingDefaults"]["customBehaviors"] == [
+        "git+https://github.com/webrecorder/custom-behaviors"
+    ]
 
 
 def test_rename_org(admin_auth_headers, default_org_id):


### PR DESCRIPTION
Backend support for #2151 

Adds support for specifying custom behaviors via a list of strings.

When workflows are added or modified, minimal backend validation is done to ensure that all custom behavior URLs are valid URLs (after removing the git prefix and custom query arguments).

A separate `POST /crawlconfigs/validate/custom-behavior` endpoint is also added, which can be used to validate a custom behavior URL. It performs the same syntax check as above and then:
- For URL directly to behavior file, ensures URL resolves and returns a 2xx/3xx status code
- For Git repositories, uses `git ls-remote` to ensure they exist (and that branch exists if specified)