### PR TITLE
Bug: load correct workflow page on initial render

### DIFF
--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -173,6 +173,7 @@ export class Pagination extends LitElement {
   set page(page: number) {
     if (page !== this._page) {
       this.setPage(page);
+      this._page = page;
     }
   }
 

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -154,7 +154,6 @@ export class WorkflowsList extends BtrixElement {
     const refetchDataProps = [...resetToFirstPageProps];
 
     if (refetchDataProps.some((k) => changedProperties.has(k))) {
-      console.log(changedProperties);
       const isInitialRender = resetToFirstPageProps
         .map((k) => changedProperties.get(k))
         .every((v) => v === undefined);

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -142,18 +142,20 @@ export class WorkflowsList extends BtrixElement {
   protected async willUpdate(
     changedProperties: PropertyValues<this> & Map<string, unknown>,
   ) {
-    if (
-      changedProperties.has("orderBy") ||
-      changedProperties.has("filterByCurrentUser") ||
-      changedProperties.has("filterByScheduled") ||
-      changedProperties.has("filterBy")
-    ) {
-      const isInitialRender = [
-        "orderBy",
-        "filterByCurrentUser",
-        "filterByScheduled",
-        "filterBy",
-      ]
+    // Props that reset the page to 1 when changed
+    const resetToFirstPageProps = [
+      "filterByCurrentUser",
+      "filterByScheduled",
+      "filterBy",
+      "orderBy",
+    ];
+
+    // Props that require a data refetch
+    const refetchDataProps = [...resetToFirstPageProps];
+
+    if (refetchDataProps.some((k) => changedProperties.has(k))) {
+      console.log(changedProperties);
+      const isInitialRender = resetToFirstPageProps
         .map((k) => changedProperties.get(k))
         .every((v) => v === undefined);
       void this.fetchWorkflows({

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -148,12 +148,20 @@ export class WorkflowsList extends BtrixElement {
       changedProperties.has("filterByScheduled") ||
       changedProperties.has("filterBy")
     ) {
+      const isInitialRender = [
+        "orderBy",
+        "filterByCurrentUser",
+        "filterByScheduled",
+        "filterBy",
+      ]
+        .map((k) => changedProperties.get(k))
+        .every((v) => v === undefined);
       void this.fetchWorkflows({
         page:
-          // If we've already loaded workflows and are switching filters, reset the page; otherwise, use the page from the URL or default to 1
-          this.workflows
-            ? 1
-            : parsePage(new URLSearchParams(location.search).get("page")) || 1,
+          // If this is the initial render, use the page from the URL or default to 1; otherwise, reset the page to 1
+          isInitialRender
+            ? parsePage(new URLSearchParams(location.search).get("page")) || 1
+            : 1,
       });
     }
     if (changedProperties.has("filterByCurrentUser")) {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -4,6 +4,7 @@ import type {
   SlDialog,
   SlSelectEvent,
 } from "@shoelace-style/shoelace";
+import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -513,27 +514,27 @@ export class WorkflowsList extends BtrixElement {
       <btrix-workflow-list>
         ${this.workflows.items.map(this.renderWorkflowItem)}
       </btrix-workflow-list>
-      ${when(
-        total > pageSize,
-        () => html`
-          <footer class="mt-6 flex justify-center">
-            <btrix-pagination
-              page=${page}
-              totalCount=${total}
-              size=${pageSize}
-              @page-change=${async (e: PageChangeEvent) => {
-                await this.fetchWorkflows({
-                  page: e.detail.page,
-                });
+      <footer
+        class=${clsx(
+          tw`mt-6 flex justify-center`,
+          total <= pageSize && tw`hidden`,
+        )}
+      >
+        <btrix-pagination
+          page=${page}
+          totalCount=${total}
+          size=${pageSize}
+          @page-change=${async (e: PageChangeEvent) => {
+            await this.fetchWorkflows({
+              page: e.detail.page,
+            });
 
-                // Scroll to top of list
-                // TODO once deep-linking is implemented, scroll to top of pushstate
-                this.scrollIntoView({ behavior: "smooth" });
-              }}
-            ></btrix-pagination>
-          </footer>
-        `,
-      )}
+            // Scroll to top of list
+            // TODO once deep-linking is implemented, scroll to top of pushstate
+            this.scrollIntoView({ behavior: "smooth" });
+          }}
+        ></btrix-pagination>
+      </footer>
     `;
   }
 

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -148,7 +148,11 @@ export class WorkflowsList extends BtrixElement {
       changedProperties.has("filterBy")
     ) {
       void this.fetchWorkflows({
-        page: 1,
+        page:
+          // If we've already loaded workflows and are switching filters, reset the page; otherwise, use the page from the URL or default to 1
+          this.workflows
+            ? 1
+            : parsePage(new URLSearchParams(location.search).get("page")) || 1,
       });
     }
     if (changedProperties.has("filterByCurrentUser")) {


### PR DESCRIPTION
Fixes #2676 
cc @SuaYoo 

## Changes
- Only resets page to 1 when switching filters after initial load
- Always renders `<btrix-pagination>` so that page changes are always reflected in the URL

## Testing
Tested locally, it seems to work