### PR TITLE
feat: Differentiate dedupe dependencies

### DIFF
--- a/frontend/src/features/archived-items/index.ts
+++ b/frontend/src/features/archived-items/index.ts
@@ -9,6 +9,7 @@ import("./crawl-queue");
 import("./crawl-status");
 import("./file-uploader");
 import("./item-dependency-tree");
+import("./item-dependents");
 import("./item-list-controls");
 import("./qa-rating-filter");
 import("./upload-status");

--- a/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
+++ b/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
@@ -27,6 +27,9 @@ const styles = unsafeCSS(stylesheet);
 const dependenciesWithoutSelf = (item: ArchivedItem) =>
   item.requiresCrawls.filter((id) => id !== item.id);
 
+/**
+ * @cssPart tree
+ */
 @customElement("btrix-item-dependency-tree")
 @localized()
 export class ItemDependencyTree extends BtrixElement {
@@ -127,6 +130,7 @@ export class ItemDependencyTree extends BtrixElement {
           this.showHeader && tw`rounded border`,
         )}
         selection="leaf"
+        part="tree"
       >
         ${repeat(this.items, ({ id }) => id, this.renderItem)}
       </sl-tree>

--- a/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
+++ b/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
@@ -8,6 +8,8 @@ import { repeat } from "lit/directives/repeat.js";
 import { until } from "lit/directives/until.js";
 import queryString from "query-string";
 
+import { collectionStatusIcon } from "../templates/collection-status-icon";
+
 import stylesheet from "./item-dependency-tree.stylesheet.css";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -16,8 +18,7 @@ import type { ArchivedItemSectionName } from "@/pages/org/archived-item-detail/a
 import { OrgTab, WorkflowTab } from "@/routes";
 import type { APIPaginatedList } from "@/types/api";
 import type { ArchivedItem } from "@/types/crawler";
-import type { IconLibrary } from "@/types/shoelace";
-import { isActive, isCrawl, renderName } from "@/utils/crawler";
+import { isCrawl, renderName } from "@/utils/crawler";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
 
@@ -219,37 +220,6 @@ export class ItemDependencyTree extends BtrixElement {
     const inCollection =
       collectionId && item.collectionIds.includes(collectionId);
 
-    const status = () => {
-      let icon = "dash-circle";
-      let library: IconLibrary = "default";
-      let variant = tw`text-neutral-400`;
-      let tooltip = msg("Not in Collection");
-
-      if (inCollection) {
-        icon = "check-circle";
-        variant = tw`text-cyan-500`;
-
-        if (collectionId) {
-          tooltip = msg("In Same Collection");
-        } else {
-          tooltip = msg("In Collection");
-        }
-      } else if (isCrawl(item) && isActive(item)) {
-        icon = "dot";
-        library = "app";
-        variant = tw`animate-pulse text-success`;
-        tooltip = msg("Active Run");
-      }
-
-      return html`<sl-tooltip content=${tooltip} hoist placement="left">
-        <sl-icon
-          name=${icon}
-          class=${clsx(variant, tw`text-base`)}
-          library=${library}
-        ></sl-icon>
-      </sl-tooltip>`;
-    };
-
     const date = (value: string) =>
       this.localize.date(value, {
         month: "2-digit",
@@ -266,7 +236,7 @@ export class ItemDependencyTree extends BtrixElement {
         this.showHeader && "component--withHeader",
       )}
     >
-      ${status()}
+      ${collectionStatusIcon({ item, collectionId })}
       <div class="component--detail">${renderName(item)}</div>
 
       <sl-tooltip content=${msg("Dependencies")} hoist placement="left">

--- a/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
+++ b/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
@@ -271,11 +271,15 @@ export class ItemDependencyTree extends BtrixElement {
 
       <sl-tooltip content=${msg("Dependencies")} hoist placement="left">
         <div class="component--detail">
-          ${dedupeIcon({ hasDependencies: true, hasDependents: true })}
-          ${this.localize.number(dependencies.length)}
           ${this.showHeader
-            ? nothing
-            : pluralOf("dependencies", dependencies.length)}
+            ? this.localize.number(dependencies.length)
+            : dependencies.length
+              ? html`
+                  ${dedupeIcon({ hasDependencies: true, hasDependents: true })}
+                  ${this.localize.number(dependencies.length)}
+                  ${pluralOf("dependencies", dependencies.length)}
+                `
+              : nothing}
         </div>
       </sl-tooltip>
 

--- a/frontend/src/features/archived-items/item-dependents.ts
+++ b/frontend/src/features/archived-items/item-dependents.ts
@@ -1,15 +1,14 @@
 import { localized, msg } from "@lit/localize";
-import clsx from "clsx";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+
+import { collectionStatusIcon } from "./templates/collection-status-icon";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { ArchivedItemSectionName } from "@/pages/org/archived-item-detail/archived-item-detail";
 import { OrgTab, WorkflowTab } from "@/routes";
 import type { ArchivedItem } from "@/types/crawler";
-import type { IconLibrary } from "@/types/shoelace";
-import { isActive, isCrawl, renderName } from "@/utils/crawler";
-import { tw } from "@/utils/tailwind";
+import { isCrawl, renderName } from "@/utils/crawler";
 
 @customElement("btrix-item-dependents")
 @localized()
@@ -63,44 +62,14 @@ export class ItemDependents extends BtrixElement {
   private readonly renderRow = (item: ArchivedItem) => {
     const crawled = isCrawl(item);
 
-    const collectionId = this.collectionId;
-    const inCollection =
-      collectionId && item.collectionIds.includes(collectionId);
-
-    const status = () => {
-      let icon = "dash-circle";
-      let library: IconLibrary = "default";
-      let variant = tw`text-neutral-400`;
-      let tooltip = msg("Not in Collection");
-
-      if (inCollection) {
-        icon = "check-circle";
-        variant = tw`text-cyan-500`;
-
-        if (collectionId) {
-          tooltip = msg("In Same Collection");
-        } else {
-          tooltip = msg("In Collection");
-        }
-      } else if (isCrawl(item) && isActive(item)) {
-        icon = "dot";
-        library = "app";
-        variant = tw`animate-pulse text-success`;
-        tooltip = msg("Active Run");
-      }
-
-      return html`<sl-tooltip content=${tooltip} hoist placement="left">
-        <sl-icon
-          name=${icon}
-          class=${clsx(variant, tw`text-base`)}
-          library=${library}
-        ></sl-icon>
-      </sl-tooltip>`;
-    };
-
     return html`<btrix-table-row>
-      <btrix-table-cell> ${status()} </btrix-table-cell>
-      <btrix-table-cell class="pl-0"> ${renderName(item)} </btrix-table-cell>
+      <btrix-table-cell
+        >${collectionStatusIcon({
+          item,
+          collectionId: this.collectionId,
+        })}</btrix-table-cell
+      >
+      <btrix-table-cell class="pl-0">${renderName(item)}</btrix-table-cell>
       <btrix-table-cell>
         ${this.localize.number(item.requiredByCrawls.length, {
           notation: "compact",

--- a/frontend/src/features/archived-items/item-dependents.ts
+++ b/frontend/src/features/archived-items/item-dependents.ts
@@ -1,0 +1,137 @@
+import { localized, msg } from "@lit/localize";
+import clsx from "clsx";
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import type { ArchivedItemSectionName } from "@/pages/org/archived-item-detail/archived-item-detail";
+import { OrgTab, WorkflowTab } from "@/routes";
+import type { ArchivedItem } from "@/types/crawler";
+import type { IconLibrary } from "@/types/shoelace";
+import { isActive, isCrawl, renderName } from "@/utils/crawler";
+import { tw } from "@/utils/tailwind";
+
+@customElement("btrix-item-dependents")
+@localized()
+export class ItemDependents extends BtrixElement {
+  @property({ type: String })
+  collectionId?: string;
+
+  @property({ type: Array })
+  items?: ArchivedItem[];
+
+  render() {
+    if (!this.items?.length) return;
+
+    return html`
+      <btrix-table
+        style="--btrix-table-grid-template-columns: ${[
+          "min-content",
+          "repeat(4, auto)",
+          "min-content",
+        ].join(" ")}"
+      >
+        <btrix-table-head
+          class="mb-2 [--btrix-table-cell-padding-x:var(--sl-spacing-x-small)]"
+        >
+          <btrix-table-header-cell>
+            <span class="sr-only">${msg("Status")}</span>
+          </btrix-table-header-cell>
+          <btrix-table-header-cell class="pl-0"
+            >${msg("Name")}</btrix-table-header-cell
+          >
+          <btrix-table-header-cell>
+            ${msg("Dependents")}
+          </btrix-table-header-cell>
+          <btrix-table-header-cell>
+            ${msg("Date Created")}
+          </btrix-table-header-cell>
+          <btrix-table-header-cell>${msg("Size")}</btrix-table-header-cell>
+          <btrix-table-header-cell>
+            <span class="sr-only">${msg("Actions")}</span>
+          </btrix-table-header-cell>
+        </btrix-table-head>
+        <btrix-table-body
+          class="divide-y rounded border [--btrix-table-cell-padding-x:var(--sl-spacing-x-small)] [--btrix-table-cell-padding-y:var(--sl-spacing-2x-small)]"
+        >
+          ${this.items.map(this.renderRow)}
+        </btrix-table-body>
+      </btrix-table>
+    `;
+  }
+
+  private readonly renderRow = (item: ArchivedItem) => {
+    const crawled = isCrawl(item);
+
+    const collectionId = this.collectionId;
+    const inCollection =
+      collectionId && item.collectionIds.includes(collectionId);
+
+    const status = () => {
+      let icon = "dash-circle";
+      let library: IconLibrary = "default";
+      let variant = tw`text-neutral-400`;
+      let tooltip = msg("Not in Collection");
+
+      if (inCollection) {
+        icon = "check-circle";
+        variant = tw`text-cyan-500`;
+
+        if (collectionId) {
+          tooltip = msg("In Same Collection");
+        } else {
+          tooltip = msg("In Collection");
+        }
+      } else if (isCrawl(item) && isActive(item)) {
+        icon = "dot";
+        library = "app";
+        variant = tw`animate-pulse text-success`;
+        tooltip = msg("Active Run");
+      }
+
+      return html`<sl-tooltip content=${tooltip} hoist placement="left">
+        <sl-icon
+          name=${icon}
+          class=${clsx(variant, tw`text-base`)}
+          library=${library}
+        ></sl-icon>
+      </sl-tooltip>`;
+    };
+
+    return html`<btrix-table-row>
+      <btrix-table-cell> ${status()} </btrix-table-cell>
+      <btrix-table-cell class="pl-0"> ${renderName(item)} </btrix-table-cell>
+      <btrix-table-cell>
+        ${this.localize.number(item.requiredByCrawls.length, {
+          notation: "compact",
+        })}
+      </btrix-table-cell>
+      <btrix-table-cell>
+        ${this.localize.date(item.finished || item.started, {
+          dateStyle: "short",
+          timeStyle: "short",
+        })}
+      </btrix-table-cell>
+      <btrix-table-cell>
+        ${this.localize.bytes(item.fileSize || 0, { unitDisplay: "short" })}
+      </btrix-table-cell>
+      <btrix-table-cell>
+        ${this.renderLink(
+          crawled
+            ? `${this.navigate.orgBasePath}/${OrgTab.Workflows}/${item.cid}/${WorkflowTab.Crawls}/${item.id}#${"overview" as ArchivedItemSectionName}`
+            : `${this.navigate.orgBasePath}/${OrgTab.Items}/${item.type}/${item.id}`,
+        )}
+      </btrix-table-cell>
+    </btrix-table-row>`;
+  };
+
+  private renderLink(href: string) {
+    return html`<sl-icon-button
+      name="link"
+      href=${href}
+      label=${msg("Link")}
+      @click=${this.navigate.link}
+    >
+    </sl-icon-button>`;
+  }
+}

--- a/frontend/src/features/archived-items/templates/collection-status-icon.ts
+++ b/frontend/src/features/archived-items/templates/collection-status-icon.ts
@@ -1,0 +1,47 @@
+import { msg } from "@lit/localize";
+import clsx from "clsx";
+import { html } from "lit";
+
+import type { ArchivedItem } from "@/types/crawler";
+import type { IconLibrary } from "@/types/shoelace";
+import { isActive, isCrawl } from "@/utils/crawler";
+import { tw } from "@/utils/tailwind";
+
+export function collectionStatusIcon({
+  item,
+  collectionId,
+}: {
+  item: ArchivedItem;
+  collectionId?: string;
+}) {
+  const inCollection =
+    collectionId && item.collectionIds.includes(collectionId);
+  let icon = "dash-circle";
+  let library: IconLibrary = "default";
+  let variant = tw`text-neutral-400`;
+  let tooltip = msg("Not in Collection");
+
+  if (inCollection) {
+    icon = "check-circle";
+    variant = tw`text-cyan-500`;
+
+    if (collectionId) {
+      tooltip = msg("In Same Collection");
+    } else {
+      tooltip = msg("In Collection");
+    }
+  } else if (isCrawl(item) && isActive(item)) {
+    icon = "dot";
+    library = "app";
+    variant = tw`animate-pulse text-success`;
+    tooltip = msg("Active Run");
+  }
+
+  return html`<sl-tooltip content=${tooltip} hoist placement="left">
+    <sl-icon
+      name=${icon}
+      class=${clsx(variant, tw`text-base`)}
+      library=${library}
+    ></sl-icon>
+  </sl-tooltip>`;
+}

--- a/frontend/src/features/collections/dedupe-workflows/dedupe-workflows.ts
+++ b/frontend/src/features/collections/dedupe-workflows/dedupe-workflows.ts
@@ -154,7 +154,7 @@ export class DedupeWorkflows extends BtrixElement {
             <sl-tooltip content=${msg("Workflow Name")} hoist>
               <sl-icon
                 name="file-code-fill"
-                class="text-base text-neutral-600"
+                class="shrink-0 text-base text-neutral-600"
               ></sl-icon>
             </sl-tooltip>
             ${renderName(workflow)}

--- a/frontend/src/layouts/info-popover.ts
+++ b/frontend/src/layouts/info-popover.ts
@@ -11,7 +11,7 @@ export function infoPopover({
   placement?: Popover["placement"];
 }) {
   return html`<btrix-popover placement=${ifDefined(placement)} hoist>
-    <sl-icon class="text-neutral-500" name="info-circle"></sl-icon>
+    <sl-icon class="text-base text-neutral-500" name="info-circle"></sl-icon>
     <div slot="content">${content}</div>
   </btrix-popover>`;
 }

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1206,12 +1206,11 @@ export class ArchivedItemDetail extends BtrixElement {
                     )}
                   </div>
                 </div>
-                <btrix-item-dependency-tree
+                <btrix-item-dependents
                   .items=${deps.items}
                   collectionId=${ifDefined(dedupeCollId || undefined)}
-                  showHeader
                 >
-                </btrix-item-dependency-tree>`
+                </btrix-item-dependents>`
             : noDeps,
       })}
     `;

--- a/frontend/src/pages/org/collection-detail/dedupe.ts
+++ b/frontend/src/pages/org/collection-detail/dedupe.ts
@@ -640,6 +640,40 @@ export class CollectionDetailDedupe extends BtrixElement {
     const enableInWorkflow =
       this.dedupeWorkflowsTask.value && !this.dedupeWorkflowsTask.value.total;
 
+    const loading = () => html`
+      <sl-skeleton effect="sheen" class="h-9"></sl-skeleton>
+    `;
+    const items = (items?: APIPaginatedList<ArchivedItem>) =>
+      items?.items.length
+        ? html`
+            <btrix-item-dependency-tree
+              class="part-[tree]:rounded part-[tree]:border"
+              .items=${items.items}
+              collectionId=${this.collectionId}
+            ></btrix-item-dependency-tree>
+
+            <footer class="mt-6 flex justify-center">
+              <btrix-pagination
+                name=${CRAWLS_PAGE_NAME}
+                page=${items.page}
+                totalCount=${items.total}
+                size=${items.pageSize}
+                @page-change=${async (e: PageChangeEvent) => {
+                  this.crawlsPagination = {
+                    ...this.crawlsPagination,
+                    page: e.detail.page,
+                  };
+
+                  await this.dedupeCrawlsTask.taskComplete;
+
+                  // Scroll to top of list
+                  // TODO once deep-linking is implemented, scroll to top of pushstate
+                  this.scrollIntoView({ behavior: "smooth" });
+                }}
+              ></btrix-pagination>
+            </footer>
+          `
+        : empty();
     const empty = () => {
       return panelBody({
         content: emptyMessage({
@@ -675,10 +709,50 @@ export class CollectionDetailDedupe extends BtrixElement {
       });
     };
 
-    return html`${this.renderDependencyTree(this.dedupeCrawlsTask, empty)}`;
+    return html`${this.dedupeCrawlsTask.render({
+      initial: loading,
+      pending: () =>
+        this.dedupeCrawlsTask.value
+          ? items(this.dedupeCrawlsTask.value)
+          : loading(),
+      complete: items,
+    })}`;
   };
 
   private readonly renderDependenciesView = () => {
+    const loading = () => html`
+      <sl-skeleton effect="sheen" class="h-9"></sl-skeleton>
+    `;
+    const items = (items?: APIPaginatedList<ArchivedItem>) =>
+      items?.items.length
+        ? html`
+            <btrix-item-dependents
+              collectionId=${this.collectionId}
+              .items=${items.items}
+            ></btrix-item-dependents>
+
+            <footer class="mt-6 flex justify-center">
+              <btrix-pagination
+                name=${DEPENDENCIES_PAGE_NAME}
+                page=${items.page}
+                totalCount=${items.total}
+                size=${items.pageSize}
+                @page-change=${async (e: PageChangeEvent) => {
+                  this.dependenciesPagination = {
+                    ...this.dependenciesPagination,
+                    page: e.detail.page,
+                  };
+
+                  await this.dependenciesTask.taskComplete;
+
+                  // Scroll to top of list
+                  // TODO once deep-linking is implemented, scroll to top of pushstate
+                  this.scrollIntoView({ behavior: "smooth" });
+                }}
+              ></btrix-pagination>
+            </footer>
+          `
+        : empty();
     const empty = () =>
       panelBody({
         content: emptyMessage({
@@ -719,71 +793,23 @@ export class CollectionDetailDedupe extends BtrixElement {
       `;
     };
 
-    return html` ${when(
-      // TODO More accurate warning by checking if all required IDs exist
-      this.dedupeCrawlsTask.value?.total &&
-        !this.dependenciesTask.value?.total &&
-        this.collection?.indexStats?.removedCrawls,
-      deletedItemsWarning,
-    )}
-    ${this.renderDependencyTree(this.dependenciesTask, empty)}`;
-  };
-
-  private readonly renderDependencyTree = (
-    itemsTask: CollectionDetailDedupe["dedupeCrawlsTask"],
-    empty: () => TemplateResult,
-  ) => {
-    const dependenciesView =
-      this.view.value[ITEMS_VIEW_PARAM] === ItemsView.Dependencies;
-    const loading = () => html`
-      <sl-skeleton effect="sheen" class="h-9"></sl-skeleton>
+    return html`
+      ${when(
+        // TODO More accurate warning by checking if all required IDs exist
+        this.dedupeCrawlsTask.value?.total &&
+          !this.dependenciesTask.value?.total &&
+          this.collection?.indexStats?.removedCrawls,
+        deletedItemsWarning,
+      )}
+      ${this.dependenciesTask.render({
+        initial: loading,
+        pending: () =>
+          this.dependenciesTask.value
+            ? items(this.dependenciesTask.value)
+            : loading(),
+        complete: items,
+      })}
     `;
-    const items = (items?: APIPaginatedList<ArchivedItem>) =>
-      items?.items.length
-        ? html`
-            <btrix-item-dependency-tree
-              .items=${items.items}
-              collectionId=${this.collectionId}
-              showHeader
-            ></btrix-item-dependency-tree>
-
-            <footer class="mt-6 flex justify-center">
-              <btrix-pagination
-                name=${dependenciesView
-                  ? DEPENDENCIES_PAGE_NAME
-                  : CRAWLS_PAGE_NAME}
-                page=${items.page}
-                totalCount=${items.total}
-                size=${items.pageSize}
-                @page-change=${async (e: PageChangeEvent) => {
-                  if (dependenciesView) {
-                    this.dependenciesPagination = {
-                      ...this.dependenciesPagination,
-                      page: e.detail.page,
-                    };
-                  } else {
-                    this.crawlsPagination = {
-                      ...this.crawlsPagination,
-                      page: e.detail.page,
-                    };
-                  }
-
-                  await itemsTask.taskComplete;
-
-                  // Scroll to top of list
-                  // TODO once deep-linking is implemented, scroll to top of pushstate
-                  this.scrollIntoView({ behavior: "smooth" });
-                }}
-              ></btrix-pagination>
-            </footer>
-          `
-        : empty();
-
-    return html`${itemsTask.render({
-      initial: loading,
-      pending: () => (itemsTask.value ? items(itemsTask.value) : loading()),
-      complete: items,
-    })}`;
   };
 
   private renderOverview() {

--- a/frontend/src/pages/org/collection-detail/dedupe.ts
+++ b/frontend/src/pages/org/collection-detail/dedupe.ts
@@ -271,7 +271,21 @@ export class CollectionDetailDedupe extends BtrixElement {
             ? tw`xl:row-start-1`
             : tw`xl:row-start-2`} col-span-full row-span-1 xl:col-span-4 xl:col-start-1"
         >
-          ${panelHeader({ heading: msg("Deduplicated Crawls") })}
+          ${panelHeader({
+            heading: msg("Deduplicated Crawls"),
+            actions: infoPopover({
+              content: html`
+                ${msg(
+                  "Deduplication creates interdependence between crawled and indexed items.",
+                )}
+                <br /><br />
+                ${msg(
+                  "Crawl dependencies are indexed items that are required by a deduplicated crawled item in order to provide a complete replay.",
+                )}
+              `,
+              placement: "left-start",
+            }),
+          })}
           ${this.renderDeduped()}
         </section>
       </div>`;
@@ -569,7 +583,7 @@ export class CollectionDetailDedupe extends BtrixElement {
                 slot="prefix"
                 name=${dedupeIconFor["dependency"].name}
               ></sl-icon>
-              ${msg("Dependencies")}
+              ${msg("Crawl Dependencies")}
             </sl-radio-button>
           </sl-radio-group>
         </div>
@@ -797,7 +811,8 @@ export class CollectionDetailDedupe extends BtrixElement {
       ${when(
         // TODO More accurate warning by checking if all required IDs exist
         this.dedupeCrawlsTask.value?.total &&
-          !this.dependenciesTask.value?.total &&
+          this.dependenciesTask.value &&
+          !this.dependenciesTask.value.total &&
           this.collection?.indexStats?.removedCrawls,
         deletedItemsWarning,
       )}


### PR DESCRIPTION
Follow up to https://github.com/webrecorder/browsertrix/issues/3103

## Changes

- Shows number of dependents instead of dependencies in "Dependencies" table
- Adds info popover for terminology
- Fixes workflow icon shrinking when name is truncated

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection / Deduplication | <img width="742" height="193" alt="Screenshot 2026-02-09 at 12 27 28 PM" src="https://github.com/user-attachments/assets/4d45ff88-a298-4019-897f-2cc55234aa8e" /> |
| Collection / Deduplication | <img width="378" height="139" alt="Screenshot 2026-02-09 at 12 28 23 PM" src="https://github.com/user-attachments/assets/eb3c17dd-e476-4018-ba09-297826a88cd6" /> |


<!-- ## Follow-ups -->
