### PR TITLE
feat: Update superadmin active crawls view

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -43,7 +43,7 @@ import {
   type TranslatedLocaleEnum,
 } from "@/types/localization";
 import { type AppSettings } from "@/utils/app";
-import { activeCrawlStates, DEFAULT_MAX_SCALE } from "@/utils/crawler";
+import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
 import localize from "@/utils/localize";
 import { toast } from "@/utils/notify";
 import router, { urlForName } from "@/utils/router";
@@ -122,8 +122,8 @@ export class App extends BtrixElement {
   });
 
   private readonly pollTask = new Task(this, {
-    task: async ([workflow]) => {
-      if (!workflow) return;
+    task: async ([crawls]) => {
+      if (!crawls) return;
 
       return window.setTimeout(() => {
         void this.activeCrawlsTotalTask.run();
@@ -616,15 +616,14 @@ export class App extends BtrixElement {
                     @click=${this.navigate.link}
                   >
                     ${msg("Active Crawls")}
-                    ${this.activeCrawlsTotalTask.render({
-                      complete: (total) => html`
-                        <btrix-badge
-                          variant=${total > 0 ? "primary" : "neutral"}
-                        >
+                    ${when(
+                      this.activeCrawlsTotalTask.value,
+                      (total) => html`
+                        <btrix-badge variant=${total > 0 ? "primary" : "blue"}>
                           ${this.localize.number(total)}
                         </btrix-badge>
                       `,
-                    })}
+                    )}
                   </a>
                 </div>
               `
@@ -1168,7 +1167,6 @@ export class App extends BtrixElement {
 
   private async getActiveCrawlsTotal() {
     const query = queryString.stringify({
-      state: activeCrawlStates,
       pageSize: 1,
     });
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -586,7 +586,7 @@ export class App extends BtrixElement {
                     class="font-medium text-neutral-500 hover:text-primary"
                     href=${urlForName("adminCrawls")}
                     @click=${this.navigate.link}
-                    >${msg("Running Crawls")}</a
+                    >${msg("Active Crawls")}</a
                   >
                 </div>
               `

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -3,6 +3,7 @@ import "./global";
 
 import { provide } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
+import { Task } from "@lit/task";
 import type {
   SlDialog,
   SlDrawer,
@@ -14,6 +15,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 import isEqual from "lodash/fp/isEqual";
+import queryString from "query-string";
 
 import "./components";
 import "./features";
@@ -33,13 +35,15 @@ import AuthService, {
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { NavigateEventDetail } from "@/controllers/navigate";
 import type { NotifyEventDetail } from "@/controllers/notify";
+import type { APIPaginatedList } from "@/types/api";
 import { type Auth } from "@/types/auth";
+import type { Crawl } from "@/types/crawler";
 import {
   translatedLocales,
   type TranslatedLocaleEnum,
 } from "@/types/localization";
 import { type AppSettings } from "@/utils/app";
-import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
+import { activeCrawlStates, DEFAULT_MAX_SCALE } from "@/utils/crawler";
 import localize from "@/utils/localize";
 import { toast } from "@/utils/notify";
 import router, { urlForName } from "@/utils/router";
@@ -65,6 +69,8 @@ export type APIUser = {
 export interface UserGuideEventMap {
   "btrix-user-guide-show": CustomEvent<{ path?: string }>;
 }
+
+const POLL_INTERVAL_SECONDS = 10;
 
 @customElement("browsertrix-app")
 @localized()
@@ -107,6 +113,24 @@ export class App extends BtrixElement {
 
   @query("#userGuideDrawer")
   private readonly userGuideDrawer!: SlDrawer;
+
+  private readonly activeCrawlsTotalTask = new Task(this, {
+    task: async () => {
+      return await this.getActiveCrawlsTotal();
+    },
+    args: () => [] as const,
+  });
+
+  private readonly pollTask = new Task(this, {
+    task: async ([workflow]) => {
+      if (!workflow) return;
+
+      return window.setTimeout(() => {
+        void this.activeCrawlsTotalTask.run();
+      }, POLL_INTERVAL_SECONDS * 1000);
+    },
+    args: () => [this.activeCrawlsTotalTask.value] as const,
+  });
 
   get orgSlugInPath() {
     return this.viewState.params.slug || "";
@@ -162,6 +186,12 @@ export class App extends BtrixElement {
     });
 
     this.startSyncBrowserTabs();
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    window.clearTimeout(this.pollTask.value);
   }
 
   private attachUserGuideListeners() {
@@ -579,15 +609,23 @@ export class App extends BtrixElement {
           </div>
           ${isSuperAdmin
             ? html`
-                <div
-                  class="order-3 grid w-full auto-cols-max grid-flow-col items-center gap-5 md:order-2 md:w-auto"
-                >
+                <div class="order-3 w-full auto-cols-max md:order-2 md:w-auto">
                   <a
-                    class="font-medium text-neutral-500 hover:text-primary"
+                    class="inline-flex items-center gap-2 font-medium text-neutral-500 hover:text-primary"
                     href=${urlForName("adminCrawls")}
                     @click=${this.navigate.link}
-                    >${msg("Active Crawls")}</a
                   >
+                    ${msg("Active Crawls")}
+                    ${this.activeCrawlsTotalTask.render({
+                      complete: (total) => html`
+                        <btrix-badge
+                          variant=${total > 0 ? "primary" : "neutral"}
+                        >
+                          ${this.localize.number(total)}
+                        </btrix-badge>
+                      `,
+                    })}
+                  </a>
                 </div>
               `
             : nothing}
@@ -1126,5 +1164,18 @@ export class App extends BtrixElement {
 
   private clearSelectedOrg() {
     AppStateService.updateOrgSlug(null);
+  }
+
+  private async getActiveCrawlsTotal() {
+    const query = queryString.stringify({
+      state: activeCrawlStates,
+      pageSize: 1,
+    });
+
+    const data = await this.api.fetch<APIPaginatedList<Crawl>>(
+      `/orgs/all/crawls?${query}`,
+    );
+
+    return data.total;
   }
 }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -70,7 +70,7 @@ export interface UserGuideEventMap {
   "btrix-user-guide-show": CustomEvent<{ path?: string }>;
 }
 
-const POLL_INTERVAL_SECONDS = 10;
+const POLL_INTERVAL_SECONDS = 30;
 
 @customElement("browsertrix-app")
 @localized()

--- a/frontend/src/pages/admin/admin.ts
+++ b/frontend/src/pages/admin/admin.ts
@@ -70,7 +70,7 @@ export class Admin extends BtrixElement {
     if (this.userInfo.orgs.length && !this.orgList) {
       return html`
         <btrix-document-title
-          title=${msg("Admin dashboard")}
+          title=${msg("Dashboard – Admin")}
         ></btrix-document-title>
 
         <div class="my-24 flex items-center justify-center text-3xl">
@@ -81,7 +81,7 @@ export class Admin extends BtrixElement {
 
     return html`
       <btrix-document-title
-        title=${msg("Admin dashboard")}
+        title=${msg("Dashboard – Admin")}
       ></btrix-document-title>
 
       <div class="bg-white">

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -338,6 +338,7 @@ export class Crawls extends BtrixElement {
       this.crawls = await this.getCrawls(params);
 
       // TODO Refactor to poll task
+      // https://github.com/webrecorder/browsertrix/issues/1716
       this.timerId = window.setTimeout(() => {
         void this.fetchCrawls();
       }, POLL_INTERVAL_SECONDS * 1000);

--- a/frontend/src/pages/crawls.ts
+++ b/frontend/src/pages/crawls.ts
@@ -106,7 +106,7 @@ export class Crawls extends BtrixElement {
 
   render() {
     return html`<btrix-document-title
-        title=${msg("Running crawls")}
+        title=${msg("Active Crawls – Admin")}
       ></btrix-document-title>
 
       <div class="mx-auto box-border w-full max-w-screen-desktop px-3 py-4">
@@ -122,9 +122,7 @@ export class Crawls extends BtrixElement {
       <main>
         <header class="contents">
           <div class="mb-3 flex w-full justify-between border-b pb-4">
-            <h1 class="h-8 text-xl font-semibold">
-              ${msg("All Running Crawls")}
-            </h1>
+            <h1 class="h-8 text-xl font-semibold">${msg("Active Crawls")}</h1>
           </div>
           <div
             class="sticky top-2 z-10 mb-3 rounded-lg border bg-neutral-50 p-4"

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -294,7 +294,7 @@ export class Org extends BtrixElement {
                   OrgTab.Items,
                   () => html`
                     <btrix-document-title
-                      title=${`${msg("Archived Items")} - ${userOrg.name}`}
+                      title=${`${msg("Archived Items")} – ${userOrg.name}`}
                     ></btrix-document-title>
                     ${this.renderArchivedItem()}
                   `,
@@ -303,7 +303,7 @@ export class Org extends BtrixElement {
                   OrgTab.Workflows,
                   () => html`
                     <btrix-document-title
-                      title=${`${msg("Crawl Workflows")} - ${userOrg.name}`}
+                      title=${`${msg("Crawl Workflows")} – ${userOrg.name}`}
                     ></btrix-document-title>
                     ${this.renderWorkflows()}
                   `,
@@ -312,7 +312,7 @@ export class Org extends BtrixElement {
                   OrgTab.BrowserProfiles,
                   () => html`
                     <btrix-document-title
-                      title=${`${msg("Browser Profiles")} - ${userOrg.name}`}
+                      title=${`${msg("Browser Profiles")} – ${userOrg.name}`}
                     ></btrix-document-title>
                     ${this.renderBrowserProfiles()}
                   `,
@@ -321,7 +321,7 @@ export class Org extends BtrixElement {
                   OrgTab.Collections,
                   () => html`
                     <btrix-document-title
-                      title=${`${msg("Collections")} - ${userOrg.name}`}
+                      title=${`${msg("Collections")} – ${userOrg.name}`}
                     ></btrix-document-title>
                     ${this.renderCollections()}
                   `,
@@ -332,7 +332,7 @@ export class Org extends BtrixElement {
                     this.appState.isAdmin
                       ? html`
                           <btrix-document-title
-                            title=${`${msg("Org Settings")} - ${userOrg.name}`}
+                            title=${`${msg("Org Settings")} – ${userOrg.name}`}
                           ></btrix-document-title>
                           ${this.renderOrgSettings()}
                         `

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -8,6 +8,7 @@ import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/ico
 import "@shoelace-style/shoelace/dist/themes/light.css";
 import "@shoelace-style/shoelace/dist/components/alert/alert";
 import "@shoelace-style/shoelace/dist/components/avatar/avatar";
+import "@shoelace-style/shoelace/dist/components/badge/badge";
 import "@shoelace-style/shoelace/dist/components/button/button";
 import "@shoelace-style/shoelace/dist/components/drawer/drawer";
 import "@shoelace-style/shoelace/dist/components/icon/icon";

--- a/frontend/src/shoelace.ts
+++ b/frontend/src/shoelace.ts
@@ -8,7 +8,6 @@ import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/ico
 import "@shoelace-style/shoelace/dist/themes/light.css";
 import "@shoelace-style/shoelace/dist/components/alert/alert";
 import "@shoelace-style/shoelace/dist/components/avatar/avatar";
-import "@shoelace-style/shoelace/dist/components/badge/badge";
 import "@shoelace-style/shoelace/dist/components/button/button";
 import "@shoelace-style/shoelace/dist/components/drawer/drawer";
 import "@shoelace-style/shoelace/dist/components/icon/icon";


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2571

## Changes

- Renames "Running Crawls" -> "Active Crawls" in superadmin app bar
- Shows number of active crawls next to link
- Refreshes active crawl list every 30 seconds
- Standardizes browser title

## Manual testing

1. Log in as superadmin
2. Start a crawl. Verify number next to "Active Crawls" updates within 30 seconds
3. Click "Active Crawls". Verify data updates every ~30 seconds

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Admin - Crawls | <img width="947" alt="Screenshot 2025-05-21 at 11 55 41 PM" src="https://github.com/user-attachments/assets/9f7092e4-0b1b-4a59-b990-c550eae15ce4" /> |


<!-- ## Follow-ups -->
