### PR TITLE
quickfix: ignore lastWorkers of 0 when determining if pod restart is needed

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -572,7 +572,8 @@ class CrawlOperator(BaseOperator):
         pod_info = status.podStatus[name]
 
         # compute if number of browsers for this pod has changed
-        workers_changed = pod_info.lastWorkers != workers
+        # and previous number of workers was >0
+        workers_changed = pod_info.lastWorkers != workers and pod_info.lastWorkers
         if workers_changed:
             print(f"Workers changed for {i}: {pod_info.lastWorkers} -> {workers}")
 


### PR DESCRIPTION
In crawls operator, if lastWorkers was set to 0 (default init value), operator incorrectly assumed number of windows was being changed to current number of windows, resulting in unnecessary pod restart attempt.
This could happen if pod init was delayed due to resource allocation and lastWorkers was set to 0 by default.

Testing
-------
Without this fix, can often see message `Workers changed for <POD ID>: 0 -> 4` and crawler pod is attempting a restart immediately after starting. With this fix, this should no longer happen.