### PR TITLE
K8S Deletion Fixes

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -277,8 +277,8 @@ class K8sAPI:
         return await self.delete_custom_object(name, "crawljobs")
 
     async def delete_profile_browser(self, browserid):
-        """delete custom crawljob object"""
-        name = f"profilejobs-{browserid}"
+        """delete custom profilejob object"""
+        name = f"profilejob-{browserid}"
 
         res = await self.delete_custom_object(name, "profilejobs")
 

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -282,11 +282,7 @@ class K8sAPI:
 
         res = await self.delete_custom_object(name, "profilejobs")
 
-        if res.get("success") is True:
-            return True
-        else:
-            print("Error deleting", res)
-            return False
+        return res.get("success") is True
 
     async def delete_custom_object(self, name: str, plural: str):
         """delete custom object with name and plural type"""

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -262,6 +262,7 @@ class K8sAPI:
             await self.batch_api.delete_namespaced_job(
                 name=name,
                 namespace=self.namespace,
+                propagation_policy="Background",
             )
             return True
 
@@ -281,7 +282,11 @@ class K8sAPI:
 
         res = await self.delete_custom_object(name, "profilejobs")
 
-        return res.get("success") is True
+        if res.get("success") is True:
+            return True
+        else:
+            print("Error deleting", res)
+            return False
 
     async def delete_custom_object(self, name: str, plural: str):
         """delete custom object with name and plural type"""

--- a/backend/btrixcloud/operator/collindexjob.py
+++ b/backend/btrixcloud/operator/collindexjob.py
@@ -79,6 +79,7 @@ class CollIndexImportJobOperator(BaseOperator):
         # delete succeeded job
         if data.object.get("status", {}).get("succeeded", 0) >= 1:
             self.run_task(self.k8s.delete_job(name))
+            attachments=[]
 
         return MCDecoratorSyncResponse(attachments=attachments)
 

--- a/backend/btrixcloud/operator/collindexjob.py
+++ b/backend/btrixcloud/operator/collindexjob.py
@@ -79,7 +79,7 @@ class CollIndexImportJobOperator(BaseOperator):
         # delete succeeded job
         if data.object.get("status", {}).get("succeeded", 0) >= 1:
             self.run_task(self.k8s.delete_job(name))
-            attachments=[]
+            attachments = []
 
         return MCDecoratorSyncResponse(attachments=attachments)
 


### PR DESCRIPTION
- fix typo in profilejob delete, resulting in profilejobs not being deleted in dedupe branch
- ensure import/purge job deletion has background propagation, so attached configmaps are also deleted.