### PR TITLE
Refactor workflows list to use `Task` & `SearchParamsValue`

### DIFF
--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -430,12 +430,9 @@ export class Pagination extends LitElement {
   #setPage(page: number, options: { replace?: boolean } = {}) {
     if (!this.disablePersist) {
       if (page === 1) {
-        this.searchParams.delete(this.name, { transaction: true });
+        this.searchParams.delete(this.name);
       } else {
-        this.searchParams.set(this.name, page.toString(), {
-          ...options,
-          transaction: true,
-        });
+        this.searchParams.set(this.name, page.toString(), options);
       }
     } else {
       this._page = page;

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -430,7 +430,7 @@ export class Pagination extends LitElement {
   #setPage(page: number, options: { replace?: boolean } = {}) {
     if (!this.disablePersist) {
       if (page === 1) {
-        this.searchParams.delete(this.name);
+        this.searchParams.delete(this.name, options);
       } else {
         this.searchParams.set(this.name, page.toString(), options);
       }

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -163,7 +163,7 @@ export class Pagination extends LitElement {
   @property({ type: Number })
   set page(page: number) {
     if (page !== this._page) {
-      this.setPage(page);
+      this.#setPage(page);
       this._page = page;
     }
   }
@@ -232,7 +232,7 @@ export class Pagination extends LitElement {
       if (parsedPage != this._page) {
         const page = parsePage(this.searchParams.searchParams.get(this.name));
         const constrainedPage = Math.max(1, Math.min(this.pages, page));
-        this.onPageChange(constrainedPage, { dispatch: false });
+        this.setPage(constrainedPage, { dispatch: false });
       }
     }
 
@@ -242,7 +242,7 @@ export class Pagination extends LitElement {
       (this.page > this.pages || this.page < 1)
     ) {
       const constrainedPage = Math.max(1, Math.min(this.pages, this.page));
-      this.onPageChange(constrainedPage, { dispatch: true });
+      this.setPage(constrainedPage, { dispatch: true });
     }
 
     if (changedProperties.get("_page")) {
@@ -337,7 +337,7 @@ export class Pagination extends LitElement {
               nextPage = page;
             }
 
-            this.onPageChange(nextPage);
+            this.setPage(nextPage);
           }}
           @focus=${(e: Event) => {
             // Select text on focus for easy typing
@@ -390,7 +390,7 @@ export class Pagination extends LitElement {
         .active=${isCurrent}
         .size=${"x-small"}
         .align=${"center"}
-        @click=${() => this.onPageChange(page)}
+        @click=${() => this.setPage(page)}
         aria-disabled=${isCurrent}
         >${localize.number(page)}</btrix-navigation-button
       >
@@ -398,18 +398,24 @@ export class Pagination extends LitElement {
   };
 
   private onPrev() {
-    this.onPageChange(this._page > 1 ? this._page - 1 : 1);
+    this.setPage(this._page > 1 ? this._page - 1 : 1);
   }
 
   private onNext() {
-    this.onPageChange(this._page < this.pages ? this._page + 1 : this.pages);
+    this.setPage(this._page < this.pages ? this._page + 1 : this.pages);
   }
 
-  private onPageChange(page: number, opts = { dispatch: true }) {
+  setPage(
+    page: number,
+    options: { dispatch?: boolean; replace?: boolean } = {
+      dispatch: true,
+      replace: false,
+    },
+  ) {
     if (this._page !== page) {
-      this.setPage(page);
+      this.#setPage(page, { replace: options.replace });
 
-      if (opts.dispatch) {
+      if (options.dispatch) {
         this.dispatchEvent(
           new CustomEvent<PageChangeDetail>("page-change", {
             detail: { page: page, pages: this.pages },
@@ -421,12 +427,12 @@ export class Pagination extends LitElement {
     this._page = page;
   }
 
-  private setPage(page: number) {
+  #setPage(page: number, options: { replace?: boolean } = {}) {
     if (!this.disablePersist) {
       if (page === 1) {
         this.searchParams.delete(this.name);
       } else {
-        this.searchParams.set(this.name, page.toString());
+        this.searchParams.set(this.name, page.toString(), options);
       }
     } else {
       this._page = page;

--- a/frontend/src/components/ui/pagination.ts
+++ b/frontend/src/components/ui/pagination.ts
@@ -430,9 +430,12 @@ export class Pagination extends LitElement {
   #setPage(page: number, options: { replace?: boolean } = {}) {
     if (!this.disablePersist) {
       if (page === 1) {
-        this.searchParams.delete(this.name);
+        this.searchParams.delete(this.name, { transaction: true });
       } else {
-        this.searchParams.set(this.name, page.toString(), options);
+        this.searchParams.set(this.name, page.toString(), {
+          ...options,
+          transaction: true,
+        });
       }
     } else {
       this._page = page;

--- a/frontend/src/controllers/searchParams.ts
+++ b/frontend/src/controllers/searchParams.ts
@@ -1,65 +1,6 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
-type Update = {
-  update: (prev: URLSearchParams) => URLSearchParams;
-  prevParams: URLSearchParams;
-  type: "push" | "replace";
-  source?: string;
-  pending?: PromiseLike<unknown>;
-  data?: unknown;
-};
-
 export class SearchParamsController implements ReactiveController {
-  static #pendingUpdates: Update[] = [];
-  static #transaction = false;
-  static set transaction(value: boolean) {
-    if (value) {
-      SearchParamsController.#transaction = value;
-      return;
-    }
-    if (SearchParamsController.#transaction) {
-      console.debug(
-        "SearchParamsController: transaction not closed; pending updates:",
-        SearchParamsController.#pendingUpdates,
-      );
-    }
-  }
-  static get transaction(): boolean {
-    return SearchParamsController.#transaction;
-  }
-  static #timeout: number | undefined;
-  static pushUpdate(update: Update) {
-    console.debug("pushed update", update);
-    SearchParamsController.#pendingUpdates.push(update);
-    if (SearchParamsController.#timeout) {
-      window.clearTimeout(SearchParamsController.#timeout);
-    }
-    SearchParamsController.#timeout = window.setTimeout(async () => {
-      console.debug("running updates", SearchParamsController.#pendingUpdates);
-      SearchParamsController.transaction = true;
-      let newParams = new URLSearchParams(location.search);
-      await Promise.all(
-        SearchParamsController.#pendingUpdates.map(async (update, index) => {
-          console.debug(`new params before update ${index}`, newParams);
-          newParams = update.update(newParams);
-          console.debug(`new params after update ${index}`, newParams);
-          if (update.pending) {
-            await update.pending;
-          }
-        }),
-      );
-      const url = new URL(location.toString());
-      url.search = newParams.toString();
-      if (update.type === "push") {
-        history.pushState(update.data, "", url);
-      } else {
-        history.replaceState(update.data, "", url);
-      }
-      SearchParamsController.#pendingUpdates = [];
-      SearchParamsController.#transaction = false;
-    }, 0);
-  }
-
   private readonly host: ReactiveControllerHost;
   private readonly changeHandler?: (
     searchParams: URLSearchParams,
@@ -73,28 +14,11 @@ export class SearchParamsController implements ReactiveController {
 
   public update(
     update: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams),
-    options: { replace?: boolean; data?: unknown; transaction?: boolean } = {
+    options: { replace?: boolean; data?: unknown } = {
       replace: false,
     },
   ) {
-    SearchParamsController.transaction = !!options.transaction;
     this.prevParams = new URLSearchParams(this.searchParams);
-    if (SearchParamsController.transaction) {
-      SearchParamsController.pushUpdate({
-        prevParams: this.prevParams,
-        update: (params) => {
-          if (typeof update === "function") {
-            return update(params);
-          }
-          return update;
-        },
-        source: "update",
-        type: options.replace ? "replace" : "push",
-        pending: this.host.updateComplete,
-        data: options.data,
-      });
-      return;
-    }
     const url = new URL(location.toString());
     url.search =
       typeof update === "function"
@@ -113,26 +37,11 @@ export class SearchParamsController implements ReactiveController {
   public set(
     name: string,
     value: string,
-    options: { replace?: boolean; data?: unknown; transaction?: boolean } = {
+    options: { replace?: boolean; data?: unknown } = {
       replace: false,
     },
   ) {
-    SearchParamsController.transaction = !!options.transaction;
     this.prevParams = new URLSearchParams(this.searchParams);
-    if (SearchParamsController.transaction) {
-      SearchParamsController.pushUpdate({
-        prevParams: this.prevParams,
-        update: (params) => {
-          params.set(name, value);
-          return params;
-        },
-        type: options.replace ? "replace" : "push",
-        source: "set",
-        pending: this.host.updateComplete,
-        data: options.data,
-      });
-      return;
-    }
     const url = new URL(location.toString());
     const newParams = new URLSearchParams(this.searchParams);
     newParams.set(name, value);
@@ -150,38 +59,18 @@ export class SearchParamsController implements ReactiveController {
   public delete(
     name: string,
     value: string,
-    options?: { replace?: boolean; data?: unknown; transaction?: boolean },
+    options?: { replace?: boolean; data?: unknown },
   ): void;
   public delete(
     name: string,
-    options?: { replace?: boolean; data?: unknown; transaction?: boolean },
+    options?: { replace?: boolean; data?: unknown },
   ): void;
   public delete(
     name: string,
     valueOrOptions?: string | { replace?: boolean; data?: unknown },
-    options?: { replace?: boolean; data?: unknown; transaction?: boolean },
+    options?: { replace?: boolean; data?: unknown },
   ) {
-    SearchParamsController.transaction = !!options?.transaction;
     this.prevParams = new URLSearchParams(this.searchParams);
-    if (SearchParamsController.transaction) {
-      SearchParamsController.pushUpdate({
-        prevParams: this.prevParams,
-        update: (params) => {
-          if (typeof valueOrOptions === "string") {
-            params.delete(name, valueOrOptions);
-          } else {
-            params.delete(name);
-            options = valueOrOptions;
-          }
-          return params;
-        },
-        type: options?.replace ? "replace" : "push",
-        source: "delete",
-        pending: this.host.updateComplete,
-        data: options?.data,
-      });
-      return;
-    }
     const url = new URL(location.toString());
     const newParams = new URLSearchParams(this.searchParams);
     if (typeof valueOrOptions === "string") {

--- a/frontend/src/controllers/searchParams.ts
+++ b/frontend/src/controllers/searchParams.ts
@@ -1,6 +1,65 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
+type Update = {
+  update: (prev: URLSearchParams) => URLSearchParams;
+  prevParams: URLSearchParams;
+  type: "push" | "replace";
+  source?: string;
+  pending?: PromiseLike<unknown>;
+  data?: unknown;
+};
+
 export class SearchParamsController implements ReactiveController {
+  static #pendingUpdates: Update[] = [];
+  static #transaction = false;
+  static set transaction(value: boolean) {
+    if (value) {
+      SearchParamsController.#transaction = value;
+      return;
+    }
+    if (SearchParamsController.#transaction) {
+      console.debug(
+        "SearchParamsController: transaction not closed; pending updates:",
+        SearchParamsController.#pendingUpdates,
+      );
+    }
+  }
+  static get transaction(): boolean {
+    return SearchParamsController.#transaction;
+  }
+  static #timeout: number | undefined;
+  static pushUpdate(update: Update) {
+    console.debug("pushed update", update);
+    SearchParamsController.#pendingUpdates.push(update);
+    if (SearchParamsController.#timeout) {
+      window.clearTimeout(SearchParamsController.#timeout);
+    }
+    SearchParamsController.#timeout = window.setTimeout(async () => {
+      console.debug("running updates", SearchParamsController.#pendingUpdates);
+      SearchParamsController.transaction = true;
+      let newParams = new URLSearchParams(location.search);
+      await Promise.all(
+        SearchParamsController.#pendingUpdates.map(async (update, index) => {
+          console.debug(`new params before update ${index}`, newParams);
+          newParams = update.update(newParams);
+          console.debug(`new params after update ${index}`, newParams);
+          if (update.pending) {
+            await update.pending;
+          }
+        }),
+      );
+      const url = new URL(location.toString());
+      url.search = newParams.toString();
+      if (update.type === "push") {
+        history.pushState(update.data, "", url);
+      } else {
+        history.replaceState(update.data, "", url);
+      }
+      SearchParamsController.#pendingUpdates = [];
+      SearchParamsController.#transaction = false;
+    }, 0);
+  }
+
   private readonly host: ReactiveControllerHost;
   private readonly changeHandler?: (
     searchParams: URLSearchParams,
@@ -14,9 +73,28 @@ export class SearchParamsController implements ReactiveController {
 
   public update(
     update: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams),
-    options: { replace?: boolean; data?: unknown } = { replace: false },
+    options: { replace?: boolean; data?: unknown; transaction?: boolean } = {
+      replace: false,
+    },
   ) {
+    SearchParamsController.transaction = !!options.transaction;
     this.prevParams = new URLSearchParams(this.searchParams);
+    if (SearchParamsController.transaction) {
+      SearchParamsController.pushUpdate({
+        prevParams: this.prevParams,
+        update: (params) => {
+          if (typeof update === "function") {
+            return update(params);
+          }
+          return update;
+        },
+        source: "update",
+        type: options.replace ? "replace" : "push",
+        pending: this.host.updateComplete,
+        data: options.data,
+      });
+      return;
+    }
     const url = new URL(location.toString());
     url.search =
       typeof update === "function"
@@ -35,9 +113,26 @@ export class SearchParamsController implements ReactiveController {
   public set(
     name: string,
     value: string,
-    options: { replace?: boolean; data?: unknown } = { replace: false },
+    options: { replace?: boolean; data?: unknown; transaction?: boolean } = {
+      replace: false,
+    },
   ) {
+    SearchParamsController.transaction = !!options.transaction;
     this.prevParams = new URLSearchParams(this.searchParams);
+    if (SearchParamsController.transaction) {
+      SearchParamsController.pushUpdate({
+        prevParams: this.prevParams,
+        update: (params) => {
+          params.set(name, value);
+          return params;
+        },
+        type: options.replace ? "replace" : "push",
+        source: "set",
+        pending: this.host.updateComplete,
+        data: options.data,
+      });
+      return;
+    }
     const url = new URL(location.toString());
     const newParams = new URLSearchParams(this.searchParams);
     newParams.set(name, value);
@@ -55,18 +150,38 @@ export class SearchParamsController implements ReactiveController {
   public delete(
     name: string,
     value: string,
-    options?: { replace?: boolean; data?: unknown },
+    options?: { replace?: boolean; data?: unknown; transaction?: boolean },
   ): void;
   public delete(
     name: string,
-    options?: { replace?: boolean; data?: unknown },
+    options?: { replace?: boolean; data?: unknown; transaction?: boolean },
   ): void;
   public delete(
     name: string,
     valueOrOptions?: string | { replace?: boolean; data?: unknown },
-    options?: { replace?: boolean; data?: unknown },
+    options?: { replace?: boolean; data?: unknown; transaction?: boolean },
   ) {
+    SearchParamsController.transaction = !!options?.transaction;
     this.prevParams = new URLSearchParams(this.searchParams);
+    if (SearchParamsController.transaction) {
+      SearchParamsController.pushUpdate({
+        prevParams: this.prevParams,
+        update: (params) => {
+          if (typeof valueOrOptions === "string") {
+            params.delete(name, valueOrOptions);
+          } else {
+            params.delete(name);
+            options = valueOrOptions;
+          }
+          return params;
+        },
+        type: options?.replace ? "replace" : "push",
+        source: "delete",
+        pending: this.host.updateComplete,
+        data: options?.data,
+      });
+      return;
+    }
     const url = new URL(location.toString());
     const newParams = new URLSearchParams(this.searchParams);
     if (typeof valueOrOptions === "string") {

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -1,4 +1,5 @@
 import { type ReactiveController, type ReactiveElement } from "lit";
+import isEqual from "lodash/isEqual";
 
 import { SearchParamsController } from "@/controllers/searchParams";
 
@@ -89,7 +90,12 @@ export class SearchParamsValue<T> implements ReactiveController {
   public get value(): T {
     return this.#value;
   }
+  /**
+   * Set value and request update if deep comparison with current value is not equal.
+   */
   public setValue(value: T) {
+    if (isEqual(value, this.#value)) return;
+
     const oldValue = this.#value;
     this.#value = value;
     this.#searchParams.update((params) => this.#encoder(value, params));
@@ -140,6 +146,9 @@ export class SearchParamsValue<T> implements ReactiveController {
     this.#searchParams = new SearchParamsController(this.#host, (params) => {
       const oldValue = this.#value;
       this.#value = this.#decoder(params);
+
+      if (isEqual(oldValue, this.#value)) return;
+
       this.#host.requestUpdate(this.#getPropertyName("value"), oldValue);
     });
 

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -96,9 +96,7 @@ export class SearchParamsValue<T> implements ReactiveController {
   public setValue(value: T) {
     const oldValue = this.#value;
     this.#value = value;
-    this.#searchParams.update((params) => this.#encoder(value, params), {
-      transaction: this.#options.transaction,
-    });
+    this.#searchParams.update((params) => this.#encoder(value, params));
     this.#host.requestUpdate(this.#getPropertyName("setValue"), oldValue);
   }
   // Little bit hacky/metaprogramming-y, but this lets us auto-detect property

--- a/frontend/src/controllers/searchParamsValue.ts
+++ b/frontend/src/controllers/searchParamsValue.ts
@@ -84,10 +84,6 @@ export class SearchParamsValue<T> implements ReactiveController {
   readonly #options: {
     initial?: (valueFromSearchParams?: T) => T;
     propertyKey?: PropertyKey;
-    /**
-     * Use a transaction for searchParams updates. Useful in combination with pagination, for example.
-     */
-    transaction?: boolean;
   };
 
   public get value(): T {
@@ -135,10 +131,6 @@ export class SearchParamsValue<T> implements ReactiveController {
     options?: {
       initial?: (valueFromSearchParams?: T) => T;
       propertyKey?: PropertyKey;
-      /**
-       * Use a transaction for searchParams updates. Useful in combination with pagination, for example.
-       */
-      transaction?: boolean;
     },
   ) {
     (this.#host = host).addController(this);

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -339,7 +339,7 @@ export class WorkflowProfileFilter extends BtrixElement {
         @sl-change=${async (e: SlChangeEvent) => {
           const { checked, value } = e.target as SlCheckbox;
 
-          this.selected = new Map(this.selected.set(value, checked));
+          this.selected = new Map([...this.selected, [value, checked]]);
         }}
       >
         ${repeat(

--- a/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-profile-filter.ts
@@ -72,7 +72,7 @@ export class WorkflowProfileFilter extends BtrixElement {
   }
 
   protected updated(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has("selected")) {
+    if (changedProperties.get("selected")) {
       const selectedProfiles = [];
 
       for (const [profile, value] of this.selected) {

--- a/frontend/src/features/crawl-workflows/workflow-schedule-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-schedule-filter.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import type { SlChangeEvent, SlRadioGroup } from "@shoelace-style/shoelace";
-import { html, nothing, type PropertyValues } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -24,19 +24,6 @@ enum ScheduleType {
 export class WorkflowScheduleFilter extends BtrixElement {
   @property({ type: Boolean })
   schedule?: boolean;
-
-  protected updated(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has("schedule")) {
-      this.dispatchEvent(
-        new CustomEvent<BtrixChangeWorkflowScheduleFilterEvent["detail"]>(
-          "btrix-change",
-          {
-            detail: { value: this.schedule },
-          },
-        ),
-      );
-    }
-  }
 
   render() {
     return html`
@@ -73,6 +60,14 @@ export class WorkflowScheduleFilter extends BtrixElement {
                     class="part-[label]:px-0"
                     @click=${() => {
                       this.schedule = undefined;
+
+                      this.dispatchEvent(
+                        new CustomEvent<
+                          BtrixChangeWorkflowScheduleFilterEvent["detail"]
+                        >("btrix-change", {
+                          detail: { value: this.schedule },
+                        }),
+                      );
                     }}
                     >${msg("Clear")}</sl-button
                   >`
@@ -101,6 +96,14 @@ export class WorkflowScheduleFilter extends BtrixElement {
                   this.schedule = undefined;
                   break;
               }
+
+              this.dispatchEvent(
+                new CustomEvent<
+                  BtrixChangeWorkflowScheduleFilterEvent["detail"]
+                >("btrix-change", {
+                  detail: { value: this.schedule },
+                }),
+              );
             }}
           >
             <sl-radio

--- a/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-tag-filter.ts
@@ -74,7 +74,7 @@ export class WorkflowTagFilter extends BtrixElement {
   }
 
   protected updated(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has("selected") || changedProperties.has("type")) {
+    if (changedProperties.get("selected") || changedProperties.get("type")) {
       const selectedTags = Array.from(this.selected.entries())
         .filter(([_tag, selected]) => selected)
         .map(([tag]) => tag);

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -16,7 +16,11 @@ import {
   type BtrixFilterChipChangeEvent,
   type FilterChip,
 } from "@/components/ui/filter-chip";
-import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
+import {
+  parsePage,
+  type PageChangeEvent,
+  type Pagination,
+} from "@/components/ui/pagination";
 import { ClipboardController } from "@/controllers/clipboard";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
 import { type BtrixChangeArchivedItemStateFilterEvent } from "@/features/archived-items/archived-item-state-filter";
@@ -121,6 +125,9 @@ export class CrawlsList extends BtrixElement {
     page: parsePage(new URLSearchParams(location.search).get("page")),
     pageSize: INITIAL_PAGE_SIZE,
   };
+
+  @query("btrix-pagination")
+  private readonly paginationElement?: Pagination;
 
   @state()
   private searchOptions: Record<string, string>[] = [];
@@ -382,10 +389,7 @@ export class CrawlsList extends BtrixElement {
           direction: sortableFields["finished"].defaultDirection!,
         });
       }
-      this.pagination = {
-        page: 1,
-        pageSize: INITIAL_PAGE_SIZE,
-      };
+      this.paginationElement?.setPage(1, { dispatch: true, replace: true });
 
       if (changedProperties.has("filterByCurrentUser")) {
         window.sessionStorage.setItem(

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -257,7 +257,7 @@ export class CrawlsList extends BtrixElement {
     return [
       this.filterBy.value.firstSeed,
       this.filterBy.value.name,
-      this.filterBy.value.state?.length || undefined,
+      this.filterBy.value.state.length || undefined,
       this.filterByCurrentUser.value || undefined,
       this.filterByTags.value?.length || undefined,
     ].some((v) => v !== undefined);
@@ -931,7 +931,7 @@ export class CrawlsList extends BtrixElement {
     const query = queryString.stringify(
       {
         ...params.filterBy,
-        state: params.filterBy.state?.length
+        state: params.filterBy.state.length
           ? params.filterBy.state
           : finishedCrawlStates,
         page: params.pagination.page,

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -7,7 +7,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
-import { type UnionToTuple } from "type-fest";
 
 import type { ArchivedItem, Crawl, Workflow } from "./types";
 
@@ -211,9 +210,7 @@ export class CrawlsList extends BtrixElement {
   private readonly filterBy = new SearchParamsValue<FilterBy>(
     this,
     (value, params) => {
-      const keys = ["name", "firstSeed", "state"] as UnionToTuple<
-        keyof FilterBy
-      >;
+      const keys = ["name", "firstSeed", "state"] as (keyof FilterBy)[];
       keys.forEach((key) => {
         if (value[key] == null) {
           params.delete(key);

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -7,6 +7,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
+import { type UnionToTuple } from "type-fest";
 
 import type { ArchivedItem, Crawl, Workflow } from "./types";
 
@@ -90,9 +91,9 @@ const DEFAULT_SORT_BY: SortBy = {
 };
 
 type FilterBy = {
-  state?: CrawlState[];
   name?: string;
   firstSeed?: string;
+  state?: CrawlState[];
 };
 
 /**
@@ -203,7 +204,9 @@ export class CrawlsList extends BtrixElement {
   private readonly filterBy = new SearchParamsValue<FilterBy>(
     this,
     (value, params) => {
-      const keys = ["firstSeed", "name", "state"] as (keyof FilterBy)[];
+      const keys = ["name", "firstSeed", "state"] as UnionToTuple<
+        keyof FilterBy
+      >;
       keys.forEach((key) => {
         if (value[key] == null) {
           params.delete(key);
@@ -228,8 +231,8 @@ export class CrawlsList extends BtrixElement {
       const state = params.getAll("status") as CrawlState[];
 
       return {
-        firstSeed: params.get("firstSeed") ?? undefined,
         name: params.get("name") ?? undefined,
+        firstSeed: params.get("firstSeed") ?? undefined,
         state: state.length ? state : undefined,
       };
     },
@@ -257,7 +260,7 @@ export class CrawlsList extends BtrixElement {
     return [
       this.filterBy.value.firstSeed,
       this.filterBy.value.name,
-      this.filterBy.value.state.length || undefined,
+      this.filterBy.value.state?.length || undefined,
       this.filterByCurrentUser.value || undefined,
       this.filterByTags.value?.length || undefined,
     ].some((v) => v !== undefined);
@@ -316,7 +319,7 @@ export class CrawlsList extends BtrixElement {
         } else {
           this.notify.toast({
             message: msg(
-              "Sorry, couldn't retrieve archived items at this time.",
+              "Sorry, couldn’t retrieve archived items at this time.",
             ),
             variant: "danger",
             icon: "exclamation-octagon",
@@ -931,7 +934,7 @@ export class CrawlsList extends BtrixElement {
     const query = queryString.stringify(
       {
         ...params.filterBy,
-        state: params.filterBy.state.length
+        state: params.filterBy.state?.length
           ? params.filterBy.state
           : finishedCrawlStates,
         page: params.pagination.page,

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -263,13 +263,11 @@ export class WorkflowsList extends BtrixElement {
     (params) => (params.get("tagsType") === "and" ? "and" : "or"),
   );
 
-  private readonly filterByProfiles = new SearchParamsValue<
-    string[] | undefined
-  >(
+  private readonly filterByProfiles = new SearchParamsValue<string[]>(
     this,
     (value, params) => {
       params.delete("profiles");
-      value?.forEach((v) => {
+      value.forEach((v) => {
         params.append("profiles", v);
       });
       return params;
@@ -297,7 +295,7 @@ export class WorkflowsList extends BtrixElement {
       this.filterBy.value.name || undefined,
       this.filterBy.value.isCrawlRunning || undefined,
       this.filterBy.value.schedule,
-      this.filterByProfiles.value?.length || undefined,
+      this.filterByProfiles.value.length || undefined,
       this.filterByCurrentUser.value || undefined,
       this.filterByTags.value?.length || undefined,
     ].some((v) => v !== undefined);
@@ -313,7 +311,7 @@ export class WorkflowsList extends BtrixElement {
     });
     this.filterByCurrentUser.setValue(false);
     this.filterByTags.setValue(undefined);
-    this.filterByProfiles.setValue(undefined);
+    this.filterByProfiles.setValue([]);
   }
 
   private getWorkflowsTimeout?: number;
@@ -678,7 +676,8 @@ export class WorkflowsList extends BtrixElement {
       <btrix-workflow-profile-filter
         .profiles=${this.filterByProfiles.value}
         @btrix-change=${(e: BtrixChangeWorkflowProfileFilterEvent) => {
-          this.filterByProfiles.setValue(e.detail.value);
+          this.filterByProfiles.setValue(e.detail.value ?? []);
+          console.log(e.detail.value);
         }}
       ></btrix-workflow-profile-filter>
 
@@ -731,6 +730,10 @@ export class WorkflowsList extends BtrixElement {
         .searchOptions=${this.searchOptions}
         .keyLabels=${WorkflowsList.FieldLabels}
         selectedKey=${ifDefined(this.selectedSearchFilterKey)}
+        searchByValue=${ifDefined(
+          this.selectedSearchFilterKey &&
+            this.filterBy.value[this.selectedSearchFilterKey],
+        )}
         placeholder=${msg("Search all workflows by name or crawl start URL")}
         @btrix-select=${(e: SelectEvent<typeof this.searchKeys>) => {
           const { key, value } = e.detail;
@@ -915,7 +918,7 @@ export class WorkflowsList extends BtrixElement {
         userid: params.filterByCurrentUser ? this.userInfo?.id : undefined,
         tag: params.filterByTags || undefined,
         tagMatch: params.filterByTagsType,
-        profileIds: params.filterByProfiles || undefined,
+        profileIds: params.filterByProfiles,
         sortBy: params.orderBy.field,
         sortDirection: params.orderBy.direction === "desc" ? -1 : 1,
       },

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -534,12 +534,12 @@ export class WorkflowsList extends BtrixElement {
                 // pending from user action, in order to show loading indicator
                 this.workflowsTask.value
                   ? // Render previous value while latest is loading
-                    this.renderWorkflowList()
+                    this.workflowsTask.value.total
+                    ? this.renderWorkflowList()
+                    : this.renderEmptyState()
                   : null,
-              complete: () =>
-                this.workflowsTask.value?.total
-                  ? this.renderWorkflowList()
-                  : this.renderEmptyState(),
+              complete: ({ total }) =>
+                total ? this.renderWorkflowList() : this.renderEmptyState(),
             })}
           </div>
         `,

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -861,11 +861,7 @@ export class WorkflowsList extends BtrixElement {
             >
             <button
               class="font-medium text-neutral-500 underline hover:no-underline"
-              @click=${() => {
-                this.filterBy.setValue({});
-                this.filterByCurrentUser.setValue(false);
-                this.filterByTags.setValue(undefined);
-              }}
+              @click=${this.clearFilters}
             >
               ${msg("Clear search and filters")}
             </button>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -47,6 +47,7 @@ import {
 import { isApiError } from "@/utils/api";
 import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import { renderName } from "@/utils/crawler";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 type SearchFields = "name" | "firstSeed";
@@ -122,7 +123,7 @@ export class WorkflowsList extends BtrixElement {
     firstSeed: msg("Crawl Start URL"),
   };
 
-  @state()
+  @state({ hasChanged: isNotEqual })
   private pagination: Required<APIPaginationQuery> = {
     page: parsePage(new URLSearchParams(location.search).get("page")),
     pageSize: INITIAL_PAGE_SIZE,
@@ -390,7 +391,11 @@ export class WorkflowsList extends BtrixElement {
       changedProperties.has("filterBy.setValue") ||
       changedProperties.has("orderBy.setValue")
     ) {
-      this.paginationElement?.setPage(1, { dispatch: true, replace: true });
+      this.pagination = {
+        ...this.pagination,
+        page: 1,
+      };
+      this.paginationElement?.setPage(1, { dispatch: false, replace: true });
     }
     if (changedProperties.has("filterByCurrentUser")) {
       window.sessionStorage.setItem(
@@ -757,7 +762,7 @@ export class WorkflowsList extends BtrixElement {
 
   private renderWorkflowList() {
     if (!this.workflowsTask.value) return;
-    const { total, pageSize } = this.workflowsTask.value;
+    const { page, total, pageSize } = this.workflowsTask.value;
     return html`
       <btrix-workflow-list>
         ${this.workflowsTask.value.items.map(this.renderWorkflowItem)}
@@ -769,7 +774,7 @@ export class WorkflowsList extends BtrixElement {
         )}
       >
         <btrix-pagination
-          page=${this.pagination.page}
+          page=${page}
           totalCount=${total}
           size=${pageSize}
           @page-change=${async (e: PageChangeEvent) => {

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -7,7 +7,6 @@ import { customElement, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
-import { type UnionToTuple } from "type-fest";
 
 import {
   ScopeType,
@@ -181,7 +180,7 @@ export class WorkflowsList extends BtrixElement {
         "firstSeed",
         "schedule",
         "isCrawlRunning",
-      ] as UnionToTuple<keyof FilterBy>;
+      ] as (keyof FilterBy)[];
       keys.forEach((key) => {
         if (value[key] == null) {
           params.delete(key);

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -676,7 +676,6 @@ export class WorkflowsList extends BtrixElement {
         .profiles=${this.filterByProfiles.value}
         @btrix-change=${(e: BtrixChangeWorkflowProfileFilterEvent) => {
           this.filterByProfiles.setValue(e.detail.value ?? []);
-          console.log(e.detail.value);
         }}
       ></btrix-workflow-profile-filter>
 

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -97,11 +97,6 @@ const DEFAULT_SORT_BY = {
   direction: sortableFields["lastRun"].defaultDirection!,
 } as const;
 
-// const USED_FILTERS = [
-//   "schedule",
-//   "isCrawlRunning",
-// ] as const satisfies (keyof ListWorkflow)[];
-
 type FilterBy = {
   name?: string;
   firstSeed?: string;

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -21,7 +21,7 @@ import type {
 } from "@/components/ui/filter-chip";
 import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { type SelectEvent } from "@/components/ui/search-combobox";
-import { SearchParamsController } from "@/controllers/searchParams";
+import { SearchParamsValue } from "@/controllers/searchParamsValue";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
 import {
   Action,
@@ -48,10 +48,12 @@ type SearchFields = "name" | "firstSeed";
 type SortField = "lastRun" | "name" | "firstSeed" | "created" | "modified";
 const SORT_DIRECTIONS = ["asc", "desc"] as const;
 type SortDirection = (typeof SORT_DIRECTIONS)[number];
-type Sort = {
+type SortBy = {
   field: SortField;
   direction: SortDirection;
 };
+
+type Keys<T> = (keyof T)[];
 
 const FILTER_BY_CURRENT_USER_STORAGE_KEY =
   "btrix.filterByCurrentUser.crawlConfigs";
@@ -85,15 +87,22 @@ const sortableFields: Record<
   },
 };
 
-const DEFAULT_SORT = {
+const DEFAULT_SORT_BY = {
   field: "lastRun",
   direction: sortableFields["lastRun"].defaultDirection!,
 } as const;
 
-const USED_FILTERS = [
-  "schedule",
-  "isCrawlRunning",
-] as const satisfies (keyof ListWorkflow)[];
+// const USED_FILTERS = [
+//   "schedule",
+//   "isCrawlRunning",
+// ] as const satisfies (keyof ListWorkflow)[];
+
+type FilterBy = {
+  schedule?: boolean;
+  isCrawlRunning?: boolean;
+  name?: string;
+  firstSeed?: string;
+};
 
 /**
  * Usage:
@@ -124,23 +133,132 @@ export class WorkflowsList extends BtrixElement {
   @state()
   private workflowToDelete?: ListWorkflow;
 
-  @state()
-  private orderBy: Sort = DEFAULT_SORT;
+  private readonly orderBy = new SearchParamsValue<SortBy>(
+    this,
+    (value, params) => {
+      if (value.field === DEFAULT_SORT_BY.field) {
+        params.delete("sortBy");
+      } else {
+        params.set("sortBy", value.field);
+      }
+      if (value.direction === sortableFields[value.field].defaultDirection) {
+        params.delete("sortDir");
+      } else {
+        params.set("sortDir", value.direction);
+      }
+      return params;
+    },
+    (params) => {
+      const field = params.get("sortBy") as SortBy["field"] | null;
+      if (!field) {
+        return DEFAULT_SORT_BY;
+      }
+      let direction = params.get("sortDir");
+      if (
+        !direction ||
+        (SORT_DIRECTIONS as readonly string[]).includes(direction)
+      ) {
+        direction =
+          sortableFields[field].defaultDirection || DEFAULT_SORT_BY.direction;
+      }
+      return { field, direction: direction as SortDirection };
+    },
+  );
 
-  @state()
-  private filterBy: Partial<{ [k in keyof ListWorkflow]: boolean }> = {};
+  private readonly filterBy = new SearchParamsValue<FilterBy>(
+    this,
+    (value, params) => {
+      const keys = Object.keys(value) as Keys<typeof value>;
+      keys.forEach((key) => {
+        if (value[key] == null) {
+          params.delete(key);
+        } else {
+          switch (key) {
+            case "firstSeed":
+            case "name":
+              params.set(key, value[key]);
+              break;
+            case "schedule":
+            case "isCrawlRunning":
+              if (value[key]) {
+                params.set(key, "true");
+              } else {
+                params.delete(key);
+              }
+              break;
+          }
+        }
+      });
+      return params;
+    },
+    (params) => {
+      return {
+        schedule: params.get("schedule") === "true",
+        isCrawlRunning: params.get("isCrawlRunning") === "true",
+        name: params.get("name") ?? undefined,
+        firstSeed: params.get("firstSeed") ?? undefined,
+      };
+    },
+  );
 
-  @state()
-  private filterByCurrentUser = false;
+  private readonly filterByCurrentUser = new SearchParamsValue<boolean>(
+    this,
+    (value, params) => {
+      if (value) {
+        params.set("mine", "true");
+      } else {
+        params.delete("mine");
+      }
+      return params;
+    },
+    (params) => params.get("mine") === "true",
+    {
+      initial: (initialValue) =>
+        window.sessionStorage.getItem(FILTER_BY_CURRENT_USER_STORAGE_KEY) ===
+          "true" ||
+        initialValue ||
+        false,
+    },
+  );
 
-  @state()
-  private filterByTags?: string[];
+  private readonly filterByTags = new SearchParamsValue<string[] | undefined>(
+    this,
+    (value, params) => {
+      params.delete("tags");
+      value?.forEach((v) => {
+        params.append("tags", v);
+      });
+      return params;
+    },
+    (params) => params.getAll("tags"),
+  );
 
-  @state()
-  private filterByTagsType: "and" | "or" = "or";
+  private readonly filterByTagsType = new SearchParamsValue<"and" | "or">(
+    this,
+    (value, params) => {
+      if (value === "and") {
+        params.set("tagsType", value);
+      } else {
+        params.delete("tagsType");
+      }
+      return params;
+    },
+    (params) => (params.get("tagsType") === "and" ? "and" : "or"),
+  );
 
-  @state()
-  private filterByProfiles?: string[];
+  private readonly filterByProfiles = new SearchParamsValue<
+    string[] | undefined
+  >(
+    this,
+    (value, params) => {
+      params.delete("profiles");
+      value?.forEach((v) => {
+        params.append("profiles", v);
+      });
+      return params;
+    },
+    (params) => params.getAll("profiles"),
+  );
 
   @query("#deleteDialog")
   private readonly deleteDialog?: SlDialog | null;
@@ -153,230 +271,118 @@ export class WorkflowsList extends BtrixElement {
   private timerId?: number;
 
   private get selectedSearchFilterKey() {
-    return Object.keys(WorkflowsList.FieldLabels).find((key) =>
-      Boolean((this.filterBy as Record<string, unknown>)[key]),
-    );
+    return (
+      Object.keys(WorkflowsList.FieldLabels) as Keys<
+        typeof WorkflowsList.FieldLabels
+      >
+    ).find((key) => Boolean(this.filterBy.value[key]));
   }
 
-  searchParams = new SearchParamsController(this, (params) => {
-    this.updateFiltersFromSearchParams(params);
-  });
+  // searchParams = new SearchParamsController(this, (params) => {
+  //   this.updateFiltersFromSearchParams(params);
+  // });
 
-  // TODO (emma): refactor this logic into smaller parts using `SearchParamsValue`
-  private updateFiltersFromSearchParams(
-    params = this.searchParams.searchParams,
-  ) {
-    const filterBy = { ...this.filterBy };
-    // remove filters no longer present in search params
-    for (const key of Object.keys(filterBy)) {
-      if (!params.has(key)) {
-        filterBy[key as keyof typeof filterBy] = undefined;
-      }
-    }
+  // // TODO (emma): refactor this logic into smaller parts using `SearchParamsValue`
+  // private updateFiltersFromSearchParams(
+  //   params = this.searchParams.searchParams,
+  // ) {
+  //   // remove current user filter if not present in search params
+  //   if (!params.has("mine")) {
+  //     this.filterByCurrentUser.setValue = false;
+  //   }
 
-    // remove current user filter if not present in search params
-    if (!params.has("mine")) {
-      this.filterByCurrentUser = false;
-    }
+  //   if (params.has("tags")) {
+  //     this.filterByTags = params.getAll("tags");
+  //   } else {
+  //     this.filterByTags = undefined;
+  //   }
 
-    if (params.has("tags")) {
-      this.filterByTags = params.getAll("tags");
-    } else {
-      this.filterByTags = undefined;
-    }
+  //   if (params.has("profiles")) {
+  //     this.filterByProfiles = params.getAll("profiles");
+  //   } else {
+  //     this.filterByProfiles = undefined;
+  //   }
 
-    if (params.has("profiles")) {
-      this.filterByProfiles = params.getAll("profiles");
-    } else {
-      this.filterByProfiles = undefined;
-    }
+  //   // add filters present in search params
+  //   for (const [key, value] of params) {
+  //     // Filter by current user
+  //     if (key === "mine") {
+  //       this.filterByCurrentUser = value === "true";
+  //     }
 
-    // add filters present in search params
-    for (const [key, value] of params) {
-      // Filter by current user
-      if (key === "mine") {
-        this.filterByCurrentUser = value === "true";
-      }
+  //     if (key === "tagsType") {
+  //       this.filterByTagsType = value === "and" ? "and" : "or";
+  //     }
 
-      if (key === "tagsType") {
-        this.filterByTagsType = value === "and" ? "and" : "or";
-      }
+  //     // Sorting field
+  //     if (key === "sortBy") {
+  //       if (value in sortableFields) {
+  //         this.orderBy = {
+  //           field: value as SortField,
+  //           direction:
+  //             // Use default direction for field if available, otherwise use current direction
+  //             sortableFields[value as SortField].defaultDirection ||
+  //             this.orderBy.direction,
+  //         };
+  //       }
+  //     }
+  //     if (key === "sortDir") {
+  //       if (SORT_DIRECTIONS.includes(value as SortDirection)) {
+  //         // Overrides sort direction if specified
+  //         this.orderBy = { ...this.orderBy, direction: value as SortDirection };
+  //       }
+  //     }
 
-      // Sorting field
-      if (key === "sortBy") {
-        if (value in sortableFields) {
-          this.orderBy = {
-            field: value as SortField,
-            direction:
-              // Use default direction for field if available, otherwise use current direction
-              sortableFields[value as SortField].defaultDirection ||
-              this.orderBy.direction,
-          };
-        }
-      }
-      if (key === "sortDir") {
-        if (SORT_DIRECTIONS.includes(value as SortDirection)) {
-          // Overrides sort direction if specified
-          this.orderBy = { ...this.orderBy, direction: value as SortDirection };
-        }
-      }
+  //     // Ignored params
+  //     if (
+  //       [
+  //         "page",
+  //         "mine",
+  //         "tags",
+  //         "tagsType",
+  //         "profiles",
+  //         "sortBy",
+  //         "sortDir",
+  //       ].includes(key)
+  //     )
+  //       continue;
 
-      // Ignored params
-      if (
-        [
-          "page",
-          "mine",
-          "tags",
-          "tagsType",
-          "profiles",
-          "sortBy",
-          "sortDir",
-        ].includes(key)
-      )
-        continue;
-
-      // Convert string bools to filter values
-      if (value === "true") {
-        filterBy[key as keyof typeof filterBy] = true;
-      } else if (value === "false") {
-        filterBy[key as keyof typeof filterBy] = false;
-      } else {
-        filterBy[key as keyof typeof filterBy] = undefined;
-      }
-    }
-    this.filterBy = { ...filterBy };
-  }
-
-  constructor() {
-    super();
-    this.updateFiltersFromSearchParams();
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    // Apply filterByCurrentUser from session storage, and transparently update url without pushing to history stack
-    // This needs to happen here instead of in the constructor because this only occurs once after the element is connected to the DOM,
-    // and so it overrides the filter state set in `updateFiltersFromSearchParams` but only on first render, not on subsequent navigation.
-    this.filterByCurrentUser =
-      window.sessionStorage.getItem(FILTER_BY_CURRENT_USER_STORAGE_KEY) ===
-      "true";
-    if (this.filterByCurrentUser) {
-      this.searchParams.set("mine", "true", { replace: true });
-    }
-  }
+  //     // // Convert string bools to filter values
+  //     // if (value === "true") {
+  //     //   filterBy[key] = true;
+  //     // } else if (value === "false") {
+  //     //   filterBy[key] = false;
+  //     // } else {
+  //     //   filterBy[key] = undefined;
+  //     // }
+  //   }
+  // }
 
   protected async willUpdate(
     changedProperties: PropertyValues<this> & Map<string, unknown>,
   ) {
-    // Props that reset the page to 1 when changed
-    const resetToFirstPageProps = [
-      "filterByCurrentUser",
-      "filterByTags",
-      "filterByTagsType",
-      "filterByProfiles",
-      "filterByScheduled",
-      "filterBy",
-      "orderBy",
-    ];
-
-    // Props that require a data refetch
-    const refetchDataProps = [...resetToFirstPageProps];
-
-    if (refetchDataProps.some((k) => changedProperties.has(k))) {
-      const isInitialRender = resetToFirstPageProps
-        .map((k) => changedProperties.get(k))
-        .every((v) => v === undefined);
+    if (
+      changedProperties.has("filterByCurrentUser.value") ||
+      changedProperties.has("filterByTags.value") ||
+      changedProperties.has("filterByTagsType.value") ||
+      changedProperties.has("filterByProfiles.value") ||
+      changedProperties.has("filterByScheduled.value") ||
+      changedProperties.has("filterBy.value") ||
+      changedProperties.has("orderBy.value")
+    )
       void this.fetchWorkflows({
-        page:
-          // If this is the initial render, use the page from the URL or default to 1; otherwise, reset the page to 1
-          isInitialRender
-            ? parsePage(new URLSearchParams(location.search).get("page")) || 1
-            : 1,
+        page: 1,
       });
-    }
     if (changedProperties.has("filterByCurrentUser")) {
       window.sessionStorage.setItem(
         FILTER_BY_CURRENT_USER_STORAGE_KEY,
-        this.filterByCurrentUser.toString(),
+        this.filterByCurrentUser.value.toString(),
       );
     }
   }
 
   protected firstUpdated() {
     void this.fetchConfigSearchValues();
-  }
-
-  protected updated(
-    changedProperties: PropertyValues<this> & Map<string, unknown>,
-  ) {
-    if (
-      changedProperties.has("filterBy") ||
-      changedProperties.has("filterByCurrentUser") ||
-      changedProperties.has("filterByTags") ||
-      changedProperties.has("filterByTagsType") ||
-      changedProperties.has("filterByProfiles") ||
-      changedProperties.has("orderBy")
-    ) {
-      this.searchParams.update((params) => {
-        // Reset page
-        params.delete("page");
-
-        const newParams = [
-          // Known filters
-          ...USED_FILTERS.map<[string, undefined]>((f) => [f, undefined]),
-
-          // Existing filters
-          ...Object.entries(this.filterBy),
-
-          // Filter by current user
-          ["mine", this.filterByCurrentUser || undefined],
-
-          ["tags", this.filterByTags],
-
-          [
-            "tagsType",
-            this.filterByTagsType !== "or" ? this.filterByTagsType : undefined,
-          ],
-
-          ["profiles", this.filterByProfiles],
-
-          // Sorting fields
-          [
-            "sortBy",
-            this.orderBy.field !== DEFAULT_SORT.field
-              ? this.orderBy.field
-              : undefined,
-          ],
-          [
-            "sortDir",
-            this.orderBy.direction !==
-            sortableFields[this.orderBy.field].defaultDirection
-              ? this.orderBy.direction
-              : undefined,
-          ],
-        ] satisfies [string, boolean | string | string[] | undefined][];
-
-        for (const [filter, value] of newParams) {
-          if (value !== undefined) {
-            if (Array.isArray(value)) {
-              // Rather than a more efficient method where we compare the existing & wanted arrays,
-              // it's simpler to just delete and re-append values here. If we were working with large
-              // arrays, we could change this, but we'll leave it as is for now — if we were working
-              // with truly large arrays, we wouldn't be using search params anyways.
-              params.delete(filter);
-              value.forEach((v) => {
-                params.append(filter, v);
-              });
-            } else {
-              params.set(filter, value.toString());
-            }
-          } else {
-            params.delete(filter);
-          }
-        }
-        return params;
-      });
-    }
   }
 
   disconnectedCallback(): void {
@@ -606,15 +612,15 @@ export class WorkflowsList extends BtrixElement {
             class="flex-1 md:min-w-[9.2rem]"
             size="small"
             pill
-            value=${this.orderBy.field}
+            value=${this.orderBy.value.field}
             @sl-change=${(e: Event) => {
               const field = (e.target as HTMLSelectElement).value as SortField;
-              this.orderBy = {
+              this.orderBy.setValue({
                 field: field,
                 direction:
                   sortableFields[field].defaultDirection ||
-                  this.orderBy.direction,
-              };
+                  this.orderBy.value.direction,
+              });
             }}
           >
             ${Object.entries(sortableFields).map(
@@ -624,23 +630,24 @@ export class WorkflowsList extends BtrixElement {
             )}
           </sl-select>
           <sl-tooltip
-            content=${this.orderBy.direction === "asc"
+            content=${this.orderBy.value.direction === "asc"
               ? msg("Sort in descending order")
               : msg("Sort in ascending order")}
           >
             <sl-icon-button
-              name=${this.orderBy.direction === "asc"
+              name=${this.orderBy.value.direction === "asc"
                 ? "sort-up-alt"
                 : "sort-down"}
               class="text-base"
-              label=${this.orderBy.direction === "asc"
+              label=${this.orderBy.value.direction === "asc"
                 ? msg("Sort Descending")
                 : msg("Sort Ascending")}
               @click=${() => {
-                this.orderBy = {
-                  ...this.orderBy,
-                  direction: this.orderBy.direction === "asc" ? "desc" : "asc",
-                };
+                this.orderBy.setValue({
+                  ...this.orderBy.value,
+                  direction:
+                    this.orderBy.value.direction === "asc" ? "desc" : "asc",
+                });
               }}
             ></sl-icon-button>
           </sl-tooltip>
@@ -658,51 +665,51 @@ export class WorkflowsList extends BtrixElement {
       </span>
 
       <btrix-workflow-schedule-filter
-        .schedule=${this.filterBy.schedule}
+        .schedule=${this.filterBy.value.schedule}
         @btrix-change=${(e: BtrixChangeWorkflowScheduleFilterEvent) => {
-          this.filterBy = {
-            ...this.filterBy,
+          this.filterBy.setValue({
+            ...this.filterBy.value,
             schedule: e.detail.value,
-          };
+          });
         }}
       ></btrix-workflow-schedule-filter>
 
       <btrix-workflow-tag-filter
-        .tags=${this.filterByTags}
-        .type=${this.filterByTagsType}
+        .tags=${this.filterByTags.value}
+        .type=${this.filterByTagsType.value}
         @btrix-change=${(e: BtrixChangeWorkflowTagFilterEvent) => {
-          this.filterByTags = e.detail.value?.tags;
-          this.filterByTagsType = e.detail.value?.type || "or";
+          this.filterByTags.setValue(e.detail.value?.tags);
+          this.filterByTagsType.setValue(e.detail.value?.type || "or");
         }}
       ></btrix-workflow-tag-filter>
 
       <btrix-workflow-profile-filter
-        .profiles=${this.filterByProfiles}
+        .profiles=${this.filterByProfiles.value}
         @btrix-change=${(e: BtrixChangeWorkflowProfileFilterEvent) => {
-          this.filterByProfiles = e.detail.value;
+          this.filterByProfiles.setValue(e.detail.value);
         }}
       ></btrix-workflow-profile-filter>
 
       <btrix-filter-chip
-        ?checked=${this.filterBy.isCrawlRunning === true}
+        ?checked=${this.filterBy.value.isCrawlRunning === true}
         @btrix-change=${(e: BtrixFilterChipChangeEvent) => {
           const { checked } = e.target as FilterChip;
 
-          this.filterBy = {
-            ...this.filterBy,
+          this.filterBy.setValue({
+            ...this.filterBy.value,
             isCrawlRunning: checked ? true : undefined,
-          };
+          });
         }}
       >
         ${msg("Running")}
       </btrix-filter-chip>
 
       <btrix-filter-chip
-        ?checked=${this.filterByCurrentUser}
+        ?checked=${this.filterByCurrentUser.value}
         @btrix-change=${(e: BtrixFilterChipChangeEvent) => {
           const { checked } = e.target as FilterChip;
 
-          this.filterByCurrentUser = Boolean(checked);
+          this.filterByCurrentUser.setValue(Boolean(checked));
         }}
       >
         ${msg("Mine")}
@@ -710,9 +717,9 @@ export class WorkflowsList extends BtrixElement {
 
       ${when(
         [
-          this.filterBy.schedule,
-          this.filterBy.isCrawlRunning,
-          this.filterByCurrentUser || undefined,
+          this.filterBy.value.schedule,
+          this.filterBy.value.isCrawlRunning,
+          this.filterByCurrentUser.value || undefined,
           this.filterByTags,
         ].filter((v) => v !== undefined).length > 1,
         () => html`
@@ -721,13 +728,13 @@ export class WorkflowsList extends BtrixElement {
             size="small"
             variant="text"
             @click=${() => {
-              this.filterBy = {
-                ...this.filterBy,
+              this.filterBy.setValue({
+                ...this.filterBy.value,
                 schedule: undefined,
                 isCrawlRunning: undefined,
-              };
-              this.filterByCurrentUser = false;
-              this.filterByTags = undefined;
+              });
+              this.filterByCurrentUser.setValue(false);
+              this.filterByTags.setValue(undefined);
             }}
           >
             <sl-icon slot="prefix" name="x-lg"></sl-icon>
@@ -749,17 +756,18 @@ export class WorkflowsList extends BtrixElement {
         @btrix-select=${(e: SelectEvent<typeof this.searchKeys>) => {
           const { key, value } = e.detail;
           if (key == null) return;
-          this.filterBy = {
+          this.filterBy.setValue({
+            ...this.filterBy.value,
             [key]: value,
-          };
+          });
         }}
         @btrix-clear=${() => {
           const {
             name: _name,
             firstSeed: _firstSeed,
             ...otherFilters
-          } = this.filterBy;
-          this.filterBy = otherFilters;
+          } = this.filterBy.value;
+          this.filterBy.setValue(otherFilters);
         }}
       >
       </btrix-search-combobox>
@@ -853,9 +861,9 @@ export class WorkflowsList extends BtrixElement {
 
   private renderEmptyState() {
     if (
-      Object.keys(this.filterBy).length ||
-      this.filterByCurrentUser ||
-      this.filterByTags
+      Object.keys(this.filterBy.value).length ||
+      this.filterByCurrentUser.value ||
+      this.filterByTags.value
     ) {
       return html`
         <div class="rounded-lg border bg-neutral-50 p-4">
@@ -866,9 +874,9 @@ export class WorkflowsList extends BtrixElement {
             <button
               class="font-medium text-neutral-500 underline hover:no-underline"
               @click=${() => {
-                this.filterBy = {};
-                this.filterByCurrentUser = false;
-                this.filterByTags = undefined;
+                this.filterBy.setValue({});
+                this.filterByCurrentUser.setValue(false);
+                this.filterByTags.setValue(undefined);
               }}
             >
               ${msg("Clear search and filters")}
@@ -915,7 +923,7 @@ export class WorkflowsList extends BtrixElement {
   ) {
     const query = queryString.stringify(
       {
-        ...this.filterBy,
+        ...this.filterBy.value,
         page:
           queryParams?.page ||
           this.workflows?.page ||
@@ -924,12 +932,12 @@ export class WorkflowsList extends BtrixElement {
           queryParams?.pageSize ||
           this.workflows?.pageSize ||
           INITIAL_PAGE_SIZE,
-        userid: this.filterByCurrentUser ? this.userInfo?.id : undefined,
-        tag: this.filterByTags || undefined,
-        tagMatch: this.filterByTagsType,
-        profileIds: this.filterByProfiles || undefined,
-        sortBy: this.orderBy.field,
-        sortDirection: this.orderBy.direction === "desc" ? -1 : 1,
+        userid: this.filterByCurrentUser.value ? this.userInfo?.id : undefined,
+        tag: this.filterByTags.value || undefined,
+        tagMatch: this.filterByTagsType.value,
+        profileIds: this.filterByProfiles.value || undefined,
+        sortBy: this.orderBy.value.field,
+        sortDirection: this.orderBy.value.direction === "desc" ? -1 : 1,
       },
       {
         arrayFormat: "none", // For tags

--- a/frontend/src/utils/is-not-equal.ts
+++ b/frontend/src/utils/is-not-equal.ts
@@ -1,4 +1,4 @@
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 /**
  * Inverted version of lodash `isEqual` for use in Lit `@property`/`@state` configs for `hasChanged`.


### PR DESCRIPTION
Follows #2855

## Changes

Refactors the workflows list page to:
- Use a `Task` for fetching workflows
- Use `SearchParamsValue`s for filters/sorting/search parameters

Also fixes a bug with the archived item list page where updating filters wouldn't reset the page.
- Updates the pagination component with a public-facing `setPage` method that takes some options
- Uses this method in the archived item list & workflow list to update the page, rather than setting an internal state variable that wasn't updating the search params.

## Testing

On the archived item page, test that all of the filters work as expected.
Test that pagination works as expected, and the page is reset when changing filter parameters.
Test that the browser's back and forward buttons work as expected when changing filters/search/sorting/pages.

## Known Issues

- When changing a filter when you're on a page other than the first, the page is reset to the first page in a separate step from the filter change, which means that if you use your browser's navigation buttons to go back you'll need to go back twice to get to where you were before. E.g.: 
  - `?page=3` &rarr; user sets a filter &rarr; `?mine=true` — this works as expected, but from here:
  - `?mine=true` &rarr; user presses back button in browser &rarr; `?mine=true&page=3` &rarr; user presses back button again &rarr; `?page=3` 
  
  I'm not totally sure what the best approach here is. Ideally I think we'd hook into Lit's reactive update cycle from the search values controller and only do a single `history.pushState` in the `update` stage, but I'm not sure there's an easy way to do that without digging pretty deep into Lit's internals. Open to ideas though!