### PR TITLE
Bump k3d version to working version for nightly, log tests

### DIFF
--- a/.github/workflows/k3d-log-ci.yaml
+++ b/.github/workflows/k3d-log-ci.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.8.3
           cluster-name: btrix-1
           args: >-
             --agents 1

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Create k3d Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.8.3
           cluster-name: btrix-nightly
           args: >-
             -p "30870:30870@agent:0:direct"


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/3173

Until we can replace the seemingly dead/unsupported https://github.com/AbsaOSS/k3d-action that we're relying on, which I've assigned to myself for the next sprint, this bumps the k3d version for the nightly and log tests so that they will run again, like what we did in https://github.com/webrecorder/browsertrix/pull/3171.

Nightly run off this branch available here to verify the patch works: https://github.com/webrecorder/browsertrix/actions/runs/22072148854