### PR TITLE
support overriding crawler image pull policy per channel

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -109,7 +109,9 @@ class CrawlConfigOps:
         self.coll_ops = cast(CollectionOps, None)
 
         self.default_filename_template = os.environ["DEFAULT_CRAWL_FILENAME_TEMPLATE"]
-        self.default_crawler_image_pull_policy = os.environ["DEFAULT_CRAWLER_IMAGE_PULL_POLICY"]
+        self.default_crawler_image_pull_policy = os.environ[
+            "DEFAULT_CRAWLER_IMAGE_PULL_POLICY"
+        ]
 
         self.router = APIRouter(
             prefix="/crawlconfigs",
@@ -125,12 +127,13 @@ class CrawlConfigOps:
         with open(os.environ["CRAWLER_CHANNELS_JSON"], encoding="utf-8") as fh:
             crawler_list = json.loads(fh.read())
             for channel_data in crawler_list:
-                if "imagePullPolicy" not in channel_data:
-                    channel_data["imagePullPolicy"] = self.default_crawler_image_pull_policy
                 channel = CrawlerChannel(**channel_data)
                 channels.append(channel)
                 self.crawler_images_map[channel.id] = channel.image
-                self.crawler_image_pull_policy_map[channel.id] = channel.imagePullPolicy
+                if channel.imagePullPolicy:
+                    self.crawler_image_pull_policy_map[channel.id] = (
+                        channel.imagePullPolicy
+                    )
 
             self.crawler_channels = CrawlerChannels(channels=channels)
 
@@ -968,9 +971,12 @@ class CrawlConfigOps:
 
     def get_channel_crawler_image_pull_policy(
         self, crawler_channel: Optional[str]
-    ) -> Optional[str]:
+    ) -> str:
         """Get crawler image name by id"""
-        return self.crawler_image_pull_policy_map.get(crawler_channel or "")
+        return (
+            self.crawler_image_pull_policy_map.get(crawler_channel or "")
+            or self.default_crawler_image_pull_policy
+        )
 
     def get_crawler_proxies_map(self) -> dict[str, CrawlerProxy]:
         """Load CrawlerProxy mapping from config"""

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -109,9 +109,9 @@ class CrawlConfigOps:
         self.coll_ops = cast(CollectionOps, None)
 
         self.default_filename_template = os.environ["DEFAULT_CRAWL_FILENAME_TEMPLATE"]
-        self.default_crawler_image_pull_policy = os.environ[
-            "DEFAULT_CRAWLER_IMAGE_PULL_POLICY"
-        ]
+        self.default_crawler_image_pull_policy = os.environ.get(
+            "DEFAULT_CRAWLER_IMAGE_PULL_POLICY", "IfNotPresent"
+        )
 
         self.router = APIRouter(
             prefix="/crawlconfigs",

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -33,6 +33,7 @@ class CrawlManager(K8sAPI):
         url: str,
         storage: StorageRef,
         crawler_image: str,
+        image_pull_policy: str,
         baseprofile: str = "",
         profile_filename: str = "",
         proxy_id: str = "",
@@ -57,6 +58,7 @@ class CrawlManager(K8sAPI):
             "vnc_password": secrets.token_hex(16),
             "expire_time": date_to_str(dt_now() + timedelta(seconds=30)),
             "crawler_image": crawler_image,
+            "image_pull_poilcy": image_pull_policy,
             "proxy_id": proxy_id or DEFAULT_PROXY_ID,
         }
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -58,7 +58,7 @@ class CrawlManager(K8sAPI):
             "vnc_password": secrets.token_hex(16),
             "expire_time": date_to_str(dt_now() + timedelta(seconds=30)),
             "crawler_image": crawler_image,
-            "image_pull_poilcy": image_pull_policy,
+            "image_pull_policy": image_pull_policy,
             "proxy_id": proxy_id or DEFAULT_PROXY_ID,
         }
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -603,7 +603,7 @@ class CrawlerChannel(BaseModel):
 
     id: str
     image: str
-    imagePullPolicy: Optional[str]
+    imagePullPolicy: Optional[str] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -603,7 +603,7 @@ class CrawlerChannel(BaseModel):
 
     id: str
     image: str
-    imagePullPolicy: str
+    imagePullPolicy: Optional[str]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -603,6 +603,7 @@ class CrawlerChannel(BaseModel):
 
     id: str
     image: str
+    imagePullPolicy: str
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -279,6 +279,11 @@ class CrawlOperator(BaseOperator):
         )
 
         params["crawler_image"] = status.crawlerImage
+        pull_policy = self.crawl_config_ops.get_channel_crawler_image_pull_policy(
+            crawl.crawler_channel
+        )
+        if pull_policy:
+            params["crawler_image_pull_policy"] = pull_policy
 
         if crawl.proxy_id and not crawl.is_qa:
             proxy = self.crawl_config_ops.get_crawler_proxy(crawl.proxy_id)

--- a/backend/btrixcloud/operator/profiles.py
+++ b/backend/btrixcloud/operator/profiles.py
@@ -45,6 +45,9 @@ class ProfileOperator(BaseOperator):
         params["storage_secret"] = storage_secret
         params["profile_filename"] = spec.get("profileFilename", "")
         params["crawler_image"] = spec["crawlerImage"]
+        pull_policy = spec.get("imagePullPolicy")
+        if pull_policy:
+            params["crawler_image_pull_policy"] = pull_policy
 
         proxy_id = spec.get("proxyId")
         if proxy_id:

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -126,7 +126,7 @@ class ProfileOps:
             url=str(profile_launch.url),
             storage=org.storage,
             crawler_image=crawler_image,
-            image_pull_policy=image_pull_policy or "",
+            image_pull_policy=image_pull_policy,
             baseprofile=prev_profile_id,
             profile_filename=prev_profile_path,
             proxy_id=proxy_id,

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -110,6 +110,10 @@ class ProfileOps:
         if not crawler_image:
             raise HTTPException(status_code=404, detail="crawler_not_found")
 
+        image_pull_policy = self.crawlconfigs.get_channel_crawler_image_pull_policy(
+            profile_launch.crawlerChannel
+        )
+
         # use either specified proxyId or if none, use proxyId from existing profile
         proxy_id = profile_launch.proxyId or prev_proxy_id
 
@@ -122,6 +126,7 @@ class ProfileOps:
             url=str(profile_launch.url),
             storage=org.storage,
             crawler_image=crawler_image,
+            image_pull_policy=image_pull_policy or "",
             baseprofile=prev_profile_id,
             profile_filename=prev_profile_path,
             proxy_id=proxy_id,

--- a/chart/app-templates/profile_job.yaml
+++ b/chart/app-templates/profile_job.yaml
@@ -23,6 +23,7 @@ spec:
 
   storageName: "{{ storage_name }}"
   crawlerImage: "{{ crawler_image }}"
+  imagePullPolicy: "{{ image_pull_policy }}"
 
   startUrl: "{{ url }}"
   profileFilename: "{{ profile_filename }}"

--- a/chart/examples/local-config.yaml
+++ b/chart/examples/local-config.yaml
@@ -22,10 +22,12 @@
 # crawler_channels:
 #   - id: default
 #     image: "docker.io/webrecorder/browsertrix-crawler:latest"
+#     imagePullPolicy: Always
 #
 #   # Add, remove, or edit additional crawler release channels for example:
 #   - id: custom_version
 #     image: "<DOCKER IMAGE>"
+#     imagePullPolicy: IfNotPresent  # optional
 
 # overrides to use existing images in local Docker, otherwise will pull from repository
 # backend_pull_policy: "Never"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -34,6 +34,8 @@ data:
 
   DEFAULT_CRAWL_FILENAME_TEMPLATE: "{{ .Values.default_crawl_filename_template }}"
 
+  DEFAULT_CRAWLER_IMAGE_PULL_POLICY: "{{ .Values.crawler_pull_policy }}"
+
   MAX_PAGES_PER_CRAWL: "{{ .Values.max_pages_per_crawl | default 0 }}"
 
   IDLE_TIMEOUT: "{{ .Values.profile_browser_idle_seconds | default 60 }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -237,12 +237,15 @@ redis_storage: "3Gi"
 crawler_channels:
   - id: default
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    imagePullPolicy: Always
 
   # Add, remove, or edit additional crawler versions below, for example:
   # - id: custom_version
   #   image: "<DOCKER IMAGE>"
+  #   imagePullPolicy: Always|IfNotPresent|Never (optional, defaults to crawler_pull_policy)
 
-crawler_pull_policy: "Always"
+# default crawler pull policy if not set per channel
+crawler_pull_policy: "IfNotPresent"
 
 crawler_namespace: "crawlers"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,7 +104,7 @@ replica_deletion_delay_days: 0
 # API Image
 # =========================================
 backend_image: "docker.io/webrecorder/browsertrix-backend:1.14.7"
-backend_pull_policy: "Always"
+backend_pull_policy: "IfNotPresent"
 
 backend_password_secret: "PASSWORD!"
 
@@ -162,7 +162,7 @@ backend_avg_memory_threshold: 95
 # Nginx Image
 # =========================================
 frontend_image: "docker.io/webrecorder/browsertrix-frontend:1.14.7"
-frontend_pull_policy: "Always"
+frontend_pull_policy: "IfNotPresent"
 
 frontend_cpu: "10m"
 

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -18,6 +18,7 @@ The `crawler_channels` setting is used to specify the [_Crawler Release Channel_
 crawler_channels:
   - id: default
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    imagePullPolicy: Always # optional
 ```
 
 This can be extended with additional channels. For example, here is what the value would look like adding a new x.y.z release of Browsertrix Crawler with the id `testing`:
@@ -28,7 +29,10 @@ crawler_channels:
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
   - id: testing
     image: "docker.io/webrecorder/browsertrix-crawler:x.y.z"
+    imagePullPolicy: IfNotPresent
 ```
+
+The `imagePullPolicy` per channel is optional. If not set, the value set in `crawler_pull_policy` is used as the default.
 
 ## Storage
 


### PR DESCRIPTION
- add 'imagePullPolicy' field to each crawler channel declaration
- if unset, defaults to the setting in the existing 'crawler_image_pull_policy' field.

fixes #2522