### PR TITLE
feat: Specify seed list as file in UI

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -390,10 +390,13 @@ export class ConfigDetails extends BtrixElement {
               href=${file.path}
               .removable=${false}
             >
-              <span slot="name">
-                ${file.originalFilename}
-                <span class="text-neutral-500"
-                  >&mdash; ${this.localize.number(file.seedCount)}
+              <span slot="name" class="flex gap-1 overflow-hidden">
+                <sl-tooltip content=${file.originalFilename}>
+                  <span class="truncate">${file.originalFilename}</span>
+                </sl-tooltip>
+                <span class="text-neutral-400" role="separator">&mdash;</span>
+                <span class="whitespace-nowrap text-neutral-500"
+                  >${this.localize.number(file.seedCount)}
                   ${pluralOf("URLs", file.seedCount)}</span
                 >
               </span>

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -389,7 +389,15 @@ export class ConfigDetails extends BtrixElement {
               size=${file.size}
               href=${file.path}
               .removable=${false}
-            ></btrix-file-list-item>
+            >
+              <span slot="name">
+                ${file.originalFilename}
+                <span class="text-neutral-500"
+                  >&mdash; ${this.localize.number(file.seedCount)}
+                  ${pluralOf("URLs", file.seedCount)}</span
+                >
+              </span>
+            </btrix-file-list-item>
           </btrix-file-list>`,
       );
 

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -163,7 +163,15 @@ export class FileInput extends FormControl(TailwindElement) {
     return html`
       <btrix-file-list
         @btrix-remove=${(e: BtrixFileRemoveEvent) => {
-          this.files = without([e.detail.item])(this.files);
+          if (!this.files) return;
+
+          const { item } = e.detail;
+
+          if (item instanceof File) {
+            this.files = without([item])(this.files);
+          } else {
+            this.files = this.files.filter((file) => file.name !== item.name);
+          }
         }}
       >
         ${repeat(

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -1,7 +1,7 @@
 import { localized } from "@lit/localize";
 import clsx from "clsx";
 import { html, nothing, type PropertyValues } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
 import { without } from "lodash/fp";
@@ -41,6 +41,12 @@ export class FileInput extends FormControl(TailwindElement) {
   label?: string;
 
   /**
+   * Selected files.
+   */
+  @property({ type: Array })
+  files?: File[] | null = null;
+
+  /**
    * Specify which file types are allowed
    */
   @property({ type: String })
@@ -57,9 +63,6 @@ export class FileInput extends FormControl(TailwindElement) {
    */
   @property({ type: Boolean })
   drop = false;
-
-  @state()
-  private files: File[] = [];
 
   @query("#dropzone")
   private readonly dropzone?: HTMLElement | null;
@@ -90,7 +93,7 @@ export class FileInput extends FormControl(TailwindElement) {
     // construct `FormData` instead
     const formData = new FormData();
 
-    this.files.forEach((file) => {
+    this.files?.forEach((file) => {
       formData.append(formControlName, file);
     });
 
@@ -102,7 +105,7 @@ export class FileInput extends FormControl(TailwindElement) {
       ${this.label
         ? html`<label for="fileInput" class="form-label">${this.label}</label>`
         : nothing}
-      ${this.files.length ? this.renderFiles() : this.renderInput()}
+      ${this.files?.length ? this.renderFiles() : this.renderInput()}
     `;
   }
 
@@ -155,6 +158,8 @@ export class FileInput extends FormControl(TailwindElement) {
   };
 
   private readonly renderFiles = () => {
+    if (!this.files) return;
+
     return html`
       <btrix-file-list
         @btrix-remove=${(e: BtrixFileRemoveEvent) => {

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -130,7 +130,6 @@ export class FileInput extends FormControl(TailwindElement) {
       >
         <input
           id="fileInput"
-          class="sr-only"
           type="file"
           accept=${ifDefined(this.accept)}
           ?multiple=${this.multiple}
@@ -143,7 +142,13 @@ export class FileInput extends FormControl(TailwindElement) {
           }}
         />
         <div class="relative z-10">
-          <slot></slot>
+          <slot
+            @slotchange=${{
+              // Hide input visually
+              handleEvent: () => this.input?.classList.add(tw`sr-only`),
+              once: true,
+            }}
+          ></slot>
         </div>
       </div>
     `;
@@ -220,6 +225,8 @@ export class FileInput extends FormControl(TailwindElement) {
       if (accept.startsWith(".")) {
         return file.name.endsWith(accept.trim());
       }
+
+      console.log("accept:", accept, file.type);
 
       return new RegExp(accept.trim().replace("*", ".*")).test(file.type);
     });

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -90,6 +90,16 @@ export class FileInput extends FormControl(TailwindElement) {
   // Object URLs are used to view files
   private readonly fileToObjectUrl = new Map<File, string>();
 
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    this.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        this.input?.click();
+      }
+    });
+  }
+
   disconnectedCallback(): void {
     for (const url of this.fileToObjectUrl.values()) {
       URL.revokeObjectURL(url);

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -43,6 +43,12 @@ export class FileInput extends FormControl(TailwindElement) {
   label?: string;
 
   /**
+   * Form control help text
+   */
+  @property({ type: String })
+  helpText?: string;
+
+  /**
    * Selected files.
    */
   @property({ type: Array })
@@ -193,6 +199,18 @@ export class FileInput extends FormControl(TailwindElement) {
         ? html`<label for="fileInput" class="form-label">${this.label}</label>`
         : nothing}
       ${this.files?.length ? this.renderFiles() : this.renderInput()}
+
+      <div class=${clsx(tw`form-help-text`, !this.helpText && tw`hidden`)}>
+        <slot
+          name="help-text"
+          @slotchange=${(e: Event) => {
+            (e.target as HTMLSlotElement)
+              .closest(".form-help-text")
+              ?.classList.remove(tw`hidden`);
+          }}
+          >${this.helpText}</slot
+        >
+      </div>
     `;
   }
 

--- a/frontend/src/components/ui/file-input.ts
+++ b/frontend/src/components/ui/file-input.ts
@@ -13,6 +13,7 @@ import type {
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { FormControl } from "@/mixins/FormControl";
+import { validationMessageFor } from "@/strings/validation";
 import { tw } from "@/utils/tailwind";
 
 import "@/components/ui/file-list";
@@ -70,6 +71,9 @@ export class FileInput extends FormControl(TailwindElement) {
   @property({ type: Boolean })
   openFile = false;
 
+  @property({ type: Boolean })
+  required = false;
+
   @query("#dropzone")
   private readonly dropzone?: HTMLElement | null;
 
@@ -105,6 +109,12 @@ export class FileInput extends FormControl(TailwindElement) {
     }
   }
 
+  protected updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has("files") || changedProperties.has("required")) {
+      this.validateFiles();
+    }
+  }
+
   private setObjectUrls(files: File[]) {
     files.forEach((file) => {
       if (this.fileToObjectUrl.get(file)) return;
@@ -127,6 +137,20 @@ export class FileInput extends FormControl(TailwindElement) {
     });
 
     this.setFormValue(formData);
+  }
+
+  private validateFiles() {
+    let validity: ValidityStateFlags = {};
+    let message: string | undefined = undefined;
+
+    if (this.required && !this.files?.length) {
+      validity = { valueMissing: true };
+      message = validationMessageFor.valueMissing;
+    } else if (this.files) {
+      // TODO Check min/max size
+    }
+
+    this.setValidity(validity, message);
   }
 
   render() {

--- a/frontend/src/components/ui/file-list/events.ts
+++ b/frontend/src/components/ui/file-list/events.ts
@@ -1,5 +1,7 @@
+import type { FileLike } from "./types";
+
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import type { BtrixRemoveEvent } from "@/events/btrix-remove";
 
-export type BtrixFileRemoveEvent = BtrixRemoveEvent<File>;
+export type BtrixFileRemoveEvent = BtrixRemoveEvent<File | FileLike>;
 export type BtrixFileChangeEvent = BtrixChangeEvent<File[]>;

--- a/frontend/src/components/ui/file-list/file-list-item.ts
+++ b/frontend/src/components/ui/file-list/file-list-item.ts
@@ -102,7 +102,9 @@ export class FileListItem extends TailwindElement {
     return html`<div class="item">
       <div class="file">
         <div class="details">
-          <div class="name">${item.name}</div>
+          <div class="name">
+            <slot name="name">${item.name}</slot>
+          </div>
           <div class="size">
             ${this.progressValue !== undefined
               ? html`${this.localize.bytes(

--- a/frontend/src/components/ui/file-list/file-list-item.ts
+++ b/frontend/src/components/ui/file-list/file-list-item.ts
@@ -99,8 +99,6 @@ export class FileListItem extends TailwindElement {
 
     if (!item) return;
 
-    console.log(this.href);
-
     return html`<div class="item">
       <div class="file">
         <div class="details">

--- a/frontend/src/components/ui/file-list/file-list-item.ts
+++ b/frontend/src/components/ui/file-list/file-list-item.ts
@@ -1,8 +1,10 @@
 import { localized, msg } from "@lit/localize";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
 
 import type { BtrixFileRemoveEvent } from "./events";
+import type { FileLike } from "./types";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import { LocalizeController } from "@/controllers/localize";
@@ -62,6 +64,21 @@ export class FileListItem extends TailwindElement {
   @property({ attribute: false })
   file?: File | null = null;
 
+  @property({ type: String })
+  name?: FileLike["name"];
+
+  @property({ type: Number })
+  size?: FileLike["size"];
+
+  @property({ type: Boolean })
+  removable = true;
+
+  /**
+   * Shows link to open the file URL in a new tab.
+   */
+  @property({ type: String })
+  href = "";
+
   @property({ type: Number })
   progressValue?: number;
 
@@ -70,30 +87,37 @@ export class FileListItem extends TailwindElement {
 
   readonly localize = new LocalizeController(this);
 
+  get item() {
+    return (
+      this.file ||
+      (this.name ? { name: this.name, size: this.size || 0 } : null)
+    );
+  }
+
   render() {
-    if (!this.file) return;
+    const item = this.item;
+
+    if (!item) return;
+
+    console.log(this.href);
+
     return html`<div class="item">
       <div class="file">
         <div class="details">
-          <div class="name">${this.file.name}</div>
+          <div class="name">${item.name}</div>
           <div class="size">
             ${this.progressValue !== undefined
               ? html`${this.localize.bytes(
-                  (this.progressValue / 100) * this.file.size,
+                  (this.progressValue / 100) * item.size,
                 )}
                 / `
-              : ""}${this.localize.bytes(this.file.size)}
+              : ""}${this.localize.bytes(item.size)}
           </div>
         </div>
         <div class="actions">
           ${this.progressValue || this.progressIndeterminate
             ? ""
-            : html`<sl-icon-button
-                name="trash3"
-                class="text-base hover:text-danger"
-                label=${msg("Remove file")}
-                @click=${this.onRemove}
-              ></sl-icon-button>`}
+            : this.renderActions()}
         </div>
       </div>
       ${this.progressValue || this.progressIndeterminate
@@ -108,14 +132,41 @@ export class FileListItem extends TailwindElement {
     </div>`;
   }
 
+  private renderActions() {
+    return html`${when(
+      this.href,
+      (href) =>
+        html`<sl-tooltip content=${msg("View File")}>
+          <sl-icon-button
+            name="box-arrow-up-right"
+            class="text-base"
+            href=${href}
+            target="_blank"
+          ></sl-icon-button>
+        </sl-tooltip>`,
+    )}
+    ${when(
+      this.removable,
+      () =>
+        html`<sl-tooltip content=${msg("Remove File")}>
+          <sl-icon-button
+            name="trash3"
+            class="text-base hover:text-danger"
+            @click=${this.onRemove}
+          ></sl-icon-button>
+        </sl-tooltip>`,
+    )}`;
+  }
+
   private readonly onRemove = async () => {
-    if (!this.file) return;
+    const item = this.item;
+
+    if (!item) return;
+
     await this.updateComplete;
     this.dispatchEvent(
       new CustomEvent<BtrixFileRemoveEvent["detail"]>("btrix-remove", {
-        detail: {
-          item: this.file,
-        },
+        detail: { item },
         composed: true,
         bubbles: true,
       }),

--- a/frontend/src/components/ui/file-list/types.ts
+++ b/frontend/src/components/ui/file-list/types.ts
@@ -1,0 +1,1 @@
+export type FileLike = Pick<File, "name" | "size">;

--- a/frontend/src/context/docs-url.ts
+++ b/frontend/src/context/docs-url.ts
@@ -1,0 +1,5 @@
+import { createContext } from "@lit/context";
+
+export type DocsUrlContext = string | null;
+
+export const docsUrlContext = createContext<DocsUrlContext>("docsUrl");

--- a/frontend/src/controllers/api.ts
+++ b/frontend/src/controllers/api.ts
@@ -213,6 +213,14 @@ export class APIController implements ReactiveController {
         if (xhr.status === 403) {
           reject(AbortReason.QuotaReached);
         }
+        if (xhr.status === 404) {
+          reject(
+            new APIError({
+              message: xhr.statusText,
+              status: xhr.status,
+            }),
+          );
+        }
       });
       xhr.addEventListener("error", () => {
         reject(

--- a/frontend/src/controllers/api.ts
+++ b/frontend/src/controllers/api.ts
@@ -151,6 +151,7 @@ export class APIController implements ReactiveController {
       default: {
         if (typeof errorDetail === "string") {
           errorMessage = errorDetail;
+          errorDetails = [errorDetail];
         } else if (Array.isArray(errorDetail) && errorDetail.length) {
           errorDetails = errorDetail;
 

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -319,7 +319,7 @@ export class FileUploader extends BtrixElement {
 
   private readonly handleRemoveFile = (e: FileRemoveEvent) => {
     this.cancelUpload();
-    const idx = this.fileList.indexOf(e.detail.item);
+    const idx = this.fileList.indexOf(e.detail.item as File);
     if (idx === -1) return;
     this.fileList = [
       ...this.fileList.slice(0, idx),

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1063,9 +1063,9 @@ https://replayweb.page/docs`}
 
     return html`<btrix-file-input
       id="seedUrlList"
-      drop
       accept=".${SEED_LIST_FILE_EXT}"
       .files=${this.formState.seedFile ? [this.formState.seedFile] : null}
+      drop
     >
       <sl-icon
         name="file-earmark-arrow-up"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -94,6 +94,7 @@ import {
 import type { UnderlyingFunction } from "@/types/utils";
 import {
   NewWorkflowOnlyScopeType,
+  type StorageSeedFile,
   type WorkflowTag,
   type WorkflowTags,
 } from "@/types/workflow";
@@ -271,6 +272,9 @@ export class WorkflowEditor extends BtrixElement {
 
   @property({ type: Array })
   initialSeeds?: Seed[];
+
+  @property({ type: Object })
+  initialSeedFile?: StorageSeedFile;
 
   @state()
   private showCrawlerChannels = false;
@@ -1060,6 +1064,21 @@ https://replayweb.page/docs`}
   };
 
   private readonly renderSeedListFileUpload = () => {
+    const file = this.initialSeedFile;
+
+    if (!this.formState.seedFile && file) {
+      return html`<btrix-file-list>
+        <btrix-file-list-item
+          name=${file.originalFilename}
+          size=${file.size}
+          href=${file.path}
+          @btrix-remove=${() => {
+            console.log("TODO");
+          }}
+        ></btrix-file-list-item>
+      </btrix-file-list>`;
+    }
+
     const browseFilesButton = html`<button
       class="text-primary-500 transition-colors hover:text-primary-600"
     >

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1107,10 +1107,13 @@ https://replayweb.page/docs`}
             });
           }}
         >
-          <span slot="name">
-            ${file.originalFilename}
-            <span class="text-neutral-500"
-              >&mdash; ${this.localize.number(file.seedCount)}
+          <span slot="name" class="flex gap-1 overflow-hidden">
+            <sl-tooltip content=${file.originalFilename}>
+              <span class="truncate">${file.originalFilename}</span>
+            </sl-tooltip>
+            <span class="text-neutral-400" role="separator">&mdash;</span>
+            <span class="whitespace-nowrap text-neutral-500"
+              >${this.localize.number(file.seedCount)}
               ${pluralOf("URLs", file.seedCount)}</span
             >
           </span>

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -123,7 +123,7 @@ import {
   MAX_SEED_FILE_BYTES,
   rangeBrowserWindows,
   SECTIONS,
-  SeedUrlList,
+  SeedListFormat,
   workflowTabToGuideHash,
   type FormState,
   type WorkflowDefaults,
@@ -951,47 +951,54 @@ export class WorkflowEditor extends BtrixElement {
         <sl-radio-group
           class="mb-2.5 part-[form-control-label]:sr-only"
           label="Select how to specify URL list"
-          value=${this.formState.seedUrlListType}
-          name="seedUrlListType"
+          value=${this.formState.seedListFormat}
+          name="seedListFormat"
           size="small"
         >
-          <sl-radio-button value="text">${msg("Enter URLs")}</sl-radio-button>
-          <sl-radio-button value="file"
-            >${msg("Upload a File")}</sl-radio-button
+          <sl-radio-button value=${SeedListFormat.JSON}
+            >${msg("Enter URLs")}</sl-radio-button
+          >
+          <sl-radio-button value=${SeedListFormat.File}
+            >${msg("Upload URL List")}</sl-radio-button
           >
         </sl-radio-group>
 
-        ${choose(this.formState.seedUrlListType, [
-          [SeedUrlList.Text, () => this.renderSeedUrlTextInput()],
-          [SeedUrlList.File, () => this.renderSeedUrlFileInput()],
+        ${choose(this.formState.seedListFormat, [
+          [SeedListFormat.JSON, () => this.renderSeedListTextbox()],
+          [SeedListFormat.File, () => this.renderSeedListFileUpload()],
         ])}
       `)}
       ${this.renderHelpTextCol(
-        this.formState.seedUrlListType === SeedUrlList.File
+        this.formState.seedListFormat === SeedListFormat.File
           ? html`${msg(
               "The crawler will visit and record each URL listed in the file.",
             )}
             ${this.renderUserGuideLink({
               hash: "page-urls",
-              content: msg("Read more about file uploads"),
-            })}`
-          : msg("The crawler will visit and record each URL listed here."),
+              content: msg("Read more about URL list files"),
+            })}.`
+          : html`${infoTextFor["urlList"]} ${msg("For very large lists")},
+            ${this.renderUserGuideLink({
+              hash: "page-urls",
+              content: msg("upload a URL list file"),
+            })}.`,
       )}
     `;
   }
 
-  private readonly renderSeedUrlTextInput = () =>
+  private readonly renderSeedListTextbox = () =>
     html`<sl-textarea
       id="seedUrlList"
       name="urlList"
-      placeholder=${`https://webrecorder.net/blog
-https://archiveweb.page/guide`}
-      rows="3"
+      placeholder=${`https://webrecorder.net/resources
+https://archiveweb.page/guide
+https://replayweb.page/docs`}
+      rows="4"
       autocomplete="off"
       inputmode="url"
       value=${this.formState.urlList}
       required
-      help-text=${msg("Enter 1 URL per line")}
+      help-text=${msg("Enter one URL per line.")}
       @keyup=${async (e: KeyboardEvent) => {
         if (e.key === "Enter") {
           await (e.target as SlInput).updateComplete;
@@ -1020,7 +1027,7 @@ https://archiveweb.page/guide`}
       }}
     ></sl-textarea>`;
 
-  private readonly renderSeedUrlFileInput = () => {
+  private readonly renderSeedListFileUpload = () => {
     const browseFilesButton = html`<button
       class="text-primary-500 transition-colors hover:text-primary-600"
     >
@@ -1031,15 +1038,15 @@ https://archiveweb.page/guide`}
     return html`<btrix-file-input id="seedUrlList" drop accept=".txt">
       <sl-icon
         name="file-earmark-arrow-up"
-        class="text-lg text-neutral-400"
+        class="text-xl text-neutral-400"
       ></sl-icon>
-      <p class="text-pretty text-center">
+      <p class="mt-1 text-pretty text-center">
         ${msg(html`Drag file here or ${browseFilesButton}`)}
       </p>
       <div class="form-help-text text-center leading-none">
         ${msg("TXT format")},
         ${msg(str`${maxByteSize} max`, {
-          desc: "Example: '25 MB max'. Shorthand for 'maximum'",
+          desc: "`maxByteSize` example: '25 MB'. 'max' is shorthand for 'maximum'",
         })}
       </div>
     </btrix-file-input>`;
@@ -1117,6 +1124,7 @@ https://archiveweb.page/guide`}
     }
 
     const additionalUrlList = urlListToArray(this.formState.urlList);
+    const maxUrls = this.localize.number(URL_LIST_MAX_URLS);
 
     return html`
       ${inputCol(html`
@@ -1305,9 +1313,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
               ></sl-textarea>
             `)}
             ${this.renderHelpTextCol(
-              msg(
-                str`The crawler will visit and record each URL listed here. You can enter up to ${this.localize.number(URL_LIST_MAX_URLS)} URLs.`,
-              ),
+              html`${infoTextFor["urlList"]}
+              ${msg(str`You can enter up to ${maxUrls} URLs.`, {
+                desc: "`maxUrls` example: '1,000'",
+              })}`,
             )}
           </div>
         </btrix-details>

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2550,6 +2550,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
       return;
     }
 
+    this.isSubmitting = true;
+
     const parseConfigParams: Parameters<WorkflowEditor["parseConfig"]>[0] = {};
 
     // Upload seed file first if it exists, since ID will be used to
@@ -2570,8 +2572,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
     if (this.configId) {
       config.updateRunning = this.saveAndRun && Boolean(this.isCrawlRunning);
     }
-
-    this.isSubmitting = true;
 
     try {
       const data = await (this.configId

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1066,6 +1066,7 @@ https://replayweb.page/docs`}
       accept=".${SEED_LIST_FILE_EXT}"
       .files=${this.formState.seedFile ? [this.formState.seedFile] : null}
       drop
+      openFile
     >
       <sl-icon
         name="file-earmark-arrow-up"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -138,7 +138,7 @@ import {
 
 type CrawlConfigParams = WorkflowParams & {
   config: WorkflowParams["config"] & {
-    seeds: Seed[];
+    seeds: Seed[] | null;
     seedFileId?: string | null;
   };
 };
@@ -3024,12 +3024,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "useSitemap"
     | "failOnFailedSeed"
   > {
+    const jsonSeeds = this.formState.seedListFormat === SeedListFormat.JSON;
+
     const config = {
-      seeds: urlListToArray(this.formState.urlList).map((seedUrl) => {
-        const newSeed: Seed = { url: seedUrl, scopeType: ScopeType.Page };
-        return newSeed;
-      }),
-      seedFileId: uploadParams?.seedFileId ?? this.formState.seedFileId,
+      seeds: jsonSeeds
+        ? urlListToArray(this.formState.urlList).map((seedUrl) => {
+            const newSeed: Seed = { url: seedUrl, scopeType: ScopeType.Page };
+            return newSeed;
+          })
+        : null,
+      seedFileId: jsonSeeds
+        ? null
+        : uploadParams?.seedFileId ?? this.formState.seedFileId,
       scopeType: ScopeType.Page,
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
       useSitemap: false,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2742,7 +2742,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       },
       crawlerChannel: this.formState.crawlerChannel || "default",
       proxyId: this.formState.proxyId,
-      seedFile: null,
+      seedFileId: null,
     };
 
     return config;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1067,6 +1067,7 @@ https://replayweb.page/docs`}
       .files=${this.formState.seedFile ? [this.formState.seedFile] : null}
       drop
       openFile
+      required
     >
       <sl-icon
         name="file-earmark-arrow-up"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1066,14 +1066,16 @@ https://replayweb.page/docs`}
   private readonly renderSeedListFileUpload = () => {
     const file = this.initialSeedFile;
 
-    if (!this.formState.seedFile && file) {
+    if (this.formState.seedFileId && file) {
       return html`<btrix-file-list>
         <btrix-file-list-item
           name=${file.originalFilename}
           size=${file.size}
           href=${file.path}
           @btrix-remove=${() => {
-            console.log("TODO");
+            this.updateFormState({
+              seedFileId: null,
+            });
           }}
         ></btrix-file-list-item>
       </btrix-file-list>`;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1012,7 +1012,10 @@ https://replayweb.page/docs`}
 
         if (text) {
           const textBlob = new Blob([text]);
-          if (textBlob.size > MAX_SEED_LIST_STRING_BYTES) {
+          if (
+            textBlob.size > MAX_SEED_LIST_STRING_BYTES ||
+            text.split(/\n/).length > URL_LIST_MAX_URLS
+          ) {
             const file = new File([textBlob], DEFAULT_SEED_LIST_FILE_NAME, {
               type: "text/plain",
             });

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1039,7 +1039,8 @@ https://replayweb.page/docs`}
         const text = `${(e.currentTarget as SlTextarea).value}
           ${e.clipboardData?.getData("text")}`
           // Remove zero-width characters
-          .replace(/[\u200B-\u200D\uFEFF]/g, "");
+          .replace(/[\u200B-\u200D\uFEFF]/g, "")
+          .trim();
 
         if (text) {
           const textBlob = new Blob([text]);

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -115,9 +115,9 @@ import {
   appDefaults,
   BYTES_PER_GB,
   DEFAULT_AUTOCLICK_SELECTOR,
-  DEFAULT_SEED_LIST_FILE_NAME,
   DEFAULT_SELECT_LINKS,
   defaultLabel,
+  defaultSeedListFileName,
   getDefaultFormState,
   getInitialFormState,
   getServerDefaults,
@@ -1016,7 +1016,7 @@ https://replayweb.page/docs`}
             textBlob.size > MAX_SEED_LIST_STRING_BYTES ||
             text.split(/\n/).length > URL_LIST_MAX_URLS
           ) {
-            const file = new File([textBlob], DEFAULT_SEED_LIST_FILE_NAME, {
+            const file = new File([textBlob], defaultSeedListFileName(), {
               type: "text/plain",
             });
 
@@ -1067,15 +1067,13 @@ https://replayweb.page/docs`}
     return html`<btrix-file-input
       id="seedUrlList"
       accept=".${SEED_LIST_FILE_EXT}"
+      max=${MAX_SEED_LIST_FILE_BYTES}
       .files=${this.formState.seedFile ? [this.formState.seedFile] : null}
       drop
       openFile
       required
     >
-      <sl-icon
-        name="file-earmark-arrow-up"
-        class="text-xl text-neutral-400"
-      ></sl-icon>
+      <sl-icon name="file-earmark-arrow-up"></sl-icon>
       <p class="mt-1 text-pretty text-center">
         ${msg(html`Drag file here or ${browseFilesButton}`)}
       </p>
@@ -2185,7 +2183,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private hasRequiredFields(): boolean {
     if (isPageScopeType(this.formState.scopeType)) {
-      return Boolean(this.formState.urlList);
+      return Boolean(
+        this.formState.seedListFormat === SeedListFormat.File
+          ? this.formState.seedFile
+          : this.formState.urlList,
+      );
     }
 
     return Boolean(this.formState.primarySeedUrl);

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2801,7 +2801,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             : e.details;
 
           if (typeof errorDetail === "string") {
-            let errorDetailMessage = errorDetail.replace(/_/, " ");
+            let errorDetailMessage = errorDetail.replace(/_/g, " ");
 
             if (isApiErrorDetail(errorDetail)) {
               switch (errorDetail) {
@@ -2818,12 +2818,17 @@ https://archiveweb.page/images/${"logo.svg"}`}
                 case APIErrorDetail.InvalidLang:
                   errorDetailMessage = msg("Invalid language code");
                   break;
+                case APIErrorDetail.UseOneOfSeedsOrSeedFile:
+                  errorDetailMessage = msg(
+                    "Remove URL list file, or delete entered URLs",
+                  );
+                  break;
                 default:
                   break;
               }
             }
 
-            this.serverError = `${msg("Please fix the following issue: ")} ${errorDetailMessage}`;
+            this.serverError = `${msg("Please fix the following issue:")} ${errorDetailMessage}`;
           }
         }
       } else {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2246,7 +2246,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     if (isPageScopeType(this.formState.scopeType)) {
       return Boolean(
         this.formState.seedListFormat === SeedListFormat.File
-          ? this.formState.seedFile
+          ? this.formState.seedFile || this.formState.seedFileId
           : this.formState.urlList,
       );
     }
@@ -2586,20 +2586,23 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
     this.isSubmitting = true;
 
-    const parseConfigParams: Parameters<WorkflowEditor["parseConfig"]>[0] = {};
+    const uploadParams: Parameters<WorkflowEditor["parseConfig"]>[0] = {};
 
     // Upload seed file first if it exists, since ID will be used to
     // create/update the workflow
-    if (this.formState.seedListFormat === SeedListFormat.File) {
+    if (
+      this.formState.seedListFormat === SeedListFormat.File &&
+      this.formState.seedFile
+    ) {
       try {
-        parseConfigParams.seedFileId = await this.uploadSeedFile();
+        uploadParams.seedFileId = await this.uploadSeedFile();
       } catch {
         return;
       }
     }
 
     const config: CrawlConfigParams & WorkflowRunParams = {
-      ...this.parseConfig(parseConfigParams),
+      ...this.parseConfig(uploadParams),
       runNow: this.saveAndRun && !this.isCrawlRunning,
     };
 
@@ -2895,7 +2898,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         const newSeed: Seed = { url: seedUrl, scopeType: ScopeType.Page };
         return newSeed;
       }),
-      seedFileId: uploadParams?.seedFileId,
+      seedFileId: uploadParams?.seedFileId ?? this.formState.seedFileId,
       scopeType: ScopeType.Page,
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
       useSitemap: false,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -737,8 +737,16 @@ export class WorkflowEditor extends BtrixElement {
     `;
 
     return html`
-      <div class="mb-10 flex flex-col gap-12 px-2">
+      <div class="relative mb-10 flex flex-col gap-12 px-2">
         ${this.formSections.map(formSection)}
+        ${when(
+          this.isSubmitting,
+          () =>
+            // Show loading overlay to disable form on submit
+            html`<sl-animation name="fadeIn" duration="150" iterations="1" play>
+              <div class="absolute inset-0 z-50 bg-white/50"></div>
+            </sl-animation>`,
+        )}
       </div>
     `;
   }

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -19,6 +19,7 @@ import "./components";
 import "./features";
 import "./pages";
 
+import { docsUrlContext } from "./context/docs-url";
 import { viewStateContext } from "./context/view-state";
 import { OrgTab, RouteNamespace } from "./routes";
 import type { UserInfo, UserOrg } from "./types/user";
@@ -78,6 +79,7 @@ export class App extends BtrixElement {
   /**
    * Base URL for user guide documentation
    */
+  @provide({ context: docsUrlContext })
   @property({ type: String })
   docsUrl = "/docs/";
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -869,7 +869,7 @@ export class WorkflowDetail extends BtrixElement {
           <btrix-workflow-editor
             .initialWorkflow=${this.workflow}
             .initialSeeds=${this.seeds.items}
-            .initialSeedFile=${this.seedFileTask.value}
+            .initialSeedFile=${this.seedFileTask.value || undefined}
             configId=${this.workflowId}
             @reset=${() => this.navigate.to(this.basePath)}
           ></btrix-workflow-editor>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -863,7 +863,7 @@ export class WorkflowDetail extends BtrixElement {
       <btrix-detail-page-title .item=${this.workflow}></btrix-detail-page-title>
     </header>
 
-    ${this.workflow && this.seeds
+    ${this.workflow && this.seeds && this.seedFileTask.value
       ? html`
           <btrix-workflow-editor
             .initialWorkflow=${this.workflow}
@@ -877,6 +877,7 @@ export class WorkflowDetail extends BtrixElement {
           Promise.all([
             this.workflowTask.taskComplete,
             this.seedsTask.taskComplete,
+            this.seedFileTask.taskComplete,
           ]).catch(this.renderPageError),
           this.renderLoading(),
         )}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -156,7 +156,8 @@ export class WorkflowDetail extends BtrixElement {
 
   private readonly seedFileTask = new Task(this, {
     task: async ([workflow], { signal }) => {
-      if (!workflow || !workflow.config.seedFileId) return;
+      if (!workflow) return;
+      if (!workflow.config.seedFileId) return null;
 
       return await this.getSeedFile(workflow.config.seedFileId, signal);
     },
@@ -863,7 +864,7 @@ export class WorkflowDetail extends BtrixElement {
       <btrix-detail-page-title .item=${this.workflow}></btrix-detail-page-title>
     </header>
 
-    ${this.workflow && this.seeds && this.seedFileTask.value
+    ${this.workflow && this.seeds && this.seedFileTask.value !== undefined
       ? html`
           <btrix-workflow-editor
             .initialWorkflow=${this.workflow}
@@ -878,7 +879,9 @@ export class WorkflowDetail extends BtrixElement {
             this.workflowTask.taskComplete,
             this.seedsTask.taskComplete,
             this.seedFileTask.taskComplete,
-          ]).catch(this.renderPageError),
+          ])
+            .catch(this.renderPageError)
+            .then(this.renderLoading),
           this.renderLoading(),
         )}
   `;

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -62,6 +62,7 @@ export class WorkflowsNew extends LiteElement {
         customBehaviors: [],
         clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
       },
+      seedFile: null,
       tags: [],
       crawlTimeout: null,
       maxCrawlSize: null,

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -62,7 +62,6 @@ export class WorkflowsNew extends LiteElement {
         customBehaviors: [],
         clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
       },
-      seedFileId: null,
       tags: [],
       crawlTimeout: null,
       maxCrawlSize: null,

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -62,7 +62,7 @@ export class WorkflowsNew extends LiteElement {
         customBehaviors: [],
         clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
       },
-      seedFile: null,
+      seedFileId: null,
       tags: [],
       crawlTimeout: null,
       maxCrawlSize: null,

--- a/frontend/src/stories/components/FileList.stories.ts
+++ b/frontend/src/stories/components/FileList.stories.ts
@@ -3,6 +3,11 @@ import { html } from "lit";
 
 import { renderComponent, type RenderProps } from "./FileList";
 
+const fileBlobs = [
+  new Blob(["example file content"]),
+  new Blob(["example file 2 content"]),
+];
+
 const meta = {
   title: "Components/File List",
   component: "btrix-file-list",
@@ -12,16 +17,43 @@ const meta = {
   decorators: (story) => html` <div class="m-5">${story()}</div>`,
   argTypes: {},
   args: {
-    files: [
-      new File([new Blob()], "file.txt"),
-      new File([new Blob()], "file-2.txt"),
-    ],
+    items: fileBlobs.map((blob, i) => ({
+      file: new File([blob], `file-${i + 1}.txt`),
+    })),
   },
 } satisfies Meta<RenderProps>;
 
 export default meta;
 type Story = StoryObj<RenderProps>;
 
+/**
+ * By default, the file list accepts an array of `File` objects, which are listed as removable items.
+ */
 export const Basic: Story = {
   args: {},
+};
+
+/**
+ * File-like objects can also be displayed as items.
+ */
+export const OverrideFile: Story = {
+  args: {
+    items: [
+      { name: "uploaded-file.txt", size: 5 * 1e6 },
+      { name: "uploaded-file-2.txt", size: 1500 * 1e6 },
+    ],
+  },
+};
+
+/**
+ * Files can viewed in a new tab by specifying the URL as `href`.
+ * Use `URL.createObjectURL` to view files without an associated remote URL.
+ */
+export const LinkToFile: Story = {
+  args: {
+    items: fileBlobs.map((blob, i) => ({
+      file: new File([blob], `file-${i + 1}.txt`),
+      href: URL.createObjectURL(blob),
+    })),
+  },
 };

--- a/frontend/src/stories/components/FileList.ts
+++ b/frontend/src/stories/components/FileList.ts
@@ -1,15 +1,23 @@
 import { html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import "@/components/ui/file-list";
 
-export type RenderProps = { files: File[] };
+import type { FileListItem } from "@/components/ui/file-list/file-list-item";
 
-export const renderComponent = ({ files }: Partial<RenderProps>) => {
+export type RenderProps = { items: Partial<FileListItem>[] };
+
+export const renderComponent = ({ items }: Partial<RenderProps>) => {
   return html`
     <btrix-file-list @btrix-remove=${console.log}>
-      ${files?.map(
-        (file) => html`
-          <btrix-file-list-item .file=${file}></btrix-file-list-item>
+      ${items?.map(
+        (item) => html`
+          <btrix-file-list-item
+            .file=${item.file}
+            name=${ifDefined(item.name)}
+            size=${ifDefined(item.size)}
+            href=${ifDefined(item.href)}
+          ></btrix-file-list-item>
         `,
       )}
     </btrix-file-list>

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -6,6 +6,7 @@ import { type FormState } from "@/utils/workflow";
 type Field = keyof FormState;
 
 export const infoTextFor = {
+  urlList: msg("The crawler will visit and record each URL listed here."),
   exclusions: msg(
     "Specify exclusion rules for what pages should not be visited.",
   ),

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -143,6 +143,11 @@
     display: inline-block;
     margin-bottom: var(--sl-spacing-3x-small);
   }
+  .form-control-label--required::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+    color: var(--sl-input-required-content-color);
+  }
   .form-help-text,
   btrix-tag-input::part(form-control-help-text),
   sl-input::part(form-control-help-text),

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -44,6 +44,7 @@ export enum APIErrorDetail {
   InvalidCustomBehavior = "invalid_custom_behavior",
   CustomBehaviorNotFound = "custom_behavior_not_found",
   CustomBehaviorBranchNotFound = "custom_behavior_branch_not_found",
+  UseOneOfSeedsOrSeedFile = "use_one_of_seeds_or_seedfile",
 }
 export const APIErrorDetailEnum = z.nativeEnum(APIErrorDetail);
 export type APIErrorDetailEnum = z.infer<typeof APIErrorDetailEnum>;

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { storageFileSchema } from "./storage";
+
 export enum CollectionAccess {
   Private = "private",
   Public = "public",
@@ -30,12 +32,7 @@ export const publicCollectionSchema = z.object({
   resources: z.array(z.string()),
   dateEarliest: z.string().datetime().nullable(),
   dateLatest: z.string().datetime().nullable(),
-  thumbnail: z
-    .object({
-      name: z.string(),
-      path: z.string().url(),
-    })
-    .nullable(),
+  thumbnail: storageFileSchema.nullable(),
   thumbnailSource: collectionThumbnailSourceSchema.nullable(),
   defaultThumbnailName: z.string().nullable(),
   crawlCount: z.number(),

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -59,6 +59,7 @@ export type WorkflowParams = {
   browserWindows: number;
   profileid: string | null;
   config: SeedConfig;
+  seedFile: string | null;
   tags: string[];
   crawlTimeout: number | null;
   maxCrawlSize: number | null;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -59,7 +59,6 @@ export type WorkflowParams = {
   browserWindows: number;
   profileid: string | null;
   config: SeedConfig;
-  seedFileId: string | null;
   tags: string[];
   crawlTimeout: number | null;
   maxCrawlSize: number | null;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -59,7 +59,7 @@ export type WorkflowParams = {
   browserWindows: number;
   profileid: string | null;
   config: SeedConfig;
-  seedFile: string | null;
+  seedFileId: string | null;
   tags: string[];
   crawlTimeout: number | null;
   maxCrawlSize: number | null;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -1,4 +1,5 @@
 import type { CrawlState } from "./crawlState";
+import type { StorageFile } from "./storage";
 
 export enum ScopeType {
   Prefix = "prefix",
@@ -32,6 +33,7 @@ type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 
 export type SeedConfig = Expand<
   Pick<Seed, "scopeType" | "include" | "exclude" | "limit" | "extraHops"> & {
+    seedFileId?: string | null;
     lang?: string | null;
     blockAds?: boolean;
     behaviorTimeout: number | null;
@@ -188,13 +190,7 @@ export type Crawl = ArchivedItemBase &
     scale: number;
     browserWindows: number;
     shouldPause: boolean | null;
-    resources?: {
-      name: string;
-      path: string;
-      hash: string;
-      size: number;
-      numReplicas: number;
-    }[];
+    resources?: (StorageFile & { numReplicas: number })[];
   };
 
 export type Upload = ArchivedItemBase & {

--- a/frontend/src/types/storage.ts
+++ b/frontend/src/types/storage.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const storageFileSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  path: z.string().url(),
+  hash: z.string(),
+  size: z.number(),
+  originalFilename: z.string(),
+  mime: z.string(),
+  created: z.string(),
+});
+
+export type StorageFile = z.infer<typeof storageFileSchema>;

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,3 +1,5 @@
+import type { StorageFile } from "./storage";
+
 import { ScopeType } from "@/types/crawler";
 
 export enum NewWorkflowOnlyScopeType {
@@ -13,4 +15,9 @@ export type WorkflowTag = {
 
 export type WorkflowTags = {
   tags: WorkflowTag[];
+};
+
+export type StorageSeedFile = StorageFile & {
+  firstSeed: string;
+  seedCount: number;
 };

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -107,6 +107,7 @@ export type FormState = {
   primarySeedUrl: string;
   urlList: string;
   seedListFormat: SeedListFormat;
+  seedFileId: string | null;
   seedFile: File | null;
   includeLinkedPages: boolean;
   useSitemap: boolean;
@@ -168,6 +169,7 @@ export const getDefaultFormState = (): FormState => ({
   primarySeedUrl: "",
   urlList: "",
   seedListFormat: SeedListFormat.JSON,
+  seedFileId: null,
   seedFile: null,
   includeLinkedPages: false,
   useSitemap: false,
@@ -250,6 +252,7 @@ export function getInitialFormState(params: {
     formState.useSitemap = seedsConfig.useSitemap;
   } else {
     if (params.initialWorkflow.config.seedFileId) {
+      formState.seedFileId = params.initialWorkflow.config.seedFileId;
       formState.scopeType = WorkflowScopeType.PageList;
       formState.seedListFormat = SeedListFormat.File;
     } else if (params.initialSeeds?.length) {

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -27,7 +27,6 @@ export const BYTES_PER_GB = 1e9;
 export const DEFAULT_SELECT_LINKS = ["a[href]->href" as const];
 export const DEFAULT_AUTOCLICK_SELECTOR = "a";
 export const SEED_LIST_FILE_EXT = "txt";
-export const DEFAULT_SEED_LIST_FILE_NAME = `url-list.${SEED_LIST_FILE_EXT}`;
 export const MAX_SEED_LIST_STRING_BYTES = 500 * 1000;
 export const MAX_SEED_LIST_FILE_BYTES = 25 * 1e6;
 
@@ -95,6 +94,13 @@ export function defaultLabel(value: unknown): string {
     return msg(str`Default: ${value}`);
   }
   return "";
+}
+
+export function defaultSeedListFileName() {
+  return `url-list-${new Date()
+    .toISOString()
+    .split(".")[0]
+    .replace(/[^0-9]/g, "")}.${SEED_LIST_FILE_EXT}`;
 }
 
 export type FormState = {

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -26,7 +26,10 @@ import localize, { getDefaultLang } from "@/utils/localize";
 export const BYTES_PER_GB = 1e9;
 export const DEFAULT_SELECT_LINKS = ["a[href]->href" as const];
 export const DEFAULT_AUTOCLICK_SELECTOR = "a";
-export const MAX_SEED_FILE_BYTES = 25 * 1e6;
+export const SEED_LIST_FILE_EXT = "txt";
+export const DEFAULT_SEED_LIST_FILE_NAME = `url-list.${SEED_LIST_FILE_EXT}`;
+export const MAX_SEED_LIST_STRING_BYTES = 500 * 1000;
+export const MAX_SEED_LIST_FILE_BYTES = 25 * 1e6;
 
 export const SECTIONS = [
   "scope",
@@ -98,6 +101,7 @@ export type FormState = {
   primarySeedUrl: string;
   urlList: string;
   seedListFormat: SeedListFormat;
+  seedFile: File | null;
   includeLinkedPages: boolean;
   useSitemap: boolean;
   failOnFailedSeed: boolean;
@@ -158,6 +162,7 @@ export const getDefaultFormState = (): FormState => ({
   primarySeedUrl: "",
   urlList: "",
   seedListFormat: SeedListFormat.JSON,
+  seedFile: null,
   includeLinkedPages: false,
   useSitemap: false,
   failOnFailedSeed: false,
@@ -246,9 +251,10 @@ export function getInitialFormState(params: {
       }
 
       formState.urlList = mapSeedToUrl(params.initialSeeds).join("\n");
-
-      // TODO Check if file
-      // formState.seedUrlListType = SeedUrlList.File
+    } else if (params.initialWorkflow.seedFile) {
+      // TODO Convert file
+      // formState.seedFile = params.initialWorkflow.seedFile
+      formState.seedListFormat = SeedListFormat.File;
     }
 
     formState.failOnFailedSeed = seedsConfig.failOnFailedSeed;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -249,7 +249,10 @@ export function getInitialFormState(params: {
     }
     formState.useSitemap = seedsConfig.useSitemap;
   } else {
-    if (params.initialSeeds?.length) {
+    if (params.initialWorkflow.config.seedFileId) {
+      formState.scopeType = WorkflowScopeType.PageList;
+      formState.seedListFormat = SeedListFormat.File;
+    } else if (params.initialSeeds?.length) {
       if (params.initialSeeds.length === 1) {
         formState.scopeType = WorkflowScopeType.Page;
       } else {

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -26,6 +26,7 @@ import localize, { getDefaultLang } from "@/utils/localize";
 export const BYTES_PER_GB = 1e9;
 export const DEFAULT_SELECT_LINKS = ["a[href]->href" as const];
 export const DEFAULT_AUTOCLICK_SELECTOR = "a";
+export const MAX_SEED_FILE_BYTES = 25 * 1e6;
 
 export const SECTIONS = [
   "scope",
@@ -45,6 +46,11 @@ export enum GuideHash {
   BrowserSettings = "browser-settings",
   Scheduling = "scheduling",
   Metadata = "metadata",
+}
+
+export enum SeedUrlList {
+  Text = "text",
+  File = "file",
 }
 
 export const workflowTabToGuideHash: Record<SectionsEnum, GuideHash> = {
@@ -91,6 +97,7 @@ export function defaultLabel(value: unknown): string {
 export type FormState = {
   primarySeedUrl: string;
   urlList: string;
+  seedUrlListType: SeedUrlList;
   includeLinkedPages: boolean;
   useSitemap: boolean;
   failOnFailedSeed: boolean;
@@ -150,6 +157,7 @@ export const appDefaults: WorkflowDefaults = {
 export const getDefaultFormState = (): FormState => ({
   primarySeedUrl: "",
   urlList: "",
+  seedUrlListType: SeedUrlList.File,
   includeLinkedPages: false,
   useSitemap: false,
   failOnFailedSeed: false,
@@ -238,6 +246,9 @@ export function getInitialFormState(params: {
       }
 
       formState.urlList = mapSeedToUrl(params.initialSeeds).join("\n");
+
+      // TODO Check if file
+      // formState.seedUrlListType = SeedUrlList.File
     }
 
     formState.failOnFailedSeed = seedsConfig.failOnFailedSeed;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -97,7 +97,7 @@ export function defaultLabel(value: unknown): string {
 }
 
 export function defaultSeedListFileName() {
-  return `url-list-${new Date()
+  return `URL-List-${new Date()
     .toISOString()
     .split(".")[0]
     .replace(/[^0-9]/g, "")}.${SEED_LIST_FILE_EXT}`;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -48,8 +48,8 @@ export enum GuideHash {
   Metadata = "metadata",
 }
 
-export enum SeedUrlList {
-  Text = "text",
+export enum SeedListFormat {
+  JSON = "json",
   File = "file",
 }
 
@@ -97,7 +97,7 @@ export function defaultLabel(value: unknown): string {
 export type FormState = {
   primarySeedUrl: string;
   urlList: string;
-  seedUrlListType: SeedUrlList;
+  seedListFormat: SeedListFormat;
   includeLinkedPages: boolean;
   useSitemap: boolean;
   failOnFailedSeed: boolean;
@@ -157,7 +157,7 @@ export const appDefaults: WorkflowDefaults = {
 export const getDefaultFormState = (): FormState => ({
   primarySeedUrl: "",
   urlList: "",
-  seedUrlListType: SeedUrlList.File,
+  seedListFormat: SeedListFormat.JSON,
   includeLinkedPages: false,
   useSitemap: false,
   failOnFailedSeed: false,

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -251,7 +251,7 @@ export function getInitialFormState(params: {
       }
 
       formState.urlList = mapSeedToUrl(params.initialSeeds).join("\n");
-    } else if (params.initialWorkflow.seedFile) {
+    } else if (params.initialWorkflow.seedFileId) {
       // TODO Convert file
       // formState.seedFile = params.initialWorkflow.seedFile
       formState.seedListFormat = SeedListFormat.File;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -257,10 +257,6 @@ export function getInitialFormState(params: {
       }
 
       formState.urlList = mapSeedToUrl(params.initialSeeds).join("\n");
-    } else if (params.initialWorkflow.seedFileId) {
-      // TODO Convert file
-      // formState.seedFile = params.initialWorkflow.seedFile
-      formState.seedListFormat = SeedListFormat.File;
     }
 
     formState.failOnFailedSeed = seedsConfig.failOnFailedSeed;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2646
Depends on https://github.com/webrecorder/browsertrix/pull/2710

## Changes

Allows users to specify URL list as file.

## Manual testing

If running backend locally, backend should be built from `issue-2673-seed-file-backend-support`.

To test existing file:
1. Log in as crawler
2. Go to New Workflow
3. Choose "List of Pages" as Crawl Scope
4. Click "Upload URL List"
5. Click "Save". Verify workflow does not save, and validation message is displayed
6. Drag or choose URL list file
7. Click box-arrow icon to view file. Verify file loads as expected
8. Click "Save". Verify workflow saves
9. Click "Settings". Verify file is shown under Page URLs
10. Click box-arrow icon to view file. Verify file loads as expected
11. Go to edit workflow
12. Remove file and attempt to save. Verify workflow does not save, and validation message is displayed

To test paste:
1. Go to New Workflow
2. Paste > 100 URLs into "Enter URLs". Verify list is converted to a file
3. Remove file
4. Paste > 500 kB into "Enter URLs". Verify list is converted to a file

Repeat tests for editing a workflow.

Additionally, regression test typing in page URLs.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Editor | **File upload**<br /><img width="548" height="198" alt="Screenshot 2025-07-15 at 5 00 05 PM" src="https://github.com/user-attachments/assets/f202750b-24d4-4ac6-bc3c-b98555553dfb" /> |
| Workflow Editor | **From paste**<br /><img width="545" height="161" alt="Screenshot 2025-07-15 at 4 59 35 PM" src="https://github.com/user-attachments/assets/1e39d041-56d6-4053-a71f-0b1c5233f8ab" /> |
| Workflow Editor | **Removing existing file**<br /><img width="547" height="216" alt="Screenshot 2025-07-15 at 4 58 51 PM" src="https://github.com/user-attachments/assets/1f6065a4-3b61-49ad-9af9-c44a8439c2d9" /> |
| Workflow Settings | **User provided file**<br /><img width="929" height="267" alt="Screenshot 2025-07-15 at 5 02 55 PM" src="https://github.com/user-attachments/assets/adcd24b7-9d78-42e7-a406-5e2407acd44b" /> |
| Workflow Settings | **File from paste**<br /><img width="931" height="259" alt="Screenshot 2025-07-15 at 5 02 08 PM" src="https://github.com/user-attachments/assets/e564a218-047f-474e-b1c8-dbcb8fac52cf" /> |


## Follow-ups

Duplicating seed files in workflows will be handled in https://github.com/webrecorder/browsertrix/issues/2732
