### PR TITLE
feat: Duplicate workflows with seed file

### DIFF
--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -25,6 +25,7 @@ import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow
 import { OrgTab, RouteNamespace, WorkflowTab } from "@/routes";
 import type { ProxiesAPIResponse } from "@/types/crawler";
 import type { UserOrg } from "@/types/user";
+import type { DuplicateWorkflowSettings } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
 import type { ViewState } from "@/utils/APIRouter";
 import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
@@ -542,7 +543,8 @@ export class Org extends BtrixElement {
     }
 
     if (this.orgPath.startsWith("/workflows/new")) {
-      const { workflow, seeds, seedFile, scopeType } = this.viewStateData || {};
+      const { workflow, seeds, seedFile, scopeType } = (this.viewStateData ||
+        {}) satisfies Partial<DuplicateWorkflowSettings>;
 
       return html` <btrix-workflows-new
         class="col-span-5"

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -25,9 +25,9 @@ import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow
 import { OrgTab, RouteNamespace, WorkflowTab } from "@/routes";
 import type { ProxiesAPIResponse } from "@/types/crawler";
 import type { UserOrg } from "@/types/user";
-import type { DuplicateWorkflowSettings } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
 import type { ViewState } from "@/utils/APIRouter";
+import type { DuplicateWorkflowSettings } from "@/utils/crawl-workflows/settingsForDuplicate";
 import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
 import { type OrgData } from "@/utils/orgs";
 import { AppStateService } from "@/utils/state";

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -542,13 +542,14 @@ export class Org extends BtrixElement {
     }
 
     if (this.orgPath.startsWith("/workflows/new")) {
-      const { workflow, seeds, scopeType } = this.viewStateData || {};
+      const { workflow, seeds, seedFile, scopeType } = this.viewStateData || {};
 
       return html` <btrix-workflows-new
         class="col-span-5"
         ?isCrawler=${this.appState.isCrawler}
         .initialWorkflow=${workflow}
         .initialSeeds=${seeds}
+        .initialSeedFile=${seedFile}
         scopeType=${ifDefined(scopeType)}
         @select-new-dialog=${this.onSelectNewDialog}
       ></btrix-workflows-new>`;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -11,7 +11,7 @@ import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
-import type { Crawl, CrawlLog, Seed, Workflow, WorkflowParams } from "./types";
+import type { Crawl, CrawlLog, Seed, Workflow } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Alert } from "@/components/ui/alert";
@@ -29,12 +29,9 @@ import { WorkflowTab } from "@/routes";
 import { deleteConfirmation, noData, notApplicable } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
-import {
-  NewWorkflowOnlyScopeType,
-  type DuplicateWorkflowSettings,
-  type StorageSeedFile,
-} from "@/types/workflow";
+import { type StorageSeedFile } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
+import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import {
   DEFAULT_MAX_SCALE,
   inactiveCrawlStates,
@@ -2156,7 +2153,7 @@ export class WorkflowDetail extends BtrixElement {
       <btrix-config-details
         .crawlConfig=${this.workflow}
         .seeds=${this.seeds?.items}
-        .seedFile=${this.seedFileTask.value}
+        .seedFile=${this.seedFileTask.value || undefined}
         anchorLinks
       ></btrix-config-details>
     </section>`;
@@ -2312,31 +2309,22 @@ export class WorkflowDetail extends BtrixElement {
   private async duplicateConfig() {
     if (!this.workflow) await this.workflowTask.taskComplete;
 
-    await Promise.all([
-      this.seedsTask.taskComplete,
-      this.seedFileTask.taskComplete,
-    ]);
+    if (this.workflow?.config.seedFileId) {
+      await this.seedFileTask.taskComplete;
+    } else {
+      await this.seedsTask.taskComplete;
+    }
 
     await this.updateComplete;
     if (!this.workflow) return;
 
-    const workflowParams: WorkflowParams = {
-      ...this.workflow,
-      name: this.workflow.name ? msg(str`${this.workflow.name} Copy`) : "",
-    };
+    const settings = settingsForDuplicate({
+      workflow: this.workflow,
+      seeds: this.seeds,
+      seedFile: this.seedFileTask.value ?? undefined,
+    });
 
-    const seeds = this.seeds?.items;
-    const seedFile = this.seedFileTask.value ?? undefined;
-
-    this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, {
-      scopeType:
-        seedFile || (seeds?.length && seeds.length > 1)
-          ? NewWorkflowOnlyScopeType.PageList
-          : workflowParams.config.scopeType,
-      workflow: workflowParams,
-      seeds,
-      seedFile,
-    } satisfies DuplicateWorkflowSettings);
+    this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, settings);
 
     this.notify.toast({
       message: msg("Copied settings to new workflow."),

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -31,6 +31,7 @@ import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
 import {
   NewWorkflowOnlyScopeType,
+  type DuplicateWorkflowSettings,
   type StorageSeedFile,
 } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
@@ -2325,7 +2326,7 @@ export class WorkflowDetail extends BtrixElement {
     };
 
     const seeds = this.seeds?.items;
-    const seedFile = this.seedFileTask.value;
+    const seedFile = this.seedFileTask.value ?? undefined;
 
     this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, {
       scopeType:
@@ -2335,7 +2336,7 @@ export class WorkflowDetail extends BtrixElement {
       workflow: workflowParams,
       seeds,
       seedFile,
-    });
+    } satisfies DuplicateWorkflowSettings);
 
     this.notify.toast({
       message: msg("Copied settings to new workflow."),

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -2318,20 +2318,35 @@ export class WorkflowDetail extends BtrixElement {
     await this.updateComplete;
     if (!this.workflow) return;
 
+    const seeds = this.seeds;
+
     const settings = settingsForDuplicate({
       workflow: this.workflow,
-      seeds: this.seeds,
+      seeds,
       seedFile: this.seedFileTask.value ?? undefined,
     });
 
     this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, settings);
 
-    this.notify.toast({
-      message: msg("Copied settings to new workflow."),
-      variant: "success",
-      icon: "check2-circle",
-      id: "workflow-copied-success",
-    });
+    if (seeds && seeds.total > seeds.items.length) {
+      const urlCount = this.localize.number(seeds.items.length);
+
+      // This is likely an edge case for old workflows with >1,000 seeds
+      // or URL list workflows created via API.
+      this.notify.toast({
+        title: msg(str`Partially copied workflow settings`),
+        message: msg(str`Only the first ${urlCount} URLs were copied.`),
+        variant: "warning",
+        id: "workflow-copied-status",
+      });
+    } else {
+      this.notify.toast({
+        message: msg("Copied settings to new workflow."),
+        variant: "success",
+        icon: "check2-circle",
+        id: "workflow-copied-status",
+      });
+    }
   }
 
   private async delete(): Promise<void> {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -12,7 +12,6 @@ import {
   type ListWorkflow,
   type Seed,
   type Workflow,
-  type WorkflowParams,
 } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -35,10 +34,10 @@ import { deleteConfirmation } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import {
   NewWorkflowOnlyScopeType,
-  type DuplicateWorkflowSettings,
   type StorageSeedFile,
 } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
+import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { tw } from "@/utils/tailwind";
 
@@ -1063,20 +1062,13 @@ export class WorkflowsList extends BtrixElement {
       seeds = await this.getSeeds(workflow);
     }
 
-    const workflowParams: WorkflowParams = {
-      ...fullWorkflow,
-      name: workflow.name ? msg(str`${workflow.name} Copy`) : "",
-    };
-
-    this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, {
-      scopeType:
-        seedFile || (seeds?.items.length && seeds.items.length > 1)
-          ? NewWorkflowOnlyScopeType.PageList
-          : workflowParams.config.scopeType,
-      workflow: workflowParams,
-      seeds: seeds?.items,
+    const settings = settingsForDuplicate({
+      workflow: fullWorkflow,
+      seeds,
       seedFile,
-    } satisfies DuplicateWorkflowSettings);
+    });
+
+    this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, settings);
 
     if (seeds && seeds.total > SEEDS_MAX) {
       this.notify.toast({

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -55,8 +55,6 @@ const FILTER_BY_CURRENT_USER_STORAGE_KEY =
 const INITIAL_PAGE_SIZE = 10;
 const POLL_INTERVAL_SECONDS = 10;
 const ABORT_REASON_THROTTLE = "throttled";
-// NOTE Backend pagination max is 1000
-const SEEDS_MAX = 1000;
 
 const sortableFields: Record<
   SortField,
@@ -1070,11 +1068,15 @@ export class WorkflowsList extends BtrixElement {
 
     this.navigate.to(`${this.navigate.orgBasePath}/workflows/new`, settings);
 
-    if (seeds && seeds.total > SEEDS_MAX) {
+    if (seeds && seeds.total > seeds.items.length) {
+      const urlCount = this.localize.number(seeds.items.length);
+
+      // This is likely an edge case for old workflows with >1,000 seeds
+      // or URL list workflows created via API.
       this.notify.toast({
-        title: msg(str`Partially copied Workflow`),
+        title: msg(str`Partially copied workflow settings`),
         message: msg(
-          str`Only first ${this.localize.number(SEEDS_MAX)} URLs were copied.`,
+          str`The first ${urlCount} URLs were copied. To copy more, use URL list files.`,
         ),
         variant: "warning",
         id: "workflow-copied-status",

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -1075,9 +1075,7 @@ export class WorkflowsList extends BtrixElement {
       // or URL list workflows created via API.
       this.notify.toast({
         title: msg(str`Partially copied workflow settings`),
-        message: msg(
-          str`The first ${urlCount} URLs were copied. To copy more, use URL list files.`,
-        ),
+        message: msg(str`The first ${urlCount} URLs were copied.`),
         variant: "warning",
         id: "workflow-copied-status",
       });

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -1075,7 +1075,7 @@ export class WorkflowsList extends BtrixElement {
       });
     } else {
       this.notify.toast({
-        message: msg(str`Copied Workflow to new template.`),
+        message: msg("Copied settings to new workflow."),
         variant: "success",
         icon: "check2-circle",
         id: "workflow-copied-status",

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -1,6 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { mergeDeep } from "immutable";
+import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
@@ -8,9 +9,9 @@ import type { PartialDeep } from "type-fest";
 
 import { ScopeType, type Seed, type WorkflowParams } from "./types";
 
+import { BtrixElement } from "@/classes/BtrixElement";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
-import { WorkflowScopeType } from "@/types/workflow";
-import LiteElement, { html } from "@/utils/LiteElement";
+import { WorkflowScopeType, type StorageSeedFile } from "@/types/workflow";
 import { tw } from "@/utils/tailwind";
 import {
   DEFAULT_AUTOCLICK_SELECTOR,
@@ -28,12 +29,15 @@ import {
  */
 @customElement("btrix-workflows-new")
 @localized()
-export class WorkflowsNew extends LiteElement {
+export class WorkflowsNew extends BtrixElement {
   @property({ type: Boolean })
   isCrawler!: boolean;
 
   @property({ type: Array })
   initialSeeds?: Seed[];
+
+  @property({ type: Object })
+  initialSeedFile?: StorageSeedFile;
 
   @property({ type: String })
   scopeType?: WorkflowFormState["scopeType"];
@@ -76,7 +80,7 @@ export class WorkflowsNew extends LiteElement {
   private renderBreadcrumbs() {
     const breadcrumbs: Breadcrumb[] = [
       {
-        href: `${this.orgBasePath}/workflows`,
+        href: `${this.navigate.orgBasePath}/workflows`,
         content: msg("Crawl Workflows"),
       },
       {
@@ -148,6 +152,7 @@ export class WorkflowsNew extends LiteElement {
             )}
             .initialWorkflow=${initialWorkflow}
             .initialSeeds=${this.initialSeeds}
+            .initialSeedFile=${this.initialSeedFile}
           ></btrix-workflow-editor>
         `;
       })}

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,6 +1,6 @@
 import type { StorageFile } from "./storage";
 
-import { ScopeType } from "@/types/crawler";
+import { ScopeType, type Seed, type WorkflowParams } from "@/types/crawler";
 
 export enum NewWorkflowOnlyScopeType {
   PageList = "page-list",
@@ -20,4 +20,11 @@ export type WorkflowTags = {
 export type StorageSeedFile = StorageFile & {
   firstSeed: string;
   seedCount: number;
+};
+
+export type DuplicateWorkflowSettings = {
+  workflow: WorkflowParams;
+  scopeType?: ScopeType | NewWorkflowOnlyScopeType;
+  seeds?: Seed[];
+  seedFile?: StorageSeedFile;
 };

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,6 +1,6 @@
 import type { StorageFile } from "./storage";
 
-import { ScopeType, type Seed, type WorkflowParams } from "@/types/crawler";
+import { ScopeType } from "@/types/crawler";
 
 export enum NewWorkflowOnlyScopeType {
   PageList = "page-list",
@@ -20,11 +20,4 @@ export type WorkflowTags = {
 export type StorageSeedFile = StorageFile & {
   firstSeed: string;
   seedCount: number;
-};
-
-export type DuplicateWorkflowSettings = {
-  workflow: WorkflowParams;
-  scopeType?: ScopeType | NewWorkflowOnlyScopeType;
-  seeds?: Seed[];
-  seedFile?: StorageSeedFile;
 };

--- a/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
+++ b/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
@@ -1,0 +1,50 @@
+/**
+ * Join workflow settings for duplicating a workflow
+ */
+import { msg, str } from "@lit/localize";
+
+import type { APIPaginatedList } from "@/types/api";
+import type {
+  ScopeType,
+  Seed,
+  Workflow,
+  WorkflowParams,
+} from "@/types/crawler";
+import {
+  NewWorkflowOnlyScopeType,
+  type StorageSeedFile,
+} from "@/types/workflow";
+
+export type DuplicateWorkflowSettings = {
+  workflow: WorkflowParams;
+  scopeType?: ScopeType | NewWorkflowOnlyScopeType;
+  seeds?: Seed[];
+  seedFile?: StorageSeedFile;
+};
+
+export function settingsForDuplicate({
+  workflow,
+  seeds,
+  seedFile,
+}: {
+  workflow: Workflow;
+  seeds?: APIPaginatedList<Seed>;
+  seedFile?: StorageSeedFile;
+}): DuplicateWorkflowSettings {
+  const workflowParams: WorkflowParams = {
+    ...workflow,
+    name: workflow.name ? msg(str`${workflow.name} Copy`) : "",
+  };
+
+  const seedItems = seeds?.items;
+
+  return {
+    scopeType:
+      seedFile || (seedItems?.length && seedItems.length > 1)
+        ? NewWorkflowOnlyScopeType.PageList
+        : workflowParams.config.scopeType,
+    workflow: workflowParams,
+    seeds: seedItems,
+    seedFile,
+  };
+}

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -1,3 +1,6 @@
+/**
+ * TODO Move to utils/crawl-configs/
+ */
 import { msg, str } from "@lit/localize";
 import { z } from "zod";
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2732

## Changes

Allows users to duplicate workflows with a seed file.

## Manual testing

1. Log in as crawler
2. Go to workflows list
3. Click a seed file workflow's "..." overflow menu and select "Duplicate Workflow". Verify navigation to new workflow page with "Upload URL List" pre-filled with the seed file
4. Save. Verify seed file is saved as expected
5. Click "Actions" -> "Duplicate Workflow". Verify same as 3-4.

Regression tested manually entered URL list and other scope types.