### PR TITLE
Set higher priority for dedupe index pod + detect when not ready

### DIFF
--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -347,7 +347,9 @@ class CollIndexOperator(BaseOperator):
 
         return "bgsave_in_progress:0" in info and "last_bgsave_status:ok" in info
 
-    async def update_stats_from_redis(self, status: CollIndexStatus, coll_id: UUID) -> bool:
+    async def update_stats_from_redis(
+        self, status: CollIndexStatus, coll_id: UUID
+    ) -> bool:
         """update stats from redis, set other changes based on prev and new state"""
         # attempt to set the last updated from redis when import is finished
         try:

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -80,6 +80,7 @@ class CollIndexOperator(BaseOperator):
         ]
 
         self.shared_params["obj_type"] = "coll"
+        self.shared_params["priorityClassName"] = "dedupe-index"
 
         self.shared_params["use_kvrocks"] = self.shared_params["dedupe_use_kvrocks"]
 
@@ -274,7 +275,9 @@ class CollIndexOperator(BaseOperator):
 
         # update stats if redis is available
         if status.index.running:
-            await self.update_stats_from_redis(status, coll_id)
+            # if redis not available, reset state back to 'initing' until it is
+            if not await self.update_stats_from_redis(status, coll_id):
+                desired_state = "initing"
 
         if desired_state != status.state:
             await self.set_state(desired_state, status, coll_id)
@@ -344,13 +347,13 @@ class CollIndexOperator(BaseOperator):
 
         return "bgsave_in_progress:0" in info and "last_bgsave_status:ok" in info
 
-    async def update_stats_from_redis(self, status: CollIndexStatus, coll_id: UUID):
+    async def update_stats_from_redis(self, status: CollIndexStatus, coll_id: UUID) -> bool:
         """update stats from redis, set other changes based on prev and new state"""
         # attempt to set the last updated from redis when import is finished
         try:
             redis = await self.k8s.get_redis_connected("coll-" + str(coll_id))
             if not redis:
-                return
+                return False
 
             # readd appendonly if using redis
             if status.state == "initing" and self.backend_type == "redis":
@@ -373,11 +376,13 @@ class CollIndexOperator(BaseOperator):
                     **stats,
                 ),
             )
+            return True
 
         # pylint: disable=broad-exception-caught
         except Exception as e:
             print(e)
             traceback.print_exc()
+            return False
 
     def get_related(self, data: MCBaseRequest):
         """return crawljobs that use this dedupe index"""

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -448,6 +448,7 @@ class CrawlOperator(BaseOperator):
 
         pod_info = status.podStatus[name]
         params["name"] = name
+        params["priorityClassName"] = ""
         params["obj_type"] = "crawl"
         params["cpu"] = pod_info.newCpu or params.get("redis_cpu")
         params["memory"] = pod_info.newMemory or params.get("redis_memory")

--- a/chart/app-templates/redis.yaml
+++ b/chart/app-templates/redis.yaml
@@ -51,6 +51,10 @@ spec:
   terminationGracePeriodSeconds: 300
   restartPolicy: {{ "OnFailure" if save_dump else "Always" }}
 
+  {% if priorityClassName %}
+  priorityClassName: {{ priorityClassName }}
+  {% endif %}
+
   volumes:
     - name: shared-redis-conf
       configMap:

--- a/chart/templates/priorities.yaml
+++ b/chart/templates/priorities.yaml
@@ -35,7 +35,7 @@ value: -1000
 globalDefault: false
 description: "Priority for background jobs"
 
-# Higher Priority for Indexing
+# Higher Priorities for Indexing
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -44,5 +44,14 @@ metadata:
 value: 5
 globalDefault: false
 description: "Priority for indexing"
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: dedupe-index
+value: 6
+globalDefault: false
+description: "Priority for dedupe index pod"
 
 


### PR DESCRIPTION
- ensure dedupe index pod has highest priority and pod takes precedence over index jobs and crawl pods, since it is needed for both
- reset index state to 'initing' if redis/kvrocks not actually available.