### PR TITLE
Only replicate files after crawl successfully completes

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -32,6 +32,7 @@ from .models import (
     User,
     SuccessResponse,
     SuccessResponseId,
+    CRAWL_TYPES,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import dt_now
@@ -104,7 +105,7 @@ class BackgroundJobOps:
     async def handle_replica_job_succeeded(self, job: CreateReplicaJob) -> None:
         """Update replicas in corresponding file objects, based on type"""
         res = None
-        if job.object_type in ("crawl", "upload"):
+        if job.object_type in CRAWL_TYPES:
             res = await self.base_crawl_ops.add_crawl_file_replica(
                 job.object_id, job.file_path, job.replica_storage
             )

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -1134,9 +1134,6 @@ def init_base_crawls_api(app, user_dep, *args):
         if description:
             description = urllib.parse.unquote(description)
 
-        if crawlType and crawlType not in CRAWL_TYPES:
-            raise HTTPException(status_code=400, detail="invalid_crawl_type")
-
         crawls, total = await ops.list_all_base_crawls(
             org,
             userid=userid,
@@ -1165,9 +1162,6 @@ def init_base_crawls_api(app, user_dep, *args):
         org: Organization = Depends(org_viewer_dep),
         crawlType: Optional[TYPE_CRAWL_TYPES] = None,
     ):
-        if crawlType and crawlType not in CRAWL_TYPES:
-            raise HTTPException(status_code=400, detail="invalid_crawl_type")
-
         return await ops.get_all_crawl_search_values(org, type_=crawlType)
 
     @app.get(
@@ -1180,9 +1174,6 @@ def init_base_crawls_api(app, user_dep, *args):
         onlySuccessful: bool = True,
         crawlType: Optional[TYPE_CRAWL_TYPES] = None,
     ):
-        if crawlType and crawlType not in CRAWL_TYPES:
-            raise HTTPException(status_code=400, detail="invalid_crawl_type")
-
         tags = await ops.get_all_crawls_tag_counts(
             org, only_successful=onlySuccessful, type_=crawlType
         )

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -297,6 +297,15 @@ ALL_CRAWL_STATES = [*RUNNING_AND_WAITING_STATES, *NON_RUNNING_STATES]
 
 
 # ============================================================================
+
+### CRAWL TYPES
+
+# ============================================================================
+TYPE_CRAWL_TYPES = Literal["crawl", "upload"]
+CRAWL_TYPES = get_args(TYPE_CRAWL_TYPES)
+
+
+# ============================================================================
 class CrawlStats(BaseModel):
     """Crawl Stats for pages and size"""
 
@@ -846,7 +855,7 @@ class CoreCrawlable(BaseModel):
 class BaseCrawl(CoreCrawlable, BaseMongoModel):
     """Base Crawl object (representing crawls, uploads and manual sessions)"""
 
-    type: str
+    type: TYPE_CRAWL_TYPES
 
     oid: UUID
     cid: Optional[UUID] = None
@@ -885,7 +894,7 @@ class CrawlOut(BaseMongoModel):
 
     # pylint: disable=duplicate-code
 
-    type: str
+    type: TYPE_CRAWL_TYPES
 
     id: str
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1414,18 +1414,6 @@ class CrawlOperator(BaseOperator):
 
         await self.org_ops.inc_org_bytes_stored(crawl.oid, filecomplete.size, "crawl")
 
-        # no replicas for QA for now
-        if crawl.is_qa:
-            return filecomplete.size
-
-        try:
-            await self.background_job_ops.create_replica_jobs(
-                crawl.oid, crawl_file, crawl.id, "crawl"
-            )
-        # pylint: disable=broad-except
-        except Exception as exc:
-            print("Replicate Exception", exc, flush=True)
-
         return filecomplete.size
 
     async def is_crawl_stopping(
@@ -1762,6 +1750,7 @@ class CrawlOperator(BaseOperator):
             await self.coll_ops.add_successful_crawl_to_collections(
                 crawl.id, crawl.cid, crawl.oid
             )
+            await self.crawl_ops.replicate_crawl_files(crawl.id, crawl.org, "crawl")
 
             if stats and stats.profile_update and crawl.profileid:
                 await self.crawl_config_ops.profiles.update_profile_from_crawl_upload(

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -200,11 +200,7 @@ class UploadOps(BaseCrawlOps):
 
         quota_reached = self.orgs.storage_quota_reached(org)
 
-        if uploaded.files:
-            for file in uploaded.files:
-                await self.background_job_ops.create_replica_jobs(
-                    org.id, file, crawl_id, "upload"
-                )
+        await self.replicate_crawl_files(crawl_id, org, "upload")
 
         return {"id": crawl_id, "added": True, "storageQuotaReached": quota_reached}
 

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -625,8 +625,7 @@ def test_get_all_crawls_by_type(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls?crawlType=invalid",
         headers=admin_auth_headers,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "invalid_crawl_type"
+    assert r.status_code == 422
 
 
 def test_get_all_crawls_by_user(
@@ -892,8 +891,7 @@ def test_all_crawls_search_values(
         f"{API_PREFIX}/orgs/{default_org_id}/all-crawls/search-values?crawlType=invalid",
         headers=admin_auth_headers,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "invalid_crawl_type"
+    assert r.status_code == 422
 
 
 def test_get_upload_from_all_crawls(admin_auth_headers, default_org_id, upload_id_2):


### PR DESCRIPTION
Fixes #3068 

This resolves failed replication jobs for WACZs uploaded for crawls that fail. Along with https://github.com/webrecorder/browsertrix/pull/3082, this should greatly reduce the number of failed replication background jobs.

Also included is some improved typing for crawl types in the backend.