### PR TITLE
Ensure that profile and crawlconfig sorting of names and URLs is case-insensitive

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -535,7 +535,7 @@ class CollectionOps:
         )
 
         cursor = self.collections.aggregate(
-            aggregate, collation=pymongo.collation.Collation(locale="en")
+            aggregate, collation=case_insensitive_collation
         )
         results = await cursor.to_list(length=1)
         result = results[0]

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -12,7 +12,6 @@ import os
 import asyncio
 import pymongo
 import aiohttp
-from pymongo.collation import Collation
 from fastapi import Depends, HTTPException, Response
 from fastapi.responses import StreamingResponse
 from starlette.requests import Request
@@ -104,7 +103,9 @@ class CollectionOps:
 
     async def init_index(self):
         """init lookup index"""
-        case_insensitive_collation = Collation(locale="en", strength=1)
+        case_insensitive_collation = pymongo.collation.Collation(
+            locale="en", strength=1
+        )
         await self.collections.create_index(
             [("oid", pymongo.ASCENDING), ("name", pymongo.ASCENDING)],
             unique=True,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -54,6 +54,7 @@ from .utils import (
     slug_from_name,
     get_duplicate_key_error_field,
     get_origin,
+    case_insensitive_collation,
 )
 
 if TYPE_CHECKING:
@@ -103,9 +104,6 @@ class CollectionOps:
 
     async def init_index(self):
         """init lookup index"""
-        case_insensitive_collation = pymongo.collation.Collation(
-            locale="en", strength=1
-        )
         await self.collections.create_index(
             [("oid", pymongo.ASCENDING), ("name", pymongo.ASCENDING)],
             unique=True,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -859,7 +859,7 @@ class CrawlConfigOps:
         )
 
         cursor = self.crawl_configs.aggregate(
-            aggregate, collation=pymongo.collation.Collation(locale="en")
+            aggregate, collation=case_insensitive_collation
         )
         results = await cursor.to_list(length=1)
         result = results[0]

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -211,7 +211,13 @@ class CrawlConfigOps:
         )
 
         await self.crawl_configs.create_index(
-            [("oid", pymongo.ASCENDING), ("tags", pymongo.ASCENDING)]
+            [("oid", pymongo.ASCENDING), ("tags", pymongo.ASCENDING)],
+            collation=case_insensitive_collation,
+        )
+
+        await self.crawl_configs.create_index(
+            [("oid", pymongo.ASCENDING), ("name", pymongo.ASCENDING)],
+            collation=case_insensitive_collation,
         )
 
         await self.crawl_configs.create_index(
@@ -850,7 +856,9 @@ class CrawlConfigOps:
             ]
         )
 
-        cursor = self.crawl_configs.aggregate(aggregate)
+        cursor = self.crawl_configs.aggregate(
+            aggregate, collation=pymongo.collation.Collation(locale="en")
+        )
         results = await cursor.to_list(length=1)
         result = results[0]
         items = result["items"]

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -202,6 +202,10 @@ class CrawlConfigOps:
 
     async def init_index(self):
         """init index for crawlconfigs db collection"""
+        case_insensitive_collation = pymongo.collation.Collation(
+            locale="en", strength=1
+        )
+
         await self.crawl_configs.create_index(
             [("oid", pymongo.HASHED), ("inactive", pymongo.ASCENDING)]
         )

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -221,6 +221,11 @@ class CrawlConfigOps:
         )
 
         await self.crawl_configs.create_index(
+            [("oid", pymongo.ASCENDING), ("firstSeed", pymongo.ASCENDING)],
+            collation=case_insensitive_collation,
+        )
+
+        await self.crawl_configs.create_index(
             [
                 ("oid", pymongo.ASCENDING),
                 ("inactive", pymongo.ASCENDING),

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -72,6 +72,7 @@ from .utils import (
     validate_language_code,
     is_url,
     browser_windows_from_scale,
+    case_insensitive_collation,
 )
 
 if TYPE_CHECKING:
@@ -202,10 +203,6 @@ class CrawlConfigOps:
 
     async def init_index(self):
         """init index for crawlconfigs db collection"""
-        case_insensitive_collation = pymongo.collation.Collation(
-            locale="en", strength=1
-        )
-
         await self.crawl_configs.create_index(
             [("oid", pymongo.HASHED), ("inactive", pymongo.ASCENDING)]
         )

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -33,7 +33,9 @@ if TYPE_CHECKING:
 else:
     UserManager = OrgOps = CrawlConfigOps = CrawlOps = CollectionOps = InviteOps = (
         StorageOps
-    ) = PageOps = BackgroundJobOps = FileUploadOps = CrawlLogOps = CrawlManager = object
+    ) = PageOps = BackgroundJobOps = FileUploadOps = CrawlLogOps = CrawlManager = (
+        ProfileOps
+    ) = object
 
 
 CURR_DB_VERSION = "0054"

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from .background_jobs import BackgroundJobOps
     from .file_uploads import FileUploadOps
     from .crawlmanager import CrawlManager
+    from .profiles import ProfileOps
 else:
     UserManager = OrgOps = CrawlConfigOps = CrawlOps = CollectionOps = InviteOps = (
         StorageOps
@@ -103,6 +104,7 @@ async def update_and_prepare_db(
     background_job_ops: BackgroundJobOps,
     file_ops: FileUploadOps,
     crawl_log_ops: CrawlLogOps,
+    profile_ops: ProfileOps,
     crawl_manager: CrawlManager,
 ) -> None:
     """Prepare database for application.
@@ -139,6 +141,7 @@ async def update_and_prepare_db(
         storage_ops,
         file_ops,
         crawl_log_ops,
+        profile_ops,
     )
     await user_manager.create_super_user()
     await org_ops.create_default_org()
@@ -262,6 +265,7 @@ async def create_indexes(
     storage_ops,
     file_ops,
     crawl_log_ops,
+    profile_ops,
 ):
     """Create database indexes."""
     print("Creating database indexes", flush=True)
@@ -275,6 +279,7 @@ async def create_indexes(
     await storage_ops.init_index()
     await file_ops.init_index()
     await crawl_log_ops.init_index()
+    await profile_ops.init_index()
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -29,7 +29,7 @@ async def main() -> int:
         _,
         page_ops,
         coll_ops,
-        _,
+        profile_ops,
         storage_ops,
         background_job_ops,
         _,
@@ -55,6 +55,7 @@ async def main() -> int:
         background_job_ops,
         file_ops,
         crawl_log_ops,
+        profile_ops,
         crawl_manager,
     )
 

--- a/backend/btrixcloud/migrations/migration_0039_coll_slugs.py
+++ b/backend/btrixcloud/migrations/migration_0039_coll_slugs.py
@@ -5,11 +5,10 @@ Migration 0039 -- collection slugs
 from uuid import UUID
 
 from pymongo.errors import DuplicateKeyError
-from pymongo.collation import Collation
 import pymongo
 
 from btrixcloud.migrations import BaseMigration
-from btrixcloud.utils import slug_from_name
+from btrixcloud.utils import slug_from_name, case_insensitive_collation
 
 MIGRATION_VERSION = "0039"
 
@@ -53,7 +52,6 @@ class Migration(BaseMigration):
         Add slug to collections that don't have one yet, based on name
         """
         colls_mdb = self.mdb["collections"]
-        case_insensitive_collation = Collation(locale="en", strength=1)
 
         await colls_mdb.drop_indexes()
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -16,7 +16,6 @@ from typing import Optional, TYPE_CHECKING, Dict, Callable, List, AsyncGenerator
 
 from pydantic import ValidationError
 from pymongo import ReturnDocument
-from pymongo.collation import Collation
 from pymongo.errors import AutoReconnect, DuplicateKeyError
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -93,6 +92,7 @@ from .utils import (
     validate_language_code,
     JSONSerializer,
     browser_windows_from_scale,
+    case_insensitive_collation,
 )
 
 if TYPE_CHECKING:
@@ -189,7 +189,6 @@ class OrgOps:
 
     async def init_index(self) -> None:
         """init lookup index"""
-        case_insensitive_collation = Collation(locale="en", strength=1)
         while True:
             try:
                 await self.orgs.create_index(

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -511,7 +511,7 @@ class ProfileOps:
         )
 
         cursor = self.profiles.aggregate(
-            aggregate, collation=pymongo.collation.Collation(locale="en")
+            aggregate, collation=case_insensitive_collation
         )
         results = await cursor.to_list(length=1)
         result = results[0]

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -47,7 +47,7 @@ from .models import (
     TagsResponse,
     ListFilterType,
 )
-from .utils import dt_now, str_to_date
+from .utils import dt_now, str_to_date, case_insensitive_collation
 
 if TYPE_CHECKING:
     from .orgs import OrgOps
@@ -107,9 +107,6 @@ class ProfileOps:
 
     async def init_index(self):
         """init lookup index"""
-        case_insensitive_collation = pymongo.collation.Collation(
-            locale="en", strength=1
-        )
         await self.profiles.create_index(
             [("oid", pymongo.ASCENDING), ("name", pymongo.ASCENDING)],
             collation=case_insensitive_collation,

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -18,6 +18,7 @@ from uuid import UUID
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from iso639 import is_language
+from pymongo.collation import Collation
 from pymongo.errors import DuplicateKeyError
 from slugify import slugify
 
@@ -25,6 +26,8 @@ from slugify import slugify
 default_origin = os.environ.get("APP_ORIGIN", "")
 
 browsers_per_pod = int(os.environ.get("NUM_BROWSERS", 1))
+
+case_insensitive_collation = Collation(locale="en", strength=1)
 
 
 class JSONSerializer(json.JSONEncoder):

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -207,7 +207,7 @@ def _crawler_create_config_only(crawler_auth_headers, default_org_id):
     # Start crawl.
     crawl_data = {
         "runNow": False,
-        "name": "Crawler User Test Crawl",
+        "name": "crawler User Test Crawl",
         "description": "crawler test crawl",
         "config": {
             "seeds": [{"url": "https://old.webrecorder.net/"}],
@@ -232,7 +232,7 @@ def crawler_crawl_id(crawler_auth_headers, default_org_id):
     # Start crawl.
     crawl_data = {
         "runNow": True,
-        "name": "Crawler User Test Crawl",
+        "name": "crawler User Test Crawl",
         "description": "crawler test crawl",
         "tags": ["wr-test-2"],
         "config": {"seeds": [{"url": "https://old.webrecorder.net/"}], "limit": 3},
@@ -702,7 +702,7 @@ PROFILE_NAME_UPDATED = "Updated test profile"
 PROFILE_DESC_UPDATED = "Updated profile used for backend tests"
 PROFILE_TAGS_UPDATED = ["profile", "profile-updated", "old-webrecorder"]
 
-PROFILE_2_NAME = "Second test profile"
+PROFILE_2_NAME = "second test profile"
 PROFILE_2_DESC = "Second profile used to test list endpoint"
 PROFILE_2_TAGS = ["profile", "specs-webrecorder"]
 

--- a/backend/test/test_crawl_config_search_values.py
+++ b/backend/test/test_crawl_config_search_values.py
@@ -44,7 +44,7 @@ def test_get_search_values_1(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, "Admin Test Crawl", "Crawler User Test Crawl"]
+        [NAME_1, "Admin Test Crawl", "crawler User Test Crawl"]
     )
     assert sorted(data["descriptions"]) == sorted(
         ["Admin Test Crawl description", "crawler test crawl", DESCRIPTION_1]
@@ -74,7 +74,7 @@ def test_get_search_values_2(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, NAME_2, "Admin Test Crawl", "Crawler User Test Crawl"]
+        [NAME_1, NAME_2, "Admin Test Crawl", "crawler User Test Crawl"]
     )
     assert sorted(data["descriptions"]) == sorted(
         [
@@ -111,7 +111,7 @@ def test_get_search_values_3(admin_auth_headers, default_org_id):
     )
     data = r.json()
     assert sorted(data["names"]) == sorted(
-        [NAME_1, NAME_2, "Admin Test Crawl", "Crawler User Test Crawl"]
+        [NAME_1, NAME_2, "Admin Test Crawl", "crawler User Test Crawl"]
     )
     assert sorted(data["descriptions"]) == sorted(
         [

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -42,7 +42,7 @@ def test_get_configs_by_first_seed(
 
 
 def test_get_configs_by_name(crawler_auth_headers, default_org_id, crawler_crawl_id):
-    name = "Crawler User Test Crawl"
+    name = "crawler User Test Crawl"
     encoded_name = urllib.parse.quote(name)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?name={encoded_name}",
@@ -150,7 +150,7 @@ def test_get_crawls_by_first_seed(
 
 
 def test_get_crawls_by_name(crawler_auth_headers, default_org_id, crawler_crawl_id):
-    name = "Crawler User Test Crawl"
+    name = "crawler User Test Crawl"
     encoded_name = urllib.parse.quote(name)
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls?name={encoded_name}",
@@ -571,6 +571,42 @@ def test_sort_crawl_configs(
         elif last_updated_time and config_last_updated:
             assert config_last_updated >= last_updated_time
         last_updated_time = config_last_updated
+
+    # Sort by name, ascending
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=name&sortDirection=1",
+        headers=crawler_auth_headers,
+    )
+    data = r.json()
+    items = data["items"]
+    last_name = None
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
+        config_last_name = config.get("name")
+        if not config_last_name:
+            continue
+        elif last_name and config_last_name:
+            assert config_last_name.lower() <= last_name.lower()
+        last_name = config_last_last
+
+    # Sort by name, descending
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs?sortBy=name&sortDirection=-1",
+        headers=crawler_auth_headers,
+    )
+    data = r.json()
+    items = data["items"]
+    last_name = None
+    for config in items:
+        assert config["createdByName"]
+        assert config["modifiedByName"]
+        config_last_name = config.get("name")
+        if not config_last_name:
+            continue
+        elif last_name and config_last_name:
+            assert config_last_name.lower() >= last_name.lower()
+        last_name = config_last_last
 
     # Invalid sort value
     r = requests.get(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -588,7 +588,7 @@ def test_sort_crawl_configs(
             continue
         elif last_name and config_last_name:
             assert config_last_name.lower() <= last_name.lower()
-        last_name = config_last_last
+        last_name = config_last_name
 
     # Sort by name, descending
     r = requests.get(
@@ -606,7 +606,7 @@ def test_sort_crawl_configs(
             continue
         elif last_name and config_last_name:
             assert config_last_name.lower() >= last_name.lower()
-        last_name = config_last_last
+        last_name = config_last_name
 
     # Invalid sort value
     r = requests.get(

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -587,7 +587,7 @@ def test_sort_crawl_configs(
         if not config_last_name:
             continue
         elif last_name and config_last_name:
-            assert config_last_name.lower() <= last_name.lower()
+            assert config_last_name.lower() >= last_name.lower()
         last_name = config_last_name
 
     # Sort by name, descending
@@ -605,7 +605,7 @@ def test_sort_crawl_configs(
         if not config_last_name:
             continue
         elif last_name and config_last_name:
-            assert config_last_name.lower() >= last_name.lower()
+            assert config_last_name.lower() <= last_name.lower()
         last_name = config_last_name
 
     # Invalid sort value

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -565,7 +565,7 @@ def test_get_all_crawls_by_name(
     assert items[0]["id"] == upload_id_2
     assert items[0]["name"] == "test2.wacz"
 
-    crawl_name = "Crawler User Test Crawl"
+    crawl_name = "crawler User Test Crawl"
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?name={crawl_name}",
         headers=admin_auth_headers,
@@ -825,7 +825,7 @@ def test_all_crawls_search_values(
 
     assert len(data["names"]) == 8
     expected_names = [
-        "Crawler User Test Crawl",
+        "crawler User Test Crawl",
         "Custom Behavior Logs",
         "My Upload Updated",
         "test2.wacz",
@@ -854,7 +854,7 @@ def test_all_crawls_search_values(
         "Admin Test Crawl",
         "All Crawls Test Crawl",
         "Crawler User Crawl for Testing QA",
-        "Crawler User Test Crawl",
+        "crawler User Test Crawl",
         "Custom Behavior Logs",
     ]
     for expected_name in expected_names:


### PR DESCRIPTION
Fixes #3012 

- Add profile indexes 
- Add case-insensitive collation to indexes for crawlconfigs and profile fields that should be sorted regardless of case (e.g. name, tags, URLs)
- Update tests

## Screenshots

https://github.com/user-attachments/assets/a7c7b324-8cbe-4e74-a51c-42433e23bee2

