### PR TITLE
Quick fix: use custom `getFn`s for user-related keys in superadmin

### DIFF
--- a/frontend/src/components/orgs-list.ts
+++ b/frontend/src/components/orgs-list.ts
@@ -91,8 +91,16 @@ export class OrgsList extends BtrixElement {
       "id",
       "name",
       "slug",
-      "users.name",
-      "users.email",
+      {
+        name: "users.name",
+        getFn: (org) =>
+          org.users ? Object.values(org.users).map((user) => user.name) : [],
+      },
+      {
+        name: "users.email",
+        getFn: (org) =>
+          org.users ? Object.values(org.users).map((user) => user.email) : [],
+      },
       "subscription.subId",
       "subscription.planId",
     ],


### PR DESCRIPTION
## Changes

Users are stored as a record of emails to full user objects, so we don't statically know the keys of the `orgList.users` object at fuse init time. Instead, we can use `Object.values` to turn the record into an array that we can then `map` to get the desired values from the user objects.