### PR TITLE
Pause / resume frontend tweaks

### DIFF
--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -133,7 +133,6 @@ export class CrawlStatus extends TailwindElement {
         break;
 
       case "unpausing":
-        color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
           name="play-circle"
           class="animatePulse"
@@ -144,7 +143,6 @@ export class CrawlStatus extends TailwindElement {
         break;
 
       case "paused":
-        color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
           name="pause-circle"
           slot="prefix"

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -124,7 +124,7 @@ export class CrawlStatus extends TailwindElement {
       case "pausing":
         color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
-          name="pause-btn"
+          name="pause-circle"
           class="animatePulse"
           slot="prefix"
           style="color: ${color}"
@@ -135,7 +135,7 @@ export class CrawlStatus extends TailwindElement {
       case "unpausing":
         color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
-          name="play-btn"
+          name="play-circle"
           class="animatePulse"
           slot="prefix"
           style="color: ${color}"
@@ -146,7 +146,7 @@ export class CrawlStatus extends TailwindElement {
       case "paused":
         color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
-          name="pause-btn"
+          name="pause-circle"
           slot="prefix"
           style="color: ${color}"
         ></sl-icon>`;

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -281,11 +281,15 @@ export class WorkflowListItem extends BtrixElement {
               if (diff < 1000) {
                 return "";
               }
-              return msg(
-                str`Running for ${this.localize.humanizeDuration(diff, {
-                  compact: true,
-                })}`,
-              );
+              const duration = this.localize.humanizeDuration(diff, {
+                compact: true,
+              });
+
+              if (workflow.lastCrawlState === "paused") {
+                return msg(str`Active for ${duration}`);
+              }
+
+              return msg(str`Running for ${duration}`);
             }
             return notSpecified;
           })}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -616,33 +616,37 @@ export class WorkflowDetail extends BtrixElement {
     const workflow = this.workflow;
 
     const archivingDisabled = isArchivingDisabled(this.org, true);
+    const paused = workflow.lastCrawlState === "paused";
+    const hidePause =
+      !this.lastCrawlId ||
+      this.isCancelingOrStoppingCrawl ||
+      this.workflow.lastCrawlStopping;
+    const disablePause =
+      this.workflow.lastCrawlPausing ===
+      (this.workflow.lastCrawlState === "running");
 
     return html`
       ${when(
         this.workflow.isCrawlRunning,
         () => html`
           <sl-button-group>
-            <sl-button
-              size="small"
-              @click=${this.pauseUnpause}
-              ?disabled=${!this.lastCrawlId ||
-              this.isCancelingOrStoppingCrawl ||
-              this.workflow?.lastCrawlStopping ||
-              this.workflow?.lastCrawlPausing ===
-                (this.workflow?.lastCrawlState === "running")}
-            >
-              <sl-icon
-                name=${workflow.lastCrawlState !== "paused"
-                  ? "pause-circle"
-                  : "play-circle"}
-                slot="prefix"
-              ></sl-icon>
-              <span
-                >${workflow.lastCrawlState !== "paused"
-                  ? msg("Pause")
-                  : msg("Resume")}</span
-              >
-            </sl-button>
+            ${when(
+              !hidePause,
+              () => html`
+                <sl-button
+                  size="small"
+                  @click=${this.pauseUnpause}
+                  ?disabled=${disablePause}
+                  variant=${ifDefined(paused ? "primary" : undefined)}
+                >
+                  <sl-icon
+                    name=${paused ? "play-circle" : "pause-circle"}
+                    slot="prefix"
+                  ></sl-icon>
+                  <span>${paused ? msg("Resume") : msg("Pause")}</span>
+                </sl-button>
+              `,
+            )}
             <sl-button
               size="small"
               @click=${() => (this.openDialogName = "stop")}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1569,7 +1569,9 @@ export class WorkflowDetail extends BtrixElement {
       }
     } catch {
       this.notify.toast({
-        message: msg("Something went wrong, couldn't pause or unpause crawl."),
+        message: pause
+          ? msg("Something went wrong, couldn't pause crawl.")
+          : msg("Something went wrong, couldn't resume paused crawl."),
         variant: "danger",
         icon: "exclamation-octagon",
         id: "crawl-pause-error",

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -633,8 +633,8 @@ export class WorkflowDetail extends BtrixElement {
             >
               <sl-icon
                 name=${workflow.lastCrawlState !== "paused"
-                  ? "pause-btn"
-                  : "play-btn"}
+                  ? "pause-circle"
+                  : "play-circle"}
                 slot="prefix"
               ></sl-icon>
               <span

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1571,6 +1571,13 @@ export class WorkflowDetail extends BtrixElement {
       } else {
         throw data;
       }
+
+      this.notify.toast({
+        message: pause ? msg("Pausing crawl.") : msg("Resuming paused crawl."),
+        variant: "success",
+        icon: "check2-circle",
+        id: "crawl-pause-unpause-status",
+      });
     } catch {
       this.notify.toast({
         message: pause
@@ -1578,7 +1585,7 @@ export class WorkflowDetail extends BtrixElement {
           : msg("Something went wrong, couldn't resume paused crawl."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "crawl-pause-error",
+        id: "crawl-pause-unpause-status",
       });
     }
   }


### PR DESCRIPTION
Frontend tweaks to https://github.com/webrecorder/browsertrix/pull/2572:

- Hide "Pause" button if it's not relevant, instead of disabling without a displayed reason
- Make "Resume" button primary
  <img width="399" alt="Screenshot 2025-04-29 at 4 21 05 PM" src="https://github.com/user-attachments/assets/c1de7f0c-fb0e-4d6f-9342-0f46c9d14149" />
- Use circular icons to match other status icons
  <img width="106" alt="Screenshot 2025-04-29 at 4 12 46 PM" src="https://github.com/user-attachments/assets/c6987ca2-6aa1-470a-a669-8984b01c43ef" />
  <img width="268" alt="Screenshot 2025-04-29 at 4 12 53 PM" src="https://github.com/user-attachments/assets/27f7eee6-75de-41c8-98a4-9ca6d6032d3b" />
- Show toast message on successful pause/unpause