### PR TITLE
Persist pagination state in url

### DIFF
--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -6,6 +6,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 
+import { SearchParamsController } from "@/controllers/searchParams";
 import { srOnly } from "@/utils/css";
 import chevronLeft from "~assets/icons/chevron-left.svg";
 import chevronRight from "~assets/icons/chevron-right.svg";
@@ -120,8 +121,13 @@ export class Pagination extends LitElement {
     `,
   ];
 
+  searchParams = new SearchParamsController(this);
+
   @property({ type: Number })
   page = 1;
+
+  @property({ type: String })
+  name = "page";
 
   @property({ type: Number })
   totalCount = 0;
@@ -150,6 +156,32 @@ export class Pagination extends LitElement {
 
     if (changedProperties.get("page") && this.page) {
       this.inputValue = `${this.page}`;
+      this.searchParams.set((prev) => {
+        if (this.page > 1) {
+          prev.set(this.name, `${this.page}`);
+        } else {
+          prev.delete(this.name);
+        }
+        return prev;
+      });
+    }
+
+    if (
+      changedProperties.has("searchParams") &&
+      this.searchParams.searchParams.get(this.name)
+    ) {
+      try {
+        const page = parseInt(
+          this.searchParams.searchParams.get(this.name) ?? "0",
+        );
+        if (Number.isFinite(page)) {
+          this.page = page;
+        } else {
+          throw new Error("couldn't parse page value from search");
+        }
+      } catch (e) {
+        console.error("couldn't set page", e);
+      }
     }
   }
 

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -28,9 +28,19 @@ export type PageChangeEvent = CustomEvent<PageChangeDetail>;
 /**
  * Pagination
  *
+ * Persists via a search param in the URL. Defaults to `page`, but can be set with the `name` attribute.
+ *
  * Usage example:
  * ```ts
- * <btrix-pagination totalCount="11" @page-change=${this.console.log}>
+ * <btrix-pagination totalCount="11" @page-change=${console.log}>
+ * </btrix-pagination>
+ * ```
+ *
+ * You can have multiple paginations on one page by setting different names:
+ * ```ts
+ * <btrix-pagination name="page-a" totalCount="11" @page-change=${console.log}>
+ * </btrix-pagination>
+ * <btrix-pagination name="page-b" totalCount="2" @page-change=${console.log}>
  * </btrix-pagination>
  * ```
  *
@@ -139,7 +149,13 @@ export class Pagination extends LitElement {
 
   @state()
   public get page() {
-    return parsePage(this.searchParams.searchParams.get(this.name));
+    return Math.min(
+      1,
+      Math.max(
+        this.totalCount,
+        parsePage(this.searchParams.searchParams.get(this.name)),
+      ),
+    );
   }
 
   @property({ type: String })

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -141,7 +141,15 @@ export class Pagination extends LitElement {
 
   searchParams = new SearchParamsController(this, (params) => {
     const page = parsePage(params.get(this.name));
-    this.onPageChange(page);
+    if (this.page !== page) {
+      this.dispatchEvent(
+        new CustomEvent<PageChangeDetail>("page-change", {
+          detail: { page: page, pages: this.pages },
+          composed: true,
+        }),
+      );
+      this.page = page;
+    }
   });
 
   @state()

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -147,15 +147,14 @@ export class Pagination extends LitElement {
     this.onPageChange(page, 0);
   });
 
-  @state()
+  // @property({ type: Number })
+  // public set page(page: number) {
+  //   this.onPageChange(page);
+  // }
+
   public get page() {
-    return Math.min(
-      1,
-      Math.max(
-        this.totalCount,
-        parsePage(this.searchParams.searchParams.get(this.name)),
-      ),
-    );
+    const page = parsePage(this.searchParams.searchParams.get(this.name));
+    return Math.max(1, Math.min(this.pages, page));
   }
 
   @property({ type: String })
@@ -184,6 +183,14 @@ export class Pagination extends LitElement {
   async willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("totalCount") || changedProperties.has("size")) {
       this.calculatePages();
+    }
+
+    const parsedPage = parseFloat(
+      this.searchParams.searchParams.get(this.name) ?? "1",
+    );
+    if (parsedPage > this.pages || parsedPage < 1 || parsedPage % 1 !== 0) {
+      this.onPageChange(this.page, parsedPage);
+      this.requestUpdate("page", parsedPage);
     }
 
     if (changedProperties.get("page") && this.page) {

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -11,7 +11,7 @@ import { srOnly } from "@/utils/css";
 import chevronLeft from "~assets/icons/chevron-left.svg";
 import chevronRight from "~assets/icons/chevron-right.svg";
 
-const parsePage = (value: string | undefined | null) => {
+export const parsePage = (value: string | undefined | null) => {
   const page = parseInt(value || "1");
   if (!Number.isFinite(page)) {
     throw new Error("couldn't parse page value from search");

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -121,7 +121,22 @@ export class Pagination extends LitElement {
     `,
   ];
 
-  searchParams = new SearchParamsController(this);
+  searchParams = new SearchParamsController(this, (params) => {
+    console.log("maybe page change");
+    if (`${this.page}` !== params.get(this.name)) {
+      try {
+        const page = parseInt(
+          this.searchParams.searchParams.get(this.name) ?? "1",
+        );
+        if (!Number.isFinite(page)) {
+          throw new Error("couldn't parse page value from search");
+        }
+        this.onPageChange(page);
+      } catch (e) {
+        console.error("couldn't set page", e);
+      }
+    }
+  });
 
   @property({ type: Number })
   page = 1;
@@ -156,6 +171,7 @@ export class Pagination extends LitElement {
 
     if (changedProperties.get("page") && this.page) {
       this.inputValue = `${this.page}`;
+      console.log("changed page", this.page, changedProperties.get("page"));
       this.searchParams.set((prev) => {
         if (this.page > 1) {
           prev.set(this.name, `${this.page}`);
@@ -166,22 +182,18 @@ export class Pagination extends LitElement {
       });
     }
 
-    if (
-      changedProperties.has("searchParams") &&
-      this.searchParams.searchParams.get(this.name)
-    ) {
-      try {
-        const page = parseInt(
-          this.searchParams.searchParams.get(this.name) ?? "0",
-        );
-        if (Number.isFinite(page)) {
-          this.page = page;
-        } else {
-          throw new Error("couldn't parse page value from search");
-        }
-      } catch (e) {
-        console.error("couldn't set page", e);
+    try {
+      const page = parseInt(
+        this.searchParams.searchParams.get(this.name) ?? "0",
+      );
+      if (!Number.isFinite(page)) {
+        throw new Error("couldn't parse page value from search");
       }
+      if (this.page !== page) {
+        this.onPageChange(page);
+      }
+    } catch (e) {
+      console.error("couldn't set page", e);
     }
   }
 

--- a/frontend/src/controllers/searchParams.ts
+++ b/frontend/src/controllers/searchParams.ts
@@ -1,0 +1,54 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+export class SearchParamsController implements ReactiveController {
+  private _host!: ReactiveControllerHost;
+
+  private set host(host: ReactiveControllerHost) {
+    console.log("host set", host);
+    this._host = host;
+  }
+
+  private get host() {
+    console.log("host get", this._host);
+    return this._host;
+  }
+
+  public searchParams = new URLSearchParams(location.search);
+
+  public set(
+    update: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams),
+    options: { replace?: boolean; data?: unknown } = { replace: false },
+  ) {
+    const url = new URL(location.toString());
+    if (typeof update === "function") {
+      const val = update(this.searchParams);
+      console.log(val);
+      url.search = val.toString();
+    } else {
+      url.search = update.toString();
+    }
+    if (options.replace) {
+      history.replaceState(options.data, "", url);
+    } else {
+      history.pushState(options.data, "", url);
+    }
+  }
+
+  constructor(host: ReactiveControllerHost) {
+    this.host = host;
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    window.addEventListener("popstate", this.onPopState);
+  }
+
+  hostDisconnected(): void {
+    window.removeEventListener("popstate", this.onPopState);
+  }
+
+  private onPopState(_e: PopStateEvent) {
+    this.searchParams = new URLSearchParams(location.search);
+    this.host.requestUpdate();
+  }
+}

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -24,7 +24,9 @@ export class CrawlPendingExclusions extends BtrixElement {
   matchedURLs: URLs | null = null;
 
   @state()
-  private page = 1;
+  private page = parseInt(
+    new URLSearchParams(location.search).get("page") ?? "1",
+  );
 
   private get pageSize() {
     return 10;

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import { type PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 
 type URLs = string[];
 
@@ -24,9 +24,7 @@ export class CrawlPendingExclusions extends BtrixElement {
   matchedURLs: URLs | null = null;
 
   @state()
-  private page = parseInt(
-    new URLSearchParams(location.search).get("page") ?? "1",
-  );
+  private page = parsePage(new URLSearchParams(location.search).get("page"));
 
   private get pageSize() {
     return 10;

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -17,7 +17,7 @@ import type {
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { type CheckboxChangeEventDetail } from "@/features/archived-items/archived-item-list";
 import type {
   FilterBy,
@@ -695,23 +695,23 @@ export class CollectionItemsDialog extends BtrixElement {
 
   private async initSelection() {
     void this.fetchCrawls({
-      page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+      page: parsePage(new URLSearchParams(location.search).get("page")),
       pageSize: DEFAULT_PAGE_SIZE,
     });
     void this.fetchUploads({
-      page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+      page: parsePage(new URLSearchParams(location.search).get("page")),
       pageSize: DEFAULT_PAGE_SIZE,
     });
     void this.fetchSearchValues();
 
     const [crawls, uploads] = await Promise.all([
       this.getCrawls({
-        page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+        page: parsePage(new URLSearchParams(location.search).get("page")),
         pageSize: COLLECTION_ITEMS_MAX,
         collectionId: this.collectionId,
       }).then(({ items }) => items),
       this.getUploads({
-        page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+        page: parsePage(new URLSearchParams(location.search).get("page")),
         pageSize: COLLECTION_ITEMS_MAX,
         collectionId: this.collectionId,
       }).then(({ items }) => items),

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -694,18 +694,24 @@ export class CollectionItemsDialog extends BtrixElement {
   }
 
   private async initSelection() {
-    void this.fetchCrawls({ page: 1, pageSize: DEFAULT_PAGE_SIZE });
-    void this.fetchUploads({ page: 1, pageSize: DEFAULT_PAGE_SIZE });
+    void this.fetchCrawls({
+      page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+    void this.fetchUploads({
+      page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
     void this.fetchSearchValues();
 
     const [crawls, uploads] = await Promise.all([
       this.getCrawls({
-        page: 1,
+        page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize: COLLECTION_ITEMS_MAX,
         collectionId: this.collectionId,
       }).then(({ items }) => items),
       this.getUploads({
-        page: 1,
+        page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize: COLLECTION_ITEMS_MAX,
         collectionId: this.collectionId,
       }).then(({ items }) => items),

--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -11,7 +11,7 @@ import RegexColorize from "regex-colorize";
 import type { Exclusion } from "./queue-exclusion-form";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import { type PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import type { SeedConfig } from "@/pages/org/types";
 import { regexEscape, regexUnescape } from "@/utils/string";
 import { tw } from "@/utils/tailwind";
@@ -90,9 +90,7 @@ export class QueueExclusionTable extends TailwindElement {
   private results: Exclusion[] = [];
 
   @state()
-  private page = parseInt(
-    new URLSearchParams(location.search).get("page") ?? "1",
-  );
+  private page = parsePage(new URLSearchParams(location.search).get("page"));
 
   @state()
   private exclusionToRemove?: string;

--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -90,7 +90,9 @@ export class QueueExclusionTable extends TailwindElement {
   private results: Exclusion[] = [];
 
   @state()
-  private page = 1;
+  private page = parseInt(
+    new URLSearchParams(location.search).get("page") ?? "1",
+  );
 
   @state()
   private exclusionToRemove?: string;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -245,6 +245,7 @@ export class App extends BtrixElement {
       // Redirect to logged in home page
       this.viewState = this.router.match(this.navigate.orgBasePath);
       window.history.replaceState(this.viewState, "", this.viewState.pathname);
+      console.log("replace state");
     } else {
       const nextViewState = this.router.match(
         `${pathname}${window.location.search}`,
@@ -256,6 +257,7 @@ export class App extends BtrixElement {
       ) {
         this.viewState = nextViewState;
         this.updateOrgSlugIfNeeded();
+        console.log("next view state", nextViewState);
       }
     }
   }
@@ -322,8 +324,10 @@ export class App extends BtrixElement {
     }`;
 
     if (replace) {
+      console.log("new state replaced");
       window.history.replaceState(this.viewState, "", urlStr);
     } else {
+      console.log("new state pushed");
       window.history.pushState(this.viewState, "", urlStr);
     }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -191,7 +191,6 @@ export class App extends BtrixElement {
   willUpdate(changedProperties: Map<string, unknown>) {
     if (changedProperties.has("settings")) {
       AppStateService.updateSettings(this.settings || null);
-
     }
     if (changedProperties.has("viewState")) {
       this.handleViewStateChange(
@@ -245,7 +244,6 @@ export class App extends BtrixElement {
       // Redirect to logged in home page
       this.viewState = this.router.match(this.navigate.orgBasePath);
       window.history.replaceState(this.viewState, "", this.viewState.pathname);
-      console.log("replace state");
     } else {
       const nextViewState = this.router.match(
         `${pathname}${window.location.search}`,
@@ -257,7 +255,6 @@ export class App extends BtrixElement {
       ) {
         this.viewState = nextViewState;
         this.updateOrgSlugIfNeeded();
-        console.log("next view state", nextViewState);
       }
     }
   }
@@ -324,10 +321,8 @@ export class App extends BtrixElement {
     }`;
 
     if (replace) {
-      console.log("new state replaced");
       window.history.replaceState(this.viewState, "", urlStr);
     } else {
-      console.log("new state pushed");
       window.history.pushState(this.viewState, "", urlStr);
     }
 

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -6,7 +6,7 @@ import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import needLogin from "@/decorators/needLogin";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
@@ -357,7 +357,7 @@ export class Crawls extends BtrixElement {
         page:
           queryParams?.page ||
           this.crawls?.page ||
-          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+          parsePage(new URLSearchParams(location.search).get("page")),
         pageSize: queryParams?.pageSize || this.crawls?.pageSize || 100,
         sortBy: this.orderBy.field,
         sortDirection: this.orderBy.direction === "desc" ? -1 : 1,

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -354,7 +354,10 @@ export class Crawls extends BtrixElement {
       {
         ...this.filterBy,
         ...queryParams,
-        page: queryParams?.page || this.crawls?.page || 1,
+        page:
+          queryParams?.page ||
+          this.crawls?.page ||
+          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize: queryParams?.pageSize || this.crawls?.pageSize || 100,
         sortBy: this.orderBy.field,
         sortDirection: this.orderBy.direction === "desc" ? -1 : 1,

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -15,7 +15,7 @@ import queryString from "query-string";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { type Dialog } from "@/components/ui/dialog";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { ClipboardController } from "@/controllers/clipboard";
 import { iconFor as iconForPageReview } from "@/features/qa/page-list/helpers";
 import * as pageApproval from "@/features/qa/page-list/helpers/approval";
@@ -895,7 +895,7 @@ export class ArchivedItemDetailQA extends BtrixElement {
         page:
           params?.page ??
           this.pages?.page ??
-          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+          parsePage(new URLSearchParams(location.search).get("page")),
         pageSize: params?.pageSize ?? this.pages?.pageSize ?? 10,
         sortBy,
         sortDirection,

--- a/frontend/src/pages/org/archived-item-detail/ui/qa.ts
+++ b/frontend/src/pages/org/archived-item-detail/ui/qa.ts
@@ -892,7 +892,10 @@ export class ArchivedItemDetailQA extends BtrixElement {
       }
 
       this.pages = await this.getPages({
-        page: params?.page ?? this.pages?.page ?? 1,
+        page:
+          params?.page ??
+          this.pages?.page ??
+          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize: params?.pageSize ?? this.pages?.pageSize ?? 10,
         sortBy,
         sortDirection,

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -92,7 +92,7 @@ export class CrawlsList extends BtrixElement {
 
   @state()
   private pagination: Required<APIPaginationQuery> = {
-    page: 1,
+    page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
     pageSize: INITIAL_PAGE_SIZE,
   };
 

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -11,7 +11,7 @@ import queryString from "query-string";
 import type { ArchivedItem, Crawl, Workflow } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { ClipboardController } from "@/controllers/clipboard";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { pageHeader } from "@/layouts/pageHeader";
@@ -92,7 +92,7 @@ export class CrawlsList extends BtrixElement {
 
   @state()
   private pagination: Required<APIPaginationQuery> = {
-    page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+    page: parsePage(new URLSearchParams(location.search).get("page")),
     pageSize: INITIAL_PAGE_SIZE,
   };
 

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -441,7 +441,10 @@ export class BrowserProfilesList extends BtrixElement {
     try {
       this.isLoading = true;
       const data = await this.getProfiles({
-        page: params?.page || this.browserProfiles?.page || 1,
+        page:
+          params?.page ||
+          this.browserProfiles?.page ||
+          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize:
           params?.pageSize ||
           this.browserProfiles?.pageSize ||

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -10,7 +10,7 @@ import type { Profile } from "./types";
 import type { SelectNewDialogEvent } from ".";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import {
   SortDirection,
   type SortValues,
@@ -444,7 +444,7 @@ export class BrowserProfilesList extends BtrixElement {
         page:
           params?.page ||
           this.browserProfiles?.page ||
-          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+          parsePage(new URLSearchParams(location.search).get("page")),
         pageSize:
           params?.pageSize ||
           this.browserProfiles?.pageSize ||

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -12,7 +12,7 @@ import type { Embed as ReplayWebPage } from "replaywebpage";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { MarkdownEditor } from "@/components/ui/markdown-editor";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { viewStateContext, type ViewStateContext } from "@/context/view-state";
 import { ClipboardController } from "@/controllers/clipboard";
 import type { EditDialogTab } from "@/features/collections/collection-edit-dialog";
@@ -130,7 +130,7 @@ export class CollectionDetail extends BtrixElement {
     if (changedProperties.has("collectionId")) {
       void this.fetchCollection();
       void this.fetchArchivedItems({
-        page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+        page: parsePage(new URLSearchParams(location.search).get("page")),
       });
     }
     if (changedProperties.has("collectionTab") && this.collectionTab === null) {
@@ -1038,7 +1038,7 @@ export class CollectionDetail extends BtrixElement {
         page:
           params?.page ||
           this.archivedItems?.page ||
-          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+          parsePage(new URLSearchParams(location.search).get("page")),
         pageSize:
           params?.pageSize ||
           this.archivedItems?.pageSize ||

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -129,7 +129,9 @@ export class CollectionDetail extends BtrixElement {
   ) {
     if (changedProperties.has("collectionId")) {
       void this.fetchCollection();
-      void this.fetchArchivedItems({ page: 1 });
+      void this.fetchArchivedItems({
+        page: parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+      });
     }
     if (changedProperties.has("collectionTab") && this.collectionTab === null) {
       this.collectionTab = Tab.Replay;
@@ -1033,7 +1035,10 @@ export class CollectionDetail extends BtrixElement {
     const query = queryString.stringify(
       {
         ...params,
-        page: params?.page || this.archivedItems?.page || 1,
+        page:
+          params?.page ||
+          this.archivedItems?.page ||
+          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize:
           params?.pageSize ||
           this.archivedItems?.pageSize ||

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -757,7 +757,10 @@ export class CollectionsList extends BtrixElement {
     const query = queryString.stringify(
       {
         ...this.filterBy,
-        page: queryParams?.page || this.collections?.page || 1,
+        page:
+          queryParams?.page ||
+          this.collections?.page ||
+          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize:
           queryParams?.pageSize ||
           this.collections?.pageSize ||

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -12,7 +12,7 @@ import queryString from "query-string";
 import type { SelectNewDialogEvent } from ".";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { ClipboardController } from "@/controllers/clipboard";
 import type { CollectionSavedEvent } from "@/features/collections/collection-create-dialog";
 import { SelectCollectionAccess } from "@/features/collections/select-collection-access";
@@ -760,7 +760,7 @@ export class CollectionsList extends BtrixElement {
         page:
           queryParams?.page ||
           this.collections?.page ||
-          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+          parsePage(new URLSearchParams(location.search).get("page")),
         pageSize:
           queryParams?.pageSize ||
           this.collections?.pageSize ||

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -14,7 +14,7 @@ import queryString from "query-string";
 import type { SelectNewDialogEvent } from ".";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import { type PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { type CollectionSavedEvent } from "@/features/collections/collection-edit-dialog";
 import { pageHeading } from "@/layouts/page";
 import { pageHeader } from "@/layouts/pageHeader";
@@ -70,9 +70,7 @@ export class Dashboard extends BtrixElement {
   collectionsView = CollectionGridView.Public;
 
   @state()
-  collectionPage = parseInt(
-    new URLSearchParams(location.search).get("page") ?? "1",
-  );
+  collectionPage = parsePage(new URLSearchParams(location.search).get("page"));
 
   // Used for busting cache when updating visible collection
   cacheBust = 0;

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -70,7 +70,9 @@ export class Dashboard extends BtrixElement {
   collectionsView = CollectionGridView.Public;
 
   @state()
-  collectionPage = 1;
+  collectionPage = parseInt(
+    new URLSearchParams(location.search).get("page") ?? "1",
+  );
 
   // Used for busting cache when updating visible collection
   cacheBust = 0;

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -19,7 +19,7 @@ import {
 } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { PageChangeEvent } from "@/components/ui/pagination";
+import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { type SelectEvent } from "@/components/ui/search-combobox";
 import { ClipboardController } from "@/controllers/clipboard";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
@@ -178,10 +178,7 @@ export class WorkflowsList extends BtrixElement {
     } catch (e) {
       if (isApiError(e)) {
         this.fetchErrorStatusCode = e.statusCode;
-      } else if (
-        (e as Error).name === "AbortError" ||
-        e === ABORT_REASON_THROTTLE
-      ) {
+      } else if ((e as Error).name === "AbortError") {
         console.debug("Fetch archived items aborted to throttle");
       } else {
         this.notify.toast({
@@ -754,7 +751,7 @@ export class WorkflowsList extends BtrixElement {
         page:
           queryParams?.page ||
           this.workflows?.page ||
-          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
+          parsePage(new URLSearchParams(location.search).get("page")),
         pageSize:
           queryParams?.pageSize ||
           this.workflows?.pageSize ||

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -178,7 +178,10 @@ export class WorkflowsList extends BtrixElement {
     } catch (e) {
       if (isApiError(e)) {
         this.fetchErrorStatusCode = e.statusCode;
-      } else if ((e as Error).name === "AbortError") {
+      } else if (
+        (e as Error).name === "AbortError" ||
+        e === ABORT_REASON_THROTTLE
+      ) {
         console.debug("Fetch archived items aborted to throttle");
       } else {
         this.notify.toast({
@@ -748,7 +751,10 @@ export class WorkflowsList extends BtrixElement {
     const query = queryString.stringify(
       {
         ...this.filterBy,
-        page: queryParams?.page || this.workflows?.page || 1,
+        page:
+          queryParams?.page ||
+          this.workflows?.page ||
+          parseInt(new URLSearchParams(location.search).get("page") ?? "1"),
         pageSize:
           queryParams?.pageSize ||
           this.workflows?.pageSize ||

--- a/frontend/src/utils/localize.ts
+++ b/frontend/src/utils/localize.ts
@@ -88,6 +88,7 @@ const numberFormatter = cached(
       mergeLocales(lang, useNavigatorLocales, navigatorLocales),
       options,
     ),
+  { cacheConstructor: Map },
 );
 
 /**
@@ -108,6 +109,7 @@ const dateFormatter = cached(
       mergeLocales(lang, useNavigatorLocales, navigatorLocales),
       options,
     ),
+  { cacheConstructor: Map },
 );
 
 /**
@@ -128,6 +130,7 @@ const durationFormatter = cached(
       mergeLocales(lang, useNavigatorLocales, navigatorLocales),
       options,
     ),
+  { cacheConstructor: Map },
 );
 
 const pluralFormatter = cached(
@@ -141,6 +144,7 @@ const pluralFormatter = cached(
       mergeLocales(lang, useNavigatorLocales, navigatorLocales),
       options,
     ),
+  { cacheConstructor: Map },
 );
 
 export class Localize {

--- a/frontend/src/utils/weakCache.ts
+++ b/frontend/src/utils/weakCache.ts
@@ -102,7 +102,7 @@ export function cached<
       );
     }
     if (cache.has(k)) {
-      return cache.get(k)!;
+      return cache.get(k) as Result;
     } else {
       const v = fn(...args);
       cache.set(k, v);


### PR DESCRIPTION
Closes #1944 

## Changes
- Pagination stores page number in url search params, rather than internal state, allowing going back to a specific page in a list
- Pagination navigation pushes to history stack, and listens to history changes to be able to respond to browser history navigation (back/forward)
- Search parameter reactive controller powers pagination component
- Pagination component allows for multiple simultaneous paginations via custom `name` property

## Manual testing

1. Log in as any role
2. Go to one of the list views on an org with enough items in the list to span more than one page
3. Click on one of the pages, and navigate back in your browser. The selected page should respect this navigation and return to the initial numbered page.
4. Navigate forward in your browser. The selected page should respect this navigation and switch to the numbered page from the previous step.
5. Click on a non-default page, and then click on one of the items in the list to go to its detail page. Then, using your browser's back button, return to the list page. You should be on the same numbered page as before.