### PR TITLE
Optimize single-page crawl workflows

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -327,7 +327,16 @@ class CrawlConfigOps:
 
     def is_single_page(self, config: RawCrawlConfig):
         """return true if this config represents a single page crawl"""
-        return config.seeds and len(config.seeds) == 1 and config.extraHops == 0
+        if not config.seeds or len(config.seeds) != 1:
+            return False
+
+        if config.limit == 1:
+            return True
+
+        extra_hops = config.seeds[0].extraHops or config.extraHops
+        scope_type = config.seeds[0].scopeType or config.scopeType
+
+        return extra_hops == 0 and scope_type == "page"
 
     def _validate_link_selectors(self, link_selectors: List[str]):
         """Validate link selectors

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -220,6 +220,7 @@ class CrawlManager(K8sAPI):
         warc_prefix: str,
         storage_filename: str,
         profile_filename: str,
+        is_single_page: bool,
     ) -> str:
         """create new crawl job from config"""
         cid = str(crawlconfig.id)
@@ -244,6 +245,7 @@ class CrawlManager(K8sAPI):
             storage_filename=storage_filename,
             profile_filename=profile_filename,
             proxy_id=crawlconfig.proxyId or DEFAULT_PROXY_ID,
+            is_single_page=is_single_page,
         )
 
     async def reload_running_crawl_config(self, crawl_id: str):

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -95,6 +95,7 @@ class K8sAPI:
         profile_filename: str = "",
         qa_source: str = "",
         proxy_id: str = "",
+        is_single_page: bool = False,
     ):
         """load job template from yaml"""
         if not crawl_id:
@@ -119,6 +120,7 @@ class K8sAPI:
             "profile_filename": profile_filename,
             "qa_source": qa_source,
             "proxy_id": proxy_id,
+            "is_single_page": "1" if is_single_page else "0",
         }
 
         data = self.templates.env.get_template("crawl_job.yaml").render(params)
@@ -142,6 +144,7 @@ class K8sAPI:
         profile_filename: str = "",
         qa_source: str = "",
         proxy_id: str = "",
+        is_single_page: bool = False,
     ) -> str:
         """load and init crawl job via k8s api"""
         crawl_id, data = self.new_crawl_job_yaml(
@@ -161,6 +164,7 @@ class K8sAPI:
             profile_filename=profile_filename,
             qa_source=qa_source,
             proxy_id=proxy_id,
+            is_single_page=is_single_page,
         )
 
         # create job directly

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -37,7 +37,6 @@ from btrixcloud.utils import (
     date_to_str,
     dt_now,
     scale_from_browser_windows,
-    browser_windows_from_scale,
 )
 
 from .baseoperator import BaseOperator, Redis

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -190,10 +190,7 @@ class CrawlOperator(BaseOperator):
         )
 
         if crawl.qa_source_crawl_id:
-            crawl.browser_windows = int(
-                params.get("qa_browser_instances")
-                or browser_windows_from_scale(params.get("qa_scale") or 1)
-            )
+            crawl.browser_windows = int(params.get("qa_scale", 1))
 
         # if finalizing, crawl is being deleted
         if data.finalizing:

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -140,6 +140,7 @@ class CronJobOperator(BaseOperator):
             storage_filename=self.crawl_config_ops.default_filename_template,
             profile_filename=profile_filename or "",
             proxy_id=crawlconfig.proxyId or "",
+            is_single_page=self.crawl_config_ops.is_single_page(crawlconfig.config),
         )
 
         return MCDecoratorSyncResponse(attachments=list(yaml.safe_load_all(crawljob)))

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -86,6 +86,7 @@ class CrawlSpec(BaseModel):
     max_crawl_size: int = 0
     qa_source_crawl_id: Optional[str] = ""
     proxy_id: Optional[str] = None
+    is_single_page: bool = False
 
     @property
     def db_crawl_id(self) -> str:

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -333,6 +333,7 @@ def sample_crawl_data():
         "name": "Test Crawl",
         "config": {"seeds": [{"url": "https://example.com/"}]},
         "tags": ["tag1", "tag2"],
+        "extraHops": 1,
     }
 
 

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -331,9 +331,8 @@ def sample_crawl_data():
     return {
         "runNow": False,
         "name": "Test Crawl",
-        "config": {"seeds": [{"url": "https://example.com/"}]},
+        "config": {"seeds": [{"url": "https://example.com/"}], "extraHops": 1},
         "tags": ["tag1", "tag2"],
-        "extraHops": 1,
     }
 
 

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -67,6 +67,39 @@ def test_verify_default_browser_windows(
     assert data["browserWindows"] == 2
 
 
+def test_add_crawl_config_single_page(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    # Create crawl config
+    sample_crawl_data["schedule"] = "0 0 * * *"
+    sample_crawl_data["profileid"] = ""
+    sample_crawl_data["limit"] = 1
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
+        headers=crawler_auth_headers,
+        json=sample_crawl_data,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    global cid
+    cid = data["id"]
+
+
+def test_verify_default_browser_windows_single_page(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data.get("scale") is None
+    assert data["browserWindows"] == 1
+
+
 def test_custom_browser_windows(
     crawler_auth_headers, default_org_id, sample_crawl_data
 ):

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -6,6 +6,7 @@ from .conftest import API_PREFIX
 
 
 cid = None
+cid_single_page = None
 UPDATED_NAME = "Updated name"
 UPDATED_DESCRIPTION = "Updated description"
 UPDATED_TAGS = ["tag3", "tag4"]
@@ -71,9 +72,7 @@ def test_add_crawl_config_single_page(
     crawler_auth_headers, default_org_id, sample_crawl_data
 ):
     # Create crawl config
-    sample_crawl_data["schedule"] = "0 0 * * *"
-    sample_crawl_data["profileid"] = ""
-    sample_crawl_data["limit"] = 1
+    sample_crawl_data["config"]["limit"] = 1
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
         headers=crawler_auth_headers,
@@ -82,15 +81,15 @@ def test_add_crawl_config_single_page(
     assert r.status_code == 200
 
     data = r.json()
-    global cid
-    cid = data["id"]
+    global cid_single_page
+    cid_single_page = data["id"]
 
 
 def test_verify_default_browser_windows_single_page(
     crawler_auth_headers, default_org_id, sample_crawl_data
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid_single_page}/",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -11,8 +11,8 @@ def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 7
-    assert r.json()["total"] == 7
+    assert len(r.json()["items"]) == 8
+    assert r.json()["total"] == 8
 
 
 def test_get_config_by_modified_by(
@@ -23,8 +23,8 @@ def test_get_config_by_modified_by(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?modifiedBy={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 7
-    assert r.json()["total"] == 7
+    assert len(r.json()["items"]) == 8
+    assert r.json()["total"] == 8
 
 
 def test_get_configs_by_first_seed(
@@ -362,9 +362,9 @@ def test_sort_crawl_configs(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 13
+    assert data["total"] == 14
     items = data["items"]
-    assert len(items) == 13
+    assert len(items) == 14
 
     last_created = None
     for config in items:

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -39,3 +39,5 @@ spec:
 
   pausedAt: "{{ pausedAt }}"
 
+  isSinglePage: "{{ is_single_page }}"
+

--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -1,3 +1,4 @@
+{% if not no_pvc %}
 # -------
 # PVC
 # -------
@@ -23,7 +24,7 @@ spec:
   storageClassName: {{ volume_storage_class }}
   {% endif %}
 
-
+{% endif %}
 
 # -------
 # CRAWLER
@@ -67,8 +68,12 @@ spec:
         name: qa-replay-{{ qa_source_crawl_id }}
     {% endif %}
     - name: crawl-data
+    {% if not no_pvc %}
       persistentVolumeClaim:
         claimName: {{ name }}
+    {% else %}
+      emptyDir: {}
+    {% endif %}
     {% if proxy_id %}
     - name: proxies
       secret:

--- a/chart/app-templates/redis.yaml
+++ b/chart/app-templates/redis.yaml
@@ -1,3 +1,4 @@
+{% if not no_pvc %}
 # -------
 # PVC
 # -------
@@ -22,6 +23,7 @@ spec:
   {% if volume_storage_class %}
   storageClassName: {{ volume_storage_class }}
   {% endif %}
+{% endif %}
 
 # --------
 # REDIS
@@ -51,8 +53,12 @@ spec:
             path: redis.conf
 
     - name: redis-data
+      {% if not no_pvc %}
       persistentVolumeClaim:
         claimName: {{ name }}
+      {% else %}
+      emptyDir: {}
+      {% endif %}
 
   affinity:
     nodeAffinity:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -277,9 +277,12 @@ crawler_memory_base: 1024Mi
 # number of browser workers per crawler instances
 crawler_browser_instances: 2
 
-# number of browser workers per crawler instances for QA runs
+# number of browser workers per QA pod to run for QA runs
 # defaults to 'crawler_browser_instances' if not set
-# qa_browser_instances: 2
+qa_browser_instances: 1
+
+# fixed scale (number of QA pods) to run
+qa_scale: 1
 
 # this value is added to crawler_cpu_base, for each additional browser
 # crawler_cpu = crawler_cpu_base + crawler_pu_per_extra_browser * (crawler_browser_instances - 1)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -281,9 +281,6 @@ crawler_browser_instances: 2
 # defaults to 'crawler_browser_instances' if not set
 # qa_browser_instances: 2
 
-# number of browser windows for QA runs
-qa_browser_instances: 1
-
 # this value is added to crawler_cpu_base, for each additional browser
 # crawler_cpu = crawler_cpu_base + crawler_pu_per_extra_browser * (crawler_browser_instances - 1)
 crawler_extra_cpu_per_browser: 600m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -281,8 +281,8 @@ crawler_browser_instances: 2
 # defaults to 'crawler_browser_instances' if not set
 # qa_browser_instances: 2
 
-# fixed scale (number of crawler pods) for QA runs
-qa_scale: 1
+# number of browser windows for QA runs
+qa_browser_instances: 1
 
 # this value is added to crawler_cpu_base, for each additional browser
 # crawler_cpu = crawler_cpu_base + crawler_pu_per_extra_browser * (crawler_browser_instances - 1)


### PR DESCRIPTION
For single page crawls:
- Always force 1 browser to be used, ignoring browser windows/scale setting
- Don't use custom PVC volumes in crawler / redis, just use emptyDir - no chance of crawler being interrupted and restarted on different machine for a single page.

Adds a 'is_single_page' check to CrawlConfig, checking for either limit or scopeType / no extra hops.

Also: use `qa_browser_instances` instead of `qa_scale` for consistency for setting number of browsers for QA.

Fixes #2655 