### PR TITLE
feat: Make saving simple workflow more efficient

### DIFF
--- a/frontend/src/components/utils/observable.ts
+++ b/frontend/src/components/utils/observable.ts
@@ -20,10 +20,15 @@ export class Observable extends LitElement {
   @property({ type: Object })
   options?: IntersectionObserverInit;
 
-  private readonly observable = new ObservableController(this);
+  private observable?: ObservableController;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.observable = new ObservableController(this, this.options);
+  }
 
   firstUpdated() {
-    this.observable.observe(this);
+    this.observable?.observe(this);
   }
 
   render() {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -261,6 +261,9 @@ export class WorkflowEditor extends BtrixElement {
   @state()
   private isCrawlRunning: boolean | null = this.configId ? null : false;
 
+  @query("#formFooter")
+  private readonly formFooter?: HTMLElement | null;
+
   // For observing panel sections position in viewport
   private readonly observable = new ObservableController(this, {
     // Add some padding to account for stickied elements
@@ -433,7 +436,23 @@ export class WorkflowEditor extends BtrixElement {
           sticky: true,
           stickyTopClassname: tw`lg:top-16`,
         })}
-        ${this.renderFooter()}
+        <btrix-observable
+          @btrix-intersect=${(e: IntersectEvent) => {
+            if (!this.formFooter) return;
+
+            const [entry] = e.detail.entries;
+
+            if (entry.isIntersecting) {
+              if (this.formFooter.classList.contains(tw`sticky`)) {
+                console.log("stickied");
+              } else {
+                this.formFooter.classList.add(tw`sticky`);
+              }
+            }
+          }}
+        >
+          ${this.renderFooter()}
+        </btrix-observable>
       </form>
     `;
   }
@@ -454,7 +473,7 @@ export class WorkflowEditor extends BtrixElement {
 
     return html`
       <btrix-tab-list
-        class="hidden lg:block"
+        class="mb-5 hidden lg:block"
         tab=${ifDefined(this.progressState?.activeTab)}
       >
         ${STEPS.map(button)}
@@ -619,20 +638,15 @@ export class WorkflowEditor extends BtrixElement {
   private renderFooter() {
     return html`
       <footer
+        id="formFooter"
         class=${clsx(
-          "flex items-center justify-end gap-2 rounded-lg border bg-white px-6 py-4 mb-7",
-          this.configId || this.serverError
-            ? tw`z- sticky bottom-3 z-20 shadow-md`
-            : tw`shadow`,
+          "flex items-center justify-end gap-2 rounded-lg border bg-white px-6 py-4 mb-7 z-50 shadow-md bottom-3",
         )}
       >
-        ${this.configId
-          ? html`
-              <sl-button class="mr-auto" size="small" type="reset">
-                ${msg("Cancel")}
-              </sl-button>
-            `
-          : nothing}
+        <sl-button class="mr-auto" size="small" type="reset">
+          ${msg("Cancel")}
+        </sl-button>
+
         ${when(this.serverError, (error) => this.renderErrorAlert(error))}
         ${when(this.configId, this.renderCrawlStatus)}
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -683,9 +683,9 @@ export class WorkflowEditor extends BtrixElement {
     return html`
       <footer
         class=${clsx(
-          "flex items-center justify-end gap-2 rounded-lg border bg-white px-6 py-4 mb-7 z-50 shadow bottom-3 duration-slow",
+          tw`bottom-3 z-50 mb-7 flex items-center justify-end gap-2 rounded-lg border bg-white px-6 py-4 shadow duration-slow`,
           this.stickyFooter && [
-            `sticky`,
+            tw`sticky`,
             this.stickyFooter === "animate" &&
               tw`motion-safe:animate-[sticky-footer_var(--sl-transition-medium)_ease-in-out]`,
           ],

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2260,16 +2260,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
     };
 
   private onKeyDown(event: KeyboardEvent) {
-    const el = event.target as HTMLElement;
-    if (!("value" in el)) return;
     const { key, metaKey } = event;
 
-    if (metaKey) {
-      if (!this.showKeyboardShortcuts) {
-        // Show meta keyboard shortcut
-        this.showKeyboardShortcuts = true;
-      }
+    if (metaKey && !this.showKeyboardShortcuts) {
+      // Show meta keyboard shortcut
+      this.showKeyboardShortcuts = true;
+      this.animateStickyFooter();
+    }
 
+    const el = event.target as HTMLElement;
+    if (!("value" in el)) return;
+
+    if (metaKey) {
       if (key === "s" || key === "Enter") {
         event.preventDefault();
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -283,6 +283,8 @@ export class WorkflowEditor extends BtrixElement {
   @state()
   private showKeyboardShortcuts = false;
 
+  private saveAndRun = false;
+
   // For observing panel sections position in viewport
   private readonly observable = new ObservableController(this, {
     // Add some padding to account for stickied elements
@@ -2271,6 +2273,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
       if (key === "s" || key === "Enter") {
         event.preventDefault();
 
+        this.saveAndRun = key === "Enter";
+
         this.formElem?.requestSubmit();
         return;
       }
@@ -2296,17 +2300,16 @@ https://archiveweb.page/images/${"logo.svg"}`}
   private async onSubmit(event: SubmitEvent) {
     event.preventDefault();
 
-    console.log("submitter:", event.submitter);
+    // Submitter may not exist if requesting submit from keyboard shortcuts
+    if (event.submitter) {
+      const submitType = (
+        event.submitter as HTMLButtonElement & {
+          value?: SubmitType;
+        }
+      ).value;
 
-    const submitType = event.submitter
-      ? (
-          event.submitter as HTMLButtonElement & {
-            value?: SubmitType;
-          }
-        ).value
-      : null;
-
-    const saveAndRun = submitType === SubmitType.SaveAndRun;
+      this.saveAndRun = submitType === SubmitType.SaveAndRun;
+    }
 
     if (!this.formElem) return;
 
@@ -2337,11 +2340,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
     const config: CrawlConfigParams & WorkflowRunParams = {
       ...this.parseConfig(),
-      runNow: saveAndRun && !this.isCrawlRunning,
+      runNow: this.saveAndRun && !this.isCrawlRunning,
     };
 
     if (this.configId) {
-      config.updateRunning = saveAndRun && Boolean(this.isCrawlRunning);
+      config.updateRunning = this.saveAndRun && Boolean(this.isCrawlRunning);
     }
 
     this.isSubmitting = true;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1,6 +1,7 @@
 import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import type {
+  SlBlurEvent,
   SlCheckbox,
   SlDetails,
   SlHideEvent,
@@ -2260,8 +2261,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private onKeyDown(event: KeyboardEvent) {
     const el = event.target as HTMLElement;
-    const tagName = el.tagName.toLowerCase();
-    if (tagName !== "sl-input") return;
+    if (!("value" in el)) return;
     const { key, metaKey } = event;
 
     if (metaKey) {
@@ -2275,7 +2275,23 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
         this.saveAndRun = key === "Enter";
 
-        this.formElem?.requestSubmit();
+        // Trigger blur to run value transformations and validation
+        el.addEventListener(
+          "sl-blur",
+          async (e: SlBlurEvent) => {
+            const input = e.currentTarget as SlInput;
+
+            // Wait for all transformations and validations to run
+            await input.updateComplete;
+            await this.updateComplete;
+
+            this.formElem?.requestSubmit();
+          },
+          { once: true },
+        );
+
+        el.blur();
+
         return;
       }
     }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2622

## Changes

- Sticks workflow form save/run buttons to the viewport if all the required fields are filled
- Adds keyboard shortcuts to save (cmd/ctrl + S to save, cmd/ctrl + Enter to save and run)
- Adds "Cancel" button to new workflow

## Manual testing

1. Log in as crawler
2. Click "New Workflow"
3. Type in valid page/crawl start URL. Verify footer is animated into visibility
4. Reload
5. Scroll to bottom of page until footer is visible
6. Scroll back up. Verify footer is still visible
7. Click "Cancel". Verify navigation to workflow list
8. Duplicate a workflow. Verify footer is visible
9. Edit a workflow. Verify footer is visible
10. Type ctrl/cmd + S. Verify workflow is saved
11. Go back to edit workflow
12. Type ctl/cmd + Enter/Return. Verify workflow saves and runs

## Screenshots

Keyboard shortcut visible upon pressing ctrl or cmd key:

<img width="284" alt="Screenshot 2025-05-28 at 1 58 38 PM" src="https://github.com/user-attachments/assets/5a39cdab-8262-40c5-b373-6bbd2e4839f4" />
