### PR TITLE
Replace passlib with pwdlib for password hashing

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -5,8 +5,11 @@ from uuid import UUID, uuid4
 import asyncio
 from datetime import timedelta
 from typing import Optional, Tuple, List
-from passlib import pwd
-from passlib.context import CryptContext
+import string
+import secrets
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
+from pwdlib.hashers.bcrypt import BcryptHasher
 
 from pydantic import BaseModel
 import jwt
@@ -39,7 +42,12 @@ ALGORITHM = "HS256"
 
 RESET_VERIFY_TOKEN_LIFETIME_MINUTES = 60
 
-PWD_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
+PWD_CONTEXT = PasswordHash(
+    (
+        Argon2Hasher(),
+        BcryptHasher(),
+    )
+)
 
 # Audiences
 CUSTOM_AUTH_AUD = "btrix:custom-auth"
@@ -164,7 +172,8 @@ def get_password_hash(password: str) -> str:
 # ============================================================================
 def generate_password() -> str:
     """generate new secure password"""
-    return pwd.genword()
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for i in range(20))
 
 
 # ============================================================================

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -4,8 +4,11 @@ import os
 from uuid import UUID, uuid4
 from datetime import timedelta
 from typing import Optional, Tuple, List
-from passlib import pwd
-from passlib.context import CryptContext
+import string
+import secrets
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
+from pwdlib.hashers.bcrypt import BcryptHasher
 
 from pydantic import BaseModel
 import jwt
@@ -38,7 +41,12 @@ ALGORITHM = "HS256"
 
 RESET_VERIFY_TOKEN_LIFETIME_MINUTES = 60
 
-PWD_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
+PWD_CONTEXT = PasswordHash(
+    (
+        Argon2Hasher(),
+        BcryptHasher(),
+    )
+)
 
 # Audiences
 CUSTOM_AUTH_AUD = "btrix:custom-auth"
@@ -163,7 +171,8 @@ def get_password_hash(password: str) -> str:
 # ============================================================================
 def generate_password() -> str:
     """generate new secure password"""
-    return pwd.genword()
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for i in range(20))
 
 
 # ============================================================================

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,4 +29,4 @@ remotezip
 json-stream
 aiostream
 iso639-lang>=2.6.0
-setuptools<82.0.0
+setuptools

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ gunicorn
 uvicorn[standard]
 fastapi==0.128.0
 motor
-passlib
+pwdlib[argon2,bcrypt]
 PyJWT==2.8.0
 pydantic==2.12.5
 email-validator


### PR DESCRIPTION
Closes #3179 
Resolves underlying issue behind #3162 and #3163

- migrate from passlib `context` to pwdlib `PasswordHash`
- replace `pwd.genword()` with secrets-based generator
- update dependencies to use `pwdlib` with argon2+bcrypt support
- preferentially use argon2, with bcrypt fallback support (updates hash on next login)

Tested locally with multiple accounts.

Testing instructions:
1. Run cluster off of `main`, set up multiple accounts if desired
2. Check local mongo instance, verify that all accounts' hashes start with `$2b$` (bcrypt)
3. Switch to this branch, build the backend, and update the cluster
4. Log in as any desired accounts, and ensure that the login works as expected
5. Verify that the hashes for those accounts are updated to start with `$argon2id$`
6. While running on this branch, create a new user. Create a password for this user, and verify that the new user's hash also starts with `$argon2id$`.