### PR TITLE
quickfix: profile chart: use 'memory_limit' same as crawler instead of more strict limit for profile browser

### DIFF
--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -85,6 +85,7 @@ class K8sOpAPI(K8sAPI):
         p["qa_cpu"] = qa_cpu
         p["qa_memory"] = qa_memory
         p["qa_workers"] = qa_num_workers
+        p["memory_limit"] = self.max_crawler_memory_size
 
     def compute_for_num_browsers(
         self, num_browsers, crawler_memory_fixed="", crawler_cpu_fixed=""

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -79,6 +79,12 @@ class K8sOpAPI(K8sAPI):
 
         print(f"max crawler memory size: {self.max_crawler_memory_size}")
 
+        if self.max_crawler_memory_size < crawler_memory:
+            raise ValueError(
+                "Invalid memory config: max crawler memory "
+                + f"{self.max_crawler_memory_size} < crawler memory {crawler_memory}"
+            )
+
         p["crawler_cpu"] = crawler_cpu
         p["crawler_memory"] = crawler_memory
         p["crawler_workers"] = num_workers
@@ -130,6 +136,12 @@ class K8sOpAPI(K8sAPI):
         print("profile browser resources")
         print(f"cpu = {profile_cpu}")
         print(f"memory = {profile_memory}")
+
+        if self.max_crawler_memory_size < profile_memory:
+            raise ValueError(
+                "Invalid memory config: max crawler memory "
+                + f"{self.max_crawler_memory_size} < profile memory {profile_memory}"
+            )
 
     async def async_init(self) -> None:
         """perform any async init here"""

--- a/chart/app-templates/profilebrowser.yaml
+++ b/chart/app-templates/profilebrowser.yaml
@@ -142,7 +142,7 @@ spec:
 
       resources:
         limits:
-          memory: "{{ profile_memory }}"
+          memory: "{{ memory_limit }}"
 
         requests:
           cpu: "{{ profile_cpu }}"


### PR DESCRIPTION
- ensure profile browsers don't see ooms as frequently, but can start with a smaller default base