### PR TITLE
fix: Close "please log in" alert when accepting invite

### DIFF
--- a/frontend/src/pages/invite/accept.ts
+++ b/frontend/src/pages/invite/accept.ts
@@ -65,6 +65,8 @@ export class AcceptInvite extends BtrixElement {
       this.notify.toast({
         message: msg("Please log in to accept this invite."),
         variant: "warning",
+        icon: "exclamation-triangle",
+        id: "invite-status",
       });
 
       this.navigate.to(
@@ -244,6 +246,7 @@ export class AcceptInvite extends BtrixElement {
           ),
           variant: "success",
           icon: "check2-circle",
+          id: "invite-status",
         });
 
         this.navigate.to(
@@ -268,6 +271,7 @@ export class AcceptInvite extends BtrixElement {
       ),
       variant: "info",
       icon: "info-circle",
+      id: "invite-status",
     });
 
     this.navigate.to(this.navigate.orgBasePath);


### PR DESCRIPTION
No issue created, quick fix for edge case

## Changes

Adds ID to accept page toast messages so that "Please log in ..." message closes once the invite is accepted or declined.

## Manual testing

1. Log in as org admin
2. Invite user (one you have access to) to an org
3. Log out and log in as invited user
4. Click invite link in inbox
5. Click accept quickly. Verify "Please log in ..." message is replaced with "You've joined ..."