### PR TITLE
Use dedicated mongo session in quota update method

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -37,31 +37,17 @@ if TYPE_CHECKING:
     from .crawlmanager import CrawlManager
     from .profiles import ProfileOps
 else:
-    UserManager = (
-        OrgOps
-    ) = (
-        CrawlConfigOps
-    ) = (
-        CrawlOps
-    ) = (
-        CollectionOps
-    ) = (
-        InviteOps
-    ) = (
+    UserManager = OrgOps = CrawlConfigOps = CrawlOps = CollectionOps = InviteOps = (
         StorageOps
-    ) = (
-        PageOps
-    ) = (
-        BackgroundJobOps
-    ) = FileUploadOps = CrawlLogOps = CrawlManager = ProfileOps = object
+    ) = PageOps = BackgroundJobOps = FileUploadOps = CrawlLogOps = CrawlManager = (
+        ProfileOps
+    ) = object
 
 
 CURR_DB_VERSION = "0054"
 
 
 # ============================================================================
-
-
 def resolve_db_url() -> str:
     """get the mongo db url, either from MONGO_DB_URL or
     from separate username, password and host settings"""

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -176,6 +176,7 @@ def main() -> None:
 
     org_ops = init_orgs_api(
         app,
+        dbclient,
         mdb,
         user_manager,
         crawl_manager,

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -56,7 +56,7 @@ def init_ops() -> Tuple[
 
     user_manager = UserManager(mdb, email, invite_ops)
 
-    org_ops = OrgOps(mdb, invite_ops, user_manager, crawl_manager)
+    org_ops = OrgOps(dbclient, mdb, invite_ops, user_manager, crawl_manager)
 
     event_webhook_ops = EventWebhookOps(mdb, org_ops)
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -24,7 +24,7 @@ from typing import (
     Any,
 )
 
-from motor.motor_asyncio import AsyncIOMotorDatabase
+from motor.motor_asyncio import AsyncIOMotorClientSession, AsyncIOMotorDatabase
 from pydantic import ValidationError
 from pymongo import ReturnDocument
 from pymongo.errors import AutoReconnect, DuplicateKeyError
@@ -33,6 +33,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 import json_stream
 from aiostream import stream
+
+from backend.btrixcloud.db import TransactionDecorator, with_transaction
 
 from .models import (
     SUCCESSFUL_STATES,
@@ -659,12 +661,14 @@ class OrgOps(BaseOrgs):
             },
         )
 
+    @with_transaction
     async def update_quotas(
         self,
         org: Organization,
         quotas: OrgQuotasIn,
         mode: Literal["set", "add"],
         sub_event_id: str | None = None,
+        session: AsyncIOMotorClientSession | None = None,
     ) -> None:
         """update organization quotas"""
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -38,8 +38,6 @@ from fastapi.responses import StreamingResponse
 import json_stream
 from aiostream import stream
 
-from backend.btrixcloud.db import TransactionDecorator, with_transaction
-
 from .models import (
     SUCCESSFUL_STATES,
     RUNNING_STATES,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -702,17 +702,13 @@ class OrgOps(BaseOrgs):
                         "$inc": {},
                     }
 
-                    if mode == "set":
-                        increment_update = quotas.model_dump(
-                            exclude_unset=True, exclude_defaults=True, exclude_none=True
-                        )
-                    ),
-                    subEventId=sub_event_id,
-                ).model_dump()
-            },
-            "$inc": {},
-            "$set": {},
-        }
+                    for field, value in quotas.model_dump(
+                        exclude_unset=True, exclude_defaults=True, exclude_none=True
+                    ).items():
+                        if value is None:
+                            continue
+                        inc = max(value, -org.quotas.model_dump().get(field, 0))
+                        increment_update["$inc"][f"quotas.{field}"] = inc
 
                     updated_org = await self.orgs.find_one_and_update(
                         {"_id": org.id},
@@ -734,7 +730,7 @@ class OrgOps(BaseOrgs):
                                     exclude_none=True,
                                 )
                             ),
-                            context=context,
+                            subEventId=sub_event_id,
                         ).model_dump()
                     },
                     "$inc": {},

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -141,6 +141,15 @@ def test_add_execution_mins_extra_quotas(
         assert update["update"]
     assert data["quotaUpdates"][-1]["context"] == "test context 123"
 
+    # Reset back to previous value
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
+        headers=admin_auth_headers,
+        json={
+            "extraExecMinutes": EXTRA_MINS_QUOTA,
+        },
+    )
+
 
 @pytest.mark.timeout(1200)
 def test_crawl_paused_when_quota_reached_with_extra(

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -105,52 +105,6 @@ def test_set_execution_mins_extra_quotas(org_with_quotas, admin_auth_headers):
         assert update["update"]
 
 
-def test_add_execution_mins_extra_quotas(
-    org_with_quotas, admin_auth_headers, preshared_secret_auth_headers
-):
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas/add",
-        headers=preshared_secret_auth_headers,
-        json={
-            "extraExecMinutes": EXTRA_MINS_ADDED_QUOTA,
-            "context": "test context 123",
-        },
-    )
-    data = r.json()
-    assert data.get("updated") == True
-
-    # Ensure org data looks as we expect
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{org_with_quotas}",
-        headers=admin_auth_headers,
-    )
-    data = r.json()
-    assert (
-        data["extraExecSecondsAvailable"] == EXTRA_SECS_QUOTA + EXTRA_SECS_ADDED_QUOTA
-    )
-    assert data["giftedExecSecondsAvailable"] == GIFTED_SECS_QUOTA
-    assert data["extraExecSeconds"] == {}
-    assert data["giftedExecSeconds"] == {}
-    assert (
-        get_total_exec_seconds(data["crawlExecSeconds"])
-        >= EXEC_SECS_QUOTA + EXTRA_SECS_ADDED_QUOTA
-    )
-    assert len(data["quotaUpdates"])
-    for update in data["quotaUpdates"]:
-        assert update["modified"]
-        assert update["update"]
-    assert data["quotaUpdates"][-1]["context"] == "test context 123"
-
-    # Reset back to previous value
-    r = requests.post(
-        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas",
-        headers=admin_auth_headers,
-        json={
-            "extraExecMinutes": EXTRA_MINS_QUOTA,
-        },
-    )
-
-
 @pytest.mark.timeout(1200)
 def test_crawl_paused_when_quota_reached_with_extra(
     org_with_quotas, admin_auth_headers

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -105,6 +105,43 @@ def test_set_execution_mins_extra_quotas(org_with_quotas, admin_auth_headers):
         assert update["update"]
 
 
+def test_add_execution_mins_extra_quotas(
+    org_with_quotas, admin_auth_headers, preshared_secret_auth_headers
+):
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{org_with_quotas}/quotas/add",
+        headers=preshared_secret_auth_headers,
+        json={
+            "extraExecMinutes": EXTRA_MINS_ADDED_QUOTA,
+            "context": "test context 123",
+        },
+    )
+    data = r.json()
+    assert data.get("updated") == True
+
+    # Ensure org data looks as we expect
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{org_with_quotas}",
+        headers=admin_auth_headers,
+    )
+    data = r.json()
+    assert (
+        data["extraExecSecondsAvailable"] == EXTRA_SECS_QUOTA + EXTRA_SECS_ADDED_QUOTA
+    )
+    assert data["giftedExecSecondsAvailable"] == GIFTED_SECS_QUOTA
+    assert data["extraExecSeconds"] == {}
+    assert data["giftedExecSeconds"] == {}
+    assert (
+        get_total_exec_seconds(data["crawlExecSeconds"])
+        >= EXEC_SECS_QUOTA + EXTRA_SECS_ADDED_QUOTA
+    )
+    assert len(data["quotaUpdates"])
+    for update in data["quotaUpdates"]:
+        assert update["modified"]
+        assert update["update"]
+    assert data["quotaUpdates"][-1]["context"] == "test context 123"
+
+
 @pytest.mark.timeout(1200)
 def test_crawl_paused_when_quota_reached_with_extra(
     org_with_quotas, admin_auth_headers


### PR DESCRIPTION
To be merged into #2944 

Adds a causally consistent session specifically to the quota update method so that its three operations can operate more-or-less atomically.

We'd looked at doing this with a transaction, but they require a replica set or sharding, which isn't always included in self-hosted Browsertrix deployments. For now this should improve reliability for the multi-operation `update_quotas` method, even if it's not perfectly atomic — it's pretty unlikely at the scale we're working with here for there to be multiple simultaneous operations for a single org.

Tested with local deployment.