### PR TITLE
fix: Fix QA analysis icon color

### DIFF
--- a/frontend/src/features/archived-items/archived-item-list/archived-item-list-item.ts
+++ b/frontend/src/features/archived-items/archived-item-list/archived-item-list-item.ts
@@ -175,7 +175,7 @@ export class ArchivedItemListItem extends BtrixElement {
                     class="text-base text-neutral-300"
                     style=${ifDefined(
                       lastQAState === "complete"
-                        ? "color: ${qaStatus.cssColor}"
+                        ? `color: ${qaStatus.cssColor}`
                         : undefined,
                     )}
                     name=${isUpload ? "slash-lg" : "microscope"}


### PR DESCRIPTION
## Changes

Fixes QA analysis icon in archived item list not displaying the correct color variant.

## Manual testing

1. Log in
2. Go to Archived Items
3. Sort by "Last Analysis Run" to find archived item with analysis run. Verify icon color matches status.

## Screenshots

<img width="1238" height="128" alt="Screenshot 2026-01-06 at 11 57 03 AM" src="https://github.com/user-attachments/assets/244bea85-56fa-4ebf-81ed-2b63ebfc7b37" />
