### PR TITLE
Optimize Concurrent Crawl Check

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -123,8 +123,8 @@ class CrawlOps(BaseCrawlOps):
         )
         await self.crawls.create_index(
             [
-                ("type", pymongo.HASHED),
-                ("oid", pymongo.DESCENDING),
+                ("state", pymongo.ASCENDING),
+                ("oid", pymongo.ASCENDING),
                 ("started", pymongo.ASCENDING),
             ]
         )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -121,7 +121,13 @@ class CrawlOps(BaseCrawlOps):
         await self.crawls.create_index(
             [("type", pymongo.HASHED), ("fileSize", pymongo.DESCENDING)]
         )
-
+        await self.crawls.create_index(
+            [
+                ("type", pymongo.HASHED),
+                ("oid", pymongo.DESCENDING),
+                ("started", pymongo.ASCENDING),
+            ]
+        )
         await self.crawls.create_index([("finished", pymongo.DESCENDING)])
         await self.crawls.create_index([("oid", pymongo.HASHED)])
         await self.crawls.create_index([("cid", pymongo.HASHED)])
@@ -335,6 +341,18 @@ class CrawlOps(BaseCrawlOps):
             crawls.append(crawl)
 
         return crawls, total
+
+    async def get_active_crawls(self, oid: UUID, limit: int) -> list[str]:
+        """get list of waiting crawls, sorted from earliest to latest"""
+        res = (
+            self.crawls.find(
+                {"state": {"$in": RUNNING_AND_WAITING_STATES}, "oid": oid}, {"_id": 1}
+            )
+            .sort({"started": 1})
+            .limit(limit)
+        )
+        res_list = await res.to_list()
+        return [res["_id"] for res in res_list]
 
     async def delete_crawls(
         self,

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -21,7 +21,6 @@ from btrixcloud.models import (
     TYPE_NON_RUNNING_STATES,
     TYPE_RUNNING_STATES,
     TYPE_ALL_CRAWL_STATES,
-    # NON_RUNNING_STATES,
     RUNNING_STATES,
     WAITING_STATES,
     RUNNING_AND_STARTING_ONLY,
@@ -53,7 +52,6 @@ from .models import (
     CMAP,
     PVC,
     CJS,
-    # BTRIX_API,
 )
 
 


### PR DESCRIPTION
Use DB and query first N non-completed crawls (by start time), instead of querying all k8s crawljob objects.
Add additional index on crawls optimized for this query.

Follow-up to #2940 to make concurrent crawler queue efficient even when there is no limit set.