### PR TITLE
Fix backend `k8sapi.py` not respecting `fqdn_suffix` configuration

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -29,6 +29,7 @@ class K8sAPI:
     def __init__(self):
         super().__init__()
         self.namespace = os.environ.get("CRAWLER_NAMESPACE") or "crawlers"
+        self.crawler_fqdn_suffix = os.environ.get("CRAWLER_FQDN_SUFFIX") or f"{self.namespace}.svc.cluster.local"
         self.custom_resources = {}
 
         self.templates = Jinja2Templates(
@@ -63,7 +64,7 @@ class K8sAPI:
     def get_redis_url(self, crawl_id):
         """get redis url for crawl id"""
         redis_url = (
-            f"redis://redis-{crawl_id}.redis.{self.namespace}.svc.cluster.local/0"
+            f"redis://redis-{crawl_id}.redis.{self.crawler_fqdn_suffix}/0"
         )
         return redis_url
 

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -29,7 +29,7 @@ class K8sAPI:
     def __init__(self):
         super().__init__()
         self.namespace = os.environ.get("CRAWLER_NAMESPACE") or "crawlers"
-        self.crawler_fqdn_suffix = os.environ.get("CRAWLER_FQDN_SUFFIX") or f"{self.namespace}.svc.cluster.local"
+        self.crawler_fqdn_suffix = os.environ.get("CRAWLER_FQDN_SUFFIX") or f".{self.namespace}.svc.cluster.local"
         self.custom_resources = {}
 
         self.templates = Jinja2Templates(
@@ -64,7 +64,7 @@ class K8sAPI:
     def get_redis_url(self, crawl_id):
         """get redis url for crawl id"""
         redis_url = (
-            f"redis://redis-{crawl_id}.redis.{self.crawler_fqdn_suffix}/0"
+            f"redis://redis-{crawl_id}.redis{self.crawler_fqdn_suffix}/0"
         )
         return redis_url
 

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -29,7 +29,10 @@ class K8sAPI:
     def __init__(self):
         super().__init__()
         self.namespace = os.environ.get("CRAWLER_NAMESPACE") or "crawlers"
-        self.crawler_fqdn_suffix = os.environ.get("CRAWLER_FQDN_SUFFIX") or f".{self.namespace}.svc.cluster.local"
+        self.crawler_fqdn_suffix = (
+            os.environ.get("CRAWLER_FQDN_SUFFIX")
+            or f".{self.namespace}.svc.cluster.local"
+        )
         self.custom_resources = {}
 
         self.templates = Jinja2Templates(
@@ -63,9 +66,7 @@ class K8sAPI:
 
     def get_redis_url(self, crawl_id):
         """get redis url for crawl id"""
-        redis_url = (
-            f"redis://redis-{crawl_id}.redis{self.crawler_fqdn_suffix}/0"
-        )
+        redis_url = f"redis://redis-{crawl_id}.redis{self.crawler_fqdn_suffix}/0"
         return redis_url
 
     async def get_redis_client(self, redis_url):


### PR DESCRIPTION
Hey all,

earlier today I encountered an issue which I have reported in #2889.

TL;DR is: When creating crawlers their Redis-URL is always built using `.svc.cluster.local` instead of respecting the `fqdn_suffix` value. 

Since this seemed like an easy fix I thought I may as well just open a PR.

This PR changes the `redis_url` generation to use the `CRAWLER_FQDN_SUFFIX` environment variable, which was already defined in the backend config map: https://github.com/webrecorder/browsertrix/blob/5be85770fea19532aacec411b142e46e3ead10a9/chart/templates/configmap.yaml#L17C3-L17C22

Fixes #2889

Hope this helps! 🙂 