### PR TITLE
docs: Remove reference to "Crawl URL"

### DIFF
--- a/frontend/docs/docs/user-guide/presentation-sharing.md
+++ b/frontend/docs/docs/user-guide/presentation-sharing.md
@@ -41,7 +41,7 @@ From the Public Collection Gallery. When Public Collection Gallery is enabled, y
 
 ### Name
 
-A **Name** is always required, so by default, your Collection's name is determined by the Metadata section from your crawl workflow — either a custom name you had set or the first Crawl URL from your workflow.
+A **Name** is always required, so by default, your Collection's name is determined by the name of your crawl workflow.
 
 You can edit the **Name** as long as its within 50 characters, which is roughly between 7 words and 13 words with spaces included in the character count.
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -102,7 +102,7 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 When enabled, the crawler will visit all the links it finds within each URL defined in the [URL input field](#crawl-start-url-urls-to-crawl) under _Crawl Scope_.
 
 ??? example "Crawling tags & search queries with Page List crawls"
-    This setting can be useful for crawling a list of specific pages, such as a list of search queries. For example, you can create a list of multiple URLs such as: `https://example.com/search?q=search_this`, `https://example.com/search?q=also_search_this`, etc... to the _URLs to Crawl_ text box and enable _Include Any Linked Page_ to crawl all the content present on these search query pages.
+    This setting can be useful for crawling a list of specific pages and pages they link to, such as a list of search queries. For example, you can add a list of multiple URLs such as: `https://example.com/search?q=search_this`, `https://example.com/search?q=also_search_this`, etc... to the _URLs to Crawl_ text box and enable _Include Any Linked Page_ to crawl all the content present on these search query pages.
 
 ### Fail Crawl if Not Logged In
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -102,7 +102,7 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 When enabled, the crawler will visit all the links it finds within each URL defined in the [URL input field](#crawl-start-url-urls-to-crawl) under _Crawl Scope_.
 
 ??? example "Crawling tags & search queries with Page List crawls"
-    This setting can be useful for crawling the content of specific tags or search queries. Specify the tag or search query URL(s) in the _Crawl URL(s)_ field, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
+    This setting can be useful for crawling the content of specific tags or search queries. Specify the tag or search query URL(s) in the URL to crawl, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
 
 ### Fail Crawl if Not Logged In
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -102,7 +102,7 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 When enabled, the crawler will visit all the links it finds within each URL defined in the [URL input field](#crawl-start-url-urls-to-crawl) under _Crawl Scope_.
 
 ??? example "Crawling tags & search queries with Page List crawls"
-    This setting can be useful for crawling the content of specific tags or search queries. Specify the tag or search query URL(s) in the URL to crawl, e.g: `https://example.com/search?q=tag`, and enable _Include Any Linked Page_ to crawl all the content present on that search query page.
+    This setting can be useful for crawling a list of specific pages, such as a list of search queries. For example, you can create a list of multiple URLs such as: `https://example.com/search?q=search_this`, `https://example.com/search?q=also_search_this`, etc... to the _URLs to Crawl_ text box and enable _Include Any Linked Page_ to crawl all the content present on these search query pages.
 
 ### Fail Crawl if Not Logged In
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2801

## Changes

Removes remaining references to "Crawl URL" following https://github.com/webrecorder/browsertrix/pull/2803