### PR TITLE
tests: use self-hosted example.com mirror

### DIFF
--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -332,7 +332,7 @@ def sample_crawl_data():
     return {
         "runNow": False,
         "name": "Test Crawl",
-        "config": {"seeds": [{"url": "https://example.com/"}], "extraHops": 1},
+        "config": {"seeds": [{"url": "https://example-com.webrecorder.net/"}], "extraHops": 1},
         "tags": ["tag1", "tag2"],
     }
 
@@ -558,7 +558,7 @@ def url_list_config_id(crawler_auth_headers, default_org_id):
         "config": {
             "seeds": [
                 {"url": "https://webrecorder.net"},
-                {"url": "https://example.com"},
+                {"url": "https://example-com.webrecorder.net"},
                 {"url": "https://specs.webrecorder.net"},
             ],
             "limit": 1,

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1110,7 +1110,7 @@ def test_list_public_collections(
 
     # Enable public profile on org
     public_description = "This is a test public org!"
-    public_url = "https://example.com"
+    public_url = "https://example-com.webrecorder.net"
 
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/public-profile",
@@ -1340,7 +1340,7 @@ def test_upload_collection_thumbnail(crawler_auth_headers, default_org_id):
     assert thumbnailSource["urlTs"]
     assert thumbnailSource["urlPageId"]
 
-    assert thumbnailSource["url"] == "https://example.com/"
+    assert thumbnailSource["url"] == "https://example-com.webrecorder.net/"
     assert thumbnailSource["urlTs"] == "2024-08-16T08:00:21.601000Z"
     assert thumbnailSource["urlPageId"] == "1bba4aba-d5be-4943-ad48-d6710633d754"
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1340,7 +1340,7 @@ def test_upload_collection_thumbnail(crawler_auth_headers, default_org_id):
     assert thumbnailSource["urlTs"]
     assert thumbnailSource["urlPageId"]
 
-    assert thumbnailSource["url"] == "https://example-com.webrecorder.net/"
+    assert thumbnailSource["url"] == "https://example.com/"
     assert thumbnailSource["urlTs"] == "2024-08-16T08:00:21.601000Z"
     assert thumbnailSource["urlPageId"] == "1bba4aba-d5be-4943-ad48-d6710633d754"
 

--- a/backend/test/test_crawl_config_profile_filter.py
+++ b/backend/test/test_crawl_config_profile_filter.py
@@ -8,7 +8,7 @@ def get_sample_crawl_data(profile_id=None):
     data = {
         "runNow": False,
         "name": "Test Crawl",
-        "config": {"seeds": [{"url": "https://example.com/"}]},
+        "config": {"seeds": [{"url": "https://example-com.webrecorder.net/"}]},
     }
     if profile_id:
         data["profileid"] = profile_id

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -10,7 +10,7 @@ def get_sample_crawl_data(tags):
     return {
         "runNow": False,
         "name": "Test Crawl",
-        "config": {"seeds": [{"url": "https://example.com/"}]},
+        "config": {"seeds": [{"url": "https://example-com.webrecorder.net/"}]},
         "tags": tags,
     }
 

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -221,7 +221,7 @@ def test_verify_update(crawler_auth_headers, default_org_id):
     assert data["description"] == UPDATED_DESCRIPTION
     assert sorted(data["tags"]) == sorted(UPDATED_TAGS)
     assert data["autoAddCollections"] == [_coll_id]
-    assert data["firstSeed"] == "https://example.com/"
+    assert data["firstSeed"] == "https://example-com.webrecorder.net/"
 
 
 def test_update_config_invalid_format(
@@ -232,7 +232,7 @@ def test_update_config_invalid_format(
         headers=crawler_auth_headers,
         json={
             "config": {
-                "seeds": ["https://example.com/"],
+                "seeds": ["https://example-com.webrecorder.net/"],
                 "scopeType": "domain",
                 "limit": 10,
             }
@@ -323,7 +323,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
         headers=crawler_auth_headers,
         json={
             "config": {
-                "seeds": [{"url": "https://example.com/"}],
+                "seeds": [{"url": "https://example-com.webrecorder.net/"}],
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
                 "clickSelector": "button",
@@ -353,7 +353,7 @@ def test_update_config_no_changes(
         headers=crawler_auth_headers,
         json={
             "config": {
-                "seeds": [{"url": "https://example.com/"}],
+                "seeds": [{"url": "https://example-com.webrecorder.net/"}],
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
                 "clickSelector": "button",
@@ -664,7 +664,7 @@ def test_get_config_seeds(crawler_auth_headers, default_org_id, url_list_config_
 
     EXPECTED_SEED_URLS = [
         "https://webrecorder.net/",
-        "https://example.com/",
+        "https://example-com.webrecorder.net/",
         "https://specs.webrecorder.net/",
     ]
     found_seed_urls = []


### PR DESCRIPTION
Change uses of https://example.com/ for crawling with self-hosted mirror at https://example-com.webrecorder.net/ to avoid rate limits or external errors.