### PR TITLE
fix: Display correct page after renaming org slug

### DIFF
--- a/frontend/src/__mocks__/api/users/me.js
+++ b/frontend/src/__mocks__/api/users/me.js
@@ -1,0 +1,17 @@
+const mockAPIUser = {
+  id: "740d7b63-b257-4311-ba3f-adc46a5fafb8",
+  email: "test-user@example.com",
+  name: "Test User",
+  is_verified: false,
+  is_superuser: false,
+  orgs: [
+    {
+      id: "e21ab647-2d0e-489d-97d1-88ac91774942",
+      name: "test org",
+      slug: "test-org",
+      role: 10,
+    },
+  ],
+};
+
+export default mockAPIUser;

--- a/frontend/src/pages/org/settings/components/general.test.ts
+++ b/frontend/src/pages/org/settings/components/general.test.ts
@@ -1,0 +1,46 @@
+import { expect, fixture } from "@open-wc/testing";
+import { html } from "lit";
+import { restore, stub } from "sinon";
+
+import "./general";
+
+import type { OrgSettingsGeneral } from "./general";
+
+import mockAPIUser from "@/__mocks__/api/users/me.js";
+import { AppStateService } from "@/utils/state";
+
+describe("btrix-org-settings-general", () => {
+  beforeEach(() => {
+    AppStateService.resetAll();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    stub(window.history, "pushState");
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  describe("#renameOrg", () => {
+    it("redirects to the correct page", async () => {
+      const el = await fixture<OrgSettingsGeneral>(
+        html`<btrix-org-settings-general></btrix-org-settings-general>`,
+      );
+
+      stub(el.navigate, "to");
+      stub(el.api, "fetch").callsFake(async (path) => {
+        if (path === "/users/me") {
+          return Promise.resolve(mockAPIUser);
+        }
+        return Promise.resolve({});
+      });
+
+      // @ts-expect-error renameOrg is private
+      await el.renameOrg({ name: "Fake Org Name 2", slug: "fake-org-name-2" });
+
+      expect(el.navigate.to).to.have.been.calledWith(
+        "/orgs/fake-org-name-2/settings",
+      );
+    });
+  });
+});

--- a/frontend/src/pages/org/settings/components/general.ts
+++ b/frontend/src/pages/org/settings/components/general.ts
@@ -364,8 +364,6 @@ export class OrgSettingsGeneral extends BtrixElement {
 
     AppStateService.updateUser(formatAPIUser(user), slug);
 
-    await this.updateComplete;
-
     this.navigate.to(`${this.navigate.orgBasePath}/settings`);
   }
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2658

## Changes

Removes unnecessary `await` which was causing the 404 page introduced in 7c32e27f94bedef1eee2992463cbefc68f4440d9 to show instead.

## Manual testing

See repro steps in https://github.com/webrecorder/browsertrix/issues/2658