### PR TITLE
Fix securityContext for pod

### DIFF
--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -55,8 +55,6 @@ spec:
     runAsUser: {{ crawler_uid }}
     runAsGroup: {{ crawler_gid }}
     fsGroup: {{ crawler_fsgroup }}
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
 
   terminationGracePeriodSeconds: {{ termination_grace_secs }}
   volumes:
@@ -185,6 +183,11 @@ spec:
        {% endif %}
         - name: crawl-data
           mountPath: /crawls
+
+        - name: crawl-data
+          mountPath: /crawls/tmp
+          subPath: tmp
+
       envFrom:
         - configMapRef:
             name: shared-crawler-config
@@ -200,6 +203,9 @@ spec:
       env:
         - name: HOME
           value: /crawls/home
+
+        - name: TMPDIR
+          value: /crawls/tmp
 
         - name: CRAWL_ID
           value: "{{ id }}"
@@ -237,5 +243,9 @@ spec:
         periodSeconds: 120
         failureThreshold: 3
       {% endif %}
+
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
 
 {% endif %}

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -185,7 +185,7 @@ spec:
           mountPath: /crawls
 
         - name: crawl-data
-          mountPath: /crawls/tmp
+          mountPath: /tmp
           subPath: tmp
 
       envFrom:
@@ -203,9 +203,6 @@ spec:
       env:
         - name: HOME
           value: /crawls/home
-
-        - name: TMPDIR
-          value: /crawls/tmp
 
         - name: CRAWL_ID
           value: "{{ id }}"


### PR DESCRIPTION
Some of the `securityContext` settings need to be on the container, not on the pod.
This enables the read-only file system.
Also map the crawler /tmp directory to use the same volume as crawls (as crawler currently uses /tmp dir)