### PR TITLE
Ensure seed files are deleted on org delete

### DIFF
--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -394,6 +394,20 @@ class FileUploadOps:
         if errored:
             raise RuntimeError(f"Error deleting unused seed files: {error_msg}")
 
+    async def delete_org_files(self, org: Organization):
+        """Delete all files associated with an org from database and storage"""
+        match_query = {"oid": org.id}
+        async for file_dict in self.files.find(match_query):
+            file_id = file_dict["_id"]
+            try:
+                await self.delete_seed_file(file_id, org)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error deleting seed file {file_id} from deleted org: {err}",
+                    flush=True,
+                )
+
 
 # ============================================================================
 def init_file_uploads_api(

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1401,6 +1401,9 @@ class OrgOps:
 
         await self.crawl_configs_db.delete_many({"oid": org.id})
 
+        # Delete seed files and other user-uploaded files from database and storage
+        await self.file_ops.delete_org_files(org)
+
         # Delete profiles
         async for profile in self.profiles_db.find({"oid": org.id}, projection=["_id"]):
             await self.profile_ops.delete_profile(profile["_id"], org)


### PR DESCRIPTION
Fixes #2918

## Testing

1. Create an org in a local instance running off this branch
2. Create a workflow with an uploaded seed file
3. Delete the org
4. Verify that the seed file is deleted from storage and from the database

I've tested that this works correctly and that the seed files are left behind on org delete in current main.