### PR TITLE
Add backend tags support for profiles

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1150,6 +1150,7 @@ class CrawlConfigOps:
 
     async def get_crawl_config_tag_counts(self, org):
         """get distinct tags from all crawl configs for this org"""
+        # pylint: disable=duplicate-code
         tags = await self.crawl_configs.aggregate(
             [
                 {"$match": {"oid": org.id}},

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1633,7 +1633,10 @@ def init_crawl_config_api(
         ] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        tag: Annotated[Optional[List[str]], Query(title="Tags")] = None,
+        tag: Annotated[
+            Optional[List[str]], Query(title="Tags", deprecated=True)
+        ] = None,
+        tags: Annotated[Optional[List[str]], Query(title="Tags")] = None,
         tag_match: Annotated[
             Optional[ListFilterType],
             Query(
@@ -1665,6 +1668,10 @@ def init_crawl_config_api(
         if description:
             description = urllib.parse.unquote(description)
 
+        # check deprecated 'tag' if 'tags' not provided
+        if tag and not tags:
+            tags = tag
+
         crawl_configs, total = await ops.get_crawl_configs(
             org,
             created_by=user_id,
@@ -1673,7 +1680,7 @@ def init_crawl_config_api(
             first_seed=first_seed,
             name=name,
             description=description,
-            tags=tag,
+            tags=tags,
             tag_match=tag_match,
             last_crawl_state=last_crawl_state,
             schedule=schedule,

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2454,6 +2454,8 @@ class Profile(BaseMongoModel):
 
     inUse: bool = False
 
+    tags: Optional[List[str]] = []
+
 
 # ============================================================================
 class ProfileBrowserMetadata(BaseModel):
@@ -2504,6 +2506,7 @@ class ProfileCreate(BaseModel):
     browserid: str
     name: str
     description: Optional[str] = ""
+    tags: Optional[List[str]] = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -700,7 +700,7 @@ def init_profiles_api(
     async def list_profiles(
         org: Organization = Depends(org_crawl_dep),
         userid: Optional[UUID] = None,
-        tag: Annotated[Optional[List[str]], Query(title="Tags")] = None,
+        tags: Annotated[Optional[List[str]], Query(title="Tags")] = None,
         tag_match: Annotated[
             Optional[ListFilterType],
             Query(
@@ -717,7 +717,7 @@ def init_profiles_api(
         profiles, total = await ops.list_profiles(
             org,
             userid,
-            tags=tag,
+            tags=tags,
             tag_match=tag_match,
             page_size=pageSize,
             page=page,

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -699,12 +699,15 @@ def echo_server():
 
 PROFILE_NAME = "Test profile"
 PROFILE_DESC = "Profile used for backend tests"
+PROFILE_TAGS = ["profile", "old-webrecorder"]
 
 PROFILE_NAME_UPDATED = "Updated test profile"
 PROFILE_DESC_UPDATED = "Updated profile used for backend tests"
+PROFILE_TAGS_UPDATED = ["profile", "profile-updated", "old-webrecorder"]
 
 PROFILE_2_NAME = "Second test profile"
 PROFILE_2_DESC = "Second profile used to test list endpoint"
+PROFILE_2_TAGS = ["profile", "specs-webrecorder"]
 
 
 def prepare_browser_for_profile_commit(
@@ -782,6 +785,7 @@ def profile_id(admin_auth_headers, default_org_id, profile_browser_id):
                     "browserid": profile_browser_id,
                     "name": PROFILE_NAME,
                     "description": PROFILE_DESC,
+                    "tags": PROFILE_TAGS,
                 },
                 timeout=10,
             )
@@ -873,6 +877,7 @@ def profile_2_id(admin_auth_headers, default_org_id, profile_browser_2_id):
                     "browserid": profile_browser_2_id,
                     "name": PROFILE_2_NAME,
                     "description": PROFILE_2_DESC,
+                    "tags": PROFILE_2_TAGS,
                 },
                 timeout=10,
             )

--- a/backend/test/test_crawl_config_tags.py
+++ b/backend/test/test_crawl_config_tags.py
@@ -149,7 +149,7 @@ def test_get_configs_filter_multiple_tags_or(admin_auth_headers, default_org_id)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs",
         headers=admin_auth_headers,
-        params={"tag": ["tag-1", "tag-3"], "tagMatch": "or"},
+        params={"tags": ["tag-1", "tag-3"], "tagMatch": "or"},
     )
     assert r.status_code == 200
     data = r.json()
@@ -162,10 +162,25 @@ def test_get_configs_filter_multiple_tags_and(admin_auth_headers, default_org_id
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs",
         headers=admin_auth_headers,
-        params={"tag": ["tag-1", "tag-2"], "tagMatch": "and"},
+        params={"tags": ["tag-1", "tag-2"], "tagMatch": "and"},
     )
     assert r.status_code == 200
     data = r.json()
 
     assert len(data["items"]) == 1
     assert data["items"][0]["id"] == new_cid_1
+
+
+def test_get_configs_filter_multiple_tags_deprecated_field(
+    admin_auth_headers, default_org_id
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs",
+        headers=admin_auth_headers,
+        params={"tag": ["tag-1", "tag-3"], "tagMatch": "or"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    assert len(data["items"]) == 2
+    assert {item["id"] for item in data["items"]} == {new_cid_1, new_cid_2}

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -154,6 +154,56 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             time.sleep(1)
 
 
+def test_list_profiles_filter_by_tag(
+    admin_auth_headers, default_org_id, profile_id, profile_2_id
+):
+    # Test multiple tags with implicit and explicit AND tagMatch
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile,old-webrecorder",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["id"] == profile_id
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile,old-webrecorder&tagMatch=and",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["id"] == profile_id
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=old-webrecorder,specs-webrecorder&tagMatch=and",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 0
+
+    # Test single tag
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=specs-webrecorder",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["items"][0]["id"] == profile_2_id
+
+    # Test multiple tags with explicit OR tagMatch
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile,old-webrecorder&tagMatch=or",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+
+
 def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_id):
     # Get original created/modified times
     r = requests.get(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -159,7 +159,7 @@ def test_list_profiles_filter_by_tag(
 ):
     # Test multiple tags with implicit and explicit AND tagMatch
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile,old-webrecorder",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile&tag=old-webrecorder",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -168,7 +168,7 @@ def test_list_profiles_filter_by_tag(
     assert data["items"][0]["id"] == profile_id
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile,old-webrecorder&tagMatch=and",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile&tag=old-webrecorder&tagMatch=and",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -177,7 +177,7 @@ def test_list_profiles_filter_by_tag(
     assert data["items"][0]["id"] == profile_id
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=old-webrecorder,specs-webrecorder&tagMatch=and",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=old-webrecorder&tag=specs-webrecorder&tagMatch=and",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -196,7 +196,7 @@ def test_list_profiles_filter_by_tag(
 
     # Test multiple tags with explicit OR tagMatch
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile,old-webrecorder&tagMatch=or",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile&tag=old-webrecorder&tagMatch=or",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -159,7 +159,7 @@ def test_list_profiles_filter_by_tag(
 ):
     # Test multiple tags with implicit and explicit AND tagMatch
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile&tag=old-webrecorder",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tags=profile&tags=old-webrecorder",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -168,7 +168,7 @@ def test_list_profiles_filter_by_tag(
     assert data["items"][0]["id"] == profile_id
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile&tag=old-webrecorder&tagMatch=and",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tags=profile&tags=old-webrecorder&tagMatch=and",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -177,7 +177,7 @@ def test_list_profiles_filter_by_tag(
     assert data["items"][0]["id"] == profile_id
 
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=old-webrecorder&tag=specs-webrecorder&tagMatch=and",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tags=old-webrecorder&tags=specs-webrecorder&tagMatch=and",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -186,7 +186,7 @@ def test_list_profiles_filter_by_tag(
 
     # Test single tag
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=specs-webrecorder",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tags=specs-webrecorder",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -196,7 +196,7 @@ def test_list_profiles_filter_by_tag(
 
     # Test multiple tags with explicit OR tagMatch
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tag=profile&tag=old-webrecorder&tagMatch=or",
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?tags=profile&tags=old-webrecorder&tagMatch=or",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -9,10 +9,13 @@ from .conftest import (
     API_PREFIX,
     PROFILE_NAME,
     PROFILE_DESC,
+    PROFILE_TAGS,
     PROFILE_NAME_UPDATED,
     PROFILE_DESC_UPDATED,
     PROFILE_2_NAME,
     PROFILE_2_DESC,
+    PROFILE_2_TAGS,
+    PROFILE_TAGS_UPDATED,
     prepare_browser_for_profile_commit,
 )
 
@@ -36,6 +39,7 @@ def test_get_profile(admin_auth_headers, default_org_id, profile_id, profile_con
             assert data["id"] == profile_id
             assert data["name"] == PROFILE_NAME
             assert data["description"] == PROFILE_DESC
+            assert data["tags"] == PROFILE_TAGS
             assert data["userid"]
             assert data["oid"] == default_org_id
             assert data.get("origins") or data.get("origins") == []
@@ -95,6 +99,7 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_2["id"] == profile_2_id
             assert profile_2["name"] == PROFILE_2_NAME
             assert profile_2["description"] == PROFILE_2_DESC
+            assert profile_2["tags"] == PROFILE_2_TAGS
             assert profile_2["userid"]
             assert profile_2["oid"] == default_org_id
             assert profile_2.get("origins") or data.get("origins") == []
@@ -121,6 +126,7 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert profile_1["id"] == profile_id
             assert profile_1["name"] == PROFILE_NAME
             assert profile_1["description"] == PROFILE_DESC
+            assert profile_1["tags"] == PROFILE_TAGS
             assert profile_1["userid"]
             assert profile_1["oid"] == default_org_id
             assert profile_1.get("origins") or data.get("origins") == []
@@ -166,6 +172,7 @@ def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_i
         json={
             "name": PROFILE_NAME_UPDATED,
             "description": PROFILE_DESC_UPDATED,
+            "tags": PROFILE_TAGS_UPDATED,
         },
     )
     assert r.status_code == 200
@@ -183,6 +190,7 @@ def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_i
     assert data["id"] == profile_id
     assert data["name"] == PROFILE_NAME_UPDATED
     assert data["description"] == PROFILE_DESC_UPDATED
+    assert data["tags"] == PROFILE_TAGS_UPDATED
 
     # Ensure modified was updated but created was not
     assert data["modified"] > original_modified
@@ -225,6 +233,7 @@ def test_commit_browser_to_existing_profile(
                 "browserid": profile_browser_3_id,
                 "name": PROFILE_NAME_UPDATED,
                 "description": PROFILE_DESC_UPDATED,
+                "tags": PROFILE_TAGS_UPDATED,
             },
         )
         assert r.status_code == 200
@@ -315,6 +324,23 @@ def test_sort_profiles(
             if time.monotonic() - start_time > time_limit:
                 raise
             time.sleep(1)
+
+
+def test_profile_tag_counts(admin_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/tagCounts",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data == {
+        "tags": [
+            {"tag": "profile", "count": 2},
+            {"tag": "old-webrecorder", "count": 1},
+            {"tag": "profile-updated", "count": 1},
+            {"tag": "specs-webrecorder", "count": 1},
+        ]
+    }
 
 
 def test_delete_profile(admin_auth_headers, default_org_id, profile_2_id):


### PR DESCRIPTION
Fixes #2961 

- Add support for tags in profile create and update endpoints
- Add profile tagCounts endpoint to aid in list filters/search
- Add tests