### PR TITLE
Frontend browser profile UI enhancements origin check fix

### DIFF
--- a/frontend/src/features/browser-profiles/profile-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-browser-dialog.ts
@@ -154,7 +154,7 @@ export class ProfileBrowserDialog extends BtrixElement {
     const isCrawler = this.appState.isCrawler;
     const creatingNew = this.duplicating || !this.profile;
     const incomplete =
-      this.browserStatus !== BrowserStatus.Ready || !this.originsLoaded;
+      !this.originsLoaded || this.browserStatus !== BrowserStatus.Ready;
     const saving = this.saveProfileTask.status === TaskStatus.PENDING;
 
     return html`<btrix-dialog

--- a/frontend/src/features/browser-profiles/profile-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-browser-dialog.ts
@@ -29,7 +29,6 @@ enum BrowserStatus {
   Initial,
   Pending,
   Ready,
-  Complete,
   Error,
 }
 
@@ -53,6 +52,9 @@ export class ProfileBrowserDialog extends BtrixElement {
 
   @state()
   private browserStatus = BrowserStatus.Initial;
+
+  @state()
+  private originsLoaded = false;
 
   @state()
   private showConfirmation = false;
@@ -151,7 +153,8 @@ export class ProfileBrowserDialog extends BtrixElement {
   render() {
     const isCrawler = this.appState.isCrawler;
     const creatingNew = this.duplicating || !this.profile;
-    const incomplete = this.browserStatus !== BrowserStatus.Complete;
+    const incomplete =
+      this.browserStatus !== BrowserStatus.Ready || !this.originsLoaded;
     const saving = this.saveProfileTask.status === TaskStatus.PENDING;
 
     return html`<btrix-dialog
@@ -341,7 +344,7 @@ export class ProfileBrowserDialog extends BtrixElement {
     e: CustomEvent<BrowserOriginsChange>,
   ) => {
     if (e.detail.origins.length) {
-      this.browserStatus = BrowserStatus.Complete;
+      this.originsLoaded = true;
     }
   };
 

--- a/frontend/src/features/browser-profiles/profile-browser.ts
+++ b/frontend/src/features/browser-profiles/profile-browser.ts
@@ -173,11 +173,7 @@ export class ProfileBrowser extends BtrixElement {
       try {
         const { origins } = await this.pingBrowser(browser.id, signal);
 
-        if (
-          this.originsTask.value &&
-          origins &&
-          isNotEqual(this.originsTask.value, origins)
-        ) {
+        if (origins && isNotEqual(this.originsTask.value, origins)) {
           this.dispatchEvent(
             new CustomEvent<BrowserOriginsChange>(
               "btrix-browser-origins-change",


### PR DESCRIPTION
- Fix for 'Create Profile' button sometimes not being enabled due to event not firing, see: https://github.com/webrecorder/browsertrix/pull/3024#issuecomment-3587067342
- Ensure that if origins are loaded before browser is ready, both are checked separately.