### PR TITLE
refactor to add 'pendingSize' to crawl which unambiguously stores the…

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -370,7 +370,7 @@ class CrawlOps(BaseCrawlOps):
         cursor = self.crawls.aggregate(
             [
                 {"$match": {"state": {"$in": RUNNING_AND_WAITING_STATES}, "oid": oid}},
-                {"$group": {"_id": None, "totalSum": {"$sum": "pendingSize"}}},
+                {"$group": {"_id": None, "totalSum": {"$sum": "$pendingSize"}}},
             ]
         )
         results = await cursor.to_list(length=1)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -304,8 +304,6 @@ class CrawlStats(BaseModel):
     done: int = 0
     size: int = 0
 
-    profile_update: Optional[str] = ""
-
 
 # ============================================================================
 
@@ -907,6 +905,7 @@ class CrawlOut(BaseMongoModel):
 
     fileSize: int = 0
     fileCount: int = 0
+    pendingSize: int = 0
 
     tags: Optional[List[str]] = []
 
@@ -1090,6 +1089,8 @@ class Crawl(BaseCrawl, CrawlConfigCore):
 
     qa: Optional[QARun] = None
     qaFinished: Optional[Dict[str, QARun]] = {}
+
+    pendingSize: int = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -6,7 +6,12 @@ from uuid import UUID
 from typing import Optional, DefaultDict, Literal, Annotated, Any
 from pydantic import BaseModel, Field
 from kubernetes.utils import parse_quantity
-from btrixcloud.models import StorageRef, TYPE_ALL_CRAWL_STATES, Organization
+from btrixcloud.models import (
+    StorageRef,
+    TYPE_ALL_CRAWL_STATES,
+    Organization,
+    CrawlStats,
+)
 
 
 BTRIX_API = "btrix.cloud/v1"
@@ -204,6 +209,13 @@ class PodInfo(BaseModel):
 
 
 # ============================================================================
+class OpCrawlStats(CrawlStats):
+    """crawl stats + internal profile update"""
+
+    profile_update: Optional[str] = ""
+
+
+# ============================================================================
 # pylint: disable=invalid-name
 class CrawlStatus(BaseModel):
     """status from k8s CrawlJob object"""
@@ -214,6 +226,9 @@ class CrawlStatus(BaseModel):
     size: int = 0
     # human readable size string
     sizeHuman: str = ""
+
+    # pending size (not uploaded)
+    sizePending: int = 0
 
     # actual observed scale (number of pods active)
     scale: int = 0
@@ -254,6 +269,9 @@ class CrawlStatus(BaseModel):
 
     # don't include in status, use by metacontroller
     resync_after: Optional[int] = Field(default=None, exclude=True)
+
+    # track size of files just added on this sync
+    just_added_size: int = Field(default=0, exclude=True)
 
     # last state
     last_state: TYPE_ALL_CRAWL_STATES = Field(default="starting", exclude=True)

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -270,9 +270,6 @@ class CrawlStatus(BaseModel):
     # don't include in status, use by metacontroller
     resync_after: Optional[int] = Field(default=None, exclude=True)
 
-    # track size of files just added on this sync
-    just_added_size: int = Field(default=0, exclude=True)
-
     # last state
     last_state: TYPE_ALL_CRAWL_STATES = Field(default="starting", exclude=True)
 


### PR DESCRIPTION
… pending, un-uploaded size

- use pending size to determine if quota reached
- also request pause to be set before assuming paused state
- also ensure data is actually committed before shutting down pods (in case of any edge cases)
- clear paused flag in redis after crawler pods shutdown
- add OpCrawlStats to avoid adding unnecessary profile_update to public API

this assumes changes in crawler to support: clearing size after WACZ upload, ensure upload happens if pod starts when crawl is paused