### PR TITLE
Only modify CrawlConfig.config fields included in PATCH request

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -498,6 +498,29 @@ class CrawlConfigOps:
 
         return False
 
+    def check_crawlconfig_config_changed(
+        self, crawlconfig: CrawlConfig, update: UpdateCrawlConfig
+    ) -> bool:
+        """check if update config will modify existing crawlconfig.config"""
+        if update.config is None:
+            return False
+
+        orig_raw_config = crawlconfig.config.dict()
+        for key, update_value in update.config.dict(exclude_unset=True).items():
+            orig_value = orig_raw_config.get(key)
+            # For seeds, need to compare list of dicts of full seed objects
+            if key == "seeds":
+                if orig_value is None:
+                    return True
+                orig_seeds = [Seed(**seed).dict() for seed in orig_value]
+                update_seeds = [Seed(**seed).dict() for seed in update_value]
+                if orig_seeds != update_seeds:
+                    return True
+            elif orig_value != update_value:
+                return True
+
+        return False
+
     async def update_crawl_config(
         self, cid: UUID, org: Organization, user: User, update: UpdateCrawlConfig
     ) -> CrawlConfigUpdateResponse:
@@ -577,7 +600,7 @@ class CrawlConfigOps:
         # indicates if any k8s crawl config settings changed
         changed = False
         changed = changed or (
-            self.check_attr_changed(orig_crawl_config, update, "config")
+            self.check_crawlconfig_config_changed(orig_crawl_config, update)
         )
         changed = changed or (
             self.check_attr_changed(orig_crawl_config, update, "crawlTimeout")

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -696,7 +696,7 @@ class CrawlConfigOps:
                 query["proxyId"] = update.proxyId
 
         if update.config is not None:
-            query["config"] = RawCrawlConfig(**orig_crawl_config.config.dict()).dict()
+            query["config"] = orig_crawl_config.config.dict()
             for key, value in update.config.dict(exclude_unset=True).items():
                 query["config"][key] = value
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -576,7 +576,7 @@ class CrawlConfigOps:
 
         merged_raw_config_dict = None
         if update.config:
-            merged_raw_config_dict = orig_crawl_config.config.model_dump()
+            merged_raw_config_dict = orig_crawl_config.config.dict()
             merged_raw_config_dict.update(update.config.dict(exclude_unset=True))
 
         # indicates if any k8s crawl config settings changed

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -673,7 +673,9 @@ class CrawlConfigOps:
                 query["proxyId"] = update.proxyId
 
         if update.config is not None:
-            query["config"] = update.config.dict()
+            query["config"] = RawCrawlConfig(**orig_crawl_config.config.dict()).dict()
+            for key, value in update.config.dict(exclude_unset=True).items():
+                query["config"][key] = value
 
         if update.config and update.config.seedFileId:
             query["firstSeed"] = seed_file.firstSeed

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -650,7 +650,6 @@ class CrawlConfigOps:
             return CrawlConfigUpdateResponse(
                 settings_changed=changed,
                 metadata_changed=metadata_changed,
-                updated=changed or metadata_changed,
             )
 
         if changed:
@@ -742,7 +741,6 @@ class CrawlConfigOps:
             metadata_changed=metadata_changed,
             storageQuotaReached=self.org_ops.storage_quota_reached(org),
             execMinutesQuotaReached=self.org_ops.exec_mins_quota_reached(org),
-            updated=changed or metadata_changed,
         )
 
         if run_now:

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -576,10 +576,8 @@ class CrawlConfigOps:
 
         merged_raw_config_dict = None
         if update.config:
-            merged_raw_config_dict = RawCrawlConfig(
-                **orig_crawl_config.config.dict(),
-                **update.config.dict(exclude_unset=True),
-            ).dict()
+            merged_raw_config_dict = orig_crawl_config.config.model_dump()
+            merged_raw_config_dict.update(update.config.dict(exclude_unset=True))
 
         # indicates if any k8s crawl config settings changed
         changed = False

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -576,7 +576,7 @@ class CrawlConfigOps:
 
         merged_raw_config_dict = None
         if update.config:
-            merged_raw_config_dict = orig_crawl_config.config.dict()
+            merged_raw_config_dict = orig_crawl_config.config.dict(exclude_unset=True)
             merged_raw_config_dict.update(update.config.dict(exclude_unset=True))
 
         # indicates if any k8s crawl config settings changed
@@ -584,7 +584,8 @@ class CrawlConfigOps:
 
         changed = (
             merged_raw_config_dict is not None
-            and merged_raw_config_dict != orig_crawl_config.config.dict()
+            and merged_raw_config_dict
+            != orig_crawl_config.config.dict(exclude_unset=True)
         )
 
         changed = changed or (
@@ -647,7 +648,9 @@ class CrawlConfigOps:
 
         if not changed and not metadata_changed and not run_now:
             return CrawlConfigUpdateResponse(
-                settings_changed=changed, metadata_changed=metadata_changed
+                settings_changed=changed,
+                metadata_changed=metadata_changed,
+                updated=changed or metadata_changed,
             )
 
         if changed:
@@ -739,6 +742,7 @@ class CrawlConfigOps:
             metadata_changed=metadata_changed,
             storageQuotaReached=self.org_ops.storage_quota_reached(org),
             execMinutesQuotaReached=self.org_ops.exec_mins_quota_reached(org),
+            updated=changed or metadata_changed,
         )
 
         if run_now:

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -22,6 +22,8 @@ CRAWLER_USERNAME = "CraWleR@example.com"
 CRAWLER_USERNAME_LOWERCASE = "crawler@example.com"
 CRAWLER_PW = "crawlerPASSWORD!"
 
+BROWSERTRIX_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3 (+Browsertrix)"
+
 _admin_config_id = None
 _crawler_config_id = None
 _auto_add_config_id = None
@@ -339,6 +341,12 @@ def sample_crawl_data():
         "config": {
             "seeds": [{"url": "https://example-com.webrecorder.net/"}],
             "extraHops": 1,
+            # Add some extra config fields so we can ensure they're
+            # not modified when we do a PATCH for other fields in the
+            # config object
+            "lang": "en",
+            "postLoadDelay": 1,
+            "userAgent": BROWSERTRIX_USER_AGENT
         },
         "tags": ["tag1", "tag2"],
     }

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -346,7 +346,7 @@ def sample_crawl_data():
             # config object
             "lang": "en",
             "postLoadDelay": 1,
-            "userAgent": BROWSERTRIX_USER_AGENT
+            "userAgent": BROWSERTRIX_USER_AGENT,
         },
         "tags": ["tag1", "tag2"],
     }

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -2,7 +2,7 @@ import time
 
 import requests
 
-from .conftest import API_PREFIX
+from .conftest import API_PREFIX, BROWSERTRIX_USER_AGENT
 
 cid = None
 cid_single_page = None
@@ -339,10 +339,16 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
     assert r.status_code == 200
 
     data = r.json()
+    config = data["config"]
 
-    assert data["config"]["scopeType"] == "domain"
-    assert data["config"]["selectLinks"] == ["a[href]->href", "script[src]->src"]
-    assert data["config"]["clickSelector"] == "button"
+    assert config["scopeType"] == "domain"
+    assert config["selectLinks"] == ["a[href]->href", "script[src]->src"]
+    assert config["clickSelector"] == "button"
+
+    # Verify fields set in config originally are unchanged
+    assert config["lang"] == "en"
+    assert config["postLoadDelay"] == 1
+    assert config["userAgent"] == BROWSERTRIX_USER_AGENT
 
 
 def test_update_config_no_changes(


### PR DESCRIPTION
Fixes #3065 

This PR modifies the crawlconfig PATCH endpoint to do what myself and most users probably always assumed it did, which is to only modify fields in the `CrawlConfig.config` that are explicitly included in the PATCH request, rather than replacing the entirety of the `config` with what's in the PATCH request.

Arguably this could be seen as a breaking change, but I think given the semantics of PATCH and the fact that at least some users were confused by the previous behavior, I think we might be okay to just consider this a bugfix without need for a compatibility flag or similar in the API endpoint.

Tests have been updated accordingly.

## Manual testing steps

1. Spin up a local Browsertrix instance off of main
2. Create and save a workflow with some `config` fields filled out - e.g. set browser language to English and a custom user agent
3. Update local Browsertrix instance to this branch
4. Submit a PATCH request with cURL or similar for with a payload containing 1-2 `config` field updates (e.g. `{"config": {"blockAds": true}}`) and verify that the rest of the `config` remains as it was originally saved.
5. Submit a PATCH request with some `config` fields in the payload but using their current values, verify that the response includes `"settings_changed":false`