### PR TITLE
fix: Show correct empty message for workflows

### DIFF
--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -858,11 +858,7 @@ export class WorkflowsList extends BtrixElement {
   `;
 
   private renderEmptyState() {
-    if (
-      Object.keys(this.filterBy.value).length ||
-      this.filterByCurrentUser.value ||
-      this.filterByTags.value
-    ) {
+    if (this.hasFiltersSet) {
       return html`
         <div class="rounded-lg border bg-neutral-50 p-4">
           <p class="text-center">


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2928

## Changes

Uses filter check to show correct empty message for workflows.

## Manual testing

1. Log in to org without workflows
2. Go to "Crawling". Verify that "no workflows yet" message is displayed.