### PR TITLE
feat: Workflow "latest crawl" tab

### DIFF
--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -41,6 +41,7 @@ export class DescListItem extends LitElement {
       font-family: var(--font-monostyle-family);
       font-variation-settings: var(--font-monostyle-variation);
       line-height: 1rem;
+      min-height: calc(1rem + var(--sl-spacing-2x-small));
     }
 
     .item {

--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -93,6 +93,7 @@ export class DescList extends LitElement {
       display: inline-block;
       flex: 1 0 0;
       min-width: min-content;
+      padding-top: var(--sl-spacing-2x-small);
     }
 
     .horizontal ::slotted(btrix-desc-list-item)::before {

--- a/frontend/src/components/ui/navigation/navigation-button.ts
+++ b/frontend/src/components/ui/navigation/navigation-button.ts
@@ -100,13 +100,13 @@ export class NavigationButton extends TailwindElement {
             tw`outline-primary-600`,
             this.active
               ? tw`bg-primary-100/80 text-primary-800 shadow-primary-900/20`
-              : tw`text-neutral-700 hover:bg-primary-50`,
+              : tw`bg-white/80 text-neutral-700 outline-primary-100/80 hover:bg-primary-50`,
           ],
           error: [
             tw`outline-red-600`,
             this.active
               ? tw`bg-red-100/80 text-red-800 shadow-red-900/20`
-              : tw`text-red-700 ring-1 ring-red-300 hover:bg-red-50`,
+              : tw`bg-white/80 text-red-700 ring-1 ring-red-300 hover:bg-red-50`,
           ],
         }[this.variant],
       ])}

--- a/frontend/src/components/ui/tab-group/tab-group.ts
+++ b/frontend/src/components/ui/tab-group/tab-group.ts
@@ -72,6 +72,7 @@ export class TabGroup extends TailwindElement {
         @keydown=${this.onKeyDown}
       ></slot>`,
       main: html`<slot></slot>`,
+      action: html`<slot name="action"></slot>`,
       placement: this.placement,
       sticky: this.sticky,
     });

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -26,7 +26,6 @@ import { TailwindElement } from "@/classes/TailwindElement";
 import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
 import type { Crawl } from "@/types/crawler";
 import { renderName } from "@/utils/crawler";
-import { pluralOf } from "@/utils/pluralize";
 
 /**
  * @slot menu
@@ -185,20 +184,20 @@ export class CrawlListItem extends BtrixElement {
           )}
         </btrix-table-cell>
         <btrix-table-cell>
-          ${this.localize.bytes(this.crawl.fileSize || 0, {
-            unitDisplay: "narrow",
-          })}
-        </btrix-table-cell>
-        <btrix-table-cell>
           ${this.safeRender((crawl) => {
             const pagesFound = +(crawl.stats?.found || 0);
             if (crawl.finished) {
               const pagesComplete = crawl.pageCount ? +crawl.pageCount : 0;
-              return `${this.localize.number(pagesComplete, { notation: "compact" })} ${pluralOf("pages", pagesComplete)}`;
+              return `${this.localize.number(pagesComplete, { notation: "compact" })}`;
             }
 
             const pagesComplete = +(crawl.stats?.done || 0);
-            return `${this.localize.number(pagesComplete, { notation: "compact" })} / ${this.localize.number(pagesFound, { notation: "compact" })} ${pluralOf("pages", pagesFound)}`;
+            return `${this.localize.number(pagesComplete, { notation: "compact" })} / ${this.localize.number(pagesFound, { notation: "compact" })}`;
+          })}
+        </btrix-table-cell>
+        <btrix-table-cell>
+          ${this.localize.bytes(this.crawl.fileSize || 0, {
+            unitDisplay: "narrow",
           })}
         </btrix-table-cell>
         <btrix-table-cell>
@@ -305,10 +304,8 @@ export class CrawlList extends TailwindElement {
             <btrix-table-header-cell
               >${msg("Duration")}</btrix-table-header-cell
             >
+            <btrix-table-header-cell>${msg("Pages")}</btrix-table-header-cell>
             <btrix-table-header-cell>${msg("Size")}</btrix-table-header-cell>
-            <btrix-table-header-cell
-              >${msg("Pages Crawled")}</btrix-table-header-cell
-            >
             <btrix-table-header-cell>
               ${msg("Created By")}
             </btrix-table-header-cell>

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -257,6 +257,7 @@ export class CrawlQueue extends BtrixElement {
         void this.fetchQueue();
       }, POLL_INTERVAL_SECONDS * 1000);
     } catch (e) {
+      console.log("crawl queue:", e);
       if ((e as Error).message !== "invalid_regex") {
         this.notify.toast({
           message: msg("Sorry, couldn't fetch crawl queue at this time."),

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -257,15 +257,22 @@ export class CrawlQueue extends BtrixElement {
         void this.fetchQueue();
       }, POLL_INTERVAL_SECONDS * 1000);
     } catch (e) {
-      console.log("crawl queue:", e);
-      if ((e as Error).message !== "invalid_regex") {
-        this.notify.toast({
-          message: msg("Sorry, couldn't fetch crawl queue at this time."),
-          variant: "danger",
-          icon: "exclamation-octagon",
-          id: "crawl-queue-status",
-        });
+      const errorMessage = (e as Error).message;
+
+      if (
+        errorMessage === "invalid_regex" ||
+        errorMessage === "crawl_not_running"
+      ) {
+        console.debug(errorMessage);
+        return;
       }
+
+      this.notify.toast({
+        message: msg("Sorry, couldn't fetch crawl queue at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+        id: "crawl-queue-status",
+      });
     }
   }
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -73,6 +73,7 @@ import type { UserGuideEventMap } from "@/index";
 import { infoCol, inputCol } from "@/layouts/columns";
 import { pageSectionsWithNav } from "@/layouts/pageSectionsWithNav";
 import { panel } from "@/layouts/panel";
+import { WorkflowTab } from "@/routes";
 import { infoTextFor } from "@/strings/crawl-workflows/infoText";
 import { labelFor } from "@/strings/crawl-workflows/labels";
 import scopeTypeLabels from "@/strings/crawl-workflows/scopeType";
@@ -2294,7 +2295,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       this.navigate.to(
         `${this.navigate.orgBasePath}/workflows/${this.configId || data.id}${
           crawlId && !storageQuotaReached && !executionMinutesQuotaReached
-            ? "#watch"
+            ? `/${WorkflowTab.LatestCrawl}`
             : ""
         }`,
       );
@@ -2363,7 +2364,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private async onReset() {
     this.navigate.to(
-      `${this.navigate.orgBasePath}/workflows${this.configId ? `/${this.configId}#settings` : ""}`,
+      `${this.navigate.orgBasePath}/workflows${this.configId ? `/${this.configId}/${WorkflowTab.Settings}` : ""}`,
     );
     // this.initializeEditor();
   }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2293,10 +2293,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
       });
 
       this.navigate.to(
-        `${this.navigate.orgBasePath}/workflows/${this.configId || data.id}${
+        `${this.navigate.orgBasePath}/workflows/${this.configId || data.id}/${
           crawlId && !storageQuotaReached && !executionMinutesQuotaReached
-            ? `/${WorkflowTab.LatestCrawl}`
-            : ""
+            ? WorkflowTab.LatestCrawl
+            : WorkflowTab.Settings
         }`,
       );
     } catch (e) {

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -221,9 +221,7 @@ export class WorkflowListItem extends BtrixElement {
         }
         e.preventDefault();
         await this.updateComplete;
-        const href = `/orgs/${this.orgSlugState}/workflows/${
-          this.workflow?.id
-        }/${this.workflow?.isCrawlRunning ? WorkflowTab.LatestCrawl : WorkflowTab.Crawls}`;
+        const href = `/orgs/${this.orgSlugState}/workflows/${this.workflow?.id}/${WorkflowTab.LatestCrawl}`;
         this.navigate.to(href);
       }}
     >

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -22,6 +22,7 @@ import {
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
+import { WorkflowTab } from "@/routes";
 import type { ListWorkflow } from "@/types/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import { srOnly, truncate } from "@/utils/css";
@@ -222,7 +223,7 @@ export class WorkflowListItem extends BtrixElement {
         await this.updateComplete;
         const href = `/orgs/${this.orgSlugState}/workflows/${
           this.workflow?.id
-        }#${this.workflow?.isCrawlRunning ? "watch" : "crawls"}`;
+        }/${this.workflow?.isCrawlRunning ? WorkflowTab.LatestCrawl : WorkflowTab.Crawls}`;
         this.navigate.to(href);
       }}
     >

--- a/frontend/src/layouts/pageSectionsWithNav.ts
+++ b/frontend/src/layouts/pageSectionsWithNav.ts
@@ -29,7 +29,7 @@ export function pageSectionsWithNav({
         class=${clsx(
           tw`flex w-full flex-1 flex-col gap-2`,
           sticky && [
-            tw`z-50 lg:sticky lg:self-start`,
+            tw`scrim scrim-to-b z-50 before:-top-2 lg:sticky lg:self-start`,
             stickyTopClassname || tw`lg:top-2`,
           ],
           placement === "start"

--- a/frontend/src/layouts/pageSectionsWithNav.ts
+++ b/frontend/src/layouts/pageSectionsWithNav.ts
@@ -1,17 +1,19 @@
 import clsx from "clsx";
-import { html, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 
 import { tw } from "@/utils/tailwind";
 
 export function pageSectionsWithNav({
   nav,
   main,
+  action,
   placement = "start",
   sticky = false,
   stickyTopClassname,
 }: {
   nav: TemplateResult;
   main: TemplateResult;
+  action?: TemplateResult;
   placement?: "start" | "top";
   sticky?: boolean;
   stickyTopClassname?: string; // e.g. `lg:top-0`
@@ -25,14 +27,23 @@ export function pageSectionsWithNav({
     >
       <div
         class=${clsx(
-          tw`flex flex-1 flex-col gap-2`,
-          sticky &&
-            [tw`lg:sticky lg:self-start`, stickyTopClassname || tw`lg:top-2`],
-          placement === "start" ? tw`lg:max-w-[16.5rem]` : tw`lg:flex-row`,
+          tw`flex w-full flex-1 flex-col gap-2`,
+          sticky && [
+            tw`z-50 lg:sticky lg:self-start`,
+            stickyTopClassname || tw`lg:top-2`,
+          ],
+          placement === "start"
+            ? tw`lg:max-w-[16.5rem]`
+            : tw`lg:flex-row lg:items-center`,
         )}
         part="tabs"
       >
         ${nav}
+        ${action
+          ? html`<div class=${clsx(placement === "top" && tw`lg:ml-auto`)}>
+              ${action}
+            </div>`
+          : nothing}
       </div>
       <div class="flex-1" part="content">${main}</div>
     </div>

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -9,6 +9,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import needLogin from "@/decorators/needLogin";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
+import { WorkflowTab } from "@/routes";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import type { Crawl } from "@/types/crawler";
 import type { CrawlState } from "@/types/crawlState";
@@ -291,10 +292,14 @@ export class Crawls extends BtrixElement {
   private readonly renderCrawlItem = (crawl: Crawl) => {
     const crawlPath = `/orgs/${this.slugLookup[crawl.oid]}/workflows/${crawl.cid}`;
     return html`
-      <btrix-crawl-list-item href=${`${crawlPath}#watch`} .crawl=${crawl}>
+      <btrix-crawl-list-item
+        href=${`${crawlPath}/${WorkflowTab.LatestCrawl}`}
+        .crawl=${crawl}
+      >
         <sl-menu slot="menu">
           <sl-menu-item
-            @click=${() => this.navigate.to(`${crawlPath}#settings`)}
+            @click=${() =>
+              this.navigate.to(`${crawlPath}/${WorkflowTab.Settings}`)}
           >
             ${msg("View Workflow Settings")}
           </sl-menu-item>

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -10,6 +10,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import { type Dialog } from "@/components/ui/dialog";
 import { ClipboardController } from "@/controllers/clipboard";
 import { pageBack, pageNav, type Breadcrumb } from "@/layouts/pageHeader";
+import { WorkflowTab } from "@/routes";
 import type { APIPaginatedList } from "@/types/api";
 import type {
   ArchivedItem,
@@ -123,7 +124,7 @@ export class ArchivedItemDetail extends BtrixElement {
   private get listUrl(): string {
     let path = "items";
     if (this.workflowId) {
-      path = `workflows/crawl/${this.workflowId}#crawls`;
+      path = `workflows/crawl/${this.workflowId}/${WorkflowTab.Crawls}`;
     } else if (this.collectionId) {
       path = `collections/view/${this.collectionId}/items`;
     } else if (this.item?.type === "upload") {
@@ -202,7 +203,7 @@ export class ArchivedItemDetail extends BtrixElement {
           // Items can technically be "running" on the backend, but only
           // workflows should be considered running by the frontend
           this.navigate.to(
-            `${this.navigate.orgBasePath}/workflows/${this.item.cid}#watch`,
+            `${this.navigate.orgBasePath}/workflows/${this.item.cid}/${WorkflowTab.LatestCrawl}`,
             undefined,
             undefined,
             true,
@@ -454,7 +455,7 @@ export class ArchivedItemDetail extends BtrixElement {
           content: this.workflow ? renderName(this.workflow) : undefined,
         },
         {
-          href: `${this.navigate.orgBasePath}/workflows/${this.item?.cid}#crawls`,
+          href: `${this.navigate.orgBasePath}/workflows/${this.item?.cid}/${WorkflowTab.Crawls}`,
           content: msg("Crawls"),
         },
       );

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -11,6 +11,7 @@ import { type Dialog } from "@/components/ui/dialog";
 import { ClipboardController } from "@/controllers/clipboard";
 import { pageBack, pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { WorkflowTab } from "@/routes";
+import { tooltipFor } from "@/strings/archived-items/tooltips";
 import type { APIPaginatedList } from "@/types/api";
 import type {
   ArchivedItem,
@@ -315,15 +316,15 @@ export class ArchivedItemDetail extends BtrixElement {
       case "files":
         sectionContent = this.renderPanel(
           html` ${this.renderTitle(this.tabLabels.files)}
-            <sl-tooltip content=${msg("Download all files as a single WACZ")}>
+            <sl-tooltip content=${tooltipFor.downloadMultWacz}>
               <sl-button
                 href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}`}
-                download
+                download=${`browsertrix-${this.itemId}.wacz`}
                 size="small"
                 variant="primary"
               >
                 <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-                ${msg("Download as Multi-WACZ")}
+                ${msg("Download Files")}
               </sl-button>
             </sl-tooltip>`,
           this.renderFiles(),
@@ -332,19 +333,15 @@ export class ArchivedItemDetail extends BtrixElement {
       case "logs":
         sectionContent = this.renderPanel(
           html` ${this.renderTitle(this.tabLabels.logs)}
-            <sl-tooltip
-              content=${msg(
-                "Download entire log, including verbose logging levels",
-              )}
-            >
+            <sl-tooltip content=${tooltipFor.downloadLogs}>
               <sl-button
                 href=${`/api/orgs/${this.orgId}/crawls/${this.itemId}/logs?auth_bearer=${authToken}`}
-                download=${`btrix-${this.itemId}-logs.txt`}
+                download=${`browsertrix-${this.itemId}-logs.log`}
                 size="small"
                 variant="primary"
               >
-                <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-                ${msg("Download All Logs")}
+                <sl-icon slot="prefix" name="file-earmark-arrow-down"></sl-icon>
+                ${msg("Download Logs")}
               </sl-button>
             </sl-tooltip>`,
           this.renderLogs(),

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -22,7 +22,7 @@ import type { QuotaUpdateDetail } from "@/controllers/api";
 import needLogin from "@/decorators/needLogin";
 import type { CollectionSavedEvent } from "@/features/collections/collection-create-dialog";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
-import { OrgTab, RouteNamespace } from "@/routes";
+import { OrgTab, RouteNamespace, WorkflowTab } from "@/routes";
 import type { ProxiesAPIResponse } from "@/types/crawler";
 import type { UserOrg } from "@/types/user";
 import { isApiError } from "@/utils/api";
@@ -53,6 +53,7 @@ export type SelectNewDialogEvent = CustomEvent<ResourceName>;
 type ArchivedItemPageParams = {
   itemId?: string;
   workflowId?: string;
+  workflowTab?: WorkflowTab;
   collectionId?: string;
 };
 export type OrgParams = {
@@ -529,6 +530,9 @@ export class Org extends BtrixElement {
         <btrix-workflow-detail
           class="col-span-5"
           workflowId=${workflowId}
+          workflowTab=${ifDefined(
+            params.itemId ? WorkflowTab.Crawls : params.workflowTab,
+          )}
           openDialogName=${this.viewStateData?.dialog}
           ?isEditing=${isEditing}
           ?isCrawler=${this.appState.isCrawler}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -554,8 +554,6 @@ export class WorkflowDetail extends BtrixElement {
               ?disabled=${!this.lastCrawlId ||
               this.isCancelingOrStoppingCrawl ||
               this.workflow?.lastCrawlStopping}
-              ?loading=${this.isCancelingOrStoppingCrawl ||
-              this.workflow?.lastCrawlStopping}
             >
               <sl-icon name="dash-square" slot="prefix"></sl-icon>
               <span>${msg("Stop")}</span>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1198,7 +1198,6 @@ export class WorkflowDetail extends BtrixElement {
         source="${replaySource}"
         url="${(this.workflow.seedCount === 1 && this.workflow.firstSeed) ||
         ""}"
-        coll=${this.lastCrawlId}
         config="${config}"
         replayBase="/replay/"
         noSandbox="true"

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -209,10 +209,10 @@ export class WorkflowDetail extends BtrixElement {
         message:
           isApiError(e) && e.statusCode === 404
             ? msg("Workflow not found.")
-            : msg("Sorry, couldn't retrieve Workflow at this time."),
+            : msg("Sorry, couldn't retrieve workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "workflow-retrieve-error",
+        id: "workflow-data-retrieve-error",
       });
     }
 
@@ -894,7 +894,7 @@ export class WorkflowDetail extends BtrixElement {
           slot="nav"
           panel=${WorkflowTab.LatestCrawl}
           href="${this.basePath}/${WorkflowTab.LatestCrawl}"
-          @click=${this.navigate.link}
+          @click=${(e: MouseEvent) => this.navigate.link(e, undefined, false)}
         >
           ${when(
             this.workflow?.isCrawlRunning,
@@ -912,7 +912,7 @@ export class WorkflowDetail extends BtrixElement {
           slot="nav"
           panel=${WorkflowTab.Logs}
           href="${this.basePath}/${WorkflowTab.Logs}"
-          @click=${this.navigate.link}
+          @click=${(e: MouseEvent) => this.navigate.link(e, undefined, false)}
         >
           <sl-icon name="terminal-fill"></sl-icon>
           ${this.tabLabels.logs}
@@ -1015,7 +1015,7 @@ export class WorkflowDetail extends BtrixElement {
                   ? ` / ${this.localize.number(+(this.lastCrawlStats.found || 0))}`
                   : ""
               }`
-            : html`<sl-spinner></sl-spinner>`,
+            : skeleton,
         )}
         ${this.renderDetailItem(msg("Duration"), (workflow) =>
           this.lastCrawlStartTime
@@ -1383,7 +1383,7 @@ export class WorkflowDetail extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "archived-item-retrieve-error",
+        id: "workflow-data-retrieve-error",
       });
     }
   }
@@ -1403,7 +1403,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Sorry, couldn't get crawls at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "archived-item-retrieve-error",
+        id: "workflow-data-retrieve-error",
       });
     }
   }
@@ -1438,7 +1438,7 @@ export class WorkflowDetail extends BtrixElement {
       this.lastCrawlStats = stats;
     } catch {
       this.notify.toast({
-        message: msg("Sorry, couldn't get latest crawl at this time."),
+        message: msg("Sorry, couldn't retrieve latest crawl at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
         id: "archived-item-retrieve-error",
@@ -1448,6 +1448,7 @@ export class WorkflowDetail extends BtrixElement {
     try {
       this.errorLogsTotal = await this.getErrorLogsTotal(this.lastCrawlId);
     } catch (err) {
+      // Fail silently, since we're fetching just the total
       console.debug(err);
     }
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1555,11 +1555,12 @@ export class WorkflowDetail extends BtrixElement {
     }
 
     if (
+      !this.logTotals ||
       (crawlState && isActive({ state: crawlState })) ||
       this.workflowTab === WorkflowTab.Logs
     ) {
       try {
-        this.logTotals = await this.getLogsTotal(this.lastCrawlId);
+        this.logTotals = await this.getLogTotals(this.lastCrawlId);
       } catch (err) {
         // Fail silently, since we're fetching just the total
         console.debug(err);
@@ -1575,7 +1576,7 @@ export class WorkflowDetail extends BtrixElement {
     return data;
   }
 
-  private async getLogsTotal(
+  private async getLogTotals(
     crawlId: Crawl["id"],
   ): Promise<WorkflowDetail["logTotals"]> {
     const query = queryString.stringify({ pageSize: 1 });

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -16,6 +16,7 @@ import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { WorkflowTab } from "@/routes";
+import { tooltipFor } from "@/strings/archived-items/tooltips";
 import { deleteConfirmation } from "@/strings/ui";
 import type { APIPaginatedList } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
@@ -212,7 +213,7 @@ export class WorkflowDetail extends BtrixElement {
             : msg("Sorry, couldn't retrieve workflow at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "workflow-data-retrieve-error",
+        id: "data-retrieve-error",
       });
     }
 
@@ -944,27 +945,52 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private renderLatestCrawlAction() {
-    if (this.workflowTab === WorkflowTab.Logs) {
-      const authToken = this.authState?.headers.Authorization.split(" ")[1];
-      const isDownloadEnabled = Boolean(
-        this.workflow?.lastCrawlId && !this.workflow.isCrawlRunning,
-      );
+    const authToken = this.authState?.headers.Authorization.split(" ")[1];
+    const showDownload = this.lastCrawlId && this.workflow?.lastCrawlSize;
+    const enableDownload = Boolean(
+      this.workflow && !this.workflow.isCrawlRunning,
+    );
+    const downloadDisabledMessage = msg(
+      "Downloading will be enabled when this crawl is finished",
+    );
 
-      return html` <sl-tooltip
+    if (this.workflowTab === WorkflowTab.LatestCrawl && showDownload) {
+      return html`<sl-tooltip
         content=${msg(
-          "Downloading will be enabled when this crawl is finished.",
+          enableDownload
+            ? tooltipFor.downloadMultWacz
+            : downloadDisabledMessage,
         )}
-        ?disabled=${!this.workflow?.isCrawlRunning}
+        hoist
       >
-        <sl-button
-          href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
-          download=${`btrix-${this.lastCrawlId}-logs.txt`}
-          size="small"
-          ?disabled=${!isDownloadEnabled}
+        <sl-icon-button
+          class="text-base"
+          name="cloud-download"
+          href=${`/api/orgs/${this.orgId}/all-crawls/${this.lastCrawlId}/download?auth_bearer=${authToken}`}
+          download=${`browsertrix-${this.lastCrawlId}.wacz`}
+          label=${msg("Download")}
+          ?disabled=${!enableDownload}
         >
-          <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-          ${msg("Download All Logs")}
-        </sl-button>
+        </sl-icon-button>
+      </sl-tooltip> `;
+    }
+
+    if (this.workflowTab === WorkflowTab.Logs && showDownload) {
+      return html`<sl-tooltip
+        content=${msg(
+          enableDownload ? tooltipFor.downloadLogs : downloadDisabledMessage,
+        )}
+        hoist
+      >
+        <sl-icon-button
+          class="text-base"
+          name="file-earmark-arrow-down"
+          href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
+          download=${`browsertrix-${this.lastCrawlId}-logs.log`}
+          label=${msg("Download")}
+          ?disabled=${!enableDownload}
+        >
+        </sl-icon-button>
       </sl-tooltip>`;
     }
 
@@ -1434,7 +1460,7 @@ export class WorkflowDetail extends BtrixElement {
         ),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "workflow-data-retrieve-error",
+        id: "data-retrieve-error",
       });
     }
   }
@@ -1454,7 +1480,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Sorry, couldn't get crawls at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "workflow-data-retrieve-error",
+        id: "data-retrieve-error",
       });
     }
   }
@@ -1492,7 +1518,7 @@ export class WorkflowDetail extends BtrixElement {
         message: msg("Sorry, couldn't retrieve latest crawl at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "archived-item-retrieve-error",
+        id: "data-retrieve-error",
       });
     }
 

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -24,6 +24,7 @@ import { type SelectEvent } from "@/components/ui/search-combobox";
 import { ClipboardController } from "@/controllers/clipboard";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
 import { pageHeader } from "@/layouts/pageHeader";
+import { WorkflowTab } from "@/routes";
 import scopeTypeLabels from "@/strings/crawl-workflows/scopeType";
 import { deleteConfirmation } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
@@ -585,7 +586,7 @@ export class WorkflowsList extends BtrixElement {
           <sl-menu-item
             @click=${() =>
               this.navigate.to(
-                `${this.navigate.orgBasePath}/workflows/${workflow.id}#watch`,
+                `${this.navigate.orgBasePath}/workflows/${workflow.id}/${WorkflowTab.LatestCrawl}`,
                 {
                   dialog: "scale",
                 },
@@ -598,7 +599,7 @@ export class WorkflowsList extends BtrixElement {
             ?disabled=${workflow.lastCrawlState !== "running"}
             @click=${() =>
               this.navigate.to(
-                `${this.navigate.orgBasePath}/workflows/${workflow.id}#watch`,
+                `${this.navigate.orgBasePath}/workflows/${workflow.id}/${WorkflowTab.LatestCrawl}`,
                 {
                   dialog: "exclusions",
                 },
@@ -900,7 +901,8 @@ export class WorkflowsList extends BtrixElement {
             <br />
             <a
               class="underline hover:no-underline"
-              href="${this.navigate.orgBasePath}/workflows/${workflow.id}#watch"
+              href="${this.navigate
+                .orgBasePath}/workflows/${workflow.id}/${WorkflowTab.LatestCrawl}"
               @click=${this.navigate.link.bind(this)}
               >Watch crawl</a
             >`,

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -95,7 +95,7 @@ export class WorkflowsNew extends LiteElement {
     return html`
       <div class="mb-5">${this.renderBreadcrumbs()}</div>
       <header
-        class="scrim scrim-to-b z-10 flex flex-wrap items-start justify-between gap-2 to-white before:-top-3 lg:sticky lg:top-3"
+        class="scrim scrim-to-b z-10 flex flex-wrap items-start justify-between gap-2 before:-top-3 lg:sticky lg:top-3"
       >
         <h2 class="mb-6 text-xl font-semibold">${msg("New Crawl Workflow")}</h2>
         <sl-button

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -13,6 +13,15 @@ export enum RouteNamespace {
   Superadmin = "admin",
 }
 
+export enum WorkflowTab {
+  LatestCrawl = "latest",
+  Crawls = "crawls",
+  Logs = "logs",
+  Settings = "settings",
+}
+
+const archivedItemPath = "/:itemId(/review/:qaTab)";
+
 export const ROUTES = {
   home: "/",
   join: "/join/:token",
@@ -29,8 +38,8 @@ export const ROUTES = {
     `/${RouteNamespace.PrivateOrgs}/:slug(/)`,
     // Org sections:
     `(/${OrgTab.Dashboard})`,
-    `(/${OrgTab.Workflows}(/new)(/:workflowId(/crawls/:itemId(/review/:qaTab))))`,
-    `(/${OrgTab.Items}(/:itemType(/:itemId(/review/:qaTab))))`,
+    `(/${OrgTab.Workflows}(/new)(/:workflowId(/:workflowTab)(/crawls${archivedItemPath})))`,
+    `(/${OrgTab.Items}(/:itemType(${archivedItemPath})))`,
     `(/${OrgTab.Collections}(/new)(/view/:collectionId(/:collectionTab)))`,
     `(/${OrgTab.BrowserProfiles}(/profile(/browser/:browserId)(/:browserProfileId)))`,
     `(/${OrgTab.Settings}(/:settingsTab))`,

--- a/frontend/src/strings/archived-items/tooltips.ts
+++ b/frontend/src/strings/archived-items/tooltips.ts
@@ -1,10 +1,6 @@
 import { msg } from "@lit/localize";
 
 export const tooltipFor = {
-  downloadMultWacz: msg(
-    msg("This will combine all files into a single multi-WACZ file."),
-  ),
-  downloadLogs: msg(
-    "This will download the entire log file, including verbose logging levels that are hidden below.",
-  ),
+  downloadMultWacz: msg(msg("Download Files as Multi-WACZ")),
+  downloadLogs: msg("Download Entire Log File"),
 };

--- a/frontend/src/strings/archived-items/tooltips.ts
+++ b/frontend/src/strings/archived-items/tooltips.ts
@@ -1,0 +1,10 @@
+import { msg } from "@lit/localize";
+
+export const tooltipFor = {
+  downloadMultWacz: msg(
+    msg("This will combine all files into a single multi-WACZ file."),
+  ),
+  downloadLogs: msg(
+    "This will download the entire log file, including verbose logging levels that are hidden below.",
+  ),
+};

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -260,7 +260,7 @@
   /* Style tooltip with white background */
   sl-tooltip.invert-tooltip {
     --sl-tooltip-arrow-size: 0;
-    --sl-tooltip-background-color: var(--sl-color-neutral-0);
+    --sl-tooltip-background-color: var(--sl-color-neutral-50);
     --sl-tooltip-color: var(--sl-color-neutral-700);
   }
 

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -169,6 +169,58 @@ const plurals = {
       id: "rows.plural.other",
     }),
   },
+  errors: {
+    zero: msg("errors", {
+      desc: 'plural form of "errors" for zero errors',
+      id: "errors.plural.zero",
+    }),
+    one: msg("error", {
+      desc: 'singular form for "error"',
+      id: "errors.plural.one",
+    }),
+    two: msg("errors", {
+      desc: 'plural form of "errors" for two errors',
+      id: "errors.plural.two",
+    }),
+    few: msg("errors", {
+      desc: 'plural form of "errors" for few errors',
+      id: "errors.plural.few",
+    }),
+    many: msg("errors", {
+      desc: 'plural form of "errors" for many errors',
+      id: "errors.plural.many",
+    }),
+    other: msg("errors", {
+      desc: 'plural form of "errors" for multiple/other errors',
+      id: "errors.plural.other",
+    }),
+  },
+  browserWindows: {
+    zero: msg("browser windows", {
+      desc: 'plural form of "browser windows" for zero browser windows',
+      id: "browserWindows.plural.zero",
+    }),
+    one: msg("browser window", {
+      desc: 'singular form for "browser window"',
+      id: "browserWindows.plural.one",
+    }),
+    two: msg("browser windows", {
+      desc: 'plural form of "browser windows" for two browser windows',
+      id: "browserWindows.plural.two",
+    }),
+    few: msg("browser windows", {
+      desc: 'plural form of "browser windows" for few browser windows',
+      id: "browserWindows.plural.few",
+    }),
+    many: msg("browser windows", {
+      desc: 'plural form of "browser windows" for many browser windows',
+      id: "browserWindows.plural.many",
+    }),
+    other: msg("browser windows", {
+      desc: 'plural form of "browser windows" for multiple/other browser windows',
+      id: "browserWindows.plural.other",
+    }),
+  },
 };
 
 export const pluralOf = (word: keyof typeof plurals, count: number) => {


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2603

## Changes

- Combines "Watch" and "Logs" into single "Latest Crawl" tab
- Updates workflow routes and adds redirects
- Enables replaying and downloading latest crawl from the workflow detail view
- Tweaks crawl list table header labels and and archived item download button labels for consistency
- Fixes crawl queue showing error when stopping crawl

## Manual testing

To test the UI:
1. Log in as crawler
2. Click "Crawling"
3. Click complete workflow. Verify navigation to "Latest Crawl" tab and replay renders.
4. Click cloud icon download button. Verify crawl is downloaded as WACZ.
5. Click "Logs". Verify logs are disabled and downloadable if there are any.
6. Click "Run Crawl". Verify Replay tab changes to "Watch"
7. Wait for crawl to start. Verify watch renders as expected
8. Wait for crawl to finish. Verify replay renders as expected

To test redirects, verify:
- `/workflows/<id>#watch` redirects to `/latest`
- `/workflows/<id>#logs` redirects to `/logs`
- `/workflows/<id>#crawls` redirects to `/crawls`
- `/workflows/<id>#settings` redirects to `/settings`

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow (side nav) | <img width="288" alt="Screenshot 2025-05-13 at 10 09 08 AM" src="https://github.com/user-attachments/assets/87b33558-ce20-4daf-b481-cb5c4a4b790b" /> |
| Workflow - Latest Crawl | **No crawls:**<br/><img width="973" alt="Screenshot 2025-05-13 at 10 10 14 AM" src="https://github.com/user-attachments/assets/6334b318-d5d0-4129-84c1-ca3bfa9c3bbb" /> |
| Workflow - Latest Crawl |  **Canceled crawl:**<br/><img width="985" alt="Screenshot 2025-05-13 at 10 30 58 AM" src="https://github.com/user-attachments/assets/130c7861-252b-474e-ad8a-296f1c713832" /> |
| Workflow - Latest Crawl | **Running crawl:**<br/><img width="972" alt="Screenshot 2025-05-13 at 10 50 55 AM" src="https://github.com/user-attachments/assets/fe886d40-78fa-4fd0-9a8c-29fd33b5a4cb" /> |
| Workflow - Latest Crawl | **Finished crawl:**<br/><img width="963" alt="Screenshot 2025-05-13 at 10 48 14 AM" src="https://github.com/user-attachments/assets/55fc2f97-a106-4548-af4b-facee3f3531a" /> |
| Workflow - Logs | <img width="960" alt="Screenshot 2025-05-13 at 10 10 04 AM" src="https://github.com/user-attachments/assets/532ff73f-bc37-439e-95de-198772c7168b" /> |



<!-- ## Follow-ups -->
