### PR TITLE
Ensure crawl page counts are correct when re-adding pages

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -32,7 +32,7 @@ else:
     ) = PageOps = BackgroundJobOps = object
 
 
-CURR_DB_VERSION = "0044"
+CURR_DB_VERSION = "0045"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0045_crawl_counts.py
+++ b/backend/btrixcloud/migrations/migration_0045_crawl_counts.py
@@ -21,7 +21,7 @@ class Migration(BaseMigration):
     async def migrate_up(self):
         """Perform migration up.
 
-        Recalculate collection stats to get top host names
+        Recalculate crawl filePageCount and errorPageCount for all crawls
         """
         crawls_mdb = self.mdb["crawls"]
 

--- a/backend/btrixcloud/migrations/migration_0045_crawl_counts.py
+++ b/backend/btrixcloud/migrations/migration_0045_crawl_counts.py
@@ -1,0 +1,56 @@
+"""
+Migration 0045 - Recalculate crawl filePageCount and errorPageCount
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0045"
+
+
+# pylint: disable=duplicate-code
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+        self.page_ops = kwargs.get("page_ops")
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Recalculate collection stats to get top host names
+        """
+        crawls_mdb = self.mdb["crawls"]
+
+        if self.page_ops is None:
+            print(
+                "Unable to reset crawl page counts, missing page_ops",
+                flush=True,
+            )
+            return
+
+        # Reset filePageCount and errorPageCount to 0 for all crawls
+        await crawls_mdb.update_many(
+            {},
+            {
+                "$set": {
+                    "filePageCount": 0,
+                    "errorPageCount": 0,
+                }
+            },
+        )
+
+        # Recalculate filePageCount and errorPageCount for every crawl
+        async for crawl_raw in crawls_mdb.find({}):
+            crawl_id = crawl_raw["_id"]
+            try:
+                await self.page_ops.update_crawl_file_and_error_counts(crawl_id)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update page counts for crawl {crawl_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -246,18 +246,25 @@ class PageOps:
             await self.add_qa_run_for_page(page.id, oid, qa_run_id, compare)
 
     async def update_crawl_file_and_error_counts(
-        self, crawl_id: str, pages: List[Page]
+        self, crawl_id: str, pages: Optional[List[Page]] = None
     ):
         """Update crawl filePageCount and errorPageCount for pages."""
         file_count = 0
         error_count = 0
 
-        for page in pages:
-            if page.isFile:
-                file_count += 1
-
-            if page.isError:
-                error_count += 1
+        if pages is not None:
+            for page in pages:
+                if page.isFile:
+                    file_count += 1
+                if page.isError:
+                    error_count += 1
+        else:
+            # If page list not supplied, count all pages in crawl
+            async for page_raw in self.pages.find({"crawl_id": crawl_id}):
+                if page_raw.get("isFile"):
+                    file_count += 1
+                if page_raw.get("isError"):
+                    error_count += 1
 
         if file_count == 0 and error_count == 0:
             return

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -276,7 +276,7 @@ class PageOps:
         )
 
     async def delete_crawl_pages(self, crawl_id: str, oid: Optional[UUID] = None):
-        """Delete crawl pages from db"""
+        """Delete crawl pages from db and clear crawl page counts"""
         query: Dict[str, Union[str, UUID]] = {"crawl_id": crawl_id}
         if oid:
             query["oid"] = oid
@@ -286,6 +286,25 @@ class PageOps:
         except Exception as err:
             print(
                 f"Error deleting pages from crawl {crawl_id}: {err}",
+                flush=True,
+            )
+
+        try:
+            await self.crawls.find_one_and_update(
+                {"_id": crawl_id},
+                {
+                    "$set": {
+                        "pageCount": 0,
+                        "uniquePageCount": 0,
+                        "filePageCount": 0,
+                        "errorPageCount": 0,
+                    }
+                },
+            )
+        # pylint: disable=broad-except
+        except Exception as err:
+            print(
+                f"Error resetting page counts for crawl {crawl_id}: {err}",
                 flush=True,
             )
 


### PR DESCRIPTION
Fixes #2600 

This PR fixes the issue by ensuring that crawl page counts (total, unique, files, errors) are reset to 0 when crawl pages are deleted, such as right before being re-added.

It also adds a migration will recalculates file and error page counts for each crawl without re-adding pages from the WACZ files.