### PR TITLE
Add seed file support to Browsertrix backend

### DIFF
--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -1,9 +1,6 @@
 name: Nightly tests (K3d)
 
 on:
-  push:
-    branches:
-      - issue-2673-seed-file-backend-support
   schedule:
     # Run daily at 8am UTC
     - cron:  '0 8 * * *'

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -1,6 +1,9 @@
 name: Nightly tests (K3d)
 
 on:
+  push:
+    branches:
+      - issue-2673-seed-file-backend-support
   schedule:
     # Run daily at 8am UTC
     - cron:  '0 8 * * *'

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -505,7 +505,7 @@ class BackgroundJobOps:
             )
             await self.jobs.insert_one(cleanup_job.to_dict())
             if not success:
-                await self._send_bg_job_failure_email(job, finished)
+                await self._send_bg_job_failure_email(cleanup_job, finished)
             return
 
         job = await self.get_background_job(job_id)

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -491,8 +491,8 @@ class BackgroundJobOps:
         """Update job as finished, including
         job-specific task handling"""
 
-        # For weekly cron seed file cleanup jobs, no database record will exist
-        # for each run before this point, so create it here
+        # For seed file cleanup jobs, no database record will exist for each
+        # run before this point, so create it here
         if job_type == BgJobType.CLEANUP_SEED_FILES:
             if not started:
                 started = finished

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -45,8 +45,8 @@ from .models import (
     CollAccessType,
     UpdateCollHomeUrl,
     User,
-    ImageFile,
-    ImageFilePreparer,
+    UserFile,
+    UserFilePreparer,
     MIN_UPLOAD_PART_SIZE,
     PublicCollOut,
 )
@@ -379,10 +379,8 @@ class CollectionOps:
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
-            image_file = ImageFile(**thumbnail)
-            result["thumbnail"] = await image_file.get_image_file_out(
-                org, self.storage_ops
-            )
+            image_file = UserFile(**thumbnail)
+            result["thumbnail"] = await image_file.get_file_out(org, self.storage_ops)
 
         return CollOut.from_dict(result)
 
@@ -411,8 +409,8 @@ class CollectionOps:
 
         thumbnail = result.get("thumbnail")
         if thumbnail:
-            image_file = ImageFile(**thumbnail)
-            result["thumbnail"] = await image_file.get_public_image_file_out(
+            image_file = UserFile(**thumbnail)
+            result["thumbnail"] = await image_file.get_public_file_out(
                 org, self.storage_ops
             )
 
@@ -430,10 +428,8 @@ class CollectionOps:
         if not thumbnail:
             raise HTTPException(status_code=404, detail="thumbnail_not_found")
 
-        image_file = ImageFile(**thumbnail)
-        image_file_out = await image_file.get_public_image_file_out(
-            org, self.storage_ops
-        )
+        image_file = UserFile(**thumbnail)
+        image_file_out = await image_file.get_public_file_out(org, self.storage_ops)
 
         path = self.storage_ops.resolve_internal_access_path(image_file_out.path)
 
@@ -540,14 +536,14 @@ class CollectionOps:
         for res in items:
             thumbnail = res.get("thumbnail")
             if thumbnail:
-                image_file = ImageFile(**thumbnail)
+                image_file = UserFile(**thumbnail)
 
                 if public_colls_out:
-                    res["thumbnail"] = await image_file.get_public_image_file_out(
+                    res["thumbnail"] = await image_file.get_public_file_out(
                         org, self.storage_ops
                     )
                 else:
-                    res["thumbnail"] = await image_file.get_image_file_out(
+                    res["thumbnail"] = await image_file.get_file_out(
                         org, self.storage_ops
                     )
 
@@ -879,7 +875,7 @@ class CollectionOps:
 
         prefix = org.storage.get_storage_extra_path(str(org.id)) + "images/"
 
-        file_prep = ImageFilePreparer(
+        file_prep = UserFilePreparer(
             prefix,
             image_filename,
             original_filename=filename,
@@ -907,7 +903,7 @@ class CollectionOps:
 
         print("Collection thumbnail stream upload complete", flush=True)
 
-        thumbnail_file = file_prep.get_image_file(org.storage)
+        thumbnail_file = file_prep.get_user_file(org.storage)
 
         if thumbnail_file.size > THUMBNAIL_MAX_SIZE:
             print(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -222,7 +222,11 @@ class CollectionOps:
         )
 
     async def add_crawls_to_collection(
-        self, coll_id: UUID, crawl_ids: List[str], org: Organization
+        self,
+        coll_id: UUID,
+        crawl_ids: List[str],
+        org: Organization,
+        headers: Optional[dict] = None,
     ) -> CollOut:
         """Add crawls to collection"""
         await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
@@ -245,10 +249,14 @@ class CollectionOps:
             )
         )
 
-        return await self.get_collection_out(coll_id, org)
+        return await self.get_collection_out(coll_id, org, headers)
 
     async def remove_crawls_from_collection(
-        self, coll_id: UUID, crawl_ids: List[str], org: Organization
+        self,
+        coll_id: UUID,
+        crawl_ids: List[str],
+        org: Organization,
+        headers: Optional[dict] = None,
     ) -> CollOut:
         """Remove crawls from collection"""
         await self.crawl_ops.remove_from_collection(crawl_ids, coll_id)
@@ -270,7 +278,7 @@ class CollectionOps:
             )
         )
 
-        return await self.get_collection_out(coll_id, org)
+        return await self.get_collection_out(coll_id, org, headers)
 
     async def get_collection_raw(
         self, coll_id: UUID, oid: UUID, public_or_unlisted_only: bool = False
@@ -1067,9 +1075,11 @@ def init_collections_api(
         response_model=CollOut,
     )
     async def get_collection(
-        coll_id: UUID, org: Organization = Depends(org_viewer_dep)
+        coll_id: UUID, request: Request, org: Organization = Depends(org_viewer_dep)
     ):
-        return await colls.get_collection_out(coll_id, org)
+        return await colls.get_collection_out(
+            coll_id, org, headers=dict(request.headers)
+        )
 
     @app.get(
         "/orgs/{oid}/collections/{coll_id}/replay.json",
@@ -1136,9 +1146,12 @@ def init_collections_api(
     async def add_crawl_to_collection(
         crawlList: AddRemoveCrawlList,
         coll_id: UUID,
+        request: Request,
         org: Organization = Depends(org_crawl_dep),
     ) -> CollOut:
-        return await colls.add_crawls_to_collection(coll_id, crawlList.crawlIds, org)
+        return await colls.add_crawls_to_collection(
+            coll_id, crawlList.crawlIds, org, headers=dict(request.headers)
+        )
 
     @app.post(
         "/orgs/{oid}/collections/{coll_id}/remove",
@@ -1148,10 +1161,11 @@ def init_collections_api(
     async def remove_crawl_from_collection(
         crawlList: AddRemoveCrawlList,
         coll_id: UUID,
+        request: Request,
         org: Organization = Depends(org_crawl_dep),
     ) -> CollOut:
         return await colls.remove_crawls_from_collection(
-            coll_id, crawlList.crawlIds, org
+            coll_id, crawlList.crawlIds, org, headers=dict(request.headers)
         )
 
     @app.delete(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -854,7 +854,7 @@ class CollectionOps:
 
         return {"updated": True}
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, duplicate-code
     async def upload_thumbnail_stream(
         self,
         stream,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1022,6 +1022,7 @@ def init_collections_api(
         namePrefix: Optional[str] = None,
         access: Optional[str] = None,
     ):
+        # pylint: disable=duplicate-code
         collections, total = await colls.list_collections(
             org,
             page_size=pageSize,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -282,7 +282,9 @@ class CrawlConfigOps:
 
         if config_in.config.seedFileId:
             # Validate file with that id exists
-            seed_file = await self.file_ops.get_file(config_in.config.seedFileId, org)
+            seed_file = await self.file_ops.get_seed_file(
+                config_in.config.seedFileId, org
+            )
 
             # Validate seeds not set
             if config_in.config.seeds:
@@ -504,7 +506,7 @@ class CrawlConfigOps:
 
         if update.config and update.config.seedFileId:
             # Validate file with that id exists
-            seed_file = await self.file_ops.get_file(update.config.seedFileId, org)
+            seed_file = await self.file_ops.get_seed_file(update.config.seedFileId, org)
 
             # Validate seeds not set
             if update.config.seeds or (
@@ -636,7 +638,7 @@ class CrawlConfigOps:
             and update.config.seedFileId is None
         ):
             try:
-                await self.file_ops.delete_user_file(
+                await self.file_ops.delete_seed_file(
                     orig_crawl_config.config.seedFileId, org
                 )
             except HTTPException:
@@ -976,7 +978,7 @@ class CrawlConfigOps:
         if not crawlconfig.crawlAttemptCount:
             if crawlconfig.config and crawlconfig.config.seedFileId:
                 try:
-                    await self.file_ops.delete_user_file(
+                    await self.file_ops.delete_seed_file(
                         crawlconfig.config.seedFileId, org
                     )
                 except HTTPException:
@@ -1127,7 +1129,7 @@ class CrawlConfigOps:
                     status_code=400, detail="seed_file_not_supported_by_crawler"
                 )
 
-            seed_file_out = await self.file_ops.get_file_out(
+            seed_file_out = await self.file_ops.get_seed_file_out(
                 crawlconfig.config.seedFileId, org
             )
             seed_file_url = seed_file_out.path

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -4,7 +4,7 @@ Crawl Config API handling
 
 # pylint: disable=too-many-lines
 
-from typing import List, Optional, TYPE_CHECKING, cast, Dict, Tuple, Annotated
+from typing import List, Optional, TYPE_CHECKING, cast, Dict, Tuple, Annotated, Union
 
 import asyncio
 import json

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1092,6 +1092,13 @@ class CrawlConfigOps:
             crawlconfig.crawlFilenameTemplate or self.default_filename_template
         )
 
+        seed_file_url = None
+        if crawlconfig.config.seedFileId:
+            seed_file_out = await self.file_ops.get_file_out(
+                crawlconfig.config.seedFileId, org
+            )
+            seed_file_url = seed_file_out.path
+
         try:
             crawl_id = await self.crawl_manager.create_crawl_job(
                 crawlconfig,
@@ -1101,6 +1108,7 @@ class CrawlConfigOps:
                 storage_filename=storage_filename,
                 profile_filename=profile_filename or "",
                 is_single_page=self.is_single_page(crawlconfig.config),
+                seed_file_url=seed_file_url,
             )
             await self.add_new_crawl(crawl_id, crawlconfig, user, org, manual=True)
             return crawl_id

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -64,8 +64,11 @@ if TYPE_CHECKING:
     from .profiles import ProfileOps
     from .crawls import CrawlOps
     from .colls import CollectionOps
+    from .file_uploads import FileUploadOps
 else:
-    OrgOps = CrawlManager = UserManager = ProfileOps = CrawlOps = CollectionOps = object
+    OrgOps = CrawlManager = UserManager = ProfileOps = CrawlOps = CollectionOps = (
+        FileUploadOps
+    ) = object
 
 
 ALLOWED_SORT_KEYS = (
@@ -93,6 +96,7 @@ class CrawlConfigOps:
     profiles: ProfileOps
     crawl_ops: CrawlOps
     coll_ops: CollectionOps
+    file_ops: FileUploadOps
 
     crawler_channels: CrawlerChannels
     crawler_images_map: dict[str, str]
@@ -108,6 +112,7 @@ class CrawlConfigOps:
         org_ops,
         crawl_manager,
         profiles,
+        file_ops,
     ):
         self.dbclient = dbclient
         self.crawls = mdb["crawls"]
@@ -120,6 +125,7 @@ class CrawlConfigOps:
         self.profiles.set_crawlconfigs(self)
         self.crawl_ops = cast(CrawlOps, None)
         self.coll_ops = cast(CollectionOps, None)
+        self.file_ops = cast(FileUploadOps, None)
 
         self.default_filename_template = os.environ["DEFAULT_CRAWL_FILENAME_TEMPLATE"]
         self.default_crawler_image_pull_policy = os.environ.get(
@@ -1358,11 +1364,14 @@ def init_crawl_config_api(
     org_ops,
     crawl_manager,
     profiles,
+    file_ops,
 ):
     """Init /crawlconfigs api routes"""
     # pylint: disable=invalid-name
 
-    ops = CrawlConfigOps(dbclient, mdb, user_manager, org_ops, crawl_manager, profiles)
+    ops = CrawlConfigOps(
+        dbclient, mdb, user_manager, org_ops, crawl_manager, profiles, file_ops
+    )
 
     router = ops.router
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1059,8 +1059,10 @@ class CrawlConfigOps:
 
         first_seeds = set()
         async for config in self.crawl_configs.find({"oid": org.id}):
-            first_seed = config["config"]["seeds"][0]["url"]
-            first_seeds.add(first_seed)
+            seeds = config["config"].get("seeds")
+            if seeds:
+                first_seed = seeds[0]["url"]
+                first_seeds.add(first_seed)
 
         return {
             "names": names,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1092,7 +1092,7 @@ class CrawlConfigOps:
             crawlconfig.crawlFilenameTemplate or self.default_filename_template
         )
 
-        seed_file_url = None
+        seed_file_url = ""
         if crawlconfig.config.seedFileId:
             seed_file_out = await self.file_ops.get_file_out(
                 crawlconfig.config.seedFileId, org

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1130,9 +1130,7 @@ class CrawlConfigOps:
             seed_file_out = await self.file_ops.get_file_out(
                 crawlconfig.config.seedFileId, org
             )
-            seed_file_url = self.storage_ops.resolve_internal_access_path(
-                seed_file_out.path
-            )
+            seed_file_url = seed_file_out.path
 
         try:
             crawl_id = await self.crawl_manager.create_crawl_job(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -521,7 +521,10 @@ class CrawlConfigOps:
             )
 
         if update.config and update.config.seeds:
-            if update.config.seedFileId:
+            if update.config.seedFileId or (
+                orig_crawl_config.config.seedFileId
+                and update.config.seedFileId is not None
+            ):
                 raise HTTPException(
                     status_code=400, detail="use_one_of_seeds_or_seedfile"
                 )

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1428,6 +1428,7 @@ def init_crawl_config_api(
     """Init /crawlconfigs api routes"""
     # pylint: disable=invalid-name
 
+    # pylint: disable=duplicate-code
     ops = CrawlConfigOps(
         dbclient,
         mdb,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -112,6 +112,7 @@ class CrawlConfigOps:
         org_ops,
         crawl_manager,
         profiles,
+        # pylint: disable=unused-argument
         file_ops,
     ):
         self.dbclient = dbclient

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -734,7 +734,10 @@ class CrawlConfigOps:
             match_query["isCrawlRunning"] = is_crawl_running
 
         # pylint: disable=duplicate-code
-        aggregate: List[Dict[str, Union[object, str, int]]] = [{"$match": match_query}]
+        aggregate: List[Dict[str, Union[object, str, int]]] = [
+            {"$match": match_query},
+            {"$unset": ["config"]},
+        ]
 
         if first_seed:
             aggregate.extend([{"$match": {"firstSeed": first_seed}}])

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -229,7 +229,7 @@ class CrawlManager(K8sAPI):
             )
             if cron_job:
                 print(
-                    "Weekly cron job to clean up used seed files already exists",
+                    "Cron job to clean up used seed files already exists",
                     flush=True,
                 )
                 return
@@ -237,7 +237,10 @@ class CrawlManager(K8sAPI):
         except Exception as err:
             print(f"Exception trying to find seed file clean up job: {err}", flush=True)
 
-        print("Creating weekly cron job to clean up used seed files", flush=True)
+        print(
+            f"Creating cron job to clean up used seed files, schedule: {job_schedule}",
+            flush=True,
+        )
 
         params = {
             "id": job_id,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -234,8 +234,8 @@ class CrawlManager(K8sAPI):
                 )
                 return
         # pylint: disable=broad-exception-caught
-        except Exception as err:
-            print(f"Exception trying to find seed file clean up job: {err}", flush=True)
+        except Exception:
+            pass
 
         print(
             f"Creating cron job to clean up used seed files, schedule: {job_schedule}",
@@ -254,7 +254,7 @@ class CrawlManager(K8sAPI):
             params
         )
 
-        await self.create_from_yaml(data, namespace=self.namespace)
+        await self.create_from_yaml(data, namespace=DEFAULT_NAMESPACE)
 
     async def create_crawl_job(
         self,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -225,7 +225,7 @@ class CrawlManager(K8sAPI):
         try:
             cron_job = await self.batch_api.read_namespaced_cron_job(
                 name=job_id,
-                namespace=self.namespace,
+                namespace=DEFAULT_NAMESPACE,
             )
             if cron_job:
                 print(

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -221,6 +221,7 @@ class CrawlManager(K8sAPI):
         storage_filename: str,
         profile_filename: str,
         is_single_page: bool,
+        seed_file_url: Optional[str] = None,
     ) -> str:
         """create new crawl job from config"""
         cid = str(crawlconfig.id)
@@ -246,6 +247,7 @@ class CrawlManager(K8sAPI):
             profile_filename=profile_filename,
             proxy_id=crawlconfig.proxyId or DEFAULT_PROXY_ID,
             is_single_page=is_single_page,
+            seed_file_url=seed_file_url,
         )
 
     async def reload_running_crawl_config(self, crawl_id: str):

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -221,7 +221,7 @@ class CrawlManager(K8sAPI):
         storage_filename: str,
         profile_filename: str,
         is_single_page: bool,
-        seed_file_url: Optional[str] = None,
+        seed_file_url: str,
     ) -> str:
         """create new crawl job from config"""
         cid = str(crawlconfig.id)

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -221,15 +221,20 @@ class CrawlManager(K8sAPI):
         weekly_schedule = "0 0 * * 0"
 
         # Don't create a duplicate cron job if already exists
-        cron_job = await self.batch_api.read_namespaced_cron_job(
-            name=job_id,
-            namespace=self.namespace,
-        )
-        if cron_job:
-            print(
-                "Weekly cron job to clean up used seed files already exists", flush=True
+        try:
+            cron_job = await self.batch_api.read_namespaced_cron_job(
+                name=job_id,
+                namespace=self.namespace,
             )
-            return
+            if cron_job:
+                print(
+                    "Weekly cron job to clean up used seed files already exists",
+                    flush=True,
+                )
+                return
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(f"Exception trying to find seed file clean up job: {err}", flush=True)
 
         print("Creating weekly cron job to clean up used seed files", flush=True)
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -217,8 +217,9 @@ class CrawlManager(K8sAPI):
 
         job_id = "cleanup-seed-files-cron"
 
-        # Midnight every Sunday
-        weekly_schedule = "0 0 * * 0"
+        # Default schedule is midnight every Sunday
+        default_schedule = "0 0 * * 0"
+        job_schedule = os.environ.get("CLEANUP_JOB_CRON_SCHEDULE", default_schedule)
 
         # Don't create a duplicate cron job if already exists
         try:
@@ -243,7 +244,7 @@ class CrawlManager(K8sAPI):
             "job_type": BgJobType.CLEANUP_SEED_FILES.value,
             "backend_image": os.environ.get("BACKEND_IMAGE", ""),
             "pull_policy": os.environ.get("BACKEND_IMAGE_PULL_POLICY", ""),
-            "schedule": weekly_schedule,
+            "schedule": job_schedule,
         }
 
         data = self.templates.env.get_template("background_cron_job.yaml").render(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -186,9 +186,7 @@ class CrawlOps(BaseCrawlOps):
         # pylint: disable=duplicate-code
         aggregate = [
             {"$match": query},
-            {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
-            {"$set": {"firstSeed": "$firstSeedObject.url"}},
-            {"$unset": ["firstSeedObject", "errors", "behaviorLogs", "config"]},
+            {"$unset": ["errors", "behaviorLogs", "config"]},
             {"$set": {"activeQAStats": "$qa.stats"}},
             {
                 "$set": {
@@ -314,9 +312,7 @@ class CrawlOps(BaseCrawlOps):
         for result in items:
             crawl = cls.from_dict(result)
             files = result.get("files") if resources else None
-            crawl = await self._resolve_crawl_refs(
-                crawl, org, files=files, add_first_seed=False
-            )
+            crawl = await self._resolve_crawl_refs(crawl, org, files=files)
             crawls.append(crawl)
 
         return crawls, total
@@ -386,6 +382,8 @@ class CrawlOps(BaseCrawlOps):
             proxyId=crawlconfig.proxyId,
             image=image,
             version=2,
+            firstSeed=crawlconfig.firstSeed,
+            seedCount=crawlconfig.seedCount,
         )
 
         try:

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -33,7 +33,7 @@ else:
     ) = PageOps = BackgroundJobOps = FileUploadOps = object
 
 
-CURR_DB_VERSION = "0047"
+CURR_DB_VERSION = "0048"
 
 
 # ============================================================================

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -33,7 +33,7 @@ else:
     ) = PageOps = BackgroundJobOps = FileUploadOps = object
 
 
-CURR_DB_VERSION = "0048"
+CURR_DB_VERSION = "0049"
 
 
 # ============================================================================

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -26,10 +26,11 @@ if TYPE_CHECKING:
     from .storages import StorageOps
     from .pages import PageOps
     from .background_jobs import BackgroundJobOps
+    from .file_uploads import FileUploadOps
 else:
     UserManager = OrgOps = CrawlConfigOps = CrawlOps = CollectionOps = InviteOps = (
         StorageOps
-    ) = PageOps = BackgroundJobOps = object
+    ) = PageOps = BackgroundJobOps = FileUploadOps = object
 
 
 CURR_DB_VERSION = "0047"
@@ -98,6 +99,7 @@ async def update_and_prepare_db(
     storage_ops: StorageOps,
     page_ops: PageOps,
     background_job_ops: BackgroundJobOps,
+    file_ops: FileUploadOps,
 ) -> None:
     """Prepare database for application.
 
@@ -123,6 +125,7 @@ async def update_and_prepare_db(
         user_manager,
         page_ops,
         storage_ops,
+        file_ops,
     )
     await user_manager.create_super_user()
     await org_ops.create_default_org()
@@ -233,6 +236,7 @@ async def create_indexes(
     user_manager,
     page_ops,
     storage_ops,
+    file_ops,
 ):
     """Create database indexes."""
     print("Creating database indexes", flush=True)
@@ -244,6 +248,7 @@ async def create_indexes(
     await user_manager.init_index()
     await page_ops.init_index()
     await storage_ops.init_index()
+    await file_ops.init_index()
 
 
 # ============================================================================

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -112,7 +112,7 @@ async def update_and_prepare_db(
     await ping_db(mdb)
     print("Database setup started", flush=True)
     if await run_db_migrations(
-        mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops
+        mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops, file_ops
     ):
         await drop_indexes(mdb)
 
@@ -136,7 +136,7 @@ async def update_and_prepare_db(
 # ============================================================================
 # pylint: disable=too-many-locals, too-many-arguments
 async def run_db_migrations(
-    mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops
+    mdb, user_manager, page_ops, org_ops, background_job_ops, coll_ops, file_ops
 ):
     """Run database migrations."""
 
@@ -175,6 +175,7 @@ async def run_db_migrations(
                 org_ops=org_ops,
                 background_job_ops=background_job_ops,
                 coll_ops=coll_ops,
+                file_ops=file_ops,
             )
             if await migration.run():
                 migrations_run = True

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -330,9 +330,16 @@ class FileUploadOps:
         return total_size
 
     async def cleanup_unused_seed_files(self):
-        """Delete older seed files (at least one day old) not used in workflows"""
-        one_day_ago = dt_now() - timedelta(days=1)
-        match_query = {"type": "seedFile", "created": {"$lt": one_day_ago}}
+        """Delete older seed files that are not used in workflows"""
+        cleanup_after_mins = int(os.environ.get("CLEANUP_FILES_AFTER_MINUTES", 1440))
+
+        print(
+            f"Cleaning up unused seed files more than {cleanup_after_mins} minutes old",
+            flush=True,
+        )
+
+        cleanup_before = dt_now() - timedelta(minutes=cleanup_after_mins)
+        match_query = {"type": "seedFile", "created": {"$lt": cleanup_before}}
 
         errored = False
         error_msg = ""

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -102,6 +102,8 @@ class FileUploadOps:
         upload_type: str = "seedFile",
     ) -> Dict[str, Union[bool, UUID]]:
         """Upload file stream and return its id"""
+        self.org_ops.can_write_data(org, include_time=False)
+
         _, extension = os.path.splitext(filename)
 
         # Validate extension

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -109,7 +109,7 @@ class FileUploadOps:
         filename: str,
         org: Organization,
         user: User,
-        upload_type: str = "seedFile",
+        upload_type: str = "seedfile",
     ) -> Dict[str, Union[bool, UUID]]:
         """Upload file stream and return its id"""
         self.org_ops.can_write_data(org, include_time=False)

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -15,8 +15,8 @@ from .models import (
     UserUploadFile,
     UserUploadFileOut,
     SeedFile,
-    ImageFile,
-    ImageFilePreparer,
+    UserFile,
+    UserFilePreparer,
     Organization,
     User,
     AddedResponseId,
@@ -200,7 +200,7 @@ class FileUploadOps:
 
         prefix = org.storage.get_storage_extra_path(str(org.id)) + f"{upload_type}s/"
 
-        file_prep = ImageFilePreparer(
+        file_prep = UserFilePreparer(
             prefix,
             new_filename,
             original_filename=filename,
@@ -228,7 +228,7 @@ class FileUploadOps:
 
         print(f"{upload_type} stream upload complete", flush=True)
 
-        file_obj = file_prep.get_image_file(org.storage)
+        file_obj = file_prep.get_user_file(org.storage)
 
         # Validate size
         max_size = SEED_FILE_MAX_SIZE
@@ -271,16 +271,16 @@ class FileUploadOps:
         return {"added": True, "id": file_id}
 
     async def _parse_seed_info_from_file(
-        self, file_obj: ImageFile, org: Organization
+        self, file_obj: UserFile, org: Organization
     ) -> Tuple[str, int]:
         first_seed = ""
         seed_count = 0
 
-        image_file_out = await file_obj.get_image_file_out(org, self.storage_ops)
+        file_out = await file_obj.get_file_out(org, self.storage_ops)
 
         with tempfile.TemporaryFile() as fp:
             async with aiohttp.ClientSession() as session:
-                async with session.get(image_file_out.path) as resp:
+                async with session.get(file_out.path) as resp:
                     async for chunk in resp.content.iter_chunked(4096):
                         fp.write(chunk)
 

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -1,0 +1,235 @@
+"""user-uploaded files"""
+
+from typing import TYPE_CHECKING, Union, Any, Optional, Dict
+
+import os
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+import pymongo
+
+from .models import (
+    UserUploadFile,
+    SeedFile,
+    ImageFilePreparer,
+    Organization,
+    User,
+    AddedResponseId,
+    SuccessResponse,
+    MIN_UPLOAD_PART_SIZE,
+)
+from .utils import dt_now
+
+if TYPE_CHECKING:
+    from .orgs import OrgOps
+    from .storages import StorageOps
+
+else:
+    OrgOps = StorageOps = object
+
+
+ALLOWED_UPLOAD_TYPES = ["seedFile"]
+
+SEED_FILE_MAX_SIZE = 25_000_000
+SEED_FILE_ALLOWED_EXTENSIONS = [".txt"]
+
+
+# ============================================================================
+# pylint: disable=too-many-instance-attributes
+class FileUploadOps:
+    """user non-wacz file upload management"""
+
+    org_ops: OrgOps
+    storage_ops: StorageOps
+
+    # pylint: disable=too-many-locals, too-many-arguments, invalid-name
+
+    def __init__(self, mdb, org_ops, storage_ops):
+        self.files = mdb["file_uploads"]
+
+        self.org_ops = org_ops
+        self.storage_ops = storage_ops
+
+        self.router = APIRouter(
+            prefix="/files",
+            tags=["userfiles"],
+            responses={404: {"description": "Not found"}},
+        )
+
+    async def init_index(self):
+        """init index for user file uploads db collection"""
+        await self.files.create_index([("oid", pymongo.HASHED)])
+
+    async def get_file_raw(
+        self,
+        file_id: UUID,
+        org: Optional[Organization] = None,
+        type_: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get raw file from db"""
+        query: dict[str, object] = {"_id": file_id}
+        if org:
+            query["oid"] = org.id
+
+        if type_:
+            query["type"] = type_
+
+        res = await self.files.find_one(query)
+
+        if not res:
+            raise HTTPException(status_code=404, detail="file_not_found")
+
+        return res
+
+    async def get_file_by_id(
+        self,
+        file_id: UUID,
+        org: Optional[Organization] = None,
+        type_: Optional[str] = None,
+    ) -> UserUploadFile:
+        """Get file by UUID"""
+        file_raw = await self.get_file_raw(file_id, org, type_)
+
+        cls = UserUploadFile
+        if type_ == "seedFile":
+            cls = SeedFile
+
+        return cls.from_dict(file_raw)
+
+    # pylint: disable=duplicate-code
+    async def upload_user_file_stream(
+        self,
+        stream,
+        filename: str,
+        org: Organization,
+        user: User,
+        upload_type: str = "seedFile",
+    ) -> Dict[str, Union[bool, UUID]]:
+        """Upload file stream and return its id"""
+        _, extension = os.path.splitext(filename)
+
+        # Validate extension
+        allowed_extensions = SEED_FILE_ALLOWED_EXTENSIONS
+        if extension not in allowed_extensions:
+            raise HTTPException(status_code=400, detail="invalid_extension")
+
+        file_id = uuid4()
+
+        new_filename = f"{upload_type}-{str(file_id)}{extension}"
+
+        prefix = org.storage.get_storage_extra_path(str(org.id)) + f"{upload_type}s/"
+
+        file_prep = ImageFilePreparer(
+            prefix,
+            new_filename,
+            original_filename=filename,
+            user=user,
+            created=dt_now(),
+        )
+
+        async def stream_iter():
+            """iterate over each chunk and compute and digest + total size"""
+            async for chunk in stream:
+                file_prep.add_chunk(chunk)
+                yield chunk
+
+        print(f"{upload_type} stream upload starting", flush=True)
+
+        if not await self.storage_ops.do_upload_multipart(
+            org,
+            file_prep.upload_name,
+            stream_iter(),
+            MIN_UPLOAD_PART_SIZE,
+            mime=file_prep.mime,
+        ):
+            print(f"{upload_type} stream upload failed", flush=True)
+            raise HTTPException(status_code=400, detail="upload_failed")
+
+        print(f"{upload_type} stream upload complete", flush=True)
+
+        file_obj = file_prep.get_image_file(org.storage)
+
+        # Validate size
+        max_size = SEED_FILE_MAX_SIZE
+        if file_obj.size > max_size:
+            print(
+                f"{upload_type} stream upload failed: max size (25 MB) exceeded",
+                flush=True,
+            )
+            await self.storage_ops.delete_file_obj(org, file_obj)
+            raise HTTPException(
+                status_code=400,
+                detail="max_size_25_mb_exceeded",
+            )
+
+        # Save file to database
+        file_to_insert = SeedFile(
+            id=file_id,
+            oid=org.id,
+            filename=file_obj.upload_name,
+            hash=file_obj.upload_hasher.hexdigest(),
+            size=file_obj.upload_size,
+            storage=file_obj.storage,
+            originalFilename=file_obj.original_filename,
+            mime=file_obj.mime,
+            userid=file_obj.userid,
+            userName=file_obj.user_name,
+            created=file_obj.created,
+        )
+
+        await self.files.insert_one(file_to_insert.to_dict())
+
+        return {"added": True, "id": file_id}
+
+    async def delete_user_file(
+        self, file_id: UUID, org: Organization
+    ) -> Dict[str, bool]:
+        """Delete user-uploaded file from storage and db"""
+        file = await self.get_file_by_id(file_id, org)
+        await self.storage_ops.delete_file_obj(org, file)
+        await self.files.delete_one(file)
+
+        return {"success": True}
+
+
+# ============================================================================
+def init_file_uploads_api(
+    mdb,
+    org_ops,
+    storage_ops,
+    user_dep,
+):
+    """Init /files api routes"""
+
+    ops = FileUploadOps(mdb, org_ops, storage_ops)
+
+    router = ops.router
+
+    org_crawl_dep = org_ops.org_crawl_dep
+    # org_viewer_dep = org_ops.org_viewer_dep
+
+    @router.put("", response_model=AddedResponseId)
+    async def upload_user_file(
+        request: Request,
+        filename: str,
+        upload_type: str,
+        org: Organization = Depends(org_crawl_dep),
+        user: User = Depends(user_dep),
+    ):
+        if upload_type not in ALLOWED_UPLOAD_TYPES:
+            raise HTTPException(status_code=400, detail="invalid_upload_type")
+
+        return await ops.upload_user_file_stream(
+            request.stream(), filename, org, user, upload_type
+        )
+
+    @router.delete("/{file_id}", response_model=SuccessResponse)
+    async def delete_user_file(
+        file_id: UUID, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await ops.delete_user_file(file_id, org)
+
+    if org_ops.router:
+        org_ops.router.include_router(router)
+
+    return ops

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -385,7 +385,7 @@ def init_file_uploads_api(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: str = "modified",
+        sortBy: str = "created",
         sortDirection: int = -1,
     ):
         # pylint: disable=duplicate-code

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -96,6 +96,7 @@ class K8sAPI:
         qa_source: str = "",
         proxy_id: str = "",
         is_single_page: bool = False,
+        seed_file_url: Optional[str] = None,
     ):
         """load job template from yaml"""
         if not crawl_id:
@@ -121,6 +122,7 @@ class K8sAPI:
             "qa_source": qa_source,
             "proxy_id": proxy_id,
             "is_single_page": "1" if is_single_page else "0",
+            "seed_file_url": seed_file_url,
         }
 
         data = self.templates.env.get_template("crawl_job.yaml").render(params)
@@ -145,6 +147,7 @@ class K8sAPI:
         qa_source: str = "",
         proxy_id: str = "",
         is_single_page: bool = False,
+        seed_file_url: Optional[str] = None,
     ) -> str:
         """load and init crawl job via k8s api"""
         crawl_id, data = self.new_crawl_job_yaml(
@@ -165,6 +168,7 @@ class K8sAPI:
             qa_source=qa_source,
             proxy_id=proxy_id,
             is_single_page=is_single_page,
+            seed_file_url=seed_file_url,
         )
 
         # create job directly

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -96,7 +96,7 @@ class K8sAPI:
         qa_source: str = "",
         proxy_id: str = "",
         is_single_page: bool = False,
-        seed_file_url: Optional[str] = None,
+        seed_file_url: str = "",
     ):
         """load job template from yaml"""
         if not crawl_id:
@@ -147,7 +147,7 @@ class K8sAPI:
         qa_source: str = "",
         proxy_id: str = "",
         is_single_page: bool = False,
-        seed_file_url: Optional[str] = None,
+        seed_file_url: str = "",
     ) -> str:
         """load and init crawl job via k8s api"""
         crawl_id, data = self.new_crawl_job_yaml(

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -231,6 +231,7 @@ def main() -> None:
         crawl_manager,
         profiles,
         file_ops,
+        storage_ops,
     )
 
     coll_ops = init_collections_api(

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -288,6 +288,8 @@ def main() -> None:
     # await db init, migrations should have already completed in init containers
     asyncio.create_task(await_db_and_migrations(mdb, db_inited))
 
+    asyncio.create_task(background_job_ops.ensure_cron_cleanup_jobs_exist())
+
     app.include_router(org_ops.router)
 
     @app.get("/settings", tags=["settings"], response_model=SettingsResponse)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -36,6 +36,7 @@ from .webhooks import init_event_webhooks_api
 from .background_jobs import init_background_jobs_api
 from .pages import init_pages_api
 from .subs import init_subs_api
+from .file_uploads import init_file_uploads_api
 
 from .crawlmanager import CrawlManager
 from .utils import register_exit_handler, is_bool
@@ -67,6 +68,7 @@ tags = [
     "jobs",
     "invites",
     "subscriptions",
+    "userfiles",
 ]
 
 
@@ -197,6 +199,8 @@ def main() -> None:
         org_ops, crawl_manager, app, mdb, current_active_user
     )
 
+    file_ops = init_file_uploads_api(mdb, org_ops, storage_ops, current_active_user)
+
     background_job_ops = init_background_jobs_api(
         app,
         mdb,
@@ -226,6 +230,7 @@ def main() -> None:
         org_ops,
         crawl_manager,
         profiles,
+        file_ops,
     )
 
     coll_ops = init_collections_api(

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -273,7 +273,9 @@ def main() -> None:
     crawls.set_page_ops(page_ops)
     upload_ops.set_page_ops(page_ops)
 
-    org_ops.set_ops(base_crawl_ops, profiles, coll_ops, background_job_ops, page_ops)
+    org_ops.set_ops(
+        base_crawl_ops, profiles, coll_ops, background_job_ops, page_ops, file_ops
+    )
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)
 

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -30,7 +30,7 @@ async def main():
         )
         return 1
 
-    (org_ops, _, _, _, _, page_ops, coll_ops, _, _, _, _, user_manager, _, _, _) = (
+    (org_ops, _, _, _, _, page_ops, coll_ops, _, _, _, _, user_manager, _, _, _, _) = (
         init_ops()
     )
 

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -59,6 +59,15 @@ async def main():
             traceback.print_exc()
             return 1
 
+    if job_type == BgJobType.CLEANUP_SEED_FILES:
+        try:
+            await file_ops.cleanup_unused_seed_files()
+            return 0
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            traceback.print_exc()
+            return 1
+
     # Run job (org-specific)
     if not oid:
         print("Org id missing, quitting")
@@ -95,15 +104,6 @@ async def main():
                 await page_ops.re_add_crawl_pages(crawl_id=crawl_id, oid=org.id)
 
             await coll_ops.recalculate_org_collection_stats(org)
-            return 0
-        # pylint: disable=broad-exception-caught
-        except Exception:
-            traceback.print_exc()
-            return 1
-
-    if job_type == BgJobType.CLEANUP_SEED_FILES:
-        try:
-            await file_ops.cleanup_unused_seed_files()
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -30,9 +30,24 @@ async def main():
         )
         return 1
 
-    (org_ops, _, _, _, _, page_ops, coll_ops, _, _, _, _, user_manager, _, _, _, _) = (
-        init_ops()
-    )
+    (
+        org_ops,
+        _,
+        _,
+        _,
+        _,
+        page_ops,
+        coll_ops,
+        _,
+        _,
+        _,
+        _,
+        user_manager,
+        _,
+        file_ops,
+        _,
+        _,
+    ) = init_ops()
 
     # Run job (generic)
     if job_type == BgJobType.OPTIMIZE_PAGES:
@@ -80,6 +95,15 @@ async def main():
                 await page_ops.re_add_crawl_pages(crawl_id=crawl_id, oid=org.id)
 
             await coll_ops.recalculate_org_collection_stats(org)
+            return 0
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            traceback.print_exc()
+            return 1
+
+    if job_type == BgJobType.CLEANUP_SEED_FILES:
+        try:
+            await file_ops.cleanup_unused_seed_files()
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -35,6 +35,7 @@ async def main() -> int:
         _,
         user_manager,
         invite_ops,
+        file_ops,
         _,
         mdb,
     ) = init_ops()
@@ -50,6 +51,7 @@ async def main() -> int:
         storage_ops,
         page_ops,
         background_job_ops,
+        file_ops,
     )
 
     return 0

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -42,6 +42,7 @@ def main():
         _,
         _,
         _,
+        _,
     ) = init_ops()
 
     return init_operator_api(

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -62,14 +62,14 @@ class Migration(BaseMigration):
                 )
 
         # Crawls
-        match_query: Dict[str, Any] = {
+        crawl_query: Dict[str, Any] = {
             "type": "crawl",
             "$or": [
                 {"firstSeed": {"$in": [None, ""]}},
                 {"seedCount": {"$in": [None, 0]}},
             ],
         }
-        async for crawl_raw in crawls_mdb.find(match_query):
+        async for crawl_raw in crawls_mdb.find(crawl_query):
             crawl_id = crawl_raw["_id"]
             try:
                 crawl = Crawl.from_dict(crawl_raw)

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -19,7 +19,7 @@ class Migration(BaseMigration):
     def __init__(self, mdb, **kwargs):
         super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
-    async def migrate_up(self):
+    async def migrate_up(self) -> None:
         """Perform migration up.
 
         Calculate firstSeed and seedCount for workflows and store in db

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -1,0 +1,87 @@
+"""
+Migration 0048 - Calculate firstSeed/seedCount and store directly in database
+"""
+
+from typing import cast, List
+
+from btrixcloud.migrations import BaseMigration
+from btrixcloud.models import CrawlConfig, Seed
+
+
+MIGRATION_VERSION = "0048"
+
+
+# pylint: disable=duplicate-code
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Calculate firstSeed and seedCount for workflows and store in db
+        """
+        crawls_mdb = self.mdb["crawls"]
+        crawl_configs_mdb = self.mdb["crawlconfigs"]
+
+        match_query = {"$or": [{"firstSeed": None}, {"seedCount": None}]}
+
+        # Workflows
+        async for config_raw in crawl_configs_mdb.find(match_query):
+            config = CrawlConfig.from_dict(config_raw)
+
+            try:
+                if not config.config.seeds:
+                    print(
+                        f"Unable to find seeds for config {config.id}, skipping",
+                        flush=True,
+                    )
+                    continue
+
+                seeds = cast(List[Seed], config.config.seeds)
+                seed_count = len(seeds)
+                first_seed = seeds[0].url
+
+                await crawl_configs_mdb.find_one_and_update(
+                    {"_id": config.id},
+                    {
+                        "$set": {
+                            "firstSeed": first_seed,
+                            "seedCount": seed_count,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update seed info for workflow {config.id}: {err}",
+                    flush=True,
+                )
+
+        # Crawls
+        async for crawl_raw in crawls_mdb.find(match_query):
+            crawl_id = crawl_raw["_id"]
+            config_raw = await crawl_configs_mdb.find_one({"_id": crawl_raw["cid"]})
+
+            try:
+                seed_count = config_raw.get("seedCount", 0)
+                first_seed = config_raw.get("firstSeed", "")
+
+                await crawls_mdb.find_one_and_update(
+                    {"_id": crawl_id},
+                    {
+                        "$set": {
+                            "firstSeed": first_seed,
+                            "seedCount": seed_count,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update seed info for crawl {crawl_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
+++ b/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
@@ -16,21 +16,43 @@ class Migration(BaseMigration):
         super().__init__(mdb, migration_version=MIGRATION_VERSION)
 
         self.org_ops = kwargs.get("org_ops")
+        self.coll_ops = kwargs.get("coll_ops")
+        self.file_ops = kwargs.get("file_ops")
 
     async def migrate_up(self):
-        """Perform migration up. Recalculate storage for each org."""
+        """Perform migration up. Add thumbnail and seed file storage to orgs."""
         # pylint: disable=duplicate-code, line-too-long
-        if self.org_ops is None:
-            print("Unable to recalculate org storage, missing org_ops", flush=True)
+        if self.org_ops is None or self.coll_ops is None or self.file_ops is None:
+            print("Unable to recalculate org storage, missing ops", flush=True)
             return
 
         orgs_db = self.mdb["organizations"]
-        async for org_dict in orgs_db.find({}):
+
+        match_query = {
+            "$or": [{"bytesStoredSeedFiles": None}, {"bytesStoredThumbnails": None}]
+        }
+
+        async for org_dict in orgs_db.find(match_query):
             oid = org_dict.get("_id")
 
             try:
                 org = await self.org_ops.get_org_by_id(oid)
-                await self.org_ops.recalculate_storage(org)
+
+                seed_file_size = await self.file_ops.calculate_seed_file_storage(oid)
+                thumbnail_size = await self.coll_ops.calculate_thumbnail_storage(oid)
+
+                await orgs_db.find_one_and_update(
+                    {"_id": oid},
+                    {
+                        "$set": {
+                            "bytesStored": org.bytesStored
+                            + seed_file_size
+                            + thumbnail_size,
+                            "bytesStoredSeedFiles": seed_file_size,
+                            "bytesStoredThumbnails": thumbnail_size,
+                        }
+                    },
+                )
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(

--- a/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
+++ b/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
@@ -1,0 +1,39 @@
+"""
+Migration 0049 - Recalculate org storage for seed file and thumbnail size
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0049"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+        self.org_ops = kwargs.get("org_ops")
+
+    async def migrate_up(self):
+        """Perform migration up. Recalculate storage for each org."""
+        # pylint: disable=duplicate-code, line-too-long
+        if self.org_ops is None:
+            print("Unable to recalculate org storage, missing org_ops", flush=True)
+            return
+
+        orgs_db = self.mdb["organizations"]
+        async for org_dict in orgs_db.find({}):
+            oid = org_dict.get("_id")
+
+            try:
+                org = await self.org_ops.get_org_by_id(oid)
+                await self.org_ops.recalculate_storage(org)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error recalculating storage for org {oid}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1205,10 +1205,12 @@ class UserFile(BaseFile):
     userName: str
     created: datetime
 
-    async def get_file_out(self, org, storage_ops) -> UserFileOut:
+    async def get_file_out(
+        self, org, storage_ops, headers: Optional[dict] = None
+    ) -> UserFileOut:
         """Get UserFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
-        presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
+        presigned_url = storage_ops.resolve_relative_access_path(presigned_url, headers)
 
         return UserFileOut(
             name=self.filename,
@@ -1222,10 +1224,12 @@ class UserFile(BaseFile):
             created=self.created,
         )
 
-    async def get_public_file_out(self, org, storage_ops) -> PublicUserFileOut:
+    async def get_public_file_out(
+        self, org, storage_ops, headers: Optional[dict] = None
+    ) -> PublicUserFileOut:
         """Get PublicUserFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
-        presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
+        presigned_url = storage_ops.resolve_relative_access_path(presigned_url, headers)
 
         return PublicUserFileOut(
             name=self.filename,
@@ -1313,10 +1317,12 @@ class UserUploadFile(BaseMongoModel):
     firstSeed: Optional[str] = None
     seedCount: Optional[int] = None
 
-    async def get_file_out(self, org, storage_ops) -> UserUploadFileOut:
+    async def get_file_out(
+        self, org, storage_ops, headers: Optional[dict] = None
+    ) -> UserUploadFileOut:
         """Get UserUploadFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
-        presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
+        presigned_url = storage_ops.resolve_relative_access_path(presigned_url, headers)
 
         return UserUploadFileOut(
             name=self.filename,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1274,6 +1274,12 @@ class UserUploadFile(BaseMongoModel):
 
 
 # ============================================================================
+class UserUploadFileOut(UserUploadFile):
+
+    type: str
+
+
+# ============================================================================
 class SeedFile(UserUploadFile):
     """Seed file for crawl workflows"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -441,6 +441,9 @@ class CrawlConfigCore(BaseMongoModel):
     crawlerChannel: Optional[str] = None
     proxyId: Optional[str] = None
 
+    firstSeed: str = ""
+    seedCount: int = 0
+
 
 # ============================================================================
 class CrawlConfigAdditional(BaseModel):
@@ -508,8 +511,6 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     lastCrawlPausedAt: Optional[datetime] = None
     lastCrawlPausedExpiry: Optional[datetime] = None
     profileName: Optional[str] = None
-    firstSeed: Optional[str] = None
-    seedCount: int = 0
 
     createdByName: Optional[str] = None
     modifiedByName: Optional[str] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -3048,6 +3048,13 @@ class PaginatedUserOutResponse(PaginatedResponse):
 
 
 # ============================================================================
+class PaginatedUserFileResponse(PaginatedResponse):
+    """Response model for user-uploaded files (e.g. seed files)"""
+
+    items: List[UserUploadFileOut]
+
+
+# ============================================================================
 class PageUrlCountResponse(BaseModel):
     """Response model for page count by url"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1295,7 +1295,7 @@ class UserUploadFile(BaseMongoModel):
     seedCount: Optional[int] = None
 
     async def get_file_out(self, org, storage_ops) -> UserUploadFileOut:
-        """Get ImageFileOut with new presigned url"""
+        """Get UserUploadFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
         presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1253,6 +1253,15 @@ class ImageFilePreparer(FilePreparer):
 
 
 # ============================================================================
+class UserUploadFileOut(ImageFileOut):
+    """Output model for user-uploaded files"""
+
+    id: UUID
+    oid: UUID
+    type: str
+
+
+# ============================================================================
 class UserUploadFile(BaseMongoModel):
     """User-uploaded file saved in files mongo collection"""
 
@@ -1272,11 +1281,26 @@ class UserUploadFile(BaseMongoModel):
     userName: str
     created: datetime
 
-
-# ============================================================================
-class UserUploadFileOut(UserUploadFile):
-
     type: str
+
+    async def get_file_out(self, org, storage_ops) -> UserUploadFileOut:
+        """Get ImageFileOut with new presigned url"""
+        presigned_url, _ = await storage_ops.get_presigned_url(org, self)
+
+        return UserUploadFileOut(
+            name=self.filename,
+            path=presigned_url or "",
+            hash=self.hash,
+            size=self.size,
+            originalFilename=self.originalFilename,
+            mime=self.mime,
+            userid=self.userid,
+            userName=self.userName,
+            created=self.created,
+            id=self.id,
+            oid=self.oid,
+            type=self.type,
+        )
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -578,6 +578,7 @@ class CrawlConfigAddedResponse(BaseModel):
     run_now_job: Optional[str] = None
     storageQuotaReached: bool
     execMinutesQuotaReached: bool
+    errorDetail: Optional[str] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1253,6 +1253,34 @@ class ImageFilePreparer(FilePreparer):
 
 
 # ============================================================================
+class UserUploadFile(BaseMongoModel):
+    """User-uploaded file saved in files mongo collection"""
+
+    id: UUID
+    oid: UUID
+
+    filename: str
+    hash: str
+    size: int
+    storage: StorageRef
+
+    replicas: Optional[List[StorageRef]] = []
+
+    originalFilename: str
+    mime: str
+    userid: UUID
+    userName: str
+    created: datetime
+
+
+# ============================================================================
+class SeedFile(UserUploadFile):
+    """Seed file for crawl workflows"""
+
+    type: Literal["seedFile"] = "seedFile"
+
+
+# ============================================================================
 
 ### PAGES ###
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1293,25 +1293,11 @@ class UserUploadFileOut(UserFileOut):
 
 
 # ============================================================================
-class UserUploadFile(BaseMongoModel):
+class UserUploadFile(UserFile, BaseMongoModel):
     """User-uploaded file saved in files mongo collection"""
 
     id: UUID
     oid: UUID
-
-    filename: str
-    hash: str
-    size: int
-    storage: StorageRef
-
-    replicas: Optional[List[StorageRef]] = []
-
-    originalFilename: str
-    mime: str
-    userid: UUID
-    userName: str
-    created: datetime
-
     type: str
 
     firstSeed: Optional[str] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2697,6 +2697,7 @@ class BgJobType(str, Enum):
     RECALCULATE_ORG_STATS = "recalculate-org-stats"
     READD_ORG_PAGES = "readd-org-pages"
     OPTIMIZE_PAGES = "optimize-pages"
+    CLEANUP_SEED_FILES = "cleanup-seed-files"
 
 
 # ============================================================================
@@ -2767,6 +2768,13 @@ class OptimizePagesJob(BackgroundJob):
 
 
 # ============================================================================
+class CleanupSeedFilesJob(BackgroundJob):
+    """Model for tracking jobs to cleanup unused seed files"""
+
+    type: Literal[BgJobType.CLEANUP_SEED_FILES] = BgJobType.CLEANUP_SEED_FILES
+
+
+# ============================================================================
 # Union of all job types, for response model
 
 AnyJob = RootModel[
@@ -2778,6 +2786,7 @@ AnyJob = RootModel[
         RecalculateOrgStatsJob,
         ReAddOrgPagesJob,
         OptimizePagesJob,
+        CleanupSeedFilesJob,
     ]
 ]
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -600,7 +600,7 @@ class CrawlConfigSearchValues(BaseModel):
 
     names: List[str]
     descriptions: List[str]
-    firstSeeds: List[AnyHttpUrl]
+    firstSeeds: List[str]
     workflowIds: List[UUID]
 
 
@@ -954,7 +954,7 @@ class CrawlSearchValuesResponse(BaseModel):
 
     names: List[str]
     descriptions: List[str]
-    firstSeeds: List[AnyHttpUrl]
+    firstSeeds: List[str]
 
 
 # ============================================================================
@@ -1188,6 +1188,7 @@ class ImageFile(BaseFile):
     async def get_image_file_out(self, org, storage_ops) -> ImageFileOut:
         """Get ImageFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
+        presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
 
         return ImageFileOut(
             name=self.filename,
@@ -1204,6 +1205,7 @@ class ImageFile(BaseFile):
     async def get_public_image_file_out(self, org, storage_ops) -> PublicImageFileOut:
         """Get PublicImageFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
+        presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
 
         return PublicImageFileOut(
             name=self.filename,
@@ -1256,11 +1258,14 @@ class ImageFilePreparer(FilePreparer):
 
 # ============================================================================
 class UserUploadFileOut(ImageFileOut):
-    """Output model for user-uploaded files"""
+    """Output model for all user-uploaded files"""
 
     id: UUID
     oid: UUID
     type: str
+
+    firstSeed: Optional[str] = None
+    seedCount: Optional[int] = None
 
 
 # ============================================================================
@@ -1285,9 +1290,13 @@ class UserUploadFile(BaseMongoModel):
 
     type: str
 
+    firstSeed: Optional[str] = None
+    seedCount: Optional[int] = None
+
     async def get_file_out(self, org, storage_ops) -> UserUploadFileOut:
         """Get ImageFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
+        presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
 
         return UserUploadFileOut(
             name=self.filename,
@@ -1302,6 +1311,8 @@ class UserUploadFile(BaseMongoModel):
             id=self.id,
             oid=self.oid,
             type=self.type,
+            firstSeed=self.firstSeed,
+            seedCount=self.seedCount,
         )
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1150,8 +1150,14 @@ class FilePreparer:
 
 
 # ============================================================================
-class ImageFileOut(BaseModel):
-    """output for user-upload imaged file (conformance to Data Resource Spec)"""
+class UserFileOut(BaseModel):
+    """output for user-uploaded file as stored on other document
+
+    Used for collection thumbnails.
+    Should merge with UserUploadFile models below (used to store files in
+    distinct files mongo collection) eventually.
+    Conforms to Data Resource Spec.
+    """
 
     name: str
     path: str
@@ -1166,8 +1172,14 @@ class ImageFileOut(BaseModel):
 
 
 # ============================================================================
-class PublicImageFileOut(BaseModel):
-    """public output for user-upload imaged file (conformance to Data Resource Spec)"""
+class PublicUserFileOut(BaseModel):
+    """public output for user-uploaded file stored on other document
+
+    Used for collection thumbnails.
+    Should merge with UserUploadFile models below (used to store files in
+    distinct files mongo collection) eventually.
+    Conforms to Data Resource Spec.
+    """
 
     name: str
     path: str
@@ -1178,8 +1190,14 @@ class PublicImageFileOut(BaseModel):
 
 
 # ============================================================================
-class ImageFile(BaseFile):
-    """User-uploaded image file"""
+class UserFile(BaseFile):
+    """User-uploaded file stored on anther mongo document
+
+    Used for collection thumbnails.
+    Should merge with UserUploadFile models below (used to store files in
+    distinct files mongo collection) eventually.
+    Conforms to Data Resource Spec.
+    """
 
     originalFilename: str
     mime: str
@@ -1187,12 +1205,12 @@ class ImageFile(BaseFile):
     userName: str
     created: datetime
 
-    async def get_image_file_out(self, org, storage_ops) -> ImageFileOut:
-        """Get ImageFileOut with new presigned url"""
+    async def get_file_out(self, org, storage_ops) -> UserFileOut:
+        """Get UserFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
         presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
 
-        return ImageFileOut(
+        return UserFileOut(
             name=self.filename,
             path=presigned_url or "",
             hash=self.hash,
@@ -1204,12 +1222,12 @@ class ImageFile(BaseFile):
             created=self.created,
         )
 
-    async def get_public_image_file_out(self, org, storage_ops) -> PublicImageFileOut:
-        """Get PublicImageFileOut with new presigned url"""
+    async def get_public_file_out(self, org, storage_ops) -> PublicUserFileOut:
+        """Get PublicUserFileOut with new presigned url"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
         presigned_url = storage_ops.resolve_internal_access_path(presigned_url)
 
-        return PublicImageFileOut(
+        return PublicUserFileOut(
             name=self.filename,
             path=presigned_url or "",
             hash=self.hash,
@@ -1219,8 +1237,8 @@ class ImageFile(BaseFile):
 
 
 # ============================================================================
-class ImageFilePreparer(FilePreparer):
-    """Wrapper for user image streaming uploads"""
+class UserFilePreparer(FilePreparer):
+    """Wrapper for user streaming uploads"""
 
     # pylint: disable=too-many-arguments, too-many-function-args
 
@@ -1240,12 +1258,12 @@ class ImageFilePreparer(FilePreparer):
         self.user_name = user.name
         self.created = created
 
-    def get_image_file(
+    def get_user_file(
         self,
         storage: StorageRef,
-    ) -> ImageFile:
-        """get user-uploaded image file"""
-        return ImageFile(
+    ) -> UserFile:
+        """get user-uploaded file"""
+        return UserFile(
             filename=self.upload_name,
             hash=self.upload_hasher.hexdigest(),
             size=self.upload_size,
@@ -1259,8 +1277,8 @@ class ImageFilePreparer(FilePreparer):
 
 
 # ============================================================================
-class UserUploadFileOut(ImageFileOut):
-    """Output model for all user-uploaded files"""
+class UserUploadFileOut(UserFileOut):
+    """Output model for all user-uploaded files stored in files mongo collection"""
 
     id: UUID
     oid: UUID
@@ -1562,7 +1580,7 @@ class Collection(BaseMongoModel):
     homeUrlTs: Optional[datetime] = None
     homeUrlPageId: Optional[UUID] = None
 
-    thumbnail: Optional[ImageFile] = None
+    thumbnail: Optional[UserFile] = None
     thumbnailSource: Optional[CollectionThumbnailSource] = None
     defaultThumbnailName: Optional[str] = None
 
@@ -1618,7 +1636,7 @@ class CollOut(BaseMongoModel):
     homeUrlPageId: Optional[UUID] = None
 
     resources: List[CrawlFileOut] = []
-    thumbnail: Optional[ImageFileOut] = None
+    thumbnail: Optional[UserFileOut] = None
     thumbnailSource: Optional[CollectionThumbnailSource] = None
     defaultThumbnailName: Optional[str] = None
 
@@ -1661,7 +1679,7 @@ class PublicCollOut(BaseMongoModel):
     homeUrlTs: Optional[datetime] = None
 
     resources: List[CrawlFileOut] = []
-    thumbnail: Optional[PublicImageFileOut] = None
+    thumbnail: Optional[PublicUserFileOut] = None
     defaultThumbnailName: Optional[str] = None
 
     allowPublicDownload: bool = True

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2058,6 +2058,8 @@ class OrgOut(BaseMongoModel):
     bytesStoredCrawls: int
     bytesStoredUploads: int
     bytesStoredProfiles: int
+    bytesStoredSeedFiles: int = 0
+    bytesStoredThumbnails: int = 0
     origin: Optional[AnyHttpUrl] = None
 
     storageQuotaReached: Optional[bool] = False
@@ -2121,6 +2123,8 @@ class Organization(BaseMongoModel):
     bytesStoredCrawls: int = 0
     bytesStoredUploads: int = 0
     bytesStoredProfiles: int = 0
+    bytesStoredSeedFiles: int = 0
+    bytesStoredThumbnails: int = 0
 
     # total usage + exec time
     usage: Dict[str, int] = {}
@@ -2268,6 +2272,8 @@ class OrgMetrics(BaseModel):
     storageUsedCrawls: int
     storageUsedUploads: int
     storageUsedProfiles: int
+    storageUsedSeedFiles: int
+    storageUsedThumbnails: int
     storageQuotaBytes: int
     archivedItemCount: int
     crawlCount: int

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -321,6 +321,8 @@ class RawCrawlConfig(BaseModel):
 
     seeds: Optional[List[Seed]] = []
 
+    seedFileId: Optional[UUID] = None
+
     scopeType: Optional[ScopeType] = ScopeType.PREFIX
 
     include: Union[str, List[str], None] = None

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -28,6 +28,7 @@ class BgJobOperator(BaseOperator):
         async def mc_finalize_background_jobs(data: MCDecoratorSyncData):
             return await self.finalize_background_job(data)
 
+    # pylint: disable=too-many-locals
     async def finalize_background_job(self, data: MCDecoratorSyncData) -> dict:
         """handle finished background job"""
 
@@ -44,11 +45,16 @@ class BgJobOperator(BaseOperator):
             print(
                 "Succeeded: {status.get('succeeded')}, Num Pods: {spec.get('parallelism')}"
             )
+        start_time = status.get("startTime")
         completion_time = status.get("completionTime")
 
         finalized = True
 
+        started = None
         finished = None
+
+        if start_time:
+            started = str_to_date(start_time)
         if completion_time:
             finished = str_to_date(completion_time)
         if not finished:
@@ -62,7 +68,12 @@ class BgJobOperator(BaseOperator):
 
         try:
             await self.background_job_ops.job_finished(
-                job_id, job_type, success=success, finished=finished, oid=org_id
+                job_id,
+                job_type,
+                success=success,
+                started=started,
+                finished=finished,
+                oid=org_id,
             )
             # print(
             #    f"{job_type} background job completed: success: {success}, {job_id}",

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -182,6 +182,7 @@ class CrawlOperator(BaseOperator):
             scheduled=spec.get("manual") != "1",
             qa_source_crawl_id=spec.get("qaSourceCrawlId"),
             is_single_page=spec.get("isSinglePage") == "1",
+            seed_file_url=spec.get("seedFileUrl"),
         )
 
         # if finalizing, crawl is being deleted
@@ -469,6 +470,10 @@ class CrawlOperator(BaseOperator):
         raw_config["behaviors"] = self._filter_autoclick_behavior(
             raw_config["behaviors"], params["crawler_image"]
         )
+
+        if crawl.seed_file_url:
+            raw_config["seedFile"] = crawl.seed_file_url
+        raw_config.pop("seedFileId", None)
 
         params["config"] = json.dumps(raw_config)
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -182,7 +182,7 @@ class CrawlOperator(BaseOperator):
             scheduled=spec.get("manual") != "1",
             qa_source_crawl_id=spec.get("qaSourceCrawlId"),
             is_single_page=spec.get("isSinglePage") == "1",
-            seed_file_url=spec.get("seedFileUrl"),
+            seed_file_url=spec.get("seedFileUrl", ""),
         )
 
         # if finalizing, crawl is being deleted

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -87,6 +87,7 @@ class CrawlSpec(BaseModel):
     qa_source_crawl_id: Optional[str] = ""
     proxy_id: Optional[str] = None
     is_single_page: bool = False
+    seed_file_url: Optional[str] = None
 
     @property
     def db_crawl_id(self) -> str:

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -87,7 +87,7 @@ class CrawlSpec(BaseModel):
     qa_source_crawl_id: Optional[str] = ""
     proxy_id: Optional[str] = None
     is_single_page: bool = False
-    seed_file_url: Optional[str] = None
+    seed_file_url: Optional[str] = ""
 
     @property
     def db_crawl_id(self) -> str:

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -77,6 +77,7 @@ def init_ops() -> Tuple[
         crawl_manager,
         profile_ops,
         file_ops,
+        storage_ops,
     )
 
     coll_ops = CollectionOps(mdb, storage_ops, org_ops, event_webhook_ops)

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -69,6 +69,7 @@ def init_ops() -> Tuple[
         mdb, org_ops, crawl_manager, storage_ops, background_job_ops
     )
 
+    # pylint: disable=duplicate-code
     crawl_config_ops = CrawlConfigOps(
         dbclient,
         mdb,

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -110,7 +110,9 @@ def init_ops() -> Tuple[
 
     background_job_ops.set_ops(crawl_ops, profile_ops)
 
-    org_ops.set_ops(base_crawl_ops, profile_ops, coll_ops, background_job_ops, page_ops)
+    org_ops.set_ops(
+        base_crawl_ops, profile_ops, coll_ops, background_job_ops, page_ops, file_ops
+    )
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)
 

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -12,6 +12,7 @@ from .basecrawls import BaseCrawlOps
 from .colls import CollectionOps
 from .crawls import CrawlOps
 from .crawlconfigs import CrawlConfigOps
+from .file_uploads import FileUploadOps
 from .invites import InviteOps
 from .orgs import OrgOps
 from .pages import PageOps
@@ -37,6 +38,7 @@ def init_ops() -> Tuple[
     EventWebhookOps,
     UserManager,
     InviteOps,
+    FileUploadOps,
     AsyncIOMotorClient,
     AsyncIOMotorDatabase,
 ]:
@@ -57,6 +59,8 @@ def init_ops() -> Tuple[
 
     storage_ops = StorageOps(org_ops, crawl_manager, mdb)
 
+    file_ops = FileUploadOps(mdb, org_ops, storage_ops)
+
     background_job_ops = BackgroundJobOps(
         mdb, email, user_manager, org_ops, crawl_manager, storage_ops
     )
@@ -72,6 +76,7 @@ def init_ops() -> Tuple[
         org_ops,
         crawl_manager,
         profile_ops,
+        file_ops,
     )
 
     coll_ops = CollectionOps(mdb, storage_ops, org_ops, event_webhook_ops)
@@ -127,6 +132,7 @@ def init_ops() -> Tuple[
         event_webhook_ops,
         user_manager,
         invite_ops,
+        file_ops,
         dbclient,
         mdb,
     )

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1462,7 +1462,9 @@ class OrgOps:
     async def inc_org_bytes_stored_field(self, oid: UUID, field: str, size: int):
         """Increment specific org bytesStored* field"""
         try:
-            await self.orgs.find_one_and_update({"_id": oid}, {"$inc": {field: size}})
+            await self.orgs.find_one_and_update(
+                {"_id": oid}, {"$inc": {field: size, "bytesStored": size}}
+            )
         # pylint: disable=broad-exception-caught
         except Exception as err:
             print(f"Error updating field {field} on org {oid}: {err}", flush=True)

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -101,9 +101,10 @@ if TYPE_CHECKING:
     from .users import UserManager
     from .background_jobs import BackgroundJobOps
     from .pages import PageOps
+    from .file_uploads import FileUploadOps
 else:
     InviteOps = BaseCrawlOps = ProfileOps = CollectionOps = object
-    BackgroundJobOps = UserManager = PageOps = object
+    BackgroundJobOps = UserManager = PageOps = FileUploadOps = object
 
 
 DEFAULT_ORG = os.environ.get("DEFAULT_ORG", "My Organization")
@@ -160,6 +161,7 @@ class OrgOps:
         coll_ops: CollectionOps,
         background_job_ops: BackgroundJobOps,
         page_ops: PageOps,
+        file_ops: FileUploadOps,
     ) -> None:
         """Set additional ops classes"""
         # pylint: disable=attribute-defined-outside-init
@@ -168,6 +170,7 @@ class OrgOps:
         self.coll_ops = coll_ops
         self.background_job_ops = background_job_ops
         self.page_ops = page_ops
+        self.file_ops = file_ops
 
     def set_default_primary_storage(self, storage: StorageRef):
         """set default primary storage"""
@@ -994,6 +997,8 @@ class OrgOps:
             "storageUsedCrawls": org.bytesStoredCrawls,
             "storageUsedUploads": org.bytesStoredUploads,
             "storageUsedProfiles": org.bytesStoredProfiles,
+            "storageUsedSeedFiles": org.bytesStoredSeedFiles or 0,
+            "storageUsedThumbnails": org.bytesStoredThumbnails or 0,
             "storageQuotaBytes": storage_quota,
             "archivedItemCount": archived_item_count,
             "crawlCount": crawl_count,
@@ -1417,7 +1422,13 @@ class OrgOps:
                 org.id
             )
 
-            org_size = total_crawl_size + profile_size
+            seed_file_size = await self.file_ops.calculate_seed_file_storage(org.id)
+
+            thumbnail_size = await self.coll_ops.calculate_thumbnail_storage(org.id)
+
+            user_file_size = seed_file_size + thumbnail_size
+
+            org_size = total_crawl_size + profile_size + user_file_size
 
             await self.orgs.find_one_and_update(
                 {"_id": org.id},
@@ -1427,6 +1438,8 @@ class OrgOps:
                         "bytesStoredCrawls": crawl_size,
                         "bytesStoredUploads": upload_size,
                         "bytesStoredProfiles": profile_size,
+                        "bytesStoredSeedFiles": seed_file_size,
+                        "bytesStoredThumbnails": thumbnail_size,
                     }
                 },
             )
@@ -1445,6 +1458,14 @@ class OrgOps:
             {"_id": oid},
             {"$set": {"lastCrawlFinished": last_crawl_finished}},
         )
+
+    async def inc_org_bytes_stored_field(self, oid: UUID, field: str, size: int):
+        """Increment specific org bytesStored* field"""
+        try:
+            await self.orgs.find_one_and_update({"_id": oid}, {"$inc": {field: size}})
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(f"Error updating field {field} on org {oid}: {err}", flush=True)
 
 
 # ============================================================================

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -56,7 +56,6 @@ from .models import (
     PresignedUrl,
     SuccessResponse,
     User,
-    UserUploadFile,
 )
 
 from .utils import slug_from_name, dt_now, get_origin
@@ -630,7 +629,7 @@ class StorageOps:
         return urls, now + self.signed_duration_delta
 
     async def delete_file_object(
-        self, org: Organization, crawlfile: Union[BaseFile, UserUploadFile]
+        self, org: Organization, crawlfile: Union[BaseFile]
     ) -> bool:
         """delete crawl file from storage."""
         return await self._delete_file(org, crawlfile.filename, crawlfile.storage)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -56,7 +56,7 @@ from .models import (
     PresignedUrl,
     SuccessResponse,
     User,
-    UserUploadFileOut,
+    UserUploadFile,
 )
 
 from .utils import slug_from_name, dt_now
@@ -622,7 +622,7 @@ class StorageOps:
         return urls, now + self.signed_duration_delta
 
     async def delete_file_object(
-        self, org: Organization, crawlfile: Union[BaseFile, UserUploadFileOut]
+        self, org: Organization, crawlfile: Union[BaseFile, UserUploadFile]
     ) -> bool:
         """delete crawl file from storage."""
         return await self._delete_file(org, crawlfile.filename, crawlfile.storage)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -59,7 +59,7 @@ from .models import (
     UserUploadFile,
 )
 
-from .utils import slug_from_name, dt_now
+from .utils import slug_from_name, dt_now, get_origin
 from .version import __version__
 
 
@@ -350,6 +350,14 @@ class StorageOps:
         """Resolve relative path for internal access to minio bucket"""
         if path.startswith("/"):
             return self.frontend_origin + path
+        return path
+
+    def resolve_relative_access_path(self, path: str, headers: Optional[dict] = None):
+        """Resolve relative path for internal access or external if headers provided"""
+        if path.startswith("/"):
+            if headers is None:
+                return self.frontend_origin + path
+            return get_origin(headers) + path
         return path
 
     def get_org_relative_path(

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -12,6 +12,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     cast,
+    Union,
 )
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
@@ -55,6 +56,7 @@ from .models import (
     PresignedUrl,
     SuccessResponse,
     User,
+    UserUploadFileOut,
 )
 
 from .utils import slug_from_name, dt_now
@@ -619,7 +621,9 @@ class StorageOps:
 
         return urls, now + self.signed_duration_delta
 
-    async def delete_file_object(self, org: Organization, crawlfile: BaseFile) -> bool:
+    async def delete_file_object(
+        self, org: Organization, crawlfile: Union[BaseFile, UserUploadFileOut]
+    ) -> bool:
         """delete crawl file from storage."""
         return await self._delete_file(org, crawlfile.filename, crawlfile.storage)
 

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -844,6 +844,7 @@ def seed_file_config_id(crawler_auth_headers, default_org_id, seed_file_id):
             "seedFileId": seed_file_id,
             "limit": 2,
         },
+        "crawlerChannel": "test",
     }
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -826,7 +826,7 @@ def profile_2_id(admin_auth_headers, default_org_id, profile_browser_2_id):
 def seed_file_id(crawler_auth_headers, default_org_id):
     with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
         r = requests.put(
-            f"{API_PREFIX}/orgs/{default_org_id}/files/seedfile?filename=seedfile.txt",
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
             headers=crawler_auth_headers,
             data=read_in_chunks(fh),
         )

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -838,7 +838,7 @@ def seed_file_id(crawler_auth_headers, default_org_id):
 def seed_file_config_id(crawler_auth_headers, default_org_id, seed_file_id):
     crawl_data = {
         "runNow": False,
-        "name": "Seed File Workflow",
+        "name": "Seed File Test Crawl",
         "config": {
             "scopeType": "page",
             "seedFileId": seed_file_id,

--- a/backend/test/data/seedfile.txt
+++ b/backend/test/data/seedfile.txt
@@ -1,0 +1,2 @@
+https://specs.webrecorder.net
+https://webrecorder.net

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1283,7 +1283,7 @@ def test_upload_collection_thumbnail(crawler_auth_headers, default_org_id):
     thumbnail = collection["thumbnail"]
 
     assert thumbnail["name"]
-    assert thumbnail["path"]
+    assert thumbnail["path"].startswith("http://localhost:30870/data/")
     assert thumbnail["hash"]
     assert thumbnail["size"] > 0
 
@@ -1369,7 +1369,7 @@ def test_list_public_colls_home_url_thumbnail():
             assert thumbnail
 
             assert thumbnail["name"]
-            assert thumbnail["path"]
+            assert thumbnail["path"].startswith("http://localhost:30870/data/")
             assert thumbnail["hash"]
             assert thumbnail["size"]
             assert thumbnail["mime"]
@@ -1419,7 +1419,7 @@ def test_get_public_collection(default_org_id):
     assert thumbnail
 
     assert thumbnail["name"]
-    assert thumbnail["path"]
+    assert thumbnail["path"].startswith("http://localhost:30870/data/")
     assert thumbnail["hash"]
     assert thumbnail["size"]
     assert thumbnail["mime"]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1276,7 +1276,7 @@ def test_upload_collection_thumbnail(crawler_auth_headers, default_org_id):
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
-        headers=crawler_auth_headers,
+        headers={"Host": "localhost:30870", **crawler_auth_headers},
     )
     assert r.status_code == 200
     collection = r.json()
@@ -1335,7 +1335,11 @@ def test_list_public_colls_home_url_thumbnail():
     )
     non_public_image_fields = ("originalFilename", "userid", "userName", "created")
 
-    r = requests.get(f"{API_PREFIX}/public/orgs/{default_org_slug}/collections")
+    r = requests.get(
+        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections",
+        headers={"Host": "localhost:30870"},
+    )
+
     assert r.status_code == 200
     collections = r.json()["collections"]
     assert len(collections) == 2
@@ -1385,7 +1389,8 @@ def test_list_public_colls_home_url_thumbnail():
 
 def test_get_public_collection(default_org_id):
     r = requests.get(
-        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections/{PUBLIC_COLLECTION_SLUG}"
+        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections/{PUBLIC_COLLECTION_SLUG}",
+        headers={"Host": "localhost:30870"},
     )
     assert r.status_code == 200
     coll = r.json()

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -1,9 +1,13 @@
+import os
 import time
 
 import requests
 
 from .conftest import API_PREFIX
+from .utils import read_in_chunks
 
+
+curr_dir = os.path.dirname(os.path.realpath(__file__))
 
 cid = None
 cid_single_page = None
@@ -13,6 +17,8 @@ UPDATED_TAGS = ["tag3", "tag4"]
 
 _coll_id = None
 _admin_crawl_cid = None
+
+_seed_file_id = None
 
 
 def test_crawl_config_usernames(
@@ -943,3 +949,19 @@ def test_validate_custom_behavior(crawler_auth_headers, default_org_id):
     )
     assert r.status_code == 404
     assert r.json()["detail"] == "custom_behavior_branch_not_found"
+
+
+def test_add_crawl_config_with_seed_file(
+    crawler_auth_headers, default_org_id, seed_file_id, seed_file_config_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{seed_file_config_id}/",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert data["id"] == seed_file_config_id
+    assert data["name"] == "Seed File Workflow"
+    assert data["config"]["seedFileId"] == seed_file_id
+    assert data["config"]["seeds"] == []

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -957,6 +957,6 @@ def test_add_crawl_config_with_seed_file(
 
     data = r.json()
     assert data["id"] == seed_file_config_id
-    assert data["name"] == "Seed File Workflow"
+    assert data["name"] == "Seed File Test Crawl"
     assert data["config"]["seedFileId"] == seed_file_id
     assert data["config"]["seeds"] is None

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -960,3 +960,22 @@ def test_add_crawl_config_with_seed_file(
     assert data["name"] == "Seed File Test Crawl"
     assert data["config"]["seedFileId"] == seed_file_id
     assert data["config"]["seeds"] is None
+
+
+def test_delete_in_use_seed_file(
+    crawler_auth_headers, default_org_id, seed_file_id, seed_file_config_id
+):
+    # Attempt to delete in-use seed file, verify we get 400 response
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "seed_file_in_use"
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["id"] == seed_file_id

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -1,13 +1,8 @@
-import os
 import time
 
 import requests
 
 from .conftest import API_PREFIX
-from .utils import read_in_chunks
-
-
-curr_dir = os.path.dirname(os.path.realpath(__file__))
 
 cid = None
 cid_single_page = None

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -959,4 +959,4 @@ def test_add_crawl_config_with_seed_file(
     assert data["id"] == seed_file_config_id
     assert data["name"] == "Seed File Workflow"
     assert data["config"]["seedFileId"] == seed_file_id
-    assert data["config"]["seeds"] == []
+    assert data["config"]["seeds"] is None

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -46,6 +46,8 @@ def test_seed_file_upload(crawler_auth_headers, default_org_id):
     assert data["created"]
 
     assert data["type"] == "seedFile"
+    assert data["firstSeed"] == "https://specs.webrecorder.net"
+    assert data["seedCount"] == 2
 
 
 def test_delete_seed_file(crawler_auth_headers, default_org_id):

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -35,7 +35,7 @@ def test_seed_file_upload(crawler_auth_headers, default_org_id):
     assert data["oid"] == default_org_id
 
     assert data["name"]
-    assert data["path"]
+    assert data["path"].startswith("http://localhost:30870/data/")
     assert data["hash"]
     assert data["size"] > 0
 
@@ -69,7 +69,7 @@ def test_list_user_files(crawler_auth_headers, default_org_id):
         assert data["oid"] == default_org_id
 
         assert data["name"]
-        assert data["path"]
+        assert data["path"].startswith("http://localhost:30870/data/")
         assert data["hash"]
         assert data["size"] > 0
 

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -50,6 +50,40 @@ def test_seed_file_upload(crawler_auth_headers, default_org_id):
     assert data["seedCount"] == 2
 
 
+def test_list_user_files(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    items = data["items"]
+    total = data["total"]
+
+    assert total >= 0
+    assert total == len(items)
+
+    for data in items:
+        assert data["id"]
+        assert data["oid"] == default_org_id
+
+        assert data["name"]
+        assert data["path"]
+        assert data["hash"]
+        assert data["size"] > 0
+
+        assert data["originalFilename"]
+        assert data["mime"]
+        assert data["userid"]
+        assert data["userName"]
+        assert data["created"]
+
+        assert data["type"] == "seedFile"
+        assert data["firstSeed"]
+        assert data["seedCount"]
+
+
 def test_delete_seed_file(crawler_auth_headers, default_org_id):
     r = requests.delete(
         f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -12,7 +12,7 @@ _seed_file_id = None
 def test_seed_file_upload(crawler_auth_headers, default_org_id):
     with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
         r = requests.put(
-            f"{API_PREFIX}/orgs/{default_org_id}/files/seedfile?filename=seedfile.txt",
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
             headers=crawler_auth_headers,
             data=read_in_chunks(fh),
         )

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -10,7 +10,6 @@ _seed_file_id = None
 
 
 def test_seed_file_upload(crawler_auth_headers, default_org_id):
-    # https://dev.browsertrix.com/api/orgs/c69247f4-415e-4abc-b449-e85d2f26c626/collections/b764fbe1-baab-4dc5-8dca-2db6f82c250b/data?filename=page-data_47fe599e-ed62-4edd-b078-93d4bf281e0f.jpeg&sourceUrl=https%3A%2F%2Fspecs.webrecorder.net%2F&sourceTs=2024-08-16T08%3A00%3A21.601000Z&sourcePageId=47fe599e-ed62-4edd-b078-93d4bf281e0f
     with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
         r = requests.put(
             f"{API_PREFIX}/orgs/{default_org_id}/files/seedfile?filename=seedfile.txt",

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -26,7 +26,7 @@ def test_seed_file_upload(crawler_auth_headers, default_org_id):
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
-        headers=crawler_auth_headers,
+        headers={"Host": "custom-host.example.com", **crawler_auth_headers},
     )
     assert r.status_code == 200
     data = r.json()
@@ -35,7 +35,7 @@ def test_seed_file_upload(crawler_auth_headers, default_org_id):
     assert data["oid"] == default_org_id
 
     assert data["name"]
-    assert data["path"].startswith("http://localhost:30870/data/")
+    assert data["path"].startswith("http://custom-host.example.com/data/")
     assert data["hash"]
     assert data["size"] > 0
 
@@ -53,7 +53,7 @@ def test_seed_file_upload(crawler_auth_headers, default_org_id):
 def test_list_user_files(crawler_auth_headers, default_org_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/files",
-        headers=crawler_auth_headers,
+        headers={"Host": "localhost", **crawler_auth_headers},
     )
     assert r.status_code == 200
     data = r.json()
@@ -69,7 +69,7 @@ def test_list_user_files(crawler_auth_headers, default_org_id):
         assert data["oid"] == default_org_id
 
         assert data["name"]
-        assert data["path"].startswith("http://localhost:30870/data/")
+        assert data["path"].startswith("http://localhost/data/")
         assert data["hash"]
         assert data["size"] > 0
 

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -2,6 +2,7 @@ import os
 import requests
 
 from .conftest import API_PREFIX
+from .utils import read_in_chunks
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -1,0 +1,63 @@
+import os
+import requests
+
+from .conftest import API_PREFIX
+
+curr_dir = os.path.dirname(os.path.realpath(__file__))
+
+_seed_file_id = None
+
+
+def test_seed_file_upload(crawler_auth_headers, default_org_id):
+    # https://dev.browsertrix.com/api/orgs/c69247f4-415e-4abc-b449-e85d2f26c626/collections/b764fbe1-baab-4dc5-8dca-2db6f82c250b/data?filename=page-data_47fe599e-ed62-4edd-b078-93d4bf281e0f.jpeg&sourceUrl=https%3A%2F%2Fspecs.webrecorder.net%2F&sourceTs=2024-08-16T08%3A00%3A21.601000Z&sourcePageId=47fe599e-ed62-4edd-b078-93d4bf281e0f
+    with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
+        r = requests.put(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedfile?filename=seedfile.txt",
+            headers=crawler_auth_headers,
+            data=read_in_chunks(fh),
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["added"]
+        assert data["id"]
+
+        global _seed_file_id
+        _seed_file_id = data["id"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["id"] == _seed_file_id
+    assert data["oid"] == default_org_id
+
+    assert data["name"]
+    assert data["path"]
+    assert data["hash"]
+    assert data["size"] > 0
+
+    assert data["originalFilename"] == "seedfile.txt"
+    assert data["mime"] == "text/plain"
+    assert data["userid"]
+    assert data["userName"]
+    assert data["created"]
+
+    assert data["type"] == "seedFile"
+
+
+def test_delete_seed_file(crawler_auth_headers, default_org_id):
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 404

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -11,8 +11,8 @@ def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 8
-    assert r.json()["total"] == 8
+    assert len(r.json()["items"]) == 9
+    assert r.json()["total"] == 9
 
 
 def test_get_config_by_modified_by(
@@ -23,8 +23,8 @@ def test_get_config_by_modified_by(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?modifiedBy={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 8
-    assert r.json()["total"] == 8
+    assert len(r.json()["items"]) == 9
+    assert r.json()["total"] == 9
 
 
 def test_get_configs_by_first_seed(
@@ -362,9 +362,9 @@ def test_sort_crawl_configs(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 14
+    assert data["total"] == 15
     items = data["items"]
-    assert len(items) == 14
+    assert len(items) == 15
 
     last_created = None
     for config in items:

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -496,12 +496,16 @@ def test_org_metrics(crawler_auth_headers, default_org_id):
     assert data["storageUsedBytes"] > 0
     assert data["storageUsedCrawls"] > 0
     assert data["storageUsedUploads"] >= 0
+    assert data["storageUsedThumbnails"] >= 0
+    assert data["storageUsedThumbnails"] >= 0
     assert data["storageUsedProfiles"] >= 0
     assert (
         data["storageUsedBytes"]
         == data["storageUsedCrawls"]
         + data["storageUsedUploads"]
         + data["storageUsedProfiles"]
+        + data["storageUsedSeedFiles"]
+        + data["storageUsedThumbnails"]
     )
     assert data["storageQuotaBytes"] >= 0
     assert data["archivedItemCount"] > 0

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -1413,6 +1413,6 @@ def test_seed_file_crawl(
     assert data["total"] == 2
     for page in data["items"]:
         assert page["url"] in (
-            "https://specs.webrecorder.net",
-            "https://webrecorder.net",
+            "https://specs.webrecorder.net/",
+            "https://webrecorder.net/",
         )

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -1366,3 +1366,53 @@ def test_crawls_exclude_behavior_logs(
     crawls = r.json()["items"]
     for crawl in crawls:
         assert data.get("behaviorLogs") == []
+
+
+def test_seed_file_crawl(
+    crawler_auth_headers, default_org_id, seed_file_id, seed_file_config_id
+):
+    # Run crawl from workflow with seed file
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{seed_file_config_id}/run",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    crawl_id = r.json()["started"]
+
+    # Wait for it to complete
+    while True:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+            headers=crawler_auth_headers,
+        )
+        data = r.json()
+        if data["state"] in FINISHED_STATES:
+            break
+        time.sleep(5)
+
+    time.sleep(10)
+
+    # Check on crawl
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["config"]["seedFileId"] == seed_file_id
+    assert data["state"] == "complete"
+
+    # Validate crawl pages
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/pages",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+    for page in data["items"]:
+        assert page["url"] in (
+            "https://specs.webrecorder.net",
+            "https://webrecorder.net",
+        )

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -607,7 +607,7 @@ def test_get_all_crawls_by_type(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 6
+    assert data["total"] == 7
     for item in data["items"]:
         assert item["type"] == "crawl"
 
@@ -639,7 +639,7 @@ def test_get_all_crawls_by_user(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 5
+    assert data["total"] == 6
     for item in data["items"]:
         assert item["userid"] == crawler_userid
 
@@ -823,7 +823,7 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 8
+    assert len(data["names"]) == 9
     expected_names = [
         "Crawler User Test Crawl",
         "Custom Behavior Logs",
@@ -831,6 +831,7 @@ def test_all_crawls_search_values(
         "test2.wacz",
         "All Crawls Test Crawl",
         "Crawler User Crawl for Testing QA",
+        "Seed File Test Crawl",
     ]
     for expected_name in expected_names:
         assert expected_name in data["names"]
@@ -857,6 +858,7 @@ def test_all_crawls_search_values(
         "Crawler User Crawl for Testing QA",
         "Crawler User Test Crawl",
         "Custom Behavior Logs",
+        "Seed File Test Crawl",
     ]
     for expected_name in expected_names:
         assert expected_name in data["names"]

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -851,7 +851,7 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 5
+    assert len(data["names"]) == 6
     expected_names = [
         "Admin Test Crawl",
         "All Crawls Test Crawl",

--- a/backend/test_nightly/data/seedfile.txt
+++ b/backend/test_nightly/data/seedfile.txt
@@ -1,0 +1,2 @@
+https://specs.webrecorder.net
+https://webrecorder.net

--- a/backend/test_nightly/test_cleanup_seed_files.py
+++ b/backend/test_nightly/test_cleanup_seed_files.py
@@ -54,7 +54,6 @@ def seed_file_config_id(crawler_auth_headers, default_org_id, seed_file_used_id)
     return r.json()["id"]
 
 
-
 def test_seed_file_cleanup_cron_job(
     admin_auth_headers,
     default_org_id,

--- a/backend/test_nightly/test_cleanup_seed_files.py
+++ b/backend/test_nightly/test_cleanup_seed_files.py
@@ -1,0 +1,63 @@
+import os
+import requests
+import time
+
+import pytest
+
+from .conftest import API_PREFIX
+from .utils import read_in_chunks
+
+curr_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.fixture(scope="session")
+def seed_file_id(crawler_auth_headers, default_org_id):
+    with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
+        r = requests.put(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
+            headers=crawler_auth_headers,
+            data=read_in_chunks(fh),
+        )
+        assert r.status_code == 200
+        return r.json()["id"]
+
+
+def test_seed_file_cleanup_cron_job(admin_auth_headers, default_org_id, seed_file_id):
+    # Verify seed file exists
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == seed_file_id
+    assert data["oid"] == default_org_id
+
+    # Wait 5 minutes to give cleanup job time to run
+    time.sleep(300)
+
+    # Check that at least one bg job entry exists for cleanup jobs and that
+    # the jobs are marked as successful
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/jobs?jobType=cleanup-seed-files",
+        headers=admin_auth_headers
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["total"] > 0
+    for job in data["items"]:
+        print(job)
+        assert job["id"]
+        assert job["type"] == "cleanup-seed-files"
+        assert job["success"]
+        assert job["started"]
+        assert job["finished"]
+
+    # Check that seed file was deleted from database
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+

--- a/backend/test_nightly/test_cleanup_seed_files.py
+++ b/backend/test_nightly/test_cleanup_seed_files.py
@@ -39,8 +39,8 @@ def test_seed_file_cleanup_cron_job(admin_auth_headers, default_org_id, seed_fil
     # Check that at least one bg job entry exists for cleanup jobs and that
     # the jobs are marked as successful
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs?jobType=cleanup-seed-files",
-        headers=admin_auth_headers
+        f"{API_PREFIX}/orgs/all/jobs?jobType=cleanup-seed-files",
+        headers=admin_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
@@ -60,4 +60,3 @@ def test_seed_file_cleanup_cron_job(admin_auth_headers, default_org_id, seed_fil
         headers=admin_auth_headers,
     )
     assert r.status_code == 404
-

--- a/btrix
+++ b/btrix
@@ -78,6 +78,7 @@ reset(){
     echo "Deleting data..."
     kubectl delete pvc --all
     kubectl delete cronjob -n crawlers --all
+    kubectl delete cronjob --all
     kubectl delete configmap -n crawlers -l btrix.crawlconfig
 }
 
@@ -92,6 +93,7 @@ resetMicrok8s(){
     echo "Deleting data..."
     microk8s kubectl delete pvc --all
     microk8s kubectl delete cronjob -n crawlers --all
+    microk8s kubectl delete cronjob --all
     microk8s kubectl delete configmap -n crawlers -l btrix.crawlconfig
 }
 

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "{{ id }}"
+  labels:
+    role: "cron-background-job"
+    job_type: {{ job_type }}
+
+spec:
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 2
+
+  schedule: "{{ schedule }}"
+
+  jobTemplate:
+    metadata:
+      labels:
+        role: "background-job"
+        job_type: {{ job_type }}
+        job_id: {{ id }}
+
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          priorityClassName: bg-job
+          podFailurePolicy:
+            rules:
+            - action: FailJob
+              onExitCodes:
+                containerName: btrixbgjob
+                operator: NotIn
+                values: [0]
+          
+          volumes:
+            - name: ops-configs
+              secret:
+                secretName: ops-configs
+
+          containers:
+            - name: btrixbgjob
+              image: {{ backend_image }}
+              imagePullPolicy: {{ pull_policy }}
+              env:
+              - name: BG_JOB_TYPE
+                value: {{ job_type }}
+
+              envFrom:
+                - configMapRef:
+                    name: backend-env-config
+                - secretRef:
+                    name: mongo-auth
+
+              volumeMounts:
+                - name: ops-configs
+                  mountPath: /ops-configs/
+
+              command: ["python3", "-m", "btrixcloud.main_bg"]
+
+              resources:
+{% if larger_resources %}
+                limits:
+                  memory: "1200Mi"
+
+                requests:
+                  memory: "500Mi"
+                  cpu: "200m"
+{% else %}
+                limits:
+                  memory: "200Mi"
+
+                requests:
+                  memory: "200Mi"
+                  cpu: "50m"
+{% endif %}

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
 
   schedule: "{{ schedule }}"
@@ -33,6 +33,11 @@ spec:
                 operator: NotIn
                 values: [0]
 
+          volumes:
+            - name: ops-configs
+              secret:
+                secretName: ops-configs
+
           containers:
             - name: btrixbgjob
               image: {{ backend_image }}
@@ -41,11 +46,19 @@ spec:
               - name: BG_JOB_TYPE
                 value: {{ job_type }}
 
+              volumeMounts:
+                - name: ops-configs
+                  mountPath: /ops-configs/
+
               envFrom:
                 - configMapRef:
                     name: backend-env-config
                 - secretRef:
                     name: mongo-auth
+
+              volumeMounts:
+                - name: ops-configs
+                  mountPath: /ops-configs/
 
               command: ["python3", "-m", "btrixcloud.main_bg"]
 

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -32,11 +32,6 @@ spec:
                 containerName: btrixbgjob
                 operator: NotIn
                 values: [0]
-          
-          volumes:
-            - name: ops-configs
-              secret:
-                secretName: ops-configs
 
           containers:
             - name: btrixbgjob
@@ -51,10 +46,6 @@ spec:
                     name: backend-env-config
                 - secretRef:
                     name: mongo-auth
-
-              volumeMounts:
-                - name: ops-configs
-                  mountPath: /ops-configs/
 
               command: ["python3", "-m", "btrixcloud.main_bg"]
 

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -41,3 +41,4 @@ spec:
 
   isSinglePage: "{{ is_single_page }}"
 
+  seedFileUrl: "{{ seed_file_url }}"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -103,6 +103,8 @@ data:
 
   CLEANUP_JOB_CRON_SCHEDULE: "{{ .Values.cleanup_job_cron_schedule }}"
 
+  CLEANUP_FILES_AFTER_MINUTES: "{{ .Values.cleanup_files_after_minutes | default 1440 }}"
+
 
 ---
 apiVersion: v1

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -71,6 +71,8 @@ data:
 
   MIN_AUTOCLICK_CRAWLER_IMAGE: "{{ .Values.min_autoclick_crawler_image }}"
 
+  MIN_SEED_FILE_CRAWLER_IMAGE: "{{ .Values.min_seed_file_crawler_image }}"
+
   NUM_BROWSERS: "{{ .Values.crawler_browser_instances }}"
 
   MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -101,6 +101,8 @@ data:
 
   PRESIGN_BATCH_SIZE: "{{ .Values.presign_batch_size | default 8 }}"
 
+  CLEANUP_JOB_CRON_SCHEDULE: "{{ .Values.cleanup_job_cron_schedule }}"
+
 
 ---
 apiVersion: v1

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -29,7 +29,7 @@ metadata:
   name: bg-job
 rules:
   - apiGroups: ["batch"]
-    resources: ["jobs"]
+    resources: ["jobs", "cronjobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 
 ---

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -7,6 +7,9 @@ max_pages_per_crawl: 300
 # Every minute, for use in testing cleaning up seed files
 cleanup_job_cron_schedule: "* * * * *"
 
+# Clean up files > 1 minute old in testing
+cleanup_files_after_minutes: 1
+
 # enable to allow access to minio directly
 minio_local_access_port: 30090
 

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -4,6 +4,8 @@ invite_expire_seconds: 10
 
 max_pages_per_crawl: 300
 
+# Every minute, for use in testing cleaning up seed files
+cleanup_job_cron_schedule: "* * * * *"
 
 # enable to allow access to minio directly
 minio_local_access_port: 30090

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -24,7 +24,7 @@ crawler_channels:
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
   - id: test
-    image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    image: "docker.io/webrecorder/browsertrix-crawler:1.7.0-beta.0"
 
 mongo_auth:
   # specify either username + password (for local mongo)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -255,8 +255,11 @@ crawler_namespace: "crawlers"
 # if set, will restrict QA to image names that are >= than this value
 # min_qa_crawler_image: ""
 
-# if set, will restrict autoclick behavior to image names that are >= than this value
+# if set, will restrict autoclick behavior to image names that are >= this value
 min_autoclick_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.5.0"
+
+# if set, will restrict seed files to image names that are >= this value
+min_seed_file_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.7.0"
 
 # optional: enable to use a persist volume claim for all crawls
 # can be enabled to use a multi-write shared filesystem

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -166,6 +166,10 @@ backend_avg_memory_threshold: 95
 # Defaults to every Sunday at midnight
 cleanup_job_cron_schedule: "0 0 * * 0"
 
+# number of minutes before unused seed files are eligible
+# for cleanup. defaults to 1 day (1440 minutes) 
+cleanup_files_after_minutes: 1440
+
 
 # Nginx Image
 # =========================================

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,6 +162,11 @@ backend_avg_cpu_threshold: 80
 # scale up if avg memory utilization exceeds
 backend_avg_memory_threshold: 95
 
+# Cron schedule for periodically cleaning up unused files
+# Defaults to every Sunday at midnight
+cleanup_job_cron_schedule: "0 0 * * 0"
+
+
 # Nginx Image
 # =========================================
 frontend_image: "docker.io/webrecorder/browsertrix-frontend:1.17.4"


### PR DESCRIPTION
Fixes #2673 

Changes in this PR:

- Adds a new `file_uploads.py` module and corresponding `/files` API prefix with methods/endpoints for uploading, GETing, and deleting seed files (can be extended to other types of files moving forward)
- Seed files are supported via `CrawlConfig.config.seedFileId` on POST and PATCH endpoints. This seedFileId is replaced by a presigned url when passed to the crawler by the operator
- Seed files are read when first uploaded to calculate `firstSeed` and `seedCount` and store them in the database, and this is copied into the workflow and crawl documents when they are created.
- Logic is added to store `firstSeed` and `seedCount` for other workflows as well, and a migration added to backfill data, to maintain consistency and fix some of the pymongo aggregations that previously assumed all workflows would have at least one `Seed` object in `CrawlConfig.seeds`
- Seed file and thumbnail storage stats are added to org stats
- Seed file and thumbnail uploads first check that the org's storage quota has not been exceeded and return a 400 if so
- A cron background job (run weekly each Sunday at midnight by default, but configurable) is added to look for seed files at least x minutes old (1440 minutes, or 1 day, by default, but configurable) that are not in use in any workflows, and to delete them when they are found. The backend pods will ensure this k8s batch job exists when starting up and create it if it does not already exist. A database entry for each run of the job is created in the operator on job completion so that it'll appear in the `/jobs` API endpoints, but retrying of this type of regularly scheduled background job is not supported as we don't want to accidentally create multiple competing scheduled jobs.
- Adds a `min_seed_file_crawler_image` value to the Helm chart that is checked before creating a crawl from a workflow if set. If a workflow cannot be run, return the detail of the exception in `CrawlConfigAddedResponse.errorDetail` so that we can display the reason in the frontend

~~## Todo~~

~~- Modify test chart crawler release back to latest once crawler with seed file support is properly released~~