### PR TITLE
Remove workflows from GET profile endpoint + Add inUse flag

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -515,15 +515,6 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
 
 
 # ============================================================================
-class CrawlConfigProfileOut(BaseMongoModel):
-    """Crawl Config basic info for profiles"""
-
-    name: str
-    firstSeed: str
-    seedCount: int
-
-
-# ============================================================================
 class UpdateCrawlConfig(BaseModel):
     """Update crawl config name, crawl schedule, or tags"""
 
@@ -2319,12 +2310,7 @@ class Profile(BaseMongoModel):
     crawlerChannel: Optional[str] = None
     proxyId: Optional[str] = None
 
-
-# ============================================================================
-class ProfileWithCrawlConfigs(Profile):
-    """Profile with list of crawlconfigs using this profile"""
-
-    crawlconfigs: List[CrawlConfigProfileOut] = []
+    inUse: bool = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -588,12 +588,12 @@ def init_profiles_api(
 
         return {"updated": True}
 
-    @router.get("/{profileid}", response_model=ProfileWithCrawlConfigs)
+    @router.get("/{profileid}", response_model=Profile)
     async def get_profile(
         profileid: UUID,
         org: Organization = Depends(org_crawl_dep),
     ):
-        return await ops.get_profile_with_configs(profileid, org)
+        return await ops.get_profile(profileid, org)
 
     @router.delete("/{profileid}", response_model=SuccessResponseStorageQuota)
     async def delete_profile(

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -395,7 +395,7 @@ class ProfileOps:
         profile = await self.get_profile(profileid, org)
 
         if profile.inUse:
-            return {"error": "in_use"}
+            raise HTTPException(status_code=400, detail="profile_in_use")
 
         query: dict[str, object] = {"_id": profileid}
         if org:

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -1,5 +1,5 @@
 import { localized, msg, str } from "@lit/localize";
-import { html, nothing, type TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -16,7 +16,6 @@ import { pageNav } from "@/layouts/pageHeader";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 import { isArchivingDisabled } from "@/utils/orgs";
-import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 
 const DESCRIPTION_MAXLENGTH = 500;
@@ -555,7 +554,7 @@ export class BrowserProfilesDetail extends BtrixElement {
     const profileName = this.profile!.name;
 
     try {
-      const data = await this.api.fetch<Profile & { error: boolean }>(
+      await this.api.fetch<Profile & { error: boolean }>(
         `/orgs/${this.orgId}/profiles/${this.profile!.id}`,
         {
           method: "DELETE",

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -574,7 +574,7 @@ export class BrowserProfilesDetail extends BtrixElement {
       );
 
       if (isApiError(e)) {
-        if (e.details === "profile_in_use") {
+        if (e.message === "profile_in_use") {
           message = msg(
             html`Could not delete <strong>${profileName}</strong>, currently in
               use. Please remove browser profile from all crawl workflows to

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -554,20 +554,32 @@ export class BrowserProfilesDetail extends BtrixElement {
     const profileName = this.profile!.name;
 
     try {
-      await this.api.fetch<Profile & { error: boolean }>(
+      const data = await this.api.fetch<Profile & { error: boolean }>(
         `/orgs/${this.orgId}/profiles/${this.profile!.id}`,
         {
           method: "DELETE",
         },
       );
 
-      this.navigate.to(`${this.navigate.orgBasePath}/browser-profiles`);
+      if (data.error && data.inUse) {
+        this.notify.toast({
+          message: msg(
+            html`Could not delete <strong>${profileName}</strong>, currently in
+              use. Please remove browser profile from all Crawl Workflows to
+              continue.`,
+          ),
+          variant: "warning",
+          duration: 15000,
+        });
+      } else {
+        this.navigate.to(`${this.navigate.orgBasePath}/browser-profiles`);
 
-      this.notify.toast({
-        message: msg(html`Deleted <strong>${profileName}</strong>.`),
-        variant: "success",
-        icon: "check2-circle",
-      });
+        this.notify.toast({
+          message: msg(html`Deleted <strong>${profileName}</strong>.`),
+          variant: "success",
+          icon: "check2-circle",
+        });
+      }
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't delete browser profile at this time."),

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -6,7 +6,7 @@ import { when } from "lit/directives/when.js";
 import capitalize from "lodash/fp/capitalize";
 import queryString from "query-string";
 
-import type { Profile, ProfileWorkflow } from "./types";
+import type { Profile } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
@@ -263,17 +263,6 @@ export class BrowserProfilesDetail extends BtrixElement {
         >
       </section>
 
-      <section class="mb-7">
-        <h2 class="mb-2 text-lg font-medium leading-none">
-          ${msg("Crawl Workflows")}${this.profile?.crawlconfigs?.length
-            ? html`<span class="font-normal text-neutral-500">
-                (${this.localize.number(this.profile.crawlconfigs.length)})
-              </span>`
-            : nothing}
-        </h2>
-        ${this.renderCrawlWorkflows()}
-      </section>
-
       <btrix-dialog id="discardChangesDialog" .label=${msg("Cancel Editing?")}>
         ${msg(
           "Are you sure you want to discard changes to this browser profile?",
@@ -321,52 +310,6 @@ export class BrowserProfilesDetail extends BtrixElement {
     ];
 
     return pageNav(breadcrumbs);
-  }
-
-  private renderCrawlWorkflows() {
-    if (this.profile?.crawlconfigs?.length) {
-      return html`<ul>
-        ${this.profile.crawlconfigs.map(
-          (workflow) => html`
-            <li
-              class="border-x border-b first:rounded-t first:border-t last:rounded-b"
-            >
-              <a
-                class="block p-2 transition-colors focus-within:bg-neutral-50 hover:bg-neutral-50"
-                href=${`${this.navigate.orgBasePath}/workflows/${workflow.id}`}
-                @click=${this.navigate.link}
-              >
-                ${this.renderWorkflowName(workflow)}
-              </a>
-            </li>
-          `,
-        )}
-      </ul>`;
-    }
-
-    return html`<div class="rounded border p-5 text-center text-neutral-400">
-      ${msg("Not used in any crawl workflows.")}
-    </div>`;
-  }
-
-  private renderWorkflowName(workflow: ProfileWorkflow) {
-    if (workflow.name)
-      return html`<span class="truncate">${workflow.name}</span>`;
-    if (!workflow.firstSeed)
-      return html`<span class="truncate font-mono">${workflow.id}</span>
-        <span class="text-neutral-400">${msg("(no name)")}</span>`;
-    const remainder = workflow.seedCount - 1;
-    let nameSuffix: string | TemplateResult<1> = "";
-    if (remainder) {
-      nameSuffix = html`<span class="ml-2 text-neutral-500"
-        >+${this.localize.number(remainder, { notation: "compact" })}
-        ${pluralOf("URLs", remainder)}</span
-      >`;
-    }
-    return html`
-      <span class="primaryUrl truncate">${workflow.firstSeed}</span
-      >${nameSuffix}
-    `;
   }
 
   private readonly renderVisitedSites = () => {
@@ -619,26 +562,13 @@ export class BrowserProfilesDetail extends BtrixElement {
         },
       );
 
-      if (data.error && data.crawlconfigs) {
-        this.notify.toast({
-          message: msg(
-            html`Could not delete <strong>${profileName}</strong>, in use by
-              <strong
-                >${data.crawlconfigs.map(({ name }) => name).join(", ")}</strong
-              >. Please remove browser profile from Workflow to continue.`,
-          ),
-          variant: "warning",
-          duration: 15000,
-        });
-      } else {
-        this.navigate.to(`${this.navigate.orgBasePath}/browser-profiles`);
+      this.navigate.to(`${this.navigate.orgBasePath}/browser-profiles`);
 
-        this.notify.toast({
-          message: msg(html`Deleted <strong>${profileName}</strong>.`),
-          variant: "success",
-          icon: "check2-circle",
-        });
-      }
+      this.notify.toast({
+        message: msg(html`Deleted <strong>${profileName}</strong>.`),
+        variant: "success",
+        icon: "check2-circle",
+      });
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't delete browser profile at this time."),

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -554,35 +554,36 @@ export class BrowserProfilesDetail extends BtrixElement {
     const profileName = this.profile!.name;
 
     try {
-      const data = await this.api.fetch<Profile & { error: boolean }>(
+      await this.api.fetch<Profile>(
         `/orgs/${this.orgId}/profiles/${this.profile!.id}`,
         {
           method: "DELETE",
         },
       );
 
-      if (data.error && data.inUse) {
-        this.notify.toast({
-          message: msg(
-            html`Could not delete <strong>${profileName}</strong>, currently in
-              use. Please remove browser profile from all Crawl Workflows to
-              continue.`,
-          ),
-          variant: "warning",
-          duration: 15000,
-        });
-      } else {
-        this.navigate.to(`${this.navigate.orgBasePath}/browser-profiles`);
+      this.navigate.to(`${this.navigate.orgBasePath}/browser-profiles`);
 
-        this.notify.toast({
-          message: msg(html`Deleted <strong>${profileName}</strong>.`),
-          variant: "success",
-          icon: "check2-circle",
-        });
-      }
-    } catch (e) {
       this.notify.toast({
-        message: msg("Sorry, couldn't delete browser profile at this time."),
+        message: msg(html`Deleted <strong>${profileName}</strong>.`),
+        variant: "success",
+        icon: "check2-circle",
+      });
+    } catch (e) {
+      let message = msg(
+        html`Sorry, couldn't delete browser profile at this time.`,
+      );
+
+      if (isApiError(e)) {
+        if (e.details === "profile_in_use") {
+          message = msg(
+            html`Could not delete <strong>${profileName}</strong>, currently in
+              use. Please remove browser profile from all crawl workflows to
+              continue.`,
+          );
+        }
+      }
+      this.notify.toast({
+        message: message,
         variant: "danger",
         icon: "exclamation-octagon",
         id: "browser-profile-error",

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -382,21 +382,33 @@ export class BrowserProfilesList extends BtrixElement {
 
   private async deleteProfile(profile: Profile) {
     try {
-      await this.api.fetch<Profile & { error?: boolean }>(
+      const data = await this.api.fetch<Profile & { error?: boolean }>(
         `/orgs/${this.orgId}/profiles/${profile.id}`,
         {
           method: "DELETE",
         },
       );
 
-      this.notify.toast({
-        message: msg(html`Deleted <strong>${profile.name}</strong>.`),
-        variant: "success",
-        icon: "check2-circle",
-        id: "browser-profile-deleted-status",
-      });
+      if (data.error && data.inUse) {
+        this.notify.toast({
+          message: msg(
+            html`Could not delete <strong>${profile.name}</strong>, currently in
+              use. Please remove browser profile from all Crawl Workflows to
+              continue.`,
+          ),
+          variant: "warning",
+          duration: 15000,
+        });
+      } else {
+        this.notify.toast({
+          message: msg(html`Deleted <strong>${profile.name}</strong>.`),
+          variant: "success",
+          icon: "check2-circle",
+          id: "browser-profile-deleted-status",
+        });
 
-      void this.fetchBrowserProfiles();
+        void this.fetchBrowserProfiles();
+      }
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't delete browser profile at this time."),

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -404,7 +404,7 @@ export class BrowserProfilesList extends BtrixElement {
       );
 
       if (isApiError(e)) {
-        if (e.details === "profile_in_use") {
+        if (e.message === "profile_in_use") {
           message = msg(
             html`Could not delete <strong>${profile.name}</strong>, currently in
               use. Please remove browser profile from all crawl workflows to

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -382,7 +382,7 @@ export class BrowserProfilesList extends BtrixElement {
 
   private async deleteProfile(profile: Profile) {
     try {
-      const data = await this.api.fetch<Profile & { error?: boolean }>(
+      await this.api.fetch<Profile & { error?: boolean }>(
         `/orgs/${this.orgId}/profiles/${profile.id}`,
         {
           method: "DELETE",

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -389,27 +389,14 @@ export class BrowserProfilesList extends BtrixElement {
         },
       );
 
-      if (data.error && data.crawlconfigs) {
-        this.notify.toast({
-          message: msg(
-            html`Could not delete <strong>${profile.name}</strong>, in use by
-              <strong
-                >${data.crawlconfigs.map(({ name }) => name).join(", ")}</strong
-              >. Please remove browser profile from Workflow to continue.`,
-          ),
-          variant: "warning",
-          duration: 15000,
-        });
-      } else {
-        this.notify.toast({
-          message: msg(html`Deleted <strong>${profile.name}</strong>.`),
-          variant: "success",
-          icon: "check2-circle",
-          id: "browser-profile-deleted-status",
-        });
+      this.notify.toast({
+        message: msg(html`Deleted <strong>${profile.name}</strong>.`),
+        variant: "success",
+        icon: "check2-circle",
+        id: "browser-profile-deleted-status",
+      });
 
-        void this.fetchBrowserProfiles();
-      }
+      void this.fetchBrowserProfiles();
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't delete browser profile at this time."),

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -125,6 +125,7 @@ export type Profile = {
   profileId: string;
   baseProfileName: string;
   oid: string;
+  inUse: boolean;
   resource?: {
     name: string;
     path: string;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -113,13 +113,6 @@ export type ProfileReplica = {
   custom?: boolean;
 };
 
-export type ProfileWorkflow = {
-  id: string;
-  name: string;
-  firstSeed: string;
-  seedCount: number;
-};
-
 export type Profile = {
   id: string;
   name: string;
@@ -132,7 +125,6 @@ export type Profile = {
   profileId: string;
   baseProfileName: string;
   oid: string;
-  crawlconfigs?: ProfileWorkflow[];
   resource?: {
     name: string;
     path: string;


### PR DESCRIPTION
Connected to #2661 

- Removes crawl workflows from being returned as part of the profile response.
- Frontend: removes display of workflows in profile details.
- Adds 'inUse' flag to all profile responses to indicate profile is in use by at least one workflow
- Adds 'profileid' as possible filter for workflows search in preparation for filtering by profile id (#2708)
- Make 'profile_in_use' a proper error (returning 400) on profile delete.