### PR TITLE
Optimize presigning for replay.json

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -492,9 +492,7 @@ class BaseCrawlOps:
         async def async_gen():
             yield {"presigned": presigned, "files": files_dict, "_id": crawl_id}
 
-        out_files, _ = await self.process_presigned_files(
-            async_gen(), org, force_update
-        )
+        out_files, _ = await self.bulk_presigned_files(async_gen(), org, force_update)
 
         return out_files
 
@@ -517,9 +515,9 @@ class BaseCrawlOps:
             ]
         )
 
-        return await self.process_presigned_files(cursor, org)
+        return await self.bulk_presigned_files(cursor, org)
 
-    async def process_presigned_files(
+    async def bulk_presigned_files(
         self,
         cursor: AsyncIterable[dict[str, Any]],
         org: Organization,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -476,7 +476,6 @@ class BaseCrawlOps:
     ) -> List[CrawlFileOut]:
         """Regenerate presigned URLs for files as necessary"""
         if not files:
-            print("no files")
             return []
 
         out_files = []
@@ -489,6 +488,7 @@ class BaseCrawlOps:
 
         files_dict = [file.dict() for file in files]
 
+        # need an async generator to call bulk_presigned_files
         async def async_gen():
             yield {"presigned": presigned, "files": files_dict, "_id": crawl_id}
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -39,6 +39,7 @@ from .models import (
     AddedResponse,
     DeletedResponse,
     CollectionSearchValuesResponse,
+    CollectionAllResponse,
     OrgPublicCollections,
     PublicOrgDetails,
     CollAccessType,
@@ -1007,6 +1008,7 @@ def init_collections_api(
     @app.get(
         "/orgs/{oid}/collections/$all",
         tags=["collections"],
+        response_model=CollectionAllResponse,
     )
     async def get_collection_all(org: Organization = Depends(org_viewer_dep)):
         results = {}

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -597,8 +597,6 @@ class CollectionOps:
 
         sign_files = []
 
-        crawl_id = None
-
         async for result in cursor:
             mapping = {}
             # create mapping of filename -> file data

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -562,6 +562,7 @@ class CollectionOps:
 
         return collections, total
 
+    # pylint: disable=too-many-locals
     async def get_collection_crawl_resources(
         self, coll_id: Optional[UUID], org: Organization
     ) -> tuple[List[CrawlFileOut], List[str], bool]:
@@ -596,10 +597,13 @@ class CollectionOps:
 
         sign_files = []
 
+        crawl_id = None
+
         async for result in cursor:
             mapping = {}
             # create mapping of filename -> file data
             for file in result["files"]:
+                file["crawl_id"] = result.get("_id")
                 mapping[file["filename"]] = file
 
             # add already presigned resources
@@ -614,7 +618,7 @@ class CollectionOps:
                             path=presigned["url"],
                             hash=file["hash"],
                             size=file["size"],
-                            crawlId=result.get("_id"),
+                            crawlId=file["crawl_id"],
                             numReplicas=len(file.get("replicas") or []),
                             expireAt=date_to_str(
                                 presigned["signedAt"]
@@ -646,7 +650,7 @@ class CollectionOps:
                         path=url,
                         hash=file["hash"],
                         size=file["size"],
-                        crawlId=result.get("_id"),
+                        crawlId=file["crawl_id"],
                         numReplicas=len(file.get("replicas") or []),
                         expireAt=date_to_str(expire_at),
                     )

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1084,7 +1084,7 @@ def init_collections_api(
     )
     async def get_collection_all(org: Organization = Depends(org_viewer_dep)):
         results = {}
-        results["resources"] = colls.get_collection_crawl_resources(None, org)
+        results["resources"] = await colls.get_collection_crawl_resources(None, org)
         return results
 
     @app.get(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1599,6 +1599,13 @@ class CollectionSearchValuesResponse(BaseModel):
 
 
 # ============================================================================
+class CollectionAllResponse(BaseModel):
+    """Response model for '$all' collection endpoint"""
+
+    resources: List[CrawlFileOut] = []
+
+
+# ============================================================================
 
 ### ORGS ###
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -541,7 +541,7 @@ class StorageOps:
         urls = []
 
         futures = []
-        num_batch = 8
+        num_batch = 16
 
         now = dt_now()
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -105,6 +105,7 @@ class StorageOps:
         self.frontend_origin = f"{frontend_origin}.{default_namespace}"
 
         self.local_minio_access_path = os.environ.get("LOCAL_MINIO_ACCESS_PATH")
+        self.presign_batch_size = int(os.environ.get("PRESIGN_BATCH_SIZE", 8))
 
         with open(os.environ["STORAGES_JSON"], encoding="utf-8") as fh:
             storage_list = json.loads(fh.read())
@@ -541,7 +542,7 @@ class StorageOps:
         urls = []
 
         futures = []
-        num_batch = 16
+        num_batch = self.presign_batch_size
 
         now = dt_now()
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -587,7 +587,7 @@ class StorageOps:
                     presigned_obj.append(
                         PresignedUrl(
                             id=filename, url=presigned_url, signedAt=now, oid=org.id
-                        ).dict()
+                        ).to_dict()
                     )
 
                 await self.presigned_urls.insert_many(presigned_obj, ordered=False)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -158,7 +158,7 @@ class StorageOps:
             # if so, just delete this index (as this collection is temporary anyway)
             # and recreate
             print("Recreating presigned_urls index")
-            await self.presigned_urls.drop_index("signedAt")
+            await self.presigned_urls.drop_indexes()
 
             await self.presigned_urls.create_index(
                 "signedAt", expireAfterSeconds=self.expire_at_duration_seconds

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -516,7 +516,7 @@ class StorageOps:
                 ExpiresIn=PRESIGN_DURATION_SECONDS,
             )
 
-            host_endpoint_url = self.get_host_endpoint_url(s3storage, bucket)
+            host_endpoint_url = self.get_host_endpoint_url(s3storage, bucket, key)
 
         if host_endpoint_url:
             presigned_url = presigned_url.replace(
@@ -538,7 +538,9 @@ class StorageOps:
 
         return presigned_url, now + self.signed_duration_delta
 
-    def get_host_endpoint_url(self, s3storage: S3Storage, bucket: str) -> Optional[str]:
+    def get_host_endpoint_url(
+        self, s3storage: S3Storage, bucket: str, key: str
+    ) -> Optional[str]:
         """compute host endpoint for given storage for replacement for access"""
         if not s3storage.access_endpoint_url:
             return None
@@ -549,9 +551,9 @@ class StorageOps:
         is_virtual = s3storage.access_addressing_style == "virtual"
         parts = urlsplit(s3storage.endpoint_url)
         host_endpoint_url = (
-            f"{parts.scheme}://{bucket}.{parts.netloc}/"
+            f"{parts.scheme}://{bucket}.{parts.netloc}/{key}"
             if is_virtual
-            else f"{parts.scheme}://{parts.netloc}/{bucket}/"
+            else f"{parts.scheme}://{parts.netloc}/{bucket}/{key}"
         )
         return host_endpoint_url
 
@@ -581,7 +583,7 @@ class StorageOps:
                     )
                 )
 
-            host_endpoint_url = self.get_host_endpoint_url(s3storage, bucket)
+            host_endpoint_url = self.get_host_endpoint_url(s3storage, bucket, key)
 
         for i in range(0, len(futures), num_batch):
             batch = futures[i : i + num_batch]

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -94,6 +94,8 @@ data:
 
   REPLICA_DELETION_DELAY_DAYS: "{{ .Values.replica_deletion_delay_days | default 0 }}"
 
+  PRESIGN_BATCH_SIZE: "{{ .Values.presign_batch_size | default 8 }}"
+
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Fixes #2515.

This PR introduces a significantly optimized logic for presigning URLs for crawls and collections.
- For collections, the files needed from all crawls are looked up, and then the 'presign_urls' table is merged in one pass, resulting in a unified iterator containing files and presign urls for those files.
- For crawls, the presign URLs are also looked up once, and the same iterator is used for a single crawl with passed in list of CrawlFiles
- URLs that are already signed are added to the return list.
- For any remaining URLs to be signed, a bulk presigning function is added, which shares an HTTP connection and signing 8 files in parallels (customizable via helm chart, though may not be needed). This function is used to call the presigning API in parallel.


Testing:
1. Call clear presigned API endpoint to clear presigned.
2. Test by loading crawl or collection with large number of files (eg. Vice crawl).
3. Repeat with this branch and current main
4. Collection and crawls should load an order of magnitude faster with this approach.