### PR TITLE
Ensure asyncio tasks aren't garbage collected before they complete

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -2,7 +2,6 @@
 
 import os
 from uuid import UUID, uuid4
-import asyncio
 from datetime import timedelta
 from typing import Optional, Tuple, List
 from passlib import pwd
@@ -22,7 +21,7 @@ from fastapi import (
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
 from .models import User, UserOut
-from .utils import dt_now
+from .utils import dt_now, run_async_task
 
 
 # ============================================================================
@@ -250,7 +249,7 @@ def init_jwt_auth(user_manager):
                             flush=True,
                         )
 
-                asyncio.create_task(send_reset_if_needed())
+                run_async_task(send_reset_if_needed())
 
             # any further attempt is a failure, increment to track further attempts
             # and avoid sending email again

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -1,6 +1,5 @@
 """k8s background jobs"""
 
-import asyncio
 import os
 import secrets
 from datetime import datetime
@@ -36,7 +35,7 @@ from .models import (
     CRAWL_TYPES,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import dt_now
+from .utils import dt_now, run_async_task
 
 if TYPE_CHECKING:
     from .orgs import OrgOps
@@ -83,20 +82,10 @@ class BackgroundJobOps:
             responses={404: {"description": "Not found"}},
         )
 
-        # to avoid background tasks being garbage collected
-        # see: https://stackoverflow.com/a/74059981
-        self.bg_tasks = set()
-
     def set_ops(self, base_crawl_ops: BaseCrawlOps, profile_ops: ProfileOps) -> None:
         """basecrawlops and profileops for updating files"""
         self.base_crawl_ops = base_crawl_ops
         self.profile_ops = profile_ops
-
-    def _run_task(self, func) -> None:
-        """add bg tasks to set to avoid premature garbage collection"""
-        task = asyncio.create_task(func)
-        self.bg_tasks.add(task)
-        task.add_done_callback(self.bg_tasks.discard)
 
     def strip_bucket(self, endpoint_url: str) -> tuple[str, str]:
         """split the endpoint_url into the origin and return rest of endpoint as bucket path"""
@@ -602,7 +591,7 @@ class BackgroundJobOps:
             if job.oid:
                 org = await self.org_ops.get_org_by_id(job.oid)
 
-            self._run_task(
+            run_async_task(
                 self.email.send_background_job_failed(
                     job, finished, superuser.email, org
                 )
@@ -854,28 +843,20 @@ class BackgroundJobOps:
     async def retry_failed_org_background_jobs(
         self, org: Organization
     ) -> Dict[str, Union[bool, Optional[str]]]:
-        """Retry all failed background jobs in an org
-
-        Keep track of tasks in set to prevent them from being garbage collected
-        See: https://stackoverflow.com/a/74059981
-        """
+        """Retry all failed background jobs in an org"""
         async for job in self.jobs.find({"oid": org.id, "success": False}):
-            self._run_task(self.retry_background_job(job["_id"], org))
+            run_async_task(self.retry_background_job(job["_id"], org))
         return {"success": True}
 
     async def retry_all_failed_background_jobs(
         self,
     ) -> Dict[str, Union[bool, Optional[str]]]:
-        """Retry all failed background jobs from all orgs
-
-        Keep track of tasks in set to prevent them from being garbage collected
-        See: https://stackoverflow.com/a/74059981
-        """
+        """Retry all failed background jobs from all orgs"""
         async for job in self.jobs.find({"success": False}):
             org = None
             if job.get("oid"):
                 org = await self.org_ops.get_org_by_id(job["oid"])
-            self._run_task(self.retry_background_job(job["_id"], org))
+            run_async_task(self.retry_background_job(job["_id"], org))
         return {"success": True}
 
 

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -49,7 +49,7 @@ from .models import (
     CRAWL_TYPES,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
-from .utils import dt_now, get_origin, date_to_str
+from .utils import dt_now, get_origin, date_to_str, run_async_task
 
 if TYPE_CHECKING:
     from .crawlconfigs import CrawlConfigOps
@@ -107,16 +107,6 @@ class BaseCrawlOps:
         self.background_job_ops = background_job_ops
         self.crawl_log_ops = crawl_log_ops
         self.page_ops = cast(PageOps, None)
-
-        # to avoid background tasks being garbage collected
-        # see: https://stackoverflow.com/a/74059981
-        self.bg_tasks = set()
-
-    def _run_task(self, func) -> None:
-        """add bg tasks to set to avoid premature garbage collection"""
-        task = asyncio.create_task(func)
-        self.bg_tasks.add(task)
-        task.add_done_callback(self.bg_tasks.discard)
 
     def set_page_ops(self, page_ops):
         """set page ops reference"""
@@ -328,7 +318,7 @@ class BaseCrawlOps:
         if update_values.get("reviewStatus"):
             crawl = BaseCrawl.from_dict(result)
 
-            self._run_task(
+            run_async_task(
                 self.event_webhook_ops.create_crawl_reviewed_notification(
                     crawl.id,
                     crawl.oid,
@@ -469,13 +459,13 @@ class BaseCrawlOps:
                         cids_to_update[cid]["successful"] = 0
 
             if type_ == "crawl":
-                self._run_task(
+                run_async_task(
                     self.event_webhook_ops.create_crawl_deleted_notification(
                         crawl_id, org
                     )
                 )
             if type_ == "upload":
-                self._run_task(
+                run_async_task(
                     self.event_webhook_ops.create_upload_deleted_notification(
                         crawl_id, org
                     )

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -9,7 +9,6 @@ from uuid import UUID, uuid4
 from typing import Optional, List, TYPE_CHECKING, cast, Dict, Any, Union
 import os
 
-import asyncio
 import pymongo
 import aiohttp
 from fastapi import Depends, HTTPException, Response
@@ -62,6 +61,7 @@ from .utils import (
     get_duplicate_key_error_field,
     get_origin,
     case_insensitive_collation,
+    run_async_task,
 )
 
 from .auth import get_custom_jwt_token
@@ -123,16 +123,6 @@ class CollectionOps:
             "DEDUPE_IMPORTER_CHANNEL", "default"
         )
 
-        # to avoid background tasks being garbage collected
-        # see: https://stackoverflow.com/a/74059981
-        self.bg_tasks = set()
-
-    def _run_task(self, func) -> None:
-        """add bg tasks to set to avoid premature garbage collection"""
-        task = asyncio.create_task(func)
-        self.bg_tasks.add(task)
-        task.add_done_callback(self.bg_tasks.discard)
-
     def set_crawl_ops(self, ops):
         """set crawl ops"""
         self.crawl_ops = ops
@@ -192,7 +182,7 @@ class CollectionOps:
                 await self.background_job_ops.create_update_collection_stats_job(
                     org.id, coll_id
                 )
-                self._run_task(
+                run_async_task(
                     self.event_webhook_ops.create_added_to_collection_notification(
                         crawl_ids, coll_id, org
                     )
@@ -290,7 +280,7 @@ class CollectionOps:
         if result.get("indexState"):
             await self.run_index_import_job(coll_id, org.id)
 
-        self._run_task(
+        run_async_task(
             self.event_webhook_ops.create_added_to_collection_notification(
                 crawl_ids, coll_id, org
             )
@@ -321,7 +311,7 @@ class CollectionOps:
         if result.get("indexState"):
             await self.run_index_import_job(coll_id, org.id)
 
-        self._run_task(
+        run_async_task(
             self.event_webhook_ops.create_removed_from_collection_notification(
                 crawl_ids, coll_id, org
             )
@@ -732,7 +722,7 @@ class CollectionOps:
         if result.deleted_count < 1:
             raise HTTPException(status_code=404, detail="collection_not_found")
 
-        self._run_task(
+        run_async_task(
             self.event_webhook_ops.create_collection_deleted_notification(coll_id, org)
         )
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -79,6 +79,7 @@ from .utils import (
     browser_windows_from_scale,
     case_insensitive_collation,
     crawler_image_below_minimum,
+    run_async_task,
 )
 
 if TYPE_CHECKING:
@@ -1996,7 +1997,7 @@ def init_crawl_config_api(
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
 
-        asyncio.create_task(ops.re_add_all_scheduled_cron_jobs())
+        run_async_task(ops.re_add_all_scheduled_cron_jobs())
         return {"success": True}
 
     @router.post("/validate/custom-behavior", response_model=SuccessResponse)

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -4,7 +4,6 @@ supports docker and kubernetes based deployments of multiple browsertrix-crawler
 """
 
 import os
-import asyncio
 import sys
 from typing import List, Optional
 
@@ -40,7 +39,7 @@ from .subs import init_subs_api
 from .file_uploads import init_file_uploads_api
 
 from .crawlmanager import CrawlManager
-from .utils import register_exit_handler, is_bool
+from .utils import register_exit_handler, is_bool, run_async_task
 from .version import __version__
 
 API_PREFIX = "/api"
@@ -50,7 +49,6 @@ OPENAPI_URL = API_PREFIX + "/openapi.json"
 app_root = FastAPI(docs_url=None, redoc_url=None, OPENAPI_URL=OPENAPI_URL)
 
 db_inited = {"inited": False}
-
 
 tags = [
     "crawlconfigs",
@@ -298,9 +296,9 @@ def main() -> None:
     coll_ops.set_page_ops(page_ops)
 
     # await db init, migrations should have already completed in init containers
-    asyncio.create_task(await_db_and_migrations(mdb, db_inited))
+    run_async_task(await_db_and_migrations(mdb, db_inited))
 
-    asyncio.create_task(background_job_ops.ensure_cron_cleanup_jobs_exist())
+    run_async_task(background_job_ops.ensure_cron_cleanup_jobs_exist())
 
     app.include_router(org_ops.router)
 

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -1,6 +1,5 @@
 """Base Operator class for all operators"""
 
-import asyncio
 import os
 import json
 from typing import TYPE_CHECKING, Any
@@ -186,19 +185,10 @@ class BaseOperator:
         self.user_ops = crawl_config_ops.user_manager
         self.crawl_log_ops = crawl_log_ops
 
-        # to avoid background tasks being garbage collected
-        # see: https://stackoverflow.com/a/74059981
-        self.bg_tasks = set()
         self.fast_retry_secs = int(os.environ.get("FAST_RETRY_SECS") or 0)
 
     def init_routes(self, app) -> None:
         """init routes for this operator"""
-
-    def run_task(self, func) -> None:
-        """add bg tasks to set to avoid premature garbage collection"""
-        task = asyncio.create_task(func)
-        self.bg_tasks.add(task)
-        task.add_done_callback(self.bg_tasks.discard)
 
     def is_configmap_update_needed(self, path: str, configmap: dict[str, Any]):
         """check if any presigned resources in this configmap have expired"""

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -20,6 +20,7 @@ from btrixcloud.utils import (
     gb_storage_ceil,
     gb_storage_floor,
     is_bool,
+    run_async_task,
 )
 from btrixcloud.models import (
     TYPE_DEDUPE_INDEX_STATES,
@@ -203,7 +204,7 @@ class CollIndexOperator(BaseOperator):
             if self.is_expired(status) or data.finalizing:
                 # do actual deletion here
                 if not data.finalizing:
-                    self.run_task(self.do_delete(coll_id))
+                    run_async_task(self.do_delete(coll_id))
 
                 # Saving process
                 # 1. run bgsave while redis is active

--- a/backend/btrixcloud/operator/collindexjob.py
+++ b/backend/btrixcloud/operator/collindexjob.py
@@ -1,5 +1,7 @@
 """Operator handler for Dedupe Index Import Job"""
 
+from btrixcloud.utils import run_async_task
+
 from .models import (
     MCBaseRequest,
     MCDecoratorSyncData,
@@ -74,7 +76,7 @@ class CollIndexImportJobOperator(BaseOperator):
 
         # delete succeeded job
         if data.object.get("status", {}).get("succeeded", 0) >= 1:
-            self.run_task(self.k8s.delete_job(name))
+            run_async_task(self.k8s.delete_job(name))
             attachments = []
 
         return MCDecoratorSyncResponse(attachments=attachments)

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -40,6 +40,7 @@ from btrixcloud.utils import (
     dt_now,
     scale_from_browser_windows,
     crawler_image_below_minimum,
+    run_async_task,
 )
 
 from .baseoperator import BaseOperator, Redis
@@ -221,7 +222,7 @@ class CrawlOperator(BaseOperator):
             print(
                 f"warn crawl {crawl_id} finished but not deleted, post-finish taking too long?"
             )
-            self.run_task(self.k8s.delete_crawl_job(crawl.id))
+            run_async_task(self.k8s.delete_crawl_job(crawl.id))
             return await self.finalize_response(
                 crawl,
                 status,
@@ -909,7 +910,7 @@ class CrawlOperator(BaseOperator):
             print(f"============== POD STATUS: {name} ==============")
             pprint(pods[name]["status"])
 
-        self.run_task(self.k8s.print_pod_logs(pod_names, self.log_failed_crawl_lines))
+        run_async_task(self.k8s.print_pod_logs(pod_names, self.log_failed_crawl_lines))
 
         return True
 
@@ -959,7 +960,7 @@ class CrawlOperator(BaseOperator):
                 finalized = True
 
         if finalized and crawl.is_qa:
-            self.run_task(self.crawl_ops.qa_run_finished(crawl.db_crawl_id))
+            run_async_task(self.crawl_ops.qa_run_finished(crawl.db_crawl_id))
 
         return {
             "status": status.dict(exclude_none=True),
@@ -1196,13 +1197,13 @@ class CrawlOperator(BaseOperator):
             print("Crawl first started, webhooks called", now, crawl.id)
             # call initial running webhook
             if not crawl.qa_source_crawl_id:
-                self.run_task(
+                run_async_task(
                     self.event_webhook_ops.create_crawl_started_notification(
                         crawl.id, crawl.oid, scheduled=crawl.scheduled
                     )
                 )
             else:
-                self.run_task(
+                run_async_task(
                     self.event_webhook_ops.create_qa_analysis_started_notification(
                         crawl.id, crawl.oid, crawl.qa_source_crawl_id
                     )
@@ -1496,7 +1497,7 @@ class CrawlOperator(BaseOperator):
             return reason
 
         print(f"request pause for {reason}")
-        self.run_task(self.crawl_ops.pause_crawl(crawl.id, crawl.org, pause=True))
+        run_async_task(self.crawl_ops.pause_crawl(crawl.id, crawl.org, pause=True))
         return None
 
     async def get_redis_crawl_stats(
@@ -1786,11 +1787,11 @@ class CrawlOperator(BaseOperator):
 
         # Regular Crawl Finished
         if not crawl.is_qa:
-            self.run_task(self.do_crawl_finished_tasks(crawl, status, state, stats))
+            run_async_task(self.do_crawl_finished_tasks(crawl, status, state, stats))
 
         # QA Run Finished
         else:
-            self.run_task(self.do_qa_run_finished_tasks(crawl, state))
+            run_async_task(self.do_qa_run_finished_tasks(crawl, state))
 
         return True
 

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from typing import Optional
 import yaml
 
-from btrixcloud.utils import date_to_str, dt_now
+from btrixcloud.utils import date_to_str, dt_now, run_async_task
 from .models import MCDecoratorSyncData, CJS, MCDecoratorSyncResponse
 from .baseoperator import BaseOperator
 
@@ -43,7 +43,7 @@ class CronJobOperator(BaseOperator):
                 "completionTime": finished,
             }
 
-        self.run_task(self.k8s.unsuspend_k8s_job(metadata.get("name")))
+        run_async_task(self.k8s.unsuspend_k8s_job(metadata.get("name")))
 
         return MCDecoratorSyncResponse(
             attachments=[],

--- a/backend/btrixcloud/operator/profiles.py
+++ b/backend/btrixcloud/operator/profiles.py
@@ -1,6 +1,6 @@
 """Operator handler for ProfileJobs"""
 
-from btrixcloud.utils import str_to_date, dt_now
+from btrixcloud.utils import str_to_date, dt_now, run_async_task
 
 from btrixcloud.models import StorageRef
 
@@ -27,7 +27,7 @@ class ProfileOperator(BaseOperator):
         browserid = spec.get("id")
 
         if expire_time and dt_now() >= expire_time:
-            self.run_task(self.k8s.delete_profile_browser(browserid))
+            run_async_task(self.k8s.delete_profile_browser(browserid))
             return {"status": {}, "children": []}
 
         params = {}

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -13,7 +13,6 @@ from typing import (
 )
 from uuid import UUID, uuid4
 import os
-import asyncio
 import json
 
 from urllib.parse import urlencode
@@ -49,7 +48,7 @@ from .models import (
     ListFilterType,
     ProfileSearchValuesResponse,
 )
-from .utils import dt_now, str_to_date, case_insensitive_collation
+from .utils import dt_now, str_to_date, case_insensitive_collation, run_async_task
 
 if TYPE_CHECKING:
     from .orgs import OrgOps
@@ -79,8 +78,6 @@ class ProfileOps:
     browser_fqdn_suffix: str
     router: APIRouter
 
-    bg_tasks: set
-
     def __init__(self, mdb, orgs, crawl_manager, storage_ops, background_job_ops):
         self.profiles = mdb["profiles"]
         self.orgs = orgs
@@ -98,10 +95,6 @@ class ProfileOps:
         )
 
         self.crawlconfigs = cast(CrawlConfigOps, None)
-
-        # to avoid background tasks being garbage collected
-        # see: https://stackoverflow.com/a/74059981
-        self.bg_tasks = set()
 
     def set_crawlconfigs(self, crawlconfigs):
         """set crawlconfigs ops"""
@@ -253,7 +246,7 @@ class ProfileOps:
         self.orgs.can_write_data(org, include_time=False)
 
         if not metadata.committing:
-            self._run_task(
+            run_async_task(
                 self.do_commit_to_profile(
                     metadata=metadata,
                     browser_commit=browser_commit,
@@ -701,12 +694,6 @@ class ProfileOps:
         # Remove empty strings
         names = [name for name in names if name]
         return {"names": names}
-
-    def _run_task(self, func) -> None:
-        """add bg tasks to set to avoid premature garbage collection"""
-        task = asyncio.create_task(func)
-        self.bg_tasks.add(task)
-        task.add_done_callback(self.bg_tasks.discard)
 
 
 # ============================================================================

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -50,7 +50,7 @@ from .models import (
     REASON_CANCELED,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import dt_now
+from .utils import dt_now, run_async_task
 
 
 # if set, will enable this api
@@ -141,7 +141,7 @@ class SubOps:
             )
 
         if update.futureCancelDate and self.should_send_cancel_email(org, update):
-            asyncio.create_task(self.send_cancel_emails(update.futureCancelDate, org))
+            run_async_task(self.send_cancel_emails(update.futureCancelDate, org))
 
         return {"updated": True}
 

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -4,7 +4,6 @@ import uuid
 from urllib.parse import unquote
 from uuid import UUID
 
-import asyncio
 from io import BufferedReader
 from typing import Optional, List, Any
 from fastapi import Depends, UploadFile, File
@@ -31,7 +30,7 @@ from .models import (
     TagsResponse,
 )
 from .pagination import paginated_format, DEFAULT_PAGE_SIZE
-from .utils import dt_now
+from .utils import dt_now, run_async_task
 
 
 # ============================================================================
@@ -188,11 +187,11 @@ class UploadOps(BaseCrawlOps):
             {"_id": crawl_id}, {"$set": uploaded.to_dict()}, upsert=True
         )
 
-        asyncio.create_task(
+        run_async_task(
             self.event_webhook_ops.create_upload_finished_notification(crawl_id, org.id)
         )
 
-        asyncio.create_task(
+        run_async_task(
             self._add_pages_and_update_collections(crawl_id, org.id, collections)
         )
 

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -4,7 +4,6 @@ FastAPI user handling (via fastapi-users)
 
 import os
 from uuid import UUID, uuid4
-import asyncio
 
 from typing import Optional, List, TYPE_CHECKING, cast, Callable, Tuple, Type
 
@@ -39,7 +38,7 @@ from .models import (
     PaginatedUserOutResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import is_bool, dt_now
+from .utils import is_bool, dt_now, run_async_task
 
 from .auth import (
     init_jwt_auth,
@@ -161,7 +160,7 @@ class UserManager:
                 default_register_org, user.id, UserRole.CRAWLER
             )
 
-            asyncio.create_task(self.request_verify(user, request))
+            run_async_task(self.request_verify(user, request))
 
         return user
 

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -30,6 +30,10 @@ browsers_per_pod = int(os.environ.get("NUM_BROWSERS", 1))
 
 case_insensitive_collation = Collation(locale="en", strength=1)
 
+# to avoid background tasks being garbage collected
+# see: https://stackoverflow.com/a/74059981
+bg_tasks = set()
+
 
 class JSONSerializer(json.JSONEncoder):
     """Serializer class for json.dumps with UUID and datetime support"""
@@ -250,3 +254,10 @@ def gb_storage_floor(storage: float) -> str:
     """approx min GB storage, rounded up"""
     gb = math.floor(storage / 1_000_000_000)
     return f"{gb}Gi"
+
+
+def run_async_task(func) -> None:
+    """add bg task to set to avoid premature garbage collection"""
+    task = asyncio.create_task(func)
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -1,6 +1,5 @@
 """Webhook management"""
 
-import asyncio
 from typing import List, Union, Optional, TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
@@ -27,7 +26,7 @@ from .models import (
     Organization,
     QARun,
 )
-from .utils import dt_now
+from .utils import dt_now, run_async_task
 
 if TYPE_CHECKING:
     from .orgs import OrgOps
@@ -601,7 +600,7 @@ def init_event_webhooks_api(mdb, org_ops, app):
         org: Organization = Depends(org_owner_dep),
     ):
         notification = await ops.get_notification(org, notificationid)
-        asyncio.create_task(ops.send_notification(org, notification))
+        run_async_task(ops.send_notification(org, notification))
         return {"success": True}
 
     init_openapi_webhooks(app)


### PR DESCRIPTION
Fixes #3240 

Prevents common but problematic Python behavior which affects `asyncio.create_task` fire-and-forget tasks, occasionally garbage collecting them before the tasks can finish or even start in some cases.

- Ensures all instances of `asyncio.create_task` add their tasks to a set to avoid premature garbage collection
- Centralizes this into a single set and helper function in `utils.py` to avoid unnecessary duplication throughout the backend

Follows on https://github.com/webrecorder/browsertrix/pull/3241, will need rebase on main after that's merged