### PR TITLE
Popover styling fixes

### DIFF
--- a/frontend/src/components/ui/popover.ts
+++ b/frontend/src/components/ui/popover.ts
@@ -40,7 +40,7 @@ export class Popover extends SlTooltip {
         --sl-tooltip-line-height: var(--sl-line-height-dense);
       }
 
-      ::part(body) {
+      .tooltip__body {
         border: var(--btrix-border);
         box-shadow: var(--sl-shadow-small), var(--sl-shadow-large);
       }

--- a/frontend/src/components/ui/popover.ts
+++ b/frontend/src/components/ui/popover.ts
@@ -49,23 +49,23 @@ export class Popover extends SlTooltip {
         z-index: 1;
       }
 
-      [placement^="bottom"]::part(arrow),
-      [placement^="left"]::part(arrow) {
+      [data-current-placement^="bottom"]::part(arrow),
+      [data-current-placement^="left"]::part(arrow) {
         border-top: var(--btrix-border);
       }
 
-      [placement^="bottom"]::part(arrow),
-      [placement^="right"]::part(arrow) {
+      [data-current-placement^="bottom"]::part(arrow),
+      [data-current-placement^="right"]::part(arrow) {
         border-left: var(--btrix-border);
       }
 
-      [placement^="top"]::part(arrow),
-      [placement^="right"]::part(arrow) {
+      [data-current-placement^="top"]::part(arrow),
+      [data-current-placement^="right"]::part(arrow) {
         border-bottom: var(--btrix-border);
       }
 
-      [placement^="top"]::part(arrow),
-      [placement^="left"]::part(arrow) {
+      [data-current-placement^="top"]::part(arrow),
+      [data-current-placement^="left"]::part(arrow) {
         border-right: var(--btrix-border);
       }
     `,


### PR DESCRIPTION
## Changes
- Uses `.tooltip__body` selector instead of `::part(body)` for tooltip body from within element — `::part(body)` would work if targeting from outside the element, but not from inside, since we're inheriting `sl-tooltip`'s `render` method
- Uses `data-current-placement` instead of `placement` attribute to determine which sides of the arrow should have borders, so that when a popover is flipped to another side the correct borders show up on the arrow

cc @SuaYoo 

## Testing

Tested locally on latest Chrome, Safari, and Firefox

