### PR TITLE
Update to docker/setup-buildx-action@v3

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 

--- a/.github/workflows/frontend-lint-test-build.yaml
+++ b/.github/workflows/frontend-lint-test-build.yaml
@@ -286,7 +286,7 @@ jobs:
 
       # Check build:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       -
         name: Login to Docker Hub


### PR DESCRIPTION
## Changes
- Updates `docker/setup-buildx-action` from v2 to v3
  - This should fix the intermittent build error seen here: https://github.com/webrecorder/browsertrix/actions/runs/14362787038/job/40268326912?pr=2538
  - The breaking change from v2 to v3 is the minimum node version is updated to 20, which is already the minimum version we use
  - Relevant buildx issue here: https://github.com/docker/buildx/issues/681