### PR TITLE
quickfix: helm chart: only set AVAILABLE_PLANS if actually defined 

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -107,7 +107,9 @@ data:
 
   CLEANUP_FILES_AFTER_MINUTES: "{{ .Values.cleanup_files_after_minutes | default 1440 }}"
 
+  {{- if .Values.available_plans }}
   AVAILABLE_PLANS: {{ .Values.available_plans | toJson }}
+  {{- end }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
otherwise, results in possible error with empty value passed to toJson