### PR TITLE
file upload cleanup cronjob:

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -250,6 +250,7 @@ class CrawlManager(K8sAPI):
             "backend_image": os.environ.get("BACKEND_IMAGE", ""),
             "pull_policy": os.environ.get("BACKEND_IMAGE_PULL_POLICY", ""),
             "schedule": job_schedule,
+            "larger_resources": True,
         }
 
         data = self.templates.env.get_template("background_cron_job.yaml").render(

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 2
 
   schedule: "{{ schedule }}"


### PR DESCRIPTION
- use larger resources (saw an OOM on one job)
- don't keep successful job pods (nothing to see in logs except ids of deleted files, if any)