### PR TITLE
Show "updating" indicator for collection stats (frontend work for #3218)

### DIFF
--- a/frontend/src/layouts/collections/metadataColumn.ts
+++ b/frontend/src/layouts/collections/metadataColumn.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { when } from "lit/directives/when.js";
 
+import { updatingOverlay } from "@/layouts/updatingOverlay";
 import { metadata } from "@/strings/collections/metadata";
 import { monthYearDateRange } from "@/strings/utils";
 import type { Collection, PublicCollection } from "@/types/collection";
@@ -34,9 +35,13 @@ export function metadataColumn(
   { publicView } = { publicView: false },
 ) {
   const metadataItem = metadataItemWithCollection(collection);
+  const isUpdating =
+    collection &&
+    "runningUpdatesCount" in collection &&
+    collection.runningUpdatesCount;
 
   return html`
-    <btrix-desc-list>
+    <btrix-desc-list class="relative" aria-busy="${isUpdating}">
       ${metadataItem({
         label: metadata.dateLatest,
         render: (col) => html`
@@ -77,6 +82,7 @@ export function metadataColumn(
             )}
           </table>`,
       })}
+      ${isUpdating ? updatingOverlay() : nothing}
     </btrix-desc-list>
   `;
 }

--- a/frontend/src/layouts/updatingOverlay.ts
+++ b/frontend/src/layouts/updatingOverlay.ts
@@ -1,0 +1,23 @@
+import { msg } from "@lit/localize";
+import clsx from "clsx";
+import { html, type nothing, type TemplateResult } from "lit";
+
+import { tw } from "@/utils/tailwind";
+
+export function updatingOverlay(props?: {
+  message?: string | TemplateResult | null | undefined | typeof nothing;
+  class?: string;
+}) {
+  return html`
+    <div
+      class=${clsx(
+        tw`backdrop-blur-px bg-radial absolute inset-0 grid place-items-center from-white/90 to-white/10`,
+        props?.class,
+      )}
+    >
+      <span class="flex items-center gap-2">
+        <sl-spinner></sl-spinner> ${props?.message ?? msg("Updating...")}
+      </span>
+    </div>
+  `;
+}

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -40,6 +40,7 @@ import {
 import { emptyMessage } from "@/layouts/emptyMessage";
 import { pageNav, pageTitle, type Breadcrumb } from "@/layouts/pageHeader";
 import { panelBody, panelHeader } from "@/layouts/panel";
+import { updatingOverlay } from "@/layouts/updatingOverlay";
 import { getIndexErrorMessage } from "@/strings/collections/index-error";
 import {
   type APIPaginatedList,
@@ -48,6 +49,7 @@ import {
 } from "@/types/api";
 import {
   CollectionAccess,
+  collectionSchema,
   type Collection,
   type PublicCollection,
 } from "@/types/collection";
@@ -313,10 +315,10 @@ export class CollectionDetail extends BtrixElement {
       </header>
 
       <div
-        class="mt-3 rounded-lg border px-4 py-2"
+        class="relative mt-3 rounded-lg border bg-white px-4 py-2"
         aria-busy="${
           // TODO Switch to task and use task status
-          this.collection === undefined
+          this.collection === undefined || this.collection.runningUpdatesCount
         }"
       >
         ${this.renderInfoBar()}
@@ -340,15 +342,19 @@ export class CollectionDetail extends BtrixElement {
                             ? undefined
                             : msg("Please wait for replay load"),
                         )}
-                        ?disabled=${!this.isRwpLoaded}
+                        ?disabled=${!this.isRwpLoaded ||
+                        this.collection.runningUpdatesCount}
                       >
-                        ${this.isRwpLoaded
+                        ${this.isRwpLoaded &&
+                        !this.collection.runningUpdatesCount
                           ? html`<sl-icon name="house" slot="prefix"></sl-icon>`
                           : html`<sl-spinner slot="prefix"></sl-spinner>`}
                         ${msg("Set Initial View")}
                       </sl-button>
                     `
-                  : nothing,
+                  : this.collection?.runningUpdatesCount
+                    ? html`<sl-spinner slot="prefix"></sl-spinner>`
+                    : nothing,
             ],
             [
               Tab.Items,
@@ -677,7 +683,7 @@ export class CollectionDetail extends BtrixElement {
 
     return html`
       <btrix-overflow-scroll
-        class="-mx-3 max-w-[calc(100%+theme(spacing.6))] part-[content]:px-3"
+        class="-mx-3 -my-2 max-w-[calc(100%+theme(spacing.6))] part-[content]:px-3 part-[content]:py-2"
       >
         <nav class="flex min-w-max gap-2">
           ${tabs.map((tabName) => {
@@ -759,6 +765,10 @@ export class CollectionDetail extends BtrixElement {
                 ${msg("Set Initial View")}
               </sl-menu-item>
             `,
+            () =>
+              this.collection?.runningUpdatesCount
+                ? html`<sl-spinner slot="prefix"></sl-spinner>`
+                : nothing,
           )}
           <sl-menu-item
             @click=${async () => {
@@ -926,6 +936,9 @@ export class CollectionDetail extends BtrixElement {
           : this.renderDetailItem(msg("Last Modified"), (col) =>
               col.modified ? this.localize.relativeDate(col.modified) : "",
             )}
+        ${this.collection.runningUpdatesCount
+          ? updatingOverlay({ class: "rounded-lg" })
+          : nothing}
       </btrix-desc-list>
     `;
   }
@@ -1323,6 +1336,7 @@ export class CollectionDetail extends BtrixElement {
         icon: "exclamation-octagon",
         id: "collection-retrieve-status",
       });
+      console.error(e);
     }
   }
 
@@ -1331,7 +1345,7 @@ export class CollectionDetail extends BtrixElement {
       `/orgs/${this.orgId}/collections/${this.collectionId}/replay.json`,
     );
 
-    return data;
+    return collectionSchema.parse(data);
   }
 
   /**

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -1312,13 +1312,8 @@ export class CollectionDetail extends BtrixElement {
     try {
       this.collection = await this.getCollection();
 
-      // Clear current timer, if it exists
-      if (this.timerId != null) {
-        window.clearTimeout(this.timerId);
-      }
-
-      // Restart timer for next poll
-      this.timerId = window.setTimeout(() => {
+      // Start polling if not already
+      this.timerId ??= window.setInterval(() => {
         void this.fetchCollection();
       }, 1000 * POLL_INTERVAL_SECONDS);
     } catch (e) {

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -66,6 +66,7 @@ import { tw } from "@/utils/tailwind";
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_ITEMS_PAGE_SIZE = 20;
 const POLL_INTERVAL_SECONDS = 10;
+const POLL_INTERVAL_ACTIVE_SECONDS = 1;
 
 @customElement("btrix-collection-detail")
 @localized()
@@ -1325,10 +1326,16 @@ export class CollectionDetail extends BtrixElement {
     try {
       this.collection = await this.getCollection();
 
-      // Start polling if not already
-      this.timerId ??= window.setInterval(() => {
-        void this.fetchCollection();
-      }, 1000 * POLL_INTERVAL_SECONDS);
+      if (this.timerId) window.clearTimeout(this.timerId);
+      if (this.collection.runningUpdatesCount > 0) {
+        this.timerId = window.setTimeout(() => {
+          void this.fetchCollection();
+        }, 1000 * POLL_INTERVAL_ACTIVE_SECONDS);
+      } else {
+        this.timerId = window.setTimeout(() => {
+          void this.fetchCollection();
+        }, 1000 * POLL_INTERVAL_SECONDS);
+      }
     } catch (e) {
       this.notify.toast({
         message: msg("Sorry, couldn't retrieve Collection at this time."),

--- a/frontend/src/pages/org/collection-detail/dedupe.ts
+++ b/frontend/src/pages/org/collection-detail/dedupe.ts
@@ -554,7 +554,7 @@ export class CollectionDetailDedupe extends BtrixElement {
   private renderDeduped() {
     return html`
       <div
-        class="mb-3 flex items-center justify-between gap-3 rounded-lg border bg-neutral-50 p-3"
+        class="mb-3 flex items-center justify-between gap-3 rounded-lg border bg-neutral-50 py-3"
       >
         <div class="flex items-center gap-2">
           <label for="view" class="whitespace-nowrap text-neutral-500"

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -65,6 +65,7 @@ export const collectionSchema = publicCollectionSchema.extend({
   indexLastSavedAt: z.string().datetime().nullable(),
   indexState: z.enum(DEDUPE_INDEX_STATES).nullable(),
   indexStats: dedupeIndexStatsSchema.optional().nullable(),
+  runningUpdatesCount: z.number(),
 });
 export type Collection = z.infer<typeof collectionSchema>;
 

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -33,7 +33,18 @@ export const publicCollectionSchema = z.object({
   modified: z.string().datetime().nullable(),
   caption: z.string().nullable(),
   description: z.string().nullable(),
-  resources: z.array(z.string()),
+  resources: z.array(
+    z.object({
+      name: z.string(),
+      path: z.string(),
+      hash: z.string(),
+      size: z.number(),
+      crawlId: z.string().nullable(),
+      numReplicas: z.number(),
+      expireAt: z.string().datetime().nullable(),
+      fromDependency: z.boolean(),
+    }),
+  ),
   dateEarliest: z.string().datetime().nullable(),
   dateLatest: z.string().datetime().nullable(),
   thumbnail: storageFileSchema.nullable(),
@@ -65,6 +76,18 @@ export const collectionSchema = publicCollectionSchema.extend({
   indexLastSavedAt: z.string().datetime().nullable(),
   indexState: z.enum(DEDUPE_INDEX_STATES).nullable(),
   indexStats: dedupeIndexStatsSchema.optional().nullable(),
+  /**
+   * The number of running updates for this collection.
+   * Updates may affect:
+   * - {@linkcode collectionSchema._type.crawlCount | crawlCount}
+   * - {@linkcode collectionSchema._type.pageCount | pageCount}
+   * - {@linkcode collectionSchema._type.uniquePageCount | uniquePageCount}
+   * - {@linkcode collectionSchema._type.totalSize | totalSize}
+   * - {@linkcode collectionSchema._type.tags | tags}
+   * - {@linkcode collectionSchema._type.topPageHosts | topPageHosts}
+   * - {@linkcode collectionSchema._type.dateEarliest | dateEarliest}
+   * - {@linkcode collectionSchema._type.dateLatest | dateLatest}
+   */
   runningUpdatesCount: z.number(),
 });
 export type Collection = z.infer<typeof collectionSchema>;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -128,6 +128,12 @@ function makeTheme() {
     outlineOffset: {
       3: "3px",
     },
+    backdropBlur: {
+      px: "1px",
+    },
+    backgroundImage: {
+      radial: "radial-gradient(var(--tw-gradient-stops))",
+    },
   };
 }
 


### PR DESCRIPTION
To be merged into or after #3241 

## Changes

Adds an "updating" indicator to various places in the collection detail page when a collection's `runningUpdatesCount` is > 0.

## Screenshots

| Replay tab |
|--------|
| <img width="1272" height="230" alt="Screenshot 2026-04-15 at 4 15 56 PM" src="https://github.com/user-attachments/assets/5431df3e-ac92-4687-b15d-67eb9e957d47" /> | 

| About tab |
|--------|
| <img width="1279" height="525" alt="Screenshot 2026-04-15 at 4 16 06 PM" src="https://github.com/user-attachments/assets/350a721e-aa62-4934-8d3e-1ac752283f86" /> | 
