### PR TITLE
Additional tagCounts endpoints and options

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -26,7 +26,7 @@ from .models import (
     ConfigRevision,
     CrawlConfig,
     CrawlConfigOut,
-    CrawlConfigTags,
+    TagsResponse,
     CrawlOut,
     CrawlOutWithResources,
     UpdateCrawlConfig,
@@ -1622,7 +1622,7 @@ def init_crawl_config_api(
         """
         return await ops.get_crawl_config_tags(org)
 
-    @router.get("/tagCounts", response_model=CrawlConfigTags)
+    @router.get("/tagCounts", response_model=TagsResponse)
     async def get_crawl_config_tag_counts(org: Organization = Depends(org_viewer_dep)):
         return {"tags": await ops.get_crawl_config_tag_counts(org)}
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -78,6 +78,7 @@ from .models import (
     CrawlQueueResponse,
     MatchCrawlQueueResponse,
     CrawlLogLine,
+    TagsResponse,
 )
 
 
@@ -1354,6 +1355,20 @@ def init_crawls_api(
         return DeletedCountResponseQuota(
             deleted=count, storageQuotaReached=quota_reached
         )
+
+    @app.get(
+        "/orgs/{oid}/crawls/tagCounts",
+        tags=["crawls"],
+        response_model=TagsResponse,
+    )
+    async def get_crawls_tag_counts(
+        org: Organization = Depends(org_viewer_dep),
+        onlySuccessful: bool = True,
+    ):
+        tags = await ops.get_all_crawls_tag_counts(
+            org, only_successful=onlySuccessful, type_="crawl"
+        )
+        return {"tags": tags}
 
     @app.get("/orgs/all/crawls/stats", tags=["crawls"], response_model=bytes)
     async def get_all_orgs_crawl_stats(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -603,18 +603,18 @@ class CrawlConfigAddedResponse(BaseModel):
 
 
 # ============================================================================
-class CrawlConfigTagCount(BaseModel):
-    """Response model for crawlconfig tag count"""
+class TagCount(BaseModel):
+    """Response model for crawlconfig/crawl tag count"""
 
     tag: str
     count: int
 
 
 # ============================================================================
-class CrawlConfigTags(BaseModel):
-    """Response model for crawlconfig tags"""
+class TagsResponse(BaseModel):
+    """Response model for crawlconfig/crawl tags"""
 
-    tags: List[CrawlConfigTagCount]
+    tags: List[TagCount]
 
 
 # ============================================================================

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -28,6 +28,7 @@ from .models import (
     AddedResponseIdQuota,
     FilePreparer,
     MIN_UPLOAD_PART_SIZE,
+    TagsResponse,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
 from .utils import dt_now
@@ -361,6 +362,19 @@ def init_uploads_api(app, user_dep, *args):
             type_="upload",
         )
         return paginated_format(uploads, total, page, pageSize)
+
+    @app.get(
+        "/orgs/{oid}/uploads/tagCounts",
+        tags=["uploads"],
+        response_model=TagsResponse,
+    )
+    async def get_uploads_tag_counts(
+        org: Organization = Depends(org_viewer_dep),
+    ):
+        tags = await ops.get_all_crawls_tag_counts(
+            org, only_successful=False, type_="upload"
+        )
+        return {"tags": tags}
 
     @app.get(
         "/orgs/{oid}/uploads/{crawlid}",

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -1065,6 +1065,104 @@ def test_clear_all_presigned_urls(
     assert r.json()["success"]
 
 
+def test_all_crawls_tag_counts(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/tagCounts",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "tags": [
+            {"tag": "wr-test-1", "count": 3},
+            {"tag": "wr-test-2", "count": 2},
+            {"tag": "all-crawls", "count": 1},
+            {"tag": "behaviors", "count": 1},
+            {"tag": "four", "count": 1},
+            {"tag": "qa", "count": 1},
+            {"tag": "three", "count": 1},
+            {"tag": "wr-test-1-updated-again", "count": 1},
+            {"tag": "wr-test-2-updated-again", "count": 1},
+        ]
+    }
+
+
+def test_all_crawls_tag_counts_including_failed(
+    crawler_auth_headers, default_org_id, canceled_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/tagCounts?onlySuccessful=false",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "tags": [
+            {"tag": "wr-test-1", "count": 3},
+            {"tag": "wr-test-2", "count": 2},
+            {"tag": "all-crawls", "count": 1},
+            {"tag": "behaviors", "count": 1},
+            {"tag": "canceled", "count": 1},
+            {"tag": "four", "count": 1},
+            {"tag": "qa", "count": 1},
+            {"tag": "three", "count": 1},
+            {"tag": "wr-test-1-updated-again", "count": 1},
+            {"tag": "wr-test-2-updated-again", "count": 1},
+        ]
+    }
+
+
+def test_crawls_tag_counts(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/tagCounts",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "tags": [
+            {"tag": "wr-test-1", "count": 3},
+            {"tag": "wr-test-2", "count": 2},
+            {"tag": "all-crawls", "count": 1},
+            {"tag": "behaviors", "count": 1},
+            {"tag": "qa", "count": 1},
+        ]
+    }
+
+
+def test_crawls_tag_counts_including_failed(
+    crawler_auth_headers, default_org_id, canceled_crawl_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/tagCounts?onlySuccessful=false",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "tags": [
+            {"tag": "wr-test-1", "count": 3},
+            {"tag": "wr-test-2", "count": 2},
+            {"tag": "all-crawls", "count": 1},
+            {"tag": "behaviors", "count": 1},
+            {"tag": "canceled", "count": 1},
+            {"tag": "qa", "count": 1},
+        ]
+    }
+
+
+def test_uploads_tag_counts(crawler_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/uploads/tagCounts",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "tags": [
+            {"tag": "four", "count": 1},
+            {"tag": "three", "count": 1},
+            {"tag": "wr-test-1-updated-again", "count": 1},
+            {"tag": "wr-test-2-updated-again", "count": 1},
+        ]
+    }
+
+
 def test_delete_form_upload_and_crawls_from_all_crawls(
     admin_auth_headers,
     crawler_auth_headers,

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -641,6 +641,7 @@ export class CrawlsList extends BtrixElement {
 
           <btrix-archived-item-tag-filter
             .tags=${this.filterByTags.value}
+            itemType=${ifDefined(this.itemType || undefined)}
             @btrix-change=${(e: BtrixChangeArchivedItemTagFilterEvent) => {
               this.filterByTags.setValue(e.detail.value?.tags);
               this.filterByTagsType.setValue(e.detail.value?.type || "or");


### PR DESCRIPTION
Fixes #2922 

- Add `onlySuccessful` flag to `/all-crawls/tagCounts` endpoint (defaulting to true to avoid breaking change)
- Add `crawlType` option to `/all-crawls/tagCounts` (to match search-values endpoint)
- Add filtered `/crawls/tagCounts` and `/uploads/tagCounts` endpoints
- Rename `CrawlConfigTags` response model to `TagsResponse` now that it's used for crawls/uploads in addition to workflows
- Add tests