### PR TITLE
feat: Filter archived items by ID

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -669,6 +669,7 @@ class BaseCrawlOps:
         self,
         org: Optional[Organization] = None,
         userid: Optional[UUID] = None,
+        ids: Optional[List[str]] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         tags: list[str] | None = None,
@@ -781,6 +782,9 @@ class BaseCrawlOps:
 
         if not resources:
             aggregate.extend([{"$unset": ["files"]}])
+
+        if ids:
+            aggregate.extend([{"$match": {"id": {"$in": ids}}}])
 
         if name:
             aggregate.extend([{"$match": {"name": name}}])


### PR DESCRIPTION
Allows retrieving multiple archived items at once by ID. For getting crawls of `requiredByCrawls`/`requiresCrawls`