### PR TITLE
Bugfix: remove `crawlType` param from archived items api call when not set

### DIFF
--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -935,7 +935,7 @@ export class CrawlsList extends BtrixElement {
         userid: params.filterByCurrentUser ? this.userInfo!.id : undefined,
         sortBy: params.orderBy.field,
         sortDirection: params.orderBy.direction === "desc" ? -1 : 1,
-        crawlType: params.itemType,
+        crawlType: params.itemType ?? undefined,
       },
       {
         arrayFormat: "none",


### PR DESCRIPTION
Was preventing archived items from loading on the "all items" tab. May be caused by changes made in https://github.com/webrecorder/browsertrix/pull/3084, specifically the change from a `str` type to a string literal, where FastAPI interprets `?crawlType&...` as an empty string.

Tested locally against dev.