### PR TITLE
Apply changes from filter chip dropdowns immediately

### DIFF
--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -255,7 +255,6 @@ export class ArchivedItemStateFilter extends BtrixElement {
           this.selected = new Map(
             this.selected.set(value as CrawlState, checked),
           );
-          this.requestUpdate("selectedStates");
         }}
       >
         ${repeat(

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -53,7 +53,7 @@ export class ArchivedItemStateFilter extends BtrixElement {
   private readonly fuse = new Fuse<CrawlState>(finishedCrawlStates);
 
   @state()
-  private get selectedStates() {
+  get selectedStates() {
     return Array.from(this.selected.entries())
       .filter(([_tag, selected]) => selected)
       .map(([tag]) => tag);
@@ -68,6 +68,15 @@ export class ArchivedItemStateFilter extends BtrixElement {
       } else if (changedProperties.get("states")) {
         this.selected = new Map();
       }
+    }
+    if (changedProperties.has("selectedStates")) {
+      this.dispatchEvent(
+        new CustomEvent<
+          BtrixChangeEvent<ChangeArchivedItemStateEventDetails>["detail"]
+        >("btrix-change", {
+          detail: { value: this.selectedStates },
+        }),
+      );
     }
   }
 
@@ -87,14 +96,6 @@ export class ArchivedItemStateFilter extends BtrixElement {
         }}
         @sl-after-hide=${() => {
           this.searchString = "";
-
-          this.dispatchEvent(
-            new CustomEvent<
-              BtrixChangeEvent<ChangeArchivedItemStateEventDetails>["detail"]
-            >("btrix-change", {
-              detail: { value: this.selectedStates },
-            }),
-          );
         }}
       >
         ${this.states?.length

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -15,6 +15,7 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { isEqual } from "lodash";
 import { isFocusable } from "tabbable";
 
 import { CrawlStatus } from "./crawl-status";
@@ -52,7 +53,7 @@ export class ArchivedItemStateFilter extends BtrixElement {
 
   private readonly fuse = new Fuse<CrawlState>(finishedCrawlStates);
 
-  @state()
+  @state({ hasChanged: isEqual })
   selected = new Map<CrawlState, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -53,13 +53,7 @@ export class ArchivedItemStateFilter extends BtrixElement {
   private readonly fuse = new Fuse<CrawlState>(finishedCrawlStates);
 
   @state()
-  get selectedStates() {
-    return Array.from(this.selected.entries())
-      .filter(([_tag, selected]) => selected)
-      .map(([tag]) => tag);
-  }
-
-  private selected = new Map<CrawlState, boolean>();
+  selected = new Map<CrawlState, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("states")) {
@@ -69,12 +63,19 @@ export class ArchivedItemStateFilter extends BtrixElement {
         this.selected = new Map();
       }
     }
-    if (changedProperties.has("selectedStates")) {
+  }
+
+  protected updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("selected")) {
       this.dispatchEvent(
         new CustomEvent<
           BtrixChangeEvent<ChangeArchivedItemStateEventDetails>["detail"]
         >("btrix-change", {
-          detail: { value: this.selectedStates },
+          detail: {
+            value: Array.from(this.selected.entries())
+              .filter(([_tag, selected]) => selected)
+              .map(([tag]) => tag),
+          },
         }),
       );
     }
@@ -251,7 +252,9 @@ export class ArchivedItemStateFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected.set(value as CrawlState, checked);
+          this.selected = new Map(
+            this.selected.set(value as CrawlState, checked),
+          );
           this.requestUpdate("selectedStates");
         }}
       >

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -17,6 +17,7 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { isEqual } from "lodash";
 import { isFocusable } from "tabbable";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -56,11 +57,11 @@ export class ArchivedItemTagFilter extends BtrixElement {
     keys: ["tag"],
   });
 
-  @state()
+  @state({ hasChanged: isEqual })
   selected = new Map<string, boolean>();
 
   @state()
-  private type: "and" | "or" = "or";
+  type: "and" | "or" = "or";
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("tags")) {
@@ -72,8 +73,8 @@ export class ArchivedItemTagFilter extends BtrixElement {
     }
   }
 
-  updated(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has("selected")) {
+  protected updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("selected") || changedProperties.has("type")) {
       const selectedTags = Array.from(this.selected.entries())
         .filter(([_tag, selected]) => selected)
         .map(([tag]) => tag);

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -58,13 +58,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
   });
 
   @state()
-  get selectedTags() {
-    return Array.from(this.selected.entries())
-      .filter(([_tag, selected]) => selected)
-      .map(([tag]) => tag);
-  }
-
-  private selected = new Map<string, boolean>();
+  selected = new Map<string, boolean>();
 
   @state()
   private type: "and" | "or" = "or";
@@ -80,14 +74,20 @@ export class ArchivedItemTagFilter extends BtrixElement {
         this.selected = new Map();
       }
     }
-    if (changedProperties.has("selectedTags")) {
+  }
+
+  updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("selected")) {
+      const selectedTags = Array.from(this.selected.entries())
+        .filter(([_tag, selected]) => selected)
+        .map(([tag]) => tag);
       this.dispatchEvent(
         new CustomEvent<
           BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
         >("btrix-change", {
           detail: {
-            value: this.selectedTags.length
-              ? { tags: this.selectedTags, type: this.type }
+            value: selectedTags.length
+              ? { tags: selectedTags, type: this.type }
               : undefined,
           },
         }),
@@ -309,8 +309,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected.set(value, checked);
-          this.requestUpdate("selectedTags");
+          this.selected = new Map(this.selected.set(value, checked));
         }}
       >
         ${repeat(

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -159,6 +159,16 @@ export class ArchivedItemTagFilter extends BtrixElement {
                       });
 
                       this.type = "or";
+
+                      this.dispatchEvent(
+                        new CustomEvent<
+                          BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
+                        >("btrix-change", {
+                          detail: {
+                            value: undefined,
+                          },
+                        }),
+                      );
                     }}
                     >${msg("Clear")}</sl-button
                   >`

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -20,7 +20,6 @@ import { repeat } from "lit/directives/repeat.js";
 import { isFocusable } from "tabbable";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import { type FilterChip } from "@/components/ui/filter-chip";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type WorkflowTag, type WorkflowTags } from "@/types/workflow";
 import { stopProp } from "@/utils/events";
@@ -62,9 +61,6 @@ export class ArchivedItemTagFilter extends BtrixElement {
 
   @state()
   private type: "and" | "or" = "or";
-
-  @query("btrix-filter-chip")
-  private readonly filterChip?: FilterChip | null;
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("tags")) {

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -20,6 +20,7 @@ import { repeat } from "lit/directives/repeat.js";
 import { isFocusable } from "tabbable";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import { type FilterChip } from "@/components/ui/filter-chip";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type WorkflowTag, type WorkflowTags } from "@/types/workflow";
 import { stopProp } from "@/utils/events";
@@ -57,7 +58,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
   });
 
   @state()
-  private get selectedTags() {
+  get selectedTags() {
     return Array.from(this.selected.entries())
       .filter(([_tag, selected]) => selected)
       .map(([tag]) => tag);
@@ -68,6 +69,9 @@ export class ArchivedItemTagFilter extends BtrixElement {
   @state()
   private type: "and" | "or" = "or";
 
+  @query("btrix-filter-chip")
+  private readonly filterChip?: FilterChip | null;
+
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("tags")) {
       if (this.tags) {
@@ -75,6 +79,19 @@ export class ArchivedItemTagFilter extends BtrixElement {
       } else if (changedProperties.get("tags")) {
         this.selected = new Map();
       }
+    }
+    if (changedProperties.has("selectedTags")) {
+      this.dispatchEvent(
+        new CustomEvent<
+          BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
+        >("btrix-change", {
+          detail: {
+            value: this.selectedTags.length
+              ? { tags: this.selectedTags, type: this.type }
+              : undefined,
+          },
+        }),
+      );
     }
   }
 
@@ -105,18 +122,6 @@ export class ArchivedItemTagFilter extends BtrixElement {
         }}
         @sl-after-hide=${() => {
           this.searchString = "";
-
-          this.dispatchEvent(
-            new CustomEvent<
-              BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
-            >("btrix-change", {
-              detail: {
-                value: this.selectedTags.length
-                  ? { tags: this.selectedTags, type: this.type }
-                  : undefined,
-              },
-            }),
-          );
         }}
       >
         ${this.tags?.length
@@ -154,16 +159,6 @@ export class ArchivedItemTagFilter extends BtrixElement {
                       });
 
                       this.type = "or";
-
-                      this.dispatchEvent(
-                        new CustomEvent<
-                          BtrixChangeEvent<ChangeArchivedItemTagEventDetails>["detail"]
-                        >("btrix-change", {
-                          detail: {
-                            value: undefined,
-                          },
-                        }),
-                      );
                     }}
                     >${msg("Clear")}</sl-button
                   >`

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -68,6 +68,9 @@ export class WorkflowProfileFilter extends BtrixElement {
         this.selected = new Map();
       }
     }
+  }
+
+  protected updated(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("selected")) {
       const selectedProfiles = [];
 
@@ -163,8 +166,6 @@ export class WorkflowProfileFilter extends BtrixElement {
                         checkbox.checked = false;
                       });
                       this.selected = new Map();
-
-                      this.requestUpdate("selected");
                     }}
                     >${msg("Clear")}</sl-button
                   >`
@@ -337,8 +338,7 @@ export class WorkflowProfileFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected.set(value, checked);
-          this.requestUpdate("selected");
+          this.selected = new Map(this.selected.set(value, checked));
         }}
       >
         ${repeat(

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -168,17 +168,9 @@ export class WorkflowProfileFilter extends BtrixElement {
                       this.checkboxes.forEach((checkbox) => {
                         checkbox.checked = false;
                       });
+                      this.selected = new Map();
 
-                      this.dispatchEvent(
-                        new CustomEvent<BtrixChangeEvent["detail"]>(
-                          "btrix-change",
-                          {
-                            detail: {
-                              value: undefined,
-                            },
-                          },
-                        ),
-                      );
+                      this.requestUpdate("selectedProfiles");
                     }}
                     >${msg("Clear")}</sl-button
                   >`

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -17,6 +17,7 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { isEqual } from "lodash";
 import queryString from "query-string";
 import { isFocusable } from "tabbable";
 
@@ -57,7 +58,7 @@ export class WorkflowProfileFilter extends BtrixElement {
     keys: ["id", "name", "description", "origins"],
   });
 
-  @state()
+  @state({ hasChanged: isEqual })
   selected = new Map<string, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -57,20 +57,8 @@ export class WorkflowProfileFilter extends BtrixElement {
     keys: ["id", "name", "description", "origins"],
   });
 
-  private selected = new Map<string, boolean>();
-
   @state()
-  get selectedProfiles() {
-    const selectedProfiles = [];
-
-    for (const [profile, value] of this.selected) {
-      if (value) {
-        selectedProfiles.push(profile);
-      }
-    }
-
-    return selectedProfiles;
-  }
+  private selected = new Map<string, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("profiles")) {
@@ -81,12 +69,18 @@ export class WorkflowProfileFilter extends BtrixElement {
       }
     }
     if (changedProperties.has("selectedProfiles")) {
+      const selectedProfiles = [];
+
+      for (const [profile, value] of this.selected) {
+        if (value) {
+          selectedProfiles.push(profile);
+        }
+      }
+
       this.dispatchEvent(
         new CustomEvent<BtrixChangeEvent["detail"]>("btrix-change", {
           detail: {
-            value: this.selectedProfiles.length
-              ? this.selectedProfiles
-              : undefined,
+            value: selectedProfiles.length ? selectedProfiles : undefined,
           },
         }),
       );
@@ -170,7 +164,7 @@ export class WorkflowProfileFilter extends BtrixElement {
                       });
                       this.selected = new Map();
 
-                      this.requestUpdate("selectedProfiles");
+                      this.requestUpdate("selected");
                     }}
                     >${msg("Clear")}</sl-button
                   >`
@@ -344,7 +338,7 @@ export class WorkflowProfileFilter extends BtrixElement {
           const { checked, value } = e.target as SlCheckbox;
 
           this.selected.set(value, checked);
-          this.requestUpdate("selectedProfiles");
+          this.requestUpdate("selected");
         }}
       >
         ${repeat(

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -59,6 +59,19 @@ export class WorkflowProfileFilter extends BtrixElement {
 
   private selected = new Map<string, boolean>();
 
+  @state()
+  get selectedProfiles() {
+    const selectedProfiles = [];
+
+    for (const [profile, value] of this.selected) {
+      if (value) {
+        selectedProfiles.push(profile);
+      }
+    }
+
+    return selectedProfiles;
+  }
+
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("profiles")) {
       if (this.profiles) {
@@ -66,6 +79,17 @@ export class WorkflowProfileFilter extends BtrixElement {
       } else if (changedProperties.get("profiles")) {
         this.selected = new Map();
       }
+    }
+    if (changedProperties.has("selectedProfiles")) {
+      this.dispatchEvent(
+        new CustomEvent<BtrixChangeEvent["detail"]>("btrix-change", {
+          detail: {
+            value: this.selectedProfiles.length
+              ? this.selectedProfiles
+              : undefined,
+          },
+        }),
+      );
     }
   }
 
@@ -105,22 +129,6 @@ export class WorkflowProfileFilter extends BtrixElement {
         }}
         @sl-after-hide=${() => {
           this.searchString = "";
-
-          const selectedProfiles = [];
-
-          for (const [profile, value] of this.selected) {
-            if (value) {
-              selectedProfiles.push(profile);
-            }
-          }
-
-          this.dispatchEvent(
-            new CustomEvent<BtrixChangeEvent["detail"]>("btrix-change", {
-              detail: {
-                value: selectedProfiles.length ? selectedProfiles : undefined,
-              },
-            }),
-          );
         }}
       >
         ${this.profiles?.length
@@ -344,6 +352,7 @@ export class WorkflowProfileFilter extends BtrixElement {
           const { checked, value } = e.target as SlCheckbox;
 
           this.selected.set(value, checked);
+          this.requestUpdate("selectedProfiles");
         }}
       >
         ${repeat(

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -58,7 +58,7 @@ export class WorkflowProfileFilter extends BtrixElement {
   });
 
   @state()
-  private selected = new Map<string, boolean>();
+  selected = new Map<string, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("profiles")) {
@@ -68,7 +68,7 @@ export class WorkflowProfileFilter extends BtrixElement {
         this.selected = new Map();
       }
     }
-    if (changedProperties.has("selectedProfiles")) {
+    if (changedProperties.has("selected")) {
       const selectedProfiles = [];
 
       for (const [profile, value] of this.selected) {

--- a/frontend/src/features/crawl-workflows/workflow-schedule-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-schedule-filter.ts
@@ -25,7 +25,7 @@ export class WorkflowScheduleFilter extends BtrixElement {
   @property({ type: Boolean })
   schedule?: boolean;
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("schedule")) {
       this.dispatchEvent(
         new CustomEvent<BtrixChangeWorkflowScheduleFilterEvent["detail"]>(

--- a/frontend/src/features/crawl-workflows/workflow-schedule-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-schedule-filter.ts
@@ -1,5 +1,5 @@
 import { localized, msg } from "@lit/localize";
-import type { SlSelectEvent } from "@shoelace-style/shoelace";
+import type { SlChangeEvent, SlRadioGroup } from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
@@ -25,35 +25,24 @@ export class WorkflowScheduleFilter extends BtrixElement {
   @property({ type: Boolean })
   schedule?: boolean;
 
-  #schedule?: boolean;
-
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("schedule")) {
-      this.#schedule = this.schedule;
+      this.dispatchEvent(
+        new CustomEvent<BtrixChangeWorkflowScheduleFilterEvent["detail"]>(
+          "btrix-change",
+          {
+            detail: { value: this.schedule },
+          },
+        ),
+      );
     }
   }
 
   render() {
-    const option = (label: string, value: string) => html`
-      <sl-menu-item value=${value}>${label}</sl-menu-item>
-    `;
-
     return html`
       <btrix-filter-chip
         ?checked=${this.schedule !== undefined}
         selectFromDropdown
-        @sl-after-hide=${() => {
-          if (this.#schedule !== this.schedule) {
-            this.dispatchEvent(
-              new CustomEvent<BtrixChangeWorkflowScheduleFilterEvent["detail"]>(
-                "btrix-change",
-                {
-                  detail: { value: this.#schedule },
-                },
-              ),
-            );
-          }
-        }}
       >
         ${this.schedule === undefined
           ? msg("Schedule")
@@ -61,59 +50,71 @@ export class WorkflowScheduleFilter extends BtrixElement {
               >${this.schedule ? msg("Scheduled") : msg("No Schedule")}</span
             >`}
 
-        <sl-menu
+        <div
           slot="dropdown-content"
-          class="pt-0"
-          @sl-select=${(e: SlSelectEvent) => {
-            const { item } = e.detail;
-
-            switch (item.value as ScheduleType) {
-              case ScheduleType.Scheduled:
-                this.#schedule = true;
-                break;
-              case ScheduleType.None:
-                this.#schedule = false;
-                break;
-              default:
-                this.#schedule = undefined;
-                break;
-            }
-          }}
+          class="flex max-h-[var(--auto-size-available-height)] max-w-[var(--auto-size-available-width)] flex-col overflow-hidden rounded border bg-white text-left"
         >
-          <sl-menu-label
-            class="part-[base]:flex part-[base]:items-center part-[base]:justify-between part-[base]:gap-4 part-[base]:px-3"
+          <header
+            class="flex-shrink-0 flex-grow-0 overflow-hidden rounded-t border-b bg-white"
           >
-            <div
-              id="schedule-list-label"
-              class="leading-[var(--sl-input-height-small)]"
+            <sl-menu-label
+              class="part-[base]:flex part-[base]:items-center part-[base]:justify-between part-[base]:gap-4 part-[base]:px-3"
             >
-              ${msg("Filter by Schedule Type")}
-            </div>
-            ${this.schedule !== undefined
-              ? html`<sl-button
-                  variant="text"
-                  size="small"
-                  class="part-[label]:px-0"
-                  @click=${() => {
-                    this.dispatchEvent(
-                      new CustomEvent<BtrixChangeEvent["detail"]>(
-                        "btrix-change",
-                        {
-                          detail: {
-                            value: undefined,
-                          },
-                        },
-                      ),
-                    );
-                  }}
-                  >${msg("Clear")}</sl-button
-                >`
-              : nothing}
-          </sl-menu-label>
+              <div
+                id="schedule-list-label"
+                class="leading-[var(--sl-input-height-small)]"
+              >
+                ${msg("Filter by Schedule Type")}
+              </div>
+              ${this.schedule !== undefined
+                ? html`<sl-button
+                    variant="text"
+                    size="small"
+                    class="part-[label]:px-0"
+                    @click=${() => {
+                      this.schedule = undefined;
+                    }}
+                    >${msg("Clear")}</sl-button
+                  >`
+                : nothing}
+            </sl-menu-label>
+          </header>
 
-          ${option(msg("Scheduled"), ScheduleType.Scheduled)}
-          ${option(msg("No Schedule"), ScheduleType.None)}
-        </sl-menu>
+          <sl-radio-group
+            value=${this.schedule
+              ? ScheduleType.Scheduled
+              : this.schedule === false
+                ? ScheduleType.None
+                : ScheduleType.Any}
+            class="m-1"
+            @sl-change=${(e: SlChangeEvent) => {
+              const target = e.target as SlRadioGroup;
+
+              switch (target.value as ScheduleType) {
+                case ScheduleType.Scheduled:
+                  this.schedule = true;
+                  break;
+                case ScheduleType.None:
+                  this.schedule = false;
+                  break;
+                default:
+                  this.schedule = undefined;
+                  break;
+              }
+            }}
+          >
+            <sl-radio
+              value=${ScheduleType.Scheduled}
+              class="!mt-0 part-[base]:flex part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
+              >${msg("Scheduled")}</sl-radio
+            >
+            <sl-radio
+              value=${ScheduleType.None}
+              class="!mt-0 part-[base]:flex part-[base]:rounded part-[base]:p-2 part-[base]:hover:bg-primary-50"
+              >${msg("No Schedule")}</sl-radio
+            >
+          </sl-radio-group>
+        </div>
       </btrix-filter-chip>
     `;
   }

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -17,6 +17,7 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { isEqual } from "lodash";
 import { isFocusable } from "tabbable";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -56,7 +57,7 @@ export class WorkflowTagFilter extends BtrixElement {
     keys: ["tag"],
   });
 
-  @state()
+  @state({ hasChanged: isEqual })
   selected = new Map<string, boolean>();
 
   @state()

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -156,7 +156,6 @@ export class WorkflowTagFilter extends BtrixElement {
                       this.selected = new Map();
 
                       this.type = "or";
-                      this.requestUpdate("selectedTags");
                     }}
                     >${msg("Clear")}</sl-button
                   >`

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -57,13 +57,7 @@ export class WorkflowTagFilter extends BtrixElement {
   });
 
   @state()
-  get selectedTags() {
-    return Array.from(this.selected.entries())
-      .filter(([_tag, selected]) => selected)
-      .map(([tag]) => tag);
-  }
-
-  private selected = new Map<string, boolean>();
+  selected = new Map<string, boolean>();
 
   @state()
   type: "and" | "or" = "or";
@@ -76,17 +70,20 @@ export class WorkflowTagFilter extends BtrixElement {
         this.selected = new Map();
       }
     }
-    if (
-      changedProperties.has("selectedTags") ||
-      changedProperties.has("type")
-    ) {
+  }
+
+  protected updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("selected") || changedProperties.has("type")) {
+      const selectedTags = Array.from(this.selected.entries())
+        .filter(([_tag, selected]) => selected)
+        .map(([tag]) => tag);
       this.dispatchEvent(
         new CustomEvent<
           BtrixChangeEvent<ChangeWorkflowTagEventDetails>["detail"]
         >("btrix-change", {
           detail: {
-            value: this.selectedTags.length
-              ? { tags: this.selectedTags, type: this.type }
+            value: selectedTags.length
+              ? { tags: selectedTags, type: this.type }
               : undefined,
           },
         }),
@@ -300,8 +297,7 @@ export class WorkflowTagFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected.set(value, checked);
-          this.requestUpdate("selectedTags");
+          this.selected = new Map(this.selected.set(value, checked));
         }}
       >
         ${repeat(

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -66,7 +66,7 @@ export class WorkflowTagFilter extends BtrixElement {
   private selected = new Map<string, boolean>();
 
   @state()
-  private type: "and" | "or" = "or";
+  type: "and" | "or" = "or";
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("tags")) {
@@ -76,7 +76,10 @@ export class WorkflowTagFilter extends BtrixElement {
         this.selected = new Map();
       }
     }
-    if (changedProperties.has("selectedTags")) {
+    if (
+      changedProperties.has("selectedTags") ||
+      changedProperties.has("type")
+    ) {
       this.dispatchEvent(
         new CustomEvent<
           BtrixChangeEvent<ChangeWorkflowTagEventDetails>["detail"]

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -57,7 +57,7 @@ export class WorkflowTagFilter extends BtrixElement {
   });
 
   @state()
-  private get selectedTags() {
+  get selectedTags() {
     return Array.from(this.selected.entries())
       .filter(([_tag, selected]) => selected)
       .map(([tag]) => tag);
@@ -75,6 +75,19 @@ export class WorkflowTagFilter extends BtrixElement {
       } else if (changedProperties.get("tags")) {
         this.selected = new Map();
       }
+    }
+    if (changedProperties.has("selectedTags")) {
+      this.dispatchEvent(
+        new CustomEvent<
+          BtrixChangeEvent<ChangeWorkflowTagEventDetails>["detail"]
+        >("btrix-change", {
+          detail: {
+            value: this.selectedTags.length
+              ? { tags: this.selectedTags, type: this.type }
+              : undefined,
+          },
+        }),
+      );
     }
   }
 
@@ -105,18 +118,6 @@ export class WorkflowTagFilter extends BtrixElement {
         }}
         @sl-after-hide=${() => {
           this.searchString = "";
-
-          this.dispatchEvent(
-            new CustomEvent<
-              BtrixChangeEvent<ChangeWorkflowTagEventDetails>["detail"]
-            >("btrix-change", {
-              detail: {
-                value: this.selectedTags.length
-                  ? { tags: this.selectedTags, type: this.type }
-                  : undefined,
-              },
-            }),
-          );
         }}
       >
         ${this.tags?.length

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -156,18 +156,10 @@ export class WorkflowTagFilter extends BtrixElement {
                       this.checkboxes.forEach((checkbox) => {
                         checkbox.checked = false;
                       });
+                      this.selected = new Map();
 
                       this.type = "or";
-
-                      this.dispatchEvent(
-                        new CustomEvent<
-                          BtrixChangeEvent<ChangeWorkflowTagEventDetails>["detail"]
-                        >("btrix-change", {
-                          detail: {
-                            value: undefined,
-                          },
-                        }),
-                      );
+                      this.requestUpdate("selectedTags");
                     }}
                     >${msg("Clear")}</sl-button
                   >`

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -301,6 +301,10 @@ export class CrawlsList extends BtrixElement {
           signal,
         );
 
+        if (this.getArchivedItemsTimeout) {
+          window.clearTimeout(this.getArchivedItemsTimeout);
+        }
+
         this.getArchivedItemsTimeout = window.setTimeout(() => {
           void this.archivedItemsTask.run();
         }, POLL_INTERVAL_SECONDS * 1000);

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -669,6 +669,7 @@ export class WorkflowsList extends BtrixElement {
 
       <btrix-workflow-tag-filter
         .tags=${this.filterByTags}
+        .type=${this.filterByTagsType}
         @btrix-change=${(e: BtrixChangeWorkflowTagFilterEvent) => {
           this.filterByTags = e.detail.value?.tags;
           this.filterByTagsType = e.detail.value?.type || "or";


### PR DESCRIPTION
## Changes

This PR addresses some user feedback about filter chip dropdowns being confusing: specifically, about how when selecting a filter from a dropdown, it's not clear that you need to click outside the dropdown to apply the changes, leading to worries about user actions not being saved (see [source in Discord](https://discord.com/channels/895426029194207262/1423361788589637686/1423362488636014705)).

This addresses this by changing filter chip behaviour to update its state (and re-fetch data) immediately when changes are made inside the dropdowns.

This also reworks the "schedule" filter chip in the workflow list page to show the selected option with a radio button so that it's more clear which state is selected and how switching states will work.

Finally, this addresses a bug in the archived item list where changing filters repeatedly would cause cascades of unnecessary re-fetches.

## Demo

https://github.com/user-attachments/assets/51bac346-0776-4384-afab-9604f9289b50

## Testing

On the workflow & archived item pages, try changing all of the filters, and make sure they all update & can be cleared (where relevant) as expected.