### PR TITLE
Download archived items as single WACZ file when possible via new download endpoint query parameter

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -1373,9 +1373,13 @@ def init_crawls_api(
         "/orgs/{oid}/crawls/{crawl_id}/download", tags=["crawls"], response_model=bytes
     )
     async def download_crawl_as_single_wacz(
-        crawl_id: str, org: Organization = Depends(org_viewer_dep)
+        crawl_id: str,
+        preferSingleWACZ: bool = False,
+        org: Organization = Depends(org_viewer_dep),
     ):
-        return await ops.download_crawl_as_single_wacz(crawl_id, org)
+        return await ops.download_crawl_as_single_wacz(
+            crawl_id, org, prefer_single_wacz=preferSingleWACZ
+        )
 
     # QA APIs
     # ---------------------

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -836,7 +836,7 @@ class StorageOps:
     ) -> Iterator[bytes]:
         """generate streaming zip as sync"""
 
-        def get_file(path: str) -> Iterable[bytes]:
+        def get_file(path: str) -> Iterator[bytes]:
             path = self.resolve_internal_access_path(path)
             r = requests.get(path, stream=True, timeout=None)
             yield from r.iter_content(CHUNK_SIZE)

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -829,9 +829,22 @@ class StorageOps:
                 yield from file_stream
 
     def _sync_dl(
-        self, metadata: dict[str, str], all_files: List[CrawlFileOut]
+        self,
+        metadata: dict[str, str],
+        all_files: List[CrawlFileOut],
+        prefer_single_wacz: bool = False,
     ) -> Iterator[bytes]:
         """generate streaming zip as sync"""
+
+        def get_file(path: str) -> Iterable[bytes]:
+            path = self.resolve_internal_access_path(path)
+            r = requests.get(path, stream=True, timeout=None)
+            yield from r.iter_content(CHUNK_SIZE)
+
+        if len(all_files) == 1 and prefer_single_wacz:
+            wacz_file = all_files[0]
+            return get_file(wacz_file.path)
+
         datapackage = {
             "profile": "multi-wacz-package",
             "resources": [
@@ -850,11 +863,6 @@ class StorageOps:
 
         def get_datapackage() -> Iterable[bytes]:
             yield datapackage_bytes
-
-        def get_file(path: str) -> Iterable[bytes]:
-            path = self.resolve_internal_access_path(path)
-            r = requests.get(path, stream=True, timeout=None)
-            yield from r.iter_content(CHUNK_SIZE)
 
         def member_files() -> (
             Iterable[tuple[str, datetime, int, Method, Iterable[bytes]]]
@@ -884,13 +892,18 @@ class StorageOps:
         return cast(Iterator[bytes], stream_zip(member_files(), chunk_size=CHUNK_SIZE))
 
     async def download_streaming_wacz(
-        self, metadata: dict[str, str], files: List[CrawlFileOut]
+        self,
+        metadata: dict[str, str],
+        files: List[CrawlFileOut],
+        prefer_single_wacz: bool = False,
     ) -> Iterator[bytes]:
         """return an iter for downloading a stream nested wacz file
         from list of files"""
         loop = asyncio.get_event_loop()
 
-        resp = await loop.run_in_executor(None, self._sync_dl, metadata, files)
+        resp = await loop.run_in_executor(
+            None, self._sync_dl, metadata, files, prefer_single_wacz
+        )
 
         return resp
 

--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -220,7 +220,7 @@ export class WorkflowActionMenu extends BtrixElement {
     return html`
       <sl-menu slot="submenu">
         <btrix-menu-item-link
-          href=${`/api/orgs/${this.orgId}/all-crawls/${latestCrawl.id}/download?auth_bearer=${authToken}`}
+          href=${`/api/orgs/${this.orgId}/all-crawls/${latestCrawl.id}/download?auth_bearer=${authToken}&preferSingleWACZ=true`}
           ?disabled=${!latestCrawl.fileSize}
           download
         >

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -342,7 +342,7 @@ export class ArchivedItemDetail extends BtrixElement {
           html` ${this.renderTitle(this.tabLabels.files)}
             <sl-tooltip content=${msg("Download Files as Multi-WACZ")}>
               <sl-button
-                href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}`}
+                href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}&preferSingleWACZ=true`}
                 download=${`browsertrix-${this.itemId}.wacz`}
                 size="small"
                 variant="primary"
@@ -671,7 +671,7 @@ export class ArchivedItemDetail extends BtrixElement {
                 `,
               )}
               <btrix-menu-item-link
-                href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}`}
+                href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}&preferSingleWACZ=true`}
                 download
               >
                 <sl-icon name="cloud-download" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -340,7 +340,9 @@ export class ArchivedItemDetail extends BtrixElement {
       case "files":
         sectionContent = this.renderPanel(
           html` ${this.renderTitle(this.tabLabels.files)}
-            <sl-tooltip content=${msg("Download Files as Multi-WACZ")}>
+            <sl-tooltip
+              content=${msg("Download all files as a single WACZ file")}
+            >
               <sl-button
                 href=${`/api/orgs/${this.orgId}/all-crawls/${this.itemId}/download?auth_bearer=${authToken}&preferSingleWACZ=true`}
                 download=${`browsertrix-${this.itemId}.wacz`}
@@ -348,7 +350,7 @@ export class ArchivedItemDetail extends BtrixElement {
                 variant="primary"
               >
                 <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-                ${msg("Download Files")}
+                ${msg("Download All")}
               </sl-button>
             </sl-tooltip>`,
           this.renderFiles(),

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -602,7 +602,7 @@ export class CrawlsList extends BtrixElement {
         isSuccessfullyFinished(item),
         () => html`
           <btrix-menu-item-link
-            href=${`/api/orgs/${this.orgId}/all-crawls/${item.id}/download?auth_bearer=${authToken}`}
+            href=${`/api/orgs/${this.orgId}/all-crawls/${item.id}/download?auth_bearer=${authToken}&preferSingleWACZ=true`}
             download
           >
             <sl-icon name="cloud-download" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -719,7 +719,7 @@ export class WorkflowDetail extends BtrixElement {
       const authToken = this.authState?.headers.Authorization.split(" ")[1];
       const disableDownload = this.isRunning;
       const disableReplay = !latestCrawl.fileSize;
-      const replayHref = `/api/orgs/${this.orgId}/all-crawls/${latestCrawlId}/download?auth_bearer=${authToken}`;
+      const replayHref = `/api/orgs/${this.orgId}/all-crawls/${latestCrawlId}/download?auth_bearer=${authToken}&preferSingleWACZ=true`;
       const replayFilename = `browsertrix-${latestCrawlId}.wacz`;
 
       return html`


### PR DESCRIPTION
Fixes #2648 

Replaces https://github.com/webrecorder/browsertrix/pull/2805

This PR introduces a `preferSingleWACZ` query parameter to the `/all-crawls/<crawl_id>/download` and `/crawls/<crawl_id>/download` endpoints. When set to true, these endpoints will only create multi-WACZs when a crawl has more than one WACZ file, and otherwise will stream the original crawl WACZ.

This flag is not enabled by default to prevent introducing breaking changes to the API, but the frontend is updated to use it in all places where it seemed appropriate.

A new backend test is also added to account for the change.

Comments and suggestions on other ways to implement this behavior are very welcome!