### PR TITLE
devex: Refactor `syntax-input` and `link-selector-table` into form controls

### DIFF
--- a/frontend/src/components/ui/code.ts
+++ b/frontend/src/components/ui/code.ts
@@ -8,7 +8,7 @@ import { html as staticHtml, unsafeStatic } from "lit/static-html.js";
 import { TailwindElement } from "@/classes/TailwindElement";
 import { tw } from "@/utils/tailwind";
 
-enum Language {
+export enum Language {
   Javascript = "javascript",
   XML = "xml",
   CSS = "css",

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -503,7 +503,10 @@ export class ConfigDetails extends BtrixElement {
       selectors.length
         ? html`
             <div class="mb-2">
-              <btrix-link-selector-table .selectors=${selectors}>
+              <btrix-link-selector-table
+                .selectors=${selectors}
+                aria-readonly="true"
+              >
               </btrix-link-selector-table>
             </div>
           `

--- a/frontend/src/components/ui/data-grid/controllers/rows.ts
+++ b/frontend/src/components/ui/data-grid/controllers/rows.ts
@@ -69,6 +69,11 @@ export class DataGridRowsController implements ReactiveController {
     }
   }
 
+  public updateItem<T extends GridItem = GridItem>(id: GridRowId, item: T) {
+    this.rows.set(id, item);
+    this.#host.requestUpdate();
+  }
+
   public addRows<T extends GridItem = GridItem>(
     defaultItem: T | EmptyObject = {},
     count = 1,

--- a/frontend/src/components/ui/data-grid/controllers/rows.ts
+++ b/frontend/src/components/ui/data-grid/controllers/rows.ts
@@ -65,8 +65,6 @@ export class DataGridRowsController implements ReactiveController {
     if (!this.#prevItems || items !== this.#prevItems) {
       this.setRowsFromItems(items);
 
-      // this.#host.requestUpdate();
-
       this.#prevItems = items;
     }
   }

--- a/frontend/src/components/ui/data-grid/data-grid-cell.ts
+++ b/frontend/src/components/ui/data-grid/data-grid-cell.ts
@@ -44,6 +44,9 @@ export class DataGridCell extends TableCell {
   @property({ type: Object })
   item?: GridItem;
 
+  @property({ type: String })
+  value?: GridItem[keyof GridItem];
+
   @property({ type: Boolean })
   editable = false;
 
@@ -104,7 +107,7 @@ export class DataGridCell extends TableCell {
     if (!this.column || !this.item) return html`<slot></slot>`;
 
     if (this.editable) {
-      return this.renderEditCell({ item: this.item });
+      return this.renderEditCell({ item: this.item, value: this.value });
     }
 
     return this.renderCell({ item: this.item });
@@ -114,12 +117,18 @@ export class DataGridCell extends TableCell {
     return html`${(this.column && item[this.column.field]) ?? ""}`;
   };
 
-  renderEditCell = ({ item }: { item: GridItem }) => {
+  renderEditCell = ({
+    item,
+    value: cellValue,
+  }: {
+    item: GridItem;
+    value?: GridItem[keyof GridItem];
+  }) => {
     const col = this.column;
 
     if (!col) return html``;
 
-    const value = item[col.field] ?? "";
+    const value = cellValue ?? item[col.field] ?? "";
 
     switch (col.inputType) {
       case GridColumnType.Select: {

--- a/frontend/src/components/ui/data-grid/data-grid-cell.ts
+++ b/frontend/src/components/ui/data-grid/data-grid-cell.ts
@@ -6,7 +6,12 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import { TableCell } from "../table/table-cell";
 
-import type { GridColumn, GridColumnSelectType, GridItem } from "./types";
+import type {
+  GridColumn,
+  GridColumnSelectType,
+  GridItem,
+  GridItemValue,
+} from "./types";
 import { GridColumnType } from "./types";
 
 import { DataGridFocusController } from "@/components/ui/data-grid/controllers/focus";
@@ -45,7 +50,7 @@ export class DataGridCell extends TableCell {
   item?: GridItem;
 
   @property({ type: String })
-  value?: GridItem[keyof GridItem];
+  value?: GridItemValue;
 
   @property({ type: Boolean })
   editable = false;
@@ -122,7 +127,7 @@ export class DataGridCell extends TableCell {
     value: cellValue,
   }: {
     item: GridItem;
-    value?: GridItem[keyof GridItem];
+    value?: GridItemValue;
   }) => {
     const col = this.column;
 

--- a/frontend/src/components/ui/data-grid/data-grid.ts
+++ b/frontend/src/components/ui/data-grid/data-grid.ts
@@ -127,12 +127,6 @@ export class DataGrid extends TailwindElement {
   @property({ attribute: false })
   rowsController = new DataGridRowsController(this);
 
-  /**
-   * Make grid focusable on validation.
-   */
-  @property({ type: Number, reflect: true })
-  tabindex = 0;
-
   render() {
     if (!this.columns?.length) return;
 

--- a/frontend/src/components/ui/data-grid/renderRows.ts
+++ b/frontend/src/components/ui/data-grid/renderRows.ts
@@ -5,11 +5,14 @@ import type { GridItem, GridRowId, GridRows } from "./types";
 
 export function renderRows<T = GridItem>(
   rows: GridRows<GridItem>,
-  renderRow: ({ id, item }: { id: GridRowId; item: T }) => TemplateResult,
+  renderRow: (
+    { id, item }: { id: GridRowId; item: T },
+    index: number,
+  ) => TemplateResult,
 ) {
   return repeat(
     rows,
     ([id]) => id,
-    ([id, item]) => renderRow({ id, item: item as T }),
+    ([id, item], i) => renderRow({ id, item: item as T }, i),
   );
 }

--- a/frontend/src/components/ui/data-grid/types.ts
+++ b/frontend/src/components/ui/data-grid/types.ts
@@ -6,6 +6,9 @@ export type GridItem<T extends PropertyKey = string> = Record<
   string | number | null | undefined
 >;
 
+export type GridItemValue<T extends PropertyKey = string> =
+  GridItem<T>[keyof GridItem<T>];
+
 export enum GridColumnType {
   Text = "text",
   Number = "number",

--- a/frontend/src/components/ui/data-grid/types.ts
+++ b/frontend/src/components/ui/data-grid/types.ts
@@ -30,8 +30,11 @@ export type GridColumn<T = string> = {
   required?: boolean;
   inputPlaceholder?: string;
   width?: string;
-  renderEditCell?: ({ item }: { item: GridItem }) => TemplateResult<1>;
-  renderCell?: ({ item }: { item: GridItem }) => TemplateResult<1>;
+  renderEditCell?: (props: {
+    item: GridItem;
+    value?: GridItem[keyof GridItem];
+  }) => TemplateResult<1>;
+  renderCell?: (props: { item: GridItem }) => TemplateResult<1>;
 } & (
   | {
       inputType?: GridColumnType;

--- a/frontend/src/components/ui/data-table.ts
+++ b/frontend/src/components/ui/data-table.ts
@@ -6,6 +6,8 @@ import { TailwindElement } from "@/classes/TailwindElement";
 type CellContent = string | TemplateResult<1>;
 
 /**
+ * @deprecated Use `<btrix-data-grid>` instead.
+ *
  * Styled tables for handling lists of tabular data.
  * Data tables are less flexible than `<btrix-table>` but require less configuration.
  */

--- a/frontend/src/components/ui/syntax-input.ts
+++ b/frontend/src/components/ui/syntax-input.ts
@@ -1,4 +1,3 @@
-import { localized } from "@lit/localize";
 import type {
   SlInput,
   SlInputEvent,
@@ -6,13 +5,14 @@ import type {
   SlTooltip,
 } from "@shoelace-style/shoelace";
 import clsx from "clsx";
-import { html } from "lit";
+import { html, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import type { Code } from "@/components/ui/code";
 import { FormControl } from "@/mixins/FormControl";
+import { validationMessageFor } from "@/strings/validation";
 import { tw } from "@/utils/tailwind";
 
 /**
@@ -22,7 +22,6 @@ import { tw } from "@/utils/tailwind";
  * @fires btrix-change
  */
 @customElement("btrix-syntax-input")
-@localized()
 export class SyntaxInput extends FormControl(TailwindElement) {
   @property({ type: String })
   value = "";
@@ -100,6 +99,17 @@ export class SyntaxInput extends FormControl(TailwindElement) {
     document.removeEventListener("selectionchange", this.onSelectionChange);
   }
 
+  protected updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has("value") || changedProperties.has("required")) {
+      if (this.required && !this.value) {
+        this.setValidity(
+          { valueMissing: true },
+          validationMessageFor.valueMissing,
+        );
+      }
+    }
+  }
+
   render() {
     return html`<sl-tooltip
       content=${this.error}
@@ -147,6 +157,7 @@ export class SyntaxInput extends FormControl(TailwindElement) {
                 new CustomEvent("btrix-input", {
                   detail: { value },
                   bubbles: true,
+                  composed: true,
                 }),
               );
 
@@ -185,6 +196,7 @@ export class SyntaxInput extends FormControl(TailwindElement) {
                 new CustomEvent("btrix-change", {
                   detail: { value: this.code.value },
                   bubbles: true,
+                  composed: true,
                 }),
               );
             }

--- a/frontend/src/components/ui/table/table.ts
+++ b/frontend/src/components/ui/table/table.ts
@@ -19,11 +19,9 @@ tableCSS.split("}").forEach((rule: string) => {
 });
 
 /**
- * @deprecated Use `<btrix-data-grid>` instead.
- *
  * Low-level component for displaying content into columns and rows.
  * To style tables, use TailwindCSS utility classes.
- * To render styled, tabular data, use `<btrix-data-table>`.
+ * To render styled, tabular data, use `<btrix-data-grid>`.
  *
  * Table columns are automatically sized according to their content.
  * To specify column sizes, use `--btrix-table-grid-template-columns`.

--- a/frontend/src/controllers/formControl.ts
+++ b/frontend/src/controllers/formControl.ts
@@ -1,0 +1,59 @@
+import type {
+  LitElement,
+  ReactiveController,
+  ReactiveControllerHost,
+} from "lit";
+
+/**
+ * Adds `user-valid`, and `user-invalid` data attributes to custom
+ * form-associated elements (e.g. ones created with `FormControl`)
+ * to match Shoelace forms.
+ */
+export class FormControlController implements ReactiveController {
+  readonly #host: ReactiveControllerHost & LitElement;
+
+  #oneUserInput = false;
+
+  constructor(host: ReactiveControllerHost & LitElement) {
+    this.#host = host;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    const inputEvents = ["sl-input", "btrix-input"];
+    const changeEvents = ["sl-change", "btrix-change"];
+
+    inputEvents.forEach((name) => {
+      this.#host.addEventListener(
+        name,
+        () => {
+          this.#oneUserInput = true;
+        },
+        { once: true },
+      );
+    });
+
+    // IDEA Mutation observer with attributeFilter to `value` could work
+    // if custom form controls consistently set a value, in the future
+    changeEvents.forEach((name) => {
+      this.#host.addEventListener(name, async (e: Event) => {
+        const el = e.target as LitElement;
+
+        if (this.#oneUserInput && "validity" in el && el.validity) {
+          await el.updateComplete;
+
+          // Add user-valid or user-invalid to match `ShoelaceFormControl`
+          if ((el.validity as ValidityState).valid) {
+            el.setAttribute("user-valid", "");
+            el.removeAttribute("user-invalid");
+          } else {
+            el.setAttribute("user-invalid", "");
+            el.removeAttribute("user-valid");
+          }
+        }
+      });
+    });
+  }
+
+  hostDisconnected() {}
+}

--- a/frontend/src/events/btrix-input.ts
+++ b/frontend/src/events/btrix-input.ts
@@ -1,0 +1,7 @@
+export type BtrixInputEvent<T = unknown> = CustomEvent<{ value: T }>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    "btrix-input": BtrixInputEvent;
+  }
+}

--- a/frontend/src/events/index.ts
+++ b/frontend/src/events/index.ts
@@ -1,1 +1,2 @@
 import "./btrix-change";
+import "./btrix-input";

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2207,15 +2207,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
     if (!this.formElem) return;
 
-    // TODO Move away from manual validation check
-    // See https://github.com/webrecorder/browsertrix/issues/2536
-    if (this.formState.autoclickBehavior && this.clickSelector) {
-      if (!this.clickSelector.checkValidity()) {
-        this.clickSelector.reportValidity();
-        return;
-      }
-    }
-
     // Wait for custom behaviors validation to finish
     // TODO Move away from manual validation check
     // See https://github.com/webrecorder/browsertrix/issues/2536

--- a/frontend/src/mixins/FormControl.ts
+++ b/frontend/src/mixins/FormControl.ts
@@ -1,6 +1,9 @@
 import type { LitElement } from "lit";
 import type { Constructor } from "type-fest";
 
+/**
+ * Associate a custom element with a form.
+ */
 export const FormControl = <T extends Constructor<LitElement>>(superClass: T) =>
   class extends superClass {
     static formAssociated = true;

--- a/frontend/src/mixins/FormControl.ts
+++ b/frontend/src/mixins/FormControl.ts
@@ -1,0 +1,53 @@
+import type { LitElement } from "lit";
+import type { Constructor } from "type-fest";
+
+export const FormControl = <T extends Constructor<LitElement>>(superClass: T) =>
+  class extends superClass {
+    static formAssociated = true;
+    readonly #internals: ElementInternals;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...args: any[]) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      super(...args);
+
+      this.tabIndex = Math.max(this.tabIndex, 0);
+      this.#internals = this.attachInternals();
+    }
+
+    public formAssociatedCallback() {}
+    public formResetCallback() {}
+    public formDisabledCallback(_disabled: boolean) {}
+    public formStateRestoreCallback(
+      _state: string | FormData,
+      _reason: string,
+    ) {}
+
+    public checkValidity(): boolean {
+      return this.#internals.checkValidity();
+    }
+
+    public reportValidity(): boolean {
+      return this.#internals.reportValidity();
+    }
+
+    public get validity(): ValidityState {
+      return this.#internals.validity;
+    }
+
+    public get validationMessage(): string {
+      return this.#internals.validationMessage;
+    }
+
+    protected setFormValue(
+      ...args: Parameters<ElementInternals["setFormValue"]>
+    ): void {
+      this.#internals.setFormValue(...args);
+    }
+
+    protected setValidity(
+      ...args: Parameters<ElementInternals["setValidity"]>
+    ): void {
+      this.#internals.setValidity(...args);
+    }
+  };

--- a/frontend/src/stories/components/SyntaxInput.stories.ts
+++ b/frontend/src/stories/components/SyntaxInput.stories.ts
@@ -1,0 +1,102 @@
+import { serialize } from "@shoelace-style/shoelace";
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+
+import {
+  defaultArgs,
+  Language,
+  renderComponent,
+  type RenderProps,
+} from "./SyntaxInput";
+
+import type { SyntaxInput } from "@/components/ui/syntax-input";
+
+const meta = {
+  title: "Components/Syntax Input",
+  component: "btrix-syntax-input",
+  tags: ["autodocs"],
+  render: renderComponent,
+  argTypes: {},
+  args: defaultArgs,
+} satisfies Meta<RenderProps>;
+
+export default meta;
+type Story = StoryObj<RenderProps>;
+
+export const Basic: Story = {
+  args: {
+    value: "<div>Edit me</div>",
+    language: Language.XML,
+    placeholder: "Enter HTML",
+  },
+};
+
+/**
+ * Syntax input supports CSS and XML.
+ */
+export const CSS: Story = {
+  args: {
+    label: "CSS Selector",
+    value: "div > a",
+    language: Language.CSS,
+    placeholder: "Enter a CSS selector",
+  },
+};
+
+/**
+ * Syntax can be used a form control.
+ *
+ * To see how the validation message is displayed, interact with
+ * the input, click "Set custom validity", and then submit.
+ */
+export const FormControl: Story = {
+  decorators: [
+    (story) =>
+      html`<form
+        @submit=${(e: SubmitEvent) => {
+          e.preventDefault();
+
+          console.log("form values:", serialize(e.target as HTMLFormElement));
+        }}
+      >
+        ${story()}
+        <div class="mt-2 rounded bg-slate-100 p-2">
+          <sl-button
+            size="small"
+            @click=${() => {
+              const input =
+                document.querySelector<SyntaxInput>("btrix-syntax-input");
+
+              input?.setCustomValidity("This is a custom validity message");
+            }}
+          >
+            Set custom validity
+          </sl-button>
+          <sl-button
+            size="small"
+            @click=${() => {
+              const input =
+                document.querySelector<SyntaxInput>("btrix-syntax-input");
+
+              input?.setCustomValidity("");
+            }}
+          >
+            Clear custom validity
+          </sl-button>
+        </div>
+        <sl-button type="reset" class="mt-3">Reset</sl-button>
+        <sl-button type="submit" variant="primary" class="mt-3"
+          >Submit</sl-button
+        >
+      </form>`,
+  ],
+  args: {
+    name: "selector",
+    label: "CSS Selector",
+    value: "div > a",
+    language: Language.CSS,
+    placeholder: "Enter a CSS selector",
+    disableTooltip: true,
+    required: true,
+  },
+};

--- a/frontend/src/stories/components/SyntaxInput.ts
+++ b/frontend/src/stories/components/SyntaxInput.ts
@@ -1,0 +1,31 @@
+import { html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { Language } from "@/components/ui/code";
+import type { SyntaxInput } from "@/components/ui/syntax-input";
+
+import "@/components/ui/syntax-input";
+
+export { Language };
+
+export type RenderProps = Pick<SyntaxInput, keyof SyntaxInput> & {
+  name?: string;
+};
+
+export const defaultArgs = {
+  value: "<div>Edit me</div>",
+  language: Language.XML,
+  placeholder: "Enter HTML",
+} satisfies Partial<RenderProps>;
+
+export const renderComponent = (opts: Partial<RenderProps>) => html`
+  <btrix-syntax-input
+    name=${ifDefined(opts.name)}
+    label=${ifDefined(opts.label)}
+    language=${ifDefined(opts.language)}
+    value=${ifDefined(opts.value)}
+    placeholder=${ifDefined(opts.placeholder)}
+    ?disableTooltip=${opts.disableTooltip}
+    ?required=${opts.required}
+  ></btrix-syntax-input>
+`;

--- a/frontend/src/stories/components/decorators/dataGridForm.ts
+++ b/frontend/src/stories/components/decorators/dataGridForm.ts
@@ -25,7 +25,10 @@ export class StorybookDataGridForm extends TailwindElement {
       e.preventDefault();
 
       const form = e.target as HTMLFormElement;
-      const value = serializeDeep(form, { parseKeys: [formControlName] });
+      const value = serializeDeep(form, {
+        parseKeys: [formControlName],
+        filterEmpty: {},
+      });
 
       console.log("form value:", value);
     };

--- a/frontend/src/strings/validation.ts
+++ b/frontend/src/strings/validation.ts
@@ -1,0 +1,7 @@
+import { msg } from "@lit/localize";
+
+export const validationMessageFor: Partial<
+  Record<keyof ValidityStateFlags, string>
+> = {
+  valueMissing: msg("Please fill out this field."),
+};

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -195,8 +195,8 @@
 
   /* Validation styles */
   /**
-   * FIXME Use [data-user-invalid] selector once following is fixed
-   * https://github.com/webrecorder/browsertrix/issues/2497
+   * FIXME Use [data-user-invalid] selector exclusion table is migrated
+   * https://github.com/webrecorder/browsertrix/issues/2542
    */
   .invalid[data-invalid]:not([disabled])::part(base),
   btrix-url-input[data-user-invalid]:not([disabled])::part(base),

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -5,7 +5,7 @@ import {
   serialize,
 } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import type { LitElement } from "lit";
-import { isEqual } from "lodash/fp";
+import isEqual from "lodash/fp/isEqual";
 import type { EmptyObject } from "type-fest";
 
 import localize from "./localize";

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -5,6 +5,8 @@ import {
   serialize,
 } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import type { LitElement } from "lit";
+import { isEqual } from "lodash/fp";
+import type { EmptyObject } from "type-fest";
 
 import localize from "./localize";
 
@@ -95,7 +97,10 @@ export function formValidator(el: LitElement) {
  */
 export function serializeDeep(
   form: HTMLFormElement,
-  opts?: { parseKeys: string[] },
+  opts?: {
+    parseKeys: string[];
+    filterEmpty?: boolean | Record<string, unknown> | EmptyObject;
+  },
 ) {
   const values = serialize(form);
 
@@ -106,9 +111,19 @@ export function serializeDeep(
       if (typeof val === "string") {
         values[key] = JSON.parse(val);
       } else if (Array.isArray(val)) {
-        values[key] = val.map<unknown>((v) =>
-          typeof v === "string" ? JSON.parse(v) : v,
-        );
+        const arr: unknown[] = [];
+
+        val.forEach((v) => {
+          if (opts.filterEmpty === true && !v) return;
+
+          const value = typeof v === "string" ? JSON.parse(v) : v;
+
+          if (opts.filterEmpty && isEqual(opts.filterEmpty, value)) return;
+
+          arr.push(value);
+        });
+
+        values[key] = arr;
       }
     });
   }


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/pull/2561
Resolves https://github.com/webrecorder/browsertrix/issues/2577
WIP https://github.com/webrecorder/browsertrix/issues/2536

## Changes

Refactors `<btrix-syntax-input>` and `<btrix-link-selector-table>` to be form-associated controls.

## Manual testing

1. Log in as crawler
2. Regression test "Link Selectors" table, verifying that validation and editing values works as expected.