### PR TITLE
fix: Use org crawling defaults for new browser profile

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -9,6 +9,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import { none, notSpecified } from "@/layouts/empty";
 import {
   Behavior,
+  CrawlerChannelImage,
   type CrawlConfig,
   type Seed,
   type SeedConfig,
@@ -257,8 +258,9 @@ export class ConfigDetails extends BtrixElement {
           )}
           ${this.renderSetting(
             msg("Crawler Channel (Exact Crawler Version)"),
-            capitalize(crawlConfig?.crawlerChannel || "default") +
-              (crawlConfig?.image ? ` (${crawlConfig.image})` : ""),
+            capitalize(
+              crawlConfig?.crawlerChannel || CrawlerChannelImage.Default,
+            ) + (crawlConfig?.image ? ` (${crawlConfig.image})` : ""),
           )}
           ${this.renderSetting(
             msg("Block Ads by Domain"),

--- a/frontend/src/components/ui/select-crawler.ts
+++ b/frontend/src/components/ui/select-crawler.ts
@@ -5,7 +5,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import capitalize from "lodash/fp/capitalize";
 
-import type { CrawlerChannel } from "@/pages/org/types";
+import { CrawlerChannelImage, type CrawlerChannel } from "@/pages/org/types";
 import LiteElement from "@/utils/LiteElement";
 
 type SelectCrawlerChangeDetail = {
@@ -131,11 +131,11 @@ export class SelectCrawler extends LiteElement {
     }
 
     if (!this.selectedCrawler) {
-      this.crawlerChannel = "default";
+      this.crawlerChannel = CrawlerChannelImage.Default;
       this.dispatchEvent(
         new CustomEvent("on-change", {
           detail: {
-            value: "default",
+            value: CrawlerChannelImage.Default,
           },
         }),
       );

--- a/frontend/src/components/ui/url-input.ts
+++ b/frontend/src/components/ui/url-input.ts
@@ -19,6 +19,7 @@ export function validURL(url: string) {
  * @attr {String} name
  * @attr {String} label
  * @attr {String} value
+ * @attr {String} autocomplete
  * @attr {Boolean} required
  */
 @customElement("btrix-url-input")

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -70,14 +70,14 @@ export class NewBrowserProfileDialog extends BtrixElement {
         @reset=${this.onReset}
         @submit=${this.onSubmit}
       >
-        <sl-input
+        <btrix-url-input
           label=${msg("Starting URL")}
           name="url"
           placeholder=${msg("https://example.com")}
           autocomplete="off"
           required
         >
-        </sl-input>
+        </btrix-url-input>
 
         <div class="mt-4">
           <btrix-select-crawler

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -30,6 +30,9 @@ export class NewBrowserProfileDialog extends BtrixElement {
   @property({ type: String })
   defaultProxyId?: string;
 
+  @property({ type: String })
+  defaultCrawlerChannel?: string;
+
   @state()
   private isSubmitting = false;
 
@@ -48,6 +51,15 @@ export class NewBrowserProfileDialog extends BtrixElement {
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("defaultProxyId") && this.defaultProxyId) {
       this.proxyId = this.proxyId || this.defaultProxyId;
+    }
+
+    if (
+      changedProperties.has("defaultCrawlerChannel") &&
+      this.defaultCrawlerChannel
+    ) {
+      this.crawlerChannel =
+        (this.crawlerChannel !== "default" && this.crawlerChannel) ||
+        this.defaultCrawlerChannel;
     }
   }
 

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -1,4 +1,3 @@
-import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import { type SlInput } from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues } from "lit";
@@ -16,23 +15,22 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import { type SelectCrawlerChangeEvent } from "@/components/ui/select-crawler";
 import { type SelectCrawlerProxyChangeEvent } from "@/components/ui/select-crawler-proxy";
-import { proxiesContext, type ProxiesContext } from "@/context/org";
-import { CrawlerChannelImage } from "@/types/crawler";
+import { CrawlerChannelImage, type Proxy } from "@/types/crawler";
 
 @customElement("btrix-new-browser-profile-dialog")
 @localized()
 export class NewBrowserProfileDialog extends BtrixElement {
-  @consume({ context: proxiesContext, subscribe: true })
-  private readonly proxies?: ProxiesContext;
-
-  @property({ type: Boolean })
-  open = false;
-
   @property({ type: String })
   defaultProxyId?: string;
 
   @property({ type: String })
   defaultCrawlerChannel?: string;
+
+  @property({ type: Array })
+  proxyServers?: Proxy[];
+
+  @property({ type: Boolean })
+  open = false;
 
   @state()
   private isSubmitting = false;
@@ -100,14 +98,12 @@ export class NewBrowserProfileDialog extends BtrixElement {
               (this.crawlerChannel = e.detail.value!)}
           ></btrix-select-crawler>
         </div>
-        ${this.proxies?.servers.length
+        ${this.proxyServers?.length
           ? html`
               <div class="mt-4">
                 <btrix-select-crawler-proxy
-                  defaultProxyId=${ifDefined(
-                    this.proxies.default_proxy_id ?? undefined,
-                  )}
-                  .proxyServers=${this.proxies.servers}
+                  defaultProxyId=${ifDefined(this.defaultProxyId || undefined)}
+                  .proxyServers=${this.proxyServers}
                   .proxyId="${this.proxyId || ""}"
                   @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                     (this.proxyId = e.detail.value)}

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -17,6 +17,7 @@ import type { Dialog } from "@/components/ui/dialog";
 import { type SelectCrawlerChangeEvent } from "@/components/ui/select-crawler";
 import { type SelectCrawlerProxyChangeEvent } from "@/components/ui/select-crawler-proxy";
 import { proxiesContext, type ProxiesContext } from "@/context/org";
+import { CrawlerChannelImage } from "@/types/crawler";
 
 @customElement("btrix-new-browser-profile-dialog")
 @localized()
@@ -37,7 +38,7 @@ export class NewBrowserProfileDialog extends BtrixElement {
   private isSubmitting = false;
 
   @state()
-  private crawlerChannel = "default";
+  private crawlerChannel: string = CrawlerChannelImage.Default;
 
   @state()
   private proxyId: string | null = null;
@@ -58,7 +59,8 @@ export class NewBrowserProfileDialog extends BtrixElement {
       this.defaultCrawlerChannel
     ) {
       this.crawlerChannel =
-        (this.crawlerChannel !== "default" && this.crawlerChannel) ||
+        (this.crawlerChannel !== (CrawlerChannelImage.Default as string) &&
+          this.crawlerChannel) ||
         this.defaultCrawlerChannel;
     }
   }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -88,6 +88,7 @@ import { AnalyticsTrackEvent } from "@/trackEvents";
 import { APIErrorDetail } from "@/types/api";
 import {
   Behavior,
+  CrawlerChannelImage,
   ScopeType,
   type Seed,
   type WorkflowParams,
@@ -3228,7 +3229,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
         clickSelector:
           this.formState.clickSelector || DEFAULT_AUTOCLICK_SELECTOR,
       },
-      crawlerChannel: this.formState.crawlerChannel || "default",
+      crawlerChannel:
+        this.formState.crawlerChannel || CrawlerChannelImage.Default,
       proxyId: this.formState.proxyId,
     };
 

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -948,8 +948,9 @@ export class ArchivedItemDetail extends BtrixElement {
     }
 
     const text =
-      capitalize(this.item.crawlerChannel || "default") +
-      (this.item.image ? ` (${this.item.image})` : "");
+      (this.item.crawlerChannel
+        ? capitalize(this.item.crawlerChannel)
+        : msg("Default")) + (this.item.image ? ` (${this.item.image})` : "");
 
     return html` <btrix-desc-list-item
       label=${msg("Crawler Channel (Exact Crawler Version)")}

--- a/frontend/src/pages/org/browser-profiles-new.ts
+++ b/frontend/src/pages/org/browser-profiles-new.ts
@@ -4,6 +4,8 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import queryString from "query-string";
 
+import { CrawlerChannelImage } from "./types";
+
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import type { BrowserConnectionChange } from "@/features/browser-profiles/profile-browser";
@@ -279,7 +281,8 @@ export class BrowserProfilesNew extends BtrixElement {
       return;
     }
 
-    const crawlerChannel = this.browserParams.crawlerChannel || "default";
+    const crawlerChannel =
+      this.browserParams.crawlerChannel || CrawlerChannelImage.Default;
     const proxyId = this.browserParams.proxyId;
     const data = await this.createBrowser({
       url,

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -450,11 +450,21 @@ export class Org extends BtrixElement {
             }
           }}
         ></btrix-file-uploader>
-        <btrix-new-browser-profile-dialog
-          ?open=${this.openDialogName === "browser-profile"}
-          @sl-hide=${() => (this.openDialogName = undefined)}
-        >
-        </btrix-new-browser-profile-dialog>
+        ${when(
+          this.proxies && this.org,
+          (org) => html`
+            <btrix-new-browser-profile-dialog
+              defaultProxyId=${ifDefined(
+                org.crawlingDefaults?.proxyId ||
+                  this.proxies?.default_proxy_id ||
+                  undefined,
+              )}
+              ?open=${this.openDialogName === "browser-profile"}
+              @sl-hide=${() => (this.openDialogName = undefined)}
+            >
+            </btrix-new-browser-profile-dialog>
+          `,
+        )}
         <btrix-collection-create-dialog
           ?open=${this.openDialogName === "collection"}
           @sl-hide=${() => (this.openDialogName = undefined)}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -450,24 +450,29 @@ export class Org extends BtrixElement {
             }
           }}
         ></btrix-file-uploader>
-        ${when(
-          this.proxies && this.org,
-          (org) => html`
-            <btrix-new-browser-profile-dialog
-              defaultProxyId=${ifDefined(
-                org.crawlingDefaults?.proxyId ||
-                  this.proxies?.default_proxy_id ||
-                  undefined,
-              )}
-              defaultCrawlerChannel=${ifDefined(
-                org.crawlingDefaults?.crawlerChannel || undefined,
-              )}
-              ?open=${this.openDialogName === "browser-profile"}
-              @sl-hide=${() => (this.openDialogName = undefined)}
-            >
-            </btrix-new-browser-profile-dialog>
-          `,
+
+        ${when(this.org, (org) =>
+          when(
+            this.proxies,
+            (proxies) => html`
+              <btrix-new-browser-profile-dialog
+                .proxyServers=${proxies.servers}
+                defaultProxyId=${ifDefined(
+                  org.crawlingDefaults?.proxyId ||
+                    proxies.default_proxy_id ||
+                    undefined,
+                )}
+                defaultCrawlerChannel=${ifDefined(
+                  org.crawlingDefaults?.crawlerChannel || undefined,
+                )}
+                ?open=${this.openDialogName === "browser-profile"}
+                @sl-hide=${() => (this.openDialogName = undefined)}
+              >
+              </btrix-new-browser-profile-dialog>
+            `,
+          ),
         )}
+
         <btrix-collection-create-dialog
           ?open=${this.openDialogName === "collection"}
           @sl-hide=${() => (this.openDialogName = undefined)}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -450,22 +450,23 @@ export class Org extends BtrixElement {
             }
           }}
         ></btrix-file-uploader>
-        ${when(this.proxies, (proxies) =>
-          when(
-            this.org,
-            (org) => html`
-              <btrix-new-browser-profile-dialog
-                defaultProxyId=${ifDefined(
-                  org.crawlingDefaults?.proxyId ||
-                    proxies.default_proxy_id ||
-                    undefined,
-                )}
-                ?open=${this.openDialogName === "browser-profile"}
-                @sl-hide=${() => (this.openDialogName = undefined)}
-              >
-              </btrix-new-browser-profile-dialog>
-            `,
-          ),
+        ${when(
+          this.proxies && this.org,
+          (org) => html`
+            <btrix-new-browser-profile-dialog
+              defaultProxyId=${ifDefined(
+                org.crawlingDefaults?.proxyId ||
+                  this.proxies?.default_proxy_id ||
+                  undefined,
+              )}
+              defaultCrawlerChannel=${ifDefined(
+                org.crawlingDefaults?.crawlerChannel || undefined,
+              )}
+              ?open=${this.openDialogName === "browser-profile"}
+              @sl-hide=${() => (this.openDialogName = undefined)}
+            >
+            </btrix-new-browser-profile-dialog>
+          `,
         )}
         <btrix-collection-create-dialog
           ?open=${this.openDialogName === "collection"}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -450,20 +450,22 @@ export class Org extends BtrixElement {
             }
           }}
         ></btrix-file-uploader>
-        ${when(
-          this.proxies && this.org,
-          (org) => html`
-            <btrix-new-browser-profile-dialog
-              defaultProxyId=${ifDefined(
-                org.crawlingDefaults?.proxyId ||
-                  this.proxies?.default_proxy_id ||
-                  undefined,
-              )}
-              ?open=${this.openDialogName === "browser-profile"}
-              @sl-hide=${() => (this.openDialogName = undefined)}
-            >
-            </btrix-new-browser-profile-dialog>
-          `,
+        ${when(this.proxies, (proxies) =>
+          when(
+            this.org,
+            (org) => html`
+              <btrix-new-browser-profile-dialog
+                defaultProxyId=${ifDefined(
+                  org.crawlingDefaults?.proxyId ||
+                    proxies.default_proxy_id ||
+                    undefined,
+                )}
+                ?open=${this.openDialogName === "browser-profile"}
+                @sl-hide=${() => (this.openDialogName = undefined)}
+              >
+              </btrix-new-browser-profile-dialog>
+            `,
+          ),
         )}
         <btrix-collection-create-dialog
           ?open=${this.openDialogName === "collection"}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -100,6 +100,7 @@ const UUID_REGEX =
 @needLogin
 export class Org extends BtrixElement {
   @provide({ context: proxiesContext })
+  @state()
   proxies: ProxiesContext = null;
 
   @property({ type: Object })

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -7,7 +7,12 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import type { PartialDeep } from "type-fest";
 
-import { ScopeType, type Seed, type WorkflowParams } from "./types";
+import {
+  CrawlerChannelImage,
+  ScopeType,
+  type Seed,
+  type WorkflowParams,
+} from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
@@ -72,7 +77,7 @@ export class WorkflowsNew extends BtrixElement {
       jobType: "custom",
       browserWindows: this.appState.settings?.numBrowsersPerInstance || 1,
       autoAddCollections: [],
-      crawlerChannel: "default",
+      crawlerChannel: CrawlerChannelImage.Default,
       proxyId: null,
     };
   }

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -19,6 +19,10 @@ export enum Behavior {
   SiteSpecific = "siteSpecific",
 }
 
+export enum CrawlerChannelImage {
+  Default = "default",
+}
+
 export type Seed = {
   url: string;
   scopeType: ScopeType | undefined;
@@ -200,7 +204,7 @@ export type Upload = ArchivedItemBase & {
   type: "upload";
   cid: undefined;
   resources: undefined;
-  crawlerChannel: "default";
+  crawlerChannel: CrawlerChannelImage.Default;
   image: null;
   manual: true;
 };

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -10,6 +10,7 @@ import type { Tags } from "@/components/ui/tag-input";
 import type { UserGuideEventMap } from "@/index";
 import {
   Behavior,
+  CrawlerChannelImage,
   ScopeType,
   type Profile,
   type Seed,
@@ -239,7 +240,7 @@ export const getDefaultFormState = (): FormState => ({
   autoscrollBehavior: true,
   autoclickBehavior: false,
   userAgent: null,
-  crawlerChannel: "default",
+  crawlerChannel: CrawlerChannelImage.Default,
   proxyId: null,
   selectLinks: DEFAULT_SELECT_LINKS,
   clickSelector: DEFAULT_AUTOCLICK_SELECTOR,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2281

## Changes

- Uses org crawling defaults when creating new browser profile
- Refactors `"default"` image to enum

## Manual testing

1. Log in as crawler to org with proxies
2. Go to "Settings" > "Crawling Defaults"
3. Set default proxy and default crawler channel
4. Go to "Browser Profiles"
5. Choose "New Browser Profile". Verify org defaults are selected