### PR TITLE
Refactor quota updates to use aggregation pipeline

### DIFF
--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -699,6 +699,8 @@ class OrgOps:
 
         # Inc org available fields for extra/gifted execution time as needed
         for extra_or_gifted in ["extra", "gifted"]:
+            if not computed_quotas[f"{extra_or_gifted}ExecMinutes"]:
+                continue
             previous_mins = {
                 "$cond": {
                     "if": {

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -699,7 +699,7 @@ class OrgOps:
 
         # Inc org available fields for extra/gifted execution time as needed
         for extra_or_gifted in ["extra", "gifted"]:
-            if not computed_quotas[f"{extra_or_gifted}ExecMinutes"]:
+            if f"{extra_or_gifted}ExecMinutes" not in computed_quotas:
                 continue
             previous_mins = {
                 "$cond": {

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -640,7 +640,7 @@ class OrgOps:
             }
         ]
 
-        computed_quotas = {}
+        computed_quotas: dict[str, Any] = {}
 
         if mode == "add":
             update[0]["$set"]["quotaUpdates"]["$concatArrays"][1][0][

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1610,7 +1610,7 @@ def init_orgs_api(
 
     router = APIRouter(
         prefix="/orgs/{oid}",
-        dependencies=[Depends(org_dep)],
+        dependencies=[Depends(org_or_shared_secret_dep)],
         responses={404: {"description": "Not found"}},
     )
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -641,9 +641,9 @@ class OrgOps:
         computed_quotas = {}
 
         if mode == "add":
-            update[0]["$set"]["quotaUpdates"]["$concatArrays"][1][0][
-                "context"
-            ] = context
+            update[0]["$set"]["quotaUpdates"]["$concatArrays"][1][0]["context"] = (
+                context
+            )
             for field, value in quotas.model_dump().items():
                 if field == "context":
                     continue
@@ -1665,7 +1665,7 @@ def init_orgs_api(
 
     router = APIRouter(
         prefix="/orgs/{oid}",
-        dependencies=[Depends(org_or_shared_secret_dep)],
+        dependencies=[Depends(org_dep)],
         responses={404: {"description": "Not found"}},
     )
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -641,9 +641,9 @@ class OrgOps:
         computed_quotas = {}
 
         if mode == "add":
-            update[0]["$set"]["quotaUpdates"]["$concatArrays"][1][0]["context"] = (
-                context
-            )
+            update[0]["$set"]["quotaUpdates"]["$concatArrays"][1][0][
+                "context"
+            ] = context
             for field, value in quotas.model_dump().items():
                 if field == "context":
                     continue


### PR DESCRIPTION
Replaces the previous multi-step update approach with a single aggregation pipeline that handles both "add" and "set" modes, ensuring atomic quota modifications.

Tested locally, confirming api calls against local mongo.