### PR TITLE
devex: add helm chart option to drop indexes on startup

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -131,6 +131,8 @@ async def update_and_prepare_db(
         crawl_manager,
     ):
         await drop_indexes(mdb)
+    elif os.environ.get("MONGO_DB_DROP_INDEXES"):
+        await drop_indexes(mdb)
 
     await create_indexes(
         org_ops,

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -45,6 +45,7 @@ data:
   IDLE_TIMEOUT: "{{ .Values.profile_browser_idle_seconds | default 60 }}"
 
   RERUN_FROM_MIGRATION: "{{ .Values.rerun_from_migration }}"
+  MONGO_DB_DROP_INDEXES: "{{ .Values.mongo_drop_indexes }}"
   MIGRATION_JOBS_SCALE: "{{ .Values.migration_jobs_scale | default 1 }}"
 
   PRESIGN_DURATION_MINUTES: "{{ .Values.storage_presign_duration_minutes }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -526,6 +526,9 @@ signer_memory: "50Mi"
 # see backend/btrixcloud/migrations/ for list of available migrations
 # rerun_from_migration:
 
+# if set, will force mongodb to drop indexes on startup
+# mongo_drop_indexes: 1
+
 # scale for certain migration background jobs
 # migration_jobs_scale: 1
 


### PR DESCRIPTION
Useful option to have when changes to indexes, but a full migration is not needed, eg. can run:
`helm upgrade --install -f ./chart/local.yaml btrix ./chart/ --set=mongo_drop_indexes=1` if needed