### PR TITLE
Add Rate-Limit Detected State and User Warning

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -244,7 +244,7 @@ class UserOrgInfoOut(BaseModel):
 
 # ============================================================================
 TYPE_RUNNING_STATES = Literal[
-    "running", "pending-wait", "generate-wacz", "uploading-wacz"
+    "running", "pending-wait", "generate-wacz", "uploading-wacz", "rate-limited"
 ]
 RUNNING_STATES = get_args(TYPE_RUNNING_STATES)
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -269,6 +269,7 @@ TYPE_AUTO_PAUSED_STATES = Literal[
     "paused_storage_quota_reached",
     "paused_time_quota_reached",
     "paused_org_readonly",
+    "paused_rate_limit_time_reached",
 ]
 
 AUTO_PAUSED_STATES = get_args(TYPE_AUTO_PAUSED_STATES)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -259,7 +259,7 @@ class UserOrgInfoOut(BaseModel):
 
 # ============================================================================
 TYPE_RUNNING_STATES = Literal[
-    "running", "pending-wait", "generate-wacz", "uploading-wacz"
+    "running", "pending-wait", "generate-wacz", "uploading-wacz", "rate-limited"
 ]
 RUNNING_STATES = get_args(TYPE_RUNNING_STATES)
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1511,6 +1511,7 @@ class CrawlOperator(BaseOperator):
         pipe.hgetall(f"{crawl_id}:size")
         pipe.get(f"{crawl_id}:profileUploaded")
         pipe.smembers(f"{crawl_id}:reqCrawls")
+        pipe.get(f"{crawl_id}:rateLimited")
 
         results = await pipe.execute()
 
@@ -1530,6 +1531,7 @@ class CrawlOperator(BaseOperator):
 
         profile_update = results[5]
         req_crawls = results[6]
+        rate_limited = results[7] == "1"
 
         stats = OpCrawlStats(
             found=pages_found,
@@ -1537,6 +1539,7 @@ class CrawlOperator(BaseOperator):
             size=archive_size,
             profile_update=profile_update,
             req_crawls=req_crawls,
+            rate_limited=rate_limited,
         )
         return stats, sizes
 
@@ -1709,6 +1712,8 @@ class CrawlOperator(BaseOperator):
         else:
             new_status: TYPE_RUNNING_STATES = "running"
 
+            if stats.rate_limited:
+                new_status = "rate-limited"
             if status_count.get("generate-wacz"):
                 new_status = "generate-wacz"
             elif status_count.get("uploading-wacz"):

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -358,7 +358,6 @@ class CrawlOperator(BaseOperator):
                 status.stopReason = stop_reason
                 await self.mark_finished(crawl, status, state)
 
-
         children = self._load_redis(params, status, crawl, data.children)
 
         storage_path = crawl.storage.get_storage_extra_path(oid)
@@ -1968,7 +1967,6 @@ class CrawlOperator(BaseOperator):
             await self.set_state(
                 new_status, status, crawl, allowed_from=RUNNING_AND_WAITING_STATES
             )
-
 
         return status
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -295,8 +295,11 @@ class CrawlOperator(BaseOperator):
                     "starting", status, crawl, allowed_from=["waiting_dedupe_index"]
                 )
 
-        # clear this here if no longer in 'rate-limited' state
-        if status.rateLimitedAtTime and status.state != "rate-limited":
+        # clear rateLimitedAtTime if crawl in a non-rate limited running state or already paused
+        if status.rateLimitedAtTime and (
+            (status.state != "rate-limited" and status.state in RUNNING_STATES)
+            or crawl.paused_at
+        ):
             status.rateLimitedAtTime = ""
 
         status.scale = len(pods)

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1707,6 +1707,7 @@ class CrawlOperator(BaseOperator):
         pipe.hgetall(f"{crawl_id}:size")
         pipe.get(f"{crawl_id}:profileUploaded")
         pipe.smembers(f"{crawl_id}:reqCrawls")
+        pipe.get(f"{crawl_id}:rateLimited")
 
         results = await pipe.execute()
 
@@ -1726,6 +1727,7 @@ class CrawlOperator(BaseOperator):
 
         profile_update = results[5]
         req_crawls = results[6]
+        rate_limited = results[7] == "1"
 
         stats = OpCrawlStats(
             found=pages_found,
@@ -1733,6 +1735,7 @@ class CrawlOperator(BaseOperator):
             size=archive_size,
             profile_update=profile_update,
             req_crawls=req_crawls,
+            rate_limited=rate_limited,
         )
         return stats, sizes
 
@@ -1921,6 +1924,8 @@ class CrawlOperator(BaseOperator):
         else:
             new_status: TYPE_RUNNING_STATES = "running"
 
+            if stats.rate_limited:
+                new_status = "rate-limited"
             if status_count.get("generate-wacz"):
                 new_status = "generate-wacz"
             elif status_count.get("uploading-wacz"):

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -295,6 +295,10 @@ class CrawlOperator(BaseOperator):
                     "starting", status, crawl, allowed_from=["waiting_dedupe_index"]
                 )
 
+        # clear this here if no longer in 'rate-limited' state
+        if status.rateLimitedAtTime and status.state != "rate-limited":
+            status.rateLimitedAtTime = ""
+
         status.scale = len(pods)
         if status.scale:
             for pod_name, pod in pods.items():
@@ -354,8 +358,6 @@ class CrawlOperator(BaseOperator):
                 status.stopReason = stop_reason
                 await self.mark_finished(crawl, status, state)
 
-            # clear rate limited at time, to be reset on future resume
-            status.rateLimitedAtTime = ""
 
         children = self._load_redis(params, status, crawl, data.children)
 
@@ -1967,8 +1969,6 @@ class CrawlOperator(BaseOperator):
                 new_status, status, crawl, allowed_from=RUNNING_AND_WAITING_STATES
             )
 
-            if status.rateLimitedAtTime and new_status == "running":
-                status.rateLimitedAtTime = ""
 
         return status
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -102,6 +102,8 @@ class CrawlOperator(BaseOperator):
 
     paused_expires_delta: timedelta
 
+    rate_limit_duration_delta: timedelta | None = None
+
     def __init__(self, *args):
         super().__init__(*args)
 
@@ -123,6 +125,15 @@ class CrawlOperator(BaseOperator):
         )
 
         self.paused_expires_delta = timedelta(minutes=paused_crawl_limit_minutes)
+
+        rate_limit_duration_minutes = int(
+            os.environ.get("RATE_LIMIT_DURATION_MINUTES") or 0
+        )
+
+        if rate_limit_duration_minutes:
+            self.rate_limit_duration_delta = timedelta(
+                minutes=rate_limit_duration_minutes
+            )
 
     def init_routes(self, app):
         """init routes for this operator"""
@@ -342,6 +353,9 @@ class CrawlOperator(BaseOperator):
                 status.stopping = True
                 status.stopReason = stop_reason
                 await self.mark_finished(crawl, status, state)
+
+            # clear rate limited at time, to be reset on future resume
+            status.rateLimitedAtTime = ""
 
         children = self._load_redis(params, status, crawl, data.children)
 
@@ -1631,7 +1645,7 @@ class CrawlOperator(BaseOperator):
         return filecomplete.size
 
     async def is_crawl_stopping(
-        self, crawl: CrawlSpec, status: CrawlStatus
+        self, crawl: CrawlSpec, status: CrawlStatus, stats: OpCrawlStats
     ) -> StopReason | None:
         """check if crawl is stopping and set reason"""
         # if user requested stop, then enter stopping phase
@@ -1671,6 +1685,18 @@ class CrawlOperator(BaseOperator):
         # pause crawl if execution time quota is reached
         if self.org_ops.exec_mins_quota_reached(org):
             return self.request_pause_crawl("paused_time_quota_reached", crawl)
+
+        if (
+            stats.rate_limited
+            and status.rateLimitedAtTime
+            and self.rate_limit_duration_delta
+        ):
+            rate_limited_at = str_to_date(status.rateLimitedAtTime)
+            if (
+                rate_limited_at
+                and (dt_now() - rate_limited_at) > self.rate_limit_duration_delta
+            ):
+                return self.request_pause_crawl("paused_rate_limit_time_reached", crawl)
 
         if crawl.paused_at and status.stopReason not in PAUSED_STATES:
             return "paused"
@@ -1814,7 +1840,7 @@ class CrawlOperator(BaseOperator):
             await redis.delete(f"{crawl.id}:paused")
 
         if not status.stopping:
-            status.stopReason = await self.is_crawl_stopping(crawl, status)
+            status.stopReason = await self.is_crawl_stopping(crawl, status, stats)
             status.stopping = status.stopReason is not None
 
         # mark crawl as pausing or stopping
@@ -1865,6 +1891,8 @@ class CrawlOperator(BaseOperator):
                     paused_state = "paused_storage_quota_reached"
                 elif status.stopReason == "paused_time_quota_reached":
                     paused_state = "paused_time_quota_reached"
+                elif status.stopReason == "paused_rate_limit_time_reached":
+                    paused_state = "paused_rate_limit_time_reached"
                 elif status.stopReason == "paused_org_readoly":
                     paused_state = "paused_org_readonly"
                 else:
@@ -1926,6 +1954,8 @@ class CrawlOperator(BaseOperator):
 
             if stats.rate_limited:
                 new_status = "rate-limited"
+                if not status.rateLimitedAtTime:
+                    status.rateLimitedAtTime = date_to_str(dt_now())
             if status_count.get("generate-wacz"):
                 new_status = "generate-wacz"
             elif status_count.get("uploading-wacz"):
@@ -1936,6 +1966,9 @@ class CrawlOperator(BaseOperator):
             await self.set_state(
                 new_status, status, crawl, allowed_from=RUNNING_AND_WAITING_STATES
             )
+
+            if status.rateLimitedAtTime and new_status == "running":
+                status.rateLimitedAtTime = ""
 
         return status
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -295,10 +295,14 @@ class CrawlOperator(BaseOperator):
                     "starting", status, crawl, allowed_from=["waiting_dedupe_index"]
                 )
 
+        # paused_at is set, and state is a valid paused state
+        is_paused = bool(crawl.paused_at) and status.state in PAUSED_STATES
+
         # clear rateLimitedAtTime if crawl in a non-rate limited running state or already paused
-        if status.rateLimitedAtTime and (
-            (status.state != "rate-limited" and status.state in RUNNING_STATES)
-            or crawl.paused_at
+        if (
+            status.rateLimitedAtTime
+            and status.state != "rate-limited"
+            and (is_paused or (status.state in RUNNING_STATES))
         ):
             status.rateLimitedAtTime = ""
 
@@ -447,9 +451,6 @@ class CrawlOperator(BaseOperator):
 
         if status.pagesFound < status.desiredScale:
             status.desiredScale = max(1, status.pagesFound)
-
-        # paused_at is set, and state is a valid paused state
-        is_paused = bool(crawl.paused_at) and status.state in PAUSED_STATES
 
         for i in range(0, status.desiredScale):
             if status.pagesFound < i * num_browsers_per_pod:

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -218,6 +218,7 @@ class OpCrawlStats(CrawlStats):
     """crawl stats + internal profile update"""
 
     profile_update: Optional[str] = ""
+    rate_limited: Optional[bool] = False
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -35,6 +35,7 @@ StopReason = Literal[
     "stopped_org_readonly",
     "paused_storage_quota_reached",
     "paused_time_quota_reached",
+    "paused_rate_limit_time_reached",
     "paused_org_readonly",
 ]
 
@@ -273,6 +274,9 @@ class CrawlStatus(BaseModel):
 
     # any pods exited
     anyCrawlPodNewExit: bool | None = Field(default=False, exclude=True)
+
+    # if status is 'rate-limited', when first became rate-limited
+    rateLimitedAtTime: str | None = None
 
     # don't include in status, use by metacontroller
     resync_after: int | None = Field(default=None, exclude=True)

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -219,6 +219,7 @@ class OpCrawlStats(CrawlStats):
     """crawl stats + internal profile update"""
 
     profile_update: str | None = ""
+    rate_limited: bool | None = False
 
 
 # ============================================================================

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -142,7 +142,7 @@ metadata:
   namespace: {{ .Values.crawler_namespace }}
 
 data:
-  {{- define "btrix.crawler_args" }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --logBehaviorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }} {{- end }}
+  {{- define "btrix.crawler_args" }} --sizeLimit {{ .Values.crawler_session_size_limit_bytes }} --timeLimit {{ .Values.crawler_session_time_limit_seconds }} --maxPageLimit {{ .Values.max_pages_per_crawl | default 0 }} --healthCheckPort {{ .Values.crawler_liveness_port }} --diskUtilization {{ .Values.disk_utilization_threshold }} --logging {{ .Values.crawler_logging_opts }} --text {{ .Values.crawler_extract_full_text }} --rateLimitInterruptCount {{ .Values.rate_limit_threshold }} --generateWACZ --collection thecrawl --screencastPort 9037 --logErrorsToRedis --logBehaviorsToRedis --writePagesToRedis --restartsOnError --headless --screenshot view,thumbnail {{ .Values.crawler_extra_args }} {{- end }}
 
   CRAWL_ARGS: {{- include "btrix.crawler_args" . }}
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -127,6 +127,8 @@ data:
 
   DEDUPE_FEATURE_ENABLED_DEFAULT: "{{ .Values.dedupe.default_enabled }}"
 
+  RATE_LIMIT_DURATION_MINUTES: "{{ .Values.rate_limit_max_duration_minutes }}"
+
 
   {{- if .Values.available_plans }}
   AVAILABLE_PLANS: {{ .Values.available_plans | toJson }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -91,6 +91,10 @@ invite_expire_seconds: "1209600"
 # number of minutes before paused crawls are stopped - default is 7 days
 paused_crawl_limit_minutes: 10080
 
+# number of minutes before a rate-limited crawl will be marked as paused - default is 12 hours
+# set to 0 to disable
+rate_limit_max_duration_minutes: 720
+
 # base url for replayweb.page
 rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage/"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,6 +95,10 @@ paused_crawl_limit_minutes: 10080
 # set to 0 to disable
 rate_limit_max_duration_minutes: 720
 
+# Number of consecutive rate limited pages after which the crawl
+# will enter 'rate-limited' state and will be interrupted
+rate_limit_threshold: 5
+
 # base url for replayweb.page
 rwp_base_url: "https://cdn.jsdelivr.net/npm/replaywebpage/"
 

--- a/frontend/docs/docs/user-guide/crawl-workflows.md
+++ b/frontend/docs/docs/user-guide/crawl-workflows.md
@@ -48,11 +48,12 @@ Statuses may be displayed with a reason that details how the current status came
 | <span class="status-violet-600">:bootstrap-hourglass-split: Waiting: _Reason_</span> | The workflow run is queued for one of the following reasons:<br/>**At Crawl Limit**: Org has reached maximum number of concurrent crawls<br/>**Dedupe Index**: An update to the deduplication index is in progress |
 | <span class="status-violet-600">:btrix-status-dot: Starting</span> | The crawler is being initialized. Crawling will begin shortly. |
 | <span class="status-green-600">:btrix-status-dot: Running</span> | The crawler is visiting and archiving pages. |
-| <span class="status-amber-600">:bootstrap-exclamation-triangle-fill: Rate Limited</span> | The crawler has detected [rate limiting](running-crawl.md#rate-limit-detection) from the sites that are being crawled and is running more slowly. |
+| <span class="status-amber-600">:btrix-status-dot: Running (Rate Limited)</span> | The crawler is running more slowly to capture [rate limited](running-crawl.md#rate-limit-detection) webpages. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing</span> | The crawler has been instructed to pause and is finishing crawl of the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Finishing Downloads)</span> | The crawler is finalizing downloads on the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Creating WACZ)</span> | Pages crawled so far are being packaged into WACZ files and transferred to storage. |
 | <span class="status-neutral-500">:bootstrap-pause-circle: Paused</span> | The workflow run has been paused by a user. It can be resumed for up to 7 days; afterwards, the run stops. |
+| <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout</span> | The workflow run has been paused automatically due to being [rate limited](running-crawl.md#rate-limit-detection) for too long. |
 | <span class="status-neutral-500">:bootstrap-pause-circle: Paused: _Reason_</span> | The workflow run has been paused automatically due to an enforced limit, as specified in the reason. |
 | <span class="status-violet-600">:bootstrap-play-circle: Resuming</span> | The workflow run is starting back up after being paused. |
 | <span class="status-violet-600">:btrix-status-dot: Stopping</span> | The crawler has been instructed to stop and is finishing crawl of the current page.|

--- a/frontend/docs/docs/user-guide/crawl-workflows.md
+++ b/frontend/docs/docs/user-guide/crawl-workflows.md
@@ -48,6 +48,7 @@ Statuses may be displayed with a reason that details how the current status came
 | <span class="status-violet-600">:bootstrap-hourglass-split: Waiting: _Reason_</span> | The workflow run is queued for one of the following reasons:<br/>**At Crawl Limit**: Org has reached maximum number of concurrent crawls<br/>**Dedupe Index**: An update to the deduplication index is in progress |
 | <span class="status-violet-600">:btrix-status-dot: Starting</span> | The crawler is being initialized. Crawling will begin shortly. |
 | <span class="status-green-600">:btrix-status-dot: Running</span> | The crawler is visiting and archiving pages. |
+| <span class="status-amber-600">:bootstrap-exclamation-triangle-fill: Rate Limited</span> | The crawler has detected [rate limiting](running-crawl.md#rate-limit-detection) from the sites that are being crawled and is running more slowly. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing</span> | The crawler has been instructed to pause and is finishing crawl of the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Finishing Downloads)</span> | The crawler is finalizing downloads on the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Creating WACZ)</span> | Pages crawled so far are being packaged into WACZ files and transferred to storage. |

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -37,6 +37,28 @@ To resume a paused crawl, simply click the _Resume_ button. The crawl status wil
 ???+ Note
     Paused crawls that are not resumed within 7 days of being paused are automatically updated to _Stopped_. Once stopped, the crawl is finished and can no longer be resumed.
 
+## Rate Limit Detection
+
+A site may 'rate limit' a crawl by returning error codes or showing CAPTCHA pages. Browsertrix will automatically
+attempt to detect such error pages, and skip archiving them. If enough consecutive error pages are show, the
+crawl will enter into a <span class="status-amber-600">:bootstrap-exclamation-triangle-fill: Rate Limited</span> state, indicating that the crawl is being rate limited by the current site.
+
+In this state, the crawler will slow down and retry at slower interval, up to once every 5 minutes. Pages that were
+not captured before will be queued to be retried.
+
+While rate limited, the crawler will use only a few seconds of crawling time to check if it is still rate limited,
+thus avoiding wasting crawling minutes on rate limited pages.
+
+If the crawl remains rate limited for an extended period of time (12 hours by default), it may revert to a <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout Reached</span>
+state to avoid running indefinitely.
+
+While a crawl is rate limited, there is not much Browsertrix can do, unfortunately. Occasionally, adding a [browser profile](browser-profiles/browser-profiles-overview.md) or configuring a [proxy server](../workflow-setup/#crawler-proxy-server) (if available) may help reduce rate limit for certain sites, while other sites may require permission to be crawled, such as allow-listing the IP address range(s) used by Browsertrix. If Browsertrix detects that the crawler is no longer being rate limited, the crawl status will switch back to *Running*.
+
+???+ Note
+    If you are a customer of our service and need help with rate limits on your own site, please reach out to [Support](support@webrecorder.org) and we may be able to assist.
+    
+
+
 ## End a Crawl
 
 If a crawl workflow is not crawling websites as intended it may be preferable to end crawling operations and update the crawl workflow's settings before trying again. There are two operations to end crawls, available both on the workflow's details page, or as part of the actions menu in the workflow list.

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -39,25 +39,23 @@ To resume a paused crawl, simply click the _Resume_ button. The crawl status wil
 
 ## Rate Limit Detection
 
-A site may 'rate limit' a crawl by returning error codes or showing CAPTCHA pages. Browsertrix will automatically
-attempt to detect such error pages, and skip archiving them. If enough consecutive error pages are show, the
-crawl will enter into a <span class="status-amber-600">:bootstrap-exclamation-triangle-fill: Rate Limited</span> state, indicating that the crawl is being rate limited by the current site.
+A website may limit the number of requests it receives in a given amount of time. This practice is called [rate limiting](https://en.wikipedia.org/wiki/Rate_limiting) and it can improve server performance, mitigate network attacks, and reduce spam traffic.
 
-In this state, the crawler will slow down and retry at slower interval, up to once every 5 minutes. Pages that were
-not captured before will be queued to be retried.
+Rate limiting can also make pages harder to archive: when a visitor (human, bot, or crawler) is rate limited by a website, they may see an error or [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) page instead of the actual page content for the given URL. Browsertrix attempts to capture only actual page content (i.e. prevent including error pages in an archive) by automatically detecting and temporarily skipping such error pages.
 
-While rate limited, the crawler will use only a few seconds of crawling time to check if it is still rate limited,
-thus avoiding wasting crawling minutes on rate limited pages.
+If too many error pages are encountered, the crawler adapts by slowing down and retrying the page URL after a longer delay. This behavior is distinct from the [page delay](workflow-setup.md#delay-before-next-page) workflow setting, which can reduce the chance of being rate limited by increasing the time spent on each page, at the cost of increasing the overall crawl time.
 
-If the crawl remains rate limited for an extended period of time (12 hours by default), it may revert to a <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout Reached</span>
-state to avoid running indefinitely.
+Unfortunately, there is not much Browsertrix can do to prevent being rate limited altogether. Adding a [browser profile](browser-profiles/browser-profiles-overview.md) or configuring a [proxy server](workflow-setup.md#crawler-proxy-server) may help reduce rate limits for certain sites, while other sites may need to provide explicit permission to be crawled, thus requiring the list of IP ranges used by Browsertrix.
 
-While a crawl is rate limited, there is not much Browsertrix can do, unfortunately. Occasionally, adding a [browser profile](browser-profiles/browser-profiles-overview.md) or configuring a [proxy server](../workflow-setup/#crawler-proxy-server) (if available) may help reduce rate limit for certain sites, while other sites may require permission to be crawled, such as allow-listing the IP address range(s) used by Browsertrix. If Browsertrix detects that the crawler is no longer being rate limited, the crawl status will switch back to *Running*.
+???+ "Allow-listing Browsertrix on your website"
+    `Paid Feature`{ .badge-green }
+    If you subscribe to hosted Browsertrix and need help with being rate limited by your own website, please reach out to [support](support@webrecorder.org) for assistance.
 
-???+ Note
-    If you are a customer of our service and need help with rate limits on your own site, please reach out to [Support](support@webrecorder.org) and we may be able to assist.
-    
+### Rate Limited Workflow Status
 
+If the crawler can no longer continue by skipping error pages while being rate limited, it will switch to a time-delay-based strategy to continue running. The workflow status during this state will be <span class="status-amber-600">:btrix-status-dot: Running (Rate Limited)</span>. In this state, the crawler will slow down and retry the page URL at longer intervals, up to once every 5 minutes. Pages that were not captured before will be queued to be retried. Crawls in this state will only use a few seconds of crawl time to check that it is still rate limited, thus avoiding wasting execution minutes on error pages.
+
+If the crawl remains rate limited for an extended period of time (12 hours by default), the crawl may be automatically paused to avoid retrying indefinitely. The workflow status will then be <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout</span>.
 
 ## End a Crawl
 

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -126,6 +126,16 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Running");
         break;
 
+      case "rate-limited":
+        color = "var(--warning)";
+        icon = html`<sl-icon
+          name="exclamation-triangle-fill"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Rate Limited");
+        break;
+
       case "stopping":
         color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -147,6 +147,16 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Running");
         break;
 
+      case "rate-limited":
+        color = "var(--warning)";
+        icon = html`<sl-icon
+          name="exclamation-triangle-fill"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Rate Limited");
+        break;
+
       case "stopping":
         color = "var(--sl-color-violet-600)";
         icon = html`<sl-icon

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -90,7 +90,7 @@ export class CrawlStatus extends TailwindElement {
           : originalState.endsWith("_org_readonly")
             ? msg("Crawling Disabled")
             : originalState.endsWith("_rate_limit_time_reached")
-              ? msg("Rate Limit Timeout Reached")
+              ? msg("Rate Limit Timeout")
               : ""
       : "";
     let substate = "";
@@ -152,11 +152,14 @@ export class CrawlStatus extends TailwindElement {
       case "rate-limited":
         color = "var(--warning)";
         icon = html`<sl-icon
-          name="exclamation-triangle-fill"
+          name="dot"
+          library="app"
+          class="animatePulse"
           slot="prefix"
           style="color: ${color}"
         ></sl-icon>`;
-        label = msg("Rate Limited");
+        label = msg("Running");
+        substate = msg("Rate Limited");
         break;
 
       case "stopping":

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -89,7 +89,9 @@ export class CrawlStatus extends TailwindElement {
           ? msg("Time Quota Reached")
           : originalState.endsWith("_org_readonly")
             ? msg("Crawling Disabled")
-            : ""
+            : originalState.endsWith("_rate_limit_time_reached")
+              ? msg("Rate Limit Timeout Reached")
+              : ""
       : "";
     let substate = "";
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -365,7 +365,8 @@ export class WorkflowDetail extends BtrixElement {
     return (
       this.workflow?.isCrawlRunning &&
       !this.workflow.lastCrawlStopping &&
-      this.workflow.lastCrawlState === "running"
+      this.workflow.lastCrawlState &&
+      ["running", "rate-limited"].includes(this.workflow.lastCrawlState)
     );
   }
 
@@ -702,7 +703,8 @@ export class WorkflowDetail extends BtrixElement {
         ${this.renderCrawls()}
       </btrix-tab-group-panel>
       <btrix-tab-group-panel name=${WorkflowTab.LatestCrawl}>
-        ${this.renderPausedNotice()} ${this.renderLatestCrawl()}
+        ${this.renderRateLimitedNotice()} ${this.renderPausedNotice()}
+        ${this.renderLatestCrawl()}
       </btrix-tab-group-panel>
       <btrix-tab-group-panel name=${WorkflowTab.Settings}>
         ${this.renderSettings()}
@@ -1492,6 +1494,35 @@ export class WorkflowDetail extends BtrixElement {
       </btrix-alert>
     `;
   };
+
+  private renderRateLimitedNotice() {
+    if (this.workflow?.lastCrawlState !== "rate-limited") {
+      return html``;
+    }
+    return html`
+      <btrix-alert
+        id="pausedNotice"
+        class="sticky top-2 z-50 part-[base]:mb-5"
+        variant="info"
+      >
+        <div class="mb-2 flex justify-between">
+          <span class="inline-flex items-center gap-1.5">
+            <sl-icon class="text-base" name="exclamation-triangle"></sl-icon>
+            <strong class="font-medium">
+              ${msg("The site is blocking or rate limiting our crawling")}
+            </strong>
+          </span>
+        </div>
+        <div class="text-pretty text-neutral-600">
+          <p class="mb-2">
+            ${msg(
+              "The crawl has encountered error or CAPTCHA pages and is skipping them. See our guide for more info",
+            )}
+          </p>
+        </div>
+      </btrix-alert>
+    `;
+  }
 
   private renderLatestCrawlAction() {
     if (!this.workflow || !this.lastCrawlId) return;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -369,7 +369,8 @@ export class WorkflowDetail extends BtrixElement {
     return (
       this.workflow?.isCrawlRunning &&
       !this.workflow.lastCrawlStopping &&
-      this.workflow.lastCrawlState === "running"
+      this.workflow.lastCrawlState &&
+      ["running", "rate-limited"].includes(this.workflow.lastCrawlState)
     );
   }
 
@@ -706,7 +707,8 @@ export class WorkflowDetail extends BtrixElement {
         ${this.renderCrawls()}
       </btrix-tab-group-panel>
       <btrix-tab-group-panel name=${WorkflowTab.LatestCrawl}>
-        ${this.renderPausedNotice()} ${this.renderLatestCrawl()}
+        ${this.renderRateLimitedNotice()} ${this.renderPausedNotice()}
+        ${this.renderLatestCrawl()}
       </btrix-tab-group-panel>
       <btrix-tab-group-panel name=${WorkflowTab.Settings}>
         ${this.renderSettings()}
@@ -1489,6 +1491,35 @@ export class WorkflowDetail extends BtrixElement {
       </btrix-alert>
     `;
   };
+
+  private renderRateLimitedNotice() {
+    if (this.workflow?.lastCrawlState !== "rate-limited") {
+      return html``;
+    }
+    return html`
+      <btrix-alert
+        id="pausedNotice"
+        class="sticky top-2 z-50 part-[base]:mb-5"
+        variant="info"
+      >
+        <div class="mb-2 flex justify-between">
+          <span class="inline-flex items-center gap-1.5">
+            <sl-icon class="text-base" name="exclamation-triangle"></sl-icon>
+            <strong class="font-medium">
+              ${msg("The site is blocking or rate limiting our crawling")}
+            </strong>
+          </span>
+        </div>
+        <div class="text-pretty text-neutral-600">
+          <p class="mb-2">
+            ${msg(
+              "The crawl has encountered error or CAPTCHA pages and is skipping them. See our guide for more info",
+            )}
+          </p>
+        </div>
+      </btrix-alert>
+    `;
+  }
 
   private renderLatestCrawlAction() {
     if (!this.workflow || !this.lastCrawlId) return;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import { Task, TaskStatus } from "@lit/task";
 import type { SlDropdown } from "@shoelace-style/shoelace";
@@ -19,6 +20,7 @@ import { type Crawl, type CrawlLog, type Seed, type Workflow } from "./types";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Alert } from "@/components/ui/alert";
 import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
+import { docsUrlContext, type DocsUrlContext } from "@/context/docs-url";
 import { ClipboardController } from "@/controllers/clipboard";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { missingDependenciesNotice } from "@/features/archived-items/templates/missing-dependencies-notice";
@@ -116,6 +118,9 @@ export class WorkflowDetail extends BtrixElement {
       new URLSearchParams(location.search).get(CRAWLS_PAGINATION_NAME),
     ),
   };
+
+  @consume({ context: docsUrlContext })
+  private readonly docsUrl?: DocsUrlContext;
 
   @query("#pausedNotice")
   private readonly pausedNotice?: Alert | null;
@@ -1496,6 +1501,7 @@ export class WorkflowDetail extends BtrixElement {
     if (this.workflow?.lastCrawlState !== "rate-limited") {
       return html``;
     }
+
     return html`
       <btrix-alert
         id="pausedNotice"
@@ -1506,15 +1512,24 @@ export class WorkflowDetail extends BtrixElement {
           <span class="inline-flex items-center gap-1.5">
             <sl-icon class="text-base" name="exclamation-triangle"></sl-icon>
             <strong class="font-medium">
-              ${msg("The site is blocking or rate limiting our crawling")}
+              ${msg("Crawling is being rate limited or blocked")}
             </strong>
           </span>
         </div>
         <div class="text-pretty text-neutral-600">
           <p class="mb-2">
             ${msg(
-              "The crawl has encountered error or CAPTCHA pages and is skipping them. See our guide for more info",
+              `Browsertrix has detected that pages being crawled are error or CAPTCHA pages and is skipping them.`,
             )}
+            <a
+              target="_blank"
+              href="${this
+                .docsUrl}user-guide/running-crawl/#rate-limit-detection"
+            >
+              <strong class="font-semibold"
+                >${msg("More Info on Rate Limit Detection")}</strong
+              ></a
+            >
           </p>
         </div>
       </btrix-alert>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1503,23 +1503,22 @@ export class WorkflowDetail extends BtrixElement {
     }
 
     return html`
-      <btrix-alert
-        id="pausedNotice"
-        class="sticky top-2 z-50 part-[base]:mb-5"
-        variant="info"
-      >
+      <btrix-alert class="sticky top-2 z-50 part-[base]:mb-5" variant="warning">
         <div class="mb-2 flex justify-between">
           <span class="inline-flex items-center gap-1.5">
-            <sl-icon class="text-base" name="exclamation-triangle"></sl-icon>
+            <sl-icon
+              class="text-base"
+              name="exclamation-diamond-fill"
+            ></sl-icon>
             <strong class="font-medium">
-              ${msg("Crawling is being rate limited or blocked")}
+              ${msg("Rate Limiting Detected")}
             </strong>
           </span>
         </div>
-        <div class="text-pretty text-neutral-600">
-          <p class="mb-2">
+        <div class="text-pretty">
+          <p>
             ${msg(
-              `Browsertrix has detected that pages being crawled are error or CAPTCHA pages and is skipping them.`,
+              "This crawl is running slower due to being rate limited by a website being crawled.",
             )}
             <a
               target="_blank"
@@ -1527,7 +1526,7 @@ export class WorkflowDetail extends BtrixElement {
                 .docsUrl}user-guide/running-crawl/#rate-limit-detection"
             >
               <strong class="font-semibold"
-                >${msg("More Info on Rate Limit Detection")}</strong
+                >${msg("More Information")}</strong
               ></a
             >
           </p>

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -4,6 +4,7 @@ export const RUNNING_STATES = [
   "pending-wait",
   "generate-wacz",
   "uploading-wacz",
+  "rate-limited",
 ] as const;
 
 // Match backend TYPE_WAITING_NOT_PAUSED_STATES in models.py

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -1,10 +1,10 @@
 // Match backend TYPE_RUNNING_STATES in models.py
 export const RUNNING_STATES = [
   "running",
+  "rate-limited",
   "pending-wait",
   "generate-wacz",
   "uploading-wacz",
-  "rate-limited",
 ] as const;
 
 // Match backend TYPE_WAITING_NOT_PAUSED_STATES in models.py

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -21,6 +21,7 @@ export const PAUSED_STATES = [
   "paused_storage_quota_reached",
   "paused_time_quota_reached",
   "paused_org_readonly",
+  "paused_rate_limit_time_reached",
 ] as const;
 
 // Match backend TYPE_WAITING_STATES in models.py


### PR DESCRIPTION
Introduces a new `rate-limited` state to indicate crawl has been rate limited but is still running.
After being in a rate-limited state for a fixed period of time (default 12 hours), the crawl is set to a new paused state, `paused_rate_limit_time_reached` state.

backend:
- crawl is in exponential backoff loop, set state to 'rate-limited' when corresponding redis key is set
- depends on crawler 1.14 beta or higher, which includes support for rate limiting.
- `rate_limit_max_duration_minutes` (default 270) how long to wait before pausing rate limited crawl (0 to disable)
- `rate_limit_threshold`: after how many pages will a crawl be marked as rate limited and interrupted (default 5)

frontend:
- show 'Rate Limited' state and warning message indicating the crawl is rate limited, though still running
- show new `Paused: Rate Limit Timeout Reached` when a crawl has been in rate-limited state for too long.

docs:
- add new rate-limited state to list of states
- describe rate limit detection and mitigations on running crawls page.

fixes #3259, closes https://github.com/webrecorder/browsertrix/issues/3260, closes https://github.com/webrecorder/browsertrix/issues/3268

## Sceenshots:

Rate Limited View:
<img width="1296" height="371" alt="Screenshot 2026-07-07 at 12 25 50 AM" src="https://github.com/user-attachments/assets/29d40bdb-cc8e-4bed-9c36-3b3cc3814908" />

Paused after rate limit timeout reached:
<img width="1260" height="93" alt="Screenshot 2026-07-07 at 12 33 42 AM" src="https://github.com/user-attachments/assets/10cbed70-278c-4f8e-9c7e-18e34846bbde" />

## Testing:
- Ensure a 1.14 crawler beta is being used.
- Set `rate_limit_max_duration_minutes: 2` in local helm chart.
- Run a crawl on a site that has aggressive rate limiting, eg. medium.com/
- The crawl should enter `Rate Limited` state after a few pages (5+ by default) that show CAPTCHAs
- After 2 minutes, the crawl should enter the `Paused: Rate Limit Timeout Reached` state.
- Pages that had CAPTCHAs should not be captured
- Resuming the crawl will retry previous CAPTCHA pages (might take a while!)