### PR TITLE
Fix Total Pages Computation

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1501,8 +1501,8 @@ class CrawlOperator(BaseOperator):
         pipe.get(f"{crawl_id}:profileUploaded")
         results = await pipe.execute()
 
-        pages_done = int(results[0]) or 0
-        pages_found = int(results[1]) - int(results[2] or 0) - int(results[3] or 0)
+        pages_done = int(results[0] or 0)
+        pages_found = int(results[1] or 0) - int(results[2] or 0) - int(results[3] or 0)
 
         sizes = results[4]
         archive_size = sum(int(x) for x in sizes.values())


### PR DESCRIPTION
Crawler 1.10.1 introduced a separate key for tracking excluded URLs, this total should also be subtracted to compute 'pages found'.
This PR adds that and also converts the redis stats query into a pipeline, as that should be more performant, combining all the stats requests into one network request.
Compatibility with very old crawler (2.5 years old!) is also removed for simplification.