### PR TITLE
allow seed cleanup job to delete orphaned seed files after org has be…

### DIFF
--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -198,9 +198,12 @@ class FileUploadOps:
 
         file_id = uuid4()
 
-        new_filename = f"{upload_type}-{str(file_id)}{extension}"
+        new_filename = f"{str(file_id)}{extension}"
 
-        prefix = org.storage.get_storage_extra_path(str(org.id)) + f"{upload_type}s/"
+        prefix = (
+            org.storage.get_storage_extra_path(str(org.id))
+            + f"{upload_type}s/{upload_type}"
+        )
 
         file_prep = UserFilePreparer(
             prefix,

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -383,6 +383,22 @@ class FileUploadOps:
                 org = await self.org_ops.get_org_by_id(file_dict["oid"])
                 await self.delete_seed_file(file_id, org)
                 print(f"Deleted unused seed file {file_id}", flush=True)
+
+            except HTTPException as e:
+                # handle case where org is deleted by seed file still exists
+                if e.detail == "invalid_org_id":
+                    try:
+                        await self.storage_ops.delete_file_from_default_storage(
+                            file_dict["filename"]
+                        )
+                        await self.files.delete_one({"_id": file_id})
+                    # pylint: disable=broad-exception-caught
+                    except Exception as err:
+                        print(
+                            f"Error deleting orphaned seed file without org {file_id}: {err}",
+                            flush=True,
+                        )
+
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(f"Error deleting unused seed file {file_id}: {err}", flush=True)

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 CURR=$(dirname "${BASH_SOURCE[0]}")
 
-docker build -t ${REGISTRY}webrecorder/browsertrix-backend:latest $CURR/../backend/
+docker build --load -t ${REGISTRY}webrecorder/browsertrix-backend:latest $CURR/../backend/
 
 if [ -n "$REGISTRY" ]; then
     docker push ${REGISTRY}webrecorder/browsertrix-backend


### PR DESCRIPTION
…en deleted:

- in seed cleanup, catch if org doesn't exist and attempt to delete file directly
- add delete_file_from_default_storage() to allow deleting left-over seed files, assuming they are stored in default storage
- side effect of #2918, which will be fixed in #2919
- no need for migration, as will be picked up existing cleanup seed files job