### PR TITLE
fix: Update custom behavior file placeholder text

### DIFF
--- a/frontend/src/features/crawl-workflows/custom-behaviors-table-row.ts
+++ b/frontend/src/features/crawl-workflows/custom-behaviors-table-row.ts
@@ -77,7 +77,7 @@ const errorFor: Record<ValidationErrorCode, string> = {
 };
 
 const inputStyle = [
-  tw`[--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)] [--sl-input-background-color-hover:transparent] [--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent]`,
+  tw`[--sl-input-background-color-hover:transparent] [--sl-input-background-color:transparent] [--sl-input-border-color-hover:transparent] [--sl-input-border-radius-medium:0] [--sl-input-spacing-medium:var(--sl-spacing-small)]`,
   tw`data-[valid]:[--sl-input-border-color:transparent]`,
   tw`part-[form-control-help-text]:mx-1 part-[form-control-help-text]:mb-1`,
 ];
@@ -356,7 +356,7 @@ export class CustomBehaviorsTableRow extends BtrixElement {
     }
 
     return this.renderUrlInput(behavior, {
-      placeholder: msg("Enter URL to JavaScript file"),
+      placeholder: msg("Enter location of behavior file"),
     });
   }
 


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/issues/2151

## Changes

Updates placeholder text for custom behavior files, since we now accept JSON.

## Screenshots

<img width="556" alt="Screenshot 2025-04-09 at 10 52 50 AM" src="https://github.com/user-attachments/assets/956daba6-8b3b-42ec-8ae2-834ee28fc1d7" />
