### PR TITLE
Pause / Resume Crawls Initial Implmentation.

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -35,7 +35,7 @@ from .models import (
     User,
     StorageRef,
     RUNNING_AND_WAITING_STATES,
-    SUCCESSFUL_STATES,
+    SUCCESSFUL_AND_PAUSED_STATES,
     QARun,
     UpdatedResponse,
     DeletedResponseQuota,
@@ -460,7 +460,7 @@ class BaseCrawlOps:
 
         if (
             files
-            and crawl.state in SUCCESSFUL_STATES
+            and crawl.state in SUCCESSFUL_AND_PAUSED_STATES
             and isinstance(crawl, CrawlOutWithResources)
         ):
             crawl.resources = await self._files_to_resources(files, org, crawl.id)

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -765,6 +765,7 @@ class CrawlConfigOps:
         crawlconfig.lastCrawlState = crawl.state
         crawlconfig.lastCrawlSize = crawl.stats.size if crawl.stats else 0
         crawlconfig.lastCrawlStopping = crawl.stopping
+        crawlconfig.lastCrawlPausing = crawl.pausing
         crawlconfig.isCrawlRunning = True
 
     async def get_crawl_config_out(self, cid: UUID, org: Organization):

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -771,7 +771,7 @@ class CrawlConfigOps:
         crawlconfig.lastCrawlState = crawl.state
         crawlconfig.lastCrawlSize = crawl.stats.size if crawl.stats else 0
         crawlconfig.lastCrawlStopping = crawl.stopping
-        crawlconfig.lastCrawlPausing = crawl.pausing
+        crawlconfig.lastCrawlShouldPause = crawl.shouldPause
         crawlconfig.lastCrawlPausedAt = crawl.pausedAt
         crawlconfig.lastCrawlPausedExpiry = None
         if crawl.pausedAt:

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -4,7 +4,7 @@ import os
 import secrets
 
 from typing import Optional, Dict, Tuple
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from fastapi import HTTPException
 
@@ -386,9 +386,13 @@ class CrawlManager(K8sAPI):
 
         return await self.delete_crawl_job(crawl_id)
 
-    async def pause_resume_crawl(self, crawl_id: str, pause: bool) -> dict:
+    async def pause_resume_crawl(
+        self, crawl_id: str, paused_at: Optional[datetime] = None
+    ) -> dict:
         """pause or unpause a crawl"""
-        return await self._patch_job(crawl_id, {"paused": int(pause)})
+        return await self._patch_job(
+            crawl_id, {"pausedAt": date_to_str(paused_at) if paused_at else ""}
+        )
 
     async def delete_crawl_configs_for_org(self, org: str) -> None:
         """Delete all crawl configs for given org"""

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -386,6 +386,10 @@ class CrawlManager(K8sAPI):
 
         return await self.delete_crawl_job(crawl_id)
 
+    async def pause_resume_crawl(self, crawl_id: str, pause: bool) -> dict:
+        """pause or unpause a crawl"""
+        return await self._patch_job(crawl_id, {"paused": int(pause)})
+
     async def delete_crawl_configs_for_org(self, org: str) -> None:
         """Delete all crawl configs for given org"""
         await self._delete_crawl_configs(f"btrix.org={org}")

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -389,7 +389,7 @@ class CrawlManager(K8sAPI):
     async def pause_resume_crawl(
         self, crawl_id: str, paused_at: Optional[datetime] = None
     ) -> dict:
-        """pause or unpause a crawl"""
+        """pause or resume a crawl"""
         return await self._patch_job(
             crawl_id, {"pausedAt": date_to_str(paused_at) if paused_at else ""}
         )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -769,6 +769,31 @@ class CrawlOps(BaseCrawlOps):
 
         return crawls_data
 
+    async def pause_crawl(
+        self, crawl_id: str, org: Organization, pause: bool
+    ) -> Dict[str, bool]:
+        """pause or unpause a crawl temporarily"""
+        crawl = await self.get_base_crawl(crawl_id, org)
+        if crawl and crawl.type != "crawl":
+            raise HTTPException(status_code=400, detail="not_a_crawl")
+
+        result = None
+        try:
+            result = await self.crawl_manager.pause_resume_crawl(crawl_id, pause=pause)
+
+            if result.get("success"):
+                await self.crawls.find_one_and_update(
+                    {"_id": crawl_id, "type": "crawl", "oid": org.id},
+                    {"$set": {"pausing": pause}},
+                )
+
+                return {"success": True}
+        # pylint: disable=bare-except
+        except:
+            pass
+
+        raise HTTPException(status_code=404, detail="crawl_not_found")
+
     async def shutdown_crawl(
         self, crawl_id: str, org: Organization, graceful: bool
     ) -> Dict[str, bool]:
@@ -1241,6 +1266,22 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
     )
     async def crawl_graceful_stop(crawl_id, org: Organization = Depends(org_crawl_dep)):
         return await ops.shutdown_crawl(crawl_id, org, graceful=True)
+
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/pause",
+        tags=["crawls"],
+        response_model=SuccessResponse,
+    )
+    async def pause_crawl(crawl_id, org: Organization = Depends(org_crawl_dep)):
+        return await ops.pause_crawl(crawl_id, org, pause=True)
+
+    @app.post(
+        "/orgs/{oid}/crawls/{crawl_id}/unpause",
+        tags=["crawls"],
+        response_model=SuccessResponse,
+    )
+    async def unpause_crawl(crawl_id, org: Organization = Depends(org_crawl_dep)):
+        return await ops.pause_crawl(crawl_id, org, pause=False)
 
     @app.post(
         "/orgs/{oid}/crawls/delete",

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -772,7 +772,7 @@ class CrawlOps(BaseCrawlOps):
     async def pause_crawl(
         self, crawl_id: str, org: Organization, pause: bool
     ) -> Dict[str, bool]:
-        """pause or unpause a crawl temporarily"""
+        """pause or resume a crawl temporarily"""
         crawl = await self.get_base_crawl(crawl_id, org)
         if crawl and crawl.type != "crawl":
             raise HTTPException(status_code=400, detail="not_a_crawl")
@@ -1284,11 +1284,11 @@ def init_crawls_api(crawl_manager: CrawlManager, app, user_dep, *args):
         return await ops.pause_crawl(crawl_id, org, pause=True)
 
     @app.post(
-        "/orgs/{oid}/crawls/{crawl_id}/unpause",
+        "/orgs/{oid}/crawls/{crawl_id}/resume",
         tags=["crawls"],
         response_model=SuccessResponse,
     )
-    async def unpause_crawl(crawl_id, org: Organization = Depends(org_crawl_dep)):
+    async def resume_crawl(crawl_id, org: Organization = Depends(org_crawl_dep)):
         return await ops.pause_crawl(crawl_id, org, pause=False)
 
     @app.post(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -792,7 +792,7 @@ class CrawlOps(BaseCrawlOps):
             if result.get("success"):
                 await self.crawls.find_one_and_update(
                     {"_id": crawl_id, "type": "crawl", "oid": org.id},
-                    {"$set": {"pausing": pause, "pausedAt": paused_at}},
+                    {"$set": {"shouldPause": pause, "pausedAt": paused_at}},
                 )
 
                 return {"success": True}

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -778,13 +778,21 @@ class CrawlOps(BaseCrawlOps):
             raise HTTPException(status_code=400, detail="not_a_crawl")
 
         result = None
+
+        if pause:
+            paused_at = dt_now()
+        else:
+            paused_at = None
+
         try:
-            result = await self.crawl_manager.pause_resume_crawl(crawl_id, pause=pause)
+            result = await self.crawl_manager.pause_resume_crawl(
+                crawl_id, paused_at=paused_at
+            )
 
             if result.get("success"):
                 await self.crawls.find_one_and_update(
                     {"_id": crawl_id, "type": "crawl", "oid": org.id},
-                    {"$set": {"pausing": pause}},
+                    {"$set": {"pausing": pause, "pausedAt": paused_at}},
                 )
 
                 return {"success": True}

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -124,6 +124,8 @@ class SettingsResponse(BaseModel):
 
     localesEnabled: Optional[List[str]]
 
+    pausedExpiryMinutes: int
+
 
 # ============================================================================
 # pylint: disable=too-many-locals, duplicate-code
@@ -158,6 +160,7 @@ def main() -> None:
             if os.environ.get("LOCALES_ENABLED")
             else None
         ),
+        pausedExpiryMinutes=int(os.environ.get("PAUSED_CRAWL_LIMIT_MINUTES", 10080)),
     )
 
     invites = init_invites(mdb, email)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -244,6 +244,7 @@ TYPE_SUCCESSFUL_STATES = Literal[
     "stopped_org_readonly",
 ]
 SUCCESSFUL_STATES = get_args(TYPE_SUCCESSFUL_STATES)
+SUCCESSFUL_AND_PAUSED_STATES = ["paused", *SUCCESSFUL_STATES]
 
 TYPE_RUNNING_AND_WAITING_STATES = Literal[TYPE_WAITING_STATES, TYPE_RUNNING_STATES]
 RUNNING_AND_WAITING_STATES = [*WAITING_STATES, *RUNNING_STATES]
@@ -481,7 +482,7 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     id: UUID
 
     lastCrawlStopping: Optional[bool] = False
-    lastCrawlPausing: Optional[bool] = False
+    lastCrawlShouldPause: Optional[bool] = False
     lastCrawlPausedAt: Optional[datetime] = None
     lastCrawlPausedExpiry: Optional[datetime] = None
     profileName: Optional[str] = None
@@ -869,7 +870,7 @@ class CrawlOut(BaseMongoModel):
     seedCount: Optional[int] = None
     profileName: Optional[str] = None
     stopping: Optional[bool] = False
-    pausing: Optional[bool] = False
+    shouldPause: Optional[bool] = False
     pausedAt: Optional[datetime] = None
     manual: bool = False
     cid_rev: Optional[int] = None
@@ -1025,7 +1026,7 @@ class Crawl(BaseCrawl, CrawlConfigCore):
     manual: bool = False
 
     stopping: Optional[bool] = False
-    pausing: Optional[bool] = False
+    shouldPause: Optional[bool] = False
 
     qaCrawlExecSeconds: int = 0
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -238,6 +238,7 @@ FAILED_STATES = get_args(TYPE_FAILED_STATES)
 TYPE_SUCCESSFUL_STATES = Literal[
     "complete",
     "stopped_by_user",
+    "stopped_pause_expired",
     "stopped_storage_quota_reached",
     "stopped_time_quota_reached",
     "stopped_org_readonly",
@@ -481,6 +482,8 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
 
     lastCrawlStopping: Optional[bool] = False
     lastCrawlPausing: Optional[bool] = False
+    lastCrawlPausedAt: Optional[datetime] = None
+    lastCrawlPausedExpiry: Optional[datetime] = None
     profileName: Optional[str] = None
     firstSeed: Optional[str] = None
     seedCount: int = 0
@@ -867,6 +870,7 @@ class CrawlOut(BaseMongoModel):
     profileName: Optional[str] = None
     stopping: Optional[bool] = False
     pausing: Optional[bool] = False
+    pausedAt: Optional[datetime] = None
     manual: bool = False
     cid_rev: Optional[int] = None
     scale: Scale = 1

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -218,11 +218,13 @@ class UserOrgInfoOut(BaseModel):
 
 # ============================================================================
 TYPE_RUNNING_STATES = Literal[
-    "running", "pending-wait", "generate-wacz", "uploading-wacz", "paused"
+    "running", "pending-wait", "generate-wacz", "uploading-wacz"
 ]
 RUNNING_STATES = get_args(TYPE_RUNNING_STATES)
 
-TYPE_WAITING_STATES = Literal["starting", "waiting_capacity", "waiting_org_limit"]
+TYPE_WAITING_STATES = Literal[
+    "starting", "waiting_capacity", "waiting_org_limit", "paused"
+]
 WAITING_STATES = get_args(TYPE_WAITING_STATES)
 
 TYPE_FAILED_STATES = Literal[

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -218,7 +218,7 @@ class UserOrgInfoOut(BaseModel):
 
 # ============================================================================
 TYPE_RUNNING_STATES = Literal[
-    "running", "pending-wait", "generate-wacz", "uploading-wacz"
+    "running", "pending-wait", "generate-wacz", "uploading-wacz", "paused"
 ]
 RUNNING_STATES = get_args(TYPE_RUNNING_STATES)
 
@@ -478,6 +478,7 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     id: UUID
 
     lastCrawlStopping: Optional[bool] = False
+    lastCrawlPausing: Optional[bool] = False
     profileName: Optional[str] = None
     firstSeed: Optional[str] = None
     seedCount: int = 0
@@ -863,6 +864,7 @@ class CrawlOut(BaseMongoModel):
     seedCount: Optional[int] = None
     profileName: Optional[str] = None
     stopping: Optional[bool] = False
+    pausing: Optional[bool] = False
     manual: bool = False
     cid_rev: Optional[int] = None
     scale: Scale = 1
@@ -1017,6 +1019,7 @@ class Crawl(BaseCrawl, CrawlConfigCore):
     manual: bool = False
 
     stopping: Optional[bool] = False
+    pausing: Optional[bool] = False
 
     qaCrawlExecSeconds: int = 0
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -360,7 +360,7 @@ class CrawlOperator(BaseOperator):
         for i in range(0, status.scale):
             children.extend(
                 self._load_crawler(
-                    params, i, status, data.children, bool(crawl.paused_at)
+                    params, i, status, data.children, status.state == "paused"
                 )
             )
 
@@ -1024,17 +1024,6 @@ class CrawlOperator(BaseOperator):
 
                 if "containerStatuses" in pstatus:
                     cstatus = pstatus["containerStatuses"][0]
-
-                    # don't consider 'ContainerCreating' as running for now
-                    # may be stuck in this state for other reasons
-                    #
-                    # waiting = cstatus["state"].get("waiting")
-                    # if (
-                    #    phase == "Pending"
-                    #    and waiting
-                    #    and waiting.get("reason") == "ContainerCreating"
-                    # ):
-                    #    running = True
 
                     self.handle_terminated_pod(
                         name, role, status, cstatus["state"].get("terminated")

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -76,6 +76,7 @@ class CrawlSpec(BaseModel):
     started: str
     crawler_channel: str
     stopping: bool = False
+    paused: bool = False
     scheduled: bool = False
     timeout: int = 0
     max_crawl_size: int = 0

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -1,6 +1,7 @@
 """Operator Models"""
 
 from collections import defaultdict
+from datetime import datetime
 from uuid import UUID
 from typing import Optional, DefaultDict, Literal, Annotated, Any
 from pydantic import BaseModel, Field
@@ -17,6 +18,7 @@ CJS = f"CrawlJob.{BTRIX_API}"
 
 StopReason = Literal[
     "stopped_by_user",
+    "stopped_pause_expired",
     "time-limit",
     "size-limit",
     "stopped_storage_quota_reached",
@@ -76,7 +78,7 @@ class CrawlSpec(BaseModel):
     started: str
     crawler_channel: str
     stopping: bool = False
-    paused: bool = False
+    paused_at: Optional[datetime] = None
     scheduled: bool = False
     timeout: int = 0
     max_crawl_size: int = 0

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -18,6 +18,7 @@ CJS = f"CrawlJob.{BTRIX_API}"
 
 StopReason = Literal[
     "stopped_by_user",
+    "paused",
     "stopped_pause_expired",
     "time-limit",
     "size-limit",

--- a/backend/test/test_api.py
+++ b/backend/test/test_api.py
@@ -51,4 +51,5 @@ def test_api_settings():
         "salesEmail": "",
         "supportEmail": "",
         "localesEnabled": None,
+        "pausedExpiryMinutes": 10080,
     }

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -36,5 +36,5 @@ spec:
 
   proxyId: "{{ proxy_id }}"
 
-  paused: {{ paused or 0 }}
+  pausedAt: "{{ pausedAt }}"
 

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -35,3 +35,6 @@ spec:
   storageName: "{{ storage_name }}"
 
   proxyId: "{{ proxy_id }}"
+
+  paused: {{ paused or 0 }}
+

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -28,7 +28,7 @@ spec:
 # -------
 # CRAWLER
 # -------
-{% if not do_restart %}
+{% if init_crawler %}
 ---
 apiVersion: v1
 kind: Pod

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -20,6 +20,8 @@ data:
 
   INVITE_EXPIRE_SECONDS: "{{ .Values.invite_expire_seconds }}"
 
+  PAUSED_CRAWL_LIMIT_MINUTES: "{{ .Values.paused_crawl_limit_minutes }}"
+
   REGISTRATION_ENABLED: "{{ .Values.registration_enabled | default 0 }}"
 
   REGISTER_TO_ORG_ID: "{{ .Values.registration_org_id }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -82,6 +82,9 @@ allow_dupe_invites: "0"
 # number of seconds before pending invites expire - default is 7 days
 invite_expire_seconds: 604800
 
+# number of minutes before paused crawls are stopped - default is 7 days
+paused_crawl_limit_minutes: 10080
+
 # base url for replayweb.page
 rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage@2.3.3/"
 

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -127,9 +127,10 @@ export class CrawlListItem extends BtrixElement {
       >
         <btrix-table-cell class="pr-0">
           ${this.safeRender(
-            (workflow) => html`
+            (crawl: Crawl) => html`
               <btrix-crawl-status
-                state=${workflow.state}
+                state=${crawl.state}
+                ?shouldPause=${crawl.shouldPause}
                 hideLabel
                 hoist
               ></btrix-crawl-status>

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -26,6 +26,9 @@ export class CrawlStatus extends TailwindElement {
   stopping = false;
 
   @property({ type: Boolean })
+  pausing = false;
+
+  @property({ type: Boolean })
   hoist = false;
 
   static styles = [
@@ -116,6 +119,38 @@ export class CrawlStatus extends TailwindElement {
           style="color: ${color}"
         ></sl-icon>`;
         label = msg("Stopping");
+        break;
+
+      case "pausing":
+        color = "var(--sl-color-violet-600)";
+        icon = html`<sl-icon
+          name="pause-btn"
+          class="animatePulse"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Pausing");
+        break;
+
+      case "unpausing":
+        color = "var(--sl-color-violet-600)";
+        icon = html`<sl-icon
+          name="play-btn"
+          class="animatePulse"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Resuming");
+        break;
+
+      case "paused":
+        color = "var(--sl-color-violet-600)";
+        icon = html`<sl-icon
+          name="pause-btn"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Paused");
         break;
 
       case "pending-wait":
@@ -258,9 +293,21 @@ export class CrawlStatus extends TailwindElement {
     return { icon, label, cssColor: color };
   }
 
+  filterState() {
+    if (this.stopping && this.state === "running") {
+      return "stopping";
+    }
+    if (this.pausing && this.state === "running") {
+      return "pausing";
+    }
+    if (!this.pausing && this.state === "paused") {
+      return "unpausing";
+    }
+    return this.state;
+  }
+
   render() {
-    const state =
-      this.stopping && this.state === "running" ? "stopping" : this.state;
+    const state = this.filterState();
     const { icon, label } = CrawlStatus.getContent(state, this.type);
     if (this.hideLabel) {
       return html`<div class="flex items-center">

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -124,7 +124,7 @@ export class CrawlStatus extends TailwindElement {
       case "pausing":
         color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
-          name="pause-btn"
+          name="pause-circle"
           class="animatePulse"
           slot="prefix"
           style="color: ${color}"
@@ -133,9 +133,8 @@ export class CrawlStatus extends TailwindElement {
         break;
 
       case "unpausing":
-        color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
-          name="play-btn"
+          name="play-circle"
           class="animatePulse"
           slot="prefix"
           style="color: ${color}"
@@ -144,9 +143,8 @@ export class CrawlStatus extends TailwindElement {
         break;
 
       case "paused":
-        color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
-          name="pause-btn"
+          name="pause-circle"
           slot="prefix"
           style="color: ${color}"
         ></sl-icon>`;

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -143,6 +143,7 @@ export class CrawlStatus extends TailwindElement {
         break;
 
       case "paused":
+        color = "var(--sl-color-neutral-500)";
         icon = html`<sl-icon
           name="pause-circle"
           slot="prefix"

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -26,7 +26,7 @@ export class CrawlStatus extends TailwindElement {
   stopping = false;
 
   @property({ type: Boolean })
-  pausing = false;
+  shouldPause = false;
 
   @property({ type: Boolean })
   hoist = false;
@@ -132,7 +132,7 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Pausing");
         break;
 
-      case "unpausing":
+      case "resuming":
         icon = html`<sl-icon
           name="play-circle"
           class="animatePulse"
@@ -306,11 +306,11 @@ export class CrawlStatus extends TailwindElement {
     if (this.stopping && this.state === "running") {
       return "stopping";
     }
-    if (this.pausing && this.state === "running") {
+    if (this.shouldPause && this.state === "running") {
       return "pausing";
     }
-    if (!this.pausing && this.state === "paused") {
-      return "unpausing";
+    if (!this.shouldPause && this.state === "paused") {
+      return "resuming";
     }
     return this.state;
   }

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -241,6 +241,16 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Stopped");
         break;
 
+      case "stopped_pause_expired":
+        color = "var(--warning)";
+        icon = html`<sl-icon
+          name="dash-square-fill"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Stopped: Paused Too Long");
+        break;
+
       case "stopped_storage_quota_reached":
         color = "var(--warning)";
         icon = html`<sl-icon

--- a/frontend/src/features/crawl-workflows/live-workflow-status.ts
+++ b/frontend/src/features/crawl-workflows/live-workflow-status.ts
@@ -107,7 +107,7 @@ export class LiveWorkflowStatus extends BtrixElement {
           class="block"
           state=${lastCrawlState}
           ?stopping=${workflow.lastCrawlStopping}
-          ?pausing=${workflow.lastCrawlPausing}
+          ?shouldPause=${workflow.lastCrawlShouldPause}
         ></btrix-crawl-status>
       `;
     });

--- a/frontend/src/features/crawl-workflows/live-workflow-status.ts
+++ b/frontend/src/features/crawl-workflows/live-workflow-status.ts
@@ -106,6 +106,8 @@ export class LiveWorkflowStatus extends BtrixElement {
         <btrix-crawl-status
           class="block"
           state=${lastCrawlState}
+          ?stopping=${workflow.lastCrawlStopping}
+          ?pausing=${workflow.lastCrawlPausing}
         ></btrix-crawl-status>
       `;
     });

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -250,6 +250,7 @@ export class WorkflowListItem extends BtrixElement {
               <btrix-crawl-status
                 state=${workflow.lastCrawlState || msg("No Crawls Yet")}
                 ?stopping=${workflow.lastCrawlStopping}
+                ?pausing=${workflow.lastCrawlPausing}
               ></btrix-crawl-status>
             `,
           )}

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -250,7 +250,7 @@ export class WorkflowListItem extends BtrixElement {
               <btrix-crawl-status
                 state=${workflow.lastCrawlState || msg("No Crawls Yet")}
                 ?stopping=${workflow.lastCrawlStopping}
-                ?pausing=${workflow.lastCrawlPausing}
+                ?shouldPause=${workflow.lastCrawlShouldPause}
               ></btrix-crawl-status>
             `,
           )}

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -280,11 +280,15 @@ export class WorkflowListItem extends BtrixElement {
               if (diff < 1000) {
                 return "";
               }
-              return msg(
-                str`Running for ${this.localize.humanizeDuration(diff, {
-                  compact: true,
-                })}`,
-              );
+              const duration = this.localize.humanizeDuration(diff, {
+                compact: true,
+              });
+
+              if (workflow.lastCrawlState === "paused") {
+                return msg(str`Active for ${duration}`);
+              }
+
+              return msg(str`Running for ${duration}`);
             }
             return notSpecified;
           })}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -571,6 +571,27 @@ export class WorkflowDetail extends BtrixElement {
           <sl-button-group>
             <sl-button
               size="small"
+              @click=${this.pauseUnpause}
+              ?disabled=${!this.lastCrawlId ||
+              this.isCancelingOrStoppingCrawl ||
+              this.workflow?.lastCrawlStopping ||
+              this.workflow?.lastCrawlPausing ===
+                (this.workflow?.lastCrawlState === "running")}
+            >
+              <sl-icon
+                name=${workflow.lastCrawlState !== "paused"
+                  ? "pause-btn"
+                  : "play-btn"}
+                slot="prefix"
+              ></sl-icon>
+              <span
+                >${workflow.lastCrawlState !== "paused"
+                  ? msg("Pause")
+                  : msg("Resume")}</span
+              >
+            </sl-button>
+            <sl-button
+              size="small"
               @click=${() => (this.openDialogName = "stop")}
               ?disabled=${!this.lastCrawlId ||
               this.isCancelingOrStoppingCrawl ||
@@ -710,6 +731,7 @@ export class WorkflowDetail extends BtrixElement {
             <btrix-crawl-status
               state=${workflow.lastCrawlState || msg("No Crawls Yet")}
               ?stopping=${workflow.lastCrawlStopping}
+              ?pausing=${workflow.lastCrawlPausing}
             ></btrix-crawl-status>
           `,
         )}
@@ -1651,6 +1673,33 @@ export class WorkflowDetail extends BtrixElement {
         variant: "danger",
         icon: "exclamation-octagon",
         id: "workflow-delete-status",
+      });
+    }
+  }
+
+  private async pauseUnpause() {
+    if (!this.lastCrawlId) return;
+
+    const pause = this.workflow?.lastCrawlState !== "paused";
+
+    try {
+      const data = await this.api.fetch<{ success: boolean }>(
+        `/orgs/${this.orgId}/crawls/${this.lastCrawlId}/${pause ? "pause" : "unpause"}`,
+        {
+          method: "POST",
+        },
+      );
+      if (data.success) {
+        void this.fetchWorkflow();
+      } else {
+        throw data;
+      }
+    } catch {
+      this.notify.toast({
+        message: msg("Something went wrong, couldn't pause or unpause crawl."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+        id: "crawl-pause-error",
       });
     }
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -563,33 +563,37 @@ export class WorkflowDetail extends BtrixElement {
     const workflow = this.workflow;
 
     const archivingDisabled = isArchivingDisabled(this.org, true);
+    const paused = workflow.lastCrawlState === "paused";
+    const hidePause =
+      !this.lastCrawlId ||
+      this.isCancelingOrStoppingCrawl ||
+      this.workflow.lastCrawlStopping;
+    const disablePause =
+      this.workflow.lastCrawlPausing ===
+      (this.workflow.lastCrawlState === "running");
 
     return html`
       ${when(
         this.workflow.isCrawlRunning,
         () => html`
           <sl-button-group>
-            <sl-button
-              size="small"
-              @click=${this.pauseUnpause}
-              ?disabled=${!this.lastCrawlId ||
-              this.isCancelingOrStoppingCrawl ||
-              this.workflow?.lastCrawlStopping ||
-              this.workflow?.lastCrawlPausing ===
-                (this.workflow?.lastCrawlState === "running")}
-            >
-              <sl-icon
-                name=${workflow.lastCrawlState !== "paused"
-                  ? "pause-btn"
-                  : "play-btn"}
-                slot="prefix"
-              ></sl-icon>
-              <span
-                >${workflow.lastCrawlState !== "paused"
-                  ? msg("Pause")
-                  : msg("Resume")}</span
-              >
-            </sl-button>
+            ${when(
+              !hidePause,
+              () => html`
+                <sl-button
+                  size="small"
+                  @click=${this.pauseUnpause}
+                  ?disabled=${disablePause}
+                  variant=${ifDefined(paused ? "primary" : undefined)}
+                >
+                  <sl-icon
+                    name=${paused ? "play-circle" : "pause-circle"}
+                    slot="prefix"
+                  ></sl-icon>
+                  <span>${paused ? msg("Resume") : msg("Pause")}</span>
+                </sl-button>
+              `,
+            )}
             <sl-button
               size="small"
               @click=${() => (this.openDialogName = "stop")}
@@ -1694,12 +1698,21 @@ export class WorkflowDetail extends BtrixElement {
       } else {
         throw data;
       }
+
+      this.notify.toast({
+        message: pause ? msg("Pausing crawl.") : msg("Resuming paused crawl."),
+        variant: "success",
+        icon: "check2-circle",
+        id: "crawl-pause-unpause-status",
+      });
     } catch {
       this.notify.toast({
-        message: msg("Something went wrong, couldn't pause or unpause crawl."),
+        message: pause
+          ? msg("Something went wrong, couldn't pause crawl.")
+          : msg("Something went wrong, couldn't resume paused crawl."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "crawl-pause-error",
+        id: "crawl-pause-unpause-status",
       });
     }
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -570,10 +570,10 @@ export class WorkflowDetail extends BtrixElement {
       this.isCancelingOrStoppingCrawl ||
       this.workflow.lastCrawlStopping;
     // disable pause/resume button if desired state is already in the process of being set.
-    // if crawl is running, and already pausing, don't allow clicking Pausing
-    // if crawl not running, and already unpausing (lastCrawlPausing is false), don't allow clicking Resume
+    // if crawl is running, and pause requested (shouldPause is true), don't allow clicking Pausing
+    // if crawl not running, and resume requested (shouldPause is false), don't allow clicking Resume
     const disablePauseResume =
-      this.workflow.lastCrawlPausing ===
+      this.workflow.lastCrawlShouldPause ===
       (this.workflow.lastCrawlState === "running");
 
     return html`
@@ -739,7 +739,7 @@ export class WorkflowDetail extends BtrixElement {
             <btrix-crawl-status
               state=${workflow.lastCrawlState || msg("No Crawls Yet")}
               ?stopping=${workflow.lastCrawlStopping}
-              ?pausing=${workflow.lastCrawlPausing}
+              ?shouldPause=${workflow.lastCrawlShouldPause}
             ></btrix-crawl-status>
           `,
         )}

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -4,6 +4,7 @@ export const RUNNING_STATES = [
   "pending-wait",
   "generate-wacz",
   "uploading-wacz",
+  "paused",
 ] as const;
 
 // Match backend TYPE_WAITING_STATES in models.py

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -4,7 +4,6 @@ export const RUNNING_STATES = [
   "pending-wait",
   "generate-wacz",
   "uploading-wacz",
-  "paused",
 ] as const;
 
 // Match backend TYPE_WAITING_STATES in models.py
@@ -12,12 +11,14 @@ export const WAITING_STATES = [
   "starting",
   "waiting_capacity",
   "waiting_org_limit",
+  "paused",
 ] as const;
 
 // Match backend TYPE_SUCCESSFUL_STATES in models.py
 export const SUCCESSFUL_STATES = [
   "complete",
   "stopped_by_user",
+  "stopped_pause_expired",
   "stopped_storage_quota_reached",
   "stopped_time_quota_reached",
   "stopped_org_readonly",

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -92,6 +92,7 @@ export type Workflow = CrawlConfig & {
   lastCrawlSize: number | null;
   lastStartedByName: string | null;
   lastCrawlStopping: boolean | null;
+  lastCrawlPausing: boolean | null;
   lastRun: string;
   totalSize: string | null;
   inactive: boolean;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -92,7 +92,7 @@ export type Workflow = CrawlConfig & {
   lastCrawlSize: number | null;
   lastStartedByName: string | null;
   lastCrawlStopping: boolean | null;
-  lastCrawlPausing: boolean | null;
+  lastCrawlShouldPause: boolean | null;
   lastRun: string;
   totalSize: string | null;
   inactive: boolean;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -189,6 +189,7 @@ export type Crawl = ArchivedItemBase &
     schedule: string;
     manual: boolean;
     scale: number;
+    shouldPause: boolean | null;
     resources?: {
       name: string;
       path: string;


### PR DESCRIPTION
Work on #2566 
Fixes #2576 

- add 'pause' crawl state (fixes #2567)
- turns off crawler pods, and then redis pod when paused
- crawler uploads WACZ before shutting down (dependent on webrecorder/browsertrix-crawler#824)
- add 'paused_at' on crawl spec to indicate when crawl is paused
- support max pause time limit, after which crawl becomes automatically stopped.
- add 'stopped_pause_expired' when pause automatically expires and crawl is stopped
- /crawl/<id>/{un}pause apis to toggle 'paused' on crawl spec
- ui: add pause/resume button, paused state (partially addresses #2568)
- ui: add pausing/unpausing derivative states when crawl is running and pausing, or paused and not pausing (partially addresses #2569)

Todo:
- How to handle crawler versions that don't auto-upload WACZ / don't respond to pause message
