### PR TITLE
fix incorrect height of compact current page indicator

### DIFF
--- a/frontend/src/components/ui/navigation/navigation-button.ts
+++ b/frontend/src/components/ui/navigation/navigation-button.ts
@@ -80,7 +80,7 @@ export class NavigationButton extends TailwindElement {
       class=${clsx([
         tw`flex w-full cursor-pointer items-center gap-2 rounded font-medium leading-[16px] transition hover:transition-none focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-1 disabled:cursor-not-allowed disabled:bg-transparent disabled:opacity-50`,
         {
-          "x-small": tw`min-size-6 px-1 py-0`,
+          "x-small": tw`min-h-6 min-w-6 px-1 py-0`,
           small: tw`min-h-6 px-2 py-0`,
           medium: tw`p-2`,
           large: tw`px-2 py-4`,

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -107,6 +107,8 @@ export class Pagination extends LitElement {
 
       /* Use width of text to determine input width */
       .totalPages {
+        /* Match the height of '<btrix-inline-input size="small">' */
+        --sl-input-height-small: var(--sl-font-size-x-large);
         padding: 0 1ch;
         height: var(--sl-input-height-small);
         min-width: 1ch;


### PR DESCRIPTION
issue raised in discord https://discord.com/channels/895426029194207262/910966759165657161/1397283696192782477

fixes mismatched heights for page input & incorrectly applied min width and height for x-small nav buttons