### PR TITLE
fix: Hide divider for empty tag options

### DIFF
--- a/frontend/src/components/ui/tag-input.ts
+++ b/frontend/src/components/ui/tag-input.ts
@@ -121,6 +121,9 @@ export class TagInput extends LitElement {
   @property({ type: Array })
   tagOptions: WorkflowTag[] = [];
 
+  @property({ type: Number })
+  maxTagOptions = 3;
+
   @property({ type: Boolean })
   disabled = false;
 
@@ -186,6 +189,10 @@ export class TagInput extends LitElement {
 
   render() {
     const placeholder = msg("Tags separated by comma");
+    const tagOptions = this.tagOptions
+      .filter(({ tag }) => !this.tags.includes(tag))
+      .slice(0, this.maxTagOptions);
+
     return html`
       <div class="form-control form-control--has-label">
         <label
@@ -266,20 +273,17 @@ export class TagInput extends LitElement {
                 }}
                 @sl-select=${this.onSelect}
               >
-                ${this.tagOptions
-                  .slice(0, 3)
-                  .filter(({ tag }) => !this.tags.includes(tag))
-                  .map(
-                    ({ tag, count }) => html`
-                      <sl-menu-item role="option" value=${tag}
-                        >${tag}
-                        <btrix-badge pill variant="cyan" slot="suffix"
-                          >${count}</btrix-badge
-                        ></sl-menu-item
-                      >
-                    `,
-                  )}
-                ${this.tagOptions.length ? html`<sl-divider></sl-divider>` : ""}
+                ${tagOptions.map(
+                  ({ tag, count }) => html`
+                    <sl-menu-item role="option" value=${tag}
+                      >${tag}
+                      <btrix-badge pill variant="cyan" slot="suffix"
+                        >${count}</btrix-badge
+                      ></sl-menu-item
+                    >
+                  `,
+                )}
+                ${tagOptions.length ? html`<sl-divider></sl-divider>` : ""}
 
                 <sl-menu-item role="option" value=${this.inputValue}>
                   ${msg(str`Add “${this.inputValue.toLocaleLowerCase()}”`)}


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3190

## Changes

Fixes UI bug where divider was displayed in tag input even if there aren't options to choose.

## Manual testing

1. Log in as crawler
2. Go to workflow with tags
3. Go to Edit Workflow > Metadata
4. Start typing in a tag that is already on the workflow. Verify only "Add..." is displayed

## Screenshots

| Before | After |
| ---- | ----------- |
| <img width="545" height="166" alt="Screenshot 2026-02-23 at 10 02 17 AM" src="https://github.com/user-attachments/assets/e92c7fca-9fb6-40ed-aeed-5543a006dae0" /> | <img width="558" height="129" alt="Screenshot 2026-02-23 at 10 31 13 AM" src="https://github.com/user-attachments/assets/cf571f27-8cc2-44a9-89a7-bbac75f9b033" /> |


<!-- ## Follow-ups -->
