### PR TITLE
feat: Apply saved workflow settings to current crawl

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -387,7 +387,7 @@ class CrawlConfigOps:
 
     async def update_crawl_config(
         self, cid: UUID, org: Organization, user: User, update: UpdateCrawlConfig
-    ) -> dict[str, bool | str]:
+    ) -> CrawlConfigUpdateResponse:
         # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
 
@@ -455,11 +455,9 @@ class CrawlConfigOps:
         run_now = update.runNow
 
         if not changed and not metadata_changed and not run_now:
-            return {
-                "updated": True,
-                "settings_changed": changed,
-                "metadata_changed": metadata_changed,
-            }
+            return CrawlConfigUpdateResponse(
+                settings_changed=changed, metadata_changed=metadata_changed
+            )
 
         if changed:
             orig_dict = orig_crawl_config.dict(exclude_unset=True, exclude_none=True)
@@ -498,10 +496,11 @@ class CrawlConfigOps:
                 status_code=404, detail=f"Crawl Config '{cid}' not found"
             )
 
+        crawlconfig = CrawlConfig.from_dict(result)
+
         # update in crawl manager to change schedule
         if schedule_changed:
             try:
-                crawlconfig = CrawlConfig.from_dict(result)
                 await self.crawl_manager.update_scheduled_job(crawlconfig, str(user.id))
 
             except Exception as exc:
@@ -511,16 +510,24 @@ class CrawlConfigOps:
                     status_code=404, detail=f"Crawl Config '{cid}' not found"
                 )
 
-        ret: dict[str, bool | str] = {
-            "updated": True,
-            "settings_changed": changed,
-            "metadata_changed": metadata_changed,
-            "storageQuotaReached": self.org_ops.storage_quota_reached(org),
-            "execMinutesQuotaReached": self.org_ops.exec_mins_quota_reached(org),
-        }
+        ret = CrawlConfigUpdateResponse(
+            settings_changed=changed,
+            metadata_changed=metadata_changed,
+            storageQuotaReached=self.org_ops.storage_quota_reached(org),
+            execMinutesQuotaReached=self.org_ops.exec_mins_quota_reached(org),
+        )
+
         if run_now:
             crawl_id = await self.run_now(cid, org, user)
-            ret["started"] = crawl_id
+            ret.started = crawl_id
+        elif update.updateRunning and changed:
+            running_crawl = await self.get_running_crawl(cid)
+            if running_crawl:
+                await self.crawl_manager.update_running_crawl_config(
+                    running_crawl.id, crawlconfig
+                )
+                ret.updated_running = True
+
         return ret
 
     async def update_usernames(self, userid: UUID, updated_name: str) -> None:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -526,7 +526,7 @@ class CrawlConfigOps:
                 await self.crawl_manager.update_running_crawl_config(
                     running_crawl.id, crawlconfig
                 )
-                ret.updated_running = True
+                ret.updatedRunning = True
 
         return ret
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -249,6 +249,22 @@ class CrawlManager(K8sAPI):
             crawl_id, {"lastConfigUpdate": date_to_str(dt_now())}
         )
 
+    async def update_running_crawl_config(
+        self, crawl_id: str, crawlconfig: CrawlConfig
+    ):
+        """force update of config for running crawl"""
+        # pylint: disable=use-dict-literal
+        patch = dict(
+            crawlerChannel=crawlconfig.crawlerChannel,
+            scale=crawlconfig.scale,
+            timeout=crawlconfig.crawlTimeout,
+            maxCrawlSize=crawlconfig.maxCrawlSize,
+            proxyId=crawlconfig.proxyId or DEFAULT_PROXY_ID,
+            lastConfigUpdate=date_to_str(dt_now()),
+        )
+
+        return await self._patch_job(crawl_id, patch)
+
     async def create_qa_crawl_job(
         self,
         crawlconfig: CrawlConfig,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -253,6 +253,8 @@ class CrawlManager(K8sAPI):
         self, crawl_id: str, crawlconfig: CrawlConfig
     ):
         """force update of config for running crawl"""
+        time_now = date_to_str(dt_now())
+
         # pylint: disable=use-dict-literal
         patch = dict(
             crawlerChannel=crawlconfig.crawlerChannel,
@@ -260,7 +262,8 @@ class CrawlManager(K8sAPI):
             timeout=crawlconfig.crawlTimeout,
             maxCrawlSize=crawlconfig.maxCrawlSize,
             proxyId=crawlconfig.proxyId or DEFAULT_PROXY_ID,
-            lastConfigUpdate=date_to_str(dt_now()),
+            lastConfigUpdate=time_now,
+            restartTime=time_now,
         )
 
         return await self._patch_job(crawl_id, patch)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -506,6 +506,7 @@ class UpdateCrawlConfig(BaseModel):
     description: Optional[str] = None
     autoAddCollections: Optional[List[UUID]] = None
     runNow: bool = False
+    updateRunning: bool = False
 
     # crawl data: revision tracked
     schedule: Optional[str] = None
@@ -578,9 +579,10 @@ class CrawlConfigSearchValues(BaseModel):
 class CrawlConfigUpdateResponse(BaseModel):
     """Response model for updating crawlconfigs"""
 
-    updated: bool
+    updated: bool = True
     settings_changed: bool
     metadata_changed: bool
+    updated_running: bool = False
 
     storageQuotaReached: Optional[bool] = False
     execMinutesQuotaReached: Optional[bool] = False

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -582,7 +582,7 @@ class CrawlConfigUpdateResponse(BaseModel):
     updated: bool = True
     settings_changed: bool
     metadata_changed: bool
-    updated_running: bool = False
+    updatedRunning: bool = False
 
     storageQuotaReached: Optional[bool] = False
     execMinutesQuotaReached: Optional[bool] = False

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -1305,8 +1305,7 @@ def test_custom_behavior_logs(
         if log["context"] == "behaviorScriptCustom":
             assert log["message"] in (
                 "test-stat",
-                "done!",
-                "Using Site-Specific Behavior: TestBehavior",
+                "In Test Behavior!",
             )
             if log["message"] in ("test-stat", "done!"):
                 assert log["details"]["behavior"] == "TestBehavior"
@@ -1314,7 +1313,7 @@ def test_custom_behavior_logs(
 
             custom_log_line_count += 1
 
-    assert custom_log_line_count == 3
+    assert custom_log_line_count == 2
 
 
 def test_crawls_exclude_behavior_logs(

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -115,7 +115,7 @@ type CrawlConfigParams = WorkflowParams & {
     seeds: Seed[];
   };
 };
-type WorkflowRunParams = { runNow: boolean; updateRunning: boolean };
+type WorkflowRunParams = { runNow: boolean; updateRunning?: boolean };
 
 const STEPS = SECTIONS;
 type StepName = (typeof STEPS)[number];
@@ -2237,8 +2237,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
     const config: CrawlConfigParams & WorkflowRunParams = {
       ...this.parseConfig(),
       runNow: Boolean(opts?.runNow),
-      updateRunning: Boolean(opts?.updateRunning),
     };
+
+    if (this.configId) {
+      config.updateRunning = Boolean(opts?.updateRunning);
+    }
 
     this.isSubmitting = true;
 

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -81,7 +81,6 @@ export type FormState = {
     minute: number;
     period: "AM" | "PM";
   };
-  runNow: boolean;
   jobName: WorkflowParams["name"];
   browserProfile: Profile | null;
   tags: Tags;
@@ -139,7 +138,6 @@ export const getDefaultFormState = (): FormState => ({
     minute: 0,
     period: "AM",
   },
-  runNow: false,
   jobName: "",
   browserProfile: null,
   tags: [],
@@ -275,10 +273,6 @@ export function getInitialFormState(params: {
     lang: params.initialWorkflow.config.lang ?? defaultFormState.lang,
     scheduleType: defaultFormState.scheduleType,
     scheduleFrequency: defaultFormState.scheduleFrequency,
-    runNow:
-      params.org?.storageQuotaReached || params.org?.execMinutesQuotaReached
-        ? false
-        : defaultFormState.runNow,
     tags: params.initialWorkflow.tags,
     autoAddCollections: params.initialWorkflow.autoAddCollections,
     jobName: params.initialWorkflow.name || defaultFormState.jobName,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2366

## Changes

Allows users to update current crawl with newly saved workflow settings.

## Manual testing

1. Log in as crawler
2. Start a crawl
3. Go to edit workflow. Verify "Update Crawl" button is shown
4. Click "Update Crawl". Verify crawl is updated with new settings

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit Workflow | <img width="384" alt="Screenshot 2025-03-24 at 3 51 36 PM" src="https://github.com/user-attachments/assets/9426a8b0-6bf0-4344-bdf7-a683a6f6c685" /> |


<!-- ## Follow-ups -->
