### PR TITLE
Dedupe Recreate Index on Use

### DIFF
--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -501,16 +501,9 @@ class CrawlManager(K8sAPI):
 
     async def create_coll_index(self, collection: Collection):
         """create collection index"""
-        params = {
-            "id": str(collection.id),
-            "oid": str(collection.oid),
-            "collItemsUpdatedAt": date_to_str(collection.modified or dt_now()),
-        }
-        data = self.templates.env.get_template("coll_index.yaml").render(params)
-
-        await self.create_from_yaml(data)
-
-        return str(collection.id)
+        await self.create_coll_index_direct(
+            str(collection.id), str(collection.oid), collection.modified
+        )
 
     async def update_coll_index(self, coll_id: UUID):
         """force collection index to update"""

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -461,7 +461,7 @@ class K8sAPI:
     async def create_coll_index_direct(
         self, coll_id: str, oid: str, modified: Optional[datetime] = None
     ):
-        """create collection index"""
+        """create collection index if doesn't exist"""
         params = {
             "id": coll_id,
             "oid": oid,
@@ -473,5 +473,6 @@ class K8sAPI:
             await self.create_from_yaml(data)
 
         except ApiException as e:
+            # 409 if object already exists, ignore silently
             if e.status != 409:
                 raise e

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -273,7 +273,7 @@ class CrawlOperator(BaseOperator):
                 )
 
         if status.state in ("starting", "waiting_dedupe_index"):
-            if self.is_waiting_for_dedupe_index(crawl, data):
+            if await self.is_waiting_for_dedupe_index(crawl, data):
                 await self.set_state(
                     "waiting_dedupe_index", status, crawl, allowed_from=["starting"]
                 )
@@ -841,22 +841,34 @@ class CrawlOperator(BaseOperator):
 
         return False
 
-    def is_waiting_for_dedupe_index(self, crawl: CrawlSpec, data: MCSyncData) -> bool:
+    async def is_waiting_for_dedupe_index(
+        self, crawl: CrawlSpec, data: MCSyncData
+    ) -> bool:
         """return true if we need to wait for dedupe index to be ready
         before starting the crawl"""
         if not crawl.dedupe_coll_id:
             return False
 
         # index object doesn't exist
-        if not data.related[COLLINDEX]:
-            return False
+        coll_indexes = data.related.get(COLLINDEX, {})
 
-        for index in data.related[COLLINDEX].values():
+        print("COLL", coll_indexes)
+
+        found = False
+
+        for index in coll_indexes.values():
+            found = True
             if index.get("status", {}).get("state") == "ready":
                 return False
 
             # only check first index, should only be one
             break
+
+        # if index not found, create it
+        if not found:
+            await self.k8s.create_coll_index_direct(
+                str(crawl.dedupe_coll_id), str(crawl.oid)
+            )
 
         return True
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -852,8 +852,6 @@ class CrawlOperator(BaseOperator):
         # index object doesn't exist
         coll_indexes = data.related.get(COLLINDEX, {})
 
-        print("COLL", coll_indexes)
-
         found = False
 
         for index in coll_indexes.values():


### PR DESCRIPTION
- Ensure the CollIndex object is created by the operator if it doesn't exist when the crawl is starting.
Generally, shouldn't happen, as index should be created when a workflow is saved, by an extra caution to make this more robust.
- Also ensures crawl enters into Waiting for Dedupe Index state if index object does not exist
(Happened on dev due to branch switching)