### PR TITLE
Add crawl list filters for deduplication dependencies

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -682,6 +682,10 @@ class BaseCrawlOps:
         tag_match: ListFilterType | None = None,
         collection_id: Optional[UUID] = None,
         dedupe_coll_id: Optional[UUID] = None,
+        requires_crawls: list[str] | None = None,
+        required_by_crawls: list[str] | None = None,
+        has_requires_crawls: Optional[bool] = None,
+        has_required_by_crawls: Optional[bool] = None,
         crawl_ids: Optional[List[str]] = None,
         states: Optional[List[str]] = None,
         first_seed: Optional[str] = None,
@@ -726,6 +730,16 @@ class BaseCrawlOps:
         if tags:
             query_type = "$all" if tag_match == ListFilterType.AND else "$in"
             query["tags"] = {query_type: tags}
+
+        if requires_crawls:
+            query["requiresCrawls"] = {"$in": requires_crawls}
+        elif has_requires_crawls:
+            query["requiresCrawls"] = {"$nin": [None, []]}
+
+        if required_by_crawls:
+            query["requiredByCrawls"] = {"$in": required_by_crawls}
+        elif has_required_by_crawls:
+            query["requiredByCrawls"] = {"$nin": [None, []]}
 
         aggregate = [
             {"$match": query},
@@ -1097,6 +1111,10 @@ def init_base_crawls_api(app, user_dep, *args):
         ] = ListFilterType.AND,
         collectionId: Optional[UUID] = None,
         dedupeCollId: Optional[UUID] = None,
+        requiresCrawls: Annotated[list[str] | None, Query()] = None,
+        requiredByCrawls: Annotated[list[str] | None, Query()] = None,
+        hasRequiresCrawls: Optional[bool] = None,
+        hasRequiredByCrawls: Optional[bool] = None,
         ids: Annotated[list[str] | None, Query()] = None,
         crawlType: Optional[str] = None,
         cid: Optional[UUID] = None,
@@ -1131,6 +1149,10 @@ def init_base_crawls_api(app, user_dep, *args):
             tag_match=tag_match,
             collection_id=collectionId,
             dedupe_coll_id=dedupeCollId,
+            requires_crawls=requiresCrawls,
+            required_by_crawls=requiredByCrawls,
+            has_requires_crawls=hasRequiresCrawls,
+            has_required_by_crawls=hasRequiredByCrawls,
             crawl_ids=ids,
             states=states,
             first_seed=firstSeed,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -735,11 +735,15 @@ class BaseCrawlOps:
             query["requiresCrawls"] = {"$in": requires_crawls}
         elif has_requires_crawls:
             query["requiresCrawls"] = {"$nin": [None, []]}
+        elif has_requires_crawls is False:
+            query["requiresCrawls"] = {"$in": [None, []]}
 
         if required_by_crawls:
             query["requiredByCrawls"] = {"$in": required_by_crawls}
         elif has_required_by_crawls:
             query["requiredByCrawls"] = {"$nin": [None, []]}
+        elif has_required_by_crawls is False:
+            query["requiredByCrawls"] = {"$in": [None, []]}
 
         aggregate = [
             {"$match": query},

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -219,11 +219,15 @@ class CrawlOps(BaseCrawlOps):
             query["requiresCrawls"] = {"$in": requires_crawls}
         elif has_requires_crawls:
             query["requiresCrawls"] = {"$nin": [None, []]}
+        elif has_requires_crawls is False:
+            query["requiresCrawls"] = {"$in": [None, []]}
 
         if required_by_crawls:
             query["requiredByCrawls"] = {"$in": required_by_crawls}
         elif has_required_by_crawls:
             query["requiredByCrawls"] = {"$nin": [None, []]}
+        elif has_required_by_crawls is False:
+            query["requiredByCrawls"] = {"$in": [None, []]}
 
         # Override running_only if state list is explicitly passed
         if state:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -179,6 +179,10 @@ class CrawlOps(BaseCrawlOps):
         tag_match: ListFilterType | None = ListFilterType.AND,
         collection_id: Optional[UUID] = None,
         dedupe_coll_id: Optional[UUID] = None,
+        requires_crawls: list[str] | None = None,
+        required_by_crawls: list[str] | None = None,
+        has_requires_crawls: Optional[bool] = None,
+        has_required_by_crawls: Optional[bool] = None,
         crawl_ids: Optional[List[str]] = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
@@ -210,6 +214,16 @@ class CrawlOps(BaseCrawlOps):
         if tags:
             query_type = "$all" if tag_match == ListFilterType.AND else "$in"
             query["tags"] = {query_type: tags}
+
+        if requires_crawls:
+            query["requiresCrawls"] = {"$in": requires_crawls}
+        elif has_requires_crawls:
+            query["requiresCrawls"] = {"$nin": [None, []]}
+
+        if required_by_crawls:
+            query["requiredByCrawls"] = {"$in": required_by_crawls}
+        elif has_required_by_crawls:
+            query["requiredByCrawls"] = {"$nin": [None, []]}
 
         # Override running_only if state list is explicitly passed
         if state:
@@ -1403,6 +1417,10 @@ def init_crawls_api(
         ] = ListFilterType.AND,
         collectionId: Optional[UUID] = None,
         dedupeCollId: Optional[UUID] = None,
+        requiresCrawls: Annotated[list[str] | None, Query()] = None,
+        requiredByCrawls: Annotated[list[str] | None, Query()] = None,
+        hasRequiresCrawls: Optional[bool] = None,
+        hasRequiredByCrawls: Optional[bool] = None,
         ids: Annotated[list[str] | None, Query()] = None,
         sortBy: Optional[str] = None,
         sortDirection: int = -1,
@@ -1436,6 +1454,10 @@ def init_crawls_api(
             tag_match=tag_match,
             collection_id=collectionId,
             dedupe_coll_id=dedupeCollId,
+            requires_crawls=requiresCrawls,
+            required_by_crawls=requiredByCrawls,
+            has_requires_crawls=hasRequiresCrawls,
+            has_required_by_crawls=hasRequiredByCrawls,
             crawl_ids=ids,
             page_size=pageSize,
             page=page,


### PR DESCRIPTION
Backend for https://github.com/webrecorder/browsertrix/issues/3103

To be used for filtering archived items within collections by deduplication dependecies.

Adds the following filters to the `all-crawls/` and `crawls/` API list endpoints:

- `requiresCrawls`: takes a list of archived item items, applies `or` logic
- `requiredByCrawls`: takes a list of archived item items, applies `or` logic
- `hasRequiresCrawls`: takes a bool, filters by items that have any value for `requiresCrawls` besides null or an empty array
- `hasRequiredByCrawls`: takes a bool, filters by items that have any value for `requiredByCrawls` besides null or an empty array

We could collapse these filters by making `requiresCrawls` and `requiredByCrawls` take either a list of strings or a bool, but I think that having these as separate filters is a bit cleaner.