### PR TITLE
docs: sync local-config sample password with real one

### DIFF
--- a/chart/examples/local-config.yaml
+++ b/chart/examples/local-config.yaml
@@ -55,4 +55,4 @@
 
 #   # optional: if not set, automatically generated
 #   # change or remove this
-#   password: PASSWORD!
+#   password: PASSW0RD!


### PR DESCRIPTION
The sample superuser email here is the real one, but the sample password is subtly different from the actual one. I was checking the config in the YAML to remind myself what the generated password was and was slightly surprised it wasn't working for me. I figure this might help reduce some confusion in the future.

See the docs' reference to the real default password: https://docs.browsertrix.com/deploy/local/#installing-from-github-release-directly