### PR TITLE
profile constraints improvements

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -639,6 +639,9 @@ class CrawlConfigOps:
             profile = await self.profiles.get_profile(cast(UUID, update.profileid), org)
             query["profileid"] = update.profileid
             proxy_id = profile.proxyId
+        # don't change the proxy if profile is set, as it should match the profile proxy
+        elif orig_crawl_config.profileid:
+            proxy_id = None
 
         if proxy_id is not None:
             query["proxyId"] = proxy_id

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -125,18 +125,17 @@ class CronJobOperator(BaseOperator):
             )
             print("Scheduled Crawl Created: " + crawl_id)
 
-        profile_filename, profile_proxy_id = (
-            await self.crawl_config_ops.profiles.get_profile_filename_and_proxy(
-                crawlconfig.profileid, org
+        if crawlconfig.profileid:
+            profile_filename, crawlconfig.proxyId, _ = (
+                await self.crawl_config_ops.profiles.get_profile_filename_proxy_channel(
+                    crawlconfig.profileid, org
+                )
             )
-        )
-        if crawlconfig.profileid and not profile_filename:
-            print(f"error: missing profile {crawlconfig.profileid}")
-            return self.get_finished_response(metadata)
-
-        save_profile_id = self.crawl_config_ops.get_save_profile_id(
-            profile_proxy_id, crawlconfig
-        )
+            if not profile_filename:
+                print(f"error: missing profile {crawlconfig.profileid}")
+                return self.get_finished_response(metadata)
+        else:
+            profile_filename = ""
 
         crawl_id, crawljob = self.k8s.new_crawl_job_yaml(
             cid=str(cid),
@@ -153,7 +152,7 @@ class CronJobOperator(BaseOperator):
             warc_prefix=warc_prefix,
             storage_filename=self.crawl_config_ops.default_filename_template,
             profile_filename=profile_filename or "",
-            profileid=save_profile_id,
+            profileid=str(crawlconfig.profileid) if crawlconfig else "",
             proxy_id=crawlconfig.proxyId or "",
             is_single_page=self.crawl_config_ops.is_single_page(crawlconfig.config),
         )

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -112,9 +112,12 @@ class ProfileOps:
         prev_profile_path = ""
         prev_profile_id = ""
         prev_proxy_id = ""
+        prev_channel = ""
         if profile_launch.profileId:
-            prev_profile_path, prev_proxy_id = (
-                await self.get_profile_filename_and_proxy(profile_launch.profileId, org)
+            prev_profile_path, prev_proxy_id, prev_channel = (
+                await self.get_profile_filename_proxy_channel(
+                    profile_launch.profileId, org
+                )
             )
 
             if not prev_profile_path:
@@ -122,14 +125,14 @@ class ProfileOps:
 
             prev_profile_id = str(profile_launch.profileId)
 
-        crawler_image = self.crawlconfigs.get_channel_crawler_image(
-            profile_launch.crawlerChannel
-        )
+        crawler_channel = profile_launch.crawlerChannel or prev_channel
+
+        crawler_image = self.crawlconfigs.get_channel_crawler_image(crawler_channel)
         if not crawler_image:
             raise HTTPException(status_code=404, detail="crawler_not_found")
 
         image_pull_policy = self.crawlconfigs.get_channel_crawler_image_pull_policy(
-            profile_launch.crawlerChannel
+            crawler_channel
         )
 
         # use either specified proxyId or if none, use proxyId from existing profile
@@ -512,23 +515,23 @@ class ProfileOps:
         profile.inUse = await self.crawlconfigs.is_profile_in_use(profileid, org)
         return profile
 
-    async def get_profile_filename_and_proxy(
+    async def get_profile_filename_proxy_channel(
         self, profileid: Optional[UUID], org: Organization
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, str]:
         """return profile path filename (relative path) for given profile id and org"""
         if not profileid:
-            return "", ""
+            return "", "", ""
 
         try:
             profile = await self.get_profile(profileid, org)
             storage_path = profile.resource.filename if profile.resource else ""
             storage_path = storage_path.lstrip(f"{org.id}/")
-            return storage_path, profile.proxyId or ""
+            return storage_path, profile.proxyId or "", profile.crawlerChannel or ""
         # pylint: disable=bare-except
         except:
             pass
 
-        return "", ""
+        return "", "", ""
 
     async def get_profile_name(self, profileid: UUID, org: Organization) -> str:
         """return profile for given profile id and org"""


### PR DESCRIPTION
profile crawlerChannel default:
- use crawlerChannel from profile when launching browser for profile

profile proxyId constraint: (backend part of #2982)
- ensure workflow proxyId set to that profile.proxyId when creating or updating workflow
- also ensure correct proxyId from profile is used when starting crawls