### PR TITLE
feat: Download single WACZ file when possible

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -10,6 +10,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import { ClipboardController } from "@/controllers/clipboard";
 import { WorkflowTab } from "@/routes";
 import type { Crawl, ListWorkflow, Workflow } from "@/types/crawler";
+import { downloadLink } from "@/utils/crawl-workflows/downloadLink";
 import { isNotFailed, isSuccessfullyFinished } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
 
@@ -209,23 +210,14 @@ export class WorkflowActionMenu extends BtrixElement {
   private renderLatestCrawlMenu(latestCrawl: Crawl) {
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
     const logTotals = this.logTotals;
-
-    let path = `/api/orgs/${this.orgId}/all-crawls/${latestCrawl.id}/download?auth_bearer=${authToken}`;
-    let name = `${latestCrawl.id}.wacz`;
-
-    if (latestCrawl.resources?.length === 1) {
-      const file = latestCrawl.resources[0];
-
-      path = file.path;
-      name = file.name;
-    }
+    const download = downloadLink(latestCrawl, this.authState);
 
     return html`
       <sl-menu slot="submenu">
         <btrix-menu-item-link
-          href=${path}
+          href=${download.path}
           ?disabled=${!latestCrawl.fileSize}
-          download=${name}
+          download=${download.name}
         >
           <sl-icon name="cloud-download" slot="prefix"></sl-icon>
           ${msg("Download Item")}

--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -210,12 +210,22 @@ export class WorkflowActionMenu extends BtrixElement {
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
     const logTotals = this.logTotals;
 
+    let path = `/api/orgs/${this.orgId}/all-crawls/${latestCrawl.id}/download?auth_bearer=${authToken}`;
+    let name = `${latestCrawl.id}.wacz`;
+
+    if (latestCrawl.resources?.length === 1) {
+      const file = latestCrawl.resources[0];
+
+      path = file.path;
+      name = file.name;
+    }
+
     return html`
       <sl-menu slot="submenu">
         <btrix-menu-item-link
-          href=${`/api/orgs/${this.orgId}/all-crawls/${latestCrawl.id}/download?auth_bearer=${authToken}`}
+          href=${path}
           ?disabled=${!latestCrawl.fileSize}
-          download
+          download=${name}
         >
           <sl-icon name="cloud-download" slot="prefix"></sl-icon>
           ${msg("Download Item")}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -280,6 +280,7 @@ export class ArchivedItemDetail extends BtrixElement {
   }
 
   render() {
+    const authToken = this.authState?.headers.Authorization.split(" ")[1];
     let sectionContent: string | TemplateResult<1> = "";
 
     switch (this.activeTab) {
@@ -329,7 +330,7 @@ export class ArchivedItemDetail extends BtrixElement {
           html` ${this.renderTitle(this.tabLabels.logs)}
             <sl-tooltip content=${msg("Download Entire Log File")}>
               <sl-button
-                href=${`/api/orgs/${this.orgId}/crawls/${this.itemId}/logs?auth_bearer=${this.authState?.headers.Authorization.split(" ")[1]}`}
+                href=${`/api/orgs/${this.orgId}/crawls/${this.itemId}/logs?auth_bearer=${authToken}`}
                 download=${`browsertrix-${this.itemId}-logs.log`}
                 size="small"
                 variant="primary"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -20,6 +20,7 @@ import type {
   Workflow,
 } from "@/types/crawler";
 import type { QARun } from "@/types/qa";
+import type { NonEmptyArray } from "@/types/utils";
 import { isApiError } from "@/utils/api";
 import {
   isActive,
@@ -145,11 +146,13 @@ export class ArchivedItemDetail extends BtrixElement {
 
   private timerId?: number;
 
-  private get hasFiles(): boolean | null {
-    if (!this.item) return null;
-    if (!this.item.resources) return false;
+  private hasFiles(item?: ArchivedItem): item is ArchivedItem & {
+    resources: NonEmptyArray<ArchivedItem["resources"]>;
+  } {
+    if (!item) return false;
+    if (!item.resources) return false;
 
-    return this.item.resources.length > 0;
+    return Boolean(item.resources[0]);
   }
 
   private get formattedFinishedDate() {
@@ -763,7 +766,7 @@ export class ArchivedItemDetail extends BtrixElement {
 
     const config = JSON.stringify({ headers });
 
-    const canReplay = this.hasFiles;
+    const canReplay = this.hasFiles(this.item);
 
     return html`
       <!-- https://github.com/webrecorder/browsertrix-crawler/blob/9f541ab011e8e4bccf8de5bd7dc59b632c694bab/screencast/index.html -->
@@ -977,10 +980,10 @@ export class ArchivedItemDetail extends BtrixElement {
 
   private renderFiles() {
     return html`
-      ${this.hasFiles
+      ${this.hasFiles(this.item)
         ? html`
             <ul class="rounded-lg border text-sm">
-              ${this.item!.resources!.map(
+              ${this.item.resources.map(
                 (file) => html`
                   <li
                     class="flex justify-between border-t p-3 first:border-t-0"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1039,8 +1039,6 @@ export class ArchivedItemDetail extends BtrixElement {
 
     const file = this.item.resources[0];
 
-    console.log(file);
-
     return html`
       <sl-button
         href=${file.path}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -718,8 +718,16 @@ export class WorkflowDetail extends BtrixElement {
       const authToken = this.authState?.headers.Authorization.split(" ")[1];
       const disableDownload = this.isRunning;
       const disableReplay = !latestCrawl.fileSize;
-      const replayHref = `/api/orgs/${this.orgId}/all-crawls/${latestCrawlId}/download?auth_bearer=${authToken}`;
-      const replayFilename = `browsertrix-${latestCrawlId}.wacz`;
+
+      let path = `/api/orgs/${this.orgId}/all-crawls/${latestCrawlId}/download?auth_bearer=${authToken}`;
+      let name = `${latestCrawlId}.wacz`;
+
+      if (latestCrawl.resources?.length === 1) {
+        const file = latestCrawl.resources[0];
+
+        path = file.path;
+        name = file.name;
+      }
 
       return html`
         <btrix-copy-button
@@ -736,22 +744,15 @@ export class WorkflowDetail extends BtrixElement {
           ?disabled=${!disableDownload}
         >
           <sl-button-group>
-            <sl-tooltip
-              content="${msg("Download Item as WACZ")} (${this.localize.bytes(
-                latestCrawl.fileSize || 0,
-              )})"
-              ?disabled=${disableReplay}
+            <sl-button
+              size="small"
+              href=${path}
+              download=${name}
+              ?disabled=${disableDownload || disableReplay}
             >
-              <sl-button
-                size="small"
-                href=${replayHref}
-                download=${replayFilename}
-                ?disabled=${disableDownload || disableReplay}
-              >
-                <sl-icon name="cloud-download" slot="prefix"></sl-icon>
-                ${msg("Download")}
-              </sl-button>
-            </sl-tooltip>
+              <sl-icon name="cloud-download" slot="prefix"></sl-icon>
+              ${msg("Download")}
+            </sl-button>
             <sl-dropdown distance="4" placement="bottom-end" hoist>
               <sl-button
                 slot="trigger"
@@ -765,9 +766,9 @@ export class WorkflowDetail extends BtrixElement {
               </sl-button>
               <sl-menu>
                 <btrix-menu-item-link
-                  href=${replayHref}
+                  href=${path}
                   ?disabled=${disableDownload || disableReplay}
-                  download=${replayFilename}
+                  download=${name}
                 >
                   <sl-icon name="cloud-download" slot="prefix"></sl-icon>
                   ${msg("Item")}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -37,6 +37,7 @@ import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
 import { type StorageSeedFile } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
+import { downloadLink } from "@/utils/crawl-workflows/downloadLink";
 import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import {
   DEFAULT_MAX_SCALE,
@@ -718,16 +719,7 @@ export class WorkflowDetail extends BtrixElement {
       const authToken = this.authState?.headers.Authorization.split(" ")[1];
       const disableDownload = this.isRunning;
       const disableReplay = !latestCrawl.fileSize;
-
-      let path = `/api/orgs/${this.orgId}/all-crawls/${latestCrawlId}/download?auth_bearer=${authToken}`;
-      let name = `${latestCrawlId}.wacz`;
-
-      if (latestCrawl.resources?.length === 1) {
-        const file = latestCrawl.resources[0];
-
-        path = file.path;
-        name = file.name;
-      }
+      const download = downloadLink(latestCrawl, this.authState);
 
       return html`
         <btrix-copy-button
@@ -746,8 +738,8 @@ export class WorkflowDetail extends BtrixElement {
           <sl-button-group>
             <sl-button
               size="small"
-              href=${path}
-              download=${name}
+              href=${download.path}
+              download=${download.name}
               ?disabled=${disableDownload || disableReplay}
             >
               <sl-icon name="cloud-download" slot="prefix"></sl-icon>
@@ -766,9 +758,9 @@ export class WorkflowDetail extends BtrixElement {
               </sl-button>
               <sl-menu>
                 <btrix-menu-item-link
-                  href=${path}
+                  href=${download.path}
                   ?disabled=${disableDownload || disableReplay}
-                  download=${name}
+                  download=${download.name}
                 >
                   <sl-icon name="cloud-download" slot="prefix"></sl-icon>
                   ${msg("Item")}

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -22,6 +22,9 @@ export type Range<F extends number, T extends number> = Exclude<
   Enumerate<F>
 >;
 
+/** Array with at least one item */
+export type NonEmptyArray<T> = [T, ...T[]];
+
 export enum SortDirection {
   Descending = -1,
   Ascending = 1,

--- a/frontend/src/utils/crawl-workflows/downloadLink.ts
+++ b/frontend/src/utils/crawl-workflows/downloadLink.ts
@@ -2,6 +2,9 @@ import type { Auth } from "@/types/auth";
 import type { ArchivedItem } from "@/types/crawler";
 import { hasFiles } from "@/utils/crawl-workflows/hasFiles";
 
+/**
+ * Get link to download archived item
+ */
 export function downloadLink(
   item?: ArchivedItem,
   authState?: Auth | null,

--- a/frontend/src/utils/crawl-workflows/downloadLink.ts
+++ b/frontend/src/utils/crawl-workflows/downloadLink.ts
@@ -1,0 +1,21 @@
+import type { Auth } from "@/types/auth";
+import type { ArchivedItem } from "@/types/crawler";
+import { hasFiles } from "@/utils/crawl-workflows/hasFiles";
+
+export function downloadLink(
+  item?: ArchivedItem,
+  authState?: Auth | null,
+): { path: string; name: string } {
+  if (!hasFiles(item)) return { path: "", name: "" };
+
+  if (item.resources.length > 1) {
+    return {
+      path: `/api/orgs/${item.oid}/all-crawls/${item.id}/download?auth_bearer=${authState?.headers.Authorization.split(" ")[1]}`,
+      name: `${item.id}.wacz`,
+    };
+  }
+
+  const { path, name } = item.resources[0];
+
+  return { path, name };
+}

--- a/frontend/src/utils/crawl-workflows/hasFiles.ts
+++ b/frontend/src/utils/crawl-workflows/hasFiles.ts
@@ -1,6 +1,9 @@
 import type { ArchivedItem } from "@/types/crawler";
 import type { NonEmptyArray } from "@/types/utils";
 
+/**
+ * Check whether archived item has at least one WACZ file
+ */
 export function hasFiles(item?: ArchivedItem): item is ArchivedItem & {
   resources: NonEmptyArray<NonNullable<ArchivedItem["resources"]>[number]>;
 } {

--- a/frontend/src/utils/crawl-workflows/hasFiles.ts
+++ b/frontend/src/utils/crawl-workflows/hasFiles.ts
@@ -1,0 +1,11 @@
+import type { ArchivedItem } from "@/types/crawler";
+import type { NonEmptyArray } from "@/types/utils";
+
+export function hasFiles(item?: ArchivedItem): item is ArchivedItem & {
+  resources: NonEmptyArray<NonNullable<ArchivedItem["resources"]>[number]>;
+} {
+  if (!item) return false;
+  if (!item.resources) return false;
+
+  return Boolean(item.resources[0]);
+}


### PR DESCRIPTION
Superseded by https://github.com/webrecorder/browsertrix/pull/2850

## Changes

Uses sole WACZ file instead of creating new multi-WACZ when downloading an archived item.

## Manual testing

1. Log in
2. Go to an archived item with a single WACZ file
3. Go to "Files" tab. Verify "Download File" button is shown
4. Select "Download File". Verify the same WACZ file as the one listed in "WACZ Files" list is downloaded
5. Go to workflow for the archived item
6. Select "Download" from the "Latest Crawl" tab. Verify same single WACZ file is downloaded
7. Regression test for archived item with multiple WACZ files

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Item / WACZ Files | <img width="683" height="115" alt="Screenshot 2025-08-14 at 1 00 10 PM" src="https://github.com/user-attachments/assets/941185fc-a98f-4d32-bc19-7bfb3aad42de" /> |


## Follow-ups

"Download Item" in the archived items list still downloads a multi-WACZ file since `resources` is omitted in the `all-crawls` response. If we want to enable single WACZ downloads from this view, we could do follow-up work to request the item `resources` in a separate frontend API call, or the backend could include a download link in the list response data.