### PR TITLE
task: Move "Fail if not logged in" to browser settings

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1001,23 +1001,6 @@ export class WorkflowEditor extends BtrixElement {
   };
 
   private readonly renderPageScope = () => {
-    const linkToBrowserSettings = (label: string) =>
-      html`<button
-        type="button"
-        class="text-blue-600 hover:text-blue-500"
-        @click=${async () => {
-          this.updateProgressState({ activeTab: "browserSettings" });
-
-          await this.updateComplete;
-
-          void this.scrollToActivePanel();
-        }}
-      >
-        ${label}
-      </button>`;
-    const link_to_browser_profile = linkToBrowserSettings(
-      msg("Browser Profile"),
-    );
     return html`
       ${this.formState.scopeType === ScopeType.Page
         ? html`
@@ -1094,32 +1077,6 @@ export class WorkflowEditor extends BtrixElement {
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor["useRobots"], false)}
-      ${inputCol(html`
-        <sl-checkbox
-          name="failOnContentCheck"
-          ?checked=${this.formState.failOnContentCheck &&
-          this.formState.browserProfile !== null}
-          ?disabled=${this.formState.browserProfile === null}
-        >
-          ${this.formState.browserProfile === null
-            ? html`<span slot="help-text">
-                ${msg(
-                  html`Custom logged in ${link_to_browser_profile} is required
-                  to use this option.`,
-                )}
-              </span>`
-            : nothing}
-          ${msg("Fail crawl if not logged in")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(
-        html`${infoTextFor["failOnContentCheck"]}
-        ${this.renderUserGuideLink({
-          hash: "fail-crawl-if-not-logged-in",
-          content: msg("More details"),
-        })}.`,
-        false,
-      )}
       ${when(this.formState.includeLinkedPages, () =>
         this.renderLinkSelectors(),
       )}
@@ -1471,24 +1428,6 @@ https://replayweb.page/docs`}
     const additionalUrlList = urlListToArray(this.formState.urlList);
     const maxUrls = this.localize.number(URL_LIST_MAX_URLS);
 
-    const linkToBrowserSettings = (label: string) =>
-      html`<button
-        type="button"
-        class="text-blue-600 hover:text-blue-500"
-        @click=${async () => {
-          this.updateProgressState({ activeTab: "browserSettings" });
-
-          await this.updateComplete;
-
-          void this.scrollToActivePanel();
-        }}
-      >
-        ${label}
-      </button>`;
-    const link_to_browser_profile = linkToBrowserSettings(
-      msg("Browser Profile"),
-    );
-
     return html`
       ${inputCol(html`
         <sl-input
@@ -1701,31 +1640,6 @@ https://archiveweb.page/es/`}
         msg(
           `If checked, the crawler will check for a sitemap at /sitemap.xml and use it to discover pages to crawl if present.`,
         ),
-        false,
-      )}
-      ${inputCol(html`
-        <sl-checkbox
-          name="failOnContentCheck"
-          ?checked=${this.formState.failOnContentCheck &&
-          this.formState.browserProfile !== null}
-          ?disabled=${this.formState.browserProfile === null}
-        >
-          ${this.formState.browserProfile === null
-            ? html`<span slot="help-text">
-                ${msg(
-                  html`Select a ${link_to_browser_profile} to use this option.`,
-                )}
-              </span>`
-            : nothing}
-          ${msg("Fail crawl if not logged in")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(
-        html`${infoTextFor["failOnContentCheck"]}
-        ${this.renderUserGuideLink({
-          hash: "fail-crawl-if-not-logged-in",
-          content: msg("More details"),
-        })}.`,
         false,
       )}
       ${this.renderLinkSelectors()}
@@ -2164,6 +2078,28 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ></btrix-select-browser-profile>
       `)}
       ${this.renderHelpTextCol(infoTextFor["browserProfile"])}
+      ${when(
+        this.formState.browserProfile,
+        () => html`
+          ${inputCol(html`
+            <sl-checkbox
+              name="failOnContentCheck"
+              ?checked=${this.formState.failOnContentCheck &&
+              this.formState.browserProfile !== null}
+            >
+              ${msg("Fail crawl if not logged in")}
+            </sl-checkbox>
+          `)}
+          ${this.renderHelpTextCol(
+            html`${infoTextFor["failOnContentCheck"]}
+            ${this.renderUserGuideLink({
+              hash: "fail-crawl-if-not-logged-in",
+              content: msg("More details"),
+            })}.`,
+            false,
+          )}
+        `,
+      )}
       ${proxies?.servers.length
         ? [
             inputCol(html`


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3192

## Changes

Moves "Fail if not logged in" checkbox to browser settings to better represent relationship with browser profile.

## Manual testing

1. Log in as crawler
2. Go to new workflow
3. Go to "Browser Settings". Verify "Fail if not logged" option is not displayed
4. Select browser profile. Verify "Fail if not logged in" option is displayed

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit Workflow | <img width="556" height="156" alt="Screenshot 2026-02-23 at 12 07 25 PM" src="https://github.com/user-attachments/assets/ac0b0555-ec1b-4af9-96c2-41b956c73741" /> |


<!-- ## Follow-ups -->
