### PR TITLE
volumes: use emptyDir for tmp dir volume

### DIFF
--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -74,6 +74,8 @@ spec:
     {% else %}
       emptyDir: {}
     {% endif %}
+    - name: tmpdir
+      emptyDir: {}
     {% if proxy_id %}
     - name: proxies
       secret:
@@ -189,9 +191,8 @@ spec:
         - name: crawl-data
           mountPath: /crawls
 
-        - name: crawl-data
+        - name: tmpdir
           mountPath: /tmp
-          subPath: tmp
 
       envFrom:
         - configMapRef:


### PR DESCRIPTION
- don't use a persistent volume for /tmp, instead use a temporary emptyDir
- use volume to avoid permission issues with default /tmp dir
- follow-up to #2623 