### PR TITLE
add index post crawl jobs for crawls with dedupe index:

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -768,7 +768,7 @@ class CollectionOps:
         job_type: TYPE_INDEX_JOB_TYPES = "import",
         crawl_id: Optional[str] = None,
     ):
-        """update index with import / purge job"""
+        """update index with import / purge / post-crawl job"""
 
         crawler_image = self.crawl_ops.crawl_configs.get_channel_crawler_image(
             self.dedupe_importer_channel

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -53,6 +53,7 @@ from .models import (
     ResourcesOnly,
     DeleteDedupeIndex,
     TYPE_DEDUPE_INDEX_STATES,
+    TYPE_INDEX_JOB_TYPES,
 )
 from .utils import (
     dt_now,
@@ -757,10 +758,16 @@ class CollectionOps:
         if coll.indexState not in ("ready", "idle"):
             raise HTTPException(status_code=400, detail="dedupe_index_not_ready")
 
-        await self.run_index_import_job(coll.id, org.id, is_purge=True)
+        await self.run_index_import_job(coll.id, org.id, "purge")
         return {"updated": True}
 
-    async def run_index_import_job(self, coll_id: UUID, oid: UUID, is_purge=False):
+    async def run_index_import_job(
+        self,
+        coll_id: UUID,
+        oid: UUID,
+        job_type: TYPE_INDEX_JOB_TYPES = "import",
+        crawl_id: Optional[str] = None,
+    ):
         """update index with import / purge job"""
 
         crawler_image = self.crawl_ops.crawl_configs.get_channel_crawler_image(
@@ -779,13 +786,14 @@ class CollectionOps:
         )
 
         await self.crawl_manager.run_index_import_job(
-            str(coll_id), str(oid), crawler_image, pull_policy, is_purge
+            str(coll_id), str(oid), crawler_image, pull_policy, job_type, crawl_id
         )
 
-        # if job created, update state here so its reflected in the UI more quickly
-        await self.update_dedupe_index_info(
-            coll_id, state="purging" if is_purge else "importing"
-        )
+        if job_type in ("import", "purge"):
+            # if job created, update state here so its reflected in the UI more quickly
+            await self.update_dedupe_index_info(
+                coll_id, state="purging" if job_type == "purge" else "importing"
+            )
 
     async def delete_dedupe_index(
         self, coll: Collection, org: Organization, remove_from_workflows: bool = False

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -16,6 +16,7 @@ from .models import (
     CrawlConfig,
     BgJobType,
     ProfileBrowserMetadata,
+    TYPE_INDEX_JOB_TYPES,
 )
 
 
@@ -227,16 +228,17 @@ class CrawlManager(K8sAPI):
         oid: str,
         image: str,
         image_pull_policy: str,
-        is_purging: bool,
+        job_type: TYPE_INDEX_JOB_TYPES,
+        crawl_id: Optional[str] = None,
     ):
-        """create dedupe index import/purge job"""
+        """create dedupe index import/purge/post-crawl job"""
 
         # create unique import job or fixed purge job, as can only have one purge job
         # at a time
         name = (
-            f"import-{coll_id}-{secrets.token_hex(5)}"
-            if not is_purging
-            else f"purge-{coll_id}"
+            f"{job_type}-index-{coll_id}-{secrets.token_hex(5)}"
+            if job_type != "purge"
+            else f"purge-index-{coll_id}"
         )
 
         params = {
@@ -245,8 +247,9 @@ class CrawlManager(K8sAPI):
             "oid": oid,
             "crawler_image": image,
             "crawler_image_pull_policy": image_pull_policy,
-            "is_purging": is_purging,
+            "job_type": job_type,
             "redis_url": self.get_redis_url("coll-" + str(coll_id)),
+            "crawl_id": crawl_id,
         }
 
         data = self.templates.env.get_template("index-import-job.yaml").render(params)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1598,6 +1598,11 @@ TYPE_DEDUPE_INDEX_STATES = Literal[
 DEDUPE_INDEX_STATES = get_args(TYPE_DEDUPE_INDEX_STATES)
 
 
+TYPE_INDEX_JOB_TYPES = Literal["import", "purge", "commit", "cancel"]
+
+INDEX_JOB_TYPES = get_args(TYPE_INDEX_JOB_TYPES)
+
+
 # ============================================================================
 class CollAccessType(str, Enum):
     """Collection access types"""

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1800,11 +1800,15 @@ class CrawlOperator(BaseOperator):
         stats: Optional[OpCrawlStats],
     ) -> None:
         """Run tasks after crawl completes in asyncio.task coroutine."""
-        if state in SUCCESSFUL_STATES and crawl.oid:
+        if state in SUCCESSFUL_STATES:
             # do this first, in case dedupe index may become idle
             # and redis pod will be shut down eventually
             if crawl.dedupe_coll_id:
                 await self.add_crawl_dedupe_stats(crawl)
+
+                await self.coll_ops.run_index_import_job(
+                    UUID(crawl.dedupe_coll_id), crawl.oid, "commit", crawl.id
+                )
 
             await self.crawl_config_ops.stats_recompute_last(
                 crawl.cid, status.filesAddedSize, 1, 1
@@ -1830,10 +1834,16 @@ class CrawlOperator(BaseOperator):
                     crawl.oid, crawl.id, stats.req_crawls
                 )
 
-        if state in FAILED_STATES:
+        # failed states
+        else:
             await self.crawl_config_ops.stats_recompute_last(crawl.cid, 0, 1, 0)
             await self.crawl_ops.delete_failed_crawl_files(crawl.id, crawl.oid)
             await self.page_ops.delete_crawl_pages(crawl.id, crawl.oid)
+
+            if crawl.dedupe_coll_id:
+                await self.coll_ops.run_index_import_job(
+                    UUID(crawl.dedupe_coll_id), crawl.oid, "cancel", crawl.id
+                )
 
         await self.event_webhook_ops.create_crawl_finished_notification(
             crawl.id, crawl.oid, state

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -20,7 +20,7 @@ spec:
 
 # if purging, set completions to disallow changing parallelism
 # for import, omit to allow increasing later
-{% if job_type == "import" %}
+{% if job_type == "purge" %}
   completions: 1
 {% endif %}
 

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ name }}
   labels:
     role: index-import-job
+    type: {{ job_type }}
     coll: {{ id }}
     oid: {{ oid }}
 
@@ -19,7 +20,7 @@ spec:
 
 # if purging, set completions to disallow changing parallelism
 # for import, omit to allow increasing later
-{% if is_purging %}
+{% if job_type == "import" %}
   completions: 1
 {% endif %}
 
@@ -28,12 +29,15 @@ spec:
     metadata:
       labels:
         role: index-import-job
+        type: {{ job_type }}
         coll: {{ id }}
         oid: {{ oid }}
 
     spec:
       restartPolicy: OnFailure
       priorityClassName: index-import-job
+
+      {% if job_type == "import" or job_type == "purge" %}
       volumes:
         - name: config
           configMap:
@@ -41,6 +45,7 @@ spec:
 
         - name: tmpdir
           emptyDir: {}
+      {% endif %}
 
       containers:
         - name: indexer
@@ -48,14 +53,29 @@ spec:
           imagePullPolicy: {{ crawler_image_pull_policy }}
           command:
             - indexer
-            - --sourceUrl
-            - /btrix-config/config.json
             - --redisDedupeUrl
             - {{ redis_url }}
-          {% if is_purging %}
+
+          {% if job_type == "import" %}
+            - --sourceUrl
+            - /btrix-config/config.json
+
+          {% elif job_type == "purge" %}
+            - --sourceUrl
+            - /btrix-config/config.json
             - --removing
+
+          {% elif job_type == "commit" %}
+            - --commitCrawlId
+            - {{ crawl_id }}
+
+          {% elif job_type == "cancel" %}
+            - --cancelCrawlId
+            - {{ crawl_id }}
+
           {% endif %}
 
+          {% if job_type == "import" or job_type == "purge" %}
           volumeMounts:
             - name: tmpdir
               mountPath: /tmp
@@ -63,6 +83,7 @@ spec:
             - name: config
               mountPath: /btrix-config/
               readOnly: True
+          {% endif %}
 
           resources:
             limits:


### PR DESCRIPTION
- add 'commit' and 'cancel' to 'import' and 'purge' jobs, pass job by type instead of is_purging=True
- when deduped crawl succeeds, start 'commit' job, when canceled, start 'cancel' job
- update index-import-job template to pass --commitCrawlId / --cancelCrawlId to indexer (see: webrecorder/browsertrix-crawler#978 for support)
- fixes #3183 