### PR TITLE
API option to include dependencies

### DIFF
--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -258,7 +258,7 @@ class BaseCrawlOps:
     async def find_missing_crawls(self, crawl_ids: list[str], oid: UUID) -> list[str]:
         """returns a list of crawl ids that are no longer in the db from a given list"""
         cursor = self.crawls.find(
-            {"_id": {"$in": crawl_ids}, "oid": oid}, {"$project": {"_id": 1}}
+            {"_id": {"$in": crawl_ids}, "oid": oid}, projection=["_id"]
         )
         found_crawls = await cursor.to_list(len(crawl_ids))
         existing = {found["_id"] for found in found_crawls}

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -221,13 +221,21 @@ class BaseCrawlOps:
             if crawl.requiresCrawls and with_dependencies:
                 match = {"_id": {"$in": crawl.requiresCrawls}}
                 resources, _ = await self.get_presigned_files(match, org)
+
+                crawl.fileSizeWithDeps = crawl.fileSize
+
                 for resource in resources:
                     resource.fromDependency = True
+                    crawl.fileSizeWithDeps += resource.size
 
                 if not crawl.resources:
                     crawl.resources = resources
                 else:
                     crawl.resources.extend(resources)
+
+                crawl.missingRequiresCrawls = await self.find_missing_crawls(
+                    crawl.requiresCrawls, org.id
+                )
 
         crawl.storageQuotaReached = self.orgs.storage_quota_reached(org)
         crawl.execMinutesQuotaReached = self.orgs.exec_mins_quota_reached(org)
@@ -246,6 +254,16 @@ class BaseCrawlOps:
             file_.path = self.storage_ops.resolve_internal_access_path(file_.path)
 
         return crawl_out
+
+    async def find_missing_crawls(self, crawl_ids: list[str], oid: UUID) -> list[str]:
+        """returns a list of crawl ids that are no longer in the db from a given list"""
+        cursor = self.crawls.find(
+            {"_id": {"$in": crawl_ids}, "oid": oid}, {"$project": {"_id": 1}}
+        )
+        found_crawls = await cursor.to_list(len(crawl_ids))
+        existing = {found["_id"] for found in found_crawls}
+        missing = [crawl_id for crawl_id in crawl_ids if crawl_id not in existing]
+        return missing
 
     async def _update_crawl_collections(
         self, crawl_id: str, org: Organization, collection_ids: List[UUID]

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -1089,7 +1089,11 @@ class BaseCrawlOps:
             metadata, crawl.resources, prefer_single_wacz=prefer_single_wacz
         )
 
-        filename = f"{crawl_id}.wacz" if not with_dependencies else f"{crawl_id}-with-deps.wacz"
+        filename = (
+            f"{crawl_id}.wacz"
+            if not with_dependencies
+            else f"{crawl_id}-with-deps.wacz"
+        )
         if len(crawl.resources) == 1 and prefer_single_wacz:
             filename = crawl.resources[0].name
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -170,7 +170,7 @@ class BaseCrawlOps:
         skip_resources=False,
         headers: Optional[dict] = None,
         cid: Optional[UUID] = None,
-        include_dependencies=True,
+        with_dependencies=False,
     ) -> CrawlOutWithResources:
         """Get crawl data for api output"""
         res = await self.get_crawl_raw(crawlid, org, type_)
@@ -218,15 +218,16 @@ class BaseCrawlOps:
                 crawl.config.seeds = None
 
             # add dependencies
-            if crawl.requiresCrawls and include_dependencies:
-                all_req_crawls = await self.get_all_dependency_crawls(crawl.id)
-                if all_req_crawls:
-                    match = {"_id": {"$in": all_req_crawls}}
-                    resources, _ = await self.get_presigned_files(match, org)
-                    if not crawl.resources:
-                        crawl.resources = resources
-                    else:
-                        crawl.resources.extend(resources)
+            if crawl.requiresCrawls and with_dependencies:
+                match = {"_id": {"$in": crawl.requiresCrawls}}
+                resources, _ = await self.get_presigned_files(match, org)
+                for resource in resources:
+                    resource.fromDependency = True
+
+                if not crawl.resources:
+                    crawl.resources = resources
+                else:
+                    crawl.resources.extend(resources)
 
         crawl.storageQuotaReached = self.orgs.storage_quota_reached(org)
         crawl.execMinutesQuotaReached = self.orgs.exec_mins_quota_reached(org)
@@ -935,26 +936,6 @@ class BaseCrawlOps:
 
         return crawls, total
 
-    async def get_all_dependency_crawls(self, crawl_id: str) -> list[str]:
-        """get flat list of all crawl dependencies using mongo graphLookup aggregation"""
-        aggregate = [
-            {"$match": {"_id": crawl_id}},
-            {
-                "$graphLookup": {
-                    "from": "crawls",
-                    "startWith": "$requiresCrawls",
-                    "connectFromField": "requiresCrawls",
-                    "connectToField": "_id",
-                    "as": "allReq",
-                }
-            },
-            {"$project": {"allReqArray": "$allReq._id"}},
-        ]
-
-        cursor = self.crawls.aggregate(aggregate)
-        results = await cursor.to_list(length=1)
-        return results[0]["allReqArray"]
-
     async def delete_crawls_all_types(
         self,
         delete_list: DeleteCrawlList,
@@ -1056,7 +1037,11 @@ class BaseCrawlOps:
         }
 
     async def download_crawl_as_single_wacz(
-        self, crawl_id: str, org: Organization, prefer_single_wacz: bool = False
+        self,
+        crawl_id: str,
+        org: Organization,
+        prefer_single_wacz: bool = False,
+        with_dependencies=False,
     ):
         """Download archived item as a single WACZ file
 
@@ -1064,7 +1049,9 @@ class BaseCrawlOps:
         If prefer_single_wacz is true and archived item has only one WACZ,
         returns that instead
         """
-        crawl = await self.get_crawl_out(crawl_id, org)
+        crawl = await self.get_crawl_out(
+            crawl_id, org, with_dependencies=with_dependencies
+        )
 
         if not crawl.resources:
             raise HTTPException(status_code=400, detail="no_crawl_resources")
@@ -1290,22 +1277,39 @@ def init_base_crawls_api(app, user_dep, *args):
         response_model=CrawlOutWithResources,
     )
     async def get_base_crawl(
-        crawl_id: str, request: Request, org: Organization = Depends(org_crawl_dep)
+        crawl_id: str,
+        request: Request,
+        org: Organization = Depends(org_crawl_dep),
+        with_dependencies=False,
     ):
-        return await ops.get_crawl_out(crawl_id, org, headers=dict(request.headers))
+        return await ops.get_crawl_out(
+            crawl_id,
+            org,
+            headers=dict(request.headers),
+            with_dependencies=with_dependencies,
+        )
 
     @app.get(
         "/orgs/all/all-crawls/{crawl_id}/replay.json",
         tags=["all-crawls"],
         response_model=CrawlOutWithResources,
+        with_dependencies=False,
     )
     async def get_base_crawl_admin(
-        crawl_id, request: Request, user: User = Depends(user_dep)
+        crawl_id,
+        request: Request,
+        user: User = Depends(user_dep),
+        with_dependencies=False,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
-        return await ops.get_crawl_out(crawl_id, None, headers=dict(request.headers))
+        return await ops.get_crawl_out(
+            crawl_id,
+            None,
+            headers=dict(request.headers),
+            with_dependencies=with_dependencies,
+        )
 
     @app.get(
         "/orgs/{oid}/all-crawls/{crawl_id}/replay.json",
@@ -1313,9 +1317,17 @@ def init_base_crawls_api(app, user_dep, *args):
         response_model=CrawlOutWithResources,
     )
     async def get_crawl_out(
-        crawl_id, request: Request, org: Organization = Depends(org_viewer_dep)
+        crawl_id,
+        request: Request,
+        org: Organization = Depends(org_viewer_dep),
+        with_dependencies=False,
     ):
-        return await ops.get_crawl_out(crawl_id, org, headers=dict(request.headers))
+        return await ops.get_crawl_out(
+            crawl_id,
+            org,
+            headers=dict(request.headers),
+            with_dependencies=with_dependencies,
+        )
 
     @app.get(
         "/orgs/{oid}/all-crawls/{crawl_id}/download",
@@ -1326,9 +1338,13 @@ def init_base_crawls_api(app, user_dep, *args):
         crawl_id: str,
         preferSingleWACZ: bool = False,
         org: Organization = Depends(org_viewer_dep),
+        with_dependencies=False,
     ):
         return await ops.download_crawl_as_single_wacz(
-            crawl_id, org, prefer_single_wacz=preferSingleWACZ
+            crawl_id,
+            org,
+            prefer_single_wacz=preferSingleWACZ,
+            with_dependencies=with_dependencies,
         )
 
     @app.patch(

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -170,7 +170,7 @@ class BaseCrawlOps:
         skip_resources=False,
         headers: Optional[dict] = None,
         cid: Optional[UUID] = None,
-        with_dependencies=False,
+        with_dependencies: bool = False,
     ) -> CrawlOutWithResources:
         """Get crawl data for api output"""
         res = await self.get_crawl_raw(crawlid, org, type_)
@@ -234,7 +234,9 @@ class BaseCrawlOps:
 
         return crawl
 
-    async def get_internal_crawl_out(self, crawl_id, with_dependencies=False):
+    async def get_internal_crawl_out(
+        self, crawl_id: str, with_dependencies: bool = False
+    ):
         """add internal prefix for relative paths"""
         crawl_out = await self.get_crawl_out(
             crawl_id, with_dependencies=with_dependencies
@@ -1043,7 +1045,7 @@ class BaseCrawlOps:
         crawl_id: str,
         org: Organization,
         prefer_single_wacz: bool = False,
-        with_dependencies=False,
+        with_dependencies: bool = False,
     ):
         """Download archived item as a single WACZ file
 
@@ -1282,13 +1284,13 @@ def init_base_crawls_api(app, user_dep, *args):
         crawl_id: str,
         request: Request,
         org: Organization = Depends(org_crawl_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         return await ops.get_crawl_out(
             crawl_id,
             org,
             headers=dict(request.headers),
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     @app.get(
@@ -1301,7 +1303,7 @@ def init_base_crawls_api(app, user_dep, *args):
         crawl_id,
         request: Request,
         user: User = Depends(user_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
@@ -1310,7 +1312,7 @@ def init_base_crawls_api(app, user_dep, *args):
             crawl_id,
             None,
             headers=dict(request.headers),
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     @app.get(
@@ -1322,13 +1324,13 @@ def init_base_crawls_api(app, user_dep, *args):
         crawl_id,
         request: Request,
         org: Organization = Depends(org_viewer_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         return await ops.get_crawl_out(
             crawl_id,
             org,
             headers=dict(request.headers),
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     @app.get(
@@ -1340,13 +1342,13 @@ def init_base_crawls_api(app, user_dep, *args):
         crawl_id: str,
         preferSingleWACZ: bool = False,
         org: Organization = Depends(org_viewer_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         return await ops.download_crawl_as_single_wacz(
             crawl_id,
             org,
             prefer_single_wacz=preferSingleWACZ,
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     @app.patch(

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -1319,7 +1319,6 @@ def init_base_crawls_api(app, user_dep, *args):
         "/orgs/all/all-crawls/{crawl_id}/replay.json",
         tags=["all-crawls"],
         response_model=CrawlOutWithResources,
-        with_dependencies=False,
     )
     async def get_base_crawl_admin(
         crawl_id,

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -1089,7 +1089,7 @@ class BaseCrawlOps:
             metadata, crawl.resources, prefer_single_wacz=prefer_single_wacz
         )
 
-        filename = f"{crawl_id}.wacz"
+        filename = f"{crawl_id}.wacz" if not with_dependencies else f"{crawl_id}-with-deps.wacz"
         if len(crawl.resources) == 1 and prefer_single_wacz:
             filename = crawl.resources[0].name
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -234,9 +234,11 @@ class BaseCrawlOps:
 
         return crawl
 
-    async def get_internal_crawl_out(self, crawl_id):
+    async def get_internal_crawl_out(self, crawl_id, with_dependencies=False):
         """add internal prefix for relative paths"""
-        crawl_out = await self.get_crawl_out(crawl_id)
+        crawl_out = await self.get_crawl_out(
+            crawl_id, with_dependencies=with_dependencies
+        )
         resources = crawl_out.resources or []
         for file_ in resources:
             file_.path = self.storage_ops.resolve_internal_access_path(file_.path)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -1572,13 +1572,20 @@ def init_crawls_api(
         response_model=CrawlOutWithResources,
     )
     async def get_crawl_admin(
-        crawl_id, request: Request, user: User = Depends(user_dep)
+        crawl_id,
+        request: Request,
+        user: User = Depends(user_dep),
+        with_dependencies=False,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         return await ops.get_crawl_out(
-            crawl_id, None, "crawl", headers=dict(request.headers)
+            crawl_id,
+            None,
+            "crawl",
+            headers=dict(request.headers),
+            with_dependencies=with_dependencies,
         )
 
     @app.get(
@@ -1587,10 +1594,17 @@ def init_crawls_api(
         response_model=CrawlOutWithResources,
     )
     async def get_crawl_out(
-        crawl_id, request: Request, org: Organization = Depends(org_viewer_dep)
+        crawl_id,
+        request: Request,
+        org: Organization = Depends(org_viewer_dep),
+        with_dependencies=False,
     ):
         return await ops.get_crawl_out(
-            crawl_id, org, "crawl", headers=dict(request.headers)
+            crawl_id,
+            org,
+            "crawl",
+            headers=dict(request.headers),
+            with_dependencies=with_dependencies,
         )
 
     @app.get(
@@ -1600,9 +1614,13 @@ def init_crawls_api(
         crawl_id: str,
         preferSingleWACZ: bool = False,
         org: Organization = Depends(org_viewer_dep),
+        with_dependencies=False,
     ):
         return await ops.download_crawl_as_single_wacz(
-            crawl_id, org, prefer_single_wacz=preferSingleWACZ
+            crawl_id,
+            org,
+            prefer_single_wacz=preferSingleWACZ,
+            with_dependencies=with_dependencies,
         )
 
     # QA APIs

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -1575,7 +1575,7 @@ def init_crawls_api(
         crawl_id,
         request: Request,
         user: User = Depends(user_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
@@ -1585,7 +1585,7 @@ def init_crawls_api(
             None,
             "crawl",
             headers=dict(request.headers),
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     @app.get(
@@ -1597,14 +1597,14 @@ def init_crawls_api(
         crawl_id,
         request: Request,
         org: Organization = Depends(org_viewer_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         return await ops.get_crawl_out(
             crawl_id,
             org,
             "crawl",
             headers=dict(request.headers),
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     @app.get(
@@ -1614,13 +1614,13 @@ def init_crawls_api(
         crawl_id: str,
         preferSingleWACZ: bool = False,
         org: Organization = Depends(org_viewer_dep),
-        with_dependencies=False,
+        withDependencies: bool = False,
     ):
         return await ops.download_crawl_as_single_wacz(
             crawl_id,
             org,
             prefer_single_wacz=preferSingleWACZ,
-            with_dependencies=with_dependencies,
+            with_dependencies=withDependencies,
         )
 
     # QA APIs

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -943,6 +943,9 @@ class CrawlOut(BaseMongoModel):
     fileCount: int = 0
     pendingSize: int = 0
 
+    # computed only if dependencies are looked up
+    fileSizeWithDeps: Optional[int] = None
+
     tags: Optional[List[str]] = []
 
     dedupeCollId: Optional[UUID] = None
@@ -995,6 +998,9 @@ class CrawlOut(BaseMongoModel):
     # Linked Crawls for dedupe
     requiresCrawls: Optional[list[str]] = []
     requiredByCrawls: Optional[list[str]] = []
+
+    # computed only if dependencies are looked up
+    missingRequiresCrawls: Optional[list[str]] = None
 
     dedupeStats: Optional[CrawlDedupeStats] = None
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -833,6 +833,7 @@ class CrawlFileOut(BaseModel):
     crawlId: Optional[str] = None
     numReplicas: int = 0
     expireAt: Optional[str] = None
+    fromDependency: Optional[bool] = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -833,7 +833,7 @@ class CrawlFileOut(BaseModel):
     crawlId: Optional[str] = None
     numReplicas: int = 0
     expireAt: Optional[str] = None
-    fromDependency: Optional[bool] = False
+    fromDependency: bool = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -543,7 +543,9 @@ class CrawlOperator(BaseOperator):
             }
             return [configmap]
 
-        crawl_replay = await self.crawl_ops.get_internal_crawl_out(qa_source_crawl_id)
+        crawl_replay = await self.crawl_ops.get_internal_crawl_out(
+            qa_source_crawl_id, with_dependencies=True
+        )
 
         params["name"] = name
         params["qa_source_replay_json"] = crawl_replay.json(include={"resources"})


### PR DESCRIPTION
Fixes #3178 

Add a `withDependencies` query arg to the GET `/replay.json` and `/download` endpoints, which results in WACZs from dependent crawls also being presigned and pulled in.
Sets `fromDependency` on those WACZs to mark them as such.