### PR TITLE
storage: use s3v4 signature for presigning urls

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1667,6 +1667,7 @@ class S3StorageIn(BaseModel):
     bucket: str
     access_endpoint_url: Optional[str] = None
     region: str = ""
+    use_v4_signature: bool = False
 
 
 # ============================================================================
@@ -1681,6 +1682,7 @@ class S3Storage(BaseModel):
     secret_key: str
     access_endpoint_url: str
     region: str = ""
+    use_v4_signature: bool = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1666,8 +1666,8 @@ class S3StorageIn(BaseModel):
     endpoint_url: str
     bucket: str
     access_endpoint_url: Optional[str] = None
+    access_addressing_style: Literal["virtual", "path"] = "virtual"
     region: str = ""
-    use_v4_signature: bool = False
 
 
 # ============================================================================
@@ -1681,8 +1681,8 @@ class S3Storage(BaseModel):
     access_key: str
     secret_key: str
     access_endpoint_url: str
+    access_addressing_style: Literal["virtual", "path"] = "virtual"
     region: str = ""
-    use_v4_signature: bool = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -162,6 +162,7 @@ class StorageOps:
             access_key=storage["access_key"],
             secret_key=storage["secret_key"],
             region=storage.get("region", ""),
+            use_v4_signature=storage.get("useV4Signature", False),
             endpoint_url=endpoint_url,
             endpoint_no_bucket_url=endpoint_no_bucket_url,
             access_endpoint_url=access_endpoint_url,
@@ -296,7 +297,9 @@ class StorageOps:
         if for_presign and storage.access_endpoint_url != storage.endpoint_url:
             s3 = {"addressing_style": "virtual"}
 
-        config = AioConfig(signature_version="s3v4", s3=s3)
+        config = AioConfig(
+            signature_version="s3v4" if storage.use_v4_signature else "s3", s3=s3
+        )
 
         async with session.create_client(
             "s3",

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -291,9 +291,12 @@ class StorageOps:
 
         session = aiobotocore.session.get_session()
 
-        config = None
+        s3 = None
+
         if for_presign and storage.access_endpoint_url != storage.endpoint_url:
-            config = AioConfig(s3={"addressing_style": "virtual"})
+            s3 = {"addressing_style": "virtual"}
+
+        config = AioConfig(signature_version="s3v4", s3=s3)
 
         async with session.create_client(
             "s3",

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
 
   FRONTEND_ORIGIN: {{ .Values.frontend_alias | default "http://browsertrix-cloud-frontend" }}
 
-  CRAWLER_FQDN_SUFFIX: ".{{ .Values.crawler_namespace }}.svc.cluster.local"
+  CRAWLER_FQDN_SUFFIX: ".{{ .Values.crawler_namespace }}{{ .Values.fqdn_suffix }}"
 
   DEFAULT_ORG: "{{ .Values.default_org }}"
 
@@ -52,6 +52,8 @@ data:
   LOG_FAILED_CRAWL_LINES: "{{ .Values.log_failed_crawl_lines | default 0 }}"
 
   IS_LOCAL_MINIO: "{{ .Values.minio_local }}"
+
+  LOCAL_MINIO_ACCESS_PATH: "{{ .Values.minio_access_path }}"
 
   STORAGES_JSON: "/ops-configs/storages.json"
 

--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -41,7 +41,7 @@ spec:
               value: {{ .Values.name }}-backend
 
             - name: CRAWLER_FQDN_SUFFIX
-              value: ".{{ .Values.crawler_namespace }}.svc.cluster.local"
+              value: ".{{ .Values.crawler_namespace }}{{ .Values.fqdn_suffix }}"
 
             - name: NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE
               value: "1"
@@ -60,7 +60,10 @@ spec:
 
             - name: LOCAL_BUCKET
               value: "{{ .Values.minio_local_bucket_name }}"
-            {{- end }}
+
+            - name: LOCAL_ACCESS_PATH
+              value: "{{ .Values.minio_access_path }}"
+             {{- end }}
 
             {{- if .Values.inject_extra }}
             - name: INJECT_EXTRA

--- a/chart/templates/minio.yaml
+++ b/chart/templates/minio.yaml
@@ -136,6 +136,23 @@ spec:
       {{- end }}
       name: minio
 
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  namespace: {{ .Values.crawler_namespace }}
+  name: local-minio
+  labels:
+    app: local-minio
+
+spec:
+  type: ExternalName
+  externalName: "local-minio.{{ .Release.Namespace }}{{ .Values.fqdn_suffix }}"
+  ports:
+    - port: 9000
+
+
 {{- if .Values.minio_local_console_port }}
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -398,6 +398,9 @@ minio_pull_policy: "IfNotPresent"
 
 minio_local_bucket_name: &local_bucket_name "btrix-data"
 
+# path for serving from local minio bucket
+minio_access_path: &minio_access_path "/data/"
+
 minio_cpu: "10m"
 minio_memory: "1024Mi"
 
@@ -413,8 +416,8 @@ storages:
     secret_key: "PASSW0RD"
     bucket_name: *local_bucket_name
 
-    endpoint_url: "http://local-minio.default:9000/"
-    access_endpoint_url: "/data/"
+    endpoint_url: "http://local-minio:9000/"
+    access_endpoint_url: *minio_access_path
 
 
 # optional: duration in minutes for WACZ download links to be valid
@@ -494,6 +497,9 @@ signer_memory: "50Mi"
 
 # Other Settings
 # =========================================
+
+# default FQDN suffix, shouldn't need to change
+fqdn_suffix: .svc.cluster.local
 
 # Optional: configure load balancing annotations
 # service:

--- a/frontend/00-browsertrix-nginx-init.sh
+++ b/frontend/00-browsertrix-nginx-init.sh
@@ -7,7 +7,9 @@ if [ -z "$LOCAL_MINIO_HOST" ]; then
   echo "no local minio, clearing out minio route"
   echo "" >/etc/nginx/includes/minio.conf
 else
-  echo "local minio: replacing \$LOCAL_MINIO_HOST with \"$LOCAL_MINIO_HOST\", \$LOCAL_BUCKET with \"$LOCAL_BUCKET\""
+  LOCAL_ACCESS_PATH=$(printf '%s\n' "$LOCAL_ACCESS_PATH" | sed -e 's/[\/&]/\\&/g')
+  echo "local minio: replacing \$LOCAL_MINIO_HOST with \"$LOCAL_MINIO_HOST\", \$LOCAL_BUCKET with \"$LOCAL_BUCKET\", \$LOCAL_ACCESS_PATH with \"$LOCAL_ACCESS_PATH\""
+  sed -i "s/\$LOCAL_ACCESS_PATH/$LOCAL_ACCESS_PATH/g" /etc/nginx/includes/minio.conf
   sed -i "s/\$LOCAL_MINIO_HOST/$LOCAL_MINIO_HOST/g" /etc/nginx/includes/minio.conf
   sed -i "s/\$LOCAL_BUCKET/$LOCAL_BUCKET/g" /etc/nginx/includes/minio.conf
 fi

--- a/frontend/minio.conf
+++ b/frontend/minio.conf
@@ -1,4 +1,4 @@
-location /data/ {
+location $LOCAL_ACCESS_PATH {
   proxy_pass http://$LOCAL_MINIO_HOST/$LOCAL_BUCKET/;
   proxy_redirect off;
   proxy_buffering off;


### PR DESCRIPTION
Use V4 ('s3v4') signature version for for all presigning URLs to support backblaze, fixes #2472 
- add 'access_addressing_style' to be able to choose virtual/path addressing for access endpoint (default to 'virtual' as before)
- fix minio presigning with v4 by using 'path' addressing style for minio
- if path matches '/data/' for internal minio bucket, then always use 'path'
- also make minio access path '/data/' configurable

also simplify running in any namespace with default settings:
- don't hardcode 'local-minio.default'
- in crawlers namespace, add a 'local-minio' externalName service which maps to the service in which the main namespace is