### PR TITLE
fix: Hide irrelevant tabs in failed crawl detail view

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -545,27 +545,33 @@ export class ArchivedItemDetail extends BtrixElement {
           iconLibrary: "default",
           icon: "info-circle-fill",
         })}
-        ${when(
-          this.itemType === "crawl" && this.isCrawler,
-          () => html`
-            ${renderNavItem({
-              section: "qa",
-              iconLibrary: "default",
-              icon: "clipboard2-data-fill",
-              detail: html`<btrix-beta-icon></btrix-beta-icon>`,
-            })}
-          `,
+        ${when(this.item, (item) =>
+          isSuccessfullyFinished(item)
+            ? html`
+                ${when(
+                  this.itemType === "crawl" && this.isCrawler,
+                  () => html`
+                    ${renderNavItem({
+                      section: "qa",
+                      iconLibrary: "default",
+                      icon: "clipboard2-data-fill",
+                      detail: html`<btrix-beta-icon></btrix-beta-icon>`,
+                    })}
+                  `,
+                )}
+                ${renderNavItem({
+                  section: "replay",
+                  iconLibrary: "app",
+                  icon: "replaywebpage",
+                })}
+                ${renderNavItem({
+                  section: "files",
+                  iconLibrary: "default",
+                  icon: "folder-fill",
+                })}
+              `
+            : nothing,
         )}
-        ${renderNavItem({
-          section: "replay",
-          iconLibrary: "app",
-          icon: "replaywebpage",
-        })}
-        ${renderNavItem({
-          section: "files",
-          iconLibrary: "default",
-          icon: "folder-fill",
-        })}
         ${when(
           this.itemType === "crawl",
           () => html`


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2693

## Changes

Hides QA, replay, and files tabs for failed ("failed", "canceled", and skipped) crawls.

## Manual testing

1. Click workflow with "Failed" status
2. Click "View Crawl Details". Verify only Overview, Logs, and Crawl Settings tabs are shown
3. Repeat 2 for workflows with "Canceled" and "Skipped" statuses

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl Detail | <img width="1281" alt="Screenshot 2025-06-26 at 1 57 17 PM" src="https://github.com/user-attachments/assets/01a71584-3548-44f8-b96a-9bfd874e05dd" /> |


<!-- ## Follow-ups -->
