### PR TITLE
Dedupe make feature flag default configurable + doc beta notice

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -36,6 +36,8 @@ from slugify import slugify
 
 from .db import BaseMongoModel
 
+from .utils import is_bool
+
 # num browsers per crawler instance
 NUM_BROWSERS = int(os.environ.get("NUM_BROWSERS", 2))
 
@@ -64,6 +66,12 @@ PRESIGN_DURATION_SECONDS = min(PRESIGN_DURATION_MINUTES, PRESIGN_MINUTES_MAX) * 
 
 # Minimum part size for file uploads
 MIN_UPLOAD_PART_SIZE = 10000000
+
+# enable dedupe by default
+DEDUPE_FEATURE_ENABLED_DEFAULT = is_bool(
+    os.environ.get("DEDUPE_FEATURE_ENABLED_DEFAULT")
+)
+
 
 # annotated types
 # ============================================================================
@@ -2325,7 +2333,7 @@ class FeatureFlags(ValidatedFeatureFlags):
 
     dedupeEnabled: bool = Field(
         description="Enable deduplication options for an org. Intended for beta-testing dedupe.",
-        default=False,
+        default=DEDUPE_FEATURE_ENABLED_DEFAULT,
     )
 
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -114,6 +114,8 @@ data:
 
   ENABLE_AUTO_RESIZE_INDEX_STORAGE: "{{ .Values.dedupe.enable_auto_resize }}"
 
+  DEDUPE_FEATURE_ENABLED_DEFAULT: "{{ .Values.dedupe.default_enabled }}"
+
 
   {{- if .Values.available_plans }}
   AVAILABLE_PLANS: {{ .Values.available_plans | toJson }}

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -26,6 +26,8 @@ dedupe:
 
   importer_channel: dedupe
 
+  default_enabled: false
+
   memory: "1Gi"
   cpu: "100m"
   storage: "1Gi"

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -24,6 +24,9 @@ redis_storage: "100Mi"
 profile_browser_workdir_size: "100Mi"
 crawler_storage: "500Mi"
 
+# dedupe
+dedupe:
+  default_enabled: false
 
 # for testing only
 crawler_extra_cpu_per_browser: 300m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,6 +55,7 @@ crawler_extra_args: ""
 # max allowed browser windows per crawl
 max_browser_windows: 8
 
+
 # Cluster Settings
 # =========================================
 name: browsertrix-cloud
@@ -250,7 +251,7 @@ redis_memory: "200Mi"
 redis_storage: "3Gi"
 
 
-# Redis Dedup Index
+# Dedupe Index
 # =========================================
 dedupe:
   backend_type: kvrocks
@@ -260,6 +261,9 @@ dedupe:
   # to use redis:
   # backend_type: redis
   # dedupe_image: redis
+
+  # enabled by default without feature flag
+  default_enabled: true
 
   memory: "1Gi"
   cpu: "100m"

--- a/frontend/docs/docs/user-guide/deduplication.md
+++ b/frontend/docs/docs/user-guide/deduplication.md
@@ -1,5 +1,10 @@
 # Deduplication
 
+!!! info "Deduplication is in Beta"
+
+    As of current release, the feature is still beta and may not be available to all users.
+    If you don't see the options below, consult your admin or reach out to support to request access.
+
 ## Overview
 
 Deduplication (or “dedupe”) is the process of preventing duplicate content from being stored during crawling. In Browsertrix, deduplication is facilitated through [collections](./collection.md), which allow arbitrary grouping of crawled content as needed.

--- a/frontend/docs/docs/user-guide/deduplication.md
+++ b/frontend/docs/docs/user-guide/deduplication.md
@@ -2,7 +2,7 @@
 
 !!! info "Deduplication is in Beta"
 
-    As of current release, the feature is still beta and may not be available to all users.
+    As of the current release, the feature is still in beta and may not be available to all users.
     If you don't see the options below, consult your admin or reach out to support to request access.
 
 ## Overview

--- a/frontend/docs/docs/user-guide/org-settings.md
+++ b/frontend/docs/docs/user-guide/org-settings.md
@@ -31,6 +31,11 @@ Set default suggested settings for all new crawl workflows. When creating a new 
 
 ## Deduplication
 
+!!! info "Deduplication is in Beta"
+
+    As of current release, the feature is still beta and may not be available to all users.
+    If you don't see the options below, consult your admin or reach out to support to request access.
+
 View and manage deduplication indexes for all collections used as [deduplication sources](deduplication.md) in the org. Each entry includes information such as how many archived items and URLs are included in the index and how many deleted archived items are purgeable from the index. From the action menu, purge or delete the deduplication index for each collection.
 
 <!-- ## Limits

--- a/frontend/docs/docs/user-guide/org-settings.md
+++ b/frontend/docs/docs/user-guide/org-settings.md
@@ -33,7 +33,7 @@ Set default suggested settings for all new crawl workflows. When creating a new 
 
 !!! info "Deduplication is in Beta"
 
-    As of current release, the feature is still beta and may not be available to all users.
+    As of the current release, the feature is still in beta and may not be available to all users.
     If you don't see the options below, consult your admin or reach out to support to request access.
 
 View and manage deduplication indexes for all collections used as [deduplication sources](deduplication.md) in the org. Each entry includes information such as how many archived items and URLs are included in the index and how many deleted archived items are purgeable from the index. From the action menu, purge or delete the deduplication index for each collection.

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -429,7 +429,7 @@ Cron schedules are always in [UTC](https://en.wikipedia.org/wiki/Coordinated_Uni
 
 !!! info "Deduplication is in Beta"
 
-    As of current release, the feature is still beta and may not be available to all users.
+    As of the current release, the feature is still in beta and may not be available to all users.
     If you don't see the options below, consult your admin or reach out to support to request access.
 
 Prevent duplicate content from being crawled and stored.

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -427,6 +427,11 @@ Cron schedules are always in [UTC](https://en.wikipedia.org/wiki/Coordinated_Uni
 
 ## Deduplication
 
+!!! info "Deduplication is in Beta"
+
+    As of current release, the feature is still beta and may not be available to all users.
+    If you don't see the options below, consult your admin or reach out to support to request access.
+
 Prevent duplicate content from being crawled and stored.
 
 ### Crawl Deduplication


### PR DESCRIPTION
- allow configuring feature flag default
- set 'dedupe.default_enabled: true' to enable dedupe by default for self-deploy users
- docs: add info admonitions noting dedupe is in beta, may not yet be available to all users