### PR TITLE
fix: Prevent showing "not found" page when opening link in new tab

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -849,6 +849,11 @@ export class App extends BtrixElement {
 
       case "org": {
         if (!this.isUserInCurrentOrg) {
+          if (this.authState && !this.userInfo) {
+            // Wait for user info to finish loading
+            return this.renderSpinner();
+          }
+
           return this.renderNotFoundPage();
         }
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2848

## Changes

Fixes "not found" page briefly being shown while app page is loading in a new tab.

## Manual testing

Test using repro instructions in https://github.com/webrecorder/browsertrix/issues/2848.

## Follow-ups

This may potentially impact WIP in https://github.com/webrecorder/browsertrix/pull/2699