### PR TITLE
helm: add crawler_network_policy_additional_egress

### DIFF
--- a/chart/templates/networkpolicies.yaml
+++ b/chart/templates/networkpolicies.yaml
@@ -11,6 +11,9 @@ spec:
   policyTypes:
     - Egress
   egress:
+  {{- if .Values.crawler_network_policy_additional_egress | default false -}}
+  {{- .Values.crawler_network_policy_additional_egress | toYaml | nindent 4 -}}
+  {{- end -}}
   {{- if .Values.crawler_network_policy_egress | default false -}}
   {{- .Values.crawler_network_policy_egress | toYaml | nindent 4 -}}
   {{- else }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -373,12 +373,15 @@ btrix-proxies:
 # crawler_fsgroup: 201407
 
 
-# optional: enable/disable crawler network policy
+# optional: enable/disable crawler network policy, prevents crawler pods from accessing internal services
 crawler_enable_network_policy: true
 
-# optional: replace the default crawler egress policy with your own
+# optional: add additional egress rules to the default crawler network policy (See chart/templates/networkpolicies.yaml for an example)
+# crawler_network_policy_additional_egress: []
+
+# optional: replace the default crawler egress policy with your own egress rules (See chart/templates/networkpolicies.yaml for an example)
 # see chart/templates/networkpolicies.yaml for an example
-# crawler_network_policy_egress: {}
+# crawler_network_policy_egress: []
 
 # time to wait for graceful stop
 grace_period: 1000

--- a/frontend/docs/docs/deploy/customization.md
+++ b/frontend/docs/docs/deploy/customization.md
@@ -275,10 +275,9 @@ crawler_network_policy_additional_egress:
         protocol: TCP
 
   - to:
-    - namespaceSelector:
-      - podSelector:
-          matchLabels:
-            app: my-custom-minio
+    - podSelector:
+        matchLabels:
+          app: my-custom-minio
 
     ports:
       - port: 9000


### PR DESCRIPTION
Adds `crawler_network_policy_additional_egress` setting, to add egress rules to the existing crawler network policy. Useful for when you want to allow-list a single IPs without replacing the whole network policy. Resolves #2121