### PR TITLE
Support purging dedupe index of removed crawls

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -912,7 +912,7 @@ class CollectionOps:
         if coll.dedupeIndex.state != "ready":
             raise HTTPException(status_code=400, detail="dedupe_index_not_ready")
 
-        await self.crawl_manager.update_coll_index(coll_id, True)
+        await self.crawl_manager.update_coll_index(coll_id, is_purge=True)
         return {"success": True}
 
     async def get_org_public_collections(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -903,6 +903,18 @@ class CollectionOps:
             )
             await self.update_crawl_collections(crawl_id, oid)
 
+    async def purge_dedupe_index(self, coll_id: UUID, org: Organization):
+        """purge dedupe index on collection, raise exception if no index or not ready"""
+        coll = await self.get_collection(coll_id, org.id)
+        if not coll.hasDedupeIndex or not coll.dedupeIndex:
+            raise HTTPException(status_code=400, detail="no_dedupe_index_on_collection")
+
+        if coll.dedupeIndex.state != "ready":
+            raise HTTPException(status_code=400, detail="dedupe_index_not_ready")
+
+        await self.crawl_manager.update_coll_index(coll_id, True)
+        return {"success": True}
+
     async def get_org_public_collections(
         self,
         org_slug: str,
@@ -1428,5 +1440,16 @@ def init_collections_api(
         org: Organization = Depends(org_crawl_dep),
     ):
         return await colls.delete_thumbnail(coll_id, org)
+
+    @app.post(
+        "/orgs/{oid}/collections/{coll_id}/purgeDedupeIndex",
+        tags=["collections", "dedupe"],
+        response_model=SuccessResponse,
+    )
+    async def purge_dedupe_index(
+        coll_id: UUID,
+        org: Organization = Depends(org_crawl_dep),
+    ):
+        return await colls.purge_dedupe_index(coll_id, org)
 
     return colls

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -505,11 +505,12 @@ class CrawlManager(K8sAPI):
             str(collection.id), str(collection.oid), collection.modified
         )
 
-    async def update_coll_index(self, coll_id: UUID):
+    async def update_coll_index(self, coll_id: UUID, is_purge=False):
         """force collection index to update"""
+        field = "collItemsUpdatedAt" if not is_purge else "purgeRequestedAt"
         return await self.patch_custom_object(
             f"collindex-{coll_id}",
-            {"collItemsUpdatedAt": date_to_str(dt_now())},
+            {field: date_to_str(dt_now())},
             "collindexes",
         )
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -505,7 +505,7 @@ class CrawlManager(K8sAPI):
             str(collection.id), str(collection.oid), collection.modified
         )
 
-    async def update_coll_index(self, coll_id: UUID, is_purge=False):
+    async def update_coll_index(self, coll_id: UUID, is_purge: bool = False):
         """force collection index to update"""
         field = "collItemsUpdatedAt" if not is_purge else "purgeRequestedAt"
         return await self.patch_custom_object(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1566,7 +1566,7 @@ class CrawlOutWithResources(CrawlOut):
 
 ### COLLECTIONS ###
 
-TYPE_DEDUPE_INDEX_STATES = Literal["initing", "importing", "ready"]
+TYPE_DEDUPE_INDEX_STATES = Literal["initing", "importing", "ready", "purging"]
 DEDUPE_INDEX_STATES = get_args(TYPE_DEDUPE_INDEX_STATES)
 
 

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -37,6 +37,9 @@ spec:
             - /tmp/config/config.json
             - --redisDedupeUrl
             - {{ redis_url }}
+          {% if is_purging %}
+            - --removing
+          {% endif %}
 
           volumeMounts:
             - name: config


### PR DESCRIPTION
(Should be merged after #3072, builds on that and adds new purge API endpoint)

- purge is just like an import operation, with additional flag to crawler to remove existing data
- use different purgeRequestedAt timestamp on collindex object to request purge
- if both purge and regular update are requested at same time, the purge takes precedence
- add "/orgs/{oid}/collections/{coll_id}/purgeDedupeIndex" endpoint that will trigger a purge
- can only call purge when index is in 'ready' state
- new 'purging' state to CollIndex added
