### PR TITLE
additional minutes data model changes:

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -2125,6 +2125,14 @@ class OrgQuotaUpdate(BaseModel):
 
 
 # ============================================================================
+class OrgQuotaUpdateOut(BaseModel):
+    """Organization quota update output for admins"""
+
+    modified: datetime
+    update: OrgQuotas
+
+
+# ============================================================================
 class OrgReadOnlyUpdate(BaseModel):
     """Organization readonly update"""
 
@@ -2198,7 +2206,7 @@ class OrgOut(BaseMongoModel):
     giftedExecSecondsAvailable: int = 0
 
     quotas: OrgQuotas = OrgQuotas()
-    quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
+    quotaUpdates: Optional[List[OrgQuotaUpdateOut]] = []
 
     webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1961,10 +1961,9 @@ class SubscriptionAddMinutes(BaseModel):
 
     oid: UUID
     minutes: int
-    total_price: float
+    totalPrice: float
     currency: str
-
-    context: str
+    paymentId: str
 
 
 # ============================================================================
@@ -2122,7 +2121,7 @@ class OrgQuotaUpdate(BaseModel):
 
     modified: datetime
     update: OrgQuotas
-    context: str | None = None
+    subEventId: str | None = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -555,19 +555,7 @@ class OrgOps:
         if not org_data:
             return None
 
-        org = Organization.from_dict(org_data)
-        if update.quotas:
-            # don't change gifted or extra minutes here
-            update.quotas.giftedExecMinutes = None
-            update.quotas.extraExecMinutes = None
-            await self.update_quotas(
-                org,
-                update.quotas,
-                mode="set",
-                context=f"subscription_change:{update.planId}",
-            )
-
-        return org
+        return Organization.from_dict(org_data)
 
     async def cancel_subscription_data(
         self, cancel: SubscriptionCancel
@@ -621,7 +609,7 @@ class OrgOps:
         org: Organization,
         quotas: OrgQuotasIn,
         mode: Literal["set", "add"],
-        context: str | None = None,
+        sub_event_id: str | None = None,
     ) -> None:
         """update organization quotas"""
 
@@ -666,7 +654,7 @@ class OrgOps:
                             exclude_unset=True, exclude_defaults=True, exclude_none=True
                         )
                     ),
-                    context=context,
+                    subEventId=sub_event_id,
                 ).model_dump()
             },
             "$inc": {},

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -926,7 +926,7 @@ def test_subscription_add_minutes(admin_auth_headers):
             "minutes": 75,
             "total_price": 350,
             "currency": "usd",
-            "context": "addon",
+            "paymentId": "789",
         },
     )
 
@@ -948,7 +948,7 @@ def test_subscription_add_minutes(admin_auth_headers):
     assert event["minutes"] == 75
     assert event["total_price"] == 350
     assert event["currency"] == "usd"
-    assert event["context"] == "addon"
+    assert event["paymentId"] == "789"
 
     # check org quota updates for corresponding entry
     r = requests.get(
@@ -960,7 +960,7 @@ def test_subscription_add_minutes(admin_auth_headers):
     quota_updates = r.json()["quotaUpdates"]
     assert len(quota_updates)
     last_update = quota_updates[-1]
-    assert last_update["context"] == "addon"
+    assert last_update["subEventId"]
     assert last_update["update"] == {
         "maxPagesPerCrawl": 100,
         "storageQuota": 1000000,

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -924,7 +924,7 @@ def test_subscription_add_minutes(admin_auth_headers):
         json={
             "oid": str(new_subs_oid_2),
             "minutes": 75,
-            "total_price": 350,
+            "totalPrice": 350,
             "currency": "usd",
             "paymentId": "789",
         },
@@ -946,7 +946,7 @@ def test_subscription_add_minutes(admin_auth_headers):
     assert event["type"] == "add-minutes"
     assert event["oid"] == new_subs_oid_2
     assert event["minutes"] == 75
-    assert event["total_price"] == 350
+    assert event["totalPrice"] == 350
     assert event["currency"] == "usd"
     assert event["paymentId"] == "789"
 

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -960,7 +960,7 @@ def test_subscription_add_minutes(admin_auth_headers):
     quota_updates = r.json()["quotaUpdates"]
     assert len(quota_updates)
     last_update = quota_updates[-1]
-    assert last_update["subEventId"]
+    assert "subEventId" not in last_update
     assert last_update["update"] == {
         "maxPagesPerCrawl": 100,
         "storageQuota": 1000000,


### PR DESCRIPTION
- remove context
- total_price -> totalPrice
- context -> paymentId
- store subEventId in quota update, linking to subscription event id
- org fields: don't include subEventId in org quota updates output, add OrgQuotaUpdateOut for this