### PR TITLE
dedupe: Update org member permissions info text

### DIFF
--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -495,12 +495,13 @@ export class OrgSettings extends BtrixElement {
                   ${msg("All Viewer permissions, plus:")}
                 </p>
                 <ul class="ms-4 list-disc text-gray-500">
-                  <li>${msg("Create crawl workflows")}</li>
-                  <li>${msg("Create browser profiles")}</li>
+                  <li>${msg("Manage crawl workflows and browser profiles")}</li>
                   <li>${msg("Upload archived items")}</li>
-                  <li>${msg("Run QA analysis")}</li>
-                  <li>${msg("Rate and review archived items")}</li>
+                  <li>
+                    ${msg("Run QA analysis, rate, and review archived items")}
+                  </li>
                   <li>${msg("Create, edit, and share collections")}</li>
+                  <li>${msg("Enable crawl deduplication")}</li>
                 </ul>
               </sl-details>
             </sl-radio>
@@ -533,6 +534,7 @@ export class OrgSettings extends BtrixElement {
                     <li class="text-warning">
                       ${msg("Manage billing details")}
                     </li>`}
+                  <li>${msg("Purge and delete deduplication indices")}</li>
                   <li>${msg("Edit org name and URL")}</li>
                   <li>${msg("Manage org members")}</li>
                   <li>${msg("View and edit org defaults")}</li>


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/2860

## Changes

Updates info text listing permissions for each org member role to include dedupe.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Org settings | <img width="462" height="414" alt="Screenshot 2026-01-22 at 11 45 53 AM" src="https://github.com/user-attachments/assets/00e4d6c3-e265-4d70-b55e-eb919c234400" /> |


<!-- ## Follow-ups -->
