### PR TITLE
fix: Proxies and channels render inconsistently in crawling defaults

### DIFF
--- a/frontend/src/components/ui/select-crawler.ts
+++ b/frontend/src/components/ui/select-crawler.ts
@@ -83,7 +83,7 @@ export class SelectCrawler extends LiteElement {
             </sl-option>`,
         )}
         <div slot="help-text">
-          ${msg("Version:")}
+          ${msg("Current version")}:
           ${selectedCrawler
             ? html`
                 <span class="font-monospace leading-tight"

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -5,7 +5,6 @@ import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import type { LanguageCode } from "iso-639-1";
 import { css, html, type TemplateResult } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import type { Entries } from "type-fest";
 
@@ -295,24 +294,22 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
     return html`
       <div class="rounded-lg border">
         <form @submit=${this.onSubmit}>
-          ${guard([this.defaults, this.org], () =>
-            Object.entries(this.fields).map(([sectionName, fields]) => {
-              const cols: Cols = [];
+          ${Object.entries(this.fields).map(([sectionName, fields]) => {
+            const cols: Cols = [];
 
-              (Object.entries(fields) as Entries<Field>).forEach(
-                ([fieldName, field]) => {
-                  if (field) {
-                    cols.push([
-                      field,
-                      infoTextFor[fieldName as keyof typeof infoTextFor],
-                    ]);
-                  }
-                },
-              );
+            (Object.entries(fields) as Entries<Field>).forEach(
+              ([fieldName, field]) => {
+                if (field) {
+                  cols.push([
+                    field,
+                    infoTextFor[fieldName as keyof typeof infoTextFor],
+                  ]);
+                }
+              },
+            );
 
-              return section(sectionName as SectionsEnum, cols);
-            }),
-          )}
+            return section(sectionName as SectionsEnum, cols);
+          })}
           <footer class="flex justify-end border-t px-4 py-3">
             <sl-button type="submit" size="small" variant="primary">
               ${msg("Save Changes")}

--- a/frontend/src/pages/org/settings/components/crawling-defaults.ts
+++ b/frontend/src/pages/org/settings/components/crawling-defaults.ts
@@ -26,6 +26,7 @@ import { columns, type Cols } from "@/layouts/columns";
 import { infoTextFor } from "@/strings/crawl-workflows/infoText";
 import { labelFor } from "@/strings/crawl-workflows/labels";
 import sectionStrings from "@/strings/crawl-workflows/section";
+import { CrawlerChannelImage } from "@/types/crawler";
 import { crawlingDefaultsSchema, type CrawlingDefaults } from "@/types/org";
 import { formValidator } from "@/utils/form";
 import {
@@ -244,7 +245,8 @@ export class OrgSettingsCrawlWorkflows extends BtrixElement {
         crawlerChannels && crawlerChannels.length > 1
           ? html`
               <btrix-select-crawler
-                crawlerChannel=${ifDefined(orgDefaults.crawlerChannel)}
+                crawlerChannel=${orgDefaults.crawlerChannel ??
+                CrawlerChannelImage.Default}
                 size="small"
               ></btrix-select-crawler>
             `


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3167

## Changes

- Fixes proxy and channel selector not rendering intermittently in org defaults due to race condition
- Fixes "Default" not selected by default for crawler channel and empty "Version" being displayed
- Updates help text to "Current version" to make it clearer that "Default" will not always be the same version

## Manual testing

1. Log in as admin to org with proxies and channels
2. Go to Settings > Crawling Defaults
3. Reload page a few times. Verify that proxies and channels are always displayed and that "Default" channel is selected