### PR TITLE
Fix a variety of layout issues

### DIFF
--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -123,7 +123,7 @@ export function pageHeader({
   return html`
     <header
       class=${clsx(
-        tw`mt-5 flex flex-col gap-3 lg:flex-row`,
+        tw`mt-5 flex flex-row flex-wrap gap-3`,
         border && tw`border-b pb-3`,
         classNames,
       )}

--- a/frontend/src/layouts/pageSectionsWithNav.ts
+++ b/frontend/src/layouts/pageSectionsWithNav.ts
@@ -21,7 +21,7 @@ export function pageSectionsWithNav({
   return html`
     <div
       class=${clsx(
-        tw`flex flex-col`,
+        tw`relative flex flex-col`,
         placement === "start" && tw`gap-8 lg:flex-row`,
       )}
     >
@@ -29,7 +29,7 @@ export function pageSectionsWithNav({
         class=${clsx(
           tw`flex w-full flex-1 flex-col gap-2`,
           sticky && [
-            tw`scrim scrim-to-b z-20 before:-top-2 lg:sticky lg:self-start`,
+            tw`scrim scrim-to-b relative z-20 before:-top-2 lg:sticky lg:self-start`,
             stickyTopClassname || tw`lg:top-2`,
           ],
           placement === "start"

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -358,7 +358,7 @@ export class Org extends BtrixElement {
         class="mx-auto box-border w-full overflow-x-hidden overscroll-contain"
       >
         <btrix-overflow-scroll class="-mx-3 part-[content]:px-3">
-          <nav class="flex items-end xl:px-6">
+          <nav class="flex w-max items-end xl:px-6">
             ${this.renderNavTab({
               tabName: OrgTab.Dashboard,
               label: msg("Dashboard"),

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -891,7 +891,7 @@ export class WorkflowDetail extends BtrixElement {
     <div class="col-span-1">${this.renderBreadcrumbs()}</div>
 
     <header
-      class="scrim scrim-to-b z-10 col-span-1 mb-3 flex flex-wrap gap-2 before:-top-3 lg:sticky lg:top-3"
+      class="scrim scrim-to-b relative z-10 col-span-1 mb-3 flex flex-wrap gap-2 before:-top-3 lg:sticky lg:top-3"
     >
       <btrix-detail-page-title .item=${this.workflow}></btrix-detail-page-title>
     </header>

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -99,7 +99,7 @@ export class WorkflowsNew extends BtrixElement {
     return html`
       <div class="mb-5">${this.renderBreadcrumbs()}</div>
       <header
-        class="scrim scrim-to-b z-10 flex flex-wrap items-start justify-between gap-2 before:-top-3 lg:sticky lg:top-3"
+        class="scrim scrim-to-b relative z-10 flex flex-wrap items-start justify-between gap-2 before:-top-3 lg:sticky lg:top-3"
       >
         <h2 class="mb-6 text-xl font-semibold">${msg("New Crawl Workflow")}</h2>
         <sl-button


### PR DESCRIPTION
Fixes a variety of layout issues/bugs that have been bugging me lately.

Closes #2778

## Changes

- Changes page headers to fix unnecessary stacking at smaller viewport widths
- Fixes issues where scrim shows up over entire page at smaller viewport widths
- Fixes an issue where the main nav wouldn't scroll all the way to the right when viewport is smaller than its width

## Screenshots

| Location | Before | After |
|--------|--------|--------|
| New Crawl Workflow | <img width="1454" height="1696" alt="dev browsertrix com_admin (1)" src="https://github.com/user-attachments/assets/48f5f11f-7b6d-4672-ab7c-0dd19abe238f" /> | <img width="1454" height="1696" alt="localhost_9870_orgs_default-org_workflows_new (1)" src="https://github.com/user-attachments/assets/08884e61-8b03-4813-b666-7ddacbf679ac" /> |
| Edit Crawl Workflow | <img width="1454" height="1696" alt="dev browsertrix com_admin" src="https://github.com/user-attachments/assets/dfc802bc-4d9b-460b-aeac-565e8e29a162" /> | <img width="1454" height="1696" alt="localhost_9870_orgs_default-org_workflows_new" src="https://github.com/user-attachments/assets/2ed7ad6e-1305-435b-aea2-c279a0d34ed4" /> |
| Workflow Details | <img width="1454" height="1696" alt="dev browsertrix com_admin (2)" src="https://github.com/user-attachments/assets/66ab128d-c7e2-4b5a-8294-2bf24f6a5f6b" /> | <img width="1454" height="1696" alt="localhost_9870_orgs_default-org_workflows_new (2)" src="https://github.com/user-attachments/assets/d2bcb14b-b7b7-4fd0-afcb-0b22907accb0" /> |
| Org Settings | <img width="882" height="1696" alt="dev browsertrix com_orgs_default-org_workflows_7c9b8c46-73aa-4b88-98d6-bab410c645b7_latest" src="https://github.com/user-attachments/assets/e7417737-190e-4a61-b9c2-b8158545960b" /> | <img width="882" height="1696" alt="localhost_9870_orgs_default-org_workflows_new (3)" src="https://github.com/user-attachments/assets/c28773ff-4550-4374-a05c-c2c5637850f5" /> | 
| Dashboard | <img width="882" height="840" alt="dev browsertrix com_orgs_default-org_workflows_7c9b8c46-73aa-4b88-98d6-bab410c645b7_latest (1)" src="https://github.com/user-attachments/assets/7ae331d9-1947-42ed-b77d-7861e70ef803" /> | <img width="1454" height="1696" alt="localhost_9870_orgs_default-org_workflows_new" src="https://github.com/user-attachments/assets/be7190f8-49b4-4d88-81e7-c6016e94a91e" /> |


