### PR TITLE
Fix ui docs showing up in main docs site

### DIFF
--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -99,9 +99,6 @@ nav:
         - develop/ui/components.md
         - develop/ui/storybook.md
         - develop/localization.md
-        - Design:
-          - develop/ui/design-action-menus.md
-          - develop/ui/design-status-icons.md
 
   - API Reference: !ENV [ API_DOCS_URL, "/api/" ]
 


### PR DESCRIPTION
Quick fix for some 404 links on the docs site. UI documentation has been moved to storybook in https://github.com/webrecorder/browsertrix/pull/2597, but links to these pages in the docs sidebar wasn't removed in that PR.

Reported [on Discord](https://discord.com/channels/895426029194207262/1054901789696208906/1400354633049706578) — thanks @Shrinks99!