### PR TITLE
Add hardcoded exceptions to preventing enter keypresses in workflow form

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2272,7 +2272,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
     if (metaKey) {
       if (key === "s" || key === "Enter") {
         event.preventDefault();
-        debugger;
 
         this.saveAndRun = key === "Enter";
 
@@ -2301,7 +2300,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
       // Prevent typing non-numeric keys
       if (!metaKey && !event.shiftKey && key.length === 1 && /\D/.test(key)) {
         event.preventDefault();
-        debugger;
         return;
       }
     }
@@ -2314,7 +2312,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
     ) {
       // Prevent submission by "Enter" keypress if not on last tab
       event.preventDefault();
-      debugger;
     }
   }
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2272,6 +2272,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     if (metaKey) {
       if (key === "s" || key === "Enter") {
         event.preventDefault();
+        debugger;
 
         this.saveAndRun = key === "Enter";
 
@@ -2300,16 +2301,20 @@ https://archiveweb.page/images/${"logo.svg"}`}
       // Prevent typing non-numeric keys
       if (!metaKey && !event.shiftKey && key.length === 1 && /\D/.test(key)) {
         event.preventDefault();
+        debugger;
         return;
       }
     }
 
     if (
       key === "Enter" &&
-      this.progressState!.activeTab !== STEPS[STEPS.length - 1]
+      this.progressState!.activeTab !== STEPS[STEPS.length - 1] &&
+      // Prevent places where Enter is valid from being stopped
+      !["TEXTAREA", "SL-TEXTAREA"].includes(el.tagName)
     ) {
       // Prevent submission by "Enter" keypress if not on last tab
       event.preventDefault();
+      debugger;
     }
   }
 


### PR DESCRIPTION
cc @SuaYoo 

Fixes https://github.com/webrecorder/browsertrix/issues/2675

Quick fix for [issue reported in Discord](https://discord.com/channels/895426029194207262/910966759165657161/1384919867345473566) where enter no longer works inside `textarea`s (including `sl-textarea`s). Adds explicit exceptions for these.

Tested locally.