### PR TITLE
Update browser launch calls to pass crawlerChannel and proxyId

### DIFF
--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -36,7 +36,7 @@ import {
   type Workflow,
 } from "@/types/crawler";
 import type { CrawlState } from "@/types/crawlState";
-import { SortDirection } from "@/types/utils";
+import { SortDirection, type RequireAllKeys } from "@/types/utils";
 import { isApiError } from "@/utils/api";
 import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import { isNotEqual } from "@/utils/is-not-equal";
@@ -338,7 +338,12 @@ export class BrowserProfilesProfilePage extends BtrixElement {
                 : undefined,
             )}
             @btrix-start-browser=${(e: BtrixStartBrowserEvent) => {
-              void this.openBrowser(e.detail);
+              void this.openBrowser({
+                url: e.detail.url,
+                crawlerChannel: e.detail.crawlerChannel,
+                proxyId: e.detail.proxyId,
+                replaceBrowser: e.detail.replaceBrowser,
+              });
             }}
             @sl-after-hide=${() => {
               if (this.openDialog?.startsWith("start-browser")) {
@@ -361,7 +366,13 @@ export class BrowserProfilesProfilePage extends BtrixElement {
           <li class="flex items-center gap-2">
             <button
               class="flex h-8 flex-1 items-center overflow-hidden border-r text-left transition-colors duration-fast hover:bg-cyan-50/50"
-              @click=${() => void this.openBrowser({ url: origin })}
+              @click=${() =>
+                void this.openBrowser({
+                  url: origin,
+                  crawlerChannel: profile.crawlerChannel,
+                  proxyId: profile.proxyId,
+                  replaceBrowser: false,
+                })}
             >
               <sl-tooltip placement="left" content=${msg("Load URL")}>
                 <sl-icon name="window" class="mx-2 block"></sl-icon>
@@ -685,7 +696,12 @@ export class BrowserProfilesProfilePage extends BtrixElement {
                     <sl-menu slot="menu">
                       <sl-menu-item
                         @click=${() =>
-                          void this.openBrowser({ url: workflow.firstSeed })}
+                          void this.openBrowser({
+                            url: workflow.firstSeed,
+                            crawlerChannel: workflow.crawlerChannel,
+                            proxyId: workflow.proxyId ?? undefined,
+                            replaceBrowser: false,
+                          })}
                       >
                         <sl-icon
                           slot="prefix"
@@ -791,7 +807,7 @@ export class BrowserProfilesProfilePage extends BtrixElement {
   };
 
   private readonly openBrowser = async (
-    opts: BrowserProfilesProfilePage["browserLoadParams"],
+    opts: RequireAllKeys<BrowserProfilesProfilePage["browserLoadParams"]>,
   ) => {
     let { url } = opts;
 

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -26,3 +26,10 @@ export enum SortDirection {
   Descending = -1,
   Ascending = 1,
 }
+
+/**
+ * Require all properties in an object type, but still allow them to be null/undefined
+ */
+export type RequireAllKeys<T> = {
+  [K in keyof Required<T>]: T[K];
+};


### PR DESCRIPTION
Closes #3148 

## Changes

Adds a `RequireAllKeys` type helper, and uses it to ensure all available options are explicitly included when calling `openBrowser` to open a browser profile viewer/editor.

## Testing

Tested locally.