### PR TITLE
feat: Standardize browser profile display and proxy setting

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -45,6 +45,13 @@ jobs:
     needs: paths-filter
     if: needs.paths-filter.outputs.matches == 'true'
     steps:
+      - name: Initial Disk Cleanup
+        uses: mathio/gha-cleanup@v1
+        with:
+          remove-browsers: true
+          verbose: true
+
+
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2
         with:

--- a/frontend/src/components/ui/badge.ts
+++ b/frontend/src/components/ui/badge.ts
@@ -14,7 +14,8 @@ export type BadgeVariant =
   | "cyan"
   | "blue"
   | "high-contrast"
-  | "text";
+  | "text"
+  | "text-neutral";
 
 /**
  * Show numeric value in a label
@@ -66,6 +67,7 @@ export class Badge extends TailwindElement {
                   cyan: tw`bg-cyan-50 text-cyan-600 ring-cyan-600`,
                   blue: tw`bg-blue-50 text-blue-600 ring-blue-600`,
                   text: tw`text-blue-500 ring-blue-600`,
+                  "text-neutral": tw`text-neutral-500 ring-neutral-600`,
                 }[this.variant],
               ]
             : {
@@ -78,6 +80,7 @@ export class Badge extends TailwindElement {
                 cyan: tw`bg-cyan-50 text-cyan-600`,
                 blue: tw`bg-blue-50 text-blue-600`,
                 text: tw`text-blue-500`,
+                "text-neutral": tw`text-neutral-500`,
               }[this.variant],
           this.pill
             ? [

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import ISO6391 from "iso-639-1";
 import { html, nothing, type TemplateResult } from "lit";
@@ -6,6 +7,10 @@ import { when } from "lit/directives/when.js";
 import capitalize from "lodash/fp/capitalize";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import {
+  orgProxiesContext,
+  type OrgProxiesContext,
+} from "@/context/org-proxies";
 import { none, notSpecified } from "@/layouts/empty";
 import {
   Behavior,
@@ -36,6 +41,9 @@ import { getServerDefaults } from "@/utils/workflow";
 @customElement("btrix-config-details")
 @localized()
 export class ConfigDetails extends BtrixElement {
+  @consume({ context: orgProxiesContext, subscribe: true })
+  private readonly orgProxies?: OrgProxiesContext;
+
   @property({ type: Object })
   crawlConfig?: CrawlConfig;
 
@@ -235,16 +243,16 @@ export class ConfigDetails extends BtrixElement {
             msg("Browser Profile"),
             when(
               crawlConfig?.profileid,
-              () =>
-                html`<a
-                  class="text-blue-500 hover:text-blue-600"
+              () => html`
+                <btrix-link
                   href=${`${this.navigate.orgBasePath}/browser-profiles/profile/${
                     crawlConfig!.profileid
                   }`}
-                  @click=${this.navigate.link}
+                  hideIcon
                 >
                   ${crawlConfig?.profileName}
-                </a>`,
+                </btrix-link>
+              `,
               () =>
                 crawlConfig?.profileName ||
                 html`<span class="text-neutral-400"
@@ -252,6 +260,14 @@ export class ConfigDetails extends BtrixElement {
                 >`,
             ),
           )}
+          ${crawlConfig?.proxyId
+            ? this.renderSetting(
+                msg("Crawler Proxy Server"),
+                this.orgProxies?.servers.find(
+                  ({ id }) => id === crawlConfig.proxyId,
+                )?.label || capitalize(crawlConfig.proxyId),
+              )
+            : nothing}
           ${this.renderSetting(
             msg("Browser Windows"),
             crawlConfig?.browserWindows ? `${crawlConfig.browserWindows}` : "",
@@ -283,9 +299,6 @@ export class ConfigDetails extends BtrixElement {
                 msg("Language"),
                 ISO6391.getName(seedsConfig.lang),
               )
-            : nothing}
-          ${crawlConfig?.proxyId
-            ? this.renderSetting(msg("Proxy"), capitalize(crawlConfig.proxyId))
             : nothing}
         `,
       })}

--- a/frontend/src/components/ui/link.ts
+++ b/frontend/src/components/ui/link.ts
@@ -25,7 +25,7 @@ export class Link extends BtrixElement {
     return html`
       <a
         class=${clsx(
-          "group inline-flex items-center gap-1 transition-colors",
+          "group inline-flex items-center gap-1 transition-colors duration-fast",
           {
             primary: "text-primary-500 hover:text-primary-600",
             neutral: "text-blue-500 hover:text-blue-600",
@@ -42,7 +42,7 @@ export class Link extends BtrixElement {
         <sl-icon
           slot="suffix"
           name="arrow-right"
-          class="size-4 transition-transform group-hover:translate-x-1"
+          class="size-4 transition-transform duration-fast group-hover:translate-x-1"
         ></sl-icon
       ></a>
     `;

--- a/frontend/src/components/ui/link.ts
+++ b/frontend/src/components/ui/link.ts
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -18,6 +18,9 @@ export class Link extends BtrixElement {
 
   @property({ type: String })
   variant: "primary" | "neutral" = "neutral";
+
+  @property({ type: Boolean })
+  hideIcon = false;
 
   render() {
     if (!this.href) return;
@@ -39,12 +42,16 @@ export class Link extends BtrixElement {
           : this.navigate.link}
       >
         <slot></slot>
-        <sl-icon
-          slot="suffix"
-          name="arrow-right"
-          class="size-4 transition-transform duration-fast group-hover:translate-x-1"
-        ></sl-icon
-      ></a>
+        ${this.hideIcon
+          ? nothing
+          : html`
+              <sl-icon
+                slot="suffix"
+                name="arrow-right"
+                class="size-4 transition-transform duration-fast group-hover:translate-x-1"
+              ></sl-icon>
+            `}
+      </a>
     `;
   }
 }

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -47,6 +47,9 @@ export class SelectCrawlerProxy extends BtrixElement {
   proxyId: string | null = null;
 
   @property({ type: String })
+  label?: string;
+
+  @property({ type: String })
   size?: SlSelect["size"];
 
   @property({ type: String })
@@ -93,7 +96,7 @@ export class SelectCrawlerProxy extends BtrixElement {
     return html`
       <sl-select
         name="proxyId"
-        label=${msg("Crawler Proxy Server")}
+        label=${this.label || msg("Crawler Proxy Server")}
         value=${this.selectedProxy?.id || ""}
         placeholder=${this.defaultProxy
           ? `${msg(`Default Proxy:`)} ${this.defaultProxy.label}`

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import type { SlSelect } from "@shoelace-style/shoelace";
-import { html } from "lit";
+import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -49,6 +49,12 @@ export class SelectCrawlerProxy extends BtrixElement {
   @property({ type: String })
   size?: SlSelect["size"];
 
+  @property({ type: String })
+  helpText?: string;
+
+  @property({ type: Boolean })
+  disabled?: boolean;
+
   @state()
   private selectedProxy?: Proxy;
 
@@ -57,6 +63,18 @@ export class SelectCrawlerProxy extends BtrixElement {
 
   public get value() {
     return this.selectedProxy?.id || "";
+  }
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("proxyId")) {
+      if (this.proxyId) {
+        this.selectedProxy = this.proxyServers.find(
+          ({ id }) => id === this.proxyId,
+        );
+      } else if (changedProperties.get("proxyId")) {
+        this.selectedProxy = undefined;
+      }
+    }
   }
 
   protected firstUpdated() {
@@ -82,6 +100,7 @@ export class SelectCrawlerProxy extends BtrixElement {
           : msg("No Proxy")}
         hoist
         clearable
+        ?disabled=${this.disabled}
         size=${ifDefined(this.size)}
         @sl-change=${this.onChange}
         @sl-hide=${this.stopProp}

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -40,6 +40,9 @@ export class SelectCrawlerProxy extends BtrixElement {
   @property({ type: String })
   defaultProxyId: string | null = null;
 
+  @property({ type: String })
+  profileProxyId?: string | null = null;
+
   @property({ type: Array })
   proxyServers: Proxy[] = [];
 
@@ -51,6 +54,9 @@ export class SelectCrawlerProxy extends BtrixElement {
 
   @property({ type: String })
   size?: SlSelect["size"];
+
+  @property({ type: String })
+  placeholder?: string;
 
   @property({ type: String })
   helpText?: string;
@@ -103,12 +109,14 @@ export class SelectCrawlerProxy extends BtrixElement {
           : msg("No Proxy")}
         hoist
         clearable
-        ?disabled=${this.disabled}
+        ?disabled=${this.disabled ?? Boolean(this.profileProxyId)}
         size=${ifDefined(this.size)}
         @sl-change=${this.onChange}
         @sl-hide=${this.stopProp}
         @sl-after-hide=${this.stopProp}
       >
+        <slot name="prefix" slot="prefix"></slot>
+        <slot name="suffix" slot="suffix"></slot>
         ${this.proxyServers.map(
           (server) =>
             html` <sl-option value=${server.id}>

--- a/frontend/src/components/ui/select-crawler-proxy.ts
+++ b/frontend/src/components/ui/select-crawler-proxy.ts
@@ -137,6 +137,7 @@ export class SelectCrawlerProxy extends BtrixElement {
               </div>
             `
           : ``}
+        <slot name="help-text" slot="help-text"></slot>
       </sl-select>
     `;
   }

--- a/frontend/src/controllers/localize.ts
+++ b/frontend/src/controllers/localize.ts
@@ -55,7 +55,11 @@ export class LocalizeController extends SlLocalizeController {
               })
             : seconds > 60
               ? html`<sl-relative-time
-                  class=${ifDefined(capitalize ? tw`capitalize` : undefined)}
+                  class=${ifDefined(
+                    capitalize
+                      ? tw`inline-block first-letter:capitalize`
+                      : undefined,
+                  )}
                   sync
                   date=${dateStr}
                 ></sl-relative-time>`

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -120,6 +120,7 @@ export class NewBrowserProfileDialog extends BtrixElement {
             ? html`
                 <div class="mt-4">
                   <btrix-select-crawler-proxy
+                    .label=${msg("Proxy Server")}
                     defaultProxyId=${ifDefined(
                       this.defaultProxyId || undefined,
                     )}
@@ -130,7 +131,7 @@ export class NewBrowserProfileDialog extends BtrixElement {
                   >
                     <div slot="help-text">
                       ${msg(
-                        "When a proxy is selected, websites will see traffic as coming from the IP address of the proxy rather than where the Browsertrix Crawler node is deployed.",
+                        "When a proxy is selected, websites will see traffic as coming from the IP address of the proxy rather than where Browsertrix is deployed.",
                       )}
                     </div>
                   </btrix-select-crawler-proxy>
@@ -144,16 +145,17 @@ export class NewBrowserProfileDialog extends BtrixElement {
             name="profile-name"
             placeholder=${msg("example.com")}
             value=${ifDefined(this.defaultUrl)}
-            help-text=${msg("Defaults to site's domain name if omitted.")}
+            help-text=${msg(
+              "Defaults to the primary site's domain name if omitted.",
+            )}
             maxlength="50"
           >
           </sl-input>
 
           ${showChannels
             ? html`<btrix-details class="mt-4">
-                <span slot="title">${msg("Crawler Settings")}</span>
+                <span slot="title">${msg("Browser Session Settings")}</span>
                 <div class="mt-4">
-                  <p>${msg("These settings will be applied")}</p>
                   <btrix-select-crawler
                     .crawlerChannel=${this.crawlerChannel}
                     @on-change=${(e: SelectCrawlerChangeEvent) =>

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -116,6 +116,28 @@ export class NewBrowserProfileDialog extends BtrixElement {
           >
           </btrix-url-input>
 
+          ${showProxies
+            ? html`
+                <div class="mt-4">
+                  <btrix-select-crawler-proxy
+                    defaultProxyId=${ifDefined(
+                      this.defaultProxyId || undefined,
+                    )}
+                    .proxyServers=${proxyServers}
+                    .proxyId="${this.proxyId || ""}"
+                    @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
+                      (this.proxyId = e.detail.value)}
+                  >
+                    <div slot="help-text">
+                      ${msg(
+                        "When a proxy is selected, websites will see traffic as coming from the IP address of the proxy rather than where the Browsertrix Crawler node is deployed.",
+                      )}
+                    </div>
+                  </btrix-select-crawler-proxy>
+                </div>
+              `
+            : nothing}
+
           <sl-input
             class="mt-4"
             label=${msg("Profile Name")}
@@ -127,39 +149,18 @@ export class NewBrowserProfileDialog extends BtrixElement {
           >
           </sl-input>
 
-          ${when(
-            showChannels || showProxies,
-            () => html`
-              <btrix-details class="mt-4" open>
+          ${showChannels
+            ? html`<btrix-details class="mt-4">
                 <span slot="title">${msg("Crawler Settings")}</span>
-
-                ${showChannels
-                  ? html`<div class="mt-4">
-                      <btrix-select-crawler
-                        .crawlerChannel=${this.crawlerChannel}
-                        @on-change=${(e: SelectCrawlerChangeEvent) =>
-                          (this.crawlerChannel = e.detail.value!)}
-                      ></btrix-select-crawler>
-                    </div>`
-                  : nothing}
-                ${showProxies
-                  ? html`
-                      <div class="mt-4">
-                        <btrix-select-crawler-proxy
-                          defaultProxyId=${ifDefined(
-                            this.defaultProxyId || undefined,
-                          )}
-                          .proxyServers=${proxyServers}
-                          .proxyId="${this.proxyId || ""}"
-                          @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
-                            (this.proxyId = e.detail.value)}
-                        ></btrix-select-crawler-proxy>
-                      </div>
-                    `
-                  : nothing}
-              </btrix-details>
-            `,
-          )}
+                <div class="mt-4">
+                  <p>${msg("These settings will be applied")}</p>
+                  <btrix-select-crawler
+                    .crawlerChannel=${this.crawlerChannel}
+                    @on-change=${(e: SelectCrawlerChangeEvent) =>
+                      (this.crawlerChannel = e.detail.value!)}
+                  ></btrix-select-crawler></div
+              ></btrix-details>`
+            : nothing}
 
           <input class="invisible block size-0" type="submit" />
         </form>

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -1,5 +1,9 @@
 import { localized, msg } from "@lit/localize";
-import type { SlDrawer, SlSelect } from "@shoelace-style/shoelace";
+import type {
+  SlChangeEvent,
+  SlDrawer,
+  SlSelect,
+} from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -119,6 +123,7 @@ export class SelectBrowserProfile extends BtrixElement {
                   ${this.localize.relativeDate(
                     this.selectedProfile.modified ||
                       this.selectedProfile.created,
+                    { capitalize: true },
                   )}
                 </span>
               `
@@ -188,6 +193,7 @@ export class SelectBrowserProfile extends BtrixElement {
             <btrix-desc-list-item label=${msg("Last Modified")}>
               ${this.localize.relativeDate(
                 modifiedByAnyDate || profile.created,
+                { capitalize: true },
               )}
             </btrix-desc-list-item>
           </btrix-desc-list>
@@ -279,7 +285,7 @@ export class SelectBrowserProfile extends BtrixElement {
     `;
   }
 
-  private async onChange(e: Event) {
+  private async onChange(e: SlChangeEvent) {
     this.selectedProfile = this.browserProfiles?.find(
       ({ id }) => id === (e.target as SlSelect | null)?.value,
     );

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -267,7 +267,7 @@ export class SelectBrowserProfile extends BtrixElement {
 
         <sl-divider class="my-5"></sl-divider>
 
-        ${pageHeading({ content: msg("Configured Sites"), level: 3 })}
+        ${pageHeading({ content: msg("Saved Sites"), level: 3 })}
         <section class="mt-5">
           ${profile.origins.length
             ? html`<ul class="divide-y rounded-lg border">

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -7,6 +7,7 @@ import orderBy from "lodash/fp/orderBy";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Profile } from "@/pages/org/types";
+import { OrgTab } from "@/routes";
 import type { APIPaginatedList } from "@/types/api";
 
 type SelectBrowserProfileChangeDetail = {
@@ -101,15 +102,11 @@ export class SelectBrowserProfile extends BtrixElement {
           ${this.selectedProfile
             ? html`
                 <span>
-                  ${msg("Last updated")}
-                  <btrix-format-date
-                    .date=${this.selectedProfile.modified}
-                    month="2-digit"
-                    day="2-digit"
-                    year="numeric"
-                    hour="2-digit"
-                    minute="2-digit"
-                  ></btrix-format-date>
+                  ${msg("Last modified")}
+                  ${this.localize.relativeDate(
+                    this.selectedProfile.modified ||
+                      this.selectedProfile.created,
+                  )}
                 </span>
                 ${this.selectedProfile.proxyId
                   ? html` <span>
@@ -117,25 +114,25 @@ export class SelectBrowserProfile extends BtrixElement {
                       <b>${this.selectedProfile.proxyId}</b>
                     </span>`
                   : ``}
-                <a
-                  class="flex items-center gap-1 text-blue-500 hover:text-blue-600"
-                  href=${`${this.navigate.orgBasePath}/browser-profiles/profile/${this.selectedProfile.id}`}
+                <btrix-link
+                  href="${this.navigate
+                    .orgBasePath}/${OrgTab.BrowserProfiles}/profile/${this
+                    .selectedProfile.id}"
                   target="_blank"
                 >
-                  ${msg("Check Profile")}
-                  <sl-icon name="box-arrow-up-right"></sl-icon>
-                </a>
+                  ${msg("View Browser Profile")}
+                </btrix-link>
               `
             : this.browserProfiles
               ? html`
-                  <a
-                    class="ml-auto flex items-center gap-1 text-blue-500 hover:text-blue-600"
-                    href=${`${this.navigate.orgBasePath}/browser-profiles`}
+                  <btrix-link
+                    class="ml-auto"
+                    href="${this.navigate
+                      .orgBasePath}/${OrgTab.BrowserProfiles}"
                     target="_blank"
                   >
-                    ${msg("View Profiles")}
-                    <sl-icon name="box-arrow-up-right"></sl-icon>
-                  </a>
+                    ${msg("View Browser Profiles")}
+                  </btrix-link>
                 `
               : nothing}
         </div>

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -59,6 +59,9 @@ export class SelectBrowserProfile extends BtrixElement {
   @property({ type: String })
   profileId?: string;
 
+  @property({ type: String })
+  profileName?: string;
+
   @state()
   selectedProfile?: Profile;
 
@@ -103,11 +106,12 @@ export class SelectBrowserProfile extends BtrixElement {
   render() {
     const selectedProfile = this.selectedProfile;
     const browserProfiles = this.profilesTask.value;
+    const loading = !browserProfiles && !this.profileName;
 
     return html`
       <sl-select
         label=${msg("Browser Profile")}
-        value=${selectedProfile?.id || ""}
+        value=${this.profileId || selectedProfile?.id || ""}
         placeholder=${browserProfiles
           ? msg("No custom profile")
           : msg("Loading")}
@@ -118,15 +122,7 @@ export class SelectBrowserProfile extends BtrixElement {
         @sl-hide=${this.stopProp}
         @sl-after-hide=${this.stopProp}
       >
-        ${when(
-          selectedProfile?.proxyId,
-          (proxyId) => html`
-            <btrix-proxy-badge
-              slot="suffix"
-              proxyId=${proxyId}
-            ></btrix-proxy-badge>
-          `,
-        )}
+        ${loading ? html`<sl-spinner slot="prefix"></sl-spinner>` : nothing}
         ${browserProfiles
           ? html`
               <sl-option value="">${msg("No custom profile")}</sl-option>
@@ -137,7 +133,11 @@ export class SelectBrowserProfile extends BtrixElement {
                   `
                 : nothing}
             `
-          : html` <sl-spinner slot="prefix"></sl-spinner> `}
+          : this.profileName
+            ? html`<sl-option value=${ifDefined(this.profileId)}>
+                ${this.profileName}
+              </sl-option>`
+            : nothing}
         ${browserProfiles?.items.map(
           (profile, i) => html`
             <btrix-popover

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -10,8 +10,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import orderBy from "lodash/fp/orderBy";
 
-import { channelBadge, proxyBadge } from "./templates/badges";
-
 import { BtrixElement } from "@/classes/BtrixElement";
 import { none } from "@/layouts/empty";
 import { pageHeading } from "@/layouts/page";
@@ -178,15 +176,16 @@ export class SelectBrowserProfile extends BtrixElement {
                 : none}
             </btrix-desc-list-item>
             <btrix-desc-list-item label=${msg("Crawler Channel")}>
-              ${channelBadge(
-                profile.crawlerChannel || CrawlerChannelImage.Default,
-              )}
+              <btrix-crawler-channel-badge
+                channelId=${profile.crawlerChannel ||
+                CrawlerChannelImage.Default}
+              ></btrix-crawler-channel-badge>
             </btrix-desc-list-item>
             ${when(
               profile.proxyId,
-              (proxy) => html`
+              (proxyId) => html`
                 <btrix-desc-list-item label=${msg("Proxy")}>
-                  ${proxyBadge(proxy)}
+                  <btrix-proxy-badge proxyId=${proxyId}></btrix-proxy-badge>
                 </btrix-desc-list-item>
               `,
             )}

--- a/frontend/src/features/browser-profiles/start-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/start-browser-dialog.ts
@@ -310,7 +310,7 @@ export class StartBrowserDialog extends BtrixElement {
                 <sl-menu-label
                   >${msg("Suggestions from Related Workflows")}</sl-menu-label
                 >
-                ${seeds.map(option)}
+                ${seeds.slice(0, 10).map(option)}
               `
             : nothing,
         )}

--- a/frontend/src/features/browser-profiles/start-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/start-browser-dialog.ts
@@ -223,7 +223,7 @@ export class StartBrowserDialog extends BtrixElement {
                   name="exclamation-triangle"
                 ></sl-icon>
                 ${msg(
-                  "Data, proxy settings, and browsing activity of all previously saved sites will be removed upon saving this browser profile session.",
+                  "Data and browsing activity of all previously saved sites will be removed upon saving this browser profile session.",
                 )}
               </div>
             `,

--- a/frontend/src/features/browser-profiles/start-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/start-browser-dialog.ts
@@ -223,48 +223,39 @@ export class StartBrowserDialog extends BtrixElement {
                   name="exclamation-triangle"
                 ></sl-icon>
                 ${msg(
-                  "Data and browsing activity of all previously saved sites will be removed upon saving this browser profile session.",
+                  "Data, proxy settings, and browsing activity of all previously saved sites will be removed upon saving this browser profile session.",
                 )}
               </div>
             `,
           )}
         </sl-checkbox>
 
-        ${when(
-          this.open && (showChannels || showProxies),
-          () => html`
-            <btrix-details
-              class="mt-4"
-              ?open=${this.details?.open || this.replaceBrowser}
-            >
+        ${showProxies
+          ? html`<div class="mt-4">
+              <btrix-select-crawler-proxy
+                defaultProxyId=${ifDefined(
+                  this.org?.crawlingDefaults?.profileid ||
+                    proxies.default_proxy_id ||
+                    undefined,
+                )}
+                .proxyServers=${proxyServers}
+                .proxyId=${profile.proxyId || ""}
+              >
+              </btrix-select-crawler-proxy>
+            </div>`
+          : nothing}
+        ${this.open && showChannels
+          ? html`<btrix-details class="mt-4" ?open=${this.details?.open}>
               <span slot="title">${msg("Crawler Settings")}</span>
-
-              ${showChannels
-                ? html`<div class="mt-4">
-                    <btrix-select-crawler
-                      .crawlerChannel=${profile.crawlerChannel ||
-                      this.org?.crawlingDefaults?.crawlerChannel}
-                    >
-                    </btrix-select-crawler>
-                  </div>`
-                : nothing}
-              ${showProxies
-                ? html`<div class="mt-4">
-                    <btrix-select-crawler-proxy
-                      defaultProxyId=${ifDefined(
-                        this.org?.crawlingDefaults?.profileid ||
-                          proxies.default_proxy_id ||
-                          undefined,
-                      )}
-                      .proxyServers=${proxyServers}
-                      .proxyId=${profile.proxyId || ""}
-                    >
-                    </btrix-select-crawler-proxy>
-                  </div>`
-                : nothing}
-            </btrix-details>
-          `,
-        )}
+              <div class="mt-4">
+                <btrix-select-crawler
+                  .crawlerChannel=${profile.crawlerChannel ||
+                  this.org?.crawlingDefaults?.crawlerChannel}
+                >
+                </btrix-select-crawler>
+              </div>
+            </btrix-details>`
+          : nothing}
       </form>
       <div slot="footer" class="flex justify-between">
         <sl-button size="small" @click=${() => void this.dialog?.hide()}

--- a/frontend/src/features/browser-profiles/start-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/start-browser-dialog.ts
@@ -233,6 +233,7 @@ export class StartBrowserDialog extends BtrixElement {
         ${showProxies
           ? html`<div class="mt-4">
               <btrix-select-crawler-proxy
+                .label=${msg("Proxy Server")}
                 defaultProxyId=${ifDefined(
                   this.org?.crawlingDefaults?.profileid ||
                     proxies.default_proxy_id ||
@@ -246,7 +247,7 @@ export class StartBrowserDialog extends BtrixElement {
           : nothing}
         ${this.open && showChannels
           ? html`<btrix-details class="mt-4" ?open=${this.details?.open}>
-              <span slot="title">${msg("Crawler Settings")}</span>
+              <span slot="title">${msg("Browser Session Settings")}</span>
               <div class="mt-4">
                 <btrix-select-crawler
                   .crawlerChannel=${profile.crawlerChannel ||

--- a/frontend/src/features/browser-profiles/templates/badges.ts
+++ b/frontend/src/features/browser-profiles/templates/badges.ts
@@ -1,12 +1,15 @@
 import { msg } from "@lit/localize";
 import { html, nothing } from "lit";
 import { when } from "lit/directives/when.js";
-import capitalize from "lodash/fp/capitalize";
 
-import { CrawlerChannelImage, type Profile } from "@/types/crawler";
+import { type Profile } from "@/types/crawler";
 
 export const usageBadge = (inUse: boolean) =>
-  html`<sl-tooltip content=${msg("Crawl Workflow Usage")}>
+  html`<sl-tooltip
+    content="${msg("Crawl Workflow Usage")}: ${inUse
+      ? msg("In Use")
+      : msg("Not In Use")}"
+  >
     <btrix-badge variant=${inUse ? "cyan" : "neutral"} class="font-monostyle">
       <sl-icon
         name=${inUse ? "check-circle" : "dash-circle"}
@@ -16,32 +19,25 @@ export const usageBadge = (inUse: boolean) =>
     </btrix-badge>
   </sl-tooltip>`;
 
-export const channelBadge = (channel: CrawlerChannelImage | AnyString) =>
-  html`<sl-tooltip content=${msg("Crawler Release Channel")}>
-    <btrix-badge
-      variant=${channel === CrawlerChannelImage.Default ? "neutral" : "blue"}
-      class="font-monostyle"
-    >
-      <sl-icon name="boxes" class="mr-1.5"></sl-icon>
-      ${capitalize(channel)}
-    </btrix-badge>
-  </sl-tooltip>`;
-
-export const proxyBadge = (proxy: string) =>
-  html`<sl-tooltip content=${msg("Crawler Proxy Server")}>
-    <btrix-badge variant="blue" class="font-monostyle">
-      <sl-icon name="globe2" class="mr-1.5"></sl-icon>
-      ${proxy}
-    </btrix-badge>
-  </sl-tooltip>`;
-
 export const badges = (
   profile: Partial<Pick<Profile, "inUse" | "crawlerChannel" | "proxyId">>,
 ) => {
   return html`<div class="flex flex-wrap gap-3 whitespace-nowrap">
     ${profile.inUse === undefined ? nothing : usageBadge(profile.inUse)}
-    ${when(profile.crawlerChannel, channelBadge)}
-    ${when(profile.proxyId, proxyBadge)}
+    ${when(
+      profile.crawlerChannel,
+      (channelImage) => html`
+        <btrix-crawler-channel-badge
+          channelId=${channelImage}
+        ></btrix-crawler-channel-badge>
+      `,
+    )}
+    ${when(
+      profile.proxyId,
+      (proxyId) => html`
+        <btrix-proxy-badge proxyId=${proxyId}></btrix-proxy-badge>
+      `,
+    )}
   </div> `;
 };
 

--- a/frontend/src/features/browser-profiles/templates/badges.ts
+++ b/frontend/src/features/browser-profiles/templates/badges.ts
@@ -16,36 +16,32 @@ export const usageBadge = (inUse: boolean) =>
     </btrix-badge>
   </sl-tooltip>`;
 
+export const channelBadge = (channel: CrawlerChannelImage | AnyString) =>
+  html`<sl-tooltip content=${msg("Crawler Release Channel")}>
+    <btrix-badge
+      variant=${channel === CrawlerChannelImage.Default ? "neutral" : "blue"}
+      class="font-monostyle"
+    >
+      <sl-icon name="boxes" class="mr-1.5"></sl-icon>
+      ${capitalize(channel)}
+    </btrix-badge>
+  </sl-tooltip>`;
+
+export const proxyBadge = (proxy: string) =>
+  html`<sl-tooltip content=${msg("Crawler Proxy Server")}>
+    <btrix-badge variant="blue" class="font-monostyle">
+      <sl-icon name="globe2" class="mr-1.5"></sl-icon>
+      ${proxy}
+    </btrix-badge>
+  </sl-tooltip>`;
+
 export const badges = (
   profile: Partial<Pick<Profile, "inUse" | "crawlerChannel" | "proxyId">>,
 ) => {
   return html`<div class="flex flex-wrap gap-3 whitespace-nowrap">
     ${profile.inUse === undefined ? nothing : usageBadge(profile.inUse)}
-    ${when(
-      profile.crawlerChannel,
-      (channel) =>
-        html`<sl-tooltip content=${msg("Crawler Release Channel")}>
-          <btrix-badge
-            variant=${channel === CrawlerChannelImage.Default
-              ? "neutral"
-              : "blue"}
-            class="font-monostyle"
-          >
-            <sl-icon name="boxes" class="mr-1.5"></sl-icon>
-            ${capitalize(channel)}
-          </btrix-badge>
-        </sl-tooltip>`,
-    )}
-    ${when(
-      profile.proxyId,
-      (proxy) =>
-        html`<sl-tooltip content=${msg("Crawler Proxy Server")}>
-          <btrix-badge variant="blue" class="font-monostyle">
-            <sl-icon name="globe2" class="mr-1.5"></sl-icon>
-            ${proxy}
-          </btrix-badge>
-        </sl-tooltip>`,
-    )}
+    ${when(profile.crawlerChannel, channelBadge)}
+    ${when(profile.proxyId, proxyBadge)}
   </div> `;
 };
 

--- a/frontend/src/features/browser-profiles/templates/badges.ts
+++ b/frontend/src/features/browser-profiles/templates/badges.ts
@@ -6,9 +6,9 @@ import { type Profile } from "@/types/crawler";
 
 export const usageBadge = (inUse: boolean) =>
   html`<sl-tooltip
-    content="${msg("Crawl Workflow Usage")}: ${inUse
-      ? msg("In Use")
-      : msg("Not In Use")}"
+    content=${inUse
+      ? msg("In Use by Crawl Workflow")
+      : msg("Not In Use by Crawl Workflow")}
   >
     <btrix-badge variant=${inUse ? "cyan" : "neutral"} class="font-monostyle">
       <sl-icon

--- a/frontend/src/features/browser-profiles/templates/origins-with-remainder.ts
+++ b/frontend/src/features/browser-profiles/templates/origins-with-remainder.ts
@@ -1,0 +1,39 @@
+import { html, nothing } from "lit";
+
+import type { Profile } from "@/types/crawler";
+import localize from "@/utils/localize";
+
+/**
+ * Displays primary origin with remainder in a popover badge
+ */
+export function originsWithRemainder(
+  origins: Profile["origins"],
+  { disablePopover } = { disablePopover: false },
+) {
+  const startingUrl = origins[0];
+  const otherOrigins = origins.slice(1);
+
+  return html`<div class="flex w-full items-center overflow-hidden">
+    <btrix-code
+      class="w-0 min-w-[10ch] max-w-min flex-1"
+      language="url"
+      value=${startingUrl}
+      noWrap
+      truncate
+    ></btrix-code>
+    ${otherOrigins.length
+      ? html`
+          <btrix-popover placement="right" hoist ?disabled=${disablePopover}>
+            <btrix-badge
+              variant=${disablePopover ? "text-neutral" : "text"}
+              size="large"
+              >+${localize.number(otherOrigins.length)}</btrix-badge
+            >
+            <ul slot="content">
+              ${otherOrigins.map((url) => html`<li>${url}</li>`)}
+            </ul>
+          </btrix-popover>
+        `
+      : nothing}
+  </div>`;
+}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -34,6 +34,7 @@ import {
   state,
 } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
+import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
 import { when } from "lit/directives/when.js";
@@ -1999,11 +2000,37 @@ https://archiveweb.page/images/${"logo.svg"}`}
       profile?.proxyId ||
       this.formState.proxyId;
 
+    const priorityOrigins = () => {
+      if (!this.formState.urlList && !this.formState.primarySeedUrl) {
+        return [];
+      }
+
+      const crawlUrls = urlListToArray(this.formState.urlList);
+
+      if (this.formState.primarySeedUrl) {
+        crawlUrls.unshift(this.formState.primarySeedUrl);
+      }
+
+      return crawlUrls
+        .map((url) => {
+          try {
+            return new URL(url).hostname.replace(/^www\./, "");
+          } catch {
+            return "";
+          }
+        })
+        .filter((url) => url);
+    };
+
     return html`
       ${inputCol(html`
         <btrix-select-browser-profile
           .profileId=${this.formState.browserProfile?.id}
           .profileName=${this.formState.browserProfile?.name}
+          .suggestOrigins=${guard(
+            [this.formState.primarySeedUrl, this.formState.urlList],
+            priorityOrigins,
+          )}
           @on-change=${(e: SelectBrowserProfileChangeEvent) => {
             const profile = e.detail.value;
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2050,11 +2050,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
                 .proxyServers=${proxies.servers}
                 .proxyId=${profileProxyId || this.formState.proxyId || ""}
                 .profileProxyId=${profileProxyId}
-                title=${ifDefined(
-                  this.formState.browserProfile
-                    ? msg("Disabled by browser profile")
-                    : undefined,
-                )}
                 @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                   this.updateFormState({
                     proxyId: e.detail.value,
@@ -2066,7 +2061,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
                     <span
                       slot="suffix"
                       class="whitespace-nowrap text-neutral-1000"
-                      >${msg("Same as browser profile")}</span
+                      >${msg("Set by profile")}</span
                     >
                   `,
                 )}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -644,8 +644,8 @@ export class WorkflowEditor extends BtrixElement {
         class=${clsx(
           tw`part-[base]:rounded-lg part-[base]:border part-[base]:transition-shadow part-[base]:focus:shadow`,
           tw`part-[content]:pb-8 part-[content]:[border-top:solid_1px_var(--sl-panel-border-color)]`,
-          tw`part-[header]:p-0 part-[header]:text-neutral-500 part-[header]:hover:text-blue-400`,
-          tw`part-[summary-icon]:mx-4 part-[summary-icon]:[rotate:none]`,
+          tw`part-[header]:text-neutral-500 part-[header]:hover:text-blue-400`,
+          tw`part-[summary-icon]:[rotate:none]`,
           hasError &&
             tw`part-[header]:cursor-default part-[summary-icon]:cursor-not-allowed part-[summary-icon]:text-neutral-400`,
         )}
@@ -746,7 +746,7 @@ export class WorkflowEditor extends BtrixElement {
         </div>
 
         <p
-          class="w-full cursor-default px-4 py-3 text-neutral-700"
+          class="cursor-text select-text text-neutral-700"
           slot="summary"
           @click=${(e: MouseEvent) => {
             // Decrease click target size of details header

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -644,8 +644,8 @@ export class WorkflowEditor extends BtrixElement {
         class=${clsx(
           tw`part-[base]:rounded-lg part-[base]:border part-[base]:transition-shadow part-[base]:focus:shadow`,
           tw`part-[content]:pb-8 part-[content]:[border-top:solid_1px_var(--sl-panel-border-color)]`,
-          tw`part-[header]:text-neutral-500 part-[header]:hover:text-blue-400`,
-          tw`part-[summary-icon]:[rotate:none]`,
+          tw`part-[header]:p-0 part-[header]:text-neutral-500 part-[header]:hover:text-blue-400`,
+          tw`part-[summary-icon]:mx-4 part-[summary-icon]:[rotate:none]`,
           hasError &&
             tw`part-[header]:cursor-default part-[summary-icon]:cursor-not-allowed part-[summary-icon]:text-neutral-400`,
         )}
@@ -745,7 +745,17 @@ export class WorkflowEditor extends BtrixElement {
           )}
         </div>
 
-        <p class="text-neutral-700" slot="summary">${desc}</p>
+        <p
+          class="cursor-default px-4 py-3 text-neutral-700"
+          slot="summary"
+          @click=${(e: MouseEvent) => {
+            // Decrease click target size of details header
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          ${desc}
+        </p>
         <div class="grid grid-cols-5 gap-5">${render.bind(this)()}</div>
       </sl-details>`;
     };

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1994,11 +1994,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
     if (!this.formState.lang) throw new Error("missing formstate.lang");
 
     const proxies = this.proxies;
-    const profile = this.profileTask.value;
-    const selectedProxyId =
+    const profileProxyId =
       this.formState.browserProfile?.proxyId ||
-      profile?.proxyId ||
-      this.formState.proxyId;
+      (this.formState.browserProfile?.id && this.formState.proxyId);
 
     const priorityOrigins = () => {
       if (!this.formState.urlList && !this.formState.primarySeedUrl) {
@@ -2050,25 +2048,29 @@ https://archiveweb.page/images/${"logo.svg"}`}
                   proxies.default_proxy_id ?? undefined,
                 )}
                 .proxyServers=${proxies.servers}
-                .proxyId=${selectedProxyId || ""}
-                ?disabled=${!!this.formState.browserProfile}
+                .proxyId=${profileProxyId || this.formState.proxyId || ""}
+                .profileProxyId=${profileProxyId}
+                title=${ifDefined(
+                  this.formState.browserProfile
+                    ? msg("Disabled by browser profile")
+                    : undefined,
+                )}
                 @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                   this.updateFormState({
                     proxyId: e.detail.value,
                   })}
-              ></btrix-select-crawler-proxy>
-              ${when(
-                this.formState.browserProfile,
-                () => html`
-                  <div class="form-help-text">
-                    <sl-icon
-                      class="mr-0.5 align-[-.175em]"
-                      name="info-circle"
-                    ></sl-icon>
-                    ${msg("Using browser profile proxy settings.")}
-                  </div>
-                `,
-              )}
+              >
+                ${when(
+                  profileProxyId,
+                  () => html`
+                    <span
+                      slot="suffix"
+                      class="whitespace-nowrap text-neutral-1000"
+                      >${msg("Same as browser profile")}</span
+                    >
+                  `,
+                )}
+              </btrix-select-crawler-proxy>
             `),
             this.renderHelpTextCol(infoTextFor["proxyId"]),
           ]

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -745,17 +745,7 @@ export class WorkflowEditor extends BtrixElement {
           )}
         </div>
 
-        <p
-          class="cursor-text select-text text-neutral-700"
-          slot="summary"
-          @click=${(e: MouseEvent) => {
-            // Decrease click target size of details header
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          ${desc}
-        </p>
+        <p class="text-neutral-700" slot="summary">${desc}</p>
         <div class="grid grid-cols-5 gap-5">${render.bind(this)()}</div>
       </sl-details>`;
     };
@@ -2003,16 +1993,17 @@ https://archiveweb.page/images/${"logo.svg"}`}
     if (!this.formState.lang) throw new Error("missing formstate.lang");
 
     const proxies = this.proxies;
-    const selectedProfile = this.profileTask.value;
+    const profile = this.profileTask.value;
     const selectedProxyId =
       this.formState.browserProfile?.proxyId ||
-      selectedProfile?.proxyId ||
+      profile?.proxyId ||
       this.formState.proxyId;
 
     return html`
       ${inputCol(html`
         <btrix-select-browser-profile
           .profileId=${this.formState.browserProfile?.id}
+          .profileName=${this.formState.browserProfile?.name}
           @on-change=${(e: SelectBrowserProfileChangeEvent) => {
             const profile = e.detail.value;
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1987,10 +1987,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
       ${inputCol(html`
         <btrix-select-browser-profile
           .profileId=${this.formState.browserProfile?.id}
-          @on-change=${(e: SelectBrowserProfileChangeEvent) =>
+          @on-change=${(e: SelectBrowserProfileChangeEvent) => {
+            const profile = e.detail.value;
+
             this.updateFormState({
-              browserProfile: e.detail.value ?? null,
-            })}
+              browserProfile: profile ?? null,
+              proxyId: profile?.proxyId ?? null,
+            });
+          }}
         ></btrix-select-browser-profile>
       `)}
       ${this.renderHelpTextCol(infoTextFor["browserProfile"])}
@@ -2003,11 +2007,24 @@ https://archiveweb.page/images/${"logo.svg"}`}
                 )}
                 .proxyServers=${proxies.servers}
                 .proxyId="${this.formState.proxyId || ""}"
+                ?disabled=${!!this.formState.browserProfile}
                 @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                   this.updateFormState({
                     proxyId: e.detail.value,
                   })}
               ></btrix-select-crawler-proxy>
+              ${when(
+                this.formState.browserProfile,
+                () => html`
+                  <div class="form-help-text">
+                    <sl-icon
+                      class="mr-0.5 align-[-.175em]"
+                      name="info-circle"
+                    ></sl-icon>
+                    ${msg("Using proxy from browser profile.")}
+                  </div>
+                `,
+              )}
             `),
             this.renderHelpTextCol(infoTextFor["proxyId"]),
           ]

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -746,7 +746,7 @@ export class WorkflowEditor extends BtrixElement {
         </div>
 
         <p
-          class="cursor-default px-4 py-3 text-neutral-700"
+          class="w-full cursor-default px-4 py-3 text-neutral-700"
           slot="summary"
           @click=${(e: MouseEvent) => {
             // Decrease click target size of details header

--- a/frontend/src/features/crawls/crawler-channel-badge.ts
+++ b/frontend/src/features/crawls/crawler-channel-badge.ts
@@ -1,0 +1,46 @@
+import { consume } from "@lit/context";
+import { localized, msg } from "@lit/localize";
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import {
+  orgCrawlerChannelsContext,
+  type OrgCrawlerChannelsContext,
+} from "@/context/org-crawler-channels";
+import { CrawlerChannelImage } from "@/types/crawler";
+
+@customElement("btrix-crawler-channel-badge")
+@localized()
+export class CrawlerChannelBadge extends TailwindElement {
+  @consume({ context: orgCrawlerChannelsContext, subscribe: true })
+  private readonly crawlerChannels?: OrgCrawlerChannelsContext;
+
+  @property({ type: String })
+  channelId?: CrawlerChannelImage | AnyString;
+
+  render() {
+    if (!this.channelId || !this.crawlerChannels) return;
+
+    const crawlerChannel = this.crawlerChannels.find(
+      ({ id }) => id === this.channelId,
+    );
+
+    return html`<sl-tooltip
+      content="${msg("Crawler Release Channel")}${crawlerChannel
+        ? `: ${crawlerChannel.image}`
+        : ""}"
+      hoist
+    >
+      <btrix-badge
+        variant=${this.channelId === CrawlerChannelImage.Default
+          ? "neutral"
+          : "blue"}
+        class="font-monostyle"
+      >
+        <sl-icon name="boxes" class="mr-1.5"></sl-icon>
+        <span class="capitalize">${this.channelId}</span>
+      </btrix-badge>
+    </sl-tooltip>`;
+  }
+}

--- a/frontend/src/features/crawls/crawler-channel-badge.ts
+++ b/frontend/src/features/crawls/crawler-channel-badge.ts
@@ -36,7 +36,7 @@ export class CrawlerChannelBadge extends TailwindElement {
         variant=${this.channelId === CrawlerChannelImage.Default
           ? "neutral"
           : "blue"}
-        class="font-monostyle"
+        class="font-monostyle whitespace-nowrap"
       >
         <sl-icon name="boxes" class="mr-1.5"></sl-icon>
         <span class="capitalize">${this.channelId}</span>

--- a/frontend/src/features/crawls/crawler-channel-badge.ts
+++ b/frontend/src/features/crawls/crawler-channel-badge.ts
@@ -1,7 +1,8 @@
 import { consume } from "@lit/context";
-import { localized, msg } from "@lit/localize";
+import { localized } from "@lit/localize";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import {
@@ -26,10 +27,9 @@ export class CrawlerChannelBadge extends TailwindElement {
       ({ id }) => id === this.channelId,
     );
 
-    return html`<sl-tooltip
-      content="${msg("Crawler Release Channel")}${crawlerChannel
-        ? `: ${crawlerChannel.image}`
-        : ""}"
+    return html`<btrix-popover
+      content=${ifDefined(crawlerChannel?.image)}
+      ?disabled=${!crawlerChannel?.image}
       hoist
     >
       <btrix-badge
@@ -41,6 +41,6 @@ export class CrawlerChannelBadge extends TailwindElement {
         <sl-icon name="boxes" class="mr-1.5"></sl-icon>
         <span class="capitalize">${this.channelId}</span>
       </btrix-badge>
-    </sl-tooltip>`;
+    </btrix-popover>`;
   }
 }

--- a/frontend/src/features/crawls/index.ts
+++ b/frontend/src/features/crawls/index.ts
@@ -1,2 +1,4 @@
 import("./crawl-list");
 import("./crawl-state-filter");
+import("./crawler-channel-badge");
+import("./proxy-badge");

--- a/frontend/src/features/crawls/proxy-badge.ts
+++ b/frontend/src/features/crawls/proxy-badge.ts
@@ -29,7 +29,7 @@ export class ProxyBadge extends TailwindElement {
         : ""}"
       hoist
     >
-      <btrix-badge variant="blue" class="font-monostyle">
+      <btrix-badge variant="blue" class="font-monostyle whitespace-nowrap">
         <sl-icon name="globe2" class="mr-1.5"></sl-icon>
         ${proxy?.label || this.proxyId}
       </btrix-badge>

--- a/frontend/src/features/crawls/proxy-badge.ts
+++ b/frontend/src/features/crawls/proxy-badge.ts
@@ -1,0 +1,38 @@
+import { consume } from "@lit/context";
+import { localized, msg } from "@lit/localize";
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import {
+  orgProxiesContext,
+  type OrgProxiesContext,
+} from "@/context/org-proxies";
+
+@customElement("btrix-proxy-badge")
+@localized()
+export class ProxyBadge extends TailwindElement {
+  @consume({ context: orgProxiesContext, subscribe: true })
+  private readonly orgProxies?: OrgProxiesContext;
+
+  @property({ type: String })
+  proxyId?: string;
+
+  render() {
+    if (!this.proxyId || !this.orgProxies) return;
+
+    const proxy = this.orgProxies.servers.find(({ id }) => id === this.proxyId);
+
+    return html`<sl-tooltip
+      content="${msg("Crawler Proxy Server")}${proxy
+        ? `: ${proxy.description}`
+        : ""}"
+      hoist
+    >
+      <btrix-badge variant="blue" class="font-monostyle">
+        <sl-icon name="globe2" class="mr-1.5"></sl-icon>
+        ${proxy?.label || this.proxyId}
+      </btrix-badge>
+    </sl-tooltip>`;
+  }
+}

--- a/frontend/src/features/crawls/proxy-badge.ts
+++ b/frontend/src/features/crawls/proxy-badge.ts
@@ -1,7 +1,8 @@
 import { consume } from "@lit/context";
-import { localized, msg } from "@lit/localize";
+import { localized } from "@lit/localize";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
 import {
@@ -23,16 +24,15 @@ export class ProxyBadge extends TailwindElement {
 
     const proxy = this.orgProxies.servers.find(({ id }) => id === this.proxyId);
 
-    return html`<sl-tooltip
-      content="${msg("Crawler Proxy Server")}${proxy
-        ? `: ${proxy.description}`
-        : ""}"
+    return html`<btrix-popover
+      content=${ifDefined(proxy?.description || undefined)}
+      ?disabled=${!proxy?.description}
       hoist
     >
       <btrix-badge variant="blue" class="font-monostyle whitespace-nowrap">
         <sl-icon name="globe2" class="mr-1.5"></sl-icon>
         ${proxy?.label || this.proxyId}
       </btrix-badge>
-    </sl-tooltip>`;
+    </btrix-popover>`;
   }
 }

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -497,7 +497,7 @@ export class BrowserProfilesList extends BtrixElement {
           <btrix-table-header-cell>${msg("Name")}</btrix-table-header-cell>
           <btrix-table-header-cell> ${msg("Tags")} </btrix-table-header-cell>
           <btrix-table-header-cell>
-            ${msg("Configured Sites")}
+            ${msg("Saved Sites")}
           </btrix-table-header-cell>
           <btrix-table-header-cell>
             ${msg("Last Modified")}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -564,7 +564,7 @@ export class BrowserProfilesList extends BtrixElement {
             : nothing}
         </btrix-table-cell>
         <btrix-table-cell>
-          ${this.localize.relativeDate(modifiedByAnyDate)}
+          ${this.localize.relativeDate(modifiedByAnyDate, { capitalize: true })}
         </btrix-table-cell>
         <btrix-table-cell class="p-0">
           ${this.renderActions(data)}

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import { Task } from "@lit/task";
-import { html, nothing, type PropertyValues } from "lit";
+import { html, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
@@ -18,6 +18,7 @@ import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import type { BtrixChangeTagFilterEvent } from "@/components/ui/tag-filter/types";
 import { ClipboardController } from "@/controllers/clipboard";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
+import { originsWithRemainder } from "@/features/browser-profiles/templates/origins-with-remainder";
 import { emptyMessage } from "@/layouts/emptyMessage";
 import { page } from "@/layouts/page";
 import { OrgTab } from "@/routes";
@@ -71,7 +72,7 @@ const columnsCss = [
   "min-content", // Status
   "[clickable-start] minmax(min-content, 1fr)", // Name
   "30ch", // Tags
-  "minmax(max-content, 1fr)", // Origins
+  "40ch", // Origins
   "minmax(min-content, 20ch)", // Last modified
   "[clickable-end] min-content", // Actions
 ].join(" ");
@@ -520,8 +521,6 @@ export class BrowserProfilesList extends BtrixElement {
         (a, b) => (b && a && b > a ? b : a),
         data.created,
       ) || data.created;
-    const startingUrl = data.origins[0];
-    const otherOrigins = data.origins.slice(1);
 
     return html`
       <btrix-table-row
@@ -550,18 +549,8 @@ export class BrowserProfilesList extends BtrixElement {
           <btrix-tag-container class="relative hover:z-[2]" .tags=${data.tags}>
           </btrix-tag-container>
         </btrix-table-cell>
-        <btrix-table-cell class="[--btrix-table-cell-gap:0]">
-          <btrix-code language="url" value=${startingUrl} noWrap></btrix-code>
-          ${otherOrigins.length
-            ? html`<btrix-popover placement="right" hoist>
-                <btrix-badge variant="text" size="large"
-                  >+${this.localize.number(otherOrigins.length)}</btrix-badge
-                >
-                <ul slot="content">
-                  ${otherOrigins.map((url) => html`<li>${url}</li>`)}
-                </ul>
-              </btrix-popover>`
-            : nothing}
+        <btrix-table-cell>
+          ${originsWithRemainder(data.origins)}
         </btrix-table-cell>
         <btrix-table-cell>
           ${this.localize.relativeDate(modifiedByAnyDate, { capitalize: true })}

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -468,7 +468,9 @@ export class BrowserProfilesProfilePage extends BtrixElement {
           </btrix-desc-list-item>
           <btrix-desc-list-item label=${msg("Last Modified")}>
             ${this.renderDetail((profile) =>
-              this.localize.relativeDate(modifiedByAnyDate || profile.created),
+              this.localize.relativeDate(modifiedByAnyDate || profile.created, {
+                capitalize: true,
+              }),
             )}
           </btrix-desc-list-item>
           <btrix-desc-list-item label=${msg("Last Modified By")}>

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -309,7 +309,7 @@ export class BrowserProfilesProfilePage extends BtrixElement {
     const archivingDisabled = isArchivingDisabled(this.org);
 
     return panel({
-      heading: msg("Configured Sites"),
+      heading: msg("Saved Sites"),
       actions: this.appState.isCrawler
         ? html`
             <sl-button

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -364,10 +364,11 @@ export class BrowserProfilesProfilePage extends BtrixElement {
                 <sl-icon name="window" class="mx-2 block"></sl-icon>
               </sl-tooltip>
               <btrix-code
-                class="block flex-1 truncate"
+                class="block flex-1"
                 language="url"
                 value=${origin}
-                nowrap
+                noWrap
+                truncate
               ></btrix-code>
             </button>
 

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -493,7 +493,7 @@ export class Org extends BtrixElement {
               .proxyServers=${proxies.servers}
               .crawlerChannels=${crawlerChannels}
               defaultProxyId=${ifDefined(
-                org.crawlingDefaults?.profileid ||
+                org.crawlingDefaults?.proxyId ||
                   proxies.default_proxy_id ||
                   undefined,
               )}

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -20,6 +20,7 @@ import {
   orgProxiesContext,
   type OrgProxiesContext,
 } from "@/context/org-proxies";
+import type { SelectBrowserProfile } from "@/features/browser-profiles/select-browser-profile";
 import type { CustomBehaviorsTable } from "@/features/crawl-workflows/custom-behaviors-table";
 import type { QueueExclusionTable } from "@/features/crawl-workflows/queue-exclusion-table";
 import { columns, type Cols } from "@/layouts/columns";
@@ -78,6 +79,9 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
 
   @query("btrix-language-select")
   languageSelect?: LanguageSelect | null;
+
+  @query("btrix-select-browser-profile")
+  browserProfileSelect?: SelectBrowserProfile | null;
 
   @query("btrix-select-crawler-proxy")
   proxySelect?: SelectCrawlerProxy | null;
@@ -362,7 +366,7 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
       behaviorTimeout: parseNumber(values.behaviorTimeoutSeconds),
       pageExtraDelay: parseNumber(values.pageExtraDelaySeconds),
       blockAds: values.blockAds === "on",
-      profileid: values.profileid,
+      profileid: this.browserProfileSelect?.value || undefined,
       crawlerChannel: values.crawlerChannel,
       proxyId: this.proxySelect?.value || undefined,
       userAgent: values.userAgent,

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -38,7 +38,7 @@ export const infoTextFor = {
     msg(`Choose a custom profile to make use of saved cookies and logged-in
   accounts. Note that websites may log profiles out after a period of time.`),
   crawlerChannel: msg(
-    `Choose a Browsertrix Crawler Release Channel. If available, other versions may provide new/experimental crawling features.`,
+    `Choose a Browsertrix Crawler release channel. If available, other versions may provide new or experimental crawling features.`,
   ),
   blockAds: msg(
     html`Blocks advertising content from being loaded. Uses
@@ -63,9 +63,7 @@ export const infoTextFor = {
   ),
   lang: msg(`Websites that observe the browser’s language setting may serve
   content in that language if available.`),
-  proxyId: `${msg(
-    `Choose a proxy to crawl through.`,
-  )} ${msg("If using a browser profile, the profile proxy will be used instead.")}`,
+  proxyId: msg(`Choose a proxy to crawl through.`),
   selectLinks: msg(
     html`Customize how URLs are extracted from a page. The crawler will use the
       specified

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -63,9 +63,9 @@ export const infoTextFor = {
   ),
   lang: msg(`Websites that observe the browser’s language setting may serve
   content in that language if available.`),
-  proxyId: msg(
-    `Choose a proxy to crawl through. If using a browser profile, the profile proxy will be used instead.`,
-  ),
+  proxyId: `${msg(
+    `Choose a proxy to crawl through.`,
+  )} ${msg("If using a browser profile, the profile proxy will be used instead.")}`,
   selectLinks: msg(
     html`Customize how URLs are extracted from a page. The crawler will use the
       specified

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -63,7 +63,9 @@ export const infoTextFor = {
   ),
   lang: msg(`Websites that observe the browser’s language setting may serve
   content in that language if available.`),
-  proxyId: msg(`Choose a proxy to crawl through.`),
+  proxyId: msg(
+    `Choose a proxy to crawl through. If using a browser profile, the profile proxy will be used instead.`,
+  ),
   selectLinks: msg(
     html`Customize how URLs are extracted from a page. The crawler will use the
       specified

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -240,7 +240,7 @@
   sl-option:not([aria-selected="true"]):not(:disabled),
   sl-menu-item:not([disabled]),
   btrix-menu-item-link {
-    @apply part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
+    @apply part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
   }
 
   sl-option[aria-selected="true"] {
@@ -528,6 +528,11 @@
 .sl-toast-stack {
   bottom: 0;
   top: auto;
+}
+
+html {
+  /* Fixes sl-input components resizing when sl-scroll-lock is removed */
+  scrollbar-gutter: stable;
 }
 
 /* Ensure buttons in shadow dom inherit hover color */

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -217,6 +217,19 @@
     line-height: 1.5;
   }
 
+  /* Place suffix before clear button */
+  sl-select::part(suffix) {
+    order: 1;
+  }
+
+  sl-select::part(clear-button) {
+    order: 2;
+  }
+
+  sl-select::part(expand-icon) {
+    @apply order-last;
+  }
+
   /* Align left edge with prefix icon */
   sl-menu sl-menu-label::part(base) {
     padding-left: 25px;

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -122,6 +122,12 @@
 }
 
 @layer components {
+  sl-skeleton {
+    --border-radius: var(--sl-border-radius-small);
+    --color: var(--sl-color-neutral-50);
+    --sheen-color: var(--sl-color-neutral-100);
+  }
+
   sl-avatar::part(base) {
     transition: var(--sl-transition-x-fast) background-color;
   }
@@ -231,9 +237,14 @@
   }
 
   /* Adjust menu item hover and focus styles */
-  sl-menu-item,
+  sl-option:not([aria-selected="true"]):not(:disabled),
+  sl-menu-item:not([disabled]),
   btrix-menu-item-link {
     @apply part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
+  }
+
+  sl-option[aria-selected="true"] {
+    @apply part-[base]:bg-cyan-50 part-[base]:text-cyan-700;
   }
 
   /* Add menu item variants */
@@ -276,8 +287,12 @@
   }
 
   /* TODO tailwind sets border-width: 0, see if this can be fixed in tw */
-  sl-divider {
-    border-top-width: var(--sl-panel-border-width);
+  sl-divider:not([vertical]) {
+    border-top: solid var(--width) var(--color);
+  }
+
+  sl-divider[vertical] {
+    border-left: solid var(--width) var(--color);
   }
 
   /* Add more spacing between radio options */

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -240,7 +240,7 @@
   sl-option:not([aria-selected="true"]):not(:disabled),
   sl-menu-item:not([disabled]),
   btrix-menu-item-link {
-    @apply part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
+    @apply part-[base]:bg-white part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
   }
 
   sl-option[aria-selected="true"] {

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -122,12 +122,6 @@
 }
 
 @layer components {
-  sl-skeleton {
-    --border-radius: var(--sl-border-radius-small);
-    --color: var(--sl-color-neutral-50);
-    --sheen-color: var(--sl-color-neutral-100);
-  }
-
   sl-avatar::part(base) {
     transition: var(--sl-transition-x-fast) background-color;
   }
@@ -217,19 +211,6 @@
     line-height: 1.5;
   }
 
-  /* Place suffix before clear button */
-  sl-select::part(suffix) {
-    order: 1;
-  }
-
-  sl-select::part(clear-button) {
-    order: 2;
-  }
-
-  sl-select::part(expand-icon) {
-    @apply order-last;
-  }
-
   /* Align left edge with prefix icon */
   sl-menu sl-menu-label::part(base) {
     padding-left: 25px;
@@ -250,14 +231,9 @@
   }
 
   /* Adjust menu item hover and focus styles */
-  sl-option:not([aria-selected="true"]):not(:disabled),
-  sl-menu-item:not([disabled]),
+  sl-menu-item,
   btrix-menu-item-link {
     @apply part-[base]:text-neutral-700 part-[base]:hover:bg-cyan-50/50 part-[base]:hover:text-cyan-700 part-[base]:focus-visible:bg-cyan-50/50;
-  }
-
-  sl-option[aria-selected="true"] {
-    @apply part-[base]:bg-cyan-50 part-[base]:text-cyan-700;
   }
 
   /* Add menu item variants */
@@ -300,12 +276,8 @@
   }
 
   /* TODO tailwind sets border-width: 0, see if this can be fixed in tw */
-  sl-divider:not([vertical]) {
-    border-top: solid var(--width) var(--color);
-  }
-
-  sl-divider[vertical] {
-    border-left: solid var(--width) var(--color);
+  sl-divider {
+    border-top-width: var(--sl-panel-border-width);
   }
 
   /* Add more spacing between radio options */

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -411,12 +411,14 @@
   .font-monostyle {
     @apply font-mono;
     font-variation-settings: var(--font-monostyle-variation);
+    font-size: 95%;
   }
 
   /* Actually monospaced font */
   .font-monospace {
     @apply font-mono;
     font-variation-settings: var(--font-monospace-variation);
+    font-size: 95%;
   }
 
   .truncate {

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -66,6 +66,7 @@ export type WorkflowParams = {
   schedule: string;
   browserWindows: number;
   profileid: string | null;
+  profileName?: string | null;
   config: SeedConfig;
   tags: string[];
   crawlTimeout: number | null;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -383,7 +383,10 @@ export function getInitialFormState(params: {
     jobName: params.initialWorkflow.name || defaultFormState.jobName,
     description: params.initialWorkflow.description,
     browserProfile: params.initialWorkflow.profileid
-      ? ({ id: params.initialWorkflow.profileid } as Profile)
+      ? ({
+          id: params.initialWorkflow.profileid,
+          name: params.initialWorkflow.profileName,
+        } as Profile)
       : defaultFormState.browserProfile,
     scopeType: primarySeedConfig.scopeType as FormState["scopeType"],
     exclusions: seedsConfig.exclude?.length === 0 ? [""] : seedsConfig.exclude,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/2982
Fixes https://github.com/webrecorder/browsertrix/issues/3005
Depends on https://github.com/webrecorder/browsertrix/pull/3009

## Changes

- Updates browser profile and workflow form controls to make relationship between profile and proxy more apparent
- Displays suggested browser profiles based on workflow seed URLs
- Displays browser profile details when selecting a profile from a workflow
- Fixes profile not saved to crawling defaults
- Consistency fixes for how proxies and crawler release channel is displayed

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Browser Profiles | <img width="492" height="512" alt="Screenshot 2025-11-24 at 5 23 41 PM" src="https://github.com/user-attachments/assets/733c0e12-6857-4282-b0d2-bf5835473c92" /> |
| Browser Profile | <img width="495" height="664" alt="Screenshot 2025-11-24 at 5 23 13 PM" src="https://github.com/user-attachments/assets/8cf16ac2-4fb9-4feb-be4e-9236d13a4319" />
| Workflow > Edit browser settings | <img width="541" height="594" alt="Screenshot 2025-11-24 at 5 24 20 PM" src="https://github.com/user-attachments/assets/d201752d-8be6-4d8d-82fd-612e8c136064" /> |
| Workflow > Edit browser settings | <img width="546" height="219" alt="Screenshot 2025-11-24 at 5 54 07 PM" src="https://github.com/user-attachments/assets/0005e908-3ee8-468c-acd3-195e3e085cf7" /> |
| Workflow > Edit browser settings > View browser profile details | <img width="469" height="744" alt="Screenshot 2025-11-24 at 5 57 27 PM" src="https://github.com/user-attachments/assets/acc6aecf-1630-40d6-af59-99cd7e007853" /> |


<!-- ## Follow-ups -->
