### PR TITLE
fix: Fix UI consistency issues with unsuccessful crawls

### DIFF
--- a/frontend/src/components/ui/format-date.ts
+++ b/frontend/src/components/ui/format-date.ts
@@ -24,6 +24,9 @@ export class FormatDate extends LitElement {
    */
   @property() date?: Date | string | null = new Date();
 
+  @property() dateStyle?: Intl.DateTimeFormatOptions["dateStyle"];
+  @property() timeStyle?: Intl.DateTimeFormatOptions["timeStyle"];
+
   /** The format for displaying the weekday. */
   @property() weekday?: "narrow" | "short" | "long";
 
@@ -74,6 +77,8 @@ export class FormatDate extends LitElement {
     return html`
       <time datetime=${date.toISOString()}>
         ${this.localize.date(date, {
+          dateStyle: this.dateStyle,
+          timeStyle: this.timeStyle,
           weekday: this.weekday,
           era: this.era,
           year: this.year,

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -238,7 +238,6 @@ export class FileUploader extends BtrixElement {
       <div class="mt-4">
         <btrix-collections-add
           .initialCollections=${this.collectionIds}
-          .configId=${"temp"}
           label=${msg("Add to Collection")}
           @collections-change=${(e: CollectionsChangeEvent) =>
             (this.collectionIds = e.detail.collections)}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -304,6 +304,7 @@ export class ArchivedItemDetail extends BtrixElement {
 
   render() {
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
+    const isSuccess = this.item && isSuccessfullyFinished(this.item);
     let sectionContent: string | TemplateResult<1> = "";
 
     switch (this.activeTab) {
@@ -415,7 +416,12 @@ export class ArchivedItemDetail extends BtrixElement {
                 tw`rounded-lg border p-4`,
               ])}
             </div>
-            <div class="col-span-1 row-span-1 flex flex-col">
+            <div
+              class=${clsx(
+                tw`col-span-1 flex flex-col`,
+                isSuccess ? tw`row-span-1` : tw`row-span-2`,
+              )}
+            >
               ${this.renderPanel(
                 html`
                   ${this.renderTitle(msg("Metadata"))}
@@ -426,7 +432,7 @@ export class ArchivedItemDetail extends BtrixElement {
                         class="text-base"
                         name="pencil"
                         @click=${() => this.openMetadataEditor("metadata")}
-                        label=${msg("Edit Archived Item")}
+                        label=${msg("Edit Metadata")}
                       ></sl-icon-button>
                     `,
                   )}
@@ -435,26 +441,32 @@ export class ArchivedItemDetail extends BtrixElement {
                 [tw`rounded-lg border p-4`],
               )}
             </div>
-            <div class="col-span-1 row-span-1 flex flex-col">
-              ${this.renderPanel(
-                html`
-                  ${this.renderTitle(msg("Collections"))}
-                  ${when(
-                    this.isCrawler,
-                    () => html`
-                      <sl-icon-button
-                        class="text-base"
-                        name="pencil"
-                        @click=${() => this.openMetadataEditor("collections")}
-                        label=${msg("Edit Archived Item")}
-                      ></sl-icon-button>
+            ${when(
+              isSuccess,
+              () => html`
+                <div class="col-span-1 row-span-1 flex flex-col">
+                  ${this.renderPanel(
+                    html`
+                      ${this.renderTitle(msg("Collections"))}
+                      ${when(
+                        this.isCrawler && isSuccess,
+                        () => html`
+                          <sl-icon-button
+                            class="text-base"
+                            name="pencil"
+                            @click=${() =>
+                              this.openMetadataEditor("collections")}
+                            label=${msg("Edit Collections")}
+                          ></sl-icon-button>
+                        `,
+                      )}
                     `,
+                    this.renderCollections(),
+                    [tw`rounded-lg border p-4`],
                   )}
-                `,
-                this.renderCollections(),
-                [tw`rounded-lg border p-4`],
-              )}
-            </div>
+                </div>
+              `,
+            )}
           </div>
         `;
         break;
@@ -663,6 +675,7 @@ export class ArchivedItemDetail extends BtrixElement {
     if (!this.item) return;
 
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
+    const isSuccess = isSuccessfullyFinished(this.item);
 
     return html`
       <sl-dropdown placement="bottom-end" distance="4" hoist>
@@ -675,13 +688,13 @@ export class ArchivedItemDetail extends BtrixElement {
             () => html`
               <sl-menu-item @click=${this.openMetadataEditor}>
                 <sl-icon name="pencil" slot="prefix"></sl-icon>
-                ${msg("Edit Archived Item")}
+                ${isSuccess ? msg("Edit Archived Item") : msg("Edit Metadata")}
               </sl-menu-item>
               <sl-divider></sl-divider>
             `,
           )}
           ${when(
-            isSuccessfullyFinished(this.item),
+            isSuccess,
             () => html`
               ${when(
                 this.itemType === "crawl",

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -52,10 +52,11 @@ type SectionName = (typeof SECTIONS)[number];
 const POLL_INTERVAL_SECONDS = 5;
 
 /**
- * Usage:
- * ```ts
- * <btrix-archived-item-detail></btrix-archived-item-detail>
- * ```
+ * Detail page for an archived item (crawl or upload) or crawl run.
+ *
+ * Note: The component name is somewhat misleading, since this component
+ * can also be used to display crawl runs that did not result in a
+ * definitive archived item.
  */
 @customElement("btrix-archived-item-detail")
 @localized()
@@ -859,8 +860,8 @@ export class ArchivedItemDetail extends BtrixElement {
               `
             : html`<sl-skeleton class="mb-[3px] h-[16px] w-24"></sl-skeleton>`}
         </btrix-desc-list-item>
-        ${when(this.item, () =>
-          this.item!.type === "upload"
+        ${when(this.item, (item) =>
+          item.type === "upload"
             ? html`
                 <btrix-desc-list-item label=${msg("Uploaded")}>
                   ${this.formattedFinishedDate}
@@ -869,30 +870,30 @@ export class ArchivedItemDetail extends BtrixElement {
             : html`
                 <btrix-desc-list-item label=${msg("Start Time")}>
                   <btrix-format-date
-                    date=${this.item!.started}
-                    month="2-digit"
-                    day="2-digit"
-                    year="numeric"
-                    hour="numeric"
-                    minute="numeric"
-                    time-zone-name="short"
+                    date=${item.started}
+                    dateStyle="long"
+                    timeStyle="long"
                   ></btrix-format-date>
                 </btrix-desc-list-item>
                 <btrix-desc-list-item label=${msg("Finish Time")}>
-                  ${this.item!.finished
-                    ? this.formattedFinishedDate
+                  ${item.finished
+                    ? html`<btrix-format-date
+                        date=${item.finished}
+                        dateStyle="long"
+                        timeStyle="long"
+                      ></btrix-format-date>`
                     : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 </btrix-desc-list-item>
                 <btrix-desc-list-item label=${msg("Run Duration")}>
-                  ${this.item!.finished
+                  ${item.finished
                     ? html`${this.localize.humanizeDuration(
-                        new Date(this.item!.finished).valueOf() -
-                          new Date(this.item!.started).valueOf(),
+                        new Date(item.finished).valueOf() -
+                          new Date(item.started).valueOf(),
                       )}`
                     : html`
                         <span class="text-violet-600">
                           <btrix-relative-duration
-                            value=${this.item!.started}
+                            value=${item.started}
                             unitCount="3"
                             tickSeconds="1"
                           ></btrix-relative-duration>
@@ -900,22 +901,19 @@ export class ArchivedItemDetail extends BtrixElement {
                       `}
                 </btrix-desc-list-item>
                 <btrix-desc-list-item label=${msg("Execution Time")}>
-                  ${this.item!.finished
+                  ${item.finished
                     ? html`<span
-                        >${humanizeExecutionSeconds(
-                          this.item!.crawlExecSeconds,
-                          { displaySeconds: true },
-                        )}</span
+                        >${humanizeExecutionSeconds(item.crawlExecSeconds, {
+                          displaySeconds: true,
+                        })}</span
                       >`
                     : html`<span class="text-0-400">${msg("Pending")}</span>`}
                 </btrix-desc-list-item>
                 <btrix-desc-list-item label=${msg("Initiator")}>
-                  ${this.item!.manual
+                  ${item.manual
                     ? msg(
                         html`Manual start by
-                          <span
-                            >${this.item!.userName || this.item!.userid}</span
-                          >`,
+                          <span>${item.userName || item.userid}</span>`,
                       )
                     : msg(html`Scheduled start`)}
                 </btrix-desc-list-item>
@@ -929,13 +927,11 @@ export class ArchivedItemDetail extends BtrixElement {
         </btrix-desc-list-item>
         <btrix-desc-list-item label=${msg("Size")}>
           ${this.item
-            ? html`${this.item.fileSize
-                ? this.localize.bytes(this.item.fileSize || 0)
-                : html`<span class="text-0-400">${msg("Unknown")}</span>`}`
+            ? this.localize.bytes(this.item.fileSize || 0)
             : html`<sl-skeleton class="h-[16px] w-24"></sl-skeleton>`}
         </btrix-desc-list-item>
         ${this.renderCrawlChannelVersion()}
-        <btrix-desc-list-item label=${msg("Archived Item ID")}>
+        <btrix-desc-list-item label=${msg("ID")}>
           ${this.item
             ? html`<btrix-copy-field
                 value="${this.item.id}"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -676,6 +676,8 @@ export class ArchivedItemDetail extends BtrixElement {
 
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
     const isSuccess = isSuccessfullyFinished(this.item);
+    const isCrawlType = this.itemType === "crawl";
+    const isWorkflowCrawl = this.item.cid === this.workflowId;
 
     return html`
       <sl-dropdown placement="bottom-end" distance="4" hoist>
@@ -697,7 +699,7 @@ export class ArchivedItemDetail extends BtrixElement {
             isSuccess,
             () => html`
               ${when(
-                this.itemType === "crawl",
+                isCrawlType,
                 () => html`
                   <btrix-menu-item-link href=${this.reviewUrl}>
                     <sl-icon slot="prefix" name="clipboard2-data"></sl-icon>
@@ -723,7 +725,7 @@ export class ArchivedItemDetail extends BtrixElement {
             `,
           )}
           ${when(
-            this.itemType === "crawl",
+            isCrawlType,
             () => html`
               <sl-menu-item
                 @click=${() =>
@@ -750,7 +752,7 @@ export class ArchivedItemDetail extends BtrixElement {
               )}
           >
             <sl-icon name="copy" slot="prefix"></sl-icon>
-            ${msg("Copy Item ID")}
+            ${msg("Copy ID")}
           </sl-menu-item>
           <sl-menu-item
             @click=${() =>
@@ -769,7 +771,11 @@ export class ArchivedItemDetail extends BtrixElement {
                 @click=${() => void this.deleteCrawl()}
               >
                 <sl-icon name="trash3" slot="prefix"></sl-icon>
-                ${msg("Delete Item")}
+                ${isWorkflowCrawl
+                  ? msg("Delete Crawl")
+                  : isSuccess
+                    ? msg("Delete Archived Item")
+                    : msg("Delete Item")}
               </sl-menu-item>
             `,
           )}


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/2913

## Changes

- Hides collection panel and input for unsuccessful crawls
- Updates action menu labels depending on crawl success
- Fixes "Unknown" displayed for 0 file size
- Shows full date for started and finished

## Manual testing

Test with repro steps in https://github.com/webrecorder/browsertrix/issues/2913

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl Detail (canceled) | <img width="899" height="668" alt="Screenshot 2025-10-21 at 11 20 38 AM" src="https://github.com/user-attachments/assets/4d254d85-9fc1-4695-a708-1302037a379e" /> |
| Crawl Detail (canceled) | <img width="213" height="307" alt="Screenshot 2025-10-21 at 11 51 04 AM" src="https://github.com/user-attachments/assets/27b6177c-b7dd-4b34-9eba-591541e70915" /> |
| Crawl Detail (canceled) | <img width="474" height="334" alt="Screenshot 2025-10-21 at 11 20 43 AM" src="https://github.com/user-attachments/assets/b1f9981e-10bb-4c24-b553-561a97cd8841" /> |


<!-- ## Follow-ups -->
