### PR TITLE
chore: Clean up data grid component

### DIFF
--- a/frontend/src/components/ui/data-grid/controllers/focus.ts
+++ b/frontend/src/components/ui/data-grid/controllers/focus.ts
@@ -41,6 +41,7 @@ export class DataGridFocusController implements ReactiveController {
           return;
         }
 
+        // Move focus from table cell to on first tabbable element
         const el = opts.setFocusOnTabbable
           ? this.firstTabbable
           : this.firstFocusable;
@@ -54,6 +55,28 @@ export class DataGridFocusController implements ReactiveController {
           } else {
             el.focus();
           }
+        }
+
+        // Show tooltip on tab focus. Tooltip on any focus should be
+        // disabled in `btrix-data-grid-row` to prevent tooltips being
+        // showing duplicate messages during form submission.
+        const tooltip = this.#host.closest("sl-tooltip");
+
+        if (tooltip && !tooltip.disabled) {
+          const hideTooltip = () => {
+            void tooltip.hide();
+            this.#host.removeEventListener("input", hideTooltip);
+            this.#host.removeEventListener("blur", hideTooltip);
+          };
+
+          this.#host.addEventListener("input", hideTooltip, {
+            once: true,
+          });
+          this.#host.addEventListener("blur", hideTooltip, {
+            once: true,
+          });
+
+          void tooltip.show();
         }
       },
       { passive: true, capture: true },

--- a/frontend/src/components/ui/data-grid/controllers/rows.ts
+++ b/frontend/src/components/ui/data-grid/controllers/rows.ts
@@ -19,11 +19,9 @@ export class DataGridRowsController implements ReactiveController {
   readonly #host: ReactiveControllerHost &
     EventTarget & {
       items?: GridItem[];
-      rowKey?: DataGrid["rowKey"];
-      defaultItem?: DataGrid["defaultItem"];
-      removeRows?: DataGrid["removeRows"];
-      addRows?: DataGrid["addRows"];
-    };
+    } & Partial<
+      Pick<DataGrid, "rowKey" | "defaultItem" | "rowsRemovable" | "rowsAddible">
+    >;
 
   #prevItems?: GridItem[];
 

--- a/frontend/src/components/ui/data-grid/controllers/rows.ts
+++ b/frontend/src/components/ui/data-grid/controllers/rows.ts
@@ -22,7 +22,7 @@ export const emptyItem: EmptyObject = {};
  * that are slotted into `<btrix-data-grid>`, it may be necessary to
  * implement this controller on the container component.
  */
-export class DataGridRowsController<Item = GridItem>
+export class DataGridRowsController<Item extends GridItem = GridItem>
   implements ReactiveController
 {
   readonly #host: ReactiveControllerHost &
@@ -60,8 +60,8 @@ export class DataGridRowsController<Item = GridItem>
     const rowKey = this.#host.rowKey;
 
     this.rows = new Map(
-      this.#host.rowKey
-        ? items.map((item) => [item[rowKey as keyof Item] as GridRowId, item])
+      rowKey
+        ? items.map((item) => [item[rowKey] as GridRowId, item])
         : items.map(
             cached((item) => [nanoid(), item], { cacheConstructor: Map }),
           ),

--- a/frontend/src/components/ui/data-grid/data-grid-cell.ts
+++ b/frontend/src/components/ui/data-grid/data-grid-cell.ts
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import { html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import get from "lodash/fp/get";
 
 import { TableCell } from "../table/table-cell";
 
@@ -119,7 +120,7 @@ export class DataGridCell extends TableCell {
   }
 
   renderCell = ({ item }: { item: GridItem }) => {
-    return html`${(this.column && item[this.column.field]) ?? ""}`;
+    return html`${(this.column && get(this.column.field, item)) ?? ""}`;
   };
 
   renderEditCell = ({

--- a/frontend/src/components/ui/data-grid/data-grid.stylesheet.css
+++ b/frontend/src/components/ui/data-grid/data-grid.stylesheet.css
@@ -1,0 +1,37 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  :host {
+    --border: 1px solid var(--sl-panel-border-color);
+  }
+
+  .data-grid-body--horizontalRule btrix-data-grid-row:nth-of-type(n + 2),
+  .data-grid-body--horizontalRule
+    ::slotted(btrix-data-grid-row:nth-of-type(n + 2)) {
+    border-top: var(--border) !important;
+  }
+
+  .data-grid-body--rowsSelectable btrix-data-grid-row,
+  .data-grid-body--rowsSelectable ::slotted(btrix-data-grid-row) {
+    /* TODO Same ring color as edit cells */
+    @apply cursor-pointer ring-inset hover:bg-blue-50/50 hover:ring-1;
+  }
+
+  .data-grid-body--editCells btrix-data-grid-row,
+  .data-grid-body--editCells ::slotted(btrix-data-grid-row) {
+    /* TODO Support different input sizes */
+    min-height: calc(var(--sl-input-height-medium) + 1px);
+  }
+
+  .data-grid-body--not-stickyHeader btrix-data-grid-row:first-child,
+  .data-grid-body--not-stickyHeader ::slotted(btrix-data-grid-row:first-child) {
+    @apply rounded-t;
+  }
+
+  .data-grid-body--not-rowsAddible btrix-data-grid-row:last-child,
+  .data-grid-body--not-rowsAddible ::slotted(btrix-data-grid-row:last-child) {
+    @apply rounded-b;
+  }
+}

--- a/frontend/src/components/ui/data-grid/data-grid.ts
+++ b/frontend/src/components/ui/data-grid/data-grid.ts
@@ -75,7 +75,7 @@ export class DataGrid extends TailwindElement {
   selectMode: "single" | "multiple" = "single";
 
   /**
-   * Whether rows can be expanded, revealing more content below the row.
+   * WIP: Whether rows can be expanded, revealing more content below the row.
    */
   @property({ type: Boolean })
   rowsExpandable = false;

--- a/frontend/src/components/ui/data-grid/data-grid.ts
+++ b/frontend/src/components/ui/data-grid/data-grid.ts
@@ -1,7 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import type { SlChangeEvent, SlInput } from "@shoelace-style/shoelace";
 import clsx from "clsx";
-import { css, html, nothing, unsafeCSS } from "lit";
+import { html, nothing, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { nanoid } from "nanoid";
@@ -11,7 +11,6 @@ import { DataGridRowsController } from "./controllers/rows";
 import type { DataGridRow, RowRemoveEventDetail } from "./data-grid-row";
 import stylesheet from "./data-grid.stylesheet.css";
 import type { BtrixSelectRowEvent } from "./events/btrix-select-row";
-import { renderRows } from "./renderRows";
 import type { GridColumn, GridItem } from "./types";
 
 import { TailwindElement } from "@/classes/TailwindElement";
@@ -327,8 +326,7 @@ export class DataGrid extends TailwindElement {
     return html`
       <slot name="rows" class="contents" @slotchange=${this.onRowSlotChange}>
         ${this.items
-          ? renderRows(
-              this.rowsController.rows,
+          ? this.rowsController.renderRows(
               ({ id, item }) => html`
                 <btrix-data-grid-row
                   key=${id}

--- a/frontend/src/components/ui/data-grid/data-grid.ts
+++ b/frontend/src/components/ui/data-grid/data-grid.ts
@@ -20,7 +20,7 @@ import { tw } from "@/utils/tailwind";
 /**
  * Data grids structure data into rows and and columns.
  *
- * {@link https://www.figma.com/design/ySaSMMI2vctbxP3edAHXib/Webrecorder-Shoelace?node-id=1327-354&p=f}
+ * [Figma design file](https://www.figma.com/design/ySaSMMI2vctbxP3edAHXib/Webrecorder-Shoelace?node-id=1327-354&p=f)
  *
  * @slot label
  * @slot rows

--- a/frontend/src/components/ui/data-grid/events/btrix-select-row.ts
+++ b/frontend/src/components/ui/data-grid/events/btrix-select-row.ts
@@ -1,0 +1,12 @@
+import type { GridItem, GridRowId } from "../types";
+
+export type BtrixSelectRowEvent<T = GridItem> = CustomEvent<{
+  id: GridRowId;
+  item: T;
+}>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    "btrix-select-row": BtrixSelectRowEvent;
+  }
+}

--- a/frontend/src/components/ui/data-grid/renderRows.ts
+++ b/frontend/src/components/ui/data-grid/renderRows.ts
@@ -1,18 +1,19 @@
 import { type TemplateResult } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import type { EmptyObject } from "type-fest";
 
 import type { GridItem, GridRowId, GridRows } from "./types";
 
 export function renderRows<T = GridItem>(
-  rows: GridRows<T>,
+  rows: GridRows<T | EmptyObject>,
   renderRow: (
-    { id, item }: { id: GridRowId; item: T },
+    { id, item }: { id: GridRowId; item: T | EmptyObject },
     index: number,
   ) => TemplateResult,
 ) {
   return repeat(
     rows,
     ([id]) => id,
-    ([id, item], i) => renderRow({ id, item: item }, i),
+    ([id, item], i) => renderRow({ id, item }, i),
   );
 }

--- a/frontend/src/components/ui/data-grid/renderRows.ts
+++ b/frontend/src/components/ui/data-grid/renderRows.ts
@@ -4,7 +4,7 @@ import { repeat } from "lit/directives/repeat.js";
 import type { GridItem, GridRowId, GridRows } from "./types";
 
 export function renderRows<T = GridItem>(
-  rows: GridRows<GridItem>,
+  rows: GridRows<T>,
   renderRow: (
     { id, item }: { id: GridRowId; item: T },
     index: number,
@@ -13,6 +13,6 @@ export function renderRows<T = GridItem>(
   return repeat(
     rows,
     ([id]) => id,
-    ([id, item], i) => renderRow({ id, item: item as T }, i),
+    ([id, item], i) => renderRow({ id, item: item }, i),
   );
 }

--- a/frontend/src/components/ui/data-grid/types.ts
+++ b/frontend/src/components/ui/data-grid/types.ts
@@ -25,7 +25,7 @@ export type GridColumnSelectType = {
   }[];
 };
 
-export type GridColumn<T = string> = {
+export type GridColumn<T = string, Item = GridItem> = {
   field: T;
   label: string | TemplateResult;
   description?: string;
@@ -33,11 +33,13 @@ export type GridColumn<T = string> = {
   required?: boolean;
   inputPlaceholder?: string;
   width?: string;
+  align?: "start" | "center" | "end";
   renderEditCell?: (props: {
-    item: GridItem;
-    value?: GridItem[keyof GridItem];
+    item: Item;
+    value?: Item[keyof Item];
   }) => TemplateResult<1>;
-  renderCell?: (props: { item: GridItem }) => TemplateResult<1>;
+  renderCell?: (props: { item: Item }) => TemplateResult<1>;
+  renderCellTooltip?: (props: { item: Item }) => TemplateResult<1>;
 } & (
   | {
       inputType?: GridColumnType;

--- a/frontend/src/stories/components/DataGrid.stories.ts
+++ b/frontend/src/stories/components/DataGrid.stories.ts
@@ -33,6 +33,9 @@ type Story = StoryObj<RenderProps>;
  * In its most basic configuration, the only required fields
  * are a list of items, and a list of columns that define which
  * key-value pairs of an item should be displayed.
+ *
+ * Nested keys are supported by specifying a deep path, e.g.
+ * `object.nestedObject.key`.
  */
 export const Basic: Story = {
   args: {},
@@ -103,7 +106,7 @@ export const ColumnWidths: Story = {
  */
 export const RemoveRows: Story = {
   args: {
-    removeRows: true,
+    rowsRemovable: true,
   },
 };
 
@@ -112,7 +115,7 @@ export const RemoveRows: Story = {
  */
 export const AddRows: Story = {
   args: {
-    addRows: true,
+    rowsAddible: true,
     defaultItem: {
       a: "A",
       b: "--",
@@ -129,7 +132,7 @@ export const AddRows: Story = {
 export const AddRowsInput: Story = {
   name: "Add more than one row",
   args: {
-    addRows: true,
+    rowsAddible: true,
     addRowsInputValue: 5,
     defaultItem: {
       a: "A",
@@ -138,6 +141,18 @@ export const AddRowsInput: Story = {
       d: "--",
       e: "--",
     },
+  },
+};
+
+/**
+ * Rows can be selected.
+ *
+ * Open your browser console logs to view the clicked row.
+ */
+export const SelectRow: Story = {
+  args: {
+    items: makeItems(5),
+    rowsSelectable: true,
   },
 };
 
@@ -262,9 +277,9 @@ export const FormControl: Story = {
         }
         formControlLabel="Page QA Table"
         stickyHeader="table"
-        addRows
+        rowsAddible
         addRowsInputValue="10"
-        removeRows
+        rowsRemovable
         editCells
       >
         ${renderRows(

--- a/frontend/src/stories/components/DataGrid.ts
+++ b/frontend/src/stories/components/DataGrid.ts
@@ -3,6 +3,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { nanoid } from "nanoid";
 
 import type { DataGrid } from "@/components/ui/data-grid/data-grid";
+import type { BtrixSelectRowEvent } from "@/components/ui/data-grid/events/btrix-select-row";
 
 import "@/components/ui/data-grid";
 
@@ -37,9 +38,11 @@ export const renderComponent = ({
   items,
   formControlLabel,
   stickyHeader,
-  addRows,
+  rowsAddible,
   addRowsInputValue,
-  removeRows,
+  rowsRemovable,
+  rowsSelectable,
+  selectMode,
   editCells,
   defaultItem,
 }: Partial<RenderProps>) => {
@@ -50,10 +53,15 @@ export const renderComponent = ({
       .defaultItem=${defaultItem}
       formControlLabel=${ifDefined(formControlLabel)}
       stickyHeader=${ifDefined(stickyHeader)}
-      ?addRows=${addRows}
+      ?rowsAddible=${rowsAddible}
       addRowsInputValue=${ifDefined(addRowsInputValue)}
-      ?removeRows=${removeRows}
+      ?rowsRemovable=${rowsRemovable}
+      ?rowsSelectable=${rowsSelectable}
+      selectMode=${ifDefined(selectMode)}
       ?editCells=${editCells}
+      @btrix-select-row=${(e: BtrixSelectRowEvent) => {
+        console.log("row clicked:", e.detail);
+      }}
     >
     </btrix-data-grid>
   `;


### PR DESCRIPTION
WIP for https://github.com/webrecorder/browsertrix/issues/2497

## Changes

- Moves data grid styles to separate stylesheet.
- Adds `rowsSelectable` option, renames `rows-` properties to match.
- Adds WIP `rowsExpandable` option.
- Fixes showing tooltip on focus.
- Cleans up rows controller typing.

## Manual testing

No user-facing changes.