### PR TITLE
fix: Prevent duplicate settings when copying workflow settings

### DIFF
--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -5,6 +5,8 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
+import mapValues from "lodash/fp/mapValues";
+import uniq from "lodash/fp/uniq";
 import type { PartialDeep } from "type-fest";
 
 import {
@@ -25,6 +27,15 @@ import {
   type SectionsEnum,
   type FormState as WorkflowFormState,
 } from "@/utils/workflow";
+
+// Make array values unique since mergeDeep will concatenate arrays
+const makeArrUniq = mapValues((val: unknown) => {
+  if (Array.isArray(val)) {
+    return uniq(val) as unknown[];
+  }
+
+  return val;
+});
 
 /**
  * Usage:
@@ -126,7 +137,7 @@ export class WorkflowsNew extends BtrixElement {
         </sl-button>
       </header>
       ${when(this.org, (org) => {
-        const initialWorkflow = mergeDeep(
+        const mergedWorkflow = mergeDeep(
           this.defaultNewWorkflow,
           {
             profileid: org.crawlingDefaults?.profileid,
@@ -152,6 +163,11 @@ export class WorkflowsNew extends BtrixElement {
           } satisfies PartialDeep<WorkflowParams>,
           this.initialWorkflow || {},
         );
+
+        const initialWorkflow = makeArrUniq({
+          ...mergedWorkflow,
+          config: makeArrUniq(mergedWorkflow.config),
+        }) as WorkflowParams;
 
         const scopeType = this.scopeType || initialWorkflow.config.scopeType;
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3198

## Changes

Fixes duplicate link selectors and auto-add collections due to lists being concatenated when copying workflow settings.

## Manual testing

Link selectors repro:
1. Log in as crawler
2. Go to Crawling
3. Choose workflow > Duplicate Workflow. Verify that link selector is only displayed once

Dedupe repro:
1. Log in as crawler to org with default dedupe collection
2. Go to Crawling
3. Choose workflow > Duplicate Workflow
4. Go to Collections section. Verify that default dedupe collection is only displayed once