### PR TITLE
Add backend validation and migration for failOnContentCheck

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -547,8 +547,7 @@ class CrawlConfigOps:
                 )
             if orig_crawl_config.config.failOnContentCheck:
                 if not update.config or (
-                    update.config
-                    and update.config.failOnContentCheck not in (None, False)
+                    update.config and update.config.failOnContentCheck is not False
                 ):
                     raise HTTPException(
                         status_code=400, detail="fail_on_content_check_requires_profile"

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -34,7 +34,7 @@ else:
     ) = PageOps = BackgroundJobOps = FileUploadOps = CrawlLogOps = object
 
 
-CURR_DB_VERSION = "0050"
+CURR_DB_VERSION = "0051"
 
 
 # ============================================================================

--- a/backend/btrixcloud/migrations/migration_0051_fail_on_content_check_profiles.py
+++ b/backend/btrixcloud/migrations/migration_0051_fail_on_content_check_profiles.py
@@ -1,0 +1,37 @@
+"""
+Migration 0051 - Ensure failOnContentCheck is not set for workflows without profiles
+"""
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0051"
+
+
+# pylint: disable=duplicate-code
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self) -> None:
+        """Perform migration up.
+
+        Unset failOnContentCheck for workflows that don't have a profile set
+        """
+        crawl_configs_mdb = self.mdb["crawl_configs"]
+
+        try:
+            await crawl_configs_mdb.update_many(
+                {"profileid": None, "config.failOnContentCheck": True},
+                {"$set": {"config.failOnContentCheck": False}},
+            )
+
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error unsetting failOnContentCheck for configs without profiles: {err}",
+                flush=True,
+            )

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -332,7 +332,10 @@ def sample_crawl_data():
     return {
         "runNow": False,
         "name": "Test Crawl",
-        "config": {"seeds": [{"url": "https://example-com.webrecorder.net/"}], "extraHops": 1},
+        "config": {
+            "seeds": [{"url": "https://example-com.webrecorder.net/"}],
+            "extraHops": 1,
+        },
         "tags": ["tag1", "tag2"],
     }
 
@@ -820,6 +823,35 @@ def profile_2_id(admin_auth_headers, default_org_id, profile_browser_2_id):
             if time.monotonic() - start_time > time_limit:
                 raise
             time.sleep(5)
+
+
+@pytest.fixture(scope="session")
+def profile_2_config_id(admin_auth_headers, default_org_id, profile_2_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_2_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == profile_2_id
+
+    # Use profile in a workflow
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",
+        headers=admin_auth_headers,
+        json={
+            "runNow": False,
+            "name": "Profile 2 Test Crawl",
+            "description": "Crawl using browser profile",
+            "config": {
+                "seeds": [{"url": "https://webrecorder.net/"}],
+                "exclude": "community",
+            },
+            "profileid": profile_2_id,
+        },
+    )
+    data = r.json()
+    return data["id"]
 
 
 @pytest.fixture(scope="session")

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -1099,7 +1099,7 @@ def test_update_crawl_config_remove_profile_no_fail_on_content_check(
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{profile_2_config_id}/",
         headers=crawler_auth_headers,
-        json={"profileid": None},
+        json={"profileid": ""},
     )
     assert r.status_code == 200
     data = r.json()

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -23,8 +23,8 @@ def test_get_config_by_modified_by(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?modifiedBy={crawler_userid}",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 9
-    assert r.json()["total"] == 9
+    assert len(r.json()["items"]) == 10
+    assert r.json()["total"] == 10
 
 
 def test_get_configs_by_first_seed(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -362,9 +362,9 @@ def test_sort_crawl_configs(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 15
+    assert data["total"] == 16
     items = data["items"]
-    assert len(items) == 15
+    assert len(items) == 16
 
     last_created = None
     for config in items:


### PR DESCRIPTION
Fixes #2838 

- Ensure `failOnContentCheck` cannot be set when a browser profile is not set in crawlconfig POST and PATCH endpoints, else return 400 with detail `fail_on_content_check_requires_profile`
- Add migration to unset `failOnContentCheck` for any workflows in the database that currently have that flag enabled without a profile configured

I've added very detailed backend tests for the validation, and manually tested the migration on a local instance.