### PR TITLE
feat: Custom autoclick selector

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -338,6 +338,7 @@ class RawCrawlConfig(BaseModel):
     userAgent: Optional[str] = None
 
     selectLinks: List[str] = ["a[href]->href"]
+    clickSelector: str = "a"
 
 
 # ============================================================================

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -202,6 +202,17 @@ def test_verify_default_select_links(
     assert r.json()["config"]["selectLinks"] == ["a[href]->href"]
 
 
+def test_verify_default_click_selector(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["config"]["clickSelector"] == "a"
+
+
 def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_data):
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
@@ -211,6 +222,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
                 "seeds": [{"url": "https://example.com/"}],
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
+                "clickSelector": "button",
             }
         },
     )
@@ -226,6 +238,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
 
     assert data["config"]["scopeType"] == "domain"
     assert data["config"]["selectLinks"] == ["a[href]->href", "script[src]->src"]
+    assert data["config"]["clickSelector"] == "button"
 
 
 def test_update_config_no_changes(
@@ -239,6 +252,7 @@ def test_update_config_no_changes(
                 "seeds": [{"url": "https://example.com/"}],
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
+                "clickSelector": "button",
             }
         },
     )

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -187,6 +187,12 @@ When clicking a link-like element that would normally result in navigation, auto
     
     - Websites that use `<a>` in place of a `<button>` to reveal in-page content.
 
+### Click Selector
+
+When autoclick is enabled, you can customize which element is automatically clicked by specifying a CSS selector.
+
+See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors) for examples of valid CSS selectors.
+
 **Page Timing**
 
 Page timing gives you more granular control over how long the browser should stay on a page and when behaviors should run on a page. Add limits to decrease the amount of time the browser spends on a page, and add delays to increase the amount of time the browser waits on a page. Adding delays will increase the total amount of time spent on a crawl and may impact your overall crawl minutes.

--- a/frontend/src/components/ui/code.ts
+++ b/frontend/src/components/ui/code.ts
@@ -75,6 +75,7 @@ export class Code extends TailwindElement {
     }).value;
 
     return html`<pre
+      part="base"
       class=${clsx(
         tw`font-monospace m-0 text-neutral-600`,
         this.wrap ? tw`whitespace-pre-wrap` : tw`whitespace-nowrap`,

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -178,6 +178,18 @@ export class ConfigDetails extends BtrixElement {
               .filter((v) => v)
               .join(", ") || none,
           )}
+          ${when(
+            seedsConfig?.behaviors?.includes(Behavior.AutoClick) &&
+              seedsConfig.clickSelector,
+            (clickSelector) =>
+              this.renderSetting(
+                labelFor.clickSelector,
+                html`<btrix-code
+                  language="css"
+                  value=${clickSelector}
+                ></btrix-code>`,
+              ),
+          )}
           ${this.renderSetting(
             labelFor.customBehaviors,
             seedsConfig?.customBehaviors.length

--- a/frontend/src/components/ui/syntax-input.ts
+++ b/frontend/src/components/ui/syntax-input.ts
@@ -33,8 +33,17 @@ export class SyntaxInput extends TailwindElement {
   @property({ type: Boolean })
   required?: boolean;
 
+  @property({ type: Boolean })
+  disabled?: boolean;
+
   @property({ type: String })
   placeholder?: string;
+
+  @property({ type: String })
+  name?: string;
+
+  @property({ type: String })
+  label?: string;
 
   @property({ type: String })
   language?: Code["language"];
@@ -103,19 +112,22 @@ export class SyntaxInput extends TailwindElement {
       hoist
       placement="bottom"
     >
-      <div class=${clsx(tw`relative overflow-hidden p-px`)}>
+      <div class=${clsx(tw`relative`)} part="base">
         <sl-input
           class=${clsx(
             tw`relative z-10 block`,
-            tw`[--sl-input-border-color:transparent] [--sl-input-border-radius-medium:0] [--sl-input-font-family:var(--sl-font-mono)] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
+            tw`[--sl-input-font-family:var(--sl-font-mono)] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
             tw`caret-black part-[base]:bg-transparent part-[input]:text-transparent`,
           )}
           spellcheck="false"
           value=${this.value}
+          name=${ifDefined(this.name)}
+          label=${ifDefined(this.label)}
           minlength=${ifDefined(this.minlength)}
           maxlength=${ifDefined(this.maxlength)}
           placeholder=${ifDefined(this.placeholder)}
           ?required=${this.required}
+          ?disabled=${this.disabled}
           @sl-input=${async (e: SlInputEvent) => {
             const value = (e.target as SlInput).value;
 
@@ -125,6 +137,12 @@ export class SyntaxInput extends TailwindElement {
               this.code.value = value;
 
               await this.code.updateComplete;
+
+              this.dispatchEvent(
+                new CustomEvent("btrix-change", {
+                  detail: { value },
+                }),
+              );
 
               void this.scrollSync({ pad: true });
             }
@@ -157,11 +175,11 @@ export class SyntaxInput extends TailwindElement {
 
         <btrix-code
           class=${clsx(
-            tw`absolute inset-0.5 flex items-center overflow-auto px-3 [scrollbar-width:none]`,
+            tw`absolute inset-x-px bottom-0 flex h-[var(--sl-input-height-medium)] items-center overflow-auto px-3 [scrollbar-width:none]`,
+            tw`part-[base]:whitespace-pre`,
           )}
           value=${this.value}
           language=${ifDefined(this.language)}
-          .wrap=${false}
           aria-hidden="true"
         ></btrix-code>
       </div>

--- a/frontend/src/events/btrix-change.ts
+++ b/frontend/src/events/btrix-change.ts
@@ -1,0 +1,7 @@
+export type BtrixChangeEvent<T = unknown> = CustomEvent<{ value: T }>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    "btrix-change": BtrixChangeEvent<unknown>;
+  }
+}

--- a/frontend/src/events/btrix-change.ts
+++ b/frontend/src/events/btrix-change.ts
@@ -2,6 +2,6 @@ export type BtrixChangeEvent<T = unknown> = CustomEvent<{ value: T }>;
 
 declare global {
   interface GlobalEventHandlersEventMap {
-    "btrix-change": BtrixChangeEvent<unknown>;
+    "btrix-change": BtrixChangeEvent;
   }
 }

--- a/frontend/src/events/index.ts
+++ b/frontend/src/events/index.ts
@@ -1,0 +1,1 @@
+import "./btrix-change";

--- a/frontend/src/features/crawl-workflows/link-selector-table.ts
+++ b/frontend/src/features/crawl-workflows/link-selector-table.ts
@@ -9,6 +9,7 @@ import { nanoid } from "nanoid";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { SyntaxInput } from "@/components/ui/syntax-input";
+import type { BtrixChangeEvent } from "@/events/btrix-change";
 import type { SeedConfig } from "@/types/crawler";
 import { tw } from "@/utils/tailwind";
 
@@ -156,9 +157,9 @@ export class LinkSelectorTable extends BtrixElement {
                 language="css"
                 placeholder=${msg("Enter selector")}
                 ?required=${Boolean(attr)}
-                @sl-change=${(e: CustomEvent) => {
-                  const el = e.currentTarget as SyntaxInput;
-                  const value = el.input?.value.trim() || "";
+                @btrix-change=${(e: BtrixChangeEvent<typeof sel>) => {
+                  const el = e.target as SyntaxInput;
+                  const value = e.detail.value.trim();
 
                   void this.updateRows(
                     {
@@ -202,9 +203,9 @@ export class LinkSelectorTable extends BtrixElement {
                 language="xml"
                 placeholder=${msg("Enter attribute")}
                 ?required=${Boolean(sel)}
-                @sl-change=${(e: CustomEvent) => {
-                  const el = e.currentTarget as SyntaxInput;
-                  const value = el.input?.value.trim() || "";
+                @btrix-change=${(e: BtrixChangeEvent<typeof attr>) => {
+                  const el = e.target as SyntaxInput;
+                  const value = e.detail.value.trim();
 
                   void this.updateRows(
                     {

--- a/frontend/src/features/crawl-workflows/link-selector-table.ts
+++ b/frontend/src/features/crawl-workflows/link-selector-table.ts
@@ -14,6 +14,7 @@ import { tw } from "@/utils/tailwind";
 
 export const SELECTOR_DELIMITER = "->" as const;
 const emptyCells = ["", ""];
+const syntaxInputClasses = tw`flex-1 [--sl-input-border-color:transparent] [--sl-input-border-radius-medium:0]`;
 
 /**
  * @fires btrix-change
@@ -145,12 +146,12 @@ export class LinkSelectorTable extends BtrixElement {
 
     return html`
       <btrix-table-row class=${i > 0 ? "border-t" : ""}>
-        <btrix-table-cell>
+        <btrix-table-cell class=${clsx(this.editable && tw`p-0.5`)}>
           ${when(
             this.editable,
             () => html`
               <btrix-syntax-input
-                class="flex-1"
+                class=${syntaxInputClasses}
                 value=${sel}
                 language="css"
                 placeholder=${msg("Enter selector")}
@@ -189,12 +190,14 @@ export class LinkSelectorTable extends BtrixElement {
               ></btrix-code>`,
           )}
         </btrix-table-cell>
-        <btrix-table-cell class="border-l">
+        <btrix-table-cell
+          class=${clsx(tw`border-l`, this.editable && tw`p-0.5`)}
+        >
           ${when(
             this.editable,
             () => html`
               <btrix-syntax-input
-                class="flex-1"
+                class=${syntaxInputClasses}
                 value=${attr}
                 language="xml"
                 placeholder=${msg("Enter attribute")}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1274,11 +1274,32 @@ https://archiveweb.page/images/${"logo.svg"}`}
       )}
       ${inputCol(
         html`<sl-checkbox
-          name="autoclickBehavior"
-          ?checked=${this.formState.autoclickBehavior}
-        >
-          ${labelFor.autoclickBehavior}
-        </sl-checkbox>`,
+            name="autoclickBehavior"
+            ?checked=${this.formState.autoclickBehavior}
+          >
+            ${labelFor.autoclickBehavior}
+          </sl-checkbox>
+          ${when(
+            this.formState.autoclickBehavior,
+            () => html`
+              <div class="mt-4">
+                <btrix-syntax-input
+                  label=${labelFor.clickSelector}
+                  language="css"
+                  value=${this.formState.clickSelector}
+                  placeholder="${msg("Default:")} ${DEFAULT_AUTOCLICK_SELECTOR}"
+                  @btrix-change=${(e: CustomEvent) => {
+                    this.updateFormState(
+                      {
+                        clickSelector: e.detail.value,
+                      },
+                      true,
+                    );
+                  }}
+                ></btrix-syntax-input>
+              </div>
+            `,
+          )} `,
       )}
       ${this.renderHelpTextCol(
         msg(
@@ -2189,7 +2210,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         `${this.navigate.orgBasePath}/workflows/${this.configId || data.id}${
           crawlId && !storageQuotaReached && !executionMinutesQuotaReached
             ? "#watch"
-            : ""
+            : "#settings"
         }`,
       );
     } catch (e) {
@@ -2356,7 +2377,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ? this.linkSelectorTable.value
           : DEFAULT_SELECT_LINKS,
         customBehaviors: this.customBehaviorsTable?.value || [],
-        clickSelector: DEFAULT_AUTOCLICK_SELECTOR, // TODO
+        clickSelector:
+          this.formState.clickSelector.trim() || DEFAULT_AUTOCLICK_SELECTOR,
       },
       crawlerChannel: this.formState.crawlerChannel || "default",
       proxyId: this.formState.proxyId,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -96,6 +96,7 @@ import { tw } from "@/utils/tailwind";
 import {
   appDefaults,
   BYTES_PER_GB,
+  DEFAULT_AUTOCLICK_SELECTOR,
   DEFAULT_SELECT_LINKS,
   defaultLabel,
   getDefaultFormState,
@@ -2355,6 +2356,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ? this.linkSelectorTable.value
           : DEFAULT_SELECT_LINKS,
         customBehaviors: this.customBehaviorsTable?.value || [],
+        clickSelector: DEFAULT_AUTOCLICK_SELECTOR, // TODO
       },
       crawlerChannel: this.formState.crawlerChannel || "default",
       proxyId: this.formState.proxyId,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -11,6 +11,7 @@ import type {
   SlTextarea,
 } from "@shoelace-style/shoelace";
 import clsx from "clsx";
+import { createParser } from "css-selector-parser";
 import Fuse from "fuse.js";
 import { mergeDeep } from "immutable";
 import type { LanguageCode } from "iso-639-1";
@@ -44,6 +45,7 @@ import type {
   SelectCrawlerUpdateEvent,
 } from "@/components/ui/select-crawler";
 import type { SelectCrawlerProxyChangeEvent } from "@/components/ui/select-crawler-proxy";
+import type { SyntaxInput } from "@/components/ui/syntax-input";
 import type { TabListTab } from "@/components/ui/tab-list";
 import type { TagInputEvent, TagsChangeEvent } from "@/components/ui/tag-input";
 import type { TimeInputChangeEvent } from "@/components/ui/time-input";
@@ -53,6 +55,7 @@ import {
   ObservableController,
   type IntersectEvent,
 } from "@/controllers/observable";
+import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type SelectBrowserProfileChangeEvent } from "@/features/browser-profiles/select-browser-profile";
 import type { CollectionsChangeEvent } from "@/features/collections/collections-add";
 import type { CustomBehaviorsTable } from "@/features/crawl-workflows/custom-behaviors-table";
@@ -323,6 +326,13 @@ export class WorkflowEditor extends BtrixElement {
 
   @query("btrix-custom-behaviors-table")
   private readonly customBehaviorsTable?: CustomBehaviorsTable | null;
+
+  @query("btrix-syntax-input[name='clickSelector']")
+  private readonly clickSelector?: SyntaxInput | null;
+
+  // CSS parser should ideally match the parser used in browsertrix-crawler.
+  // https://github.com/webrecorder/browsertrix-crawler/blob/v1.5.8/package.json#L23
+  private readonly cssParser = createParser();
 
   connectedCallback(): void {
     this.initializeEditor();
@@ -1291,23 +1301,56 @@ https://archiveweb.page/images/${"logo.svg"}`}
         () => html`
           ${inputCol(
             html`<btrix-syntax-input
+              name="clickSelector"
               label=${labelFor.clickSelector}
               language="css"
               value=${this.formState.clickSelector}
               placeholder="${msg("Default:")} ${DEFAULT_AUTOCLICK_SELECTOR}"
-              @btrix-change=${(e: CustomEvent) => {
-                this.updateFormState(
-                  {
-                    clickSelector: e.detail.value,
-                  },
-                  true,
-                );
+              disableTooltip
+              @btrix-change=${(
+                e: BtrixChangeEvent<typeof this.formState.clickSelector>,
+              ) => {
+                const el = e.target as SyntaxInput;
+                const value = e.detail.value.trim();
+
+                if (value) {
+                  try {
+                    // Validate selector
+                    this.cssParser(value);
+
+                    this.updateFormState(
+                      {
+                        clickSelector: e.detail.value,
+                      },
+                      true,
+                    );
+
+                    this.clickSelector?.removeAttribute("data-invalid");
+                    this.clickSelector?.removeAttribute("data-user-invalid");
+                  } catch {
+                    el.setCustomValidity(
+                      msg("Please enter a valid CSS selector"),
+                    );
+                  }
+                }
+              }}
+              @btrix-invalid=${() => {
+                /**
+                 * HACK Set data attribute manually so that
+                 * table works with `syncTabErrorState`
+                 *
+                 * FIXME Should be fixed with
+                 * https://github.com/webrecorder/browsertrix/issues/2497
+                 * or
+                 * https://github.com/webrecorder/browsertrix/issues/2536
+                 */
+                this.clickSelector?.setAttribute("data-invalid", "true");
+                this.clickSelector?.setAttribute("data-user-invalid", "true");
               }}
             ></btrix-syntax-input>`,
           )}
           ${this.renderHelpTextCol(
             msg(`Customize the CSS selector used to autoclick elements.`),
-            false,
           )}
         `,
       )}
@@ -1392,6 +1435,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
              *
              * FIXME Should be fixed with
              * https://github.com/webrecorder/browsertrix/issues/2497
+             * or
+             * https://github.com/webrecorder/browsertrix/issues/2536
              */
             this.customBehaviorsTable?.setAttribute("data-invalid", "true");
             this.customBehaviorsTable?.setAttribute(
@@ -2157,7 +2202,16 @@ https://archiveweb.page/images/${"logo.svg"}`}
   private async save() {
     if (!this.formElem) return;
 
+    // TODO Move away from manual validation check
+    // See https://github.com/webrecorder/browsertrix/issues/2536
+    if (!this.clickSelector?.checkValidity()) {
+      this.clickSelector?.reportValidity();
+      return;
+    }
+
     // Wait for custom behaviors validation to finish
+    // TODO Move away from manual validation check
+    // See https://github.com/webrecorder/browsertrix/issues/2536
     try {
       await this.customBehaviorsTable?.taskComplete;
     } catch {
@@ -2382,7 +2436,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           : DEFAULT_SELECT_LINKS,
         customBehaviors: this.customBehaviorsTable?.value || [],
         clickSelector:
-          this.formState.clickSelector.trim() || DEFAULT_AUTOCLICK_SELECTOR,
+          this.formState.clickSelector || DEFAULT_AUTOCLICK_SELECTOR,
       },
       crawlerChannel: this.formState.crawlerChannel || "default",
       proxyId: this.formState.proxyId,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1350,7 +1350,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
             ></btrix-syntax-input>`,
           )}
           ${this.renderHelpTextCol(
-            msg(`Customize the CSS selector used to autoclick elements.`),
+            html`${msg(
+                `Customize the CSS selector used to autoclick elements.`,
+              )} <span class="sr-only">${msg('Defaults to "a".')}</span>`,
           )}
         `,
       )}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2214,7 +2214,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         `${this.navigate.orgBasePath}/workflows/${this.configId || data.id}${
           crawlId && !storageQuotaReached && !executionMinutesQuotaReached
             ? "#watch"
-            : "#settings"
+            : ""
         }`,
       );
     } catch (e) {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1274,38 +1274,42 @@ https://archiveweb.page/images/${"logo.svg"}`}
       )}
       ${inputCol(
         html`<sl-checkbox
-            name="autoclickBehavior"
-            ?checked=${this.formState.autoclickBehavior}
-          >
-            ${labelFor.autoclickBehavior}
-          </sl-checkbox>
-          ${when(
-            this.formState.autoclickBehavior,
-            () => html`
-              <div class="mt-4">
-                <btrix-syntax-input
-                  label=${labelFor.clickSelector}
-                  language="css"
-                  value=${this.formState.clickSelector}
-                  placeholder="${msg("Default:")} ${DEFAULT_AUTOCLICK_SELECTOR}"
-                  @btrix-change=${(e: CustomEvent) => {
-                    this.updateFormState(
-                      {
-                        clickSelector: e.detail.value,
-                      },
-                      true,
-                    );
-                  }}
-                ></btrix-syntax-input>
-              </div>
-            `,
-          )} `,
+          name="autoclickBehavior"
+          ?checked=${this.formState.autoclickBehavior}
+        >
+          ${labelFor.autoclickBehavior}
+        </sl-checkbox>`,
       )}
       ${this.renderHelpTextCol(
         msg(
-          `Automatically click on all link-like elements. Useful for capturing in-page interactions or for clicking links without navigating away from the page.`,
+          `Automatically click on all link-like elements without navigating away from the page.`,
         ),
         false,
+      )}
+      ${when(
+        this.formState.autoclickBehavior,
+        () => html`
+          ${inputCol(
+            html`<btrix-syntax-input
+              label=${labelFor.clickSelector}
+              language="css"
+              value=${this.formState.clickSelector}
+              placeholder="${msg("Default:")} ${DEFAULT_AUTOCLICK_SELECTOR}"
+              @btrix-change=${(e: CustomEvent) => {
+                this.updateFormState(
+                  {
+                    clickSelector: e.detail.value,
+                  },
+                  true,
+                );
+              }}
+            ></btrix-syntax-input>`,
+          )}
+          ${this.renderHelpTextCol(
+            msg(`Customize the CSS selector used to autoclick elements.`),
+            false,
+          )}
+        `,
       )}
       ${this.renderCustomBehaviors()}
       ${this.renderSectionHeading(msg("Page Timing"))}

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -11,6 +11,7 @@ import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { WorkflowScopeType } from "@/types/workflow";
 import LiteElement, { html } from "@/utils/LiteElement";
 import {
+  DEFAULT_AUTOCLICK_SELECTOR,
   DEFAULT_SELECT_LINKS,
   type FormState as WorkflowFormState,
 } from "@/utils/workflow";
@@ -89,6 +90,7 @@ export class WorkflowsNew extends LiteElement {
         userAgent: null,
         selectLinks: DEFAULT_SELECT_LINKS,
         customBehaviors: [],
+        clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
       },
       tags: [],
       crawlTimeout: null,

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -10,4 +10,5 @@ export const labelFor = {
   behaviorTimeoutSeconds: "Behavior Limit",
   pageExtraDelaySeconds: msg("Delay Before Next Page"),
   selectLink: msg("Link Selectors"),
+  clickSelector: msg("Click Selector"),
 };

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -46,6 +46,7 @@ export type SeedConfig = Expand<
     userAgent?: string | null;
     selectLinks: string[];
     customBehaviors: string[];
+    clickSelector: string;
   }
 >;
 

--- a/frontend/src/types/events.d.ts
+++ b/frontend/src/types/events.d.ts
@@ -5,6 +5,8 @@ import { type NotifyEventMap } from "@/controllers/notify";
 import { type UserGuideEventMap } from "@/index";
 import { type AuthEventMap } from "@/utils/AuthService";
 
+import "@/events";
+
 /**
  * Declare custom events here so that typescript can find them.
  * Custom event names should be prefixed with `btrix-`.

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -73,6 +73,10 @@ export function formValidator(el: LitElement) {
   return async function checkFormValidity(form: HTMLFormElement) {
     await el.updateComplete;
 
+    const valid = form.checkValidity();
+
+    if (!valid) return false;
+
     const formControls = getFormControls(form);
 
     return (

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -297,6 +297,7 @@ export function getInitialFormState(params: {
       ? params.initialWorkflow.config.behaviors.includes(Behavior.AutoClick)
       : defaultFormState.autoclickBehavior,
     selectLinks: params.initialWorkflow.config.selectLinks,
+    clickSelector: params.initialWorkflow.config.clickSelector,
     userAgent:
       params.initialWorkflow.config.userAgent ?? defaultFormState.userAgent,
     crawlerChannel:

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -24,6 +24,7 @@ import { regexUnescape } from "@/utils/string";
 
 export const BYTES_PER_GB = 1e9;
 export const DEFAULT_SELECT_LINKS = ["a[href]->href" as const];
+export const DEFAULT_AUTOCLICK_SELECTOR = "a" as const;
 
 export const SECTIONS = [
   "scope",
@@ -92,6 +93,7 @@ export type FormState = {
   crawlerChannel: string;
   proxyId: string | null;
   selectLinks: string[];
+  clickSelector: string;
 };
 
 export type FormStateField = keyof FormState;
@@ -148,6 +150,7 @@ export const getDefaultFormState = (): FormState => ({
   crawlerChannel: "default",
   proxyId: null,
   selectLinks: DEFAULT_SELECT_LINKS,
+  clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
 });
 
 export const mapSeedToUrl = (arr: Seed[]) =>


### PR DESCRIPTION
Resolves #2504

## Changes

- Allows users to customize autoclick selector in workflows
- Refactors `btrix-syntax-input` to support rendering label and help text `sl-input`

## Manual testing

1. Log in as crawler
2. Go to new crawl workflow
3. Scroll to "Page Behavior"
4. Enable "Autoclick" behavior. Verify that "Click Selector" input is now visible and shows default "a" option
5. Save custom click selector. Verify "Click Selector" is shown in workflow settings tab
6. Edit workflow. Test steps 3-5
7. Regression test link selectors table