### PR TITLE
more reslient downloads:

### DIFF
--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -847,13 +847,44 @@ class StorageOps:
         metadata: dict[str, str],
         all_files: List[CrawlFileOut],
         prefer_single_wacz: bool = False,
+        max_retries=5,
     ) -> Iterator[bytes]:
         """generate streaming zip as sync"""
 
         def get_file(path: str) -> Iterator[bytes]:
             path = self.resolve_internal_access_path(path)
-            r = requests.get(path, stream=True, timeout=None)
-            yield from r.iter_content(CHUNK_SIZE)
+            bytes_read = 0
+            retries = 0
+            while retries < max_retries:
+                headers = {"Range": f"bytes={bytes_read}-"} if bytes_read > 0 else None
+
+                try:
+                    with requests.get(
+                        path, headers=headers, stream=True, timeout=30
+                    ) as resp:
+                        resp.raise_for_status()
+
+                        for chunk in resp.iter_content(CHUNK_SIZE):
+                            if chunk:
+                                bytes_read += len(chunk)
+                                yield chunk
+                                retries = 0
+
+                        # successfully streamed, done
+                        return
+
+                except Exception as e:
+                    print(
+                        f"Streaming DL Error: {path}, Processed {bytes_read} - "
+                        + f"retrying ({retries + 1}/{max_retries})...",
+                        e,
+                    )
+                    time.sleep(2)
+                    retries += 1
+
+            raise HTTPException(
+                status_code=503, detail="download_failed_too_many_retries"
+            )
 
         if len(all_files) == 1 and prefer_single_wacz:
             wacz_file = all_files[0]


### PR DESCRIPTION
- wrap content iterator from requests.get() in get_file() and track how many bytes downloaded, downloading from S3 storage here.
- attempt to restart with range if iterator fails
- retry unless 5 consecutive failures, wait for 2 seconds between each retry
- fixes #3221

Local Testing:
- Create a collection of a decent size, ideally 200MB+ with multiple items
- Start downloading collection
- Immediately kill the local minio pod eg with `kubectl delete pod local-minio-<pod-name> --force`
- Observe in api logs that there is a failure and the download is retried and should succeed.