### PR TITLE
Add archived item tag filter

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -991,7 +991,7 @@ def init_base_crawls_api(app, user_dep, *args):
         page: int = 1,
         userid: Optional[UUID] = None,
         name: Optional[str] = None,
-        state: Optional[str] = None,
+        state: Annotated[list[str] | None, Query()] = None,
         firstSeed: Optional[str] = None,
         description: Optional[str] = None,
         tags: Annotated[list[str] | None, Query()] = None,
@@ -1009,7 +1009,12 @@ def init_base_crawls_api(app, user_dep, *args):
         sortBy: Optional[str] = "finished",
         sortDirection: int = -1,
     ):
-        states = state.split(",") if state else None
+        # Support both comma-separated values and multiple search parameters
+        # e.g. `?state=running,paused` and `?state=running&state=paused`
+        if state and len(state) == 1:
+            states = state[0].split(",")
+        else:
+            states = state if state else None
 
         if firstSeed:
             firstSeed = urllib.parse.unquote(firstSeed)

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -21,7 +21,6 @@ import urllib.parse
 import asyncio
 from fastapi import HTTPException, Depends, Query, Request
 from fastapi.responses import StreamingResponse
-from motor.motor_asyncio import AsyncIOMotorCollection
 import pymongo
 
 from .models import (

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -91,7 +91,7 @@ class BaseCrawlOps:
         event_webhook_ops: EventWebhookOps,
         background_job_ops: BackgroundJobOps,
     ):
-        self.crawls: AsyncIOMotorCollection[Any] = mdb["crawls"]  # pyright: ignore[reportExplicitAny]
+        self.crawls = mdb["crawls"]
         self.presigned_urls = mdb["presigned_urls"]
         self.crawl_configs = crawl_configs
         self.user_manager = users
@@ -976,7 +976,8 @@ class BaseCrawlOps:
         """get distinct tags from all archived items for this org"""
         tags = await self.crawls.aggregate(
             [
-                # Match only against the states of archived items that might be displayed in the frontend
+                # Match only against the states of archived items that might be
+                # displayed in the frontend
                 {"$match": {"oid": org.id, "state": {"$in": SUCCESSFUL_STATES}}},
                 {"$unwind": "$tags"},
                 {"$group": {"_id": "$tags", "count": {"$sum": 1}}},
@@ -1029,7 +1030,7 @@ def init_base_crawls_api(app, user_dep, *args):
         # Support both comma-separated values and multiple search parameters
         # e.g. `?state=running,paused` and `?state=running&state=paused`
         if state and len(state) == 1:
-            states = state[0].split(",")
+            states: list[str] | None = state[0].split(",")
         else:
             states = state if state else None
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -1252,7 +1252,7 @@ def init_crawls_api(
         page: int = 1,
         userid: Optional[UUID] = None,
         cid: Optional[UUID] = None,
-        state: Optional[str] = None,
+        state: Annotated[list[str] | None, Query()] = None,
         firstSeed: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
@@ -1269,10 +1269,12 @@ def init_crawls_api(
         sortBy: Optional[str] = None,
         sortDirection: int = -1,
     ):
-        # pylint: disable=duplicate-code
-        states = []
-        if state:
-            states = state.split(",")
+        # Support both comma-separated values and multiple search parameters
+        # e.g. `?state=running,paused` and `?state=running&state=paused`
+        if state and len(state) == 1:
+            states = state[0].split(",")
+        else:
+            states = state if state else None
 
         if firstSeed:
             firstSeed = urllib.parse.unquote(firstSeed)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -1272,7 +1272,7 @@ def init_crawls_api(
         # Support both comma-separated values and multiple search parameters
         # e.g. `?state=running,paused` and `?state=running&state=paused`
         if state and len(state) == 1:
-            states = state[0].split(",")
+            states: list[str] | None = state[0].split(",")
         else:
             states = state if state else None
 

--- a/frontend/src/components/ui/search-combobox.ts
+++ b/frontend/src/components/ui/search-combobox.ts
@@ -41,8 +41,8 @@ export class SearchCombobox<T> extends LitElement {
   @property({ type: String })
   placeholder: string = msg("Start typing to search");
 
-  @state()
-  private searchByValue = "";
+  @property({ type: String })
+  searchByValue = "";
 
   private get hasSearchStr() {
     return this.searchByValue.length >= MIN_SEARCH_LENGTH;

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -1,0 +1,46 @@
+import { type ReactiveController, type ReactiveControllerHost } from "lit";
+
+import { SearchParamsController } from "@/controllers/searchParams";
+
+export class SearchParamsValue<T> implements ReactiveController {
+  host: ReactiveControllerHost;
+
+  private _value: T;
+
+  private readonly searchParams;
+  private readonly encoder: (
+    value: T,
+    params: URLSearchParams,
+  ) => URLSearchParams;
+  private readonly decoder: (params: URLSearchParams) => T;
+
+  get value(): T {
+    return this._value;
+  }
+  set value(value: T) {
+    this._value = value;
+    this.searchParams.update((params) => this.encoder(value, params));
+  }
+
+  constructor(
+    host: ReactiveControllerHost,
+    encoder: (value: T, params: URLSearchParams) => URLSearchParams,
+    decoder: (params: URLSearchParams) => T,
+    options?: { initial?: (valueFromSearchParams?: T) => T },
+  ) {
+    (this.host = host).addController(this);
+    this.encoder = encoder;
+    this.decoder = decoder;
+    this.searchParams = new SearchParamsController(this.host, (params) => {
+      this._value = this.decoder(params);
+      this.host.requestUpdate();
+    });
+
+    this._value = options?.initial
+      ? options.initial(this.decoder(this.searchParams.searchParams))
+      : this.decoder(this.searchParams.searchParams);
+  }
+
+  hostConnected() {}
+  hostDisconnected() {}
+}

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -2,6 +2,54 @@ import { type ReactiveController, type ReactiveControllerHost } from "lit";
 
 import { SearchParamsController } from "@/controllers/searchParams";
 
+/**
+ * Persists arbitrary state to the URL search params via an encoder and decoder.
+ *
+ * Automatically updates the URL search params when the value changes, and
+ * updates the host when the URL search params change. Updates to the value push
+ * state to the history stack, and so browser history navigation can be used to
+ * navigate between states.
+ *
+ * ## Usage
+ *
+ * As a reactive controller, the class must be passed a host as the first
+ * argument. The second argument is the encoder, which receives the current
+ * (incoming) value and the current URLSearchParams object, and returns a
+ * modified URLSearchParams object that represents the new value. The third
+ * argument is the decoder, which receives the current URLSearchParams object
+ * and converts this into a valid value.
+ *
+ * To access the value, use the `value` property. Setting the value will update
+ * the URL search params and push state to the history stack, and reading it is
+ * cached, so performance should be good no matter what.
+ *
+ * There is currently one option available via a third parameter, `initial`,
+ * which can be used to modify the initial value based on the URL search params
+ * at the time of initialization. This is useful if there's a default value that
+ * should be used if the URL search params are empty, but otherwise the value
+ * from the URL should be prioritized, for example.
+ *
+ * Example usage:
+ * ```ts
+ * class MyComponent extends LitElement {
+ *   query = new SearchParamsValue<string>(
+ *     this,
+ *     (value, params) => {
+ *       if (value) {
+ *         params.set("q", value);
+ *       } else {
+ *         params.delete("q");
+ *       }
+ *       return params;
+ *     },
+ *     (params) => params.get("q") ?? ""
+ *   );
+ *   render() {
+ *     return html`<input .value=${this.query.value} @input=${(e) => {this.query.value = e.target.value}} />`;
+ *   }
+ * }
+ * ```
+ */
 export class SearchParamsValue<T> implements ReactiveController {
   host: ReactiveControllerHost;
 

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -20,6 +20,7 @@ export class SearchParamsValue<T> implements ReactiveController {
   set value(value: T) {
     this._value = value;
     this.searchParams.update((params) => this.encoder(value, params));
+    this.host.requestUpdate();
   }
 
   constructor(

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -19,9 +19,9 @@ import { SearchParamsController } from "@/controllers/searchParams";
  * argument is the decoder, which receives the current URLSearchParams object
  * and converts this into a valid value.
  *
- * To access the value, use the `value` property. Setting the value will update
- * the URL search params and push state to the history stack, and reading it is
- * cached, so performance should be good no matter what.
+ * To access the value, use the `value` property. Setting the value with
+ * `setValue` will update the URL search params and push state to the history
+ * stack, and reading it is cached, so performance should be good no matter what.
  *
  * There is currently one option available via a third parameter, `initial`,
  * which can be used to modify the initial value based on the URL search params
@@ -45,7 +45,7 @@ import { SearchParamsController } from "@/controllers/searchParams";
  *     (params) => params.get("q") ?? ""
  *   );
  *   render() {
- *     return html`<input .value=${this.query.value} @input=${(e) => {this.query.value = e.target.value}} />`;
+ *     return html`<input .value=${this.query.value} @input=${(e) => {this.query.setValue(e.target.value)}} />`;
  *   }
  * }
  * ```
@@ -62,10 +62,10 @@ export class SearchParamsValue<T> implements ReactiveController {
   ) => URLSearchParams;
   private readonly decoder: (params: URLSearchParams) => T;
 
-  get value(): T {
+  public get value(): T {
     return this._value;
   }
-  set value(value: T) {
+  public setValue(value: T) {
     this._value = value;
     this.searchParams.update((params) => this.encoder(value, params));
     this.host.requestUpdate();

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -1,0 +1,256 @@
+import { localized, msg, str } from "@lit/localize";
+import type {
+  SlChangeEvent,
+  SlCheckbox,
+  SlInput,
+  SlInputEvent,
+} from "@shoelace-style/shoelace";
+import Fuse from "fuse.js";
+import { html, type PropertyValues } from "lit";
+import {
+  customElement,
+  property,
+  query,
+  queryAll,
+  state,
+} from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
+import { isFocusable } from "tabbable";
+
+import { CrawlStatus } from "./crawl-status";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import type { BtrixChangeEvent } from "@/events/btrix-change";
+import { type CrawlState } from "@/types/crawlState";
+import { finishedCrawlStates } from "@/utils/crawler";
+
+const MAX_STATES_IN_LABEL = 2;
+
+type ChangeArchivedItemStateEventDetails = CrawlState[];
+
+export type BtrixChangeArchivedItemStateFilterEvent =
+  BtrixChangeEvent<ChangeArchivedItemStateEventDetails>;
+
+/**
+ * @fires btrix-change
+ */
+@customElement("btrix-archived-item-state-filter")
+@localized()
+export class ArchivedItemStateFilter extends BtrixElement {
+  @property({ type: Array })
+  states?: CrawlState[];
+
+  @state()
+  private searchString = "";
+
+  @query("sl-input")
+  private readonly input?: SlInput | null;
+
+  @queryAll("sl-checkbox")
+  private readonly checkboxes!: NodeListOf<SlCheckbox>;
+
+  private readonly fuse = new Fuse<CrawlState>(finishedCrawlStates);
+
+  @state()
+  private get selectedStates() {
+    return Array.from(this.selected.entries())
+      .filter(([_tag, selected]) => selected)
+      .map(([tag]) => tag);
+  }
+
+  private selected = new Map<CrawlState, boolean>();
+
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("states")) {
+      if (this.states) {
+        this.selected = new Map(this.states.map((state) => [state, true]));
+      } else if (changedProperties.get("states")) {
+        this.selected = new Map();
+      }
+    }
+  }
+
+  render() {
+    const options = this.searchString
+      ? this.fuse.search(this.searchString)
+      : finishedCrawlStates.map((state) => ({ item: state }));
+    return html`
+      <btrix-filter-chip
+        ?checked=${!!this.states?.length}
+        selectFromDropdown
+        stayOpenOnChange
+        @sl-after-show=${() => {
+          if (this.input && !this.input.disabled) {
+            this.input.focus();
+          }
+        }}
+        @sl-after-hide=${() => {
+          this.searchString = "";
+
+          this.dispatchEvent(
+            new CustomEvent<
+              BtrixChangeEvent<ChangeArchivedItemStateEventDetails>["detail"]
+            >("btrix-change", {
+              detail: { value: this.selectedStates },
+            }),
+          );
+        }}
+      >
+        ${this.states?.length
+          ? html`<span class="opacity-75">${msg("Status")}</span>
+              ${this.renderStatesInLabel(this.states)}`
+          : msg("Status")}
+
+        <div
+          slot="dropdown-content"
+          class="flex max-h-[var(--auto-size-available-height)] max-w-[var(--auto-size-available-width)] flex-col overflow-hidden rounded border bg-white text-left"
+        >
+          <header
+            class="flex-shrink-0 flex-grow-0 overflow-hidden rounded-t border-b bg-white pb-3"
+          >
+            <sl-menu-label
+              class="min-h-[var(--sl-input-height-small)] part-[base]:flex part-[base]:items-center part-[base]:justify-between part-[base]:gap-4 part-[base]:px-3"
+            >
+              <div
+                id="tag-list-label"
+                class="leading-[var(--sl-input-height-small)]"
+              >
+                ${msg("Filter by Status")}
+              </div>
+              ${this.states?.length
+                ? html`<sl-button
+                    variant="text"
+                    size="small"
+                    class="part-[label]:px-0"
+                    @click=${() => {
+                      this.checkboxes.forEach((checkbox) => {
+                        checkbox.checked = false;
+                      });
+
+                      this.dispatchEvent(
+                        new CustomEvent<
+                          BtrixChangeEvent<ChangeArchivedItemStateEventDetails>["detail"]
+                        >("btrix-change", {
+                          detail: {
+                            value: [],
+                          },
+                        }),
+                      );
+                    }}
+                    >${msg("Clear")}</sl-button
+                  >`
+                : html`<span class="opacity-50">${msg("Any")}</span>`}
+            </sl-menu-label>
+
+            <div class="flex gap-2 px-3">${this.renderSearch()}</div>
+          </header>
+
+          ${options.length > 0
+            ? this.renderList(options)
+            : html`<div class="p-3 text-neutral-500">
+                ${msg("No matching states found.")}
+              </div>`}
+        </div>
+      </btrix-filter-chip>
+    `;
+  }
+
+  private renderStatesInLabel(states: string[]) {
+    const formatter = this.localize.list(
+      states.length > MAX_STATES_IN_LABEL
+        ? [
+            ...states.slice(0, MAX_STATES_IN_LABEL),
+            msg(
+              str`${this.localize.number(states.length - MAX_STATES_IN_LABEL)} more`,
+            ),
+          ]
+        : states,
+      { type: "disjunction" },
+    );
+
+    return formatter.map((part, index, array) =>
+      part.type === "literal"
+        ? html`<span class="opacity-75">${part.value}</span>`
+        : states.length > MAX_STATES_IN_LABEL && index === array.length - 1
+          ? html`<span class="text-primary-500"> ${part.value} </span>`
+          : html`<span>${this.renderLabel(part.value as CrawlState)}</span>`,
+    );
+  }
+
+  private renderLabel(state: CrawlState) {
+    const { icon, label } = CrawlStatus.getContent({ state });
+    return html`${icon}${label}`;
+  }
+
+  private renderSearch() {
+    return html`
+      <label for="state-search" class="sr-only"
+        >${msg("Filter statuses")}</label
+      >
+      <sl-input
+        class="min-w-[30ch]"
+        id="state-search"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded="true"
+        aria-controls="state-listbox"
+        aria-activedescendant="state-selected-option"
+        value=${this.searchString}
+        placeholder=${msg("Search for status")}
+        size="small"
+        @sl-input=${(e: SlInputEvent) =>
+          (this.searchString = (e.target as SlInput).value)}
+        @keydown=${(e: KeyboardEvent) => {
+          // Prevent moving to next tabbable element since dropdown should close
+          if (e.key === "Tab") e.preventDefault();
+          if (e.key === "ArrowDown" && isFocusable(this.checkboxes[0])) {
+            this.checkboxes[0].focus();
+          }
+        }}
+      >
+        <sl-icon slot="prefix" name="search"></sl-icon>
+      </sl-input>
+    `;
+  }
+
+  private renderList(opts: { item: CrawlState }[]) {
+    const state = (state: CrawlState) => {
+      const checked = this.selected.get(state) === true;
+
+      const { icon, label } = CrawlStatus.getContent({ state });
+
+      return html`
+        <li role="option" aria-checked=${checked}>
+          <sl-checkbox
+            class="w-full part-[label]:flex part-[base]:w-full part-[label]:w-full part-[label]:items-center part-[label]:justify-between part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
+            value=${state}
+            ?checked=${checked}
+            >${icon}${label}
+          </sl-checkbox>
+        </li>
+      `;
+    };
+
+    return html`
+      <ul
+        id="state-listbox"
+        class="flex-1 overflow-auto p-1"
+        role="listbox"
+        aria-labelledby="tag-list-label"
+        aria-multiselectable="true"
+        @sl-change=${async (e: SlChangeEvent) => {
+          const { checked, value } = e.target as SlCheckbox;
+
+          this.selected.set(value as CrawlState, checked);
+          this.requestUpdate("selectedStates");
+        }}
+      >
+        ${repeat(
+          opts,
+          ({ item }) => item,
+          ({ item }) => state(item),
+        )}
+      </ul>
+    `;
+  }
+}

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -23,6 +23,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type CrawlState } from "@/types/crawlState";
 import { finishedCrawlStates } from "@/utils/crawler";
+import { tw } from "@/utils/tailwind";
 
 const MAX_STATES_IN_LABEL = 2;
 
@@ -179,7 +180,10 @@ export class ArchivedItemStateFilter extends BtrixElement {
 
   private renderLabel(state: CrawlState) {
     const { icon, label } = CrawlStatus.getContent({ state });
-    return html`${icon}${label}`;
+    return html`<span
+      class=${tw`inline-flex items-baseline gap-1 [&_sl-icon]:relative [&_sl-icon]:bottom-[-0.05rem]`}
+      >${icon}${label}</span
+    >`;
   }
 
   private renderSearch() {
@@ -225,7 +229,12 @@ export class ArchivedItemStateFilter extends BtrixElement {
             class="w-full part-[label]:flex part-[base]:w-full part-[label]:w-full part-[label]:items-center part-[label]:justify-between part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
             value=${state}
             ?checked=${checked}
-            >${icon}${label}
+          >
+            <span class="contents"
+              >${label}<span class="ml-2 flex place-content-center"
+                >${icon}</span
+              ></span
+            >
           </sl-checkbox>
         </li>
       `;

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -1,0 +1,319 @@
+import { localized, msg, str } from "@lit/localize";
+import { Task } from "@lit/task";
+import type {
+  SlChangeEvent,
+  SlCheckbox,
+  SlInput,
+  SlInputEvent,
+} from "@shoelace-style/shoelace";
+import clsx from "clsx";
+import Fuse from "fuse.js";
+import { html, nothing, type PropertyValues } from "lit";
+import {
+  customElement,
+  property,
+  query,
+  queryAll,
+  state,
+} from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
+import { isFocusable } from "tabbable";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import type { BtrixChangeEvent } from "@/events/btrix-change";
+import { type WorkflowTag, type WorkflowTags } from "@/types/workflow";
+import { stopProp } from "@/utils/events";
+import { tw } from "@/utils/tailwind";
+
+const MAX_TAGS_IN_LABEL = 5;
+
+type ChangeArchivedItemTagEventDetails =
+  | { tags: string[]; type: "and" | "or" }
+  | undefined;
+
+export type BtrixChangeArchivedItemTagFilterEvent =
+  BtrixChangeEvent<ChangeArchivedItemTagEventDetails>;
+
+/**
+ * @fires btrix-change
+ */
+@customElement("btrix-archived-item-tag-filter")
+@localized()
+export class ArchivedItemTagFilter extends BtrixElement {
+  @property({ type: Array })
+  tags?: string[];
+
+  @state()
+  private searchString = "";
+
+  @query("sl-input")
+  private readonly input?: SlInput | null;
+
+  @queryAll("sl-checkbox")
+  private readonly checkboxes!: NodeListOf<SlCheckbox>;
+
+  private readonly fuse = new Fuse<WorkflowTag>([], {
+    keys: ["tag"],
+  });
+
+  @state()
+  private get selectedTags() {
+    return Array.from(this.selected.entries())
+      .filter(([_tag, selected]) => selected)
+      .map(([tag]) => tag);
+  }
+
+  private selected = new Map<string, boolean>();
+
+  @state()
+  private type: "and" | "or" = "or";
+
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("tags")) {
+      if (this.tags) {
+        this.selected = new Map(this.tags.map((tag) => [tag, true]));
+      } else if (changedProperties.get("tags")) {
+        this.selected = new Map();
+      }
+    }
+  }
+
+  private readonly orgTagsTask = new Task(this, {
+    task: async () => {
+      const { tags } = await this.api.fetch<WorkflowTags>(
+        `/orgs/${this.orgId}/crawlconfigs/tagCounts`,
+      );
+
+      this.fuse.setCollection(tags);
+
+      // Match fuse shape
+      return tags.map((item) => ({ item }));
+    },
+    args: () => [] as const,
+  });
+
+  render() {
+    return html`
+      <btrix-filter-chip
+        ?checked=${!!this.tags?.length}
+        selectFromDropdown
+        stayOpenOnChange
+        @sl-after-show=${() => {
+          if (this.input && !this.input.disabled) {
+            this.input.focus();
+          }
+        }}
+        @sl-after-hide=${() => {
+          this.searchString = "";
+
+          this.dispatchEvent(
+            new CustomEvent<
+              BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
+            >("btrix-change", {
+              detail: {
+                value: this.selectedTags.length
+                  ? { tags: this.selectedTags, type: this.type }
+                  : undefined,
+              },
+            }),
+          );
+        }}
+      >
+        ${this.tags?.length
+          ? html`<span class="opacity-75">${msg("Tagged")}</span>
+              ${this.renderTagsInLabel(this.tags)}`
+          : msg("Tags")}
+
+        <div
+          slot="dropdown-content"
+          class="flex max-h-[var(--auto-size-available-height)] max-w-[var(--auto-size-available-width)] flex-col overflow-hidden rounded border bg-white text-left"
+        >
+          <header
+            class=${clsx(
+              this.orgTagsTask.value && tw`border-b`,
+              tw`flex-shrink-0 flex-grow-0 overflow-hidden rounded-t bg-white pb-3`,
+            )}
+          >
+            <sl-menu-label
+              class="min-h-[var(--sl-input-height-small)] part-[base]:flex part-[base]:items-center part-[base]:justify-between part-[base]:gap-4 part-[base]:px-3"
+            >
+              <div
+                id="tag-list-label"
+                class="leading-[var(--sl-input-height-small)]"
+              >
+                ${msg("Filter by Tags")}
+              </div>
+              ${this.tags?.length
+                ? html`<sl-button
+                    variant="text"
+                    size="small"
+                    class="part-[label]:px-0"
+                    @click=${() => {
+                      this.checkboxes.forEach((checkbox) => {
+                        checkbox.checked = false;
+                      });
+
+                      this.type = "or";
+
+                      this.dispatchEvent(
+                        new CustomEvent<
+                          BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
+                        >("btrix-change", {
+                          detail: {
+                            value: undefined,
+                          },
+                        }),
+                      );
+                    }}
+                    >${msg("Clear")}</sl-button
+                  >`
+                : nothing}
+            </sl-menu-label>
+
+            <div class="flex gap-2 px-3">
+              ${this.renderSearch()}
+              <sl-radio-group
+                size="small"
+                value=${this.type}
+                @sl-change=${(event: SlChangeEvent) => {
+                  this.type = (event.target as HTMLInputElement).value as
+                    | "or"
+                    | "and";
+                }}
+                @sl-after-hide=${stopProp}
+              >
+                <sl-tooltip hoist content=${msg("Any of the selected tags")}>
+                  <sl-radio-button value="or" checked>
+                    <sl-icon name="union" slot="prefix"></sl-icon>
+                    ${msg("Any")}
+                  </sl-radio-button>
+                </sl-tooltip>
+                <sl-tooltip hoist content=${msg("All of the selected tags")}>
+                  <sl-radio-button value="and">
+                    <sl-icon name="intersect" slot="prefix"></sl-icon>
+                    ${msg("All")}
+                  </sl-radio-button>
+                </sl-tooltip>
+              </sl-radio-group>
+            </div>
+          </header>
+
+          ${this.orgTagsTask.render({
+            complete: (tags) => {
+              let options = tags;
+
+              if (tags.length && this.searchString) {
+                options = this.fuse.search(this.searchString);
+              }
+
+              if (options.length) {
+                return this.renderList(options);
+              }
+
+              return html`<div class="p-3 text-neutral-500">
+                ${this.searchString
+                  ? msg("No matching tags found.")
+                  : msg("No tags found.")}
+              </div>`;
+            },
+          })}
+        </div>
+      </btrix-filter-chip>
+    `;
+  }
+
+  private renderTagsInLabel(tags: string[]) {
+    const formatter2 = this.localize.list(
+      tags.length > MAX_TAGS_IN_LABEL
+        ? [
+            ...tags.slice(0, MAX_TAGS_IN_LABEL),
+            msg(
+              str`${this.localize.number(tags.length - MAX_TAGS_IN_LABEL)} more`,
+            ),
+          ]
+        : tags,
+      { type: this.type === "and" ? "conjunction" : "disjunction" },
+    );
+
+    return formatter2.map((part, index, array) =>
+      part.type === "literal"
+        ? html`<span class="opacity-75">${part.value}</span>`
+        : tags.length > MAX_TAGS_IN_LABEL && index === array.length - 1
+          ? html`<span class="text-primary-500"> ${part.value} </span>`
+          : html`<span>${part.value}</span>`,
+    );
+  }
+
+  private renderSearch() {
+    return html`
+      <label for="tag-search" class="sr-only">${msg("Filter tags")}</label>
+      <sl-input
+        class="min-w-[30ch]"
+        id="tag-search"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded="true"
+        aria-controls="tag-listbox"
+        aria-activedescendant="tag-selected-option"
+        value=${this.searchString}
+        placeholder=${msg("Search for tag")}
+        size="small"
+        ?disabled=${!this.orgTagsTask.value?.length}
+        @sl-input=${(e: SlInputEvent) =>
+          (this.searchString = (e.target as SlInput).value)}
+        @keydown=${(e: KeyboardEvent) => {
+          // Prevent moving to next tabbable element since dropdown should close
+          if (e.key === "Tab") e.preventDefault();
+          if (e.key === "ArrowDown" && isFocusable(this.checkboxes[0])) {
+            this.checkboxes[0].focus();
+          }
+        }}
+      >
+        ${this.orgTagsTask.render({
+          pending: () => html`<sl-spinner slot="prefix"></sl-spinner>`,
+          complete: () => html`<sl-icon slot="prefix" name="search"></sl-icon>`,
+        })}
+      </sl-input>
+    `;
+  }
+
+  private renderList(opts: { item: WorkflowTag }[]) {
+    const tag = (tag: WorkflowTag) => {
+      const checked = this.selected.get(tag.tag) === true;
+
+      return html`
+        <li role="option" aria-checked=${checked}>
+          <sl-checkbox
+            class="w-full part-[label]:flex part-[base]:w-full part-[label]:w-full part-[label]:items-center part-[label]:justify-between part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
+            value=${tag.tag}
+            ?checked=${checked}
+            >${tag.tag}
+            <btrix-badge pill variant="cyan">${tag.count}</btrix-badge>
+          </sl-checkbox>
+        </li>
+      `;
+    };
+
+    return html`
+      <ul
+        id="tag-listbox"
+        class="flex-1 overflow-auto p-1"
+        role="listbox"
+        aria-labelledby="tag-list-label"
+        aria-multiselectable="true"
+        @sl-change=${async (e: SlChangeEvent) => {
+          const { checked, value } = e.target as SlCheckbox;
+
+          this.selected.set(value, checked);
+          this.requestUpdate("selectedTags");
+        }}
+      >
+        ${repeat(
+          opts,
+          ({ item }) => item,
+          ({ item }) => tag(item),
+        )}
+      </ul>
+    `;
+  }
+}

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -81,7 +81,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
   private readonly orgTagsTask = new Task(this, {
     task: async () => {
       const { tags } = await this.api.fetch<WorkflowTags>(
-        `/orgs/${this.orgId}/crawlconfigs/tagCounts`,
+        `/orgs/${this.orgId}/all-crawls/tagCounts`,
       );
 
       this.fuse.setCollection(tags);

--- a/frontend/src/features/archived-items/index.ts
+++ b/frontend/src/features/archived-items/index.ts
@@ -1,4 +1,6 @@
 import("./archived-item-list");
+import("./archived-item-state-filter");
+import("./archived-item-tag-filter");
 import("./crawl-list");
 import("./crawl-log-table");
 import("./crawl-logs");

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -255,7 +255,15 @@ export class CrawlsList extends BtrixElement {
 
   private readonly archivedItemsTask = new Task(this, {
     task: async (
-      [itemType, pagination, orderBy, filterBy, filterByCurrentUser],
+      [
+        itemType,
+        pagination,
+        orderBy,
+        filterBy,
+        filterByCurrentUser,
+        filterByTags,
+        filterByTagsType,
+      ],
       { signal },
     ) => {
       try {
@@ -266,6 +274,8 @@ export class CrawlsList extends BtrixElement {
             orderBy,
             filterBy,
             filterByCurrentUser,
+            filterByTags,
+            filterByTagsType,
           },
           signal,
         );
@@ -296,9 +306,11 @@ export class CrawlsList extends BtrixElement {
       [
         this.itemType,
         this.pagination,
-        this.orderBy,
-        this.filterBy,
-        this.filterByCurrentUser,
+        this.orderBy.value,
+        this.filterBy.value,
+        this.filterByCurrentUser.value,
+        this.filterByTags.value,
+        this.filterByTagsType.value,
       ] as const,
   });
 
@@ -925,29 +937,27 @@ export class CrawlsList extends BtrixElement {
     params: {
       itemType: CrawlsList["itemType"];
       pagination: CrawlsList["pagination"];
-      orderBy: CrawlsList["orderBy"];
-      filterBy: CrawlsList["filterBy"];
-      filterByCurrentUser: CrawlsList["filterByCurrentUser"];
-      filterbyTags: CrawlsList["filterByTags"];
-      filterbyTagsType: CrawlsList["filterByTagsType"];
+      orderBy: CrawlsList["orderBy"]["value"];
+      filterBy: CrawlsList["filterBy"]["value"];
+      filterByCurrentUser: CrawlsList["filterByCurrentUser"]["value"];
+      filterbyTags: CrawlsList["filterByTags"]["value"];
+      filterbyTagsType: CrawlsList["filterByTagsType"]["value"];
     },
     signal: AbortSignal,
   ) {
     const query = queryString.stringify(
       {
-        ...params.filterBy.value,
-        state: params.filterBy.value.state?.length
-          ? params.filterBy.value.state
+        ...params.filterBy,
+        state: params.filterBy.state?.length
+          ? params.filterBy.state
           : finishedCrawlStates,
         page: params.pagination.page,
         pageSize: params.pagination.pageSize,
-        tag: params.filterbyTags.value,
-        tagMatch: params.filterbyTagsType.value,
-        userid: params.filterByCurrentUser.value
-          ? this.userInfo!.id
-          : undefined,
-        sortBy: params.orderBy.value.field,
-        sortDirection: params.orderBy.value.direction === "desc" ? -1 : 1,
+        tags: params.filterbyTags,
+        tagMatch: params.filterbyTagsType,
+        userid: params.filterByCurrentUser ? this.userInfo!.id : undefined,
+        sortBy: params.orderBy.field,
+        sortDirection: params.orderBy.direction === "desc" ? -1 : 1,
         crawlType: params.itemType,
       },
       {

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -264,14 +264,14 @@ export class CrawlsList extends BtrixElement {
   }
 
   private clearFilters() {
-    this.filterBy.value = {
+    this.filterBy.setValue({
       ...this.filterBy.value,
       firstSeed: undefined,
       name: undefined,
       state: undefined,
-    };
-    this.filterByCurrentUser.value = false;
-    this.filterByTags.value = undefined;
+    });
+    this.filterByCurrentUser.setValue(false);
+    this.filterByTags.setValue(undefined);
   }
 
   private readonly archivedItemsTask = new Task(this, {
@@ -348,9 +348,10 @@ export class CrawlsList extends BtrixElement {
 
   constructor() {
     super();
-    this.filterByCurrentUser.value =
+    this.filterByCurrentUser.setValue(
       window.sessionStorage.getItem(FILTER_BY_CURRENT_USER_STORAGE_KEY) ===
-      "true";
+        "true",
+    );
   }
 
   protected willUpdate(
@@ -368,11 +369,11 @@ export class CrawlsList extends BtrixElement {
         changedProperties.has("itemType") &&
         changedProperties.get("itemType")
       ) {
-        this.filterBy.value = {};
-        this.orderBy.value = {
+        this.filterBy.setValue({});
+        this.orderBy.setValue({
           field: "finished",
           direction: sortableFields["finished"].defaultDirection!,
-        };
+        });
       }
       this.pagination = {
         page: 1,
@@ -614,18 +615,18 @@ export class CrawlsList extends BtrixElement {
           <btrix-archived-item-state-filter
             .states=${this.filterBy.value.state}
             @btrix-change=${(e: BtrixChangeArchivedItemStateFilterEvent) => {
-              this.filterBy.value = {
+              this.filterBy.setValue({
                 ...this.filterBy.value,
                 state: e.detail.value,
-              };
+              });
             }}
           ></btrix-archived-item-state-filter>
 
           <btrix-archived-item-tag-filter
             .tags=${this.filterByTags.value}
             @btrix-change=${(e: BtrixChangeArchivedItemTagFilterEvent) => {
-              this.filterByTags.value = e.detail.value?.tags;
-              this.filterByTagsType.value = e.detail.value?.type || "or";
+              this.filterByTags.setValue(e.detail.value?.tags);
+              this.filterByTagsType.setValue(e.detail.value?.type || "or");
             }}
           ></btrix-archived-item-tag-filter>
 
@@ -634,7 +635,7 @@ export class CrawlsList extends BtrixElement {
                 ?checked=${this.filterByCurrentUser.value}
                 @btrix-change=${(e: BtrixFilterChipChangeEvent) => {
                   const { checked } = e.target as FilterChip;
-                  this.filterByCurrentUser.value = Boolean(checked);
+                  this.filterByCurrentUser.setValue(Boolean(checked));
                 }}
               >
                 ${msg("Mine")}
@@ -674,12 +675,12 @@ export class CrawlsList extends BtrixElement {
         value=${this.orderBy.value.field}
         @sl-change=${(e: Event) => {
           const field = (e.target as HTMLSelectElement).value as SortField;
-          this.orderBy.value = {
+          this.orderBy.setValue({
             field: field,
             direction:
               sortableFields[field].defaultDirection ||
               this.orderBy.value.direction,
-          };
+          });
         }}
       >
         ${options}
@@ -698,11 +699,11 @@ export class CrawlsList extends BtrixElement {
             ? msg("Sort Descending")
             : msg("Sort Ascending")}
           @click=${() => {
-            this.orderBy.value = {
+            this.orderBy.setValue({
               ...this.orderBy.value,
               direction:
                 this.orderBy.value.direction === "asc" ? "desc" : "asc",
-            };
+            });
           }}
         ></sl-icon-button>
       </sl-tooltip>
@@ -727,10 +728,10 @@ export class CrawlsList extends BtrixElement {
             : msg("Search all items by name or crawl start URL")}
         @btrix-select=${(e: CustomEvent) => {
           const { key, value } = e.detail;
-          this.filterBy.value = {
+          this.filterBy.setValue({
             ...this.filterBy.value,
             [key]: value,
-          };
+          });
         }}
         @btrix-clear=${() => {
           const {
@@ -738,7 +739,7 @@ export class CrawlsList extends BtrixElement {
             firstSeed: _firstSeed,
             ...otherFilters
           } = this.filterBy.value;
-          this.filterBy.value = otherFilters;
+          this.filterBy.setValue(otherFilters);
         }}
       >
       </btrix-search-combobox>

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -214,9 +214,9 @@ export class CrawlsList extends BtrixElement {
               params.set(key, value[key]);
               break;
             case "state":
-              params.delete(key);
+              params.delete("status");
               value[key].forEach((state) => {
-                params.append(key, state);
+                params.append("status", state);
               });
               break;
           }
@@ -225,7 +225,7 @@ export class CrawlsList extends BtrixElement {
       return params;
     },
     (params) => {
-      const state = params.getAll("state") as CrawlState[];
+      const state = params.getAll("status") as CrawlState[];
 
       return {
         firstSeed: params.get("firstSeed") ?? undefined,
@@ -325,94 +325,6 @@ export class CrawlsList extends BtrixElement {
     ).find((key) => Boolean(this.filterBy.value[key]));
   }
 
-  // searchParams = new SearchParamsController(this, (params) => {
-  //   this.updateFiltersFromSearchParams(params);
-  // });
-
-  // private updateFiltersFromSearchParams(
-  //   params = this.searchParams.searchParams,
-  // ) {
-  //   const filterBy = { ...this.filterBy.value };
-  //   // remove filters no longer present in search params
-  //   for (const key of Object.keys(filterBy) as Keys<typeof filterBy>) {
-  //     if (!params.has(key)) {
-  //       filterBy[key] = undefined;
-  //     }
-  //   }
-
-  //   // remove current user filter if not present in search params
-  //   if (!params.has("mine")) {
-  //     this.filterByCurrentUser.value = false;
-  //   }
-
-  //   if (params.has("tags")) {
-  //     this.filterByTags. = params.getAll("tags");
-  //   } else {
-  //     this.filterByTags = undefined;
-  //   }
-
-  //   // if (params.has("profiles")) {
-  //   //   this.filterByProfiles = params.getAll("profiles");
-  //   // } else {
-  //   //   this.filterByProfiles = undefined;
-  //   // }
-
-  //   // add filters present in search params
-  //   for (const [key, value] of params) {
-  //     // Filter by current user
-  //     if (key === "mine") {
-  //       this.filterByCurrentUser = value === "true";
-  //     }
-
-  //     if (key === "tagsType") {
-  //       this.filterByTagsType = value === "and" ? "and" : "or";
-  //     }
-
-  //     // Sorting field
-  //     if (key === "sortBy") {
-  //       if (value in sortableFields) {
-  //         this.orderBy = {
-  //           field: value as SortField,
-  //           direction:
-  //             // Use default direction for field if available, otherwise use current direction
-  //             sortableFields[value as SortField].defaultDirection ||
-  //             this.orderBy.direction,
-  //         };
-  //       }
-  //     }
-  //     if (key === "sortDir") {
-  //       if (SORT_DIRECTIONS.includes(value as SortDirection)) {
-  //         // Overrides sort direction if specified
-  //         this.orderBy = { ...this.orderBy, direction: value as SortDirection };
-  //       }
-  //     }
-
-  //     // Ignored params
-  //     if (
-  //       [
-  //         "page",
-  //         "mine",
-  //         "tags",
-  //         "tagsType",
-  //         "profiles",
-  //         "sortBy",
-  //         "sortDir",
-  //       ].includes(key)
-  //     )
-  //       continue;
-
-  //     // // Convert string bools to filter values
-  //     // if (value === "true") {
-  //     //   filterBy[key as keyof typeof filterBy] = true;
-  //     // } else if (value === "false") {
-  //     //   filterBy[key as keyof typeof filterBy] = false;
-  //     // } else {
-  //     //   filterBy[key as keyof typeof filterBy] = undefined;
-  //     // }
-  //   }
-  //   this.filterBy = { ...filterBy };
-  // }
-
   constructor() {
     super();
     this.filterByCurrentUser.value =
@@ -431,7 +343,10 @@ export class CrawlsList extends BtrixElement {
       changedProperties.has("filterByTags.value") ||
       changedProperties.has("filterByTagsType.value")
     ) {
-      if (changedProperties.has("itemType")) {
+      if (
+        changedProperties.has("itemType") &&
+        changedProperties.get("itemType")
+      ) {
         this.filterBy.value = {};
         this.orderBy.value = {
           field: "finished",

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -710,6 +710,10 @@ export class CrawlsList extends BtrixElement {
         .searchOptions=${this.searchOptions}
         .keyLabels=${CrawlsList.FieldLabels}
         selectedKey=${ifDefined(this.selectedSearchFilterKey)}
+        searchByValue=${ifDefined(
+          this.selectedSearchFilterKey &&
+            this.filterBy.value[this.selectedSearchFilterKey],
+        )}
         placeholder=${this.itemType === "upload"
           ? msg("Search all uploads by name")
           : this.itemType === "crawl"

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -253,6 +253,27 @@ export class CrawlsList extends BtrixElement {
   @query("#stateSelect")
   stateSelect?: SlSelect;
 
+  private get hasFiltersSet() {
+    return [
+      this.filterBy.value.firstSeed,
+      this.filterBy.value.name,
+      this.filterBy.value.state?.length || undefined,
+      this.filterByCurrentUser.value || undefined,
+      this.filterByTags.value?.length || undefined,
+    ].some((v) => v !== undefined);
+  }
+
+  private clearFilters() {
+    this.filterBy.value = {
+      ...this.filterBy.value,
+      firstSeed: undefined,
+      name: undefined,
+      state: undefined,
+    };
+    this.filterByCurrentUser.value = false;
+    this.filterByTags.value = undefined;
+  }
+
   private readonly archivedItemsTask = new Task(this, {
     task: async (
       [
@@ -620,28 +641,13 @@ export class CrawlsList extends BtrixElement {
               </btrix-filter-chip> `
             : ""}
           ${when(
-            [
-              this.filterBy.value.firstSeed,
-              this.filterBy.value.name,
-              this.filterBy.value.state?.length || undefined,
-              this.filterByCurrentUser.value || undefined,
-              this.filterByTags.value?.length || undefined,
-            ].some((v) => v !== undefined),
+            this.hasFiltersSet,
             () => html`
               <sl-button
                 class="[--sl-color-primary-600:var(--sl-color-neutral-500)] part-[label]:font-medium"
                 size="small"
                 variant="text"
-                @click=${() => {
-                  this.filterBy.value = {
-                    ...this.filterBy.value,
-                    firstSeed: undefined,
-                    name: undefined,
-                    state: undefined,
-                  };
-                  this.filterByCurrentUser.value = false;
-                  this.filterByTags.value = undefined;
-                }}
+                @click=${this.clearFilters}
               >
                 <sl-icon slot="prefix" name="x-lg"></sl-icon>
                 ${msg("Clear All")}
@@ -852,7 +858,7 @@ export class CrawlsList extends BtrixElement {
   };
 
   private renderEmptyState() {
-    if (Object.keys(this.filterBy).length) {
+    if (this.hasFiltersSet) {
       return html`
         <div class="rounded-lg border bg-neutral-50 p-4">
           <p class="text-center">
@@ -862,7 +868,7 @@ export class CrawlsList extends BtrixElement {
             <button
               class="font-medium text-neutral-500 underline hover:no-underline"
               @click=${() => {
-                this.filterBy.value = {};
+                this.clearFilters();
                 if (this.stateSelect) {
                   // TODO pass in value to sl-select after upgrading
                   // shoelace to >=2.0.0-beta.88. Passing an array value

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -894,6 +894,14 @@ export class CrawlsList extends BtrixElement {
       `;
     }
 
+    if (this.itemType === "upload") {
+      return html`
+        <div class="border-b border-t py-5">
+          <p class="text-center text-neutral-500">${msg("No uploads yet.")}</p>
+        </div>
+      `;
+    }
+
     return html`
       <div class="border-b border-t py-5">
         <p class="text-center text-neutral-500">

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -961,7 +961,7 @@ export class CrawlsList extends BtrixElement {
         crawlType: params.itemType,
       },
       {
-        arrayFormat: "comma",
+        arrayFormat: "none",
       },
     );
 

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -940,8 +940,8 @@ export class CrawlsList extends BtrixElement {
       orderBy: CrawlsList["orderBy"]["value"];
       filterBy: CrawlsList["filterBy"]["value"];
       filterByCurrentUser: CrawlsList["filterByCurrentUser"]["value"];
-      filterbyTags: CrawlsList["filterByTags"]["value"];
-      filterbyTagsType: CrawlsList["filterByTagsType"]["value"];
+      filterByTags: CrawlsList["filterByTags"]["value"];
+      filterByTagsType: CrawlsList["filterByTagsType"]["value"];
     },
     signal: AbortSignal,
   ) {
@@ -953,8 +953,8 @@ export class CrawlsList extends BtrixElement {
           : finishedCrawlStates,
         page: params.pagination.page,
         pageSize: params.pagination.pageSize,
-        tags: params.filterbyTags,
-        tagMatch: params.filterbyTagsType,
+        tags: params.filterByTags,
+        tagMatch: params.filterByTagsType,
         userid: params.filterByCurrentUser ? this.userInfo!.id : undefined,
         sortBy: params.orderBy.field,
         sortDirection: params.orderBy.direction === "desc" ? -1 : 1,

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -162,6 +162,7 @@ export class WorkflowsList extends BtrixElement {
     this.updateFiltersFromSearchParams(params);
   });
 
+  // TODO (emma): refactor this logic into smaller parts using `SearchParamsValue`
   private updateFiltersFromSearchParams(
     params = this.searchParams.searchParams,
   ) {


### PR DESCRIPTION
Closes #2853

## Changes

Adds a tag filter to the archived items list.

Along the way, this PR...
- adds a `/orgs/{oid}/all-crawls/tagCounts` endpoint for displaying tag counts of archived items, much like the `/orgs/{oid}/crawlconfigs/tagCounts` endpoint that exists for tags on workflows
- adds tag filters to the two main crawl list endpoints
  - I didn't add them to the superadmin crawl list endpoints — I don't imagine we'll likely want to use that at the moment, but if we end up wanting it it'll be easy to add later
- adds a `SearchParamsValue` controller that automatically converts values to and from search params using an encoder/decoder pair. This simplifies a bunch of the complex logic implemented in the workflow list controls — I intend to rewrite those using this controller in the near future as well.
  - Because this uses the `SearchParamsController` I wrote a little while ago, it automatically pushes history to the stack, and so the browser's back/forward buttons work as expected for any value hooked up to this!
- adds persistence via the URL for all controls in the archived item list, *including* the search field
  - As with before, I intend to backport this change to the workflow list as well!

## Screenshots

<img width="409" height="523" alt="Screenshot 2025-09-29 at 1 59 03 AM" src="https://github.com/user-attachments/assets/5a72b09e-2954-4e2a-bd58-74b04449e824" />
<img width="862" height="361" alt="Screenshot 2025-09-29 at 1 59 33 AM" src="https://github.com/user-attachments/assets/fd48c962-4bba-47b9-a569-7c3abe1e2c8c" />


## Testing

As this PR contains both frontend and backend changes, both parts need to be deployed together to test this PR.

To test:
1. Ensure you have both the frontend and backend deployed (e.g. locally or on dev)
2. Visit an org with a variety of crawls/uploads in various states, some of which use tags 
3. On the archived items page, verify that you can filter by name/starting url (via the search bar), crawl status, tags, and "mine"
4. Verify that on a page with multiple pages of results, switching filters resets the page to the first page
5. Verify that all filter controls and pagination controls show up in the URL
6. Verify that you can use your browser's navigation controls to move through changes to the filters you have set
7. Verify that you can copy the URL or reload the page and the filters you had selected are still selected

## Next Steps

- The workflow list tag filter and archived item tag filter are nearly identical, they should probably be refactored into a single component with a property for which tag counts to use
- The workflow list controls should be refactored to use `SearchParamsValue`, and the search input should be hooked up to it as well
- We're displaying page count in the archived item list, but don't allow it as a sort field — we should allow sorting by page count