### PR TITLE
fix qa page sorting: 

### DIFF
--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -647,8 +647,8 @@ class PageOps:
                     raise HTTPException(
                         status_code=400, detail="qa_run_id_missing_for_qa_sort"
                     )
-
-                sort_by = f"qa.{qa_run_id}.{sort_by}"
+                # note: not using qa.{qa_run_id} because $set above means qa = qa.{qa_run_id}
+                sort_by = f"qa.{sort_by}"
 
             aggregate.extend([{"$sort": {sort_by: sort_direction}}])
 


### PR DESCRIPTION
was sorting on qa.{qa_run_id} after the value was already replaced with 'qa', thus was sorting on non-existent value
fixes #2529