### PR TITLE
Fix browser profile launch by specifying relative path inside oid dir to profilejob

### DIFF
--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -414,6 +414,7 @@ class ProfileOps:
         try:
             profile = await self.get_profile(profileid, org)
             storage_path = profile.resource.filename if profile.resource else ""
+            storage_path = storage_path.lstrip(f"{org.id}/")
             return storage_path, profile.proxyId or ""
         # pylint: disable=bare-except
         except:

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -64,7 +64,7 @@ def test_create_new_config(admin_auth_headers, default_org_id):
     assert data["storageQuotaReached"] is False
 
 
-def test_start_crawl(admin_auth_headers, default_org_id):
+def test_start_crawl(admin_auth_headers, default_org_id, profile_id):
     # Start crawl.
     crawl_data = {
         "runNow": True,
@@ -77,6 +77,7 @@ def test_start_crawl(admin_auth_headers, default_org_id):
             # limit now set via 'max_pages_per_crawl' global limit
             # "limit": 1,
         },
+        "profileid": profile_id,
     }
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/",


### PR DESCRIPTION
Fixes #2911 

Follow-up to https://github.com/webrecorder/browsertrix/issues/2891

This commit strips the oid prefix from the profile filename before passing it along to the profilejob so that it's in the format the crawler expects.

I've also added a profile to an existing test that runs a crawl and verifies that state is `complete` at finished (i.e. not failed) to catch any similar type regression in the future.

## Testing

- Spin up a local instance of Browsertrix
- Verify you can now spin up profile browsers
- Run nightly test that actually launches a profile browser: `python -m pytest backend/test_nightly/test_crawl_not_logged_in.py`