### PR TITLE
fix: Hide incorrect menu item for running workflow crawl

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1,5 +1,6 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlSelect } from "@shoelace-style/shoelace";
+import clsx from "clsx";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
@@ -26,6 +27,7 @@ import {
 } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import { isArchivingDisabled } from "@/utils/orgs";
+import { tw } from "@/utils/tailwind";
 
 const SECTIONS = ["crawls", "watch", "settings", "logs"] as const;
 type Tab = (typeof SECTIONS)[number];
@@ -895,6 +897,9 @@ export class WorkflowDetail extends BtrixElement {
               this.crawls!.items.map(
                 (crawl: Crawl) =>
                   html` <btrix-crawl-list-item
+                    class=${clsx(
+                      isActive(crawl) && tw`cursor-default text-neutral-500`,
+                    )}
                     href=${ifDefined(
                       isActive(crawl)
                         ? undefined

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -911,7 +911,7 @@ export class WorkflowDetail extends BtrixElement {
                         ${msg("Copy Crawl ID")}
                       </sl-menu-item>
                       ${when(
-                        this.isCrawler,
+                        this.isCrawler && !isActive(crawl),
                         () => html`
                           <sl-divider></sl-divider>
                           <sl-menu-item


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2589

## Changes

- Hides the "Delete" menu item for a running crawl in the workflows crawls list.
- Slightly grays out row for running crawl to indicate that it's not clickable.

## Manual testing

1. Log in as crawler
2. Start a crawl
3. Go to workflow -> Crawls
4. Click "..." menu icon in running crawl row. Verify "Delete" is not visible

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow - Crawls | <img width="1089" alt="Screenshot 2025-05-05 at 5 13 56 PM" src="https://github.com/user-attachments/assets/9207bce6-a8d9-40be-aee3-bd190e486e9d" /> |


<!-- ## Follow-ups -->
