### PR TITLE
Make trial banner informational at start of trial

### DIFF
--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -33,10 +33,8 @@ const iconForVariant = (
   }
 };
 
-// show banner if <= this many days of trial is left
-const TRIAL_DAYS_SHOW_BANNER = 7;
 // show banner as warning if <= this many days of trial is left
-const TRIAL_DAYS_SHOW_WARNING = 4;
+const TRIAL_DAYS_LEFT_SHOW_WARNING = 4;
 
 @customElement("btrix-org-status-banner")
 @localized()
@@ -87,16 +85,19 @@ export class OrgStatusBanner extends BtrixElement {
     const readOnlyOnCancel =
       subscription?.readOnlyOnCancel ?? this.org.readOnlyOnCancel;
 
-    let hoursDiff = 0;
-    let daysDiff = 0;
-    let dateStr = "";
+    let hoursUntilTrialEnd = 0;
+    let daysUntilTrialEnd = 0;
+    let trialEndDate = "";
     const futureCancelDate = subscription?.futureCancelDate || null;
 
     if (futureCancelDate) {
-      hoursDiff = differenceInHours(new Date(), new Date(futureCancelDate));
-      daysDiff = Math.ceil(hoursDiff / 24);
+      hoursUntilTrialEnd = differenceInHours(
+        new Date(),
+        new Date(futureCancelDate),
+      );
+      daysUntilTrialEnd = Math.ceil(hoursUntilTrialEnd / 24);
 
-      dateStr = this.localize.date(futureCancelDate, {
+      trialEndDate = this.localize.date(futureCancelDate, {
         month: "long",
         day: "numeric",
         year: "numeric",
@@ -118,15 +119,17 @@ export class OrgStatusBanner extends BtrixElement {
         content: () => {
           return {
             title:
-              hoursDiff < 24
+              hoursUntilTrialEnd < 24
                 ? msg("Your org will be deleted within one day")
-                : daysDiff === 1
+                : daysUntilTrialEnd === 1
                   ? msg("Your org will be deleted in one day.")
-                  : msg(str`Your org will be deleted in ${daysDiff} days`),
+                  : msg(
+                      str`Your org will be deleted in ${daysUntilTrialEnd} days`,
+                    ),
             detail: html`
               <p>
                 ${msg(
-                  str`Your subscription ends on ${dateStr}. Your user account, org, and all associated data will be deleted.`,
+                  str`Your subscription ends on ${trialEndDate}. Your user account, org, and all associated data will be deleted.`,
                 )}
               </p>
               <p>
@@ -142,28 +145,25 @@ export class OrgStatusBanner extends BtrixElement {
       },
       {
         test: () =>
-          !readOnly &&
-          !readOnlyOnCancel &&
-          !!futureCancelDate &&
-          ((isTrial && daysDiff <= TRIAL_DAYS_SHOW_BANNER) || isCancelingTrial),
+          !readOnly && !readOnlyOnCancel && !!futureCancelDate && isTrial,
         variant: isCancelingTrial
           ? "danger"
-          : isTrial && daysDiff <= TRIAL_DAYS_SHOW_WARNING
+          : isTrial && daysUntilTrialEnd <= TRIAL_DAYS_LEFT_SHOW_WARNING
             ? "warning"
             : "primary",
         content: () => {
           return {
             title:
-              hoursDiff < 24
+              hoursUntilTrialEnd < 24
                 ? msg("Your trial ends within one day")
-                : daysDiff === 1
+                : daysUntilTrialEnd === 1
                   ? msg("You have one day left of your Browsertrix trial")
                   : msg(
-                      str`You have ${daysDiff} days left of your Browsertrix trial`,
+                      str`You have ${daysUntilTrialEnd} days left of your Browsertrix trial`,
                     ),
 
             detail: html`<p>
-                ${msg(str`Your free trial ends on ${dateStr}.`)}
+                ${msg(str`Your free trial ends on ${trialEndDate}.`)}
                 ${isCancelingTrial
                   ? msg(
                       html`To continue using Browsertrix, select
@@ -198,13 +198,15 @@ export class OrgStatusBanner extends BtrixElement {
         content: () => {
           return {
             title:
-              daysDiff > 1
-                ? msg(str`Archiving will be disabled in ${daysDiff} days`)
+              daysUntilTrialEnd > 1
+                ? msg(
+                    str`Archiving will be disabled in ${daysUntilTrialEnd} days`,
+                  )
                 : msg("Archiving will be disabled within one day"),
             detail: html`
               <p>
                 ${msg(
-                  str`Your subscription ends on ${dateStr}. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.`,
+                  str`Your subscription ends on ${trialEndDate}. You will no longer be able to run crawls, upload files, create browser profiles, or create collections.`,
                 )}
               </p>
               <p>

--- a/frontend/src/features/org/org-status-banner.ts
+++ b/frontend/src/features/org/org-status-banner.ts
@@ -34,9 +34,9 @@ const iconForVariant = (
 };
 
 // show banner if <= this many days of trial is left
-const MAX_TRIAL_DAYS_SHOW_BANNER = 7;
-// display banner as warning if <=
-const MAX_TRIAL_DAYS_SHOW_WARNING = 4;
+const TRIAL_DAYS_SHOW_BANNER = 7;
+// show banner as warning if <= this many days of trial is left
+const TRIAL_DAYS_SHOW_WARNING = 4;
 
 @customElement("btrix-org-status-banner")
 @localized()
@@ -145,11 +145,10 @@ export class OrgStatusBanner extends BtrixElement {
           !readOnly &&
           !readOnlyOnCancel &&
           !!futureCancelDate &&
-          ((isTrial && daysDiff <= MAX_TRIAL_DAYS_SHOW_BANNER) ||
-            isCancelingTrial),
+          ((isTrial && daysDiff <= TRIAL_DAYS_SHOW_BANNER) || isCancelingTrial),
         variant: isCancelingTrial
           ? "danger"
-          : isTrial && daysDiff <= MAX_TRIAL_DAYS_SHOW_WARNING
+          : isTrial && daysDiff <= TRIAL_DAYS_SHOW_WARNING
             ? "warning"
             : "primary",
         content: () => {


### PR DESCRIPTION
## Changes

Following https://github.com/webrecorder/browsertrix/pull/2651/commits/bbd5fb81c4f5746c14cb1f6217a6a79f73704e00, since the banner is shown throughout all 7 days of a trial, it should be made informational at the beginning of the trial so that it's not as obtrusive.

## Manual testing

Log in to org with 5 or more trial days left. Verify banner is shown in informational variant.

## Screenshots


<img width="1500" alt="Screenshot 2025-06-11 at 3 45 30 PM" src="https://github.com/user-attachments/assets/127e0241-56a4-43da-bdad-b1996c5e834e" />

<img width="1512" alt="Screenshot 2025-06-11 at 3 45 40 PM" src="https://github.com/user-attachments/assets/34194a87-6c1f-4fd8-a8db-98886800736c" />


<!-- ## Follow-ups -->
