### PR TITLE
docs: Update frontend dev docs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,19 @@
-[Development guide](../docs/develop/frontend-dev.md)
+# Browsertrix Frontend
+
+This directory contains the following components:
+
+## Docs (`/docs`)
+
+Documentation for running, developing, and writing docs:
+- Hosted: [docs.browsertrix.com/develop/docs](https://docs.browsertrix.com/develop/docs)
+- Local: [develop/docs.md](./docs/docs/develop/docs.md)
+
+## User Interface (`/src`)
+
+Documentation for developing the user interface:
+- Hosted: [docs.browsertrix.com/develop/frontend-dev](https://docs.browsertrix.com/develop/frontend-dev)
+- Local: [develop/frontend-dev.md](./docs/docs/develop/frontend-dev.md)
+
+## Configuration
+
+Config files for the frontend Docker build and nginx routing can also be found in this directory.

--- a/frontend/docs/docs/develop/local-dev-setup.md
+++ b/frontend/docs/docs/develop/local-dev-setup.md
@@ -130,6 +130,5 @@ After making any changes to backend code (in `./backend`) or frontend code (in `
 
 Changes to settings in `./chart/local.yaml` can be deployed with `helm upgrade ...` directly.
 
-## Deploying Frontend Only
-
-If you are just making changes to the frontend, you can also [deploy the frontend separately](frontend-dev.md) using a dev server for quicker iteration.
+??? Info "Alternative method for developing the frontend"
+    If you are not writing backend code or otherwise making changes to the backend, you can run the frontend outside of Docker to quickly iterate on the user interface. See [UI Development](./frontend-dev.md) for instructions on how to develop the frontend using Node.js tools.


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2633

## Changes

- Replaces broken link in frontend README with hosted and local links
- Clarifies that frontend is not deployed separately in dev docs

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Docs / Setup for Local Development | <img width="707" alt="Screenshot 2025-06-11 at 1 29 15 PM" src="https://github.com/user-attachments/assets/142faf12-f592-40bc-9f04-df6e21bed76d" /> |


<!-- ## Follow-ups -->
