### PR TITLE
Extend max workflow & collection names from 50 to 80 characters

### DIFF
--- a/frontend/src/features/collections/collection-edit-dialog.ts
+++ b/frontend/src/features/collections/collection-edit-dialog.ts
@@ -23,6 +23,8 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import { type TabGroupPanel } from "@/components/ui/tab-group/tab-panel";
 import {
+  COLLECTION_CAPTION_MAX_LENGTH,
+  COLLECTION_NAME_MAX_LENGTH,
   type Collection,
   type CollectionThumbnailSource,
 } from "@/types/collection";
@@ -37,8 +39,10 @@ export type CollectionSavedEvent = CustomEvent<{
   id: string;
 }>;
 
-export const validateNameMax = maxLengthValidator(50);
-export const validateCaptionMax = maxLengthValidator(150);
+export const validateNameMax = maxLengthValidator(COLLECTION_NAME_MAX_LENGTH);
+export const validateCaptionMax = maxLengthValidator(
+  COLLECTION_CAPTION_MAX_LENGTH,
+);
 
 /**
  * @fires btrix-collection-saved CollectionSavedEvent Fires

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -353,7 +353,7 @@ export class WorkflowEditor extends BtrixElement {
 
   private readonly handleCurrentTarget = makeCurrentTargetHandler(this);
   private readonly checkFormValidity = formValidator(this);
-  private readonly validateNameMax = maxLengthValidator(50);
+  private readonly validateNameMax = maxLengthValidator(80);
   private readonly validateDescriptionMax = maxLengthValidator(350);
 
   private readonly tabLabels = sectionStrings;

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { DEDUPE_INDEX_STATES, dedupeIndexStatsSchema } from "./dedupe";
 import { storageFileSchema } from "./storage";
 
-export const COLLECTION_NAME_MAX_LENGTH = 50;
+export const COLLECTION_NAME_MAX_LENGTH = 80;
 export const COLLECTION_CAPTION_MAX_LENGTH = 150;
 
 export enum CollectionAccess {


### PR DESCRIPTION
Quick change to address request in Discord (page titles often being too long for workflow names).

No validation is done on title lengths on the backend, so this is a quick change.