### PR TITLE
quickfix: add frame-ancestors csp policy

### DIFF
--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -151,7 +151,7 @@ server {
       proxy_pass http://browser-$browserid.browser$fqdn_suffix:9223/vnc/;
       proxy_set_header Host "localhost";
 
-      add_header Content-Security-Policy "frame-ancestors *";
+      add_header Content-Security-Policy "frame-ancestors 'self' localhost:*";
     }
 
     location = /access_check_profiles {

--- a/frontend/frontend.conf.template
+++ b/frontend/frontend.conf.template
@@ -39,6 +39,8 @@ server {
       root   /usr/share/nginx/html;
       index  index.html index.htm;
       try_files $uri /index.html;
+
+      add_header Content-Security-Policy "frame-ancestors 'self'";
     }
 
     location ~* /docs/(.*)$ {
@@ -148,6 +150,8 @@ server {
 
       proxy_pass http://browser-$browserid.browser$fqdn_suffix:9223/vnc/;
       proxy_set_header Host "localhost";
+
+      add_header Content-Security-Policy "frame-ancestors *";
     }
 
     location = /access_check_profiles {


### PR DESCRIPTION
- disallow external framing most of the app, except profile browsers for debugging