### PR TITLE
fix: Workflow pagination regression

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-last-crawl-state-filter.ts
+++ b/frontend/src/features/crawl-workflows/workflow-last-crawl-state-filter.ts
@@ -65,7 +65,7 @@ export class WorkflowLastCrawlStateFilter extends BtrixElement {
   }
 
   protected updated(changedProperties: PropertyValues<this>): void {
-    if (changedProperties.has("selected")) {
+    if (changedProperties.get("selected")) {
       this.dispatchEvent(
         new CustomEvent<
           BtrixChangeEvent<ChangeWorkflowLastCrawlStateEventDetails>["detail"]


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/pull/2902

## Changes

Fixes workflow pagination regression.

## Manual testing

1. Log in
2. Go to "Crawling"
3. Go to any page
4. Reload. Workflow should load with correct paginated items