### PR TITLE
Better handle collection and index deletion for dedupe sources

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -51,6 +51,7 @@ from .models import (
     MIN_UPLOAD_PART_SIZE,
     PublicCollOut,
     ResourcesOnly,
+    DeleteDedupeIndex,
     TYPE_DEDUPE_INDEX_STATES,
 )
 from .utils import (
@@ -1558,13 +1559,13 @@ def init_collections_api(
     )
     async def delete_dedupe_index(
         coll_id: UUID,
-        removeFromWorkflows: bool = False,
+        delete: DeleteDedupeIndex,
         org: Organization = Depends(org_owner_dep),
     ):
         coll = await colls.get_collection(coll_id, org.id)
 
         return await colls.delete_dedupe_index(
-            coll, org, remove_from_workflows=removeFromWorkflows
+            coll, org, remove_from_workflows=delete.removeFromWorkflows
         )
 
     return colls

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -768,7 +768,9 @@ class CollectionOps:
             str(coll.id), str(oid), crawler_image, pull_policy, is_purge
         )
 
-    async def delete_dedupe_index(self, coll: Collection, org: Organization):
+    async def delete_dedupe_index(
+        self, coll: Collection, org: Organization, disable_workflow_dudupe: bool = False
+    ):
         """delete coll dedupe index, if possible"""
         if not coll.indexStats:
             raise HTTPException(status_code=404, detail="no_dedupe_index")
@@ -796,6 +798,12 @@ class CollectionOps:
                 }
             },
         )
+
+        if disable_workflow_dudupe:
+            await self.crawl_configs.update_many(
+                {"oid": org.id, "dedupeCollId": coll.id},
+                {"$set": {"dedupeCollId": None}},
+            )
 
         return {"deleted": True}
 
@@ -1548,10 +1556,13 @@ def init_collections_api(
     )
     async def delete_dedupe_index(
         coll_id: UUID,
+        disableWorkflowDedupe: bool = False,
         org: Organization = Depends(org_owner_dep),
     ):
         coll = await colls.get_collection(coll_id, org.id)
 
-        return await colls.delete_dedupe_index(coll, org)
+        return await colls.delete_dedupe_index(
+            coll, org, disable_workflow_dudupe=disableWorkflowDedupe
+        )
 
     return colls

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -672,7 +672,9 @@ class CollectionOps:
         coll = await self.get_collection(coll_id, org.id)
 
         if coll.indexStats:
-            await self.delete_dedupe_index(coll, org)
+            raise HTTPException(
+                status_code=400, detail="not_allowed_while_dedupe_index_exists"
+            )
 
         await self.crawl_ops.remove_collection_from_all_crawls(coll_id, org)
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -771,7 +771,7 @@ class CollectionOps:
         )
 
     async def delete_dedupe_index(
-        self, coll: Collection, org: Organization, disable_workflow_dudupe: bool = False
+        self, coll: Collection, org: Organization, remove_from_workflows: bool = False
     ):
         """delete coll dedupe index, if possible"""
         if not coll.indexStats:
@@ -801,7 +801,7 @@ class CollectionOps:
             },
         )
 
-        if disable_workflow_dudupe:
+        if remove_from_workflows:
             await self.crawl_configs.update_many(
                 {"oid": org.id, "dedupeCollId": coll.id},
                 {"$set": {"dedupeCollId": None}},
@@ -1558,13 +1558,13 @@ def init_collections_api(
     )
     async def delete_dedupe_index(
         coll_id: UUID,
-        disableWorkflowDedupe: bool = False,
+        removeFromWorkflows: bool = False,
         org: Organization = Depends(org_owner_dep),
     ):
         coll = await colls.get_collection(coll_id, org.id)
 
         return await colls.delete_dedupe_index(
-            coll, org, disable_workflow_dudupe=disableWorkflowDedupe
+            coll, org, remove_from_workflows=removeFromWorkflows
         )
 
     return colls

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1840,6 +1840,13 @@ class CollectionAllResponse(BaseModel):
 
 
 # ============================================================================
+class DeleteDedupeIndex(BaseModel):
+    """Options for deleting dedupe index on collection"""
+
+    removeFromWorkflows: bool = False
+
+
+# ============================================================================
 
 ### ORGS ###
 


### PR DESCRIPTION
Backend work for #3077 

- Prevent deletion of collections that have a dedupe index
- Add `removeFromWorkflows` option to `POST collections/{coll_id}/dedupeIndex/delete` endpoint: this will remove the `dedupeCollId` reference on all related workflows, making it easy to disable dedupe for the collection in a single action

When a collection is fully deleted, `dedupeCollId` is already set to `None` and the collection is removed from `autoAddCollections` on all related workflows.