### PR TITLE
feat: Allow users to find crawls by ID

### DIFF
--- a/frontend/src/components/ui/search-combobox.ts
+++ b/frontend/src/components/ui/search-combobox.ts
@@ -89,6 +89,7 @@ export class SearchCombobox<T> extends TailwindElement {
   protected fuse = new Fuse<T>(this.searchOptions, {
     ...defaultFuseOptions,
     keys: this.searchKeys,
+    shouldSort: true,
   });
 
   disconnectedCallback(): void {

--- a/frontend/src/components/ui/search-combobox.ts
+++ b/frontend/src/components/ui/search-combobox.ts
@@ -212,6 +212,11 @@ export class SearchCombobox<T> extends TailwindElement {
                 >`
               : nothing}
             ${value}
+            ${value === this.searchByValue
+              ? html`<sl-tag slot="prefix" size="small" pill variant="success"
+                  >${msg("Exact")}</sl-tag
+                >`
+              : nothing}
           </sl-menu-item>
         `;
       }

--- a/frontend/src/components/ui/search-combobox.ts
+++ b/frontend/src/components/ui/search-combobox.ts
@@ -213,8 +213,8 @@ export class SearchCombobox<T> extends TailwindElement {
               : nothing}
             ${value}
             ${value === this.searchByValue
-              ? html`<sl-tag slot="prefix" size="small" pill variant="success"
-                  >${msg("Exact")}</sl-tag
+              ? html`<btrix-badge slot="suffix" variant="success" outline
+                  >${msg("Exact match")}</btrix-badge
                 >`
               : nothing}
           </sl-menu-item>

--- a/frontend/src/features/crawl-workflows/workflow-search.ts
+++ b/frontend/src/features/crawl-workflows/workflow-search.ts
@@ -3,12 +3,13 @@ import { customElement, property } from "lit/decorators.js";
 
 import { SearchCombobox } from "@/components/ui/search-combobox";
 
-export type SearchFields = "name" | "firstSeed";
+export type SearchFields = "id" | "name" | "firstSeed";
 
 @customElement("btrix-workflow-search")
 @localized()
 export class WorkflowSearch extends SearchCombobox<{ [x: string]: string }> {
   static FieldLabels: Record<SearchFields, string> = {
+    id: msg("ID"),
     name: msg("Name"),
     firstSeed: msg("Crawl Start URL"),
   };
@@ -19,7 +20,7 @@ export class WorkflowSearch extends SearchCombobox<{ [x: string]: string }> {
   @property({ type: String })
   selectedKey?: string;
 
-  readonly searchKeys = ["name", "firstSeed"];
+  readonly searchKeys = ["id", "name", "firstSeed"];
   readonly keyLabels = WorkflowSearch.FieldLabels;
 
   placeholder = msg("Search by workflow name or crawl start URL");

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -889,7 +889,7 @@ export class ArchivedItemDetail extends BtrixElement {
               )}
           >
             <sl-icon name="copy" slot="prefix"></sl-icon>
-            ${msg("Copy ID")}
+            ${msg("Copy Item ID")}
           </sl-menu-item>
           <sl-menu-item
             @click=${() =>

--- a/frontend/src/pages/org/archived-item-detail/templates/missing-dependencies-panel.ts
+++ b/frontend/src/pages/org/archived-item-detail/templates/missing-dependencies-panel.ts
@@ -44,7 +44,7 @@ export function missingDependenciesPanel({
             <div class="font-monostyle text-neutral-700">${id}</div>
             <btrix-copy-button
               value=${id}
-              content=${msg("Copy ID")}
+              content=${msg("Copy Item ID")}
               hoist
             ></btrix-copy-button>
           </li>`,

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -300,14 +300,7 @@ export class CrawlsList extends BtrixElement {
   }
 
   private clearFilters() {
-    this.filterBy.setValue({
-      ...this.filterBy.value,
-      id: undefined,
-      firstSeed: undefined,
-      name: undefined,
-      state: undefined,
-      reviewStatus: undefined,
-    });
+    this.filterBy.setValue({});
     this.filterByCurrentUser.setValue(false);
     this.filterByTags.setValue([]);
     this.filterByTagsType.setValue("or");
@@ -412,7 +405,6 @@ export class CrawlsList extends BtrixElement {
         changedProperties.has("itemType") &&
         changedProperties.get("itemType")
       ) {
-        this.filterBy.setValue({});
         this.orderBy.setValue({
           field: "finished",
           direction: sortableFields["finished"].defaultDirection!,
@@ -429,6 +421,7 @@ export class CrawlsList extends BtrixElement {
     }
 
     if (changedProperties.has("itemType")) {
+      this.filterBy.setValue({});
       void this.fetchConfigSearchValues();
     }
   }

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -42,7 +42,7 @@ import { isArchivingDisabled } from "@/utils/orgs";
 import { tw } from "@/utils/tailwind";
 
 type ArchivedItems = APIPaginatedList<ArchivedItem>;
-type SearchFields = "name" | "firstSeed";
+type SearchFields = "id" | "name" | "firstSeed";
 type SortField =
   | "finished"
   | "fileSize"
@@ -98,6 +98,7 @@ const DEFAULT_SORT_BY: SortBy = {
 };
 
 type FilterBy = {
+  id?: string;
   name?: string;
   firstSeed?: string;
   state?: CrawlState[];
@@ -113,6 +114,7 @@ type FilterBy = {
 @localized()
 export class CrawlsList extends BtrixElement {
   static FieldLabels: Record<SearchFields, string> = {
+    id: msg("ID"),
     name: msg("Name"),
     firstSeed: msg("Crawl Start URL"),
   };
@@ -215,6 +217,7 @@ export class CrawlsList extends BtrixElement {
     this,
     (value, params) => {
       const keys = [
+        "id",
         "name",
         "firstSeed",
         "state",
@@ -225,6 +228,7 @@ export class CrawlsList extends BtrixElement {
           params.delete(key);
         } else {
           switch (key) {
+            case "id":
             case "firstSeed":
             case "name":
               params.set(key, value[key]);
@@ -256,6 +260,7 @@ export class CrawlsList extends BtrixElement {
         : undefined;
 
       return {
+        id: params.get("id") ?? undefined,
         name: params.get("name") ?? undefined,
         firstSeed: params.get("firstSeed") ?? undefined,
         state: state.length ? state : undefined,
@@ -284,6 +289,7 @@ export class CrawlsList extends BtrixElement {
 
   private get hasFiltersSet() {
     return [
+      this.filterBy.value.id,
       this.filterBy.value.firstSeed,
       this.filterBy.value.name,
       this.filterBy.value.state?.length || undefined,
@@ -296,6 +302,7 @@ export class CrawlsList extends BtrixElement {
   private clearFilters() {
     this.filterBy.setValue({
       ...this.filterBy.value,
+      id: undefined,
       firstSeed: undefined,
       name: undefined,
       state: undefined,
@@ -374,7 +381,7 @@ export class CrawlsList extends BtrixElement {
   private getArchivedItemsTimeout?: number;
 
   // For fuzzy search:
-  private readonly searchKeys = ["name", "firstSeed"];
+  private readonly searchKeys = ["id", "name", "firstSeed"];
 
   private get selectedSearchFilterKey() {
     return (
@@ -757,10 +764,10 @@ export class CrawlsList extends BtrixElement {
             this.filterBy.value[this.selectedSearchFilterKey],
         )}
         placeholder=${this.itemType === "upload"
-          ? msg("Search all uploads by name")
+          ? msg("Search all uploads by name or ID")
           : this.itemType === "crawl"
-            ? msg("Search all crawls by name or crawl start URL")
-            : msg("Search all items by name or crawl start URL")}
+            ? msg("Search all crawls by name, crawl start URL, or ID")
+            : msg("Search all items by name, crawl start URL, or ID")}
         @btrix-select=${(e: BtrixSearchComboboxSelectEvent) => {
           const { key, value } = e.detail.item;
 
@@ -773,6 +780,7 @@ export class CrawlsList extends BtrixElement {
         }}
         @btrix-clear=${() => {
           const {
+            id: _id,
             name: _name,
             firstSeed: _firstSeed,
             ...otherFilters
@@ -959,12 +967,12 @@ export class CrawlsList extends BtrixElement {
     },
     signal: AbortSignal,
   ) {
+    const { id, ...filterBy } = params.filterBy;
     const query = queryString.stringify(
       {
-        ...params.filterBy,
-        state: params.filterBy.state?.length
-          ? params.filterBy.state
-          : finishedCrawlStates,
+        ...filterBy,
+        ids: id ? [id] : undefined,
+        state: filterBy.state?.length ? filterBy.state : finishedCrawlStates,
         page: params.pagination.page,
         pageSize: params.pagination.pageSize,
         tags: params.filterByTags,
@@ -973,7 +981,6 @@ export class CrawlsList extends BtrixElement {
         sortBy: params.orderBy.field,
         sortDirection: params.orderBy.direction === "desc" ? -1 : 1,
         crawlType: params.itemType ?? undefined,
-        reviewStatus: params.filterBy.reviewStatus,
       },
       {
         arrayFormat: "none",
@@ -992,7 +999,7 @@ export class CrawlsList extends BtrixElement {
         crawlType: this.itemType ?? undefined,
       });
       const data: {
-        crawlIds: string[];
+        ids: string[];
         names: string[];
         descriptions: string[];
         firstSeeds: string[];
@@ -1005,6 +1012,7 @@ export class CrawlsList extends BtrixElement {
         [key]: value,
       });
       this.searchOptions = [
+        ...data.ids.map(toSearchItem("id")),
         ...data.names.map(toSearchItem("name")),
         ...data.firstSeeds.map(toSearchItem("firstSeed")),
       ];

--- a/frontend/src/pages/org/crawls.ts
+++ b/frontend/src/pages/org/crawls.ts
@@ -82,6 +82,7 @@ const DEFAULT_SORT_BY: SortBy = {
 };
 
 type FilterBy = {
+  id?: string;
   name?: string;
   firstSeed?: string;
   state?: CrawlState[];
@@ -186,12 +187,13 @@ export class OrgCrawls extends BtrixElement {
   private readonly filterBy = new SearchParamsValue<FilterBy>(
     this,
     (value, params) => {
-      const keys = ["name", "firstSeed", "state"] as (keyof FilterBy)[];
+      const keys = ["id", "name", "firstSeed", "state"] as (keyof FilterBy)[];
       keys.forEach((key) => {
         if (value[key] == null) {
           params.delete(key);
         } else {
           switch (key) {
+            case "id":
             case "firstSeed":
             case "name":
               params.set(key, value[key]);
@@ -211,6 +213,7 @@ export class OrgCrawls extends BtrixElement {
       const state = params.getAll("status") as CrawlState[];
 
       return {
+        id: params.get("id") ?? undefined,
         name: params.get("name") ?? undefined,
         firstSeed: params.get("firstSeed") ?? undefined,
         state: state.length ? state : undefined,
@@ -235,6 +238,7 @@ export class OrgCrawls extends BtrixElement {
 
   private get hasFiltersSet() {
     return [
+      this.filterBy.value.id,
       this.filterBy.value.firstSeed,
       this.filterBy.value.name,
       this.filterBy.value.state?.length || undefined,
@@ -246,6 +250,7 @@ export class OrgCrawls extends BtrixElement {
   private clearFilters() {
     this.filterBy.setValue({
       ...this.filterBy.value,
+      id: undefined,
       firstSeed: undefined,
       name: undefined,
       state: undefined,
@@ -318,7 +323,7 @@ export class OrgCrawls extends BtrixElement {
   private getArchivedItemsTimeout?: number;
 
   // For fuzzy search:
-  private readonly searchKeys = ["name", "firstSeed"];
+  private readonly searchKeys = ["id", "name", "firstSeed"];
 
   private get selectedSearchFilterKey() {
     return (
@@ -594,7 +599,9 @@ export class OrgCrawls extends BtrixElement {
           this.selectedSearchFilterKey &&
             this.filterBy.value[this.selectedSearchFilterKey],
         )}
-        placeholder=${msg("Search by workflow name or crawl start URL")}
+        placeholder=${msg(
+          "Search by workflow name, crawl start URL, or crawl ID",
+        )}
         @btrix-select=${(e: BtrixSearchComboboxSelectEvent) => {
           const { key, value } = e.detail.item;
           console.log(key, value);
@@ -606,6 +613,7 @@ export class OrgCrawls extends BtrixElement {
         }}
         @btrix-clear=${() => {
           const {
+            id: _id,
             name: _name,
             firstSeed: _firstSeed,
             ...otherFilters
@@ -776,10 +784,11 @@ export class OrgCrawls extends BtrixElement {
     },
     signal: AbortSignal,
   ) {
+    const { id, ...filterBy } = params.filterBy;
     const query = queryString.stringify(
       {
-        ...params.filterBy,
-        state: params.filterBy.state,
+        ...filterBy,
+        ids: id ? [id] : undefined,
         page: params.pagination.page,
         pageSize: params.pagination.pageSize,
         tags: params.filterByTags,
@@ -806,7 +815,7 @@ export class OrgCrawls extends BtrixElement {
         crawlType: "crawl",
       });
       const data: {
-        crawlIds: string[];
+        ids: string[];
         names: string[];
         descriptions: string[];
         firstSeeds: string[];
@@ -819,6 +828,7 @@ export class OrgCrawls extends BtrixElement {
         [key]: value,
       });
       this.searchOptions = [
+        ...data.ids.map(toSearchItem("id")),
         ...data.names.map(toSearchItem("name")),
         ...data.firstSeeds.map(toSearchItem("firstSeed")),
       ];

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -92,6 +92,7 @@ const DEFAULT_SORT_BY = {
 } as const;
 
 type FilterBy = {
+  id?: string;
   name?: string;
   firstSeed?: string;
   schedule?: boolean;


### PR DESCRIPTION
Resolves #3269

## Changes

- Allows users to find crawl by crawl/archived item ID.
- Fixes "Copy Crawl/Item ID" label inconsistency.

## Manual testing

1. Log in
2. Go to Crawling > Crawl Runs
3. Paste crawl ID into search bar. Verify crawl ID is shown
4. Choose crawl ID with exact match. Verify crawls are filtered to show matching crawl
5. Repeat 3-4 for Archived Items and Archived Items > Crawled Items
6. Enter `?id=<item ID>` into URL. Verify page loads with filtered result.

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Items | <img width="1277" height="354" alt="Screenshot 2026-04-20 at 4 35 58 PM" src="https://github.com/user-attachments/assets/1f07b277-b812-4871-ac11-38c1eddb17db" /> |


## Follow-ups

As noted in Discord, the current search implementation searches for possible filterable values such as name, rather than actually searching for the item. This PR doesn't fix this UX issue but attempts to mitigate it when entering an ID by showing an "Exact match" badge.