### PR TITLE
fix: Show latest crawl logs for failed workflows

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -244,7 +244,7 @@ export class WorkflowListItem extends BtrixElement {
         }
         e.preventDefault();
         await this.updateComplete;
-        const href = `/orgs/${this.orgSlugState}/workflows/${this.workflow?.id}/${WorkflowTab.LatestCrawl}`;
+        const href = `/orgs/${this.orgSlugState}/workflows/${this.workflow?.id}/${this.workflow?.lastCrawlState === "failed" ? WorkflowTab.Logs : WorkflowTab.LatestCrawl}`;
         this.navigate.to(href);
       }}
     >

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1872,12 +1872,46 @@ export class WorkflowDetail extends BtrixElement {
     let message = msg("This workflow hasn’t been run yet.");
 
     if (this.lastCrawlId) {
-      if (this.workflow.lastCrawlState === "canceled") {
-        message = msg("This crawl can’t be replayed since it was canceled.");
-      } else {
-        message = msg("Replay is not available for this crawl.");
+      switch (this.workflow.lastCrawlState) {
+        case "canceled":
+          message = msg("This crawl can’t be replayed since it was canceled.");
+          break;
+        case "failed":
+          message = msg("This crawl can’t be replayed because it failed.");
+          break;
+        default:
+          message = msg("Replay is not available for this crawl.");
+          break;
       }
     }
+
+    const actionButton = (workflow: Workflow) => {
+      if (!workflow.lastCrawlId) return;
+
+      if (workflow.lastCrawlState === "failed") {
+        return html`<div class="mt-4">
+          <sl-button
+            size="small"
+            href="${this.basePath}/logs"
+            @click=${this.navigate.link}
+          >
+            ${msg("View Error Logs")}
+            <sl-icon slot="prefix" name="terminal-fill"></sl-icon>
+          </sl-button>
+        </div>`;
+      }
+
+      return html`<div class="mt-4">
+        <sl-button
+          size="small"
+          href="${this.basePath}/crawls/${workflow.lastCrawlId}"
+          @click=${this.navigate.link}
+        >
+          ${msg("View Crawl Details")}
+          <sl-icon slot="suffix" name="arrow-right"></sl-icon>
+        </sl-button>
+      </div>`;
+    };
 
     return html`
       <section
@@ -1889,20 +1923,7 @@ export class WorkflowDetail extends BtrixElement {
           this.isCrawler && !this.lastCrawlId,
           () => html`<div class="mt-4">${this.renderRunNowButton()}</div>`,
         )}
-        ${when(
-          this.lastCrawlId,
-          (id) =>
-            html`<div class="mt-4">
-              <sl-button
-                size="small"
-                href="${this.basePath}/crawls/${id}"
-                @click=${this.navigate.link}
-              >
-                ${msg("View Crawl Details")}
-                <sl-icon slot="suffix" name="arrow-right"></sl-icon>
-              </sl-button>
-            </div>`,
-        )}
+        ${when(this.workflow, actionButton)}
       </section>
     `;
   }

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -33,11 +33,15 @@ export function isActive({ state }: Partial<Crawl | QARun>) {
   return (activeCrawlStates as readonly (typeof state)[]).includes(state);
 }
 
-export function isSuccessfullyFinished({ state }: { state: string }) {
+export function isSuccessfullyFinished({ state }: { state: string | null }) {
   return state && (SUCCESSFUL_STATES as readonly string[]).includes(state);
 }
 
-export function isNotFailed({ state }: { state: string }) {
+export function isSkipped({ state }: { state: string | null }) {
+  return state?.startsWith("skipped");
+}
+
+export function isNotFailed({ state }: { state: string | null }) {
   return (
     state && !(FAILED_STATES as readonly string[]).some((str) => str === state)
   );


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2692

## Changes

Shows "Logs" tab for failed workflows, and links directly to logs when clicking a failed workflow in the workflow list.

## Manual testing

1. Go to "Crawling"
2. Click failed workflow. Verify navigation to "Logs" tab
3. Click "Replay" tab. Verify link to "View Error Logs" is shown
4. Click dropdown arrow next to "Download". Verify download item is disabled and logs are enabled
5. Regression test clicking into completed and canceled workflows

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow Detail (failed) | <img width="968" alt="Screenshot 2025-06-26 at 1 46 07 PM" src="https://github.com/user-attachments/assets/54a05202-232a-4498-ba73-03a60846592f" /> |


<!-- ## Follow-ups -->
