### PR TITLE
dedupe: Show beta badge for dedupe features

### DIFF
--- a/frontend/src/components/ui/tab-list.ts
+++ b/frontend/src/components/ui/tab-list.ts
@@ -29,6 +29,7 @@ export class TabListTab extends TailwindElement {
         aria-controls=${ifDefined(this.name)}
         aria-disabled=${ifDefined(this.disabled)}
         tabindex=${this.disabled ? "-1" : "0"}
+        part="base"
       >
         <slot></slot>
       </li>

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -621,13 +621,19 @@ export class WorkflowEditor extends BtrixElement {
   private renderNav() {
     const button = (tab: StepName) => {
       const isActive = tab === this.progressState?.activeTab;
+      const section = this.formSections.find(({ name }) => name === tab);
       return html`
         <btrix-tab-list-tab
+          class="part-[base]:flex part-[base]:items-center part-[base]:gap-2"
           name=${tab}
           .active=${isActive}
           @click=${this.tabClickHandler(tab)}
         >
           ${this.tabLabels[tab]}
+          ${when(
+            section?.beta,
+            () => html`<btrix-beta-icon></btrix-beta-icon>`,
+          )}
         </btrix-tab-list-tab>
       `;
     };
@@ -650,7 +656,6 @@ export class WorkflowEditor extends BtrixElement {
       desc,
       render,
       required,
-      beta,
     }: (typeof this.formSections)[number]) => {
       const tabProgress = this.progressState?.tabs[name];
       const hasError = tabProgress?.error;
@@ -755,10 +760,7 @@ export class WorkflowEditor extends BtrixElement {
           )}
         </div>
 
-        <div slot="summary" class="flex items-center gap-2">
-          <p class="text-neutral-700">${desc}</p>
-          ${when(beta, () => html`<btrix-beta-badge></btrix-beta-badge>`)}
-        </div>
+        <p class="text-neutral-700" slot="summary">${desc}</p>
         <div class="grid grid-cols-5 gap-5">${render.bind(this)()}</div>
       </sl-details>`;
     };
@@ -772,7 +774,15 @@ export class WorkflowEditor extends BtrixElement {
             `${formName}${panelSuffix}--active`,
           tw`scroll-mt-7`,
         ),
-        heading: this.tabLabels[section.name],
+        heading: {
+          content: html`<div class="inline-flex items-center gap-2">
+            ${this.tabLabels[section.name]}
+            ${when(
+              section.beta,
+              () => html`<btrix-beta-badge></btrix-beta-badge>`,
+            )}
+          </div>`,
+        },
         body: panelBody(section),
         actions: section.required
           ? html`<p class="text-xs font-normal text-neutral-500">

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -650,6 +650,7 @@ export class WorkflowEditor extends BtrixElement {
       desc,
       render,
       required,
+      beta,
     }: (typeof this.formSections)[number]) => {
       const tabProgress = this.progressState?.tabs[name];
       const hasError = tabProgress?.error;
@@ -754,7 +755,10 @@ export class WorkflowEditor extends BtrixElement {
           )}
         </div>
 
-        <p class="text-neutral-700" slot="summary">${desc}</p>
+        <div slot="summary" class="flex items-center gap-2">
+          <p class="text-neutral-700">${desc}</p>
+          ${when(beta, () => html`<btrix-beta-badge></btrix-beta-badge>`)}
+        </div>
         <div class="grid grid-cols-5 gap-5">${render.bind(this)()}</div>
       </sl-details>`;
     };
@@ -2730,6 +2734,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     desc: string;
     render: () => TemplateResult<1>;
     required?: boolean;
+    beta?: boolean;
   }[] = [
     {
       name: "scope",
@@ -2761,6 +2766,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       name: "deduplication",
       desc: msg("Prevent duplicate content from being crawled and stored."),
       render: this.renderDeduplication,
+      beta: true,
     },
     {
       name: "collections",

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -387,9 +387,7 @@ export class ArchivedItemDetail extends BtrixElement {
           break;
         }
         sectionContent = this.renderPanel(
-          html`${this.renderTitle(
-              html`${this.tabLabels.qa} <btrix-beta-badge></btrix-beta-badge>`,
-            )}
+          html`${this.renderTitle(this.tabLabels.qa, { beta: true })}
             <div class="ml-auto flex flex-wrap justify-end gap-2">
               ${when(!dedupeDependent && this.qaRuns, this.renderQAHeader)}
             </div> `,
@@ -487,7 +485,9 @@ export class ArchivedItemDetail extends BtrixElement {
         break;
       case "dependencies":
         sectionContent = this.renderPanel(
-          html` ${this.renderTitle(msg("Dependencies"))} `,
+          html`
+            ${this.renderTitle(this.tabLabels.dependencies, { beta: true })}
+          `,
           this.renderDependencies(),
         );
         break;
@@ -672,12 +672,12 @@ export class ArchivedItemDetail extends BtrixElement {
       section,
       iconLibrary,
       icon,
-      detail,
+      beta,
     }: {
       section: SectionName;
       iconLibrary: "app" | "default";
       icon: string;
-      detail?: TemplateResult<1>;
+      beta?: boolean;
     }) => {
       const isActive = section === this.activeTab;
       const baseUrl = window.location.pathname.split("#")[0];
@@ -695,8 +695,9 @@ export class ArchivedItemDetail extends BtrixElement {
             aria-hidden="true"
             library=${iconLibrary}
           ></sl-icon>
-          ${this.tabLabels[section]}${detail}</btrix-navigation-button
-        >
+          ${this.tabLabels[section]}
+          ${when(beta, () => html`<btrix-beta-icon></btrix-beta-icon>`)}
+        </btrix-navigation-button>
       `;
     };
     return html`
@@ -719,7 +720,7 @@ export class ArchivedItemDetail extends BtrixElement {
                       section: "qa",
                       iconLibrary: "default",
                       icon: "clipboard2-data-fill",
-                      detail: html`<btrix-beta-icon></btrix-beta-icon>`,
+                      beta: true,
                     })}
                   `,
                 )}
@@ -756,6 +757,7 @@ export class ArchivedItemDetail extends BtrixElement {
               section: "dependencies",
               iconLibrary: "default",
               icon: "layers-fill",
+              beta: true,
             })
           : nothing}
       </nav>
@@ -893,12 +895,16 @@ export class ArchivedItemDetail extends BtrixElement {
     `;
   }
 
-  private renderTitle(title: string | TemplateResult) {
-    return html`<h2
-      class="flex items-center gap-2 text-lg font-medium leading-8"
-    >
-      ${title}
-    </h2>`;
+  private renderTitle(
+    title: string | TemplateResult,
+    { beta } = { beta: false },
+  ) {
+    return html`<div class="flex items-center gap-2">
+      <h2 class="text-lg font-medium leading-8">
+        ${title}
+        ${when(beta, () => html`<btrix-beta-badge></btrix-beta-badge>`)}
+      </h2>
+    </div>`;
   }
 
   private renderPanel(

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -129,7 +129,7 @@ export class CollectionDetail extends BtrixElement {
 
   private readonly tabLabels: Record<
     Tab,
-    { icon: { name: string; library: string }; text: string }
+    { icon: { name: string; library: string }; text: string; beta?: boolean }
   > = {
     [Tab.Replay]: {
       icon: { name: "replaywebpage", library: "app" },
@@ -146,6 +146,7 @@ export class CollectionDetail extends BtrixElement {
     [Tab.Deduplication]: {
       icon: { name: "stack", library: "default" },
       text: msg("Deduplication"),
+      beta: true,
     },
   };
 
@@ -644,8 +645,12 @@ export class CollectionDetail extends BtrixElement {
                 name=${tab.icon.name}
                 library=${tab.icon.library}
               ></sl-icon>
-              ${tab.text}</btrix-navigation-button
-            >
+              ${tab.text}
+              ${when(
+                tab.beta,
+                () => html`<btrix-beta-badge></btrix-beta-badge>`,
+              )}
+            </btrix-navigation-button>
           `;
         })}
       </nav>

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -251,7 +251,7 @@ export class OrgSettings extends BtrixElement {
     `;
   }
 
-  private renderTab(name: Tab, path: string, opts = { beta: false }) {
+  private renderTab(name: Tab, path: string, { beta } = { beta: false }) {
     return html`
       <btrix-tab-group-tab
         slot="nav"
@@ -273,7 +273,7 @@ export class OrgSettings extends BtrixElement {
           ["deduplication", () => html`<sl-icon name="stack"></sl-icon>`],
         ])}
         ${this.tabLabels[name]}
-        ${when(opts.beta, () => html`<btrix-beta-icon></btrix-beta-icon>`)}
+        ${when(beta, () => html`<btrix-beta-icon></btrix-beta-icon>`)}
       </btrix-tab-group-tab>
     `;
   }

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -166,7 +166,9 @@ export class OrgSettings extends BtrixElement {
           this.renderTab("billing", "settings/billing"),
         )}
         ${this.renderTab("crawling-defaults", "settings/crawling-defaults")}
-        ${this.renderTab("deduplication", "settings/deduplication")}
+        ${this.renderTab("deduplication", "settings/deduplication", {
+          beta: true,
+        })}
 
         <btrix-tab-group-panel name="information">
           ${this.renderPanelHeader({ title: msg("General") })}
@@ -220,7 +222,10 @@ export class OrgSettings extends BtrixElement {
           <btrix-org-settings-crawling-defaults></btrix-org-settings-crawling-defaults>
         </btrix-tab-group-panel>
         <btrix-tab-group-panel name="deduplication">
-          ${this.renderPanelHeader({ title: msg("Deduplication Sources") })}
+          ${this.renderPanelHeader({
+            title: msg("Deduplication Sources"),
+            beta: true,
+          })}
           <btrix-org-settings-deduplication></btrix-org-settings-deduplication>
         </btrix-tab-group-panel>
       </btrix-tab-group>`;
@@ -229,19 +234,24 @@ export class OrgSettings extends BtrixElement {
   private renderPanelHeader({
     title,
     actions,
+    beta,
   }: {
     title: string;
     actions?: TemplateResult;
+    beta?: boolean;
   }) {
     return html`
       <header class="mb-2 flex items-center justify-between">
-        <h3 class="text-lg font-medium">${title}</h3>
+        <div class="flex items-center gap-2">
+          <h3 class="text-lg font-medium">${title}</h3>
+          ${when(beta, () => html`<btrix-beta-badge></btrix-beta-badge>`)}
+        </div>
         ${actions}
       </header>
     `;
   }
 
-  private renderTab(name: Tab, path: string) {
+  private renderTab(name: Tab, path: string, opts = { beta: false }) {
     return html`
       <btrix-tab-group-tab
         slot="nav"
@@ -263,6 +273,7 @@ export class OrgSettings extends BtrixElement {
           ["deduplication", () => html`<sl-icon name="stack"></sl-icon>`],
         ])}
         ${this.tabLabels[name]}
+        ${when(opts.beta, () => html`<btrix-beta-icon></btrix-beta-icon>`)}
       </btrix-tab-group-tab>
     `;
   }


### PR DESCRIPTION
WIP for https://github.com/webrecorder/browsertrix/issues/3125

## Changes

Displays beta icon and badge in dedupe features.


## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Org settings | <img width="1256" height="250" alt="Screenshot 2026-01-22 at 1 02 04 PM" src="https://github.com/user-attachments/assets/bdc2f8ec-3c33-4167-8fd5-896499084b7b" /> |
| Workflow editor | <img width="1252" height="448" alt="Screenshot 2026-01-22 at 1 22 00 PM" src="https://github.com/user-attachments/assets/6ce5d1e7-e6b9-4466-91e8-8ef3dcb78899" /> |
| Archived item detail | <img width="1003" height="288" alt="Screenshot 2026-01-22 at 1 09 19 PM" src="https://github.com/user-attachments/assets/63cae228-509f-4bfa-bafa-558a7accece9" /> |
| Collection detail | <img width="526" height="46" alt="Screenshot 2026-01-22 at 1 01 42 PM" src="https://github.com/user-attachments/assets/8d08c3b0-c303-458b-91dd-f49efe736549" /> |


<!-- ## Follow-ups -->
