### PR TITLE
Additional minutes addon purchase  add sub add minutes events

### DIFF
--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -17,6 +17,12 @@ jobs:
   btrix-microk8s-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Initial Disk Cleanup
+        uses: mathio/gha-cleanup@v1
+        with:
+          remove-browsers: true
+          verbose: true
+
       - uses: balchua/microk8s-actions@v0.3.1
         with:
           channel: "1.25/stable"

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -181,7 +181,6 @@ def main() -> None:
         crawl_manager,
         invites,
         current_active_user,
-        shared_secret_or_superuser,
     )
 
     init_subs_api(app, mdb, org_ops, user_manager, shared_secret_or_superuser)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1829,6 +1829,8 @@ ACTIVE = "active"
 REASON_PAUSED = "subscriptionPaused"
 REASON_CANCELED = "subscriptionCanceled"
 
+SubscriptionEventType = Literal["create", "import", "update", "cancel", "add-minutes"]
+
 
 # ============================================================================
 class OrgQuotas(BaseModel):
@@ -1881,6 +1883,7 @@ class SubscriptionEventOut(BaseModel):
 
     oid: UUID
     timestamp: datetime
+    type: SubscriptionEventType
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2101,6 +2101,7 @@ class OrgQuotaUpdate(BaseModel):
 
     modified: datetime
     update: OrgQuotas
+    context: str | None = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1975,6 +1975,24 @@ class SubscriptionAddMinutesOut(SubscriptionAddMinutes, SubscriptionEventOut):
 
 
 # ============================================================================
+SubscriptionEventAny = Union[
+    SubscriptionCreate,
+    SubscriptionUpdate,
+    SubscriptionCancel,
+    SubscriptionImport,
+    SubscriptionAddMinutes,
+]
+
+SubscriptionEventAnyOut = Union[
+    SubscriptionCreateOut,
+    SubscriptionUpdateOut,
+    SubscriptionCancelOut,
+    SubscriptionImportOut,
+    SubscriptionAddMinutesOut,
+]
+
+
+# ============================================================================
 class SubscriptionTrialEndReminder(BaseModel):
     """Email reminder that subscription will end soon"""
 
@@ -3146,14 +3164,7 @@ class PaginatedProfileResponse(PaginatedResponse):
 class PaginatedSubscriptionEventResponse(PaginatedResponse):
     """Response model for paginated subscription events"""
 
-    items: List[
-        Union[
-            SubscriptionCreateOut,
-            SubscriptionUpdateOut,
-            SubscriptionCancelOut,
-            SubscriptionImportOut,
-        ]
-    ]
+    items: List[SubscriptionEventAnyOut]
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1948,18 +1948,37 @@ class SubscriptionCancel(BaseModel):
 
 
 # ============================================================================
+class SubscriptionCancelOut(SubscriptionCancel, SubscriptionEventOut):
+    """Output model for subscription cancellation event"""
+
+    type: Literal["cancel"] = "cancel"
+
+
+# ============================================================================
+class SubscriptionAddMinutes(BaseModel):
+    """Represents a purchase of additional minutes"""
+
+    oid: UUID
+    minutes: int
+    total_price: float
+    currency: str
+
+    context: str
+
+
+# ============================================================================
+class SubscriptionAddMinutesOut(SubscriptionAddMinutes, SubscriptionEventOut):
+    """SubscriptionAddMinutes output model"""
+
+    type: Literal["add-minutes"] = "add-minutes"
+
+
+# ============================================================================
 class SubscriptionTrialEndReminder(BaseModel):
     """Email reminder that subscription will end soon"""
 
     subId: str
     behavior_on_trial_end: Literal["cancel", "continue", "read-only"]
-
-
-# ============================================================================
-class SubscriptionCancelOut(SubscriptionCancel, SubscriptionEventOut):
-    """Output model for subscription cancellation event"""
-
-    type: Literal["cancel"] = "cancel"
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1857,8 +1857,6 @@ class OrgQuotasIn(BaseModel):
     extraExecMinutes: Optional[int] = None
     giftedExecMinutes: Optional[int] = None
 
-    context: str | None = None
-
 
 # ============================================================================
 class Plan(BaseModel):
@@ -2103,7 +2101,6 @@ class OrgQuotaUpdate(BaseModel):
 
     modified: datetime
     update: OrgQuotas
-    context: str | None = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1546,7 +1546,6 @@ def init_orgs_api(
     crawl_manager: CrawlManager,
     invites: InviteOps,
     user_dep: Callable[[str], Awaitable[User]],
-    superuser_or_shared_secret_dep: Callable[[str], Awaitable[User]],
 ):
     """Init organizations api router for /orgs"""
     # pylint: disable=too-many-locals,invalid-name
@@ -1702,19 +1701,6 @@ def init_orgs_api(
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         await ops.update_quotas(org, quotas, mode="set", context=quotas.context)
-
-        return {"updated": True}
-
-    @app.post(
-        "/orgs/{oid}/quotas/add", tags=["organizations"], response_model=UpdatedResponse
-    )
-    async def update_quotas_add(
-        oid: UUID,
-        quotas: OrgQuotasIn,
-        _user: User = Depends(superuser_or_shared_secret_dep),
-    ):
-        org = await ops.get_org_by_id(oid)
-        await ops.update_quotas(org, quotas, mode="add", context=quotas.context)
 
         return {"updated": True}
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -625,8 +625,6 @@ class OrgOps:
     ) -> None:
         """update organization quotas"""
 
-        quotas.context = None
-
         previous_extra_mins = (
             org.quotas.extraExecMinutes
             if (org.quotas and org.quotas.extraExecMinutes)
@@ -1700,7 +1698,7 @@ def init_orgs_api(
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
-        await ops.update_quotas(org, quotas, mode="set", context=quotas.context)
+        await ops.update_quotas(org, quotas, mode="set")
 
         return {"updated": True}
 

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -2,13 +2,13 @@
 Subscription API handling
 """
 
-from typing import Awaitable, Callable, Union, Any, Optional, Tuple, List
+from typing import Awaitable, Callable, Union, Any, Optional, Tuple, List, Annotated
 import os
 import asyncio
 from uuid import UUID
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 import aiohttp
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
@@ -29,6 +29,7 @@ from .models import (
     SubscriptionUpdateOut,
     SubscriptionCancelOut,
     SubscriptionAddMinutesOut,
+    SubscriptionEventType,
     Subscription,
     SubscriptionPortalUrlRequest,
     SubscriptionPortalUrlResponse,
@@ -245,7 +246,7 @@ class SubOps:
 
     async def add_sub_event(
         self,
-        type_: str,
+        type_: SubscriptionEventType,
         event: Union[
             SubscriptionCreate,
             SubscriptionImport,
@@ -290,6 +291,7 @@ class SubOps:
         sub_id: Optional[str] = None,
         oid: Optional[UUID] = None,
         plan_id: Optional[str] = None,
+        type_: Optional[SubscriptionEventType] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: Optional[str] = None,
@@ -321,6 +323,8 @@ class SubOps:
             query["planId"] = plan_id
         if oid:
             query["oid"] = oid
+        if type_:
+            query["type"] = type_
 
         aggregate = [{"$match": query}]
 
@@ -572,6 +576,7 @@ def init_subs_api(
         subId: Optional[str] = None,
         oid: Optional[UUID] = None,
         planId: Optional[str] = None,
+        type_: Annotated[Optional[SubscriptionEventType], Query(alias="type")] = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sortBy: Optional[str] = "timestamp",
@@ -583,6 +588,7 @@ def init_subs_api(
             oid=oid,
             plan_id=planId,
             page_size=pageSize,
+            type_=type_,
             page=page,
             sort_by=sortBy,
             sort_direction=sortDirection,

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -278,8 +278,10 @@ class SubOps:
             return SubscriptionUpdateOut(**data)
         if data["type"] == "add-minutes":
             return SubscriptionAddMinutesOut(**data)
+        if data["type"] == "cancel":
+            return SubscriptionCancelOut(**data)
 
-        return SubscriptionCancelOut(**data)
+        raise HTTPException(status_code=500, detail="unknown sub event")
 
     # pylint: disable=too-many-arguments
     async def list_sub_events(

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -922,7 +922,7 @@ def test_subscription_add_minutes(admin_auth_headers):
         f"{API_PREFIX}/subscriptions/add-minutes",
         headers=admin_auth_headers,
         json={
-            "oid": str(new_subs_oid),
+            "oid": str(new_subs_oid_2),
             "minutes": 75,
             "total_price": 350,
             "currency": "usd",
@@ -930,12 +930,11 @@ def test_subscription_add_minutes(admin_auth_headers):
         },
     )
 
-    print(r.json())
     assert r.status_code == 200
     assert r.json() == {"updated": True}
 
     r = requests.post(
-        f"{API_PREFIX}/orgs/{new_subs_oid}",
+        f"{API_PREFIX}/orgs/{new_subs_oid_2}",
         headers=admin_auth_headers,
     )
 
@@ -947,8 +946,8 @@ def test_subscription_add_minutes(admin_auth_headers):
     assert last_update["type"] == "add-minutes"
     assert last_update["context"] == "addon"
     assert last_update["update"] == {
-        "maxPagesPerCrawl": 50,
-        "storageQuota": 500000,
+        "maxPagesPerCrawl": 100,
+        "storageQuota": 1000000,
         "extraExecMinutes": 75,  # only this value updated from previous
         "giftedExecMinutes": 0,
         "maxConcurrentCrawls": 1,

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -762,7 +762,7 @@ def test_subscription_events_log_filter_sort(admin_auth_headers):
 
     last_id = None
     for event in events:
-        sub_id = event["subId"]
+        sub_id = event.get("subId")
         if last_id:
             assert last_id <= sub_id
         last_id = sub_id
@@ -778,7 +778,7 @@ def test_subscription_events_log_filter_sort(admin_auth_headers):
 
     last_id = None
     for event in events:
-        sub_id = event["subId"]
+        sub_id = event.get("subId")
         if last_id:
             assert last_id >= sub_id
         last_id = sub_id
@@ -961,7 +961,7 @@ def test_subscription_add_minutes(admin_auth_headers):
     assert len(quota_updates)
     last_update = quota_updates[len(quota_updates) - 1]
 
-    assert last_update["type"] == "add-minutes"
+    print(last_update)
     assert last_update["context"] == "addon"
     assert last_update["update"] == {
         "maxPagesPerCrawl": 100,

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -933,7 +933,25 @@ def test_subscription_add_minutes(admin_auth_headers):
     assert r.status_code == 200
     assert r.json() == {"updated": True}
 
-    r = requests.post(
+    # get event from log
+    r = requests.get(
+        f"{API_PREFIX}/subscriptions/events?oid={new_subs_oid_2}&type=add-minutes",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["items"]) == 1
+    event = data["items"][0]
+
+    assert event["type"] == "add-minutes"
+    assert event["oid"] == new_subs_oid_2
+    assert event["minutes"] == 75
+    assert event["total_price"] == 350
+    assert event["currency"] == "usd"
+    assert event["context"] == "addon"
+
+    # check org quota updates for corresponding entry
+    r = requests.get(
         f"{API_PREFIX}/orgs/{new_subs_oid_2}",
         headers=admin_auth_headers,
     )

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -508,7 +508,6 @@ def test_subscription_events_log(admin_auth_headers, non_default_org_id):
             "planId": "basic2",
             "futureCancelDate": None,
             "quotas": {
-                "context": None,
                 "maxPagesPerCrawl": 50,
                 "storageQuota": 500000,
                 "extraExecMinutes": None,
@@ -577,7 +576,6 @@ def test_subscription_events_log_filter_sub_id(admin_auth_headers):
             "planId": "basic2",
             "futureCancelDate": None,
             "quotas": {
-                "context": None,
                 "maxPagesPerCrawl": 50,
                 "storageQuota": 500000,
                 "extraExecMinutes": None,
@@ -639,7 +637,6 @@ def test_subscription_events_log_filter_oid(admin_auth_headers):
             "planId": "basic2",
             "futureCancelDate": None,
             "quotas": {
-                "context": None,
                 "maxPagesPerCrawl": 50,
                 "storageQuota": 500000,
                 "extraExecMinutes": None,
@@ -675,7 +672,6 @@ def test_subscription_events_log_filter_plan_id(admin_auth_headers):
             "planId": "basic2",
             "futureCancelDate": None,
             "quotas": {
-                "context": None,
                 "maxPagesPerCrawl": 50,
                 "storageQuota": 500000,
                 "extraExecMinutes": None,
@@ -727,7 +723,6 @@ def test_subscription_events_log_filter_status(admin_auth_headers):
             "planId": "basic2",
             "futureCancelDate": None,
             "quotas": {
-                "context": None,
                 "maxPagesPerCrawl": 50,
                 "storageQuota": 500000,
                 "extraExecMinutes": None,

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -922,7 +922,7 @@ def test_subscription_add_minutes(admin_auth_headers):
         f"{API_PREFIX}/subscriptions/add-minutes",
         headers=admin_auth_headers,
         json={
-            "oid": new_subs_oid,
+            "oid": str(new_subs_oid),
             "minutes": 75,
             "total_price": 350,
             "currency": "usd",
@@ -930,6 +930,7 @@ def test_subscription_add_minutes(admin_auth_headers):
         },
     )
 
+    print(r.json())
     assert r.status_code == 200
     assert r.json() == {"updated": True}
 

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -959,9 +959,7 @@ def test_subscription_add_minutes(admin_auth_headers):
     assert r.status_code == 200
     quota_updates = r.json()["quotaUpdates"]
     assert len(quota_updates)
-    last_update = quota_updates[len(quota_updates) - 1]
-
-    print(last_update)
+    last_update = quota_updates[-1]
     assert last_update["context"] == "addon"
     assert last_update["update"] == {
         "maxPagesPerCrawl": 100,

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -196,36 +196,3 @@ def test_unset_execution_mins_quota(org_with_quotas, admin_auth_headers):
     )
     data = r.json()
     assert data.get("updated") == True
-
-
-def test_add_execution_mins_extra_quotas(
-    org_with_quotas, admin_auth_headers, preshared_secret_auth_headers
-):
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas/add",
-        headers=preshared_secret_auth_headers,
-        json={
-            "extraExecMinutes": EXTRA_MINS_ADDED_QUOTA,
-            "context": "test context 123",
-        },
-    )
-    data = r.json()
-    assert data.get("updated") == True
-
-    # Ensure org data looks as we expect
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{org_with_quotas}",
-        headers=admin_auth_headers,
-    )
-    data = r.json()
-    assert (
-        data["extraExecSecondsAvailable"] == EXTRA_SECS_QUOTA + EXTRA_SECS_ADDED_QUOTA
-    )
-    assert data["giftedExecSecondsAvailable"] == GIFTED_SECS_QUOTA
-    assert data["extraExecSeconds"] == {}
-    assert data["giftedExecSeconds"] == {}
-    assert len(data["quotaUpdates"])
-    for update in data["quotaUpdates"]:
-        assert update["modified"]
-        assert update["update"]
-    assert data["quotaUpdates"][-1]["context"] == "test context 123"

--- a/chart/test/microk8s-ci.yaml
+++ b/chart/test/microk8s-ci.yaml
@@ -15,6 +15,4 @@ crawler_extra_cpu_per_browser: 300m
 
 crawler_extra_memory_per_browser: 256Mi
 
-backend_memory: "500Mi"
-
-backend_workers: 2
+backend_memory: "350Mi"

--- a/chart/test/microk8s-ci.yaml
+++ b/chart/test/microk8s-ci.yaml
@@ -14,3 +14,7 @@ frontend_pull_policy: "IfNotPresent"
 crawler_extra_cpu_per_browser: 300m
 
 crawler_extra_memory_per_browser: 256Mi
+
+backend_memory: "500Mi"
+
+backend_workers: 2

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -16,6 +16,9 @@ operator_resync_seconds: 3
 
 qa_scale: 2
 
+backend_memory: "500Mi"
+
+
 # lower storage sizes
 redis_storage: "100Mi"
 profile_browser_workdir_size: "100Mi"


### PR DESCRIPTION
- Fixes #3052 
- New SubscriptionAddMinutes event, added via /subscription/add-minutes endpoint, storing total_price, currency, context, oid and minutes added.
- Remove org/quotas/add endpoint (can readd if needed for superadmin use later)
- Remove 'context' from OrgQuotasIn, only added from SubscriptionAddMinutes, though keep on OrgQuotasUpdate list on orgs
- add filtering by 'add-minutes' subscription event type