### PR TITLE
Update k3d version in k3d CI run

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.6.0
+          k3d-version: v5.8.3
           cluster-name: btrix-1
           args: >-
             -p "30870:30870@agent:0:direct"


### PR DESCRIPTION
Fix for error in run https://github.com/webrecorder/browsertrix/actions/runs/21970188051/job/63469708815:
```
ERRO[0000] Failed to get nodes for cluster 'btrix-1': docker failed to get containers with labels 'map[k3d.cluster:btrix-1]': failed to list containers: Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
```