### PR TITLE
crawl replay: remove isSeed=true from initialPages query

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -164,7 +164,7 @@ class BaseCrawlOps:
 
             if res.get("version", 1) == 2:
                 res["initialPages"], _ = await self.page_ops.list_pages(
-                    crawl_ids=[crawlid], is_seed=True, page_size=25
+                    crawl_ids=[crawlid], page_size=25
                 )
 
                 oid = res.get("oid")

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -184,7 +184,7 @@ def test_wait_for_complete(admin_auth_headers, default_org_id):
     assert len(data["resources"]) == 1
     assert data["resources"][0]["path"]
 
-    assert len(data["initialPages"]) == 1
+    assert len(data["initialPages"]) == 4
     assert data["pagesQueryUrl"].endswith(
         f"/orgs/{default_org_id}/crawls/{admin_crawl_id}/pagesSearch"
     )


### PR DESCRIPTION
- matches initial query for collections
- fixes 'Show Non-Seed Pages' not appearing for crawl replay