### PR TITLE
Update collection editing and sharing UI

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -13,8 +13,18 @@ import mimetypes
 import math
 import os
 
-from typing import Optional, List, Dict, Self, Union, Literal, Any, get_args, get_origin
-from typing_extensions import Annotated
+from typing import (
+    Optional,
+    List,
+    Dict,
+    Self,
+    Union,
+    Literal,
+    Any,
+    get_args,
+    get_origin,
+    Annotated,
+)
 
 from pydantic import (
     BaseModel,

--- a/frontend/config/tailwind/plugins/host.js
+++ b/frontend/config/tailwind/plugins/host.js
@@ -1,0 +1,9 @@
+const plugin = require("tailwindcss/plugin");
+module.exports = plugin(function ({ addVariant, matchVariant }) {
+  addVariant("host-hover", `:host(:hover) &`);
+  addVariant("host-active", `:host(:active) &`);
+  addVariant("host-focus", `:host(:focus) &`);
+  addVariant("host-focus-within", `:host(:focus-within) &`);
+  addVariant("host-focus-visible", `:host(:focus-visible) &`);
+  matchVariant("host-", (value) => `:host(${value}) &`);
+});

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -17,7 +17,7 @@ export class EditableTextField extends TailwindElement {
   value = "";
 
   @state()
-  inputValue = this.value;
+  inputValue = "";
 
   @property({ type: String })
   innerClass = "";
@@ -61,23 +61,33 @@ export class EditableTextField extends TailwindElement {
   @state()
   valid: boolean | undefined = true;
 
+  private readonly handleClick = () => {
+    this.editing = true;
+    this.updateWidth();
+  };
+
+  private readonly handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") {
+      this.toggleEditing();
+    }
+    if (e.key === "Escape") {
+      this.endEditing(false);
+    }
+    if (e.key === "Space") {
+      this.startEditing();
+    }
+  };
+
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener("click", async () => {
-      this.editing = true;
-      this.updateWidth();
-    });
-    this.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") {
-        this.toggleEditing();
-      }
-      if (e.key === "Escape") {
-        this.endEditing(false);
-      }
-      if (e.key === "Space") {
-        this.startEditing();
-      }
-    });
+    this.addEventListener("click", this.handleClick);
+    this.addEventListener("keydown", this.handleKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener("click", this.handleClick);
+    this.removeEventListener("keydown", this.handleKeydown);
+    super.disconnectedCallback();
   }
 
   toggleEditing() {

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -68,13 +68,10 @@ export class EditableTextField extends TailwindElement {
 
   private readonly handleKeydown = (e: KeyboardEvent) => {
     if (e.key === "Enter") {
-      this.toggleEditing();
+      this.save();
     }
     if (e.key === "Escape") {
       this.endEditing(false);
-    }
-    if (e.key === "Space") {
-      this.startEditing();
     }
   };
 
@@ -109,6 +106,21 @@ export class EditableTextField extends TailwindElement {
     }
     this.valid = true;
     this.updateWidth();
+  }
+
+  save() {
+    if (this.checkValidity()) {
+      this.endEditing();
+      this.dispatchEvent(
+        new CustomEvent("btrix-change", {
+          detail: this.inputValue,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    } else {
+      this.showUnsavedWarning = true;
+    }
   }
 
   updateWidth() {
@@ -181,20 +193,8 @@ export class EditableTextField extends TailwindElement {
         @focus=${() => {
           this.startEditing();
         }}
-        @blur=${() => {
-          if (this.checkValidity()) {
-            this.endEditing();
-            this.dispatchEvent(
-              new CustomEvent("btrix-change", {
-                detail: this.inputValue,
-                bubbles: true,
-                composed: true,
-              }),
-            );
-          } else {
-            this.showUnsavedWarning = true;
-          }
-        }}
+        @blur=${this.save}
+        @keydown=${this.handleKeydown}
         style=${styleMap({
           color: this.editing ? undefined : "transparent",
           width: `min(${minWidth}px, calc(100% - 2rem))`,

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -1,0 +1,206 @@
+import { localized } from "@lit/localize";
+import clsx from "clsx";
+import { css, html, type PropertyValues, type TemplateResult } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import { measureTextWithElement } from "@/utils/measure-text";
+import { tw } from "@/utils/tailwind";
+
+@customElement("btrix-editable-text-field")
+@localized()
+export class EditableTextField extends TailwindElement {
+  @property({ type: String })
+  value = "";
+
+  @state()
+  inputValue = this.value;
+
+  @property({ type: String })
+  innerClass = "";
+
+  @state()
+  editing = false;
+
+  @state()
+  width = 0;
+
+  @property({ type: Number })
+  minLength?: number;
+
+  @property({ type: Number })
+  maxLength?: number;
+
+  @property({ type: Object })
+  renderContent?: (text: string) => TemplateResult;
+
+  static styles = css`
+    :host {
+      display: inline-block;
+      position: relative;
+      cursor: text;
+      border-radius: var(--sl-border-radius-medium);
+    }
+  `;
+
+  @query("input")
+  input?: HTMLInputElement;
+
+  @query("span")
+  label?: HTMLSpanElement;
+
+  @property({ type: String })
+  placeholder?: string;
+
+  @state()
+  placeholderWidth = 0;
+
+  @state()
+  valid: boolean | undefined = true;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.addEventListener("click", async () => {
+      this.editing = true;
+      void this.updateWidth();
+    });
+    this.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        this.toggleEditing();
+      }
+      if (e.key === "Escape") {
+        this.endEditing(false);
+      }
+      if (e.key === "Space") {
+        this.startEditing();
+      }
+    });
+    setTimeout(() => {
+      void this.updateWidth();
+      void this.updatePlaceholderWidth();
+    }, 0);
+  }
+
+  toggleEditing() {
+    if (this.editing) {
+      this.endEditing();
+    } else {
+      this.startEditing();
+    }
+  }
+
+  startEditing() {
+    this.editing = true;
+    void this.updateWidth();
+  }
+
+  endEditing(save = true) {
+    this.editing = false;
+    if (!save) {
+      this.inputValue = this.value;
+    }
+    void this.updateWidth();
+  }
+
+  async updateWidth() {
+    await this.updateComplete;
+    if (!this.label) return;
+    const width = measureTextWithElement(
+      this.inputValue || this.placeholder || "",
+      this.label,
+      true,
+    ).width;
+    if (width) this.width = width;
+  }
+
+  async updatePlaceholderWidth() {
+    if (!this.placeholder) return;
+    await this.updateComplete;
+    if (!this.label) return;
+    const width = measureTextWithElement(this.placeholder, this.label).width;
+    if (width) this.placeholderWidth = width;
+  }
+
+  willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("value")) {
+      this.inputValue = this.value;
+    }
+  }
+
+  updated(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("editing") && this.editing) {
+      this.input?.focus();
+      setTimeout(() => {
+        void this.updateWidth();
+        void this.updatePlaceholderWidth();
+      }, 0);
+    }
+  }
+
+  firstUpdated() {
+    void this.updateWidth();
+    void this.updatePlaceholderWidth();
+  }
+
+  checkValidity() {
+    let valid = true;
+    if (this.minLength && this.inputValue.length < this.minLength) {
+      valid = false;
+    }
+    if (this.maxLength && this.inputValue.length > this.maxLength) {
+      valid = false;
+    }
+    this.valid = valid;
+    return valid;
+  }
+
+  render() {
+    return html`<input
+        class="absolute inset-3 rounded bg-transparent"
+        type="text"
+        .value=${this.inputValue}
+        placeholder=${ifDefined(this.placeholder)}
+        @input=${(e: Event) => {
+          this.inputValue = (e.target as HTMLInputElement).value;
+          void this.updateWidth();
+        }}
+        @blur=${() => {
+          if (this.checkValidity()) {
+            this.endEditing();
+            this.dispatchEvent(
+              new CustomEvent("btrix-change", {
+                detail: this.inputValue,
+                bubbles: true,
+                composed: true,
+              }),
+            );
+          } else {
+            this.endEditing(false);
+          }
+        }}
+        style=${styleMap({
+          color: this.editing ? undefined : "transparent",
+          width: `${this.width}px`,
+          minWidth: `${this.placeholderWidth}px`,
+        })}
+      />
+      <span
+        class=${clsx(
+          tw`pointer-events-none block truncate rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] host-hover:outline`,
+          !this.inputValue && tw`text-neutral-500`,
+        )}
+        style=${styleMap({
+          visibility: this.editing ? "hidden" : "visible",
+          minWidth: this.editing ? `${this.placeholderWidth}px` : undefined,
+        })}
+      >
+        ${this.inputValue
+          ? this.renderContent
+            ? this.renderContent(this.inputValue)
+            : this.inputValue
+          : this.placeholder}
+      </span>`;
+  }
+}

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -1,4 +1,4 @@
-import { localized } from "@lit/localize";
+import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { css, html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -41,8 +41,6 @@ export class EditableTextField extends TailwindElement {
     :host {
       display: inline-block;
       position: relative;
-      cursor: text;
-      border-radius: var(--sl-border-radius-medium);
     }
   `;
 
@@ -61,10 +59,12 @@ export class EditableTextField extends TailwindElement {
   @state()
   valid: boolean | undefined = true;
 
-  private readonly handleClick = () => {
-    this.editing = true;
-    this.updateWidth();
-  };
+  /**
+   * Used to show an unsaved warning when the user blurs the field with an
+   * invalid value.
+   */
+  @state()
+  showUnsavedWarning = false;
 
   private readonly handleKeydown = (e: KeyboardEvent) => {
     if (e.key === "Enter") {
@@ -80,12 +80,10 @@ export class EditableTextField extends TailwindElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener("click", this.handleClick);
     this.addEventListener("keydown", this.handleKeydown);
   }
 
   disconnectedCallback() {
-    this.removeEventListener("click", this.handleClick);
     this.removeEventListener("keydown", this.handleKeydown);
     super.disconnectedCallback();
   }
@@ -105,6 +103,7 @@ export class EditableTextField extends TailwindElement {
 
   endEditing(save = true) {
     this.editing = false;
+    this.showUnsavedWarning = false;
     if (!save) {
       this.inputValue = this.value;
     }
@@ -164,10 +163,13 @@ export class EditableTextField extends TailwindElement {
     // text measurements, rather than element measurements which cause reflows
     this.updateWidth();
     this.updatePlaceholderWidth();
+
+    const minWidth = Math.max(this.placeholderWidth, this.width, 1);
+
     return html`<input
         class=${clsx(
-          tw`absolute inset-4 rounded bg-transparent`,
-          !this.valid && tw`outline outline-danger`,
+          tw`peer absolute inset-4 rounded bg-transparent`,
+          !this.valid && tw`z-[11] outline outline-danger`,
         )}
         type="text"
         .value=${this.inputValue}
@@ -175,6 +177,9 @@ export class EditableTextField extends TailwindElement {
         @input=${(e: Event) => {
           this.inputValue = (e.target as HTMLInputElement).value;
           this.checkValidity();
+        }}
+        @focus=${() => {
+          this.startEditing();
         }}
         @blur=${() => {
           if (this.checkValidity()) {
@@ -187,23 +192,23 @@ export class EditableTextField extends TailwindElement {
               }),
             );
           } else {
-            // this.endEditing(false);
+            this.showUnsavedWarning = true;
           }
         }}
         style=${styleMap({
           color: this.editing ? undefined : "transparent",
-          width: `min(${Math.max(this.placeholderWidth, this.width)}px, calc(100% - 2rem))`,
+          width: `min(${minWidth}px, calc(100% - 2rem))`,
           minWidth: `${this.placeholderWidth}px`,
         })}
       />
       <span
         class=${clsx(
-          tw`pointer-events-none block select-none truncate whitespace-pre rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] host-hover:outline host-active:outline-none host-focus-within:outline-none`,
+          tw`pointer-events-none block cursor-text select-none truncate whitespace-pre rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] peer-hover:outline peer-active:outline-none host-focus-within:outline-none`,
           !this.inputValue && tw`text-neutral-500`,
         )}
         style=${styleMap({
           visibility: this.editing ? "hidden" : "visible",
-          width: `min(${Math.max(this.placeholderWidth, this.width)}px, auto)`,
+          width: this.editing ? `${minWidth}px` : "auto",
         })}
         >${this.inputValue
           ? this.renderContent
@@ -213,8 +218,9 @@ export class EditableTextField extends TailwindElement {
       >
       ${this.maxLength && !this.valid
         ? html`<span
-            class="absolute bottom-0 right-4 text-xs leading-none text-danger"
+            class="absolute bottom-0 right-4 z-10 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"
           >
+            ${this.showUnsavedWarning ? html`${msg("Unsaved")} - ` : null}
             ${localize.number(this.inputValue.length)} /
             ${localize.number(this.maxLength)}
           </span>`

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -6,6 +6,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
+import localize from "@/utils/localize";
 import { measureTextWithElement } from "@/utils/measure-text";
 import { tw } from "@/utils/tailwind";
 
@@ -60,11 +61,11 @@ export class EditableTextField extends TailwindElement {
   @state()
   valid: boolean | undefined = true;
 
-  connectedCallback(): void {
+  connectedCallback() {
     super.connectedCallback();
     this.addEventListener("click", async () => {
       this.editing = true;
-      void this.updateWidth();
+      this.updateWidth();
     });
     this.addEventListener("keydown", (e) => {
       if (e.key === "Enter") {
@@ -77,10 +78,6 @@ export class EditableTextField extends TailwindElement {
         this.startEditing();
       }
     });
-    setTimeout(() => {
-      void this.updateWidth();
-      void this.updatePlaceholderWidth();
-    }, 0);
   }
 
   toggleEditing() {
@@ -93,7 +90,7 @@ export class EditableTextField extends TailwindElement {
 
   startEditing() {
     this.editing = true;
-    void this.updateWidth();
+    this.updateWidth();
   }
 
   endEditing(save = true) {
@@ -101,11 +98,12 @@ export class EditableTextField extends TailwindElement {
     if (!save) {
       this.inputValue = this.value;
     }
-    void this.updateWidth();
+    this.valid = true;
+    this.updateWidth();
   }
 
-  async updateWidth() {
-    await this.updateComplete;
+  updateWidth() {
+    // await this.updateComplete;
     if (!this.label) return;
     const width = measureTextWithElement(
       this.inputValue || this.placeholder || "",
@@ -115,9 +113,9 @@ export class EditableTextField extends TailwindElement {
     if (width) this.width = width;
   }
 
-  async updatePlaceholderWidth() {
+  updatePlaceholderWidth() {
     if (!this.placeholder) return;
-    await this.updateComplete;
+    // await this.updateComplete;
     if (!this.label) return;
     const width = measureTextWithElement(this.placeholder, this.label).width;
     if (width) this.placeholderWidth = width;
@@ -133,15 +131,10 @@ export class EditableTextField extends TailwindElement {
     if (changedProperties.has("editing") && this.editing) {
       this.input?.focus();
       setTimeout(() => {
-        void this.updateWidth();
-        void this.updatePlaceholderWidth();
+        this.updateWidth();
+        this.updatePlaceholderWidth();
       }, 0);
     }
-  }
-
-  firstUpdated() {
-    void this.updateWidth();
-    void this.updatePlaceholderWidth();
   }
 
   checkValidity() {
@@ -157,14 +150,22 @@ export class EditableTextField extends TailwindElement {
   }
 
   render() {
+    // Normally we wouldn't want to run code like this on every render, but it's
+    // a) cached by args already, and b) very quick to run - these use canvas
+    // text measurements, rather than element measurements which cause reflows
+    this.updateWidth();
+    this.updatePlaceholderWidth();
     return html`<input
-        class="absolute inset-3 rounded bg-transparent"
+        class=${clsx(
+          tw`absolute inset-4 rounded bg-transparent`,
+          !this.valid && tw`outline outline-danger`,
+        )}
         type="text"
         .value=${this.inputValue}
         placeholder=${ifDefined(this.placeholder)}
         @input=${(e: Event) => {
           this.inputValue = (e.target as HTMLInputElement).value;
-          void this.updateWidth();
+          this.checkValidity();
         }}
         @blur=${() => {
           if (this.checkValidity()) {
@@ -177,30 +178,37 @@ export class EditableTextField extends TailwindElement {
               }),
             );
           } else {
-            this.endEditing(false);
+            // this.endEditing(false);
           }
         }}
         style=${styleMap({
           color: this.editing ? undefined : "transparent",
-          width: `${this.width}px`,
+          width: `min(${Math.max(this.placeholderWidth, this.width)}px, calc(100% - 2rem))`,
           minWidth: `${this.placeholderWidth}px`,
         })}
       />
       <span
         class=${clsx(
-          tw`pointer-events-none block truncate rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] host-hover:outline`,
+          tw`pointer-events-none block select-none truncate whitespace-pre rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] host-hover:outline host-active:outline-none host-focus-within:outline-none`,
           !this.inputValue && tw`text-neutral-500`,
         )}
         style=${styleMap({
           visibility: this.editing ? "hidden" : "visible",
-          minWidth: this.editing ? `${this.placeholderWidth}px` : undefined,
+          width: `min(${Math.max(this.placeholderWidth, this.width)}px, auto)`,
         })}
-      >
-        ${this.inputValue
+        >${this.inputValue
           ? this.renderContent
             ? this.renderContent(this.inputValue)
             : this.inputValue
-          : this.placeholder}
-      </span>`;
+          : this.placeholder}</span
+      >
+      ${this.maxLength && !this.valid
+        ? html`<span
+            class="absolute bottom-0 right-4 text-xs leading-none text-danger"
+          >
+            ${localize.number(this.inputValue.length)} /
+            ${localize.number(this.maxLength)}
+          </span>`
+        : null}`;
   }
 }

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -108,7 +108,6 @@ export class EditableTextField extends TailwindElement {
     const width = measureTextWithElement(
       this.inputValue || this.placeholder || "",
       this.label,
-      true,
     ).width;
     if (width) this.width = width;
   }

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -125,7 +125,6 @@ export class EditableTextField extends TailwindElement {
   }
 
   updateWidth() {
-    // await this.updateComplete;
     if (!this.label) return;
     const width = measureTextWithElement(
       this.inputValue || this.placeholder || "",
@@ -136,7 +135,6 @@ export class EditableTextField extends TailwindElement {
 
   updatePlaceholderWidth() {
     if (!this.placeholder) return;
-    // await this.updateComplete;
     if (!this.label) return;
     const width = measureTextWithElement(this.placeholder, this.label).width;
     if (width) this.placeholderWidth = width;

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -112,6 +112,7 @@ export class EditableTextField extends TailwindElement {
       this.inputValue = this.value;
     }
     this.valid = true;
+    this.input?.blur();
     this.updateWidth();
   }
 

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -35,7 +35,7 @@ export class EditableTextField extends TailwindElement {
   @property({ type: Number })
   maxLength?: number;
 
-  @property({ type: Object })
+  @property({ attribute: false })
   renderContent?: (text: string) => TemplateResult;
 
   /**

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -2,6 +2,7 @@ import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { css, html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import type { DirectiveResult } from "lit/directive.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
@@ -36,7 +37,7 @@ export class EditableTextField extends TailwindElement {
   maxLength?: number;
 
   @property({ attribute: false })
-  renderContent?: (text: string) => TemplateResult;
+  renderContent?: (text: string) => TemplateResult | DirectiveResult;
 
   /**
    * Extra width to add to the computed width to accommodate the suffix slot.
@@ -53,9 +54,6 @@ export class EditableTextField extends TailwindElement {
 
   @query("input")
   input?: HTMLInputElement;
-
-  @query("span")
-  label?: HTMLSpanElement;
 
   @property({ type: String })
   placeholder?: string;
@@ -114,6 +112,7 @@ export class EditableTextField extends TailwindElement {
     this.valid = true;
     this.input?.blur();
     this.updateWidth();
+    this.updatePlaceholderWidth();
   }
 
   save() {
@@ -132,24 +131,30 @@ export class EditableTextField extends TailwindElement {
   }
 
   updateWidth() {
-    if (!this.label) return;
     const width = measureTextWithElement(
       this.inputValue || this.placeholder || "",
-      this.label,
+      this,
     ).width;
     if (width) this.width = width + this.extraWidth;
   }
 
   updatePlaceholderWidth() {
     if (!this.placeholder) return;
-    if (!this.label) return;
-    const width = measureTextWithElement(this.placeholder, this.label).width;
+    const width = measureTextWithElement(this.placeholder, this).width;
     if (width) this.placeholderWidth = width;
   }
 
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("value")) {
       this.inputValue = this.value;
+    }
+
+    if (
+      changedProperties.has("inputValue") ||
+      changedProperties.has("placeholder")
+    ) {
+      this.updateWidth();
+      this.updatePlaceholderWidth();
     }
   }
 
@@ -172,12 +177,6 @@ export class EditableTextField extends TailwindElement {
   }
 
   render() {
-    // Normally we wouldn't want to run code like this on every render, but it's
-    // a) cached by args already, and b) very quick to run - these use canvas
-    // text measurements, rather than element measurements which cause reflows
-    this.updateWidth();
-    this.updatePlaceholderWidth();
-
     const minWidth = Math.max(this.placeholderWidth, this.width, 1);
 
     return html`<input

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -117,14 +117,16 @@ export class EditableTextField extends TailwindElement {
 
   save() {
     if (this.checkValidity()) {
+      if (this.editing) {
+        this.dispatchEvent(
+          new CustomEvent<BtrixChangeEventDetail<string>>("btrix-change", {
+            detail: { value: this.inputValue },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      }
       this.endEditing();
-      this.dispatchEvent(
-        new CustomEvent<BtrixChangeEventDetail<string>>("btrix-change", {
-          detail: { value: this.inputValue },
-          bubbles: true,
-          composed: true,
-        }),
-      );
     } else {
       this.showUnsavedWarning = true;
     }

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -6,6 +6,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
+import { type BtrixChangeEventDetail } from "@/events/btrix-change";
 import localize from "@/utils/localize";
 import { measureTextWithElement } from "@/utils/measure-text";
 import { tw } from "@/utils/tailwind";
@@ -112,8 +113,8 @@ export class EditableTextField extends TailwindElement {
     if (this.checkValidity()) {
       this.endEditing();
       this.dispatchEvent(
-        new CustomEvent("btrix-change", {
-          detail: this.inputValue,
+        new CustomEvent<BtrixChangeEventDetail<string>>("btrix-change", {
+          detail: { value: this.inputValue },
           bubbles: true,
           composed: true,
         }),

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -38,6 +38,12 @@ export class EditableTextField extends TailwindElement {
   @property({ type: Object })
   renderContent?: (text: string) => TemplateResult;
 
+  /**
+   * Extra width to add to the computed width to accommodate the suffix slot.
+   */
+  @property({ type: Number })
+  extraWidth = 0;
+
   static styles = css`
     :host {
       display: inline-block;
@@ -130,7 +136,7 @@ export class EditableTextField extends TailwindElement {
       this.inputValue || this.placeholder || "",
       this.label,
     ).width;
-    if (width) this.width = width;
+    if (width) this.width = width + this.extraWidth;
   }
 
   updatePlaceholderWidth() {
@@ -209,8 +215,8 @@ export class EditableTextField extends TailwindElement {
           ? this.renderContent
             ? this.renderContent(this.inputValue)
             : this.inputValue
-          : this.placeholder}</span
-      >
+          : this.placeholder}<slot name="suffix"></slot
+      ></span>
       ${this.maxLength && !this.valid
         ? html`<span
             class="absolute bottom-0 right-4 z-10 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -149,10 +149,6 @@ export class EditableTextField extends TailwindElement {
   updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("editing") && this.editing) {
       this.input?.focus();
-      setTimeout(() => {
-        this.updateWidth();
-        this.updatePlaceholderWidth();
-      }, 0);
     }
   }
 

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -19,6 +19,7 @@ import("./copy-field");
 import("./tag-container");
 import("./data-grid");
 import("./details");
+import("./editable-text-field");
 import("./file-input");
 import("./file-list");
 import("./filter-chip");

--- a/frontend/src/events/btrix-change.ts
+++ b/frontend/src/events/btrix-change.ts
@@ -1,4 +1,8 @@
-export type BtrixChangeEvent<T = unknown> = CustomEvent<{ value: T }>;
+export type BtrixChangeEventDetail<T = unknown> = { value: T };
+
+export type BtrixChangeEvent<T = unknown> = CustomEvent<
+  BtrixChangeEventDetail<T>
+>;
 
 declare global {
   interface GlobalEventHandlersEventMap {

--- a/frontend/src/features/collections/collection-edit-dialog.ts
+++ b/frontend/src/features/collections/collection-edit-dialog.ts
@@ -123,6 +123,15 @@ export class CollectionEdit extends BtrixElement {
   public readonly thumbnailPreview?: CollectionSnapshotPreview | null;
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("tab")) {
+      this.dispatchEvent(
+        new CustomEvent("btrix-collection-edit-dialog-tab-change", {
+          detail: this.tab,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
     if (changedProperties.has("collectionId") && this.collectionId) {
       void this.fetchCollection(this.collectionId);
     }

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -69,8 +69,10 @@ export class ShareCollection extends BtrixElement {
     return html`
       <div class="flex items-center gap-2">
         <btrix-copy-button
+          name="link"
+          size="medium"
           .getValue=${() => this.shareLink}
-          content=${msg("Copy Link")}
+          content=${msg("Copy Public Link")}
           @click=${() => {
             void this.clipboardController.copy(this.shareLink);
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -879,7 +879,7 @@ export class App extends BtrixElement {
         }
 
         return html`<btrix-collection
-          class="w-full"
+          class="w-full pt-3"
           orgSlug=${this.viewState.params.slug}
           collectionSlug=${collectionSlug}
           tab=${ifDefined(collectionTab || undefined)}

--- a/frontend/src/layouts/page.ts
+++ b/frontend/src/layouts/page.ts
@@ -39,7 +39,7 @@ export function page(
     ></btrix-document-title>
 
     <div
-      class="mx-auto box-border flex min-h-full w-full max-w-screen-desktop flex-1 flex-col gap-3 lg:px-10 lg:pb-10"
+      class="mx-auto box-border flex min-h-full w-full max-w-screen-desktop flex-1 flex-col gap-3 px-3 lg:px-10 lg:pb-10"
     >
       ${header.breadcrumbs ? html` ${pageNav(header.breadcrumbs)} ` : nothing}
       ${pageHeader(header)}

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -56,7 +56,7 @@ function breadcrumbLink({ href, content }: Breadcrumb, classNames?: string) {
 
 function pageBreadcrumbs(breadcrumbs: Breadcrumb[]) {
   return html`
-    <nav class="flex flex-wrap items-center gap-2 text-neutral-500">
+    <nav class="flex max-w-full flex-wrap items-center gap-2 text-neutral-500">
       ${breadcrumbs.length
         ? breadcrumbs.map(
             (breadcrumb, i) => html`

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -37,7 +37,8 @@ function breadcrumbLink({ href, content }: Breadcrumb, classNames?: string) {
   return html`
     <a
       class=${clsx(
-        tw`flex h-5 items-center gap-1 truncate whitespace-nowrap leading-5`,
+        typeof content === "string" ? tw`block` : tw`flex`,
+        tw`h-5 items-center gap-1 truncate whitespace-nowrap leading-5`,
         href
           ? tw`font-medium text-neutral-500 transition-colors hover:text-neutral-700`
           : tw`font-medium text-primary`,

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -83,12 +83,13 @@ export function pageBack({ href, content }: Breadcrumb) {
 export function pageTitle(
   title?: string | TemplateResult | typeof nothing,
   skeletonClass?: string,
+  headerClass?: string,
 ) {
   return html`
-    <h1 class="min-w-0 text-xl font-semibold leading-8">
+    <h1 class=${clsx(tw`min-w-0 text-xl font-semibold leading-8`, headerClass)}>
       ${title ||
       html`<sl-skeleton
-        class=${skeletonClass ?? "my-.5 h-5 w-60"}
+        class=${skeletonClass ?? tw`my-.5 h-5 w-60`}
         effect="sheen"
       ></sl-skeleton>`}
     </h1>

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -117,7 +117,9 @@ export class Collection extends BtrixElement {
 
     if (collection.caption) {
       header.secondary = html`
-        <div class="text-pretty text-stone-500">
+        <div
+          class="max-w-full hyphens-auto text-pretty break-words text-neutral-600"
+        >
           ${richText(collection.caption)}
         </div>
       `;

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -624,11 +624,25 @@ export class CollectionDetail extends BtrixElement {
             content=${SelectCollectionAccess.Options[CollectionAccess.Private]
               .label}
           >
-            <sl-icon
-              class="text-lg text-neutral-600"
-              name=${SelectCollectionAccess.Options[CollectionAccess.Private]
-                .icon}
-            ></sl-icon>
+            ${this.isCrawler
+              ? html` <sl-icon-button
+                  class="-m-2 text-lg text-neutral-600"
+                  name=${SelectCollectionAccess.Options[
+                    CollectionAccess.Private
+                  ].icon}
+                  @click=${() => {
+                    this.openDialogName = "edit";
+                    this.editTab = "sharing";
+                  }}
+                ></sl-icon-button>`
+              : html`
+                  <sl-icon
+                    class="text-lg text-neutral-600"
+                    name=${SelectCollectionAccess.Options[
+                      CollectionAccess.Private
+                    ].icon}
+                  ></sl-icon>
+                `}
           </sl-tooltip>
         `,
       ],
@@ -639,11 +653,27 @@ export class CollectionDetail extends BtrixElement {
             content=${SelectCollectionAccess.Options[CollectionAccess.Unlisted]
               .label}
           >
-            <sl-icon
-              class="text-lg text-neutral-600"
-              name=${SelectCollectionAccess.Options[CollectionAccess.Unlisted]
-                .icon}
-            ></sl-icon>
+            ${this.isCrawler
+              ? html`
+                  <sl-icon-button
+                    class="-m-2 text-lg text-neutral-600"
+                    name=${SelectCollectionAccess.Options[
+                      CollectionAccess.Unlisted
+                    ].icon}
+                    @click=${() => {
+                      this.openDialogName = "edit";
+                      this.editTab = "sharing";
+                    }}
+                  ></sl-icon-button>
+                `
+              : html`
+                  <sl-icon
+                    class="text-lg text-neutral-600"
+                    name=${SelectCollectionAccess.Options[
+                      CollectionAccess.Unlisted
+                    ].icon}
+                  ></sl-icon>
+                `}
           </sl-tooltip>
         `,
       ],
@@ -654,11 +684,27 @@ export class CollectionDetail extends BtrixElement {
             content=${SelectCollectionAccess.Options[CollectionAccess.Public]
               .label}
           >
-            <sl-icon
-              class="text-lg text-success-600"
-              name=${SelectCollectionAccess.Options[CollectionAccess.Public]
-                .icon}
-            ></sl-icon>
+            ${this.isCrawler
+              ? html`
+                  <sl-icon-button
+                    class="-m-2 text-lg text-success-600"
+                    name=${SelectCollectionAccess.Options[
+                      CollectionAccess.Public
+                    ].icon}
+                    @click=${() => {
+                      this.openDialogName = "edit";
+                      this.editTab = "sharing";
+                    }}
+                  ></sl-icon-button>
+                `
+              : html`
+                  <sl-icon
+                    class="text-lg text-success-600"
+                    name=${SelectCollectionAccess.Options[
+                      CollectionAccess.Public
+                    ].icon}
+                  ></sl-icon>
+                `}
           </sl-tooltip>
         `,
       ],

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -279,16 +279,6 @@ export class CollectionDetail extends BtrixElement {
             tw`mb-2 h-6 w-60`,
             tw`grid`,
           )}
-          ${this.collection && this.isCrawler
-            ? html`<sl-icon-button
-                name="pencil"
-                aria-label=${msg("Edit Collection Name and Description")}
-                @click=${() => {
-                  this.openDialogName = "edit";
-                  this.editTab = "general";
-                }}
-              ></sl-icon-button>`
-            : nothing}
         </div>
         <div
           class="-mx-3 -mb-3 -mt-3 grid overflow-clip px-3 pb-3 lg:col-span-2"

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -222,7 +222,9 @@ export class CollectionDetail extends BtrixElement {
     >`;
     const caption = (text?: Collection["caption"]) => {
       if (text) {
-        return html`<div class="text-pretty text-neutral-600">
+        return html`<div
+          class="max-w-full hyphens-auto text-pretty break-words text-neutral-600"
+        >
           ${richText(text)}
         </div>`;
       }
@@ -256,49 +258,52 @@ export class CollectionDetail extends BtrixElement {
       </div>
       <header
         class=${clsx(
-          tw`mt-5 flex flex-col gap-3 lg:flex-row`,
+          tw`mt-5 grid gap-3 lg:grid-cols-[1fr_auto]`,
           this.isCrawler && tw`min-h-16`,
         )}
       >
-        <div class="-m-3 grid overflow-hidden p-3">
-          <div class="flex flex-wrap items-center gap-2.5">
-            ${this.renderAccessIcon()}${pageTitle(
-              this.isCrawler
-                ? html`<btrix-editable-text-field
-                    class="overflow-hidden p-3"
-                    minLength=${1}
-                    maxLength=${COLLECTION_NAME_MAX_LENGTH}
-                    .value=${this.collection?.name}
-                    placeholder=${msg("Collection name")}
-                    @btrix-change=${(e: CustomEvent<string>) => {
-                      void this.updateName(e.detail);
-                    }}
-                  ></btrix-editable-text-field>`
-                : this.collection?.name,
-              tw`mb-2 h-6 w-60`,
-              tw`-m-3 grid`,
-            )}
-            ${this.collection && this.isCrawler
-              ? html`<sl-icon-button
-                  name="pencil"
-                  aria-label=${msg("Edit Collection Name and Description")}
-                  @click=${() => {
-                    this.openDialogName = "edit";
-                    this.editTab = "general";
+        <div class="flex items-center gap-2.5">
+          ${this.renderAccessIcon()}${pageTitle(
+            this.isCrawler
+              ? html`<btrix-editable-text-field
+                  class="-m-4 overflow-hidden p-4"
+                  minLength=${1}
+                  maxLength=${COLLECTION_NAME_MAX_LENGTH}
+                  .value=${this.collection?.name}
+                  placeholder=${msg("Collection name")}
+                  @btrix-change=${(e: CustomEvent<string>) => {
+                    void this.updateName(e.detail);
                   }}
-                ></sl-icon-button>`
-              : nothing}
-          </div>
+                ></btrix-editable-text-field>`
+              : this.collection?.name,
+            tw`mb-2 h-6 w-60`,
+            tw`grid`,
+          )}
+          ${this.collection && this.isCrawler
+            ? html`<sl-icon-button
+                name="pencil"
+                aria-label=${msg("Edit Collection Name and Description")}
+                @click=${() => {
+                  this.openDialogName = "edit";
+                  this.editTab = "general";
+                }}
+              ></sl-icon-button>`
+            : nothing}
+        </div>
+        <div class="-mx-3 -mt-3 grid overflow-clip px-3 lg:col-span-2">
           ${this.isCrawler
             ? when(
                 this.collection,
                 (col) =>
                   html`<btrix-editable-text-field
-                    class="-mx-3 overflow-hidden p-3"
+                    class="-mx-4 -my-3 -mb-2 overflow-hidden p-4 text-neutral-600"
                     maxLength=${COLLECTION_CAPTION_MAX_LENGTH}
                     .value=${col.caption}
                     placeholder=${msg("Add a summary...")}
-                    .renderContent=${(text: string) => caption(text)}
+                    .renderContent=${(text: string) =>
+                      richText(text, {
+                        linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
+                      })}
                     @btrix-change=${(e: CustomEvent<string>) => {
                       void this.updateSummary(e.detail);
                     }}
@@ -307,7 +312,9 @@ export class CollectionDetail extends BtrixElement {
             : caption(this.collection?.caption)}
         </div>
 
-        <div class="ml-auto flex flex-shrink-0 items-center gap-2">
+        <div
+          class="mb-0.5 ml-auto flex flex-shrink-0 items-center gap-2 lg:col-start-2 lg:row-start-1"
+        >
           <btrix-share-collection
             orgSlug=${this.orgSlugState || ""}
             collectionId=${this.collectionId}
@@ -1476,7 +1483,6 @@ export class CollectionDetail extends BtrixElement {
   }
 
   private async updateName(name: string) {
-    name = name.trim();
     if (name === this.collection?.name) return;
     try {
       await this.api.fetch<Collection>(

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -621,7 +621,7 @@ export class CollectionDetail extends BtrixElement {
           >
             ${this.isCrawler
               ? html` <sl-icon-button
-                  class="z-10 -mx-2 text-lg text-neutral-600"
+                  class="z-10 -mx-2 -mb-0.5 text-lg text-neutral-600"
                   name=${SelectCollectionAccess.Options[
                     CollectionAccess.Private
                   ].icon}
@@ -651,7 +651,7 @@ export class CollectionDetail extends BtrixElement {
             ${this.isCrawler
               ? html`
                   <sl-icon-button
-                    class="z-10 -mx-2 text-lg text-neutral-600"
+                    class="z-10 -mx-2 -mb-0.5 text-lg text-neutral-600"
                     name=${SelectCollectionAccess.Options[
                       CollectionAccess.Unlisted
                     ].icon}
@@ -682,7 +682,7 @@ export class CollectionDetail extends BtrixElement {
             ${this.isCrawler
               ? html`
                   <sl-icon-button
-                    class="z-10 -mx-2 text-lg text-success-600"
+                    class="z-10 -mx-2 -mb-0.5 text-lg text-success-600"
                     name=${SelectCollectionAccess.Options[
                       CollectionAccess.Public
                     ].icon}

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -290,7 +290,9 @@ export class CollectionDetail extends BtrixElement {
               ></sl-icon-button>`
             : nothing}
         </div>
-        <div class="-mx-3 -mt-3 grid overflow-clip px-3 lg:col-span-2">
+        <div
+          class="-mx-3 -mb-3 -mt-3 grid overflow-clip px-3 pb-3 lg:col-span-2"
+        >
           ${this.isCrawler
             ? when(
                 this.collection,

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -719,6 +719,17 @@ export class CollectionDetail extends BtrixElement {
     const authToken = this.authState?.headers.Authorization.split(" ")[1];
 
     return html`
+      <sl-tooltip content=${msg("Share")}>
+        <sl-icon-button
+          name="box-arrow-up"
+          @click=${() => {
+            this.openDialogName = "edit";
+            this.editTab = "sharing";
+          }}
+        >
+          <sl-icon slot="prefix"></sl-icon>
+        </sl-icon-button>
+      </sl-tooltip>
       <sl-tooltip content=${msg("Edit Collection Settings")}>
         <sl-icon-button
           name="gear"

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -584,6 +584,11 @@ export class CollectionDetail extends BtrixElement {
           // TODO maybe we can return the updated collection from the update endpoint, and avoid an extra fetch?
           void this.fetchCollection();
         }}
+        @btrix-collection-edit-dialog-tab-change=${(
+          e: CustomEvent<EditDialogTab>,
+        ) => {
+          this.editTab = e.detail;
+        }}
         @btrix-change=${() => {
           // Don't do full refresh of rwp so that rwp-url-change fires
           this.isRwpLoaded = false;

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -48,6 +48,8 @@ import {
   type APISortQuery,
 } from "@/types/api";
 import {
+  COLLECTION_CAPTION_MAX_LENGTH,
+  COLLECTION_NAME_MAX_LENGTH,
   CollectionAccess,
   collectionSchema,
   type Collection,
@@ -258,13 +260,23 @@ export class CollectionDetail extends BtrixElement {
           this.isCrawler && tw`min-h-16`,
         )}
       >
-        <div
-          class="-mb-1 -ml-2 -mr-1 -mt-1 flex flex-none flex-col gap-2 self-start rounded-lg pb-1 pl-2 pr-1 pt-1 transition-colors has-[.addSummary:hover]:bg-primary-50 has-[sl-icon-button:hover]:bg-primary-50"
-        >
+        <div class="-m-3 grid overflow-hidden p-3">
           <div class="flex flex-wrap items-center gap-2.5">
             ${this.renderAccessIcon()}${pageTitle(
-              this.collection?.name,
+              this.isCrawler
+                ? html`<btrix-editable-text-field
+                    class="overflow-hidden p-3"
+                    minLength=${1}
+                    maxLength=${COLLECTION_NAME_MAX_LENGTH}
+                    .value=${this.collection?.name}
+                    placeholder=${msg("Collection name")}
+                    @btrix-change=${(e: CustomEvent<string>) => {
+                      void this.updateName(e.detail);
+                    }}
+                  ></btrix-editable-text-field>`
+                : this.collection?.name,
               tw`mb-2 h-6 w-60`,
+              tw`-m-3 grid`,
             )}
             ${this.collection && this.isCrawler
               ? html`<sl-icon-button
@@ -281,21 +293,16 @@ export class CollectionDetail extends BtrixElement {
             ? when(
                 this.collection,
                 (col) =>
-                  col.caption
-                    ? caption(col.caption)
-                    : html`
-                        <div
-                          class="addSummary text-pretty rounded-md px-1 font-light text-neutral-500"
-                          role="button"
-                          @click=${() => {
-                            this.openDialogName = "edit";
-                            this.editTab = "general";
-                          }}
-                        >
-                          ${msg("Add a summary...")}
-                        </div>
-                      `,
-                () => html`<sl-skeleton></sl-skeleton>`,
+                  html`<btrix-editable-text-field
+                    class="-mx-3 overflow-hidden p-3"
+                    maxLength=${COLLECTION_CAPTION_MAX_LENGTH}
+                    .value=${col.caption}
+                    placeholder=${msg("Add a summary...")}
+                    .renderContent=${(text: string) => caption(text)}
+                    @btrix-change=${(e: CustomEvent<string>) => {
+                      void this.updateSummary(e.detail);
+                    }}
+                  ></btrix-editable-text-field>`,
               )
             : caption(this.collection?.caption)}
         </div>
@@ -1447,7 +1454,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg(str`Successfully removed item from Collection.`),
         variant: "success",
         icon: "check2-circle",
-        id: "collection-item-remove-status",
+        id: "update",
       });
       this.refreshReplay();
       void this.fetchCollection();
@@ -1464,6 +1471,86 @@ export class CollectionDetail extends BtrixElement {
         variant: "danger",
         icon: "exclamation-octagon",
         id: "collection-item-remove-status",
+      });
+    }
+  }
+
+  private async updateName(name: string) {
+    name = name.trim();
+    if (name === this.collection?.name) return;
+    try {
+      await this.api.fetch<Collection>(
+        `/orgs/${this.orgId}/collections/${this.collectionId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            name,
+          }),
+        },
+      );
+
+      this.notify.toast({
+        message: msg("Name updated."),
+        variant: "success",
+        icon: "check2-circle",
+        id: "update",
+      });
+
+      if (this.collection) {
+        this.collection = {
+          ...this.collection,
+          name,
+        };
+      }
+
+      void this.fetchCollection();
+    } catch (err) {
+      console.debug(err);
+
+      this.notify.toast({
+        message: msg("Sorry, couldn't save collection name at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+      });
+    }
+  }
+
+  private async updateSummary(caption: string) {
+    caption = caption.trim();
+    if (caption === this.collection?.caption) return;
+    try {
+      await this.api.fetch<Collection>(
+        `/orgs/${this.orgId}/collections/${this.collectionId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            caption,
+          }),
+        },
+      );
+
+      this.notify.toast({
+        message: msg("Summary updated."),
+        variant: "success",
+        icon: "check2-circle",
+        id: "update",
+      });
+
+      if (this.collection) {
+        this.collection = {
+          ...this.collection,
+          caption,
+        };
+      }
+
+      void this.fetchCollection();
+    } catch (err) {
+      console.debug(err);
+
+      this.notify.toast({
+        message: msg("Sorry, couldn't save collection summary at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
       });
     }
   }
@@ -1491,6 +1578,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg("Description updated."),
         variant: "success",
         icon: "check2-circle",
+        id: "update",
       });
 
       if (this.collection) {

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -795,17 +795,6 @@ export class CollectionDetail extends BtrixElement {
           }}
         ></sl-icon-button>
       </sl-tooltip>
-      <sl-tooltip content=${msg("Edit Collection Settings")}>
-        <sl-icon-button
-          name="gear"
-          @click=${() => {
-            this.openDialogName = "edit";
-            this.editTab = "general";
-          }}
-        >
-          <sl-icon slot="prefix"></sl-icon>
-        </sl-icon-button>
-      </sl-tooltip>
       <sl-dropdown distance="4">
         <sl-button slot="trigger" size="small" caret
           >${msg("Actions")}</sl-button

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -795,6 +795,17 @@ export class CollectionDetail extends BtrixElement {
           }}
         ></sl-icon-button>
       </sl-tooltip>
+      <sl-tooltip content=${msg("Edit Collection Settings")}>
+        <sl-icon-button
+          name="gear"
+          @click=${() => {
+            this.openDialogName = "edit";
+            this.editTab = "general";
+          }}
+        >
+          <sl-icon slot="prefix"></sl-icon>
+        </sl-icon-button>
+      </sl-tooltip>
       <sl-dropdown distance="4">
         <sl-button slot="trigger" size="small" caret
           >${msg("Actions")}</sl-button

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -740,9 +740,7 @@ export class CollectionDetail extends BtrixElement {
             this.openDialogName = "edit";
             this.editTab = "sharing";
           }}
-        >
-          <sl-icon slot="prefix"></sl-icon>
-        </sl-icon-button>
+        ></sl-icon-button>
       </sl-tooltip>
       <sl-tooltip content=${msg("Edit Collection Settings")}>
         <sl-icon-button
@@ -1323,7 +1321,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg(html`Deleted <strong>${name}</strong> Collection.`),
         variant: "success",
         icon: "check2-circle",
-        id: "collection-delete-status",
+        id: "update",
       });
 
       // Collection may be used in crawling default, request update
@@ -1339,10 +1337,10 @@ export class CollectionDetail extends BtrixElement {
       );
     } catch {
       this.notify.toast({
-        message: msg("Sorry, couldn't delete Collection at this time."),
+        message: msg("Sorry, couldn’t delete Collection at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "collection-delete-status",
+        id: "update",
       });
     }
   }
@@ -1363,10 +1361,10 @@ export class CollectionDetail extends BtrixElement {
       }
     } catch (e) {
       this.notify.toast({
-        message: msg("Sorry, couldn't retrieve Collection at this time."),
+        message: msg("Sorry, couldn’t retrieve Collection at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "collection-retrieve-status",
+        id: "update",
       });
       console.error(e);
     }
@@ -1402,10 +1400,10 @@ export class CollectionDetail extends BtrixElement {
         console.debug("Fetch web captures aborted to throttle");
       } else {
         this.notify.toast({
-          message: msg("Sorry, couldn't retrieve web captures at this time."),
+          message: msg("Sorry, couldn’t retrieve web captures at this time."),
           variant: "danger",
           icon: "exclamation-octagon",
-          id: "collection-retrieve-status",
+          id: "update",
         });
       }
     }
@@ -1473,11 +1471,10 @@ export class CollectionDetail extends BtrixElement {
       console.debug((e as Error | undefined)?.message);
       this.notify.toast({
         message: msg(
-          "Sorry, couldn't remove item from Collection at this time.",
+          "Sorry, couldn’t remove item from Collection at this time.",
         ),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "collection-item-remove-status",
       });
     }
   }
@@ -1514,7 +1511,7 @@ export class CollectionDetail extends BtrixElement {
       console.debug(err);
 
       this.notify.toast({
-        message: msg("Sorry, couldn't save collection name at this time."),
+        message: msg("Sorry, couldn’t save collection name at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
       });
@@ -1554,9 +1551,10 @@ export class CollectionDetail extends BtrixElement {
       console.debug(err);
 
       this.notify.toast({
-        message: msg("Sorry, couldn't save collection summary at this time."),
+        message: msg("Sorry, couldn’t save collection summary at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "update",
       });
     }
   }
@@ -1601,10 +1599,11 @@ export class CollectionDetail extends BtrixElement {
 
       this.notify.toast({
         message: msg(
-          "Sorry, couldn't save collection description at this time.",
+          "Sorry, couldn’t save collection description at this time.",
         ),
         variant: "danger",
         icon: "exclamation-octagon",
+        id: "update",
       });
     }
   }
@@ -1636,16 +1635,16 @@ export class CollectionDetail extends BtrixElement {
             }),
         variant: "success",
         icon: "check2-circle",
-        id: "dedupe-index-update-status",
+        id: "update",
       });
     } catch (err) {
       console.debug(err);
 
       this.notify.toast({
-        message: msg("Sorry, couldn't created index at this time."),
+        message: msg("Sorry, couldn’t create index at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "dedupe-index-update-status",
+        id: "update",
       });
     }
   }
@@ -1665,7 +1664,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg("Purging deduplication index..."),
         variant: "success",
         icon: "check2-circle",
-        id: "dedupe-index-update-status",
+        id: "update",
       });
     } catch (err) {
       const message =
@@ -1676,7 +1675,7 @@ export class CollectionDetail extends BtrixElement {
         message,
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "dedupe-index-update-status",
+        id: "update",
       });
     }
   }
@@ -1697,7 +1696,7 @@ export class CollectionDetail extends BtrixElement {
         message: msg("Deleted deduplication index."),
         variant: "success",
         icon: "check2-circle",
-        id: "dedupe-index-update-status",
+        id: "update",
       });
     } catch (err) {
       const message =
@@ -1708,7 +1707,7 @@ export class CollectionDetail extends BtrixElement {
         message,
         variant: "danger",
         icon: "exclamation-octagon",
-        id: "dedupe-index-update-status",
+        id: "update",
       });
     }
   }

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -626,7 +626,7 @@ export class CollectionDetail extends BtrixElement {
           >
             ${this.isCrawler
               ? html` <sl-icon-button
-                  class="-m-2 text-lg text-neutral-600"
+                  class="z-10 -mx-2 text-lg text-neutral-600"
                   name=${SelectCollectionAccess.Options[
                     CollectionAccess.Private
                   ].icon}
@@ -656,7 +656,7 @@ export class CollectionDetail extends BtrixElement {
             ${this.isCrawler
               ? html`
                   <sl-icon-button
-                    class="-m-2 text-lg text-neutral-600"
+                    class="z-10 -mx-2 text-lg text-neutral-600"
                     name=${SelectCollectionAccess.Options[
                       CollectionAccess.Unlisted
                     ].icon}
@@ -687,7 +687,7 @@ export class CollectionDetail extends BtrixElement {
             ${this.isCrawler
               ? html`
                   <sl-icon-button
-                    class="-m-2 text-lg text-success-600"
+                    class="z-10 -mx-2 text-lg text-success-600"
                     name=${SelectCollectionAccess.Options[
                       CollectionAccess.Public
                     ].icon}

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -231,7 +231,7 @@ export class CollectionDetail extends BtrixElement {
     };
 
     return html`
-      <div class="mb-7 flex justify-between align-baseline">
+      <div class="mb-7 flex flex-wrap justify-between gap-y-3 align-baseline">
         ${this.renderBreadcrumbs()}
         ${this.collection &&
         (this.collection.access === CollectionAccess.Unlisted ||
@@ -305,7 +305,7 @@ export class CollectionDetail extends BtrixElement {
         </div>
 
         <div
-          class="mb-0.5 ml-auto flex flex-shrink-0 items-center gap-2 lg:col-start-2 lg:row-start-1"
+          class="mb-0.5 ml-auto flex flex-shrink-0 flex-wrap items-center justify-end gap-2 lg:col-start-2 lg:row-start-1"
         >
           <btrix-share-collection
             orgSlug=${this.orgSlugState || ""}

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -25,6 +25,7 @@ import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { viewStateContext, type ViewStateContext } from "@/context/view-state";
 import { ClipboardController } from "@/controllers/clipboard";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
+import { type BtrixChangeEvent } from "@/events/btrix-change";
 import type { BtrixRequestOrgUpdate } from "@/events/btrix-request-org-update";
 import type { EditDialogTab } from "@/features/collections/collection-edit-dialog";
 import { collectionShareLink } from "@/features/collections/helpers/share-link";
@@ -271,8 +272,8 @@ export class CollectionDetail extends BtrixElement {
                   maxLength=${COLLECTION_NAME_MAX_LENGTH}
                   .value=${this.collection?.name}
                   placeholder=${msg("Collection name")}
-                  @btrix-change=${(e: CustomEvent<string>) => {
-                    void this.updateName(e.detail);
+                  @btrix-change=${(e: BtrixChangeEvent<string>) => {
+                    void this.updateName(e.detail.value);
                   }}
                 ></btrix-editable-text-field>`
               : this.collection?.name,
@@ -296,8 +297,8 @@ export class CollectionDetail extends BtrixElement {
                       richText(text, {
                         linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
                       })}
-                    @btrix-change=${(e: CustomEvent<string>) => {
-                      void this.updateSummary(e.detail);
+                    @btrix-change=${(e: BtrixChangeEvent<string>) => {
+                      void this.updateSummary(e.detail.value);
                     }}
                   ></btrix-editable-text-field>`,
               )

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -301,10 +301,7 @@ export class CollectionDetail extends BtrixElement {
                     maxLength=${COLLECTION_CAPTION_MAX_LENGTH}
                     .value=${col.caption}
                     placeholder=${msg("Add a summary...")}
-                    .renderContent=${(text: string) =>
-                      richText(text, {
-                        linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
-                      })}
+                    .renderContent=${this.renderCaption}
                     @btrix-change=${(e: BtrixChangeEvent<string>) => {
                       void this.updateSummary(e.detail.value);
                     }}
@@ -626,6 +623,11 @@ export class CollectionDetail extends BtrixElement {
       })}
     `;
   }
+
+  private readonly renderCaption = (text: string) =>
+    richText(text, {
+      linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
+    });
 
   private renderAccessIcon() {
     return choose(this.collection?.access, [

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -829,6 +829,24 @@ export class CollectionDetail extends BtrixElement {
               }
 
               this.openDialogName = "edit";
+              this.editTab = "sharing";
+            }}
+          >
+            <sl-icon name="box-arrow-up" slot="prefix"></sl-icon>
+            ${msg("Share Collection")}
+          </sl-menu-item>
+          <sl-menu-item
+            @click=${async () => {
+              // replay-web-page needs to be available in order to configure start page
+              if (this.collectionTab !== Tab.Replay) {
+                this.navigate.to(
+                  `${this.navigate.orgBasePath}/collections/view/${this.collectionId}/${Tab.Replay}`,
+                );
+                await this.updateComplete;
+              }
+
+              this.openDialogName = "edit";
+              this.editTab = "general";
             }}
           >
             <sl-icon name="gear" slot="prefix"></sl-icon>

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -275,7 +275,15 @@ export class CollectionDetail extends BtrixElement {
                   @btrix-change=${(e: BtrixChangeEvent<string>) => {
                     void this.updateName(e.detail.value);
                   }}
-                ></btrix-editable-text-field>`
+                  extraWidth=${24}
+                >
+                  <sl-icon
+                    slot="suffix"
+                    name="pencil"
+                    class="ml-2 size-4"
+                    aria-label=${msg("Edit Collection Name")}
+                  ></sl-icon>
+                </btrix-editable-text-field>`
               : this.collection?.name,
             tw`mb-2 h-6 w-60`,
             tw`grid`,
@@ -300,7 +308,15 @@ export class CollectionDetail extends BtrixElement {
                     @btrix-change=${(e: BtrixChangeEvent<string>) => {
                       void this.updateSummary(e.detail.value);
                     }}
-                  ></btrix-editable-text-field>`,
+                    extraWidth=${24}
+                  >
+                    <sl-icon
+                      slot="suffix"
+                      name="pencil"
+                      class="ml-2 size-3"
+                      aria-label=${msg("Edit Collection Name")}
+                    ></sl-icon>
+                  </btrix-editable-text-field>`,
               )
             : caption(this.collection?.caption)}
         </div>

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -634,7 +634,7 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
         </btrix-table-cell>
         <btrix-table-cell rowClickTarget="a">
           <a
-            class="block truncate py-3"
+            class="max-w-lg! block truncate py-3"
             href=${`${this.navigate.orgBasePath}/collections/view/${col.id}`}
             @click=${this.navigate.link}
           >

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -634,7 +634,7 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
         </btrix-table-cell>
         <btrix-table-cell rowClickTarget="a">
           <a
-            class="max-w-lg! block truncate py-3"
+            class="block !max-w-3xl truncate py-3"
             href=${`${this.navigate.orgBasePath}/collections/view/${col.id}`}
             @click=${this.navigate.link}
           >

--- a/frontend/src/utils/measure-text.ts
+++ b/frontend/src/utils/measure-text.ts
@@ -44,8 +44,11 @@ export function getFontFromElement(element: HTMLElement): string {
 }
 export function measureTextWithElement(text: string, element: HTMLElement) {
   const result = measureText(text, getFontFromElement(element));
-  if (result.width == undefined) {
+  if (
+    (result as { width: number | undefined } | undefined)?.width == undefined
+  ) {
     console.error("measureTextWithElement empty", { text }, result);
+    throw new Error(`text measurement unexpectedly returned nothing`);
   }
   return result;
 }

--- a/frontend/src/utils/measure-text.ts
+++ b/frontend/src/utils/measure-text.ts
@@ -49,5 +49,8 @@ export function measureTextWithElement(
 ) {
   const result = measureText(text, getFontFromElement(element));
   if (log) console.log("measureTextWithElement", { text }, result);
+  if (result.width == undefined) {
+    console.error("measureTextWithElement empty", { text }, result);
+  }
   return result;
 }

--- a/frontend/src/utils/measure-text.ts
+++ b/frontend/src/utils/measure-text.ts
@@ -1,0 +1,53 @@
+// Some parts of this pulled from Pretext (https://github.com/chenglou/pretext/blob/main/src/measurement.ts)
+
+import { cached } from "./weakCache";
+
+let measureContext:
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D
+  | null = null;
+
+export function getMeasureContext():
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D {
+  if (measureContext !== null) return measureContext;
+
+  if (typeof OffscreenCanvas !== "undefined") {
+    measureContext = new OffscreenCanvas(1, 1).getContext("2d")!;
+    return measureContext;
+  }
+
+  if (typeof document !== "undefined") {
+    measureContext = document.createElement("canvas").getContext("2d")!;
+    return measureContext;
+  }
+
+  throw new Error(
+    "Text measurement requires OffscreenCanvas or a DOM canvas context.",
+  );
+}
+
+export const measureText = cached(function measureText(
+  text: string,
+  font: string,
+): { width: number | undefined; height: number | undefined } {
+  const ctx = getMeasureContext();
+  ctx.font = font;
+  const metrics = ctx.measureText(text);
+  return {
+    width: metrics.width,
+    height: metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
+  };
+});
+export function getFontFromElement(element: HTMLElement): string {
+  return window.getComputedStyle(element).font;
+}
+export function measureTextWithElement(
+  text: string,
+  element: HTMLElement,
+  log = false,
+) {
+  const result = measureText(text, getFontFromElement(element));
+  if (log) console.log("measureTextWithElement", { text }, result);
+  return result;
+}

--- a/frontend/src/utils/measure-text.ts
+++ b/frontend/src/utils/measure-text.ts
@@ -42,13 +42,8 @@ export const measureText = cached(function measureText(
 export function getFontFromElement(element: HTMLElement): string {
   return window.getComputedStyle(element).font;
 }
-export function measureTextWithElement(
-  text: string,
-  element: HTMLElement,
-  log = false,
-) {
+export function measureTextWithElement(text: string, element: HTMLElement) {
   const result = measureText(text, getFontFromElement(element));
-  if (log) console.log("measureTextWithElement", { text }, result);
   if (result.width == undefined) {
     console.error("measureTextWithElement empty", { text }, result);
   }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,7 @@ import { tailwindTransform } from "postcss-lit";
 import attributes from "./config/tailwind/plugins/attributes";
 import containPlugin from "./config/tailwind/plugins/contain";
 import contentVisibilityPlugin from "./config/tailwind/plugins/content-visibility";
+import cssHostPlugin from "./config/tailwind/plugins/host";
 import cssPartsPlugin from "./config/tailwind/plugins/parts";
 
 /**
@@ -171,5 +172,6 @@ module.exports = {
     containPlugin,
     contentVisibilityPlugin,
     cssPartsPlugin,
+    cssHostPlugin,
   ],
 };


### PR DESCRIPTION
Closes #3130

## Changes

- adds inline collection name and caption editing on the detail page
- changes "copy link" button text from "Copy Link" to "Copy Public Link" for clarity when collection is public
- modifies the collection detail page to make the access icon next to the collection title into a clickable button that opens the sharing tab in the edit dialog 
- adds a dedicated share button to the header actions with a share icon that also opens the sharing tab
- normalizes toast ids to "update" to not clutter screen when making consecutive changes
- fixes a variety of wrapping/clipping/text truncation issues on the collection detail page, public collection page, and collection list view
- adds a minimum collection name length that's validated on the back-end, as previously the name could be set to an empty string, which would cause requests to fail involving that collection
- fixes a few bugs with smaller viewport sizes

## Demo


https://github.com/user-attachments/assets/ba7a78ed-b603-4830-a708-74f8c1e60575

