### PR TITLE
feat: Update storage stats with seed file and collection thumbnails

### DIFF
--- a/frontend/docs/docs/user-guide/overview.md
+++ b/frontend/docs/docs/user-guide/overview.md
@@ -4,11 +4,12 @@ Your **Dashboard** delivers key statistics about the org's resource usage. You c
 
 ## Storage
 
+The storage panel displays the total size and count of archived items and browser profiles.
+
 For organizations with a set storage quota, the storage panel displays a visual breakdown of how much space the organization has left and how much has been taken up by all types of archived items and browser profiles. To view additional information about each item, hover over its section in the graph.
 
-For organizations with no storage limits the storage panel displays the total size and count of all types of archived items and browser profiles.
-
-For all organizations the storage panel displays the total number of archived items.
+??? Info "Miscellaneous storage"
+    You may see an additional _Miscellaneous_ size depending on your crawl workflow and collection configuration. _Miscellaneous_ is the total size of all supplementary files in use by your organization, such as [workflow URL list files](./workflow-setup.md#page-urls) and [custom collection thumbnails](./presentation-sharing.md#thumbnail).
 
 ## Crawling
 

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -972,13 +972,14 @@ export class Dashboard extends BtrixElement {
         ${when(
           stat.button,
           (button) =>
-            html`<btrix-button size="x-small" href=${`${this.navigate.orgBasePath}${button.url}`} @click=${this.navigate.link}
-              >${
-                button.label ??
-                html`<sl-tooltip content=${msg("View All")} placement="right"
-                  ><sl-icon name="arrow-right-circle"></sl-icon
-                ></sl-tooltip>`
-              }</sl-button
+            html`<btrix-button
+              size="x-small"
+              href=${`${this.navigate.orgBasePath}${button.url}`}
+              @click=${this.navigate.link}
+              >${button.label ??
+              html`<sl-tooltip content=${msg("View All")} placement="right"
+                ><sl-icon name="arrow-right-circle"></sl-icon
+              ></sl-tooltip>`}</btrix-button
             >`,
         )}
       </div>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -307,7 +307,7 @@ export class Dashboard extends BtrixElement {
                   singleLabel: msg("Browser Profile"),
                   pluralLabel: msg("Browser Profiles"),
                   iconProps: {
-                    name: "window-fullscreen",
+                    name: "pass-fill",
                     class: this.colors.browserProfiles,
                   },
                   button: {
@@ -553,7 +553,7 @@ export class Dashboard extends BtrixElement {
         <dt class="mr-auto flex items-center tabular-nums">
           <sl-icon
             class=${clsx(tw`mr-2 text-base`, this.colors.misc)}
-            name="box2"
+            name="box2-fill"
           ></sl-icon>
           ${msg("Miscellaneous")}
         </dt>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -126,7 +126,6 @@ export class Dashboard extends BtrixElement {
   }
 
   render() {
-    const hasQuota = Boolean(this.metrics?.storageQuotaBytes);
     const quotaReached =
       this.metrics &&
       this.metrics.storageQuotaBytes > 0 &&
@@ -251,11 +250,9 @@ export class Dashboard extends BtrixElement {
               <dl>
                 ${this.renderStat({
                   value: metrics.archivedItemCount,
-                  secondaryValue: hasQuota
-                    ? ""
-                    : this.localize.bytes(
-                        metrics.storageUsedCrawls + metrics.storageUsedUploads,
-                      ),
+                  secondaryValue: this.localize.bytes(
+                    metrics.storageUsedCrawls + metrics.storageUsedUploads,
+                  ),
                   singleLabel: msg("Archived Item"),
                   pluralLabel: msg("Archived Items"),
                   iconProps: { name: "file-zip-fill" },
@@ -265,9 +262,9 @@ export class Dashboard extends BtrixElement {
                 })}
                 ${this.renderStat({
                   value: metrics.crawlCount,
-                  secondaryValue: hasQuota
-                    ? ""
-                    : this.localize.bytes(metrics.storageUsedCrawls),
+                  secondaryValue: this.localize.bytes(
+                    metrics.storageUsedCrawls,
+                  ),
                   singleLabel: msg("Crawl"),
                   pluralLabel: msg("Crawls"),
                   indent: true,
@@ -281,9 +278,9 @@ export class Dashboard extends BtrixElement {
                 })}
                 ${this.renderStat({
                   value: metrics.uploadCount,
-                  secondaryValue: hasQuota
-                    ? ""
-                    : this.localize.bytes(metrics.storageUsedUploads),
+                  secondaryValue: this.localize.bytes(
+                    metrics.storageUsedUploads,
+                  ),
                   singleLabel: msg("Upload"),
                   pluralLabel: msg("Uploads"),
                   indent: true,
@@ -294,9 +291,9 @@ export class Dashboard extends BtrixElement {
                 })}
                 ${this.renderStat({
                   value: metrics.profileCount,
-                  secondaryValue: hasQuota
-                    ? ""
-                    : this.localize.bytes(metrics.storageUsedProfiles),
+                  secondaryValue: this.localize.bytes(
+                    metrics.storageUsedProfiles,
+                  ),
                   singleLabel: msg("Browser Profile"),
                   pluralLabel: msg("Browser Profiles"),
                   iconProps: {

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -648,7 +648,7 @@ export class Dashboard extends BtrixElement {
                   ${this.localize.bytes(
                     metrics.storageQuotaBytes - metrics.storageUsedBytes,
                   )}
-                  ${msg("Available")}
+                  ${msg("available")}
                 `
               : "",
         )}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -568,6 +568,16 @@ export class Dashboard extends BtrixElement {
             name="box2"
           ></sl-icon>
           ${msg("Miscellaneous")}
+          <btrix-popover
+            content=${msg(
+              "Total size of all supplementary files in use by your organization, such as workflow URL list files and custom collection thumbnails.",
+            )}
+          >
+            <sl-icon
+              name="info-circle"
+              class="ml-1.5 text-neutral-500"
+            ></sl-icon>
+          </btrix-popover>
         </dt>
         <dd class="font-monostyle text-xs text-neutral-500">
           ${this.localize.bytes(

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -305,9 +305,6 @@ export class Dashboard extends BtrixElement {
                 ></sl-divider>
                 ${this.renderStat({
                   value: metrics.archivedItemCount,
-                  secondaryValue: this.localize.bytes(
-                    metrics.storageUsedCrawls + metrics.storageUsedUploads,
-                  ),
                   singleLabel: msg("Archived Item"),
                   pluralLabel: msg("Archived Items"),
                   iconProps: {
@@ -318,6 +315,20 @@ export class Dashboard extends BtrixElement {
                     url: "/items",
                   },
                 })}
+                ${when(
+                  metrics.storageUsedBytes && !metrics.storageQuotaBytes,
+                  () => html`
+                    ${this.renderStat({
+                      value: this.localize.bytes(metrics.storageUsedBytes, {
+                        compactDisplay: "short",
+                      }),
+                      singleLabel: msg("Total"),
+                      iconProps: {
+                        name: "database-fill",
+                      },
+                    })}
+                  `,
+                )}
               </dl>
             `,
           )}

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -82,12 +82,12 @@ export class Dashboard extends BtrixElement {
 
   private readonly colors = {
     default: tw`text-neutral-600`,
-    crawls: tw`text-green-600`,
-    uploads: tw`text-sky-600`,
-    archivedItems: tw`text-cyan-500`,
-    browserProfiles: tw`text-indigo-600`,
+    crawls: tw`text-lime-500`,
+    uploads: tw`text-sky-500`,
+    archivedItems: tw`text-primary-500`,
+    browserProfiles: tw`text-orange-500`,
     runningTime: tw`text-blue-600`,
-    misc: tw`text-neutral-500`,
+    misc: tw`text-gray-400`,
   };
 
   private readonly collections = new Task(this, {
@@ -281,6 +281,25 @@ export class Dashboard extends BtrixElement {
                     url: "/items/upload",
                   },
                 })}
+                ${this.renderStat({
+                  value: metrics.profileCount,
+                  secondaryValue: this.localize.bytes(
+                    metrics.storageUsedProfiles,
+                  ),
+                  singleLabel: msg("Browser Profile"),
+                  pluralLabel: msg("Browser Profiles"),
+                  iconProps: {
+                    name: "window-fullscreen",
+                    class: this.colors.browserProfiles,
+                  },
+                  button: {
+                    url: "/browser-profiles",
+                  },
+                })}
+                ${metrics.storageUsedSeedFiles || metrics.storageUsedThumbnails
+                  ? this.renderMiscStorage(metrics)
+                  : nothing}
+
                 <sl-divider
                   style="--spacing:var(--sl-spacing-small)"
                 ></sl-divider>
@@ -299,24 +318,6 @@ export class Dashboard extends BtrixElement {
                     url: "/items",
                   },
                 })}
-                ${this.renderStat({
-                  value: metrics.profileCount,
-                  secondaryValue: this.localize.bytes(
-                    metrics.storageUsedProfiles,
-                  ),
-                  singleLabel: msg("Browser Profile"),
-                  pluralLabel: msg("Browser Profiles"),
-                  iconProps: {
-                    name: "pass-fill",
-                    class: this.colors.browserProfiles,
-                  },
-                  button: {
-                    url: "/browser-profiles",
-                  },
-                })}
-                ${metrics.storageUsedSeedFiles || metrics.storageUsedThumbnails
-                  ? this.renderMiscStorage(metrics)
-                  : nothing}
               </dl>
             `,
           )}
@@ -553,7 +554,7 @@ export class Dashboard extends BtrixElement {
         <dt class="mr-auto flex items-center tabular-nums">
           <sl-icon
             class=${clsx(tw`mr-2 text-base`, this.colors.misc)}
-            name="box2-fill"
+            name="box2"
           ></sl-icon>
           ${msg("Miscellaneous")}
         </dt>
@@ -608,10 +609,17 @@ export class Dashboard extends BtrixElement {
       hasQuota && metrics.storageUsedBytes >= metrics.storageQuotaBytes;
     const misc = metrics.storageUsedSeedFiles + metrics.storageUsedThumbnails;
 
-    const renderBar = (value: number, label: string, color: string) => html`
+    const renderBar = (
+      value: number,
+      label: string,
+      colorClassname: string,
+    ) => html`
       <btrix-meter-bar
         value=${(value / metrics.storageUsedBytes) * 100}
-        style="--background-color:var(--sl-color-${color}-400)"
+        style="--background-color:var(--sl-color-${colorClassname.replace(
+          "text-",
+          "",
+        )})"
       >
         <div class="text-center">
           <div>${label}</div>

--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -250,12 +250,27 @@ export class Dashboard extends BtrixElement {
               ${this.renderStorageMeter(metrics)}
               <dl>
                 ${this.renderStat({
+                  value: metrics.archivedItemCount,
+                  secondaryValue: hasQuota
+                    ? ""
+                    : this.localize.bytes(
+                        metrics.storageUsedCrawls + metrics.storageUsedUploads,
+                      ),
+                  singleLabel: msg("Archived Item"),
+                  pluralLabel: msg("Archived Items"),
+                  iconProps: { name: "file-zip-fill" },
+                  button: {
+                    url: "/items",
+                  },
+                })}
+                ${this.renderStat({
                   value: metrics.crawlCount,
                   secondaryValue: hasQuota
                     ? ""
                     : this.localize.bytes(metrics.storageUsedCrawls),
                   singleLabel: msg("Crawl"),
                   pluralLabel: msg("Crawls"),
+                  indent: true,
                   iconProps: {
                     name: "gear-wide-connected",
                     class: this.colors.crawls,
@@ -271,6 +286,7 @@ export class Dashboard extends BtrixElement {
                     : this.localize.bytes(metrics.storageUsedUploads),
                   singleLabel: msg("Upload"),
                   pluralLabel: msg("Uploads"),
+                  indent: true,
                   iconProps: { name: "upload", class: this.colors.uploads },
                   button: {
                     url: "/items/upload",
@@ -289,21 +305,6 @@ export class Dashboard extends BtrixElement {
                   },
                   button: {
                     url: "/browser-profiles",
-                  },
-                })}
-                <sl-divider
-                  style="--spacing:var(--sl-spacing-small)"
-                ></sl-divider>
-                ${this.renderStat({
-                  value: metrics.archivedItemCount,
-                  secondaryValue: hasQuota
-                    ? ""
-                    : this.localize.bytes(metrics.storageUsedBytes),
-                  singleLabel: msg("Archived Item"),
-                  pluralLabel: msg("Archived Items"),
-                  iconProps: { name: "file-zip-fill" },
-                  button: {
-                    url: "/items",
                   },
                 })}
               </dl>
@@ -935,8 +936,9 @@ export class Dashboard extends BtrixElement {
   }
 
   private renderStat(stat: {
-    value: number | string | TemplateResult;
+    value: number | string | TemplateResult | null;
     secondaryValue?: number | string | TemplateResult;
+    indent?: boolean;
     button?: { label?: string | TemplateResult; url: string };
     singleLabel: string;
     pluralLabel: string;
@@ -944,7 +946,12 @@ export class Dashboard extends BtrixElement {
   }) {
     const { value, iconProps } = stat;
     return html`
-      <div class="mb-2 flex items-center gap-2 last:mb-0">
+      <div
+        class=${clsx(
+          tw`mb-2 flex items-center gap-2 last:mb-0`,
+          stat.indent && tw`pl-6`,
+        )}
+      >
         <div class="mr-auto flex items-center tabular-nums">
           <sl-icon
             class=${clsx(


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2733

## Changes

- Always displays storage size breakdown in dashboard panel
- Includes "Miscellaneous" storage size
- Fixes storage meter bar background color (tested with https://www.color-blindness.com/coblis-color-blindness-simulator/)

## Manual testing

1. Log in as superadmin
2. Go to org quotas. Verify size for each storage line item is displayed
3. Go to org with seed files. Verify "Miscellaneous" line item is displayed

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Dashboard | **Org with quotas and no seed files:**<br/> <img width="411" height="312" alt="Screenshot 2025-07-24 at 11 16 56 AM" src="https://github.com/user-attachments/assets/9852b463-7bc5-48c4-991f-c0f547b14c8c" /> |
| Dashboard | **Org with quotas and with seed files:**<br/><img width="413" height="316" alt="Screenshot 2025-07-24 at 11 16 49 AM" src="https://github.com/user-attachments/assets/d4fffeff-0e2c-465f-b9b6-09382b8e0ac4" /> |
| Dashboard | **Org without quotas and with seed files:**<br/><img width="413" height="250" alt="Screenshot 2025-07-24 at 11 17 05 AM" src="https://github.com/user-attachments/assets/178869a5-7a9c-4a35-b1ad-9b4395b4bfe0" /> |
| User Guide | <img width="722" height="362" alt="Screenshot 2025-07-24 at 10 46 37 AM" src="https://github.com/user-attachments/assets/ce4aa7ad-0722-4020-a8e2-92d6844a376f" /> |



<!-- ## Follow-ups -->
