### PR TITLE
Quickfix: Anticipate that crawl profile may have been deleted

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -464,11 +464,14 @@ class BaseCrawlOps:
                 raise HTTPException(status_code=400, detail="missing_org")
 
         if hasattr(crawl, "profileid") and crawl.profileid:
-            profile = await self.crawl_configs.profiles.get_profile(
-                crawl.profileid, org
-            )
-            if profile:
+            try:
+                profile = await self.crawl_configs.profiles.get_profile(
+                    crawl.profileid, org
+                )
                 crawl.profileName = profile.name
+            # pylint: disable=bare-except
+            except:
+                crawl.profileName = ""
 
         if (
             files

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1044,9 +1044,8 @@ class CrawlConfigOps:
 
         if crawlconfig.profileid:
             profile = await self.profiles.get_profile(crawlconfig.profileid, org)
-            if profile:
-                crawlconfig.profileName = profile.name
-                crawlconfig.proxyId = profile.proxyId
+            crawlconfig.profileName = profile.name
+            crawlconfig.proxyId = profile.proxyId
 
         crawlconfig.config.seeds = None
 


### PR DESCRIPTION
Regression fix for issue discovered during testing of the 1.20 beta release which resulted in the GET `/all-crawls` endpoint returning a 404 if a profile that any crawl references no longer exists (which we should anticipate and allow).