### PR TITLE
feat: Enable custom cron schedule

### DIFF
--- a/chart/app-templates/crawl_cron_job.yaml
+++ b/chart/app-templates/crawl_cron_job.yaml
@@ -30,5 +30,5 @@ spec:
           restartPolicy: Never
           containers:
             - name: noop
-              image: "docker.io/tianon/true"
+              image: "docker.io/tianon/true:multiarch"
               imagePullPolicy: IfNotPresent

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -362,16 +362,16 @@ Sets the time that the scheduled crawl will start according to your current time
 
 ### Cron Schedule
 
-When using a `Custom` frequency, a custom schedule can be specified by using a Cron expression or supported macros.
+When using a `Custom` _Frequency_, a custom schedule can be specified by using a Cron expression or supported macros.
 
 Cron expressions should follow the Unix Cron format:
 
 | Position | * | * | * | * | * |
 | - | - | - | - | - | - |
 | **Description** | minute | hour | day of the month | month | day of the week |
-| **Possible Values** | 0 - 59 | 0 - 23 | 1 - 31 | 1 - 12 | 0 - 6<br/>sun, mon, tue, wed, thu, fri, sat |
+| **Possible Values** | 0 - 59 | 0 - 23 | 1 - 31 | 1 - 12 | 0 - 6<br/>or `sun`, `mon`, `tue`, `wed`, `thu`, `fri`, `sat` |
 
-For example, `0 0 31 12 *` would run a crawl on December 31st every year.
+For example, `0 0 31 12 *` would run a crawl on December 31st every year and `0 0 * * fri` would run a crawl every Friday at midnight.
 
 Additionally, the following macros are supported:
 
@@ -383,7 +383,7 @@ Additionally, the following macros are supported:
 | `@daily` | Run once a day at midnight |
 | `@hourly` | Run once an hour at the beginning of the hour |
 
-You can use a tool like [CronExpert](https://cronexpert.com/) to generate and check Cron syntax validity and view common expressions.
+You can use a tool like [crontab.guru](https://crontab.guru/) to check Cron syntax validity and view [common expressions](https://crontab.guru/examples.html).
 
 Cron schedules are always in [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -318,9 +318,6 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
 
 ### Crawl Schedule Type
 
-#### Run Immediately on Save
-:   When selected, the crawl will run immediately as configured. It will not run again unless manually instructed.
-
 #### Run on a Recurring Basis
 :   When selected, additional configuration options for instructing the system when to run the crawl will be shown. If a crawl is already running when the schedule is set to activate it, the scheduled crawl will not run.
 
@@ -365,14 +362,28 @@ Sets the time that the scheduled crawl will start according to your current time
 
 ### Cron Schedule
 
-Specify a custom schedule using a Cron expression that follows the Unix Cron format:
+When using a `Custom` frequency, a custom schedule can be specified by using a Cron expression or supported macros.
+
+Cron expressions should follow the Unix Cron format:
 
 | Position | * | * | * | * | * |
 | - | - | - | - | - | - |
 | **Description** | minute | hour | day of the month | month | day of the week |
 | **Possible Values** | 0 - 59 | 0 - 23 | 1 - 31 | 1 - 12 | 0 - 6<br/>sun, mon, tue, wed, thu, fri, sat |
 
-For example, `0 * * * *` would run a crawl at the top of every UTC hour. `0 0 31 12 *` would run a crawl on December 31st every year. You can use a tool like [crontab.guru](https://crontab.guru/) to generate and check valid Cron syntax and view common expressions.
+For example, `0 0 31 12 *` would run a crawl on December 31st every year.
+
+Additionally, the following macros are supported:
+
+| Value | Description |
+| - | - |
+| `@yearly` | Run once a year at midnight of 1 January |
+| `@monthly` | 	Run once a month at midnight of the first day of the month |
+| `@weekly` | Run once a week at midnight on Sunday |
+| `@daily` | Run once a day at midnight |
+| `@hourly` | Run once an hour at the beginning of the hour |
+
+You can use a tool like [CronExpert](https://cronexpert.com/) to generate and check Cron syntax validity and view common expressions.
 
 Cron schedules are always in [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -372,7 +372,7 @@ Specify a custom schedule using a Cron expression that follows the Unix Cron for
 | **Description** | minute | hour | day of the month | month | day of the week |
 | **Possible Values** | 0 - 59 | 0 - 23 | 1 - 31 | 1 - 12 | 0 - 6<br/>sun, mon, tue, wed, thu, fri, sat |
 
-For example, `0 * * * *` would run a crawl at the top of every UTC hour. `0 0 31 12 *` would run a crawl on December 31st every year. You can use a tool like [CronExpert](https://cronexpert.com/) to generate and check valid Cron syntax and view common expressions.
+For example, `0 * * * *` would run a crawl at the top of every UTC hour. `0 0 31 12 *` would run a crawl on December 31st every year. You can use a tool like [crontab.guru](https://crontab.guru/) to generate and check valid Cron syntax and view common expressions.
 
 Cron schedules are always in [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -331,6 +331,26 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
 
 Set how often a scheduled crawl will run.
 
+#### Options
+
+All option support specifying the specific hour and minute the crawl should run.
+
+##### Daily
+
+Run crawl once every day.
+
+##### Weekly
+
+Run crawl once every week.
+
+##### Monthly
+
+Run crawl once every month.
+
+##### Custom
+
+Run crawl at a custom interval, such as hourly or yearly. See [Cron Schedule](#cron-schedule) for details.
+
 ### Day
 
 Sets the day of the week for which crawls scheduled with a `Weekly` _Frequency_ will run.
@@ -342,6 +362,19 @@ Sets the date of the month for which crawls scheduled with a `Monthly` _Frequenc
 ### Start Time
 
 Sets the time that the scheduled crawl will start according to your current timezone.
+
+### Cron Schedule
+
+Specify a custom schedule using a Cron expression that follows the Unix Cron format:
+
+| Position | * | * | * | * | * |
+| - | - | - | - | - | - |
+| **Description** | minute | hour | day of the month | month | day of the week |
+| **Possible Values** | 0 - 59 | 0 - 23 | 1 - 31 | 1 - 12 | 0 - 6<br/>sun, mon, tue, wed, thu, fri, sat |
+
+For example, `0 * * * *` would run a crawl at the top of every UTC hour. `0 0 31 12 *` would run a crawl on December 31st every year. You can use a tool like [CronExpert](https://cronexpert.com/) to generate and check valid Cron syntax and view common expressions.
+
+Cron schedules are always in [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
 ## Metadata
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "color": "^4.0.1",
     "construct-style-sheets-polyfill": "^3.1.0",
     "copy-webpack-plugin": "^12.0.2",
+    "cronstrue": "^3.2.0",
     "css-loader": "^6.3.0",
     "css-selector-parser": "^3.0.5",
     "date-fns": "^3.6.0",

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2055,7 +2055,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private readonly renderScheduleCron = () => {
-    const scheduledDate = (schedule?: string) => {
+    const scheduledDate = (schedule?: string, opts?: { utc: boolean }) => {
       if (!schedule) return nothing;
 
       const humanized = humanizeSchedule(schedule);
@@ -2070,7 +2070,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           </p>
           <p>
             ${msg("Next scheduled run:")}
-            <span>${humanizeNextDate(schedule)}</span>
+            <span>${humanizeNextDate(schedule, opts)}</span>
           </p>
         </div>
       `;
@@ -2186,7 +2186,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               label=${msg("Cron Schedule")}
               placeholder="* * * * *"
               value=${ifDefined(this.formState.scheduleCustom)}
-              minlength="9"
+              minlength="6"
               @sl-change=${(e: SlChangeEvent) => {
                 const input = e.target as SlInput;
                 const value = (e.target as SlInput).value;
@@ -2218,7 +2218,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               required
             >
             </sl-input>
-            ${scheduledDate(this.formState.scheduleCustom)}
+            ${scheduledDate(this.formState.scheduleCustom, { utc: true })}
           `)}
           ${this.renderHelpTextCol(html`
             ${msg(`Specify a schedule in Cron format.`)}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2184,13 +2184,15 @@ https://archiveweb.page/images/${"logo.svg"}`}
             <sl-input
               name="scheduleCustom"
               label=${msg("Cron Schedule")}
-              placeholder="* * * * *"
+              placeholder="@hourly"
               value=${ifDefined(this.formState.scheduleCustom)}
               minlength="6"
               @sl-change=${(e: SlChangeEvent) => {
                 const input = e.target as SlInput;
                 const value = (e.target as SlInput).value;
                 const parsed = parseCron(value);
+
+                if (!value) return;
 
                 if (parsed) {
                   input.helpText = "";
@@ -2221,7 +2223,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
             ${scheduledDate(this.formState.scheduleCustom, { utc: true })}
           `)}
           ${this.renderHelpTextCol(html`
-            ${msg(`Specify a schedule in Cron format.`)}
+            ${msg("Specify a schedule in Cron format.")}
+            ${msg(
+              html`Supports Unix cron syntax and certain macros like
+                <code>@hourly</code> and <code>@yearly</code>.`,
+            )}
             ${this.renderUserGuideLink({
               hash: "cron-schedule",
               content: msg("More details"),

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -3051,7 +3051,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
       description: this.formState.description,
       browserWindows: this.formState.browserWindows,
       profileid: this.formState.browserProfile?.id || "",
-      schedule: this.formState.scheduleType === "cron" ? this.utcSchedule : "",
+      schedule:
+        (this.formState.scheduleType === "cron" &&
+        this.formState.scheduleFrequency
+          ? this.utcSchedule
+          : this.formState.scheduleCustom) || "",
       crawlTimeout: this.formState.crawlTimeoutMinutes * 60,
       maxCrawlSize: this.formState.maxCrawlSizeGB * BYTES_PER_GB,
       tags: this.formState.tags,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2170,7 +2170,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ${inputCol(html`
             <sl-input
               name="scheduleCustom"
-              label=${msg("Cron Schedule in UTC")}
+              label=${msg("Cron Schedule")}
               placeholder="* * * * *"
               value=${ifDefined(this.formState.scheduleCustom)}
               required
@@ -2180,12 +2180,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
           `)}
           ${this.renderHelpTextCol(html`
             ${msg(`Specify a schedule in Cron format.`)}
-            <a
-              href="https://crontab.guru"
-              class="text-blue-600 hover:text-blue-500"
-              target="_blank"
-              >${msg("Open crontab guru in new tab")}</a
-            >
+            ${this.renderUserGuideLink({
+              hash: "cron-schedule",
+              content: msg("More details"),
+            })}
           `)}
         `,
       )}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2047,27 +2047,21 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private readonly renderScheduleCron = () => {
-    const utcSchedule = this.utcSchedule;
-    const scheduledDate = html`
-      <div class="mt-3 text-xs text-neutral-500">
-        <p class="mb-1">
-          ${msg("Schedule:")}
-          <span class="text-blue-500"
-            >${utcSchedule
-              ? humanizeSchedule(utcSchedule)
-              : msg("Invalid schedule")}</span
-          >
-        </p>
-        <p>
-          ${msg("Next scheduled run:")}
-          <span
-            >${utcSchedule
-              ? humanizeNextDate(utcSchedule)
-              : msg("Invalid date")}</span
-          >
-        </p>
-      </div>
-    `;
+    const scheduledDate = (schedule?: string) =>
+      schedule
+        ? html`
+            <div class="mt-3 text-xs text-neutral-500">
+              <p class="mb-1">
+                ${msg("Schedule:")}
+                <span class="text-blue-500">${humanizeSchedule(schedule)}</span>
+              </p>
+              <p>
+                ${msg("Next scheduled run:")}
+                <span>${humanizeNextDate(schedule)}</span>
+              </p>
+            </div>
+          `
+        : nothing;
 
     return html`
       ${this.renderSectionHeading(msg("Set Schedule"))}
@@ -2084,7 +2078,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               scheduleFrequency,
               scheduleCustom: scheduleFrequency
                 ? ""
-                : this.formState.scheduleCustom || "* * * * *",
+                : this.formState.scheduleCustom || "",
             });
           }}
         >
@@ -2167,7 +2161,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             >
               <span slot="label">${msg("Start Time")}</span>
             </btrix-time-input>
-            ${scheduledDate}
+            ${scheduledDate(this.utcSchedule)}
           `)}
           ${this.renderHelpTextCol(
             msg(`A crawl will run at this time in your current timezone.`),
@@ -2176,13 +2170,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ${inputCol(html`
             <sl-input
               name="scheduleCustom"
-              label=${msg("Cron Schedule")}
+              label=${msg("Cron Schedule in UTC")}
               placeholder="* * * * *"
               value=${ifDefined(this.formState.scheduleCustom)}
               required
             >
             </sl-input>
-            ${scheduledDate}
+            ${scheduledDate(this.formState.scheduleCustom)}
           `)}
           ${this.renderHelpTextCol(html`
             ${msg(`Specify a schedule in Cron format.`)}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2220,7 +2220,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               required
             >
             </sl-input>
-            ${scheduledDate(this.formState.scheduleCustom, { utc: true })}
+            ${scheduledDate(this.formState.scheduleCustom)}
           `)}
           ${this.renderHelpTextCol(html`
             ${msg("Specify a schedule in Cron format.")}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -267,7 +267,12 @@ export class WorkflowEditor extends BtrixElement {
   @property({ type: String })
   initialScopeType?: FormState["scopeType"];
 
-  @property({ type: Object })
+  @property({
+    type: Object,
+    // Fixes values being reset on navigation events,
+    // such as when the user guide is open
+    hasChanged: (a, b) => !isEqual(a, b),
+  })
   initialWorkflow?: WorkflowParams;
 
   private updatingScopeType = false;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -3084,10 +3084,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
       browserWindows: this.formState.browserWindows,
       profileid: this.formState.browserProfile?.id || "",
       schedule:
-        (this.formState.scheduleType === "cron" &&
-        this.formState.scheduleFrequency
-          ? this.utcSchedule
-          : this.formState.scheduleCustom) || "",
+        this.formState.scheduleType === "none"
+          ? ""
+          : (this.formState.scheduleFrequency
+              ? this.utcSchedule
+              : this.formState.scheduleCustom) || "",
       crawlTimeout: this.formState.crawlTimeoutMinutes * 60,
       maxCrawlSize: this.formState.maxCrawlSizeGB * BYTES_PER_GB,
       tags: this.formState.tags,

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -18,14 +18,16 @@ describe("cron utils", () => {
     });
 
     it("returns null if not daily, weekly, or monthly", () => {
-      // Every second:
+      // Every minute:
       expect(getScheduleInterval("* * * * *")).to.equal(null);
       expect(getScheduleInterval("* 1 * * *")).to.equal(null);
       expect(getScheduleInterval("* * 1 * *")).to.equal(null);
       expect(getScheduleInterval("* * * 1 *")).to.equal(null);
       expect(getScheduleInterval("* * * * 1")).to.equal(null);
+      expect(getScheduleInterval("*/5 * * * *")).to.equal(null);
       // Hourly:
       expect(getScheduleInterval("1 * * * *")).to.equal(null);
+      expect(getScheduleInterval("0 */5 * * *")).to.equal(null);
       // Yearly:
       expect(getScheduleInterval("1 1 1 JAN *")).to.equal(null);
       expect(getScheduleInterval("1 1 1 1 *")).to.equal(null);

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -10,6 +10,7 @@ describe("cron utils", () => {
 
     it("handles weekly intervals", () => {
       expect(getScheduleInterval("1 1 * * 1")).to.equal("weekly");
+      expect(getScheduleInterval("1 1 * * FRI")).to.equal("weekly");
     });
 
     it("handles monthly intervals", () => {
@@ -26,6 +27,7 @@ describe("cron utils", () => {
       // Hourly:
       expect(getScheduleInterval("1 * * * *")).to.equal(null);
       // Yearly:
+      expect(getScheduleInterval("1 1 1 JAN *")).to.equal(null);
       expect(getScheduleInterval("1 1 1 1 *")).to.equal(null);
       expect(getScheduleInterval("1 1 1 1 1")).to.equal(null);
     });

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "@open-wc/testing";
+
+import { getScheduleInterval, humanizeSchedule } from "./cron";
+
+describe("cron utils", () => {
+  describe("getScheduleInterval()", () => {
+    it("handles daily intervals", () => {
+      expect(getScheduleInterval("1 1 * * *")).to.equal("daily");
+    });
+
+    it("handles weekly intervals", () => {
+      expect(getScheduleInterval("1 1 * * 1")).to.equal("weekly");
+    });
+
+    it("handles monthly intervals", () => {
+      expect(getScheduleInterval("1 1 1 * *")).to.equal("monthly");
+    });
+
+    it("returns null if not daily, weekly, or monthly", () => {
+      // Every second:
+      expect(getScheduleInterval("* * * * *")).to.equal(null);
+      expect(getScheduleInterval("* 1 * * *")).to.equal(null);
+      expect(getScheduleInterval("* * 1 * *")).to.equal(null);
+      expect(getScheduleInterval("* * * 1 *")).to.equal(null);
+      expect(getScheduleInterval("* * * * 1")).to.equal(null);
+      // Hourly:
+      expect(getScheduleInterval("1 * * * *")).to.equal(null);
+      // Yearly:
+      expect(getScheduleInterval("1 1 1 1 *")).to.equal(null);
+      expect(getScheduleInterval("1 1 1 1 1")).to.equal(null);
+    });
+  });
+
+  describe("humanizeSchedule()", () => {
+    it("humanizes daily schedule", () => {
+      expect(humanizeSchedule("30 1 * * *")).to.equal(
+        "Every day at 7:30 PM GMT-6",
+      );
+    });
+
+    it("humanizes weekly schedule", () => {
+      expect(humanizeSchedule("30 1 * * 1")).to.equal(
+        "Every Sunday at 7:30 PM GMT-6",
+      );
+    });
+
+    it("humanizes monthly schedule", () => {
+      expect(humanizeSchedule("30 1 1 * *")).to.equal(
+        "On day 31 of the month at 7:30 PM GMT-6",
+      );
+    });
+
+    it("humanizes schedule without a known interval", () => {
+      expect(humanizeSchedule("* * * * *")).to.equal("Every minute (UTC)");
+      expect(humanizeSchedule("30 * 1 * *")).to.equal(
+        "At 30 minutes past the hour, on day 1 of the month (UTC)",
+      );
+    });
+  });
+});

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -33,6 +33,14 @@ describe("cron utils", () => {
       expect(getScheduleInterval("1 1 1 1 *")).to.equal(null);
       expect(getScheduleInterval("1 1 1 1 1")).to.equal(null);
     });
+
+    it("returns null for macros", () => {
+      expect(getScheduleInterval("@yearly")).to.equal(null);
+      expect(getScheduleInterval("@monthly")).to.equal(null);
+      expect(getScheduleInterval("@weekly")).to.equal(null);
+      expect(getScheduleInterval("@daily")).to.equal(null);
+      expect(getScheduleInterval("@hourly")).to.equal(null);
+    });
   });
 
   describe("humanizeSchedule()", () => {

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -52,13 +52,13 @@ describe("cron utils", () => {
 
     it("humanizes weekly schedule", () => {
       expect(humanizeSchedule("30 1 * * 1")).to.equal(
-        "Every Sunday at 7:30 PM GMT-6",
+        "Every Sunday at 8:30 PM GMT-5",
       );
     });
 
     it("humanizes monthly schedule", () => {
       expect(humanizeSchedule("30 1 1 * *")).to.equal(
-        "On day 31 of the month at 7:30 PM GMT-6",
+        "On day 30 of the month at 8:30 PM GMT-5",
       );
     });
 

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -47,7 +47,7 @@ export function getScheduleInterval(schedule: string): ScheduleInterval | null {
  **/
 export function humanizeNextDate(
   schedule: string,
-  options: { length?: "short" } = {},
+  options: { length?: "short"; utc?: boolean } = {},
 ): string {
   const locale = localize.activeLanguage;
   const nextDate = parseCron.nextDate(schedule);
@@ -61,6 +61,7 @@ export function humanizeNextDate(
       year: "numeric",
       hour: "numeric",
       minute: "numeric",
+      timeZone: options.utc ? "UTC" : undefined,
     });
   }
 
@@ -72,6 +73,7 @@ export function humanizeNextDate(
     hour: "numeric",
     minute: "numeric",
     timeZoneName: "short",
+    timeZone: options.utc ? "UTC" : undefined,
   });
 }
 

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -17,7 +17,11 @@ export type ScheduleInterval = "daily" | "weekly" | "monthly";
  * Monthly: minute hour dayOfMonth * *
  **/
 export function getScheduleInterval(schedule: string): ScheduleInterval | null {
-  const [minute, hour, dayOfMonth, month, dayOfWeek] = schedule.split(" ");
+  const parts = schedule.split(" ");
+
+  if (parts.length !== 5) return null;
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
   if (minute.startsWith("*") || hour.startsWith("*") || month !== "*") {
     return null;
   }
@@ -83,13 +87,17 @@ export function humanizeSchedule(
   const interval = getScheduleInterval(schedule);
 
   if (!interval) {
-    const humanized = cronstrue.toString(schedule, {
-      verbose: false, // TODO Support shorter string
-      locale,
-    });
+    try {
+      const humanized = cronstrue.toString(schedule, {
+        verbose: false, // TODO Support shorter string
+        locale,
+      });
 
-    // Add timezone prefix
-    return `${humanized} (UTC)`;
+      // Add timezone prefix
+      return `${humanized} (UTC)`;
+    } catch {
+      return "";
+    }
   }
 
   const parsed = parseCron(schedule);

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -18,7 +18,7 @@ export type ScheduleInterval = "daily" | "weekly" | "monthly";
  **/
 export function getScheduleInterval(schedule: string): ScheduleInterval | null {
   const [minute, hour, dayOfMonth, month, dayOfWeek] = schedule.split(" ");
-  if (minute === "*" || hour === "*" || month !== "*") {
+  if (minute.startsWith("*") || hour.startsWith("*") || month !== "*") {
     return null;
   }
 

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -77,6 +77,28 @@ export function humanizeNextDate(
   });
 }
 
+export function validateCron(schedule: string): {
+  valid: boolean;
+  error?: string;
+} {
+  const locale = localize.activeLanguage;
+
+  try {
+    cronstrue.toString(schedule, {
+      locale,
+    });
+
+    return { valid: true };
+  } catch (err) {
+    if (typeof err === "string") {
+      // TODO Custom localized errors since construe doesn't translate errors
+      return { valid: false, error: err.replace("Error: ", "") };
+    }
+  }
+
+  return { valid: false };
+}
+
 /**
  * Get human-friendly schedule from cron expression
  * Example: "Every day at 9:30 AM CDT"

--- a/frontend/src/utils/localize.ts
+++ b/frontend/src/utils/localize.ts
@@ -261,6 +261,15 @@ export class Localize {
   };
 
   private async setTranslation(lang: LanguageCode) {
+    // Load cron string translation
+    try {
+      await import(
+        /* webpackChunkName: 'cronstrue'*/ `cronstrue/locales/${lang}`
+      );
+    } catch (err) {
+      console.debug(err);
+    }
+
     if (
       lang !== getLocale() &&
       (translatedLocales as AllLanguageCodes).includes(lang)

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -141,6 +141,7 @@ export type FormState = {
     minute: number;
     period: "AM" | "PM";
   };
+  scheduleCustom?: string;
   jobName: WorkflowParams["name"];
   browserProfile: Profile | null;
   tags: Tags;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -132,15 +132,39 @@ export type FormState = {
   browserWindows: WorkflowParams["browserWindows"];
   blockAds: WorkflowParams["config"]["blockAds"];
   lang: WorkflowParams["config"]["lang"];
+  /**
+   * NOTE The UI currently only supports "cron" and "none".
+   */
   scheduleType: "date" | "cron" | "none";
+  /**
+   * One of known frequency enums.
+   *
+   * If an empty string, either `scheduleType` should be `"none"`
+   * or `scheduleCustom` should be set.
+   */
   scheduleFrequency: "daily" | "weekly" | "monthly" | "";
+  /**
+   * Day of the month local to the user's browser timezone.
+   * Only used if `scheduleFrequency` is `"monthly"`.
+   */
   scheduleDayOfMonth?: number;
+  /**
+   * Day of the week local to the user's browser timezone.
+   * Only used if `scheduleFrequency` is `"weekly"`.
+   */
   scheduleDayOfWeek?: number;
+  /**
+   * Time local to the user's browser timezone.
+   * Only used if `scheduleFrequency` is specified.
+   */
   scheduleTime?: {
     hour: number;
     minute: number;
     period: "AM" | "PM";
   };
+  /**
+   * Custom schedule in cron format.
+   */
   scheduleCustom?: string;
   jobName: WorkflowParams["name"];
   browserProfile: Profile | null;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -317,6 +317,7 @@ export function getInitialFormState(params: {
         period: hours > 11 ? "PM" : "AM",
       };
     } else {
+      formState.scheduleFrequency = "";
       formState.scheduleCustom = params.initialWorkflow.schedule;
     }
   } else {

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -279,18 +279,22 @@ export function getInitialFormState(params: {
 
   if (params.initialWorkflow.schedule) {
     formState.scheduleType = "cron";
-    formState.scheduleFrequency = getScheduleInterval(
-      params.initialWorkflow.schedule,
-    );
-    const nextDate = getNextDate(params.initialWorkflow.schedule)!;
-    formState.scheduleDayOfMonth = nextDate.getDate();
-    formState.scheduleDayOfWeek = nextDate.getDay();
-    const hours = nextDate.getHours();
-    formState.scheduleTime = {
-      hour: hours % 12 || 12,
-      minute: nextDate.getMinutes(),
-      period: hours > 11 ? "PM" : "AM",
-    };
+    const interval = getScheduleInterval(params.initialWorkflow.schedule);
+
+    if (interval) {
+      formState.scheduleFrequency = interval;
+      const nextDate = getNextDate(params.initialWorkflow.schedule)!;
+      formState.scheduleDayOfMonth = nextDate.getDate();
+      formState.scheduleDayOfWeek = nextDate.getDay();
+      const hours = nextDate.getHours();
+      formState.scheduleTime = {
+        hour: hours % 12 || 12,
+        minute: nextDate.getMinutes(),
+        period: hours > 11 ? "PM" : "AM",
+      };
+    } else {
+      formState.scheduleCustom = params.initialWorkflow.schedule;
+    }
   } else {
     formState.scheduleType = "none";
   }

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -67,6 +67,7 @@ export default {
         "node_modules/url-pattern/**/*",
         "node_modules/lodash/**/*",
         "node_modules/color/**/*",
+        "node_modules/cronstrue/**/*",
         "node_modules/slugify/**/*",
         "node_modules/parse-ms/**/*",
         "node_modules/regex-colorize/**/*",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4854,6 +4854,11 @@ crelt@^1.0.5:
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
   integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
+cronstrue@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-3.2.0.tgz#36138f9752fde512deb81c84db31207bc9fb7fdd"
+  integrity sha512-CqpqV5bCei+jmKyIw2Wihz+npXDuSkeExWCItEn5hlpD8+QFMXUU2YW5W3Vh/hFxWwzWhguoGXm5gl1os+L2Hw==
+
 cross-fetch@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2786
Fixes https://github.com/webrecorder/browsertrix/issues/2796

## Changes

Enables setting and viewing custom cron schedules.

## Manual testing

First, run `yarn` to install new dependencies.

1. Log in as crawler
2. Go to edit workflow
3. Go to "Scheduling" section
4. Choose "Run on recurring basis"
5. Open frequency dropdown. Verify "Custom" option is shown
6. Choose "Custom" option
7. Enter "Cron Schedule". Verify error messages, "Schedule:", and "Next date:" populate as expected based on the [Kubernetes cronjob spec](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec)
8. Save workflow. Verify schedule is shown as expected

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow editor | <img width="908" height="217" alt="Screenshot 2025-08-20 at 2 13 32 PM" src="https://github.com/user-attachments/assets/60cc2987-b4a6-40f6-8b9e-4511c9fd763d" /> |
| Workflow editor (errors | <img width="556" height="112" alt="Screenshot 2025-08-20 at 2 13 45 PM" src="https://github.com/user-attachments/assets/02d3bc68-7718-4e4e-8236-3396d11bb372" /><br/><br/><img width="552" height="112" alt="Screenshot 2025-08-20 at 2 13 56 PM" src="https://github.com/user-attachments/assets/0664f0a3-a9aa-41ec-a0aa-863de31738b4" /> |
| Workflow detail | <img width="155" height="63" alt="Screenshot 2025-08-20 at 2 24 04 PM" src="https://github.com/user-attachments/assets/a554fb0b-43ef-4295-a834-91e8891f5ae3" /> |
| User guide / Workflow setup | <img width="831" height="1116" alt="Screenshot 2025-08-20 at 2 20 39 PM" src="https://github.com/user-attachments/assets/cc26cf72-aa6f-4e81-8ae4-e295301f8a2d" /> |



<!-- ## Follow-ups -->
