### PR TITLE
fix: Collection detail consistency fixes

### DIFF
--- a/frontend/src/layouts/collections/metadataColumn.ts
+++ b/frontend/src/layouts/collections/metadataColumn.ts
@@ -64,7 +64,9 @@ export function metadataColumn(collection?: Collection | PublicCollection) {
               (x) => html`
                 <tr>
                   <td>${x.host}</td>
-                  <td class="pl-4">${x.count}</td>
+                  <td class="pl-4">
+                    ${localize.number(x.count, { notation: "compact" })}
+                  </td>
                 </tr>
               `,
             )}

--- a/frontend/src/layouts/collections/metadataColumn.ts
+++ b/frontend/src/layouts/collections/metadataColumn.ts
@@ -1,4 +1,4 @@
-import { html, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { when } from "lit/directives/when.js";
 
 import { metadata } from "@/strings/collections/metadata";
@@ -29,7 +29,10 @@ export function metadataItemWithCollection(
   };
 }
 
-export function metadataColumn(collection?: Collection | PublicCollection) {
+export function metadataColumn(
+  collection?: Collection | PublicCollection,
+  { publicView } = { publicView: false },
+) {
   const metadataItem = metadataItemWithCollection(collection);
 
   return html`
@@ -52,10 +55,12 @@ export function metadataColumn(collection?: Collection | PublicCollection) {
         render: (col) =>
           `${localize.number(col.pageCount)} ${pluralOf("pages", col.pageCount)}`,
       })}
-      ${metadataItem({
-        label: metadata.totalSize,
-        render: (col) => `${localize.bytes(col.totalSize)}`,
-      })}
+      ${publicView
+        ? metadataItem({
+            label: metadata.totalSize,
+            render: (col) => `${localize.bytes(col.totalSize)}`,
+          })
+        : nothing}
       ${metadataItem({
         label: metadata.topPageHosts,
         render: (col) =>

--- a/frontend/src/pages/collections/collection.ts
+++ b/frontend/src/pages/collections/collection.ts
@@ -204,7 +204,7 @@ export class Collection extends BtrixElement {
   }
 
   private renderAbout(collection: PublicCollection) {
-    const metadata = metadataColumn(collection);
+    const metadata = metadataColumn(collection, { publicView: true });
 
     if (collection.description) {
       return html`

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -866,7 +866,7 @@ export class CollectionDetail extends BtrixElement {
         ${this.renderDetailItem(
           msg("Total Pages"),
           (col) =>
-            `${this.localize.number(col.pageCount)} ${pluralOf("pages", col.pageCount)}`,
+            `${this.localize.number(col.pageCount, { notation: "compact" })} ${pluralOf("pages", col.pageCount)}`,
         )}
         ${this.renderDetailItem(
           msg("Total Size"),

--- a/frontend/src/strings/collections/metadata.ts
+++ b/frontend/src/strings/collections/metadata.ts
@@ -3,7 +3,7 @@ import { msg } from "@lit/localize";
 export const metadata = {
   dateLatest: msg("Collection Period"),
   uniquePageCount: msg("Unique Pages in Collection"),
-  pageCount: msg("Total Pages Crawled"),
+  pageCount: msg("Total Pages"),
   totalSize: msg("Collection Size"),
   topPageHosts: msg("Top Page Hostnames"),
 };


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3138

## Changes

- Fixes formatting of top hostnames counts.
- Fixes inconsistency between "Total Pages" label.
- Hides redundant "Collection Size" when in private view.

## Manual testing

1. Log in
2. Go to collection detail
3. Go to "About" tab. Verify formatting and labels are consistent.

## Note on PR branch

Although this PR is unrelated to dedupe, it's branched from `feature-dedupe` because moves `collection-details.ts` to a separate directory. Since the bug isn't critical, it could be merged as a part of `feature-dedupe` or rebased and merged afterwards if we want to keep the work separate.