### PR TITLE
feat: Load first seed in profile

### DIFF
--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -669,6 +669,17 @@ export class BrowserProfilesProfilePage extends BtrixElement {
                 (workflow) =>
                   html`<btrix-workflow-list-item .workflow=${workflow}>
                     <sl-menu slot="menu">
+                      <sl-menu-item
+                        @click=${() =>
+                          void this.openBrowser({ url: workflow.firstSeed })}
+                      >
+                        <sl-icon
+                          slot="prefix"
+                          name="window-fullscreen"
+                        ></sl-icon>
+                        ${msg("Load Crawl Start URL")}
+                      </sl-menu-item>
+                      <sl-divider></sl-divider>
                       ${when(
                         this.appState.isCrawler,
                         () => html`
@@ -679,19 +690,8 @@ export class BrowserProfilesProfilePage extends BtrixElement {
                             <sl-icon name="gear" slot="prefix"></sl-icon>
                             ${msg("Edit Workflow Settings")}
                           </btrix-menu-item-link>
-                          <sl-divider></sl-divider>
                         `,
                       )}
-                      <btrix-menu-item-link
-                        href="${this.navigate
-                          .orgBasePath}/${OrgTab.Workflows}/${workflow.id}"
-                      >
-                        <sl-icon
-                          name="arrow-return-right"
-                          slot="prefix"
-                        ></sl-icon>
-                        ${msg("Go to Workflow")}
-                      </btrix-menu-item-link>
                     </sl-menu>
                   </btrix-workflow-list-item>`,
               )}

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -38,7 +38,7 @@ import { WorkflowTab } from "@/routes";
 import { deleteConfirmation } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
-import { type StorageSeedFile } from "@/types/workflow";
+import type { StorageSeedFile, WorkflowSearchValues } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
 import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import { renderName } from "@/utils/crawler";
@@ -994,12 +994,7 @@ export class WorkflowsList extends BtrixElement {
 
   private async fetchConfigSearchValues() {
     try {
-      const data: {
-        crawlIds: string[];
-        names: string[];
-        descriptions: string[];
-        firstSeeds: string[];
-      } = await this.api.fetch(
+      const data = await this.api.fetch<WorkflowSearchValues>(
         `/orgs/${this.orgId}/crawlconfigs/search-values`,
       );
 

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -237,9 +237,14 @@
   }
 
   /* Adjust menu item hover and focus styles */
-  sl-menu-item,
+  sl-option:not([aria-selected="true"]):not(:disabled),
+  sl-menu-item:not([disabled]),
   btrix-menu-item-link {
     @apply part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
+  }
+
+  sl-option[aria-selected="true"] {
+    @apply part-[base]:bg-cyan-50 part-[base]:text-cyan-700;
   }
 
   /* Add menu item variants */

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -16,3 +16,10 @@ export type StorageSeedFile = StorageFile & {
   firstSeed: string;
   seedCount: number;
 };
+
+export type WorkflowSearchValues = {
+  crawlIds: string[];
+  names: string[];
+  descriptions: string[];
+  firstSeeds: string[];
+};


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2978
Fixes https://github.com/webrecorder/browsertrix/issues/3001
Depends on https://github.com/webrecorder/browsertrix/pull/3000

## Changes

- Replaces redundant "Go to workflow" menu item in browser profile workflow list with "Load Crawl Start URL".
- Fixes not being able to open a workflow in a new tab (https://github.com/webrecorder/browsertrix/issues/3001)
- Adds suggestions to site dropdown

## Screenshots

<img width="456" height="153" alt="Screenshot 2025-11-18 at 3 45 10 PM" src="https://github.com/user-attachments/assets/7ed477d7-7bb8-4361-bab9-c892a20f72a7" />

<img width="508" height="411" alt="Screenshot 2025-11-19 at 11 58 51 AM" src="https://github.com/user-attachments/assets/35f7fea3-383c-4617-a843-93e3c5d2ec19" />

