### PR TITLE
Use curly quote for default archive name instead of straight quote

### DIFF
--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -719,12 +719,12 @@ class OrgOps:
     async def set_default_org_name_from_user_name(
         self, org: Organization, user_name: str
     ) -> None:
-        """set's the org name and slug as "<USERNAME>'s Archive", adding a suffix for duplicates"""
+        """set's the org name and slug as "<USERNAME>’s Archive", adding a suffix for duplicates"""
         suffix = ""
         count = 1
 
         while True:
-            org.name = f"{user_name}'s Archive{suffix}"
+            org.name = f"{user_name}’s Archive{suffix}"
             org.slug = slug_from_name(org.name)
 
             try:

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -122,7 +122,7 @@ def test_validate_new_org_with_quotas_and_update_name(admin_auth_headers):
 
     data = r.json()
     assert data["slug"] == "test-users-archive"
-    assert data["name"] == "Test User's Archive"
+    assert data["name"] == "Test User’s Archive"
 
     assert data["quotas"] == {
         "maxPagesPerCrawl": 100,
@@ -239,7 +239,7 @@ def test_login_existing_user_for_invite():
     org = data["org"]
 
     assert org["id"] == new_subs_oid_2
-    assert org["name"] == "Test User's Archive 2"
+    assert org["name"] == "Test User’s Archive 2"
     assert org["slug"] == "test-users-archive-2"
 
     assert org["quotas"] == {


### PR DESCRIPTION
Tiny little thing that's been bugging me for a little while now. 