### PR TITLE
feat: Add custom behaviors to workflow

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -179,6 +179,16 @@ export class ConfigDetails extends BtrixElement {
               .join(", ") || none,
           )}
           ${this.renderSetting(
+            labelFor.customBehaviors,
+            seedsConfig?.customBehaviors.length
+              ? html`
+                  <btrix-custom-behaviors-table
+                    .customBehaviors=${seedsConfig.customBehaviors}
+                  ></btrix-custom-behaviors-table>
+                `
+              : none,
+          )}
+          ${this.renderSetting(
             labelFor.pageLoadTimeoutSeconds,
             renderTimeLimit(
               seedsConfig?.pageLoadTimeout,

--- a/frontend/src/components/ui/copy-field.ts
+++ b/frontend/src/components/ui/copy-field.ts
@@ -36,6 +36,9 @@ export class CopyField extends TailwindElement {
   hoist = false;
 
   @property({ type: Boolean })
+  border = true;
+
+  @property({ type: Boolean })
   monostyle = true;
 
   @property({ type: Boolean })
@@ -65,12 +68,14 @@ export class CopyField extends TailwindElement {
       <div
         role="group"
         class=${clsx(
-          tw`rounded border`,
+          this.border && tw`rounded border`,
           this.filled ? tw`bg-slate-50` : tw`border-neutral-150`,
           this.monostyle && tw`font-monostyle`,
         )}
       >
-        <div class="relative inline-flex w-full items-stretch justify-start">
+        <div
+          class="relative inline-flex w-full items-stretch justify-start break-all"
+        >
           <slot name="prefix"></slot>
           <span
             aria-hidden=${this.hideContentFromScreenReaders}

--- a/frontend/src/components/ui/copy-field.ts
+++ b/frontend/src/components/ui/copy-field.ts
@@ -73,9 +73,7 @@ export class CopyField extends TailwindElement {
           this.monostyle && tw`font-monostyle`,
         )}
       >
-        <div
-          class="relative inline-flex w-full items-stretch justify-start break-all"
-        >
+        <div class="relative inline-flex w-full items-stretch justify-start">
           <slot name="prefix"></slot>
           <span
             aria-hidden=${this.hideContentFromScreenReaders}

--- a/frontend/src/components/ui/url-input.ts
+++ b/frontend/src/components/ui/url-input.ts
@@ -22,7 +22,7 @@ export function validURL(url: string) {
  * @attr {Boolean} required
  */
 @customElement("btrix-url-input")
-export class Component extends SlInput {
+export class UrlInput extends SlInput {
   @property({ type: Number, reflect: true })
   minlength = 4;
 

--- a/frontend/src/components/ui/url-input.ts
+++ b/frontend/src/components/ui/url-input.ts
@@ -1,4 +1,3 @@
-// import type { SlInputEvent } from "@shoelace-style/shoelace";
 import { msg } from "@lit/localize";
 import SlInput from "@shoelace-style/shoelace/dist/components/input/input.js";
 import { customElement, property } from "lit/decorators.js";
@@ -20,6 +19,7 @@ export function validURL(url: string) {
  * @attr {String} name
  * @attr {String} label
  * @attr {String} value
+ * @attr {Boolean} required
  */
 @customElement("btrix-url-input")
 export class Component extends SlInput {
@@ -29,36 +29,31 @@ export class Component extends SlInput {
   @property({ type: String, reflect: true })
   placeholder = "https://example.com";
 
-  connectedCallback(): void {
+  constructor() {
+    super();
+
     this.inputmode = "url";
 
-    super.connectedCallback();
-
     this.addEventListener("sl-input", this.onInput);
-    this.addEventListener("sl-blur", this.onBlur);
+    this.addEventListener("sl-change", this.onChange);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
 
     this.removeEventListener("sl-input", this.onInput);
-    this.removeEventListener("sl-blur", this.onBlur);
+    this.removeEventListener("sl-change", this.onChange);
   }
 
-  private readonly onInput = async () => {
-    console.log("input 1");
-    await this.updateComplete;
-
+  private readonly onInput = () => {
     if (!this.checkValidity() && validURL(this.value)) {
       this.setCustomValidity("");
       this.helpText = "";
     }
   };
 
-  private readonly onBlur = async () => {
-    await this.updateComplete;
-
-    const value = this.value;
+  private readonly onChange = () => {
+    const value = this.value.trim();
 
     if (value && !validURL(value)) {
       const text = msg("Please enter a valid URL.");

--- a/frontend/src/controllers/api.ts
+++ b/frontend/src/controllers/api.ts
@@ -170,6 +170,7 @@ export class APIController implements ReactiveController {
       message: errorMessage,
       status: resp.status,
       details: errorDetails,
+      errorCode: errorDetail,
     });
   }
 

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table-row.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table-row.ts
@@ -1,0 +1,554 @@
+import { localized, msg } from "@lit/localize";
+import { Task } from "@lit/task";
+import type {
+  SlChangeEvent,
+  SlInput,
+  SlInputEvent,
+  SlSelect,
+} from "@shoelace-style/shoelace";
+import clsx from "clsx";
+import { css, html, type PropertyValues } from "lit";
+import {
+  customElement,
+  property,
+  query,
+  queryAll,
+  state,
+} from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import type { UrlInput } from "@/components/ui/url-input";
+import { notSpecified } from "@/layouts/empty";
+import { APIErrorDetail } from "@/types/api";
+import type { SeedConfig } from "@/types/crawler";
+import { APIError } from "@/utils/api";
+import { tw } from "@/utils/tailwind";
+
+export type CustomBehaviors = SeedConfig["customBehaviors"];
+export type CustomBehaviorSource = CustomBehaviors[number];
+export enum CustomBehaviorType {
+  FileURL = "fileUrl",
+  GitRepo = "gitRepo",
+}
+
+const ValidationErrorCodes = [
+  APIErrorDetail.InvalidCustomBehavior,
+  APIErrorDetail.CustomBehaviorBranchNotFound,
+  APIErrorDetail.CustomBehaviorNotFound,
+] as const;
+type ValidationErrorCode = (typeof ValidationErrorCodes)[number];
+type RowValidation = { success: true };
+
+type BehaviorBase = {
+  type: CustomBehaviorType;
+  url: string;
+  path?: string;
+  branch?: string;
+};
+
+export type BehaviorFileURL = BehaviorBase & {
+  type: CustomBehaviorType.FileURL;
+};
+
+export type BehaviorGitRepo = Required<BehaviorBase> & {
+  type: CustomBehaviorType.GitRepo;
+};
+
+export type ChangeEventDetail = {
+  value: CustomBehaviorSource;
+};
+
+export type RemoveEventDetail = {
+  item: CustomBehaviorSource;
+};
+
+const labelFor: Record<CustomBehaviorType, string> = {
+  [CustomBehaviorType.FileURL]: msg("URL"),
+  [CustomBehaviorType.GitRepo]: msg("Git Repo"),
+};
+
+const errorFor: Record<ValidationErrorCode, string> = {
+  [APIErrorDetail.InvalidCustomBehavior]: msg("Please enter a valid URL"),
+  [APIErrorDetail.CustomBehaviorBranchNotFound]: msg(
+    "Please enter a valid branch",
+  ),
+  [APIErrorDetail.CustomBehaviorNotFound]: msg("Please enter an existing URL"),
+};
+
+const inputStyle = [
+  tw`[--sl-input-background-color-hover:transparent] [--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent] [--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
+  tw`data-[valid]:[--sl-input-border-color:transparent]`,
+  tw`part-[form-control-help-text]:mx-1 part-[form-control-help-text]:mb-1`,
+];
+
+const INPUT_CLASSNAME = "input" as const;
+const INVALID_CLASSNAME = "invalid" as const;
+export const GIT_PREFIX = "git+" as const;
+export const isGitRepo = (url: CustomBehaviorSource) =>
+  url.startsWith(GIT_PREFIX);
+export const stringifyGitRepo = (behavior: BehaviorGitRepo): string => {
+  return `${GIT_PREFIX}${behavior.url}?branch=${behavior.branch}&path=${behavior.path}`;
+};
+export const stringifyBehavior = (behavior: BehaviorBase): string => {
+  if (!behavior.url) return "";
+
+  if (behavior.type === CustomBehaviorType.GitRepo) {
+    return stringifyGitRepo(behavior as BehaviorGitRepo);
+  }
+  return behavior.url;
+};
+const parseGitRepo = (repoUrl: string): Omit<BehaviorGitRepo, "type"> => {
+  const url = new URL(repoUrl.slice(GIT_PREFIX.length));
+
+  return {
+    url: `${url.origin}${url.pathname}`,
+    path: url.searchParams.get("path") || "",
+    branch: url.searchParams.get("branch") || "",
+  };
+};
+export const parseBehavior = (url: string): BehaviorBase => {
+  if (!url) {
+    return {
+      type: CustomBehaviorType.GitRepo,
+      url: "",
+      path: "",
+      branch: "",
+    };
+  }
+
+  if (isGitRepo(url)) {
+    try {
+      return {
+        type: CustomBehaviorType.GitRepo,
+        ...parseGitRepo(url),
+      };
+    } catch {
+      return {
+        type: CustomBehaviorType.GitRepo,
+        url: "",
+        path: "",
+        branch: "",
+      };
+    }
+  }
+
+  return {
+    type: CustomBehaviorType.FileURL,
+    url,
+  };
+};
+
+/**
+ * @fires btrix-change
+ * @fires btrix-invalid
+ * @fires btrix-remove
+ */
+@customElement("btrix-custom-behaviors-table-row")
+@localized()
+export class CustomBehaviorsTableRow extends BtrixElement {
+  static styles = css`
+    :host {
+      display: contents;
+    }
+  `;
+
+  @property({ type: String })
+  behaviorSource?: string;
+
+  @property({ type: Boolean })
+  editable = false;
+
+  @state()
+  private behavior?: BehaviorBase;
+
+  @queryAll(`.${INPUT_CLASSNAME}`)
+  private readonly inputs!: NodeListOf<SlInput | UrlInput>;
+
+  @query(`#url`)
+  private readonly urlInput?: UrlInput | null;
+
+  @query(`#branch`)
+  private readonly branchInput?: SlInput | null;
+
+  @query(`#path`)
+  private readonly pathInput?: SlInput | null;
+
+  public get taskComplete() {
+    return this.validateTask.taskComplete;
+  }
+
+  public checkValidity(): boolean {
+    return ![...this.inputs].some((input) => !input.checkValidity());
+  }
+
+  public reportValidity(): boolean {
+    return ![...this.inputs].some((input) => !input.reportValidity());
+  }
+
+  private readonly validateTask = new Task(this, {
+    task: async ([behaviorSource], { signal }) => {
+      if (!behaviorSource) {
+        return null;
+      }
+
+      try {
+        return await this.validateBehavior(behaviorSource, signal);
+      } catch (err) {
+        if (
+          typeof err === "string" &&
+          ValidationErrorCodes.includes(err as ValidationErrorCode)
+        ) {
+          this.setInputCustomValidity(err);
+          throw err;
+        }
+
+        console.error(err);
+      }
+    },
+    args: () => [this.behaviorSource] as const,
+  });
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("behaviorSource")) {
+      this.behavior = parseBehavior(this.behaviorSource || "");
+    }
+  }
+
+  protected updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has("behavior") && this.behavior) {
+      this.dispatchEvent(
+        new CustomEvent<ChangeEventDetail>("btrix-change", {
+          detail: {
+            value: stringifyBehavior(this.behavior),
+          },
+        }),
+      );
+    }
+  }
+
+  render() {
+    const behavior = this.behavior;
+
+    if (!behavior) return;
+
+    return html`
+      <btrix-table-row class="border-t">
+        <btrix-table-cell
+          class=${clsx(
+            this.editable
+              ? tw`h-[var(--sl-input-height-medium)] p-1`
+              : tw`items-start`,
+          )}
+        >
+          ${this.renderType(behavior)}
+        </btrix-table-cell>
+        <btrix-table-cell
+          class=${clsx(
+            tw`block border-l p-0`,
+            this.editable ? tw`overflow-visible` : tw`overflow-auto`,
+          )}
+        >
+          ${behavior.type === CustomBehaviorType.GitRepo
+            ? this.renderGitRepoCell(behavior as BehaviorGitRepo)
+            : this.renderFileUrlCell(behavior as BehaviorFileURL)}
+        </btrix-table-cell>
+        ${when(
+          this.editable,
+          () => html`
+            <btrix-table-cell class="border-l p-1">
+              <sl-icon-button
+                class="text-base hover:text-danger"
+                name="trash3"
+                @click=${() =>
+                  this.dispatchEvent(
+                    new CustomEvent<RemoveEventDetail>("btrix-remove"),
+                  )}
+              ></sl-icon-button>
+            </btrix-table-cell>
+          `,
+        )}
+      </btrix-table-row>
+    `;
+  }
+
+  private renderType(behavior: BehaviorBase) {
+    if (!this.editable) {
+      return html`${labelFor[behavior.type]}`;
+    }
+
+    return html`
+      <sl-select
+        placeholder=${msg("Select Source")}
+        size="small"
+        class="w-[8em]"
+        value=${behavior.type}
+        @sl-change=${(e: SlChangeEvent) => {
+          const el = e.target as SlSelect;
+
+          this.behavior = {
+            ...behavior,
+            type: el.value as CustomBehaviorType,
+            path: behavior.path || "",
+            branch: behavior.branch || "",
+          };
+        }}
+      >
+        ${Object.values(CustomBehaviorType).map(
+          (behaviorType) => html`
+            <sl-option value=${behaviorType} class="whitespace-nowrap">
+              ${labelFor[behaviorType]}
+            </sl-option>
+          `,
+        )}
+      </sl-select>
+    `;
+  }
+
+  private renderGitRepoCell(behavior: BehaviorGitRepo) {
+    const subgridStyle = tw`grid grid-cols-[max-content_1fr] border-t`;
+    const labelStyle = tw`flex inline-flex items-center justify-end border-r bg-neutral-50 p-2 text-xs leading-none text-neutral-700`;
+    const pathLabel = msg("Path");
+    const branchLabel = msg("Branch");
+
+    if (!this.editable) {
+      return html`
+        ${this.renderReadonlyUrl(behavior)}
+        <dl class=${subgridStyle}>
+          <dt class=${clsx(labelStyle, tw`border-b`)}>${pathLabel}</dt>
+          <dd class="border-b p-2">${behavior.path || notSpecified}</dd>
+          <dt class=${labelStyle}>${branchLabel}</dt>
+          <dd class="p-2">${behavior.branch || notSpecified}</dd>
+        </dl>
+      `;
+    }
+
+    return html`${this.renderUrlInput(behavior, {
+        placeholder: msg("Enter URL to Git repository"),
+      })}
+      <div class=${subgridStyle}>
+        <label for="path" class=${clsx(labelStyle, tw`border-b`)}
+          >${pathLabel}</label
+        >
+        <div class="border-b">
+          ${this.renderGitDetailInput(behavior, {
+            placeholder: msg("Optional path"),
+            key: "path",
+          })}
+        </div>
+        <label for="branch" class=${labelStyle}>${branchLabel}</label>
+        <div>
+          ${this.renderGitDetailInput(behavior, {
+            placeholder: msg("Optional branch"),
+            key: "branch",
+          })}
+        </div>
+      </div> `;
+  }
+
+  private renderFileUrlCell(behavior: BehaviorFileURL) {
+    if (!this.editable) {
+      return this.renderReadonlyUrl(behavior);
+    }
+
+    return this.renderUrlInput(behavior, {
+      placeholder: msg("Enter URL to JavaScript file"),
+    });
+  }
+
+  private renderReadonlyUrl(behavior: BehaviorBase) {
+    return html`
+      <btrix-copy-field
+        class="mt-0.5"
+        .value=${behavior.url}
+        .monostyle=${false}
+        .border=${false}
+        .filled=${false}
+      >
+        <sl-tooltip slot="prefix" content=${msg("Open in New Tab")} hoist>
+          <sl-icon-button
+            href=${behavior.url}
+            name="box-arrow-up-right"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            class="m-px"
+          >
+          </sl-icon-button>
+        </sl-tooltip>
+      </btrix-copy-field>
+    `;
+  }
+
+  private renderUrlInput(
+    behavior: BehaviorBase,
+    { placeholder }: { placeholder: string },
+  ) {
+    return html`
+      <btrix-url-input
+        id="url"
+        placeholder=${placeholder}
+        class=${clsx(inputStyle, INPUT_CLASSNAME)}
+        value=${behavior.url}
+        @sl-input=${this.onInput}
+        @sl-change=${this.onInputChangeForKey(behavior, "url")}
+        @sl-invalid=${() =>
+          this.dispatchEvent(new CustomEvent("btrix-invalid"))}
+      >
+        ${this.validateTask.render({
+          pending: this.renderPendingValidation,
+          complete: this.renderValidTooltip,
+          error: this.renderInvalidTooltip,
+        })}
+      </btrix-url-input>
+    `;
+  }
+
+  private readonly renderPendingValidation = () => {
+    return html`
+      <div slot="suffix" class="inline-flex items-center">
+        <sl-spinner class="size-4 text-base"></sl-spinner>
+      </div>
+    `;
+  };
+
+  private readonly renderInvalidTooltip = (err: unknown) => {
+    const message =
+      typeof err === "string" && errorFor[err as ValidationErrorCode];
+
+    if (!message) {
+      console.debug("no message for error:", err);
+      return;
+    }
+
+    return html`
+      <div slot="suffix" class="inline-flex items-center">
+        <sl-tooltip hoist content=${message} placement="bottom-end">
+          <sl-icon
+            name="exclamation-lg"
+            class="size-4 text-base text-danger"
+          ></sl-icon>
+        </sl-tooltip>
+      </div>
+    `;
+  };
+
+  private readonly renderValidTooltip = (
+    validation: typeof this.validateTask.value,
+  ) => {
+    if (!validation) return;
+
+    return html`
+      <div slot="suffix" class="inline-flex items-center">
+        <sl-tooltip hoist content=${msg("URL is valid")} placement="bottom-end">
+          <sl-icon
+            name="check-lg"
+            class="size-4 text-base text-success"
+          ></sl-icon>
+        </sl-tooltip>
+      </div>
+    `;
+  };
+
+  private renderGitDetailInput(
+    behavior: BehaviorGitRepo,
+    { placeholder, key }: { placeholder: string; key: "path" | "branch" },
+  ) {
+    return html`
+      <sl-input
+        id=${key}
+        class=${clsx(inputStyle, INPUT_CLASSNAME, key)}
+        size="small"
+        value=${behavior[key]}
+        placeholder=${placeholder}
+        spellcheck="false"
+        @sl-input=${this.onInput}
+        @sl-change=${this.onInputChangeForKey(behavior, key)}
+        @sl-invalid=${() =>
+          this.dispatchEvent(new CustomEvent("btrix-invalid"))}
+      ></sl-input>
+    `;
+  }
+
+  private readonly onInput = (e: SlInputEvent) => {
+    const el = e.target as SlInput;
+
+    el.classList.remove(INVALID_CLASSNAME);
+    el.setCustomValidity("");
+  };
+
+  private readonly onInputChangeForKey =
+    (behavior: BehaviorBase, key: string) => async (e: SlChangeEvent) => {
+      const el = e.target as SlInput;
+      const value = el.value.trim();
+
+      this.behavior = {
+        ...behavior,
+        [key]: value,
+      };
+    };
+
+  private setInputCustomValidity(error: unknown) {
+    const updateValidity = (
+      input: SlInput | null | undefined,
+      error?: ValidationErrorCode,
+    ) => {
+      if (!input) return;
+
+      if (error) {
+        input.classList.add(INVALID_CLASSNAME);
+      } else {
+        input.classList.remove(INVALID_CLASSNAME);
+      }
+
+      input.setCustomValidity(error ? errorFor[error] : "");
+    };
+
+    switch (error) {
+      case APIErrorDetail.InvalidCustomBehavior: {
+        updateValidity(this.urlInput, APIErrorDetail.InvalidCustomBehavior);
+        updateValidity(this.branchInput);
+        updateValidity(this.pathInput);
+        break;
+      }
+      case APIErrorDetail.CustomBehaviorBranchNotFound: {
+        updateValidity(
+          this.branchInput,
+          APIErrorDetail.CustomBehaviorBranchNotFound,
+        );
+        break;
+      }
+      case APIErrorDetail.CustomBehaviorNotFound: {
+        updateValidity(this.urlInput, APIErrorDetail.CustomBehaviorNotFound);
+        updateValidity(this.branchInput);
+        updateValidity(this.pathInput);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  private async validateBehavior(
+    behaviorSource: CustomBehaviorSource,
+    signal: AbortSignal,
+  ): Promise<RowValidation | undefined> {
+    try {
+      return await this.api.fetch<RowValidation>(
+        `/orgs/${this.orgId}/crawlconfigs/validate/custom-behavior`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            customBehavior: behaviorSource,
+          }),
+          signal,
+        },
+      );
+    } catch (err) {
+      if (err instanceof APIError) {
+        throw err.details;
+      }
+
+      throw err;
+    }
+  }
+}

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table-row.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table-row.ts
@@ -203,7 +203,11 @@ export class CustomBehaviorsTableRow extends BtrixElement {
           throw err;
         }
 
-        console.error(err);
+        if (err instanceof Error && err.name === "AbortError") {
+          console.debug(err);
+        } else {
+          console.error(err);
+        }
       }
     },
     args: () => [this.behaviorSource] as const,
@@ -545,7 +549,7 @@ export class CustomBehaviorsTableRow extends BtrixElement {
       );
     } catch (err) {
       if (err instanceof APIError) {
-        throw err.details;
+        throw err.errorCode;
       }
 
       throw err;

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -139,7 +139,7 @@ const errorFor: Record<ValidityErrorCodes, string> = {
 };
 
 const inputStyle = [
-  tw`[--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent] [--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
+  tw`[--sl-input-background-color-hover:transparent] [--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent] [--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
   tw`data-[valid]:[--sl-input-border-color:transparent]`,
   tw`part-[form-control-help-text]:mx-1 part-[form-control-help-text]:mb-1`,
 ];

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -1,0 +1,103 @@
+import { localized, msg } from "@lit/localize";
+import clsx from "clsx";
+import { html, type PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import { tw } from "@/utils/tailwind";
+
+const GIT_PREFIX = "git+" as const;
+
+type BehaviorURL = {
+  type: "url";
+  url: string;
+};
+
+type BehaviorGitRepo = {
+  type: "gitRepo";
+  url: string;
+  path: string;
+  branch: string;
+};
+
+type Behavior = BehaviorURL | BehaviorGitRepo;
+
+const isGitRepo = (url: string) => url.startsWith(GIT_PREFIX);
+
+const parseGitUrl = (fullUrl: string): Omit<BehaviorGitRepo, "type"> => {
+  const url = new URL(fullUrl.slice(GIT_PREFIX.length));
+
+  return {
+    url: `${url.origin}${url.pathname}`,
+    path: url.searchParams.get("path") || "",
+    branch: url.searchParams.get("branch") || "",
+  };
+};
+
+const urlToBehavior = (url: string): Behavior | null => {
+  if (isGitRepo(url)) {
+    try {
+      return {
+        type: "gitRepo",
+        ...parseGitUrl(url),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    type: "url",
+    url,
+  };
+};
+
+@customElement("btrix-custom-behaviors-table")
+@localized()
+export class CustomBehaviorsTable extends TailwindElement {
+  @property({ type: Array })
+  customBehaviors: string[] = [];
+
+  @state()
+  private rows: Behavior[] = [];
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("customBehaviors")) {
+      this.rows = this.customBehaviors
+        .map(urlToBehavior)
+        .filter((item): item is Behavior => item !== null);
+    }
+  }
+
+  render() {
+    return html`
+      <btrix-table
+        class=${clsx(
+          tw`relative h-full w-full grid-cols-[10em_1fr_min-content] rounded border`,
+          // TODO Consolidate with data-table
+          // https://github.com/webrecorder/browsertrix/issues/2497
+          tw`[--btrix-cell-padding-bottom:var(--sl-spacing-x-small)] [--btrix-cell-padding-left:var(--sl-spacing-x-small)] [--btrix-cell-padding-right:var(--sl-spacing-x-small)] [--btrix-cell-padding-top:var(--sl-spacing-x-small)]`,
+        )}
+      >
+        <btrix-table-head>
+          <btrix-table-header-cell class="border-r">
+            ${msg("Source")}
+          </btrix-table-header-cell>
+          <btrix-table-header-cell>
+            ${msg("Script Location")}
+          </btrix-table-header-cell>
+        </btrix-table-head>
+        <btrix-table-body>${this.rows.map(this.renderRow)}</btrix-table-body>
+      </btrix-table>
+    `;
+  }
+
+  private readonly renderRow = (row: Behavior) => {
+    return html`
+      <btrix-table-row class="first:border-t">
+        <btrix-table-cell class="border-r">${row.type}</btrix-table-cell>
+        <btrix-table-cell>${row.url}</btrix-table-cell>
+      </btrix-table-row>
+    `;
+  };
+}

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -272,9 +272,7 @@ export class CustomBehaviorsTable extends BtrixElement {
         >
           ${this.renderType(row)}
         </btrix-table-cell>
-        <btrix-table-cell
-          class=${clsx(tw`block overflow-auto break-all border-l p-0`)}
-        >
+        <btrix-table-cell class="block overflow-visible break-all border-l p-0">
           ${row.type === BehaviorType.GitRepo
             ? this.renderGitRepoCell(row)
             : this.renderFileUrlCell(row)}

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -1,10 +1,4 @@
 import { localized, msg } from "@lit/localize";
-import type {
-  SlChangeEvent,
-  SlInput,
-  SlInputEvent,
-  SlSelect,
-} from "@shoelace-style/shoelace";
 import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, queryAll, state } from "lit/decorators.js";
@@ -14,137 +8,22 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { TableRow } from "@/components/ui/table/table-row";
-import type { UrlInput } from "@/components/ui/url-input";
-import { notSpecified } from "@/layouts/empty";
-import { APIErrorDetail } from "@/types/api";
-import type { SeedConfig } from "@/types/crawler";
-import { APIError } from "@/utils/api";
+import {
+  type CustomBehaviors,
+  type CustomBehaviorSource,
+  type CustomBehaviorsTableRow,
+  type ChangeEventDetail as RowChangeEventDetail,
+} from "@/features/crawl-workflows/custom-behaviors-table-row";
 import { tw } from "@/utils/tailwind";
 
-type CustomBehaviorValue = SeedConfig["customBehaviors"];
-type ChangeEventDetail = {
-  value: CustomBehaviorValue;
-};
+import "@/features/crawl-workflows/custom-behaviors-table-row";
 
-enum BehaviorType {
-  FileURL = "fileUrl",
-  GitRepo = "gitRepo",
-}
+type ChangeEventDetail = {
+  value: CustomBehaviors;
+};
 
 const rowIdSchema = z.string().nanoid();
 type RowId = z.infer<typeof rowIdSchema>;
-
-const UnknownErrorCode = "UNKNOWN_ERROR" as const;
-const ValidityErrorCodes = [
-  APIErrorDetail.InvalidCustomBehavior,
-  APIErrorDetail.CustomBehaviorBranchNotFound,
-  APIErrorDetail.CustomBehaviorNotFound,
-  UnknownErrorCode,
-] as const;
-type ValidityErrorCode = (typeof ValidityErrorCodes)[number];
-type RowValidity = { valid: true } | { error: ValidityErrorCode };
-
-type BehaviorBase = {
-  id: RowId;
-  type: BehaviorType;
-  url: string;
-  path?: string;
-  branch?: string;
-};
-
-type BehaviorFileURL = BehaviorBase & {
-  type: BehaviorType.FileURL;
-};
-
-type BehaviorGitRepo = Required<BehaviorBase> & {
-  type: BehaviorType.GitRepo;
-};
-
-type Behavior = BehaviorFileURL | BehaviorGitRepo;
-
-const GIT_PREFIX = "git+" as const;
-const EMPTY_ROW: Omit<BehaviorGitRepo, "id"> = {
-  type: BehaviorType.GitRepo,
-  url: "",
-  path: "",
-  branch: "",
-} as const;
-const INPUT_CLASSNAME = "input" as const;
-
-const isGitRepo = (url: string) => url.startsWith(GIT_PREFIX);
-
-const parseGitRepo = (
-  repoUrl: string,
-): Omit<BehaviorGitRepo, "id" | "type"> => {
-  const url = new URL(repoUrl.slice(GIT_PREFIX.length));
-
-  return {
-    url: `${url.origin}${url.pathname}`,
-    path: url.searchParams.get("path") || "",
-    branch: url.searchParams.get("branch") || "",
-  };
-};
-
-const stringifyGitRepo = (behavior: BehaviorGitRepo): string => {
-  return `${GIT_PREFIX}${behavior.url}?branch=${behavior.branch}&path=${behavior.path}`;
-};
-
-const urlToBehavior = (url: string): Behavior | null => {
-  if (isGitRepo(url)) {
-    try {
-      return {
-        id: nanoid(),
-        type: BehaviorType.GitRepo,
-        ...parseGitRepo(url),
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  return {
-    id: nanoid(),
-    type: BehaviorType.FileURL,
-    url,
-  };
-};
-
-const valueFromRows = (rows: Map<RowId, Behavior>): CustomBehaviorValue => {
-  const values: CustomBehaviorValue = [];
-
-  rows.forEach((item) => {
-    if (!item.url) return;
-
-    if (item.type === BehaviorType.GitRepo) {
-      values.push(stringifyGitRepo(item));
-    } else {
-      values.push(item.url);
-    }
-  });
-
-  return values;
-};
-
-const labelFor: Record<BehaviorType, string> = {
-  [BehaviorType.FileURL]: msg("URL"),
-  [BehaviorType.GitRepo]: msg("Git Repo"),
-};
-
-const errorFor: Record<ValidityErrorCode, string> = {
-  [APIErrorDetail.InvalidCustomBehavior]: msg("Please enter a valid URL"),
-  [APIErrorDetail.CustomBehaviorBranchNotFound]: msg(
-    "Please enter a valid branch",
-  ),
-  [APIErrorDetail.CustomBehaviorNotFound]: msg("Please enter an existing URL"),
-  [UnknownErrorCode]: msg("Please enter a valid custom behavior"),
-};
-
-const inputStyle = [
-  tw`[--sl-input-background-color-hover:transparent] [--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent] [--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
-  tw`data-[valid]:[--sl-input-border-color:transparent]`,
-  tw`part-[form-control-help-text]:mx-1 part-[form-control-help-text]:mb-1`,
-];
 
 /**
  * @fires btrix-change
@@ -154,54 +33,41 @@ const inputStyle = [
 @localized()
 export class CustomBehaviorsTable extends BtrixElement {
   @property({ type: Array })
-  customBehaviors: CustomBehaviorValue = [];
+  customBehaviors: CustomBehaviors = [];
 
   @property({ type: Boolean })
   editable = false;
 
   @state()
-  private rows = new Map<RowId, Behavior>();
+  private rows = new Map<RowId, CustomBehaviorSource>();
 
-  @state()
-  private validity = new Map<RowId, RowValidity>();
+  @queryAll("btrix-custom-behaviors-table-row")
+  private readonly rowElems!: NodeListOf<CustomBehaviorsTableRow>;
 
-  @queryAll(`.${INPUT_CLASSNAME}`)
-  private readonly inputs!: NodeListOf<SlInput | UrlInput>;
+  public get value(): CustomBehaviors {
+    return [...this.rows.values()].filter((v) => v);
+  }
 
-  public get value(): CustomBehaviorValue {
-    return valueFromRows(this.rows);
+  public get taskComplete() {
+    return Promise.all([...this.rowElems].map(async (row) => row.taskComplete));
   }
 
   public checkValidity(): boolean {
-    return ![...this.inputs].some((input) => !input.checkValidity());
+    return ![...this.rowElems].some((row) => !row.checkValidity());
   }
 
   public reportValidity(): boolean {
-    return ![...this.inputs].some((input) => !input.reportValidity());
+    return ![...this.rowElems].some((row) => !row.reportValidity());
   }
 
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("customBehaviors")) {
-      this.validity = new Map();
-
       if (!this.customBehaviors.length) {
         const id = nanoid();
-        this.rows = new Map([
-          [
-            id,
-            {
-              ...EMPTY_ROW,
-              id,
-            },
-          ],
-        ]);
+        this.rows = new Map([[id, ""]]);
       } else {
-        this.rows = new Map(
-          this.customBehaviors
-            .map(urlToBehavior)
-            .filter((item): item is Behavior => item !== null)
-            .map((item) => [item.id, item]),
-        );
+        // TODO Reuse IDs?
+        this.rows = new Map(this.customBehaviors.map((url) => [nanoid(), url]));
       }
     }
   }
@@ -246,7 +112,7 @@ export class CustomBehaviorsTable extends BtrixElement {
           ${repeat(
             this.rows,
             ([id]) => id,
-            ([_, row]) => this.renderRow(row),
+            (args) => this.renderRow(...args),
           )}
         </btrix-table-body>
       </btrix-table>
@@ -262,335 +128,37 @@ export class CustomBehaviorsTable extends BtrixElement {
     `;
   }
 
-  private readonly renderRow = (row: Behavior) => {
+  private readonly renderRow = (id: RowId, url: CustomBehaviorSource) => {
     return html`
-      <btrix-table-row class="border-t">
-        <btrix-table-cell
-          class=${clsx(
-            this.editable
-              ? tw`h-[var(--sl-input-height-medium)] p-1`
-              : tw`items-start`,
-          )}
-        >
-          ${this.renderType(row)}
-        </btrix-table-cell>
-        <btrix-table-cell
-          class=${clsx(
-            tw`block border-l p-0`,
-            this.editable ? tw`overflow-visible` : tw`overflow-auto`,
-          )}
-        >
-          ${row.type === BehaviorType.GitRepo
-            ? this.renderGitRepoCell(row)
-            : this.renderFileUrlCell(row)}
-        </btrix-table-cell>
-        ${when(
-          this.editable,
-          () => html`
-            <btrix-table-cell class="border-l p-1">
-              <sl-icon-button
-                class="text-base hover:text-danger"
-                name="trash3"
-                @click=${() => this.removeRow(row.id)}
-              ></sl-icon-button>
-            </btrix-table-cell>
-          `,
-        )}
-      </btrix-table-row>
-    `;
-  };
+      <btrix-custom-behaviors-table-row
+        behaviorSource=${url}
+        ?editable=${this.editable}
+        @btrix-remove=${() => this.removeRow(id)}
+        @btrix-change=${(e: CustomEvent<RowChangeEventDetail>) => {
+          const url = e.detail.value;
 
-  private renderType(row: Behavior) {
-    if (!this.editable) {
-      return html`${labelFor[row.type]}`;
-    }
-
-    return html`
-      <sl-select
-        placeholder=${msg("Select Source")}
-        size="small"
-        class="w-[8em]"
-        value=${row.type}
-        @sl-change=${(e: SlChangeEvent) => {
-          const el = e.target as SlSelect;
-
-          this.rows = new Map(
-            this.rows.set(row.id, {
-              ...row,
-              type: el.value as BehaviorType,
-              path: row.path || "",
-              branch: row.branch || "",
-            }),
-          );
+          this.rows = new Map(this.rows.set(id, url));
         }}
-      >
-        ${Object.values(BehaviorType).map(
-          (behaviorType) => html`
-            <sl-option value=${behaviorType} class="whitespace-nowrap">
-              ${labelFor[behaviorType]}
-            </sl-option>
-          `,
-        )}
-      </sl-select>
-    `;
-  }
-
-  private renderGitRepoCell(row: BehaviorGitRepo) {
-    const subgridStyle = tw`grid grid-cols-[max-content_1fr] border-t`;
-    const labelStyle = tw`flex inline-flex items-center justify-end border-r bg-neutral-50 p-2 text-xs leading-none text-neutral-700`;
-    const pathLabel = msg("Path");
-    const branchLabel = msg("Branch");
-
-    if (!this.editable) {
-      return html`
-        ${this.renderReadonlyUrl(row)}
-        <dl class=${subgridStyle}>
-          <dt class=${clsx(labelStyle, tw`border-b`)}>${pathLabel}</dt>
-          <dd class="border-b p-2">${row.path || notSpecified}</dd>
-          <dt class=${labelStyle}>${branchLabel}</dt>
-          <dd class="p-2">${row.branch || notSpecified}</dd>
-        </dl>
-      `;
-    }
-
-    return html`${this.renderUrlInput(row, {
-        placeholder: msg("Enter URL to Git repository"),
-      })}
-      <div class=${subgridStyle}>
-        <label for="path-${row.id}" class=${clsx(labelStyle, tw`border-b`)}
-          >${pathLabel}</label
-        >
-        <div class="border-b">
-          ${this.renderGitDetailInput(row, {
-            placeholder: msg("Optional path"),
-            key: "path",
-          })}
-        </div>
-        <label for="branch-${row.id}" class=${labelStyle}>${branchLabel}</label>
-        <div>
-          ${this.renderGitDetailInput(row, {
-            placeholder: msg("Optional branch"),
-            key: "branch",
-          })}
-        </div>
-      </div> `;
-  }
-
-  private renderFileUrlCell(row: BehaviorFileURL) {
-    if (!this.editable) {
-      return this.renderReadonlyUrl(row);
-    }
-
-    return this.renderUrlInput(row, {
-      placeholder: msg("Enter URL to JavaScript file"),
-    });
-  }
-
-  private renderReadonlyUrl(row: Behavior) {
-    return html`
-      <btrix-copy-field
-        class="mt-0.5"
-        .value=${row.url}
-        .monostyle=${false}
-        .border=${false}
-        .filled=${false}
-      >
-        <sl-tooltip slot="prefix" content=${msg("Open in New Tab")} hoist>
-          <sl-icon-button
-            href=${row.url}
-            name="box-arrow-up-right"
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            class="m-px"
-          >
-          </sl-icon-button>
-        </sl-tooltip>
-      </btrix-copy-field>
-    `;
-  }
-
-  private renderUrlInput(
-    row: Behavior,
-    { placeholder }: { placeholder: string },
-  ) {
-    let prefix: {
-      icon: string;
-      tooltip: string;
-      className: string;
-    } | null = null;
-
-    const validity = this.validity.get(row.id) || {};
-
-    if ("error" in validity) {
-      prefix = {
-        icon: "exclamation-lg",
-        tooltip: errorFor[validity.error as ValidityErrorCode],
-        className: tw`text-danger`,
-      };
-    } else if ("valid" in validity) {
-      prefix = {
-        icon: "check-lg",
-        tooltip: msg("URL is valid"),
-        className: tw`text-success`,
-      };
-    }
-
-    return html`
-      <btrix-url-input
-        placeholder=${placeholder}
-        class=${clsx(inputStyle, INPUT_CLASSNAME)}
-        value=${row.url}
-        @sl-input=${this.onInputForRow(row)}
-        @sl-change=${this.onInputChangeForKey(row, "url")}
-        @sl-invalid=${() =>
+        @btrix-invalid=${() =>
           this.dispatchEvent(new CustomEvent("btrix-invalid"))}
       >
-        ${when(
-          prefix,
-          ({ tooltip, icon, className }) => html`
-            <div slot="suffix" class="inline-flex items-center">
-              <sl-tooltip hoist content=${tooltip} placement="bottom-end">
-                <sl-icon
-                  name=${icon}
-                  class=${clsx(tw`size-4 text-base`, className)}
-                ></sl-icon>
-              </sl-tooltip>
-            </div>
-          `,
-        )}
-      </btrix-url-input>
+      </btrix-custom-behaviors-table-row>
     `;
-  }
-
-  private renderGitDetailInput(
-    row: BehaviorGitRepo,
-    { placeholder, key }: { placeholder: string; key: "path" | "branch" },
-  ) {
-    return html`
-      <sl-input
-        id="${key}-${row.id}"
-        class=${clsx(inputStyle, INPUT_CLASSNAME, key)}
-        size="small"
-        value=${row[key]}
-        placeholder=${placeholder}
-        spellcheck="false"
-        @sl-input=${this.onInputForRow(row)}
-        @sl-change=${this.onInputChangeForKey(row, key)}
-        @sl-invalid=${() =>
-          this.dispatchEvent(new CustomEvent("btrix-invalid"))}
-      ></sl-input>
-    `;
-  }
-
-  private readonly onInputForRow = (row: Behavior) => (e: SlInputEvent) => {
-    const el = e.target as SlInput;
-
-    el.setCustomValidity("");
-
-    if (this.validity.get(row.id)) {
-      this.validity.delete(row.id);
-      this.validity = new Map(this.validity);
-    }
   };
-
-  private readonly onInputChangeForKey =
-    (row: Behavior, key: string) => async (e: SlChangeEvent) => {
-      const el = e.target as SlInput;
-      const value = el.value.trim();
-
-      const behavior = {
-        ...row,
-        [key]: value,
-      };
-
-      this.rows = new Map(this.rows.set(behavior.id, behavior));
-
-      if (el.checkValidity() || this.validity.get(row.id)) {
-        const rowEl = el.closest<TableRow>("btrix-table-row");
-        const rowInputs = rowEl?.querySelectorAll<SlInput>(
-          `.${INPUT_CLASSNAME}`,
-        );
-
-        const validity = await this.validateBehavior(behavior);
-
-        let invalidInput = el;
-
-        if (validity && "error" in validity) {
-          if (validity.error === APIErrorDetail.CustomBehaviorBranchNotFound) {
-            invalidInput =
-              rowEl?.querySelector<SlInput>(`.${INPUT_CLASSNAME}.branch`) || el;
-          }
-
-          rowInputs?.forEach((input) => {
-            if (input === invalidInput) {
-              input.setCustomValidity(errorFor[validity.error]);
-            } else {
-              input.setCustomValidity("");
-            }
-          });
-        }
-
-        invalidInput.checkValidity();
-      }
-    };
 
   private addRow() {
     const id = nanoid();
 
-    this.rows = new Map(
-      this.rows.set(id, {
-        ...EMPTY_ROW,
-        id,
-      }),
-    );
+    this.rows = new Map(this.rows.set(id, ""));
   }
 
-  private removeRow(id: string) {
+  private removeRow(id: RowId) {
     this.rows.delete(id);
-    this.validity.delete(id);
 
-    this.rows = new Map(this.rows);
-    this.validity = new Map(this.validity);
-  }
-
-  private async validateBehavior(
-    behavior: Behavior,
-  ): Promise<RowValidity | undefined> {
-    try {
-      await this.validateUrl(
-        behavior.type === BehaviorType.GitRepo
-          ? stringifyGitRepo(behavior)
-          : behavior.url,
-      );
-
-      this.validity = new Map(this.validity.set(behavior.id, { valid: true }));
-    } catch (err) {
-      let error: ValidityErrorCode = UnknownErrorCode;
-
-      if (err instanceof APIError) {
-        // TODO switch to error code
-        // https://github.com/webrecorder/browsertrix/issues/2512
-        const errorCode = err.details as ValidityErrorCode;
-        if (ValidityErrorCodes.includes(errorCode)) {
-          error = errorCode;
-        }
-      }
-
-      this.validity = new Map(this.validity.set(behavior.id, { error }));
+    if (this.rows.size === 0) {
+      this.addRow();
+    } else {
+      this.rows = new Map(this.rows);
     }
-
-    return this.validity.get(behavior.id);
-  }
-
-  private async validateUrl(url: string) {
-    return await this.api.fetch<{ success: true }>(
-      `/orgs/${this.orgId}/crawlconfigs/validate/custom-behavior`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          customBehavior: url,
-        }),
-      },
-    );
   }
 }

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -357,14 +357,16 @@ export class CustomBehaviorsTable extends BtrixElement {
         placeholder: msg("Enter URL to Git repository"),
       })}
       <div class=${subgridStyle}>
-        <label class=${clsx(labelStyle, tw`border-b`)}>${pathLabel}</label>
+        <label for="path-${row.id}" class=${clsx(labelStyle, tw`border-b`)}
+          >${pathLabel}</label
+        >
         <div class="border-b">
           ${this.renderGitDetailInput(row, {
             placeholder: msg("Optional path"),
             key: "path",
           })}
         </div>
-        <label class=${labelStyle}>${branchLabel}</label>
+        <label for="branch-${row.id}" class=${labelStyle}>${branchLabel}</label>
         <div>
           ${this.renderGitDetailInput(row, {
             placeholder: msg("Optional branch"),
@@ -466,6 +468,7 @@ export class CustomBehaviorsTable extends BtrixElement {
   ) {
     return html`
       <sl-input
+        id="${key}-${row.id}"
         class=${clsx(inputStyle, INPUT_CLASSNAME, key)}
         size="small"
         value=${row[key]}

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -1,27 +1,32 @@
 import { localized, msg } from "@lit/localize";
+import type { SlChangeEvent, SlSelect } from "@shoelace-style/shoelace";
 import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
+import { nanoid } from "nanoid";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { tw } from "@/utils/tailwind";
-
-const GIT_PREFIX = "git+" as const;
 
 enum BehaviorType {
   URL = "url",
   GitRepo = "gitRepo",
 }
 
-type BehaviorURL = {
-  type: BehaviorType.URL;
+type BehaviorBase = {
+  id: string;
+  type: BehaviorType;
   url: string;
 };
 
-type BehaviorGitRepo = {
+type BehaviorURL = BehaviorBase & {
+  type: BehaviorType.URL;
+};
+
+type BehaviorGitRepo = BehaviorBase & {
   type: BehaviorType.GitRepo;
-  url: string;
   path: string;
   branch: string;
 };
@@ -30,7 +35,7 @@ type Behavior = BehaviorURL | BehaviorGitRepo;
 
 const isGitRepo = (url: string) => url.startsWith(GIT_PREFIX);
 
-const parseGitUrl = (fullUrl: string): Omit<BehaviorGitRepo, "type"> => {
+const parseGitUrl = (fullUrl: string): Omit<BehaviorGitRepo, "id" | "type"> => {
   const url = new URL(fullUrl.slice(GIT_PREFIX.length));
 
   return {
@@ -44,6 +49,7 @@ const urlToBehavior = (url: string): Behavior | null => {
   if (isGitRepo(url)) {
     try {
       return {
+        id: nanoid(),
         type: BehaviorType.GitRepo,
         ...parseGitUrl(url),
       };
@@ -53,6 +59,7 @@ const urlToBehavior = (url: string): Behavior | null => {
   }
 
   return {
+    id: nanoid(),
     type: BehaviorType.URL,
     url,
   };
@@ -62,6 +69,10 @@ const labelFor: Record<BehaviorType, string> = {
   [BehaviorType.URL]: msg("URL"),
   [BehaviorType.GitRepo]: msg("Git Repo"),
 };
+
+const inputCellStyles = tw`[--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent] [--sl-input-border-color:transparent] [--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)]`;
+
+const GIT_PREFIX = "git+" as const;
 
 @customElement("btrix-custom-behaviors-table")
 @localized()
@@ -73,13 +84,16 @@ export class CustomBehaviorsTable extends TailwindElement {
   editable = false;
 
   @state()
-  private rows: Behavior[] = [];
+  private rows = new Map<string, Behavior>();
 
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("customBehaviors")) {
-      this.rows = this.customBehaviors
-        .map(urlToBehavior)
-        .filter((item): item is Behavior => item !== null);
+      this.rows = new Map(
+        this.customBehaviors
+          .map(urlToBehavior)
+          .filter((item): item is Behavior => item !== null)
+          .map((item) => [item.id, item]),
+      );
     }
   }
 
@@ -107,21 +121,42 @@ export class CustomBehaviorsTable extends TailwindElement {
             `,
           )}
         </btrix-table-head>
-        <btrix-table-body>${this.rows.map(this.renderRow)}</btrix-table-body>
+        <btrix-table-body>
+          ${repeat(
+            this.rows,
+            ([id]) => id,
+            ([_, row]) => this.renderRow(row),
+          )}
+        </btrix-table-body>
       </btrix-table>
+      ${when(
+        this.editable,
+        () => html`
+          <sl-button class="mt-2 w-full" @click=${() => this.addRow()}>
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            <span class="text-neutral-600">${msg("Add More")}</span>
+          </sl-button>
+        `,
+      )}
     `;
   }
 
   private readonly renderRow = (row: Behavior) => {
     return html`
       <btrix-table-row class="border-t">
-        <btrix-table-cell class="items-start border-r">
+        <btrix-table-cell
+          class=${clsx(
+            this.editable
+              ? tw`h-[var(--sl-input-height-medium)] p-1`
+              : tw`items-start`,
+          )}
+        >
           ${this.renderType(row)}
         </btrix-table-cell>
         <btrix-table-cell
           class=${clsx(
-            tw`block break-all`,
-            row.type === BehaviorType.GitRepo && tw`p-0`,
+            tw`block break-all border-l`,
+            (row.type === BehaviorType.GitRepo || this.editable) && tw`p-0`,
           )}
         >
           ${row.type === BehaviorType.GitRepo
@@ -131,8 +166,12 @@ export class CustomBehaviorsTable extends TailwindElement {
         ${when(
           this.editable,
           () => html`
-            <btrix-table-cell>
-              <sl-icon-button name="trash3"></sl-icon-button>
+            <btrix-table-cell class="border-l p-1">
+              <sl-icon-button
+                class="text-base hover:text-danger"
+                name="trash3"
+                @click=${() => this.removeRow(row.id)}
+              ></sl-icon-button>
             </btrix-table-cell>
           `,
         )}
@@ -149,11 +188,36 @@ export class CustomBehaviorsTable extends TailwindElement {
       <sl-select
         placeholder=${msg("Select Source")}
         size="small"
+        class="w-[8em]"
         value=${row.type}
+        @sl-change=${(e: SlChangeEvent) => {
+          const el = e.target as SlSelect;
+
+          const { id, url } = row;
+
+          this.rows = new Map(
+            this.rows.set(
+              row.id,
+              el.value === BehaviorType.GitRepo
+                ? {
+                    id,
+                    url,
+                    type: BehaviorType.GitRepo,
+                    path: "",
+                    branch: "",
+                  }
+                : {
+                    id,
+                    url,
+                    type: BehaviorType.URL,
+                  },
+            ),
+          );
+        }}
       >
         ${Object.values(BehaviorType).map(
           (behaviorType) => html`
-            <sl-option value=${behaviorType}>
+            <sl-option value=${behaviorType} class="whitespace-nowrap">
               ${labelFor[behaviorType]}
             </sl-option>
           `,
@@ -163,21 +227,50 @@ export class CustomBehaviorsTable extends TailwindElement {
   }
 
   private renderGitRepoCell(row: BehaviorGitRepo) {
-    if (!this.editable) {
-      const labelStyle = tw`fle inline-flex items-center justify-end border-r bg-neutral-50 p-2 text-xs leading-none text-neutral-700`;
+    const subgridStyle = tw`grid grid-cols-[max-content_1fr] border-t`;
+    const labelStyle = tw`fle inline-flex items-center justify-end border-r bg-neutral-50 p-2 text-xs leading-none text-neutral-700`;
+    const pathLabel = msg("Path");
+    const branchLabel = msg("Branch");
 
+    if (!this.editable) {
       return html`
         <div class="break-all p-2">${row.url}</div>
-        <dl class="grid grid-cols-[max-content_1fr] border-t">
-          <dt class=${clsx(labelStyle, tw`border-b`)}>${msg("Path")}</dt>
+        <dl class=${subgridStyle}>
+          <dt class=${clsx(labelStyle, tw`border-b`)}>${pathLabel}</dt>
           <dd class="border-b p-2">${row.path}</dd>
-          <dt class=${labelStyle}>${msg("Branch")}</dt>
+          <dt class=${labelStyle}>${branchLabel}</dt>
           <dd class="p-2">${row.branch}</dd>
         </dl>
       `;
     }
 
-    return html`TODO`;
+    return html`<btrix-url-input
+        placeholder=${msg("Enter URL to Git repository")}
+        class=${clsx(inputCellStyles)}
+        value=${row.url}
+      ></btrix-url-input>
+      <div class=${subgridStyle}>
+        <label class=${clsx(labelStyle, tw`border-b`)}>${pathLabel}</label>
+        <div class="border-b">
+          <sl-input
+            class=${clsx(inputCellStyles)}
+            size="small"
+            value=${row.path}
+            placeholder=${msg("Optional path")}
+            spellcheck="false"
+          ></sl-input>
+        </div>
+        <label class=${labelStyle}>${branchLabel}</label>
+        <div>
+          <sl-input
+            class=${clsx(inputCellStyles)}
+            size="small"
+            value=${row.branch}
+            placeholder=${msg("Optional branch")}
+            spellcheck="false"
+          ></sl-input>
+        </div>
+      </div> `;
   }
 
   private renderUrlCell(row: BehaviorURL) {
@@ -185,6 +278,27 @@ export class CustomBehaviorsTable extends TailwindElement {
       return html`${row.url}`;
     }
 
-    return html`TODO`;
+    return html`<btrix-url-input
+      placeholder=${msg("Enter URL to JavaScript file")}
+      class=${clsx(inputCellStyles)}
+      value=${row.url}
+    ></btrix-url-input>`;
+  }
+
+  private addRow() {
+    const id = nanoid();
+
+    this.rows = new Map(
+      this.rows.set(id, {
+        id,
+        type: BehaviorType.URL,
+        url: "",
+      }),
+    );
+  }
+
+  private removeRow(id: string) {
+    this.rows.delete(id);
+    this.rows = new Map(this.rows);
   }
 }

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -2,19 +2,25 @@ import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { tw } from "@/utils/tailwind";
 
 const GIT_PREFIX = "git+" as const;
 
+enum BehaviorType {
+  URL = "url",
+  GitRepo = "gitRepo",
+}
+
 type BehaviorURL = {
-  type: "url";
+  type: BehaviorType.URL;
   url: string;
 };
 
 type BehaviorGitRepo = {
-  type: "gitRepo";
+  type: BehaviorType.GitRepo;
   url: string;
   path: string;
   branch: string;
@@ -38,7 +44,7 @@ const urlToBehavior = (url: string): Behavior | null => {
   if (isGitRepo(url)) {
     try {
       return {
-        type: "gitRepo",
+        type: BehaviorType.GitRepo,
         ...parseGitUrl(url),
       };
     } catch {
@@ -47,9 +53,14 @@ const urlToBehavior = (url: string): Behavior | null => {
   }
 
   return {
-    type: "url",
+    type: BehaviorType.URL,
     url,
   };
+};
+
+const labelFor: Record<BehaviorType, string> = {
+  [BehaviorType.URL]: msg("URL"),
+  [BehaviorType.GitRepo]: msg("Git Repo"),
 };
 
 @customElement("btrix-custom-behaviors-table")
@@ -57,6 +68,9 @@ const urlToBehavior = (url: string): Behavior | null => {
 export class CustomBehaviorsTable extends TailwindElement {
   @property({ type: Array })
   customBehaviors: string[] = [];
+
+  @property({ type: Boolean })
+  editable = false;
 
   @state()
   private rows: Behavior[] = [];
@@ -73,19 +87,25 @@ export class CustomBehaviorsTable extends TailwindElement {
     return html`
       <btrix-table
         class=${clsx(
-          tw`relative h-full w-full grid-cols-[10em_1fr_min-content] rounded border`,
+          tw`relative h-full w-full grid-cols-[max-content_1fr_min-content] rounded border`,
           // TODO Consolidate with data-table
           // https://github.com/webrecorder/browsertrix/issues/2497
           tw`[--btrix-cell-padding-bottom:var(--sl-spacing-x-small)] [--btrix-cell-padding-left:var(--sl-spacing-x-small)] [--btrix-cell-padding-right:var(--sl-spacing-x-small)] [--btrix-cell-padding-top:var(--sl-spacing-x-small)]`,
         )}
       >
-        <btrix-table-head>
-          <btrix-table-header-cell class="border-r">
-            ${msg("Source")}
-          </btrix-table-header-cell>
-          <btrix-table-header-cell>
+        <btrix-table-head class="rounded-t bg-neutral-50">
+          <btrix-table-header-cell> ${msg("Source")} </btrix-table-header-cell>
+          <btrix-table-header-cell class="border-l">
             ${msg("Script Location")}
           </btrix-table-header-cell>
+          ${when(
+            this.editable,
+            () => html`
+              <btrix-table-header-cell class="border-l">
+                <span class="sr-only">${msg("Row actions")}</span>
+              </btrix-table-header-cell>
+            `,
+          )}
         </btrix-table-head>
         <btrix-table-body>${this.rows.map(this.renderRow)}</btrix-table-body>
       </btrix-table>
@@ -94,10 +114,77 @@ export class CustomBehaviorsTable extends TailwindElement {
 
   private readonly renderRow = (row: Behavior) => {
     return html`
-      <btrix-table-row class="first:border-t">
-        <btrix-table-cell class="border-r">${row.type}</btrix-table-cell>
-        <btrix-table-cell>${row.url}</btrix-table-cell>
+      <btrix-table-row class="border-t">
+        <btrix-table-cell class="items-start border-r">
+          ${this.renderType(row)}
+        </btrix-table-cell>
+        <btrix-table-cell
+          class=${clsx(
+            tw`block break-all`,
+            row.type === BehaviorType.GitRepo && tw`p-0`,
+          )}
+        >
+          ${row.type === BehaviorType.GitRepo
+            ? this.renderGitRepoCell(row)
+            : this.renderUrlCell(row)}
+        </btrix-table-cell>
+        ${when(
+          this.editable,
+          () => html`
+            <btrix-table-cell>
+              <sl-icon-button name="trash3"></sl-icon-button>
+            </btrix-table-cell>
+          `,
+        )}
       </btrix-table-row>
     `;
   };
+
+  private renderType(row: Behavior) {
+    if (!this.editable) {
+      return html`${labelFor[row.type]}`;
+    }
+
+    return html`
+      <sl-select
+        placeholder=${msg("Select Source")}
+        size="small"
+        value=${row.type}
+      >
+        ${Object.values(BehaviorType).map(
+          (behaviorType) => html`
+            <sl-option value=${behaviorType}>
+              ${labelFor[behaviorType]}
+            </sl-option>
+          `,
+        )}
+      </sl-select>
+    `;
+  }
+
+  private renderGitRepoCell(row: BehaviorGitRepo) {
+    if (!this.editable) {
+      const labelStyle = tw`fle inline-flex items-center justify-end border-r bg-neutral-50 p-2 text-xs leading-none text-neutral-700`;
+
+      return html`
+        <div class="break-all p-2">${row.url}</div>
+        <dl class="grid grid-cols-[max-content_1fr] border-t">
+          <dt class=${clsx(labelStyle, tw`border-b`)}>${msg("Path")}</dt>
+          <dd class="border-b p-2">${row.path}</dd>
+          <dt class=${labelStyle}>${msg("Branch")}</dt>
+          <dd class="p-2">${row.branch}</dd>
+        </dl>
+      `;
+    }
+
+    return html`TODO`;
+  }
+
+  private renderUrlCell(row: BehaviorURL) {
+    if (!this.editable) {
+      return html`${row.url}`;
+    }
+
+    return html`TODO`;
+  }
 }

--- a/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table.ts
@@ -274,7 +274,12 @@ export class CustomBehaviorsTable extends BtrixElement {
         >
           ${this.renderType(row)}
         </btrix-table-cell>
-        <btrix-table-cell class="block overflow-visible break-all border-l p-0">
+        <btrix-table-cell
+          class=${clsx(
+            tw`block border-l p-0`,
+            this.editable ? tw`overflow-visible` : tw`overflow-auto`,
+          )}
+        >
           ${row.type === BehaviorType.GitRepo
             ? this.renderGitRepoCell(row)
             : this.renderFileUrlCell(row)}

--- a/frontend/src/features/crawl-workflows/index.ts
+++ b/frontend/src/features/crawl-workflows/index.ts
@@ -1,3 +1,4 @@
+import("./custom-behaviors-table");
 import("./exclusion-editor");
 import("./live-workflow-status");
 import("./link-selector-table");

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1333,6 +1333,24 @@ https://archiveweb.page/images/${"logo.svg"}`}
         html`<btrix-custom-behaviors-table
           .customBehaviors=${this.initialWorkflow?.config.customBehaviors || []}
           editable
+          @btrix-change=${() => {
+            this.customBehaviorsTable?.removeAttribute("data-invalid");
+            this.customBehaviorsTable?.removeAttribute("data-user-invalid");
+          }}
+          @btrix-invalid=${() => {
+            /**
+             * HACK Set data attribute manually so that
+             * table works with `syncTabErrorState`
+             *
+             * FIXME Should be fixed with
+             * https://github.com/webrecorder/browsertrix/issues/2497
+             */
+            this.customBehaviorsTable?.setAttribute("data-invalid", "true");
+            this.customBehaviorsTable?.setAttribute(
+              "data-user-invalid",
+              "true",
+            );
+          }}
         ></btrix-custom-behaviors-table>`,
       )}
       ${this.renderHelpTextCol(
@@ -1916,6 +1934,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
   /**
    * HACK Set data attribute manually so that
    * exclusions table works with `syncTabErrorState`
+   *
+   * FIXME Should be fixed with
+   * https://github.com/webrecorder/browsertrix/issues/2497
    */
   private updateExclusionsValidity() {
     if (this.exclusionTable?.checkValidity() === false) {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1331,6 +1331,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             "https://example.com/script.js",
             "git+https://git.example.com/custom-behaviors?branch=dev&path=path/to/behaviors",
           ]}
+          editable
         ></btrix-custom-behaviors-table>`,
       )}
       ${this.renderHelpTextCol(

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1259,6 +1259,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ),
         false,
       )}
+      ${this.renderCustomBehaviors()}
       ${this.renderSectionHeading(msg("Page Timing"))}
       ${inputCol(html`
         <sl-input
@@ -1318,6 +1319,26 @@ https://archiveweb.page/images/${"logo.svg"}`}
         </sl-input>
       `)}
       ${this.renderHelpTextCol(infoTextStrings["pageExtraDelaySeconds"])}
+    `;
+  }
+
+  private renderCustomBehaviors() {
+    return html`
+      ${this.renderSectionHeading(msg("Custom Behaviors"))}
+      ${inputCol(
+        html`<btrix-custom-behaviors-table
+          .customBehaviors=${[
+            "https://example.com/script.js",
+            "git+https://git.example.com/custom-behaviors?branch=dev&path=path/to/behaviors",
+          ]}
+        ></btrix-custom-behaviors-table>`,
+      )}
+      ${this.renderHelpTextCol(
+        msg(
+          `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
+        ),
+        false,
+      )}
     `;
   }
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2201,12 +2201,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
             if (isApiErrorDetail(errorDetail)) {
               switch (errorDetail) {
-                case APIErrorDetail.WorkflowInvalidLinkSelector:
+                case APIErrorDetail.InvalidLinkSelector:
                   errorDetailMessage = msg(
                     "Page link selectors contain invalid selector or attribute",
                   );
                   break;
-                case APIErrorDetail.WorkflowInvalidRegex:
+                case APIErrorDetail.InvalidRegex:
                   errorDetailMessage = msg(
                     "Page exclusion contains invalid regex",
                   );

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2109,6 +2109,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
   private async save() {
     if (!this.formElem) return;
 
+    // Wait for custom behaviors validation to finish
+    try {
+      await this.customBehaviorsTable?.taskComplete;
+    } catch {
+      this.customBehaviorsTable?.reportValidity();
+      return;
+    }
+
     const isValid = await this.checkFormValidity(this.formElem);
 
     if (!isValid || this.formHasError) {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1328,7 +1328,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private renderCustomBehaviors() {
     return html`
-      ${this.renderSectionHeading(msg("Custom Behaviors"))}
+      ${this.renderSectionHeading(labelFor.customBehaviors)}
       ${inputCol(
         html`<btrix-custom-behaviors-table
           .customBehaviors=${this.initialWorkflow?.config.customBehaviors || []}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -52,6 +52,7 @@ import {
 } from "@/controllers/observable";
 import { type SelectBrowserProfileChangeEvent } from "@/features/browser-profiles/select-browser-profile";
 import type { CollectionsChangeEvent } from "@/features/collections/collections-add";
+import type { CustomBehaviorsTable } from "@/features/crawl-workflows/custom-behaviors-table";
 import type { CrawlStatusChangedEventDetail } from "@/features/crawl-workflows/live-workflow-status";
 import type {
   ExclusionChangeEvent,
@@ -315,6 +316,9 @@ export class WorkflowEditor extends BtrixElement {
 
   @query("btrix-link-selector-table")
   private readonly linkSelectorTable?: LinkSelectorTable | null;
+
+  @query("btrix-custom-behaviors-table")
+  private readonly customBehaviorsTable?: CustomBehaviorsTable | null;
 
   connectedCallback(): void {
     this.initializeEditor();
@@ -1327,10 +1331,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       ${this.renderSectionHeading(msg("Custom Behaviors"))}
       ${inputCol(
         html`<btrix-custom-behaviors-table
-          .customBehaviors=${[
-            "https://example.com/script.js",
-            "git+https://git.example.com/custom-behaviors?branch=dev&path=path/to/behaviors",
-          ]}
+          .customBehaviors=${this.initialWorkflow?.config.customBehaviors || []}
           editable
         ></btrix-custom-behaviors-table>`,
       )}
@@ -2302,6 +2303,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         selectLinks: this.linkSelectorTable?.value.length
           ? this.linkSelectorTable.value
           : DEFAULT_SELECT_LINKS,
+        customBehaviors: this.customBehaviorsTable?.value || [],
       },
       crawlerChannel: this.formState.crawlerChannel || "default",
       proxyId: this.formState.proxyId,

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -88,6 +88,7 @@ export class WorkflowsNew extends LiteElement {
         failOnFailedSeed: false,
         userAgent: null,
         selectLinks: DEFAULT_SELECT_LINKS,
+        customBehaviors: [],
       },
       tags: [],
       crawlTimeout: null,

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -2,6 +2,7 @@ import { msg } from "@lit/localize";
 
 export const labelFor = {
   behaviors: msg("Built-in Behaviors"),
+  customBehaviors: msg("Custom Behaviors"),
   autoscrollBehavior: msg("Autoscroll"),
   autoclickBehavior: msg("Autoclick"),
   pageLoadTimeoutSeconds: msg("Page Load Limit"),

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -189,12 +189,14 @@
    * FIXME Use [data-user-invalid] selector once following is fixed
    * https://github.com/webrecorder/browsertrix/issues/2497
    */
+  .invalid[data-invalid]:not([disabled])::part(base),
   btrix-url-input[data-user-invalid]:not([disabled])::part(base),
   sl-input[data-user-invalid]:not([disabled])::part(base),
   sl-textarea[data-user-invalid]:not([disabled])::part(base) {
     border-color: var(--sl-color-danger-400);
   }
 
+  .invalid[data-invalid]:focus-within::part(base),
   btrix-url-input[data-user-invalid]:focus-within::part(base),
   sl-input[data-user-invalid]:focus-within::part(base),
   sl-textarea[data-user-invalid]:focus-within::part(base) {

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -185,13 +185,11 @@
   }
 
   /* Validation styles */
-  sl-input[data-user-invalid]:not([disabled])::part(base),
-  sl-textarea[data-user-invalid]:not([disabled])::part(base) {
+  [data-user-invalid]:not([disabled])::part(base) {
     border-color: var(--sl-color-danger-400);
   }
 
-  sl-input[data-user-invalid]:focus-within::part(base),
-  sl-textarea[data-user-invalid]:focus-within::part(base) {
+  [data-user-invalid]:focus-within::part(base) {
     box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-color-danger-100);
   }
 

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -185,11 +185,19 @@
   }
 
   /* Validation styles */
-  [data-user-invalid]:not([disabled])::part(base) {
+  /**
+   * FIXME Use [data-user-invalid] selector once following is fixed
+   * https://github.com/webrecorder/browsertrix/issues/2497
+   */
+  btrix-url-input[data-user-invalid]:not([disabled])::part(base),
+  sl-input[data-user-invalid]:not([disabled])::part(base),
+  sl-textarea[data-user-invalid]:not([disabled])::part(base) {
     border-color: var(--sl-color-danger-400);
   }
 
-  [data-user-invalid]:focus-within::part(base) {
+  btrix-url-input[data-user-invalid]:focus-within::part(base),
+  sl-input[data-user-invalid]:focus-within::part(base),
+  sl-textarea[data-user-invalid]:focus-within::part(base) {
     box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-color-danger-100);
   }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -38,10 +38,11 @@ export type APISortQuery<T = Record<string, unknown>> = {
 // TODO Add all error codes
 // https://github.com/webrecorder/browsertrix/issues/2512
 export enum APIErrorDetail {
-  WorkflowInvalidLinkSelector = "invalid_link_selector",
-  WorkflowInvalidRegex = "invalid_regex",
-  WorkflowCustomBehaviorNotFound = "custom_behavior_not_found",
-  WorkflowCustomBehaviorBranchNotFound = "custom_behavior_branch_not_found",
+  InvalidLinkSelector = "invalid_link_selector",
+  InvalidRegex = "invalid_regex",
+  InvalidCustomBehavior = "invalid_custom_behavior",
+  CustomBehaviorNotFound = "custom_behavior_not_found",
+  CustomBehaviorBranchNotFound = "custom_behavior_branch_not_found",
 }
 export const APIErrorDetailEnum = z.nativeEnum(APIErrorDetail);
 export type APIErrorDetailEnum = z.infer<typeof APIErrorDetailEnum>;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -40,6 +40,8 @@ export type APISortQuery<T = Record<string, unknown>> = {
 export enum APIErrorDetail {
   WorkflowInvalidLinkSelector = "invalid_link_selector",
   WorkflowInvalidRegex = "invalid_regex",
+  WorkflowCustomBehaviorNotFound = "custom_behavior_not_found",
+  WorkflowCustomBehaviorBranchNotFound = "custom_behavior_branch_not_found",
 }
 export const APIErrorDetailEnum = z.nativeEnum(APIErrorDetail);
 export type APIErrorDetailEnum = z.infer<typeof APIErrorDetailEnum>;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -45,6 +45,7 @@ export type SeedConfig = Expand<
     depth?: number | null;
     userAgent?: string | null;
     selectLinks: string[];
+    customBehaviors: string[];
   }
 >;
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2151
Follows https://github.com/webrecorder/browsertrix/pull/2505

## Changes

Allows users to set custom behaviors in workflow editor.

## Manual testing

Pre-requisites:
1. Point backend to https://github.com/webrecorder/browsertrix/pull/2505
2. Run `yarn` to install new dependencies

Testing:
1. Log in as crawler
3. Go to New Workflow
4. Scroll to "Page Behavior". Verify "Custom Behaviors" table is shown
5. Interact with table. Verify input works as expected
6. Save
7. Go to "Settings" tab. Verify "Custom Behaviors" is shown
8. Repeat 3-6 for edit workflow

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Workflow | <img width="913" alt="Screenshot 2025-03-31 at 2 30 12 PM" src="https://github.com/user-attachments/assets/218e137d-4252-48a0-9d59-39a0fca3385a" /> |
| Edit Workflow | **Validation states:**<br/><br/><img width="548" alt="Screenshot 2025-03-31 at 2 30 45 PM" src="https://github.com/user-attachments/assets/7ffdd252-6314-4c7b-9008-b2c86e537587" /><br/><br/><img width="543" alt="Screenshot 2025-03-31 at 2 31 03 PM" src="https://github.com/user-attachments/assets/a23fa450-3a37-4a88-89b0-8df7f470ecc9" /><br/><br/><img width="547" alt="Screenshot 2025-03-31 at 2 31 23 PM" src="https://github.com/user-attachments/assets/c78cfa48-7d7d-404b-8e5a-a22c88cd795d" /> |
| Workflow - Settings | <img width="921" alt="Screenshot 2025-03-31 at 2 38 56 PM" src="https://github.com/user-attachments/assets/b5f00faf-87b5-4632-9073-b5a482a13493" /> |


## Follow-ups

This MVP doesn't wait until Git repo/remote URL validation is complete before saving a workflow since validation could take a while. This means there could be workflows saved with invalid Git repos or nonexistent URLs.