### PR TITLE
Add "cancellation scheduled" state to superadmin org list

### DIFF
--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -16,6 +16,7 @@ import {
   type TemplateResult,
 } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -24,6 +25,14 @@ import { ClipboardController } from "@/controllers/clipboard";
 import { SubscriptionStatus } from "@/types/billing";
 import type { ProxiesAPIResponse, Proxy } from "@/types/crawler";
 import type { OrgData } from "@/utils/orgs";
+
+const none = html`
+  <sl-icon
+    name="slash"
+    class="text-base text-neutral-400"
+    label=${msg("None")}
+  ></sl-icon>
+`;
 
 /**
  * @fires update-quotas
@@ -150,7 +159,7 @@ export class OrgsList extends BtrixElement {
             </btrix-table-header-cell>
           </btrix-table-head>
           <btrix-table-body class="rounded border">
-            ${orgs?.map(this.renderOrg)}
+            ${repeat(orgs || [], (org) => org.id, this.renderOrg)}
           </btrix-table-body>
         </btrix-table>
       </btrix-overflow-scroll>
@@ -611,14 +620,6 @@ export class OrgsList extends BtrixElement {
     const isUserOrg = this.userInfo.orgs.some(({ id }) => id === org.id);
 
     const memberCount = Object.keys(org.users || {}).length;
-
-    const none = html`
-      <sl-icon
-        name="slash"
-        class="text-base text-neutral-400"
-        label=${msg("None")}
-      ></sl-icon>
-    `;
 
     let status = {
       icon: html`<sl-icon

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -226,24 +226,23 @@ export class OrgsList extends BtrixElement {
     options: { label: string; icon: string; filter: OrgFilter },
   ) {
     const { label, icon, filter } = options;
-    return (
-      this.orgList?.some((org) => this.filterOrg(org, filter)) &&
-      html`
-        <sl-radio-button
-          pill
-          value=${filter}
-          class="part-[label]:items-baseline"
-        >
-          <sl-icon name=${icon} slot="prefix"></sl-icon>
-          ${label}
-          <span class="ml-2 text-xs font-normal tabular-nums"
-            >${this.localize.number(
-              orgs?.filter((org) => this.filterOrg(org, filter)).length ?? 0,
-            )}</span
+    return this.orgList?.some((org) => this.filterOrg(org, filter))
+      ? html`
+          <sl-radio-button
+            pill
+            value=${filter}
+            class="part-[label]:items-baseline"
           >
-        </sl-radio-button>
-      `
-    );
+            <sl-icon name=${icon} slot="prefix"></sl-icon>
+            ${label}
+            <span class="ml-2 text-xs font-normal tabular-nums"
+              >${this.localize.number(
+                orgs?.filter((org) => this.filterOrg(org, filter)).length ?? 0,
+              )}</span
+            >
+          </sl-radio-button>
+        `
+      : nothing;
   }
 
   private filterOrg(org: OrgData, filter: OrgFilter): boolean {

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -776,7 +776,12 @@ export class OrgsList extends BtrixElement {
     if (org.subscription) {
       switch (org.subscription.status) {
         case SubscriptionStatus.Active:
-          if (org.subscription.futureCancelDate) {
+          if (
+            org.subscription.futureCancelDate &&
+            new Date(org.subscription.futureCancelDate).getTime() -
+              new Date().getTime() >=
+              0
+          ) {
             subscription = {
               icon: html`<sl-icon
                 class="text-base text-warning"
@@ -794,6 +799,37 @@ export class OrgsList extends BtrixElement {
                     timeStyle: "medium",
                     dateStyle: "medium",
                   })})
+                </div>`,
+            };
+          } else if (
+            org.subscription.futureCancelDate &&
+            new Date(org.subscription.futureCancelDate).getTime() -
+              new Date().getTime() <
+              0
+          ) {
+            subscription = {
+              icon: html`<sl-icon
+                  class="text-base text-warning"
+                  name="calendar2-x"
+                  label=${msg("Subscription Cancellation Scheduled")}
+                ></sl-icon>
+                <sl-icon
+                  class="text-base text-danger"
+                  name="x-octagon-fill"
+                  label=${msg("Subscription Cancellation Scheduled")}
+                ></sl-icon>`,
+              description: html`${msg(
+                  "Subscription Cancellation Scheduled in the Past",
+                )}
+                <div class="mt-2 text-xs">
+                  ${msg("Subscription was scheduled for cancellation at")}
+                  ${this.localize.date(org.subscription.futureCancelDate, {
+                    timeStyle: "medium",
+                    dateStyle: "medium",
+                  })}
+                </div>
+                <div class="my-2 font-bold text-danger-300">
+                  ${msg("This indicates something has gone wrong.")}
                 </div>`,
             };
           } else {

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -963,55 +963,64 @@ export class OrgsList extends BtrixElement {
             @click=${(e: MouseEvent) => e.stopPropagation()}
           >
             <sl-menu>
-              <sl-menu-label>${msg("Subscription")}</sl-menu-label>
+              <sl-menu-label
+                >${msg("Subscription")}
+                ${when(
+                  org.subscription,
+                  (sub) => html`
+                    <table class="w-full mt-1 text-xs whitespace-nowrap font-normal">
+                      <tr>
+                        <th scope="row" class="font-normal text-left">${msg("Plan ID")}</th>
+                        <td class="text-right font-monospace text-neutral-900">
+                            ${sub.planId}
+                        </td>
+                      </tr>
+                      <tr>
+                        <th scope="row" class="font-normal text-left">${msg("Action on Cancel")}</td>
+                        <td class="text-right font-bold text-neutral-900">
+                          ${
+                            sub.readOnlyOnCancel
+                              ? msg("Read-Only")
+                              : msg("Delete")
+                          }
+                        </td>
+                      </tr>
+                    </table>
+                  `,
+                )}
+              </sl-menu-label>
               ${org.subscription
-                ? html`
-                    ${org.subscription.subId.startsWith("stripe:")
-                      ? html`<sl-menu-item
-                          @click=${() => {
-                            window.open(
-                              `https://dashboard.stripe.com/subscriptions/${org.subscription!.subId.slice(7)}`,
-                              "_blank",
-                            );
-                          }}
-                        >
-                          <sl-icon slot="prefix" name="stripe"></sl-icon>
-                          ${msg("Open in Stripe")}
-                          <sl-icon
-                            slot="suffix"
-                            name="box-arrow-up-right"
-                          ></sl-icon>
-                        </sl-menu-item>`
-                      : html`<sl-menu-item
-                          @click=${() => {
-                            ClipboardController.copyToClipboard(
-                              org.subscription!.subId,
-                            );
-                            this.notify.toast({
-                              message: msg("Subscription ID Copied"),
-                              duration: 1000,
-                              variant: "success",
-                              id: "item-copied",
-                            });
-                          }}
-                        >
-                          ${msg("Copy Subscription ID")}
-                        </sl-menu-item>`}
-                    <sl-menu-item disabled>
-                      ${msg("Plan ID")}
-                      <span class="font-monospace" slot="suffix"
-                        >${org.subscription.planId}</span
-                      >
-                    </sl-menu-item>
-                    <sl-menu-item disabled>
-                      ${msg("Action on Cancel")}
-                      <span class="font-bold" slot="suffix"
-                        >${org.subscription.readOnlyOnCancel
-                          ? msg("Read-Only")
-                          : msg("Delete")}</span
-                      >
-                    </sl-menu-item>
-                  `
+                ? org.subscription.subId.startsWith("stripe:")
+                  ? html`<sl-menu-item
+                      @click=${() => {
+                        window.open(
+                          `https://dashboard.stripe.com/subscriptions/${org.subscription!.subId.slice(7)}`,
+                          "_blank",
+                        );
+                      }}
+                    >
+                      <sl-icon slot="prefix" name="stripe"></sl-icon>
+                      ${msg("Open in Stripe")}
+                      <sl-icon
+                        slot="suffix"
+                        name="box-arrow-up-right"
+                      ></sl-icon>
+                    </sl-menu-item>`
+                  : html`<sl-menu-item
+                      @click=${() => {
+                        ClipboardController.copyToClipboard(
+                          org.subscription!.subId,
+                        );
+                        this.notify.toast({
+                          message: msg("Subscription ID Copied"),
+                          duration: 1000,
+                          variant: "success",
+                          id: "item-copied",
+                        });
+                      }}
+                    >
+                      ${msg("Copy Subscription ID")}
+                    </sl-menu-item>`
                 : html`<sl-menu-item disabled>
                     <sl-icon
                       name="slash"

--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -20,6 +20,7 @@ import { when } from "lit/directives/when.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
+import { ClipboardController } from "@/controllers/clipboard";
 import { SubscriptionStatus } from "@/types/billing";
 import type { ProxiesAPIResponse, Proxy } from "@/types/crawler";
 import type { OrgData } from "@/utils/orgs";
@@ -818,6 +819,65 @@ export class OrgsList extends BtrixElement {
             @click=${(e: MouseEvent) => e.stopPropagation()}
           >
             <sl-menu>
+              <sl-menu-label>${msg("Subscription")}</sl-menu-label>
+              ${org.subscription
+                ? html`
+                    ${org.subscription.subId.startsWith("stripe:")
+                      ? html`<sl-menu-item
+                          @click=${() => {
+                            window.open(
+                              `https://dashboard.stripe.com/subscriptions/${org.subscription!.subId.slice(7)}`,
+                              "_blank",
+                            );
+                          }}
+                        >
+                          <sl-icon slot="prefix" name="stripe"></sl-icon>
+                          ${msg("Open in Stripe")}
+                          <sl-icon
+                            slot="suffix"
+                            name="box-arrow-up-right"
+                          ></sl-icon>
+                        </sl-menu-item>`
+                      : html`<sl-menu-item
+                          @click=${() => {
+                            ClipboardController.copyToClipboard(
+                              org.subscription!.subId,
+                            );
+                            this.notify.toast({
+                              message: msg("Subscription ID Copied"),
+                              duration: 1000,
+                              variant: "success",
+                              id: "item-copied",
+                            });
+                          }}
+                        >
+                          ${msg("Copy Subscription ID")}
+                        </sl-menu-item>`}
+                    <sl-menu-item disabled>
+                      ${msg("Plan ID")}
+                      <span class="font-monospace" slot="suffix"
+                        >${org.subscription.planId}</span
+                      >
+                    </sl-menu-item>
+                    <sl-menu-item disabled>
+                      ${msg("Action on Cancel")}
+                      <span class="font-bold" slot="suffix"
+                        >${org.subscription.readOnlyOnCancel
+                          ? msg("Read-Only")
+                          : msg("Delete")}</span
+                      >
+                    </sl-menu-item>
+                  `
+                : html`<sl-menu-item disabled>
+                    <sl-icon
+                      name="slash"
+                      class="text-base text-neutral-400"
+                      slot="prefix"
+                    ></sl-icon>
+                    ${msg("No Subscription")}</sl-menu-item
+                  >`}
+              <sl-divider></sl-divider>
+              <sl-menu-label>${msg("Manage Org")}</sl-menu-label>
               <sl-menu-item
                 @click=${() => {
                   this.currOrg = org;

--- a/frontend/src/components/ui/overflow-scroll.ts
+++ b/frontend/src/components/ui/overflow-scroll.ts
@@ -50,7 +50,7 @@ export class OverflowScroll extends LitElement {
         content: "";
         width: var(--btrix-overflow-scrim-width, 3rem);
         position: absolute;
-        z-index: 1;
+        z-index: 10;
         top: 0;
         height: 100%;
         pointer-events: none;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -823,7 +823,7 @@ export class App extends BtrixElement {
       case "admin":
         return this.renderAdminPage(
           () => html`
-            <btrix-admin class="w-full md:bg-neutral-50"></btrix-admin>
+            <btrix-admin class="w-full bg-neutral-50"></btrix-admin>
           `,
         );
 

--- a/frontend/src/pages/admin/admin.ts
+++ b/frontend/src/pages/admin/admin.ts
@@ -102,7 +102,7 @@ export class Admin extends BtrixElement {
   private renderAdminOrgs() {
     return html`
       <div class="grid gap-6 lg:grid-cols-[1fr,minmax(320px,20%)]">
-        <div class="grid grid-cols-2 gap-4 lg:order-1 lg:block">
+        <div class="flex flex-wrap gap-4 *:flex-1 lg:order-1 lg:block">
           <btrix-instance-stats
             .orgList=${this.orgList ?? []}
           ></btrix-instance-stats>
@@ -113,7 +113,7 @@ export class Admin extends BtrixElement {
             ${this.renderInvite()}
           </section>
         </div>
-        <section>
+        <section class="min-w-0">
           <header class="mb-3 flex items-center justify-between border-b pb-3">
             <h2 class="text-lg font-medium">${msg("All Organizations")}</h2>
             <sl-button

--- a/frontend/src/pages/admin/admin.ts
+++ b/frontend/src/pages/admin/admin.ts
@@ -101,7 +101,7 @@ export class Admin extends BtrixElement {
 
   private renderAdminOrgs() {
     return html`
-      <div class="grid gap-6 lg:grid-cols-[auto,auto]">
+      <div class="grid gap-6 lg:grid-cols-[1fr,minmax(320px,20%)]">
         <div class="grid grid-cols-2 gap-4 lg:order-1 lg:block">
           <btrix-instance-stats
             .orgList=${this.orgList ?? []}

--- a/frontend/src/pages/admin/admin.ts
+++ b/frontend/src/pages/admin/admin.ts
@@ -101,30 +101,8 @@ export class Admin extends BtrixElement {
 
   private renderAdminOrgs() {
     return html`
-      <div class="grid grid-cols-3 gap-6">
-        <div class="col-span-3 md:col-span-2">
-          <section>
-            <header
-              class="mb-3 flex items-center justify-between border-b pb-3"
-            >
-              <h2 class="text-lg font-medium">${msg("All Organizations")}</h2>
-              <sl-button
-                variant="primary"
-                size="small"
-                @click=${() => (this.isAddingOrg = true)}
-              >
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("New Organization")}
-              </sl-button>
-            </header>
-            <btrix-orgs-list
-              .orgList=${this.orgList}
-              @update-quotas=${this.onUpdateOrgQuotas}
-              @update-proxies=${this.onUpdateOrgProxies}
-            ></btrix-orgs-list>
-          </section>
-        </div>
-        <div class="col-span-3 md:col-span-1">
+      <div class="grid gap-6 lg:grid-cols-[auto,auto]">
+        <div class="grid grid-cols-2 gap-4 lg:order-1 lg:block">
           <btrix-instance-stats
             .orgList=${this.orgList ?? []}
           ></btrix-instance-stats>
@@ -135,6 +113,24 @@ export class Admin extends BtrixElement {
             ${this.renderInvite()}
           </section>
         </div>
+        <section>
+          <header class="mb-3 flex items-center justify-between border-b pb-3">
+            <h2 class="text-lg font-medium">${msg("All Organizations")}</h2>
+            <sl-button
+              variant="primary"
+              size="small"
+              @click=${() => (this.isAddingOrg = true)}
+            >
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              ${msg("New Organization")}
+            </sl-button>
+          </header>
+          <btrix-orgs-list
+            .orgList=${this.orgList}
+            @update-quotas=${this.onUpdateOrgQuotas}
+            @update-proxies=${this.onUpdateOrgProxies}
+          ></btrix-orgs-list>
+        </section>
       </div>
     `;
   }

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -170,8 +170,13 @@
     line-height: 1.5;
   }
 
+  /* Align left edge with prefix icon */
+  sl-menu sl-menu-label::part(base) {
+    padding-left: 25px;
+  }
+
   /* Align left edge with selected item */
-  sl-menu-label::part(base) {
+  sl-select sl-menu-label::part(base) {
     padding-left: var(--sl-spacing-medium);
   }
 

--- a/frontend/src/types/billing.ts
+++ b/frontend/src/types/billing.ts
@@ -15,7 +15,9 @@ export const subscriptionStatusSchema = z.nativeEnum(SubscriptionStatus);
 export const subscriptionSchema = z.object({
   status: subscriptionStatusSchema,
   planId: z.string(),
+  readOnlyOnCancel: z.boolean(),
   futureCancelDate: apiDateSchema.nullable(),
+  subId: z.string(),
 });
 export type Subscription = z.infer<typeof subscriptionSchema>;
 


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2595

## Changes

Adds "Subscription Cancellation Scheduled" state/icon/tooltip to superadmin org list, with future cancellation duration/date.

Adds more subscription-related info and features to the action menu in the same org list
- "Open in Stripe" action is visible if subscription id is a Stripe object id
- "Plan ID" and "Action on Cancel" correspond to `planId` and `readOnlyOnCancel` properties on `subscription` object
  - ~~I know using menu items for informational/tabular data like this isn't ideal, but until we build a more complete admin view of orgs I think it's good enough for here — we should avoid this in non-admin parts of the UI though.~~ Addressed in 1e447fd
  - There's also some additional highlighting for possible errors (hopefully only visible on dev) — see the last screenshot for an example

Adds first pass at filters for superadmin org list
- The filters' counts update when searching
- I took an initial pass at figuring out which filters would be most useful — we can always go back and tweak them later

## Screenshots

| "Cancellation Scheduled" subscription status & tooltip | Expanded subscription items in action menu |
|--------|--------|
| <img width="327" alt="Screenshot 2025-05-06 at 4 28 07 PM" src="https://github.com/user-attachments/assets/50c77b38-57cf-400e-a694-b32bef018e5c" /> | <img width="269" alt="Screenshot 2025-05-06 at 6 50 00 PM" src="https://github.com/user-attachments/assets/db053c46-0630-467b-ab5f-ba43918f24de" /> |


| Filters | Highlighted should-be-impossible state |
|--------|----|
| <img width="882" alt="Screenshot 2025-05-06 at 6 01 44 PM" src="https://github.com/user-attachments/assets/bb4b20d4-12d8-4538-8b55-bd59bb60ebf0" /> | <img width="386" alt="Screenshot 2025-05-06 at 6 51 07 PM" src="https://github.com/user-attachments/assets/a4122947-af7b-487b-820e-ecdcf5d559d8" /> |
