### PR TITLE
Update seed file cleanup cron job schedule if needed on startup

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -234,6 +234,19 @@ class CrawlManager(K8sAPI):
                     "Cron job to clean up used seed files already exists",
                     flush=True,
                 )
+
+                if cron_job.spec.schedule != job_schedule:
+                    cron_job.spec.schedule = job_schedule
+
+                    await self.batch_api.patch_namespaced_cron_job(
+                        name=cron_job.metadata.name,
+                        namespace=DEFAULT_NAMESPACE,
+                        body=cron_job,
+                    )
+                    print(
+                        f"Updated cron job to clean up used seed files, new schedule: {job_schedule}",
+                        flush=True,
+                    )
                 return
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -231,7 +231,7 @@ class CrawlManager(K8sAPI):
             )
             if cron_job:
                 print(
-                    "Cron job to clean up used seed files already exists",
+                    "Cron job to clean up unused seed files already exists",
                     flush=True,
                 )
 
@@ -244,7 +244,7 @@ class CrawlManager(K8sAPI):
                         body=cron_job,
                     )
                     print(
-                        f"Cron job to clean up used seed files updated, schedule: {job_schedule}",
+                        f"Cron job to clean up unused seed files updated, schedule: {job_schedule}",
                         flush=True,
                     )
                 return
@@ -253,7 +253,7 @@ class CrawlManager(K8sAPI):
             pass
 
         print(
-            f"Creating cron job to clean up used seed files, schedule: {job_schedule}",
+            f"Creating cron job to clean up unused seed files, schedule: {job_schedule}",
             flush=True,
         )
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -244,7 +244,7 @@ class CrawlManager(K8sAPI):
                         body=cron_job,
                     )
                     print(
-                        f"Updated cron job to clean up used seed files, new schedule: {job_schedule}",
+                        f"Cron job to clean up used seed files updated, schedule: {job_schedule}",
                         flush=True,
                     )
                 return


### PR DESCRIPTION
Fixes #2921

## Testing

1. Spin up local Browsertrix, verify seed file cleanup cron job is created with schedule set in `values.yaml` or `local.yaml` Helm chart override
2. Specify a different schedule with `cleanup_job_cron_schedule` in `local.yaml` and redeploy
3. Verify that backend logs print a message indicating the cron job schedule has been updated
4. Verify schedule was in fact updated: `kubectl get cronjobs`