### PR TITLE
devex: Fix Storybook build

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -35,6 +35,7 @@ const config: StorybookConfig = {
             sideEffects: true,
             include: [
               path.resolve(__dirname, "../src"),
+              path.resolve(__dirname, "../node_modules/@awesome.me/webawesome"),
               path.resolve(
                 __dirname,
                 "../node_modules/@shoelace-style/shoelace",


### PR DESCRIPTION
## Changes

Fixes Storybook not building due to missing CSS loader usage.

## Manual testing

Start Storybook with `yarn storybook:watch`. Verify Storybook loads in localhost:6006