### PR TITLE
Add initial disk cleanup action for nightly tests

### DIFF
--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -30,6 +30,12 @@ jobs:
         module: ${{fromJSON(needs.collect-test-modules.outputs.matrix)}}
       fail-fast: false
     steps:
+       - name: Initial Disk Cleanup
+        uses: mathio/gha-cleanup@v1
+        with:
+          remove-browsers: true
+          verbose: true
+
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2
         with:

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -30,7 +30,7 @@ jobs:
         module: ${{fromJSON(needs.collect-test-modules.outputs.matrix)}}
       fail-fast: false
     steps:
-       - name: Initial Disk Cleanup
+      - name: Initial Disk Cleanup
         uses: mathio/gha-cleanup@v1
         with:
           remove-browsers: true


### PR DESCRIPTION
Add same action as was added in backend tests to nightly, to help with test stability following GitHub's recent infrastructure changes.