### PR TITLE
feat: Consistently display UI info bars

### DIFF
--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -94,7 +94,7 @@ export class DescList extends LitElement {
       display: inline-block;
       flex: 1 0 0;
       min-width: min-content;
-      padding-top: var(--sl-spacing-x-small);
+      padding: var(--sl-spacing-x-small) var(--sl-spacing-medium) 0;
     }
 
     .horizontal ::slotted(btrix-desc-list-item)::before {

--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -74,7 +74,7 @@ export class DescList extends LitElement {
     dl {
       display: grid;
       margin: 0;
-      gap: 1rem;
+      gap: var(--sl-spacing-medium);
     }
 
     .vertical {
@@ -92,7 +92,7 @@ export class DescList extends LitElement {
     .horizontal ::slotted(btrix-desc-list-item) {
       position: relative;
       display: inline-block;
-      flex: 1 0 0;
+      flex: 1 1 auto;
       min-width: min-content;
       padding: var(--sl-spacing-x-small) var(--sl-spacing-medium) 0;
     }

--- a/frontend/src/controllers/localize.ts
+++ b/frontend/src/controllers/localize.ts
@@ -1,4 +1,5 @@
 import { LocalizeController as SlLocalizeController } from "@shoelace-style/localize";
+import { html } from "lit";
 import type { Options as PrettyMsOptions } from "pretty-ms";
 
 import localize from "@/utils/localize";
@@ -14,6 +15,48 @@ export class LocalizeController extends SlLocalizeController {
    * Custom date formatter that takes missing `Z` into account
    */
   readonly date = localize.date;
+
+  /**
+   * Custom relative date formatter that also renders tooltip
+   */
+  readonly relativeDate = (
+    dateStr: string,
+    { prefix }: { prefix?: string } = {},
+  ) => {
+    const date = new Date(dateStr);
+    const diff = new Date().getTime() - date.getTime();
+    const seconds = diff / 1000;
+    const minutes = seconds / 60;
+    const hours = minutes / 60;
+
+    return html`
+      <sl-tooltip
+        content=${this.date(date, {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          timeZoneName: "short",
+        })}
+        hoist
+        placement="bottom"
+      >
+        <span>
+          ${prefix}
+          ${hours > 24
+            ? this.date(date, {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              })
+            : seconds > 60
+              ? html`<sl-relative-time sync date=${dateStr}></sl-relative-time>`
+              : `<${this.relativeTime(-1, "minute", { style: "narrow" })}`}
+        </span>
+      </sl-tooltip>
+    `;
+  };
 
   /**
    * Custom duration formatter

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -590,6 +590,55 @@ export class CollectionDetail extends BtrixElement {
   };
 
   private renderInfoBar() {
+    const relativeDate = (
+      dateStr: string,
+      { prefix }: { prefix?: string } = {},
+    ) => {
+      const date = new Date(dateStr);
+      const diff = new Date().getTime() - date.getTime();
+      const seconds = diff / 1000;
+      const minutes = seconds / 60;
+      const hours = minutes / 60;
+
+      return html`
+        <sl-tooltip
+          content=${this.localize.date(date, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+            timeZoneName: "short",
+          })}
+          hoist
+          placement="bottom"
+        >
+          <span>
+            ${prefix}
+            ${hours > 24
+              ? this.localize.date(date, {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })
+              : seconds > 60
+                ? html`<sl-relative-time
+                    sync
+                    date=${dateStr}
+                  ></sl-relative-time>`
+                : `<${this.localize.relativeTime(-1, "minute", { style: "narrow" })}`}
+          </span>
+        </sl-tooltip>
+      `;
+    };
+
+    const createdDate =
+      this.collection?.created &&
+      (!this.collection.modified ||
+        this.collection.created === this.collection.modified)
+        ? this.collection.created
+        : null;
+
     return html`
       <btrix-desc-list horizontal>
         ${this.renderDetailItem(
@@ -602,37 +651,13 @@ export class CollectionDetail extends BtrixElement {
           (col) =>
             `${this.localize.number(col.pageCount)} ${pluralOf("pages", col.pageCount)}`,
         )}
-        ${when(this.collection?.created, (created) =>
-          // Collections created before 49516bc4 is released may not have date in db
-          created
-            ? this.renderDetailItem(
-                msg("Date Created"),
-                () =>
-                  html`<btrix-format-date
-                    date=${created}
-                    month="long"
-                    day="numeric"
-                    year="numeric"
-                    hour="numeric"
-                    minute="numeric"
-                    time-zone-name="short"
-                  ></btrix-format-date>`,
-              )
-            : nothing,
-        )}
-        ${this.renderDetailItem(
-          msg("Last Modified"),
-          (col) =>
-            html`<btrix-format-date
-              date=${col.modified}
-              month="long"
-              day="numeric"
-              year="numeric"
-              hour="numeric"
-              minute="numeric"
-              time-zone-name="short"
-            ></btrix-format-date>`,
-        )}
+        ${createdDate
+          ? this.renderDetailItem(msg("Created"), () =>
+              relativeDate(createdDate),
+            )
+          : this.renderDetailItem(msg("Last Modified"), (col) =>
+              col.modified ? relativeDate(col.modified) : "",
+            )}
       </btrix-desc-list>
     `;
   }

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -234,7 +234,13 @@ export class CollectionDetail extends BtrixElement {
         </div>
       </header>
 
-      <div class="mt-3 rounded-lg border px-4 py-2">
+      <div
+        class="mt-3 rounded-lg border px-4 py-2"
+        aria-busy="${
+          // TODO Switch to task and use task status
+          this.collection === undefined
+        }"
+      >
         ${this.renderInfoBar()}
       </div>
       <div class="flex items-center justify-between py-3">
@@ -590,8 +596,14 @@ export class CollectionDetail extends BtrixElement {
   };
 
   private renderInfoBar() {
+    if (!this.collection) {
+      return html`<div class="h-14">
+        <span class="sr-only">${msg("Loading details")}</span>
+      </div>`;
+    }
+
     const createdDate =
-      this.collection?.created &&
+      this.collection.created &&
       (!this.collection.modified ||
         this.collection.created === this.collection.modified)
         ? this.collection.created

--- a/frontend/src/pages/org/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail.ts
@@ -590,48 +590,6 @@ export class CollectionDetail extends BtrixElement {
   };
 
   private renderInfoBar() {
-    const relativeDate = (
-      dateStr: string,
-      { prefix }: { prefix?: string } = {},
-    ) => {
-      const date = new Date(dateStr);
-      const diff = new Date().getTime() - date.getTime();
-      const seconds = diff / 1000;
-      const minutes = seconds / 60;
-      const hours = minutes / 60;
-
-      return html`
-        <sl-tooltip
-          content=${this.localize.date(date, {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-            timeZoneName: "short",
-          })}
-          hoist
-          placement="bottom"
-        >
-          <span>
-            ${prefix}
-            ${hours > 24
-              ? this.localize.date(date, {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })
-              : seconds > 60
-                ? html`<sl-relative-time
-                    sync
-                    date=${dateStr}
-                  ></sl-relative-time>`
-                : `<${this.localize.relativeTime(-1, "minute", { style: "narrow" })}`}
-          </span>
-        </sl-tooltip>
-      `;
-    };
-
     const createdDate =
       this.collection?.created &&
       (!this.collection.modified ||
@@ -653,10 +611,10 @@ export class CollectionDetail extends BtrixElement {
         )}
         ${createdDate
           ? this.renderDetailItem(msg("Created"), () =>
-              relativeDate(createdDate),
+              this.localize.relativeDate(createdDate),
             )
           : this.renderDetailItem(msg("Last Modified"), (col) =>
-              col.modified ? relativeDate(col.modified) : "",
+              col.modified ? this.localize.relativeDate(col.modified) : "",
             )}
       </btrix-desc-list>
     `;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1063,48 +1063,6 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private renderDetails() {
-    const relativeDate = (
-      dateStr: string,
-      { prefix }: { prefix?: string } = {},
-    ) => {
-      const date = new Date(dateStr);
-      const diff = new Date().getTime() - date.getTime();
-      const seconds = diff / 1000;
-      const minutes = seconds / 60;
-      const hours = minutes / 60;
-
-      return html`
-        <sl-tooltip
-          content=${this.localize.date(date, {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-            timeZoneName: "short",
-          })}
-          hoist
-          placement="bottom"
-        >
-          <span>
-            ${prefix}
-            ${hours > 24
-              ? this.localize.date(date, {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })
-              : seconds > 60
-                ? html`<sl-relative-time
-                    sync
-                    date=${dateStr}
-                  ></sl-relative-time>`
-                : `<${this.localize.relativeTime(-1, "minute", { style: "narrow" })}`}
-          </span>
-        </sl-tooltip>
-      `;
-    };
-
     return html`
       <btrix-desc-list horizontal>
         ${this.renderDetailItem(
@@ -1120,7 +1078,7 @@ export class WorkflowDetail extends BtrixElement {
         ${this.renderDetailItem(msg("Last Run"), (workflow) =>
           workflow.lastRun
             ? // TODO Use `lastStartedByName` when it's updated to be null for scheduled runs
-              relativeDate(workflow.lastRun, {
+              this.localize.relativeDate(workflow.lastRun, {
                 prefix:
                   workflow.lastRun === workflow.lastCrawlStartTime
                     ? msg("Started")
@@ -1149,7 +1107,7 @@ export class WorkflowDetail extends BtrixElement {
         ${this.renderDetailItem(
           msg("Last Modified"),
           (workflow) =>
-            html`${relativeDate(workflow.modified)} ${msg("by")}
+            html`${this.localize.relativeDate(workflow.modified)} ${msg("by")}
             ${workflow.modifiedByName}`,
         )}
       </btrix-desc-list>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -491,7 +491,11 @@ export class WorkflowDetail extends BtrixElement {
             </div>
           </header>
 
-          <section class="col-span-1 rounded-lg border px-4 py-2">
+          <section
+            class="col-span-1 rounded-lg border px-4 py-2"
+            aria-busy="${this.workflowTask.status === TaskStatus.INITIAL ||
+            this.workflowTask.status === TaskStatus.PENDING}"
+          >
             ${this.renderDetails()}
           </section>
         </div>
@@ -1063,6 +1067,12 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private renderDetails() {
+    if (!this.workflow) {
+      return html`<div class="h-14">
+        <span class="sr-only">${msg("Loading details")}</span>
+      </div>`;
+    }
+
     return html`
       <btrix-desc-list horizontal>
         ${this.renderDetailItem(


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2896

## Changes

- Ensures info bar columns use all available space
- Consistently displays same number of collection info columns
- Moves relative date utility to shared controller

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow detail | <img width="1256" height="167" alt="Screenshot 2025-10-13 at 10 34 11 AM" src="https://github.com/user-attachments/assets/2f65bad5-dc5b-47ca-909a-2df2e50c39b8" /> |
| Collection detail | <img width="1261" height="86" alt="Screenshot 2025-10-13 at 10 52 03 AM" src="https://github.com/user-attachments/assets/2f9cb578-5578-4c87-8401-f421aa1c7d6f" /><br/><br/><img width="1255" height="86" alt="Screenshot 2025-10-13 at 10 52 10 AM" src="https://github.com/user-attachments/assets/767891a5-c818-4b65-b7b4-7e5e80d40dbb" /> |

## Follow-ups

A longer term solution would be to reorganize the workflow detail info bar so that there isn't too much information that we're trying to fit here. This will need some design work.