### PR TITLE
Set default MongoDB version to 7.0.25

### DIFF
--- a/ansible/roles/digital_ocean/setup/tasks/main.yml
+++ b/ansible/roles/digital_ocean/setup/tasks/main.yml
@@ -21,7 +21,7 @@
   register: db_check
 
 - name: d_ocean | db | create mongodb database
-  ansible.builtin.command: doctl databases create {{ db_name }} --region {{ droplet_region }} --engine mongodb --version 6 --output json
+  ansible.builtin.command: doctl databases create {{ db_name }} --region {{ droplet_region }} --engine mongodb --version 7 --output json
   async: 1800
   poll: 60
   register: db_create

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -217,7 +217,7 @@ mongo_local: true
 
 mongo_host: "local-mongo"
 
-mongo_image: "docker.io/library/mongo:6.0.5"
+mongo_image: "docker.io/library/mongo:7.0.25"
 mongo_pull_policy: "IfNotPresent"
 
 mongo_cpu: "12m"


### PR DESCRIPTION
Resolves #2680 

## Changes

- Sets the default MongoDB version in Ansible to version 7.0.25
- Sets the default MongoDB version in DigitalOcean to version 7

## Tests

This has been tested with a new DigitalOcean deployment. I assume there is also a level of automated tests which I am unfamiliar with. 

## Comments

Should the Docker image version be exact (ie: `docker.io/library/mongo:7.0.25`), or should it maybe be scoped to `docker.io/library/mongo:7` to include all future 7.* releases? If this needs changing then please let me know and I'll update the MR.