### PR TITLE
Check and auto-resize dedupe index disk space

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -867,6 +867,17 @@ class CollectionOps:
             return coll.get("indexLastSavedAt")
         return None
 
+    async def get_dedupe_index_disk_size(self, coll_id: UUID) -> int:
+        """return min disk size for dedupe index when uncompressed on disk.
+        only return if index has been saved"""
+        coll = await self.collections.find_one(
+            {"_id": coll_id, "indexLastSavedAt": {"$ne": None}},
+            projection={"diskSpace": "$indexStats.indexDiskSpaceUsed"},
+        )
+        if coll:
+            return coll.get("diskSpace", 0)
+        return 0
+
     # END DEDUPE OPS
 
     async def recalculate_org_collection_stats(self, org: Organization):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -834,11 +834,18 @@ class CollectionOps:
 
         return {"deleted": True}
 
-    async def update_dedupe_index_stats(self, coll_id: UUID, stats: DedupeIndexStats):
+    async def update_dedupe_index_stats(
+        self, coll_id: UUID, stats: DedupeIndexStats, disk_space_used: int = 0
+    ):
         """update dedupe index stats for specified collection"""
         self.collections.find_one_and_update(
             {"_id": coll_id},
-            {"$set": {"indexStats": stats.dict()}},
+            {
+                "$set": {
+                    "indexStats": stats.dict(),
+                    "indexDiskSpaceUsed": disk_space_used,
+                }
+            },
         )
 
     async def update_dedupe_index_info(
@@ -872,10 +879,10 @@ class CollectionOps:
         only return if index has been saved"""
         coll = await self.collections.find_one(
             {"_id": coll_id, "indexLastSavedAt": {"$ne": None}},
-            projection={"diskSpace": "$indexStats.indexDiskSpaceUsed"},
+            projection={"indexDiskSpaceUsed": 1},
         )
         if coll:
-            return coll.get("diskSpace", 0)
+            return coll.get("indexDiskSpaceUsed", 0)
         return 0
 
     # END DEDUPE OPS

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1673,6 +1673,9 @@ class DedupeIndexStats(BaseModel):
     uniqueHashes: int = 0
     estimatedRedundantSize: int = 0
 
+    # size of db on disk when in use
+    indexDiskSpaceUsed: int = 0
+
 
 # ============================================================================
 class Collection(BaseMongoModel):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1673,9 +1673,6 @@ class DedupeIndexStats(BaseModel):
     uniqueHashes: int = 0
     estimatedRedundantSize: int = 0
 
-    # size of db on disk when in use
-    indexDiskSpaceUsed: int = 0
-
 
 # ============================================================================
 class Collection(BaseMongoModel):
@@ -1721,6 +1718,9 @@ class Collection(BaseMongoModel):
     indexState: Optional[TYPE_DEDUPE_INDEX_STATES] = None
 
     indexStats: Optional[DedupeIndexStats] = None
+
+    # size of db on disk when in use
+    indexDiskSpaceUsed: int = 0
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -21,7 +21,7 @@ from btrixcloud.models import (
 
 from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
-
+from kubernetes.utils import parse_quantity
 
 USED_DISK_THRESHOLD = 0.75
 USED_DISK_TARGET = 0.50
@@ -373,6 +373,8 @@ class CollIndexOperator(BaseOperator):
                 if last_update_ts:
                     status.updated = last_update_ts
 
+            disk_space_used = await self.check_disk_size(redis, status)
+
             # update db stats from redis
             stats = await redis.hgetall("allcounts")
             num_unique_hashes = await redis.hlen("alldupes")
@@ -382,12 +384,11 @@ class CollIndexOperator(BaseOperator):
                 DedupeIndexStats(
                     uniqueHashes=num_unique_hashes,
                     totalCrawls=num_crawls,
+                    indexDiskSpaceUsed=disk_space_used,
                     **stats,
                 ),
             )
             return True
-
-            await self.check_disk_size(redis, status)
 
         # pylint: disable=broad-exception-caught
         except Exception as e:
@@ -401,17 +402,25 @@ class CollIndexOperator(BaseOperator):
         if not keyspace:
             return
 
-        capacity = float(keyspace["disk_capacity"])
-        used = float(keyspace["used_disk_size"])
+        capacity = keyspace["disk_capacity"]
+        used = keyspace["used_disk_size"]
+        self.update_desired_storage(used, capacity, status)
+        return used
 
+    def update_desired_storage(self, used: int, capacity: int, status: CollIndexStatus):
+        """set desired storage based on used and current capacity"""
         status.storageCapacity = gb_storage(capacity)
         status.storageUsed = gb_storage(used)
 
-        if used < capacity and (used / capacity) > USED_DISK_THRESHOLD:
-            status.storageDesired = gb_storage(used / USED_DISK_TARGET)
+        if used < capacity and (float(used) / capacity) > USED_DISK_THRESHOLD:
+            status.storageDesired = gb_storage(float(used) / USED_DISK_TARGET)
             print(
                 f"Expanding Dedupe Index Capacity {status.storageCapacity} -> {status.storageDesired}"
             )
+
+        print(f"used: {status.storageUsed}")
+        print(f"capacity: {status.storageCapacity}")
+        print(f"desired: {status.storageDesired}")
 
     def get_related(self, data: MCBaseRequest):
         """return crawljobs that use this dedupe index"""
@@ -468,7 +477,16 @@ class CollIndexOperator(BaseOperator):
             spec.id, org
         )
 
-        params["redis_storage"] = status.storageDesired or params["dedupe_storage"]
+        if not status.storageCapacity or not status.storageDesired:
+            status.storageDesired = params["dedupe_storage"]
+            initial_disk_usage = await self.coll_ops.get_dedupe_index_disk_size(coll_id)
+            self.update_desired_storage(
+                initial_disk_usage,
+                int(parse_quantity(params["dedupe_storage"])),
+                status,
+            )
+
+        params["redis_storage"] = status.storageDesired
 
         return self.load_from_yaml("redis.yaml", params)
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -29,7 +29,10 @@ from btrixcloud.models import (
 from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
 
-USED_DISK_THRESHOLD = 0.55
+# Threshold used / capacity at which a resize should happen
+USED_DISK_THRESHOLD = 0.70
+
+# Target used / capacity ratio
 USED_DISK_TARGET = 0.50
 
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from pydantic import BaseModel
 from redis.asyncio.client import Redis
 
-from btrixcloud.utils import str_to_date, date_to_str, dt_now
+from btrixcloud.utils import str_to_date, date_to_str, dt_now, gb_storage
 from btrixcloud.models import (
     TYPE_DEDUPE_INDEX_STATES,
     DedupeIndexStats,
@@ -21,6 +21,10 @@ from btrixcloud.models import (
 
 from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
+
+
+USED_DISK_THRESHOLD = 0.75
+USED_DISK_TARGET = 0.50
 
 
 # ============================================================================
@@ -51,6 +55,10 @@ class CollIndexStatus(BaseModel):
     # redis pod states
     index: IndexPodState = IndexPodState()
 
+    storageCapacity: str = ""
+    storageUsed: str = ""
+    storageDesired: str = ""
+
 
 # ============================================================================
 class CollIndexSpec(BaseModel):
@@ -70,7 +78,6 @@ class CollIndexOperator(BaseOperator):
     def __init__(self, *args):
         super().__init__(*args)
         self.shared_params.update(self.k8s.shared_params)
-        self.shared_params["redis_storage"] = self.shared_params["dedupe_storage"]
         self.shared_params["memory"] = self.shared_params["dedupe_memory"]
         self.shared_params["cpu"] = self.shared_params["dedupe_cpu"]
 
@@ -380,11 +387,31 @@ class CollIndexOperator(BaseOperator):
             )
             return True
 
+            await self.check_disk_size(redis, status)
+
         # pylint: disable=broad-exception-caught
         except Exception as e:
             print(e)
             traceback.print_exc()
             return False
+
+    async def check_disk_size(self, redis: Redis, status: CollIndexStatus):
+        """adjust disk capacity as dedupe index grows to meet min threshold"""
+        keyspace = await redis.info("keyspace") or {}
+        if not keyspace:
+            return
+
+        capacity = float(keyspace["disk_capacity"])
+        used = float(keyspace["used_disk_size"])
+
+        status.storageCapacity = gb_storage(capacity)
+        status.storageUsed = gb_storage(used)
+
+        if used < capacity and (used / capacity) > USED_DISK_THRESHOLD:
+            status.storageDesired = gb_storage(used / USED_DISK_TARGET)
+            print(
+                f"Expanding Dedupe Index Capacity {status.storageCapacity} -> {status.storageDesired}"
+            )
 
     def get_related(self, data: MCBaseRequest):
         """return crawljobs that use this dedupe index"""
@@ -440,6 +467,8 @@ class CollIndexOperator(BaseOperator):
         params["remote_file_path"] = parts.path[1:] + self.get_index_storage_filename(
             spec.id, org
         )
+
+        params["redis_storage"] = status.storageDesired or params["dedupe_storage"]
 
         return self.load_from_yaml("redis.yaml", params)
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -23,7 +23,7 @@ from btrixcloud.models import (
 from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
 
-USED_DISK_THRESHOLD = 0.60
+USED_DISK_THRESHOLD = 0.55
 USED_DISK_TARGET = 0.50
 
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -3,6 +3,7 @@
 import re
 import datetime
 import traceback
+import os
 
 from typing import Literal
 from urllib.parse import urlsplit
@@ -18,6 +19,7 @@ from btrixcloud.utils import (
     dt_now,
     gb_storage_ceil,
     gb_storage_floor,
+    is_bool,
 )
 from btrixcloud.models import (
     TYPE_DEDUPE_INDEX_STATES,
@@ -84,6 +86,8 @@ class CollIndexOperator(BaseOperator):
     backend_type: Literal["redis", "kvrocks"]
     shared_params = {}
 
+    enable_auto_resize_index_storage: bool
+
     def __init__(self, *args):
         super().__init__(*args)
         self.shared_params.update(self.k8s.shared_params)
@@ -116,6 +120,10 @@ class CollIndexOperator(BaseOperator):
         self.idle_expire_time = datetime.timedelta(seconds=self.idle_secs)
 
         self.rclone_save = "save"
+
+        self.enable_auto_resize_index_storage = is_bool(
+            os.environ.get("ENABLE_AUTO_RESIZE_INDEX_STORAGE")
+        )
 
     def init_routes(self, app):
         """init routes for this operator"""
@@ -420,6 +428,8 @@ class CollIndexOperator(BaseOperator):
         """set desired storage based on used and current capacity"""
         status.storageCapacity = gb_storage_floor(capacity)
         status.storageUsed = gb_storage_ceil(used)
+        if not self.enable_auto_resize_index_storage:
+            return
 
         if used < capacity and (float(used) / capacity) > USED_DISK_THRESHOLD:
             status.storageDesired = gb_storage_ceil(float(used) / USED_DISK_TARGET)
@@ -489,7 +499,6 @@ class CollIndexOperator(BaseOperator):
         if not status.storageCapacity or not status.storageDesired:
             status.storageDesired = params["dedupe_storage"]
             initial_disk_usage = await self.coll_ops.get_dedupe_index_disk_size(coll_id)
-            print("initial_disk_usage", initial_disk_usage)
             self.update_desired_storage(
                 initial_disk_usage,
                 int(parse_quantity(params["dedupe_storage"])),

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -393,9 +393,9 @@ class CollIndexOperator(BaseOperator):
                 DedupeIndexStats(
                     uniqueHashes=num_unique_hashes,
                     totalCrawls=num_crawls,
-                    indexDiskSpaceUsed=disk_space_used,
                     **stats,
                 ),
+                disk_space_used=disk_space_used,
             )
             return True
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 from uuid import UUID
 from pydantic import BaseModel
 from redis.asyncio.client import Redis
+from kubernetes.utils import parse_quantity
 
 from btrixcloud.utils import str_to_date, date_to_str, dt_now, gb_storage
 from btrixcloud.models import (
@@ -21,7 +22,6 @@ from btrixcloud.models import (
 
 from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
-from kubernetes.utils import parse_quantity
 
 USED_DISK_THRESHOLD = 0.75
 USED_DISK_TARGET = 0.50
@@ -415,7 +415,10 @@ class CollIndexOperator(BaseOperator):
         if used < capacity and (float(used) / capacity) > USED_DISK_THRESHOLD:
             status.storageDesired = gb_storage(float(used) / USED_DISK_TARGET)
             print(
-                f"Expanding Dedupe Index Capacity {status.storageCapacity} -> {status.storageDesired}"
+                (
+                    "Expanding Dedupe Index Capacity "
+                    + f"{status.storageCapacity} -> {status.storageDesired}"
+                )
             )
 
         print(f"used: {status.storageUsed}")

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -411,6 +411,7 @@ class CollIndexOperator(BaseOperator):
         """set desired storage based on used and current capacity"""
         status.storageCapacity = gb_storage(capacity)
         status.storageUsed = gb_storage(used)
+        print("used / capacity", used, capacity, float(used) / capacity)
 
         if used < capacity and (float(used) / capacity) > USED_DISK_THRESHOLD:
             status.storageDesired = gb_storage(float(used) / USED_DISK_TARGET)
@@ -483,6 +484,7 @@ class CollIndexOperator(BaseOperator):
         if not status.storageCapacity or not status.storageDesired:
             status.storageDesired = params["dedupe_storage"]
             initial_disk_usage = await self.coll_ops.get_dedupe_index_disk_size(coll_id)
+            print("initial_disk_usage", initial_disk_usage)
             self.update_desired_storage(
                 initial_disk_usage,
                 int(parse_quantity(params["dedupe_storage"])),

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -23,7 +23,7 @@ from btrixcloud.models import (
 from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
 
-USED_DISK_THRESHOLD = 0.75
+USED_DISK_THRESHOLD = 0.60
 USED_DISK_TARGET = 0.50
 
 

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -12,7 +12,13 @@ from pydantic import BaseModel
 from redis.asyncio.client import Redis
 from kubernetes.utils import parse_quantity
 
-from btrixcloud.utils import str_to_date, date_to_str, dt_now, gb_storage
+from btrixcloud.utils import (
+    str_to_date,
+    date_to_str,
+    dt_now,
+    gb_storage_ceil,
+    gb_storage_floor,
+)
 from btrixcloud.models import (
     TYPE_DEDUPE_INDEX_STATES,
     DedupeIndexStats,
@@ -409,22 +415,18 @@ class CollIndexOperator(BaseOperator):
 
     def update_desired_storage(self, used: int, capacity: int, status: CollIndexStatus):
         """set desired storage based on used and current capacity"""
-        status.storageCapacity = gb_storage(capacity)
-        status.storageUsed = gb_storage(used)
-        print("used / capacity", used, capacity, float(used) / capacity)
+        status.storageCapacity = gb_storage_floor(capacity)
+        status.storageUsed = gb_storage_ceil(used)
 
         if used < capacity and (float(used) / capacity) > USED_DISK_THRESHOLD:
-            status.storageDesired = gb_storage(float(used) / USED_DISK_TARGET)
+            status.storageDesired = gb_storage_ceil(float(used) / USED_DISK_TARGET)
+            print("used / capacity", used, capacity, float(used) / capacity)
             print(
                 (
                     "Expanding Dedupe Index Capacity "
                     + f"{status.storageCapacity} -> {status.storageDesired}"
                 )
             )
-
-        print(f"used: {status.storageUsed}")
-        print(f"capacity: {status.storageCapacity}")
-        print(f"desired: {status.storageDesired}")
 
     def get_related(self, data: MCBaseRequest):
         """return crawljobs that use this dedupe index"""

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -238,3 +238,9 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
         return True
 
     return False
+
+
+def gb_storage(storage: float) -> str:
+    """approx min GB storage, rounded up"""
+    gb = math.ceil(storage / 1_000_000_000)
+    return f"{gb}Gi"

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -240,7 +240,13 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
     return False
 
 
-def gb_storage(storage: float) -> str:
+def gb_storage_ceil(storage: float) -> str:
     """approx min GB storage, rounded up"""
     gb = math.ceil(storage / 1_000_000_000)
+    return f"{gb}Gi"
+
+
+def gb_storage_floor(storage: float) -> str:
+    """approx min GB storage, rounded up"""
+    gb = math.floor(storage / 1_000_000_000)
     return f"{gb}Gi"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -112,6 +112,8 @@ data:
 
   DEDUPE_IMPORTER_CHANNEL: "{{ .Values.dedupe.importer_channel }}"
 
+  ENABLE_AUTO_RESIZE_INDEX_STORAGE: "{{ .Values.dedupe.enable_auto_resize }}"
+
 
   {{- if .Values.available_plans }}
   AVAILABLE_PLANS: {{ .Values.available_plans | toJson }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -262,8 +262,12 @@ dedupe:
   # dedupe_image: redis
 
   memory: "1Gi"
-  storage: "5Gi"
   cpu: "100m"
+
+  storage: "5Gi"
+  # allow auto resizing the storage used for dedupe index
+  # if enabled, will be resized upwards from above 'storage' value
+  enable_auto_resize: true
 
   # time until index is considered 'idle'
   # redis pod is backed up and shutdown
@@ -272,6 +276,7 @@ dedupe:
   # set this to custom crawler channel (from one of options below)
   # used for dedupe index importing
   importer_channel: "default"
+
 
 # Crawler Channels
 # =========================================


### PR DESCRIPTION
Automatically resize the PVC volume used for dedupe index, based on usage.
Uses two thresholds (currently hard-coded):
- the USED_DISK_THRESHOLD, when to resize
- the USED_DISK_TARGET, what to adjust to.
Eg. if resize threshold is 75%, and min ratio threshold is 50%, the PVC volume is resize if more than 75% is used and set such that only 50% is used.
Current disk size is also stored in the collection, so that when loading the index from S3, it can be properly resize as well (using the above parameters).
The desired target is rounded up to the nearest GB, and used disk is rounded up and capacity rounded down (for setting status)

Note: only works for kvrocks, and may need an option to disable, as certain k8s system (Docker for Mac) may not report the PVC size correctly.