### PR TITLE
Add profile search-values endpoint

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2540,6 +2540,13 @@ class ProfileBrowserGetUrlResponse(BaseModel):
 
 
 # ============================================================================
+class ProfileSearchValuesResponse(BaseModel):
+    """Response model for profiles search values"""
+
+    names: List[str]
+
+
+# ============================================================================
 
 ### USERS ###
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -445,6 +445,7 @@ class ProfileOps:
         userid: Optional[UUID] = None,
         tags: Optional[List[str]] = None,
         tag_match: Optional[ListFilterType] = ListFilterType.AND,
+        name: Optional[str] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: str = "modified",
@@ -463,6 +464,8 @@ class ProfileOps:
         if tags:
             query_type = "$all" if tag_match == ListFilterType.AND else "$in"
             match_query["tags"] = {query_type: tags}
+        if name:
+            match_query["name"] = name
 
         aggregate: List[Dict[str, Any]] = [{"$match": match_query}]
 
@@ -723,6 +726,7 @@ def init_profiles_api(
                 description='Defaults to `"and"` if omitted',
             ),
         ] = ListFilterType.AND,
+        name: Optional[str] = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sortBy: str = "modified",
@@ -733,6 +737,7 @@ def init_profiles_api(
             userid,
             tags=tags,
             tag_match=tag_match,
+            name=name,
             page_size=pageSize,
             page=page,
             sort_by=sortBy,

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -205,6 +205,20 @@ def test_list_profiles_filter_by_tag(
     assert data["total"] == 2
 
 
+def test_list_profiles_filter_by_name(admin_auth_headers, default_org_id, profile_2_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles?name={PROFILE_2_NAME}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+
+    profile = data["items"][0]
+    assert profile["id"] == profile_2_id
+    assert profile["name"] == PROFILE_2_NAME
+
+
 def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_id):
     # Get original created/modified times
     r = requests.get(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -450,6 +450,16 @@ def test_profile_tag_counts(admin_auth_headers, default_org_id):
     }
 
 
+def test_profile_search_values(admin_auth_headers, default_org_id):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/search-values",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert sorted(data["names"]) == sorted([PROFILE_NAME_UPDATED, PROFILE_2_NAME])
+
+
 def test_delete_profile(admin_auth_headers, default_org_id, profile_2_id):
     # Delete second profile
     r = requests.delete(


### PR DESCRIPTION
Backend implementation for #3010 

I've kept the endpoint as `/search-values` to be consistent with our other search values endpoints. This is inconsistent with our other profile endpoints' casing, so could go the other way if anyone has strong opinions. Something to address when we have a v2 API.