### PR TITLE
default container image fixes

### DIFF
--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -713,7 +713,7 @@ def test_get_crawler_channels(crawler_auth_headers, default_org_id):
     assert r.status_code == 200
     crawler_channels = r.json()["channels"]
     assert crawler_channels
-    assert len(crawler_channels) == 3
+    assert len(crawler_channels) == 2
     for crawler_channel in crawler_channels:
         assert crawler_channel["id"]
         assert crawler_channel["image"]

--- a/backend/test_nightly/test_dedupe.py
+++ b/backend/test_nightly/test_dedupe.py
@@ -391,15 +391,16 @@ def test_can_delete_while_indexing(
     )
     assert r.status_code == 200
 
-    time.sleep(1)
-
-    res = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{dedupe_coll_id}",
-        headers=crawler_auth_headers,
-    )
-    data = res.json()
-    state = data.get("indexState")
-    assert state == "importing"
+    while True:
+        time.sleep(1)
+        res = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{dedupe_coll_id}",
+            headers=crawler_auth_headers,
+        )
+        data = res.json()
+        state = data.get("indexState")
+        if state == "importing":
+            break
 
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{dedupe_coll_id}/dedupeIndex/delete",

--- a/backend/test_nightly/test_dedupe.py
+++ b/backend/test_nightly/test_dedupe.py
@@ -47,7 +47,6 @@ def dedupe_workflow_id(crawler_auth_headers, default_org_id, dedupe_coll_id):
             "limit": 10,
             "exclude": "community",
         },
-        "crawlerChannel": "dedupe",
         "dedupeCollId": dedupe_coll_id,
     }
     r = requests.post(

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -24,8 +24,6 @@ registration_enabled: "1"
 dedupe:
   idle_secs: 30
 
-  importer_channel: dedupe
-
   memory: "1Gi"
   cpu: "100m"
   storage: "1Gi"

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -37,9 +37,6 @@ crawler_channels:
   - id: test
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
-  - id: dedupe
-    image: "docker.io/webrecorder/browsertrix-crawler:latest"
-
 mongo_image: "docker.io/library/mongo:8.0"
 
 

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -33,6 +33,7 @@ crawler_extra_memory_per_browser: 256Mi
 crawler_channels:
   - id: default
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    imagePullPolicy: Always
 
   - id: test
     image: "docker.io/webrecorder/browsertrix-crawler:latest"

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -38,8 +38,7 @@ crawler_channels:
     image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
   - id: dedupe
-    image: "docker.io/webrecorder/browsertrix-crawler:1.12.0-beta.2"
-    imagePullPolicy: Always
+    image: "docker.io/webrecorder/browsertrix-crawler:latest"
 
 mongo_image: "docker.io/library/mongo:8.0"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -240,7 +240,7 @@ mongo_auth:
 
 # Redis Image
 # =========================================
-redis_image: "redis"
+redis_image: "redis:8.6.1"
 redis_pull_policy: "IfNotPresent"
 
 redis_cpu: "10m"
@@ -254,7 +254,7 @@ redis_storage: "3Gi"
 # =========================================
 dedupe:
   backend_type: kvrocks
-  image: apache/kvrocks
+  image: apache/kvrocks:2.15.0
   image_pull_policy: IfNotPresent
 
   # to use redis:
@@ -443,7 +443,6 @@ minio_scheme: "http"
 minio_host: "local-minio:9000"
 
 minio_image: docker.io/minio/minio:RELEASE.2022-10-24T18-35-07Z
-minio_mc_image: minio/mc
 minio_pull_policy: "IfNotPresent"
 
 minio_local_bucket_name: &local_bucket_name "btrix-data"


### PR DESCRIPTION
- test: use latest crawler now dedupe now that 1.12 has been released
- remove unused value
- chart: use pinned version of redis and kvrocks to avoid version issues, since pull policy is set to IfNotPresent

In general, should only use unpinned (:latest) images if pull policy is Always, to avoid issues where different versions may be present on different nodes.