### PR TITLE
docs(deployment): add note about potential firewall issues on RHEL

### DIFF
--- a/frontend/docs/docs/deploy/local.md
+++ b/frontend/docs/docs/deploy/local.md
@@ -186,8 +186,10 @@ If the pod is running, or previously ran, you can also get the logs from the con
 
 The outputs of these commands are helpful when reporting an issue [on GitHub](https://github.com/webrecorder/browsertrix/issues).
 
-On Red Hat Enterprise Linux and derivatives, communication between pods might be blocked by firewalld.
-There are short guides in the [k3s](https://docs.k3s.io/installation/requirements?&os=rhel#operating-systems) and [Microk8s](https://microk8s.io/docs/troubleshooting#:~:text=Pod%20communication%20problems%20when%20using%20firewall-cmd) documentation showing how to configure the firewall for kubernetes.
+??? info "Firewall rules (on RHEL/Fedora)"
+
+    On Red Hat Enterprise Linux and derivatives, communication between pods might be blocked by firewalld.
+    There are short guides on configuring the firewall for these systems in the [k3s](https://docs.k3s.io/installation/requirements?&os=rhel#operating-systems) and [Microk8s](https://microk8s.io/docs/troubleshooting#:~:text=Pod%20communication%20problems%20when%20using%20firewall-cmd) documentation.
 
 ## Updating the Cluster
 

--- a/frontend/docs/docs/deploy/local.md
+++ b/frontend/docs/docs/deploy/local.md
@@ -180,11 +180,11 @@ There should be 4 pods listed: backend, frontend, minio, and mongodb. If any one
 
 To get more details about why a pod has not started, run `#!sh kubectl describe <podname>` and see the latest status at the bottom.
 
-Often, the error may be obvious, such as failed to pull an image.
+Often, the error may be obvious, such as "failed to pull an image."
 
-If the pod is running, or previously ran, you can also get the logs from the container by running `#!sh kubectl logs <podname>`
+If the pod is running, or previously ran, you can also get the logs from the container by running `#!sh kubectl logs <podname>`.
 
-The outputs of these commands are helpful when reporting an issue [on GitHub](https://github.com/webrecorder/browsertrix/issues)
+The outputs of these commands are helpful when reporting an issue [on GitHub](https://github.com/webrecorder/browsertrix/issues).
 
 ## Updating the Cluster
 

--- a/frontend/docs/docs/deploy/local.md
+++ b/frontend/docs/docs/deploy/local.md
@@ -186,6 +186,9 @@ If the pod is running, or previously ran, you can also get the logs from the con
 
 The outputs of these commands are helpful when reporting an issue [on GitHub](https://github.com/webrecorder/browsertrix/issues).
 
+On Red Hat Enterprise Linux and derivatives, communication between pods might be blocked by firewalld.
+There are short guides in the [k3s](https://docs.k3s.io/installation/requirements?&os=rhel#operating-systems) and [Microk8s](https://microk8s.io/docs/troubleshooting#:~:text=Pod%20communication%20problems%20when%20using%20firewall-cmd) documentation showing how to configure the firewall for kubernetes.
+
 ## Updating the Cluster
 
 To update the cluster, for example to update to new version `NEWVERSION`, re-run the same command again, which will pull the latest images. In this way, you can upgrade to the latest release of Browsertrix. The upgrade will preserve the database and current archives.


### PR DESCRIPTION
Add a warning box to the [troubleshooting advice](https://docs.browsertrix.com/deploy/local/#debugging-pod-issues) in the local deployment guide about firewall rules on Red Hat Enterprise Linux. See [this forum thread](https://forum.webrecorder.net/t/browsertrix-deployment-stalls-when-initializing-container-migrations/916/5) for context.

After some time searching online this morning there are a lot of different ways to tweak the firewall rules with varying degrees of safety. The k3s documentation suggests simply disabling firewalld as a first step. I don't feel able to make a recommendation here on the _best_ solution, just highlight the issue to short-circuit what could be a very frustrating troubleshooting process.