### PR TITLE
fix: Correct post load delay label

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -208,7 +208,7 @@ export class ConfigDetails extends BtrixElement {
             ),
           )}
           ${this.renderSetting(
-            labelFor.pageLoadTimeoutSeconds,
+            labelFor.postLoadDelaySeconds,
             renderTimeLimit(seedsConfig?.postLoadDelay, 0),
           )}
           ${this.renderSetting(


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2586

## Manual testing

Confirm using reproduction steps in bug report.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow - Settings | <img width="166" alt="Screenshot 2025-05-06 at 9 24 59 AM" src="https://github.com/user-attachments/assets/3b80f569-3a70-4249-a1a0-5a8e65e3c8cb" /> |


<!-- ## Follow-ups -->
