### PR TITLE
feat: Handle paused state + workflow performance improvements

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1504,6 +1504,7 @@ class CrawlOperator(BaseOperator):
                 await self.set_state(
                     "paused", status, crawl, allowed_from=RUNNING_AND_WAITING_STATES
                 )
+                return status
 
         # if at least one is done according to redis, consider crawl successful
         # ensure pod successfully exited as well

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -1,6 +1,6 @@
 # Modifying Running Crawls
 
-Running crawls can be modified from the crawl workflow **Latest Crawl** tab. You may want to modify a runnning crawl if you find that the workflow is crawling pages that you didn't intend to archive, or if you want a boost of speed.
+Running crawls can be modified from the crawl workflow **Latest Crawl** tab. You may want to modify a running crawl if you find that the workflow is crawling pages that you didn't intend to archive, or if you want a boost of speed.
 
 ## Crawl Workflow Status
 

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -12,7 +12,8 @@ A crawl workflow that is in progress can be in one of the following states:
 | <span class="status-waiting">:btrix-status-dot: Starting</span>       | New resources are starting up. Crawling should begin shortly.|
 | <span class="status-success">:btrix-status-dot: Running</span>        | The crawler is finding and capturing pages! |
 | <span class="status-waiting">:btrix-status-dot: Stopping</span> | A user has instructed this workflow to stop. Finishing capture of the current pages.|
-| <span class="status-waiting">:btrix-status-dot: Finishing Crawl</span> | The workflow has finished crawling and data is being packaged into WACZ files.|
+| <span class="status-waiting">:btrix-status-dot: Finishing Downloads</span> | The workflow has finished crawling and is finalizing downloads.|
+| <span class="status-waiting">:btrix-status-dot: Generating WACZ</span> | Data is being packaged into WACZ files.|
 | <span class="status-waiting">:btrix-status-dot: Uploading WACZ</span> | WACZ files have been created and are being transferred to storage.|
 
 ## Watch Crawl

--- a/frontend/src/components/detail-page-title.ts
+++ b/frontend/src/components/detail-page-title.ts
@@ -70,7 +70,7 @@ export class DetailPageTitle extends TailwindElement {
   private renderIcon() {
     if (!this.item?.state) return;
 
-    const crawlStatus = CrawlStatus.getContent(this.item.state, this.item.type);
+    const crawlStatus = CrawlStatus.getContent(this.item);
 
     let icon = html`<sl-tooltip
       content=${msg(str`Crawl: ${crawlStatus.label}`)}

--- a/frontend/src/components/not-found.ts
+++ b/frontend/src/components/not-found.ts
@@ -3,28 +3,26 @@ import { html, nothing } from "lit";
 import { customElement } from "lit/decorators.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import { pageError } from "@/layouts/pageError";
 
 @localized()
 @customElement("btrix-not-found")
 export class NotFound extends BtrixElement {
   render() {
     return html`
-      <div class="text-center">
-        <p class="my-4 border-b py-4 text-xl leading-none text-neutral-500">
-          ${msg("Sorry, we couldn’t find that page")}
-        </p>
-        <p class="text-neutral-600">
-          ${msg("Check the URL to make sure you’ve entered it correctly.")}
-        </p>
-        <div class="my-4">
-          <sl-button href="/" @click=${this.navigate.link} size="small"
-            >${msg("Go to Home")}</sl-button
-          >
-        </div>
-        <p class="text-neutral-500">
+      ${pageError({
+        heading: msg("Sorry, we couldn’t find that page"),
+        detail: msg("Check the URL to make sure you’ve entered it correctly."),
+        primaryAction: html`<sl-button
+          href="/"
+          @click=${this.navigate.link}
+          size="small"
+          >${msg("Go to Home")}</sl-button
+        >`,
+        secondaryAction: html`
           ${msg("Did you click a link to get here?")}
           <button
-            class="text-cyan-500 transition-colors hover:text-cyan-600"
+            class="text-blue-500 transition-colors hover:text-blue-600"
             @click=${() => {
               window.history.back();
             }}
@@ -42,8 +40,8 @@ export class NotFound extends BtrixElement {
                   ${msg("Report a Broken Link")}
                 </btrix-link>
               `}
-        </p>
-      </div>
+        `,
+      })}
     `;
   }
 }

--- a/frontend/src/components/ui/alert.ts
+++ b/frontend/src/components/ui/alert.ts
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 
@@ -18,28 +18,42 @@ export class Alert extends TailwindElement {
   @property({ type: String })
   variant: "success" | "warning" | "danger" | "info" = "info";
 
+  @state()
+  open = true;
+
   static styles = css`
     :host {
       display: block;
     }
   `;
 
+  public hide() {
+    // TODO Animate for nicer transition
+    this.open = false;
+  }
+
+  public show() {
+    // TODO Animate for nicer transition
+    this.open = true;
+  }
+
   render() {
-    return html`
-      <div
-        class="${clsx(
-          "px-3 py-2 rounded border",
-          {
-            success: "bg-success-50 text-success-800 border-success-200",
-            warning: "bg-warning-50 text-warning-800 border-warning-200",
-            danger: "bg-danger-50 text-danger-800 border-danger-200",
-            info: "bg-primary-50 text-primary-800 border-primary-200",
-          }[this.variant],
-        )}"
-        role="alert"
-      >
-        <slot></slot>
-      </div>
-    `;
+    if (!this.open) return;
+
+    return html`<div
+      class="${clsx(
+        "px-3 py-2 rounded-lg border",
+        {
+          success: "bg-success-50 text-success-800 border-success-200",
+          warning: "bg-warning-50 text-warning-800 border-warning-200",
+          danger: "bg-danger-50 text-danger-800 border-danger-200",
+          info: "bg-primary-50 text-primary-600 border-primary-100",
+        }[this.variant],
+      )}"
+      role="alert"
+      part="base"
+    >
+      <slot></slot>
+    </div>`;
   }
 }

--- a/frontend/src/components/ui/badge.ts
+++ b/frontend/src/components/ui/badge.ts
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
@@ -38,17 +39,19 @@ export class Badge extends TailwindElement {
   render() {
     return html`
       <span
-        class="h-4.5 ${{
-          success: tw`bg-success-500 text-neutral-0`,
-          warning: tw`bg-warning-600 text-neutral-0`,
-          danger: tw`bg-danger-500 text-neutral-0`,
-          neutral: tw`bg-neutral-100 text-neutral-600`,
-          "high-contrast": tw`bg-neutral-600 text-neutral-0`,
-          primary: tw`bg-primary text-neutral-0`,
-          blue: tw`bg-cyan-50 text-neutral-600`,
-        }[
-          this.variant
-        ]} inline-flex items-center justify-center rounded-sm px-2 align-[1px] text-xs"
+        class=${clsx(
+          tw`h-4.5 inline-flex items-center justify-center rounded-sm px-2 align-[1px] text-xs`,
+          {
+            success: tw`bg-success-500 text-neutral-0`,
+            warning: tw`bg-warning-600 text-neutral-0`,
+            danger: tw`bg-danger-500 text-neutral-0`,
+            neutral: tw`bg-neutral-100 text-neutral-600`,
+            "high-contrast": tw`bg-neutral-600 text-neutral-0`,
+            primary: tw`bg-primary text-neutral-0`,
+            blue: tw`bg-cyan-50 text-cyan-600`,
+          }[this.variant],
+        )}
+        part="base"
       >
         <slot></slot>
       </span>

--- a/frontend/src/components/ui/button.ts
+++ b/frontend/src/components/ui/button.ts
@@ -38,6 +38,9 @@ export class Button extends TailwindElement {
   @property({ type: String })
   href?: string;
 
+  @property({ type: String })
+  download?: string;
+
   @property({ type: Boolean })
   raised = false;
 
@@ -63,32 +66,49 @@ export class Button extends TailwindElement {
     return html`<${tag}
       type=${this.type === "submit" ? "submit" : "button"}
       class=${clsx(
-        tw`flex cursor-pointer items-center justify-center gap-2 text-center font-medium outline-3 outline-offset-1 outline-primary transition focus-visible:outline disabled:cursor-not-allowed disabled:text-neutral-300`,
+        this.disabled ? tw`cursor-not-allowed opacity-50` : tw`cursor-pointer`,
+        tw`flex items-center justify-center gap-2 text-center font-medium outline-3 outline-offset-1 outline-primary transition focus-visible:outline`,
         {
           "x-small": tw`min-h-4 min-w-4 text-sm`,
           small: tw`min-h-6 min-w-6 rounded-md text-base`,
           medium: tw`min-h-8 min-w-8 rounded-sm text-lg`,
         }[this.size],
-        this.raised &&
-          tw`shadow ring-1 ring-stone-500/20 hover:shadow-stone-800/20 hover:ring-stone-800/20`,
+        this.raised && [
+          tw`shadow ring-1 ring-stone-500/20`,
+          !this.disabled &&
+            tw`hover:shadow-stone-800/20 hover:ring-stone-800/20`,
+        ],
         this.filled
           ? [
               tw`text-white`,
               {
-                neutral: tw`border-primary-800 bg-primary-500 shadow-primary-800/20 hover:bg-primary-600`,
-                danger: tw`shadow-danger-800/20 border-danger-800 bg-danger-500 hover:bg-danger-600`,
+                neutral: [
+                  tw`border-primary-800 bg-primary-500 shadow-primary-800/20`,
+                  !this.disabled && tw`hover:bg-primary-600`,
+                ],
+                danger: [
+                  tw`shadow-danger-800/20 border-danger-800 bg-danger-500`,
+                  !this.disabled && tw`hover:bg-danger-600`,
+                ],
               }[this.variant],
             ]
           : [
               this.raised && tw`bg-white`,
               {
-                neutral: tw`border-gray-300 text-gray-600 hover:text-primary-600`,
-                danger: tw`shadow-danger-800/20 border-danger-300 bg-danger-50 text-danger-600 hover:bg-danger-100`,
+                neutral: [
+                  tw`border-gray-300 text-gray-600`,
+                  !this.disabled && tw`hover:text-primary-500`,
+                ],
+                danger: [
+                  tw`shadow-danger-800/20 border-danger-300 bg-danger-50 text-danger-600`,
+                  !this.disabled && tw`hover:bg-danger-100`,
+                ],
               }[this.variant],
             ],
       )}
       ?disabled=${this.disabled}
       href=${ifDefined(this.href)}
+      download=${ifDefined(this.download)}
       aria-label=${ifDefined(this.label)}
       @click=${this.handleClick}
     >

--- a/frontend/src/components/ui/copy-button.ts
+++ b/frontend/src/components/ui/copy-button.ts
@@ -4,6 +4,7 @@ import { customElement, property } from "lit/decorators.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { ClipboardController } from "@/controllers/clipboard";
+import { tw } from "@/utils/tailwind";
 
 /**
  * Copy text to clipboard on click
@@ -69,7 +70,7 @@ export class CopyButton extends TailwindElement {
                 ? this.name
                 : "copy"}
             label=${msg("Copy to clipboard")}
-            class="size-3.5"
+            class=${this.size === "medium" ? tw`size-4` : tw`size-3.5`}
           ></sl-icon>
         </btrix-button>
       </sl-tooltip>

--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -30,7 +30,7 @@ export class DescListItem extends LitElement {
       color: var(--sl-color-neutral-500);
       font-size: var(--sl-font-size-x-small);
       line-height: 1rem;
-      margin: 0 0 var(--sl-spacing-2x-small) 0;
+      margin: 0 0 var(--sl-spacing-3x-small) 0;
     }
 
     dd {
@@ -40,8 +40,8 @@ export class DescListItem extends LitElement {
       font-size: var(--sl-font-size-medium);
       font-family: var(--font-monostyle-family);
       font-variation-settings: var(--font-monostyle-variation);
-      line-height: 1rem;
-      min-height: calc(1rem + var(--sl-spacing-2x-small));
+      line-height: 1.5rem;
+      min-height: 1.5rem;
     }
 
     .item {
@@ -94,7 +94,7 @@ export class DescList extends LitElement {
       display: inline-block;
       flex: 1 0 0;
       min-width: min-content;
-      padding-top: var(--sl-spacing-2x-small);
+      padding-top: var(--sl-spacing-x-small);
     }
 
     .horizontal ::slotted(btrix-desc-list-item)::before {

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -25,6 +25,20 @@ type PageChangeDetail = {
 };
 export type PageChangeEvent = CustomEvent<PageChangeDetail>;
 
+export function calculatePages({
+  total,
+  pageSize,
+}: {
+  total: number;
+  pageSize: number;
+}) {
+  if (total && pageSize) {
+    return Math.ceil(total / pageSize);
+  } else {
+    return 0;
+  }
+}
+
 /**
  * Pagination
  *
@@ -200,7 +214,7 @@ export class Pagination extends LitElement {
     if (parsedPage != this._page) {
       const page = parsePage(this.searchParams.searchParams.get(this.name));
       const constrainedPage = Math.max(1, Math.min(this.pages, page));
-      this.onPageChange(constrainedPage);
+      this.onPageChange(constrainedPage, { dispatch: false });
     }
 
     if (changedProperties.get("page") && this._page) {
@@ -364,15 +378,18 @@ export class Pagination extends LitElement {
     this.onPageChange(this._page < this.pages ? this._page + 1 : this.pages);
   }
 
-  private onPageChange(page: number) {
+  private onPageChange(page: number, opts = { dispatch: true }) {
     if (this._page !== page) {
       this.setPage(page);
-      this.dispatchEvent(
-        new CustomEvent<PageChangeDetail>("page-change", {
-          detail: { page: page, pages: this.pages },
-          composed: true,
-        }),
-      );
+
+      if (opts.dispatch) {
+        this.dispatchEvent(
+          new CustomEvent<PageChangeDetail>("page-change", {
+            detail: { page: page, pages: this.pages },
+            composed: true,
+          }),
+        );
+      }
     }
     this._page = page;
   }
@@ -389,10 +406,9 @@ export class Pagination extends LitElement {
   }
 
   private calculatePages() {
-    if (this.totalCount && this.size) {
-      this.pages = Math.ceil(this.totalCount / this.size);
-    } else {
-      this.pages = 0;
-    }
+    this.pages = calculatePages({
+      total: this.totalCount,
+      pageSize: this.size,
+    });
   }
 }

--- a/frontend/src/components/ui/popover.ts
+++ b/frontend/src/components/ui/popover.ts
@@ -13,8 +13,10 @@ import { customElement, property } from "lit/decorators.js";
  *
  * @attr {String} content
  * @attr {String} placement
+ * @attr {String} distance
  * @attr {String} trigger
  * @attr {Boolean} open
+ * @attr {Boolean} disabled
  */
 @customElement("btrix-popover")
 @localized()
@@ -29,8 +31,9 @@ export class Popover extends SlTooltip {
     slTooltipStyles,
     css`
       :host {
-        --btrix-border: 1px solid var(--sl-panel-border-color);
-        --sl-tooltip-background-color: var(--sl-color-neutral-0);
+        --btrix-border: 1px solid var(--sl-color-neutral-300);
+        --sl-tooltip-border-radius: var(--sl-border-radius-large);
+        --sl-tooltip-background-color: var(--sl-color-neutral-50);
         --sl-tooltip-color: var(--sl-color-neutral-700);
         --sl-tooltip-font-size: var(--sl-font-size-x-small);
         --sl-tooltip-padding: var(--sl-spacing-small);
@@ -39,7 +42,7 @@ export class Popover extends SlTooltip {
 
       ::part(body) {
         border: var(--btrix-border);
-        box-shadow: var(--sl-shadow-medium);
+        box-shadow: var(--sl-shadow-small), var(--sl-shadow-large);
       }
 
       ::part(arrow) {

--- a/frontend/src/features/admin/super-admin-banner.ts
+++ b/frontend/src/features/admin/super-admin-banner.ts
@@ -22,7 +22,7 @@ export class SuperAdminBanner extends TailwindElement {
             <strong>${msg("You are logged in as a superadmin")}</strong> –
             ${msg("please be careful.")}
           </span>
-          <div class="sticky right-2 top-2 z-50">
+          <div class="sticky right-2 top-2 z-[999]">
             <button
               type="button"
               class="flex rounded-full border border-warning-800 bg-warning-700 p-2 text-warning-50 shadow-md shadow-orange-700/20 transition hover:scale-110"
@@ -41,7 +41,7 @@ export class SuperAdminBanner extends TailwindElement {
       </div>`;
     } else {
       return html`<div
-        class="sticky top-0 z-50 border-b border-b-warning-800 bg-warning-700 py-2 text-xs text-warning-50 shadow-sm shadow-orange-700/20"
+        class="sticky top-0 z-[999] border-b border-b-warning-800 bg-warning-700 py-2 text-xs text-warning-50 shadow-sm shadow-orange-700/20"
       >
         <div
           class="mx-auto box-border flex w-full items-center gap-2 px-3 xl:pl-6"

--- a/frontend/src/features/archived-items/archived-item-list.ts
+++ b/frontend/src/features/archived-items/archived-item-list.ts
@@ -80,7 +80,7 @@ export class ArchivedItemListItem extends BtrixElement {
     const checkboxId = `${this.item.id}-checkbox`;
     const rowName = renderName(this.item);
     const isUpload = this.item.type === "upload";
-    const crawlStatus = CrawlStatus.getContent(this.item.state, this.item.type);
+    const crawlStatus = CrawlStatus.getContent(this.item);
     let typeLabel = msg("Crawl");
     let typeIcon = "gear-wide-connected";
 
@@ -112,7 +112,9 @@ export class ArchivedItemListItem extends BtrixElement {
       ? Math.round((100 * activeQAStats.done) / activeQAStats.found)
       : 0;
 
-    const qaStatus = CrawlStatus.getContent(lastQAState || undefined);
+    const qaStatus = CrawlStatus.getContent({
+      state: lastQAState || undefined,
+    });
 
     return html`
       <btrix-table-row

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -303,7 +303,7 @@ export class CrawlList extends TailwindElement {
               ${msg("Finished")}
             </btrix-table-header-cell>
             <btrix-table-header-cell
-              >${msg("Duration")}</btrix-table-header-cell
+              >${msg("Duration Active")}</btrix-table-header-cell
             >
             <btrix-table-header-cell>${msg("Pages")}</btrix-table-header-cell>
             <btrix-table-header-cell>${msg("Size")}</btrix-table-header-cell>

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -26,6 +26,7 @@ import { TailwindElement } from "@/classes/TailwindElement";
 import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
 import type { Crawl } from "@/types/crawler";
 import { renderName } from "@/utils/crawler";
+import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 
 /**
  * @slot menu
@@ -185,6 +186,11 @@ export class CrawlListItem extends BtrixElement {
           )}
         </btrix-table-cell>
         <btrix-table-cell>
+          ${this.safeRender((crawl) =>
+            humanizeExecutionSeconds(crawl.crawlExecSeconds),
+          )}
+        </btrix-table-cell>
+        <btrix-table-cell>
           ${this.safeRender((crawl) => {
             const pagesFound = +(crawl.stats?.found || 0);
             if (crawl.finished) {
@@ -284,8 +290,8 @@ export class CrawlList extends TailwindElement {
     return html` <style>
         btrix-table {
           --btrix-table-grid-template-columns: min-content [clickable-start]
-            ${this.workflowId ? "" : `auto `}auto auto auto auto auto auto
-            [clickable-end] min-content;
+            ${this.workflowId ? "" : `auto `}repeat(7, auto) [clickable-end]
+            min-content;
         }
       </style>
       <btrix-overflow-scroll class="-mx-3 part-[content]:px-3">
@@ -308,12 +314,15 @@ export class CrawlList extends TailwindElement {
               ${msg("Finished")}
             </btrix-table-header-cell>
             <btrix-table-header-cell
-              >${msg("Elapsed Time")}</btrix-table-header-cell
+              >${msg("Run Duration")}</btrix-table-header-cell
+            >
+            <btrix-table-header-cell
+              >${msg("Execution Time")}</btrix-table-header-cell
             >
             <btrix-table-header-cell>${msg("Pages")}</btrix-table-header-cell>
             <btrix-table-header-cell>${msg("Size")}</btrix-table-header-cell>
             <btrix-table-header-cell>
-              ${msg("Created By")}
+              ${msg("Run By")}
             </btrix-table-header-cell>
             <btrix-table-header-cell class="pl-1 pr-1">
               <span class="sr-only">${msg("Row actions")}</span>

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -303,7 +303,7 @@ export class CrawlList extends TailwindElement {
               ${msg("Finished")}
             </btrix-table-header-cell>
             <btrix-table-header-cell
-              >${msg("Duration Active")}</btrix-table-header-cell
+              >${msg("Elapsed Time")}</btrix-table-header-cell
             >
             <btrix-table-header-cell>${msg("Pages")}</btrix-table-header-cell>
             <btrix-table-header-cell>${msg("Size")}</btrix-table-header-cell>

--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -197,9 +197,14 @@ export class CrawlListItem extends BtrixElement {
           })}
         </btrix-table-cell>
         <btrix-table-cell>
-          ${this.localize.bytes(this.crawl.fileSize || 0, {
-            unitDisplay: "narrow",
-          })}
+          ${this.safeRender((crawl) =>
+            this.localize.bytes(
+              crawl.finished ? crawl.fileSize || 0 : +(crawl.stats?.size || 0),
+              {
+                unitDisplay: "narrow",
+              },
+            ),
+          )}
         </btrix-table-cell>
         <btrix-table-cell>
           <div class="max-w-sm truncate">

--- a/frontend/src/features/archived-items/crawl-logs.ts
+++ b/frontend/src/features/archived-items/crawl-logs.ts
@@ -203,7 +203,7 @@ export class CrawlLogs extends BtrixElement {
 
           <footer class="my-4 flex justify-center">
             <btrix-pagination
-              name="logs"
+              name="logsPage"
               page=${logs.page}
               totalCount=${logs.total}
               size=${logs.pageSize}

--- a/frontend/src/features/archived-items/crawl-logs.ts
+++ b/frontend/src/features/archived-items/crawl-logs.ts
@@ -196,6 +196,7 @@ export class CrawlLogs extends BtrixElement {
         this.filter && logs.total,
         () => html`
           <btrix-crawl-log-table
+            class="mr-1.5 block"
             .logs=${logs.items}
             offset=${(logs.page - 1) * logs.pageSize}
           ></btrix-crawl-log-table>

--- a/frontend/src/features/archived-items/crawl-logs.ts
+++ b/frontend/src/features/archived-items/crawl-logs.ts
@@ -203,6 +203,7 @@ export class CrawlLogs extends BtrixElement {
 
           <footer class="my-4 flex justify-center">
             <btrix-pagination
+              name="logs"
               page=${logs.page}
               totalCount=${logs.total}
               size=${logs.pageSize}

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -325,7 +325,7 @@ export class CrawlStatus extends TailwindElement {
     if (this.stopping && this.state === "running") {
       return "stopping";
     }
-    if (this.shouldPause && this.state === "running") {
+    if (this.shouldPause && this.state !== "paused") {
       return "pausing";
     }
     if (!this.shouldPause && this.state === "paused") {

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -331,12 +331,12 @@ export class CrawlStatus extends TailwindElement {
       </div>`;
     }
     if (label) {
-      return html`<div class="flex items-center gap-2">
+      return html`<div class="flex h-6 items-center gap-2">
         ${icon}
         <div class="leading-none">${label}</div>
       </div>`;
     }
-    return html`<div class="flex items-center gap-2">
+    return html`<div class="flex h-6 items-center gap-2">
       ${icon}<sl-skeleton></sl-skeleton>
     </div>`;
   }

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -52,10 +52,13 @@ export class CrawlStatus extends TailwindElement {
 
   // TODO look into customizing sl-select multi-select
   // instead of separate utility function?
-  static getContent(
-    state?: CrawlState | AnyString,
-    type: CrawlType = "crawl",
-  ): {
+  static getContent({
+    state,
+    type = "crawl",
+  }: {
+    state?: CrawlState | AnyString;
+    type?: CrawlType | undefined;
+  }): {
     icon: TemplateResult;
     label: string;
     cssColor: string;
@@ -318,7 +321,7 @@ export class CrawlStatus extends TailwindElement {
 
   render() {
     const state = this.filterState();
-    const { icon, label } = CrawlStatus.getContent(state, this.type);
+    const { icon, label } = CrawlStatus.getContent({ state, type: this.type });
     if (this.hideLabel) {
       return html`<div class="flex items-center">
         <sl-tooltip

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -133,6 +133,7 @@ export class CrawlStatus extends TailwindElement {
         break;
 
       case "resuming":
+        color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon
           name="play-circle"
           class="animatePulse"

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -76,8 +76,6 @@ export class CrawlStatus extends TailwindElement {
     let label = "";
     let reason = "";
 
-    console.log(state, originalState);
-
     switch (state) {
       case "starting":
         color = "var(--sl-color-violet-600)";

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -622,7 +622,7 @@ export class WorkflowEditor extends BtrixElement {
         class=${clsx(
           "flex items-center justify-end gap-2 rounded-lg border bg-white px-6 py-4 mb-7",
           this.configId || this.serverError
-            ? tw`sticky bottom-3 z-50 shadow-md`
+            ? tw`z- sticky bottom-3 z-20 shadow-md`
             : tw`shadow`,
         )}
       >

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -317,7 +317,7 @@ export class WorkflowListItem extends BtrixElement {
             }
             if (workflow.lastCrawlStartTime) {
               const latestDate =
-                workflow.lastCrawlPausing && workflow.lastCrawlPausedAt
+                workflow.lastCrawlShouldPause && workflow.lastCrawlPausedAt
                   ? new Date(workflow.lastCrawlPausedAt)
                   : new Date();
               const diff =

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -72,6 +72,28 @@ const hostVars = css`
   }
 `;
 
+const shortDate = (date: string) => html`
+  <btrix-format-date
+    date=${date}
+    month="2-digit"
+    day="2-digit"
+    year="numeric"
+    hour="2-digit"
+    minute="2-digit"
+  ></btrix-format-date>
+`;
+const longDate = (date: string) => html`
+  <btrix-format-date
+    date=${date}
+    month="long"
+    day="numeric"
+    year="numeric"
+    hour="2-digit"
+    minute="2-digit"
+    time-zone-name="short"
+  ></btrix-format-date>
+`;
+
 const notSpecified = html`<span class="notSpecified" role="presentation"
   >${noData}</span
 >`;
@@ -244,7 +266,7 @@ export class WorkflowListItem extends BtrixElement {
           })}
         </div>
       </div>
-      <div class="col">${this.renderLatestCrawl()}</div>
+      <div class="col">${this.safeRender(this.renderLatestCrawl)}</div>
       <div class="col">
         <div class="detail">
           ${this.safeRender((workflow) => {
@@ -290,28 +312,7 @@ export class WorkflowListItem extends BtrixElement {
           )}
         </div>
       </div>
-      <div class="col">
-        <div class="detail truncate">
-          ${this.safeRender(
-            (workflow) =>
-              html`<span class="userName">${workflow.modifiedByName}</span>`,
-          )}
-        </div>
-        <div class="desc">
-          ${this.safeRender(
-            (workflow) => html`
-              <btrix-format-date
-                date="${workflow.modified}"
-                month="2-digit"
-                day="2-digit"
-                year="numeric"
-                hour="2-digit"
-                minute="2-digit"
-              ></btrix-format-date>
-            `,
-          )}
-        </div>
-      </div>
+      <div class="col">${this.safeRender(this.renderModifiedBy)}</div>
       <div class="col action">
         <btrix-overflow-dropdown>
           <slot
@@ -327,140 +328,148 @@ export class WorkflowListItem extends BtrixElement {
     </div>`;
   }
 
-  private readonly renderLatestCrawl = () =>
-    this.safeRender((workflow) => {
-      let tooltipContent = html``;
+  private readonly renderLatestCrawl = (workflow: ListWorkflow) => {
+    let tooltipContent: TemplateResult | null = null;
 
-      const status = () => html`
-        <btrix-crawl-status
-          state=${workflow.lastCrawlState || msg("No Crawls Yet")}
-          ?stopping=${workflow.lastCrawlStopping}
-          ?shouldPause=${workflow.lastCrawlShouldPause}
-        ></btrix-crawl-status>
-      `;
+    const status = html`
+      <btrix-crawl-status
+        state=${workflow.lastCrawlState || msg("No Crawls Yet")}
+        ?stopping=${workflow.lastCrawlStopping}
+        ?shouldPause=${workflow.lastCrawlShouldPause}
+      ></btrix-crawl-status>
+    `;
 
-      const duration = () => {
-        const inDuration = (dur: number) => {
-          const compactDuration = this.localize.humanizeDuration(dur, {
-            compact: true,
-          });
-          return msg(str`in ${compactDuration}`, {
-            desc: "`compactDuration` example: '2h'",
-          });
-        };
-        const forDuration = (dur: number) => {
-          const compactDuration = this.localize.humanizeDuration(dur, {
-            compact: true,
-          });
-          return msg(str`for ${compactDuration}`, {
-            desc: "`compactDuration` example: '2h'",
-          });
-        };
-        const afterDuration = (dur: number) => {
-          const verboseDuration = this.localize.humanizeDuration(dur, {
-            verbose: true,
-            unitCount: 2,
-          });
-          return msg(str`after ${verboseDuration}`, {
-            desc: "`verboseDuration` example: '2 hours, 15 seconds'",
-          });
-        };
+    const renderDuration = () => {
+      const compactIn = (dur: number) => {
+        const compactDuration = this.localize.humanizeDuration(dur, {
+          compact: true,
+        });
+        return msg(str`in ${compactDuration}`, {
+          desc: "`compactDuration` example: '2h'",
+        });
+      };
+      const verboseIn = (dur: number) => {
+        const verboseDuration = this.localize.humanizeDuration(dur, {
+          verbose: true,
+          unitCount: 2,
+        });
+        return msg(str`in ${verboseDuration}`, {
+          desc: "`verboseDuration` example: '2 hours, 15 seconds'",
+        });
+      };
+      const compactFor = (dur: number) => {
+        const compactDuration = this.localize.humanizeDuration(dur, {
+          compact: true,
+        });
+        return msg(str`for ${compactDuration}`, {
+          desc: "`compactDuration` example: '2h'",
+        });
+      };
+      const verboseFor = (dur: number) => {
+        const verboseDuration = this.localize.humanizeDuration(dur, {
+          verbose: true,
+          unitCount: 2,
+        });
+        return msg(str`for ${verboseDuration}`, {
+          desc: "`verboseDuration` example: '2 hours, 15 seconds'",
+        });
+      };
 
-        if (workflow.lastCrawlTime && workflow.lastCrawlStartTime) {
-          const diff =
-            new Date(workflow.lastCrawlTime).valueOf() -
-            new Date(workflow.lastCrawlStartTime).valueOf();
+      if (workflow.lastCrawlTime && workflow.lastCrawlStartTime) {
+        const diff =
+          new Date(workflow.lastCrawlTime).valueOf() -
+          new Date(workflow.lastCrawlStartTime).valueOf();
 
+        tooltipContent = html`
+          <span slot="content">
+            ${msg("Finished")} ${longDate(workflow.lastCrawlTime)}
+            ${verboseIn(diff)}
+          </span>
+        `;
+
+        return html`${shortDate(workflow.lastCrawlTime)} ${compactIn(diff)}`;
+      }
+
+      if (workflow.lastCrawlStartTime) {
+        const latestDate =
+          workflow.lastCrawlShouldPause && workflow.lastCrawlPausedAt
+            ? new Date(workflow.lastCrawlPausedAt)
+            : new Date();
+        const diff =
+          latestDate.valueOf() -
+          new Date(workflow.lastCrawlStartTime).valueOf();
+        if (diff < 1000) {
+          return "";
+        }
+
+        if (
+          workflow.lastCrawlState === "paused" &&
+          workflow.lastCrawlPausedAt
+        ) {
+          const pausedDiff =
+            new Date().valueOf() -
+            new Date(workflow.lastCrawlPausedAt).valueOf();
           tooltipContent = html`
             <span slot="content">
-              ${msg("Crawl ended on")}
-              <btrix-format-date
-                date=${workflow.lastCrawlTime}
-                month="long"
-                day="numeric"
-                year="numeric"
-                hour="2-digit"
-                minute="2-digit"
-                time-zone-name="short"
-              ></btrix-format-date>
-              ${afterDuration(diff)}
+              ${msg("Crawl paused on")} ${longDate(workflow.lastCrawlPausedAt)}
             </span>
           `;
 
-          return html`<btrix-format-date
-              date=${workflow.lastCrawlTime}
-              month="2-digit"
-              day="2-digit"
-              year="numeric"
-              hour="2-digit"
-              minute="2-digit"
-            ></btrix-format-date>
-            ${inDuration(diff)}`;
+          return html`
+            ${shortDate(workflow.lastCrawlPausedAt)} ${compactFor(pausedDiff)}
+          `;
         }
 
-        if (workflow.lastCrawlStartTime) {
-          const latestDate =
-            workflow.lastCrawlShouldPause && workflow.lastCrawlPausedAt
-              ? new Date(workflow.lastCrawlPausedAt)
-              : new Date();
-          const diff =
-            latestDate.valueOf() -
-            new Date(workflow.lastCrawlStartTime).valueOf();
-          if (diff < 1000) {
-            return "";
-          }
+        tooltipContent = html`
+          <span slot="content">
+            ${msg("Running")} ${verboseFor(diff)} ${msg("since")}
+            ${longDate(workflow.lastCrawlStartTime)}
+          </span>
+        `;
 
-          if (
-            workflow.lastCrawlState === "paused" &&
-            workflow.lastCrawlPausedAt
-          ) {
-            const pausedDiff =
-              new Date().valueOf() -
-              new Date(workflow.lastCrawlPausedAt).valueOf();
-            tooltipContent = html`
-              <span slot="content">
-                ${msg("Crawl paused on")}
-                <btrix-format-date
-                  date=${workflow.lastCrawlPausedAt}
-                  month="long"
-                  day="numeric"
-                  year="numeric"
-                  hour="2-digit"
-                  minute="2-digit"
-                  time-zone-name="short"
-                ></btrix-format-date>
-              </span>
-            `;
+        return html`${msg("Running")} ${compactFor(diff)}`;
+      }
+      return notSpecified;
+    };
 
-            return html`
-              <btrix-format-date
-                date=${workflow.lastCrawlPausedAt}
-                month="2-digit"
-                day="2-digit"
-                year="numeric"
-                hour="2-digit"
-                minute="2-digit"
-              ></btrix-format-date>
-              ${forDuration(pausedDiff)}
-            `;
-          }
+    const duration = renderDuration();
 
-          return html`${msg("Running")} ${forDuration(diff)}`;
-        }
-        return notSpecified;
-      };
+    return html`
+      <sl-tooltip hoist placement="bottom" ?disabled=${!tooltipContent}>
+        <div>
+          <div class="detail">${status}</div>
+          <div class="desc duration">${duration}</div>
+        </div>
 
-      return html`
-        <sl-tooltip hoist placement="bottom" ?disabled=${!tooltipContent}>
-          <div>
-            <div class="detail">${status()}</div>
-            <div class="desc duration">${duration()}</div>
+        ${tooltipContent}
+      </sl-tooltip>
+    `;
+  };
+
+  private readonly renderModifiedBy = (workflow: ListWorkflow) => {
+    const date = longDate(workflow.modified);
+
+    return html`
+      <sl-tooltip hoist placement="bottom">
+        <div>
+          <div class="detail truncate">
+            <span class="userName">${workflow.modifiedByName}</span>
           </div>
+          <div class="desc">${shortDate(workflow.modified)}</div>
+        </div>
 
-          ${tooltipContent}
-        </sl-tooltip>
-      `;
-    });
+        <span slot="content">
+          ${workflow.modified === workflow.created
+            ? msg("Created by")
+            : msg("Edited by")}
+          ${workflow.modifiedByName}
+          ${msg(html`on ${date}`, {
+            desc: "`date` example: 'January 1st, 2025 at 05:00 PM EST'",
+          })}
+        </span>
+      </sl-tooltip>
+    `;
+  };
 
   private safeRender(
     render: (workflow: ListWorkflow) => string | TemplateResult<1>,

--- a/frontend/src/features/org/usage-history-table.ts
+++ b/frontend/src/features/org/usage-history-table.ts
@@ -63,9 +63,7 @@ export class UsageHistoryTable extends BtrixElement {
       {
         field: Field.ElapsedTime,
         label: msg("Elapsed Time"),
-        description: msg(
-          "Total duration of workflow and QA analysis runs, from start to finish.",
-        ),
+        description: msg("Total duration of workflow and QA analysis runs."),
       },
       {
         field: Field.ExecutionTime,

--- a/frontend/src/features/org/usage-history-table.ts
+++ b/frontend/src/features/org/usage-history-table.ts
@@ -71,7 +71,7 @@ export class UsageHistoryTable extends BtrixElement {
         field: Field.ExecutionTime,
         label: msg("Execution Time"),
         description: msg(
-          "Aggregated time across all browser windows that the crawler was actively executing a crawl or QA analysis run, i.e. not in a waiting state",
+          "Aggregated time across all browser windows that the crawler was actively executing a crawl or QA analysis run, i.e. not waiting or paused",
         ),
       },
     ];

--- a/frontend/src/features/org/usage-history-table.ts
+++ b/frontend/src/features/org/usage-history-table.ts
@@ -64,14 +64,14 @@ export class UsageHistoryTable extends BtrixElement {
         field: Field.ElapsedTime,
         label: msg("Elapsed Time"),
         description: msg(
-          "Total duration of crawls and QA analysis runs, from start to finish",
+          "Total duration of workflow and QA analysis runs, from start to finish.",
         ),
       },
       {
         field: Field.ExecutionTime,
         label: msg("Execution Time"),
         description: msg(
-          "Aggregated time across all browser windows that the crawler was actively executing a crawl or QA analysis run, i.e. not waiting or paused",
+          "Aggregated time across all browser windows that the crawler was actively executing a crawl or QA analysis run, i.e. not waiting or paused.",
         ),
       },
     ];
@@ -81,7 +81,7 @@ export class UsageHistoryTable extends BtrixElement {
         field: Field.BillableExecutionTime,
         label: msg("Billable Execution Time"),
         description: msg(
-          "Execution time used that is billable to the current month of the plan",
+          "Execution time used that is billable to the current month of the plan.",
         ),
       });
     }
@@ -90,7 +90,7 @@ export class UsageHistoryTable extends BtrixElement {
         field: Field.RolloverExecutionTime,
         label: msg("Rollover Execution Time"),
         description: msg(
-          "Additional execution time used, of which any extra minutes will roll over to next month as billable time",
+          "Additional execution time used, of which any extra minutes will roll over to next month as billable time.",
         ),
       });
     }
@@ -98,7 +98,7 @@ export class UsageHistoryTable extends BtrixElement {
       cols.push({
         field: Field.GiftedExecutionTime,
         label: msg("Gifted Execution Time"),
-        description: msg("Execution time used that is free of charge"),
+        description: msg("Execution time used that is free of charge."),
       });
     }
 

--- a/frontend/src/layouts/pageError.ts
+++ b/frontend/src/layouts/pageError.ts
@@ -1,0 +1,31 @@
+import { html, nothing, type TemplateResult } from "lit";
+
+/**
+ * Render a full page error, like 404 or 500 for primary resources.
+ */
+export function pageError({
+  heading,
+  detail,
+  primaryAction,
+  secondaryAction,
+}: {
+  heading: string | TemplateResult;
+  detail: string | TemplateResult;
+  primaryAction: TemplateResult;
+  secondaryAction?: TemplateResult;
+}) {
+  return html`
+    <div class="text-center">
+      <p
+        class="mx-auto my-4 max-w-max border-b py-4 text-xl leading-none text-neutral-500"
+      >
+        ${heading}
+      </p>
+      <p class="text-neutral-600">${detail}</p>
+      <div class="my-4">${primaryAction}</div>
+      ${secondaryAction
+        ? html`<p class="text-neutral-500">${secondaryAction}</p>`
+        : nothing}
+    </div>
+  `;
+}

--- a/frontend/src/layouts/pageSectionsWithNav.ts
+++ b/frontend/src/layouts/pageSectionsWithNav.ts
@@ -29,7 +29,7 @@ export function pageSectionsWithNav({
         class=${clsx(
           tw`flex w-full flex-1 flex-col gap-2`,
           sticky && [
-            tw`scrim scrim-to-b z-50 before:-top-2 lg:sticky lg:self-start`,
+            tw`scrim scrim-to-b z-20 before:-top-2 lg:sticky lg:self-start`,
             stickyTopClassname || tw`lg:top-2`,
           ],
           placement === "start"

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -257,7 +257,7 @@ export class Crawls extends BtrixElement {
   }
 
   private readonly renderStatusMenuItem = (state: CrawlState) => {
-    const { icon, label } = CrawlStatus.getContent(state);
+    const { icon, label } = CrawlStatus.getContent({ state });
 
     return html`<sl-option value=${state}>${icon}${label}</sl-option>`;
   };

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1031,8 +1031,6 @@ ${this.item?.description}
     const qaIsRunning = this.isQAActive;
     const qaIsAvailable = !!this.mostRecentNonFailedQARun;
 
-    console.log(new URL(window.location.href).pathname);
-
     const reviewLink =
       qaIsAvailable && this.qaRunId
         ? `${new URL(window.location.href).pathname}/review/screenshots?qaRunId=${this.qaRunId}`

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -802,7 +802,7 @@ export class ArchivedItemDetail extends BtrixElement {
                     ? this.formattedFinishedDate
                     : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 </btrix-desc-list-item>
-                <btrix-desc-list-item label=${msg("Elapsed Time")}>
+                <btrix-desc-list-item label=${msg("Run Duration")}>
                   ${this.item!.finished
                     ? html`${this.localize.humanizeDuration(
                         new Date(this.item!.finished).valueOf() -

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -11,7 +11,6 @@ import { type Dialog } from "@/components/ui/dialog";
 import { ClipboardController } from "@/controllers/clipboard";
 import { pageBack, pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { WorkflowTab } from "@/routes";
-import { tooltipFor } from "@/strings/archived-items/tooltips";
 import type { APIPaginatedList } from "@/types/api";
 import type {
   ArchivedItem,
@@ -316,7 +315,7 @@ export class ArchivedItemDetail extends BtrixElement {
       case "files":
         sectionContent = this.renderPanel(
           html` ${this.renderTitle(this.tabLabels.files)}
-            <sl-tooltip content=${tooltipFor.downloadMultWacz}>
+            <sl-tooltip content=${msg("Download Files as Multi-WACZ")}>
               <sl-button
                 href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}`}
                 download=${`browsertrix-${this.itemId}.wacz`}
@@ -333,7 +332,7 @@ export class ArchivedItemDetail extends BtrixElement {
       case "logs":
         sectionContent = this.renderPanel(
           html` ${this.renderTitle(this.tabLabels.logs)}
-            <sl-tooltip content=${tooltipFor.downloadLogs}>
+            <sl-tooltip content=${msg("Download Entire Log File")}>
               <sl-button
                 href=${`/api/orgs/${this.orgId}/crawls/${this.itemId}/logs?auth_bearer=${authToken}`}
                 download=${`browsertrix-${this.itemId}-logs.log`}

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -669,7 +669,7 @@ export class CrawlsList extends BtrixElement {
   };
 
   private readonly renderStatusMenuItem = (state: CrawlState) => {
-    const { icon, label } = CrawlStatus.getContent(state);
+    const { icon, label } = CrawlStatus.getContent({ state });
 
     return html`<sl-option value=${state}>${icon}${label}</sl-option>`;
   };

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -628,34 +628,38 @@ export class WorkflowDetail extends BtrixElement {
   private renderPanelAction() {
     if (
       this.groupedWorkflowTab === WorkflowTab.LatestCrawl &&
-      this.isCrawler &&
-      this.workflow &&
-      !this.workflow.isCrawlRunning &&
-      this.lastCrawlId
+      this.lastCrawlId &&
+      this.latestCrawlTask.value?.finished
     ) {
-      return html`<sl-tooltip content=${msg("Go to Quality Assurance")}>
-        <sl-button
-          size="small"
-          href="${this.basePath}/crawls/${this.lastCrawlId}"
-          @click=${this.navigate.link}
-        >
-          ${msg("View Details")}
-          <sl-icon slot="suffix" name="arrow-right"></sl-icon>
-        </sl-button>
-      </sl-tooltip> `;
+      return html`<div class="flex items-center gap-1">
+        <btrix-copy-button
+          size="medium"
+          value=${this.lastCrawlId}
+          content=${msg("Copy Crawl ID")}
+        ></btrix-copy-button>
+
+        <sl-tooltip content=${msg("View Archived Item")}>
+          <btrix-button
+            size="medium"
+            href="${this.basePath}/crawls/${this.lastCrawlId}"
+            @click=${this.navigate.link}
+          >
+            <sl-icon name="file-earmark-zip" class="size-4"> </sl-icon>
+          </btrix-button>
+        </sl-tooltip>
+      </div>`;
     }
 
     if (this.workflowTab === WorkflowTab.Settings && this.isCrawler) {
-      return html` 
-        <sl-tooltip content=${msg("Edit Workflow Settings")}></sl-tooltip>
-          <sl-icon-button
-            name="pencil"
-            class="text-base"
-            href="${this.basePath}?edit"
-            @click=${this.navigate.link}
-          >
-          </sl-icon-button>
-        </sl-tooltip>`;
+      return html` <sl-tooltip content=${msg("Edit Workflow Settings")}>
+        <sl-icon-button
+          name="pencil"
+          class="text-base"
+          href="${this.basePath}?edit"
+          @click=${this.navigate.link}
+        >
+        </sl-icon-button>
+      </sl-tooltip>`;
     }
 
     return nothing;
@@ -1445,25 +1449,20 @@ export class WorkflowDetail extends BtrixElement {
       }
 
       return html`<div class="inline-flex items-center gap-2">
-        ${latestCrawl.reviewStatus
+        ${latestCrawl.reviewStatus || !this.isCrawler
           ? html`<btrix-qa-review-status
               status=${ifDefined(latestCrawl.reviewStatus)}
             ></btrix-qa-review-status>`
-          : html`<sl-tooltip
-              content=${msg("Add Quality Assurance Rating")}
-              placement="bottom"
-              hoist
+          : html`<sl-button
+              class="micro -ml-2"
+              size="small"
+              variant="text"
+              href="${this.basePath}/crawls/${this.lastCrawlId}#qa"
+              @click=${this.navigate.link}
             >
-              <sl-button
-                class="micro"
-                size="small"
-                href="${this.basePath}/crawls/${this.lastCrawlId}#qa"
-                @click=${this.navigate.link}
-              >
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                ${msg("Add")}
-              </sl-button>
-            </sl-tooltip>`}
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              ${msg("Add Review")}
+            </sl-button> `}
       </div> `;
     };
 
@@ -1595,11 +1594,11 @@ export class WorkflowDetail extends BtrixElement {
         )}
         ${when(
           this.lastCrawlId,
-          () =>
+          (id) =>
             html`<div class="mt-4">
               <sl-button
                 size="small"
-                href="${this.basePath}/crawls/${this.lastCrawlId}"
+                href="${this.basePath}/crawls/${id}"
                 @click=${this.navigate.link}
               >
                 ${msg("View Crawl Details")}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1353,7 +1353,7 @@ export class WorkflowDetail extends BtrixElement {
   }
 
   private readonly renderStatusMenuItem = (state: CrawlState) => {
-    const { icon, label } = CrawlStatus.getContent(state);
+    const { icon, label } = CrawlStatus.getContent({ state });
 
     return html`<sl-option value=${state}>${icon}${label}</sl-option>`;
   };

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1228,7 +1228,7 @@ export class WorkflowDetail extends BtrixElement {
 
     return html`
       <btrix-desc-list horizontal>
-        ${this.renderDetailItem(msg("Run Duration"), (workflow) =>
+        ${this.renderDetailItem(msg("Elapsed Time"), (workflow) =>
           this.lastCrawlStartTime
             ? this.localize.humanizeDuration(
                 (workflow.lastCrawlTime && !workflow.isCrawlRunning

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -650,7 +650,9 @@ export class WorkflowDetail extends BtrixElement {
     if (this.groupedWorkflowTab === WorkflowTab.LatestCrawl && latestCrawl) {
       const logTotals = this.logTotalsTask.value;
       const authToken = this.authState?.headers.Authorization.split(" ")[1];
-      const disableDownload = this.workflow?.isCrawlRunning;
+      const disableDownload =
+        this.workflow?.isCrawlRunning &&
+        this.workflow.lastCrawlState !== "paused";
 
       return html`
         <btrix-copy-button

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
+import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
@@ -606,7 +607,7 @@ export class WorkflowDetail extends BtrixElement {
 
   private renderPanelAction() {
     if (
-      this.workflowTab === WorkflowTab.LatestCrawl &&
+      this.groupedWorkflowTab === WorkflowTab.LatestCrawl &&
       this.isCrawler &&
       this.workflow &&
       !this.workflow.isCrawlRunning &&
@@ -621,8 +622,9 @@ export class WorkflowDetail extends BtrixElement {
         >
           <sl-icon slot="prefix" name="clipboard2-data-fill"></sl-icon>
           ${msg("QA Crawl")}
+          <sl-icon slot="suffix" name="arrow-right"></sl-icon>
         </sl-button>
-      </sl-tooltip>`;
+      </sl-tooltip> `;
     }
 
     if (this.workflowTab === WorkflowTab.Settings && this.isCrawler) {
@@ -1265,7 +1267,7 @@ export class WorkflowDetail extends BtrixElement {
     return html`
       <btrix-alert
         id="pausedNotice"
-        class="sticky top-2 z-50 mb-5"
+        class="sticky top-2 z-50 part-[base]:mb-5"
         variant="info"
       >
         <div class="mb-2 flex justify-between">
@@ -1302,9 +1304,10 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private renderLatestCrawlAction() {
+    if (!this.workflow || !this.lastCrawlId) return;
+
     if (
       this.isCrawler &&
-      this.workflow &&
       this.workflow.isCrawlRunning &&
       this.workflow.lastCrawlState !== "paused"
     ) {
@@ -1313,7 +1316,7 @@ export class WorkflowDetail extends BtrixElement {
         this.workflow.scale * (this.appState.settings?.numBrowsers || 1);
 
       return html`
-        <div class="text-neutral-500">
+        <div class="text-xs text-neutral-500">
           ${msg("Running in")} ${this.localize.number(windowCount)}
           ${pluralOf("browserWindows", windowCount)}
         </div>
@@ -1340,8 +1343,7 @@ export class WorkflowDetail extends BtrixElement {
 
     if (
       this.workflowTab === WorkflowTab.LatestCrawl &&
-      this.lastCrawlId &&
-      this.workflow?.lastCrawlSize
+      this.workflow.lastCrawlSize
     ) {
       return html`<sl-tooltip content=${tooltipFor.downloadMultWacz} hoist>
         <sl-icon-button
@@ -1522,7 +1524,7 @@ export class WorkflowDetail extends BtrixElement {
 
     return html`
       <div class="aspect-video overflow-hidden rounded-lg border">
-        ${this.renderReplay()}
+        ${guard([this.lastCrawlId], this.renderReplay)}
       </div>
     `;
   };
@@ -1568,7 +1570,7 @@ export class WorkflowDetail extends BtrixElement {
     `;
   }
 
-  private renderReplay() {
+  private readonly renderReplay = () => {
     if (!this.workflow || !this.lastCrawlId) return;
 
     const replaySource = `/api/orgs/${this.workflow.oid}/crawls/${this.lastCrawlId}/replay.json`;
@@ -1586,7 +1588,7 @@ export class WorkflowDetail extends BtrixElement {
         noCache="true"
       ></replay-web-page>
     `;
-  }
+  };
 
   private renderLogs() {
     return html`

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1420,8 +1420,8 @@ export class WorkflowDetail extends BtrixElement {
           (id) => html`
             <sl-dropdown slot="nav" distance="4" hoist>
               <sl-button slot="trigger" size="small" caret variant="text">
-                <sl-icon slot="prefix" name="three-dots"></sl-icon>
-                ${msg("More")}
+                <sl-icon slot="prefix" name="info-square-fill"></sl-icon>
+                ${msg("More Info")}
               </sl-button>
               <sl-menu>
                 <btrix-menu-item-link

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -667,13 +667,12 @@ export class WorkflowDetail extends BtrixElement {
           content=${msg("Copy Item ID")}
           hoist
         ></btrix-copy-button>
-        <sl-tooltip
-          class=${disableDownload ? "invert-tooltip" : ""}
+        <btrix-popover
           content=${msg(
             "Downloads are disabled while running. Pause the crawl or wait for the crawl to finish to download.",
           )}
+          placement="top"
           ?disabled=${!disableDownload}
-          hoist
         >
           <sl-button-group>
             <sl-tooltip
@@ -735,7 +734,7 @@ export class WorkflowDetail extends BtrixElement {
               </sl-menu>
             </sl-dropdown>
           </sl-button-group>
-        </sl-tooltip>
+        </btrix-popover>
       `;
     }
 
@@ -1641,16 +1640,14 @@ export class WorkflowDetail extends BtrixElement {
       if (this.isRunning) {
         return html`<span class="text-neutral-400">
           ${noData}
-          <sl-tooltip
-            class="invert-tooltip"
+          <btrix-popover
             content=${msg(
               "Execution time will be calculated once this crawl is finished or paused.",
             )}
-            hoist
-            placement="bottom"
+            distance="12"
           >
             <sl-icon name="question-circle"></sl-icon>
-          </sl-tooltip>
+          </btrix-popover>
         </span>`;
       }
 
@@ -1684,14 +1681,12 @@ export class WorkflowDetail extends BtrixElement {
       if (workflow.isCrawlRunning) {
         return html`<span class="text-neutral-400">
           ${noData}
-          <sl-tooltip
-            class="invert-tooltip"
+          <btrix-popover
             content=${msg("QA will be enabled once this crawl is complete.")}
-            hoist
-            placement="bottom"
+            distance="12"
           >
             <sl-icon name="question-circle"></sl-icon>
-          </sl-tooltip>
+          </btrix-popover>
         </span>`;
       }
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1197,7 +1197,7 @@ export class WorkflowDetail extends BtrixElement {
         return [
           this.localize.number(+(this.lastCrawl.stats?.done || 0)),
           this.localize.number(+(this.lastCrawl.stats?.found || 0)),
-        ].join(" / ");
+        ].join(` ${msg("of")} `);
       }
 
       return this.localize.number(this.lastCrawl.pageCount || 0);

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -648,6 +648,7 @@ export class WorkflowDetail extends BtrixElement {
     const latestCrawl = this.latestCrawlTask.value;
 
     if (this.groupedWorkflowTab === WorkflowTab.LatestCrawl && latestCrawl) {
+      const latestCrawlId = latestCrawl.id;
       const logTotals = this.logTotalsTask.value;
       const authToken = this.authState?.headers.Authorization.split(" ")[1];
       const disableDownload =
@@ -657,46 +658,78 @@ export class WorkflowDetail extends BtrixElement {
       return html`
         <btrix-copy-button
           class="mt-0.5"
-          value=${latestCrawl.id}
+          value=${latestCrawlId}
           content=${msg("Copy Item ID")}
           hoist
         ></btrix-copy-button>
         <sl-tooltip
-          class="invert-tooltip"
+          class=${disableDownload ? "invert-tooltip" : ""}
           content=${msg(
             "Downloads are disabled while running. Pause the crawl or wait for the crawl to finish to download.",
           )}
           ?disabled=${!disableDownload}
+          hoist
         >
-          <sl-dropdown distance="4" placement="bottom-end" hoist sync="width">
-            <sl-button
-              slot="trigger"
-              size="small"
-              ?disabled=${disableDownload}
-              caret
+          <sl-button-group>
+            <sl-tooltip
+              content="${msg("Download Item as WACZ")} (${this.localize.bytes(
+                latestCrawl.fileSize || 0,
+              )})"
+              ?disabled=${!latestCrawl.fileSize}
             >
-              <sl-icon slot="prefix" name="download"></sl-icon>
-              ${msg("Download")}
-            </sl-button>
-            <sl-menu>
-              <btrix-menu-item-link
-                href=${`/api/orgs/${this.orgId}/all-crawls/${this.lastCrawlId}/download?auth_bearer=${authToken}`}
-                ?disabled=${!latestCrawl.fileSize}
-                download
+              <sl-button
+                size="small"
+                href=${`/api/orgs/${this.orgId}/all-crawls/${latestCrawlId}/download?auth_bearer=${authToken}`}
+                download=${`browsertrix-${latestCrawlId}.wacz`}
+                ?disabled=${disableDownload || !latestCrawl.fileSize}
               >
                 <sl-icon name="cloud-download" slot="prefix"></sl-icon>
-                ${msg("Item")}
-              </btrix-menu-item-link>
-              <btrix-menu-item-link
-                href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
-                ?disabled=${!(logTotals?.errors || logTotals?.behaviors)}
-                download
+                ${msg("Download")}
+              </sl-button>
+            </sl-tooltip>
+            <sl-dropdown distance="4" placement="bottom-end" hoist>
+              <sl-button
+                slot="trigger"
+                size="small"
+                caret
+                ?disabled=${disableDownload}
               >
-                <sl-icon name="file-earmark-arrow-down" slot="prefix"></sl-icon>
-                ${msg("Log")}
-              </btrix-menu-item-link>
-            </sl-menu>
-          </sl-dropdown>
+                <sl-visually-hidden
+                  >${msg("Download options")}</sl-visually-hidden
+                >
+              </sl-button>
+              <sl-menu>
+                <btrix-menu-item-link
+                  href=${`/api/orgs/${this.orgId}/all-crawls/${this.lastCrawlId}/download?auth_bearer=${authToken}`}
+                  ?disabled=${!latestCrawl.fileSize}
+                  download
+                >
+                  <sl-icon name="cloud-download" slot="prefix"></sl-icon>
+                  ${msg("Item")}
+                  ${latestCrawl.fileSize
+                    ? html` <btrix-badge
+                        slot="suffix"
+                        class="font-monostyle text-xs text-neutral-500"
+                        >${this.localize.bytes(
+                          latestCrawl.fileSize,
+                        )}</btrix-badge
+                      >`
+                    : nothing}
+                </btrix-menu-item-link>
+                <btrix-menu-item-link
+                  href=${`/api/orgs/${this.orgId}/crawls/${this.lastCrawlId}/logs?auth_bearer=${authToken}`}
+                  ?disabled=${!(logTotals?.errors || logTotals?.behaviors)}
+                  download
+                >
+                  <sl-icon
+                    name="file-earmark-arrow-down"
+                    slot="prefix"
+                  ></sl-icon>
+                  ${msg("Log")}
+                </btrix-menu-item-link>
+              </sl-menu>
+            </sl-dropdown>
+          </sl-button-group>
         </sl-tooltip>
       `;
     }
@@ -1384,19 +1417,16 @@ export class WorkflowDetail extends BtrixElement {
               <sl-menu>
                 <btrix-menu-item-link href="${this.basePath}/crawls/${id}">
                   <sl-icon name="info-circle-fill" slot="prefix"></sl-icon>
-                  ${msg("Metadata")}
-                  <sl-icon name="arrow-right" slot="suffix"></sl-icon>
+                  ${msg("View Metadata")}
                 </btrix-menu-item-link>
                 <btrix-menu-item-link href="${this.basePath}/crawls/${id}">
                   <sl-icon name="clipboard2-data-fill" slot="prefix"></sl-icon>
-                  ${msg("Quality Assurance")}
-                  <sl-icon name="arrow-right" slot="suffix"></sl-icon>
+                  ${msg("View Quality Assurance")}
                 </btrix-menu-item-link>
 
                 <btrix-menu-item-link href="${this.basePath}/crawls/${id}">
                   <sl-icon name="folder-fill" slot="prefix"></sl-icon>
-                  ${msg("WACZ Files")}
-                  <sl-icon name="arrow-right" slot="suffix"></sl-icon>
+                  ${msg("View WACZ Files")}
                 </btrix-menu-item-link>
               </sl-menu>
             </sl-dropdown>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1128,6 +1128,8 @@ export class WorkflowDetail extends BtrixElement {
             minute: "2-digit",
             timeZoneName: "short",
           })}
+          hoist
+          placement="bottom"
         >
           ${hours > 24
             ? this.localize.date(date, {
@@ -1141,6 +1143,7 @@ export class WorkflowDetail extends BtrixElement {
         </sl-tooltip>
       `;
     };
+
     return html`
       <btrix-desc-list horizontal>
         ${this.renderDetailItem(

--- a/frontend/src/strings/archived-items/tooltips.ts
+++ b/frontend/src/strings/archived-items/tooltips.ts
@@ -1,6 +1,0 @@
-import { msg } from "@lit/localize";
-
-export const tooltipFor = {
-  downloadMultWacz: msg(msg("Download Files as Multi-WACZ")),
-  downloadLogs: msg("Download Entire Log File"),
-};

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -158,6 +158,12 @@
     font-size: var(--sl-input-help-text-font-size-medium);
   }
 
+  /* TODO Move to custom button */
+  sl-button[size="small"].micro::part(base) {
+    --sl-input-height-small: 1.5rem;
+    font-size: var(--sl-font-size-x-small);
+  }
+
   /* Update button colors */
   sl-button[variant="primary"]:not([outline])::part(base) {
     background-color: theme(colors.primary.400);

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -93,6 +93,8 @@ export type Workflow = CrawlConfig & {
   lastStartedByName: string | null;
   lastCrawlStopping: boolean | null;
   lastCrawlShouldPause: boolean | null;
+  lastCrawlPausedAt: string | null;
+  lastCrawlPausedExpiry: string | null;
   lastRun: string;
   totalSize: string | null;
   inactive: boolean;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -92,6 +92,8 @@ export type Workflow = CrawlConfig & {
   lastCrawlSize: number | null;
   lastStartedByName: string | null;
   lastCrawlStopping: boolean | null;
+  // User has requested pause, but actual state can be running or paused
+  // OR user has requested resume, but actual state is not running
   lastCrawlShouldPause: boolean | null;
   lastCrawlPausedAt: string | null;
   lastCrawlPausedExpiry: string | null;

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -111,4 +111,17 @@ describe("humanizeExecutionSeconds", () => {
     expect(el.textContent?.trim()).to.equal("<1 minute\u00a0(0m 24s)");
     expect(parentNode.innerText).to.equal("<1 minute\u00a0(0m 24s)");
   });
+  it("formats zero seconds", async () => {
+    const parentNode = document.createElement("div");
+    const el = await fixture(
+      humanizeExecutionSeconds(0, {
+        displaySeconds: true,
+      }),
+      {
+        parentNode,
+      },
+    );
+    expect(el.textContent?.trim()).to.equal("0 minutes");
+    expect(parentNode.innerText).to.equal("0 minutes");
+  });
 });

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -12,6 +12,9 @@ describe("formatHours", () => {
   it("returns 1m when given a time under a minute", () => {
     expect(humanizeSeconds(24, "en-US")).to.equal("1m");
   });
+  it("returns seconds given a time under a minute when not rounding", () => {
+    expect(humanizeSeconds(24, "en-US")).to.equal("1m");
+  });
   it("returns 0m and seconds when given a time under a minute with seconds on", () => {
     expect(humanizeSeconds(24, "en-US", true)).to.equal("0m 24s");
   });
@@ -105,7 +108,7 @@ describe("humanizeExecutionSeconds", () => {
         parentNode,
       },
     );
-    expect(el.textContent?.trim()).to.equal("1 minute\u00a0(0m 24s)");
-    expect(parentNode.innerText).to.equal("1 minute\u00a0(0m 24s)");
+    expect(el.textContent?.trim()).to.equal("<1 minute\u00a0(0m 24s)");
+    expect(parentNode.innerText).to.equal("<1 minute\u00a0(0m 24s)");
   });
 });

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -110,9 +110,7 @@ export const humanizeExecutionSeconds = (
   });
 
   const details = humanizeSeconds(seconds, locale, displaySeconds);
-  const compactMinutes =
-    (displaySeconds && seconds < 60 ? "<" : "") +
-    compactMinuteFormatter.format(minutes);
+  const compactMinutes = compactMinuteFormatter.format(minutes);
   const fullMinutes = longMinuteFormatter.format(minutes);
 
   // if the time is less than an hour and lines up exactly on the minute, don't render the details.
@@ -121,6 +119,7 @@ export const humanizeExecutionSeconds = (
     : Math.floor(seconds / 60) === 0 && seconds % 60 !== 0;
   const formattedDetails =
     detailsRelevant || seconds > 3600 ? `\u00a0(${details})` : nothing;
+  const prefix = detailsRelevant && seconds < 60 ? "<" : "";
 
   switch (style) {
     case "long":
@@ -128,12 +127,12 @@ export const humanizeExecutionSeconds = (
         title="${ifDefined(
           fullMinutes !== compactMinutes ? fullMinutes : undefined,
         )}"
-        >${compactMinutes}${formattedDetails}</span
+        >${prefix}${compactMinutes}${formattedDetails}</span
       >`;
     case "short":
       return html`<span
         title="${longMinuteFormatter.format(minutes)}${formattedDetails}"
-        >${compactMinutes}</span
+        >${prefix}${compactMinutes}</span
       >`;
   }
 };

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -88,7 +88,7 @@ export const humanizeExecutionSeconds = (
 ) => {
   const {
     style = "long",
-    displaySeconds = false,
+    displaySeconds = seconds < 60,
     round = "up",
   } = options || {};
   const locale = localize.activeLanguage;
@@ -110,7 +110,9 @@ export const humanizeExecutionSeconds = (
   });
 
   const details = humanizeSeconds(seconds, locale, displaySeconds);
-  const compactMinutes = compactMinuteFormatter.format(minutes);
+  const compactMinutes =
+    (displaySeconds && seconds < 60 ? "<" : "") +
+    compactMinuteFormatter.format(minutes);
   const fullMinutes = longMinuteFormatter.format(minutes);
 
   // if the time is less than an hour and lines up exactly on the minute, don't render the details.
@@ -126,8 +128,7 @@ export const humanizeExecutionSeconds = (
         title="${ifDefined(
           fullMinutes !== compactMinutes ? fullMinutes : undefined,
         )}"
-      >
-        ${compactMinutes}${formattedDetails}</span
+        >${compactMinutes}${formattedDetails}</span
       >`;
     case "short":
       return html`<span


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2569

## Changes

- Handles `paused` workflow state.
- Adds "Copy Crawl ID" and "View Archived Item" buttons to workflow detail
- Fixes file size not updating in workflow crawls list
- Fixes superadmin banner showing over workflow tabs
- Refactors workflow detail API calls to use `Task` to improve poll performance.
- Fixes execution time rendering when less than a minute

## Manual testing

1. Log in as crawler
2. Go to "Crawling"
3. Run a workflow. Verify "Latest Crawl" updates as expected
4. Click "Pause". Verify pause notices are shown.
5. Click "Dismiss". Verify pause notice is hidden.
6. Click "Resume". Verify pause notices are hidden.
7. Go to "Crawling"
8. Hover over running crawl status. Verify tooltip renders as expected.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow | <img width="538" alt="Screenshot 2025-05-14 at 3 51 19 PM" src="https://github.com/user-attachments/assets/c0e286bc-89f2-42bb-a7df-dcb837f32d6e" /> |
| Workflow (less than 10m to resume) | <img width="169" alt="Screenshot 2025-05-14 at 3 06 38 PM" src="https://github.com/user-attachments/assets/91192b22-edf0-4d57-b6a7-a9b4e0fd3f52" /> |
| Workflow | <img width="565" alt="Screenshot 2025-05-26 at 3 14 21 PM" src="https://github.com/user-attachments/assets/f535882d-1c63-4492-b338-93370aafe26d" /> |
| Workflow - Latest Crawl | <img width="970" alt="Screenshot 2025-05-14 at 4 37 33 PM" src="https://github.com/user-attachments/assets/0eb21ed9-8e48-4367-a496-698f87057735" /> |
| Workflow - Crawls | <img width="967" alt="Screenshot 2025-05-14 at 4 37 44 PM" src="https://github.com/user-attachments/assets/9b287470-0d9d-45ce-b465-87eac52796e9" /> |
| Workflow List | <img width="342" alt="Screenshot 2025-05-22 at 10 43 08 AM" src="https://github.com/user-attachments/assets/94ca9d94-4381-4c37-aa35-94208f8ec9d6" /> |





<!-- ## Follow-ups -->
