### PR TITLE
Add backend validation to prevent adding failed crawls to collection

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -620,7 +620,7 @@ class BaseCrawlOps:
         # convert to set to remove any duplicates
         crawl_id_set = set(crawl_ids)
 
-        count = self.crawls.count_documents(
+        count = await self.crawls.count_documents(
             {
                 "_id": {"$in": crawl_id_set},
                 "oid": org.id,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -617,7 +617,7 @@ class BaseCrawlOps:
     async def validate_all_crawls_successful(
         self, crawl_ids: List[str], org: Organization
     ):
-        """Validate that crawls in list exist and are successful or else raise exception"""
+        """Validate that crawls in list exist and did not fail or else raise exception"""
         for crawl_id in crawl_ids:
             crawl = await self.get_base_crawl(crawl_id, org)
             if crawl.state in FAILED_STATES:

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -614,10 +614,12 @@ class BaseCrawlOps:
 
         return resources, pages_optimized
 
-    async def validate_all_crawls_successful(self, crawl_ids: List[str]):
+    async def validate_all_crawls_successful(
+        self, crawl_ids: List[str], org: Organization
+    ):
         """Validate that crawls in list exist and are successful or else raise exception"""
         for crawl_id in crawl_ids:
-            crawl = await self.get_base_crawl(crawl_id)
+            crawl = await self.get_base_crawl(crawl_id, org)
             if crawl.state in FAILED_STATES:
                 raise HTTPException(status_code=400, detail="invalid_failed_crawl")
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -626,8 +626,6 @@ class BaseCrawlOps:
         self, crawl_ids: List[str], collection_id: UUID, org: Organization
     ):
         """Add crawls to collection."""
-        await self.validate_all_crawls_successful(crawl_ids)
-
         await self.crawls.update_many(
             {"_id": {"$in": crawl_ids}, "oid": org.id},
             {"$addToSet": {"collectionIds": collection_id}},

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -617,14 +617,17 @@ class BaseCrawlOps:
         self, crawl_ids: List[str], org: Organization
     ):
         """Validate that crawls in list exist and have a succesful state, or throw"""
+        # convert to set to remove any duplicates
+        crawl_id_set = set(crawl_ids)
+
         count = self.crawls.count_documents(
             {
-                "_id": {"$in": crawl_ids},
+                "_id": {"$in": crawl_id_set},
                 "oid": org.id,
                 "state": {"$in": SUCCESSFUL_STATES},
             }
         )
-        if count != len(crawl_ids):
+        if count != len(crawl_id_set):
             raise HTTPException(
                 status_code=400, detail="invalid_failed_or_unfinished_crawl"
             )

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -622,7 +622,7 @@ class BaseCrawlOps:
 
         count = await self.crawls.count_documents(
             {
-                "_id": {"$in": crawl_id_set},
+                "_id": {"$in": list(crawl_id_set)},
                 "oid": org.id,
                 "state": {"$in": SUCCESSFUL_STATES},
             }

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -615,12 +615,11 @@ class BaseCrawlOps:
         return resources, pages_optimized
 
     async def validate_all_crawls_successful(self, crawl_ids: List[str]):
-        """Validate that no crawls in list failed or else raise exception"""
-        result = await self.crawls.find_one(
-            {"_id": {"$in": crawl_ids}, "state": {"$in": FAILED_STATES}}
-        )
-        if result:
-            raise HTTPException(status_code=400, detail="invalid_failed_crawl")
+        """Validate that crawls in list exist and are successful or else raise exception"""
+        for crawl_id in crawl_ids:
+            crawl = await self.get_base_crawl(crawl_id)
+            if crawl.state in FAILED_STATES:
+                raise HTTPException(status_code=400, detail="invalid_failed_crawl")
 
     async def add_to_collection(
         self, crawl_ids: List[str], collection_id: UUID, org: Organization

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -230,7 +230,7 @@ class CollectionOps:
         headers: Optional[dict] = None,
     ) -> CollOut:
         """Add crawls to collection"""
-        await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
+        await self.crawl_ops.validate_all_crawls_successful(crawl_ids)
 
         modified = dt_now()
         result = await self.collections.find_one_and_update(
@@ -240,6 +240,8 @@ class CollectionOps:
         )
         if not result:
             raise HTTPException(status_code=404, detail="collection_not_found")
+
+        await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
 
         await self.update_collection_counts_and_tags(coll_id)
         await self.update_collection_dates(coll_id, org.id)

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -123,6 +123,8 @@ class CollectionOps:
     async def add_collection(self, oid: UUID, coll_in: CollIn):
         """Add new collection"""
         crawl_ids = coll_in.crawlIds if coll_in.crawlIds else []
+        await self.crawl_ops.validate_all_crawls_successful(crawl_ids)
+
         coll_id = uuid4()
         created = dt_now()
 

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -563,7 +563,7 @@ def custom_behaviors_crawl_id(admin_auth_headers, default_org_id):
 def canceled_crawl_id(admin_auth_headers, default_org_id):
     crawl_data = {
         "runNow": True,
-        "name": "Canceled crawl",
+        "name": "Canceled Crawl",
         "tags": ["canceled"],
         "config": {
             "seeds": [{"url": "https://old.webrecorder.net/"}],

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -563,7 +563,7 @@ def custom_behaviors_crawl_id(admin_auth_headers, default_org_id):
 def canceled_crawl_id(admin_auth_headers, default_org_id):
     crawl_data = {
         "runNow": True,
-        "name": "Canceled Crawl",
+        "name": "Canceled crawl",
         "tags": ["canceled"],
         "config": {
             "seeds": [{"url": "https://old.webrecorder.net/"}],

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1762,6 +1762,33 @@ def test_get_public_collection_slug_redirect(admin_auth_headers, default_org_id)
     assert r.status_code == 404
 
 
+def test_create_collection_with_failed_crawl(
+    admin_auth_headers, default_org_id, canceled_crawl_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections",
+        headers=admin_auth_headers,
+        json={
+            "crawlIds": [canceled_crawl_id],
+            "name": "Should get rejected",
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "invalid_failed_crawl"
+
+
+def test_add_failed_crawl_to_collection(
+    admin_auth_headers, default_org_id, canceled_crawl_id
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_second_coll_id}/add",
+        json={"crawlIds": [canceled_crawl_id]},
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "invalid_failed_crawl"
+
+
 def test_delete_collection(crawler_auth_headers, default_org_id, crawler_crawl_id):
     # Delete second collection
     r = requests.delete(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1774,7 +1774,7 @@ def test_create_collection_with_failed_crawl(
         },
     )
     assert r.status_code == 400
-    assert r.json()["detail"] == "invalid_failed_crawl"
+    assert r.json()["detail"] == "invalid_failed_or_unfinished_crawl"
 
 
 def test_add_failed_crawl_to_collection(
@@ -1786,7 +1786,7 @@ def test_add_failed_crawl_to_collection(
         headers=admin_auth_headers,
     )
     assert r.status_code == 400
-    assert r.json()["detail"] == "invalid_failed_crawl"
+    assert r.json()["detail"] == "invalid_failed_or_unfinished_crawl"
 
 
 def test_delete_collection(crawler_auth_headers, default_org_id, crawler_crawl_id):

--- a/backend/test/test_crawl_config_search_values.py
+++ b/backend/test/test_crawl_config_search_values.py
@@ -44,7 +44,7 @@ def test_get_search_values_1(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, "Admin Test Crawl", "crawler User Test Crawl"]
+        [NAME_1, "Admin Test Crawl", "Canceled Crawl", "crawler User Test Crawl"]
     )
     assert sorted(data["descriptions"]) == sorted(
         ["Admin Test Crawl description", "crawler test crawl", DESCRIPTION_1]
@@ -74,7 +74,13 @@ def test_get_search_values_2(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, NAME_2, "Admin Test Crawl", "crawler User Test Crawl"]
+        [
+            NAME_1,
+            NAME_2,
+            "Admin Test Crawl",
+            "Canceled Crawl",
+            "crawler User Test Crawl",
+        ]
     )
     assert sorted(data["descriptions"]) == sorted(
         [
@@ -111,7 +117,13 @@ def test_get_search_values_3(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, NAME_2, "Admin Test Crawl", "crawler User Test Crawl"]
+        [
+            NAME_1,
+            NAME_2,
+            "Admin Test Crawl",
+            "Canceled Crawl",
+            "crawler User Test Crawl",
+        ]
     )
     assert sorted(data["descriptions"]) == sorted(
         [

--- a/backend/test/test_crawl_config_search_values.py
+++ b/backend/test/test_crawl_config_search_values.py
@@ -44,7 +44,7 @@ def test_get_search_values_1(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, "Admin Test Crawl", "Canceled Crawl", "crawler User Test Crawl"]
+        [NAME_1, "Admin Test Crawl", "Canceled crawl", "crawler User Test Crawl"]
     )
     assert sorted(data["descriptions"]) == sorted(
         ["Admin Test Crawl description", "crawler test crawl", DESCRIPTION_1]
@@ -78,7 +78,7 @@ def test_get_search_values_2(admin_auth_headers, default_org_id):
             NAME_1,
             NAME_2,
             "Admin Test Crawl",
-            "Canceled Crawl",
+            "Canceled crawl",
             "crawler User Test Crawl",
         ]
     )
@@ -121,7 +121,7 @@ def test_get_search_values_3(admin_auth_headers, default_org_id):
             NAME_1,
             NAME_2,
             "Admin Test Crawl",
-            "Canceled Crawl",
+            "Canceled crawl",
             "crawler User Test Crawl",
         ]
     )

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -47,7 +47,7 @@ def test_get_config_by_tag_1(admin_auth_headers, default_org_id):
         headers=admin_auth_headers,
     )
     data = r.json()
-    assert sorted(data) == ["tag-1", "tag-2", "wr-test-1", "wr-test-2"]
+    assert sorted(data) == ["canceled", "tag-1", "tag-2", "wr-test-1", "wr-test-2"]
 
 
 def test_get_config_by_tag_counts_1(admin_auth_headers, default_org_id):
@@ -59,6 +59,7 @@ def test_get_config_by_tag_counts_1(admin_auth_headers, default_org_id):
     assert data == {
         "tags": [
             {"tag": "wr-test-2", "count": 2},
+            {"tag": "canceled", "count": 1},
             {"tag": "tag-1", "count": 1},
             {"tag": "tag-2", "count": 1},
             {"tag": "wr-test-1", "count": 1},
@@ -91,6 +92,7 @@ def test_get_config_by_tag_2(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data) == [
+        "canceled",
         "tag-0",
         "tag-1",
         "tag-2",
@@ -109,6 +111,7 @@ def test_get_config_by_tag_counts_2(admin_auth_headers, default_org_id):
     assert data == {
         "tags": [
             {"tag": "wr-test-2", "count": 2},
+            {"tag": "canceled", "count": 1},
             {"tag": "tag-0", "count": 1},
             {"tag": "tag-1", "count": 1},
             {"tag": "tag-2", "count": 1},

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -362,9 +362,9 @@ def test_sort_crawl_configs(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 17
+    assert data["total"] == 18
     items = data["items"]
-    assert len(items) == 17
+    assert len(items) == 18
 
     last_created = None
     for config in items:

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -102,8 +102,8 @@ def test_ensure_crawl_and_admin_user_crawls(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls",
         headers=crawler_auth_headers,
     )
-    assert len(r.json()["items"]) == 2
-    assert r.json()["total"] == 2
+    assert len(r.json()["items"]) == 3
+    assert r.json()["total"] == 3
 
 
 def test_get_crawl_job_by_user(
@@ -212,9 +212,9 @@ def test_sort_crawls(
         headers=crawler_auth_headers,
     )
     data = r.json()
-    assert data["total"] == 2
+    assert data["total"] == 3
     items = data["items"]
-    assert len(items) == 2
+    assert len(items) == 3
 
     last_created = None
     for crawl in items:

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -826,7 +826,7 @@ def test_all_crawls_search_values(
     assert len(data["names"]) == 9
     expected_names = [
         "crawler User Test Crawl",
-        "Canceled Crawl",
+        "Canceled crawl",
         "Custom Behavior Logs",
         "My Upload Updated",
         "test2.wacz",
@@ -854,7 +854,7 @@ def test_all_crawls_search_values(
     expected_names = [
         "Admin Test Crawl",
         "All Crawls Test Crawl",
-        "Canceled Crawl",
+        "Canceled crawl",
         "Crawler User Crawl for Testing QA",
         "crawler User Test Crawl",
         "Custom Behavior Logs",

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -592,7 +592,7 @@ def test_get_all_crawls_by_first_seed(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 5
+    assert data["total"] == 6
     for item in data["items"]:
         assert item["firstSeed"] == first_seed
 
@@ -607,7 +607,7 @@ def test_get_all_crawls_by_type(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["total"] == 6
+    assert data["total"] == 7
     for item in data["items"]:
         assert item["type"] == "crawl"
 
@@ -823,9 +823,10 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 8
+    assert len(data["names"]) == 9
     expected_names = [
         "crawler User Test Crawl",
+        "Canceled Crawl",
         "Custom Behavior Logs",
         "My Upload Updated",
         "test2.wacz",
@@ -849,10 +850,11 @@ def test_all_crawls_search_values(
     assert r.status_code == 200
     data = r.json()
 
-    assert len(data["names"]) == 5
+    assert len(data["names"]) == 6
     expected_names = [
         "Admin Test Crawl",
         "All Crawls Test Crawl",
+        "Canceled Crawl",
         "Crawler User Crawl for Testing QA",
         "crawler User Test Crawl",
         "Custom Behavior Logs",


### PR DESCRIPTION
Fixes #2915 

- Check before any collection updates that crawls being added exist and are not failed
- Ensure collection exists before adding crawls to it

Adds tests for creating and updating collections with a failed item.