### PR TITLE
dedupe: Keep auto-add on disable dedupe

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2405,6 +2405,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
     >
       ${msg("Auto-Add to Collections")}
     </button>`;
+    const showAutoAddWarning =
+      this.formState.dedupeType === "none" &&
+      this.initialWorkflow?.dedupeCollId &&
+      this.formState.autoAddCollections.includes(
+        this.initialWorkflow.dedupeCollId,
+      );
 
     return html` ${inputCol(html`
       <sl-radio-group
@@ -2421,7 +2427,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
             dedupeCollectionName: null,
           };
 
-          if (dedupeType === "none" && this.formState.dedupeCollectionId) {
+          if (
+            dedupeType === "none" &&
+            this.formState.dedupeCollectionId &&
+            !this.initialWorkflow?.dedupeCollId
+          ) {
             formState.autoAddCollections = without(
               [this.formState.dedupeCollectionId],
               this.formState.autoAddCollections,
@@ -2437,22 +2447,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
         >
 
         ${when(
-          this.formState.dedupeType === "none" &&
-            this.initialWorkflow?.dedupeCollId,
+          showAutoAddWarning,
           () => html`
-            <div slot="help-text" class="mt-2">
+            <div slot="help-text" class="pt-2">
               <sl-icon
                 class="mr-0.5 align-[-.175em]"
                 name="exclamation-triangle"
               ></sl-icon>
 
-              ${msg(
-                "Disabling deduplication will also disable auto-adding to the collection.",
-              )}
+              ${msg("Auto-add will remain enabled.")}
               <br />
               ${msg(
-                html`To continue to auto-add to the collection without
-                deduplication enabled, update the
+                html`To disable auto-add to the collection, update the
                 ${link_to_collections_settings} setting.`,
               )}
             </div>

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2468,7 +2468,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               ${msg("Auto-add will remain enabled.")}
               <br />
               ${msg(
-                html`To disable auto-add to the collection, update the
+                html`To disable auto-adding to the collection, update the
                 ${link_to_collections_settings} setting.`,
               )}
             </div>

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2441,6 +2441,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
           } else {
             if (this.initialWorkflow?.dedupeCollId) {
               formState.dedupeCollectionId = this.initialWorkflow.dedupeCollId;
+              formState.autoAddCollections = union(
+                formState.autoAddCollections,
+                [formState.dedupeCollectionId],
+              );
             }
           }
 
@@ -2568,12 +2572,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
       this.formState.dedupeType === "collection" &&
       !this.formState.dedupeCollectionId &&
       this.formState.dedupeCollectionName;
-    const showDedupeWarning =
-      !isEqual(
-        this.initialWorkflow?.autoAddCollections,
-        this.formState.autoAddCollections,
-      ) &&
-      (this.formState.dedupeCollectionId || newDedupeCollectionName);
+    const showDedupeWarning = newDedupeCollectionName
+      ? // New collections don't have an ID to add to list yet;
+        // check if list has any items
+        this.formState.autoAddCollections.length
+      : this.formState.dedupeCollectionId
+        ? this.formState.autoAddCollections.length > 1
+        : false;
 
     return html`
       ${inputCol(html`

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2427,15 +2427,21 @@ https://archiveweb.page/images/${"logo.svg"}`}
             dedupeCollectionName: null,
           };
 
-          if (
-            dedupeType === "none" &&
-            this.formState.dedupeCollectionId &&
-            !this.initialWorkflow?.dedupeCollId
-          ) {
-            formState.autoAddCollections = without(
-              [this.formState.dedupeCollectionId],
-              this.formState.autoAddCollections,
-            );
+          if (dedupeType === "none") {
+            if (
+              this.formState.dedupeCollectionId &&
+              !this.initialWorkflow?.dedupeCollId
+            ) {
+              // Remove from auto-add list if dedupe ID hasn't been saved yet
+              formState.autoAddCollections = without(
+                [this.formState.dedupeCollectionId],
+                this.formState.autoAddCollections,
+              );
+            }
+          } else {
+            if (this.initialWorkflow?.dedupeCollId) {
+              formState.dedupeCollectionId = this.initialWorkflow.dedupeCollId;
+            }
           }
 
           this.updateFormState(formState, true);


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3143

## Changes

Keeps collection in workflow auto-add settings when disabling deduplication.

## Manual testing

1. Log in as crawler
2. Go to workflow with dedupe enabled
3. Go to edit workflow
4. Go to "Deduplication" section
5. Choose "No deduplication". Verify warning that auto-add remains enabled is shown
6. Save. Verify settings are saved as expected

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow editor | <img width="500" height="146" alt="Screenshot 2026-01-28 at 2 19 43 PM" src="https://github.com/user-attachments/assets/6cdb4f52-b126-4d15-b5ab-f8f66684f9d9" /> |

<!-- ## Follow-ups -->
