### PR TITLE
docs: ensure correct path is generate in api docs index.htm

### DIFF
--- a/frontend/docs/copy-api-docs.sh
+++ b/frontend/docs/copy-api-docs.sh
@@ -4,7 +4,7 @@ CURR=$(dirname "${BASH_SOURCE[0]}")
 TARGET=$CURR/docs/api/
 mkdir $TARGET
 curl "$DOCS_SOURCE_URL/api/openapi.json" > $TARGET/openapi.json
-curl "$DOCS_SOURCE_URL/api/redoc" > $TARGET/index.html
+curl "$DOCS_SOURCE_URL/api/redoc" | sed 's/docs\/api-assets/api-assets/g' > $TARGET/index.html
 curl "$DOCS_SOURCE_URL/docs-logo.svg" > $TARGET/../docs-logo.svg
 
 if [ -n $ENABLE_ANALYTICS ]; then


### PR DESCRIPTION
fixes #3091 

replace `docs/api-assets` with just `/api-assets` in copied version to ensure correct path.