### PR TITLE
Add saveStorage option to workflow

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -370,6 +370,8 @@ class RawCrawlConfig(BaseModel):
     selectLinks: List[str] = ["a[href]->href"]
     clickSelector: str = "a"
 
+    saveStorage: Optional[bool] = False
+
 
 # ============================================================================
 class CrawlConfigIn(BaseModel):

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -264,7 +264,7 @@ Will prevent any content from the domains listed in [Steven Black's Unified Host
 
 ### Save Local and Session Storage
 
-When enabled, instructs the crawler to save the browser's localStorage and sessionStorage data for each page in the web archive as part of the `WARC-JSON-Metadata` field. This option may be necessary to properly archive and replay certain websites. Use caution when sharing WACZ files created with this option enabled, as the saved browser storage may contain sensitive information.
+When enabled, instructs the crawler to save the browser's `localStorage` and `sessionStorage` data for each page in the web archive as part of the `WARC-JSON-Metadata` field. This option may be necessary to properly archive and replay certain websites. Use caution when sharing WACZ files created with this option enabled, as the saved browser storage may contain sensitive information.
 
 ### User Agent
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -262,6 +262,10 @@ This setting will only be shown if multiple different release channels are avail
 
 Will prevent any content from the domains listed in [Steven Black's Unified Hosts file](https://github.com/StevenBlack/hosts) (ads & malware) from being captured by the crawler.
 
+### Save Local and Session Storage
+
+When enabled, instructs the crawler to save the browser's localStorage and sessionStorage data for each page in the web archive as part of the `WARC-JSON-Metadata` field. This option may be necessary to properly archive and replay certain websites. Use caution when sharing WACZ files created with this option enabled, as the saved browser storage may contain sensitive information.
+
 ### User Agent
 
 Sets the browser's [user agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) in outgoing requests to the specified value. If left blank, the crawler will use the Brave browser's default user agent. For a list of common user agents see [useragents.me](https://www.useragents.me/).

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -271,6 +271,10 @@ export class ConfigDetails extends BtrixElement {
             seedsConfig?.blockAds,
           )}
           ${this.renderSetting(
+            msg("Save Local and Session Storage"),
+            seedsConfig?.saveStorage,
+          )}
+          ${this.renderSetting(
             msg("User Agent"),
             seedsConfig?.userAgent
               ? seedsConfig.userAgent

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1985,7 +1985,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ${msg("Save local and session storage")}
         </sl-checkbox>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["saveStorage"])}
+      ${this.renderHelpTextCol(infoTextFor["saveStorage"], false)}
       ${inputCol(html`
         <sl-input
           name="userAgent"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1981,6 +1981,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
       `)}
       ${this.renderHelpTextCol(infoTextFor["blockAds"], false)}
       ${inputCol(html`
+        <sl-checkbox name="saveStorage" ?checked=${this.formState.saveStorage}>
+          ${msg("Save local and session storage")}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor["saveStorage"])}
+      ${inputCol(html`
         <sl-input
           name="userAgent"
           label=${msg("User Agent")}
@@ -3064,6 +3070,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "useSitemap"
     | "failOnFailedSeed"
     | "failOnContentCheck"
+    | "saveStorage"
   > {
     const jsonSeeds = this.formState.seedListFormat === SeedListFormat.JSON;
 
@@ -3082,6 +3089,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       useSitemap: false,
       failOnFailedSeed: this.formState.failOnFailedSeed,
       failOnContentCheck: this.formState.failOnContentCheck,
+      saveStorage: this.formState.saveStorage,
     };
 
     return config;
@@ -3094,6 +3102,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "useSitemap"
     | "failOnFailedSeed"
     | "failOnContentCheck"
+    | "saveStorage"
   > {
     const primarySeedUrl = this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeUrlList
@@ -3125,6 +3134,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       useSitemap: this.formState.useSitemap,
       failOnFailedSeed: false,
       failOnContentCheck: this.formState.failOnContentCheck,
+      saveStorage: this.formState.saveStorage,
     };
     return config;
   }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1985,7 +1985,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ${msg("Save local and session storage")}
         </sl-checkbox>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["saveStorage"], false)}
+      ${this.renderHelpTextCol(
+        html`${infoTextFor["saveStorage"]}
+        ${this.renderUserGuideLink({
+          hash: "save-local-and-session-storage",
+          content: msg("Implications for shared archives"),
+        })}.`,
+        false,
+      )}
       ${inputCol(html`
         <sl-input
           name="userAgent"

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -78,6 +78,7 @@ export const infoTextFor = {
   ),
   failOnContentCheck: msg(
     `Fail the crawl if a page behavior detects the browser is not logged in on supported pages.`,
+  ),
   saveStorage: msg(
     `Save the browser's localStorage and sessionStorage data for pages. Use caution sharing WACZs created with this option.`,
   ),

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -78,6 +78,8 @@ export const infoTextFor = {
   ),
   failOnContentCheck: msg(
     `Fail the crawl if a page behavior detects the browser is not logged in on supported pages.`,
+  saveStorage: msg(
+    `Save the browser's localStorage and sessionStorage in resulting web archive. Use caution sharing WACZs created with this option.`,
   ),
 } as const satisfies Partial<Record<Field, string | TemplateResult>>;
 

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -79,7 +79,7 @@ export const infoTextFor = {
   failOnContentCheck: msg(
     `Fail the crawl if a page behavior detects the browser is not logged in on supported pages.`,
   saveStorage: msg(
-    `Save the browser's localStorage and sessionStorage in resulting web archive. Use caution sharing WACZs created with this option.`,
+    `Save the browser's localStorage and sessionStorage data for pages. Use caution sharing WACZs created with this option.`,
   ),
 } as const satisfies Partial<Record<Field, string | TemplateResult>>;
 

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -80,7 +80,7 @@ export const infoTextFor = {
     `Fail the crawl if a page behavior detects the browser is not logged in on supported pages.`,
   ),
   saveStorage: msg(
-    `Save the browser's localStorage and sessionStorage data for pages. Use caution sharing WACZs created with this option.`,
+    `Include data from the browser's local and session storage in the web archive.`,
   ),
 } as const satisfies Partial<Record<Field, string | TemplateResult>>;
 

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -50,6 +50,7 @@ export type SeedConfig = Expand<
     selectLinks: string[];
     customBehaviors: string[];
     clickSelector: string;
+    saveStorage?: boolean;
   }
 >;
 

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -154,6 +154,7 @@ export type FormState = {
   proxyId: string | null;
   selectLinks: string[];
   clickSelector: string;
+  saveStorage: WorkflowParams["config"]["saveStorage"];
 };
 
 export type FormStateField = keyof FormState;
@@ -215,6 +216,7 @@ export const getDefaultFormState = (): FormState => ({
   selectLinks: DEFAULT_SELECT_LINKS,
   clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
   customBehavior: false,
+  saveStorage: false,
 });
 
 export const mapSeedToUrl = (arr: Seed[]) =>
@@ -379,6 +381,7 @@ export function getInitialFormState(params: {
     crawlerChannel:
       params.initialWorkflow.crawlerChannel || defaultFormState.crawlerChannel,
     proxyId: params.initialWorkflow.proxyId || defaultFormState.proxyId,
+    saveStorage: params.initialWorkflow.config.saveStorage,
     ...formState,
   };
 }


### PR DESCRIPTION
Fixes #2753 

- Adds `saveStorage` to `RawCrawlConfig` model in backend
- Adds option to Browser Settings pane of workflow editor
- Adds option to config details component
- Adds setting to docs

## Screenshot

<img width="1221" height="782" alt="Screenshot 2025-07-22 at 4 23 15 PM" src="https://github.com/user-attachments/assets/ae10e2b2-a36e-43e4-8d55-5fcd5aba4d00" />


