### PR TITLE
concurrent crawls: filter concurrent crawls check

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -757,7 +757,13 @@ class CrawlOperator(BaseOperator):
         if not max_crawls:
             return True
 
-        if len(data.related[CJS]) <= max_crawls:
+        active_crawls = 0
+        for crawl_job in data.related[CJS].values():
+            crawl_state = crawl_job.get("status", {}).get("state", "")
+            if crawl_state in RUNNING_AND_WAITING_STATES:
+                active_crawls += 1
+
+        if active_crawls <= max_crawls:
             return True
 
         name = data.parent.get("metadata", {}).get("name")


### PR DESCRIPTION
ensure concurrent crawls check only counts running or waiting crawls only, not all existing crawljobs