### PR TITLE
fix: Toast messages with same message ID not replaced

### DIFF
--- a/frontend/src/components/notification-stack.ts
+++ b/frontend/src/components/notification-stack.ts
@@ -56,7 +56,7 @@ export class NotificationStack extends BtrixElement {
     return html`
       <div
         class=${clsx(
-          tw`sl-toast-stack`,
+          "btrix-toast-stack",
           this.notifications.length && tw`min-h-24`,
         )}
       >

--- a/frontend/src/components/notification-stack.ts
+++ b/frontend/src/components/notification-stack.ts
@@ -21,6 +21,10 @@ import { tw } from "@/utils/tailwind";
 /**
  * Global notifications to stack in bottom end of the viewport.
  *
+ * This component reuses `.sl-toast-stack` styles instead of using Shoelace's
+ * `SlAlert.toast()` to reactively render the toast state of a notification
+ * instead of relocating it in the DOM.
+ *
  * @fires btrix-remove-notification
  */
 @customElement("btrix-notification-stack")
@@ -33,31 +37,32 @@ export class NotificationStack extends BtrixElement {
   readonly #namedNotifications = new Map<string, SlAlert>();
 
   protected updated(changedProperties: PropertyValues): void {
-    if (changedProperties.has("notifications") && this.notifications.length) {
-      void this.handleChange();
-    }
-  }
+    if (changedProperties.has("notifications")) {
+      const prevNotifications = changedProperties.get("notifications") as
+        | NotificationsContext
+        | undefined;
 
-  private async handleChange() {
-    const newItem = this.notifications[this.notifications.length - 1];
+      const newNotifications = prevNotifications
+        ? new Set(this.notifications).difference(new Set(prevNotifications))
+        : this.notifications;
 
-    if (newItem.messageId) {
-      await this.#namedNotifications.get(newItem.messageId)?.hide();
-    }
-
-    const el = this.shadowRoot?.querySelector<SlAlert>(
-      `sl-alert[data-id="${newItem.id}"]`,
-    );
-
-    if (el) {
-      void el.toast();
-    } else {
-      console.debug("no el with index", this.notifications.length - 1);
+      newNotifications.forEach((item) => {
+        void this.showAlert(item);
+      });
     }
   }
 
   render() {
-    return repeat(this.notifications, ({ id }) => id, this.renderNotification);
+    return html`
+      <div
+        class=${clsx(
+          tw`sl-toast-stack`,
+          this.notifications.length && tw`min-h-24`,
+        )}
+      >
+        ${repeat(this.notifications, ({ id }) => id, this.renderNotification)}
+      </div>
+    `;
   }
 
   private readonly renderNotification = (notification: AppNotification) => {
@@ -76,15 +81,6 @@ export class NotificationStack extends BtrixElement {
       variant=${ifDefined(variant)}
       duration=${ifDefined(notification.duration)}
       ?closable=${notification.closable}
-      @sl-show=${(e: CustomEvent) => {
-        e.stopPropagation();
-        if (notification.messageId) {
-          this.#namedNotifications.set(
-            notification.messageId,
-            e.target as SlAlert,
-          );
-        }
-      }}
       @sl-hide=${(e: CustomEvent) => {
         e.stopPropagation();
         if (notification.messageId) {
@@ -97,7 +93,7 @@ export class NotificationStack extends BtrixElement {
           new CustomEvent<NotificationEventDetail>(
             "btrix-remove-notification",
             {
-              detail: { messageId: notification.messageId },
+              detail: { id: notification.id },
               composed: true,
               bubbles: true,
             },
@@ -108,4 +104,39 @@ export class NotificationStack extends BtrixElement {
       ${notification.message}
     </sl-alert>`;
   };
+
+  private async showAlert(item: AppNotification) {
+    const messageId = item.messageId;
+    const oldAlert = messageId && this.#namedNotifications.get(messageId);
+
+    if (oldAlert) {
+      await this.hideAlert(oldAlert);
+    }
+
+    const el = this.shadowRoot?.querySelector<SlAlert>(
+      `sl-alert[data-id="${item.id}"]`,
+    );
+
+    if (!el) {
+      console.debug("no sl-alert to show");
+      return;
+    }
+
+    if (messageId) {
+      this.#namedNotifications.set(messageId, el);
+    }
+
+    await el.updateComplete;
+    await el.show();
+  }
+
+  private async hideAlert(el?: SlAlert) {
+    if (!el) {
+      console.debug("no sl-alert to hide");
+      return;
+    }
+
+    await el.updateComplete;
+    await el.hide();
+  }
 }

--- a/frontend/src/context/notifications/NotificationsContextController.ts
+++ b/frontend/src/context/notifications/NotificationsContextController.ts
@@ -1,6 +1,5 @@
 import { ContextProvider } from "@lit/context";
 import { html, nothing, type ReactiveController } from "lit";
-import { nanoid } from "nanoid";
 
 import {
   notificationsContext,
@@ -60,7 +59,7 @@ export class NotificationsContextController implements ReactiveController {
 
     this.addNotification({
       ...notification,
-      id: nanoid(),
+      id: window.crypto.randomUUID(),
       messageId: id ? id.toString() : undefined,
       message: html`${icon
         ? html`<sl-icon name=${icon} slot="icon"></sl-icon>`
@@ -78,9 +77,7 @@ export class NotificationsContextController implements ReactiveController {
     e.stopPropagation();
 
     const notifications = this.#context.value;
-    const idx = notifications.findIndex(
-      ({ messageId }) => messageId === e.detail.messageId,
-    );
+    const idx = notifications.findIndex(({ id }) => id === e.detail.id);
 
     if (idx > -1) {
       this.#context.setValue([
@@ -88,11 +85,11 @@ export class NotificationsContextController implements ReactiveController {
         ...notifications.slice(idx + 1),
       ]);
     } else {
-      console.debug("no notification with messageId"), e.detail.messageId;
+      console.debug("no notification with id"), e.detail.id;
     }
   };
 
   private addNotification(notification: AppNotification) {
-    this.#context.setValue([...this.#context.value, notification]);
+    this.#context.setValue([notification, ...this.#context.value]);
   }
 }

--- a/frontend/src/context/notifications/types.ts
+++ b/frontend/src/context/notifications/types.ts
@@ -15,7 +15,7 @@ export type AppNotification = {
 };
 
 export type NotificationEventDetail = {
-  messageId: AppNotification["messageId"];
+  id: AppNotification["id"];
 };
 
 declare global {

--- a/frontend/src/controllers/notify.ts
+++ b/frontend/src/controllers/notify.ts
@@ -74,7 +74,7 @@ export class NotifyController implements ReactiveController {
           variant,
           type: "toast",
           icon: detail.icon ?? iconMap[variant],
-          duration: detail.duration ?? 5000,
+          duration: detail.duration ?? (variant === "danger" ? 10000 : 5000),
         },
       }),
     );

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -91,6 +91,11 @@
     --sl-focus-ring-color: var(--sl-color-primary-200);
     --sl-focus-ring-width: 2px;
 
+    /* Z index */
+
+    /* Place dialog above toast */
+    --sl-z-index-dialog: 1000;
+
     /*
      * Forms
      */
@@ -585,8 +590,23 @@
 /* Following styles won't work with layers */
 
 .sl-toast-stack {
-  bottom: 0;
+  position: fixed;
   top: auto;
+  bottom: 0;
+  inset-inline-end: 0;
+  z-index: var(--sl-z-index-toast);
+  width: 28rem;
+  max-width: 100%;
+  max-height: 100%;
+  overflow: auto;
+}
+
+.sl-toast-stack sl-alert {
+  margin: var(--sl-spacing-medium);
+}
+
+.sl-toast-stack sl-alert::part(base) {
+  box-shadow: var(--sl-shadow-large);
 }
 
 html {

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -585,29 +585,30 @@
   .sl-scroll-lock.disable-scroll-lock body {
     overflow: auto !important;
   }
+
+  /* Replicate Shoelace toast stack styles to use in components */
+  .btrix-toast-stack {
+    position: fixed;
+    top: auto;
+    bottom: 0;
+    inset-inline-end: 0;
+    z-index: var(--sl-z-index-toast);
+    width: 28rem;
+    max-width: 100%;
+    max-height: 100%;
+    overflow: auto;
+  }
+
+  .btrix-toast-stack sl-alert {
+    margin: var(--sl-spacing-medium);
+  }
+
+  .btrix-toast-stack sl-alert::part(base) {
+    box-shadow: var(--sl-shadow-large);
+  }
 }
 
 /* Following styles won't work with layers */
-
-.sl-toast-stack {
-  position: fixed;
-  top: auto;
-  bottom: 0;
-  inset-inline-end: 0;
-  z-index: var(--sl-z-index-toast);
-  width: 28rem;
-  max-width: 100%;
-  max-height: 100%;
-  overflow: auto;
-}
-
-.sl-toast-stack sl-alert {
-  margin: var(--sl-spacing-medium);
-}
-
-.sl-toast-stack sl-alert::part(base) {
-  box-shadow: var(--sl-shadow-large);
-}
 
 html {
   /* Fixes sl-input components resizing when sl-scroll-lock is removed */

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -91,11 +91,6 @@
     --sl-focus-ring-color: var(--sl-color-primary-200);
     --sl-focus-ring-width: 2px;
 
-    /* Z index */
-
-    /* Place dialog above toast */
-    --sl-z-index-dialog: 1000;
-
     /*
      * Forms
      */


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/pull/3273

## Changes

- Fixes toast messages with the same message ID sometimes not being replaced due to removal from DOM by refactoring `notification-stack` to avoid `SlAlert.toast()`.
- Ensures toast messages are actually removed from context state by fixing ID lookup.
- Displays newest messages at the top of the stack.