### PR TITLE
crawl status related fixes:

### DIFF
--- a/frontend/src/features/archived-items/crawl-list.ts
+++ b/frontend/src/features/archived-items/crawl-list.ts
@@ -131,6 +131,7 @@ export class CrawlListItem extends BtrixElement {
             (crawl: Crawl) => html`
               <btrix-crawl-status
                 state=${crawl.state}
+                ?stopping=${crawl.stopping}
                 ?shouldPause=${crawl.shouldPause}
                 hideLabel
                 hoist

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -5,7 +5,7 @@ import { customElement, property } from "lit/decorators.js";
 import startCase from "lodash/fp/startCase";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import type { CrawlState } from "@/types/crawlState";
+import { RUNNING_STATES, type CrawlState } from "@/types/crawlState";
 import { animatePulse } from "@/utils/css";
 
 type CrawlType = "crawl" | "upload" | "qa";
@@ -325,7 +325,10 @@ export class CrawlStatus extends TailwindElement {
     if (this.stopping && this.state === "running") {
       return "stopping";
     }
-    if (this.shouldPause && this.state !== "paused") {
+    if (
+      this.shouldPause &&
+      (RUNNING_STATES as readonly string[]).includes(this.state || "")
+    ) {
       return "pausing";
     }
     if (!this.shouldPause && this.state === "paused") {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -318,7 +318,7 @@ export class WorkflowDetail extends BtrixElement {
   }
 
   // Workflow is for a crawl that has failed or canceled
-  private get isFailed() {
+  private get isUnsuccessfullyFinished() {
     return (FAILED_STATES as readonly string[]).includes(
       this.workflow?.lastCrawlState || "",
     );
@@ -1402,7 +1402,7 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private readonly renderLatestCrawl = () => {
-    if (!this.lastCrawlId || this.isFailed) {
+    if (!this.lastCrawlId || this.isUnsuccessfullyFinished) {
       return this.renderInactiveCrawlMessage();
     }
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -28,7 +28,7 @@ import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { WorkflowTab } from "@/routes";
 import { deleteConfirmation, noData, notApplicable } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
-import { type CrawlState } from "@/types/crawlState";
+import { FAILED_STATES, type CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
 import {
   DEFAULT_MAX_SCALE,
@@ -315,6 +315,13 @@ export class WorkflowDetail extends BtrixElement {
   // Workflow is active and not paused
   private get isRunning() {
     return this.workflow?.isCrawlRunning && !this.isPaused;
+  }
+
+  // Workflow is for a crawl that has failed or canceled
+  private get isFailed() {
+    return (FAILED_STATES as readonly string[]).includes(
+      this.workflow?.lastCrawlState || "",
+    );
   }
 
   // Crawl is explicitly running
@@ -1395,7 +1402,7 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private readonly renderLatestCrawl = () => {
-    if (!this.lastCrawlId) {
+    if (!this.lastCrawlId || this.isFailed) {
       return this.renderInactiveCrawlMessage();
     }
 
@@ -1832,7 +1839,7 @@ export class WorkflowDetail extends BtrixElement {
       if (this.workflow.lastCrawlState === "canceled") {
         message = msg("This crawl can’t be replayed since it was canceled.");
       } else {
-        message = msg("Replay is not enabled on this crawl.");
+        message = msg("Replay is not available for this crawl.");
       }
     }
 


### PR DESCRIPTION
- only set state to 'paused' if shoudPause is true and crawl is still running (using FAILED_STATES list)
- treat failed/canceled crawl as inactive, don't show replay (using RUNNING_STATES list)