### PR TITLE
Linter update, switch to ruff

### DIFF
--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -61,7 +61,8 @@ jobs:
       - name: Lint Check
         run: |
           cd backend/
-          ruff check --exit-non-zero-on-fix btrixcloud/
+          pylint btrixcloud/
+          #ruff check --exit-non-zero-on-fix btrixcloud/
 
       - name: Type Check
         run: |

--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -56,12 +56,12 @@ jobs:
 
       - name: Style Check
         run: |
-          black --check backend/btrixcloud/
+          ruff format --check backend/btrixcloud/
 
       - name: Lint Check
         run: |
           cd backend/
-          pylint btrixcloud/
+          ruff check --exit-non-zero-on-fix btrixcloud/
 
       - name: Type Check
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 24.1.1
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.14.13
   hooks:
-    - id: black
+    - id: ruff-format
       args: ["backend/btrixcloud/"]
 - repo: local
   hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,8 +6,8 @@
     "bradlc.vscode-tailwindcss",
     "redhat.vscode-yaml",
     "streetsidesoftware.code-spell-checker",
-    "ms-python.black-formatter",
     "ms-python.pylint",
-    "unifiedjs.vscode-mdx"
+    "unifiedjs.vscode-mdx",
+    "charliermarsh.ruff"
   ]
 }

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1262,10 +1262,12 @@ class CrawlConfigOps:
         await self.check_if_too_many_waiting_crawls(org)
 
         if crawlconfig.profileid:
-            profile_filename, crawlconfig.proxyId, _ = (
-                await self.profiles.get_profile_filename_proxy_channel(
-                    crawlconfig.profileid, org
-                )
+            (
+                profile_filename,
+                crawlconfig.proxyId,
+                _,
+            ) = await self.profiles.get_profile_filename_proxy_channel(
+                crawlconfig.profileid, org
             )
             if not profile_filename:
                 raise HTTPException(status_code=400, detail="invalid_profile_id")

--- a/backend/btrixcloud/migrations/migration_0030_user_invites_flatten.py
+++ b/backend/btrixcloud/migrations/migration_0030_user_invites_flatten.py
@@ -33,7 +33,7 @@ class Migration(BaseMigration):
                 invite = InvitePending(
                     userid=user["id"],
                     tokenHash=get_hash(user_invite["id"]),
-                    **user_invite
+                    **user_invite,
                 )
                 await invites_db.insert_one(invite.to_dict())
 

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -126,10 +126,12 @@ class CronJobOperator(BaseOperator):
             print("Scheduled Crawl Created: " + crawl_id)
 
         if crawlconfig.profileid:
-            profile_filename, crawlconfig.proxyId, _ = (
-                await self.crawl_config_ops.profiles.get_profile_filename_proxy_channel(
-                    crawlconfig.profileid, org
-                )
+            (
+                profile_filename,
+                crawlconfig.proxyId,
+                _,
+            ) = await self.crawl_config_ops.profiles.get_profile_filename_proxy_channel(
+                crawlconfig.profileid, org
             )
             if not profile_filename:
                 print(f"error: missing profile {crawlconfig.profileid}")

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -135,10 +135,12 @@ class ProfileOps:
         prev_proxy_id = ""
         prev_channel = ""
         if profile_launch.profileId:
-            prev_profile_path, prev_proxy_id, prev_channel = (
-                await self.get_profile_filename_proxy_channel(
-                    profile_launch.profileId, org
-                )
+            (
+                prev_profile_path,
+                prev_proxy_id,
+                prev_channel,
+            ) = await self.get_profile_filename_proxy_channel(
+                profile_launch.profileId, org
             )
 
             if not prev_profile_path:

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -586,7 +586,6 @@ class StorageOps:
             s3storage,
             for_presign=True,
         ) as (client, bucket, key):
-
             for filename in filenames:
                 futures.append(
                     client.generate_presigned_url(
@@ -879,9 +878,9 @@ class StorageOps:
         def get_datapackage() -> Iterable[bytes]:
             yield datapackage_bytes
 
-        def member_files() -> (
-            Iterable[tuple[str, datetime, int, Method, Iterable[bytes]]]
-        ):
+        def member_files() -> Iterable[
+            tuple[str, datetime, int, Method, Iterable[bytes]]
+        ]:
             modified_at = datetime(year=1980, month=1, day=1)
             perms = 0o664
             for file_ in all_files:

--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -1,3 +1,2 @@
-black
-pylint
-mypy==1.10.1
+ruff
+mypy

--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -1,2 +1,3 @@
 ruff
+pylint
 mypy


### PR DESCRIPTION
Fixes #3117 

As an alternative to #3118, switch to ruff instead of black.
It seems ruff does better formatting in some ways.
Still keeping pylint as there are many places where certain pylint warnings are ignored.