### PR TITLE
add 'dedupeIndex' to collection api model

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -25,6 +25,7 @@ from .models import (
     CollIdName,
     CollectionThumbnailSource,
     UpdateColl,
+    DedupeIndexStats,
     AddRemoveCrawlList,
     BaseCrawl,
     CrawlFileOut,
@@ -742,6 +743,15 @@ class CollectionOps:
         headers = {"Content-Disposition": f'attachment; filename="{coll.name}.wacz"'}
         return StreamingResponse(
             resp, headers=headers, media_type="application/wacz+zip"
+        )
+
+    async def update_dedupe_index_stats(
+        self, coll_id: UUID, stats: Optional[DedupeIndexStats]
+    ):
+        """update dedupe index stats for specified collection"""
+        self.collections.find_one_and_update(
+            {"_id": coll_id},
+            {"$set": {"dedupeIndex": stats.dict() if stats else None}},
         )
 
     async def recalculate_org_collection_stats(self, org: Organization):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1566,6 +1566,9 @@ class CrawlOutWithResources(CrawlOut):
 
 ### COLLECTIONS ###
 
+TYPE_DEDUPE_INDEX_STATES = Literal["initing", "importing", "ready"]
+DEDUPE_INDEX_STATES = get_args(TYPE_DEDUPE_INDEX_STATES)
+
 
 # ============================================================================
 class CollAccessType(str, Enum):
@@ -1599,6 +1602,21 @@ class HostCount(BaseModel):
 
     host: str
     count: int
+
+
+# ============================================================================
+class DedupeIndexStats(BaseModel):
+    """stats from collection dedupe index"""
+
+    state: TYPE_DEDUPE_INDEX_STATES
+
+    uniqueUrls: int = 0
+    totalUrls: int = 0
+
+    uniqueSize: int = 0
+    totalSize: int = 0
+
+    removable: int = 0
 
 
 # ============================================================================
@@ -1641,6 +1659,7 @@ class Collection(BaseMongoModel):
     previousSlugs: List[str] = []
 
     hasDedupeIndex: bool = False
+    dedupeIndex: Optional[DedupeIndexStats] = None
 
 
 # ============================================================================
@@ -1705,6 +1724,7 @@ class CollOut(BaseMongoModel):
 
     topPageHosts: List[HostCount] = []
     hasDedupeIndex: bool = False
+    dedupeIndex: Optional[DedupeIndexStats] = None
 
 
 # ============================================================================


### PR DESCRIPTION
- 'dedupeIndex' now on collection
- set whenever an exists
- includes index stats, unique vs total urls, unique vs total size used and number of crawls that can be removed by purging the index:

Current model
```
class DedupeIndexStats(BaseModel):
    """stats from collection dedupe index"""
    
    state: TYPE_DEDUPE_INDEX_STATES
    
    uniqueUrls: int = 0
    totalUrls: int = 0
    
    uniqueSize: int = 0
    totalSize: int = 0

    removable: int = 0
```
