### PR TITLE
Manually set dedupe index state to idle if index created on empty collection

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -720,10 +720,11 @@ class CollectionOps:
         # enable index by settings stats to empty value
         await self.update_dedupe_index_stats(coll.id, DedupeIndexStats())
 
-        # run import job only if collection not empty
         await self.update_dedupe_index_info(
             coll.id, state="initing" if coll.crawlCount else "idle"
         )
+
+        # run import job only if collection not empty
         if coll.crawlCount:
             await self.run_import_index_job(coll, org.id)
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -723,6 +723,8 @@ class CollectionOps:
         # run import job only if collection not empty
         if coll.crawlCount:
             await self.run_import_index_job(coll, org.id)
+        else:
+            await self.update_dedupe_index_info(coll.id, state="idle")
 
         return {"success": True}
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -721,10 +721,11 @@ class CollectionOps:
         await self.update_dedupe_index_stats(coll.id, DedupeIndexStats())
 
         # run import job only if collection not empty
+        await self.update_dedupe_index_info(
+            coll.id, state="initing" if coll.crawlCount else "idle"
+        )
         if coll.crawlCount:
             await self.run_import_index_job(coll, org.id)
-        else:
-            await self.update_dedupe_index_info(coll.id, state="idle")
 
         return {"success": True}
 


### PR DESCRIPTION
Fixes #3124 

If a dedupe index is manually created on a collection with no archived items, set the `indexState` to `idle` ("Available" in frontend). Since there's no index file to build or save, at this point we don't set `indexLastSavedAt`. When we implement an `indexCreated` date, we can add it in this hook or when a workflow first forces creation of the index, whichever happens first.

If a dedupe index is created on a collection with items, an import job will be created that will set the indexState to `initing` and then update it as the import job progresses.