### PR TITLE
quick follow to #3200: check finishedAt after 'saved'

### DIFF
--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -158,7 +158,7 @@ class CollIndexOperator(BaseOperator):
         # allow deletion only if idle
         if data.finalizing:
             is_done = False
-            if status.state == "saved" and status.index.savedAt:
+            if status.state == "saved" and status.finishedAt:
                 await self.set_state("idle", status, coll_id)
                 is_done = True
             elif status.state == "idle" and status.index.notFound:


### PR DESCRIPTION
- check for finishedAt status instead of index.savedAt to more accurately check that index pod is finished