### PR TITLE
docs: update remote deployment docs with working nginx-install example

### DIFF
--- a/chart/examples/k3s-hosted.yaml
+++ b/chart/examples/k3s-hosted.yaml
@@ -10,7 +10,7 @@
 # k3s
 # ---
 #
-# One way to deploy this is with k3s, which will require the following changes:
+# One way to deploy this is with k3s (https://k3s.io/), which will require the following changes:
 #
 # Make sure to disable traefik on your k3s cluster by adding `--no-deploy traefik` to the systemd unit that starts k3s _before_ starting your server.
 # One way to check that traefik is not running your cluster is with `kubectl get deployments -n kube-system` and see if traefik shows up in the output.

--- a/chart/examples/k3s-hosted.yaml
+++ b/chart/examples/k3s-hosted.yaml
@@ -12,10 +12,14 @@
 #
 # One way to deploy this is with k3s, which will require the following changes:
 #
-# Make sure to disable traefik on your k3s cluster by adding `--no-deploy traefik` to the systemd unit that starts k3s _before_ starting your server. One way to check that traefik is not running your cluster is with `kubectl get deployments -n kube-system` and see if traefik shows up in the output
+# Make sure to disable traefik on your k3s cluster by adding `--no-deploy traefik` to the systemd unit that starts k3s _before_ starting your server.
+# One way to check that traefik is not running your cluster is with `kubectl get deployments -n kube-system` and see if traefik shows up in the output.
 #
-# Once traefik has been disabled, you must install `nginx-ingress` which can be installed by: 
-# helm upgrade --install nginx ingress-nginx/ingress-nginx -n ingress-nginx --create-namespace
+# Once traefik has been disabled, you must install `nginx-ingress`, which can be installed by:
+# 
+# helm upgrade --install ingress-nginx ingress-nginx \
+#   --repo https://kubernetes.github.io/ingress-nginx \
+#   --namespace ingress-nginx --create-namespace
 #
 # You'll also need to install cert-manager. Browsertrix recommends installing cert-manager through jetpack with the following command: 
 #

--- a/frontend/docs/docs/deploy/remote.md
+++ b/frontend/docs/docs/deploy/remote.md
@@ -31,21 +31,28 @@ Another option for a single-machine remote deployment is [k3s](https://k3s.io)
 
 1. Install K3s, as suggested in the [local deployment guide](../deploy/local.md). Make sure to **disable traefik** which can be done by adding `--no-deploy traefik` to the `systemd` unit when installing k3s
 
-2. Install `nginx-ingress` with: `helm upgrade --install nginx ingress-nginx/ingress-nginx -n ingress-nginx --create-namespace`
+2. Install `nginx-ingress` with:
+  
+    ```zsh
+    helm upgrade --install ingress-nginx ingress-nginx \
+      --repo https://kubernetes.github.io/ingress-nginx \
+      --namespace ingress-nginx --create-namespace
+    ```
+  
 3. Install `cert-manager`. We recommend installing `cert-manager` through Jetpack, like so: 
-
-```zsh
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-
-helm repo update jetstack
-helm upgrade --install \
-  cert-manager jetstack/cert-manager \
-  --namespace cert-manager \
-  --create-namespace \
-  --version v1.12.0 \
-  --set installCRDs=true
-``` 
+  
+   ```zsh
+   helm repo add jetstack https://charts.jetstack.io
+   helm repo update
+   
+   helm repo update jetstack
+   helm upgrade --install \
+     cert-manager jetstack/cert-manager \
+     --namespace cert-manager \
+     --create-namespace \
+     --version v1.12.0 \
+     --set installCRDs=true
+   ``` 
 
 4. Copy `cp ./chart/examples/k3s-hosted.yaml ./chart/my-config.yaml` to make local changes.
 

--- a/frontend/docs/docs/deploy/remote.md
+++ b/frontend/docs/docs/deploy/remote.md
@@ -21,9 +21,10 @@ For a single-machine remote deployment, we recommend using [MicroK8s](https://mi
 
 4. Run with:
 
-   ```shell
-   helm upgrade --install -f ./chart/values.yaml -f ./chart/my-config.yaml btrix ./chart/
-   ```
+    ```shell
+    helm upgrade --install -f ./chart/values.yaml -f ./chart/my-config.yaml \
+      btrix ./chart/
+    ```
 
 ## Single Machine Deployment with k3s
 
@@ -32,27 +33,27 @@ Another option for a single-machine remote deployment is [k3s](https://k3s.io)
 1. Install K3s, as suggested in the [local deployment guide](../deploy/local.md). Make sure to **disable traefik** which can be done by adding `--no-deploy traefik` to the `systemd` unit when installing k3s
 
 2. Install `nginx-ingress` with:
-  
+
     ```zsh
     helm upgrade --install ingress-nginx ingress-nginx \
       --repo https://kubernetes.github.io/ingress-nginx \
       --namespace ingress-nginx --create-namespace
     ```
-  
+
 3. Install `cert-manager`. We recommend installing `cert-manager` through Jetpack, like so: 
-  
-   ```zsh
-   helm repo add jetstack https://charts.jetstack.io
-   helm repo update
-   
-   helm repo update jetstack
-   helm upgrade --install \
-     cert-manager jetstack/cert-manager \
-     --namespace cert-manager \
-     --create-namespace \
-     --version v1.12.0 \
-     --set installCRDs=true
-   ``` 
+
+    ```zsh
+    helm repo add jetstack https://charts.jetstack.io
+    helm repo update
+
+    helm repo update jetstack
+    helm upgrade --install \
+      cert-manager jetstack/cert-manager \
+      --namespace cert-manager \
+      --create-namespace \
+      --version v1.12.0 \
+      --set installCRDs=true
+    ```
 
 4. Copy `cp ./chart/examples/k3s-hosted.yaml ./chart/my-config.yaml` to make local changes.
 
@@ -62,9 +63,10 @@ Another option for a single-machine remote deployment is [k3s](https://k3s.io)
 
 7. Run with:
 
-   ```shell
-   helm upgrade --install -f ./chart/values.yaml -f ./chart/my-config.yaml btrix ./chart/
-   ```
+    ```shell
+    helm upgrade --install -f ./chart/values.yaml -f ./chart/my-config.yaml \
+      btrix ./chart/
+    ```
 
 ### Using Custom Storage
 


### PR DESCRIPTION
Update the docs on k3s deployment for installing `ingress-nginx`, fixes #2619.

Also fix the indentation on the code blocks so markdown carries on list numbering.
At the moment the numbering confusingly resets after point 3.

![Screenshot 2025-05-27 at 11-43-21 Remote Self-Hosted and Cloud - Browsertrix Docs](https://github.com/user-attachments/assets/28d557d4-534a-4d50-b32f-cb74d424fa64)
