### PR TITLE
fix: Handle no crawling defaults

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,6 +83,7 @@
     "thread-loader": "^4.0.4",
     "ts-loader": "^9.2.6",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
+    "type-fest": "^4.39.1",
     "typescript": "^5.3.3",
     "update-dotenv": "^1.1.1",
     "url-pattern": "^1.0.3",

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -280,10 +280,13 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
             Object.entries(this.fields).map(([sectionName, fields]) =>
               section(
                 sectionName as SectionsEnum,
-                Object.entries(fields).map(([fieldName, field]) => [
-                  field,
-                  infoTextFor[fieldName as keyof typeof infoTextFor],
-                ]),
+                Object.entries(fields)
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                  .filter(([, field]) => field)
+                  .map(([fieldName, field]) => [
+                    field,
+                    infoTextFor[fieldName as keyof typeof infoTextFor],
+                  ]),
               ),
             ),
           )}

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -280,13 +280,10 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
             Object.entries(this.fields).map(([sectionName, fields]) =>
               section(
                 sectionName as SectionsEnum,
-                Object.entries(fields)
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                  .filter(([, field]) => field)
-                  .map(([fieldName, field]) => [
-                    field,
-                    infoTextFor[fieldName as keyof typeof infoTextFor],
-                  ]),
+                Object.entries(fields).map(([fieldName, field]) => [
+                  field,
+                  infoTextFor[fieldName as keyof typeof infoTextFor],
+                ]),
               ),
             ),
           )}

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -3,6 +3,7 @@ import { mergeDeep } from "immutable";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
+import type { PartialDeep } from "type-fest";
 
 import { ScopeType, type Seed, type WorkflowParams } from "./types";
 
@@ -153,20 +154,20 @@ export class WorkflowsNew extends LiteElement {
             profileid: org.crawlingDefaults?.profileid,
             config: {
               exclude: org.crawlingDefaults?.exclude || [""],
-              behaviorTimeout: org.crawlingDefaults?.behaviorTimeout,
-              pageLoadTimeout: org.crawlingDefaults?.pageLoadTimeout,
-              pageExtraDelay: org.crawlingDefaults?.pageExtraDelay,
-              postLoadDelay: org.crawlingDefaults?.postLoadDelay,
+              behaviorTimeout: org.crawlingDefaults?.behaviorTimeout ?? null,
+              pageLoadTimeout: org.crawlingDefaults?.pageLoadTimeout ?? null,
+              pageExtraDelay: org.crawlingDefaults?.pageExtraDelay ?? null,
+              postLoadDelay: org.crawlingDefaults?.postLoadDelay ?? null,
               userAgent: org.crawlingDefaults?.userAgent,
               blockAds: org.crawlingDefaults?.blockAds,
               lang: org.crawlingDefaults?.lang,
-              customBehaviors: org.crawlingDefaults?.customBehaviors,
+              customBehaviors: org.crawlingDefaults?.customBehaviors || [],
             },
             crawlTimeout: org.crawlingDefaults?.crawlTimeout,
             maxCrawlSize: org.crawlingDefaults?.maxCrawlSize,
             crawlerChannel: org.crawlingDefaults?.crawlerChannel,
             proxyId: org.crawlingDefaults?.proxyId,
-          },
+          } satisfies PartialDeep<WorkflowParams>,
           this.initialWorkflow || {},
         );
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9172,6 +9172,11 @@ type-fest@^2.12.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
+type-fest@^4.39.1:
+  version "4.39.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.39.1.tgz#7521f6944e279abaf79cf60cfbc4823f4858083e"
+  integrity sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==
+
 type-is@^1.6.16, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"


### PR DESCRIPTION
Fixes regression introduced by https://github.com/webrecorder/browsertrix/commit/7c6bae8d618c10bc68e466536ad116d0676fe149

## Changes

Handles orgs without any crawl defaults correctly. Areas that use crawling defaults are also more strongly typed now to prevent similar issues.

## Manual testing

1. Log in as superadmin
2. Go to org with crawling defaults (Demo). Verify you're able to view a new workflow and view org settings
3. Go to org without crawling defaults (Behaviors testing). Verify previous step case