### PR TITLE
Add support for --useRobots crawler flag to Browsertrix

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -362,6 +362,8 @@ class RawCrawlConfig(BaseModel):
     combineWARC: Optional[bool] = None
 
     useSitemap: Optional[bool] = False
+    useRobots: Optional[bool] = False
+
     failOnFailedSeed: Optional[bool] = False
     failOnContentCheck: Optional[bool] = False
 
@@ -375,8 +377,6 @@ class RawCrawlConfig(BaseModel):
     clickSelector: str = "a"
 
     saveStorage: Optional[bool] = False
-
-    robots: Optional[bool] = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -376,6 +376,8 @@ class RawCrawlConfig(BaseModel):
 
     saveStorage: Optional[bool] = False
 
+    robots: Optional[bool] = False
+
 
 # ============================================================================
 class CrawlConfigIn(BaseModel):

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -97,6 +97,10 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 
     **These credentials WILL BE WRITTEN into the archive.** We recommend exercising caution and only archiving with dedicated archival accounts, changing your password or deleting the account when finished.
 
+### Skip Pages Disallowed By Robots.txt
+
+When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at /robots.txt for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
+
 ### Include Any Linked Page
 
 When enabled, the crawler will visit all the links it finds within each URL defined in the [URL input field](#crawl-start-url-urls-to-crawl) under _Crawl Scope_.

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -476,6 +476,10 @@ export class ConfigDetails extends BtrixElement {
         Boolean(config.extraHops),
       )}
       ${this.renderSetting(
+        msg("Skip Pages Disallowed By Robots.txt"),
+        Boolean(config.robots),
+      )}
+      ${this.renderSetting(
         msg("Fail Crawl If Not Logged In"),
         Boolean(config.failOnContentCheck),
       )}
@@ -548,6 +552,10 @@ export class ConfigDetails extends BtrixElement {
       ${this.renderSetting(
         msg("Include Any Linked Page (“one hop out”)"),
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
+      )}
+      ${this.renderSetting(
+        msg("Skip Pages Disallowed By Robots.txt"),
+        Boolean(config.robots),
       )}
       ${this.renderSetting(
         msg("Check For Sitemap"),

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -554,7 +554,7 @@ export class ConfigDetails extends BtrixElement {
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
       )}
       ${this.renderSetting(
-        msg("Skip Pages Disallowed By Robots.txt"),
+        msg("Skip Pages Disallowed by robots.txt"),
         Boolean(config.robots),
       )}
       ${this.renderSetting(

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -476,7 +476,7 @@ export class ConfigDetails extends BtrixElement {
         Boolean(config.extraHops),
       )}
       ${this.renderSetting(
-        msg("Skip Pages Disallowed By Robots.txt"),
+        msg("Skip Pages Disallowed by robots.txt"),
         Boolean(config.robots),
       )}
       ${this.renderSetting(

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -477,7 +477,7 @@ export class ConfigDetails extends BtrixElement {
       )}
       ${this.renderSetting(
         msg("Skip Pages Disallowed by robots.txt"),
-        Boolean(config.robots),
+        Boolean(config.useRobots),
       )}
       ${this.renderSetting(
         msg("Fail Crawl If Not Logged In"),
@@ -555,7 +555,7 @@ export class ConfigDetails extends BtrixElement {
       )}
       ${this.renderSetting(
         msg("Skip Pages Disallowed by robots.txt"),
-        Boolean(config.robots),
+        Boolean(config.useRobots),
       )}
       ${this.renderSetting(
         msg("Check For Sitemap"),

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1064,11 +1064,11 @@ export class WorkflowEditor extends BtrixElement {
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
       ${inputCol(html`
-        <sl-checkbox name="robots" ?checked=${this.formState.robots}>
+        <sl-checkbox name="useRobots" ?checked=${this.formState.useRobots}>
           ${msg("Skip pages disallowed by robots.txt")}
         </sl-checkbox>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["robots"], false)}
+      ${this.renderHelpTextCol(infoTextFor["useRobots"], false)}
       ${inputCol(html`
         <sl-checkbox
           name="failOnContentCheck"
@@ -1587,11 +1587,11 @@ https://example.net`}
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
       ${inputCol(html`
-        <sl-checkbox name="robots" ?checked=${this.formState.robots}>
+        <sl-checkbox name="useRobots" ?checked=${this.formState.useRobots}>
           ${msg("Skip pages disallowed by robots.txt")}
         </sl-checkbox>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["robots"], false)}
+      ${this.renderHelpTextCol(infoTextFor["useRobots"], false)}
       ${inputCol(html`
         <sl-checkbox name="useSitemap" ?checked=${this.formState.useSitemap}>
           ${msg("Check for sitemap")}
@@ -3355,7 +3355,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "failOnFailedSeed"
     | "failOnContentCheck"
     | "saveStorage"
-    | "robots"
+    | "useRobots"
   > {
     const jsonSeeds = this.formState.seedListFormat === SeedListFormat.JSON;
 
@@ -3375,7 +3375,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       failOnFailedSeed: this.formState.failOnFailedSeed,
       failOnContentCheck: this.formState.failOnContentCheck,
       saveStorage: this.formState.saveStorage,
-      robots: this.formState.robots,
+      useRobots: this.formState.useRobots,
     };
 
     return config;
@@ -3389,7 +3389,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "failOnFailedSeed"
     | "failOnContentCheck"
     | "saveStorage"
-    | "robots"
+    | "useRobots"
   > {
     const primarySeedUrl = this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeUrlList
@@ -3422,7 +3422,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       failOnFailedSeed: false,
       failOnContentCheck: this.formState.failOnContentCheck,
       saveStorage: this.formState.saveStorage,
-      robots: this.formState.robots,
+      useRobots: this.formState.useRobots,
     };
     return config;
   }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1064,6 +1064,12 @@ export class WorkflowEditor extends BtrixElement {
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
       ${inputCol(html`
+        <sl-checkbox name="robots" ?checked=${this.formState.robots}>
+          ${msg("Skip pages disallowed by robots.txt")}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor["robots"], false)}
+      ${inputCol(html`
         <sl-checkbox
           name="failOnContentCheck"
           ?checked=${this.formState.failOnContentCheck &&
@@ -1580,6 +1586,12 @@ https://example.net`}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
+      ${inputCol(html`
+        <sl-checkbox name="robots" ?checked=${this.formState.robots}>
+          ${msg("Skip pages disallowed by robots.txt")}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor["robots"], false)}
       ${inputCol(html`
         <sl-checkbox name="useSitemap" ?checked=${this.formState.useSitemap}>
           ${msg("Check for sitemap")}
@@ -3343,6 +3355,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "failOnFailedSeed"
     | "failOnContentCheck"
     | "saveStorage"
+    | "robots"
   > {
     const jsonSeeds = this.formState.seedListFormat === SeedListFormat.JSON;
 
@@ -3362,6 +3375,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       failOnFailedSeed: this.formState.failOnFailedSeed,
       failOnContentCheck: this.formState.failOnContentCheck,
       saveStorage: this.formState.saveStorage,
+      robots: this.formState.robots,
     };
 
     return config;
@@ -3375,6 +3389,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     | "failOnFailedSeed"
     | "failOnContentCheck"
     | "saveStorage"
+    | "robots"
   > {
     const primarySeedUrl = this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeUrlList
@@ -3407,6 +3422,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       failOnFailedSeed: false,
       failOnContentCheck: this.formState.failOnContentCheck,
       saveStorage: this.formState.saveStorage,
+      robots: this.formState.robots,
     };
     return config;
   }

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -85,6 +85,9 @@ export const infoTextFor = {
   saveStorage: msg(
     `Include data from the browser's local and session storage in the web archive.`,
   ),
+  robots: msg(
+    `Check for a /robots.txt for each host and skip any disallowed pages.`,
+  ),
 } as const satisfies Partial<Record<Field, string | TemplateResult>>;
 
 export default infoTextFor;

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -86,7 +86,7 @@ export const infoTextFor = {
     `Include data from the browser's local and session storage in the web archive.`,
   ),
   robots: msg(
-    `Check for a /robots.txt for each host and skip any disallowed pages.`,
+    `Check for a robots.txt file for each host and skip any disallowed pages.`,
   ),
 } as const satisfies Partial<Record<Field, string | TemplateResult>>;
 

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -85,7 +85,7 @@ export const infoTextFor = {
   saveStorage: msg(
     `Include data from the browser's local and session storage in the web archive.`,
   ),
-  robots: msg(
+  useRobots: msg(
     `Check for a robots.txt file for each host and skip any disallowed pages.`,
   ),
 } as const satisfies Partial<Record<Field, string | TemplateResult>>;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -55,6 +55,7 @@ export type SeedConfig = Expand<
     customBehaviors: string[];
     clickSelector: string;
     saveStorage?: boolean;
+    robots?: boolean;
   }
 >;
 

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -55,7 +55,7 @@ export type SeedConfig = Expand<
     customBehaviors: string[];
     clickSelector: string;
     saveStorage?: boolean;
-    robots?: boolean;
+    useRobots?: boolean;
   }
 >;
 

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -184,7 +184,7 @@ export type FormState = {
   selectLinks: string[];
   clickSelector: string;
   saveStorage: WorkflowParams["config"]["saveStorage"];
-  robots: WorkflowParams["config"]["robots"];
+  useRobots: WorkflowParams["config"]["useRobots"];
 };
 
 export type FormStateField = keyof FormState;
@@ -247,7 +247,7 @@ export const getDefaultFormState = (): FormState => ({
   clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
   customBehavior: false,
   saveStorage: false,
-  robots: false,
+  useRobots: false,
 });
 
 export const mapSeedToUrl = (arr: Seed[]) =>
@@ -421,7 +421,7 @@ export function getInitialFormState(params: {
       params.initialWorkflow.crawlerChannel || defaultFormState.crawlerChannel,
     proxyId: params.initialWorkflow.proxyId || defaultFormState.proxyId,
     saveStorage: params.initialWorkflow.config.saveStorage,
-    robots: params.initialWorkflow.config.robots,
+    useRobots: params.initialWorkflow.config.useRobots,
     ...formState,
   };
 }

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -184,6 +184,7 @@ export type FormState = {
   selectLinks: string[];
   clickSelector: string;
   saveStorage: WorkflowParams["config"]["saveStorage"];
+  robots: WorkflowParams["config"]["robots"];
 };
 
 export type FormStateField = keyof FormState;
@@ -246,6 +247,7 @@ export const getDefaultFormState = (): FormState => ({
   clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
   customBehavior: false,
   saveStorage: false,
+  robots: false,
 });
 
 export const mapSeedToUrl = (arr: Seed[]) =>
@@ -419,6 +421,7 @@ export function getInitialFormState(params: {
       params.initialWorkflow.crawlerChannel || defaultFormState.crawlerChannel,
     proxyId: params.initialWorkflow.proxyId || defaultFormState.proxyId,
     saveStorage: params.initialWorkflow.config.saveStorage,
+    robots: params.initialWorkflow.config.robots,
     ...formState,
   };
 }


### PR DESCRIPTION
Fixes #2935 

Adds:
- Backend API support for robots config option (now named `useRobots`, thanks Sua for the suggestion)
- Add checkbox to Scope section of crawl workflow editor in frontend for all scope types
- Documentation

I have not added the `robotsAgent` param that the crawler also supports as it seems like a pretty niche use case at this point, but can add if we'd prefer to do it all in one go.

## Dependencies

Browsertrix Crawler 1.10 (not yet released as of writing this), which should include https://github.com/webrecorder/browsertrix-crawler/pull/932