### PR TITLE
fix: Show 404 page for nonexistent org

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -832,6 +832,10 @@ export class App extends BtrixElement {
         return html`<btrix-orgs class="w-full md:bg-neutral-50"></btrix-orgs>`;
 
       case "org": {
+        if (!this.isUserInCurrentOrg) {
+          return this.renderNotFoundPage();
+        }
+
         const slug = this.viewState.params.slug;
         const orgPath = this.viewState.pathname;
         const pathname = this.getLocationPathname();

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -491,7 +491,6 @@ export class App extends BtrixElement {
                       >
                     `
                   : nothing}
-                <div role="separator" class="mx-2.5 h-7 w-0 border-l"></div>
                 ${this.renderOrgs()}
               `,
             )}
@@ -615,6 +614,7 @@ export class App extends BtrixElement {
     const orgNameLength = 50;
 
     return html`
+      <div role="separator" class="mx-2.5 h-7 w-0 border-l"></div>
       <div class="max-w-32 truncate sm:max-w-52 md:max-w-none">
         ${selectedOption.slug
           ? html`

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -602,12 +602,12 @@ export class App extends BtrixElement {
 
     const selectedOption = this.orgSlugInPath
       ? orgs.find(({ slug }) => slug === this.orgSlugInPath)
-      : { slug: "", name: msg("All Organizations") };
+      : {
+          slug: "",
+          name: msg("All Organizations"),
+        };
+
     if (!selectedOption) {
-      console.debug(
-        `Couldn't find organization with slug ${this.orgSlugInPath}`,
-        orgs,
-      );
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2617

## Changes

Renders 404 page if org in URL doesn't exist.

## Manual testing

Follow repro steps in https://github.com/webrecorder/browsertrix/issues/2617, checking for superadmin, user in multiple orgs, and user in single org.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| 404 | <img width="1081" alt="Screenshot 2025-05-22 at 2 22 36 PM" src="https://github.com/user-attachments/assets/95f9448a-a96c-4720-8cd9-5d44711ad41b" /> |


<!-- ## Follow-ups -->
