### PR TITLE
fix: Show seed file in archived item detail

### DIFF
--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -2,7 +2,7 @@ import { msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, type TemplateResult } from "lit";
 
-import type { ArchivedItem, Crawl, Workflow } from "@/types/crawler";
+import type { ArchivedItem, Crawl, Upload, Workflow } from "@/types/crawler";
 import {
   FAILED_STATES,
   RUNNING_AND_WAITING_STATES,
@@ -28,6 +28,10 @@ export const DEPTH_SUPPORTED_SCOPES = [
   "custom",
   "any",
 ];
+
+export function isCrawl(item: Crawl | Upload): item is Crawl {
+  return item.type === "crawl";
+}
 
 export function isActive({ state }: Partial<Crawl | QARun>) {
   return (activeCrawlStates as readonly (typeof state)[]).includes(state);


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2810

## Changes

Fixes seed file not being linked in archived item view

## Manual testing

1. Log in
2. Go to workflow with seed file
3. Go to "Crawls" and go to a successful crawl detail view
4. Go to "Crawl Settings". Observe that "Page URLs" is linked to a file