### PR TITLE
Profiles: Make browser commit API call idempotent 

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -37,7 +37,7 @@ class CrawlManager(K8sAPI):
         baseprofile: str = "",
         profile_filename: str = "",
         proxy_id: str = "",
-        profileid: str = ""
+        profileid: str = "",
     ) -> str:
         """run browser for profile creation"""
 
@@ -374,7 +374,7 @@ class CrawlManager(K8sAPI):
         return metadata
 
     async def keep_alive_profile_browser(
-        self, browserid: str, mark_committing = ""
+        self, browserid: str, mark_committing=""
     ) -> None:
         """update profile browser to not expire"""
         expire_at = dt_now() + timedelta(seconds=30)

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -373,15 +373,13 @@ class CrawlManager(K8sAPI):
 
         return metadata
 
-    async def keep_alive_profile_browser(
-        self, browserid: str, mark_committing=""
-    ) -> None:
+    async def keep_alive_profile_browser(self, browserid: str, committing="") -> None:
         """update profile browser to not expire"""
         expire_at = dt_now() + timedelta(seconds=30)
 
         update = {"expireTime": date_to_str(expire_at)}
-        if mark_committing:
-            update["committing"] = mark_committing
+        if committing:
+            update["committing"] = committing
 
         await self._patch_job(browserid, update, "profilejobs")
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -259,8 +259,7 @@ class ProfileOps:
             print(json)
             resource = json["resource"]
         # pylint: disable=bare-except
-        except Exception as e:
-            print(e)
+        except:
             print("Profile commit: browser not valid")
             return False
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -135,7 +135,7 @@ class ProfileOps:
             baseprofile=prev_profile_id,
             profile_filename=prev_profile_path,
             proxy_id=proxy_id,
-            profileid=str(uuid4())
+            profileid=str(uuid4()),
         )
 
         if not browserid:

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -702,7 +702,7 @@ def profile_id(admin_auth_headers, default_org_id, profile_browser_id):
 
     # Create profile
     start_time = time.monotonic()
-    time_limit = 300
+    time_limit = 30
     while True:
         try:
             r = requests.post(
@@ -793,7 +793,7 @@ def profile_2_id(admin_auth_headers, default_org_id, profile_browser_2_id):
 
     # Create profile
     start_time = time.monotonic()
-    time_limit = 300
+    time_limit = 30
     while True:
         try:
             r = requests.post(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -361,9 +361,9 @@ def test_create_profile_read_only_org(
             if detail == "waiting_for_browser":
                 time.sleep(5)
                 continue
-            if detail == "org_set_to_read_only":
-                assert r.status_code == 403
-                break
+            assert detail == "org_set_to_read_only"
+            assert r.status_code == 403
+            break
         except:
             if time.monotonic() - start_time > time_limit:
                 raise

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -344,7 +344,7 @@ def test_create_profile_read_only_org(
 
     # Try to create profile, verify we get 403 forbidden
     start_time = time.monotonic()
-    time_limit = 300
+    time_limit = 30
     while True:
         try:
             r = requests.post(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -206,20 +206,24 @@ def test_commit_browser_to_existing_profile(
     )
 
     # Commit new browser to existing profile
-    r = requests.patch(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
-        headers=admin_auth_headers,
-        json={
-            "browserid": profile_browser_3_id,
-            "name": PROFILE_NAME_UPDATED,
-            "description": PROFILE_DESC_UPDATED,
-        },
-    )
-    assert r.status_code == 200
+    while True:
+        r = requests.patch(
+            f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
+            headers=admin_auth_headers,
+            json={
+                "browserid": profile_browser_3_id,
+                "name": PROFILE_NAME_UPDATED,
+                "description": PROFILE_DESC_UPDATED,
+            },
+        )
+        assert r.status_code == 200
+        if r.json().get("detail") == "waiting_for_browser":
+            time.sleep(5)
+            continue
+
+        break
+
     assert r.json()["updated"]
-
-    time.sleep(5)
-
     # Ensure modified was updated but created was not
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",

--- a/chart/app-templates/profile_job.yaml
+++ b/chart/app-templates/profile_job.yaml
@@ -11,6 +11,7 @@ metadata:
     btrix.baseprofile: "{{ base_profile }}"
     {%- endif %}
     btrix.storage: "{{ storage_name }}"
+    profileid: {{ profileid }}
 
 spec:
   selector:

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -719,8 +719,6 @@ export class BrowserProfilesDetail extends BtrixElement {
 
       this.browserId = undefined;
     } catch (e) {
-      console.debug(e);
-
       this.notify.toast({
         message: msg("Sorry, couldn't save browser profile at this time."),
         variant: "danger",

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -719,6 +719,8 @@ export class BrowserProfilesDetail extends BtrixElement {
 
       this.browserId = undefined;
     } catch (e) {
+      console.debug(e);
+
       this.notify.toast({
         message: msg("Sorry, couldn't save browser profile at this time."),
         variant: "danger",

--- a/frontend/src/pages/org/browser-profiles-detail.ts
+++ b/frontend/src/pages/org/browser-profiles-detail.ts
@@ -679,13 +679,26 @@ export class BrowserProfilesDetail extends BtrixElement {
     };
 
     try {
-      const data = await this.api.fetch<{ updated: boolean }>(
-        `/orgs/${this.orgId}/profiles/${this.profileId}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify(params),
-        },
-      );
+      let data;
+
+      // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+      while (true) {
+        data = await this.api.fetch<{ updated?: boolean; detail?: string }>(
+          `/orgs/${this.orgId}/profiles/${this.profileId}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify(params),
+          },
+        );
+        if (data.updated !== undefined) {
+          break;
+        }
+        if (data.detail === "waiting_for_browser") {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        } else {
+          throw new Error("unknown response");
+        }
+      }
 
       if (data.updated) {
         this.notify.toast({

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -313,13 +313,26 @@ export class BrowserProfilesNew extends BtrixElement {
     };
 
     try {
-      const data = await this.api.fetch<{ id: string }>(
-        `/orgs/${this.orgId}/profiles`,
-        {
-          method: "POST",
-          body: JSON.stringify(params),
-        },
-      );
+      let data;
+
+      // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+      while (true) {
+        data = await this.api.fetch<{ id?: string; detail?: string }>(
+          `/orgs/${this.orgId}/profiles`,
+          {
+            method: "POST",
+            body: JSON.stringify(params),
+          },
+        );
+        if (data.id) {
+          break;
+        }
+        if (data.detail === "waiting_for_browser") {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        } else {
+          throw new Error("unknown response");
+        }
+      }
 
       this.notify.toast({
         message: msg("Successfully created browser profile."),

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -355,8 +355,6 @@ export class BrowserProfilesNew extends BtrixElement {
         `${this.navigate.orgBasePath}/browser-profiles/profile/${data.id}`,
       );
     } catch (e) {
-      console.debug(e);
-
       this.isSubmitting = false;
 
       let message = msg("Sorry, couldn't create browser profile at this time.");

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -314,9 +314,9 @@ export class BrowserProfilesNew extends BtrixElement {
 
     try {
       let data;
+      let retriesLeft = 300;
 
-      // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
-      while (true) {
+      while (retriesLeft > 0) {
         data = await this.api.fetch<{ id?: string; detail?: string }>(
           `/orgs/${this.orgId}/profiles`,
           {
@@ -332,6 +332,16 @@ export class BrowserProfilesNew extends BtrixElement {
         } else {
           throw new Error("unknown response");
         }
+
+        retriesLeft -= 1;
+      }
+
+      if (!retriesLeft) {
+        throw new Error("too many retries waiting for browser");
+      }
+
+      if (!data) {
+        throw new Error("unknown response");
       }
 
       this.notify.toast({
@@ -345,6 +355,8 @@ export class BrowserProfilesNew extends BtrixElement {
         `${this.navigate.orgBasePath}/browser-profiles/profile/${data.id}`,
       );
     } catch (e) {
+      console.debug(e);
+
       this.isSubmitting = false;
 
       let message = msg("Sorry, couldn't create browser profile at this time.");

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -355,6 +355,8 @@ export class BrowserProfilesNew extends BtrixElement {
         `${this.navigate.orgBasePath}/browser-profiles/profile/${data.id}`,
       );
     } catch (e) {
+      console.debug(e);
+
       this.isSubmitting = false;
 
       let message = msg("Sorry, couldn't create browser profile at this time.");


### PR DESCRIPTION
- Fix race condition related to browser commit time
- The profile commit request waits for browser to actual finish, and profile saved. This can cause request to time out, resulting in a retry, in which the browser has already been closed.
- With these changes, the commit is now 'idempotent' and returns a waiting_for_browser until the profile is actually committed.