### PR TITLE
frontend dedupe: avoid passing in large list of crawl ids for 'crawl dependencies' tab

### DIFF
--- a/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
+++ b/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
@@ -56,11 +56,11 @@ export class ItemDependencyTree extends BtrixElement {
   >();
 
   private readonly dependenciesTask = new Task(this, {
-    task: async ([_], { signal }) => {
-      //if (!items?.length) return;
+    task: async ([items], { signal }) => {
+      if (!items?.length) return;
 
       //const itemsMap = new Map(items.map((item) => [item.id, item]));
-      const newIds: string[] = [];
+      //const newIds: string[] = [];
 
       // items.forEach((item) => {
       //   dependenciesWithoutSelf(item).forEach((id) => {
@@ -81,7 +81,7 @@ export class ItemDependencyTree extends BtrixElement {
         {
           //ids: newIds,
           collectionId: this.collectionId,
-          hasRequiresCrawls: true,
+          requiredByCrawls: items.map((item) => item.id),
         },
         {
           arrayFormat: "none",
@@ -92,12 +92,16 @@ export class ItemDependencyTree extends BtrixElement {
         APIPaginatedList<ArchivedItem>
       >(`/orgs/${this.orgId}/all-crawls?${query}`, { signal });
 
-      newIds.forEach((id) => {
-        this.dependenciesMap.set(
-          id,
-          dependencies.find((item) => item.id === id),
-        );
+      dependencies.forEach((item) => {
+        this.dependenciesMap.set(item.id, item);
       });
+
+      // newIds.forEach((id) => {
+      //   this.dependenciesMap.set(
+      //     id,
+      //     dependencies.find((item) => item.id === id),
+      //   );
+      // });
     },
     args: () => [this.items] as const,
   });

--- a/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
+++ b/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
@@ -59,29 +59,27 @@ export class ItemDependencyTree extends BtrixElement {
     task: async ([items], { signal }) => {
       if (!items?.length) return;
 
-      //const itemsMap = new Map(items.map((item) => [item.id, item]));
-      //const newIds: string[] = [];
+      const itemsMap = new Map(items.map((item) => [item.id, item]));
+      const newIds: string[] = [];
 
-      // items.forEach((item) => {
-      //   dependenciesWithoutSelf(item).forEach((id) => {
-      //     if (!this.dependenciesMap.get(id)) {
-      //       const cachedItem = itemsMap.get(id);
-      //       if (cachedItem) {
-      //         this.dependenciesMap.set(id, cachedItem);
-      //       } else {
-      //         newIds.push(id);
-      //       }
-      //     }
-      //   });
-      // });
+      items.forEach((item) => {
+        dependenciesWithoutSelf(item).forEach((id) => {
+          if (!this.dependenciesMap.get(id)) {
+            const cachedItem = itemsMap.get(id);
+            if (cachedItem) {
+              this.dependenciesMap.set(id, cachedItem);
+            } else {
+              newIds.push(id);
+            }
+          }
+        });
+      });
 
-      //if (!newIds.length) return;
+      if (!newIds.length) return;
 
       const query = queryString.stringify(
         {
-          //ids: newIds,
-          collectionId: this.collectionId,
-          requiredByCrawls: items.map((item) => item.id),
+          ids: newIds,
         },
         {
           arrayFormat: "none",
@@ -92,16 +90,12 @@ export class ItemDependencyTree extends BtrixElement {
         APIPaginatedList<ArchivedItem>
       >(`/orgs/${this.orgId}/all-crawls?${query}`, { signal });
 
-      dependencies.forEach((item) => {
-        this.dependenciesMap.set(item.id, item);
+      newIds.forEach((id) => {
+        this.dependenciesMap.set(
+          id,
+          dependencies.find((item) => item.id === id),
+        );
       });
-
-      // newIds.forEach((id) => {
-      //   this.dependenciesMap.set(
-      //     id,
-      //     dependencies.find((item) => item.id === id),
-      //   );
-      // });
     },
     args: () => [this.items] as const,
   });

--- a/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
+++ b/frontend/src/features/archived-items/item-dependency-tree/item-dependency-tree.ts
@@ -56,30 +56,32 @@ export class ItemDependencyTree extends BtrixElement {
   >();
 
   private readonly dependenciesTask = new Task(this, {
-    task: async ([items], { signal }) => {
-      if (!items?.length) return;
+    task: async ([_], { signal }) => {
+      //if (!items?.length) return;
 
-      const itemsMap = new Map(items.map((item) => [item.id, item]));
+      //const itemsMap = new Map(items.map((item) => [item.id, item]));
       const newIds: string[] = [];
 
-      items.forEach((item) => {
-        dependenciesWithoutSelf(item).forEach((id) => {
-          if (!this.dependenciesMap.get(id)) {
-            const cachedItem = itemsMap.get(id);
-            if (cachedItem) {
-              this.dependenciesMap.set(id, cachedItem);
-            } else {
-              newIds.push(id);
-            }
-          }
-        });
-      });
+      // items.forEach((item) => {
+      //   dependenciesWithoutSelf(item).forEach((id) => {
+      //     if (!this.dependenciesMap.get(id)) {
+      //       const cachedItem = itemsMap.get(id);
+      //       if (cachedItem) {
+      //         this.dependenciesMap.set(id, cachedItem);
+      //       } else {
+      //         newIds.push(id);
+      //       }
+      //     }
+      //   });
+      // });
 
-      if (!newIds.length) return;
+      //if (!newIds.length) return;
 
       const query = queryString.stringify(
         {
-          ids: newIds,
+          //ids: newIds,
+          collectionId: this.collectionId,
+          hasRequiresCrawls: true,
         },
         {
           arrayFormat: "none",

--- a/frontend/src/pages/org/collection-detail/dedupe.ts
+++ b/frontend/src/pages/org/collection-detail/dedupe.ts
@@ -144,8 +144,9 @@ export class CollectionDetailDedupe extends BtrixElement {
   });
 
   /**
-   * Crawled items that are a dependency of an archived item
-   * currently in the collection
+   * All collection dependencies:
+   * Crawled items in the collection that are a dependency of another
+   * archived item currently in the collection
    */
   private readonly dependenciesTask = new Task(this, {
     task: async ([collectionId, pagination], { signal }) => {
@@ -156,36 +157,9 @@ export class CollectionDetailDedupe extends BtrixElement {
         sortBy: "finished",
         sortDirection: SortDirection.Descending,
         collectionId,
-        //dedupeCollId: collectionId,
         state: finishedCrawlStates,
-        //hasRequiresCrawls: true,
         hasRequiredByCrawls: true,
       });
-
-      // const { items } = await this.api.fetch<APIPaginatedList<ArchivedItem>>(
-      //   `/orgs/${this.orgId}/crawls?${crawlsQuery}`,
-      //   { signal },
-      // );
-
-      // const crawlIds = items.map(({ id }) => id);
-
-      // if (!crawlIds.length) return;
-
-      // // FIXME Prevent API from returning 431 by limiting IDs
-      // // should be an edge case that there are more that 100
-      // // dependencies in a collection but we would want a more
-      // // robust solution if this becomes more common.
-      // const limit = 100;
-      // const query = queryString.stringify({
-      //   ...pagination,
-      //   sortBy: "finished",
-      //   sortDirection: SortDirection.Descending,
-      //   requiredByCrawls: crawlIds.slice(0, limit),
-      // });
-
-      // if (crawlIds.length > limit) {
-      //   console.warn(`up to ${limit} dependencies queried`);
-      // }
 
       return await this.api.fetch<APIPaginatedList<ArchivedItem>>(
         `/orgs/${this.orgId}/all-crawls?${query}`,

--- a/frontend/src/pages/org/collection-detail/dedupe.ts
+++ b/frontend/src/pages/org/collection-detail/dedupe.ts
@@ -151,39 +151,41 @@ export class CollectionDetailDedupe extends BtrixElement {
     task: async ([collectionId, pagination], { signal }) => {
       if (!collectionId) return;
 
-      const crawlsQuery = queryString.stringify({
-        sortBy: "finished",
-        sortDirection: SortDirection.Descending,
-        collectionId,
-        dedupeCollId: collectionId,
-        state: finishedCrawlStates,
-        hasRequiresCrawls: true,
-      });
-
-      const { items } = await this.api.fetch<APIPaginatedList<ArchivedItem>>(
-        `/orgs/${this.orgId}/crawls?${crawlsQuery}`,
-        { signal },
-      );
-
-      const crawlIds = items.map(({ id }) => id);
-
-      if (!crawlIds.length) return;
-
-      // FIXME Prevent API from returning 431 by limiting IDs
-      // should be an edge case that there are more that 100
-      // dependencies in a collection but we would want a more
-      // robust solution if this becomes more common.
-      const limit = 100;
       const query = queryString.stringify({
         ...pagination,
         sortBy: "finished",
         sortDirection: SortDirection.Descending,
-        requiredByCrawls: crawlIds.slice(0, limit),
+        collectionId,
+        //dedupeCollId: collectionId,
+        state: finishedCrawlStates,
+        //hasRequiresCrawls: true,
+        hasRequiredByCrawls: true,
       });
 
-      if (crawlIds.length > limit) {
-        console.warn(`up to ${limit} dependencies queried`);
-      }
+      // const { items } = await this.api.fetch<APIPaginatedList<ArchivedItem>>(
+      //   `/orgs/${this.orgId}/crawls?${crawlsQuery}`,
+      //   { signal },
+      // );
+
+      // const crawlIds = items.map(({ id }) => id);
+
+      // if (!crawlIds.length) return;
+
+      // // FIXME Prevent API from returning 431 by limiting IDs
+      // // should be an edge case that there are more that 100
+      // // dependencies in a collection but we would want a more
+      // // robust solution if this becomes more common.
+      // const limit = 100;
+      // const query = queryString.stringify({
+      //   ...pagination,
+      //   sortBy: "finished",
+      //   sortDirection: SortDirection.Descending,
+      //   requiredByCrawls: crawlIds.slice(0, limit),
+      // });
+
+      // if (crawlIds.length > limit) {
+      //   console.warn(`up to ${limit} dependencies queried`);
+      // }
 
       return await this.api.fetch<APIPaginatedList<ArchivedItem>>(
         `/orgs/${this.orgId}/all-crawls?${query}`,


### PR DESCRIPTION
Use 'hasRequiredByCrawls' filter to just show all crawls that are dependencies of other crawls in the collection.

part of fix for #3230