### PR TITLE
fix: Handle trial ending without cancelation

### DIFF
--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -129,10 +129,7 @@ export class OrgStatusBanner extends BtrixElement {
           !!futureCancelDate &&
           ((isTrial && daysDiff < MAX_TRIAL_DAYS_SHOW_BANNER) ||
             isCancelingTrial),
-        variant:
-          isCancelingTrial || subscription?.futureCancelDate
-            ? "danger"
-            : "warning",
+        variant: isCancelingTrial ? "danger" : "warning",
         content: () => {
           return {
             title:
@@ -151,20 +148,13 @@ export class OrgStatusBanner extends BtrixElement {
                       html`To continue using Browsertrix, select
                         <strong>Subscribe Now</strong> in ${billingTabLink}.`,
                     )
-                  : subscription?.futureCancelDate
-                    ? // TODO See if we can differentiate whether the trial will rollover
-                      // (card on file) or become read-only because no card on file
-                      msg(
-                        html`To continue using Browsertrix, add a payment method
-                        in ${billingTabLink}.`,
-                      )
-                    : html`${msg(
-                        "Afterwards, your subscription will continue automatically.",
-                      )}
-                      ${msg(
-                        html`View and manage your subscription in
-                        ${billingTabLink}.`,
-                      )}`}
+                  : html`${msg(
+                      "Afterwards, your subscription will continue automatically.",
+                    )}
+                    ${msg(
+                      html`View and manage your subscription in
+                      ${billingTabLink}.`,
+                    )}`}
               </p>
               ${when(
                 isCancelingTrial,

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -127,7 +127,7 @@ export class OrgStatusBanner extends BtrixElement {
           !!futureCancelDate &&
           ((isTrial && daysDiff < MAX_TRIAL_DAYS_SHOW_BANNER) ||
             isCancelingTrial),
-        variant: "warning",
+        variant: isCancelingTrial ? "danger" : "warning",
         content: () => {
           return {
             title:

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -142,15 +142,23 @@ export class OrgStatusBanner extends BtrixElement {
 
             detail: html`<p>
                 ${msg(str`Your free trial ends on ${dateStr}.`)}
-                ${isCancelingTrial || readOnlyOnCancel
+                ${isCancelingTrial
                   ? msg(
                       html`To continue using Browsertrix, select
                         <strong>Subscribe Now</strong> in ${billingTabLink}.`,
                     )
-                  : msg(
-                      html`View and manage your subscription in
-                      ${billingTabLink}.`,
-                    )}
+                  : readOnlyOnCancel
+                    ? msg(
+                        html`To continue using Browsertrix, review your payment
+                        information in ${billingTabLink}.`,
+                      )
+                    : html`${msg(
+                        "Afterwards, your subscription will continue automatically.",
+                      )}
+                      ${msg(
+                        html`View and manage your subscription in
+                        ${billingTabLink}.`,
+                      )}`}
               </p>
               ${when(
                 isCancelingTrial,

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -59,11 +59,12 @@ export class OrgStatusBanner extends BtrixElement {
     const {
       readOnly,
       readOnlyReason,
-      readOnlyOnCancel,
       subscription,
       storageQuotaReached,
       execMinutesQuotaReached,
     } = this.org;
+    const readOnlyOnCancel =
+      subscription?.readOnlyOnCancel ?? this.org.readOnlyOnCancel;
 
     let hoursDiff = 0;
     let daysDiff = 0;
@@ -128,7 +129,10 @@ export class OrgStatusBanner extends BtrixElement {
           !!futureCancelDate &&
           ((isTrial && daysDiff < MAX_TRIAL_DAYS_SHOW_BANNER) ||
             isCancelingTrial),
-        variant: isCancelingTrial ? "danger" : "warning",
+        variant:
+          isCancelingTrial || subscription?.futureCancelDate
+            ? "danger"
+            : "warning",
         content: () => {
           return {
             title:
@@ -147,12 +151,12 @@ export class OrgStatusBanner extends BtrixElement {
                       html`To continue using Browsertrix, select
                         <strong>Subscribe Now</strong> in ${billingTabLink}.`,
                     )
-                  : readOnlyOnCancel
+                  : subscription?.futureCancelDate
                     ? // TODO See if we can differentiate whether the trial will rollover
                       // (card on file) or become read-only because no card on file
                       msg(
-                        html`To continue using Browsertrix, review your payment
-                        information in ${billingTabLink}.`,
+                        html`To continue using Browsertrix, add a payment method
+                        in ${billingTabLink}.`,
                       )
                     : html`${msg(
                         "Afterwards, your subscription will continue automatically.",

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -88,7 +88,7 @@ export class OrgStatusBanner extends BtrixElement {
       subscription?.status === SubscriptionStatus.Trialing || isCancelingTrial;
 
     // show banner if < this many days of trial is left
-    const MAX_TRIAL_DAYS_SHOW_BANNER = 10;
+    const MAX_TRIAL_DAYS_SHOW_BANNER = 4;
 
     return [
       {

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -3,6 +3,7 @@ import type { SlAlert } from "@shoelace-style/shoelace";
 import { differenceInHours } from "date-fns/fp";
 import { html, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { SubscriptionStatus } from "@/types/billing";
@@ -139,28 +140,29 @@ export class OrgStatusBanner extends BtrixElement {
                       str`You have ${daysDiff} days left of your Browsertrix trial`,
                     ),
 
-            detail: isCancelingTrial
-              ? html`
-                  <p>
-                    ${msg(
-                      html`Your free trial ends on ${dateStr}. To continue using
-                        Browsertrix, select <strong>Subscribe Now</strong> in
-                        ${billingTabLink}.`,
+            detail: html`<p>
+                ${msg(str`Your free trial ends on ${dateStr}.`)}
+                ${isCancelingTrial || readOnlyOnCancel
+                  ? msg(
+                      html`To continue using Browsertrix, select
+                        <strong>Subscribe Now</strong> in ${billingTabLink}.`,
+                    )
+                  : msg(
+                      html`View and manage your subscription in
+                      ${billingTabLink}.`,
                     )}
-                  </p>
+              </p>
+              ${when(
+                isCancelingTrial,
+                () => html`
                   <p>
                     ${msg(
                       str`Your web archives are always yours — you can download any archived items you'd like to keep
                   before the trial ends!`,
                     )}
                   </p>
-                `
-              : html`<p>
-                  ${msg(
-                    html`Your free trial ends on ${dateStr}. Manage your
-                    subscription in ${billingTabLink}.`,
-                  )}
-                </p>`,
+                `,
+              )} `,
           };
         },
       },

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -73,7 +73,7 @@ export class OrgStatusBanner extends BtrixElement {
 
     if (futureCancelDate) {
       hoursDiff = differenceInHours(new Date(), new Date(futureCancelDate));
-      daysDiff = Math.trunc(hoursDiff / 24);
+      daysDiff = Math.ceil(hoursDiff / 24);
 
       dateStr = this.localize.date(futureCancelDate, {
         month: "long",
@@ -90,7 +90,7 @@ export class OrgStatusBanner extends BtrixElement {
       subscription?.status === SubscriptionStatus.Trialing || isCancelingTrial;
 
     // show banner if < this many days of trial is left
-    const MAX_TRIAL_DAYS_SHOW_BANNER = 4;
+    const MAX_TRIAL_DAYS_SHOW_BANNER = 8;
 
     return [
       {

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -148,7 +148,9 @@ export class OrgStatusBanner extends BtrixElement {
                         <strong>Subscribe Now</strong> in ${billingTabLink}.`,
                     )
                   : readOnlyOnCancel
-                    ? msg(
+                    ? // TODO See if we can differentiate whether the trial will rollover
+                      // (card on file) or become read-only because no card on file
+                      msg(
                         html`To continue using Browsertrix, review your payment
                         information in ${billingTabLink}.`,
                       )

--- a/frontend/src/pages/invite/join.ts
+++ b/frontend/src/pages/invite/join.ts
@@ -124,7 +124,6 @@ export class Join extends LiteElement {
       `/api/users/invite/${token}?email=${encodeURIComponent(email)}`,
     );
 
-    console.log(this.appState.settings);
     switch (resp.status) {
       case 200:
         return (await resp.json()) as UserOrgInviteInfo;

--- a/frontend/src/pages/invite/join.ts
+++ b/frontend/src/pages/invite/join.ts
@@ -124,6 +124,7 @@ export class Join extends LiteElement {
       `/api/users/invite/${token}?email=${encodeURIComponent(email)}`,
     );
 
+    console.log(this.appState.settings);
     switch (resp.status) {
       case 200:
         return (await resp.json()) as UserOrgInviteInfo;

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -135,11 +135,11 @@ export class OrgSettingsBilling extends BtrixElement {
                       },
                     );
 
-                    const trialMessage = (detail: string) => html`
+                    const trialMessage = (detail?: string) => html`
                       <span class="font-medium text-neutral-700">
                         ${msg(str`Your trial will end on ${futureCancelDate}`)}
                       </span>
-                      &mdash; ${detail}
+                      ${when(detail, () => html`&mdash; ${detail}`)}
                     `;
 
                     return html`
@@ -154,16 +154,14 @@ export class OrgSettingsBilling extends BtrixElement {
                           ${choose(
                             org.subscription.status,
                             [
-                              // TODO See if we can differentiate whether the trial
-                              // will rollover (card on file) or become read-only (no card on file)
+                              [
+                                SubscriptionStatus.Trialing,
+                                () => trialMessage(),
+                                // TODO See if we can differentiate whether the trial
+                                // will rollover (card on file) or become read-only because no card on file
 
-                              // [
-                              //   SubscriptionStatus.Trialing,
-                              //   () =>
-                              //     trialMessage(
-                              //       msg("the card on file will be charged"),
-                              //     ),
-                              // ],
+                                // msg("the card on file will be charged"),
+                              ],
                               [
                                 SubscriptionStatus.TrialingCanceled,
                                 () =>

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -141,6 +141,9 @@ export class OrgSettingsBilling extends BtrixElement {
                       </span>
                       ${when(detail, () => html`&mdash; ${detail}`)}
                     `;
+                    const keepAccountDetail = msg(
+                      "subscribe to keep your account",
+                    );
 
                     return html`
                       <div
@@ -160,18 +163,17 @@ export class OrgSettingsBilling extends BtrixElement {
                                   trialMessage(
                                     // TODO See if we can differentiate whether the trial will rollover
                                     // (card on file) or become read-only because no card on file
-                                    msg(
-                                      "subscription will automatically continue",
-                                    ),
+                                    org.subscription?.futureCancelDate
+                                      ? keepAccountDetail
+                                      : msg(
+                                          "subscription will automatically continue",
+                                        ),
                                     // msg("the card on file will be charged"),
                                   ),
                               ],
                               [
                                 SubscriptionStatus.TrialingCanceled,
-                                () =>
-                                  trialMessage(
-                                    msg("subscribe to keep your account"),
-                                  ),
+                                () => trialMessage(keepAccountDetail),
                               ],
                             ],
                             () =>

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -158,8 +158,8 @@ export class OrgSettingsBilling extends BtrixElement {
                                 SubscriptionStatus.Trialing,
                                 () =>
                                   trialMessage(
-                                    // TODO See if we can differentiate whether the trial
-                                    // will rollover (card on file) or become read-only because no card on file
+                                    // TODO See if we can differentiate whether the trial will rollover
+                                    // (card on file) or become read-only because no card on file
                                     msg(
                                       "subscription will automatically continue",
                                     ),

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -154,13 +154,16 @@ export class OrgSettingsBilling extends BtrixElement {
                           ${choose(
                             org.subscription.status,
                             [
-                              [
-                                SubscriptionStatus.Trialing,
-                                () =>
-                                  trialMessage(
-                                    msg("the card on file will be charged"),
-                                  ),
-                              ],
+                              // TODO See if we can differentiate whether the trial
+                              // will rollover (card on file) or become read-only (no card on file)
+
+                              // [
+                              //   SubscriptionStatus.Trialing,
+                              //   () =>
+                              //     trialMessage(
+                              //       msg("the card on file will be charged"),
+                              //     ),
+                              // ],
                               [
                                 SubscriptionStatus.TrialingCanceled,
                                 () =>

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -137,7 +137,7 @@ export class OrgSettingsBilling extends BtrixElement {
 
                     const trialMessage = (detail?: string) => html`
                       <span class="font-medium text-neutral-700">
-                        ${msg(str`Your trial will end on ${futureCancelDate}`)}
+                        ${msg(str`Your trial ends ${futureCancelDate}`)}
                       </span>
                       ${when(detail, () => html`&mdash; ${detail}`)}
                     `;
@@ -156,11 +156,15 @@ export class OrgSettingsBilling extends BtrixElement {
                             [
                               [
                                 SubscriptionStatus.Trialing,
-                                () => trialMessage(),
-                                // TODO See if we can differentiate whether the trial
-                                // will rollover (card on file) or become read-only because no card on file
-
-                                // msg("the card on file will be charged"),
+                                () =>
+                                  trialMessage(
+                                    // TODO See if we can differentiate whether the trial
+                                    // will rollover (card on file) or become read-only because no card on file
+                                    msg(
+                                      "subscription will automatically continue",
+                                    ),
+                                    // msg("the card on file will be charged"),
+                                  ),
                               ],
                               [
                                 SubscriptionStatus.TrialingCanceled,

--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -141,9 +141,6 @@ export class OrgSettingsBilling extends BtrixElement {
                       </span>
                       ${when(detail, () => html`&mdash; ${detail}`)}
                     `;
-                    const keepAccountDetail = msg(
-                      "subscribe to keep your account",
-                    );
 
                     return html`
                       <div
@@ -161,19 +158,17 @@ export class OrgSettingsBilling extends BtrixElement {
                                 SubscriptionStatus.Trialing,
                                 () =>
                                   trialMessage(
-                                    // TODO See if we can differentiate whether the trial will rollover
-                                    // (card on file) or become read-only because no card on file
-                                    org.subscription?.futureCancelDate
-                                      ? keepAccountDetail
-                                      : msg(
-                                          "subscription will automatically continue",
-                                        ),
-                                    // msg("the card on file will be charged"),
+                                    msg(
+                                      "subscription will automatically continue",
+                                    ),
                                   ),
                               ],
                               [
                                 SubscriptionStatus.TrialingCanceled,
-                                () => trialMessage(keepAccountDetail),
+                                () =>
+                                  trialMessage(
+                                    msg("subscribe to keep your account"),
+                                  ),
                               ],
                             ],
                             () =>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2650

## Changes

Differentials between `trialing` and `trialing_canceled` when displaying messages:
- No changes to messages if `trialing_canceled`.
- If `trialing`, show messaging that subscription will automatically continue.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| _All_  | <img width="826" alt="Screenshot 2025-06-09 at 12 39 07 PM" src="https://github.com/user-attachments/assets/440fb790-7007-4dd8-87a0-f12c77257671" /> |
| Billing | <img width="975" alt="Screenshot 2025-06-09 at 12 41 25 PM" src="https://github.com/user-attachments/assets/e827ccdd-b979-4aa6-8cb1-b6c7ac78c056" /> |


<!-- ## Follow-ups -->
