### PR TITLE
Fix issues with filters on archived item & workflow list pages

### DIFF
--- a/frontend/src/components/ui/data-grid/data-grid-row.ts
+++ b/frontend/src/components/ui/data-grid/data-grid-row.ts
@@ -5,7 +5,6 @@ import { customElement, property, queryAll, state } from "lit/decorators.js";
 import { directive } from "lit/directive.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
-import isEqual from "lodash/fp/isEqual";
 
 import { CellDirective } from "./cellDirective";
 import type {
@@ -18,6 +17,7 @@ import type { GridColumn, GridItem, GridRowId } from "./types";
 import { DataGridFocusController } from "@/components/ui/data-grid/controllers/focus";
 import { TableRow } from "@/components/ui/table/table-row";
 import { FormControl } from "@/mixins/FormControl";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 export type RowRemoveEventDetail = {
@@ -57,7 +57,7 @@ export class DataGridRow<
   /**
    * Data to be presented as a row.
    */
-  @property({ type: Object, hasChanged: (a, b) => !isEqual(a, b) })
+  @property({ type: Object, hasChanged: isNotEqual })
   item?: T;
 
   /**

--- a/frontend/src/features/admin/org-quota-editor.ts
+++ b/frontend/src/features/admin/org-quota-editor.ts
@@ -6,7 +6,6 @@ import { customElement, property, state } from "lit/decorators.js";
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
-import { isEqual } from "lodash";
 import { type Entries } from "type-fest";
 import z from "zod";
 
@@ -17,6 +16,7 @@ import {
   GridColumnType,
   type GridColumn,
 } from "@/components/ui/data-grid/types";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { orgQuotasSchema, type OrgData, type OrgQuotas } from "@/utils/orgs";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
@@ -95,7 +95,7 @@ export class OrgQuotaEditor extends BtrixElement {
   @property({ type: Object })
   activeOrg: OrgData | null = null;
 
-  @state({ hasChanged: (a, b) => !isEqual(a, b) })
+  @state({ hasChanged: isNotEqual })
   orgQuotaAdjustments: Partial<OrgQuotas> = {};
 
   dialog: Ref<SlDialog> = createRef();

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -15,7 +15,6 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
-import { isEqual } from "lodash";
 import { isFocusable } from "tabbable";
 
 import { CrawlStatus } from "./crawl-status";
@@ -24,6 +23,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type CrawlState } from "@/types/crawlState";
 import { finishedCrawlStates } from "@/utils/crawler";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 const MAX_STATES_IN_LABEL = 2;
@@ -53,7 +53,7 @@ export class ArchivedItemStateFilter extends BtrixElement {
 
   private readonly fuse = new Fuse<CrawlState>(finishedCrawlStates);
 
-  @state({ hasChanged: isEqual })
+  @state({ hasChanged: isNotEqual })
   selected = new Map<CrawlState, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
@@ -253,9 +253,10 @@ export class ArchivedItemStateFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected = new Map(
-            this.selected.set(value as CrawlState, checked),
-          );
+          this.selected = new Map([
+            ...this.selected,
+            [value as CrawlState, checked],
+          ]);
         }}
       >
         ${repeat(

--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -17,13 +17,13 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
-import { isEqual } from "lodash";
 import { isFocusable } from "tabbable";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type WorkflowTag, type WorkflowTags } from "@/types/workflow";
 import { stopProp } from "@/utils/events";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 const MAX_TAGS_IN_LABEL = 5;
@@ -57,7 +57,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
     keys: ["tag"],
   });
 
-  @state({ hasChanged: isEqual })
+  @state({ hasChanged: isNotEqual })
   selected = new Map<string, boolean>();
 
   @state()
@@ -306,7 +306,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected = new Map(this.selected.set(value, checked));
+          this.selected = new Map([...this.selected, [value, checked]]);
         }}
       >
         ${repeat(

--- a/frontend/src/features/collections/collection-snapshot-preview.ts
+++ b/frontend/src/features/collections/collection-snapshot-preview.ts
@@ -3,11 +3,11 @@ import { Task } from "@lit/task";
 import clsx from "clsx";
 import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import { isEqual } from "lodash";
 
 import type { SelectSnapshotDetail } from "./select-collection-page";
 
 import { TailwindElement } from "@/classes/TailwindElement";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { formatRwpTimestamp } from "@/utils/replay";
 import { tw } from "@/utils/tailwind";
 
@@ -42,7 +42,7 @@ export class CollectionSnapshotPreview extends TailwindElement {
 
   @property({
     type: Object,
-    hasChanged: (a, b) => !isEqual(a, b),
+    hasChanged: isNotEqual,
   })
   snapshot?: Partial<SelectSnapshotDetail["item"]>;
 

--- a/frontend/src/features/collections/linked-collections/linked-collections.ts
+++ b/frontend/src/features/collections/linked-collections/linked-collections.ts
@@ -2,7 +2,6 @@ import { localized } from "@lit/localize";
 import { Task } from "@lit/task";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import isEqual from "lodash/fp/isEqual";
 
 import type {
   BtrixLoadedLinkedCollectionEvent,
@@ -12,6 +11,7 @@ import { isActualCollection } from "./utils";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Collection } from "@/types/collection";
+import { isNotEqual } from "@/utils/is-not-equal";
 
 /**
  * Display list of collections that are linked to a workflow or archived item by ID.
@@ -25,7 +25,7 @@ export class LinkedCollections extends BtrixElement {
    * List of collection IDs, checked against values so collection data is not
    * unnecessarily fetched if IDs have not changed
    */
-  @property({ type: Array, hasChanged: (a, b) => !isEqual(a, b) })
+  @property({ type: Array, hasChanged: isNotEqual })
   collections: (string | CollectionLikeItem)[] = [];
 
   @property({ type: Boolean })

--- a/frontend/src/features/collections/select-collection-page.ts
+++ b/frontend/src/features/collections/select-collection-page.ts
@@ -9,7 +9,6 @@ import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
-import { isEqual } from "lodash";
 import debounce from "lodash/fp/debounce";
 import filter from "lodash/fp/filter";
 import flow from "lodash/fp/flow";
@@ -21,6 +20,7 @@ import type { Combobox } from "@/components/ui/combobox";
 import type { APIPaginationQuery } from "@/types/api";
 import type { Collection } from "@/types/collection";
 import type { UnderlyingFunction } from "@/types/utils";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 type Snapshot = {
@@ -74,7 +74,7 @@ export class SelectCollectionPage extends BtrixElement {
   @state()
   private selectedPage?: Page;
 
-  @property({ type: Object, hasChanged: (a, b) => !isEqual(a, b) })
+  @property({ type: Object, hasChanged: isNotEqual })
   public selectedSnapshot?: Snapshot;
 
   @state()

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -110,6 +110,7 @@ import {
 } from "@/utils/cron";
 import { makeCurrentTargetHandler, stopProp } from "@/utils/events";
 import { formValidator, maxLengthValidator } from "@/utils/form";
+import { isNotEqual } from "@/utils/is-not-equal";
 import localize from "@/utils/localize";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { pluralOf } from "@/utils/pluralize";
@@ -277,7 +278,7 @@ export class WorkflowEditor extends BtrixElement {
     type: Object,
     // Fixes values being reset on navigation events,
     // such as when the user guide is open
-    hasChanged: (a, b) => !isEqual(a, b),
+    hasChanged: isNotEqual,
   })
   initialWorkflow?: WorkflowParams;
 

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -17,7 +17,6 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
-import { isEqual } from "lodash";
 import queryString from "query-string";
 import { isFocusable } from "tabbable";
 
@@ -25,6 +24,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type APIPaginatedList } from "@/types/api";
 import { type Profile } from "@/types/crawler";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import { tw } from "@/utils/tailwind";
@@ -58,7 +58,7 @@ export class WorkflowProfileFilter extends BtrixElement {
     keys: ["id", "name", "description", "origins"],
   });
 
-  @state({ hasChanged: isEqual })
+  @state({ hasChanged: isNotEqual })
   selected = new Map<string, boolean>();
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -17,13 +17,13 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
-import { isEqual } from "lodash";
 import { isFocusable } from "tabbable";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
 import { type WorkflowTag, type WorkflowTags } from "@/types/workflow";
 import { stopProp } from "@/utils/events";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 const MAX_TAGS_IN_LABEL = 5;
@@ -57,7 +57,7 @@ export class WorkflowTagFilter extends BtrixElement {
     keys: ["tag"],
   });
 
-  @state({ hasChanged: isEqual })
+  @state({ hasChanged: isNotEqual })
   selected = new Map<string, boolean>();
 
   @state()
@@ -297,7 +297,7 @@ export class WorkflowTagFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected = new Map(this.selected.set(value, checked));
+          this.selected = new Map([...this.selected, [value, checked]]);
         }}
       >
         ${repeat(

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -203,7 +203,7 @@ export class CrawlsList extends BtrixElement {
   private readonly filterBy = new SearchParamsValue<FilterBy>(
     this,
     (value, params) => {
-      const keys = Object.keys(value) as Keys<typeof value>;
+      const keys = ["firstSeed", "name", "state"] as (keyof FilterBy)[];
       keys.forEach((key) => {
         if (value[key] == null) {
           params.delete(key);

--- a/frontend/src/utils/is-not-equal.ts
+++ b/frontend/src/utils/is-not-equal.ts
@@ -1,0 +1,6 @@
+import { isEqual } from "lodash";
+
+/**
+ * Inverted version of lodash `isEqual` for use in Lit `@property`/`@state` configs for `hasChanged`.
+ */
+export const isNotEqual = (a: unknown, b: unknown) => !isEqual(a, b);


### PR DESCRIPTION
Closes #2885 

## Changes

- Enumerates all possible values of `filterBy` when updating search params to match value on archived item list
- Adds a new `isNotEqual` wrapper that inverts lodash's `isEqual` for use in the `hasChanged` option of `@property`/`@state` decorator functions
  - Applies these wherever relevant, both within and outside of filters
- Updates how maps are updated in checkbox filters
  - Previously they were updated by updating the value of the old map, and then creating a new map with the updated old map as an initial value. While this works fine for the default comparator which compares values by reference, because every updated causes the map to be recreated we need to compare values of the map by value instead, which meant that because the old value was updated before creating the new map, the old and new map would have the same contents when compared.
  - The solution here is to create a new map by using the existing value of the old map plus the update as a key-value tuple as the initial value. This way the old value isn't updated, so the by-value comparison works as expected.

## Testing

- On both the workflows and archived items list pages, test that all of the filter chips work as expected.
  - In particular, test that checkbox-type filters update the state of the filter chips as well as the URLs when clicked, and that they don't hang your browser
- On the archived items list page, test that you can enter a search term, and then clear that term, and that the URL updates to reflect __both__ changes.

### Known issues

The search box on the workflows list page is not yet hooked up to persist its value via URL. That's coming soon!