### PR TITLE
dedupe: misc updates for backend

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1613,8 +1613,7 @@ class DedupeIndexStats(BaseModel):
     uniqueUrls: int = 0
     totalUrls: int = 0
 
-    uniqueSize: int = 0
-    totalSize: int = 0
+    sizeSaved: int = 0
 
     removable: int = 0
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -202,7 +202,7 @@ class CollIndexOperator(BaseOperator):
         """create configmap for import job, lookup resources only on first init"""
         configmap = children[CMAP].get(name)
         # pylint: disable=duplicate-code
-        if configmap:
+        if configmap and not self.is_configmap_update_needed("config.json", configmap):
             metadata = configmap["metadata"]
             configmap["metadata"] = {
                 "name": metadata["name"],

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -184,6 +184,12 @@ class CollIndexOperator(BaseOperator):
         params["crawler_image"] = self.crawl_config_ops.get_channel_crawler_image(
             self.dedupe_importer_channel
         )
+        pull_policy = self.crawl_config_ops.get_channel_crawler_image_pull_policy(
+            self.dedupe_importer_channel
+        )
+        if pull_policy:
+            params["crawler_image_pull_policy"] = pull_policy
+
         params["is_purging"] = is_purging
 
         params["redis_url"] = self.k8s.get_redis_url("coll-" + index_id)

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -538,7 +538,11 @@ class CrawlOperator(BaseOperator):
         name = f"qa-replay-{qa_source_crawl_id}"
 
         configmap = children[CMAP].get(name)
-        if configmap and not self._qa_configmap_update_needed(name, configmap):
+        if configmap and self.is_configmap_update_needed("qa-config.json", configmap):
+            print(f"Refreshing QA configmap for QA run: {name}")
+            configmap = None
+
+        if configmap:
             metadata = configmap["metadata"]
             configmap["metadata"] = {
                 "name": metadata["name"],
@@ -626,22 +630,6 @@ class CrawlOperator(BaseOperator):
                 params["init_crawler"] = False
 
         return self.load_from_yaml("crawler.yaml", params)
-
-    def _qa_configmap_update_needed(self, name, configmap):
-        try:
-            now = dt_now()
-            resources = json.loads(configmap["data"]["qa-config.json"])["resources"]
-            for resource in resources:
-                expire_at = str_to_date(resource["expireAt"])
-                if expire_at and expire_at <= now:
-                    print(f"Refreshing QA configmap for QA run: {name}")
-                    return True
-
-        # pylint: disable=broad-exception-caught
-        except Exception as e:
-            print(e)
-
-        return False
 
     async def _resolve_scale_down(
         self,

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -69,30 +69,6 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
 
-      affinity:
-    {% if crawler_node_type %}
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: nodeType
-                  operator: In
-                  values:
-                    - "{{ crawler_node_type }}"
-    {% endif %}
-
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 10
-              podAffinityTerm:
-                topologyKey: "kubernetes.io/hostname"
-                labelSelector:
-                  matchExpressions:
-                  - key: coll
-                    operator: In
-                    values:
-                    - {{ id }}
-
       tolerations:
         - key: nodeType
           operator: Equal

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -69,6 +69,30 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
 
+      affinity:
+    {% if crawler_node_type %}
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: nodeType
+                  operator: In
+                  values:
+                    - "{{ crawler_node_type }}"
+    {% endif %}
+
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 10
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchExpressions:
+                  - key: coll
+                    operator: In
+                    values:
+                    - {{ id }}
+
       tolerations:
         - key: nodeType
           operator: Equal


### PR DESCRIPTION
- add is_configmap_update_needed() to baseoperator to ensure config updated if any resources have expired for both qa runs and collindex updates
- update dedupe model to have 'sizeSaved'
- chart: remove affinity from collindex Job, was causing errors on dev (to revisit)
- add pull policy to collindex image