### PR TITLE
fix: Prevent request with undefined org ID

### DIFF
--- a/frontend/src/pages/org/settings/components/billing.ts
+++ b/frontend/src/pages/org/settings/components/billing.ts
@@ -100,7 +100,7 @@ export class OrgSettingsBilling extends BtrixElement {
 
       return metrics;
     },
-    args: () => [this.org?.id] as const,
+    args: () => [this.orgId] as const,
   });
 
   render() {


### PR DESCRIPTION
No issue created. To reproduce, log in as org admin and go to settings with browser dev console open. Observe that `GET http://localhost:9870/api/orgs/undefined/metrics` or similar network error is shown.

## Changes

Fixes non-user-facing bug where a request for org metrics is made before the org ID is available.

## Manual testing

1. Log in as org admin
2. Open browser network inspector
3. Go to org settings. Verify that request to `GET /metrics` is made using the correct org ID