### PR TITLE
Fix pagination buttons having no horizontal padding

### DIFF
--- a/frontend/src/components/ui/navigation/navigation-button.ts
+++ b/frontend/src/components/ui/navigation/navigation-button.ts
@@ -85,7 +85,7 @@ export class NavigationButton extends TailwindElement {
 
         this.icon ? tw`min-h-6 min-w-6` : tw``,
         {
-          small: this.icon ? tw`min-h-6 p-0` : tw`min-h-6 px-2 py-0`,
+          small: this.icon ? tw`min-h-6 px-1 py-0` : tw`min-h-6 px-2 py-0`,
           medium: tw`p-2`,
           large: tw`px-2 py-4`,
         }[this.size],

--- a/frontend/src/components/ui/navigation/navigation-button.ts
+++ b/frontend/src/components/ui/navigation/navigation-button.ts
@@ -39,14 +39,11 @@ export class NavigationButton extends TailwindElement {
   @property({ type: Boolean })
   disabled = false;
 
-  @property({ type: Boolean })
-  icon = false;
-
   @property({ type: String, reflect: true })
   role: ARIAMixin["role"] = null;
 
   @property({ type: String })
-  size: "small" | "medium" | "large" = "medium";
+  size: "x-small" | "small" | "medium" | "large" = "medium";
 
   @property({ type: String })
   align: "left" | "center" | "right" = "left";
@@ -82,10 +79,9 @@ export class NavigationButton extends TailwindElement {
       part="button"
       class=${clsx([
         tw`flex w-full cursor-pointer items-center gap-2 rounded font-medium leading-[16px] transition hover:transition-none focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-1 disabled:cursor-not-allowed disabled:bg-transparent disabled:opacity-50`,
-
-        this.icon ? tw`min-h-6 min-w-6` : tw``,
         {
-          small: this.icon ? tw`min-h-6 px-1 py-0` : tw`min-h-6 px-2 py-0`,
+          "x-small": tw`min-size-6 px-1 py-0`,
+          small: tw`min-h-6 px-2 py-0`,
           medium: tw`p-2`,
           large: tw`px-2 py-4`,
         }[this.size],

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -370,9 +370,8 @@ export class Pagination extends LitElement {
     const isCurrent = page === this._page;
     return html`<li aria-current=${ifDefined(isCurrent ? "page" : undefined)}>
       <btrix-navigation-button
-        icon
         .active=${isCurrent}
-        .size=${"small"}
+        .size=${"x-small"}
         .align=${"center"}
         @click=${() => this.onPageChange(page)}
         aria-disabled=${isCurrent}


### PR DESCRIPTION
Little fix for an issue that's been bugging me.

Also removes the `icon` prop on `<btrix-navigation-button>`, replacing it with `size="x-small"`, because the only place `icon` was used was for pagination buttons, where the buttons have numbers and not icons.

| | |
|--------|--------|
| Before | <img width="482" height="39" alt="Screenshot 2025-07-16 at 6 38 22 PM" src="https://github.com/user-attachments/assets/3b086e07-ee58-44ec-b3ab-08e454fdcbd8" /> |
| After | <img width="522" height="42" alt="Screenshot 2025-07-16 at 6 37 42 PM" src="https://github.com/user-attachments/assets/6c4a34f0-4c27-4c7f-b13b-361356852289" /> | 


