### PR TITLE
mongo migrate: update to mongo 7.0 + set feature compatibility.

### DIFF
--- a/ansible/roles/digital_ocean/setup/tasks/main.yml
+++ b/ansible/roles/digital_ocean/setup/tasks/main.yml
@@ -21,7 +21,7 @@
   register: db_check
 
 - name: d_ocean | db | create mongodb database
-  ansible.builtin.command: doctl databases create {{ db_name }} --region {{ droplet_region }} --engine mongodb --version 6 --output json
+  ansible.builtin.command: doctl databases create {{ db_name }} --region {{ droplet_region }} --engine mongodb --version 7 --output json
   async: 1800
   poll: 60
   register: db_create

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -79,6 +79,7 @@ def init_db() -> tuple[AsyncIOMotorClient, AsyncIOMotorDatabase]:
 
 # ============================================================================
 async def ensure_feature_version(client: AsyncIOMotorClient):
+    """ensures the minimum feature compatibility version is set"""
     admin = client["admin"]
 
     fcv_status = await admin.command(

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -5,7 +5,7 @@ import sys
 import asyncio
 
 from .ops import init_ops
-from .db import update_and_prepare_db
+from .db import update_and_prepare_db, ensure_feature_version
 
 
 # ============================================================================
@@ -38,9 +38,11 @@ async def main() -> int:
         file_ops,
         crawl_log_ops,
         crawl_manager,
-        _,
+        dbclient,
         mdb,
     ) = init_ops()
+
+    await ensure_feature_version(dbclient)
 
     await update_and_prepare_db(
         mdb,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -223,7 +223,7 @@ mongo_local: true
 
 mongo_host: "local-mongo"
 
-mongo_image: "docker.io/library/mongo:6.0.5"
+mongo_image: "docker.io/library/mongo:7.0"
 mongo_pull_policy: "IfNotPresent"
 
 mongo_cpu: "12m"


### PR DESCRIPTION
- bumps default mongo image to 7.0
- set feature compatibility version to be 7.0 to support future upgrades
- allow updating feature compatibility version on startup
- fixes #2680

When switching from 6.0 -> 7.0, mongo remains in '6.0' compatibility mode, so we need to set it to use 7.0 features.
This allows for eventual default image upgrade to mongo 8.0. To do that, we first need to update to 7.0 and update flag to have it not stay in 6.0-compatibility mode. 8.0 does not have 6.0-compatibility mode, so direct update is not possible, unfortunately.

Browsertrix already works with 8.0, but the default image needs to be upgraded to 7.0 first before upgrading to 8.0 for this reason -- it's not possible to update from mongo 6 to mongo 8 directly.

This should be done first thing so better to do it before db migrations.


Testing
---
1) Start a new Browsertrix with mongo 6.0 (without this PR)
2) Switch to this PR, observe the image switched to 7.0 and the db version update logged in the `migrations` init container.
3) You can then update to mongo 8.0, eg. via local.yaml - not in this PR, for a future update - without issue