### PR TITLE
fix: Correct link to active crawl

### DIFF
--- a/frontend/src/pages/org/crawls.ts
+++ b/frontend/src/pages/org/crawls.ts
@@ -29,7 +29,7 @@ import {
   type SearchFields,
 } from "@/features/crawl-workflows/workflow-search";
 import { type BtrixChangeCrawlStateFilterEvent } from "@/features/crawls/crawl-state-filter";
-import { OrgTab } from "@/routes";
+import { OrgTab, WorkflowTab } from "@/routes";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import type { CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
@@ -619,7 +619,10 @@ export class OrgCrawls extends BtrixElement {
 
   private readonly renderArchivedItem = (crawl: Crawl) => html`
     <btrix-crawl-list-item
-      href=${`${this.navigate.orgBasePath}/${OrgTab.Workflows}/${crawl.cid}/crawls/${crawl.id}`}
+      href="${this.navigate
+        .orgBasePath}/${OrgTab.Workflows}/${crawl.cid}/${isActive(crawl)
+        ? WorkflowTab.LatestCrawl
+        : `${WorkflowTab.Crawls}/${crawl.id}`}"
       .crawl=${crawl}
     >
       <sl-menu slot="menu"> ${this.renderMenuItems(crawl)} </sl-menu>


### PR DESCRIPTION
Quick fix without issue

## Changes

Links crawl run directly to workflow's "Latest Crawl" tab instead of relying on redirect.

## Manual testing

1. Log in as crawler
2. Run a crawl
3. Go to "Crawl Runs"
4. Click running crawl. Verify navigation directly to workflow "Latest Crawl" tab instead of archived item then redirect to workflow.