### PR TITLE
Add migration to clean up older left-over cron and crawl jobs

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -487,45 +487,6 @@ class CrawlManager(K8sAPI):
         """Delete all browser profile jobs for given org"""
         await self._delete_custom_objects(f"btrix.org={oid_str}", plural="profilejobs")
 
-    async def delete_cron_job_by_name(self, name: str) -> None:
-        """Delete cron job by name"""
-        await self.batch_api.delete_namespaced_cron_job(
-            name=name,
-            namespace=self.namespace,
-        )
-
-    async def list_cron_jobs(self, label: str = ""):
-        """Return list of all cron jobs, optionally filtered by label"""
-        resp = await self.batch_api.list_namespaced_cron_job(
-            namespace=self.namespace,
-            label_selector=label,
-        )
-        return resp.items
-
-    # ========================================================================
-    # Internal Methods
-    async def _delete_cron_jobs(self, label: str) -> None:
-        """Delete namespaced cron jobs (e.g. crawl configs, bg jobs)"""
-
-        await self.batch_api.delete_collection_namespaced_cron_job(
-            namespace=self.namespace,
-            label_selector=label,
-        )
-
-    async def _delete_custom_objects(
-        self, label: str, plural: str = "crawljobs"
-    ) -> None:
-        """Delete custom objects (e.g. crawl jobs, profile browser jobs)"""
-        await self.custom_api.delete_collection_namespaced_custom_object(
-            group="btrix.cloud",
-            version="v1",
-            namespace=self.namespace,
-            label_selector=label,
-            plural=plural,
-            grace_period_seconds=0,
-            propagation_policy="Background",
-        )
-
     async def update_scheduled_job(
         self, crawlconfig: CrawlConfig, userid: Optional[str] = None
     ) -> Optional[str]:

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -28,10 +28,11 @@ if TYPE_CHECKING:
     from .pages import PageOps
     from .background_jobs import BackgroundJobOps
     from .file_uploads import FileUploadOps
+    from .crawlmanager import CrawlManager
 else:
     UserManager = OrgOps = CrawlConfigOps = CrawlOps = CollectionOps = InviteOps = (
         StorageOps
-    ) = PageOps = BackgroundJobOps = FileUploadOps = CrawlLogOps = object
+    ) = PageOps = BackgroundJobOps = FileUploadOps = CrawlLogOps = CrawlManager = object
 
 
 CURR_DB_VERSION = "0052"
@@ -102,6 +103,7 @@ async def update_and_prepare_db(
     background_job_ops: BackgroundJobOps,
     file_ops: FileUploadOps,
     crawl_log_ops: CrawlLogOps,
+    crawl_manager: CrawlManager,
 ) -> None:
     """Prepare database for application.
 
@@ -122,6 +124,7 @@ async def update_and_prepare_db(
         coll_ops,
         file_ops,
         crawl_log_ops,
+        crawl_manager,
     ):
         await drop_indexes(mdb)
 
@@ -147,13 +150,14 @@ async def update_and_prepare_db(
 # pylint: disable=too-many-locals, too-many-arguments
 async def run_db_migrations(
     mdb,
-    user_manager,
-    page_ops,
-    org_ops,
-    background_job_ops,
-    coll_ops,
-    file_ops,
-    crawl_log_ops,
+    user_manager: UserManager,
+    page_ops: PageOps,
+    org_ops: OrgOps,
+    background_job_ops: BackgroundJobOps,
+    coll_ops: CollectionOps,
+    file_ops: FileUploadOps,
+    crawl_log_ops: CrawlLogOps,
+    crawl_manager: CrawlManager,
 ):
     """Run database migrations."""
 
@@ -194,6 +198,7 @@ async def run_db_migrations(
                 coll_ops=coll_ops,
                 file_ops=file_ops,
                 crawl_log_ops=crawl_log_ops,
+                crawl_manager=crawl_manager,
             )
             if await migration.run():
                 migrations_run = True

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -380,3 +380,40 @@ class K8sAPI:
             print(f"Send Signal Error: {exc}", flush=True)
 
         return signaled
+
+    async def delete_cron_job_by_name(self, name: str) -> None:
+        """Delete cron job by name"""
+        await self.batch_api.delete_namespaced_cron_job(
+            name=name,
+            namespace=self.namespace,
+        )
+
+    async def list_cron_jobs(self, label: str = ""):
+        """Return list of all cron jobs, optionally filtered by label"""
+        resp = await self.batch_api.list_namespaced_cron_job(
+            namespace=self.namespace,
+            label_selector=label,
+        )
+        return resp.items
+
+    async def _delete_cron_jobs(self, label: str) -> None:
+        """Delete namespaced cron jobs (e.g. crawl configs, bg jobs)"""
+
+        await self.batch_api.delete_collection_namespaced_cron_job(
+            namespace=self.namespace,
+            label_selector=label,
+        )
+
+    async def _delete_custom_objects(
+        self, label: str, plural: str = "crawljobs"
+    ) -> None:
+        """Delete custom objects (e.g. crawl jobs, profile browser jobs)"""
+        await self.custom_api.delete_collection_namespaced_custom_object(
+            group="btrix.cloud",
+            version="v1",
+            namespace=self.namespace,
+            label_selector=label,
+            plural=plural,
+            grace_period_seconds=0,
+            propagation_policy="Background",
+        )

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -2,7 +2,7 @@
 
 import os
 import traceback
-from typing import Optional
+from typing import Optional, List
 
 import yaml
 
@@ -10,6 +10,7 @@ from kubernetes_asyncio import client, config
 from kubernetes_asyncio.stream import WsApiClient
 from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.client.api import custom_objects_api
+from kubernetes_asyncio.client.models import V1CronJob
 from kubernetes_asyncio.utils import create_from_dict
 from kubernetes_asyncio.client.exceptions import ApiException
 
@@ -388,7 +389,7 @@ class K8sAPI:
             namespace=self.namespace,
         )
 
-    async def list_cron_jobs(self, label: str = ""):
+    async def list_cron_jobs(self, label: str = "") -> List[V1CronJob]:
         """Return list of all cron jobs, optionally filtered by label"""
         resp = await self.batch_api.list_namespaced_cron_job(
             namespace=self.namespace,
@@ -398,7 +399,6 @@ class K8sAPI:
 
     async def _delete_cron_jobs(self, label: str) -> None:
         """Delete namespaced cron jobs (e.g. crawl configs, bg jobs)"""
-
         await self.batch_api.delete_collection_namespaced_cron_job(
             namespace=self.namespace,
             label_selector=label,

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -2,7 +2,7 @@
 
 import os
 import traceback
-from typing import Optional, List
+from typing import Optional, List, Any
 
 import yaml
 
@@ -396,6 +396,17 @@ class K8sAPI:
             label_selector=label,
         )
         return resp.items
+
+    async def list_crawl_jobs(self, label: str = "") -> List[dict[str, Any]]:
+        """Return list of all crawl jobs, optionally filtered by label)"""
+        resp = await self.custom_api.list_namespaced_custom_object(
+            group="btrix.cloud",
+            version="v1",
+            namespace=self.namespace,
+            plural="crawljobs",
+            label_selector=label,
+        )
+        return resp.get("items", [])
 
     async def _delete_cron_jobs(self, label: str) -> None:
         """Delete namespaced cron jobs (e.g. crawl configs, bg jobs)"""

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -48,6 +48,7 @@ async def main():
         _,
         _,
         _,
+        _,
     ) = init_ops()
 
     # Run job (generic)

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -37,6 +37,7 @@ async def main() -> int:
         invite_ops,
         file_ops,
         crawl_log_ops,
+        crawl_manager,
         _,
         mdb,
     ) = init_ops()
@@ -54,6 +55,7 @@ async def main() -> int:
         background_job_ops,
         file_ops,
         crawl_log_ops,
+        crawl_manager,
     )
 
     return 0

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -44,6 +44,7 @@ def main():
         crawl_log_ops,
         _,
         _,
+        _,
     ) = init_ops()
 
     return init_operator_api(

--- a/backend/btrixcloud/migrations/migration_0053_delete_leftover_cronjobs.py
+++ b/backend/btrixcloud/migrations/migration_0053_delete_leftover_cronjobs.py
@@ -40,15 +40,11 @@ class Migration(BaseMigration):
         for cron_job in bg_cron_jobs:
             metadata = cron_job.metadata
 
-            job_type = metadata.labels.get("job_type", "")
-            if metadata.labels.get("role") == "cron-job":
-                job_type = "scheduled crawl"
-
             oid = metadata.labels.get("btrix.org")
             if oid:
                 await self.delete_cron_job_if_org_deleted(UUID(oid), metadata.name)
 
-            if job_type == "delete-replica":
+            if metadata.labels.get("job_type") == "delete-replica":
                 await self.delete_replica_delete_job_if_finished(metadata.name)
 
         crawl_jobs = await self.crawl_manager.list_crawl_jobs()

--- a/backend/btrixcloud/migrations/migration_0053_delete_leftover_cronjobs.py
+++ b/backend/btrixcloud/migrations/migration_0053_delete_leftover_cronjobs.py
@@ -1,0 +1,104 @@
+"""
+Migration 0053 - Delete leftover cron jobs
+"""
+
+from uuid import UUID
+
+from fastapi import HTTPException
+
+from btrixcloud.migrations import BaseMigration
+
+
+MIGRATION_VERSION = "0053"
+
+
+# pylint: disable=duplicate-code
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+        self.org_ops = kwargs.get("org_ops")
+        self.background_job_ops = kwargs.get("background_job_ops")
+        self.crawl_manager = kwargs.get("crawl_manager")
+
+    async def migrate_up(self) -> None:
+        """Perform migration up.
+
+        Delete replica deletion cron jobs and config cron jobs from deleted orgs
+        that were left over accidentally, as well as replica deletion cron jobs
+        that completed (succeeded or failed) but were never cleaned up.
+        """
+        if self.crawl_manager is None:
+            print("Unable to clean up leftover cron jobs, missing ops", flush=True)
+            return
+
+        bg_cron_jobs = await self.crawl_manager.list_cron_jobs()
+        for cron_job in bg_cron_jobs:
+            metadata = cron_job.metadata
+
+            job_type = metadata.labels.get("job_type", "")
+            if metadata.labels.get("role") == "cron-job":
+                job_type = "scheduled crawl"
+
+            oid = metadata.labels.get("btrix.org")
+            if oid:
+                await self.delete_job_if_org_deleted(UUID(oid), metadata.name, job_type)
+
+            if job_type == "delete-replica":
+                await self.delete_replica_delete_job_if_finished(metadata.name)
+
+    async def delete_job_if_org_deleted(
+        self, oid: UUID, job_name: str, job_type: str
+    ) -> None:
+        """Delete job if it belongs to a deleted org"""
+        if self.org_ops is None or self.crawl_manager is None:
+            print(f"Skipping cron job {job_name} org check, missing ops", flush=True)
+            return
+
+        org_exists = True
+
+        try:
+            _ = await self.org_ops.get_org_by_id(oid)
+        except HTTPException:
+            org_exists = False
+
+        if not org_exists:
+            try:
+                await self.crawl_manager.delete_cron_job_by_name(job_name)
+                print(
+                    f"Deleted cron job {job_name} (type: {job_type}) from deleted org",
+                    flush=True,
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error deleting cron job {job_name} (type: {job_type}): {err}",
+                    flush=True,
+                )
+
+    async def delete_replica_delete_job_if_finished(self, job_name: str) -> None:
+        """Delete replica delete job if finished"""
+        if self.background_job_ops is None or self.crawl_manager is None:
+            print(
+                f"Skipping cron job {job_name} finished check, missing ops", flush=True
+            )
+            return
+
+        try:
+            job = await self.background_job_ops.get_background_job(job_name)
+            if job.finished and job.success is not None:
+                await self.crawl_manager.delete_cron_job_by_name(job_name)
+                # pylint: disable=line-too-long
+                print(
+                    f"Deleted replica delete job {job_name} (success: {job.success}, org: {job.oid})",
+                    flush=True,
+                )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error deleting replica delete cron job {job_name}: {err}",
+                flush=True,
+            )

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -41,6 +41,7 @@ def init_ops() -> Tuple[
     InviteOps,
     FileUploadOps,
     CrawlLogOps,
+    CrawlManager,
     AsyncIOMotorClient,
     AsyncIOMotorDatabase,
 ]:
@@ -142,6 +143,7 @@ def init_ops() -> Tuple[
         invite_ops,
         file_ops,
         crawl_log_ops,
+        crawl_manager,
         dbclient,
         mdb,
     )


### PR DESCRIPTION
Fast-follow to #2872

- Add migration to clean up replica deletion cron jobs that have finished but were not removed, as well as crawl config cron jobs, background cron jobs, and crawl jobs from deleted orgs that may have been stranded prior to the bug fix in #2872.
- Move a few methods that only interact with k8s APIs from crawlmanager to k8sapi module