### PR TITLE
Fix "Edit Exclusions" button

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -139,7 +139,7 @@ export class WorkflowActionMenu extends BtrixElement {
                   ${msg("Edit Browser Windows")}
                 </sl-menu-item>
                 <sl-menu-item
-                  data-action=${Action.EditBrowserWindows}
+                  data-action=${Action.EditExclusions}
                   ?disabled=${!crawling && !paused}
                 >
                   <sl-icon name="table" slot="prefix"></sl-icon>


### PR DESCRIPTION
Currently, the "Edit Exclusions" button triggers the "Edit Browser Windows" dialog. This commit fixes that.
<img width="250" height="542" alt="image" src="https://github.com/user-attachments/assets/e67f556d-b0ce-4b15-864f-33aa31e8e076" />
