### PR TITLE
model: adjust crawlconfig model to allow dedupeCollId to be "", 

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -334,7 +334,7 @@ class CrawlConfigOps:
             first_seed = seeds[0].url
 
         # the dedupe collection id must also be in auto add collections
-        if config_in.dedupeCollId:
+        if isinstance(config_in.dedupeCollId, UUID):
             if config_in.autoAddCollections is None:
                 config_in.autoAddCollections = []
 
@@ -385,7 +385,7 @@ class CrawlConfigOps:
         storage_quota_reached = False
         exec_mins_quota_reached = False
 
-        if config_in.dedupeCollId:
+        if isinstance(config_in.dedupeCollId, UUID):
             await self.coll_ops.enable_dedupe_index(config_in.dedupeCollId)
 
         if config_in.runNow:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -419,7 +419,7 @@ class CrawlConfigIn(BaseModel):
     proxyId: Optional[str] = None
 
     autoAddCollections: Optional[List[UUID]] = []
-    dedupeCollId: Optional[UUID] = None
+    dedupeCollId: Union[UUID, EmptyStr, None] = None
 
     tags: Optional[List[str]] = []
 


### PR DESCRIPTION
consistent with profileId and proxyId
to have more consistent API
avoids same issue as #1946, alternate fix to #3049