### PR TITLE
Update collection stats (e.g. date ranges, counts, tags) in background job

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -26,6 +26,7 @@ from .models import (
     ReAddOrgPagesJob,
     OptimizePagesJob,
     CleanupSeedFilesJob,
+    UpdateCollStatsJob,
     PaginatedBackgroundJobResponse,
     AnyJob,
     StorageRef,
@@ -59,7 +60,7 @@ class BackgroundJobOps:
 
     migration_jobs_scale: int
 
-    # pylint: disable=too-many-locals, too-many-arguments, invalid-name
+    # pylint: disable=too-many-locals, too-many-arguments, invalid-name, too-many-lines
 
     def __init__(self, mdb, email, user_manager, org_ops, crawl_manager, storage_ops):
         self.jobs = mdb["jobs"]
@@ -486,6 +487,51 @@ class BackgroundJobOps:
             print(f"warning: optimize pages job could not be started: {exc}")
             return None
 
+    async def create_update_collection_stats_job(
+        self,
+        oid: UUID,
+        collection_id: UUID,
+        existing_job_id: Optional[str] = None,
+    ):
+        """Create job to update collection stats"""
+        try:
+            job_id = await self.crawl_manager.run_update_coll_stats_job(
+                oid=str(oid),
+                collection_id=str(collection_id),
+                existing_job_id=existing_job_id,
+            )
+            if existing_job_id:
+                update_coll_job = await self.get_background_job(existing_job_id)
+                previous_attempt = {
+                    "started": update_coll_job.started,
+                    "finished": update_coll_job.finished,
+                }
+                if update_coll_job.previousAttempts:
+                    update_coll_job.previousAttempts.append(previous_attempt)
+                else:
+                    update_coll_job.previousAttempts = [previous_attempt]
+                update_coll_job.started = dt_now()
+                update_coll_job.finished = None
+                update_coll_job.success = None
+            else:
+                update_coll_job = UpdateCollStatsJob(
+                    id=job_id,
+                    oid=oid,
+                    collection_id=collection_id,
+                    started=dt_now(),
+                )
+
+            await self.jobs.find_one_and_update(
+                {"_id": job_id}, {"$set": update_coll_job.to_dict()}, upsert=True
+            )
+
+            return job_id
+        # pylint: disable=broad-exception-caught
+        except Exception as exc:
+            # pylint: disable=raise-missing-from
+            print(f"warning: update collection stats job could not be started: {exc}")
+            return None
+
     async def ensure_cron_cleanup_jobs_exist(self):
         """Ensure background job to clean up unused seed files weekly exists"""
         await self.crawl_manager.ensure_cleanup_seed_file_cron_job_exists()
@@ -578,6 +624,7 @@ class BackgroundJobOps:
         ReAddOrgPagesJob,
         OptimizePagesJob,
         CleanupSeedFilesJob,
+        UpdateCollStatsJob,
     ]:
         """Get background job"""
         query: dict[str, object] = {"_id": job_id}
@@ -610,6 +657,9 @@ class BackgroundJobOps:
 
         if data["type"] == BgJobType.CLEANUP_SEED_FILES:
             return CleanupSeedFilesJob.from_dict(data)
+
+        if data["type"] == BgJobType.UPDATE_COLL_STATS:
+            return UpdateCollStatsJob.from_dict(data)
 
         return DeleteOrgJob.from_dict(data)
 
@@ -787,6 +837,14 @@ class BackgroundJobOps:
                 existing_job_id=job.id,
             )
             return {"success": True}
+
+        if job.type == BgJobType.UPDATE_COLL_STATS:
+            job = cast(UpdateCollStatsJob, job)
+            await self.create_update_collection_stats_job(
+                org.id,
+                job.collection_id,
+                existing_job_id=job.id,
+            )
 
         if job.type == BgJobType.CLEANUP_SEED_FILES:
             raise HTTPException(status_code=400, detail="cron_job_retry_not_supported")

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -410,7 +410,7 @@ class BaseCrawlOps:
     ) -> tuple[int, dict[UUID, dict[str, int]], bool]:
         """Delete a list of crawls by id for given org"""
         cids_to_update: dict[UUID, dict[str, int]] = {}
-        collection_ids_to_update = set()
+        colls_to_update = dict[UUID, list[str]]
 
         size = 0
 
@@ -439,7 +439,10 @@ class BaseCrawlOps:
 
             if crawl.collectionIds:
                 for coll_id in crawl.collectionIds:
-                    collection_ids_to_update.add(coll_id)
+                    if coll_id in colls_to_update:
+                        colls_to_update[coll_id].append(crawl_id)
+                    else:
+                        colls_to_update[coll_id] = [crawl_id]
 
             if type_ == "crawl":
                 await self.delete_all_crawl_qa_files(crawl_id, org)
@@ -484,10 +487,10 @@ class BaseCrawlOps:
 
         await self.orgs.set_last_crawl_finished(org.id)
 
-        if collection_ids_to_update:
-            for coll_id in collection_ids_to_update:
-                await self.background_job_ops.create_update_collection_stats_job(
-                    org.id, coll_id
+        if colls_to_update:
+            for coll_id, coll_crawl_ids in colls_to_update.items():
+                await self.colls.update_collection_post_remove(
+                    coll_id, coll_crawl_ids, org
                 )
 
         quota_reached = self.orgs.storage_quota_reached(org)

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -410,7 +410,7 @@ class BaseCrawlOps:
     ) -> tuple[int, dict[UUID, dict[str, int]], bool]:
         """Delete a list of crawls by id for given org"""
         cids_to_update: dict[UUID, dict[str, int]] = {}
-        colls_to_update = dict[UUID, list[str]]
+        colls_to_update: dict[UUID, list[str]] = {}
 
         size = 0
 
@@ -487,11 +487,8 @@ class BaseCrawlOps:
 
         await self.orgs.set_last_crawl_finished(org.id)
 
-        if colls_to_update:
-            for coll_id, coll_crawl_ids in colls_to_update.items():
-                await self.colls.update_collection_post_remove(
-                    coll_id, coll_crawl_ids, org
-                )
+        for coll_id, coll_crawl_ids in colls_to_update.items():
+            await self.colls.update_collection_post_remove(coll_id, coll_crawl_ids, org)
 
         quota_reached = self.orgs.storage_quota_reached(org)
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -108,6 +108,16 @@ class BaseCrawlOps:
         self.crawl_log_ops = crawl_log_ops
         self.page_ops = cast(PageOps, None)
 
+        # to avoid background tasks being garbage collected
+        # see: https://stackoverflow.com/a/74059981
+        self.bg_tasks = set()
+
+    def _run_task(self, func) -> None:
+        """add bg tasks to set to avoid premature garbage collection"""
+        task = asyncio.create_task(func)
+        self.bg_tasks.add(task)
+        task.add_done_callback(self.bg_tasks.discard)
+
     def set_page_ops(self, page_ops):
         """set page ops reference"""
         self.page_ops = page_ops
@@ -318,7 +328,7 @@ class BaseCrawlOps:
         if update_values.get("reviewStatus"):
             crawl = BaseCrawl.from_dict(result)
 
-            asyncio.create_task(
+            self._run_task(
                 self.event_webhook_ops.create_crawl_reviewed_notification(
                     crawl.id,
                     crawl.oid,
@@ -455,13 +465,13 @@ class BaseCrawlOps:
                         cids_to_update[cid]["successful"] = 0
 
             if type_ == "crawl":
-                asyncio.create_task(
+                self._run_task(
                     self.event_webhook_ops.create_crawl_deleted_notification(
                         crawl_id, org
                     )
                 )
             if type_ == "upload":
-                asyncio.create_task(
+                self._run_task(
                     self.event_webhook_ops.create_upload_deleted_notification(
                         crawl_id, org
                     )
@@ -476,7 +486,7 @@ class BaseCrawlOps:
 
         if collection_ids_to_update:
             for coll_id in collection_ids_to_update:
-                await self.colls.update_collection_counts_and_tags(coll_id)
+                self._run_task(self.colls.update_collection_stats(coll_id, org.id))
 
         quota_reached = self.orgs.storage_quota_reached(org)
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -486,7 +486,9 @@ class BaseCrawlOps:
 
         if collection_ids_to_update:
             for coll_id in collection_ids_to_update:
-                self._run_task(self.colls.update_collection_stats(coll_id, org.id))
+                await self.background_job_ops.create_update_collection_stats_job(
+                    org.id, coll_id
+                )
 
         quota_reached = self.orgs.storage_quota_reached(org)
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -401,6 +401,7 @@ class BaseCrawlOps:
     async def shutdown_crawl(self, crawl_id: str, org: Organization, graceful: bool):
         """placeholder, implemented in crawls, base version does nothing"""
 
+    # pylint: disable=too-many-statements
     async def delete_crawls(
         self,
         org: Organization,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -73,8 +73,11 @@ if TYPE_CHECKING:
     from .webhooks import EventWebhookOps
     from .crawls import CrawlOps
     from .pages import PageOps
+    from .background_jobs import BackgroundJobOps
 else:
-    OrgOps = StorageOps = EventWebhookOps = CrawlOps = PageOps = object
+    OrgOps = StorageOps = EventWebhookOps = CrawlOps = PageOps = BackgroundJobOps = (
+        object
+    )
 
 
 THUMBNAIL_MAX_SIZE = 2_000_000
@@ -91,6 +94,7 @@ class CollectionOps:
     event_webhook_ops: EventWebhookOps
     crawl_ops: CrawlOps
     page_ops: PageOps
+    background_job_ops: BackgroundJobOps
     crawl_manager: CrawlManager
 
     def __init__(
@@ -100,6 +104,7 @@ class CollectionOps:
         storage_ops: StorageOps,
         crawl_manager: CrawlManager,
         event_webhook_ops: EventWebhookOps,
+        background_job_ops: BackgroundJobOps,
     ):
         self.collections = mdb["collections"]
         self.crawls = mdb["crawls"]
@@ -111,6 +116,7 @@ class CollectionOps:
         self.storage_ops = storage_ops
         self.crawl_manager = crawl_manager
         self.event_webhook_ops = event_webhook_ops
+        self.background_job_ops = background_job_ops
 
         self.dedupe_importer_channel = os.environ.get(
             "DEDUPE_IMPORTER_CHANNEL", "default"
@@ -182,7 +188,9 @@ class CollectionOps:
 
             if crawl_ids:
                 await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
-                self._run_task(self.update_collection_stats(coll_id, org.id))
+                await self.background_job_ops.create_update_collection_stats_job(
+                    org.id, coll_id
+                )
                 self._run_task(
                     self.event_webhook_ops.create_added_to_collection_notification(
                         crawl_ids, coll_id, org
@@ -258,8 +266,7 @@ class CollectionOps:
         coll_id: UUID,
         crawl_ids: List[str],
         org: Organization,
-        headers: Optional[dict] = None,
-    ) -> CollOut:
+    ) -> UpdatedResponse:
         """Add crawls to collection"""
         await self.crawl_ops.validate_all_crawls_successful(crawl_ids, org)
 
@@ -275,7 +282,9 @@ class CollectionOps:
         # do this after checking if collection exists
         await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
 
-        self._run_task(self.update_collection_stats(coll_id, org.id))
+        await self.background_job_ops.create_update_collection_stats_job(
+            org.id, coll_id
+        )
 
         if result.get("indexState"):
             await self.run_index_import_job(coll_id, org.id)
@@ -286,15 +295,14 @@ class CollectionOps:
             )
         )
 
-        return await self.get_collection_out(coll_id, org, headers)
+        return UpdatedResponse(updated=True)
 
     async def remove_crawls_from_collection(
         self,
         coll_id: UUID,
         crawl_ids: List[str],
         org: Organization,
-        headers: Optional[dict] = None,
-    ) -> CollOut:
+    ) -> UpdatedResponse:
         """Remove crawls from collection"""
         await self.crawl_ops.remove_from_collection(crawl_ids, coll_id)
         modified = dt_now()
@@ -306,7 +314,9 @@ class CollectionOps:
         if not result:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
-        self._run_task(self.update_collection_stats(coll_id, org.id))
+        await self.background_job_ops.create_update_collection_stats_job(
+            org.id, coll_id
+        )
 
         if result.get("indexState"):
             await self.run_index_import_job(coll_id, org.id)
@@ -317,7 +327,7 @@ class CollectionOps:
             )
         )
 
-        return await self.get_collection_out(coll_id, org, headers)
+        return UpdatedResponse(updated=True)
 
     async def get_collection_raw(
         self, coll_id: UUID, oid: UUID, public_or_unlisted_only: bool = False
@@ -960,6 +970,7 @@ class CollectionOps:
             {"oid": oid, "collectionIds": collection_id}
         ):
             crawl = BaseCrawl.from_dict(crawl_raw)
+
             if crawl.state not in SUCCESSFUL_STATES:
                 continue
             crawl_count += 1
@@ -1056,7 +1067,9 @@ class CollectionOps:
         modified = dt_now()
 
         for coll_id in crawl_coll_ids:
-            self._run_task(self.update_collection_stats(coll_id, oid))
+            await self.background_job_ops.create_update_collection_stats_job(
+                oid, coll_id
+            )
 
             result = await self.collections.find_one_and_update(
                 {"_id": coll_id},
@@ -1277,13 +1290,14 @@ def init_collections_api(
     storage_ops: StorageOps,
     crawl_manager: CrawlManager,
     event_webhook_ops: EventWebhookOps,
+    background_job_ops: BackgroundJobOps,
     user_dep,
 ) -> CollectionOps:
     """init collections api"""
     # pylint: disable=invalid-name, unused-argument, too-many-arguments
 
     colls: CollectionOps = CollectionOps(
-        mdb, orgs, storage_ops, crawl_manager, event_webhook_ops
+        mdb, orgs, storage_ops, crawl_manager, event_webhook_ops, background_job_ops
     )
 
     org_owner_dep = orgs.org_owner_dep
@@ -1451,40 +1465,34 @@ def init_collections_api(
     @app.post(
         "/orgs/{oid}/collections/{coll_id}/add",
         tags=["collections"],
-        response_model=CollOut,
+        response_model=UpdatedResponse,
     )
     async def add_crawl_to_collection(
         add_remove: CollectionAddRemove,
         coll_id: UUID,
-        request: Request,
         org: Organization = Depends(org_crawl_dep),
-    ) -> CollOut:
+    ) -> UpdatedResponse:
         crawl_ids = set(add_remove.crawlIds)
         crawl_ids.update(
             await colls.crawl_ops.get_config_crawl_ids(add_remove.crawlconfigIds)
         )
-        return await colls.add_crawls_to_collection(
-            coll_id, list(crawl_ids), org, headers=dict(request.headers)
-        )
+        return await colls.add_crawls_to_collection(coll_id, list(crawl_ids), org)
 
     @app.post(
         "/orgs/{oid}/collections/{coll_id}/remove",
         tags=["collections"],
-        response_model=CollOut,
+        response_model=UpdatedResponse,
     )
     async def remove_crawl_from_collection(
         add_remove: CollectionAddRemove,
         coll_id: UUID,
-        request: Request,
         org: Organization = Depends(org_crawl_dep),
-    ) -> CollOut:
+    ) -> UpdatedResponse:
         crawl_ids = set(add_remove.crawlIds)
         crawl_ids.update(
             await colls.crawl_ops.get_config_crawl_ids(add_remove.crawlconfigIds)
         )
-        return await colls.remove_crawls_from_collection(
-            coll_id, list(crawl_ids), org, headers=dict(request.headers)
-        )
+        return await colls.remove_crawls_from_collection(coll_id, list(crawl_ids), org)
 
     @app.delete(
         "/orgs/{oid}/collections/{coll_id}",

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -116,6 +116,16 @@ class CollectionOps:
             "DEDUPE_IMPORTER_CHANNEL", "default"
         )
 
+        # to avoid background tasks being garbage collected
+        # see: https://stackoverflow.com/a/74059981
+        self.bg_tasks = set()
+
+    def _run_task(self, func) -> None:
+        """add bg tasks to set to avoid premature garbage collection"""
+        task = asyncio.create_task(func)
+        self.bg_tasks.add(task)
+        task.add_done_callback(self.bg_tasks.discard)
+
     def set_crawl_ops(self, ops):
         """set crawl ops"""
         self.crawl_ops = ops
@@ -172,9 +182,8 @@ class CollectionOps:
 
             if crawl_ids:
                 await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
-                await self.update_collection_counts_and_tags(coll_id)
-                await self.update_collection_dates(coll_id, org.id)
-                asyncio.create_task(
+                self._run_task(self.update_collection_stats(coll_id, org.id))
+                self._run_task(
                     self.event_webhook_ops.create_added_to_collection_notification(
                         crawl_ids, coll_id, org
                     )
@@ -266,13 +275,12 @@ class CollectionOps:
         # do this after checking if collection exists
         await self.crawl_ops.add_to_collection(crawl_ids, coll_id, org)
 
-        await self.update_collection_counts_and_tags(coll_id)
-        await self.update_collection_dates(coll_id, org.id)
+        self._run_task(self.update_collection_stats(coll_id, org.id))
 
         if result.get("indexState"):
             await self.run_index_import_job(coll_id, org.id)
 
-        asyncio.create_task(
+        self._run_task(
             self.event_webhook_ops.create_added_to_collection_notification(
                 crawl_ids, coll_id, org
             )
@@ -298,13 +306,12 @@ class CollectionOps:
         if not result:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
-        await self.update_collection_counts_and_tags(coll_id)
-        await self.update_collection_dates(coll_id, org.id)
+        self._run_task(self.update_collection_stats(coll_id, org.id))
 
         if result.get("indexState"):
             await self.run_index_import_job(coll_id, org.id)
 
-        asyncio.create_task(
+        self._run_task(
             self.event_webhook_ops.create_removed_from_collection_notification(
                 crawl_ids, coll_id, org
             )
@@ -696,7 +703,7 @@ class CollectionOps:
         if result.deleted_count < 1:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
-        asyncio.create_task(
+        self._run_task(
             self.event_webhook_ops.create_collection_deleted_notification(coll_id, org)
         )
 
@@ -936,10 +943,13 @@ class CollectionOps:
     async def recalculate_org_collection_stats(self, org: Organization):
         """recalculate counts, tags and dates for all collections in an org"""
         async for coll in self.collections.find({"oid": org.id}, projection={"_id": 1}):
-            await self.update_collection_counts_and_tags(coll.get("_id"))
-            await self.update_collection_dates(coll.get("_id"), org.id)
+            await self.update_collection_stats(coll.get("_id"), org.id)
 
-    async def update_collection_counts_and_tags(self, collection_id: UUID):
+    async def update_collection_stats(self, collection_id: UUID, oid: UUID):
+        await self._update_collection_counts_and_tags(collection_id)
+        await self._update_collection_dates(collection_id, oid)
+
+    async def _update_collection_counts_and_tags(self, collection_id: UUID):
         """Set current crawl info in config when crawl begins"""
         # pylint: disable=too-many-locals
         crawl_count = 0
@@ -1004,7 +1014,7 @@ class CollectionOps:
             },
         )
 
-    async def update_collection_dates(self, coll_id: UUID, oid: UUID):
+    async def _update_collection_dates(self, coll_id: UUID, oid: UUID):
         """Update collection earliest and latest dates from page timestamps"""
         # pylint: disable=too-many-locals
         coll = await self.get_collection(coll_id, oid)
@@ -1053,8 +1063,7 @@ class CollectionOps:
         modified = dt_now()
 
         for coll_id in crawl_coll_ids:
-            await self.update_collection_counts_and_tags(coll_id)
-            await self.update_collection_dates(coll_id, oid)
+            self._run_task(self.update_collection_stats(coll_id, oid))
 
             result = await self.collections.find_one_and_update(
                 {"_id": coll_id},

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -52,6 +52,7 @@ from .models import (
     PublicCollOut,
     ResourcesOnly,
     DeleteDedupeIndex,
+    BgJobType,
     TYPE_DEDUPE_INDEX_STATES,
     TYPE_INDEX_JOB_TYPES,
 )
@@ -407,6 +408,7 @@ class CollectionOps:
         org: Organization,
         resources=False,
         public_or_unlisted_only=False,
+        updates_count=True,
         headers: Optional[dict] = None,
     ) -> CollOut:
         """Get CollOut by id"""
@@ -449,6 +451,11 @@ class CollectionOps:
             image_file = UserFile(**thumbnail)
             result["thumbnail"] = await image_file.get_file_out(
                 org, self.storage_ops, headers
+            )
+
+        if updates_count:
+            result["runningUpdatesCount"] = await self.get_running_updates_count(
+                coll_id, org
             )
 
         return CollOut.from_dict(result)
@@ -729,7 +736,9 @@ class CollectionOps:
 
     async def download_collection(self, coll_id: UUID, org: Organization):
         """Download all WACZs in collection as streaming nested WACZ"""
-        coll = await self.get_collection_out(coll_id, org, resources=True)
+        coll = await self.get_collection_out(
+            coll_id, org, resources=True, updates_count=False
+        )
 
         metadata = {
             "type": "collection",
@@ -1287,6 +1296,15 @@ class CollectionOps:
                 total_size += file_.get("size", 0)
 
         return total_size
+
+    async def get_running_updates_count(self, coll_id: UUID, org: Organization) -> int:
+        """Return count of running collection stats update background jobs"""
+        btrix_ids = f"btrix.collid={coll_id},btrix.org={org.id}"
+        job_type = BgJobType.UPDATE_COLL_STATS.value
+
+        return await self.crawl_manager.get_running_background_job_count(
+            f"job_type={job_type},{btrix_ids}"
+        )
 
 
 # ============================================================================

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -969,7 +969,7 @@ class CollectionOps:
         crawl_count = 0
         page_count = 0
         total_size = 0
-        tags = set()
+        tags = []
 
         crawl_ids = []
         preload_resources = []
@@ -1006,11 +1006,11 @@ class CollectionOps:
                 pass
 
             if crawl.tags:
-                tags.update(crawl.tags)
+                tags.extend(crawl.tags)
 
             crawl_ids.append(crawl.id)
 
-        sorted_tags = [tag for tag, _ in Counter(list(tags)).most_common()]
+        sorted_tags = [tag for tag, _ in Counter(tags).most_common()]
 
         unique_page_count = await self.page_ops.get_unique_page_count(crawl_ids)
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -297,14 +297,13 @@ class CollectionOps:
 
         return UpdatedResponse(updated=True)
 
-    async def remove_crawls_from_collection(
+    async def update_collection_post_remove(
         self,
-        coll_id: UUID,
+        coll_id,
         crawl_ids: List[str],
         org: Organization,
-    ) -> UpdatedResponse:
-        """Remove crawls from collection"""
-        await self.crawl_ops.remove_from_collection(crawl_ids, coll_id)
+    ):
+        """Update collection after crawls are removed or deleted outright"""
         modified = dt_now()
         result = await self.collections.find_one_and_update(
             {"_id": coll_id},
@@ -327,6 +326,15 @@ class CollectionOps:
             )
         )
 
+    async def remove_crawls_from_collection(
+        self,
+        coll_id: UUID,
+        crawl_ids: List[str],
+        org: Organization,
+    ) -> UpdatedResponse:
+        """Remove crawls from collection"""
+        await self.crawl_ops.remove_from_collection(crawl_ids, coll_id)
+        await self.update_collection_post_remove(coll_id, crawl_ids, org)
         return UpdatedResponse(updated=True)
 
     async def get_collection_raw(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -299,7 +299,7 @@ class CollectionOps:
 
     async def update_collection_post_remove(
         self,
-        coll_id,
+        coll_id: UUID,
         crawl_ids: List[str],
         org: Organization,
     ):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -501,6 +501,10 @@ class CollectionOps:
                 org, self.storage_ops, headers
             )
 
+        result["runningUpdatesCount"] = await self.get_running_updates_count(
+            coll_id, org
+        )
+
         return PublicCollOut.from_dict(result)
 
     async def get_public_thumbnail(

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1017,15 +1017,15 @@ class CollectionOps:
             },
         )
 
-    async def _get_collection_dates(self, crawl_ids: list[str], oid: UUID) -> tuple(
-        datetime, datetime
-    ):
+    async def _get_collection_dates(
+        self, crawl_ids: list[str], oid: UUID
+    ) -> tuple[datetime | None, datetime | None]:
         """Determine earliest and latest dates for collection items"""
-        earliest_ts = None
-        latest_ts = None
+        earliest_ts: datetime | None = None
+        latest_ts: datetime | None = None
 
         match_query = {
-            "oid": coll.oid,
+            "oid": oid,
             "crawl_id": {"$in": crawl_ids},
             "ts": {"$ne": None},
         }

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -946,11 +946,7 @@ class CollectionOps:
             await self.update_collection_stats(coll.get("_id"), org.id)
 
     async def update_collection_stats(self, collection_id: UUID, oid: UUID):
-        await self._update_collection_counts_and_tags(collection_id)
-        await self._update_collection_dates(collection_id, oid)
-
-    async def _update_collection_counts_and_tags(self, collection_id: UUID):
-        """Set current crawl info in config when crawl begins"""
+        """recalculate counts, tags, and dates for collection"""
         # pylint: disable=too-many-locals
         crawl_count = 0
         page_count = 0
@@ -960,7 +956,9 @@ class CollectionOps:
         crawl_ids = []
         preload_resources = []
 
-        async for crawl_raw in self.crawls.find({"collectionIds": collection_id}):
+        async for crawl_raw in self.crawls.find(
+            {"oid": oid, "collectionIds": collection_id}
+        ):
             crawl = BaseCrawl.from_dict(crawl_raw)
             if crawl.state not in SUCCESSFUL_STATES:
                 continue
@@ -999,6 +997,9 @@ class CollectionOps:
 
         top_page_hosts = await self.page_ops.get_top_page_hosts(crawl_ids)
 
+        earliest_ts, latest_ts = await self._get_collection_dates(crawl_ids, oid)
+
+        # Update collection
         await self.collections.find_one_and_update(
             {"_id": collection_id},
             {
@@ -1010,16 +1011,16 @@ class CollectionOps:
                     "tags": sorted_tags,
                     "preloadResources": preload_resources,
                     "topPageHosts": top_page_hosts,
+                    "dateEarliest": earliest_ts,
+                    "dateLatest": latest_ts,
                 }
             },
         )
 
-    async def _update_collection_dates(self, coll_id: UUID, oid: UUID):
-        """Update collection earliest and latest dates from page timestamps"""
-        # pylint: disable=too-many-locals
-        coll = await self.get_collection(coll_id, oid)
-        crawl_ids = await self.get_collection_crawl_ids(coll_id, oid)
-
+    async def _get_collection_dates(self, crawl_ids: list[str], oid: UUID) -> tuple(
+        datetime, datetime
+    ):
+        """Determine earliest and latest dates for collection items"""
         earliest_ts = None
         latest_ts = None
 
@@ -1045,15 +1046,7 @@ class CollectionOps:
         except IndexError:
             pass
 
-        await self.collections.find_one_and_update(
-            {"_id": coll_id},
-            {
-                "$set": {
-                    "dateEarliest": earliest_ts,
-                    "dateLatest": latest_ts,
-                }
-            },
-        )
+        return earliest_ts, latest_ts
 
     async def update_crawl_collections(self, crawl_id: str, oid: UUID):
         """Update counts, dates, and modified for all collections in crawl"""

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -955,7 +955,7 @@ class CollectionOps:
         crawl_count = 0
         page_count = 0
         total_size = 0
-        tags = []
+        tags = set()
 
         crawl_ids = []
         preload_resources = []
@@ -989,11 +989,11 @@ class CollectionOps:
                 pass
 
             if crawl.tags:
-                tags.extend(crawl.tags)
+                tags.update(crawl.tags)
 
             crawl_ids.append(crawl.id)
 
-        sorted_tags = [tag for tag, count in Counter(tags).most_common()]
+        sorted_tags = [tag for tag, _ in Counter(list(tags)).most_common()]
 
         unique_page_count = await self.page_ops.get_unique_page_count(crawl_ids)
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -578,6 +578,15 @@ class CrawlManager(K8sAPI):
             crawl_id, {"pausedAt": date_to_str(paused_at) if paused_at else ""}
         )
 
+    async def get_running_background_job_count(self, labels: str) -> int:
+        """return count of background jobs matching labels"""
+        resp = await self.batch_api.list_namespaced_job(
+            namespace=DEFAULT_NAMESPACE,
+            label_selector=f"role=background-job,{labels}",
+        )
+        items = resp.items or []
+        return len(items)
+
     async def delete_all_k8s_resources_for_org(self, oid_str: str) -> None:
         """Delete all k8s resources related to org"""
         await self.delete_crawl_config_cron_jobs_for_org(oid_str)

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -199,6 +199,26 @@ class CrawlManager(K8sAPI):
             job_id, job_type=BgJobType.OPTIMIZE_PAGES.value, scale=scale
         )
 
+    async def run_update_coll_stats_job(
+        self,
+        oid: str,
+        collection_id: str,
+        existing_job_id: Optional[str] = None,
+    ) -> str:
+        """run job to update collection stats"""
+
+        if existing_job_id:
+            job_id = existing_job_id
+        else:
+            job_id = f"update-coll-{secrets.token_hex(5)}"
+
+        return await self._run_bg_job_with_ops_classes(
+            job_id,
+            job_type=BgJobType.UPDATE_COLL_STATS.value,
+            oid=oid,
+            collection_id=collection_id,
+        )
+
     async def _run_bg_job_with_ops_classes(
         self,
         job_id: str,

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -462,7 +462,7 @@ class K8sAPI:
         return resp.items
 
     async def list_crawl_jobs(self, label: str = "") -> List[dict[str, Any]]:
-        """Return list of all crawl jobs, optionally filtered by label)"""
+        """Return list of all crawl jobs, optionally filtered by label"""
         resp = await self.custom_api.list_namespaced_custom_object(
             group="btrix.cloud",
             version="v1",

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -244,6 +244,7 @@ def main() -> None:
         storage_ops,
         crawl_manager,
         event_webhook_ops,
+        background_job_ops,
         current_active_user,
     )
 

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -14,6 +14,7 @@ job_type = os.environ.get("BG_JOB_TYPE")
 oid = os.environ.get("OID")
 crawl_type = os.environ.get("CRAWL_TYPE")
 crawl_id = os.environ.get("CRAWL_ID")
+coll_id = os.environ.get("COLLECTION_ID")
 
 
 # ============================================================================
@@ -106,6 +107,16 @@ async def main():
                 await page_ops.re_add_crawl_pages(crawl_id=crawl_id, oid=org.id)
 
             await coll_ops.recalculate_org_collection_stats(org)
+            return 0
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            traceback.print_exc()
+            return 1
+
+    if job_type == BgJobType.UPDATE_COLL_STATS:
+        print(f"Updating collection {coll_id}", flush=True)
+        try:
+            await coll_ops.update_collection_stats(UUID(coll_id), org.id)
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -7,6 +7,7 @@ from typing import cast
 from btrixcloud.colls import CollectionOps
 from btrixcloud.migrations import BaseMigration
 
+from btrixcloud.background_jobs import BackgroundJobOps
 from btrixcloud.orgs import OrgOps
 from btrixcloud.storages import StorageOps
 from btrixcloud.webhooks import EventWebhookOps
@@ -35,6 +36,7 @@ class Migration(BaseMigration):
             cast(StorageOps, None),
             cast(CrawlManager, None),
             cast(EventWebhookOps, None),
+            cast(BackgroundJobOps, None),
         )
 
         async for coll in coll_ops.collections.find({}):

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -40,7 +40,7 @@ class Migration(BaseMigration):
         async for coll in coll_ops.collections.find({}):
             coll_id = coll["_id"]
             try:
-                await coll_ops.update_collection_counts_and_tags(coll_id)
+                await coll_ops.update_collection_stats(coll_id, coll["oid"])
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(f"Unable to update collection {coll_id}: {err}", flush=True)

--- a/backend/btrixcloud/migrations/migration_0041_pages_snapshots.py
+++ b/backend/btrixcloud/migrations/migration_0041_pages_snapshots.py
@@ -34,7 +34,7 @@ class Migration(BaseMigration):
         async for coll in colls_mdb.find({}):
             coll_id = coll["_id"]
             try:
-                await self.coll_ops._update_collection_stats(coll_id, coll["oid"])
+                await self.coll_ops.update_collection_stats(coll_id, coll["oid"])
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(

--- a/backend/btrixcloud/migrations/migration_0041_pages_snapshots.py
+++ b/backend/btrixcloud/migrations/migration_0041_pages_snapshots.py
@@ -34,7 +34,7 @@ class Migration(BaseMigration):
         async for coll in colls_mdb.find({}):
             coll_id = coll["_id"]
             try:
-                await self.coll_ops.update_collection_counts_and_tags(coll_id)
+                await self.coll_ops._update_collection_stats(coll_id, coll["oid"])
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(

--- a/backend/btrixcloud/migrations/migration_0044_coll_stats.py
+++ b/backend/btrixcloud/migrations/migration_0044_coll_stats.py
@@ -35,7 +35,7 @@ class Migration(BaseMigration):
         async for coll in colls_mdb.find({}):
             coll_id = coll["_id"]
             try:
-                await self.coll_ops.update_collection_counts_and_tags(coll_id)
+                await self.coll_ops.update_collection_stats(coll_id, coll["oid"])
             # pylint: disable=broad-exception-caught
             except Exception as err:
                 print(

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1837,6 +1837,8 @@ class PublicCollOut(BaseMongoModel):
 
     topPageHosts: List[HostCount] = []
 
+    runningUpdatesCount: int = 0
+
 
 # ============================================================================
 class UpdateColl(BaseModel):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1798,6 +1798,8 @@ class CollOut(BaseMongoModel):
 
     indexStats: Optional[DedupeIndexStats] = None
 
+    runningUpdatesCount: int = 0
+
 
 # ============================================================================
 class PublicCollOut(BaseMongoModel):

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -3120,6 +3120,7 @@ class BgJobType(str, Enum):
     READD_ORG_PAGES = "readd-org-pages"
     OPTIMIZE_PAGES = "optimize-pages"
     CLEANUP_SEED_FILES = "cleanup-seed-files"
+    UPDATE_COLL_STATS = "update-coll-stats"
 
 
 # ============================================================================
@@ -3197,6 +3198,15 @@ class CleanupSeedFilesJob(BackgroundJob):
 
 
 # ============================================================================
+class UpdateCollStatsJob(BackgroundJob):
+    """Model for tracking jobs to readd pages for an org or single crawl"""
+
+    type: Literal[BgJobType.UPDATE_COLL_STATS] = BgJobType.UPDATE_COLL_STATS
+    oid: UUID
+    collection_id: UUID
+
+
+# ============================================================================
 # Union of all job types, for response model
 
 AnyJob = RootModel[
@@ -3209,6 +3219,7 @@ AnyJob = RootModel[
         ReAddOrgPagesJob,
         OptimizePagesJob,
         CleanupSeedFilesJob,
+        UpdateCollStatsJob,
     ]
 ]
 

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -87,7 +87,7 @@ def init_ops() -> Tuple[
     )
 
     coll_ops = CollectionOps(
-        mdb, org_ops, storage_ops, crawl_manager, event_webhook_ops
+        mdb, org_ops, storage_ops, crawl_manager, event_webhook_ops, background_job_ops
     )
 
     base_crawl_init = (

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -116,8 +116,6 @@ def init_ops() -> Tuple[
     crawl_ops.set_page_ops(page_ops)
     upload_ops.set_page_ops(page_ops)
 
-    background_job_ops.set_ops(crawl_ops, profile_ops)
-
     org_ops.set_ops(
         base_crawl_ops, profile_ops, coll_ops, background_job_ops, page_ops, file_ops
     )

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1491,7 +1491,7 @@ class OrgOps(BaseOrgs):
 
             collection = Collection.from_dict(coll_raw)
             await self.colls_db.insert_one(collection.to_dict())
-            await self.coll_ops.update_collection_counts_and_tags(collection.id)
+            await self.coll_ops.update_collection_stats(collection.id, collection.oid)
 
     async def delete_org_and_data(
         self, org: Organization, user_manager: UserManager

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -863,7 +863,7 @@ def test_list_collections(
     assert first_coll["uniquePageCount"] > 0
     assert first_coll["totalSize"] > 0
     assert first_coll["modified"]
-    assert first_coll["tags"] == ["wr-test-2", "wr-test-1"]
+    assert sorted(first_coll["tags"]) == ["wr-test-1", "wr-test-2"]
     assert first_coll["access"] == "private"
     assert first_coll["dateEarliest"]
     assert first_coll["dateLatest"]

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -139,6 +139,24 @@ def test_create_public_collection(
     global _public_coll_id
     _public_coll_id = data["id"]
 
+    # Wait until collection stats update
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 1:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
+
     # Verify that it is public
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{_public_coll_id}",
@@ -339,7 +357,7 @@ def test_add_remove_crawl_from_collection(
             assert data["uniquePageCount"] > 0
             assert data["totalSize"] > 0
             assert data["modified"] >= modified
-            assert data["tags"] == ["wr-test-2", "wr-test-1"]
+            assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
             assert data["dateEarliest"]
             assert data["dateLatest"]
             assert data["topPageHosts"] == [{"count": 7, "host": "old.webrecorder.net"}]
@@ -445,7 +463,7 @@ def test_add_remove_config_crawls_from_collection(
             assert data["uniquePageCount"] > 0
             assert data["totalSize"] > 0
             assert data["modified"] >= modified
-            assert data["tags"] == ["wr-test-2", "wr-test-1"]
+            assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
             assert data["dateEarliest"]
             assert data["dateLatest"]
             assert data["topPageHosts"]
@@ -577,7 +595,7 @@ def test_get_collection(crawler_auth_headers, default_org_id):
     assert data["uniquePageCount"] > 0
     assert data["totalSize"] > 0
     assert data["modified"] >= modified
-    assert data["tags"] == ["wr-test-2", "wr-test-1"]
+    assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
     assert data["dateEarliest"]
     assert data["dateLatest"]
     assert data["defaultThumbnailName"]
@@ -601,7 +619,7 @@ def test_get_collection_replay(crawler_auth_headers, default_org_id):
     assert data["uniquePageCount"] > 0
     assert data["totalSize"] > 0
     assert data["modified"] >= modified
-    assert data["tags"] == ["wr-test-2", "wr-test-1"]
+    assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
     assert data["dateEarliest"]
     assert data["dateLatest"]
     assert data["defaultThumbnailName"]
@@ -777,7 +795,7 @@ def test_add_upload_to_collection(crawler_auth_headers, default_org_id):
             assert data["uniquePageCount"] > 0
             assert data["totalSize"] > 0
             assert data["modified"]
-            assert data["tags"] == ["wr-test-2", "wr-test-1"]
+            assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
             assert data["dateEarliest"]
             assert data["dateLatest"]
             assert data["defaultThumbnailName"]
@@ -1042,7 +1060,7 @@ def test_remove_upload_from_collection(crawler_auth_headers, default_org_id):
             assert data["uniquePageCount"] > 0
             assert data["totalSize"] > 0
             assert data["modified"] >= modified
-            assert data.get("tags") == ["wr-test-2", "wr-test-1"]
+            assert sorted(data["tags"]) == ["wr-test-1", "wr-test-2"]
             break
 
         if count + 1 == MAX_ATTEMPTS:
@@ -1303,6 +1321,24 @@ def test_list_public_collections(
 
     global _second_public_coll_id
     _second_public_coll_id = r.json()["id"]
+
+    # Wait until collection stats update
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_second_public_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 1:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Get default org slug
     r = requests.get(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1,5 +1,6 @@
 import requests
 import os
+import time
 from uuid import uuid4
 
 from zipfile import ZipFile, ZIP_STORED
@@ -25,6 +26,8 @@ NON_PUBLIC_COLL_FIELDS = (
     "homeUrlPageId",
 )
 NON_PUBLIC_IMAGE_FIELDS = ("originalFilename", "userid", "userName", "created")
+
+MAX_ATTEMPTS = 24
 
 
 _coll_id = None
@@ -76,25 +79,41 @@ def test_create_collection(
     assert r.status_code == 200
     data = r.json()
 
-    assert data["id"] == _coll_id
-    assert data["name"] == COLLECTION_NAME
-    assert data["slug"] == COLLECTION_SLUG
-    assert data["caption"] == CAPTION
-    assert data["crawlCount"] == 1
-    assert data["pageCount"] > 0
-    assert data["uniquePageCount"] > 0
-    assert data["totalSize"] > 0
-    modified = data["modified"]
-    assert modified
-    assert modified.endswith("Z")
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
 
-    assert data["dateEarliest"]
-    assert data["dateLatest"]
+        data = r.json()
+        if data.get("crawlCount") == 1:
+            assert data["id"] == _coll_id
+            assert data["name"] == COLLECTION_NAME
+            assert data["slug"] == COLLECTION_SLUG
+            assert data["caption"] == CAPTION
+            assert data["pageCount"] > 0
+            assert data["uniquePageCount"] > 0
+            assert data["totalSize"] > 0
+            modified = data["modified"]
+            assert modified
+            assert modified.endswith("Z")
 
-    assert data["defaultThumbnailName"] == default_thumbnail_name
-    assert data["allowPublicDownload"]
+            assert data["dateEarliest"]
+            assert data["dateLatest"]
 
-    assert data["topPageHosts"] == [{"count": 3, "host": "old.webrecorder.net"}]
+            assert data["defaultThumbnailName"] == default_thumbnail_name
+            assert data["allowPublicDownload"]
+
+            assert data["topPageHosts"] == [{"count": 3, "host": "old.webrecorder.net"}]
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
 
 def test_create_public_collection(
@@ -303,17 +322,34 @@ def test_add_remove_crawl_from_collection(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 2
-    assert data["pageCount"] > 0
-    assert data["uniquePageCount"] > 0
-    assert data["totalSize"] > 0
-    assert data["modified"] >= modified
-    assert data["tags"] == ["wr-test-2", "wr-test-1"]
-    assert data["dateEarliest"]
-    assert data["dateLatest"]
-    assert data["topPageHosts"] == [{"count": 7, "host": "old.webrecorder.net"}]
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 2:
+            assert data["id"] == _coll_id
+            assert data["pageCount"] > 0
+            assert data["uniquePageCount"] > 0
+            assert data["totalSize"] > 0
+            assert data["modified"] >= modified
+            assert data["tags"] == ["wr-test-2", "wr-test-1"]
+            assert data["dateEarliest"]
+            assert data["dateLatest"]
+            assert data["topPageHosts"] == [{"count": 7, "host": "old.webrecorder.net"}]
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Verify it was added
     r = requests.get(
@@ -329,17 +365,34 @@ def test_add_remove_crawl_from_collection(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 0
-    assert data["pageCount"] == 0
-    assert data["uniquePageCount"] == 0
-    assert data["totalSize"] == 0
-    assert data["modified"] >= modified
-    assert data.get("tags", []) == []
-    assert data.get("dateEarliest") is None
-    assert data.get("dateLatest") is None
-    assert data["topPageHosts"] == []
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 0:
+            assert data["id"] == _coll_id
+            assert data["pageCount"] == 0
+            assert data["uniquePageCount"] == 0
+            assert data["totalSize"] == 0
+            assert data["modified"] >= modified
+            assert data.get("tags", []) == []
+            assert data.get("dateEarliest") is None
+            assert data.get("dateLatest") is None
+            assert data["topPageHosts"] == []
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Verify they were removed
     r = requests.get(
@@ -375,17 +428,34 @@ def test_add_remove_config_crawls_from_collection(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 2
-    assert data["pageCount"] > 0
-    assert data["uniquePageCount"] > 0
-    assert data["totalSize"] > 0
-    assert data["modified"] >= modified
-    assert data["tags"] == ["wr-test-2", "wr-test-1"]
-    assert data["dateEarliest"]
-    assert data["dateLatest"]
-    assert data["topPageHosts"]
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 2:
+            assert data["id"] == _coll_id
+            assert data["pageCount"] > 0
+            assert data["uniquePageCount"] > 0
+            assert data["totalSize"] > 0
+            assert data["modified"] >= modified
+            assert data["tags"] == ["wr-test-2", "wr-test-1"]
+            assert data["dateEarliest"]
+            assert data["dateLatest"]
+            assert data["topPageHosts"]
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Verify crawls were added to collection
     r = requests.get(
@@ -419,17 +489,34 @@ def test_add_remove_config_crawls_from_collection(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 0
-    assert data["pageCount"] == 0
-    assert data["uniquePageCount"] == 0
-    assert data["totalSize"] == 0
-    assert data["modified"] >= modified
-    assert data.get("tags", []) == []
-    assert data.get("dateEarliest") is None
-    assert data.get("dateLatest") is None
-    assert data["topPageHosts"] == []
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 0:
+            assert data["id"] == _coll_id
+            assert data["pageCount"] == 0
+            assert data["uniquePageCount"] == 0
+            assert data["totalSize"] == 0
+            assert data["modified"] >= modified
+            assert data.get("tags", []) == []
+            assert data.get("dateEarliest") is None
+            assert data.get("dateLatest") is None
+            assert data["topPageHosts"] == []
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Verify crawls were removed
     r = requests.get(
@@ -451,17 +538,25 @@ def test_add_remove_config_crawls_from_collection(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 2
-    assert data["pageCount"] > 0
-    assert data["uniquePageCount"] > 0
-    assert data["totalSize"] > 0
-    assert data["modified"] >= modified
-    assert data["tags"] == ["wr-test-2", "wr-test-1"]
-    assert data["dateEarliest"]
-    assert data["dateLatest"]
-    assert data["topPageHosts"]
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 2:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
 
 def test_get_collection(crawler_auth_headers, default_org_id):
@@ -665,17 +760,34 @@ def test_add_upload_to_collection(crawler_auth_headers, default_org_id):
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 3
-    assert data["pageCount"] > 0
-    assert data["uniquePageCount"] > 0
-    assert data["totalSize"] > 0
-    assert data["modified"]
-    assert data["tags"] == ["wr-test-2", "wr-test-1"]
-    assert data["dateEarliest"]
-    assert data["dateLatest"]
-    assert data["defaultThumbnailName"]
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 3:
+            assert data["id"] == _coll_id
+            assert data["pageCount"] > 0
+            assert data["uniquePageCount"] > 0
+            assert data["totalSize"] > 0
+            assert data["modified"]
+            assert data["tags"] == ["wr-test-2", "wr-test-1"]
+            assert data["dateEarliest"]
+            assert data["dateLatest"]
+            assert data["defaultThumbnailName"]
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Verify it was added
     r = requests.get(
@@ -913,14 +1025,31 @@ def test_remove_upload_from_collection(crawler_auth_headers, default_org_id):
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["id"] == _coll_id
-    assert data["crawlCount"] == 2
-    assert data["pageCount"] > 0
-    assert data["uniquePageCount"] > 0
-    assert data["totalSize"] > 0
-    assert data["modified"] >= modified
-    assert data.get("tags") == ["wr-test-2", "wr-test-1"]
+    assert r.json()["updated"]
+
+    # Wait for and validate collection stats update (update happens async)
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 2:
+            assert data["id"] == _coll_id
+            assert data["pageCount"] > 0
+            assert data["uniquePageCount"] > 0
+            assert data["totalSize"] > 0
+            assert data["modified"] >= modified
+            assert data.get("tags") == ["wr-test-2", "wr-test-1"]
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     # Verify it was removed
     r = requests.get(

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -3,6 +3,8 @@ import time
 
 from .conftest import API_PREFIX
 
+MAX_ATTEMPTS = 24
+
 
 def test_workflow_crawl_auto_added_to_collection(
     crawler_auth_headers,
@@ -61,13 +63,23 @@ def test_workflow_crawl_auto_added_subsequent_runs(
     assert r.status_code == 200
     assert auto_add_collection_id in r.json()["collectionIds"]
 
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{auto_add_collection_id}",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    new_crawl_count = r.json()["crawlCount"]
-    assert new_crawl_count == crawl_count + 1
+    # Wait until collection stats update
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{auto_add_collection_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == crawl_count + 1:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
 
 def test_workflow_autoadd_collection_removed_on_delete(

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -20,6 +20,24 @@ def test_workflow_crawl_auto_added_to_collection(
     assert r.status_code == 200
     assert auto_add_collection_id in r.json()["collectionIds"]
 
+    # Wait until collection stats update
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{auto_add_collection_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 1:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
+
 
 def test_workflow_crawl_auto_added_subsequent_runs(
     crawler_auth_headers,
@@ -28,13 +46,6 @@ def test_workflow_crawl_auto_added_subsequent_runs(
     auto_add_crawl_id,
     auto_add_config_id,
 ):
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/collections/{auto_add_collection_id}",
-        headers=crawler_auth_headers,
-    )
-    assert r.status_code == 200
-    crawl_count = r.json()["crawlCount"]
-
     # Run workflow again and make sure new crawl is also in collection
     # and crawl count has been incremented.
     r = requests.post(
@@ -72,7 +83,7 @@ def test_workflow_crawl_auto_added_subsequent_runs(
         )
 
         data = r.json()
-        if data.get("crawlCount") == crawl_count + 1:
+        if data.get("crawlCount") == 2:
             break
 
         if count + 1 == MAX_ATTEMPTS:

--- a/backend/test_nightly/test_dedupe.py
+++ b/backend/test_nightly/test_dedupe.py
@@ -7,6 +7,8 @@ import string
 from .conftest import API_PREFIX
 
 
+MAX_ATTEMPTS = 24
+
 last_saved_at = None
 orig_stats = None
 
@@ -263,6 +265,24 @@ def test_import_into_another_coll(
     )
     assert r.status_code == 200
 
+    # Wait until collection stats update
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{dedupe_coll_id_2}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 2:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
+
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/collections/{dedupe_coll_id_2}/dedupeIndex/create",
         headers=crawler_auth_headers,
@@ -287,6 +307,24 @@ def test_remove_crawl_from_collection(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
+
+    # Wait until collection stats update
+    count = 0
+    while count < MAX_ATTEMPTS:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/collections/{dedupe_coll_id}",
+            headers=crawler_auth_headers,
+        )
+
+        data = r.json()
+        if data.get("crawlCount") == 1:
+            break
+
+        if count + 1 == MAX_ATTEMPTS:
+            assert False
+
+        time.sleep(10)
+        count += 1
 
     data = wait_index_status(
         default_org_id, dedupe_coll_id, crawler_auth_headers, "idle"

--- a/backend/test_nightly/test_webhooks.py
+++ b/backend/test_nightly/test_webhooks.py
@@ -403,7 +403,7 @@ def test_webhooks_sent(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["id"]
+    assert data["updated"]
 
     # Delete upload
     r = requests.post(
@@ -423,7 +423,7 @@ def test_webhooks_sent(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["id"]
+    assert data["updated"]
 
     # Delete crawl
     r = requests.post(

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -52,6 +52,11 @@ spec:
             value: {{ crawl_id }}
 {% endif %}
 
+{% if collection_id %}
+          - name: COLLECTION_ID
+            value: {{ collection_id }}
+{% endif %}
+
           envFrom:
             - configMapRef:
                 name: backend-env-config

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -8,9 +8,12 @@ metadata:
 {% if oid %}
     btrix.org: {{ oid }}
 {% endif %}
+{% if collection_id %}
+    btrix.collid: {{ collection_id }}
+{% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 90
+  ttlSecondsAfterFinished: 0
   backoffLimit: 3
   {% if scale %}
   parallelism: {{ scale }}

--- a/frontend/src/layouts/collections/metadataColumn.ts
+++ b/frontend/src/layouts/collections/metadataColumn.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { when } from "lit/directives/when.js";
 
+import { updatingOverlay } from "@/layouts/updatingOverlay";
 import { metadata } from "@/strings/collections/metadata";
 import { monthYearDateRange } from "@/strings/utils";
 import type { Collection, PublicCollection } from "@/types/collection";
@@ -34,9 +35,13 @@ export function metadataColumn(
   { publicView } = { publicView: false },
 ) {
   const metadataItem = metadataItemWithCollection(collection);
+  const isUpdating =
+    collection &&
+    "runningUpdatesCount" in collection &&
+    collection.runningUpdatesCount;
 
   return html`
-    <btrix-desc-list>
+    <btrix-desc-list class="relative" aria-busy="${isUpdating}">
       ${metadataItem({
         label: metadata.dateLatest,
         render: (col) => html`
@@ -77,6 +82,7 @@ export function metadataColumn(
             )}
           </table>`,
       })}
+      ${isUpdating ? updatingOverlay() : nothing}
     </btrix-desc-list>
   `;
 }

--- a/frontend/src/layouts/updatingOverlay.ts
+++ b/frontend/src/layouts/updatingOverlay.ts
@@ -1,0 +1,23 @@
+import { msg } from "@lit/localize";
+import clsx from "clsx";
+import { html, type nothing, type TemplateResult } from "lit";
+
+import { tw } from "@/utils/tailwind";
+
+export function updatingOverlay(props?: {
+  message?: string | TemplateResult | null | undefined | typeof nothing;
+  class?: string;
+}) {
+  return html`
+    <div
+      class=${clsx(
+        tw`backdrop-blur-px bg-radial absolute inset-0 grid place-items-center from-white/90 to-white/10`,
+        props?.class,
+      )}
+    >
+      <span class="flex items-center gap-2">
+        <sl-spinner></sl-spinner> ${props?.message ?? msg("Updating...")}
+      </span>
+    </div>
+  `;
+}

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -40,6 +40,7 @@ import {
 import { emptyMessage } from "@/layouts/emptyMessage";
 import { pageNav, pageTitle, type Breadcrumb } from "@/layouts/pageHeader";
 import { panelBody, panelHeader } from "@/layouts/panel";
+import { updatingOverlay } from "@/layouts/updatingOverlay";
 import { getIndexErrorMessage } from "@/strings/collections/index-error";
 import {
   type APIPaginatedList,
@@ -48,6 +49,7 @@ import {
 } from "@/types/api";
 import {
   CollectionAccess,
+  collectionSchema,
   type Collection,
   type PublicCollection,
 } from "@/types/collection";
@@ -64,6 +66,7 @@ import { tw } from "@/utils/tailwind";
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_ITEMS_PAGE_SIZE = 20;
 const POLL_INTERVAL_SECONDS = 10;
+const POLL_INTERVAL_ACTIVE_SECONDS = 1;
 
 @customElement("btrix-collection-detail")
 @localized()
@@ -313,10 +316,10 @@ export class CollectionDetail extends BtrixElement {
       </header>
 
       <div
-        class="mt-3 rounded-lg border px-4 py-2"
+        class="relative mt-3 rounded-lg border bg-white px-4 py-2"
         aria-busy="${
           // TODO Switch to task and use task status
-          this.collection === undefined
+          this.collection === undefined || this.collection.runningUpdatesCount
         }"
       >
         ${this.renderInfoBar()}
@@ -340,15 +343,19 @@ export class CollectionDetail extends BtrixElement {
                             ? undefined
                             : msg("Please wait for replay load"),
                         )}
-                        ?disabled=${!this.isRwpLoaded}
+                        ?disabled=${!this.isRwpLoaded ||
+                        this.collection.runningUpdatesCount}
                       >
-                        ${this.isRwpLoaded
+                        ${this.isRwpLoaded &&
+                        !this.collection.runningUpdatesCount
                           ? html`<sl-icon name="house" slot="prefix"></sl-icon>`
                           : html`<sl-spinner slot="prefix"></sl-spinner>`}
                         ${msg("Set Initial View")}
                       </sl-button>
                     `
-                  : nothing,
+                  : this.collection?.runningUpdatesCount
+                    ? html`<sl-spinner slot="prefix"></sl-spinner>`
+                    : nothing,
             ],
             [
               Tab.Items,
@@ -677,7 +684,7 @@ export class CollectionDetail extends BtrixElement {
 
     return html`
       <btrix-overflow-scroll
-        class="-mx-3 max-w-[calc(100%+theme(spacing.6))] part-[content]:px-3"
+        class="-mx-3 -my-2 max-w-[calc(100%+theme(spacing.6))] part-[content]:px-3 part-[content]:py-2"
       >
         <nav class="flex min-w-max gap-2">
           ${tabs.map((tabName) => {
@@ -759,6 +766,10 @@ export class CollectionDetail extends BtrixElement {
                 ${msg("Set Initial View")}
               </sl-menu-item>
             `,
+            () =>
+              this.collection?.runningUpdatesCount
+                ? html`<sl-spinner slot="prefix"></sl-spinner>`
+                : nothing,
           )}
           <sl-menu-item
             @click=${async () => {
@@ -926,6 +937,9 @@ export class CollectionDetail extends BtrixElement {
           : this.renderDetailItem(msg("Last Modified"), (col) =>
               col.modified ? this.localize.relativeDate(col.modified) : "",
             )}
+        ${this.collection.runningUpdatesCount
+          ? updatingOverlay({ class: "rounded-lg" })
+          : nothing}
       </btrix-desc-list>
     `;
   }
@@ -1312,15 +1326,16 @@ export class CollectionDetail extends BtrixElement {
     try {
       this.collection = await this.getCollection();
 
-      // Clear current timer, if it exists
-      if (this.timerId != null) {
-        window.clearTimeout(this.timerId);
+      if (this.timerId) window.clearTimeout(this.timerId);
+      if (this.collection.runningUpdatesCount > 0) {
+        this.timerId = window.setTimeout(() => {
+          void this.fetchCollection();
+        }, 1000 * POLL_INTERVAL_ACTIVE_SECONDS);
+      } else {
+        this.timerId = window.setTimeout(() => {
+          void this.fetchCollection();
+        }, 1000 * POLL_INTERVAL_SECONDS);
       }
-
-      // Restart timer for next poll
-      this.timerId = window.setTimeout(() => {
-        void this.fetchCollection();
-      }, 1000 * POLL_INTERVAL_SECONDS);
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't retrieve Collection at this time."),
@@ -1328,6 +1343,7 @@ export class CollectionDetail extends BtrixElement {
         icon: "exclamation-octagon",
         id: "collection-retrieve-status",
       });
+      console.error(e);
     }
   }
 
@@ -1336,7 +1352,7 @@ export class CollectionDetail extends BtrixElement {
       `/orgs/${this.orgId}/collections/${this.collectionId}/replay.json`,
     );
 
-    return data;
+    return collectionSchema.parse(data);
   }
 
   /**

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -169,6 +169,11 @@ export class CollectionDetail extends BtrixElement {
     return this.appState.isCrawler;
   }
 
+  disconnectedCallback(): void {
+    window.clearTimeout(this.timerId);
+    super.disconnectedCallback();
+  }
+
   protected async willUpdate(
     changedProperties: PropertyValues<this> & Map<string, unknown>,
   ) {

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -63,6 +63,7 @@ import { tw } from "@/utils/tailwind";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_ITEMS_PAGE_SIZE = 20;
+const POLL_INTERVAL_SECONDS = 10;
 
 @customElement("btrix-collection-detail")
 @localized()
@@ -111,6 +112,8 @@ export class CollectionDetail extends BtrixElement {
 
   // Use to cancel requests
   private getArchivedItemsController: AbortController | null = null;
+
+  private timerId?: number;
 
   private readonly editing =
     new SearchParamsValue<EditingSearchParamValue | null>(
@@ -1303,6 +1306,16 @@ export class CollectionDetail extends BtrixElement {
   private async fetchCollection() {
     try {
       this.collection = await this.getCollection();
+
+      // Clear current timer, if it exists
+      if (this.timerId != null) {
+        window.clearTimeout(this.timerId);
+      }
+
+      // Restart timer for next poll
+      this.timerId = window.setTimeout(() => {
+        void this.fetchCollection();
+      }, 1000 * POLL_INTERVAL_SECONDS);
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't retrieve Collection at this time."),

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -33,7 +33,18 @@ export const publicCollectionSchema = z.object({
   modified: z.string().datetime().nullable(),
   caption: z.string().nullable(),
   description: z.string().nullable(),
-  resources: z.array(z.string()),
+  resources: z.array(
+    z.object({
+      name: z.string(),
+      path: z.string(),
+      hash: z.string(),
+      size: z.number(),
+      crawlId: z.string().nullable(),
+      numReplicas: z.number(),
+      expireAt: z.string().datetime().nullable(),
+      fromDependency: z.boolean(),
+    }),
+  ),
   dateEarliest: z.string().datetime().nullable(),
   dateLatest: z.string().datetime().nullable(),
   thumbnail: storageFileSchema.nullable(),
@@ -65,6 +76,19 @@ export const collectionSchema = publicCollectionSchema.extend({
   indexLastSavedAt: z.string().datetime().nullable(),
   indexState: z.enum(DEDUPE_INDEX_STATES).nullable(),
   indexStats: dedupeIndexStatsSchema.optional().nullable(),
+  /**
+   * The number of running updates for this collection.
+   * Updates may affect:
+   * - {@linkcode collectionSchema._type.crawlCount | crawlCount}
+   * - {@linkcode collectionSchema._type.pageCount | pageCount}
+   * - {@linkcode collectionSchema._type.uniquePageCount | uniquePageCount}
+   * - {@linkcode collectionSchema._type.totalSize | totalSize}
+   * - {@linkcode collectionSchema._type.tags | tags}
+   * - {@linkcode collectionSchema._type.topPageHosts | topPageHosts}
+   * - {@linkcode collectionSchema._type.dateEarliest | dateEarliest}
+   * - {@linkcode collectionSchema._type.dateLatest | dateLatest}
+   */
+  runningUpdatesCount: z.number(),
 });
 export type Collection = z.infer<typeof collectionSchema>;
 

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -14,7 +14,7 @@ export enum CollectionAccess {
 
 export const collectionThumbnailSourceSchema = z.object({
   url: z.string().url(),
-  urlPageId: z.string().url(),
+  urlPageId: z.string().uuid(),
   urlTs: z.string().datetime(),
 });
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -139,6 +139,12 @@ function makeTheme() {
         to: { opacity: 1 },
       },
     },
+    backdropBlur: {
+      px: "1px",
+    },
+    backgroundImage: {
+      radial: "radial-gradient(var(--tw-gradient-stops))",
+    },
   };
 }
 


### PR DESCRIPTION
Fixes #3218 

This PR moves updating of collections after changes (e.g. items being added or removed) to a background job, to ensure that collection API requests remain quick.

## Changes

- New background job added to recalculate collection stats
- Ensure all instances where collection statistics would be re-created as part of an API method now kick off a background job instead of awaiting (there are a long-running processes such as org import where we still await instead)
- Ensure that collections and collection dedupe indexes are fully updated following crawl deletion
- Add computed `runningUpdatesCount` to collection detail and replay.json endpoints
- Backend and nightly tests updated to account for the changes
- Poll in collection frontend to pick up updates after changes that kick off stats recalculation (e.g. adding or removing items) and displays an "Updating" spinner based on `runningUpdatesCount > 0` (implemented by @emma-sg, thank you!)
- A few places in the backend modules these changes touch where we were using `asyncio.create_task` have also been updated so that they will not be garbage collected before they complete (see https://github.com/webrecorder/browsertrix/issues/3240 for more context and tracking of completing this across the rest of the backend)

## Testing

- Spin up a Browsertrix instance
- Create a collection with some items
- Add and remove items and then verify that the collection stats update not long after, and an "Updating" spinner icon is shown while the updates are being applied
- Verify that background jobs have been created and marked as successful in the database via API
- Verify that deleting crawls from an item updates related collections (can check modified timestamp + verify that index update job is run for dedupe index)

Nightly test run: https://github.com/webrecorder/browsertrix/actions/runs/23769472591