### PR TITLE
Move requiresCrawls and requiredByCrawls to BaseCrawl

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -879,6 +879,9 @@ class BaseCrawl(CoreCrawlable, BaseMongoModel):
     isMigrating: Optional[bool] = None
     version: Optional[int] = None
 
+    requiresCrawls: Optional[list[str]] = []
+    requiredByCrawls: Optional[list[str]] = []
+
 
 # ============================================================================
 class CollIdName(BaseModel):
@@ -1109,9 +1112,6 @@ class Crawl(BaseCrawl, CrawlConfigCore):
     pendingSize: int = 0
 
     autoPausedEmailsSent: bool = False
-
-    requiresCrawls: Optional[list[str]] = []
-    requiredByCrawls: Optional[list[str]] = []
 
 
 # ============================================================================


### PR DESCRIPTION
Part of #3103 

Small tweak to move `requiresCrawls` and `requiredByCrawls` from the `Crawl` model to `BaseCrawl`, as uploaded crawls that are part of a collection being used as a deduplication source may also have these (specifically `requiredByCrawls`) defined.