### PR TITLE
feat: Copy workflow config as JSON

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -789,16 +789,30 @@ export class WorkflowDetail extends BtrixElement {
       `;
     }
 
-    if (this.workflowTab === WorkflowTab.Settings && this.isCrawler) {
-      return html` <sl-tooltip content=${msg("Edit Workflow Settings")}>
-        <sl-icon-button
-          name="pencil"
-          class="text-base"
-          href="${this.basePath}?edit"
-          @click=${this.navigate.link}
+    if (this.workflowTab === WorkflowTab.Settings) {
+      return html`
+        <btrix-copy-button
+          name="filetype-json"
+          value=${ifDefined(
+            this.workflow && JSON.stringify(this.workflow.config),
+          )}
+          content=${msg("Copy as JSON")}
+          size="medium"
         >
-        </sl-icon-button>
-      </sl-tooltip>`;
+        </btrix-copy-button>
+
+        ${this.isCrawler
+          ? html`<sl-tooltip content=${msg("Edit Workflow Settings")}>
+              <sl-icon-button
+                name="pencil"
+                class="text-base"
+                href="${this.basePath}?edit"
+                @click=${this.navigate.link}
+              >
+              </sl-icon-button>
+            </sl-tooltip>`
+          : nothing}
+      `;
     }
 
     return nothing;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -796,25 +796,26 @@ export class WorkflowDetail extends BtrixElement {
 
     if (this.workflowTab === WorkflowTab.Settings) {
       return html`
-        <btrix-copy-button
-          name="filetype-json"
-          value=${ifDefined(
-            this.workflow &&
-              this.seeds &&
-              JSON.stringify(
-                {
-                  ...omitNil(this.workflow.config),
-                  seeds: this.seeds.items.map(omitNil),
-                },
-                null,
-                2,
-              ),
-          )}
-          content=${msg("Copy as JSON")}
-          size="medium"
-        >
-        </btrix-copy-button>
-
+        ${this.appState.isAdmin
+          ? html`<btrix-copy-button
+              name="filetype-json"
+              value=${ifDefined(
+                this.workflow &&
+                  this.seeds &&
+                  JSON.stringify(
+                    {
+                      ...omitNil(this.workflow.config),
+                      seeds: this.seeds.items.map(omitNil),
+                    },
+                    null,
+                    2,
+                  ),
+              )}
+              content=${msg("Copy as JSON")}
+              size="medium"
+            >
+            </btrix-copy-button>`
+          : nothing}
         ${this.isCrawler
           ? html`<sl-tooltip content=${msg("Edit Workflow Settings")}>
               <sl-icon-button

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -9,6 +9,8 @@ import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
+import omitBy from "lodash/fp/omitBy";
+import isNil from "lodash/isNil";
 import queryString from "query-string";
 
 import type { Crawl, CrawlLog, Seed, Workflow } from "./types";
@@ -50,6 +52,9 @@ const POLL_INTERVAL_SECONDS = 10;
 const CRAWLS_PAGINATION_NAME = "crawlsPage";
 
 const isLoading = (task: Task) => task.status === TaskStatus.PENDING;
+
+// Omit null or undefined values from object
+const omitNil = omitBy(isNil);
 
 /**
  * Usage:
@@ -794,7 +799,16 @@ export class WorkflowDetail extends BtrixElement {
         <btrix-copy-button
           name="filetype-json"
           value=${ifDefined(
-            this.workflow && JSON.stringify(this.workflow.config),
+            this.workflow &&
+              this.seeds &&
+              JSON.stringify(
+                {
+                  ...omitNil(this.workflow.config),
+                  seeds: this.seeds.items.map(omitNil),
+                },
+                null,
+                2,
+              ),
           )}
           content=${msg("Copy as JSON")}
           size="medium"

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -804,7 +804,7 @@ export class WorkflowDetail extends BtrixElement {
         ${this.isCrawler
           ? html`<sl-tooltip content=${msg("Edit Workflow Settings")}>
               <sl-icon-button
-                name="pencil"
+                name="gear"
                 class="text-base"
                 href="${this.basePath}?edit"
                 @click=${this.navigate.link}


### PR DESCRIPTION
Partially addresses https://github.com/webrecorder/browsertrix/issues/2751

## Changes

- Enables copying workflow `config` to clipboard as JSON for superadmin.
- Fixes "Edit Workflow Settings" icon inconsistency.

## Manual testing

1. Log in
2. Go to a workflow detail page -> "Settings" tab
3. Click "JSON" icon. Verify config is copied to clipboard

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow detail | <img width="711" height="270" alt="Screenshot 2025-07-28 at 10 17 14 AM" src="https://github.com/user-attachments/assets/220d14b9-b111-4d3b-894a-adfc33c0f118" /> |


<!-- ## Follow-ups -->
