### PR TITLE
feat: Filter crawl runs by tag

### DIFF
--- a/frontend/src/features/archived-items/archived-item-tag-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-tag-filter.ts
@@ -49,6 +49,9 @@ export class ArchivedItemTagFilter extends BtrixElement {
   @property({ type: String })
   itemType?: ArchivedItem["type"];
 
+  @property({ type: Boolean })
+  includeNotSuccessful = false;
+
   @state()
   private searchString = "";
 
@@ -100,7 +103,7 @@ export class ArchivedItemTagFilter extends BtrixElement {
   private readonly orgTagsTask = new Task(this, {
     task: async ([itemType], { signal }) => {
       const query = queryString.stringify({
-        onlySuccessful: true,
+        onlySuccessful: !this.includeNotSuccessful,
         crawlType: itemType,
       });
 

--- a/frontend/src/pages/org/crawls.ts
+++ b/frontend/src/pages/org/crawls.ts
@@ -27,6 +27,7 @@ import {
   WorkflowSearch,
   type SearchFields,
 } from "@/features/crawl-workflows/workflow-search";
+import type { BtrixChangeWorkflowTagFilterEvent } from "@/features/crawl-workflows/workflow-tag-filter";
 import { type BtrixChangeCrawlStateFilterEvent } from "@/features/crawls/crawl-state-filter";
 import { OrgTab } from "@/routes";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
@@ -492,6 +493,17 @@ export class OrgCrawls extends BtrixElement {
               });
             }}
           ></btrix-crawl-state-filter>
+
+          <btrix-archived-item-tag-filter
+            .tags=${this.filterByTags.value}
+            .type=${this.filterByTagsType.value}
+            itemType="crawl"
+            includeNotSuccessful
+            @btrix-change=${(e: BtrixChangeWorkflowTagFilterEvent) => {
+              this.filterByTags.setValue(e.detail.value?.tags);
+              this.filterByTagsType.setValue(e.detail.value?.type || "or");
+            }}
+          ></btrix-archived-item-tag-filter>
 
           ${this.userInfo?.id
             ? html`<btrix-filter-chip


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/issues/2922

## Changes

- Adds tag filter to crawl runs
- Filters archived item tags by item type

## Manual testing

1. Log in
2. Go to Crawling > Crawl Runs. Verify "Tags" filter is shown
3. Choose tag filter. Verify filter works as expected
4. Go to Archived Items > Crawls
5. Open tag filter. Verify only crawl tags are shown
6. Go to Uploads
7. Open tag filter. Verify only upload tags are shown

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Crawl Runs | <img width="475" height="263" alt="Screenshot 2025-11-06 at 11 15 33 AM" src="https://github.com/user-attachments/assets/b0c70cf2-6ec2-4547-b75c-62b04214f2e0" /> |


<!-- ## Follow-ups -->
