### PR TITLE
feat: Filter browser profile list by name

### DIFF
--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -123,8 +123,8 @@ export function pageHeader({
   return html`
     <header
       class=${clsx(
-        tw`mt-5 flex flex-row flex-wrap gap-3`,
-        border && tw`border-b pb-3`,
+        tw`mt-5 flex flex-row flex-wrap gap-3 pb-3`,
+        border && tw`border-b`,
         classNames,
       )}
     >

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -411,7 +411,7 @@ export class BrowserProfilesList extends BtrixElement {
         .searchKeys=${SEARCH_KEYS}
         .searchOptions=${this.searchOptionsTask.value || []}
         .keyLabels=${{}}
-        placeholder=${msg("Search browser profiles by name")}
+        placeholder=${msg("Search by name")}
         @btrix-select=${(e: CustomEvent) => {
           const { key, value } = e.detail;
           this.filterBy.setValue({

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -190,6 +190,7 @@ export class BrowserProfilesList extends BtrixElement {
   private get hasFiltersSet() {
     const filterBy = this.filterBy.value;
     return (
+      filterBy.name ||
       filterBy.tags?.length ||
       filterBy.tagsType !== DEFAULT_TAGS_TYPE ||
       filterBy.mine

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -192,7 +192,7 @@ export class BrowserProfilesList extends BtrixElement {
     return (
       filterBy.tags?.length ||
       filterBy.tagsType !== DEFAULT_TAGS_TYPE ||
-      filterBy.mine !== undefined
+      filterBy.mine
     );
   }
 

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -47,7 +47,7 @@ const sortableFields: Record<
 > = {
   name: {
     label: msg("Name"),
-    defaultDirection: "desc",
+    defaultDirection: "asc",
   },
   url: {
     label: msg("Primary Site"),
@@ -410,7 +410,6 @@ export class BrowserProfilesList extends BtrixElement {
       <btrix-search-combobox
         .searchKeys=${SEARCH_KEYS}
         .searchOptions=${this.searchOptionsTask.value || []}
-        .keyLabels=${{}}
         placeholder=${msg("Search by name")}
         @btrix-select=${(e: CustomEvent) => {
           const { key, value } = e.detail;

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -74,7 +74,7 @@ const SEARCH_KEYS = ["name"] as const;
 const DEFAULT_TAGS_TYPE = "or";
 
 type FilterBy = {
-  name?: string | null;
+  name?: string;
   tags?: string[];
   tagsType?: "and" | "or";
   mine?: boolean;
@@ -170,7 +170,7 @@ export class BrowserProfilesList extends BtrixElement {
       return params;
     },
     (params) => ({
-      name: params.get("name") ?? undefined,
+      name: params.get("name") || undefined,
       tags: params.getAll("tags"),
       tagsType: params.get("tagsType") === "and" ? "and" : "or",
       mine: params.get("mine") === "true",
@@ -410,6 +410,7 @@ export class BrowserProfilesList extends BtrixElement {
       <btrix-search-combobox
         .searchKeys=${SEARCH_KEYS}
         .searchOptions=${this.searchOptionsTask.value || []}
+        .searchByValue=${this.filterBy.value["name"] || ""}
         placeholder=${msg("Search by name")}
         @btrix-select=${(e: CustomEvent) => {
           const { key, value } = e.detail;

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -192,7 +192,7 @@ export class BrowserProfilesList extends BtrixElement {
     return (
       filterBy.name ||
       filterBy.tags?.length ||
-      filterBy.tagsType !== DEFAULT_TAGS_TYPE ||
+      (filterBy.tagsType ?? DEFAULT_TAGS_TYPE) !== DEFAULT_TAGS_TYPE ||
       filterBy.mine
     );
   }

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -210,6 +210,7 @@ export class BrowserProfilesList extends BtrixElement {
         {
           ...pagination,
           userid: filterBy.mine ? this.userInfo?.id : undefined,
+          name: filterBy.name || undefined,
           tags: filterBy.tags,
           tagMatch: filterBy.tagsType,
           sortBy: orderBy.field,
@@ -689,6 +690,7 @@ export class BrowserProfilesList extends BtrixElement {
   private async getProfiles(
     params: {
       userid?: string;
+      name?: string;
       tags?: string[];
       tagMatch?: string;
     } & APIPaginationQuery &

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -150,6 +150,7 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
       <div class="contents">
         ${pageHeader({
           title: msg("Collections"),
+          border: false,
           actions: this.isCrawler
             ? html` <sl-button
                 variant="primary"
@@ -163,7 +164,6 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
                 ${msg("New Collection")}
               </sl-button>`
             : nothing,
-          classNames: tw`border-b-transparent`,
         })}
       </div>
 
@@ -384,7 +384,7 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
       >
         <sl-input
           size="small"
-          placeholder=${msg("Search by Name")}
+          placeholder=${msg("Search by name")}
           clearable
           @sl-clear=${() => {
             this.searchResultsOpen = false;

--- a/frontend/src/utils/searchValues.ts
+++ b/frontend/src/utils/searchValues.ts
@@ -1,0 +1,14 @@
+export type SearchValues = {
+  names: string[];
+};
+
+export type SearchField = "name";
+
+/**
+ * Convert API search values to a format compatible with Fuse collections
+ */
+export function toSearchItem<T = SearchField>(key: T) {
+  return (value: string) => ({
+    [key as string]: value,
+  });
+}


### PR DESCRIPTION
Depends on https://github.com/webrecorder/browsertrix/pull/3015
WIP for https://github.com/webrecorder/browsertrix/issues/3010

## Changes

- Allows users to filter browser profile list by name
- Fixes layout inconsistencies with browser profiles list

## Manual testing

Backend must point to latest in https://github.com/webrecorder/browsertrix/pull/3015

1. Log in
2. Go to "Browser Profiles"
3. Enter text into search box. Verify search results are shown
4. Choose search research. Verify profile list is filtered
5. Reload page. Verify search term persists

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Browser Profiles | <img width="796" height="313" alt="Screenshot 2025-11-26 at 7 56 55 AM" src="https://github.com/user-attachments/assets/60215840-de9e-4a7f-88df-d9b0551ab0ed" /> |


<!-- ## Follow-ups -->
