### PR TITLE
frontend logs rendering: make details part of log optional

### DIFF
--- a/frontend/src/features/archived-items/crawl-log-table.ts
+++ b/frontend/src/features/archived-items/crawl-log-table.ts
@@ -228,7 +228,7 @@ export class CrawlLogTable extends TailwindElement {
   }
 
   private renderPageUrl(log: CrawlLog) {
-    const url = log.details.page || log.details.url;
+    const url = log.details?.page || log.details?.url;
     return url
       ? html` <div class="truncate" title="${url}">${url}</div> `
       : html`<div class="text-neutral-400 group-hover:text-inherit">
@@ -239,7 +239,7 @@ export class CrawlLogTable extends TailwindElement {
   private renderLogDetails() {
     if (!this.selectedLog) return;
     const { context, details } = this.selectedLog;
-    const { page, stack, ...unknownDetails } = details;
+    const { page, stack, ...unknownDetails } = details || {};
 
     return html`
       <btrix-desc-list>

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -266,7 +266,7 @@ export enum CrawlLogContext {
 export type CrawlLog = {
   timestamp: string;
   logLevel: CrawlLogLevel;
-  details: Record<string, unknown> & {
+  details?: Record<string, unknown> & {
     behavior?: string;
     page?: string;
     stack?: string;

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -46,7 +46,7 @@ describe("cron utils", () => {
   describe("humanizeSchedule()", () => {
     it("humanizes daily schedule", () => {
       expect(humanizeSchedule("30 1 * * *")).to.equal(
-        "Every day at 7:30 PM GMT-6",
+        "Every day at 8:30 PM GMT-5",
       );
     });
 


### PR DESCRIPTION
some logs may not have a details set, avoid errors