### PR TITLE
dedupe backend updates/cleanup:

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -256,6 +256,19 @@ class K8sAPI:
                 status_code=400, detail="invalid_config_missing_storage_secret"
             )
 
+    async def delete_job(self, name):
+        """delete job by name"""
+        try:
+            await self.batch_api.delete_namespaced_job(
+                name=name,
+                namespace=self.namespace,
+            )
+            return True
+
+        # pylint: disable=bare-except
+        except:
+            return False
+
     async def delete_crawl_job(self, crawl_id):
         """delete custom crawljob object"""
         name = f"crawljob-{crawl_id}"

--- a/backend/btrixcloud/operator/collindexjob.py
+++ b/backend/btrixcloud/operator/collindexjob.py
@@ -76,6 +76,10 @@ class CollIndexImportJobOperator(BaseOperator):
                 coll_id, name, oid, configmap
             )
 
+        # delete succeeded job
+        if data.object.get("status", {}).get("succeeded", 0) >= 1:
+            self.run_task(self.k8s.delete_job(name))
+
         return MCDecoratorSyncResponse(attachments=attachments)
 
     async def load_import_configmap(self, coll_id: str, name: str, oid: str, configmap):

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -12,8 +12,8 @@ metadata:
     oid: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 0
-  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 6
 
 # if purging, set completions to disallow changing parallelism
 # for import, omit to allow increasing later


### PR DESCRIPTION
- check for indexState instead of indexStats to determine if index exists
- call run_index_import_job() explicitly when needed, move out of update_collection_dates()
- use run_index_import_job() not run_import_index_job() consistently
- allow only one purge job to be started at a time, using fixed name for purge job
- update state in db to imporing/purging right away for quicker user feedback
- increase backoff limit and set ttl to 5 min to be able to see any failed jobs
- delete successful index job in operator, so only failed jobs persist upto ttl