### PR TITLE
quickfix: remove 'errors' and 'behaviorLogs' fields for uploads as well

### DIFF
--- a/backend/btrixcloud/migrations/migration_0050_crawl_logs.py
+++ b/backend/btrixcloud/migrations/migration_0050_crawl_logs.py
@@ -28,7 +28,6 @@ class Migration(BaseMigration):
 
         # Migrate error and behavior logs
         match_query = {
-            "type": "crawl",
             "$or": [{"errors": {"$exists": True}}, {"behaviorLogs": {"$exists": True}}],
         }
 


### PR DESCRIPTION
avoids empty '[]' fields on uploads, since they are deleted from crawl objects as well