### PR TITLE
Update radio button styles

### DIFF
--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -615,10 +615,14 @@ export class WorkflowsList extends BtrixElement {
                 ? "scheduled"
                 : "unscheduled"}
           >
-            <sl-radio-button value="all-schedules" pill>
-              <sl-icon name="asterisk" slot="prefix"></sl-icon>
-              ${msg("All Schedule States")}
-            </sl-radio-button>
+            <sl-tooltip content=${msg("All Schedule States")}>
+              <sl-radio-button value="all-schedules" pill>
+                <sl-icon
+                  name="asterisk"
+                  label=${msg("All Schedule States")}
+                ></sl-icon>
+              </sl-radio-button>
+            </sl-tooltip>
             <sl-radio-button value="scheduled" pill>
               <sl-icon name="calendar2-check" slot="prefix"></sl-icon>
               ${msg("Scheduled")}

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -580,7 +580,7 @@ export class WorkflowsList extends BtrixElement {
       </div>
       <div class="flex flex-wrap items-center justify-end gap-4">
         <label class="flex flex-wrap items-center" for="schedule-filter">
-          <span class="text-0-500 mr-2 whitespace-nowrap text-sm">
+          <span class="mr-2 whitespace-nowrap text-xs text-neutral-500">
             ${msg("Schedule:")}
           </span>
           <sl-radio-group

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -526,9 +526,68 @@ export class WorkflowsList extends BtrixElement {
       <div class="mb-2 flex flex-wrap items-center gap-2 md:gap-4">
         <div class="grow">${this.renderSearch()}</div>
 
+        <label class="flex flex-wrap items-center" for="schedule-filter">
+          <span class="mr-2 whitespace-nowrap text-sm text-neutral-500">
+            ${msg("Schedule:")}
+          </span>
+          <sl-radio-group
+            size="small"
+            id="schedule-filter"
+            @sl-change=${(e: SlChangeEvent) => {
+              const filter = (e.target as SlRadioGroup).value;
+              switch (filter) {
+                case "all-schedules":
+                  this.filterBy = {
+                    ...this.filterBy,
+                    schedule: undefined,
+                  };
+                  break;
+                case "scheduled":
+                  this.filterBy = {
+                    ...this.filterBy,
+                    schedule: true,
+                  };
+                  break;
+                case "unscheduled":
+                  this.filterBy = {
+                    ...this.filterBy,
+                    schedule: false,
+                  };
+                  break;
+              }
+            }}
+            value=${this.filterBy.schedule === undefined
+              ? "all-schedules"
+              : this.filterBy.schedule
+                ? "scheduled"
+                : "unscheduled"}
+          >
+            <sl-tooltip content=${msg("All Schedule States")}>
+              <sl-radio-button value="all-schedules" pill>
+                <sl-icon
+                  name="asterisk"
+                  label=${msg("All Schedule States")}
+                ></sl-icon>
+              </sl-radio-button>
+            </sl-tooltip>
+            <sl-radio-button value="unscheduled" pill>
+              <sl-icon
+                name="calendar2-x"
+                slot="prefix"
+                label=${msg("No Schedule")}
+              ></sl-icon>
+              ${msg("None")}
+            </sl-radio-button>
+            <sl-radio-button value="scheduled" pill>
+              <sl-icon name="calendar2-check" slot="prefix"></sl-icon>
+              ${msg("Scheduled")}
+            </sl-radio-button>
+          </sl-radio-group>
+        </label>
+
         <div class="flex w-full items-center md:w-fit">
           <label
-            class="text-0-500 mr-2 whitespace-nowrap text-sm"
+            class="mr-2 whitespace-nowrap text-sm text-neutral-500"
             for="sort-select"
           >
             ${msg("Sort by:")}
@@ -579,61 +638,6 @@ export class WorkflowsList extends BtrixElement {
         </div>
       </div>
       <div class="flex flex-wrap items-center justify-end gap-4">
-        <label class="flex flex-wrap items-center" for="schedule-filter">
-          <span class="mr-2 whitespace-nowrap text-xs text-neutral-500">
-            ${msg("Schedule:")}
-          </span>
-          <sl-radio-group
-            size="small"
-            id="schedule-filter"
-            @sl-change=${(e: SlChangeEvent) => {
-              const filter = (e.target as SlRadioGroup).value;
-              switch (filter) {
-                case "all-schedules":
-                  this.filterBy = {
-                    ...this.filterBy,
-                    schedule: undefined,
-                  };
-                  break;
-                case "scheduled":
-                  this.filterBy = {
-                    ...this.filterBy,
-                    schedule: true,
-                  };
-                  break;
-                case "unscheduled":
-                  this.filterBy = {
-                    ...this.filterBy,
-                    schedule: false,
-                  };
-                  break;
-              }
-            }}
-            value=${this.filterBy.schedule === undefined
-              ? "all-schedules"
-              : this.filterBy.schedule
-                ? "scheduled"
-                : "unscheduled"}
-          >
-            <sl-tooltip content=${msg("All Schedule States")}>
-              <sl-radio-button value="all-schedules" pill>
-                <sl-icon
-                  name="asterisk"
-                  label=${msg("All Schedule States")}
-                ></sl-icon>
-              </sl-radio-button>
-            </sl-tooltip>
-            <sl-radio-button value="scheduled" pill>
-              <sl-icon name="calendar2-check" slot="prefix"></sl-icon>
-              ${msg("Scheduled")}
-            </sl-radio-button>
-            <sl-radio-button value="unscheduled" pill>
-              <sl-icon name="calendar2-x" slot="prefix"></sl-icon>
-              ${msg("No Schedule")}
-            </sl-radio-button>
-          </sl-radio-group>
-        </label>
-
         <label>
           <span class="mr-1 text-xs text-neutral-500"
             >${msg("Show Only Running")}</span

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -174,18 +174,15 @@
   }
 
   sl-radio-button[checked]::part(button) {
-    background-color: theme(colors.primary.50);
-    border-color: theme(colors.primary.300);
-    color: theme(colors.primary.700);
+    @apply border-primary-300 bg-primary-50 text-primary-600;
   }
 
   sl-radio-button:not([checked]):not(disabled)::part(button):not(:hover) {
-    background-color: theme(colors.white);
-    color: theme(colors.neutral.700);
+    @apply bg-white text-neutral-600;
   }
 
   sl-radio-button:not([checked]):not(disabled):hover::part(button) {
-    background-color: theme(colors.primary.400);
+    @apply bg-primary-400;
   }
 
   sl-radio-button::part(label) {

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -174,7 +174,22 @@
   }
 
   sl-radio-button[checked]::part(button) {
-    background-color: theme(colors.primary.500);
+    background-color: theme(colors.primary.50);
+    border-color: theme(colors.primary.300);
+    color: theme(colors.primary.700);
+  }
+
+  sl-radio-button:not([checked]):not(disabled)::part(button):not(:hover) {
+    background-color: theme(colors.white);
+    color: theme(colors.neutral.700);
+  }
+
+  sl-radio-button:not([checked]):not(disabled):hover::part(button) {
+    background-color: theme(colors.primary.400);
+  }
+
+  sl-radio-button::part(label) {
+    @apply font-medium;
   }
 
   /* Elevate select and buttons */


### PR DESCRIPTION
The current radio buttons make the scheduled filters stand out a lot compared to the controls. I would suggestion either option, or a variation:

Option 1: Match "Scheduled:" label to other labels on the same line, make radio button selected state stand out less (and more distinguished from clickable buttons)
<img width="1256" alt="Screenshot 2025-06-26 at 4 12 29 PM" src="https://github.com/user-attachments/assets/6169a286-f1de-4cfb-9104-b026c8592695" />

Option 2: A bit of a bigger change suggested in https://github.com/webrecorder/browsertrix/pull/2697/commits/13de05aa130e11b0007b2c31dc9de3b36a556477 -- move schedule filter to line above to match other pill controls:
<img width="1259" alt="Screenshot 2025-06-26 at 4 12 05 PM" src="https://github.com/user-attachments/assets/d744ad05-d07a-43fd-8579-79e38d3c1a3c" />

Option 2 also circumvents [this issue](https://github.com/webrecorder/browsertrix/pull/2607#pullrequestreview-2964048843):

<img width="866" alt="Screenshot 2025-06-26 at 4 17 51 PM" src="https://github.com/user-attachments/assets/2165a8bd-3b14-43fe-bf70-85b7f7520908" />
