### PR TITLE
Add seed file support to Browsertrix backend (#2710)

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -4,7 +4,7 @@ Crawl Config API handling
 
 # pylint: disable=too-many-lines
 
-from typing import List, Optional, TYPE_CHECKING, cast, Dict, Tuple, Annotated
+from typing import List, Optional, TYPE_CHECKING, cast, Dict, Tuple, Annotated, Union
 
 import asyncio
 import json
@@ -47,6 +47,8 @@ from .models import (
     ValidateCustomBehavior,
     RawCrawlConfig,
     ListFilterType,
+    ScopeType,
+    Seed,
 )
 from .utils import (
     dt_now,
@@ -64,8 +66,12 @@ if TYPE_CHECKING:
     from .profiles import ProfileOps
     from .crawls import CrawlOps
     from .colls import CollectionOps
+    from .file_uploads import FileUploadOps
+    from .storages import StorageOps
 else:
-    OrgOps = CrawlManager = UserManager = ProfileOps = CrawlOps = CollectionOps = object
+    OrgOps = CrawlManager = UserManager = ProfileOps = CrawlOps = CollectionOps = (
+        FileUploadOps
+    ) = StorageOps = object
 
 
 ALLOWED_SORT_KEYS = (
@@ -93,6 +99,8 @@ class CrawlConfigOps:
     profiles: ProfileOps
     crawl_ops: CrawlOps
     coll_ops: CollectionOps
+    file_ops: FileUploadOps
+    storage_ops: StorageOps
 
     crawler_channels: CrawlerChannels
     crawler_images_map: dict[str, str]
@@ -108,6 +116,8 @@ class CrawlConfigOps:
         org_ops,
         crawl_manager,
         profiles,
+        file_ops,
+        storage_ops,
     ):
         self.dbclient = dbclient
         self.crawls = mdb["crawls"]
@@ -117,6 +127,8 @@ class CrawlConfigOps:
         self.org_ops = org_ops
         self.crawl_manager = crawl_manager
         self.profiles = profiles
+        self.file_ops = file_ops
+        self.storage_ops = storage_ops
         self.profiles.set_crawlconfigs(self)
         self.crawl_ops = cast(CrawlOps, None)
         self.coll_ops = cast(CollectionOps, None)
@@ -125,6 +137,8 @@ class CrawlConfigOps:
         self.default_crawler_image_pull_policy = os.environ.get(
             "DEFAULT_CRAWLER_IMAGE_PULL_POLICY", "IfNotPresent"
         )
+
+        self.min_seed_file_crawler_image = os.environ.get("MIN_SEED_FILE_CRAWLER_IMAGE")
 
         self.paused_expiry_delta = timedelta(
             minutes=int(os.environ.get("PAUSED_CRAWL_LIMIT_MINUTES", "10080"))
@@ -216,7 +230,7 @@ class CrawlConfigOps:
 
         return profile_filename
 
-    # pylint: disable=invalid-name, too-many-branches
+    # pylint: disable=invalid-name, too-many-branches, too-many-statements, too-many-locals
     async def add_crawl_config(
         self,
         config_in: CrawlConfigIn,
@@ -266,6 +280,34 @@ class CrawlConfigOps:
             for url in config_in.config.customBehaviors:
                 self._validate_custom_behavior_url_syntax(url)
 
+        if config_in.config.seedFileId:
+            # Validate file with that id exists
+            seed_file = await self.file_ops.get_seed_file(
+                config_in.config.seedFileId, org
+            )
+
+            # Validate seeds not set
+            if config_in.config.seeds:
+                raise HTTPException(
+                    status_code=400, detail="use_one_of_seeds_or_seedfile"
+                )
+
+            # Ensure scopeType is set to page
+            config_in.config.scopeType = ScopeType.PAGE
+
+            first_seed = seed_file.firstSeed
+            seed_count = seed_file.seedCount
+        else:
+            if not config_in.config.seeds:
+                raise HTTPException(
+                    status_code=400, detail="use_one_of_seeds_or_seedfile"
+                )
+
+            seeds = cast(List[Seed], config_in.config.seeds)
+            seed_count = len(seeds)
+
+            first_seed = seeds[0].url
+
         now = dt_now()
         crawlconfig = CrawlConfig(
             id=uuid4(),
@@ -290,6 +332,8 @@ class CrawlConfigOps:
             crawlerChannel=config_in.crawlerChannel,
             crawlFilenameTemplate=config_in.crawlFilenameTemplate,
             proxyId=config_in.proxyId,
+            firstSeed=first_seed,
+            seedCount=seed_count,
         )
 
         if config_in.runNow:
@@ -302,6 +346,7 @@ class CrawlConfigOps:
         await self.crawl_manager.update_scheduled_job(crawlconfig, str(user.id))
 
         crawl_id = None
+        error_detail = None
         storage_quota_reached = False
         exec_mins_quota_reached = False
 
@@ -314,6 +359,7 @@ class CrawlConfigOps:
                 elif e.detail == "exec_minutes_quota_reached":
                     exec_mins_quota_reached = True
                 print(f"Can't run crawl now: {e.detail}", flush=True)
+                error_detail = e.detail
         else:
             storage_quota_reached = self.org_ops.storage_quota_reached(org)
             exec_mins_quota_reached = self.org_ops.exec_mins_quota_reached(org)
@@ -324,6 +370,7 @@ class CrawlConfigOps:
             run_now_job=crawl_id,
             storageQuotaReached=storage_quota_reached,
             execMinutesQuotaReached=exec_mins_quota_reached,
+            errorDetail=error_detail,
         )
 
     def is_single_page(self, config: RawCrawlConfig):
@@ -457,6 +504,27 @@ class CrawlConfigOps:
             if self.is_single_page(update.config or orig_crawl_config.config):
                 update.browserWindows = 1
 
+        if update.config and update.config.seedFileId:
+            # Validate file with that id exists
+            seed_file = await self.file_ops.get_seed_file(update.config.seedFileId, org)
+
+            # Validate seeds not set
+            if update.config.seeds or (
+                orig_crawl_config.config.seeds and update.config.seeds not in ([], None)
+            ):
+                raise HTTPException(
+                    status_code=400, detail="use_one_of_seeds_or_seedfile"
+                )
+
+        if update.config and update.config.seeds:
+            if update.config.seedFileId or (
+                orig_crawl_config.config.seedFileId
+                and update.config.seedFileId is not None
+            ):
+                raise HTTPException(
+                    status_code=400, detail="use_one_of_seeds_or_seedfile"
+                )
+
         # indicates if any k8s crawl config settings changed
         changed = False
         changed = changed or (
@@ -537,6 +605,17 @@ class CrawlConfigOps:
         if update.config is not None:
             query["config"] = update.config.dict()
 
+        if update.config and update.config.seedFileId:
+            query["firstSeed"] = seed_file.firstSeed
+            query["seedCount"] = seed_file.seedCount
+            query["config"]["scopeType"] = ScopeType.PAGE
+            query["seeds"] = None
+
+        if update.config and update.config.seeds:
+            query["firstSeed"] = update.config.seeds[0].url
+            query["seedCount"] = len(update.config.seeds)
+            query["seedFileId"] = None
+
         # update in db
         result = await self.crawl_configs.find_one_and_update(
             {"_id": cid, "inactive": {"$ne": True}},
@@ -550,6 +629,20 @@ class CrawlConfigOps:
             )
 
         crawlconfig = CrawlConfig.from_dict(result)
+
+        # Delete old seed file if it's been unset
+        if (
+            orig_crawl_config.config
+            and orig_crawl_config.config.seedFileId
+            and update.config
+            and update.config.seedFileId is None
+        ):
+            try:
+                await self.file_ops.delete_seed_file(
+                    orig_crawl_config.config.seedFileId, org
+                )
+            except HTTPException:
+                pass
 
         # update in crawl manager to change schedule
         if schedule_changed:
@@ -646,13 +739,9 @@ class CrawlConfigOps:
             match_query["isCrawlRunning"] = is_crawl_running
 
         # pylint: disable=duplicate-code
-        aggregate = [
+        aggregate: List[Dict[str, Union[object, str, int]]] = [
             {"$match": match_query},
-            {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
-            {"$set": {"seedCount": {"$size": "$config.seeds"}}},
-            # Set firstSeed
-            {"$set": {"firstSeed": "$firstSeedObject.url"}},
-            {"$unset": ["firstSeedObject", "config"]},
+            {"$unset": ["config"]},
         ]
 
         if first_seed:
@@ -828,29 +917,9 @@ class CrawlConfigOps:
                 crawlconfig.profileid, org
             )
 
-        if crawlconfig.config and crawlconfig.config.seeds:
-            crawlconfig.firstSeed = crawlconfig.config.seeds[0].url
-
-        crawlconfig.seedCount = await self.get_crawl_config_seed_count(cid, org)
-
         crawlconfig.config.seeds = None
 
         return crawlconfig
-
-    async def get_crawl_config_seed_count(self, cid: UUID, org: Organization):
-        """Return count of seeds in crawl config"""
-        cursor = self.crawl_configs.aggregate(
-            [
-                {"$match": {"_id": cid, "oid": org.id}},
-                {"$project": {"seedCount": {"$size": "$config.seeds"}}},
-            ]
-        )
-        results = await cursor.to_list(length=1)
-        result = results[0]
-        seed_count = result["seedCount"]
-        if seed_count:
-            return int(seed_count)
-        return 0
 
     async def get_crawl_config(
         self,
@@ -891,8 +960,7 @@ class CrawlConfigOps:
         return revisions, total
 
     async def make_inactive_or_delete(
-        self,
-        crawlconfig: CrawlConfig,
+        self, crawlconfig: CrawlConfig, org: Organization
     ):
         """Make config inactive if crawls exist, otherwise move to inactive list"""
 
@@ -908,6 +976,14 @@ class CrawlConfigOps:
 
         # if no crawls have been run, actually delete
         if not crawlconfig.crawlAttemptCount:
+            if crawlconfig.config and crawlconfig.config.seedFileId:
+                try:
+                    await self.file_ops.delete_seed_file(
+                        crawlconfig.config.seedFileId, org
+                    )
+                except HTTPException:
+                    pass
+
             result = await self.crawl_configs.delete_one(
                 {"_id": crawlconfig.id, "oid": crawlconfig.oid}
             )
@@ -931,12 +1007,12 @@ class CrawlConfigOps:
 
         return status
 
-    async def do_make_inactive(self, crawlconfig: CrawlConfig):
+    async def do_make_inactive(self, crawlconfig: CrawlConfig, org: Organization):
         """perform make_inactive in a transaction"""
 
         async with await self.dbclient.start_session() as sesh:
             async with sesh.start_transaction():
-                status = await self.make_inactive_or_delete(crawlconfig)
+                status = await self.make_inactive_or_delete(crawlconfig, org)
 
         return {"success": True, "status": status}
 
@@ -1000,20 +1076,17 @@ class CrawlConfigOps:
         names = await self.crawl_configs.distinct("name", {"oid": org.id})
         descriptions = await self.crawl_configs.distinct("description", {"oid": org.id})
         workflow_ids = await self.crawl_configs.distinct("_id", {"oid": org.id})
+        first_seeds = await self.crawl_configs.distinct("firstSeed", {"oid": org.id})
 
         # Remove empty strings
         names = [name for name in names if name]
         descriptions = [description for description in descriptions if description]
-
-        first_seeds = set()
-        async for config in self.crawl_configs.find({"oid": org.id}):
-            first_seed = config["config"]["seeds"][0]["url"]
-            first_seeds.add(first_seed)
+        first_seeds = [first_seed for first_seed in first_seeds if first_seed]
 
         return {
             "names": names,
             "descriptions": descriptions,
-            "firstSeeds": list(first_seeds),
+            "firstSeeds": first_seeds,
             "workflowIds": workflow_ids,
         }
 
@@ -1044,6 +1117,23 @@ class CrawlConfigOps:
             crawlconfig.crawlFilenameTemplate or self.default_filename_template
         )
 
+        seed_file_url = ""
+        if crawlconfig.config.seedFileId:
+            crawler_image = self.get_channel_crawler_image(crawlconfig.crawlerChannel)
+            if (
+                self.min_seed_file_crawler_image
+                and crawler_image
+                and crawler_image < self.min_seed_file_crawler_image
+            ):
+                raise HTTPException(
+                    status_code=400, detail="seed_file_not_supported_by_crawler"
+                )
+
+            seed_file_out = await self.file_ops.get_seed_file_out(
+                crawlconfig.config.seedFileId, org
+            )
+            seed_file_url = seed_file_out.path
+
         try:
             crawl_id = await self.crawl_manager.create_crawl_job(
                 crawlconfig,
@@ -1053,6 +1143,7 @@ class CrawlConfigOps:
                 storage_filename=storage_filename,
                 profile_filename=profile_filename or "",
                 is_single_page=self.is_single_page(crawlconfig.config),
+                seed_file_url=seed_file_url,
             )
             await self.add_new_crawl(crawl_id, crawlconfig, user, org, manual=True)
             return crawl_id
@@ -1358,11 +1449,23 @@ def init_crawl_config_api(
     org_ops,
     crawl_manager,
     profiles,
+    file_ops,
+    storage_ops,
 ):
     """Init /crawlconfigs api routes"""
     # pylint: disable=invalid-name
 
-    ops = CrawlConfigOps(dbclient, mdb, user_manager, org_ops, crawl_manager, profiles)
+    # pylint: disable=duplicate-code
+    ops = CrawlConfigOps(
+        dbclient,
+        mdb,
+        user_manager,
+        org_ops,
+        crawl_manager,
+        profiles,
+        file_ops,
+        storage_ops,
+    )
 
     router = ops.router
 
@@ -1547,7 +1650,7 @@ def init_crawl_config_api(
     async def make_inactive(cid: UUID, org: Organization = Depends(org_crawl_dep)):
         crawlconfig = await ops.get_crawl_config(cid, org.id)
 
-        return await ops.do_make_inactive(crawlconfig)
+        return await ops.do_make_inactive(crawlconfig, org)
 
     @app.post("/orgs/all/crawlconfigs/reAddCronjobs", response_model=SuccessResponse)
     async def re_add_all_scheduled_cron_jobs(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -186,9 +186,7 @@ class CrawlOps(BaseCrawlOps):
         # pylint: disable=duplicate-code
         aggregate = [
             {"$match": query},
-            {"$set": {"firstSeedObject": {"$arrayElemAt": ["$config.seeds", 0]}}},
-            {"$set": {"firstSeed": "$firstSeedObject.url"}},
-            {"$unset": ["firstSeedObject", "errors", "behaviorLogs", "config"]},
+            {"$unset": ["errors", "behaviorLogs", "config"]},
             {"$set": {"activeQAStats": "$qa.stats"}},
             {
                 "$set": {
@@ -314,9 +312,7 @@ class CrawlOps(BaseCrawlOps):
         for result in items:
             crawl = cls.from_dict(result)
             files = result.get("files") if resources else None
-            crawl = await self._resolve_crawl_refs(
-                crawl, org, files=files, add_first_seed=False
-            )
+            crawl = await self._resolve_crawl_refs(crawl, org, files=files)
             crawls.append(crawl)
 
         return crawls, total
@@ -386,6 +382,8 @@ class CrawlOps(BaseCrawlOps):
             proxyId=crawlconfig.proxyId,
             image=image,
             version=2,
+            firstSeed=crawlconfig.firstSeed,
+            seedCount=crawlconfig.seedCount,
         )
 
         try:

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -1,0 +1,438 @@
+"""user-uploaded files"""
+
+from typing import TYPE_CHECKING, Union, Any, Optional, Dict, Tuple, List
+
+from datetime import timedelta
+import os
+import tempfile
+from uuid import UUID, uuid4
+
+import aiohttp
+from fastapi import APIRouter, Depends, HTTPException, Request
+import pymongo
+
+from .models import (
+    SeedFileOut,
+    SeedFile,
+    UserFile,
+    UserFilePreparer,
+    Organization,
+    User,
+    AddedResponseId,
+    SuccessResponse,
+    MIN_UPLOAD_PART_SIZE,
+    PaginatedUserFileResponse,
+)
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .utils import dt_now
+from .storages import StorageOps, CHUNK_SIZE
+
+if TYPE_CHECKING:
+    from .orgs import OrgOps
+else:
+    OrgOps = object
+
+
+ALLOWED_UPLOAD_TYPES = ["seedFile"]
+
+SEED_FILE_MAX_SIZE = 25_000_000
+SEED_FILE_ALLOWED_EXTENSIONS = [".txt"]
+
+
+# ============================================================================
+# pylint: disable=too-many-instance-attributes
+class FileUploadOps:
+    """user non-wacz file upload management"""
+
+    org_ops: OrgOps
+    storage_ops: StorageOps
+
+    # pylint: disable=too-many-locals, too-many-arguments, invalid-name
+
+    def __init__(self, mdb, org_ops, storage_ops):
+        self.files = mdb["file_uploads"]
+        self.crawl_configs = mdb["crawl_configs"]
+
+        self.org_ops = org_ops
+        self.storage_ops = storage_ops
+
+        self.router = APIRouter(
+            prefix="/files",
+            tags=["userfiles"],
+            responses={404: {"description": "Not found"}},
+        )
+
+    async def init_index(self):
+        """init index for user file uploads db collection"""
+        await self.files.create_index([("oid", pymongo.HASHED)])
+
+    async def get_file_raw(
+        self,
+        file_id: UUID,
+        org: Optional[Organization] = None,
+        type_: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get raw file from db"""
+        query: dict[str, object] = {"_id": file_id}
+        if org:
+            query["oid"] = org.id
+
+        if type_:
+            query["type"] = type_
+
+        res = await self.files.find_one(query)
+
+        if not res:
+            raise HTTPException(status_code=404, detail="file_not_found")
+
+        return res
+
+    async def get_seed_file(
+        self,
+        file_id: UUID,
+        org: Optional[Organization] = None,
+        type_: Optional[str] = None,
+    ) -> SeedFile:
+        """Get file by UUID"""
+        file_raw = await self.get_file_raw(file_id, org, type_)
+        return SeedFile.from_dict(file_raw)
+
+    async def get_seed_file_out(
+        self,
+        file_id: UUID,
+        org: Optional[Organization] = None,
+        type_: Optional[str] = None,
+        headers: Optional[dict] = None,
+    ) -> SeedFileOut:
+        """Get file output model by UUID"""
+        user_file = await self.get_seed_file(file_id, org, type_)
+        return await user_file.get_file_out(org, self.storage_ops, headers)
+
+    async def list_seed_files(
+        self,
+        org: Organization,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
+        sort_by: str = "created",
+        sort_direction: int = -1,
+        headers: Optional[dict] = None,
+    ) -> Tuple[list[SeedFileOut], int]:
+        """list all user-uploaded files"""
+        # pylint: disable=too-many-locals
+
+        # Zero-index page for query
+        page = page - 1
+        skip = page_size * page
+
+        match_query = {"oid": org.id}
+
+        aggregate: List[Dict[str, Any]] = [{"$match": match_query}]
+
+        if sort_by:
+            if sort_by not in (
+                "created",
+                "size",
+                "mime",
+                "userName",
+                "type",
+                "firstSeed",
+                "seedCount",
+            ):
+                raise HTTPException(status_code=400, detail="invalid_sort_by")
+            if sort_direction not in (1, -1):
+                raise HTTPException(status_code=400, detail="invalid_sort_direction")
+
+            aggregate.extend([{"$sort": {sort_by: sort_direction}}])
+
+        aggregate.extend(
+            [
+                {
+                    "$facet": {
+                        "items": [
+                            {"$skip": skip},
+                            {"$limit": page_size},
+                        ],
+                        "total": [{"$count": "count"}],
+                    }
+                },
+            ]
+        )
+
+        cursor = self.files.aggregate(aggregate)
+        results = await cursor.to_list(length=1)
+        result = results[0]
+        items = result["items"]
+
+        try:
+            total = int(result["total"][0]["count"])
+        except (IndexError, ValueError):
+            total = 0
+
+        user_files = []
+        for res in items:
+            file_ = SeedFile.from_dict(res)
+            file_out = await file_.get_file_out(org, self.storage_ops, headers)
+            user_files.append(file_out)
+
+        return user_files, total
+
+    # pylint: disable=duplicate-code
+    async def upload_user_file_stream(
+        self,
+        stream,
+        filename: str,
+        org: Organization,
+        user: User,
+        upload_type: str = "seedFile",
+    ) -> Dict[str, Union[bool, UUID]]:
+        """Upload file stream and return its id"""
+        self.org_ops.can_write_data(org, include_time=False)
+
+        _, extension = os.path.splitext(filename)
+
+        # Validate extension
+        allowed_extensions = SEED_FILE_ALLOWED_EXTENSIONS
+        if extension not in allowed_extensions:
+            raise HTTPException(status_code=400, detail="invalid_extension")
+
+        file_id = uuid4()
+
+        new_filename = f"{upload_type}-{str(file_id)}{extension}"
+
+        prefix = org.storage.get_storage_extra_path(str(org.id)) + f"{upload_type}s/"
+
+        file_prep = UserFilePreparer(
+            prefix,
+            new_filename,
+            original_filename=filename,
+            user=user,
+            created=dt_now(),
+        )
+
+        async def stream_iter():
+            """iterate over each chunk and compute and digest + total size"""
+            async for chunk in stream:
+                file_prep.add_chunk(chunk)
+                yield chunk
+
+        print(f"{upload_type} stream upload starting", flush=True)
+
+        if not await self.storage_ops.do_upload_multipart(
+            org,
+            file_prep.upload_name,
+            stream_iter(),
+            MIN_UPLOAD_PART_SIZE,
+            mime=file_prep.mime,
+        ):
+            print(f"{upload_type} stream upload failed", flush=True)
+            raise HTTPException(status_code=400, detail="upload_failed")
+
+        print(f"{upload_type} stream upload complete", flush=True)
+
+        file_obj = file_prep.get_user_file(org.storage)
+
+        # Validate size
+        max_size = SEED_FILE_MAX_SIZE
+        if file_obj.size > max_size:
+            print(
+                f"{upload_type} stream upload failed: max size (25 MB) exceeded",
+                flush=True,
+            )
+            await self.storage_ops.delete_file_object(org, file_obj)
+            raise HTTPException(
+                status_code=400,
+                detail="max_size_25_mb_exceeded",
+            )
+
+        first_seed, seed_count = await self._parse_seed_info_from_file(file_obj, org)
+
+        # Save file to database
+        file_to_insert = SeedFile(
+            id=file_id,
+            oid=org.id,
+            filename=file_obj.filename,
+            hash=file_obj.hash,
+            size=file_obj.size,
+            storage=file_obj.storage,
+            originalFilename=file_obj.originalFilename,
+            mime=file_obj.mime,
+            userid=file_obj.userid,
+            userName=file_obj.userName,
+            created=file_obj.created,
+            firstSeed=first_seed,
+            seedCount=seed_count,
+        )
+
+        await self.files.insert_one(file_to_insert.to_dict())
+
+        await self.org_ops.inc_org_bytes_stored_field(
+            org.id, "bytesStoredSeedFiles", file_obj.size
+        )
+
+        return {"added": True, "id": file_id}
+
+    async def _parse_seed_info_from_file(
+        self, file_obj: UserFile, org: Organization
+    ) -> Tuple[str, int]:
+        first_seed = ""
+        seed_count = 0
+
+        file_url = await file_obj.get_absolute_presigned_url(
+            org, self.storage_ops, None
+        )
+
+        with tempfile.TemporaryFile() as fp:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(file_url) as resp:
+                    async for chunk in resp.content.iter_chunked(CHUNK_SIZE):
+                        fp.write(chunk)
+
+            fp.seek(0)
+
+            for line in fp:
+                if not line:
+                    continue
+
+                if not first_seed:
+                    first_seed = line.decode("utf-8").strip()
+                seed_count += 1
+
+        return first_seed, seed_count
+
+    async def delete_seed_file(
+        self, file_id: UUID, org: Organization
+    ) -> Dict[str, bool]:
+        """Delete user-uploaded file from storage and db"""
+        file = await self.get_seed_file(file_id, org)
+
+        # Make sure seed file isn't currently referenced by any workflows
+        if file.type == "seedFile":
+            matching_workflow = await self.crawl_configs.find_one(
+                {"config.seedFileId": file_id}
+            )
+            if matching_workflow:
+                raise HTTPException(status_code=400, detail="seed_file_in_use")
+
+        await self.storage_ops.delete_file_object(org, file)
+        await self.files.delete_one({"_id": file_id, "oid": org.id})
+        if file.type == "seedFile":
+            await self.org_ops.inc_org_bytes_stored_field(
+                org.id, "bytesStoredSeedFiles", -file.size
+            )
+
+        return {"success": True}
+
+    async def calculate_seed_file_storage(self, oid: UUID) -> int:
+        """Calculate total storage of seed files in org"""
+        total_size = 0
+
+        cursor = self.files.find({"oid": oid, "type": "seedFile"})
+        async for file_dict in cursor:
+            total_size += file_dict.get("size", 0)
+
+        return total_size
+
+    async def cleanup_unused_seed_files(self):
+        """Delete older seed files that are not used in workflows"""
+        cleanup_after_mins = int(os.environ.get("CLEANUP_FILES_AFTER_MINUTES", 1440))
+
+        print(
+            f"Cleaning up unused seed files more than {cleanup_after_mins} minutes old",
+            flush=True,
+        )
+
+        cleanup_before = dt_now() - timedelta(minutes=cleanup_after_mins)
+        match_query = {"type": "seedFile", "created": {"$lt": cleanup_before}}
+
+        errored = False
+        error_msg = ""
+
+        async for file_dict in self.files.find(match_query):
+            file_id = file_dict["_id"]
+
+            first_matching_workflow = await self.crawl_configs.find_one(
+                {"config.seedFileId": file_id}
+            )
+            if first_matching_workflow:
+                continue
+
+            try:
+                org = await self.org_ops.get_org_by_id(file_dict["oid"])
+                await self.delete_seed_file(file_id, org)
+                print(f"Deleted unused seed file {file_id}", flush=True)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(f"Error deleting unused seed file {file_id}: {err}", flush=True)
+                # Raise exception later so that job fails but only after attempting
+                # to clean up all files first
+                errored = True
+                error_msg = str(err)
+
+        if errored:
+            raise RuntimeError(f"Error deleting unused seed files: {error_msg}")
+
+
+# ============================================================================
+def init_file_uploads_api(
+    mdb,
+    org_ops,
+    storage_ops,
+    user_dep,
+):
+    """Init /files api routes"""
+
+    ops = FileUploadOps(mdb, org_ops, storage_ops)
+
+    router = ops.router
+
+    org_crawl_dep = org_ops.org_crawl_dep
+    org_viewer_dep = org_ops.org_viewer_dep
+
+    @router.put("/seedFile", response_model=AddedResponseId)
+    async def upload_seedfile_stream(
+        request: Request,
+        filename: str,
+        org: Organization = Depends(org_crawl_dep),
+        user: User = Depends(user_dep),
+    ):
+        return await ops.upload_user_file_stream(
+            request.stream(), filename, org, user, upload_type="seedFile"
+        )
+
+    # pylint: disable=too-many-arguments
+    @router.get("", response_model=PaginatedUserFileResponse)
+    async def list_seed_files(
+        request: Request,
+        org: Organization = Depends(org_viewer_dep),
+        pageSize: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
+        sortBy: str = "created",
+        sortDirection: int = -1,
+    ):
+        # pylint: disable=duplicate-code
+        user_files, total = await ops.list_seed_files(
+            org,
+            page_size=pageSize,
+            page=page,
+            sort_by=sortBy,
+            sort_direction=sortDirection,
+            headers=dict(request.headers),
+        )
+        return paginated_format(user_files, total, page, pageSize)
+
+    @router.get("/{file_id}", response_model=SeedFileOut)
+    async def get_seed_file(
+        file_id: UUID, request: Request, org: Organization = Depends(org_viewer_dep)
+    ):
+        return await ops.get_seed_file_out(file_id, org, headers=dict(request.headers))
+
+    @router.delete("/{file_id}", response_model=SuccessResponse)
+    async def delete_user_file(
+        file_id: UUID, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await ops.delete_seed_file(file_id, org)
+
+    if org_ops.router:
+        org_ops.router.include_router(router)
+
+    return ops

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -96,6 +96,7 @@ class K8sAPI:
         qa_source: str = "",
         proxy_id: str = "",
         is_single_page: bool = False,
+        seed_file_url: str = "",
     ):
         """load job template from yaml"""
         if not crawl_id:
@@ -121,6 +122,7 @@ class K8sAPI:
             "qa_source": qa_source,
             "proxy_id": proxy_id,
             "is_single_page": "1" if is_single_page else "0",
+            "seed_file_url": seed_file_url,
         }
 
         data = self.templates.env.get_template("crawl_job.yaml").render(params)
@@ -145,6 +147,7 @@ class K8sAPI:
         qa_source: str = "",
         proxy_id: str = "",
         is_single_page: bool = False,
+        seed_file_url: str = "",
     ) -> str:
         """load and init crawl job via k8s api"""
         crawl_id, data = self.new_crawl_job_yaml(
@@ -165,6 +168,7 @@ class K8sAPI:
             qa_source=qa_source,
             proxy_id=proxy_id,
             is_single_page=is_single_page,
+            seed_file_url=seed_file_url,
         )
 
         # create job directly

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -30,14 +30,38 @@ async def main():
         )
         return 1
 
-    (org_ops, _, _, _, _, page_ops, coll_ops, _, _, _, _, user_manager, _, _, _) = (
-        init_ops()
-    )
+    (
+        org_ops,
+        _,
+        _,
+        _,
+        _,
+        page_ops,
+        coll_ops,
+        _,
+        _,
+        _,
+        _,
+        user_manager,
+        _,
+        file_ops,
+        _,
+        _,
+    ) = init_ops()
 
     # Run job (generic)
     if job_type == BgJobType.OPTIMIZE_PAGES:
         try:
             await page_ops.optimize_crawl_pages(version=2)
+            return 0
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            traceback.print_exc()
+            return 1
+
+    if job_type == BgJobType.CLEANUP_SEED_FILES:
+        try:
+            await file_ops.cleanup_unused_seed_files()
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -35,6 +35,7 @@ async def main() -> int:
         _,
         user_manager,
         invite_ops,
+        file_ops,
         _,
         mdb,
     ) = init_ops()
@@ -50,6 +51,7 @@ async def main() -> int:
         storage_ops,
         page_ops,
         background_job_ops,
+        file_ops,
     )
 
     return 0

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -42,6 +42,7 @@ def main():
         _,
         _,
         _,
+        _,
     ) = init_ops()
 
     return init_operator_api(

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -1,0 +1,95 @@
+"""
+Migration 0048 - Calculate firstSeed/seedCount and store directly in database
+"""
+
+from typing import cast, List, Dict, Any
+
+from btrixcloud.migrations import BaseMigration
+from btrixcloud.models import CrawlConfig, Crawl, Seed
+
+
+MIGRATION_VERSION = "0048"
+
+
+# pylint: disable=duplicate-code
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self) -> None:
+        """Perform migration up.
+
+        Calculate firstSeed and seedCount for workflows and store in db
+        """
+        crawls_mdb = self.mdb["crawls"]
+        crawl_configs_mdb = self.mdb["crawl_configs"]
+
+        match_query = {"$or": [{"firstSeed": None}, {"seedCount": None}]}
+
+        # Workflows
+        async for config_raw in crawl_configs_mdb.find(match_query):
+            config = CrawlConfig.from_dict(config_raw)
+
+            try:
+                if not config.config.seeds:
+                    print(
+                        f"Unable to find seeds for config {config.id}, skipping",
+                        flush=True,
+                    )
+                    continue
+
+                seeds = cast(List[Seed], config.config.seeds)
+                seed_count = len(seeds)
+                first_seed = seeds[0].url
+
+                await crawl_configs_mdb.find_one_and_update(
+                    {"_id": config.id},
+                    {
+                        "$set": {
+                            "firstSeed": first_seed,
+                            "seedCount": seed_count,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update seed info for workflow {config.id}: {err}",
+                    flush=True,
+                )
+
+        # Crawls
+        crawl_query: Dict[str, Any] = {
+            "type": "crawl",
+            "$or": [
+                {"firstSeed": {"$in": [None, ""]}},
+                {"seedCount": {"$in": [None, 0]}},
+            ],
+        }
+        async for crawl_raw in crawls_mdb.find(crawl_query):
+            crawl_id = crawl_raw["_id"]
+            try:
+                crawl = Crawl.from_dict(crawl_raw)
+                config_raw = await crawl_configs_mdb.find_one({"_id": crawl.cid})
+
+                seed_count = config_raw.get("seedCount", 0)
+                first_seed = config_raw.get("firstSeed", "")
+
+                await crawls_mdb.find_one_and_update(
+                    {"_id": crawl_id},
+                    {
+                        "$set": {
+                            "firstSeed": first_seed,
+                            "seedCount": seed_count,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Unable to update seed info for crawl {crawl_id}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
+++ b/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
@@ -1,0 +1,61 @@
+"""
+Migration 0049 - Recalculate org storage for seed file and thumbnail size
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0049"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+        self.org_ops = kwargs.get("org_ops")
+        self.coll_ops = kwargs.get("coll_ops")
+        self.file_ops = kwargs.get("file_ops")
+
+    async def migrate_up(self):
+        """Perform migration up. Add thumbnail and seed file storage to orgs."""
+        # pylint: disable=duplicate-code, line-too-long
+        if self.org_ops is None or self.coll_ops is None or self.file_ops is None:
+            print("Unable to recalculate org storage, missing ops", flush=True)
+            return
+
+        orgs_db = self.mdb["organizations"]
+
+        match_query = {
+            "$or": [{"bytesStoredSeedFiles": None}, {"bytesStoredThumbnails": None}]
+        }
+
+        async for org_dict in orgs_db.find(match_query):
+            oid = org_dict.get("_id")
+
+            try:
+                org = await self.org_ops.get_org_by_id(oid)
+
+                seed_file_size = await self.file_ops.calculate_seed_file_storage(oid)
+                thumbnail_size = await self.coll_ops.calculate_thumbnail_storage(oid)
+
+                await orgs_db.find_one_and_update(
+                    {"_id": oid},
+                    {
+                        "$set": {
+                            "bytesStored": org.bytesStored
+                            + seed_file_size
+                            + thumbnail_size,
+                            "bytesStoredSeedFiles": seed_file_size,
+                            "bytesStoredThumbnails": thumbnail_size,
+                        }
+                    },
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error recalculating storage for org {oid}: {err}",
+                    flush=True,
+                )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -321,6 +321,8 @@ class RawCrawlConfig(BaseModel):
 
     seeds: Optional[List[Seed]] = []
 
+    seedFileId: Optional[UUID] = None
+
     scopeType: Optional[ScopeType] = ScopeType.PREFIX
 
     include: Union[str, List[str], None] = None
@@ -439,6 +441,9 @@ class CrawlConfigCore(BaseMongoModel):
     crawlerChannel: Optional[str] = None
     proxyId: Optional[str] = None
 
+    firstSeed: str = ""
+    seedCount: int = 0
+
 
 # ============================================================================
 class CrawlConfigAdditional(BaseModel):
@@ -506,8 +511,6 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
     lastCrawlPausedAt: Optional[datetime] = None
     lastCrawlPausedExpiry: Optional[datetime] = None
     profileName: Optional[str] = None
-    firstSeed: Optional[str] = None
-    seedCount: int = 0
 
     createdByName: Optional[str] = None
     modifiedByName: Optional[str] = None
@@ -575,6 +578,7 @@ class CrawlConfigAddedResponse(BaseModel):
     run_now_job: Optional[str] = None
     storageQuotaReached: bool
     execMinutesQuotaReached: bool
+    errorDetail: Optional[str] = None
 
 
 # ============================================================================
@@ -598,7 +602,7 @@ class CrawlConfigSearchValues(BaseModel):
 
     names: List[str]
     descriptions: List[str]
-    firstSeeds: List[AnyHttpUrl]
+    firstSeeds: List[str]
     workflowIds: List[UUID]
 
 
@@ -952,7 +956,7 @@ class CrawlSearchValuesResponse(BaseModel):
 
     names: List[str]
     descriptions: List[str]
-    firstSeeds: List[AnyHttpUrl]
+    firstSeeds: List[str]
 
 
 # ============================================================================
@@ -1142,28 +1146,16 @@ class FilePreparer:
 
 # ============================================================================
 
-### USER-UPLOADED IMAGES ###
+### USER-UPLOADED FILES ###
 
 
 # ============================================================================
-class ImageFileOut(BaseModel):
-    """output for user-upload imaged file (conformance to Data Resource Spec)"""
+class PublicUserFileOut(BaseModel):
+    """public output for user-uploaded file stored on other document
 
-    name: str
-    path: str
-    hash: str
-    size: int
-
-    originalFilename: str
-    mime: str
-    userid: UUID
-    userName: str
-    created: datetime
-
-
-# ============================================================================
-class PublicImageFileOut(BaseModel):
-    """public output for user-upload imaged file (conformance to Data Resource Spec)"""
+    Public User Upload File (used for collection thumbnails).
+    Conforms to Data Resource Spec.
+    """
 
     name: str
     path: str
@@ -1174,8 +1166,11 @@ class PublicImageFileOut(BaseModel):
 
 
 # ============================================================================
-class ImageFile(BaseFile):
-    """User-uploaded image file"""
+class UserFileOut(PublicUserFileOut):
+    """output for user-uploaded file as stored on other document,
+    additional non-public fields included
+    Conforms to Data Resource Spec.
+    """
 
     originalFilename: str
     mime: str
@@ -1183,13 +1178,35 @@ class ImageFile(BaseFile):
     userName: str
     created: datetime
 
-    async def get_image_file_out(self, org, storage_ops) -> ImageFileOut:
-        """Get ImageFileOut with new presigned url"""
+
+# ============================================================================
+class UserFile(BaseFile):
+    """User-uploaded file stored on anther mongo document
+
+    Base user uploaded file (currently used for collection thumbnails).
+    Conforms to Data Resource Spec.
+    """
+
+    originalFilename: str
+    mime: str
+    userid: UUID
+    userName: str
+    created: datetime
+
+    async def get_absolute_presigned_url(
+        self, org, storage_ops, headers: Optional[dict]
+    ) -> str:
+        """Get presigned URL as absolute URL"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
+        return storage_ops.resolve_relative_access_path(presigned_url, headers) or ""
 
-        return ImageFileOut(
+    async def get_file_out(
+        self, org, storage_ops, headers: Optional[dict] = None
+    ) -> UserFileOut:
+        """Get UserFileOut with new presigned url"""
+        return UserFileOut(
             name=self.filename,
-            path=presigned_url or "",
+            path=await self.get_absolute_presigned_url(org, storage_ops, headers),
             hash=self.hash,
             size=self.size,
             originalFilename=self.originalFilename,
@@ -1199,13 +1216,13 @@ class ImageFile(BaseFile):
             created=self.created,
         )
 
-    async def get_public_image_file_out(self, org, storage_ops) -> PublicImageFileOut:
-        """Get PublicImageFileOut with new presigned url"""
-        presigned_url, _ = await storage_ops.get_presigned_url(org, self)
-
-        return PublicImageFileOut(
+    async def get_public_file_out(
+        self, org, storage_ops, headers: Optional[dict] = None
+    ) -> PublicUserFileOut:
+        """Get PublicUserFileOut with new presigned url"""
+        return PublicUserFileOut(
             name=self.filename,
-            path=presigned_url or "",
+            path=await self.get_absolute_presigned_url(org, storage_ops, headers),
             hash=self.hash,
             size=self.size,
             mime=self.mime,
@@ -1213,8 +1230,8 @@ class ImageFile(BaseFile):
 
 
 # ============================================================================
-class ImageFilePreparer(FilePreparer):
-    """Wrapper for user image streaming uploads"""
+class UserFilePreparer(FilePreparer):
+    """Wrapper for user streaming uploads"""
 
     # pylint: disable=too-many-arguments, too-many-function-args
 
@@ -1234,12 +1251,12 @@ class ImageFilePreparer(FilePreparer):
         self.user_name = user.name
         self.created = created
 
-    def get_image_file(
+    def get_user_file(
         self,
         storage: StorageRef,
-    ) -> ImageFile:
-        """get user-uploaded image file"""
-        return ImageFile(
+    ) -> UserFile:
+        """get user-uploaded file"""
+        return UserFile(
             filename=self.upload_name,
             hash=self.upload_hasher.hexdigest(),
             size=self.upload_size,
@@ -1249,6 +1266,54 @@ class ImageFilePreparer(FilePreparer):
             userid=self.userid,
             userName=self.user_name,
             created=self.created,
+        )
+
+
+# ============================================================================
+class SeedFileOut(UserFileOut):
+    """Output model for user-uploaded seed files"""
+
+    id: UUID
+    oid: UUID
+    type: str
+
+    firstSeed: Optional[str] = None
+    seedCount: Optional[int] = None
+
+
+# ============================================================================
+class SeedFile(UserFile, BaseMongoModel):
+    """Stores user-uploaded file files in 'file_uploads' mongo collection
+    Used with crawl workflows
+    """
+
+    type: Literal["seedFile"] = "seedFile"
+
+    id: UUID
+    oid: UUID
+
+    firstSeed: Optional[str] = None
+    seedCount: Optional[int] = None
+
+    async def get_file_out(
+        self, org, storage_ops, headers: Optional[dict] = None
+    ) -> SeedFileOut:
+        """Get SeedFileOut with new presigned url"""
+        return SeedFileOut(
+            name=self.filename,
+            path=await self.get_absolute_presigned_url(org, storage_ops, headers),
+            hash=self.hash,
+            size=self.size,
+            originalFilename=self.originalFilename,
+            mime=self.mime,
+            userid=self.userid,
+            userName=self.userName,
+            created=self.created,
+            id=self.id,
+            oid=self.oid,
+            type=self.type,
+            firstSeed=self.firstSeed,
+            seedCount=self.seedCount,
         )
 
 
@@ -1489,7 +1554,7 @@ class Collection(BaseMongoModel):
     homeUrlTs: Optional[datetime] = None
     homeUrlPageId: Optional[UUID] = None
 
-    thumbnail: Optional[ImageFile] = None
+    thumbnail: Optional[UserFile] = None
     thumbnailSource: Optional[CollectionThumbnailSource] = None
     defaultThumbnailName: Optional[str] = None
 
@@ -1545,7 +1610,7 @@ class CollOut(BaseMongoModel):
     homeUrlPageId: Optional[UUID] = None
 
     resources: List[CrawlFileOut] = []
-    thumbnail: Optional[ImageFileOut] = None
+    thumbnail: Optional[UserFileOut] = None
     thumbnailSource: Optional[CollectionThumbnailSource] = None
     defaultThumbnailName: Optional[str] = None
 
@@ -1588,7 +1653,7 @@ class PublicCollOut(BaseMongoModel):
     homeUrlTs: Optional[datetime] = None
 
     resources: List[CrawlFileOut] = []
-    thumbnail: Optional[PublicImageFileOut] = None
+    thumbnail: Optional[PublicUserFileOut] = None
     defaultThumbnailName: Optional[str] = None
 
     allowPublicDownload: bool = True
@@ -1986,6 +2051,8 @@ class OrgOut(BaseMongoModel):
     bytesStoredCrawls: int
     bytesStoredUploads: int
     bytesStoredProfiles: int
+    bytesStoredSeedFiles: int = 0
+    bytesStoredThumbnails: int = 0
     origin: Optional[AnyHttpUrl] = None
 
     storageQuotaReached: Optional[bool] = False
@@ -2049,6 +2116,8 @@ class Organization(BaseMongoModel):
     bytesStoredCrawls: int = 0
     bytesStoredUploads: int = 0
     bytesStoredProfiles: int = 0
+    bytesStoredSeedFiles: int = 0
+    bytesStoredThumbnails: int = 0
 
     # total usage + exec time
     usage: Dict[str, int] = {}
@@ -2196,6 +2265,8 @@ class OrgMetrics(BaseModel):
     storageUsedCrawls: int
     storageUsedUploads: int
     storageUsedProfiles: int
+    storageUsedSeedFiles: int
+    storageUsedThumbnails: int
     storageQuotaBytes: int
     archivedItemCount: int
     crawlCount: int
@@ -2619,6 +2690,7 @@ class BgJobType(str, Enum):
     RECALCULATE_ORG_STATS = "recalculate-org-stats"
     READD_ORG_PAGES = "readd-org-pages"
     OPTIMIZE_PAGES = "optimize-pages"
+    CLEANUP_SEED_FILES = "cleanup-seed-files"
 
 
 # ============================================================================
@@ -2689,6 +2761,13 @@ class OptimizePagesJob(BackgroundJob):
 
 
 # ============================================================================
+class CleanupSeedFilesJob(BackgroundJob):
+    """Model for tracking jobs to cleanup unused seed files"""
+
+    type: Literal[BgJobType.CLEANUP_SEED_FILES] = BgJobType.CLEANUP_SEED_FILES
+
+
+# ============================================================================
 # Union of all job types, for response model
 
 AnyJob = RootModel[
@@ -2700,6 +2779,7 @@ AnyJob = RootModel[
         RecalculateOrgStatsJob,
         ReAddOrgPagesJob,
         OptimizePagesJob,
+        CleanupSeedFilesJob,
     ]
 ]
 
@@ -2957,6 +3037,13 @@ class PaginatedUserOutResponse(PaginatedResponse):
     """Response model for user emails with org info"""
 
     items: List[UserOutNoId]
+
+
+# ============================================================================
+class PaginatedUserFileResponse(PaginatedResponse):
+    """Response model for user-uploaded files (e.g. seed files)"""
+
+    items: List[SeedFileOut]
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -28,6 +28,7 @@ class BgJobOperator(BaseOperator):
         async def mc_finalize_background_jobs(data: MCDecoratorSyncData):
             return await self.finalize_background_job(data)
 
+    # pylint: disable=too-many-locals
     async def finalize_background_job(self, data: MCDecoratorSyncData) -> dict:
         """handle finished background job"""
 
@@ -44,11 +45,16 @@ class BgJobOperator(BaseOperator):
             print(
                 "Succeeded: {status.get('succeeded')}, Num Pods: {spec.get('parallelism')}"
             )
+        start_time = status.get("startTime")
         completion_time = status.get("completionTime")
 
         finalized = True
 
+        started = None
         finished = None
+
+        if start_time:
+            started = str_to_date(start_time)
         if completion_time:
             finished = str_to_date(completion_time)
         if not finished:
@@ -62,7 +68,12 @@ class BgJobOperator(BaseOperator):
 
         try:
             await self.background_job_ops.job_finished(
-                job_id, job_type, success=success, finished=finished, oid=org_id
+                job_id,
+                job_type,
+                success=success,
+                started=started,
+                finished=finished,
+                oid=org_id,
             )
             # print(
             #    f"{job_type} background job completed: success: {success}, {job_id}",

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -182,6 +182,7 @@ class CrawlOperator(BaseOperator):
             scheduled=spec.get("manual") != "1",
             qa_source_crawl_id=spec.get("qaSourceCrawlId"),
             is_single_page=spec.get("isSinglePage") == "1",
+            seed_file_url=spec.get("seedFileUrl", ""),
         )
 
         # if finalizing, crawl is being deleted
@@ -469,6 +470,10 @@ class CrawlOperator(BaseOperator):
         raw_config["behaviors"] = self._filter_autoclick_behavior(
             raw_config["behaviors"], params["crawler_image"]
         )
+
+        if crawl.seed_file_url:
+            raw_config["seedFile"] = crawl.seed_file_url
+        raw_config.pop("seedFileId", None)
 
         params["config"] = json.dumps(raw_config)
 

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -87,6 +87,7 @@ class CrawlSpec(BaseModel):
     qa_source_crawl_id: Optional[str] = ""
     proxy_id: Optional[str] = None
     is_single_page: bool = False
+    seed_file_url: Optional[str] = ""
 
     @property
     def db_crawl_id(self) -> str:

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -12,6 +12,7 @@ from .basecrawls import BaseCrawlOps
 from .colls import CollectionOps
 from .crawls import CrawlOps
 from .crawlconfigs import CrawlConfigOps
+from .file_uploads import FileUploadOps
 from .invites import InviteOps
 from .orgs import OrgOps
 from .pages import PageOps
@@ -37,6 +38,7 @@ def init_ops() -> Tuple[
     EventWebhookOps,
     UserManager,
     InviteOps,
+    FileUploadOps,
     AsyncIOMotorClient,
     AsyncIOMotorDatabase,
 ]:
@@ -57,6 +59,8 @@ def init_ops() -> Tuple[
 
     storage_ops = StorageOps(org_ops, crawl_manager, mdb)
 
+    file_ops = FileUploadOps(mdb, org_ops, storage_ops)
+
     background_job_ops = BackgroundJobOps(
         mdb, email, user_manager, org_ops, crawl_manager, storage_ops
     )
@@ -65,6 +69,7 @@ def init_ops() -> Tuple[
         mdb, org_ops, crawl_manager, storage_ops, background_job_ops
     )
 
+    # pylint: disable=duplicate-code
     crawl_config_ops = CrawlConfigOps(
         dbclient,
         mdb,
@@ -72,6 +77,8 @@ def init_ops() -> Tuple[
         org_ops,
         crawl_manager,
         profile_ops,
+        file_ops,
+        storage_ops,
     )
 
     coll_ops = CollectionOps(mdb, storage_ops, org_ops, event_webhook_ops)
@@ -103,7 +110,9 @@ def init_ops() -> Tuple[
 
     background_job_ops.set_ops(crawl_ops, profile_ops)
 
-    org_ops.set_ops(base_crawl_ops, profile_ops, coll_ops, background_job_ops, page_ops)
+    org_ops.set_ops(
+        base_crawl_ops, profile_ops, coll_ops, background_job_ops, page_ops, file_ops
+    )
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)
 
@@ -127,6 +136,7 @@ def init_ops() -> Tuple[
         event_webhook_ops,
         user_manager,
         invite_ops,
+        file_ops,
         dbclient,
         mdb,
     )

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -12,6 +12,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     cast,
+    Union,
 )
 from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
@@ -57,7 +58,7 @@ from .models import (
     User,
 )
 
-from .utils import slug_from_name, dt_now
+from .utils import slug_from_name, dt_now, get_origin
 from .version import __version__
 
 
@@ -350,6 +351,14 @@ class StorageOps:
             return self.frontend_origin + path
         return path
 
+    def resolve_relative_access_path(self, path: str, headers: Optional[dict] = None):
+        """Resolve relative path for internal access or external if headers provided"""
+        if path.startswith("/"):
+            if headers is None:
+                return self.frontend_origin + path
+            return get_origin(headers) + path
+        return path
+
     def get_org_relative_path(
         self, org: Organization, ref: StorageRef, file_path: str
     ) -> str:
@@ -619,7 +628,9 @@ class StorageOps:
 
         return urls, now + self.signed_duration_delta
 
-    async def delete_file_object(self, org: Organization, crawlfile: BaseFile) -> bool:
+    async def delete_file_object(
+        self, org: Organization, crawlfile: Union[BaseFile]
+    ) -> bool:
         """delete crawl file from storage."""
         return await self._delete_file(org, crawlfile.filename, crawlfile.storage)
 

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -6,6 +6,8 @@ import time
 from typing import Dict
 from uuid import UUID
 
+from .utils import read_in_chunks
+
 
 HOST_PREFIX = "http://127.0.0.1:30870"
 API_PREFIX = HOST_PREFIX + "/api"
@@ -818,3 +820,35 @@ def profile_2_id(admin_auth_headers, default_org_id, profile_browser_2_id):
             if time.monotonic() - start_time > time_limit:
                 raise
             time.sleep(5)
+
+
+@pytest.fixture(scope="session")
+def seed_file_id(crawler_auth_headers, default_org_id):
+    with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
+        r = requests.put(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
+            headers=crawler_auth_headers,
+            data=read_in_chunks(fh),
+        )
+        assert r.status_code == 200
+        return r.json()["id"]
+
+
+@pytest.fixture(scope="session")
+def seed_file_config_id(crawler_auth_headers, default_org_id, seed_file_id):
+    crawl_data = {
+        "runNow": False,
+        "name": "Seed File Test Crawl",
+        "config": {
+            "scopeType": "page",
+            "seedFileId": seed_file_id,
+            "limit": 2,
+        },
+        "crawlerChannel": "test",
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
+        headers=crawler_auth_headers,
+        json=crawl_data,
+    )
+    return r.json()["id"]

--- a/backend/test/data/seedfile.txt
+++ b/backend/test/data/seedfile.txt
@@ -1,0 +1,2 @@
+https://specs.webrecorder.net
+https://webrecorder.net

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1276,14 +1276,14 @@ def test_upload_collection_thumbnail(crawler_auth_headers, default_org_id):
 
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
-        headers=crawler_auth_headers,
+        headers={"Host": "localhost:30870", **crawler_auth_headers},
     )
     assert r.status_code == 200
     collection = r.json()
     thumbnail = collection["thumbnail"]
 
     assert thumbnail["name"]
-    assert thumbnail["path"]
+    assert thumbnail["path"].startswith("http://localhost:30870/data/")
     assert thumbnail["hash"]
     assert thumbnail["size"] > 0
 
@@ -1335,7 +1335,11 @@ def test_list_public_colls_home_url_thumbnail():
     )
     non_public_image_fields = ("originalFilename", "userid", "userName", "created")
 
-    r = requests.get(f"{API_PREFIX}/public/orgs/{default_org_slug}/collections")
+    r = requests.get(
+        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections",
+        headers={"Host": "localhost:30870"},
+    )
+
     assert r.status_code == 200
     collections = r.json()["collections"]
     assert len(collections) == 2
@@ -1369,7 +1373,7 @@ def test_list_public_colls_home_url_thumbnail():
             assert thumbnail
 
             assert thumbnail["name"]
-            assert thumbnail["path"]
+            assert thumbnail["path"].startswith("http://localhost:30870/data/")
             assert thumbnail["hash"]
             assert thumbnail["size"]
             assert thumbnail["mime"]
@@ -1385,7 +1389,8 @@ def test_list_public_colls_home_url_thumbnail():
 
 def test_get_public_collection(default_org_id):
     r = requests.get(
-        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections/{PUBLIC_COLLECTION_SLUG}"
+        f"{API_PREFIX}/public/orgs/{default_org_slug}/collections/{PUBLIC_COLLECTION_SLUG}",
+        headers={"Host": "localhost:30870"},
     )
     assert r.status_code == 200
     coll = r.json()
@@ -1419,7 +1424,7 @@ def test_get_public_collection(default_org_id):
     assert thumbnail
 
     assert thumbnail["name"]
-    assert thumbnail["path"]
+    assert thumbnail["path"].startswith("http://localhost:30870/data/")
     assert thumbnail["hash"]
     assert thumbnail["size"]
     assert thumbnail["mime"]

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -1,0 +1,99 @@
+import os
+import requests
+
+from .conftest import API_PREFIX
+from .utils import read_in_chunks
+
+curr_dir = os.path.dirname(os.path.realpath(__file__))
+
+_seed_file_id = None
+
+
+def test_seed_file_upload(crawler_auth_headers, default_org_id):
+    with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
+        r = requests.put(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
+            headers=crawler_auth_headers,
+            data=read_in_chunks(fh),
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["added"]
+        assert data["id"]
+
+        global _seed_file_id
+        _seed_file_id = data["id"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
+        headers={"Host": "custom-host.example.com", **crawler_auth_headers},
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["id"] == _seed_file_id
+    assert data["oid"] == default_org_id
+
+    assert data["name"]
+    assert data["path"].startswith("http://custom-host.example.com/data/")
+    assert data["hash"]
+    assert data["size"] > 0
+
+    assert data["originalFilename"] == "seedfile.txt"
+    assert data["mime"] == "text/plain"
+    assert data["userid"]
+    assert data["userName"]
+    assert data["created"]
+
+    assert data["type"] == "seedFile"
+    assert data["firstSeed"] == "https://specs.webrecorder.net"
+    assert data["seedCount"] == 2
+
+
+def test_list_user_files(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files",
+        headers={"Host": "localhost", **crawler_auth_headers},
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    items = data["items"]
+    total = data["total"]
+
+    assert total >= 0
+    assert total == len(items)
+
+    for data in items:
+        assert data["id"]
+        assert data["oid"] == default_org_id
+
+        assert data["name"]
+        assert data["path"].startswith("http://localhost/data/")
+        assert data["hash"]
+        assert data["size"] > 0
+
+        assert data["originalFilename"]
+        assert data["mime"]
+        assert data["userid"]
+        assert data["userName"]
+        assert data["created"]
+
+        assert data["type"] == "seedFile"
+        assert data["firstSeed"]
+        assert data["seedCount"]
+
+
+def test_delete_seed_file(crawler_auth_headers, default_org_id):
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["success"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{_seed_file_id}",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 404

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -11,8 +11,8 @@ def test_get_config_by_created_by(crawler_auth_headers, default_org_id, crawler_
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?userid={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 8
-    assert r.json()["total"] == 8
+    assert len(r.json()["items"]) == 9
+    assert r.json()["total"] == 9
 
 
 def test_get_config_by_modified_by(
@@ -23,8 +23,8 @@ def test_get_config_by_modified_by(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?modifiedBy={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 8
-    assert r.json()["total"] == 8
+    assert len(r.json()["items"]) == 9
+    assert r.json()["total"] == 9
 
 
 def test_get_configs_by_first_seed(
@@ -362,9 +362,9 @@ def test_sort_crawl_configs(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 14
+    assert data["total"] == 15
     items = data["items"]
-    assert len(items) == 14
+    assert len(items) == 15
 
     last_created = None
     for config in items:

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -496,12 +496,16 @@ def test_org_metrics(crawler_auth_headers, default_org_id):
     assert data["storageUsedBytes"] > 0
     assert data["storageUsedCrawls"] > 0
     assert data["storageUsedUploads"] >= 0
+    assert data["storageUsedThumbnails"] >= 0
+    assert data["storageUsedThumbnails"] >= 0
     assert data["storageUsedProfiles"] >= 0
     assert (
         data["storageUsedBytes"]
         == data["storageUsedCrawls"]
         + data["storageUsedUploads"]
         + data["storageUsedProfiles"]
+        + data["storageUsedSeedFiles"]
+        + data["storageUsedThumbnails"]
     )
     assert data["storageQuotaBytes"] >= 0
     assert data["archivedItemCount"] > 0

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -607,7 +607,7 @@ def test_get_all_crawls_by_type(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 6
+    assert data["total"] == 7
     for item in data["items"]:
         assert item["type"] == "crawl"
 
@@ -639,7 +639,7 @@ def test_get_all_crawls_by_user(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 5
+    assert data["total"] == 6
     for item in data["items"]:
         assert item["userid"] == crawler_userid
 
@@ -823,7 +823,7 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 8
+    assert len(data["names"]) == 9
     expected_names = [
         "Crawler User Test Crawl",
         "Custom Behavior Logs",
@@ -831,6 +831,7 @@ def test_all_crawls_search_values(
         "test2.wacz",
         "All Crawls Test Crawl",
         "Crawler User Crawl for Testing QA",
+        "Seed File Test Crawl",
     ]
     for expected_name in expected_names:
         assert expected_name in data["names"]
@@ -850,13 +851,14 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 5
+    assert len(data["names"]) == 6
     expected_names = [
         "Admin Test Crawl",
         "All Crawls Test Crawl",
         "Crawler User Crawl for Testing QA",
         "Crawler User Test Crawl",
         "Custom Behavior Logs",
+        "Seed File Test Crawl",
     ]
     for expected_name in expected_names:
         assert expected_name in data["names"]

--- a/backend/test_nightly/data/seedfile.txt
+++ b/backend/test_nightly/data/seedfile.txt
@@ -1,0 +1,2 @@
+https://specs.webrecorder.net
+https://webrecorder.net

--- a/backend/test_nightly/test_cleanup_seed_files.py
+++ b/backend/test_nightly/test_cleanup_seed_files.py
@@ -1,0 +1,119 @@
+import os
+import requests
+import time
+
+import pytest
+
+from .conftest import API_PREFIX
+from .utils import read_in_chunks
+
+curr_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.fixture(scope="session")
+def seed_file_unused_id(crawler_auth_headers, default_org_id):
+    with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
+        r = requests.put(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
+            headers=crawler_auth_headers,
+            data=read_in_chunks(fh),
+        )
+        assert r.status_code == 200
+        return r.json()["id"]
+
+
+@pytest.fixture(scope="session")
+def seed_file_used_id(crawler_auth_headers, default_org_id):
+    with open(os.path.join(curr_dir, "data", "seedfile.txt"), "rb") as fh:
+        r = requests.put(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/seedFile?filename=seedfile.txt",
+            headers=crawler_auth_headers,
+            data=read_in_chunks(fh),
+        )
+        assert r.status_code == 200
+        return r.json()["id"]
+
+
+@pytest.fixture(scope="session")
+def seed_file_config_id(crawler_auth_headers, default_org_id, seed_file_used_id):
+    crawl_data = {
+        "runNow": False,
+        "name": "Seed File Test Crawl Nightly",
+        "config": {
+            "scopeType": "page",
+            "seedFileId": seed_file_used_id,
+            "limit": 2,
+        },
+        "crawlerChannel": "test",
+    }
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
+        headers=crawler_auth_headers,
+        json=crawl_data,
+    )
+    return r.json()["id"]
+
+
+def test_seed_file_cleanup_cron_job(
+    admin_auth_headers,
+    default_org_id,
+    seed_file_unused_id,
+    seed_file_used_id,
+    seed_file_config_id,
+):
+    # Verify unused and used seed files exist
+    for seed_file_id in (seed_file_unused_id, seed_file_used_id):
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_id}",
+            headers=admin_auth_headers,
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["id"] == seed_file_id
+        assert data["oid"] == default_org_id
+
+    # Verify workflow with used seed file exists
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{seed_file_config_id}/",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == seed_file_config_id
+    assert data["config"]["seedFileId"] == seed_file_used_id
+
+    # Wait 5 minutes to give cleanup job time to run
+    time.sleep(300)
+
+    # Check that at least one bg job entry exists for cleanup jobs and that
+    # the jobs are marked as successful
+    r = requests.get(
+        f"{API_PREFIX}/orgs/all/jobs?jobType=cleanup-seed-files",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["total"] > 0
+    for job in data["items"]:
+        print(job)
+        assert job["id"]
+        assert job["type"] == "cleanup-seed-files"
+        assert job["success"]
+        assert job["started"]
+        assert job["finished"]
+
+    # Check that unused seed file was deleted from database
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_unused_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+
+    # Check that used seed file was not deleted from database
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/files/{seed_file_used_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["id"] == seed_file_used_id

--- a/btrix
+++ b/btrix
@@ -78,6 +78,7 @@ reset(){
     echo "Deleting data..."
     kubectl delete pvc --all
     kubectl delete cronjob -n crawlers --all
+    kubectl delete cronjob --all
     kubectl delete configmap -n crawlers -l btrix.crawlconfig
 }
 
@@ -92,6 +93,7 @@ resetMicrok8s(){
     echo "Deleting data..."
     microk8s kubectl delete pvc --all
     microk8s kubectl delete cronjob -n crawlers --all
+    microk8s kubectl delete cronjob --all
     microk8s kubectl delete configmap -n crawlers -l btrix.crawlconfig
 }
 

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "{{ id }}"
+  labels:
+    role: "cron-background-job"
+    job_type: {{ job_type }}
+
+spec:
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+
+  schedule: "{{ schedule }}"
+
+  jobTemplate:
+    metadata:
+      labels:
+        role: "background-job"
+        job_type: {{ job_type }}
+        job_id: {{ id }}
+
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          priorityClassName: bg-job
+          podFailurePolicy:
+            rules:
+            - action: FailJob
+              onExitCodes:
+                containerName: btrixbgjob
+                operator: NotIn
+                values: [0]
+
+          volumes:
+            - name: ops-configs
+              secret:
+                secretName: ops-configs
+
+          containers:
+            - name: btrixbgjob
+              image: {{ backend_image }}
+              imagePullPolicy: {{ pull_policy }}
+              env:
+              - name: BG_JOB_TYPE
+                value: {{ job_type }}
+
+              volumeMounts:
+                - name: ops-configs
+                  mountPath: /ops-configs/
+
+              envFrom:
+                - configMapRef:
+                    name: backend-env-config
+                - secretRef:
+                    name: mongo-auth
+
+              volumeMounts:
+                - name: ops-configs
+                  mountPath: /ops-configs/
+
+              command: ["python3", "-m", "btrixcloud.main_bg"]
+
+              resources:
+{% if larger_resources %}
+                limits:
+                  memory: "1200Mi"
+
+                requests:
+                  memory: "500Mi"
+                  cpu: "200m"
+{% else %}
+                limits:
+                  memory: "200Mi"
+
+                requests:
+                  memory: "200Mi"
+                  cpu: "50m"
+{% endif %}

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -41,3 +41,4 @@ spec:
 
   isSinglePage: "{{ is_single_page }}"
 
+  seedFileUrl: "{{ seed_file_url }}"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -71,6 +71,8 @@ data:
 
   MIN_AUTOCLICK_CRAWLER_IMAGE: "{{ .Values.min_autoclick_crawler_image }}"
 
+  MIN_SEED_FILE_CRAWLER_IMAGE: "{{ .Values.min_seed_file_crawler_image }}"
+
   NUM_BROWSERS: "{{ .Values.crawler_browser_instances }}"
 
   MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"
@@ -98,6 +100,10 @@ data:
   REPLICA_DELETION_DELAY_DAYS: "{{ .Values.replica_deletion_delay_days | default 0 }}"
 
   PRESIGN_BATCH_SIZE: "{{ .Values.presign_batch_size | default 8 }}"
+
+  CLEANUP_JOB_CRON_SCHEDULE: "{{ .Values.cleanup_job_cron_schedule }}"
+
+  CLEANUP_FILES_AFTER_MINUTES: "{{ .Values.cleanup_files_after_minutes | default 1440 }}"
 
 
 ---

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -29,7 +29,7 @@ metadata:
   name: bg-job
 rules:
   - apiGroups: ["batch"]
-    resources: ["jobs"]
+    resources: ["jobs", "cronjobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 
 ---

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -4,6 +4,11 @@ invite_expire_seconds: 10
 
 max_pages_per_crawl: 300
 
+# Every minute, for use in testing cleaning up seed files
+cleanup_job_cron_schedule: "* * * * *"
+
+# Clean up files > 1 minute old in testing
+cleanup_files_after_minutes: 1
 
 # enable to allow access to minio directly
 minio_local_access_port: 30090

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -24,7 +24,7 @@ crawler_channels:
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
   - id: test
-    image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    image: "docker.io/webrecorder/browsertrix-crawler:1.7.0-beta.0"
 
 mongo_auth:
   # specify either username + password (for local mongo)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,6 +162,15 @@ backend_avg_cpu_threshold: 80
 # scale up if avg memory utilization exceeds
 backend_avg_memory_threshold: 95
 
+# Cron schedule for periodically cleaning up unused files
+# Defaults to every Sunday at midnight
+cleanup_job_cron_schedule: "0 0 * * 0"
+
+# number of minutes before unused seed files are eligible
+# for cleanup. defaults to 1 day (1440 minutes) 
+cleanup_files_after_minutes: 1440
+
+
 # Nginx Image
 # =========================================
 frontend_image: "docker.io/webrecorder/browsertrix-frontend:1.17.4"
@@ -255,8 +264,11 @@ crawler_namespace: "crawlers"
 # if set, will restrict QA to image names that are >= than this value
 # min_qa_crawler_image: ""
 
-# if set, will restrict autoclick behavior to image names that are >= than this value
+# if set, will restrict autoclick behavior to image names that are >= this value
 min_autoclick_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.5.0"
+
+# if set, will restrict seed files to image names that are >= this value
+min_seed_file_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.7.0"
 
 # optional: enable to use a persist volume claim for all crawls
 # can be enabled to use a multi-write shared filesystem


### PR DESCRIPTION
Fixes #2673 

Changes in this PR:

- Adds a new `file_uploads.py` module and corresponding `/files` API prefix with methods/endpoints for uploading, GETing, and deleting seed files (can be extended to other types of files moving forward)
- Seed files are supported via `CrawlConfig.config.seedFileId` on POST and PATCH endpoints. This seedFileId is replaced by a presigned url when passed to the crawler by the operator
- Seed files are read when first uploaded to calculate `firstSeed` and `seedCount` and store them in the database, and this is copied into the workflow and crawl documents when they are created.
- Logic is added to store `firstSeed` and `seedCount` for other workflows as well, and a migration added to backfill data, to maintain consistency and fix some of the pymongo aggregations that previously assumed all workflows would have at least one `Seed` object in `CrawlConfig.seeds`
- Seed file and thumbnail storage stats are added to org stats
- Seed file and thumbnail uploads first check that the org's storage quota has not been exceeded and return a 400 if so
- A cron background job (run weekly each Sunday at midnight by default, but configurable) is added to look for seed files at least x minutes old (1440 minutes, or 1 day, by default, but configurable) that are not in use in any workflows, and to delete them when they are found. The backend pods will ensure this k8s batch job exists when starting up and create it if it does not already exist. A database entry for each run of the job is created in the operator on job completion so that it'll appear in the `/jobs` API endpoints, but retrying of this type of regularly scheduled background job is not supported as we don't want to accidentally create multiple competing scheduled jobs.
- Adds a `min_seed_file_crawler_image` value to the Helm chart that is checked before creating a crawl from a workflow if set. If a workflow cannot be run, return the detail of the exception in `CrawlConfigAddedResponse.errorDetail` so that we can display the reason in the frontend
- Add SeedFile model from base UserFile (former ImageFIle), ensure all APIs returning uploaded files return an absolute pre-signed URL (either with external origin or internal service origin)

---------