### PR TITLE
Fix custom page prefix scope

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2640,12 +2640,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       : [];
     const primarySeed: Seed = {
       url: primarySeedUrl,
-      // the 'custom' scope here indicates we have extra URLs, actually set to 'prefix'
-      // scope on backend to ensure seed URL is also added as part of standard prefix scope
-      scopeType:
-        this.formState.scopeType === ScopeType.Custom
-          ? ScopeType.Prefix
-          : (this.formState.scopeType as ScopeType),
+      scopeType: this.formState.scopeType as ScopeType,
       include:
         this.formState.scopeType === ScopeType.Custom
           ? [...includeUrlList.map((url) => regexEscape(url))]


### PR DESCRIPTION
Fixes #2721 

This PR removes frontend logic that set the seed-level scopeType for custom page prefix workflows to `prefix`, which was causing the scope to balloon larger than what users intended for some workflows.

## Testing instructions

1. Create a workflow with Custom Page Prefix scope, Crawl Start URL `https://med.stanford.edu/whsdm.html`, and Extra URL Prefixes in Scope `https://med.stanford.edu/whsdm/` and `https://med.stanford.edu/content/sm/whsdm/`
2. Verify that all crawled pages (18 as of writing this) fall within the desired scope, and that other pages from `https://med.stanford.edu/` prefix are no longer included