### PR TITLE
add optional rawTextMatch and csrClues fields to page qa model

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1480,7 +1480,9 @@ class PageQACompare(BaseModel):
 
     screenshotMatch: Optional[float] = None
     textMatch: Optional[float] = None
+    rawTextMatch: float | None = None
     resourceCounts: Optional[Dict[str, int]] = None
+    csrClues: dict[str, dict[str, int]] | None = None
 
 
 # ============================================================================


### PR DESCRIPTION
adds new optional fields to capture additional match data for raw text and CSR clues collections. these fields will be used to store enhanced matching information for crawled page analysis.

to make use of these new fields, set `crawler_extra_args: "--qaDetectClientSideRendering"` and `to-warc-from-raw` to `crawler_extract_full_text` in one of the yaml configs used, e.g. 
```yaml
crawler_extract_full_text: to-pages,to-warc,to-warc-from-raw
crawler_extra_args: "--qaDetectClientSideRendering"
```