### PR TITLE
Fix checking of minimum crawler versions

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -73,6 +73,7 @@ from .utils import (
     is_url,
     browser_windows_from_scale,
     case_insensitive_collation,
+    crawler_image_below_minimum,
 )
 
 if TYPE_CHECKING:
@@ -1283,7 +1284,9 @@ class CrawlConfigOps:
             if (
                 self.min_seed_file_crawler_image
                 and crawler_image
-                and crawler_image < self.min_seed_file_crawler_image
+                and crawler_image_below_minimum(
+                    crawler_image, self.min_seed_file_crawler_image
+                )
             ):
                 raise HTTPException(
                     status_code=400, detail="seed_file_not_supported_by_crawler"

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -37,6 +37,7 @@ from .utils import (
     validate_regexes,
     scale_from_browser_windows,
     browser_windows_from_scale,
+    crawler_image_below_minimum,
 )
 from .basecrawls import BaseCrawlOps
 from .crawlmanager import CrawlManager
@@ -935,7 +936,7 @@ class CrawlOps(BaseCrawlOps):
         if (
             self.min_qa_crawler_image
             and crawl.image
-            and crawl.image < self.min_qa_crawler_image
+            and crawler_image_below_minimum(crawl.image, self.min_qa_crawler_image)
         ):
             raise HTTPException(status_code=400, detail="qa_not_supported_for_crawl")
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -39,6 +39,7 @@ from btrixcloud.utils import (
     date_to_str,
     dt_now,
     scale_from_browser_windows,
+    crawler_image_below_minimum,
 )
 
 from .baseoperator import BaseOperator, Redis
@@ -457,7 +458,7 @@ class CrawlOperator(BaseOperator):
             and behaviors
             and "autoclick" in behaviors
             and crawler_image
-            and crawler_image < min_autoclick_crawler_image
+            and crawler_image_below_minimum(crawler_image, min_autoclick_crawler_image)
         ):
             print(
                 "Crawler version < min_autoclick_crawler_image, removing autoclick behavior",

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -18,6 +18,7 @@ from uuid import UUID
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from iso639 import is_language
+from packaging.version import parse
 from pymongo.collation import Collation
 from pymongo.errors import DuplicateKeyError
 from slugify import slugify
@@ -218,3 +219,22 @@ def scale_from_browser_windows(
 def browser_windows_from_scale(scale: int) -> int:
     """Return number of browser windows from specified scale"""
     return scale * browsers_per_pod
+
+
+def crawler_image_below_minimum(crawler_image: str, min_image: str):
+    """Return bool indicating if specified crawler version is below required minimum
+
+    Return False by default or if versions can't be parsed as semver (e.g. "latest")
+    """
+    try:
+        crawler_image_version = parse(crawler_image.split(":")[1])
+        min_image_version = parse(min_image.split(":")[1])
+    # pylint: disable=broad-exception-caught
+    except Exception:
+        print("Unable to compare crawler versions, allowing", flush=True)
+        return False
+
+    if crawler_image_version < min_image_version:
+        return True
+
+    return False

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -18,7 +18,7 @@ from uuid import UUID
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from iso639 import is_language
-from packaging.version import parse
+from packaging.version import parse as parse_version
 from pymongo.collation import Collation
 from pymongo.errors import DuplicateKeyError
 from slugify import slugify
@@ -227,8 +227,8 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
     Return False by default or if versions can't be parsed as semver (e.g. "latest")
     """
     try:
-        crawler_image_version = parse(crawler_image.split(":")[1])
-        min_image_version = parse(min_image.split(":")[1])
+        crawler_image_version = parse_version(crawler_image.split(":")[1])
+        min_image_version = parse_version(min_image.split(":")[1])
     # pylint: disable=broad-exception-caught
     except Exception:
         print("Unable to compare crawler versions, allowing", flush=True)

--- a/backend/test/test_utils.py
+++ b/backend/test/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from btrixcloud.utils import slug_from_name
+from btrixcloud.utils import slug_from_name, crawler_image_below_minimum
 
 
 @pytest.mark.parametrize(
@@ -18,3 +18,56 @@ from btrixcloud.utils import slug_from_name
 )
 def test_slug_from_name(name: str, expected_slug: str):
     assert slug_from_name(name) == expected_slug
+
+
+@pytest.mark.parametrize(
+    "crawler_image,min_image,expected_return",
+    [
+        # Straightforward comparisons
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.5.0",
+            "docker.io/webrecorder/browsertrix-crawler:1.5.0",
+            False,
+        ),
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.6",
+            "docker.io/webrecorder/browsertrix-crawler:1.5.0",
+            False,
+        ),
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.10.2",
+            "docker.io/webrecorder/browsertrix-crawler:1.5.0",
+            False,
+        ),
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.11.0beta1",
+            "docker.io/webrecorder/browsertrix-crawler:1.5.0",
+            False,
+        ),
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.4.6",
+            "docker.io/webrecorder/browsertrix-crawler:1.5.0",
+            True,
+        ),
+        # "latest" and similar tags for either always return False
+        (
+            "docker.io/webreocrder/browsertrix-crawler:latest",
+            "docker.io/webrecorder/browsertrix-crawler:1.9.0",
+            False,
+        ),
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.10.1",
+            "docker.io/webrecorder/browsertrix-crawler:latest",
+            False,
+        ),
+        (
+            "docker.io/webreocrder/browsertrix-crawler:dev",
+            "docker.io/webrecorder/browsertrix-crawler:dev",
+            False,
+        ),
+    ],
+)
+def test_crawler_image_below_minimum(
+    crawler_image: str, min_image: str, expected_return: str
+):
+    assert crawler_image_below_minimum(crawler_image, min_image) == expected_return


### PR DESCRIPTION
Fixes #3093 

- Moves comparison of crawler versions to reusable `util` helper, which returns `False` if both the crawler image version and the set minimum required version are valid semver and the crawler version is lower than the minimum required, and `True` in any other scenario (including if one of the tags isn't valid semver, like "latest")
- Compares versions by using a library that understands semver rather than just an alphanumeric comparison
