### PR TITLE
Fix background job email failures

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -101,7 +101,7 @@ class BackgroundJobOps:
         parts = urlsplit(endpoint_url)
         return parts.scheme + "://" + parts.netloc + "/", parts.path[1:]
 
-    async def handle_replica_job_finished(self, job: CreateReplicaJob) -> None:
+    async def handle_replica_job_succeeded(self, job: CreateReplicaJob) -> None:
         """Update replicas in corresponding file objects, based on type"""
         res = None
         if job.object_type in ("crawl", "upload"):
@@ -534,7 +534,7 @@ class BackgroundJobOps:
             raise HTTPException(status_code=400, detail="invalid_job_type")
 
         if success and job_type == BgJobType.CREATE_REPLICA:
-            await self.handle_replica_job_finished(cast(CreateReplicaJob, job))
+            await self.handle_replica_job_succeeded(cast(CreateReplicaJob, job))
 
         if job_type == BgJobType.DELETE_REPLICA:
             await self.handle_delete_replica_job_finished(cast(DeleteReplicaJob, job))

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -515,7 +515,15 @@ class BackgroundJobOps:
             )
             await self.jobs.insert_one(cleanup_job.to_dict())
             if not success:
-                await self._send_bg_job_failure_email(cleanup_job, finished)
+                try:
+                    await self._send_bg_job_failure_email(cleanup_job, finished)
+                # pylint: disable=broad-exception-caught
+                except Exception as err:
+                    print(
+                        f"Error sending bg job failure email for job {cleanup_job.id}: {err}",
+                        flush=True,
+                    )
+
             return
 
         job = await self.get_background_job(job_id)
@@ -532,7 +540,14 @@ class BackgroundJobOps:
             await self.handle_delete_replica_job_finished(cast(DeleteReplicaJob, job))
 
         if not success:
-            await self._send_bg_job_failure_email(job, finished)
+            try:
+                await self._send_bg_job_failure_email(job, finished)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                print(
+                    f"Error sending bg job failure email for job {job.id}: {err}",
+                    flush=True,
+                )
 
         await self.jobs.find_one_and_update(
             {"_id": job_id, "oid": oid},

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -538,14 +538,11 @@ class BackgroundJobOps:
         org = None
         if job.oid:
             org = await self.org_ops.get_org_by_id(job.oid)
-        await asyncio.get_event_loop().run_in_executor(
-            None,
-            self.email.send_background_job_failed,
-            job,
-            finished,
-            superuser.email,
-            org,
+        task = asyncio.create_task(
+            self.email.send_background_job_failed(job, finished, superuser.email, org)
         )
+        bg_tasks.add(task)
+        task.add_done_callback(bg_tasks.discard)
 
     async def get_background_job(
         self, job_id: str, oid: Optional[UUID] = None

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -197,7 +197,7 @@ class EmailSender:
         await self._send_encrypted(
             receiver_email,
             "failedBgJob",
-            job=job,
+            job=job.model_dump(mode="json"),
             org=str(org.id) if org else None,
             finished=finished.isoformat(),
         )

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -43,7 +43,7 @@ class BgJobOperator(BaseOperator):
         success = status.get("succeeded") == spec.get("parallelism")
         if not success:
             print(
-                "Succeeded: {status.get('succeeded')}, Num Pods: {spec.get('parallelism')}"
+                f"Succeeded: {status.get('succeeded')}, Num Pods: {spec.get('parallelism')}"
             )
         start_time = status.get("startTime")
         completion_time = status.get("completionTime")
@@ -75,10 +75,6 @@ class BgJobOperator(BaseOperator):
                 finished=finished,
                 oid=org_id,
             )
-            # print(
-            #    f"{job_type} background job completed: success: {success}, {job_id}",
-            #    flush=True,
-            # )
 
         # pylint: disable=broad-except
         except Exception:

--- a/backend/test/test_emails.py
+++ b/backend/test/test_emails.py
@@ -200,9 +200,8 @@ async def test_send_password_reset(email_sender, capsys):
 @pytest.mark.asyncio
 async def test_send_background_job_failed(email_sender, sample_org, capsys):
     """Test sending background job failure notification"""
-    # Create a mock job
     job = CreateReplicaJob(
-        id=uuid.uuid4(),
+        id="fake-create-replica-job",
         oid=sample_org.id,
         success=False,
         started=dt_now(),

--- a/chart/app-templates/replica_job.yaml
+++ b/chart/app-templates/replica_job.yaml
@@ -90,7 +90,7 @@ spec:
           value: "{{ replica_endpoint }}"
 
 {% if job_type == BgJobType.CREATE_REPLICA %}
-        command: ["rclone", "-vv", "copyto", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replicadoesntexist:{{ replica_file_path }}"]
+        command: ["rclone", "-vv", "copyto", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replica:{{ replica_file_path }}"]
 {% elif job_type == BgJobType.DELETE_REPLICA %}
         command: ["rclone", "-vv", "delete", "replica:{{ replica_file_path }}"]
 {% endif %}

--- a/chart/app-templates/replica_job.yaml
+++ b/chart/app-templates/replica_job.yaml
@@ -90,7 +90,7 @@ spec:
           value: "{{ replica_endpoint }}"
 
 {% if job_type == BgJobType.CREATE_REPLICA %}
-        command: ["rclone", "-vv", "copyto", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replica:{{ replica_file_path }}"]
+        command: ["rclone", "-vv", "copyto", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replicadoesntexist:{{ replica_file_path }}"]
 {% elif job_type == BgJobType.DELETE_REPLICA %}
         command: ["rclone", "-vv", "delete", "replica:{{ replica_file_path }}"]
 {% endif %}

--- a/emails/emails/failed-bg-job.tsx
+++ b/emails/emails/failed-bg-job.tsx
@@ -16,7 +16,7 @@ export const schema = z.object({
     replica_storage: z.object({
       name: z.string(),
       custom: z.boolean(),
-    }),
+    }).optional(),
   }),
   finished: z.coerce.date(),
 });

--- a/emails/emails/failed-bg-job.tsx
+++ b/emails/emails/failed-bg-job.tsx
@@ -13,7 +13,10 @@ export const schema = z.object({
     object_type: z.string().optional(),
     object_id: z.string().optional(),
     file_path: z.string().optional(),
-    replica_storage: z.string().optional(),
+    replica_storage: z.object({
+      name: z.string(),
+      custom: z.boolean(),
+    }),
   }),
   finished: z.coerce.date(),
 });
@@ -84,9 +87,9 @@ export const FailedBgJobEmail = ({
             <Code>{job.file_path}</Code>
           </DataRow>
         )}
-        {job.replica_storage && (
+        {job.replica_storage && job.replica_storage.name && (
           <DataRow label="Replica Storage">
-            <Code>{job.replica_storage}</Code>
+            <Code>{job.replica_storage.name}</Code>
           </DataRow>
         )}
       </table>
@@ -104,7 +107,7 @@ FailedBgJobEmail.PreviewProps = {
     object_type: "object_type",
     object_id: "object_id",
     file_path: "file_path",
-    replica_storage: "replica_storage",
+    replica_storage: {name: "replica_storage", custom: false},
   },
   finished: new Date(),
 } satisfies FailedBgJobEmailProps;


### PR DESCRIPTION
Fixes #3044 

- Use `asyncio.create_task` to send background job failure emails (tracking tasks in set in ops class to avoid garbage collection)
- Update job in database before sending emails
- Add try/except around email sending so failures are logged instead of throwing uncaught exception
- Rename `handle_replica_job_finished` to `handle_replica_job_succeeded` to better reflect intent
- Fix failed background job email template and ensure that job sent to it is JSON-serializable with `model_dump(mode="json")

**Note: The latest commit should be dropped before merging but allows for easy testing of a failed replica job that will trigger an email.**

Further job-related improvements will be handled in a future release. Some work toward that has been removed from this PR and saved as https://github.com/webrecorder/browsertrix/compare/main...job-failure-improvements-extended
