### PR TITLE
Make add and remove endpoints accept workflow ids in addition to crawl ids

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -27,7 +27,7 @@ from .models import (
     UpdateColl,
     DedupeIndexStats,
     DedupeIndexFile,
-    AddRemoveCrawlList,
+    CollectionAddRemove,
     BaseCrawl,
     CrawlFileOut,
     Organization,
@@ -1452,13 +1452,19 @@ def init_collections_api(
         response_model=CollOut,
     )
     async def add_crawl_to_collection(
-        crawlList: AddRemoveCrawlList,
+        add_remove: CollectionAddRemove,
         coll_id: UUID,
         request: Request,
         org: Organization = Depends(org_crawl_dep),
     ) -> CollOut:
+        crawl_ids = set(add_remove.crawlIds)
+
+        for config_id in add_remove.crawlconfigIds:
+            for crawl_id in await colls.crawl_ops.get_config_crawl_ids(config_id):
+                crawl_ids.add(crawl_id)
+
         return await colls.add_crawls_to_collection(
-            coll_id, crawlList.crawlIds, org, headers=dict(request.headers)
+            coll_id, list(crawl_ids), org, headers=dict(request.headers)
         )
 
     @app.post(
@@ -1467,13 +1473,19 @@ def init_collections_api(
         response_model=CollOut,
     )
     async def remove_crawl_from_collection(
-        crawlList: AddRemoveCrawlList,
+        add_remove: CollectionAddRemove,
         coll_id: UUID,
         request: Request,
         org: Organization = Depends(org_crawl_dep),
     ) -> CollOut:
+        crawl_ids = set(add_remove.crawlIds)
+
+        for config_id in add_remove.crawlconfigIds:
+            for crawl_id in await colls.crawl_ops.get_config_crawl_ids(config_id):
+                crawl_ids.add(crawl_id)
+
         return await colls.remove_crawls_from_collection(
-            coll_id, crawlList.crawlIds, org, headers=dict(request.headers)
+            coll_id, list(crawl_ids), org, headers=dict(request.headers)
         )
 
     @app.delete(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1459,9 +1459,10 @@ def init_collections_api(
     ) -> CollOut:
         crawl_ids = set(add_remove.crawlIds)
 
-        for config_id in add_remove.crawlconfigIds:
-            for crawl_id in await colls.crawl_ops.get_config_crawl_ids(config_id):
-                crawl_ids.add(crawl_id)
+        for crawl_id in await colls.crawl_ops.get_config_crawl_ids(
+            add_remove.crawlconfigIds
+        ):
+            crawl_ids.add(crawl_id)
 
         return await colls.add_crawls_to_collection(
             coll_id, list(crawl_ids), org, headers=dict(request.headers)
@@ -1480,9 +1481,10 @@ def init_collections_api(
     ) -> CollOut:
         crawl_ids = set(add_remove.crawlIds)
 
-        for config_id in add_remove.crawlconfigIds:
-            for crawl_id in await colls.crawl_ops.get_config_crawl_ids(config_id):
-                crawl_ids.add(crawl_id)
+        for crawl_id in await colls.crawl_ops.get_config_crawl_ids(
+            add_remove.crawlconfigIds
+        ):
+            crawl_ids.add(crawl_id)
 
         return await colls.remove_crawls_from_collection(
             coll_id, list(crawl_ids), org, headers=dict(request.headers)

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1458,12 +1458,9 @@ def init_collections_api(
         org: Organization = Depends(org_crawl_dep),
     ) -> CollOut:
         crawl_ids = set(add_remove.crawlIds)
-
-        for crawl_id in await colls.crawl_ops.get_config_crawl_ids(
-            add_remove.crawlconfigIds
-        ):
-            crawl_ids.add(crawl_id)
-
+        crawl_ids.update(
+            await colls.crawl_ops.get_config_crawl_ids(add_remove.crawlconfigIds)
+        )
         return await colls.add_crawls_to_collection(
             coll_id, list(crawl_ids), org, headers=dict(request.headers)
         )
@@ -1480,12 +1477,9 @@ def init_collections_api(
         org: Organization = Depends(org_crawl_dep),
     ) -> CollOut:
         crawl_ids = set(add_remove.crawlIds)
-
-        for crawl_id in await colls.crawl_ops.get_config_crawl_ids(
-            add_remove.crawlconfigIds
-        ):
-            crawl_ids.add(crawl_id)
-
+        crawl_ids.update(
+            await colls.crawl_ops.get_config_crawl_ids(add_remove.crawlconfigIds)
+        )
         return await colls.remove_crawls_from_collection(
             coll_id, list(crawl_ids), org, headers=dict(request.headers)
         )

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -386,9 +386,9 @@ class CrawlOps(BaseCrawlOps):
 
         return crawls, total
 
-    async def get_config_crawl_ids(self, cid: UUID) -> list[str]:
-        """get list of crawl ids belonging to given crawlconfig"""
-        res = self.crawls.find({"cid": cid}, {"_id": 1})
+    async def get_config_crawl_ids(self, cids: list[UUID]) -> list[str]:
+        """get list of crawl ids belonging to given crawlconfigs"""
+        res = self.crawls.find({"cid": {"$in": cids}}, {"_id": 1})
         res_list = await res.to_list()
         return [res["_id"] for res in res_list]
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -386,6 +386,12 @@ class CrawlOps(BaseCrawlOps):
 
         return crawls, total
 
+    async def get_config_crawl_ids(self, cid: UUID) -> list[str]:
+        """get list of crawl ids belonging to given crawlconfig"""
+        res = self.crawls.find({"cid": cid}, {"_id": 1})
+        res_list = await res.to_list()
+        return [res["_id"] for res in res_list]
+
     async def get_active_crawls(self, oid: UUID, limit: int) -> list[str]:
         """get list of waiting crawls, sorted from earliest to latest"""
         res = (

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1859,10 +1859,11 @@ class UpdateCollHomeUrl(BaseModel):
 
 
 # ============================================================================
-class AddRemoveCrawlList(BaseModel):
-    """Collections to add or remove from collection"""
+class CollectionAddRemove(BaseModel):
+    """Items to add or remove from collection"""
 
     crawlIds: List[str] = []
+    crawlconfigIds: List[UUID] = []
 
 
 # ============================================================================

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -354,6 +354,71 @@ def test_add_remove_crawl_from_collection(
     )
     assert _coll_id not in r.json()["collectionIds"]
 
+
+def test_add_remove_config_crawls_from_collection(
+    crawler_auth_headers,
+    default_org_id,
+    crawler_crawl_id,
+    crawler_config_id,
+    admin_crawl_id,
+    admin_config_id,
+):
+    # Add crawls by config and crawl id
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/add",
+        json={"crawlIds": [admin_crawl_id], "crawlconfigIds": [crawler_config_id]},
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == _coll_id
+    assert data["crawlCount"] == 2
+    assert data["pageCount"] > 0
+    assert data["uniquePageCount"] > 0
+    assert data["totalSize"] > 0
+    assert data["modified"] >= modified
+    assert data["tags"] == ["wr-test-2", "wr-test-1"]
+    assert data["dateEarliest"]
+    assert data["dateLatest"]
+    assert data["topPageHosts"]
+
+    # Remove crawls by crawl and config id, and test that specifying a
+    # config and also a crawl in that config separately is handled
+    # gracefully
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/remove",
+        json={
+            "crawlIds": [crawler_crawl_id],
+            "crawlconfigIds": [admin_config_id, crawler_config_id],
+        },
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == _coll_id
+    assert data["crawlCount"] == 0
+    assert data["pageCount"] == 0
+    assert data["uniquePageCount"] == 0
+    assert data["totalSize"] == 0
+    assert data["modified"] >= modified
+    assert data.get("tags", []) == []
+    assert data.get("dateEarliest") is None
+    assert data.get("dateLatest") is None
+    assert data["topPageHosts"] == []
+
+    # Verify crawls were removed
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{admin_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert _coll_id not in r.json()["collectionIds"]
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}/replay.json",
+        headers=crawler_auth_headers,
+    )
+    assert _coll_id not in r.json()["collectionIds"]
+
     # Add crawls back for further tests
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}/add",


### PR DESCRIPTION
Fixes #3225 

Modifies the existing collection `/add` and `/remove` endpoints to accept a list of workflow ids in addition to crawl ids, and gracefully handles any overlap between the two.

This will allow us to more easily add all of a workflow's crawls to a collection in the frontend.