### PR TITLE
Bump pydantic and fastapi to support Python 3.14

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,10 @@
 gunicorn
 uvicorn[standard]
-fastapi==0.103.2
+fastapi==0.121.0
 motor
 passlib
 PyJWT==2.8.0
-pydantic>=2.12.3
+pydantic==2.12.3
 email-validator
 loguru
 aiofiles

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,10 @@
 gunicorn
 uvicorn[standard]
-fastapi==0.121.0
+fastapi==0.128.0
 motor
 passlib
 PyJWT==2.8.0
-pydantic==2.12.3
+pydantic==2.12.5
 email-validator
 loguru
 aiofiles

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ fastapi==0.103.2
 motor
 passlib
 PyJWT==2.8.0
-pydantic==2.8.2
+pydantic>=2.12.3
 email-validator
 loguru
 aiofiles


### PR DESCRIPTION
Fixes #2947

Bumps pydantic and fastapi to latest versions, pinned to specific versions to ensure we're not accidentally affected by a breaking change.

Nightly test run from this branch: https://github.com/webrecorder/browsertrix/actions/runs/20763173552