### PR TITLE
misc backend profile fixes:

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2456,6 +2456,25 @@ class Profile(BaseMongoModel):
 
 
 # ============================================================================
+class ProfileBrowserMetadata(BaseModel):
+    """Profile metadata stored in ProfileJob labels"""
+
+    browser: str
+
+    oid: str = Field(alias="btrix.org")
+    userid: UUID = Field(alias="btrix.user")
+    baseprofile: Optional[UUID] = Field(alias="btrix.baseprofile", default=None)
+    storage: str = Field(alias="btrix.storage")
+
+    profileid: UUID
+
+    proxyid: str = ""
+    crawlerChannel: str
+
+    committing: Optional[str] = None
+
+
+# ============================================================================
 class UrlIn(BaseModel):
     """Request to set url"""
 
@@ -2485,17 +2504,14 @@ class ProfileCreate(BaseModel):
     browserid: str
     name: str
     description: Optional[str] = ""
-    crawlerChannel: str = "default"
-    proxyId: Optional[str] = None
 
 
 # ============================================================================
-class ProfileUpdate(BaseModel):
+class ProfileUpdate(ProfileCreate):
     """Update existing profile with new browser profile or metadata only"""
 
-    browserid: Optional[str] = ""
-    name: str
-    description: Optional[str] = ""
+    # browserid optional if only updating metadata
+    browserid: str = ""
 
 
 # ============================================================================

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -247,6 +247,8 @@ class ProfileOps:
         try:
             now = dt_now()
 
+            origins = []
+
             if existing_profile:
                 profileid = existing_profile.id
                 created = existing_profile.created
@@ -255,6 +257,9 @@ class ProfileOps:
                 prev_file_size = (
                     existing_profile.resource.size if existing_profile.resource else 0
                 )
+
+                origins = existing_profile.origins
+
             else:
                 profileid = metadata.profileid
                 created = now
@@ -286,6 +291,14 @@ class ProfileOps:
 
             baseid = metadata.baseprofile
 
+            if origins:
+                for origin in data["origins"]:
+                    if origin not in origins:
+                        origins.append(origin)
+
+            else:
+                origins = data["origins"]
+
             profile = Profile(
                 id=profileid,
                 name=browser_commit.name,
@@ -296,7 +309,7 @@ class ProfileOps:
                 modified=now,
                 modifiedBy=user.id,
                 modifiedByName=user.name if user.name else user.email,
-                origins=data["origins"],
+                origins=origins,
                 resource=profile_file,
                 userid=metadata.userid,
                 oid=org.id,

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -33,6 +33,7 @@ from .models import (
     SuccessResponseStorageQuota,
     ProfilePingResponse,
     ProfileBrowserGetUrlResponse,
+    ProfileBrowserMetadata,
 )
 from .utils import dt_now, str_to_date
 
@@ -130,6 +131,7 @@ class ProfileOps:
             str(org.id),
             url=str(profile_launch.url),
             storage=org.storage,
+            crawler_channel=profile_launch.crawlerChannel,
             crawler_image=crawler_image,
             image_pull_policy=image_pull_policy,
             baseprofile=prev_profile_id,
@@ -172,11 +174,20 @@ class ProfileOps:
         params["url"] = url
         return params
 
-    async def ping_profile_browser(self, browserid: str) -> dict[str, Any]:
+    async def ping_profile_browser(
+        self, metadata: ProfileBrowserMetadata, org: Organization
+    ) -> dict[str, Any]:
         """ping profile browser to keep it running"""
-        data = await self._send_browser_req(browserid, "/ping")
+        data = await self._send_browser_req(metadata.browser, "/ping")
+        origins = data.get("origins") or []
 
-        return {"success": True, "origins": data.get("origins") or []}
+        if metadata.baseprofile:
+            base = await self.get_profile(metadata.baseprofile, org)
+            for origin in base.origins:
+                if origin not in origins:
+                    origins.append(origin)
+
+        return {"success": True, "origins": origins}
 
     async def navigate_profile_browser(
         self, browserid: str, urlin: UrlIn
@@ -190,21 +201,19 @@ class ProfileOps:
 
     async def commit_to_profile(
         self,
-        metadata: dict,
+        metadata: ProfileBrowserMetadata,
         browser_commit: ProfileCreate,
         org: Organization,
         user: User,
         existing_profile: Optional[Profile] = None,
     ) -> dict[str, Any]:
         """commit to profile async, returning if committed, or waiting"""
-        profileid = metadata.get("profileid")
-        if not profileid:
+        if not metadata.profileid:
             raise HTTPException(status_code=400, detail="browser_not_valid")
 
         self.orgs.can_write_data(org, include_time=False)
 
-        committing = metadata.get("committing")
-        if not committing:
+        if not metadata.committing:
             self._run_task(
                 self.do_commit_to_profile(
                     metadata=metadata,
@@ -215,11 +224,11 @@ class ProfileOps:
                 )
             )
 
-        if committing == "done":
+        if metadata.committing == "done":
             await self.crawl_manager.delete_profile_browser(browser_commit.browserid)
             return {
                 "added": True,
-                "id": profileid,
+                "id": str(metadata.profileid),
                 "storageQuotaReached": self.orgs.storage_quota_reached(org),
             }
 
@@ -227,7 +236,7 @@ class ProfileOps:
 
     async def do_commit_to_profile(
         self,
-        metadata: dict,
+        metadata: ProfileBrowserMetadata,
         browser_commit: ProfileCreate,
         org: Organization,
         user: User,
@@ -247,7 +256,7 @@ class ProfileOps:
                     existing_profile.resource.size if existing_profile.resource else 0
                 )
             else:
-                profileid = UUID(metadata["profileid"])
+                profileid = metadata.profileid
                 created = now
                 created_by = user.id
                 created_by_name = user.name if user.name else user.email
@@ -275,10 +284,7 @@ class ProfileOps:
                 storage=org.storage,
             )
 
-            baseid = metadata.get("btrix.baseprofile")
-            if baseid:
-                print("baseid", baseid)
-                baseid = UUID(baseid)
+            baseid = metadata.baseprofile
 
             profile = Profile(
                 id=profileid,
@@ -292,11 +298,11 @@ class ProfileOps:
                 modifiedByName=user.name if user.name else user.email,
                 origins=data["origins"],
                 resource=profile_file,
-                userid=UUID(metadata.get("btrix.user")),
+                userid=metadata.userid,
                 oid=org.id,
                 baseid=baseid,
-                crawlerChannel=browser_commit.crawlerChannel,
-                proxyId=browser_commit.proxyId,
+                crawlerChannel=metadata.crawlerChannel,
+                proxyId=metadata.proxyid,
             )
 
             await self.profiles.find_one_and_update(
@@ -455,6 +461,9 @@ class ProfileOps:
             total = 0
 
         profiles = [Profile.from_dict(res) for res in items]
+
+        profiles = await self.crawlconfigs.mark_profiles_in_use(profiles, org)
+
         return profiles, total
 
     async def get_profile(self, profileid: UUID, org: Organization) -> Profile:
@@ -611,14 +620,26 @@ def init_profiles_api(
     org_crawl_dep = org_ops.org_crawl_dep
 
     async def browser_get_metadata(
-        browserid: str, org: Organization = Depends(org_crawl_dep)
-    ):
+        browserid: str, org: Organization
+    ) -> ProfileBrowserMetadata:
         # if await ops.redis.hget(f"br:{browserid}", "org") != str(org.id):
-        metadata = await crawl_manager.get_profile_browser_metadata(browserid)
-        if metadata.get("btrix.org") != str(org.id):
+        metadata = None
+        try:
+            metadata = await crawl_manager.get_profile_browser_metadata(browserid)
+        # pylint: disable=raise-missing-from
+        except Exception as e:
+            print(e)
+            raise HTTPException(status_code=400, detail="invalid_profile_browser")
+
+        if metadata.oid != str(org.id):
             raise HTTPException(status_code=404, detail="no_such_browser")
 
         return metadata
+
+    async def browser_metadata_dep(
+        browserid: str, org: Organization = Depends(org_crawl_dep)
+    ):
+        return await browser_get_metadata(browserid, org)
 
     async def browser_dep(browserid: str, org: Organization = Depends(org_crawl_dep)):
         await browser_get_metadata(browserid, org)
@@ -673,8 +694,6 @@ def init_profiles_api(
                     browserid=browser_commit.browserid,
                     name=browser_commit.name,
                     description=browser_commit.description or profile.description,
-                    crawlerChannel=profile.crawlerChannel,
-                    proxyId=profile.proxyId,
                 ),
                 org=org,
                 user=user,
@@ -707,8 +726,11 @@ def init_profiles_api(
         return await ops.create_new_browser(org, user, profile_launch)
 
     @router.post("/browser/{browserid}/ping", response_model=ProfilePingResponse)
-    async def ping_profile_browser(browserid: str = Depends(browser_dep)):
-        return await ops.ping_profile_browser(browserid)
+    async def ping_profile_browser(
+        metadata: ProfileBrowserMetadata = Depends(browser_metadata_dep),
+        org: Organization = Depends(org_crawl_dep),
+    ):
+        return await ops.ping_profile_browser(metadata, org)
 
     @router.post("/browser/{browserid}/navigate", response_model=SuccessResponse)
     async def navigate_profile_browser(

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -708,7 +708,10 @@ PROFILE_2_DESC = "Second profile used to test list endpoint"
 
 
 def prepare_browser_for_profile_commit(
-    browser_id: str, headers: Dict[str, str], oid: UUID
+    browser_id: str,
+    headers: Dict[str, str],
+    oid: UUID,
+    url="https://old.webrecorder.net/tools",
 ) -> None:
     # Ping to make sure it doesn't expire
     r = requests.post(
@@ -738,7 +741,7 @@ def prepare_browser_for_profile_commit(
     r = requests.post(
         f"{API_PREFIX}/orgs/{oid}/profiles/browser/{browser_id}/navigate",
         headers=headers,
-        json={"url": "https://old.webrecorder.net/tools"},
+        json={"url": url},
     )
     assert r.status_code == 200
     assert r.json()["success"]

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -212,6 +212,8 @@ def test_commit_browser_to_existing_profile(
         url="https://example-com.webrecorder.net",
     )
 
+    time.sleep(10)
+
     # Commit new browser to existing profile
     while True:
         r = requests.patch(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -104,6 +104,7 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_2["modified"]
             assert profile_2["modifiedBy"]
             assert profile_2["modifiedByName"] == "admin"
+            assert profile_2["inUse"] == False
             assert not profile_2["baseid"]
             resource = profile_2["resource"]
             assert resource
@@ -129,6 +130,7 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_1["modified"]
             assert profile_1["modifiedBy"]
             assert profile_1["modifiedByName"] == "admin"
+            assert profile_1["inUse"] == True
             assert not profile_1["baseid"]
             resource = profile_1["resource"]
             assert resource

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -206,7 +206,10 @@ def test_commit_browser_to_existing_profile(
     original_modified = data["modified"]
 
     prepare_browser_for_profile_commit(
-        profile_browser_3_id, admin_auth_headers, default_org_id
+        profile_browser_3_id,
+        admin_auth_headers,
+        default_org_id,
+        url="https://example-com.webrecorder.net",
     )
 
     # Commit new browser to existing profile
@@ -242,6 +245,11 @@ def test_commit_browser_to_existing_profile(
     assert data["created"] == original_created
     assert data["createdBy"]
     assert data["createdByName"] == "admin"
+
+    assert data.get("origins") == [
+        "https://old.webrecorder.net",
+        "https://example-com.webrecorder.net",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/chart/app-templates/profile_job.yaml
+++ b/chart/app-templates/profile_job.yaml
@@ -12,6 +12,8 @@ metadata:
     {%- endif %}
     btrix.storage: "{{ storage_name }}"
     profileid: {{ profileid }}
+    proxyid: "{{ proxy_id }}"
+    crawlerChannel: "{{ crawler_channel }}"
 
 spec:
   selector:


### PR DESCRIPTION
- update inUse for profile list (fixes #2970)
- ensure origins for existing profiles returns all origins
- ensure proxyId and crawlerChannel when committing are set from the browser, not from API request

internal improvements:
- add crawlerChannel and proxyId to ProfileJob labels
- convert labels to typed ProfileBrowserMetadata