### PR TITLE
test: Fix frontend tests that use timezone

### DIFF
--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Timezone ID is configured in web-test-runner config
+ */
 import { expect } from "@open-wc/testing";
 
 import { getScheduleInterval, humanizeSchedule } from "./cron";
@@ -46,19 +49,19 @@ describe("cron utils", () => {
   describe("humanizeSchedule()", () => {
     it("humanizes daily schedule", () => {
       expect(humanizeSchedule("30 1 * * *")).to.equal(
-        "Every day at 8:30 PM GMT-5",
+        "Every day at 1:30 PM GMT+12",
       );
     });
 
     it("humanizes weekly schedule", () => {
       expect(humanizeSchedule("30 1 * * 1")).to.equal(
-        "Every Sunday at 8:30 PM GMT-5",
+        "Every Monday at 1:30 PM GMT+12",
       );
     });
 
     it("humanizes monthly schedule", () => {
       expect(humanizeSchedule("30 1 1 * *")).to.equal(
-        "On day 30 of the month at 8:30 PM GMT-5",
+        "On day 1 of the month at 1:30 PM GMT+12",
       );
     });
 

--- a/frontend/src/utils/localize.test.ts
+++ b/frontend/src/utils/localize.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Timezone ID is configured in web-test-runner config
+ */
 import { expect } from "@open-wc/testing";
 import { restore, stub } from "sinon";
 
@@ -70,7 +73,7 @@ describe("Localize", () => {
       const localize = new Localize();
       localize.setLanguage("es");
       expect(localize.date(new Date("2024-01-01T00:00:00.000Z"))).to.equal(
-        "31/12/2023, 19:00",
+        "01/01/2024, 12:00",
       );
     });
 
@@ -110,7 +113,7 @@ describe("Localize", () => {
     it("formats with the current language", () => {
       const localize = new Localize("ko");
       expect(localize.date(new Date("2024-01-01T00:00:00.000Z"))).to.equal(
-        "2023. 12. 31. 오후 07:00",
+        "2024. 01. 01. 오후 12:00",
       );
     });
 

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -40,7 +40,7 @@ export default {
         channel: "chromium",
       },
       async createBrowserContext({ browser }) {
-        return browser.newContext({ timezoneId: "Pacific/Easter" });
+        return browser.newContext({ timezoneId: "Pacific/Fiji" }); // SDT +12:00
       },
     }),
   ],


### PR DESCRIPTION
## Changes

Fixes frontend tests failing due to mocking tests using a timezone with different offsets during daylight savings. We could also support additional mocks for SDT/DST but this seems like the simplest solution for now.