### PR TITLE
build: Discard console debug in frontend production build

### DIFF
--- a/frontend/docs/docs/develop/frontend-dev.md
+++ b/frontend/docs/docs/develop/frontend-dev.md
@@ -130,3 +130,7 @@ To run tests in multiple browsers:
 ```sh
 yarn test --browsers chromium firefox webkit
 ```
+
+## Logging
+
+Calls to `console.log()` and `console.debug()` are discarded by default in production, as configured in `frontend/webpack.prod.js`.

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -24,7 +24,7 @@ module.exports = [
         new TerserPlugin({
           terserOptions: {
             compress: {
-              drop_console: ["log", "info"],
+              drop_console: ["log", "debug"],
             },
           },
         }),


### PR DESCRIPTION
Discards `console.debug` and allows `console.info` and documents in UI development guide.