### PR TITLE
Pin setuptools<82.0.0 to fix issue preventing backend container from starting

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,3 +29,4 @@ remotezip
 json-stream
 aiostream
 iso639-lang>=2.6.0
+setuptools<82.0.0


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix/issues/3162

Resolves an issue where the backend container was crashing due to missing `pkg_resources`, required by `passlib`.

In the future we may want to replace `passlib` with https://pypi.org/project/pwdlib/, but in the meantime this fix will resolve the issue.