### PR TITLE
Sort running crawls first by default

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -608,36 +608,15 @@ class CrawlConfigOps:
             if sort_by == "name":
                 sort_query["firstSeed"] = sort_direction
 
-            # Special case for last-* fields in case crawl is running or hasn't been run yet
+            # Special case for last-* fields in case crawl is running
             elif sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
-                # Add helper to sort null values first (i.e. when a workflow hasn't been run yet)
-                aggregate.extend(
-                    [
-                        {
-                            "$addFields": {
-                                "lastRunHelper": {
-                                    "$cond": {
-                                        "if": {"$eq": ["$lastRun", None]},
-                                        "then": 1,
-                                        "else": 0,
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                )
                 sort_query = {
                     "isCrawlRunning": sort_direction,
-                    "lastRunHelper": sort_direction,
                     sort_by: sort_direction,
                     "modified": sort_direction,
                 }
 
             aggregate.extend([{"$sort": sort_query}])
-
-            if sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
-                # Remove helpers added earlier
-                aggregate.extend([{"$unset": "lastRunHelper"}])
 
         aggregate.extend(
             [

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -611,18 +611,26 @@ class CrawlConfigOps:
             # Special case for last-* fields in case crawl is running or hasn't been run yet
             elif sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
                 # Add helper to sort null values first (i.e. when a workflow hasn't been run yet)
-                aggregate.extend([{
-                    "$addFields": {
-                        "lastRunHelper": {
-                            "$cond": {"if": {"$eq": ["$lastRun", None]}, "then": 1, "else": 0}
+                aggregate.extend(
+                    [
+                        {
+                            "$addFields": {
+                                "lastRunHelper": {
+                                    "$cond": {
+                                        "if": {"$eq": ["$lastRun", None]},
+                                        "then": 1,
+                                        "else": 0,
+                                    }
+                                }
+                            }
                         }
-                    }
-                }])
+                    ]
+                )
                 sort_query = {
                     "isCrawlRunning": sort_direction,
                     "lastRunHelper": sort_direction,
                     sort_by: sort_direction,
-                    "modified": sort_direction
+                    "modified": sort_direction,
                 }
 
             aggregate.extend([{"$sort": sort_query}])
@@ -630,7 +638,6 @@ class CrawlConfigOps:
             if sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
                 # Remove helpers added earlier
                 aggregate.extend([{"$unset": "lastRunHelper"}])
-
 
         aggregate.extend(
             [

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -608,11 +608,29 @@ class CrawlConfigOps:
             if sort_by == "name":
                 sort_query["firstSeed"] = sort_direction
 
-            # modified for last* fields in case crawl hasn't been run yet
+            # Special case for last-* fields in case crawl is running or hasn't been run yet
             elif sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
-                sort_query["modified"] = sort_direction
+                # Add helper to sort null values first (i.e. when a workflow hasn't been run yet)
+                aggregate.extend([{
+                    "$addFields": {
+                        "lastRunHelper": {
+                            "$cond": {"if": {"$eq": ["$lastRun", None]}, "then": 1, "else": 0}
+                        }
+                    }
+                }])
+                sort_query = {
+                    "isCrawlRunning": sort_direction,
+                    "lastRunHelper": sort_direction,
+                    sort_by: sort_direction,
+                    "modified": sort_direction
+                }
 
             aggregate.extend([{"$sort": sort_query}])
+
+            if sort_by in ("lastRun", "lastCrawlTime", "lastCrawlStartTime"):
+                # Remove helpers added earlier
+                aggregate.extend([{"$unset": "lastRunHelper"}])
+
 
         aggregate.extend(
             [


### PR DESCRIPTION
Closes #2528, #2034

Doesn't quite do everything that #2528 does, but this is a good first step towards better workflow sorting.

## Changes

Changes workflow sort order when sorting by Latest Crawl (`lastRun` — the default sorting method in Browsertrix's frontend), `lastCrawlTime`, and `lastCrawlStartTime` to show running crawls first, then the rest of results.

## Testing

1. With this branch deployed as your backend, look at the workflow list with the default sort order. Verify that running crawls are bubbled to the top, then workflows that haven't been run yet, then the rest of the workflows in the expected order.

## Screenshots

(These are out of date, the workflows with no crawls here would be sorted at the bottom here)

| No running crawls | Running crawl |
|--------|--------|
| <img width="1270" alt="Screenshot 2025-05-05 at 4 23 47 PM" src="https://github.com/user-attachments/assets/8728a360-1877-45d7-bf2c-d2f952dbb91c" /> | <img width="1289" alt="Screenshot 2025-05-05 at 4 24 10 PM" src="https://github.com/user-attachments/assets/35d06664-2f7f-4c17-96a8-2a654355ccc1" /> |



