### PR TITLE
fix: Refresh workflow crawls list when workflow status changes

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -195,10 +195,13 @@ export class WorkflowDetail extends BtrixElement {
 
       return window.setTimeout(async () => {
         void this.workflowTask.run();
-        await this.workflowTask.taskComplete;
+        const currWorkflow = await this.workflowTask.taskComplete;
 
         // Retrieve additional data based on current tab
-        if (this.isRunning) {
+        if (
+          this.isRunning ||
+          workflow.isCrawlRunning !== currWorkflow.isCrawlRunning
+        ) {
           switch (this.groupedWorkflowTab) {
             case WorkflowTab.LatestCrawl: {
               void this.latestCrawlTask.run();

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1165,12 +1165,9 @@ export class WorkflowDetail extends BtrixElement {
               : seconds > 60
                 ? html`<sl-relative-time
                     sync
-                    format="narrow"
                     date=${dateStr}
                   ></sl-relative-time>`
-                : seconds > POLL_INTERVAL_SECONDS
-                  ? `<${this.localize.relativeTime(-1, "minute")}`
-                  : msg("Now")}
+                : `<${this.localize.relativeTime(-1, "minute", { style: "narrow" })}`}
           </span>
         </sl-tooltip>
       `;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -176,7 +176,7 @@ export class WorkflowDetail extends BtrixElement {
 
       return await this.getCrawls(workflowId, crawlsParams, signal);
     },
-    args: () => [this.workflowId, this.crawlsParams] as const,
+    args: () => [this.workflowId, this.crawlsParams, this.lastCrawlId] as const,
   });
 
   private readonly pollTask = new Task(this, {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -197,34 +197,32 @@ export class WorkflowDetail extends BtrixElement {
         void this.workflowTask.run();
         const currWorkflow = await this.workflowTask.taskComplete;
 
-        // Refresh all tabs when crawl ends
         const crawlChanged =
-          workflow.isCrawlRunning !== currWorkflow.isCrawlRunning ||
+          workflow.lastCrawlState !== currWorkflow.lastCrawlState ||
           // Handle edge case where workflow may have finished and started
           // within the same poll interval:
-          workflow.id !== currWorkflow.id;
+          workflow.lastCrawlId !== currWorkflow.lastCrawlId;
 
-        if (crawlChanged) {
+        // Retrieve additional data based on current tab
+        if (this.isRunning) {
+          switch (this.groupedWorkflowTab) {
+            case WorkflowTab.LatestCrawl: {
+              void this.latestCrawlTask.run();
+              void this.logTotalsTask.run();
+              break;
+            }
+            case WorkflowTab.Crawls: {
+              void this.crawlsTask.run();
+              break;
+            }
+            default:
+              break;
+          }
+        } else if (crawlChanged) {
+          // Refresh all data
           void this.latestCrawlTask.run();
           void this.logTotalsTask.run();
           void this.crawlsTask.run();
-        } else {
-          // Retrieve additional data based on current tab
-          if (this.isRunning) {
-            switch (this.groupedWorkflowTab) {
-              case WorkflowTab.LatestCrawl: {
-                void this.latestCrawlTask.run();
-                void this.logTotalsTask.run();
-                break;
-              }
-              case WorkflowTab.Crawls: {
-                void this.crawlsTask.run();
-                break;
-              }
-              default:
-                break;
-            }
-          }
         }
       }, POLL_INTERVAL_SECONDS * 1000);
     },


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2690

## Changes

- Refreshes crawls list on workflow status change to fix stale crawls being displayed
- Adds "Started" and "Finished" prefix to "Last Run" value 

## Manual testing

Test using repro steps in https://github.com/webrecorder/browsertrix/issues/2690

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow detail (running) | <img width="172" alt="Screenshot 2025-06-26 at 12 14 15 PM" src="https://github.com/user-attachments/assets/3cbd81f6-43a5-46a1-99f0-f57ee21605cb" /> |
| Workflow detail (finished) | <img width="201" alt="Screenshot 2025-06-26 at 12 13 50 PM" src="https://github.com/user-attachments/assets/758d7115-bbbb-4f4f-bd8b-6c697de843ab" /> |


<!-- ## Follow-ups -->
