### PR TITLE
fix: Fix tag input dropdown overlap

### DIFF
--- a/frontend/src/components/ui/tag-input.ts
+++ b/frontend/src/components/ui/tag-input.ts
@@ -5,7 +5,7 @@ import type {
   SlPopup,
   SlTag,
 } from "@shoelace-style/shoelace";
-import inputCss from "@shoelace-style/shoelace/dist/components/input/input.styles.js";
+import SlInput from "@shoelace-style/shoelace/dist/components/input/input.component.js";
 import {
   css,
   html,
@@ -49,7 +49,7 @@ export type TagInputEvent = CustomEvent<TagInputEventDetail>;
 export class TagInput extends LitElement {
   static styles = [
     dropdown,
-    inputCss,
+    SlInput.styles,
     css`
       :host {
         --tag-height: 1.5rem;

--- a/frontend/src/components/ui/tag-input.ts
+++ b/frontend/src/components/ui/tag-input.ts
@@ -81,7 +81,7 @@ export class TagInput extends LitElement {
       }
 
       sl-popup::part(popup) {
-        z-index: 5;
+        z-index: 60;
       }
 
       .shake {
@@ -211,6 +211,7 @@ export class TagInput extends LitElement {
             skidding="4"
             distance="-4"
             active
+            flip
           >
             <input
               slot="anchor"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -592,7 +592,7 @@ export class WorkflowEditor extends BtrixElement {
 
     return html`
       <btrix-tab-list
-        class="mb-5 hidden lg:block"
+        class="mb-10 hidden lg:block"
         tab=${ifDefined(this.progressState?.activeTab)}
       >
         ${STEPS.map(button)}
@@ -615,7 +615,7 @@ export class WorkflowEditor extends BtrixElement {
       return html`<sl-details
         class=${clsx(
           tw`part-[base]:rounded-lg part-[base]:border part-[base]:transition-shadow part-[base]:focus:shadow`,
-          tw`part-[content]:[border-top:solid_1px_var(--sl-panel-border-color)]`,
+          tw`part-[content]:pb-8 part-[content]:[border-top:solid_1px_var(--sl-panel-border-color)]`,
           tw`part-[header]:text-neutral-500 part-[header]:hover:text-blue-400`,
           tw`part-[summary-icon]:[rotate:none]`,
           hasError &&
@@ -748,7 +748,7 @@ export class WorkflowEditor extends BtrixElement {
     `;
 
     return html`
-      <div class="relative mb-10 flex flex-col gap-12 px-2">
+      <div class="relative mb-10 flex flex-col gap-12 px-2 lg:mb-16">
         ${this.formSections.map(formSection)}
         ${when(
           this.isSubmitting,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2882

## Changes

Fixes workflow tag input being partially obscured, plus minor label spacing issue.

## Manual testing

Verify using repro instructions in https://github.com/webrecorder/browsertrix/issues/2882

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit workflow | <img width="1303" height="274" alt="Screenshot 2025-10-07 at 3 46 38 PM" src="https://github.com/user-attachments/assets/54137f58-ffd8-4247-b61a-284f486a3f1f" /> |


<!-- ## Follow-ups -->
