### PR TITLE
qa: run siteSpecific behaviors on QA

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -113,7 +113,7 @@ data:
   CRAWL_ARGS: {{- include "btrix.crawler_args" . }}
 
   # disable behaviors for QA runs, otherwise use same args
-  QA_ARGS: {{- include "btrix.crawler_args" . }} --behaviors=""
+  QA_ARGS: {{- include "btrix.crawler_args" . }} --behaviors=siteSpecific
 
 ---
 apiVersion: v1


### PR DESCRIPTION
- allow the page loading waiting time to be applied for sites with site-specific behaviors (eg. social media)