### PR TITLE
add dedupe stats endpoint:

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -2,8 +2,9 @@
 
 import os
 import traceback
+import contextlib
 from datetime import datetime
-from typing import Optional, List, Any
+from typing import Optional, List, Any, AsyncIterator
 
 import yaml
 
@@ -98,6 +99,18 @@ class K8sAPI:
                 await redis.close()
 
             return None
+
+    @contextlib.asynccontextmanager
+    async def with_redis(self, object_id: str) -> AsyncIterator[Redis]:
+        """get redis url for object id"""
+        redis_url = self.get_redis_url(object_id)
+
+        redis = await self.get_redis_client(redis_url)
+
+        try:
+            yield redis
+        finally:
+            await redis.close()
 
     # pylint: disable=too-many-arguments, too-many-locals
     def new_crawl_job_yaml(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1767,6 +1767,19 @@ class UpdateCollHomeUrl(BaseModel):
 
 
 # ============================================================================
+class DedupeIndexStats(BaseModel):
+    """stats from collection dedupe index"""
+
+    uniqUrls: int = 0
+    totalUrls: int = 0
+
+    uniqSize: int = 0
+    totalSize: int = 0
+
+    removable: int = 0
+
+
+# ============================================================================
 class AddRemoveCrawlList(BaseModel):
     """Collections to add or remove from collection"""
 


### PR DESCRIPTION
- adding "/orgs/{oid}/collections/{coll_id}/dedupe"
- return stats from coll index redis, including uniq size vs total size, and uniq urls vs total urls, and number of purgeable (removable) crawls

Thus far, the model for the dedupe stats is:
```
class DedupeIndexStats(BaseModel):
    """stats from collection dedupe index"""

    uniqUrls: int = 0
    totalUrls: int = 0

    uniqSize: int = 0
    totalSize: int = 0

    removable: int = 0
```
