### PR TITLE
dedupe: Improve display of index in progress

### DIFF
--- a/frontend/src/components/ui/badge.ts
+++ b/frontend/src/components/ui/badge.ts
@@ -58,7 +58,7 @@ export class Badge extends TailwindElement {
     return html`
       <span
         class=${clsx(
-          tw`inline-flex min-h-4 items-center justify-center whitespace-nowrap leading-none`,
+          tw`inline-flex min-h-4 items-center justify-center whitespace-nowrap font-normal leading-none`,
           this.asLabel
             ? [this.size === "medium" && tw`text-xs`]
             : [

--- a/frontend/src/features/collections/index-import-progress.ts
+++ b/frontend/src/features/collections/index-import-progress.ts
@@ -71,7 +71,8 @@ export class IndexImportProgress extends BtrixElement {
   render() {
     return this.progressTask.render({
       initial: () => this.renderBar(this.initialValue),
-      pending: () => this.renderBar(this.progressTask.value),
+      pending: () =>
+        this.renderBar(this.progressTask.value ?? this.initialValue),
       complete: this.renderBar,
     });
   }
@@ -85,7 +86,6 @@ export class IndexImportProgress extends BtrixElement {
         ?disabled=${!value}
       >
         <sl-progress-bar
-          class="mb-0.5 mt-1.5"
           value=${Math.max(percentage, 1)}
           label=${msg("Index Import Progress")}
           ?indeterminate=${!value}


### PR DESCRIPTION
## Screenshots

<img width="612" height="211" alt="Screenshot 2026-01-28 at 12 52 03 PM" src="https://github.com/user-attachments/assets/81bf241b-7d4e-488e-be04-00ec103a7451" />

<img width="267" height="250" alt="Screenshot 2026-01-28 at 12 52 06 PM" src="https://github.com/user-attachments/assets/cdab2313-b118-4dc6-b823-fcccb66c31ca" />
