### PR TITLE
Delete k8s objects on org deletion

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -515,14 +515,13 @@ class BackgroundJobOps:
         if job.type != job_type:
             raise HTTPException(status_code=400, detail="invalid_job_type")
 
-        if success:
-            if job_type == BgJobType.CREATE_REPLICA:
-                await self.handle_replica_job_finished(cast(CreateReplicaJob, job))
-            if job_type == BgJobType.DELETE_REPLICA:
-                await self.handle_delete_replica_job_finished(
-                    cast(DeleteReplicaJob, job)
-                )
-        else:
+        if success and job_type == BgJobType.CREATE_REPLICA:
+            await self.handle_replica_job_finished(cast(CreateReplicaJob, job))
+
+        if job_type == BgJobType.DELETE_REPLICA:
+            await self.handle_delete_replica_job_finished(cast(DeleteReplicaJob, job))
+
+        if not success:
             await self._send_bg_job_failure_email(job, finished)
 
         await self.jobs.find_one_and_update(

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -500,13 +500,34 @@ class CrawlManager(K8sAPI):
     async def _delete_custom_objects(self, label, plural="crawljobs") -> None:
         """Delete custom objects (e.g. crawl jobs, profile browser jobs)"""
 
-        await self.custom_api.delete_collection_namespaced_custom_object(
+        objects = await self.custom_api.list_namespaced_custom_object(
             group="btrix.cloud",
             version="v1",
             namespace=self.namespace,
-            label_selector=label,
             plural=plural,
+            label_selector=label,
         )
+        print(f"Custom objects with label {label}, plural {plural}", flush=True)
+        items = objects.get("items")
+        item_len = len(items)
+        print(f"Items: {item_len}", flush=True)
+        for item in items:
+            print(item, flush=True)
+
+        delete_response = (
+            await self.custom_api.delete_collection_namespaced_custom_object(
+                group="btrix.cloud",
+                version="v1",
+                namespace=self.namespace,
+                label_selector=label,
+                plural=plural,
+            )
+        )
+        print(
+            f"Custom objects delete response with label {label}, plural {plural}",
+            flush=True,
+        )
+        print(delete_response, flush=True)
 
     async def update_scheduled_job(
         self, crawlconfig: CrawlConfig, userid: Optional[str] = None

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -499,35 +499,15 @@ class CrawlManager(K8sAPI):
 
     async def _delete_custom_objects(self, label, plural="crawljobs") -> None:
         """Delete custom objects (e.g. crawl jobs, profile browser jobs)"""
-
-        objects = await self.custom_api.list_namespaced_custom_object(
+        await self.custom_api.delete_collection_namespaced_custom_object(
             group="btrix.cloud",
             version="v1",
             namespace=self.namespace,
-            plural=plural,
             label_selector=label,
+            plural=plural,
+            grace_period_seconds=0,
+            propagation_policy="Background",
         )
-        print(f"Custom objects with label {label}, plural {plural}", flush=True)
-        items = objects.get("items")
-        item_len = len(items)
-        print(f"Items: {item_len}", flush=True)
-        for item in items:
-            print(item, flush=True)
-
-        delete_response = (
-            await self.custom_api.delete_collection_namespaced_custom_object(
-                group="btrix.cloud",
-                version="v1",
-                namespace=self.namespace,
-                label_selector=label,
-                plural=plural,
-            )
-        )
-        print(
-            f"Custom objects delete response with label {label}, plural {plural}",
-            flush=True,
-        )
-        print(delete_response, flush=True)
 
     async def update_scheduled_job(
         self, crawlconfig: CrawlConfig, userid: Optional[str] = None

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -142,6 +142,8 @@ def main() -> None:
 
     dbclient, mdb = init_db()
 
+    crawl_manager = CrawlManager()
+
     settings = SettingsResponse(
         registrationEnabled=is_bool(os.environ.get("REGISTRATION_ENABLED")),
         jwtTokenLifetime=JWT_TOKEN_LIFETIME,
@@ -178,6 +180,7 @@ def main() -> None:
         app,
         mdb,
         user_manager,
+        crawl_manager,
         invites,
         current_active_user,
     )
@@ -193,8 +196,6 @@ def main() -> None:
              Kubernetes not detected (KUBERNETES_SERVICE_HOST is not set), Exiting"
         )
         sys.exit(1)
-
-    crawl_manager = CrawlManager()
 
     crawl_log_ops = CrawlLogOps(mdb, org_ops)
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -39,6 +39,7 @@ NUM_BROWSERS = int(os.environ.get("NUM_BROWSERS", 2))
 MAX_BROWSER_WINDOWS = os.environ.get("MAX_BROWSER_WINDOWS") or 0
 
 # crawl scale for constraint
+# pylint: disable=invalid-name
 if MAX_BROWSER_WINDOWS:
     MAX_BROWSER_WINDOWS = int(MAX_BROWSER_WINDOWS)
     MAX_CRAWL_SCALE = math.ceil(MAX_BROWSER_WINDOWS / NUM_BROWSERS)

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -171,7 +171,7 @@ class CrawlOperator(BaseOperator):
             if e.detail == "invalid_org_id":
                 return {
                     "status": status.dict(exclude_none=True),
-                    "children": {},
+                    "children": [],
                     "finalized": True,
                 }
             raise

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -77,7 +77,11 @@ class CronJobOperator(BaseOperator):
 
         # get org
         oid = crawlconfig.oid
-        org = await self.org_ops.get_org_by_id(oid)
+        try:
+            org = await self.org_ops.get_org_by_id(oid)
+        except:
+            print(f"error: error getting org {oid}, skipping schedulued job")
+            return self.get_finished_response(metadata)
 
         # db create
         user = None

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -79,6 +79,7 @@ class CronJobOperator(BaseOperator):
         oid = crawlconfig.oid
         try:
             org = await self.org_ops.get_org_by_id(oid)
+        # pylint: disable=bare-except
         except:
             print(f"error: error getting org {oid}, skipping schedulued job")
             return self.get_finished_response(metadata)

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -49,15 +49,15 @@ def init_ops() -> Tuple[
 
     dbclient, mdb = init_db()
 
+    crawl_manager = CrawlManager()
+
     invite_ops = InviteOps(mdb, email)
 
     user_manager = UserManager(mdb, email, invite_ops)
 
-    org_ops = OrgOps(mdb, invite_ops, user_manager)
+    org_ops = OrgOps(mdb, invite_ops, user_manager, crawl_manager)
 
     event_webhook_ops = EventWebhookOps(mdb, org_ops)
-
-    crawl_manager = CrawlManager()
 
     crawl_log_ops = CrawlLogOps(mdb, org_ops)
 


### PR DESCRIPTION
Fixes #2872

This PR ensures that all k8s objects related to an org are deleted immediately after an org is deleted, so that e.g. crawl config cron jobs, paused crawl jobs, and delayed replica deletion jobs are not leftover.

## Testing

Follow instructions in issue to create an org that will have replica deletion cron job scheduled and a pause crawl job, then delete org and validate that resources have been successfully deleted.