### PR TITLE
Disable "Fail crawl if not logged in" unless a browser profile is selected

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1040,7 +1040,8 @@ export class WorkflowEditor extends BtrixElement {
           ${this.formState.browserProfile === null
             ? html`<span slot="help-text">
                 ${msg(
-                  html`Select a ${link_to_browser_profile} to use this option.`,
+                  html`Custom logged in ${link_to_browser_profile} is required
+                  to use this option.`,
                 )}
               </span>`
             : nothing}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -943,6 +943,23 @@ export class WorkflowEditor extends BtrixElement {
   };
 
   private readonly renderPageScope = () => {
+    const linkToBrowserSettings = (label: string) =>
+      html`<button
+        type="button"
+        class="text-blue-600 hover:text-blue-500"
+        @click=${async () => {
+          this.updateProgressState({ activeTab: "browserSettings" });
+
+          await this.updateComplete;
+
+          void this.scrollToActivePanel();
+        }}
+      >
+        ${label}
+      </button>`;
+    const link_to_browser_profile = linkToBrowserSettings(
+      msg("Browser Profile"),
+    );
     return html`
       ${this.formState.scopeType === ScopeType.Page
         ? html`
@@ -1017,7 +1034,15 @@ export class WorkflowEditor extends BtrixElement {
         <sl-checkbox
           name="failOnContentCheck"
           ?checked=${this.formState.failOnContentCheck}
+          ?disabled=${this.formState.browserProfile === null}
         >
+          ${this.formState.browserProfile === null
+            ? html`<span slot="help-text">
+                ${msg(
+                  html`Select a ${link_to_browser_profile} to use this option.`,
+                )}
+              </span>`
+            : nothing}
           ${msg("Fail crawl if not logged in")}
         </sl-checkbox>
       `)}
@@ -1372,6 +1397,24 @@ https://replayweb.page/docs`}
     const additionalUrlList = urlListToArray(this.formState.urlList);
     const maxUrls = this.localize.number(URL_LIST_MAX_URLS);
 
+    const linkToBrowserSettings = (label: string) =>
+      html`<button
+        type="button"
+        class="text-blue-600 hover:text-blue-500"
+        @click=${async () => {
+          this.updateProgressState({ activeTab: "browserSettings" });
+
+          await this.updateComplete;
+
+          void this.scrollToActivePanel();
+        }}
+      >
+        ${label}
+      </button>`;
+    const link_to_browser_profile = linkToBrowserSettings(
+      msg("Browser Profile"),
+    );
+
     return html`
       ${inputCol(html`
         <sl-input
@@ -1517,7 +1560,15 @@ https://example.net`}
         <sl-checkbox
           name="failOnContentCheck"
           ?checked=${this.formState.failOnContentCheck}
+          ?disabled=${this.formState.browserProfile === null}
         >
+          ${this.formState.browserProfile === null
+            ? html`<span slot="help-text">
+                ${msg(
+                  html`Select a ${link_to_browser_profile} to use this option.`,
+                )}
+              </span>`
+            : nothing}
           ${msg("Fail crawl if not logged in")}
         </sl-checkbox>
       `)}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1962,7 +1962,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           .profileId=${this.formState.browserProfile?.id}
           @on-change=${(e: SelectBrowserProfileChangeEvent) =>
             this.updateFormState({
-              browserProfile: e.detail.value,
+              browserProfile: e.detail.value ?? null,
             })}
         ></btrix-select-browser-profile>
       `)}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1033,7 +1033,8 @@ export class WorkflowEditor extends BtrixElement {
       ${inputCol(html`
         <sl-checkbox
           name="failOnContentCheck"
-          ?checked=${this.formState.failOnContentCheck}
+          ?checked=${this.formState.failOnContentCheck &&
+          this.formState.browserProfile !== null}
           ?disabled=${this.formState.browserProfile === null}
         >
           ${this.formState.browserProfile === null
@@ -1559,7 +1560,8 @@ https://example.net`}
       ${inputCol(html`
         <sl-checkbox
           name="failOnContentCheck"
-          ?checked=${this.formState.failOnContentCheck}
+          ?checked=${this.formState.failOnContentCheck &&
+          this.formState.browserProfile !== null}
           ?disabled=${this.formState.browserProfile === null}
         >
           ${this.formState.browserProfile === null
@@ -2893,6 +2895,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
         this.customBehaviorsTable.reportValidity();
         return;
       }
+    }
+
+    // Disable content check if no browser profile is selected
+    // This is done here rather than in `willChange` so that the state of the checkbox
+    // can be remembered if the switches from a browser profile to no browser profile,
+    // and then back to a browser profile
+    if (this.formState.browserProfile === null) {
+      this.formState.failOnContentCheck = false;
     }
 
     const isValid = await this.checkFormValidity(this.formElem);

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2898,7 +2898,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       }
     }
 
-    // Disable content check if no browser profile is selected
+    // Disable failOnContentCheck if no browser profile is selected
     // This is done here rather than in `willChange` so that the state of the checkbox
     // can be remembered if the switches from a browser profile to no browser profile,
     // and then back to a browser profile


### PR DESCRIPTION
Closes #2829

## Changes

Disables the "Fail crawl if not logged in" checkbox in the workflow editor unless a browser profile is selected, as otherwise the crawl will fail if it hits a website that the behaviour exists for no matter what (since there's no logins included in the default profile)