### PR TITLE
Remove deleted collection from crawling defaults

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -685,6 +685,7 @@ class CollectionOps:
             )
 
         await self.crawl_ops.remove_collection_from_all_crawls(coll_id, org)
+        await self.orgs.remove_collection_from_crawling_defaults(coll_id, org)
 
         if coll.thumbnail:
             await self.delete_thumbnail(coll, org)

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1638,9 +1638,8 @@ class OrgOps(BaseOrgs):
         except Exception as err:
             print(
                 f"Error removing coll {coll_id} from org {org.id} defaults: {err}",
-                flush=True
+                flush=True,
             )
-
 
 
 # ============================================================================

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1620,6 +1620,28 @@ class OrgOps(BaseOrgs):
         except Exception as err:
             print(f"Error updating field {field} on org {oid}: {err}", flush=True)
 
+    async def remove_collection_from_crawling_defaults(
+        self, coll_id: UUID, org: Organization
+    ):
+        """Remove collection from crawling defaults
+
+        At this point, only dedupeCollId is supported in crawloing defaults.
+        If we add auto-add collections to defaults, we'll need to clean that
+        up here as well.
+        """
+        try:
+            await self.orgs.find_one_and_update(
+                {"_id": org.id, "crawlingDefaults.dedupeCollId": coll_id},
+                {"$set": {"crawlingDefaults.dedupeCollId": None}},
+            )
+        # pylint: disable=broad-exception-caught
+        except Exception as err:
+            print(
+                f"Error removing coll {coll_id} from org {org.id} defaults: {err}",
+                flush=True
+            )
+
+
 
 # ============================================================================
 # pylint: disable=too-many-statements, too-many-arguments

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1625,7 +1625,7 @@ class OrgOps(BaseOrgs):
     ):
         """Remove collection from crawling defaults
 
-        At this point, only dedupeCollId is supported in crawloing defaults.
+        At this point, only dedupeCollId is supported in crawling defaults.
         If we add auto-add collections to defaults, we'll need to clean that
         up here as well.
         """

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1805,7 +1805,11 @@ def test_delete_collection(crawler_auth_headers, default_org_id, crawler_crawl_i
     )
     assert _second_coll_id not in r.json()["collectionIds"]
 
-    # Make a new empty (no crawls) collection and delete it
+
+def test_deleted_collection_removed_from_crawling_defaults(
+    admin_auth_headers, crawler_auth_headers, default_org_id
+):
+    # Make a new empty (no crawls) collection
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/collections",
         headers=crawler_auth_headers,
@@ -1819,9 +1823,30 @@ def test_delete_collection(crawler_auth_headers, default_org_id, crawler_crawl_i
     assert data["added"]
     coll_id = data["id"]
 
+    # Set collection as default dedupeCollId for org
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/defaults/crawling",
+        headers=admin_auth_headers,
+        json={"dedupeCollId": coll_id},
+    )
+    assert r.status_code == 200
+    assert r.json()["updated"]
+
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    data = r.json()
+    assert data["crawlingDefaults"]
+    assert data["crawlingDefaults"]["dedupeCollId"] == coll_id
+
+    # Delete collection
     r = requests.delete(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{coll_id}",
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
     assert r.json()["success"]
+
+    # Ensure collection was removed from crawling defaults
+    r = requests.get(f"{API_PREFIX}/orgs/{default_org_id}", headers=admin_auth_headers)
+    data = r.json()
+    assert data["crawlingDefaults"]
+    assert data["crawlingDefaults"]["dedupeCollId"] is None

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -25,6 +25,7 @@ import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { viewStateContext, type ViewStateContext } from "@/context/view-state";
 import { ClipboardController } from "@/controllers/clipboard";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
+import type { BtrixRequestOrgUpdate } from "@/events/btrix-request-org-update";
 import type { EditDialogTab } from "@/features/collections/collection-edit-dialog";
 import { collectionShareLink } from "@/features/collections/helpers/share-link";
 import { SelectCollectionAccess } from "@/features/collections/select-collection-access";
@@ -1273,6 +1274,18 @@ export class CollectionDetail extends BtrixElement {
         icon: "check2-circle",
         id: "collection-delete-status",
       });
+
+      // Collection may be used in crawling default, request update
+      this.dispatchEvent(
+        new CustomEvent<BtrixRequestOrgUpdate["detail"]>(
+          "btrix-request-org-update",
+          {
+            detail: { org: {} },
+            bubbles: true,
+            composed: true,
+          },
+        ),
+      );
     } catch {
       this.notify.toast({
         message: msg("Sorry, couldn't delete Collection at this time."),

--- a/frontend/src/pages/org/collections-list.ts
+++ b/frontend/src/pages/org/collections-list.ts
@@ -19,6 +19,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { WithSearchOrgContext } from "@/context/search-org/WithSearchOrgContext";
 import { ClipboardController } from "@/controllers/clipboard";
+import type { BtrixRequestOrgUpdate } from "@/events/btrix-request-org-update";
 import type { CollectionSavedEvent } from "@/features/collections/collection-create-dialog";
 import { SelectCollectionAccess } from "@/features/collections/select-collection-access";
 import { emptyMessage } from "@/layouts/emptyMessage";
@@ -846,6 +847,18 @@ export class CollectionsList extends WithSearchOrgContext(BtrixElement) {
         icon: "check2-circle",
         id: "collection-delete-status",
       });
+
+      // Collection may be used in crawling default, request update
+      this.dispatchEvent(
+        new CustomEvent<BtrixRequestOrgUpdate["detail"]>(
+          "btrix-request-org-update",
+          {
+            detail: { org: {} },
+            bubbles: true,
+            composed: true,
+          },
+        ),
+      );
     } catch (err) {
       const message =
         getIndexErrorMessage(err) ||

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -246,6 +246,20 @@ export class Org extends BtrixElement {
     }
   }
 
+  private readonly onRequestUpdateOrg = (e: BtrixRequestOrgUpdate) => {
+    e.stopPropagation();
+
+    // Optimistic update
+    if (Object.keys(e.detail.org).length) {
+      AppStateService.partialUpdateOrg({
+        id: this.orgId,
+        ...e.detail.org,
+      });
+    }
+
+    void this.updateOrg();
+  };
+
   private async updateOrg(e?: CustomEvent) {
     if (e) {
       e.stopPropagation();
@@ -292,6 +306,8 @@ export class Org extends BtrixElement {
     // Sync URL to create dialog
     const dialogName = this.getDialogName();
     if (dialogName) this.openDialog(dialogName);
+
+    this.addEventListener("btrix-request-org-update", this.onRequestUpdateOrg);
   }
 
   private getDialogName() {
@@ -685,19 +701,6 @@ export class Org extends BtrixElement {
     return html`<btrix-org-settings
       activePanel=${activePanel}
       ?isAddingMember=${isAddingMember}
-      @btrix-request-org-update=${(e: BtrixRequestOrgUpdate) => {
-        e.stopPropagation();
-
-        // Optimistic update
-        if (Object.keys(e.detail.org).length) {
-          AppStateService.partialUpdateOrg({
-            id: this.orgId,
-            ...e.detail.org,
-          });
-        }
-
-        void this.updateOrg();
-      }}
       @org-user-role-change=${this.onUserRoleChange}
       @org-remove-member=${this.onOrgRemoveMember}
     ></btrix-org-settings>`;


### PR DESCRIPTION
Fixes #3176 

Removes deleted collection from `Organization.crawlingDefaults.dedupeCollId` if the collection was set as the dedupe coll source

## Testing

1. Create a dedupe collection
2. Set it as the org crawling default dedupe source
3. Delete the collection
4. Verify that the collection is no longer set in org crawling defaults