### PR TITLE
fix: Fix incorrect option selected in search results 

### DIFF
--- a/frontend/src/components/ui/search-combobox.ts
+++ b/frontend/src/components/ui/search-combobox.ts
@@ -102,13 +102,14 @@ export class SearchCombobox<T> extends LitElement {
           this.searchResultsOpen = false;
           const item = e.detail.item as SlMenuItem;
           const key = item.dataset["key"];
-          this.searchByValue = item.value;
+          const value = item.value;
+          this.searchByValue = value;
           await this.updateComplete;
           this.dispatchEvent(
             new CustomEvent<SelectEventDetail<T>>("btrix-select", {
               detail: {
                 key: key ?? null,
-                value: item.value as T,
+                value: value as T,
               },
             }),
           );


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2908

## Changes

Fixes incorrect option selection in search combobox results by caching the value before updates.

## Manual testing

Test using repro instructions in https://github.com/webrecorder/browsertrix/issues/2908