### PR TITLE
fix: Allow toggling dedupe off + update save notification

### DIFF
--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -6,12 +6,9 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { cache } from "lit/directives/cache.js";
 import { repeat } from "lit/directives/repeat.js";
 import { when } from "lit/directives/when.js";
-import union from "lodash/fp/union";
-import without from "lodash/fp/without";
 import queryString from "query-string";
 
 import type {
-  AutoAddChangeDetail,
   CrawlsPageChangeDetail,
   SelectionChangeDetail,
 } from "./collection-workflow-list";
@@ -713,21 +710,6 @@ export class CollectionItemsDialog extends BtrixElement {
             this.workflowSelection = new Map(this.workflowSelection);
             this.selectedItems = new Set(this.selectedItems);
             this.deselectedItems = new Set(this.deselectedItems);
-          }}
-          @btrix-auto-add-change=${(e: CustomEvent<AutoAddChangeDetail>) => {
-            const { id, checked, dedupe } = e.detail;
-            const workflow = this.workflows?.items.find(
-              (workflow) => workflow.id === id,
-            );
-            if (workflow) {
-              void this.saveAutoAdd({
-                id,
-                autoAddCollections: checked
-                  ? union([this.collectionId], workflow.autoAddCollections)
-                  : without([this.collectionId], workflow.autoAddCollections),
-                dedupe,
-              });
-            }
           }}
         >
         </btrix-collection-workflow-list>
@@ -1435,51 +1417,5 @@ export class CollectionItemsDialog extends BtrixElement {
     return this.api.fetch<SearchValues>(
       `/orgs/${this.orgId}/all-crawls/search-values?crawlType=${searchType}`,
     );
-  }
-
-  private async saveAutoAdd({
-    id,
-    autoAddCollections,
-    dedupe,
-  }: Pick<Workflow, "id" | "autoAddCollections"> & { dedupe?: boolean }) {
-    const params: Pick<Workflow, "autoAddCollections" | "dedupeCollId"> = {
-      autoAddCollections: autoAddCollections,
-    };
-
-    if (dedupe === true) {
-      params.dedupeCollId = this.collectionId;
-    } else if (dedupe === false) {
-      params.dedupeCollId = "";
-    }
-
-    try {
-      await this.api.fetch(`/orgs/${this.orgId}/crawlconfigs/${id}`, {
-        method: "PATCH",
-        body: JSON.stringify(params),
-      });
-      await this.fetchWorkflows();
-      this.dispatchEvent(new CustomEvent("btrix-collection-saved"));
-
-      this.notify.toast({
-        message:
-          dedupe === true || dedupe === false
-            ? msg("Deduplication settings updated.")
-            : msg("Auto-add settings updated."),
-        variant: "success",
-        icon: "check2-circle",
-        duration: 1000,
-        id: "auto-add-status",
-      });
-    } catch (e: unknown) {
-      console.debug(e);
-      this.notify.toast({
-        message: msg(
-          "Something unexpected went wrong, couldn't save auto-add setting.",
-        ),
-        variant: "warning",
-        icon: "exclamation-circle",
-        id: "auto-add-status",
-      });
-    }
   }
 }

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -267,7 +267,7 @@ export class CollectionItemsDialog extends BtrixElement {
     return html` <btrix-dialog
       ?open=${this.open}
       class="part-[title]:overflow-hidden"
-      style="--width: var(--btrix-screen-desktop); --body-spacing: 0;"
+      style="--width: calc(var(--btrix-screen-desktop) - 3.5rem); --body-spacing: 0;"
       @sl-show=${() => (this.isReady = true)}
       @sl-after-hide=${() => this.reset()}
     >

--- a/frontend/src/features/collections/collection-workflow-list.ts
+++ b/frontend/src/features/collections/collection-workflow-list.ts
@@ -171,6 +171,9 @@ export class CollectionWorkflowList extends BtrixElement {
   @state()
   expandWorkflowSettings = false;
 
+  @state()
+  private lastSavedWorkflowId?: string;
+
   @query("sl-tree")
   private readonly tree?: SlTree | null;
 
@@ -181,7 +184,9 @@ export class CollectionWorkflowList extends BtrixElement {
       if (this.collectionId) {
         const collId = this.collectionId;
         this.expandWorkflowSettings = this.workflows.some((workflow) =>
-          workflow.autoAddCollections.some((id) => id === collId),
+          workflow.dedupeCollId
+            ? workflow.dedupeCollId === this.collectionId
+            : workflow.autoAddCollections.some((id) => id === collId),
         );
       }
     }
@@ -276,6 +281,10 @@ export class CollectionWorkflowList extends BtrixElement {
         dedupeCollId=${ifDefined(workflow.dedupeCollId || undefined)}
         .autoAddCollections=${workflow.autoAddCollections}
         ?collapse=${!this.expandWorkflowSettings}
+        ?showSaveStatus=${this.lastSavedWorkflowId === workflow.id}
+        @btrix-workflow-after-save=${() => {
+          this.lastSavedWorkflowId = workflow.id;
+        }}
       ></btrix-collection-workflow-list-settings>
     `;
   };

--- a/frontend/src/features/collections/collection-workflow-list.ts
+++ b/frontend/src/features/collections/collection-workflow-list.ts
@@ -19,7 +19,6 @@ import { when } from "lit/directives/when.js";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { PageChangeEvent } from "@/components/ui/pagination";
 import { dedupeStatusIcon } from "@/features/archived-items/templates/dedupe-status-icon";
-import type { CollectionWorkflowListSettingChangeEvent } from "@/features/collections/collection-workflow-list/settings";
 import type { APIPaginatedList } from "@/types/api";
 import type { Crawl, Workflow } from "@/types/crawler";
 import { pluralOf } from "@/utils/pluralize";
@@ -42,16 +41,10 @@ export type SelectionChangeDetail = {
     }
   >;
 };
-export type AutoAddChangeDetail = {
-  id: string;
-  checked: boolean;
-  dedupe?: boolean;
-};
 
 /**
  * @fires btrix-selection-change
  * @fires btrix-crawls-page-change
- * @fires btrix-auto-add-change
  */
 @customElement("btrix-collection-workflow-list")
 @localized()
@@ -283,22 +276,6 @@ export class CollectionWorkflowList extends BtrixElement {
         dedupeCollId=${ifDefined(workflow.dedupeCollId || undefined)}
         .autoAddCollections=${workflow.autoAddCollections}
         ?collapse=${!this.expandWorkflowSettings}
-        @btrix-change=${(e: CollectionWorkflowListSettingChangeEvent) => {
-          e.stopPropagation();
-
-          const { autoAdd, dedupe } = e.detail.value;
-
-          this.dispatchEvent(
-            new CustomEvent<AutoAddChangeDetail>("btrix-auto-add-change", {
-              detail: {
-                id: workflow.id,
-                checked: autoAdd,
-                dedupe,
-              },
-              composed: true,
-            }),
-          );
-        }}
       ></btrix-collection-workflow-list-settings>
     `;
   };

--- a/frontend/src/features/collections/collection-workflow-list/settings.ts
+++ b/frontend/src/features/collections/collection-workflow-list/settings.ts
@@ -94,7 +94,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
       // Reset success status
       this.#timerId = window.setTimeout(() => {
         this.showSaveStatus = false;
-      }, 5000);
+      }, 4000);
     }
   }
 
@@ -105,7 +105,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
 
   render() {
     return html`<sl-tooltip
-      placement="left"
+      placement="right"
       trigger="manual"
       ?open=${Boolean(this.showSaveStatus && this.saveStatus)}
       hoist
@@ -136,7 +136,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
     return html`
       <div
         class=${clsx(
-          tw`flex h-11 w-full items-center whitespace-nowrap rounded border px-4`,
+          tw`flex h-11 w-full items-center whitespace-nowrap rounded border px-3`,
           !this.collapse && tw`gap-4`,
         )}
       >

--- a/frontend/src/features/collections/collection-workflow-list/settings.ts
+++ b/frontend/src/features/collections/collection-workflow-list/settings.ts
@@ -9,6 +9,7 @@ import without from "lodash/fp/without";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Workflow } from "@/types/crawler";
+import { stopProp } from "@/utils/events";
 import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
@@ -40,6 +41,9 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   private dedupe = false;
 
   @state()
+  private showSaveStatus = false;
+
+  @state()
   private saveStatus?: "success" | "error";
 
   #timerId?: number;
@@ -62,7 +66,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
     if (changedProperties.has("saveStatus") && this.saveStatus !== undefined) {
       // Reset success status
       this.#timerId = window.setTimeout(() => {
-        this.saveStatus = undefined;
+        this.showSaveStatus = false;
       }, 5000);
     }
   }
@@ -76,9 +80,10 @@ export class CollectionWorkflowListSettings extends BtrixElement {
     return html`<sl-tooltip
       placement="left"
       trigger="manual"
-      ?open=${this.saveStatus !== undefined}
+      ?open=${Boolean(this.showSaveStatus && this.saveStatus)}
       hoist
-      @click=${() => (this.saveStatus = undefined)}
+      @click=${() => (this.showSaveStatus = false)}
+      @sl-after-hide=${() => (this.saveStatus = undefined)}
     >
       ${this.saveStatus === "success"
         ? html`<div slot="content" class="flex items-center gap-2">
@@ -118,6 +123,8 @@ export class CollectionWorkflowListSettings extends BtrixElement {
             ?disabled=${!disableDedupe}
             placement="left"
             hoist
+            @sl-hide=${stopProp}
+            @sl-after-hide=${stopProp}
           >
             <sl-switch
               class="mx-[2px] inline-block"
@@ -126,9 +133,6 @@ export class CollectionWorkflowListSettings extends BtrixElement {
               ?disabled=${!this.workflowId}
               @sl-change=${(e: CustomEvent) => {
                 e.stopPropagation();
-
-                window.clearTimeout(this.#timerId);
-                this.saveStatus = undefined;
 
                 this.autoAdd = (e.target as SlSwitch).checked;
                 this.collapse = !this.autoAdd;
@@ -159,6 +163,8 @@ export class CollectionWorkflowListSettings extends BtrixElement {
                 ?disabled=${!disableDedupe}
                 placement="bottom-end"
                 hoist
+                @sl-hide=${stopProp}
+                @sl-after-hide=${stopProp}
               >
                 <sl-switch
                   class="mx-[2px] inline-block"
@@ -170,9 +176,6 @@ export class CollectionWorkflowListSettings extends BtrixElement {
                   }}
                   @sl-change=${(e: CustomEvent) => {
                     e.stopPropagation();
-
-                    window.clearTimeout(this.#timerId);
-                    this.saveStatus = undefined;
 
                     this.dedupe = (e.target as SlSwitch).checked;
 
@@ -224,6 +227,9 @@ export class CollectionWorkflowListSettings extends BtrixElement {
       }
     }
 
+    window.clearTimeout(this.#timerId);
+    this.showSaveStatus = false;
+
     try {
       await this.api.fetch(
         `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
@@ -250,5 +256,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
         id: "auto-add-status",
       });
     }
+
+    this.showSaveStatus = true;
   }
 }

--- a/frontend/src/features/collections/collection-workflow-list/settings.ts
+++ b/frontend/src/features/collections/collection-workflow-list/settings.ts
@@ -4,16 +4,13 @@ import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
+import union from "lodash/fp/union";
+import without from "lodash/fp/without";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import type { BtrixChangeEvent } from "@/events/btrix-change";
+import type { Workflow } from "@/types/crawler";
 import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
-
-export type CollectionWorkflowListSettingChangeEvent = BtrixChangeEvent<{
-  autoAdd: boolean;
-  dedupe?: boolean;
-}>;
 
 /**
  * Additional settings for each workflow in `<btrix-collection-workflow-list>`
@@ -39,6 +36,14 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   @state()
   private autoAdd = false;
 
+  @state()
+  private dedupe = false;
+
+  @state()
+  private saveStatus?: "success" | "error";
+
+  #timerId?: number;
+
   protected willUpdate(changedProperties: PropertyValues): void {
     if (
       changedProperties.has("collectionId") ||
@@ -47,10 +52,51 @@ export class CollectionWorkflowListSettings extends BtrixElement {
       this.autoAdd = this.autoAddCollections.some(
         (id) => id === this.collectionId,
       );
+      this.dedupe = Boolean(
+        this.dedupeCollId && this.dedupeCollId === this.collectionId,
+      );
     }
   }
 
+  protected updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has("saveStatus") && this.saveStatus !== undefined) {
+      // Reset success status
+      this.#timerId = window.setTimeout(() => {
+        this.saveStatus = undefined;
+      }, 5000);
+    }
+  }
+
+  disconnectedCallback(): void {
+    window.clearTimeout(this.#timerId);
+    super.disconnectedCallback();
+  }
+
   render() {
+    return html`<sl-tooltip
+      placement="left"
+      trigger="manual"
+      ?open=${this.saveStatus !== undefined}
+      hoist
+      @click=${() => (this.saveStatus = undefined)}
+    >
+      ${this.saveStatus === "success"
+        ? html`<div slot="content" class="flex items-center gap-2">
+            <sl-icon
+              name="check-lg"
+              class="text-base text-success-400"
+            ></sl-icon>
+            ${msg("Saved Change")}
+          </div>`
+        : html`<div slot="content" class="flex items-center gap-2">
+            <sl-icon name="x-lg" class="text-base text-danger-400"></sl-icon>
+            ${msg("Could Not Save")}
+          </div>`}
+      ${this.renderToggles()}
+    </sl-tooltip>`;
+  }
+
+  private renderToggles() {
     const disableDedupe = Boolean(
       this.dedupeCollId && this.dedupeCollId !== this.collectionId,
     );
@@ -81,19 +127,15 @@ export class CollectionWorkflowListSettings extends BtrixElement {
               @sl-change=${(e: CustomEvent) => {
                 e.stopPropagation();
 
-                this.autoAdd = (e.target as SlSwitch).checked;
+                window.clearTimeout(this.#timerId);
+                this.saveStatus = undefined;
 
-                this.dispatchEvent(
-                  new CustomEvent<
-                    CollectionWorkflowListSettingChangeEvent["detail"]
-                  >("btrix-change", {
-                    detail: {
-                      value: {
-                        autoAdd: this.autoAdd,
-                      },
-                    },
-                  }),
-                );
+                this.autoAdd = (e.target as SlSwitch).checked;
+                this.collapse = !this.autoAdd;
+
+                void this.saveAutoAdd({
+                  autoAdd: this.autoAdd,
+                });
               }}
             >
               <span class="text-neutral-500">${msg("Auto-Add")}</span>
@@ -121,28 +163,22 @@ export class CollectionWorkflowListSettings extends BtrixElement {
                 <sl-switch
                   class="mx-[2px] inline-block"
                   size="small"
-                  ?checked=${Boolean(
-                    this.dedupeCollId &&
-                      this.dedupeCollId === this.collectionId,
-                  )}
+                  ?checked=${this.dedupe}
                   ?disabled=${!this.workflowId || disableDedupe}
                   @click=${(e: MouseEvent) => {
                     e.stopPropagation();
                   }}
                   @sl-change=${(e: CustomEvent) => {
                     e.stopPropagation();
-                    this.dispatchEvent(
-                      new CustomEvent<
-                        CollectionWorkflowListSettingChangeEvent["detail"]
-                      >("btrix-change", {
-                        detail: {
-                          value: {
-                            autoAdd: this.autoAdd,
-                            dedupe: (e.target as SlSwitch).checked,
-                          },
-                        },
-                      }),
-                    );
+
+                    window.clearTimeout(this.#timerId);
+                    this.saveStatus = undefined;
+
+                    this.dedupe = (e.target as SlSwitch).checked;
+
+                    void this.saveAutoAdd({
+                      dedupe: this.dedupe,
+                    });
                   }}
                 >
                   <span class="text-neutral-500">${msg("Dedupe")}</span>
@@ -152,5 +188,67 @@ export class CollectionWorkflowListSettings extends BtrixElement {
         )}
       </div>
     `;
+  }
+
+  private async saveAutoAdd({
+    autoAdd,
+    dedupe,
+  }: {
+    autoAdd?: boolean;
+    dedupe?: boolean;
+  }) {
+    const params: {
+      autoAddCollections?: Workflow["autoAddCollections"];
+      dedupeCollId?: string;
+    } = {};
+
+    if (dedupe === true) {
+      params.dedupeCollId = this.collectionId;
+    } else if (dedupe === false) {
+      params.dedupeCollId = "";
+    }
+
+    if (autoAdd === true) {
+      params.autoAddCollections = union(
+        [this.collectionId],
+        this.autoAddCollections,
+      );
+    } else if (autoAdd === false) {
+      params.autoAddCollections = without(
+        [this.collectionId],
+        this.autoAddCollections,
+      );
+
+      if (this.dedupe) {
+        params.dedupeCollId = "";
+      }
+    }
+
+    try {
+      await this.api.fetch(
+        `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify(params),
+        },
+      );
+
+      this.saveStatus = "success";
+
+      this.dispatchEvent(new CustomEvent("btrix-collection-saved"));
+    } catch (e: unknown) {
+      console.debug(e);
+
+      this.saveStatus = "error";
+
+      this.notify.toast({
+        message: msg(
+          "Something unexpected went wrong, couldn't save auto-add setting.",
+        ),
+        variant: "warning",
+        icon: "exclamation-circle",
+        id: "auto-add-status",
+      });
+    }
   }
 }

--- a/frontend/src/features/collections/collection-workflow-list/settings.ts
+++ b/frontend/src/features/collections/collection-workflow-list/settings.ts
@@ -1,9 +1,11 @@
 import { localized, msg } from "@lit/localize";
+import { Task } from "@lit/task";
 import type { SlSwitch } from "@shoelace-style/shoelace";
 import clsx from "clsx";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
+import debounce from "lodash/fp/debounce";
 import union from "lodash/fp/union";
 import without from "lodash/fp/without";
 
@@ -47,6 +49,31 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   private saveStatus?: "success" | "error";
 
   #timerId?: number;
+
+  private readonly saveAutoAddTask = new Task(this, {
+    autoRun: false,
+    task: async ([autoAdd, dedupe], { signal }) => {
+      window.clearTimeout(this.#timerId);
+      this.showSaveStatus = false;
+
+      try {
+        await this.saveAutoAdd({ autoAdd, dedupe }, signal);
+
+        this.saveStatus = "success";
+        this.showSaveStatus = true;
+
+        this.dispatchEvent(new CustomEvent("btrix-collection-saved"));
+      } catch (err) {
+        console.debug(err);
+
+        if (!signal.aborted) {
+          this.saveStatus = "error";
+          this.showSaveStatus = true;
+        }
+      }
+    },
+    args: () => [this.autoAdd, this.dedupe] as const,
+  });
 
   protected willUpdate(changedProperties: PropertyValues): void {
     if (
@@ -137,9 +164,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
                 this.autoAdd = (e.target as SlSwitch).checked;
                 this.collapse = !this.autoAdd;
 
-                void this.saveAutoAdd({
-                  autoAdd: this.autoAdd,
-                });
+                this.debouncedSaveAutoAdd();
               }}
             >
               <span class="text-neutral-500">${msg("Auto-Add")}</span>
@@ -179,9 +204,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
 
                     this.dedupe = (e.target as SlSwitch).checked;
 
-                    void this.saveAutoAdd({
-                      dedupe: this.dedupe,
-                    });
+                    this.debouncedSaveAutoAdd();
                   }}
                 >
                   <span class="text-neutral-500">${msg("Dedupe")}</span>
@@ -193,13 +216,21 @@ export class CollectionWorkflowListSettings extends BtrixElement {
     `;
   }
 
-  private async saveAutoAdd({
-    autoAdd,
-    dedupe,
-  }: {
-    autoAdd?: boolean;
-    dedupe?: boolean;
-  }) {
+  // Debounce auto add to prevent multiple requests when toggling too quickly
+  private readonly debouncedSaveAutoAdd = debounce(200)(() => {
+    void this.saveAutoAddTask.run();
+  });
+
+  private async saveAutoAdd(
+    {
+      autoAdd,
+      dedupe,
+    }: {
+      autoAdd?: boolean;
+      dedupe?: boolean;
+    },
+    signal: AbortSignal,
+  ) {
     const params: {
       autoAddCollections?: Workflow["autoAddCollections"];
       dedupeCollId?: string;
@@ -227,36 +258,13 @@ export class CollectionWorkflowListSettings extends BtrixElement {
       }
     }
 
-    window.clearTimeout(this.#timerId);
-    this.showSaveStatus = false;
-
-    try {
-      await this.api.fetch(
-        `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify(params),
-        },
-      );
-
-      this.saveStatus = "success";
-
-      this.dispatchEvent(new CustomEvent("btrix-collection-saved"));
-    } catch (e: unknown) {
-      console.debug(e);
-
-      this.saveStatus = "error";
-
-      this.notify.toast({
-        message: msg(
-          "Something unexpected went wrong, couldn't save auto-add setting.",
-        ),
-        variant: "warning",
-        icon: "exclamation-circle",
-        id: "auto-add-status",
-      });
-    }
-
-    this.showSaveStatus = true;
+    return this.api.fetch(
+      `/orgs/${this.orgId}/crawlconfigs/${this.workflowId}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(params),
+        signal,
+      },
+    );
   }
 }

--- a/frontend/src/features/collections/collection-workflow-list/settings.ts
+++ b/frontend/src/features/collections/collection-workflow-list/settings.ts
@@ -238,7 +238,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
 
     if (dedupe === true) {
       params.dedupeCollId = this.collectionId;
-    } else if (dedupe === false) {
+    } else if (dedupe === false && this.dedupeCollId === this.collectionId) {
       params.dedupeCollId = "";
     }
 
@@ -253,7 +253,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
         this.autoAddCollections,
       );
 
-      if (this.dedupe) {
+      if (this.dedupeCollId === this.collectionId) {
         params.dedupeCollId = "";
       }
     }

--- a/frontend/src/features/collections/collection-workflow-list/settings.ts
+++ b/frontend/src/features/collections/collection-workflow-list/settings.ts
@@ -17,6 +17,8 @@ import { tw } from "@/utils/tailwind";
 
 /**
  * Additional settings for each workflow in `<btrix-collection-workflow-list>`
+ *
+ * @fires btrix-workflow-after-save
  */
 @customElement("btrix-collection-workflow-list-settings")
 @localized()
@@ -36,6 +38,9 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   @property({ type: Boolean })
   collapse = false;
 
+  @property({ type: Boolean })
+  showSaveStatus = false;
+
   @state()
   private autoAdd = false;
 
@@ -43,7 +48,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   private dedupe = false;
 
   @state()
-  private showSaveStatus = false;
+  private saving?: "autoAdd" | "dedupe";
 
   @state()
   private saveStatus?: "success" | "error";
@@ -62,7 +67,7 @@ export class CollectionWorkflowListSettings extends BtrixElement {
         this.saveStatus = "success";
         this.showSaveStatus = true;
 
-        this.dispatchEvent(new CustomEvent("btrix-collection-saved"));
+        this.dispatchEvent(new CustomEvent("btrix-workflow-after-save"));
       } catch (err) {
         console.debug(err);
 
@@ -92,9 +97,12 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   protected updated(changedProperties: PropertyValues): void {
     if (changedProperties.has("saveStatus") && this.saveStatus !== undefined) {
       // Reset success status
-      this.#timerId = window.setTimeout(() => {
-        this.showSaveStatus = false;
-      }, 4000);
+      this.#timerId = window.setTimeout(
+        () => {
+          this.showSaveStatus = false;
+        },
+        this.saveStatus === "success" ? 3000 : 5000,
+      );
     }
   }
 
@@ -104,34 +112,29 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   }
 
   render() {
-    return html`<sl-tooltip
-      placement="right"
-      trigger="manual"
-      ?open=${Boolean(this.showSaveStatus && this.saveStatus)}
-      hoist
-      @click=${() => (this.showSaveStatus = false)}
-      @sl-after-hide=${() => (this.saveStatus = undefined)}
-    >
-      ${this.saveStatus === "success"
+    const disableDedupe = Boolean(
+      this.dedupeCollId && this.dedupeCollId !== this.collectionId,
+    );
+    const tooltipContent =
+      this.saveStatus === "success"
         ? html`<div slot="content" class="flex items-center gap-2">
             <sl-icon
               name="check-lg"
               class="text-base text-success-400"
             ></sl-icon>
-            ${msg("Saved Change")}
+            ${msg("Saved")}
           </div>`
         : html`<div slot="content" class="flex items-center gap-2">
             <sl-icon name="x-lg" class="text-base text-danger-400"></sl-icon>
             ${msg("Could Not Save")}
-          </div>`}
-      ${this.renderToggles()}
-    </sl-tooltip>`;
-  }
+          </div>`;
 
-  private renderToggles() {
-    const disableDedupe = Boolean(
-      this.dedupeCollId && this.dedupeCollId !== this.collectionId,
-    );
+    const tooltipClick = () => (this.showSaveStatus = false);
+    const tooltipHide = stopProp;
+    const tooltipAfterHide = (e: CustomEvent) => {
+      e.stopPropagation();
+      this.saveStatus = undefined;
+    };
 
     return html`
       <div
@@ -140,19 +143,19 @@ export class CollectionWorkflowListSettings extends BtrixElement {
           !this.collapse && tw`gap-4`,
         )}
       >
-        <div class="flex grow basis-0 transition-all">
-          <btrix-popover
-            content="${msg(
-              "This workflow is using another collection as its deduplication source.",
-            )} ${msg(
-              "Auto-adding new crawls to this collection may result in missing content.",
-            )}"
-            ?disabled=${!disableDedupe}
+        <div class="flex grow basis-0 items-center transition-all">
+          <sl-tooltip
+            trigger="manual"
             placement="left"
+            distance="10"
+            ?open=${Boolean(this.showSaveStatus && this.saveStatus)}
+            ?disabled=${this.saving !== "autoAdd"}
             hoist
-            @sl-hide=${stopProp}
-            @sl-after-hide=${stopProp}
+            @click=${tooltipClick}
+            @sl-hide=${tooltipHide}
+            @sl-after-hide=${tooltipAfterHide}
           >
+            ${tooltipContent}
             <sl-switch
               class="mx-[2px] inline-block"
               size="small"
@@ -162,54 +165,81 @@ export class CollectionWorkflowListSettings extends BtrixElement {
                 e.stopPropagation();
 
                 this.autoAdd = (e.target as SlSwitch).checked;
-                this.collapse = !this.autoAdd;
 
-                this.debouncedSaveAutoAdd();
+                if (!disableDedupe) {
+                  this.collapse = !this.autoAdd;
+                }
+
+                this.debouncedSaveAutoAdd("autoAdd");
               }}
             >
               <span class="text-neutral-500">${msg("Auto-Add")}</span>
             </sl-switch>
-          </btrix-popover>
+          </sl-tooltip>
         </div>
         ${when(
           this.featureFlags.has("dedupeEnabled"),
           () =>
             html`<div
               class=${clsx(
-                tw`basis-0 overflow-hidden transition-all`,
-                this.autoAdd ? tw`grow` : tw`shrink`,
-                this.collapse && tw`w-0`,
+                tw`overflow-hidden transition-all`,
+                !disableDedupe && [
+                  tw`basis-0`,
+                  this.autoAdd ? tw`grow` : tw`shrink`,
+                ],
+                this.collapse && !disableDedupe && tw`w-0`,
               )}
             >
-              <btrix-popover
-                content=${msg(
-                  "This workflow is using another collection as its deduplication source.",
-                )}
-                ?disabled=${!disableDedupe}
-                placement="bottom-end"
-                hoist
-                @sl-hide=${stopProp}
-                @sl-after-hide=${stopProp}
-              >
-                <sl-switch
-                  class="mx-[2px] inline-block"
-                  size="small"
-                  ?checked=${this.dedupe}
-                  ?disabled=${!this.workflowId || disableDedupe}
-                  @click=${(e: MouseEvent) => {
-                    e.stopPropagation();
-                  }}
-                  @sl-change=${(e: CustomEvent) => {
-                    e.stopPropagation();
+              ${disableDedupe
+                ? html`
+                    <btrix-popover
+                      content="${msg(
+                        "This workflow is using another collection as its deduplication source.",
+                      )} ${msg(
+                        "Auto-adding new crawls to this collection may result in missing content.",
+                      )}"
+                      placement="bottom-end"
+                      hoist
+                    >
+                      <sl-icon
+                        class=${clsx(
+                          tw`mt-px block text-base text-neutral-500`,
+                          this.collapse && `ml-2.5`,
+                        )}
+                        name="exclamation-diamond"
+                      ></sl-icon>
+                    </btrix-popover>
+                  `
+                : html`<sl-tooltip
+                    trigger="manual"
+                    placement="right"
+                    distance="10"
+                    ?open=${Boolean(this.showSaveStatus && this.saveStatus)}
+                    ?disabled=${this.saving !== "dedupe"}
+                    hoist
+                    @click=${tooltipClick}
+                    @sl-hide=${tooltipHide}
+                    @sl-after-hide=${tooltipAfterHide}
+                  >
+                    ${tooltipContent}
+                    <sl-switch
+                      class="mx-[2px] inline-block"
+                      size="small"
+                      ?checked=${this.dedupe}
+                      ?disabled=${!this.workflowId}
+                      @sl-change=${(e: CustomEvent) => {
+                        e.stopPropagation();
 
-                    this.dedupe = (e.target as SlSwitch).checked;
+                        this.dedupe = (e.target as SlSwitch).checked;
 
-                    this.debouncedSaveAutoAdd();
-                  }}
-                >
-                  <span class="text-neutral-500">${msg("Dedupe")}</span>
-                </sl-switch>
-              </btrix-popover>
+                        this.debouncedSaveAutoAdd(
+                          this.collapse ? "autoAdd" : "dedupe",
+                        );
+                      }}
+                    >
+                      <span class="text-neutral-500">${msg("Dedupe")}</span>
+                    </sl-switch>
+                  </sl-tooltip>`}
             </div>`,
         )}
       </div>
@@ -217,9 +247,12 @@ export class CollectionWorkflowListSettings extends BtrixElement {
   }
 
   // Debounce auto add to prevent multiple requests when toggling too quickly
-  private readonly debouncedSaveAutoAdd = debounce(200)(() => {
-    void this.saveAutoAddTask.run();
-  });
+  private readonly debouncedSaveAutoAdd = debounce(200)(
+    (field: "autoAdd" | "dedupe") => {
+      this.saving = field;
+      void this.saveAutoAddTask.run();
+    },
+  );
 
   private async saveAutoAdd(
     {

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -68,6 +68,11 @@
     --wa-color-neutral-90: var(--sl-color-neutral-200);
     --wa-color-neutral-95: var(--sl-color-neutral-100);
 
+    /* Z-index */
+
+    /* Place above toast notifications */
+    --sl-z-index-dialog: 1000;
+
     /*
      * Typography
      */


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/3253

## Changes

- Fixes toggling off auto-add when dedupe is enabled
- Refactors auto-add and dedupe toggle to simplify save method
- Moves toast stack to below dialogs (related to https://github.com/webrecorder/browsertrix/issues/3253)
- Shows save status for auto-add and dedupe next to toggle

## Manual testing

1. Log in as crawler
2. Go to a collection > Archived Items
3. Choose "Configure Items"
4. Find workflow with auto-add and dedupe enabled
5. Toggle "Auto-Add" off. Verify save status is displayed and disappears after 5 seconds
6. Reload browser window. Verify "Auto-Add" and dedupe for saved workflow remains toggled off

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection / Configure Items | <img width="417" height="67" alt="Screenshot 2026-04-29 at 6 56 37 PM" src="https://github.com/user-attachments/assets/01517876-bc0f-45f0-a2ef-e655bcccebae" /> |
| Collection / Configure Items | <img width="421" height="65" alt="Screenshot 2026-04-29 at 6 57 55 PM" src="https://github.com/user-attachments/assets/98c6ee2b-209c-4a60-b979-74437dfc775e" /> |


## Follow-ups

A common component or render template should be created if we continue to follow this pattern. As a part of that work, the success status should be light-themed to match the success and info toast messages.