### PR TITLE
feat: add option for backend alias in chart

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 data:
-  APP_ORIGIN: {{ .Values.backend_alias | default (printf "%s://%s:%s" (.Values.ingress.tls | ternary "https" "http") (.Values.ingress.host | default "localhost") ( .Values.local_service_port | default 9870 ) ) }}
+  APP_ORIGIN: {{ .Values.backend_alias | default (printf "%s://%s:%d" (.Values.ingress.tls | ternary "https" "http") (.Values.ingress.host | default "localhost") ( .Values.local_service_port | default 9870 ) ) }}
 
   CRAWLER_NAMESPACE: {{ .Values.crawler_namespace }}
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 data:
-  APP_ORIGIN: {{ .Values.ingress.tls | ternary "https" "http" }}://{{ or .Values.ingress.host ( print "localhost:" ( .Values.local_service_port | default 9870 )) }}
+  APP_ORIGIN: {{ .Values.backend_alias | default (printf "%s://%s:%s" (.Values.ingress.tls | ternary "https" "http") (.Values.ingress.host | default "localhost") ( .Values.local_service_port | default 9870 ) ) }}
 
   CRAWLER_NAMESPACE: {{ .Values.crawler_namespace }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,6 +162,10 @@ backend_avg_cpu_threshold: 80
 # scale up if avg memory utilization exceeds
 backend_avg_memory_threshold: 95
 
+# if not using the builtin ingress, set this to the hostname that
+# the backend will be available at
+# backend_alias: "http://browsertrix-cloud-backend"
+
 # Nginx Image
 # =========================================
 frontend_image: "docker.io/webrecorder/browsertrix-frontend:1.17.2"


### PR DESCRIPTION
I'm creating a deployment which uses an ALB Ingress (perhaps future PR to support different Ingress configurations) but for now the ability to configure the backend alias would be very helpful