### PR TITLE
quickfix: delete seedfile after the workflow has been deleted

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -976,20 +976,20 @@ class CrawlConfigOps:
 
         # if no crawls have been run, actually delete
         if not crawlconfig.crawlAttemptCount:
-            if crawlconfig.config and crawlconfig.config.seedFileId:
-                try:
-                    await self.file_ops.delete_seed_file(
-                        crawlconfig.config.seedFileId, org
-                    )
-                except HTTPException:
-                    pass
-
             result = await self.crawl_configs.delete_one(
                 {"_id": crawlconfig.id, "oid": crawlconfig.oid}
             )
 
             if result.deleted_count != 1:
                 raise HTTPException(status_code=404, detail="failed_to_delete")
+
+            if crawlconfig and crawlconfig.config.seedFileId:
+                try:
+                    await self.file_ops.delete_seed_file(
+                        crawlconfig.config.seedFileId, org
+                    )
+                except HTTPException as e:
+                    pass
 
             status = "deleted"
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -988,7 +988,7 @@ class CrawlConfigOps:
                     await self.file_ops.delete_seed_file(
                         crawlconfig.config.seedFileId, org
                     )
-                except HTTPException as e:
+                except HTTPException:
                     pass
 
             status = "deleted"

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -181,7 +181,11 @@ def test_stop_crawl_partial(
 def test_crawl_with_hostname(default_org_id, crawler_auth_headers):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawl_id}/replay.json",
-        headers={"X-Forwarded-Proto": "https", "host": "custom-domain.example.com", **crawler_auth_headers},
+        headers={
+            "X-Forwarded-Proto": "https",
+            "host": "custom-domain.example.com",
+            **crawler_auth_headers,
+        },
     )
     assert r.status_code == 200
     assert r.json()["pagesQueryUrl"].startswith("https://custom-domain.example.com/")


### PR DESCRIPTION
Since seedfile deletion checks that the seedfile is not used in any workflow, it should be deleted after the workflow is removed.
noticed in checking #2744