### PR TITLE
fix: Hide create button for viewer role

### DIFF
--- a/frontend/src/pages/org/dashboard.ts
+++ b/frontend/src/pages/org/dashboard.ts
@@ -557,7 +557,7 @@ export class Dashboard extends BtrixElement {
   }
 
   private renderNoPublicCollections() {
-    if (!this.org || !this.metrics) return;
+    if (!this.org || !this.metrics || !this.appState.isCrawler) return;
 
     let button: TemplateResult;
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3195

## Changes

Hides "Create a Collection" button dashboard for users with viewer level permissions.

## Manual testing

Log in as viewer. Verify "Create a Collection" button is not visible in "Collections" section of dashboard.