### PR TITLE
fix: Superadmin active crawl count inaccuracies

### DIFF
--- a/frontend/src/features/admin/active-crawls-badge.ts
+++ b/frontend/src/features/admin/active-crawls-badge.ts
@@ -2,7 +2,6 @@ import { localized } from "@lit/localize";
 import { Task } from "@lit/task";
 import { html } from "lit";
 import { customElement } from "lit/decorators.js";
-import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -22,8 +21,8 @@ export class ActiveCrawlsBadge extends BtrixElement {
   });
 
   private readonly pollTask = new Task(this, {
-    task: async ([crawls]) => {
-      if (!crawls) return;
+    task: async () => {
+      window.clearTimeout(this.pollTask.value);
 
       return window.setTimeout(() => {
         void this.activeCrawlsTotalTask.run();
@@ -39,14 +38,12 @@ export class ActiveCrawlsBadge extends BtrixElement {
   }
 
   render() {
-    return html`${when(
-      this.activeCrawlsTotalTask.value,
-      ({ total }) => html`
-        <btrix-badge variant=${total > 0 ? "primary" : "blue"}>
-          ${this.localize.number(total)}
-        </btrix-badge>
-      `,
-    )}`;
+    if (this.activeCrawlsTotalTask.value) {
+      const { total } = this.activeCrawlsTotalTask.value;
+      return html`<btrix-badge variant=${total > 0 ? "primary" : "blue"}>
+        ${this.localize.number(total)}
+      </btrix-badge>`;
+    }
   }
 
   private async getActiveCrawlsTotal() {

--- a/frontend/src/features/admin/active-crawls-badge.ts
+++ b/frontend/src/features/admin/active-crawls-badge.ts
@@ -1,0 +1,63 @@
+import { localized } from "@lit/localize";
+import { Task } from "@lit/task";
+import { html } from "lit";
+import { customElement } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
+import queryString from "query-string";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import type { APIPaginatedList } from "@/types/api";
+import type { Crawl } from "@/types/crawler";
+
+const POLL_INTERVAL_SECONDS = 30;
+
+@customElement("btrix-active-crawls-badge")
+@localized()
+export class ActiveCrawlsBadge extends BtrixElement {
+  private readonly activeCrawlsTotalTask = new Task(this, {
+    task: async () => {
+      return await this.getActiveCrawlsTotal();
+    },
+    args: () => [] as const,
+  });
+
+  private readonly pollTask = new Task(this, {
+    task: async ([crawls]) => {
+      if (!crawls) return;
+
+      return window.setTimeout(() => {
+        void this.activeCrawlsTotalTask.run();
+      }, POLL_INTERVAL_SECONDS * 1000);
+    },
+    args: () => [this.activeCrawlsTotalTask.value] as const,
+  });
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    window.clearTimeout(this.pollTask.value);
+  }
+
+  render() {
+    return html`${when(
+      this.activeCrawlsTotalTask.value,
+      ({ total }) => html`
+        <btrix-badge variant=${total > 0 ? "primary" : "blue"}>
+          ${this.localize.number(total)}
+        </btrix-badge>
+      `,
+    )}`;
+  }
+
+  private async getActiveCrawlsTotal() {
+    const query = queryString.stringify({
+      pageSize: 1,
+    });
+
+    const data = await this.api.fetch<APIPaginatedList<Crawl>>(
+      `/orgs/all/crawls?${query}`,
+    );
+
+    return data;
+  }
+}

--- a/frontend/src/features/admin/index.ts
+++ b/frontend/src/features/admin/index.ts
@@ -1,2 +1,3 @@
+import "./active-crawls-badge";
 import "./stats";
 import "./super-admin-banner";

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -449,7 +449,7 @@ export class App extends BtrixElement {
   }
 
   private renderNavBar() {
-    const isSuperAdmin = this.userInfo?.isSuperAdmin;
+    const isSuperAdmin = this.authState && this.userInfo?.isSuperAdmin;
 
     const showFullLogo =
       this.viewState.route === "login" || !this.authService.authState;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -3,7 +3,6 @@ import "./global";
 
 import { provide } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
-import { Task } from "@lit/task";
 import type {
   SlDialog,
   SlDrawer,
@@ -15,7 +14,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 import isEqual from "lodash/fp/isEqual";
-import queryString from "query-string";
 
 import "./components";
 import "./features";
@@ -35,9 +33,7 @@ import AuthService, {
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { NavigateEventDetail } from "@/controllers/navigate";
 import type { NotifyEventDetail } from "@/controllers/notify";
-import type { APIPaginatedList } from "@/types/api";
 import { type Auth } from "@/types/auth";
-import type { Crawl } from "@/types/crawler";
 import {
   translatedLocales,
   type TranslatedLocaleEnum,
@@ -69,8 +65,6 @@ export type APIUser = {
 export interface UserGuideEventMap {
   "btrix-user-guide-show": CustomEvent<{ path?: string }>;
 }
-
-const POLL_INTERVAL_SECONDS = 30;
 
 @customElement("browsertrix-app")
 @localized()
@@ -113,24 +107,6 @@ export class App extends BtrixElement {
 
   @query("#userGuideDrawer")
   private readonly userGuideDrawer!: SlDrawer;
-
-  private readonly activeCrawlsTotalTask = new Task(this, {
-    task: async () => {
-      return await this.getActiveCrawlsTotal();
-    },
-    args: () => [] as const,
-  });
-
-  private readonly pollTask = new Task(this, {
-    task: async ([crawls]) => {
-      if (!crawls) return;
-
-      return window.setTimeout(() => {
-        void this.activeCrawlsTotalTask.run();
-      }, POLL_INTERVAL_SECONDS * 1000);
-    },
-    args: () => [this.activeCrawlsTotalTask.value] as const,
-  });
 
   get orgSlugInPath() {
     return this.viewState.params.slug || "";
@@ -186,12 +162,6 @@ export class App extends BtrixElement {
     });
 
     this.startSyncBrowserTabs();
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-
-    window.clearTimeout(this.pollTask.value);
   }
 
   private attachUserGuideListeners() {
@@ -629,14 +599,7 @@ export class App extends BtrixElement {
                     @click=${this.navigate.link}
                   >
                     ${msg("Active Crawls")}
-                    ${when(
-                      this.activeCrawlsTotalTask.value,
-                      (total) => html`
-                        <btrix-badge variant=${total > 0 ? "primary" : "blue"}>
-                          ${this.localize.number(total)}
-                        </btrix-badge>
-                      `,
-                    )}
+                    <btrix-active-crawls-badge></btrix-active-crawls-badge>
                   </a>
                 </div>
               `
@@ -1182,17 +1145,5 @@ export class App extends BtrixElement {
 
   private clearSelectedOrg() {
     AppStateService.updateOrgSlug(null);
-  }
-
-  private async getActiveCrawlsTotal() {
-    const query = queryString.stringify({
-      pageSize: 1,
-    });
-
-    const data = await this.api.fetch<APIPaginatedList<Crawl>>(
-      `/orgs/all/crawls?${query}`,
-    );
-
-    return data.total;
   }
 }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2705

## Changes

- Fixes superadmin active crawl count not showing on first log in
- Fixes `/all/crawls` endpoint running when auth is not available or not superadmin

## Manual testing

Test using repro steps in https://github.com/webrecorder/browsertrix/issues/2705