### PR TITLE
optimizie: query item dependendents with single query arg (requiredByCrawls)

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -214,7 +214,7 @@ export class ArchivedItemDetail extends BtrixElement {
       if (!item?.requiresCrawls.length) return;
 
       const query = queryString.stringify({
-        ids: item.requiresCrawls,
+        requiredByCrawls: [item.id],
         sortBy: "started",
         sortDirection: SortDirection.Descending,
       });


### PR DESCRIPTION
- avoid passing a large list of crawl ids
- part of fix for #3230