### PR TITLE
task: Re-enable QA for archived items with dependencies

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -384,7 +384,7 @@ export class ArchivedItemDetail extends BtrixElement {
         sectionContent = this.renderPanel(
           html`${this.renderTitle(this.tabLabels.qa, { beta: true })}
             <div class="ml-auto flex flex-wrap justify-end gap-2">
-              ${when(!dedupeDependent && this.qaRuns, this.renderQAHeader)}
+              ${when(this.qaRuns, this.renderQAHeader)}
             </div> `,
           html`
             ${dedupeDependent

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -22,7 +22,6 @@ import { renderText, renderTextDiff } from "./ui/text";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
-import { dedupeQANotice } from "@/features/archived-items/templates/dedupe-qa-notice";
 import { isQaPage } from "@/features/qa/page-list/helpers/page";
 import {
   type QaFilterChangeDetail,
@@ -44,7 +43,6 @@ import type { ArchivedItemQAPage, QARun } from "@/types/qa";
 import { SortDirection as APISortDirection } from "@/types/utils";
 import {
   isActive,
-  isCrawlReplay,
   isSuccessfullyFinished,
   renderName,
   type finishedCrawlStates,
@@ -431,16 +429,11 @@ export class ArchivedItemQA extends BtrixElement {
     const searchParams = new URLSearchParams(window.location.search);
     const itemName = this.item ? renderName(this.item) : nothing;
     const [prevPage, currentPage, nextPage] = this.getPageListSliceByCurrent();
-    const hasDependencies = Boolean(
-      this.item && isCrawlReplay(this.item) && this.item.requiresCrawls.length,
-    );
 
     return html`
       ${this.renderHidden()}
 
       <div class="mb-4 flex items-center">${this.renderBackLink()}</div>
-
-      ${when(hasDependencies, () => dedupeQANotice())}
 
       <article class="qa-grid grid min-h-screen gap-x-6 gap-y-0 lg:snap-start">
         <header
@@ -458,7 +451,6 @@ export class ArchivedItemQA extends BtrixElement {
               variant="success"
               size="small"
               @click=${() => void this.reviewDialog?.show()}
-              ?disabled=${hasDependencies}
             >
               <sl-icon slot="prefix" name="patch-check"></sl-icon>
               ${msg("Finish Review")}
@@ -472,10 +464,7 @@ export class ArchivedItemQA extends BtrixElement {
                 aria-label=${msg("More options")}
               ></sl-button>
               <sl-menu>
-                <sl-menu-item
-                  @click=${() => void this.reviewDialog?.show()}
-                  ?disabled=${hasDependencies}
-                >
+                <sl-menu-item @click=${() => void this.reviewDialog?.show()}>
                   <sl-icon slot="prefix" name="patch-check-fill"></sl-icon>
                   ${msg("Rate Crawl")}
                 </sl-menu-item>
@@ -516,7 +505,6 @@ export class ArchivedItemQA extends BtrixElement {
               .itemId=${this.itemId}
               .pageId=${this.itemPageId}
               .page=${this.page}
-              ?disabled=${hasDependencies}
               @btrix-show-comments=${() => void this.commentDialog?.show()}
               @btrix-update-page-approval=${this.onUpdatePageApproval}
             ></btrix-page-qa-approval>
@@ -609,8 +597,7 @@ export class ArchivedItemQA extends BtrixElement {
                     size="small"
                     variant="primary"
                     @click=${() => void this.startQARun()}
-                    ?disabled=${isArchivingDisabled(this.org, true) ||
-                    hasDependencies}
+                    ?disabled=${isArchivingDisabled(this.org, true)}
                   >
                     <sl-icon
                       slot="prefix"


### PR DESCRIPTION
WIP for https://github.com/webrecorder/browsertrix/issues/3177

## Changes

Re-enables QA UI for archived items with dependencies.

## Manual testing

1. Log in as crawler
2. Go to archived item > QA. Verify "Review Crawl" button is present
3. Select "Review Crawl". Verify "Finish Review" button is present

## Follow-ups

The warning banner isn't updated in this PR and will be updated when handling the change to missing dependencies.
