### PR TITLE
Add API endpoint to check if subscription is activated

### DIFF
--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -552,7 +552,7 @@ class OrgOps:
         """return true if subscription for this org was 'activated', eg. at least
         one user has signed up and changed the slug
         """
-        org_data = await self.orgs.find_one({"subscription.subId", sub_id})
+        org_data = await self.orgs.find_one({"subscription.subId": sub_id})
         if not org_data:
             return False
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -548,6 +548,17 @@ class OrgOps:
         )
         return Organization.from_dict(org_data) if org_data else None
 
+    async def is_subscription_activated(self, sub_id: str) -> bool:
+        """return true if subscription for this org was 'activated', eg. at least
+        one user has signed up and changed the slug
+        """
+        org_data = await self.orgs.find_one({"subscription.subId", sub_id})
+        if not org_data:
+            return False
+
+        org = Organization.from_dict(org_data)
+        return len(org.users) > 0 and org.slug != str(org.id)
+
     async def update_custom_storages(self, org: Organization) -> bool:
         """Update storage on an existing organization"""
 

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -34,6 +34,7 @@ from .models import (
     UserRole,
     AddedResponseId,
     UpdatedResponse,
+    SuccessResponse,
     PaginatedSubscriptionEventResponse,
     REASON_CANCELED,
 )
@@ -391,6 +392,18 @@ def init_subs_api(
         return await ops.cancel_subscription(cancel)
 
     assert org_ops.router
+
+    @app.get(
+        "/subscriptions/isActivated/{sub_id}",
+        tags=["subscriptions"],
+        dependencies=[Depends(user_or_shared_secret_dep)],
+        response_model=SuccessResponse,
+    )
+    async def is_subscription_activated(
+        sub_id: str,
+    ):
+        result = await org_ops.is_subscription_activated(sub_id)
+        return {"success": result}
 
     @app.get(
         "/subscriptions/events",

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -394,7 +394,7 @@ def init_subs_api(
     assert org_ops.router
 
     @app.get(
-        "/subscriptions/isActivated/{sub_id}",
+        "/subscriptions/is-activated/{sub_id}",
         tags=["subscriptions"],
         dependencies=[Depends(user_or_shared_secret_dep)],
         response_model=SuccessResponse,

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -68,6 +68,15 @@ def test_create_sub_org_and_invite_new_user(admin_auth_headers):
     new_subs_oid = org_id
 
 
+def test_validate_new_org_not_activated(admin_auth_headers):
+    r = requests.get(
+        f"{API_PREFIX}/subscriptions/is-activated/123",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"] is False
+
+
 def test_validate_new_org_with_quotas_and_name_is_uid(admin_auth_headers):
     r = requests.get(f"{API_PREFIX}/orgs/{new_subs_oid}", headers=admin_auth_headers)
     assert r.status_code == 200
@@ -124,6 +133,15 @@ def test_validate_new_org_with_quotas_and_update_name(admin_auth_headers):
         "giftedExecMinutes": 0,
     }
     assert "subscription" in data
+
+
+def test_validate_new_org_is_activated(admin_auth_headers):
+    r = requests.get(
+        f"{API_PREFIX}/subscriptions/is-activated/123",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"] is True
 
 
 def test_create_sub_org_and_invite_existing_user_dupe_sub(admin_auth_headers):


### PR DESCRIPTION
Browsertrix-side support to ensure subscription can be auto-canceled if not activated.