### PR TITLE
Add minimized superadmin banner

### DIFF
--- a/frontend/src/features/admin/index.ts
+++ b/frontend/src/features/admin/index.ts
@@ -1,1 +1,2 @@
 import "./stats";
+import "./super-admin-banner";

--- a/frontend/src/features/admin/super-admin-banner.ts
+++ b/frontend/src/features/admin/super-admin-banner.ts
@@ -1,0 +1,67 @@
+import { localized, msg } from "@lit/localize";
+import { html } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+
+@customElement("btrix-super-admin-banner")
+@localized()
+export class SuperAdminBanner extends TailwindElement {
+  @state()
+  hide = false;
+
+  render() {
+    if (this.hide) {
+      return html` <div class="absolute bottom-0 right-2 top-0 pt-14">
+        <sl-tooltip
+          placement="left"
+          class="[--max-width:500px] [--show-delay:0] part-[base__arrow]:bg-warning-700 part-[body]:bg-warning-700 part-[body]:text-xs"
+          hoist
+        >
+          <span slot="content">
+            <strong>${msg("You are logged in as a superadmin")}</strong> –
+            ${msg("please be careful.")}
+          </span>
+          <div class="sticky right-2 top-2 z-50">
+            <button
+              type="button"
+              class="flex rounded-full border border-warning-800 bg-warning-700 p-2 text-warning-50 shadow-md shadow-orange-700/20 transition hover:scale-110"
+              @click=${() => {
+                this.hide = false;
+              }}
+            >
+              <sl-icon
+                slot="icon"
+                name="exclamation-diamond-fill"
+                class="size-4"
+              ></sl-icon>
+            </button>
+          </div>
+        </sl-tooltip>
+      </div>`;
+    } else {
+      return html`<div
+        class="sticky top-0 z-50 border-b border-b-warning-800 bg-warning-700 py-2 text-xs text-warning-50 shadow-sm shadow-orange-700/20"
+      >
+        <div
+          class="mx-auto box-border flex w-full items-center gap-2 px-3 xl:pl-6"
+        >
+          <sl-icon
+            name="exclamation-diamond-fill"
+            class="size-4"
+          ></sl-icon>
+          <span>
+            <strong>${msg("You are logged in as a superadmin")}</strong> –
+            ${msg("please be careful.")}
+          </span>
+          <button type="button"
+              class="ml-auto flex"
+              @click=${() => {
+                this.hide = true;
+              }}>
+          <sl-icon name="x-circle" class="size-4"></sl-icon>
+        </div>
+      </div>`;
+    }
+  }
+}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -336,7 +336,7 @@ export class App extends BtrixElement {
 
   render() {
     return html`
-      <div class="min-w-screen flex min-h-screen flex-col">
+      <div class="min-w-screen relative flex min-h-screen flex-col">
         ${this.renderSuperadminBanner()} ${this.renderNavBar()}
         ${this.renderAlertBanner()}
         <main
@@ -397,23 +397,9 @@ export class App extends BtrixElement {
 
   private renderSuperadminBanner() {
     if (this.userInfo?.isSuperAdmin) {
-      return html` <div
-        class="sticky top-0 z-50 border-b border-b-warning-800 bg-warning-700 py-2 text-xs text-warning-50 shadow-sm shadow-orange-700/20"
-      >
-        <div
-          class="mx-auto box-border flex w-full items-center gap-2 px-3 xl:pl-6"
-        >
-          <sl-icon
-            slot="icon"
-            name="exclamation-triangle-fill"
-            class="size-4"
-          ></sl-icon>
-          <span>
-            <strong>${msg("You are logged in as a superadmin")}</strong> –
-            ${msg("please be careful.")}
-          </span>
-        </div>
-      </div>`;
+      return html`<btrix-super-admin-banner
+        class="contents"
+      ></btrix-super-admin-banner>`;
     }
   }
 


### PR DESCRIPTION
Follows [discussion on Discord](https://discord.com/channels/895426029194207262/1011678975636013066/1370124684913283253).

Adds a minimized superadmin banner state.


## Screenshots

| Description | Screenshot |
|--------|--------|
| Normal superadmin banner (default) | <img width="1512" alt="Screenshot 2025-05-08 at 11 19 31 PM" src="https://github.com/user-attachments/assets/827bb77c-38ef-414a-a852-b98b6deaefb2" /> |
| Minimized banner | <img width="186" alt="Screenshot 2025-05-08 at 11 19 42 PM" src="https://github.com/user-attachments/assets/8f2b8d42-a555-424f-969d-65dff1e833fa" /> |
| Minimized banner, hovered | <img width="404" alt="Screenshot 2025-05-08 at 11 19 48 PM" src="https://github.com/user-attachments/assets/7935618e-e5f4-4366-a8a6-f54b426d29af" /> | 


cc @SuaYoo 

