### PR TITLE
Fix nightly test for fail on content check by adding browser profile

### DIFF
--- a/backend/test_nightly/test_crawl_not_logged_in.py
+++ b/backend/test_nightly/test_crawl_not_logged_in.py
@@ -10,11 +10,6 @@ from .conftest import API_PREFIX
 config_id = None
 
 
-@pytest.fixture(scope="session")
-def profile_browser_id(admin_auth_headers, default_org_id):
-    return _create_profile_browser(admin_auth_headers, default_org_id)
-
-
 def _create_profile_browser(
     headers: Dict[str, str], oid: UUID, url: str = "https://webrecorder.net"
 ):
@@ -38,6 +33,11 @@ def _create_profile_browser(
         if data.get("success"):
             return browser_id
         time.sleep(5)
+
+
+@pytest.fixture(scope="session")
+def profile_browser_id(admin_auth_headers, default_org_id):
+    return _create_profile_browser(admin_auth_headers, default_org_id)
 
 
 def prepare_browser_for_profile_commit(


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2856

Now that `fail_on_content_check` can't be set without a browser profile, the test fixture for the nightly test needed to be updated accordingly.

I've run the nightly test locally with this fix and verified it now passes.