### PR TITLE
Remove collection from crawl configs on delete

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -525,7 +525,6 @@ class BaseCrawlOps:
                 {"autoAddCollections": collection_id},
                 {"$pull": {"autoAddCollections": collection_id}},
             ),
-            return_exceptions=True,
         )
 
     # pylint: disable=too-many-branches, invalid-name, too-many-statements

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -515,9 +515,16 @@ class BaseCrawlOps:
 
     async def remove_collection_from_all_crawls(self, collection_id: UUID):
         """Remove collection id from all crawls it's currently in."""
-        await self.crawls.update_many(
-            {"collectionIds": collection_id},
-            {"$pull": {"collectionIds": collection_id}},
+        await asyncio.gather(
+            self.crawls.update_many(
+                {"collectionIds": collection_id},
+                {"$pull": {"collectionIds": collection_id}},
+            ),
+            self.crawl_configs.update_many(
+                {"autoAddCollections": collection_id},
+                {"$pull": {"autoAddCollections": collection_id}},
+            ),
+            return_exceptions=True,
         )
 
     # pylint: disable=too-many-branches, invalid-name, too-many-statements

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -76,6 +76,7 @@ class BaseCrawlOps:
         background_job_ops: BackgroundJobOps,
     ):
         self.crawls = mdb["crawls"]
+        self.mongo_crawl_configs = mdb["crawl_configs"]
         self.crawl_configs = crawl_configs
         self.user_manager = users
         self.orgs = orgs
@@ -520,7 +521,7 @@ class BaseCrawlOps:
                 {"collectionIds": collection_id},
                 {"$pull": {"collectionIds": collection_id}},
             ),
-            self.crawl_configs.update_many(
+            self.mongo_crawl_configs.update_many(
                 {"autoAddCollections": collection_id},
                 {"$pull": {"autoAddCollections": collection_id}},
             ),

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -636,7 +636,7 @@ class CollectionOps:
                     )
                 )
 
-                return {"success": True}
+        return {"success": True}
 
     async def download_collection(self, coll_id: UUID, org: Organization):
         """Download all WACZs in collection as streaming nested WACZ"""

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -624,12 +624,16 @@ class CollectionOps:
             async with sesh.start_transaction():
                 await self.crawl_ops.remove_collection_from_all_crawls(coll_id)
 
-                result = await self.collections.delete_one({"_id": coll_id, "oid": org.id})
+                result = await self.collections.delete_one(
+                    {"_id": coll_id, "oid": org.id}
+                )
                 if result.deleted_count < 1:
                     raise HTTPException(status_code=404, detail="collection_not_found")
 
                 asyncio.create_task(
-                    self.event_webhook_ops.create_collection_deleted_notification(coll_id, org)
+                    self.event_webhook_ops.create_collection_deleted_notification(
+                        coll_id, org
+                    )
                 )
 
                 return {"success": True}

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -971,7 +971,7 @@ def init_collections_api(
     # pylint: disable=invalid-name, unused-argument, too-many-arguments
 
     colls: CollectionOps = CollectionOps(
-        mdb, dbclient, storage_ops, orgs, event_webhook_ops
+        dbclient, mdb, storage_ops, orgs, event_webhook_ops
     )
 
     org_crawl_dep = orgs.org_crawl_dep

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -226,7 +226,7 @@ def main() -> None:
     )
 
     coll_ops = init_collections_api(
-        app, mdb, org_ops, storage_ops, event_webhook_ops, current_active_user
+        app, dbclient, mdb, org_ops, storage_ops, event_webhook_ops, current_active_user
     )
 
     base_crawl_init = (

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -22,7 +22,7 @@ class Migration(BaseMigration):
         Recompute collection data to include totalSize.
         """
         # pylint: disable=duplicate-code
-        coll_ops = CollectionOps(self.mdb, None, None, None)
+        coll_ops = CollectionOps(None, self.mdb, None, None, None)
 
         async for coll in coll_ops.collections.find({}):
             coll_id = coll["_id"]

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -74,7 +74,7 @@ def init_ops() -> Tuple[
         profile_ops,
     )
 
-    coll_ops = CollectionOps(mdb, storage_ops, org_ops, event_webhook_ops)
+    coll_ops = CollectionOps(dbclient, mdb, storage_ops, org_ops, event_webhook_ops)
 
     base_crawl_init = (
         mdb,


### PR DESCRIPTION
Closes #2609 

Ensure collection id is removed from both crawls and crawl configs when a collection is deleted.

Ideally this should be integration-tested too, will take a look at that at some point.

## Testing

Tested locally.

1. Create a collection
2. Create a workflow set to auto-add to the collection
3. Delete the collection
4. Verify that the auto-add entry in the workflow was also deleted