### PR TITLE
Ensure primary button in button group has its border appear

### DIFF
--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -324,6 +324,22 @@
   .label-same-line::part(form-control-help-text) {
     grid-column-start: 2;
   }
+
+  /* Button group tweaks */
+  [data-sl-button-group__button--first][variant="primary"]:has(
+      + [data-sl-button-group__button][variant="default"]
+    ) {
+    /* Move primary button above secondary button in button group */
+    z-index: 1;
+  }
+  [data-sl-button-group__button--first][variant="primary"]
+    + [data-sl-button-group__button][variant="default"]:not(:hover)::part(
+      base
+    ) {
+    /* Ensure left border color matches primary button's right border color
+       so that no flash of default variant border color shows on hover */
+    border-left-color: var(--sl-color-primary-600);
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Changes
Adds a couple CSS rules that make a primary button in a button group show up above a secondary button next to it, which allows the primary button's border to show on its right side instead of the secondary button's border.

Also color-matches the left border of the button to the primary button's right to the primary button's border color, so that when transitioning on hover the transition happens from the primary border color to the default hover border color, rather than from the default border color.[^1]

## Screenshots

| Before | After |
|--------|--------|
| <img width="750" alt="Screenshot 2025-05-01 at 4 12 23 PM" src="https://github.com/user-attachments/assets/9f32814a-4f68-43a3-bdd9-4484cfc27db4" /> | <img width="753" alt="Screenshot 2025-05-01 at 4 12 07 PM" src="https://github.com/user-attachments/assets/4cbfcbae-d64d-4e90-9dfd-ae513481de6d" /> | 

[^1]: This isn't quite perfect: because this just sets the border color, there's a 45 degree angle on the top and bottom of the left border that's visible for however long the animation takes, but this is ~half a pixel and only visible for a moment.

