### PR TITLE
devex: Create and document file selection components

### DIFF
--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -1,6 +1,6 @@
 import { localized } from "@lit/localize";
 import clsx from "clsx";
-import { html, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -33,6 +33,12 @@ export class FileInput extends FormControl(TailwindElement) {
    */
   @property({ type: String })
   name?: string;
+
+  /**
+   * Form control label, if used as a form control
+   */
+  @property({ type: String })
+  label?: string;
 
   /**
    * Specify which file types are allowed
@@ -93,18 +99,21 @@ export class FileInput extends FormControl(TailwindElement) {
 
   render() {
     return html`
+      ${this.label
+        ? html`<label for="fileInput" class="form-label">${this.label}</label>`
+        : nothing}
       ${this.files.length ? this.renderFiles() : this.renderInput()}
     `;
   }
 
   private readonly renderInput = () => {
     return html`
-      <label
+      <div
         id="dropzone"
         class=${clsx(
-          tw`cursor-pointer`,
+          tw`relative`,
           this.drop &&
-            tw`flex size-full flex-col items-center justify-center gap-2.5 rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:outline-primary-400`,
+            tw`flex size-full items-center justify-center rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:outline-primary-400`,
         )}
         @drop=${this.drop ? this.onDrop : undefined}
         @dragover=${this.drop ? this.onDragover : undefined}
@@ -114,8 +123,11 @@ export class FileInput extends FormControl(TailwindElement) {
         @dragleave=${this.drop
           ? () => this.dropzone?.classList.remove(droppingClass)
           : undefined}
+        dropzone="copy"
+        aria-dropeffect="copy"
       >
         <input
+          id="fileInput"
           class="sr-only"
           type="file"
           accept=${ifDefined(this.accept)}
@@ -128,8 +140,10 @@ export class FileInput extends FormControl(TailwindElement) {
             }
           }}
         />
-        <slot @click=${() => this.input?.click()}></slot>
-      </label>
+        <div class="relative z-10">
+          <slot @click=${() => this.input?.click()}></slot>
+        </div>
+      </div>
     `;
   };
 
@@ -157,6 +171,7 @@ export class FileInput extends FormControl(TailwindElement) {
     this.dropzone?.classList.remove(droppingClass);
 
     const files = e.dataTransfer?.files;
+    console.log("files:", files);
 
     if (files) {
       const list = new DataTransfer();

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -1,14 +1,21 @@
 import { localized } from "@lit/localize";
 import clsx from "clsx";
-import { html } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { html, type PropertyValues } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { repeat } from "lit/directives/repeat.js";
+import { without } from "lodash/fp";
+
+import type {
+  BtrixFileChangeEvent,
+  BtrixFileRemoveEvent,
+} from "./file-list/events";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import type { BtrixChangeEvent } from "@/events/btrix-change";
+import { FormControl } from "@/mixins/FormControl";
 import { tw } from "@/utils/tailwind";
 
-export type BtrixFileChangeEvent = BtrixChangeEvent<FileList>;
+import "@/components/ui/file-list";
 
 /**
  * Allow attaching one or more files.
@@ -17,7 +24,13 @@ export type BtrixFileChangeEvent = BtrixChangeEvent<FileList>;
  */
 @customElement("btrix-file-input")
 @localized()
-export class FileInput extends TailwindElement {
+export class FileInput extends FormControl(TailwindElement) {
+  /**
+   * Form control name, if used as a form control
+   */
+  @property({ type: String })
+  name?: string;
+
   /**
    * Specify which file types are allowed
    */
@@ -36,41 +49,124 @@ export class FileInput extends TailwindElement {
   @property({ type: Boolean })
   dropzone = false;
 
+  @state()
+  private files: File[] = [];
+
   @query("input[type='file']")
   private readonly input?: HTMLInputElement | null;
 
-  render() {
-    return html`<label
-      class=${clsx(
-        tw`cursor-pointer`,
-        this.dropzone &&
-          tw`block rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:outline-primary-400`,
-      )}
-      @drop=${this.dropzone ? this.onDrop : undefined}
-      @dragover=${this.dropzone ? this.onDragover : undefined}
-    >
-      <input
-        class="sr-only"
-        type="file"
-        accept=${ifDefined(this.accept)}
-        ?multiple=${this.multiple}
-        @change=${() => {
-          const files = this.input?.files;
+  formResetCallback() {
+    this.files = [];
 
-          if (files) {
-            void this.handleChange(files);
-          }
-        }}
-      />
-      <slot @click=${() => this.input?.click()}></slot>
-    </label>`;
+    if (this.input) {
+      this.input.value = "";
+    }
   }
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("files")) {
+      this.syncFormValue();
+    }
+  }
+
+  private syncFormValue() {
+    const formControlName = this.name;
+
+    if (!formControlName) return;
+
+    // `ElementInternals["setFormValue"]` doesn't support `FileList` yet,
+    // construct `FormData` instead
+    const formData = new FormData();
+
+    this.files.forEach((file) => {
+      formData.append(formControlName, file);
+    });
+
+    this.setFormValue(formData);
+  }
+
+  render() {
+    return html`
+      ${this.files.length ? this.renderFiles() : this.renderInput()}
+    `;
+  }
+
+  private readonly renderInput = () => {
+    return html`
+      <label
+        class=${clsx(
+          tw`cursor-pointer`,
+          this.dropzone &&
+            tw`flex size-full flex-col items-center justify-center gap-2.5 rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:outline-primary-400`,
+        )}
+        @drop=${this.dropzone ? this.onDrop : undefined}
+        @dragover=${this.dropzone ? this.onDragover : undefined}
+      >
+        <input
+          class="sr-only"
+          type="file"
+          accept=${ifDefined(this.accept)}
+          ?multiple=${this.multiple}
+          @change=${() => {
+            const files = this.input?.files;
+
+            if (files) {
+              void this.handleChange(files);
+            }
+          }}
+        />
+        <slot @click=${() => this.input?.click()}></slot>
+      </label>
+    `;
+  };
+
+  private readonly renderFiles = () => {
+    return html`
+      <btrix-file-list
+        @btrix-remove=${(e: BtrixFileRemoveEvent) => {
+          e.stopPropagation();
+
+          this.files = without([e.detail.item])(this.files);
+        }}
+      >
+        ${repeat(
+          this.files,
+          (file) => file.name,
+          (file) => html`
+            <btrix-file-list-item .file=${file}></btrix-file-list-item>
+          `,
+        )}
+      </btrix-file-list>
+    `;
+  };
 
   private readonly onDrop = (e: DragEvent) => {
     e.preventDefault();
 
-    if (e.dataTransfer?.files) {
-      void this.handleChange(e.dataTransfer.files);
+    const files = e.dataTransfer?.files;
+
+    if (files) {
+      const list = new DataTransfer();
+
+      if (this.multiple) {
+        [...files].forEach((file) => {
+          if (this.valid(file)) {
+            list.items.add(file);
+          }
+        });
+      } else {
+        const file = files[0];
+
+        if (this.valid(file)) {
+          list.items.add(file);
+        }
+      }
+
+      if (list.items.length) {
+        void this.handleChange(list.files);
+      } else {
+        console.debug("none valid:", files);
+      }
     } else {
       console.debug("no files dropped");
     }
@@ -78,14 +174,35 @@ export class FileInput extends TailwindElement {
 
   private readonly onDragover = (e: DragEvent) => {
     e.preventDefault();
+
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = "link";
+    }
   };
 
-  private async handleChange(files: FileList) {
+  /**
+   * @TODO More complex validation based on `accept`
+   */
+  private valid(file: File) {
+    if (!this.accept) return true;
+
+    return this.accept.split(",").some((accept) => {
+      if (accept.startsWith(".")) {
+        return file.name.endsWith(accept.trim());
+      }
+
+      return new RegExp(accept.trim().replace("*", ".*")).test(file.type);
+    });
+  }
+
+  private async handleChange(fileList: FileList) {
+    this.files = [...fileList];
+
     await this.updateComplete;
 
     this.dispatchEvent(
       new CustomEvent<BtrixFileChangeEvent["detail"]>("btrix-change", {
-        detail: { value: files },
+        detail: { value: this.files },
         composed: true,
         bubbles: true,
       }),

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -111,9 +111,9 @@ export class FileInput extends FormControl(TailwindElement) {
       <div
         id="dropzone"
         class=${clsx(
-          tw`relative`,
-          this.drop &&
-            tw`flex size-full items-center justify-center rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:outline-primary-400`,
+          this.drop
+            ? tw`flex size-full cursor-pointer items-center justify-center rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:bg-slate-50 hover:outline-primary-400`
+            : tw`size-max`,
         )}
         @drop=${this.drop ? this.onDrop : undefined}
         @dragover=${this.drop ? this.onDragover : undefined}
@@ -123,6 +123,8 @@ export class FileInput extends FormControl(TailwindElement) {
         @dragleave=${this.drop
           ? () => this.dropzone?.classList.remove(droppingClass)
           : undefined}
+        @click=${() => this.input?.click()}
+        role="button"
         dropzone="copy"
         aria-dropeffect="copy"
       >
@@ -141,7 +143,7 @@ export class FileInput extends FormControl(TailwindElement) {
           }}
         />
         <div class="relative z-10">
-          <slot @click=${() => this.input?.click()}></slot>
+          <slot></slot>
         </div>
       </div>
     `;
@@ -171,7 +173,6 @@ export class FileInput extends FormControl(TailwindElement) {
     this.dropzone?.classList.remove(droppingClass);
 
     const files = e.dataTransfer?.files;
-    console.log("files:", files);
 
     if (files) {
       const list = new DataTransfer();

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -1,0 +1,94 @@
+import { localized } from "@lit/localize";
+import clsx from "clsx";
+import { html } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import type { BtrixChangeEvent } from "@/events/btrix-change";
+import { tw } from "@/utils/tailwind";
+
+export type BtrixFileChangeEvent = BtrixChangeEvent<FileList>;
+
+/**
+ * Allow attaching one or more files.
+ *
+ * @fires btrix-change
+ */
+@customElement("btrix-file-input")
+@localized()
+export class FileInput extends TailwindElement {
+  /**
+   * Specify which file types are allowed
+   */
+  @property({ type: String })
+  accept?: HTMLInputElement["accept"];
+
+  /**
+   * Enable selecting more than one file
+   */
+  @property({ type: Boolean })
+  multiple?: HTMLInputElement["multiple"];
+
+  /**
+   * Enable dragging files into drop zone
+   */
+  @property({ type: Boolean })
+  dropzone = false;
+
+  @query("input[type='file']")
+  private readonly input?: HTMLInputElement | null;
+
+  render() {
+    return html`<label
+      class=${clsx(
+        tw`cursor-pointer`,
+        this.dropzone &&
+          tw`block rounded p-6 text-center outline-dashed outline-1 -outline-offset-1 outline-neutral-400 transition-all hover:outline-primary-400`,
+      )}
+      @drop=${this.dropzone ? this.onDrop : undefined}
+      @dragover=${this.dropzone ? this.onDragover : undefined}
+    >
+      <input
+        class="sr-only"
+        type="file"
+        accept=${ifDefined(this.accept)}
+        ?multiple=${this.multiple}
+        @change=${() => {
+          const files = this.input?.files;
+
+          if (files) {
+            void this.handleChange(files);
+          }
+        }}
+      />
+      <slot @click=${() => this.input?.click()}></slot>
+    </label>`;
+  }
+
+  private readonly onDrop = (e: DragEvent) => {
+    e.preventDefault();
+
+    if (e.dataTransfer?.files) {
+      void this.handleChange(e.dataTransfer.files);
+    } else {
+      console.debug("no files dropped");
+    }
+  };
+
+  private readonly onDragover = (e: DragEvent) => {
+    e.preventDefault();
+  };
+
+  private async handleChange(files: FileList) {
+    await this.updateComplete;
+
+    this.dispatchEvent(
+      new CustomEvent<BtrixFileChangeEvent["detail"]>("btrix-change", {
+        detail: { value: files },
+        composed: true,
+        bubbles: true,
+      }),
+    );
+  }
+}

--- a/frontend/src/components/ui/file-list.ts
+++ b/frontend/src/components/ui/file-list.ts
@@ -16,7 +16,7 @@ type FileRemoveDetail = {
 export type FileRemoveEvent = CustomEvent<FileRemoveDetail>;
 
 /**
- * @event on-remove FileRemoveEvent
+ * @event btrix-remove FileRemoveEvent
  */
 @customElement("btrix-file-list-item")
 @localized()
@@ -117,7 +117,7 @@ export class FileListItem extends BtrixElement {
     if (!this.file) return;
     await this.updateComplete;
     this.dispatchEvent(
-      new CustomEvent<FileRemoveDetail>("on-remove", {
+      new CustomEvent<FileRemoveDetail>("btrix-remove", {
         detail: {
           file: this.file,
         },

--- a/frontend/src/components/ui/file-list/events.ts
+++ b/frontend/src/components/ui/file-list/events.ts
@@ -1,3 +1,5 @@
+import type { BtrixChangeEvent } from "@/events/btrix-change";
 import type { BtrixRemoveEvent } from "@/events/btrix-remove";
 
-export type FileRemoveEvent = BtrixRemoveEvent<File>;
+export type BtrixFileRemoveEvent = BtrixRemoveEvent<File>;
+export type BtrixFileChangeEvent = BtrixChangeEvent<File[]>;

--- a/frontend/src/components/ui/file-list/events.ts
+++ b/frontend/src/components/ui/file-list/events.ts
@@ -1,0 +1,3 @@
+import type { BtrixRemoveEvent } from "@/events/btrix-remove";
+
+export type FileRemoveEvent = BtrixRemoveEvent<File>;

--- a/frontend/src/components/ui/file-list/file-list-item.ts
+++ b/frontend/src/components/ui/file-list/file-list-item.ts
@@ -1,26 +1,19 @@
 import { localized, msg } from "@lit/localize";
 import { css, html } from "lit";
-import {
-  customElement,
-  property,
-  queryAssignedElements,
-} from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 
-import { BtrixElement } from "@/classes/BtrixElement";
+import type { FileRemoveEvent } from "./events";
+
 import { TailwindElement } from "@/classes/TailwindElement";
+import { LocalizeController } from "@/controllers/localize";
 import { truncate } from "@/utils/css";
-
-type FileRemoveDetail = {
-  file: File;
-};
-export type FileRemoveEvent = CustomEvent<FileRemoveDetail>;
 
 /**
  * @event btrix-remove FileRemoveEvent
  */
 @customElement("btrix-file-list-item")
 @localized()
-export class FileListItem extends BtrixElement {
+export class FileListItem extends TailwindElement {
   static styles = [
     truncate,
     css`
@@ -75,6 +68,8 @@ export class FileListItem extends BtrixElement {
   @property({ type: Boolean })
   progressIndeterminate?: boolean;
 
+  readonly localize = new LocalizeController(this);
+
   render() {
     if (!this.file) return;
     return html`<div class="item">
@@ -117,50 +112,13 @@ export class FileListItem extends BtrixElement {
     if (!this.file) return;
     await this.updateComplete;
     this.dispatchEvent(
-      new CustomEvent<FileRemoveDetail>("btrix-remove", {
+      new CustomEvent<FileRemoveEvent["detail"]>("btrix-remove", {
         detail: {
-          file: this.file,
+          item: this.file,
         },
+        composed: true,
+        bubbles: true,
       }),
     );
   };
-}
-
-@customElement("btrix-file-list")
-export class FileList extends TailwindElement {
-  static styles = [
-    css`
-      ::slotted(btrix-file-list-item) {
-        --border: 1px solid var(--sl-panel-border-color);
-        --item-border-top: var(--border);
-        --item-border-left: var(--border);
-        --item-border-right: var(--border);
-        --item-border-bottom: var(--border);
-        --item-box-shadow: var(--sl-shadow-x-small);
-        --item-border-radius: var(--sl-border-radius-medium);
-        display: block;
-      }
-
-      ::slotted(btrix-file-list-item:not(:last-of-type)) {
-        margin-bottom: var(--sl-spacing-x-small);
-      }
-    `,
-  ];
-
-  @queryAssignedElements({ selector: "btrix-file-list-item" })
-  listItems!: HTMLElement[];
-
-  render() {
-    return html`<div class="list" role="list">
-      <slot @slotchange=${this.handleSlotchange}></slot>
-    </div>`;
-  }
-
-  private handleSlotchange() {
-    this.listItems.map((el) => {
-      if (!el.attributes.getNamedItem("role")) {
-        el.setAttribute("role", "listitem");
-      }
-    });
-  }
 }

--- a/frontend/src/components/ui/file-list/file-list-item.ts
+++ b/frontend/src/components/ui/file-list/file-list-item.ts
@@ -2,14 +2,14 @@ import { localized, msg } from "@lit/localize";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-import type { FileRemoveEvent } from "./events";
+import type { BtrixFileRemoveEvent } from "./events";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { LocalizeController } from "@/controllers/localize";
 import { truncate } from "@/utils/css";
 
 /**
- * @event btrix-remove FileRemoveEvent
+ * @event btrix-remove
  */
 @customElement("btrix-file-list-item")
 @localized()
@@ -112,7 +112,7 @@ export class FileListItem extends TailwindElement {
     if (!this.file) return;
     await this.updateComplete;
     this.dispatchEvent(
-      new CustomEvent<FileRemoveEvent["detail"]>("btrix-remove", {
+      new CustomEvent<BtrixFileRemoveEvent["detail"]>("btrix-remove", {
         detail: {
           item: this.file,
         },

--- a/frontend/src/components/ui/file-list/file-list.ts
+++ b/frontend/src/components/ui/file-list/file-list.ts
@@ -1,0 +1,43 @@
+import { css, html } from "lit";
+import { customElement, queryAssignedElements } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+
+@customElement("btrix-file-list")
+export class FileList extends TailwindElement {
+  static styles = [
+    css`
+      ::slotted(btrix-file-list-item) {
+        --border: 1px solid var(--sl-panel-border-color);
+        --item-border-top: var(--border);
+        --item-border-left: var(--border);
+        --item-border-right: var(--border);
+        --item-border-bottom: var(--border);
+        --item-box-shadow: var(--sl-shadow-x-small);
+        --item-border-radius: var(--sl-border-radius-medium);
+        display: block;
+      }
+
+      ::slotted(btrix-file-list-item:not(:last-of-type)) {
+        margin-bottom: var(--sl-spacing-x-small);
+      }
+    `,
+  ];
+
+  @queryAssignedElements({ selector: "btrix-file-list-item" })
+  listItems!: HTMLElement[];
+
+  render() {
+    return html`<div class="list" role="list">
+      <slot @slotchange=${this.handleSlotchange}></slot>
+    </div>`;
+  }
+
+  private handleSlotchange() {
+    this.listItems.map((el) => {
+      if (!el.attributes.getNamedItem("role")) {
+        el.setAttribute("role", "listitem");
+      }
+    });
+  }
+}

--- a/frontend/src/components/ui/file-list/index.ts
+++ b/frontend/src/components/ui/file-list/index.ts
@@ -1,4 +1,4 @@
 import "./file-list";
 import "./file-list-item";
 
-export type { FileRemoveEvent } from "./events";
+export type { BtrixFileRemoveEvent as FileRemoveEvent } from "./events";

--- a/frontend/src/components/ui/file-list/index.ts
+++ b/frontend/src/components/ui/file-list/index.ts
@@ -1,0 +1,4 @@
+import "./file-list";
+import "./file-list-item";
+
+export type { FileRemoveEvent } from "./events";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -18,6 +18,7 @@ import("./copy-button");
 import("./copy-field");
 import("./data-grid");
 import("./details");
+import("./file-input");
 import("./file-list");
 import("./format-date");
 import("./inline-input");

--- a/frontend/src/events/btrix-remove.ts
+++ b/frontend/src/events/btrix-remove.ts
@@ -1,0 +1,7 @@
+export type BtrixRemoveEvent<T = unknown> = CustomEvent<{ item: T }>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    "btrix-remove": BtrixRemoveEvent;
+  }
+}

--- a/frontend/src/events/index.ts
+++ b/frontend/src/events/index.ts
@@ -1,2 +1,0 @@
-import "./btrix-change";
-import "./btrix-input";

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -212,13 +212,10 @@ export class FileUploader extends BtrixElement {
     }
 
     return html`
-      <btrix-file-list>
+      <btrix-file-list @btrix-remove=${this.handleRemoveFile}>
         ${Array.from(this.fileList).map(
           (file) =>
-            html`<btrix-file-list-item
-              .file=${file}
-              @btrix-remove=${this.handleRemoveFile}
-            ></btrix-file-list-item>`,
+            html`<btrix-file-list-item .file=${file}></btrix-file-list-item>`,
         )}
       </btrix-file-list>
     `;
@@ -335,7 +332,7 @@ export class FileUploader extends BtrixElement {
 
   private readonly handleRemoveFile = (e: FileRemoveEvent) => {
     this.cancelUpload();
-    const idx = this.fileList.indexOf(e.detail.file);
+    const idx = this.fileList.indexOf(e.detail.item);
     if (idx === -1) return;
     this.fileList = [
       ...this.fileList.slice(0, idx),

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -217,7 +217,7 @@ export class FileUploader extends BtrixElement {
           (file) =>
             html`<btrix-file-list-item
               .file=${file}
-              @on-remove=${this.handleRemoveFile}
+              @btrix-remove=${this.handleRemoveFile}
             ></btrix-file-list-item>`,
         )}
       </btrix-file-list>
@@ -278,7 +278,7 @@ export class FileUploader extends BtrixElement {
                   html`<btrix-file-list-item
                     .file=${file}
                     progressValue=${this.progress}
-                    @on-remove=${this.handleRemoveFile}
+                    @btrix-remove=${this.handleRemoveFile}
                   ></btrix-file-list-item>`,
               )}
             </btrix-file-list>
@@ -319,7 +319,7 @@ export class FileUploader extends BtrixElement {
                 html`<btrix-file-list-item
                   .file=${file}
                   progressValue=${this.progress}
-                  @on-remove=${this.handleRemoveFile}
+                  @btrix-remove=${this.handleRemoveFile}
                 ></btrix-file-list-item>`,
             )}
           </btrix-file-list>

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -199,7 +199,7 @@ export class FileUploader extends BtrixElement {
           >${msg("Browse Files")}</sl-button
         >
 
-        <p class="text-xs text-neutral-500">
+        <p class="mt-2.5 text-xs text-neutral-500">
           ${msg("Select a .wacz file to upload")}
         </p>
       </btrix-file-input>

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -10,6 +10,7 @@ import queryString from "query-string";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { FileRemoveEvent } from "@/components/ui/file-list";
+import type { BtrixFileChangeEvent } from "@/components/ui/file-list/events";
 import type {
   TagInputEvent,
   Tags,
@@ -182,42 +183,26 @@ export class FileUploader extends BtrixElement {
   }
 
   private renderFiles() {
-    if (!this.fileList.length) {
-      return html`
-        <div class="flex h-full flex-col items-center justify-center gap-3 p-5">
-          <label>
-            <input
-              class="sr-only"
-              type="file"
-              accept=".wacz"
-              @change=${(e: Event) => {
-                const files = (e.target as HTMLInputElement).files;
-                if (files?.length) {
-                  this.fileList = Array.from(files);
-                }
-              }}
-            />
-            <sl-button
-              variant="primary"
-              @click=${(e: MouseEvent) =>
-                (e.target as SlButton).parentElement?.click()}
-              >${msg("Browse Files")}</sl-button
-            >
-          </label>
-          <p class="text-xs text-neutral-500">
-            ${msg("Select a .wacz file to upload")}
-          </p>
-        </div>
-      `;
-    }
-
     return html`
-      <btrix-file-list @btrix-remove=${this.handleRemoveFile}>
-        ${Array.from(this.fileList).map(
-          (file) =>
-            html`<btrix-file-list-item .file=${file}></btrix-file-list-item>`,
-        )}
-      </btrix-file-list>
+      <btrix-file-input
+        accept=".wacz"
+        drop
+        @btrix-change=${(e: BtrixFileChangeEvent) => {
+          this.fileList = e.detail.value;
+        }}
+        @btrix-remove=${this.handleRemoveFile}
+      >
+        <sl-button
+          variant="primary"
+          @click=${(e: MouseEvent) =>
+            (e.target as SlButton).parentElement?.click()}
+          >${msg("Browse Files")}</sl-button
+        >
+
+        <p class="text-xs text-neutral-500">
+          ${msg("Select a .wacz file to upload")}
+        </p>
+      </btrix-file-input>
     `;
   }
 

--- a/frontend/src/mixins/FormControl.ts
+++ b/frontend/src/mixins/FormControl.ts
@@ -9,6 +9,10 @@ export const FormControl = <T extends Constructor<LitElement>>(superClass: T) =>
     static formAssociated = true;
     readonly #internals: ElementInternals;
 
+    get form() {
+      return this.#internals.form;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(...args: any[]) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/frontend/src/stories/components/FileInput.stories.ts
+++ b/frontend/src/stories/components/FileInput.stories.ts
@@ -11,10 +11,10 @@ const meta = {
   render: renderComponent,
   decorators: (story) => html` <div class="m-5">${story()}</div>`,
   argTypes: {
-    anchor: { table: { disable: true } },
+    content: { table: { disable: true } },
   },
   args: {
-    anchor: html`
+    content: html`
       <sl-button size="small" variant="primary">Select File</sl-button>
     `,
   },
@@ -30,7 +30,7 @@ export const Basic: Story = {
 export const Multiple: Story = {
   args: {
     multiple: true,
-    anchor: html`
+    content: html`
       <sl-button size="small" variant="primary">Select Files</sl-button>
     `,
   },
@@ -39,11 +39,11 @@ export const Multiple: Story = {
 export const DropZone: Story = {
   args: {
     drop: true,
-    anchor: html`
+    content: html`
       <span>
         Drag file here or
         <button
-          class="text-primary-500 transition-colors hover:text-primary-600"
+          class="text-primary-500 underline underline-offset-2 transition-colors hover:no-underline"
         >
           choose from a folder
         </button>
@@ -69,10 +69,11 @@ export const FormControl: Story = {
 export const FileFormat: Story = {
   decorators: [fileInputFormDecorator],
   args: {
+    label: "Attach a Document",
     drop: true,
     multiple: true,
     accept: ".txt,.doc,.pdf",
-    anchor: html`
+    content: html`
       <div>
         Drag document here or
         <button

--- a/frontend/src/stories/components/FileInput.stories.ts
+++ b/frontend/src/stories/components/FileInput.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
 
+import { fileInputFormDecorator } from "./decorators/fileInputForm";
 import { renderComponent, type RenderProps } from "./FileInput";
 
 const meta = {
@@ -39,10 +40,49 @@ export const DropZone: Story = {
   args: {
     dropzone: true,
     anchor: html`
-      Drag file here or
-      <button class="text-primary-500 transition-colors hover:text-primary-600">
-        choose from a folder
-      </button>
+      <span>
+        Drag file here or
+        <button
+          class="text-primary-500 transition-colors hover:text-primary-600"
+        >
+          choose from a folder
+        </button>
+      </span>
+    `,
+  },
+};
+
+/**
+ * Open your browser console log to see what value gets submitted.
+ */
+export const FormControl: Story = {
+  decorators: [fileInputFormDecorator],
+  args: {
+    ...DropZone.args,
+    multiple: true,
+  },
+};
+
+/**
+ * When dragging and dropping, files that are not acceptable are filtered out.
+ */
+export const FormControlValidation: Story = {
+  decorators: [fileInputFormDecorator],
+  args: {
+    dropzone: true,
+    multiple: true,
+    accept: ".txt,.doc,.pdf",
+    anchor: html`
+      <div>
+        Drag document here or
+        <button
+          class="text-primary-500 transition-colors hover:text-primary-600"
+        >
+          choose a file
+        </button>
+        to upload
+      </div>
+      <div class="text-neutral-500">TXT, DOC, or PDF</div>
     `,
   },
 };

--- a/frontend/src/stories/components/FileInput.stories.ts
+++ b/frontend/src/stories/components/FileInput.stories.ts
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+
+import { renderComponent, type RenderProps } from "./FileInput";
+
+const meta = {
+  title: "Components/File Input",
+  component: "btrix-file-input",
+  tags: ["autodocs"],
+  render: renderComponent,
+  decorators: (story) => html` <div class="m-5">${story()}</div>`,
+  argTypes: {
+    anchor: { table: { disable: true } },
+  },
+  args: {
+    anchor: html`
+      <sl-button size="small" variant="primary">Select File</sl-button>
+    `,
+  },
+} satisfies Meta<RenderProps>;
+
+export default meta;
+type Story = StoryObj<RenderProps>;
+
+export const Basic: Story = {
+  args: {},
+};
+
+export const Multiple: Story = {
+  args: {
+    multiple: true,
+    anchor: html`
+      <sl-button size="small" variant="primary">Select Files</sl-button>
+    `,
+  },
+};
+
+export const DropZone: Story = {
+  args: {
+    dropzone: true,
+    anchor: html`
+      Drag file here or
+      <button class="text-primary-500 transition-colors hover:text-primary-600">
+        choose from a folder
+      </button>
+    `,
+  },
+};

--- a/frontend/src/stories/components/FileInput.stories.ts
+++ b/frontend/src/stories/components/FileInput.stories.ts
@@ -38,7 +38,7 @@ export const Multiple: Story = {
 
 export const DropZone: Story = {
   args: {
-    dropzone: true,
+    drop: true,
     anchor: html`
       <span>
         Drag file here or
@@ -69,7 +69,7 @@ export const FormControl: Story = {
 export const FormControlValidation: Story = {
   decorators: [fileInputFormDecorator],
   args: {
-    dropzone: true,
+    drop: true,
     multiple: true,
     accept: ".txt,.doc,.pdf",
     anchor: html`

--- a/frontend/src/stories/components/FileInput.stories.ts
+++ b/frontend/src/stories/components/FileInput.stories.ts
@@ -66,7 +66,7 @@ export const FormControl: Story = {
 /**
  * When dragging and dropping, files that are not acceptable are filtered out.
  */
-export const FormControlValidation: Story = {
+export const FileFormat: Story = {
   decorators: [fileInputFormDecorator],
   args: {
     drop: true,

--- a/frontend/src/stories/components/FileInput.ts
+++ b/frontend/src/stories/components/FileInput.ts
@@ -13,7 +13,7 @@ export type RenderProps = FileInput & {
 export const renderComponent = ({
   accept,
   multiple,
-  dropzone,
+  drop,
   anchor,
 }: Partial<RenderProps>) => {
   return html`
@@ -21,7 +21,7 @@ export const renderComponent = ({
       name=${formControlName}
       .accept=${accept}
       ?multiple=${multiple}
-      ?dropzone=${dropzone}
+      ?drop=${drop}
       @btrix-change=${console.log}
     >
       ${anchor}

--- a/frontend/src/stories/components/FileInput.ts
+++ b/frontend/src/stories/components/FileInput.ts
@@ -1,4 +1,5 @@
 import { html, type TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { formControlName } from "./decorators/fileInputForm";
 
@@ -7,24 +8,26 @@ import type { FileInput } from "@/components/ui/file-input";
 import "@/components/ui/file-input";
 
 export type RenderProps = FileInput & {
-  anchor: TemplateResult;
+  content: TemplateResult;
 };
 
 export const renderComponent = ({
+  label,
   accept,
   multiple,
   drop,
-  anchor,
+  content,
 }: Partial<RenderProps>) => {
   return html`
     <btrix-file-input
       name=${formControlName}
+      label=${ifDefined(label)}
       .accept=${accept}
       ?multiple=${multiple}
       ?drop=${drop}
       @btrix-change=${console.log}
     >
-      ${anchor}
+      ${content}
     </btrix-file-input>
   `;
 };

--- a/frontend/src/stories/components/FileInput.ts
+++ b/frontend/src/stories/components/FileInput.ts
@@ -1,0 +1,27 @@
+import { html, type TemplateResult } from "lit";
+
+import type { FileInput } from "@/components/ui/file-input";
+
+import "@/components/ui/file-input";
+
+export type RenderProps = FileInput & {
+  anchor: TemplateResult;
+};
+
+export const renderComponent = ({
+  accept,
+  multiple,
+  dropzone,
+  anchor,
+}: Partial<RenderProps>) => {
+  return html`
+    <btrix-file-input
+      .accept=${accept}
+      ?multiple=${multiple}
+      ?dropzone=${dropzone}
+      @btrix-change=${console.log}
+    >
+      ${anchor}
+    </btrix-file-input>
+  `;
+};

--- a/frontend/src/stories/components/FileInput.ts
+++ b/frontend/src/stories/components/FileInput.ts
@@ -1,5 +1,7 @@
 import { html, type TemplateResult } from "lit";
 
+import { formControlName } from "./decorators/fileInputForm";
+
 import type { FileInput } from "@/components/ui/file-input";
 
 import "@/components/ui/file-input";
@@ -16,6 +18,7 @@ export const renderComponent = ({
 }: Partial<RenderProps>) => {
   return html`
     <btrix-file-input
+      name=${formControlName}
       .accept=${accept}
       ?multiple=${multiple}
       ?dropzone=${dropzone}

--- a/frontend/src/stories/components/FileList.stories.ts
+++ b/frontend/src/stories/components/FileList.stories.ts
@@ -6,6 +6,7 @@ import { renderComponent, type RenderProps } from "./FileList";
 const meta = {
   title: "Components/File List",
   component: "btrix-file-list",
+  subcomponents: { FileListItem: "btrix-file-list-item" },
   tags: ["autodocs"],
   render: renderComponent,
   decorators: (story) => html` <div class="m-5">${story()}</div>`,

--- a/frontend/src/stories/components/FileList.stories.ts
+++ b/frontend/src/stories/components/FileList.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+
+import { renderComponent, type RenderProps } from "./FileList";
+
+const meta = {
+  title: "Components/File List",
+  component: "btrix-file-list",
+  tags: ["autodocs"],
+  render: renderComponent,
+  decorators: (story) => html` <div class="m-5">${story()}</div>`,
+  argTypes: {},
+  args: {
+    files: [
+      new File([new Blob()], "file.txt"),
+      new File([new Blob()], "file-2.txt"),
+    ],
+  },
+} satisfies Meta<RenderProps>;
+
+export default meta;
+type Story = StoryObj<RenderProps>;
+
+export const Basic: Story = {
+  args: {},
+};

--- a/frontend/src/stories/components/FileList.ts
+++ b/frontend/src/stories/components/FileList.ts
@@ -1,0 +1,19 @@
+import { html } from "lit";
+
+import "@/components/ui/file-list";
+
+// import type { FileList } from "@/components/ui/file-list";
+
+export type RenderProps = { files: File[] };
+
+export const renderComponent = ({ files }: Partial<RenderProps>) => {
+  return html`
+    <btrix-file-list>
+      ${files?.map(
+        (file) => html`
+          <btrix-file-list-item .file=${file}></btrix-file-list-item>
+        `,
+      )}
+    </btrix-file-list>
+  `;
+};

--- a/frontend/src/stories/components/FileList.ts
+++ b/frontend/src/stories/components/FileList.ts
@@ -2,13 +2,11 @@ import { html } from "lit";
 
 import "@/components/ui/file-list";
 
-// import type { FileList } from "@/components/ui/file-list";
-
 export type RenderProps = { files: File[] };
 
 export const renderComponent = ({ files }: Partial<RenderProps>) => {
   return html`
-    <btrix-file-list>
+    <btrix-file-list @btrix-remove=${console.log}>
       ${files?.map(
         (file) => html`
           <btrix-file-list-item .file=${file}></btrix-file-list-item>

--- a/frontend/src/stories/components/decorators/fileInputForm.ts
+++ b/frontend/src/stories/components/decorators/fileInputForm.ts
@@ -1,0 +1,54 @@
+import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
+import type { StoryContext, StoryFn } from "@storybook/web-components";
+import { html } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import type { RenderProps } from "../FileInput";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+
+export const formControlName = "storybook--file-input-form-example";
+
+@customElement("btrix-storybook-file-input-form")
+export class StorybookFileInputForm extends TailwindElement {
+  public renderStory!: () => ReturnType<StoryFn>;
+
+  render() {
+    const onSubmit = (e: SubmitEvent) => {
+      e.preventDefault();
+
+      const form = e.target as HTMLFormElement;
+      const value = serialize(form);
+
+      console.log("form value:", value, form.elements);
+    };
+
+    return html`
+      <form class="h-24" @submit=${onSubmit}>
+        ${this.renderStory()}
+        <footer class="mt-4">
+          <sl-button type="reset">Reset</sl-button>
+          <sl-button type="submit" variant="primary">Submit</sl-button>
+        </footer>
+      </form>
+    `;
+  }
+}
+
+export function fileInputFormDecorator(
+  story: StoryFn,
+  context: StoryContext<RenderProps>,
+) {
+  return html`
+    <btrix-storybook-file-input-form
+      .renderStory=${() => {
+        return story(
+          {
+            ...context.args,
+          },
+          context,
+        );
+      }}
+    ></btrix-storybook-file-input-form>
+  `;
+}

--- a/frontend/src/types/events.d.ts
+++ b/frontend/src/types/events.d.ts
@@ -5,8 +5,6 @@ import { type NotifyEventMap } from "@/controllers/notify";
 import { type UserGuideEventMap } from "@/index";
 import { type AuthEventMap } from "@/utils/AuthService";
 
-import "@/events";
-
 /**
  * Declare custom events here so that typescript can find them.
  * Custom event names should be prefixed with `btrix-`.


### PR DESCRIPTION
In preparation for https://github.com/webrecorder/browsertrix/issues/2646

## Changes

- Adds new `<btrix-file-input>` component
- Refactors file upload to use `btrix-file-input`

## Manual testing

1. Log in as crawler
2. Go to "Archived Items"
3. Click "Upload WACZ"
4. Drag non-WACZ file into upload area. Verify file is not displayed
5. Drag WACZ file into upload area. Verify file displays as expected
6. Remove file
7. Click "Browse Files"
8. Choose WACZ file. Verify file displays as expected
9. Continue to upload file. Verify file uploads as expected

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Items | <img width="1002" alt="Screenshot 2025-06-11 at 1 37 22 PM" src="https://github.com/user-attachments/assets/d72dcd29-1da3-49b7-8745-b12ab89b6a04" /> |
| Storybook / File Input | <img width="1029" alt="Screenshot 2025-06-10 at 7 48 55 PM" src="https://github.com/user-attachments/assets/3671ac09-7019-4a44-8983-94ff8d4dd1a8" /> |


<!-- ## Follow-ups -->
