### PR TITLE
Increase max displayed workflows crawls in collection editor

### DIFF
--- a/frontend/src/features/collections/collection-workflow-list.ts
+++ b/frontend/src/features/collections/collection-workflow-list.ts
@@ -31,7 +31,7 @@ export type AutoAddChangeDetail = {
   dedupe?: boolean;
 };
 
-const CRAWLS_PAGE_SIZE = 50;
+const CRAWLS_PAGE_SIZE = 1000;
 
 /**
  * @fires btrix-selection-change


### PR DESCRIPTION
Updates the max crawls displayed when selecting crawls from a workflow for a collection from 50 to 1000.

Addresses some issues with specific users' crawling and organization workflows.

cc @SuaYoo, we should probably implement better pagination/"load more" at some point, but this should unblock specific users for now, at the cost of potentially slowing down users' browser more.