### PR TITLE
Fix crawl running filter being passed incorrectly to backend

### DIFF
--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -190,7 +190,7 @@ export class WorkflowsList extends BtrixElement {
               params.set(key, value[key] ? "true" : "false");
               break;
             case "isCrawlRunning":
-              if (value[key] as boolean | undefined) {
+              if (value[key] as true | undefined) {
                 params.set(key, "true");
               } else {
                 params.delete(key);

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -190,7 +190,7 @@ export class WorkflowsList extends BtrixElement {
               params.set(key, value[key] ? "true" : "false");
               break;
             case "isCrawlRunning":
-              if (value[key]) {
+              if (value[key] as boolean | undefined) {
                 params.set(key, "true");
               } else {
                 params.delete(key);

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -101,7 +101,7 @@ type FilterBy = {
   name?: string;
   firstSeed?: string;
   schedule?: boolean;
-  isCrawlRunning?: boolean | undefined;
+  isCrawlRunning?: boolean;
 };
 
 /**
@@ -190,8 +190,8 @@ export class WorkflowsList extends BtrixElement {
               params.set(key, value[key] ? "true" : "false");
               break;
             case "isCrawlRunning":
-              if ((value[key] as boolean | undefined) != null) {
-                params.set(key, value[key] ? "true" : "false");
+              if (value[key]) {
+                params.set(key, "true");
               } else {
                 params.delete(key);
               }
@@ -202,19 +202,13 @@ export class WorkflowsList extends BtrixElement {
       return params;
     },
     (params) => {
-      const isCrawlRunning = params.get("isCrawlRunning");
       return {
         name: params.get("name") ?? undefined,
         firstSeed: params.get("firstSeed") ?? undefined,
         schedule: params.has("schedule")
           ? params.get("schedule") === "true"
           : undefined,
-        isCrawlRunning:
-          isCrawlRunning === "true"
-            ? true
-            : isCrawlRunning === "false"
-              ? false
-              : undefined,
+        isCrawlRunning: params.get("isCrawlRunning") === "true",
       };
     },
   );

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -101,7 +101,7 @@ type FilterBy = {
   name?: string;
   firstSeed?: string;
   schedule?: boolean;
-  isCrawlRunning?: boolean;
+  isCrawlRunning?: boolean | undefined;
 };
 
 /**
@@ -190,8 +190,8 @@ export class WorkflowsList extends BtrixElement {
               params.set(key, value[key] ? "true" : "false");
               break;
             case "isCrawlRunning":
-              if (value[key]) {
-                params.set(key, "true");
+              if ((value[key] as boolean | undefined) != null) {
+                params.set(key, value[key] ? "true" : "false");
               } else {
                 params.delete(key);
               }
@@ -202,13 +202,19 @@ export class WorkflowsList extends BtrixElement {
       return params;
     },
     (params) => {
+      const isCrawlRunning = params.get("isCrawlRunning");
       return {
         name: params.get("name") ?? undefined,
         firstSeed: params.get("firstSeed") ?? undefined,
         schedule: params.has("schedule")
           ? params.get("schedule") === "true"
           : undefined,
-        isCrawlRunning: params.get("isCrawlRunning") === "true",
+        isCrawlRunning:
+          isCrawlRunning === "true"
+            ? true
+            : isCrawlRunning === "false"
+              ? false
+              : undefined,
       };
     },
   );

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -101,7 +101,7 @@ type FilterBy = {
   name?: string;
   firstSeed?: string;
   schedule?: boolean;
-  isCrawlRunning?: boolean;
+  isCrawlRunning?: true;
 };
 
 /**
@@ -208,7 +208,7 @@ export class WorkflowsList extends BtrixElement {
         schedule: params.has("schedule")
           ? params.get("schedule") === "true"
           : undefined,
-        isCrawlRunning: params.get("isCrawlRunning") === "true",
+        isCrawlRunning: params.get("isCrawlRunning") === "true" || undefined,
       };
     },
   );


### PR DESCRIPTION
Quick fix for an issue where the default state of the crawl running filter on the workflows list page was incorrectly filtering out running crawls.