### PR TITLE
feat: Use dedupe feature flag

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -331,16 +331,20 @@ export class ConfigDetails extends BtrixElement {
           )}
         `,
       })}
-      ${this.renderSection({
-        id: "deduplication",
-        heading: sectionStrings.deduplication,
-        renderDescItems: () => html`
-          ${this.renderSetting(
-            html`<span class="mb-1 inline-block">${labelFor.dedupeType}</span>`,
-            crawlConfig?.dedupeCollId ? msg("Enabled") : msg("Disabled"),
-          )}
-        `,
-      })}
+      ${when(this.featureFlags.has("dedupeEnabled"), () =>
+        this.renderSection({
+          id: "deduplication",
+          heading: sectionStrings.deduplication,
+          renderDescItems: () => html`
+            ${this.renderSetting(
+              html`<span class="mb-1 inline-block"
+                >${labelFor.dedupeType}</span
+              >`,
+              crawlConfig?.dedupeCollId ? msg("Enabled") : msg("Disabled"),
+            )}
+          `,
+        }),
+      )}
       ${when(!this.hideMetadata, () =>
         this.renderSection({
           id: "collection",
@@ -353,7 +357,11 @@ export class ConfigDetails extends BtrixElement {
               crawlConfig?.autoAddCollections.length
                 ? html`<btrix-linked-collections
                     .collections=${crawlConfig.autoAddCollections}
-                    dedupeId=${ifDefined(crawlConfig.dedupeCollId || undefined)}
+                    dedupeId=${ifDefined(
+                      (this.featureFlags.has("dedupeEnabled") &&
+                        crawlConfig.dedupeCollId) ||
+                        undefined,
+                    )}
                   ></btrix-linked-collections>`
                 : undefined,
             )}

--- a/frontend/src/features/archived-items/archived-item-list/archived-item-list-item.ts
+++ b/frontend/src/features/archived-items/archived-item-list/archived-item-list-item.ts
@@ -3,6 +3,7 @@ import type { SlCheckbox, SlHideEvent } from "@shoelace-style/shoelace";
 import { css, html, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { dedupeStatusIcon } from "../templates/dedupe-status-icon";
 
@@ -186,7 +187,10 @@ export class ArchivedItemListItem extends BtrixElement {
                   ></sl-icon>
                 `}
           </sl-tooltip>
-          ${dedupeStatusIcon(this.item)}
+
+          ${when(this.featureFlags.has("dedupeEnabled") && this.item, (item) =>
+            dedupeStatusIcon(item),
+          )}
         </btrix-table-cell>
         <btrix-table-cell
           rowClickTarget=${ifDefined(

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -622,9 +622,9 @@ export class WorkflowEditor extends BtrixElement {
   }
 
   private renderNav() {
-    const button = (tab: StepName) => {
+    const button = (section: (typeof this.formSections)[number]) => {
+      const tab = section.name;
       const isActive = tab === this.progressState?.activeTab;
-      const section = this.formSections.find(({ name }) => name === tab);
       return html`
         <btrix-tab-list-tab
           class="part-[base]:flex part-[base]:items-center part-[base]:gap-2"
@@ -633,10 +633,7 @@ export class WorkflowEditor extends BtrixElement {
           @click=${this.tabClickHandler(tab)}
         >
           ${this.tabLabels[tab]}
-          ${when(
-            section?.beta,
-            () => html`<btrix-beta-icon></btrix-beta-icon>`,
-          )}
+          ${when(section.beta, () => html`<btrix-beta-icon></btrix-beta-icon>`)}
         </btrix-tab-list-tab>
       `;
     };
@@ -646,7 +643,7 @@ export class WorkflowEditor extends BtrixElement {
         class="mb-10 hidden lg:block"
         tab=${ifDefined(this.progressState?.activeTab)}
       >
-        ${STEPS.map(button)}
+        ${this.formSections.map(button)}
       </btrix-tab-list>
     `;
   }
@@ -2825,11 +2822,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
     >`;
   }
 
-  private readonly formSections: {
+  private readonly FormSections: {
     name: StepName;
     desc: string;
     render: () => TemplateResult<1>;
     required?: boolean;
+    hidden?: boolean;
     beta?: boolean;
   }[] = [
     {
@@ -2862,6 +2860,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       name: "deduplication",
       desc: msg("Prevent duplicate content from being crawled and stored."),
       render: this.renderDeduplication,
+      hidden: this.featureFlags.excludes("dedupeEnabled"),
       beta: true,
     },
     {
@@ -2874,7 +2873,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
       desc: msg("Describe and tag this workflow and its crawls."),
       render: this.renderJobMetadata,
     },
-  ];
+  ] as const;
+
+  private get formSections() {
+    return this.FormSections.filter(({ hidden }) => !hidden);
+  }
 
   private readonly onInputMinMax = async (e: CustomEvent) => {
     const inputEl = e.target as SlInput;

--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -340,7 +340,10 @@ export class WorkflowListItem extends BtrixElement {
                 </div>
               `);
             }
-            if (workflow.dedupeCollId) {
+            if (
+              this.featureFlags.has("dedupeEnabled") &&
+              workflow.dedupeCollId
+            ) {
               badges.push(html`
                 <div class="flex items-center gap-1.5">
                   <sl-icon name="stack" label=${msg("Deduplication")}></sl-icon>

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1147,7 +1147,10 @@ export class ArchivedItemDetail extends BtrixElement {
               <btrix-linked-collections-list
                 class="mt-1 block"
                 .collections=${item.collections}
-                dedupeId=${ifDefined(dedupeId || undefined)}
+                dedupeId=${ifDefined(
+                  (this.featureFlags.has("dedupeEnabled") && dedupeId) ||
+                    undefined,
+                )}
                 baseUrl="${this.navigate.orgBasePath}/collections/view"
               ></btrix-linked-collections-list>
             `,

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -479,11 +479,13 @@ export class ArchivedItemDetail extends BtrixElement {
         );
         break;
       case "dependencies":
-        sectionContent = this.renderPanel(
-          html`
-            ${this.renderTitle(this.tabLabels.dependencies, { beta: true })}
-          `,
-          this.renderDependencies(),
+        sectionContent = when(this.featureFlags.has("dedupeEnabled"), () =>
+          this.renderPanel(
+            html`
+              ${this.renderTitle(this.tabLabels.dependencies, { beta: true })}
+            `,
+            this.renderDependencies(),
+          ),
         );
         break;
       default:
@@ -747,14 +749,16 @@ export class ArchivedItemDetail extends BtrixElement {
             })}
           `,
         )}
-        ${this.item?.requiresCrawls.length
-          ? renderNavItem({
-              section: "dependencies",
-              iconLibrary: "default",
-              icon: "layers-fill",
-              beta: true,
-            })
-          : nothing}
+        ${when(this.featureFlags.has("dedupeEnabled"), () =>
+          this.item?.requiresCrawls.length
+            ? renderNavItem({
+                section: "dependencies",
+                iconLibrary: "default",
+                icon: "layers-fill",
+                beta: true,
+              })
+            : nothing,
+        )}
       </nav>
     `;
   }

--- a/frontend/src/pages/org/archived-item-detail/templates/badges.ts
+++ b/frontend/src/pages/org/archived-item-detail/templates/badges.ts
@@ -1,12 +1,14 @@
 import { msg, str } from "@lit/localize";
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { when } from "lit/directives/when.js";
 
 import { iconFor, labelFor, variantFor } from "@/features/qa/review-status";
 import { type ArchivedItem } from "@/types/crawler";
 import { isCrawl } from "@/utils/crawler";
 import localize from "@/utils/localize";
 import { pluralOf } from "@/utils/pluralize";
+import appState from "@/utils/state";
 
 export const itemTypeBadge = (itemType: ArchivedItem["type"]) => {
   const upload = itemType === "upload";
@@ -60,10 +62,15 @@ export const badges = (item: ArchivedItem) => {
   return html`<div class="flex flex-wrap gap-3 whitespace-nowrap">
     ${itemTypeBadge(item.type)} ${collectionBadge(item.collectionIds.length)}
     ${isCrawl(item) ? html`${qaReviewBadge(item.reviewStatus)} ` : nothing}
-    <btrix-dedupe-badge
-      .dependencies=${item.requiresCrawls}
-      .dependents=${item.requiredByCrawls}
-    ></btrix-dedupe-badge>
+    ${when(
+      appState.featureFlags.has("dedupeEnabled"),
+      () => html`
+        <btrix-dedupe-badge
+          .dependencies=${item.requiresCrawls}
+          .dependents=${item.requiredByCrawls}
+        ></btrix-dedupe-badge>
+      `,
+    )}
   </div>`;
 };
 

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -653,15 +653,17 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
                           )}
                         `)
                       : nothing}
-                    ${col.indexStats
-                      ? detail(html`
+                    ${when(
+                      this.featureFlags.has("dedupeEnabled") && col.indexStats,
+                      () =>
+                        detail(html`
                           <sl-icon
                             name="stack"
                             label=${msg("Deduplication")}
                           ></sl-icon>
                           ${msg("Dedupe source")}
-                        `)
-                      : nothing}
+                        `),
+                    )}
                   </div>
                 `
               : nothing}

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -316,38 +316,45 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
       `,
     };
 
-    const deduplication = {
-      dedupeType: html`<sl-radio-group
-        label=${labelFor.dedupeType}
-        name="dedupeType"
-        value=${this.dedupeCollection || orgDefaults.dedupeCollId
-          ? DedupeType.Collection
-          : DedupeType.None}
-        @sl-change=${(e: Event) => {
-          const value = (e.target as SlRadio).value as FormState["dedupeType"];
-
-          if (value === DedupeType.Collection) {
-            this.dedupeCollection = { name: "" };
-          } else {
-            this.dedupeCollection = null;
-          }
-        }}
-      >
-        <sl-radio value=${DedupeType.None}>
-          ${dedupeTypeLabelFor[DedupeType.None]}
-        </sl-radio>
-        <sl-radio value=${DedupeType.Collection}>
-          ${dedupeTypeLabelFor[DedupeType.Collection]}
-        </sl-radio>
-      </sl-radio-group>`,
-    };
-
-    if (this.dedupeCollection) {
-      (
-        deduplication as typeof deduplication & {
-          dedupeCollectionName: TemplateResult;
+    let deduplication:
+      | {
+          dedupeType: TemplateResult<1>;
+          dedupeCollectionName?: TemplateResult<1>;
         }
-      ).dedupeCollectionName = this.renderDedupeCollection(orgDefaults);
+      | undefined = undefined;
+
+    if (this.featureFlags.has("dedupeEnabled")) {
+      deduplication = {
+        dedupeType: html`<sl-radio-group
+          label=${labelFor.dedupeType}
+          name="dedupeType"
+          value=${this.dedupeCollection || orgDefaults.dedupeCollId
+            ? DedupeType.Collection
+            : DedupeType.None}
+          @sl-change=${(e: Event) => {
+            const value = (e.target as SlRadio)
+              .value as FormState["dedupeType"];
+
+            if (value === DedupeType.Collection) {
+              this.dedupeCollection = { name: "" };
+            } else {
+              this.dedupeCollection = null;
+            }
+          }}
+        >
+          <sl-radio value=${DedupeType.None}>
+            ${dedupeTypeLabelFor[DedupeType.None]}
+          </sl-radio>
+          <sl-radio value=${DedupeType.Collection}>
+            ${dedupeTypeLabelFor[DedupeType.Collection]}
+          </sl-radio>
+        </sl-radio-group>`,
+      };
+
+      if (this.dedupeCollection) {
+        deduplication.dedupeCollectionName =
+          this.renderDedupeCollection(orgDefaults);
+      }
     }
 
     return {
@@ -356,7 +363,9 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
       behaviors,
       browserSettings,
       deduplication,
-    } as const satisfies Partial<Record<SectionsEnum, Partial<Field>>>;
+    } as const satisfies Partial<
+      Record<SectionsEnum, Partial<Field> | undefined>
+    >;
   }
 
   private readonly renderDedupeCollection = (
@@ -384,6 +393,8 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
       <div class="rounded-lg border">
         <form @submit=${this.onSubmit}>
           ${Object.entries(this.fields).map(([sectionName, fields]) => {
+            if (!fields) return;
+
             const cols: Cols = [];
 
             (Object.entries(fields) as Entries<Field>).forEach(
@@ -470,11 +481,14 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
       lang: this.languageSelect?.value ?? undefined,
       exclude: this.exclusionTable?.exclusions?.filter((v) => v) || [],
       customBehaviors: this.customBehaviorsTable?.value || [],
-      dedupeCollId:
+    };
+
+    if (this.featureFlags.has("dedupeEnabled")) {
+      parsedValues.dedupeCollId =
         (isExistingCollection(this.dedupeCollection) &&
           this.dedupeCollection.id) ||
-        "",
-    };
+        "";
+    }
 
     // Set null or empty strings to undefined
     const params = Object.entries(parsedValues).reduce(

--- a/frontend/src/pages/org/settings/components/deduplication.ts
+++ b/frontend/src/pages/org/settings/components/deduplication.ts
@@ -169,6 +169,9 @@ export class OrgSettingsDeduplication extends BtrixElement {
 
   private readonly renderSource = (item: DedupeSource) => {
     const { indexStats, indexState } = item;
+
+    if (!indexStats) return;
+
     const updating =
       indexStats.updateProgress > 0 && indexStats.updateProgress < 1;
     const available = indexAvailable(indexState);

--- a/frontend/src/pages/org/settings/settings.ts
+++ b/frontend/src/pages/org/settings/settings.ts
@@ -163,9 +163,11 @@ export class OrgSettings extends BtrixElement {
           this.renderTab("billing", "settings/billing"),
         )}
         ${this.renderTab("crawling-defaults", "settings/crawling-defaults")}
-        ${this.renderTab("deduplication", "settings/deduplication", {
-          beta: true,
-        })}
+        ${when(this.featureFlags.has("dedupeEnabled"), () =>
+          this.renderTab("deduplication", "settings/deduplication", {
+            beta: true,
+          }),
+        )}
 
         <btrix-tab-group-panel name="information">
           ${this.renderPanelHeader({ title: msg("General") })}
@@ -218,13 +220,18 @@ export class OrgSettings extends BtrixElement {
           })}
           <btrix-org-settings-crawling-defaults></btrix-org-settings-crawling-defaults>
         </btrix-tab-group-panel>
-        <btrix-tab-group-panel name="deduplication">
-          ${this.renderPanelHeader({
-            title: msg("Deduplication Sources"),
-            beta: true,
-          })}
-          <btrix-org-settings-deduplication></btrix-org-settings-deduplication>
-        </btrix-tab-group-panel>
+        ${when(
+          this.featureFlags.has("dedupeEnabled"),
+          () => html`
+            <btrix-tab-group-panel name="deduplication">
+              ${this.renderPanelHeader({
+                title: msg("Deduplication Sources"),
+                beta: true,
+              })}
+              <btrix-org-settings-deduplication></btrix-org-settings-deduplication>
+            </btrix-tab-group-panel>
+          `,
+        )}
       </btrix-tab-group>`;
   }
 

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -64,7 +64,7 @@ export const collectionSchema = publicCollectionSchema.extend({
   access: z.nativeEnum(CollectionAccess),
   indexLastSavedAt: z.string().datetime().nullable(),
   indexState: z.enum(DEDUPE_INDEX_STATES).nullable(),
-  indexStats: dedupeIndexStatsSchema.optional(),
+  indexStats: dedupeIndexStatsSchema.optional().nullable(),
 });
 export type Collection = z.infer<typeof collectionSchema>;
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3151

## Changes

Hides dedupe UI if feature flag is not enabled.

## Manual testing

1. Log in as superadmin
2. Go to "Feature Flags"
3. Enable dedupe for an org
4. Go to org. Verify deduplication UI is visible
5. Go to superadmin dashboard > "Feature Flags"
6. Disable dedupe for the org
7. Go back to org. Verify deduplication UI is hidden on all pages