### PR TITLE
feat: allow specifying custom annotations on ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- if .Values.ingress.useOldClassAnnotation }}
     kubernetes.io/ingress.class: {{ .Values.ingress_class | default "nginx" }}
     {{- end }}
+    {{- if eq ( .Values.ingress_class | default "nginx" ) "nginx" }}
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     # for larger uploads to not timeout
@@ -21,6 +22,10 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
+    {{- end }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 
 spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -477,6 +477,14 @@ ingress:
   # Optional: Uncomment to use your own cluster-issuer instead of default ACME https validation
   # custom_cluster_issuer: custom_cluster_issuer-name
 
+  # Optional: Uncomment to apply custom annotations
+  # annotations:
+  #   alb.ingress.kubernetes.io/scheme: internet-facing
+  #   alb.ingress.kubernetes.io/target-type: ip
+  #   alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+  #   alb.ingress.kubernetes.io/certificate-arn: "certificate-arn"
+
+
 ingress_class: nginx
 
 # Optional: Front-end injected script


### PR DESCRIPTION
This allows users who don't use the nginx ingress controller to still configure the built in ingress