### PR TITLE
fix: Fix profile tag count changing after delete

### DIFF
--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -2,6 +2,7 @@ import { localized, msg } from "@lit/localize";
 import { Task } from "@lit/task";
 import { html, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
@@ -509,7 +510,7 @@ export class BrowserProfilesList extends BtrixElement {
         <btrix-table-body
           class="divide-y rounded border [--btrix-table-cell-padding-y:var(--sl-spacing-2x-small)]"
         >
-          ${profiles.map(this.renderItem)}
+          ${repeat(profiles, ({ id }) => id, this.renderItem)}
         </btrix-table-body>
       </btrix-table>
     </btrix-overflow-scroll>`;


### PR DESCRIPTION
## Changes

Fixes incorrect browser profile tag remainder calculation after a profile is deleted

## Manual testing

1. Log in as crawler into org
2. Go to "Browser Profiles"
3. Add 2 profiles with tags
4. Go back to browser profile list
5. Delete topmost profile. Verify tag counts remain unchanged