### PR TITLE
CI: use Mongo 8 for testing

### DIFF
--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -34,6 +34,10 @@ crawler_channels:
   - id: test
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
+
+mongo_image: "docker.io/library/mongo:8.0"
+
+
 mongo_auth:
   # specify either username + password (for local mongo)
   username: root


### PR DESCRIPTION
- we use it in production already
- perhaps will eliminate spurious test failures that we sometimes see
- should eventually upgrade base image, but need to add migration first (see: #2878)