### PR TITLE
config: remove two fields from local-config

### DIFF
--- a/chart/examples/local-config.yaml
+++ b/chart/examples/local-config.yaml
@@ -35,7 +35,6 @@
 # emails_pull_policy: "Never"
 # frontend_pull_policy: "Never"
 # crawler_pull_policy: "Never"
-# redis_pull_policy: "Never"
 
 # microk8s: if developing locally, can override these to use images from local microk8s repository (on localhost:32000)
 # backend_image: "localhost:32000/webrecorder/browsertrix-backend:latest"

--- a/frontend/docs/docs/develop/local-dev-setup.md
+++ b/frontend/docs/docs/develop/local-dev-setup.md
@@ -28,6 +28,7 @@ frontend_image: docker.io/webrecorder/browsertrix-frontend:latest
 backend_pull_policy: 'Never'
 emails_pull_policy: 'Never'
 frontend_pull_policy: 'Never'
+crawler_pull_policy: 'Never'
 ```
 
     ??? info "MicroK8S"


### PR DESCRIPTION
Ilya suggests that local config doesn't usually want to be uncommenting these, and we should remove these from the examples.