### PR TITLE
fix: Fix whitespace in workflow deletion toast message

### DIFF
--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -2236,10 +2236,11 @@ export class WorkflowDetail extends BtrixElement {
 
       this.navigate.to(`${this.navigate.orgBasePath}/workflows`);
 
+      const workflow_name = html`<strong class="inline-flex"
+        >${renderName(this.workflow)}</strong
+      >`;
       this.notify.toast({
-        message: msg(
-          html`Deleted <strong>${renderName(this.workflow)}</strong> Workflow.`,
-        ),
+        message: msg(html`Deleted ${workflow_name} Workflow.`),
         variant: "success",
         icon: "check2-circle",
         id: "workflow-delete-status",

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -998,10 +998,12 @@ export class WorkflowsList extends BtrixElement {
       });
 
       void this.fetchWorkflows();
+
+      const workflow_name = html`<strong class="inline-flex"
+        >${renderName(workflow)}</strong
+      >`;
       this.notify.toast({
-        message: msg(
-          html`Deleted <strong>${renderName(workflow)}</strong> Workflow.`,
-        ),
+        message: msg(html`Deleted ${workflow_name} Workflow.`),
         variant: "success",
         icon: "check2-circle",
         id: "workflow-delete-status",


### PR DESCRIPTION
No issue

## Changes

Prevents workflow name from being on new line in workflow deletion toast.

## Manual testing

1. Log in as crawler
2. Go to Crawling
3. Delete a workflow. Verify text in confirmation toast message is aligned as expected.
4. Repeat 3 from workflow detail page.

## Screenshots

| Before | After |
| ---- | ----------- |
| <img width="431" height="110" alt="Screenshot 2025-10-13 at 9 13 17 AM" src="https://github.com/user-attachments/assets/a29a6930-da04-4f0b-b24e-947b759d57d5" /> | <img width="441" height="71" alt="Screenshot 2025-10-13 at 9 19 03 AM" src="https://github.com/user-attachments/assets/3bfc848f-84d9-4c91-a911-c682b31c819c" /> |

<!-- ## Follow-ups -->
