### PR TITLE
Add securityContext for Redis pod

### DIFF
--- a/chart/app-templates/redis.yaml
+++ b/chart/app-templates/redis.yaml
@@ -40,6 +40,11 @@ metadata:
 spec:
   hostname: {{ name }}
   subdomain: redis
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
 
   terminationGracePeriodSeconds: 10
   volumes:


### PR DESCRIPTION
It seems the latest redis image changed security settings so root-mounted volumes no longer work.
This change:
- mount redis volumes as redis user/group 999
- needed to run with redis >=8.0.2