### PR TITLE
fix: Hide collection edit buttons from viewer role

### DIFF
--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -254,15 +254,16 @@ export class CollectionDetail extends BtrixElement {
               this.collection?.name,
               tw`mb-2 h-6 w-60`,
             )}
-            ${this.collection &&
-            html`<sl-icon-button
-              name="pencil"
-              aria-label=${msg("Edit Collection Name and Description")}
-              @click=${() => {
-                this.openDialogName = "edit";
-                this.editTab = "general";
-              }}
-            ></sl-icon-button>`}
+            ${this.collection && this.isCrawler
+              ? html`<sl-icon-button
+                  name="pencil"
+                  aria-label=${msg("Edit Collection Name and Description")}
+                  @click=${() => {
+                    this.openDialogName = "edit";
+                    this.editTab = "general";
+                  }}
+                ></sl-icon-button>`
+              : nothing}
           </div>
           ${this.isCrawler
             ? when(

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -206,6 +206,13 @@ export class CollectionDetail extends BtrixElement {
     const collection_name = html`<strong class="font-semibold"
       >${this.collection?.name}</strong
     >`;
+    const caption = (text?: Collection["caption"]) => {
+      if (text) {
+        return html`<div class="text-pretty text-neutral-600">
+          ${richText(text)}
+        </div>`;
+      }
+    };
 
     return html`
       <div class="mb-7 flex justify-between align-baseline">
@@ -233,7 +240,12 @@ export class CollectionDetail extends BtrixElement {
             `
           : nothing}
       </div>
-      <header class="mt-5 flex min-h-16 flex-col gap-3  lg:flex-row">
+      <header
+        class=${clsx(
+          tw`mt-5 flex flex-col gap-3 lg:flex-row`,
+          this.isCrawler && tw`min-h-16`,
+        )}
+      >
         <div
           class="-mb-1 -ml-2 -mr-1 -mt-1 flex flex-none flex-col gap-2 self-start rounded-lg pb-1 pl-2 pr-1 pt-1 transition-colors has-[.addSummary:hover]:bg-primary-50 has-[sl-icon-button:hover]:bg-primary-50"
         >
@@ -252,22 +264,27 @@ export class CollectionDetail extends BtrixElement {
               }}
             ></sl-icon-button>`}
           </div>
-          ${this.collection
-            ? this.collection.caption
-              ? html`<div class="text-pretty text-neutral-600">
-                  ${richText(this.collection.caption)}
-                </div>`
-              : html`<div
-                  class="addSummary text-pretty rounded-md px-1 font-light text-neutral-500"
-                  role="button"
-                  @click=${() => {
-                    this.openDialogName = "edit";
-                    this.editTab = "general";
-                  }}
-                >
-                  ${msg("Add a summary...")}
-                </div>`
-            : html`<sl-skeleton></sl-skeleton>`}
+          ${this.isCrawler
+            ? when(
+                this.collection,
+                (col) =>
+                  col.caption
+                    ? caption(col.caption)
+                    : html`
+                        <div
+                          class="addSummary text-pretty rounded-md px-1 font-light text-neutral-500"
+                          role="button"
+                          @click=${() => {
+                            this.openDialogName = "edit";
+                            this.editTab = "general";
+                          }}
+                        >
+                          ${msg("Add a summary...")}
+                        </div>
+                      `,
+                () => html`<sl-skeleton></sl-skeleton>`,
+              )
+            : caption(this.collection?.caption)}
         </div>
 
         <div class="ml-auto flex flex-shrink-0 items-center gap-2">

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -952,14 +952,16 @@ export class CollectionDetail extends BtrixElement {
                     </div>
                   </btrix-popover>
                 `
-              : html`<sl-tooltip content=${msg("Edit Description")}>
-                  <sl-icon-button
-                    class="text-base"
-                    name="pencil"
-                    @click=${() => (this.isEditingDescription = true)}
-                  >
-                  </sl-icon-button>
-                </sl-tooltip>`}
+              : this.isCrawler
+                ? html`<sl-tooltip content=${msg("Edit Description")}>
+                    <sl-icon-button
+                      class="text-base"
+                      name="pencil"
+                      @click=${() => (this.isEditingDescription = true)}
+                    >
+                    </sl-icon-button>
+                  </sl-tooltip>`
+                : nothing}
           </header>
           ${when(
             this.collection,
@@ -985,15 +987,23 @@ export class CollectionDetail extends BtrixElement {
                               <p class="mb-3 max-w-prose">
                                 ${msg("No description provided.")}
                               </p>
-                              <sl-button
-                                size="small"
-                                @click=${() =>
-                                  (this.isEditingDescription = true)}
-                                ?disabled=${!this.collection}
-                              >
-                                <sl-icon name="pencil" slot="prefix"></sl-icon>
-                                ${msg("Add Description")}
-                              </sl-button>
+                              ${when(
+                                this.isCrawler,
+                                () => html`
+                                  <sl-button
+                                    size="small"
+                                    @click=${() =>
+                                      (this.isEditingDescription = true)}
+                                    ?disabled=${!this.collection}
+                                  >
+                                    <sl-icon
+                                      name="pencil"
+                                      slot="prefix"
+                                    ></sl-icon>
+                                    ${msg("Add Description")}
+                                  </sl-button>
+                                `,
+                              )}
                             </div>
                           `}
                     </div>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3137

## Changes

Hides collection edit buttons for users with viewer role.

## Manual testing

1. Log in as viewer
2. Go to collection detail page. Verify that name edit button and "Add a summary" is not visible
3. Go to "About" tab. Verify that edit description button is not visible

## Note on PR branch

Although this PR is unrelated to dedupe, it's branched from `feature-dedupe` because moves `collection-details.ts` to a separate directory. Since the bug isn't critical, it could be merged as a part of `feature-dedupe` or rebased and merged afterwards if we want to keep the work separate.