### PR TITLE
fix: Allow changing dedupe collection after save

### DIFF
--- a/frontend/src/features/collections/select-dedupe-collection.ts
+++ b/frontend/src/features/collections/select-dedupe-collection.ts
@@ -45,7 +45,7 @@ export class SelectDedupeCollection extends FormControl(BtrixElement) {
   required?: boolean;
 
   @state()
-  private selectedCollection?: Collection;
+  private selectedCollection?: Collection | { id: string; name: string };
 
   @state()
   private newCollectionName?: string;
@@ -64,7 +64,12 @@ export class SelectDedupeCollection extends FormControl(BtrixElement) {
 
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("dedupeId") && this.dedupeId) {
-      this.selectedCollection = undefined;
+      if (
+        this.selectedCollection &&
+        this.dedupeId !== this.selectedCollection.id
+      ) {
+        this.selectedCollection = undefined;
+      }
       this.newCollectionName = undefined;
     }
   }

--- a/frontend/src/features/collections/select-dedupe-collection.ts
+++ b/frontend/src/features/collections/select-dedupe-collection.ts
@@ -45,7 +45,7 @@ export class SelectDedupeCollection extends FormControl(BtrixElement) {
   required?: boolean;
 
   @state()
-  private selectedCollection?: Collection | { id: string; name: string };
+  private selectedCollection?: Collection;
 
   @state()
   private newCollectionName?: string;


### PR DESCRIPTION
Regression introduced in https://github.com/webrecorder/browsertrix/issues/3147

## Changes

Fixes issue where dedupe collection cannot be changed to an existing collection once saved.

## Manual testing

1. Log in as crawler
2. Go to edit workflow with dedupe collection
3. Change dedupe collection to existing collection
4. Save. Verify collection is saved as expected