### PR TITLE
Add dedupe stats to crawls

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -84,6 +84,7 @@ from .models import (
     TagsResponse,
     TYPE_AUTO_PAUSED_STATES,
     UserRole,
+    CrawlDedupeStats,
 )
 
 
@@ -1313,6 +1314,12 @@ class CrawlOps(BaseCrawlOps):
         await self.crawls.update_many(
             {"_id": {"$in": required_crawls}, "oid": oid},
             {"$addToSet": {"requiredByCrawls": crawl_id}},
+        )
+
+    async def add_dedupe_stats(self, oid: UUID, crawl_id: str, stats: CrawlDedupeStats):
+        """Add dedupe stats to crawl in db"""
+        await self.crawls.find_one_and_update(
+            {"_id": crawl_id, "oid": oid}, {"$set": {"dedupeStats": stats.dict()}}
         )
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -834,6 +834,16 @@ class CrawlFileOut(BaseModel):
 
 
 # ============================================================================
+class CrawlDedupeStats(BaseModel):
+    """Dedupe stats for crawl"""
+
+    uniqueHashes: int = 0
+    totalUrls: int = 0
+    dedupedUrls: int = 0
+    conservedSize: int = 0
+
+
+# ============================================================================
 class CoreCrawlable(BaseModel):
     # pylint: disable=too-few-public-methods
     """Core properties for crawlable run (crawl or qa run)"""
@@ -983,6 +993,8 @@ class CrawlOut(BaseMongoModel):
     requiresCrawls: Optional[list[str]] = []
     requiredByCrawls: Optional[list[str]] = []
 
+    dedupeStats: Optional[CrawlDedupeStats] = None
+
 
 # ============================================================================
 class UpdateCrawl(BaseModel):
@@ -1122,6 +1134,8 @@ class Crawl(BaseCrawl, CrawlConfigCore):
     pendingSize: int = 0
 
     autoPausedEmailsSent: bool = False
+
+    dedupeStats: Optional[CrawlDedupeStats] = None
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -839,7 +839,7 @@ class CrawlDedupeStats(BaseModel):
 
     uniqueHashes: int = 0
     totalUrls: int = 0
-    dedupedUrls: int = 0
+    dupeUrls: int = 0
     conservedSize: int = 0
 
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -310,8 +310,8 @@ class CollIndexOperator(BaseOperator):
             if not redis:
                 return
 
-            # readd appendonly
-            if status.state == "initing":
+            # readd appendonly if using redis
+            if status.state == "initing" and self.backend_type == "redis":
                 await redis.config_set("appendonly", "yes")
 
             elif status.state == "ready":

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -31,6 +31,7 @@ from btrixcloud.models import (
     CrawlFile,
     CrawlCompleteIn,
     StorageRef,
+    CrawlDedupeStats,
 )
 
 from btrixcloud.utils import (
@@ -1718,6 +1719,34 @@ class CrawlOperator(BaseOperator):
 
         return status
 
+    async def add_crawl_dedupe_stats(self, crawl: CrawlSpec):
+        """Add crawl dedupe stats to db"""
+        if not crawl.dedupe_coll_id:
+            return
+
+        try:
+            redis = await self.k8s.get_redis_connected(
+                "coll-" + str(crawl.dedupe_coll_id)
+            )
+            if not redis:
+                return
+
+            num_unique_hashes = await redis.hlen(f"h:{crawl.id}")
+            crawl_counts = await redis.hgetall(f"h:{crawl.id}:counts")
+
+            stats = CrawlDedupeStats(
+                uniqueHashes=num_unique_hashes,
+                totalUrls=int(crawl_counts.get("totalUrls", 0)),
+                dedupedUrls=int(crawl_counts.get("dupeUrls", 0)),
+                conservedSize=int(crawl_counts.get("conservedSize", 0)),
+            )
+            await self.crawl_ops.add_dedupe_stats(crawl.oid, crawl.id, stats)
+
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            print(e)
+            traceback.print_exc()
+
     # pylint: disable=too-many-arguments
     async def mark_finished(
         self,
@@ -1795,6 +1824,9 @@ class CrawlOperator(BaseOperator):
                 await self.crawl_ops.link_required_crawls(
                     crawl.oid, crawl.id, stats.req_crawls
                 )
+
+            if crawl.dedupe_coll_id:
+                await self.add_crawl_dedupe_stats(crawl)
 
         if state in FAILED_STATES:
             await self.crawl_config_ops.stats_recompute_last(crawl.cid, 0, 1, 0)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -267,7 +267,7 @@ dedupe:
 
   # time until index is considered 'idle'
   # redis pod is backed up and shutdown
-  idle_secs: 10
+  idle_secs: 180
 
   # set this to custom crawler channel (from one of options below)
   # used for dedupe index importing


### PR DESCRIPTION
Fixes #3129 

Adds a `dedupeStats` subdocument to crawls that are run with a `dedupeCollId`, of form:

```json
"dedupeStats": {
    "uniqueHashes": 11,
    "totalUrls": 70,
    "dupeUrls": 59,
    "conservedSize": 157668019
},
```

`totalCrawlSize` from the associated issue is not added, as it is identical to the already existing `Crawl.fileSize`

## Testing

1. Spin up local Browsertrix instance (or deploy this branch to dev)
2. Run a crawl with dedupe enabled
3. Check the crawl object returned by `replay.json` after the crawl completes and ensure dedupe stats are present

