### PR TITLE
more robust coll-index operations in operator and redis/kvrocks pod:

### DIFF
--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -408,9 +408,9 @@ class K8sAPI:
         except Exception:
             return False
 
-    async def send_signal_to_pod(self, pod_name, signame) -> bool:
+    async def send_signal_to_pod(self, pod_name, signame, container=None) -> bool:
         """send signal to all pods"""
-        command = ["bash", "-c", f"kill -s {signame} 1"]
+        command = ["sh", "-c", f"kill -s {signame} 1"]
         signaled = False
 
         try:
@@ -420,6 +420,7 @@ class K8sAPI:
                 name=pod_name,
                 namespace=self.namespace,
                 command=command,
+                container=container,
                 stdout=True,
             )
             if res:

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1591,7 +1591,7 @@ class CrawlOutWithResources(CrawlOut):
 ### COLLECTIONS ###
 
 TYPE_DEDUPE_INDEX_STATES = Literal[
-    "initing", "importing", "ready", "purging", "idle", "saving", "crawling"
+    "initing", "importing", "ready", "purging", "idle", "saving", "saved", "crawling"
 ]
 DEDUPE_INDEX_STATES = get_args(TYPE_DEDUPE_INDEX_STATES)
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -169,7 +169,7 @@ class CollIndexOperator(BaseOperator):
                 # Saving process
                 # 1. run bgsave while redis is active
                 if status.index.running:
-                    await self.do_ve(spec.id, status)
+                    await self.do_save_redis(spec.id, status)
 
                 elif status.index.finished and not status.index.savedAt:
                     await self.k8s.send_signal_to_pod(redis_name, "SIGUSR1", "save")
@@ -318,7 +318,7 @@ class CollIndexOperator(BaseOperator):
         print(f"Deleting collindex {coll_id}")
         await self.k8s.delete_custom_object(f"collindex-{coll_id}", "collindexes")
 
-    async def do_ve(self, coll_id: UUID, status: CollIndexStatus):
+    async def do_save_redis(self, coll_id: UUID, status: CollIndexStatus):
         """shutdown save redis"""
         try:
             redis = await self.k8s.get_redis_connected(f"coll-{coll_id}")

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -13,7 +13,9 @@ metadata:
 
 spec:
   ttlSecondsAfterFinished: 300
-  backoffLimit: 6
+
+  # keep retrying indefinitely
+  backoffLimit: 1000000
 
 # if purging, set completions to disallow changing parallelism
 # for import, omit to allow increasing later

--- a/chart/app-templates/redis.yaml
+++ b/chart/app-templates/redis.yaml
@@ -104,7 +104,7 @@ spec:
       imagePullPolicy: {{ redis_image_pull_policy }}
 
       {% if use_kvrocks %}
-      args: ["-c", "/redis-conf/kvrocks.conf", "--dir", "/data", "--appendonly", "{{ 'no' if load_dump else 'yes' }}"]
+      args: ["-c", "/redis-conf/kvrocks.conf", "--dir", "/data"]
       {% else %}
       args: ["/redis-conf/redis.conf", "--appendonly", "{{ 'no' if load_dump else 'yes' }}"]
       {% endif %}
@@ -142,21 +142,26 @@ spec:
             - -c
             - "res=$(redis-cli ping); [[ $res = 'PONG' ]]"
 
-  initContainers:
 {% if save_dump %}
     - name: save
       image: rclone/rclone:latest
-
       command: ["sh", "-c"]
       args:
         - |
-          echo "Waiting until redis is done";
-          while [ ! -f /tmp/done ]; do 
-            sleep 1;
-          done;
+          # wait for SIGUSR1
+          trap ':' SIGUSR1
+
+          echo "Waiting for signal (SIGUSR1) when pod is done..."
+
+          sleep 1000000 &
+          sleep_pid=$!
+
+          wait $sleep_pid
+
+          # ignore any future signals
+          trap "" SIGUSR1
 
           set -e
-
 
         {% if use_kvrocks %}
           if [ ! -d /data/{{ local_file_src }} ]; then
@@ -168,10 +173,13 @@ spec:
 
           set -o pipefail
 
-          until tar cvfz - . | tee >(sha256sum > /tmp/hash.txt) | tee >(wc -c > /tmp/size.txt) | rclone --config '' rcat remote:{{ remote_file_path }} --s3-chunk-size 100M; do
+          until tar cvfz - . | tee >(sha256sum > /tmp/hash.txt) | tee >(wc -c > /tmp/size.txt) | rclone --config '' rcat remote:{{ remote_file_path }}.tmp --s3-chunk-size 64M --s3-upload-concurrency 4; do
             echo "retrying upload..."
             sleep 1;
           done
+
+          # move to final location after upload, just in case
+          rclone moveto --config '' remote:{{ remote_file_path }}.tmp remote:{{ remote_file_path }}
 
         {% else %}
           if [ ! -f /data/{{ local_file_src }} ]; then
@@ -179,7 +187,7 @@ spec:
             exit 1
           fi
 
-          until rclone -vv copyto --checksum /data/{{ local_file_src }} remote:{{ remote_file_path }} --s3-chunk-size 100M; do
+          until rclone -vv copyto --checksum /data/{{ local_file_src }} remote:{{ remote_file_path }} --s3-chunk-size 64M --s3-upload-concurrency 4; do
             echo "retrying upload..."
             sleep 1;
           done
@@ -191,14 +199,6 @@ spec:
 
           echo ""
           echo "STATS: (size,hash): $size,$hash"
-
-          rm /tmp/done
-
-      restartPolicy: Always
-      lifecycle:
-        preStop:
-          exec:
-            command: ["touch", "/tmp/done"]
 
       volumeMounts: &rclone_volumes
         - name: redis-data
@@ -237,13 +237,14 @@ spec:
 
       resources: &rclone_resources
         limits:
-          memory: "200Mi"
+          memory: "2000Mi"
 
         requests:
-          memory: "200Mi"
+          memory: "300Mi"
           cpu: "50m"
 
 {% if load_dump %}
+  initContainers:
     - name: load
       image: rclone/rclone:latest
 
@@ -252,11 +253,33 @@ spec:
         - |
           set -e
 
-        {% if use_kvrocks %}
-          mkdir -p /data/{{ local_file_dest }}
-          cd /data/{{ local_file_dest }}
+          # if remote file doesn't exist, just return success (nothing to load)
+          if ! rclone lsf remote:{{ remote_file_path }} > /dev/null 2>&1; then
+            echo "Remote {{ remote_file_path }} does not exist, nothing to load, done"
+            exit 0
+          fi
 
-          rclone --config "" cat remote:{{ remote_file_path }} | tar xzf -
+        {% if use_kvrocks %}
+          # only run if target dir doesn't exist yet
+          if [ ! -d "/data/{{ local_file_dest }}" ]; then
+
+            # remove existing + create new empty tmp dir
+            rm -rf /data/{{ local_file_dest }}.tmp
+            mkdir -p /data/{{ local_file_dest }}.tmp
+
+            cd /data/{{ local_file_dest }}.tmp
+
+            echo "Downloading from {{ remote_file_path }}"
+
+            rclone --config "" cat remote:{{ remote_file_path }} | tar xzf -
+
+            # move to final dest only if tar extract succeeds
+            mv /data/{{ local_file_dest }}.tmp /data/{{ local_file_dest }}
+
+            echo "Downloaded to /data/{{ local_file_dest }} successfully!"
+          else
+            echo "/data/{{ local_file_dest }} already present (likely pod restarted), not overwriting"
+          fi
 
         {% else %}
           rclone --config "" copyto remote:{{ remote_file_path }} /data/{{ local_file_dest }}

--- a/chart/app-templates/redis.yaml
+++ b/chart/app-templates/redis.yaml
@@ -271,6 +271,8 @@ spec:
 
             echo "Downloading from {{ remote_file_path }}"
 
+            set -o pipefail
+
             rclone --config "" cat remote:{{ remote_file_path }} | tar xzf -
 
             # move to final dest only if tar extract succeeds


### PR DESCRIPTION
- kvrocks: use main container instead of sidecar container to save index, to ensure it doesn't have timeout
- operator: add 'saved' state to determine when saving is actually complete
- operator: send custom signal instead of relying on sentinal file to indicate redis/kvrocks is done
- operator: track state of redis pod more accurately, by checking if containers completed successfully in operator

- load: don't attempt to overwrite kvrocks db if already exists
- load: download into temp dir first, then rename dir only if successful
- load: skip loading if remote file doesn't exist, nothing to do but reset index
- save: first upload to .tmp file, then rename to file destination (overwriting previous) only if successful
- save: bump max memory for save pod
- save: add upload concurrency to reduce memory consumption
- index import: set high backoff to ensure index jobs don't fail
- kvrocks: remove --appendonly flag, unsupported in kvrocks