### PR TITLE
Add browser profile filter to workflow list & add link to filtered list to profile detail pages

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -236,7 +236,7 @@ export class ConfigDetails extends BtrixElement {
               () =>
                 html`<a
                   class="text-blue-500 hover:text-blue-600"
-                  href=${`/orgs/${crawlConfig!.oid}/browser-profiles/profile/${
+                  href=${`${this.navigate.orgBasePath}/browser-profiles/profile/${
                     crawlConfig!.profileid
                   }`}
                   @click=${this.navigate.link}

--- a/frontend/src/features/crawl-workflows/index.ts
+++ b/frontend/src/features/crawl-workflows/index.ts
@@ -9,3 +9,4 @@ import("./workflow-editor");
 import("./workflow-list");
 import("./workflow-schedule-filter");
 import("./workflow-tag-filter");
+import("./workflow-profile-filter");

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -24,6 +24,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type APIPaginatedList } from "@/types/api";
 import { type Profile } from "@/types/crawler";
+import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import { tw } from "@/utils/tailwind";
 
@@ -122,7 +123,11 @@ export class WorkflowProfileFilter extends BtrixElement {
         }}
       >
         ${this.profiles?.length
-          ? html`<span class="opacity-75">${msg("Profiles")}</span>
+          ? html`<span class="opacity-75"
+                >${msg(
+                  str`Using ${pluralOf("profiles", this.profiles.length)}`,
+                )}</span
+              >
               ${this.renderProfilesInLabel(this.profiles)}`
           : msg("Browser Profile")}
 

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -271,27 +271,27 @@ export class WorkflowProfileFilter extends BtrixElement {
       return html`
         <li role="option" aria-checked=${checked}>
           <sl-checkbox
-            class="w-full part-[label]:grid part-[base]:w-full part-[label]:w-full part-[label]:items-center part-[label]:justify-between part-[label]:gap-2 part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
+            class="w-full part-[label]:grid part-[base]:w-full part-[label]:w-full part-[label]:items-center part-[label]:justify-between part-[label]:gap-x-2 part-[label]:gap-y-1 part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
             value=${profile.id}
             ?checked=${checked}
             ?disabled=${!profile.inUse}
           >
-            <span class="inline-block min-w-0 max-w-72 truncate"
+            <span class="mb-1 inline-block min-w-0 max-w-96 truncate"
               >${profile.name}</span
             >
             <btrix-format-date
               class="col-start-2 ml-auto text-xs text-stone-600"
-              date=${profile.created}
+              date=${profile.modified ?? profile.created}
             ></btrix-format-date>
             ${profile.inUse
-              ? profile.description
-                ? html`<div
-                    class="col-span-2 max-w-full truncate text-xs text-stone-600 contain-inline-size"
+              ? html`${profile.description &&
+                  html`<div
+                    class="col-span-2 min-w-0 truncate text-xs text-stone-600 contain-inline-size"
                   >
                     ${profile.description}
-                  </div>`
-                : html`<div
-                    class="col-span-2 min-w-0 max-w-full text-xs text-stone-400"
+                  </div>`}
+                  <div
+                    class="col-span-2 min-w-0 max-w-full text-xs text-stone-400 contain-inline-size"
                   >
                     ${this.localize
                       .list(
@@ -312,11 +312,10 @@ export class WorkflowProfileFilter extends BtrixElement {
                           ? part.value
                           : richText(part.value, {
                               shortenOnly: true,
-                              linkClass:
-                                "text-stone-600 font-medium truncate inline-block max-w-full",
+                              linkClass: tw`inline-block max-w-[min(theme(spacing.72),100%)] truncate font-medium text-stone-600`,
                             }),
                       )}
-                  </div>`
+                  </div> `
               : html`<div class="col-span-2 text-xs">
                   ${msg("Not in use")}
                 </div>`}

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -28,7 +28,8 @@ import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import { tw } from "@/utils/tailwind";
 
-const MAX_PROFILES_IN_LABEL = 3;
+const MAX_PROFILES_IN_LABEL = 2;
+const MAX_ORIGINS_IN_LIST = 5;
 
 export type BtrixChangeWorkflowProfileFilterEvent = BtrixChangeEvent<
   string[] | undefined
@@ -295,14 +296,11 @@ export class WorkflowProfileFilter extends BtrixElement {
                   >
                     ${this.localize
                       .list(
-                        profile.origins.length > MAX_PROFILES_IN_LABEL
+                        profile.origins.length > MAX_ORIGINS_IN_LIST
                           ? [
-                              ...profile.origins.slice(
-                                0,
-                                MAX_PROFILES_IN_LABEL,
-                              ),
+                              ...profile.origins.slice(0, MAX_ORIGINS_IN_LIST),
                               msg(
-                                str`${this.localize.number(profile.origins.length - MAX_PROFILES_IN_LABEL)} more`,
+                                str`${this.localize.number(profile.origins.length - MAX_ORIGINS_IN_LIST)} more`,
                               ),
                             ]
                           : profile.origins,

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -249,12 +249,12 @@ export class BrowserProfilesDetail extends BtrixElement {
         </header>
         <!-- display: inline -->
         <div
-          class="leading whitespace-pre-line rounded border p-5 leading-relaxed first-line:leading-[0]"
+          class="leading whitespace-pre-line rounded border p-5 leading-relaxed"
           >${this.profile
             ? this.profile.description
               ? richText(this.profile.description)
               : html`
-                  <div class="text-center text-neutral-400">
+                  <div class="text-center leading-[0] text-neutral-400">
                     &nbsp;${msg("No description added.")}
                   </div>
                 `

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -160,6 +160,9 @@ export class BrowserProfilesDetail extends BtrixElement {
       <div class="mb-7 flex flex-col gap-5 lg:flex-row">
         <section class="flex-1">
           <header class="flex items-center gap-2">
+            <h2 class="text-lg font-medium leading-none">
+              ${msg("Browser Profile")}
+            </h2>
             <sl-tooltip
               content=${isBackedUp ? msg("Backed Up") : msg("Not Backed Up")}
               ?disabled=${!this.profile}
@@ -167,7 +170,7 @@ export class BrowserProfilesDetail extends BtrixElement {
               <sl-icon
                 class="${isBackedUp
                   ? "text-success"
-                  : "text-neutral-500"} text-base"
+                  : "text-neutral-500"} ml-auto text-base"
                 name=${this.profile
                   ? isBackedUp
                     ? "clouds-fill"
@@ -175,9 +178,36 @@ export class BrowserProfilesDetail extends BtrixElement {
                   : "clouds"}
               ></sl-icon>
             </sl-tooltip>
-            <h2 class="text-lg font-medium leading-none">
-              ${msg("Browser Profile")}
-            </h2>
+
+            ${this.profile?.inUse
+              ? html`
+                  <sl-tooltip
+                    content=${msg(
+                      "View Crawl Workflows using this Browser Profile",
+                    )}
+                  >
+                    <a
+                      href=${`${this.navigate.orgBasePath}/workflows?profiles=${this.profile.id}`}
+                      @click=${this.navigate.link}
+                      class="ml-2 flex items-center gap-2 text-sm font-medium text-primary-500 transition-colors hover:text-primary-600"
+                    >
+                      ${msg("In Use")}
+                      <sl-icon
+                        class="text-base"
+                        name="arrow-right-circle"
+                      ></sl-icon>
+                    </a>
+                  </sl-tooltip>
+                `
+              : html`<sl-tooltip
+                  content=${msg("Not In Use")}
+                  ?disabled=${!this.profile}
+                >
+                  <sl-icon
+                    class="text-base text-neutral-500"
+                    name=${this.profile ? "slash-circle" : "clouds"}
+                  ></sl-icon>
+                </sl-tooltip>`}
           </header>
 
           ${when(this.isCrawler, () =>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -133,6 +133,9 @@ export class WorkflowsList extends BtrixElement {
   private filterByTags?: string[];
 
   @state()
+  private filterByTagsType: "and" | "or" = "or";
+
+  @state()
   private filterByProfiles?: string[];
 
   @query("#deleteDialog")
@@ -190,6 +193,10 @@ export class WorkflowsList extends BtrixElement {
         this.filterByCurrentUser = value === "true";
       }
 
+      if (key === "tagsType") {
+        this.filterByTagsType = value === "and" ? "and" : "or";
+      }
+
       // Sorting field
       if (key === "sortBy") {
         if (value in sortableFields) {
@@ -210,7 +217,18 @@ export class WorkflowsList extends BtrixElement {
       }
 
       // Ignored params
-      if (["page", "mine", "tags", "sortBy", "sortDir"].includes(key)) continue;
+      if (
+        [
+          "page",
+          "mine",
+          "tags",
+          "tagsType",
+          "profiles",
+          "sortBy",
+          "sortDir",
+        ].includes(key)
+      )
+        continue;
 
       // Convert string bools to filter values
       if (value === "true") {
@@ -249,6 +267,7 @@ export class WorkflowsList extends BtrixElement {
     const resetToFirstPageProps = [
       "filterByCurrentUser",
       "filterByTags",
+      "filterByTagsType",
       "filterByProfiles",
       "filterByScheduled",
       "filterBy",
@@ -289,6 +308,7 @@ export class WorkflowsList extends BtrixElement {
       changedProperties.has("filterBy") ||
       changedProperties.has("filterByCurrentUser") ||
       changedProperties.has("filterByTags") ||
+      changedProperties.has("filterByTagsType") ||
       changedProperties.has("filterByProfiles") ||
       changedProperties.has("orderBy")
     ) {
@@ -307,6 +327,11 @@ export class WorkflowsList extends BtrixElement {
           ["mine", this.filterByCurrentUser || undefined],
 
           ["tags", this.filterByTags],
+
+          [
+            "tagsType",
+            this.filterByTagsType !== "or" ? this.filterByTagsType : undefined,
+          ],
 
           ["profiles", this.filterByProfiles],
 
@@ -638,7 +663,8 @@ export class WorkflowsList extends BtrixElement {
       <btrix-workflow-tag-filter
         .tags=${this.filterByTags}
         @btrix-change=${(e: BtrixChangeWorkflowTagFilterEvent) => {
-          this.filterByTags = e.detail.value;
+          this.filterByTags = e.detail.value?.tags;
+          this.filterByTagsType = e.detail.value?.type || "or";
         }}
       ></btrix-workflow-tag-filter>
 
@@ -995,6 +1021,7 @@ export class WorkflowsList extends BtrixElement {
           INITIAL_PAGE_SIZE,
         userid: this.filterByCurrentUser ? this.userInfo?.id : undefined,
         tag: this.filterByTags || undefined,
+        tagMatch: this.filterByTagsType,
         profileIds: this.filterByProfiles || undefined,
         sortBy: this.orderBy.field,
         sortDirection: this.orderBy.direction === "desc" ? -1 : 1,

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -25,6 +25,7 @@ import { type SelectEvent } from "@/components/ui/search-combobox";
 import { ClipboardController } from "@/controllers/clipboard";
 import { SearchParamsController } from "@/controllers/searchParams";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
+import { type BtrixChangeWorkflowProfileFilterEvent } from "@/features/crawl-workflows/workflow-profile-filter";
 import type { BtrixChangeWorkflowScheduleFilterEvent } from "@/features/crawl-workflows/workflow-schedule-filter";
 import type { BtrixChangeWorkflowTagFilterEvent } from "@/features/crawl-workflows/workflow-tag-filter";
 import { pageHeader } from "@/layouts/pageHeader";
@@ -131,6 +132,9 @@ export class WorkflowsList extends BtrixElement {
   @state()
   private filterByTags?: string[];
 
+  @state()
+  private filterByProfiles?: string[];
+
   @query("#deleteDialog")
   private readonly deleteDialog?: SlDialog | null;
 
@@ -171,6 +175,12 @@ export class WorkflowsList extends BtrixElement {
       this.filterByTags = params.getAll("tags");
     } else {
       this.filterByTags = undefined;
+    }
+
+    if (params.has("profiles")) {
+      this.filterByProfiles = params.getAll("profiles");
+    } else {
+      this.filterByProfiles = undefined;
     }
 
     // add filters present in search params
@@ -239,6 +249,7 @@ export class WorkflowsList extends BtrixElement {
     const resetToFirstPageProps = [
       "filterByCurrentUser",
       "filterByTags",
+      "filterByProfiles",
       "filterByScheduled",
       "filterBy",
       "orderBy",
@@ -278,6 +289,7 @@ export class WorkflowsList extends BtrixElement {
       changedProperties.has("filterBy") ||
       changedProperties.has("filterByCurrentUser") ||
       changedProperties.has("filterByTags") ||
+      changedProperties.has("filterByProfiles") ||
       changedProperties.has("orderBy")
     ) {
       this.searchParams.update((params) => {
@@ -298,6 +310,8 @@ export class WorkflowsList extends BtrixElement {
           ["mine", this.filterByCurrentUser || undefined],
 
           ["tags", this.filterByTags],
+
+          ["profiles", this.filterByProfiles],
 
           // Sorting fields
           [
@@ -629,6 +643,13 @@ export class WorkflowsList extends BtrixElement {
           this.filterByTags = e.detail.value;
         }}
       ></btrix-workflow-tag-filter>
+
+      <btrix-workflow-profile-filter
+        .profiles=${this.filterByProfiles}
+        @btrix-change=${(e: BtrixChangeWorkflowProfileFilterEvent) => {
+          this.filterByProfiles = e.detail.value;
+        }}
+      ></btrix-workflow-profile-filter>
 
       <btrix-filter-chip
         ?checked=${this.filterBy.isCrawlRunning === true}

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -296,9 +296,6 @@ export class WorkflowsList extends BtrixElement {
         // Reset page
         params.delete("page");
 
-        // Existing tags
-        const tags = params.getAll("tags");
-
         const newParams = [
           // Known filters
           ...USED_FILTERS.map<[string, undefined]>((f) => [f, undefined]),
@@ -333,7 +330,8 @@ export class WorkflowsList extends BtrixElement {
           if (value !== undefined) {
             if (Array.isArray(value)) {
               value.forEach((v) => {
-                if (!tags.includes(v)) {
+                // Only add new array values to URL
+                if (!params.getAll(filter).includes(v)) {
                   params.append(filter, v);
                 }
               });

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -995,6 +995,7 @@ export class WorkflowsList extends BtrixElement {
           INITIAL_PAGE_SIZE,
         userid: this.filterByCurrentUser ? this.userInfo?.id : undefined,
         tag: this.filterByTags || undefined,
+        profileIds: this.filterByProfiles || undefined,
         sortBy: this.orderBy.field,
         sortDirection: this.orderBy.direction === "desc" ? -1 : 1,
       },

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -221,6 +221,32 @@ const plurals = {
       id: "browserWindows.plural.other",
     }),
   },
+  profiles: {
+    zero: msg("profiles", {
+      desc: 'plural form of "profiles" for zero profiles',
+      id: "profiles.plural.zero",
+    }),
+    one: msg("profile", {
+      desc: 'singular form for "profile"',
+      id: "profiles.plural.one",
+    }),
+    two: msg("profiles", {
+      desc: 'plural form of "profiles" for two profiles',
+      id: "profiles.plural.two",
+    }),
+    few: msg("profiles", {
+      desc: 'plural form of "profiles" for few profiles',
+      id: "profiles.plural.few",
+    }),
+    many: msg("profiles", {
+      desc: 'plural form of "profiles" for many profiles',
+      id: "profiles.plural.many",
+    }),
+    other: msg("profiles", {
+      desc: 'plural form of "profiles" for multiple/other profiles',
+      id: "profiles.plural.other",
+    }),
+  },
 };
 
 export const pluralOf = (word: keyof typeof plurals, count: number) => {


### PR DESCRIPTION
Closes #2661 
Related to #2715 — to be merged after #2717 [backend]

## Changes

- Adds new browser profile filter to workflow list
- Adds in-use state & link to view workflows using profile to browser profile detail pages
- Fixes links to profiles from workflow detail views
- Adds toggle for "any" and "all" setting for tag filter

## Manual testing

1. Deploy backend from #2717, and point frontend to it
2. On an org with workflows, profiles, and workflows that use profiles, use the browser profile filter on the workflow list page
  1. Ensure that you can select one or multiple profiles to be filtered by
  2. Ensure that the results you see are what you expect
  3. Ensure that the URL search params update when you update the filter, and that you can use your browser's back and forward buttons to navigate as expected
  4. Ensure that you can search for browser profiles; and that the search includes profile name, id, description, and origins
3. On an org with tagged workflows, use the tag filter on the workflow list page
  1. Ensure that the default behaviour when selecting multiple tags is that any workflows with **any** of the selected tags are matched
  2. Switch the toggle in the filter chip dropdown to "All". Ensure that only workflows with **all** of the selected tags are matched
  3. Ensure that these updates are reflected in the browser URL, and that you can use your browser's back and forward buttons as expected
4. View a browser profile that isn't used by any workflows: ensure that it correctly shows a "Not In Use" icon next to the cloud backup icon
5. View a browser profile that is used by workflows: ensure that it correctly shows an "In Use" link that takes you to the workflow list with that profile selected as a filter

## Screenshots

| Detail | Image/video |
| ---- | ----------- |
| Unset profile filter | <img width="198" height="53" alt="Screenshot 2025-07-10 at 8 29 12 PM" src="https://github.com/user-attachments/assets/2e91e1f5-4ce2-40d6-99cb-7267d41030cb" /> |
| Unset open profile filter | <img width="534" height="421" alt="Screenshot 2025-07-10 at 8 29 16 PM" src="https://github.com/user-attachments/assets/344cdb8e-aae6-4c46-9831-ef205312aa5c" /> |
| Set open profile filter | <img width="531" height="422" alt="Screenshot 2025-07-10 at 8 29 30 PM" src="https://github.com/user-attachments/assets/58022d86-2482-48b5-8495-34c81ddbbe90" /> |

### Browser Profile Detail Page

| "In Use" | "Not In Use" |
|--------|--------|
| <img width="790" height="297" alt="Screenshot 2025-07-10 at 8 27 03 PM" src="https://github.com/user-attachments/assets/244c3efd-8a6e-47a2-a3af-c5fb2fbf6339" /> | <img width="801" height="279" alt="Screenshot 2025-07-10 at 8 27 16 PM" src="https://github.com/user-attachments/assets/9a7ae880-b7ec-4071-a0eb-cb072d2a3fd8" />  |
| <img width="884" height="287" alt="Screenshot 2025-07-10 at 8 27 08 PM" src="https://github.com/user-attachments/assets/8a7be6dc-e14c-42ab-a83c-b034485b21c6" /> | <img width="775" height="261" alt="Screenshot 2025-07-10 at 8 27 20 PM" src="https://github.com/user-attachments/assets/06bf142a-7430-498c-bebe-24df9757cf30" /> | 

### Tag Filter Chip

| Detail | Image/video |
|--------|--------|
| "Any" setting (default) | <img width="436" height="246" alt="Screenshot 2025-07-11 at 10 14 04 PM" src="https://github.com/user-attachments/assets/1ef28be3-a43e-4946-b938-7d10a68c72d0" /> |
| "All" setting | <img width="439" height="246" alt="Screenshot 2025-07-11 at 10 14 10 PM" src="https://github.com/user-attachments/assets/69a06eab-1442-4a44-8c43-2d3ce5ceb487" /> | 
| Tooltips | <img width="203" height="85" alt="Screenshot 2025-07-11 at 10 14 18 PM" src="https://github.com/user-attachments/assets/49dcea30-3b44-43f6-b870-e97c3e453fba" /> |

<!-- ## Follow-ups -->
