### PR TITLE
fix: Fix workflow replay after updating starting URL

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1891,7 +1891,9 @@ export class WorkflowDetail extends BtrixElement {
 
     return html`
       <div class="aspect-video overflow-hidden rounded-lg border">
-        ${guard([this.lastCrawlId], this.renderReplay)}
+        ${guard([this.lastCrawlId], () =>
+          this.latestCrawlTask.render({ complete: this.renderReplay }),
+        )}
       </div>
     `;
   };
@@ -1958,18 +1960,17 @@ export class WorkflowDetail extends BtrixElement {
     `;
   }
 
-  private readonly renderReplay = () => {
-    if (!this.workflow || !this.lastCrawlId) return;
+  private readonly renderReplay = (latestCrawl: Crawl | null) => {
+    if (!latestCrawl) return;
 
-    const replaySource = `/api/orgs/${this.workflow.oid}/crawls/${this.lastCrawlId}/replay.json`;
+    const replaySource = `/api/orgs/${latestCrawl.oid}/crawls/${this.lastCrawlId}/replay.json`;
     const headers = this.authState?.headers;
     const config = JSON.stringify({ headers });
 
     return html`
       <replay-web-page
         source="${replaySource}"
-        url="${(this.workflow.seedCount === 1 && this.workflow.firstSeed) ||
-        ""}"
+        url="${(latestCrawl.seedCount === 1 && latestCrawl.firstSeed) || ""}"
         config="${config}"
         replayBase="/replay/"
         noSandbox="true"

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1892,7 +1892,7 @@ export class WorkflowDetail extends BtrixElement {
     return html`
       <div class="aspect-video overflow-hidden rounded-lg border">
         ${guard([this.lastCrawlId], () =>
-          this.latestCrawlTask.render({ complete: this.renderReplay }),
+          when(this.latestCrawlTask.value, this.renderReplay),
         )}
       </div>
     `;
@@ -1960,9 +1960,7 @@ export class WorkflowDetail extends BtrixElement {
     `;
   }
 
-  private readonly renderReplay = (latestCrawl: Crawl | null) => {
-    if (!latestCrawl) return;
-
+  private readonly renderReplay = (latestCrawl: Crawl) => {
     const replaySource = `/api/orgs/${latestCrawl.oid}/crawls/${this.lastCrawlId}/replay.json`;
     const headers = this.authState?.headers;
     const config = JSON.stringify({ headers });


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2764

## Changes

Uses crawl first seed as starting URL instead of workflow first seed to fix replay after saving workflow without running.

## Manual testing

1. Log in as crawler
2. Create a new workflow and crawl a single page, for example, https://example.com/
3. Edit the workflow to change starting URL to https://example.org/
4. Save without running
5. Go to latest crawl tab, verify replay loads https://example.com/