### PR TITLE
Fix bug preventing browser profiles and deduplication from being used together in crawls

### DIFF
--- a/chart/app-templates/crawler.yaml
+++ b/chart/app-templates/crawler.yaml
@@ -137,16 +137,19 @@ spec:
         - "{{ workers }}"
         - --redisStoreUrl
         - {{ redis_url }}
+      {% if qa_source_crawl_id %}
+        - --qaSource
+        - /tmp/qa/qa-config.json
+      {% else %}
       {% if redis_dedupe_url %}
         - --redisDedupeUrl
         - {{ redis_dedupe_url }}
-      {% elif qa_source_crawl_id %}
-        - --qaSource
-        - /tmp/qa/qa-config.json
-      {% elif profile_filename %}
+      {% endif %}
+      {% if profile_filename %}
         - --profile
         - "@{{ profile_filename }}"
-      {% if save_profile %}
+      {% endif %}
+      {% if profile_filename and save_profile %}
         - --saveProfile
       {% endif %}
       {% endif %}


### PR DESCRIPTION
Fixes #3229 

A bug was preventing browser profiles from being passed to the crawler args when dedupe was enabled. This PR fixes the conditional logic in the `crawler.yaml` template so that dedupe and profile can be used together for crawls, but neither can be used in QA.

The `save_profile` conditional could be inside of the `{% if profile_filename %}` rather than using an `and` as I do here, but I was trying to reduce the number of nested conditionals to make it more readable, especially since the conditionals can't be indented to help in that respect.

## Testing

- Spin up a local instance
- Configure a logged-in browser profile
- Run a crawl with a logged-in browser profile and a deduplication source enabled
- Run QA and verify that no dedupe or profile-related crawler args are getting passed to the QA run 

Nightly test run: https://github.com/webrecorder/browsertrix/actions/runs/23567830389