### PR TITLE
Add a CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+title: Browsertrix
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - name: Webrecorder Software LLC
+    country: US
+    website: 'https://webrecorder.net'
+identifiers:
+  - type: url
+    value: >-
+      https://github.com/webrecorder/browsertrix/releases/tag/v1.14.8
+    description: GitHub release
+repository-code: 'https://github.com/webrecorder/browsertrix/'
+url: 'https://webrecorder.net/browsertrix'
+keywords:
+  - kubernetes
+  - web-archiving
+  - wacz
+  - warc
+  - archives
+license: AGPL-3.0
+version: 1.14.8

--- a/update-version.sh
+++ b/update-version.sh
@@ -12,3 +12,7 @@ sed -E -i "" "s/^version:.*$/version: v$version/" chart/Chart.yaml
 
 sed -E -i "" "s/\/browsertrix-backend:[[:alnum:].-]+/\/browsertrix-backend:$version/" chart/values.yaml
 sed -E -i "" "s/\/browsertrix-frontend:[[:alnum:].-]+/\/browsertrix-frontend:$version/" chart/values.yaml
+
+# Update the version & release URL in CITATION.cff
+sed -E -i "" "s/^version: [0-9]+\.[0-9]+\.[0-9]+$/version: $version/" CITATION.cff
+sed -E -i "" "s|(https://github.com/webrecorder/browsertrix/releases/tag/)v[0-9]+\.[0-9]+\.[0-9]+|\1v$version|" CITATION.cff


### PR DESCRIPTION
GitHub has a [cool feature that lets people more easily cite your project](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)!  This is especially relevant for reference managers like Zotero which [will pull this data automatically](https://github.com/zotero/translators/blob/master/GitHub.js).  Occasionally researchers and academics will use Browsertrix (or Browsertrix Crawler) — it would be nice for them to cite the correct tool!  This (hopefully) helps them do that :)

### Changes
- Adds a CITATION.cff file
- Updates the `update-version.sh` script to also update the citation file with the correct version number

### Future

Could add this for Webrecorder's other repos to encourage proper software citations for Webrecorder's other work, though they don't have update scripts like Browsertrix does so this introduces extra complexity in the version number update process unless those scripts are created.