### PR TITLE
Standardize and update field length constraints

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -45,7 +45,7 @@ from .models import (
     TagsResponse,
     CrawlOut,
     CrawlOutWithResources,
-    CrawlConfigUpdate,
+    UpdateCrawlConfig,
     Organization,
     User,
     PaginatedCrawlConfigOutResponse,
@@ -510,7 +510,7 @@ class CrawlConfigOps:
         )
 
     def check_attr_changed(
-        self, crawlconfig: CrawlConfig, update: CrawlConfigUpdate, attr_name: str
+        self, crawlconfig: CrawlConfig, update: UpdateCrawlConfig, attr_name: str
     ) -> bool:
         """check if attribute is set and has changed. if not changed, clear it on the update"""
         if getattr(update, attr_name) is not None:
@@ -520,7 +520,7 @@ class CrawlConfigOps:
         return False
 
     async def update_crawl_config(
-        self, cid: UUID, org: Organization, user: User, update: CrawlConfigUpdate
+        self, cid: UUID, org: Organization, user: User, update: UpdateCrawlConfig
     ) -> CrawlConfigUpdateResponse:
         # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
@@ -1255,7 +1255,7 @@ class CrawlConfigOps:
 
         crawl_config.config.exclude = exclude
 
-        update_config = CrawlConfigUpdate(config=crawl_config.config)
+        update_config = UpdateCrawlConfig(config=crawl_config.config)
 
         await self.update_crawl_config(cid, org, user, update_config)
 
@@ -1968,7 +1968,7 @@ def init_crawl_config_api(
         response_model=CrawlConfigUpdateResponse,
     )
     async def update_crawl_config(
-        update: CrawlConfigUpdate,
+        update: UpdateCrawlConfig,
         cid: UUID,
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -45,7 +45,7 @@ from .models import (
     TagsResponse,
     CrawlOut,
     CrawlOutWithResources,
-    UpdateCrawlConfig,
+    CrawlConfigUpdate,
     Organization,
     User,
     PaginatedCrawlConfigOutResponse,
@@ -510,7 +510,7 @@ class CrawlConfigOps:
         )
 
     def check_attr_changed(
-        self, crawlconfig: CrawlConfig, update: UpdateCrawlConfig, attr_name: str
+        self, crawlconfig: CrawlConfig, update: CrawlConfigUpdate, attr_name: str
     ) -> bool:
         """check if attribute is set and has changed. if not changed, clear it on the update"""
         if getattr(update, attr_name) is not None:
@@ -520,7 +520,7 @@ class CrawlConfigOps:
         return False
 
     async def update_crawl_config(
-        self, cid: UUID, org: Organization, user: User, update: UpdateCrawlConfig
+        self, cid: UUID, org: Organization, user: User, update: CrawlConfigUpdate
     ) -> CrawlConfigUpdateResponse:
         # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         """Update name, scale, schedule, and/or tags for an existing crawl config"""
@@ -1255,7 +1255,7 @@ class CrawlConfigOps:
 
         crawl_config.config.exclude = exclude
 
-        update_config = UpdateCrawlConfig(config=crawl_config.config)
+        update_config = CrawlConfigUpdate(config=crawl_config.config)
 
         await self.update_crawl_config(cid, org, user, update_config)
 
@@ -1968,7 +1968,7 @@ def init_crawl_config_api(
         response_model=CrawlConfigUpdateResponse,
     )
     async def update_crawl_config(
-        update: UpdateCrawlConfig,
+        update: CrawlConfigUpdate,
         cid: UUID,
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -47,7 +47,7 @@ from .models import (
     UpdateCrawl,
     DeleteCrawlList,
     CrawlConfig,
-    UpdateCrawlConfig,
+    CrawlConfigUpdate,
     CrawlScale,
     CrawlStats,
     CrawlFile,
@@ -521,7 +521,7 @@ class CrawlOps(BaseCrawlOps):
         """Update crawl scale in the db"""
         crawl = await self.get_crawl(crawl_id, org)
 
-        update = UpdateCrawlConfig(browserWindows=browser_windows)
+        update = CrawlConfigUpdate(browserWindows=browser_windows)
         await self.crawl_configs.update_crawl_config(crawl.cid, org, user, update)
 
         result = await self.crawls.find_one_and_update(

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -47,7 +47,7 @@ from .models import (
     UpdateCrawl,
     DeleteCrawlList,
     CrawlConfig,
-    CrawlConfigUpdate,
+    UpdateCrawlConfig,
     CrawlScale,
     CrawlStats,
     CrawlFile,
@@ -521,7 +521,7 @@ class CrawlOps(BaseCrawlOps):
         """Update crawl scale in the db"""
         crawl = await self.get_crawl(crawl_id, org)
 
-        update = CrawlConfigUpdate(browserWindows=browser_windows)
+        update = UpdateCrawlConfig(browserWindows=browser_windows)
         await self.crawl_configs.update_crawl_config(crawl.cid, org, user, update)
 
         result = await self.crawls.find_one_and_update(

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -6,9 +6,12 @@ import importlib.util
 import os
 import urllib.parse
 import asyncio
+import contextvars
 from uuid import UUID, uuid4
 
 from typing import (
+    Any,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -17,7 +20,7 @@ from typing import (
 )
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-from pydantic import BaseModel
+from pydantic import BaseModel, WrapValidator, ValidationError
 from pymongo.errors import InvalidName
 
 from .migrations import BaseMigration
@@ -316,6 +319,40 @@ async def create_indexes(
     await profile_ops.init_index()
 
 
+_LENIENT_CTX = contextvars.ContextVar[Literal[False] | dict[str, Any]](
+    "_lenient_ctx", default=False
+)
+
+
+def _lenient_str(v, handler, info):
+    """WrapValidator: skip string validation when reading from DB."""
+    ctx = _LENIENT_CTX.get()
+    if ctx and isinstance(v, str):
+        try:
+            return handler(v)
+        except ValidationError as e:
+            doc_id = ctx.get("id", "?")
+            model = ctx.get("model", "?")
+            field = getattr(info, "field_name", "?")
+            # pylint: disable=fixme
+            # TODO: replace with logger.warning once we have structured logging in place
+            print(
+                f"WARNING: lenient read - "
+                f"{model}.{field!r} value exceeds constraints in "
+                f"document id={doc_id!r}",
+                e,
+            )
+            return v
+    return handler(v)
+
+
+LENIENT_ON_READ = WrapValidator(_lenient_str)
+"""
+Marker for fields that allow validations to fail when read from the database.
+Useful for adding new validations without breaking existing data, e.g. max
+length constraints on text fields.
+"""
+
 # ============================================================================
 T = TypeVar("T")
 
@@ -337,7 +374,11 @@ class BaseMongoModel(BaseModel):
         if not data:
             return cls()
         data["id"] = data.pop("_id")
-        return cls(**data)
+        token = _LENIENT_CTX.set({"id": data.get("id"), "model": cls.__name__})
+        try:
+            return cls(**data)
+        finally:
+            _LENIENT_CTX.reset(token)
 
     def serialize(self, **opts):
         """convert class to dict"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1703,11 +1703,11 @@ class Collection(BaseMongoModel):
     """Org collection structure"""
 
     id: UUID
-    name: Name
-    slug: Annotated[str, Field(min_length=1, max_length=1000)]
+    name: CollectionName
+    slug: CollectionSlug
     oid: UUID
-    description: Optional[str] = None
-    caption: Optional[str] = None
+    description: Description = None
+    caption: CollectionCaption = None
 
     created: Optional[datetime] = None
     modified: Optional[datetime] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -34,7 +34,7 @@ from slugify import slugify
 
 # from fastapi_users import models as fastapi_users_models
 
-from .db import BaseMongoModel
+from .db import LENIENT_ON_READ, BaseMongoModel
 
 from .utils import is_bool
 
@@ -92,17 +92,17 @@ HttpUrl = Annotated[
     str, BeforeValidator(lambda value: str(http_url_adapter.validate_python(value)))
 ]
 
-Name = Annotated[str, Field(min_length=1, max_length=1000)]
-NameOrEmptyStr = Annotated[str, Field(min_length=0, max_length=1000)]
-Description = Annotated[str | None, Field(max_length=5000)]
-Tag = Annotated[str, Field(min_length=1, max_length=80)]
+Name = Annotated[str, Field(min_length=1, max_length=1000), LENIENT_ON_READ]
+NameOrEmptyStr = Annotated[str, Field(min_length=0, max_length=1000), LENIENT_ON_READ]
+Description = Annotated[str | None, Field(max_length=5000), LENIENT_ON_READ]
+Tag = Annotated[str, Field(min_length=1, max_length=80), LENIENT_ON_READ]
 
-CollectionName = Annotated[str, Field(min_length=1, max_length=80)]
-CollectionSlug = Annotated[str, Field(min_length=1, max_length=80)]
-CollectionCaption = Annotated[str | None, Field(max_length=1000)]
+CollectionName = Annotated[str, Field(min_length=1, max_length=80), LENIENT_ON_READ]
+CollectionSlug = Annotated[str, Field(min_length=1, max_length=80), LENIENT_ON_READ]
+CollectionCaption = Annotated[str | None, Field(max_length=1000), LENIENT_ON_READ]
 
-OrgName = Annotated[str, Field(min_length=1, max_length=50)]
-OrgPublicDescription = Annotated[str | None, Field(max_length=400)]
+OrgName = Annotated[str, Field(min_length=1, max_length=50), LENIENT_ON_READ]
+OrgPublicDescription = Annotated[str | None, Field(max_length=400), LENIENT_ON_READ]
 
 
 # pylint: disable=too-few-public-methods
@@ -501,7 +501,7 @@ class CrawlConfigCore(BaseMongoModel):
     jobType: Optional[JobType] = JobType.CUSTOM
     config: Optional[RawCrawlConfig] = None
 
-    tags: Optional[List[str]] = []
+    tags: list[Tag] | None = []
 
     crawlTimeout: Optional[int] = 0
     maxCrawlSize: Optional[int] = 0
@@ -525,8 +525,8 @@ class CrawlConfigCore(BaseMongoModel):
 class CrawlConfigAdditional(BaseModel):
     """Additional fields shared by CrawlConfig and CrawlConfigOut."""
 
-    name: Optional[str] = None
-    description: Optional[str] = None
+    name: NameOrEmptyStr | None = None
+    description: Description | None = None
 
     created: datetime
     createdBy: Optional[UUID] = None
@@ -2450,7 +2450,7 @@ class OrgOut(BaseMongoModel):
     """Organization API output model"""
 
     id: UUID
-    name: str
+    name: OrgName
     slug: str
     users: Dict[str, Any] = {}
 
@@ -2513,7 +2513,7 @@ class Organization(BaseMongoModel):
     """Organization Base Model"""
 
     id: UUID
-    name: str
+    name: OrgName
     slug: str
     users: Dict[str, UserRole] = {}
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -597,7 +597,7 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
 
 
 # ============================================================================
-class CrawlConfigUpdate(BaseModel):
+class UpdateCrawlConfig(BaseModel):
     """Update crawl config name, crawl schedule, or tags"""
 
     # metadata: not revision tracked

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -95,9 +95,14 @@ HttpUrl = Annotated[
 Name = Annotated[str, Field(min_length=1, max_length=1000)]
 NameOrEmptyStr = Annotated[str, Field(min_length=0, max_length=1000)]
 Description = Annotated[str | None, Field(max_length=5000)]
-Tag = Annotated[str, Field(min_length=1, max_length=150)]
+Tag = Annotated[str, Field(min_length=1, max_length=80)]
+
+CollectionName = Annotated[str, Field(min_length=1, max_length=80)]
+CollectionSlug = Annotated[str, Field(min_length=1, max_length=80)]
+CollectionCaption = Annotated[str | None, Field(max_length=1000)]
 
 OrgName = Annotated[str, Field(min_length=1, max_length=50)]
+OrgPublicDescription = Annotated[str | None, Field(max_length=400)]
 
 
 # pylint: disable=too-few-public-methods
@@ -1746,10 +1751,10 @@ class Collection(BaseMongoModel):
 class CollIn(BaseModel):
     """Collection Passed in By User"""
 
-    name: Name
-    slug: Annotated[str | None, Field(min_length=1, max_length=1000)] = None
+    name: CollectionName
+    slug: CollectionSlug | None = None
     description: Description = None
-    caption: Annotated[str | None, Field(max_length=1000)] = None
+    caption: CollectionCaption = None
     crawlIds: Optional[List[str]] = []
 
     access: CollAccessType = CollAccessType.PRIVATE
@@ -1855,10 +1860,10 @@ class PublicCollOut(BaseMongoModel):
 class UpdateColl(BaseModel):
     """Update collection"""
 
-    name: Name | None = None
-    slug: Annotated[str | None, Field(min_length=1, max_length=1000)] = None
+    name: CollectionName | None = None
+    slug: CollectionSlug | None = None
     description: Description = None
-    caption: Annotated[str | None, Field(max_length=1000)] = None
+    caption: CollectionCaption = None
     access: Optional[CollAccessType] = None
     defaultThumbnailName: Optional[str] = None
     allowPublicDownload: Optional[bool] = None

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -92,6 +92,13 @@ HttpUrl = Annotated[
     str, BeforeValidator(lambda value: str(http_url_adapter.validate_python(value)))
 ]
 
+Name = Annotated[str, Field(min_length=1, max_length=1000)]
+NameOrEmptyStr = Annotated[str, Field(min_length=0, max_length=1000)]
+Description = Annotated[str | None, Field(max_length=5000)]
+Tag = Annotated[str, Field(min_length=1, max_length=150)]
+
+OrgName = Annotated[str, Field(min_length=1, max_length=50)]
+
 
 # pylint: disable=too-few-public-methods
 class EmailStr(CasedEmailStr):
@@ -427,9 +434,9 @@ class CrawlConfigIn(BaseModel):
 
     config: RawCrawlConfig
 
-    name: str
+    name: NameOrEmptyStr
 
-    description: Optional[str] = ""
+    description: Description = ""
 
     jobType: Optional[JobType] = JobType.CUSTOM
 
@@ -440,7 +447,7 @@ class CrawlConfigIn(BaseModel):
     autoAddCollections: Optional[List[UUID]] = []
     dedupeCollId: Union[UUID, EmptyStr, None] = None
 
-    tags: Optional[List[str]] = []
+    tags: list[Tag] | None = []
 
     crawlTimeout: int = 0
     maxCrawlSize: int = 0
@@ -585,13 +592,13 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
 
 
 # ============================================================================
-class UpdateCrawlConfig(BaseModel):
+class CrawlConfigUpdate(BaseModel):
     """Update crawl config name, crawl schedule, or tags"""
 
     # metadata: not revision tracked
-    name: Optional[str] = None
-    tags: Optional[List[str]] = None
-    description: Optional[str] = None
+    name: NameOrEmptyStr | None = None
+    tags: list[Tag] | None = None
+    description: Description = None
     autoAddCollections: Optional[List[UUID]] = None
     dedupeCollId: Union[UUID, EmptyStr, None] = None
     runNow: bool = False
@@ -1017,9 +1024,9 @@ class CrawlOut(BaseMongoModel):
 class UpdateCrawl(BaseModel):
     """Update crawl"""
 
-    name: Optional[str] = None
-    description: Optional[str] = None
-    tags: Optional[List[str]] = None
+    name: NameOrEmptyStr | None = None
+    description: Description = None
+    tags: list[Tag] | None = None
     collectionIds: Optional[List[UUID]] = []
     reviewStatus: ReviewStatus = None
 
@@ -1186,6 +1193,10 @@ class CrawlScaleResponse(BaseModel):
 # ============================================================================
 class UploadedCrawl(BaseCrawl):
     """Store State of a Crawl Upload"""
+
+    name: Name | None = ""
+    description: Description = ""
+    tags: list[Tag] | None = []
 
     type: Literal["upload"] = "upload"
     image: None = None
@@ -1687,8 +1698,8 @@ class Collection(BaseMongoModel):
     """Org collection structure"""
 
     id: UUID
-    name: str = Field(..., min_length=1)
-    slug: str = Field(..., min_length=1)
+    name: Name
+    slug: Annotated[str, Field(min_length=1, max_length=1000)]
     oid: UUID
     description: Optional[str] = None
     caption: Optional[str] = None
@@ -1735,10 +1746,10 @@ class Collection(BaseMongoModel):
 class CollIn(BaseModel):
     """Collection Passed in By User"""
 
-    name: str = Field(..., min_length=1)
-    slug: Optional[str] = None
-    description: Optional[str] = None
-    caption: Optional[str] = None
+    name: Name
+    slug: Annotated[str | None, Field(min_length=1, max_length=1000)] = None
+    description: Description = None
+    caption: Annotated[str | None, Field(max_length=1000)] = None
     crawlIds: Optional[List[str]] = []
 
     access: CollAccessType = CollAccessType.PRIVATE
@@ -1844,10 +1855,10 @@ class PublicCollOut(BaseMongoModel):
 class UpdateColl(BaseModel):
     """Update collection"""
 
-    name: Optional[str] = None
-    slug: Optional[str] = None
-    description: Optional[str] = None
-    caption: Optional[str] = None
+    name: Name | None = None
+    slug: Annotated[str | None, Field(min_length=1, max_length=1000)] = None
+    description: Description = None
+    caption: Annotated[str | None, Field(max_length=1000)] = None
     access: Optional[CollAccessType] = None
     defaultThumbnailName: Optional[str] = None
     allowPublicDownload: Optional[bool] = None
@@ -1915,7 +1926,7 @@ class RemovePendingInvite(InviteRequest):
 class RenameOrg(BaseModel):
     """Rename an existing org"""
 
-    name: str
+    name: OrgName
     slug: Optional[str] = None
 
 
@@ -2374,7 +2385,7 @@ class OrgReadOnlyOnCancel(BaseModel):
 class OrgCreate(BaseModel):
     """Create a new org"""
 
-    name: str
+    name: OrgName
     slug: Optional[str] = None
 
 
@@ -2848,9 +2859,9 @@ class ProfileCreate(BaseModel):
     """Create new profile for browser id"""
 
     browserid: str
-    name: str
-    description: Optional[str] = ""
-    tags: Optional[List[str]] = []
+    name: Name
+    description: Description = ""
+    tags: list[Tag] | None = []
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1199,7 +1199,7 @@ class CrawlScaleResponse(BaseModel):
 class UploadedCrawl(BaseCrawl):
     """Store State of a Crawl Upload"""
 
-    name: Name | None = ""
+    name: Name | None
     description: Description = ""
     tags: list[Tag] | None = []
 
@@ -2424,7 +2424,7 @@ class OrgPublicProfileUpdate(BaseModel):
     """Organization enablePublicProfile update"""
 
     enablePublicProfile: Optional[bool] = None
-    publicDescription: Optional[str] = None
+    publicDescription: OrgPublicDescription = None
     publicUrl: Optional[str] = None
 
 
@@ -2502,7 +2502,7 @@ class OrgOut(BaseMongoModel):
     lastCrawlFinished: Optional[datetime] = None
 
     enablePublicProfile: bool = False
-    publicDescription: str = ""
+    publicDescription: OrgPublicDescription = ""
     publicUrl: str = ""
 
     featureFlags: FeatureFlags = FeatureFlags()
@@ -2568,7 +2568,7 @@ class Organization(BaseMongoModel):
     lastCrawlFinished: Optional[datetime] = None
 
     enablePublicProfile: bool = False
-    publicDescription: Optional[str] = None
+    publicDescription: OrgPublicDescription = None
     publicUrl: Optional[str] = None
 
     featureFlags: FeatureFlags = FeatureFlags()

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1484,7 +1484,7 @@ class PageNote(BaseModel):
     """Model for page notes, tracking user and time"""
 
     id: UUID
-    text: str
+    text: Annotated[str, Field(max_length=5000)]
     created: datetime
     userid: UUID
     userName: str

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1199,9 +1199,7 @@ class CrawlScaleResponse(BaseModel):
 class UploadedCrawl(BaseCrawl):
     """Store State of a Crawl Upload"""
 
-    name: Name | None
-    description: Description = ""
-    tags: list[Tag] | None = []
+    name: Name
 
     type: Literal["upload"] = "upload"
     image: None = None
@@ -1210,6 +1208,8 @@ class UploadedCrawl(BaseCrawl):
 # ============================================================================
 class UpdateUpload(UpdateCrawl):
     """Update modal that also includes name"""
+
+    name: Name | None
 
 
 # ============================================================================

--- a/backend/test/test_lenient_validation.py
+++ b/backend/test/test_lenient_validation.py
@@ -1,0 +1,113 @@
+"""Tests for BaseMongoModel.from_dict lenient read via LENIENT_ON_READ"""
+
+from typing import Annotated
+from uuid import uuid4
+
+import pytest
+from pydantic import Field, ValidationError
+
+from btrixcloud.db import LENIENT_ON_READ, BaseMongoModel
+
+
+# ---------------------------------------------------------------------------
+# Minimal test models
+# ---------------------------------------------------------------------------
+
+LenientStr = Annotated[str, Field(max_length=10), LENIENT_ON_READ]
+StrictStr = Annotated[str, Field(max_length=10)]
+LenientOptionalStr = Annotated[str | None, Field(max_length=10), LENIENT_ON_READ]
+
+
+class _LenientModel(BaseMongoModel):
+    name: LenientStr
+    strict_field: StrictStr
+
+
+class _LenientOptionalModel(BaseMongoModel):
+    name: LenientOptionalStr = None
+
+
+class _NonLenientModel(BaseMongoModel):
+    strict_field: StrictStr
+
+
+class _AllOptionalModel(BaseMongoModel):
+    id: str | None = None
+    name: LenientStr | None = "default"
+    strict_field: StrictStr | None = "default"
+
+
+# ---------------------------------------------------------------------------
+# from_dict -- normal path
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_valid():
+    obj = _LenientModel.from_dict(
+        {"_id": str(uuid4()), "name": "hello", "strict_field": "world"}
+    )
+    assert obj.name == "hello"
+    assert obj.strict_field == "world"
+
+
+def test_from_dict_empty():
+    obj = _AllOptionalModel.from_dict({})
+    assert obj.name == "default"
+    assert obj.strict_field == "default"
+
+
+# ---------------------------------------------------------------------------
+# from_dict -- lenient path (over-limit data is allowed)
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_lenient_field_over_limit():
+    obj = _LenientModel.from_dict(
+        {"_id": str(uuid4()), "name": "x" * 50, "strict_field": "ok"}
+    )
+    assert len(obj.name) == 50
+    assert obj.strict_field == "ok"
+
+
+def test_from_dict_lenient_optional_over_limit():
+    obj = _LenientOptionalModel.from_dict({"_id": str(uuid4()), "name": "x" * 50})
+    assert len(obj.name) == 50
+
+
+# ---------------------------------------------------------------------------
+# from_dict -- non-lenient field errors still propagate
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_non_lenient_field_raises():
+    with pytest.raises(ValidationError):
+        _LenientModel.from_dict(
+            {"_id": str(uuid4()), "name": "ok", "strict_field": "x" * 50}
+        )
+
+
+def test_from_dict_mixed_errors_raises():
+    with pytest.raises(ValidationError):
+        _LenientModel.from_dict(
+            {"_id": str(uuid4()), "name": "x" * 50, "strict_field": "x" * 50}
+        )
+
+
+def test_from_dict_non_lenient_model_raises():
+    with pytest.raises(ValidationError):
+        _NonLenientModel.from_dict({"_id": str(uuid4()), "strict_field": "x" * 50})
+
+
+# ---------------------------------------------------------------------------
+# Strict constructor -- validation always enforced
+# ---------------------------------------------------------------------------
+
+
+def test_strict_constructor_lenient_field_over_limit_raises():
+    with pytest.raises(ValidationError):
+        _LenientModel(id=uuid4(), name="x" * 50, strict_field="ok")
+
+
+def test_strict_constructor_optional_lenient_over_limit_raises():
+    with pytest.raises(ValidationError):
+        _LenientOptionalModel(id=uuid4(), name="x" * 50)

--- a/backend/test/test_quota_updates.py
+++ b/backend/test/test_quota_updates.py
@@ -70,7 +70,7 @@ def get_org(quotas: OrgQuotas, monthly=None, **kwargs):
         storage=StorageRef(name="test-storage"),
         quotas=quotas,
         monthlyExecSeconds=monthlyExecSeconds,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/backend/test/test_quotas.py
+++ b/backend/test/test_quotas.py
@@ -19,7 +19,7 @@ def get_org(quotas: OrgQuotas, monthly=None, **kwargs):
         storage=StorageRef(name="test-storage"),
         quotas=quotas,
         monthlyExecSeconds=monthlyExecSeconds,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/backend/test/test_utils.py
+++ b/backend/test/test_utils.py
@@ -14,6 +14,7 @@ from btrixcloud.utils import slug_from_name, crawler_image_below_minimum
         ("Org with åccénted charactêrs", "org-with-accented-characters"),
         ("Org with åccénted! charactêrs@!", "org-with-accented-characters"),
         ("cATs! 🐈🐈‍⬛", "cats"),
+        ("非拉丁语系的测试名称", "fei-la-ding-yu-xi-de-ce-shi-ming-cheng"),
     ],
 )
 def test_slug_from_name(name: str, expected_slug: str):

--- a/backend/test_nightly/echo_server.py
+++ b/backend/test_nightly/echo_server.py
@@ -2,6 +2,7 @@
 """
 A web server to record POST requests and return them on a GET request
 """
+
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import json
 

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -257,6 +257,7 @@ export class ConfigDetails extends BtrixElement {
                   href=${`${this.navigate.orgBasePath}/browser-profiles/profile/${
                     crawlConfig!.profileid
                   }`}
+                  class="part-[base]:block part-[base]:truncate"
                   hideIcon
                 >
                   ${crawlConfig?.profileName}

--- a/frontend/src/components/ui/desc-list.ts
+++ b/frontend/src/components/ui/desc-list.ts
@@ -42,11 +42,13 @@ export class DescListItem extends LitElement {
       font-variation-settings: var(--font-monostyle-variation);
       line-height: 1.5rem;
       min-height: 1.5rem;
+      word-wrap: break-word;
     }
 
     .item {
       display: flex;
       justify-content: var(--justify-item, initial);
+      min-width: 0;
     }
 
     .content {

--- a/frontend/src/components/ui/tag.ts
+++ b/frontend/src/components/ui/tag.ts
@@ -3,7 +3,7 @@ import { css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-export const TAG_MAX_CHARACTERS = 40;
+export const TAG_MAX_CHARACTERS = 150;
 
 /**
  * Customized <sl-tag>

--- a/frontend/src/components/ui/tag.ts
+++ b/frontend/src/components/ui/tag.ts
@@ -3,7 +3,7 @@ import { css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-export const TAG_MAX_CHARACTERS = 150;
+export const TAG_MAX_CHARACTERS = 80;
 
 /**
  * Customized <sl-tag>

--- a/frontend/src/features/archived-items/file-uploader.ts
+++ b/frontend/src/features/archived-items/file-uploader.ts
@@ -13,6 +13,7 @@ import type { BtrixFileChangeEvent } from "@/components/ui/file-list/events";
 import type { Tags } from "@/components/ui/tag-input";
 import type { BtrixTagsChangeEvent } from "@/features/archived-items/item-tags-input";
 import { type CollectionsChangeEvent } from "@/features/collections/collections-add";
+import { DESCRIPTION_MAX_LENGTH } from "@/types/archivedItems";
 import { APIError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 
@@ -77,7 +78,9 @@ export class FileUploader extends BtrixElement {
   @queryAsync("#fileUploadForm")
   private readonly form!: Promise<HTMLFormElement>;
 
-  private readonly validateDescriptionMax = maxLengthValidator(500);
+  private readonly validateDescriptionMax = maxLengthValidator(
+    DESCRIPTION_MAX_LENGTH,
+  );
 
   // Use to cancel requests
   private uploadRequest: XMLHttpRequest | null = null;

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -1,7 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import type { SlTextarea } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
-import { html } from "lit";
+import { html, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 
@@ -12,6 +12,7 @@ import type {
   CollectionsAdd,
   CollectionsChangeEvent,
 } from "@/features/collections/collections-add";
+import { DESCRIPTION_MAX_LENGTH, NAME_MAX_LENGTH } from "@/types/archivedItems";
 import type { ArchivedItem } from "@/types/crawler";
 import { isSuccessfullyFinished } from "@/utils/crawler";
 import { maxLengthValidator } from "@/utils/form";
@@ -20,7 +21,7 @@ import { maxLengthValidator } from "@/utils/form";
  * Usage:
  * ```ts
  * <btrix-item-metadata-editor
- *   .crawl=${this.crawl}
+ *   .item=${this.crawl}
  *   ?open=${this.open}
  *   @request-close=${this.requestClose}
  *   @updated=${this.updated}
@@ -34,7 +35,7 @@ import { maxLengthValidator } from "@/utils/form";
 @localized()
 export class CrawlMetadataEditor extends BtrixElement {
   @property({ type: Object })
-  crawl?: ArchivedItem;
+  item?: ArchivedItem;
 
   @property({ type: Boolean })
   open = false;
@@ -60,18 +61,22 @@ export class CrawlMetadataEditor extends BtrixElement {
   @query("#collection-input")
   public readonly collectionInput?: CollectionsAdd | null;
 
-  private readonly validateCrawlDescriptionMax = maxLengthValidator(500);
+  private readonly validateItemNameMax = maxLengthValidator(NAME_MAX_LENGTH);
 
-  willUpdate(changedProperties: Map<string, never>) {
-    if (changedProperties.has("crawl") && this.crawl) {
-      this.includeName = this.crawl.type === "upload";
-      this.tagsToSave = this.crawl.tags;
-      this.collectionsToSave = this.crawl.collectionIds;
+  private readonly validateItemDescriptionMax = maxLengthValidator(
+    DESCRIPTION_MAX_LENGTH,
+  );
+
+  willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("item") && this.item) {
+      this.includeName = this.item.type === "upload";
+      this.tagsToSave = this.item.tags;
+      this.collectionsToSave = this.item.collectionIds;
     }
   }
 
   render() {
-    const isSuccess = this.crawl && isSuccessfullyFinished(this.crawl);
+    const isSuccess = this.item && isSuccessfullyFinished(this.item);
 
     return html`
       <btrix-dialog
@@ -87,12 +92,11 @@ export class CrawlMetadataEditor extends BtrixElement {
   }
 
   private renderEditMetadata() {
-    if (!this.crawl) return;
+    if (!this.item) return;
 
-    const item = this.crawl;
+    const item = this.item;
     const isSuccess = isSuccessfullyFinished(item);
 
-    const { helpText, validate } = this.validateCrawlDescriptionMax;
     return html`
       <form
         id="crawlDetailsForm"
@@ -102,7 +106,14 @@ export class CrawlMetadataEditor extends BtrixElement {
         ${this.includeName
           ? html`
               <div class="mb-3">
-                <sl-input label="Name" name="name" value="${item.name}">
+                <sl-input
+                  label="Name"
+                  name="name"
+                  value="${item.name}"
+                  help-text=${this.validateItemNameMax.helpText}
+                  @sl-input=${this.validateItemNameMax.validate}
+                  placeholder="${item.name}"
+                >
                 </sl-input>
               </div>
             `
@@ -116,8 +127,8 @@ export class CrawlMetadataEditor extends BtrixElement {
           rows="3"
           autocomplete="off"
           resize="auto"
-          help-text=${helpText}
-          @sl-input=${validate}
+          help-text=${this.validateItemDescriptionMax.helpText}
+          @sl-input=${this.validateItemDescriptionMax.validate}
         ></sl-textarea>
         <btrix-item-tags-input
           .tags=${item.tags}
@@ -164,7 +175,7 @@ export class CrawlMetadataEditor extends BtrixElement {
 
   private async onSubmitMetadata(e: SubmitEvent) {
     e.preventDefault();
-    if (!this.crawl) return;
+    if (!this.item) return;
 
     const formEl = e.target as HTMLFormElement;
     if (!(await this.checkFormValidity(formEl))) return;
@@ -176,21 +187,21 @@ export class CrawlMetadataEditor extends BtrixElement {
       description?: string;
       name?: string;
     } = {};
-    if (this.includeName && name && name !== this.crawl.name) {
+    if (this.includeName && name && name !== this.item.name) {
       params.name = name as string;
     }
     if (
       crawlDescription &&
-      crawlDescription !== (this.crawl.description ?? "")
+      crawlDescription !== (this.item.description ?? "")
     ) {
       params.description = crawlDescription as string;
     }
-    if (JSON.stringify(this.tagsToSave) !== JSON.stringify(this.crawl.tags)) {
+    if (JSON.stringify(this.tagsToSave) !== JSON.stringify(this.item.tags)) {
       params.tags = this.tagsToSave;
     }
     if (
       JSON.stringify(this.collectionsToSave) !==
-      JSON.stringify(this.crawl.collectionIds)
+      JSON.stringify(this.item.collectionIds)
     ) {
       params.collectionIds = this.collectionsToSave;
     }
@@ -205,7 +216,7 @@ export class CrawlMetadataEditor extends BtrixElement {
 
     try {
       const data = await this.api.fetch<{ updated: boolean }>(
-        `/orgs/${this.crawl.oid}/all-crawls/${this.crawl.id}`,
+        `/orgs/${this.item.oid}/all-crawls/${this.item.id}`,
         {
           method: "PATCH",
           body: JSON.stringify(params),

--- a/frontend/src/features/browser-profiles/profile-metadata-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-metadata-dialog.ts
@@ -10,6 +10,7 @@ import type { Dialog } from "@/components/ui/dialog";
 import type { TagInput } from "@/components/ui/tag-input";
 import type { ProfileUpdatedEvent } from "@/features/browser-profiles/types";
 import type { Profile } from "@/types/crawler";
+import { DESCRIPTION_MAX_LENGTH, NAME_MAX_LENGTH } from "@/types/workflow";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 
@@ -46,8 +47,10 @@ export class ProfileMetadataDialog extends BtrixElement {
   @query(`btrix-tag-input`)
   private readonly tagInput?: TagInput | null;
 
-  private readonly validateNameMax = maxLengthValidator(50);
-  private readonly validateDescriptionMax = maxLengthValidator(500);
+  private readonly validateNameMax = maxLengthValidator(NAME_MAX_LENGTH);
+  private readonly validateDescriptionMax = maxLengthValidator(
+    DESCRIPTION_MAX_LENGTH,
+  );
 
   private readonly submitTask = new Task(this, {
     autoRun: false,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -110,6 +110,8 @@ import {
 } from "@/types/crawler";
 import type { UnderlyingFunction } from "@/types/utils";
 import {
+  DESCRIPTION_MAX_LENGTH,
+  NAME_MAX_LENGTH,
   NewWorkflowOnlyScopeType,
   type StorageSeedFile,
 } from "@/types/workflow";
@@ -353,8 +355,10 @@ export class WorkflowEditor extends BtrixElement {
 
   private readonly handleCurrentTarget = makeCurrentTargetHandler(this);
   private readonly checkFormValidity = formValidator(this);
-  private readonly validateNameMax = maxLengthValidator(80);
-  private readonly validateDescriptionMax = maxLengthValidator(350);
+  private readonly validateNameMax = maxLengthValidator(NAME_MAX_LENGTH);
+  private readonly validateDescriptionMax = maxLengthValidator(
+    DESCRIPTION_MAX_LENGTH,
+  );
 
   private readonly tabLabels = sectionStrings;
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -25,6 +25,7 @@ import { notificationsContextKey } from "./context/notifications/types";
 import { viewStateContext } from "./context/view-state";
 import type { BtrixUserGuideShowEvent } from "./events/btrix-user-guide-show";
 import { OrgTab, RouteNamespace } from "./routes";
+import { ORG_NAME_MAX_LENGTH } from "./types/org";
 import type { UserInfo, UserOrg } from "./types/user";
 import { pageView, type AnalyticsTrackProps } from "./utils/analytics";
 import { type ViewState } from "./utils/APIRouter";
@@ -614,7 +615,7 @@ export class App extends BtrixElement {
     }
 
     // Limit org name display for orgs created before org name max length restriction
-    const orgNameLength = 50;
+    const orgNameLength = ORG_NAME_MAX_LENGTH;
 
     return html`
       <div role="separator" class="mx-2.5 h-7 w-0 border-l"></div>

--- a/frontend/src/pages/admin/admin.ts
+++ b/frontend/src/pages/admin/admin.ts
@@ -9,6 +9,7 @@ import needLogin from "@/decorators/needLogin";
 import type { InviteSuccessDetail } from "@/features/accounts/invite-form";
 import type { APIUser } from "@/index";
 import type { APIPaginatedList } from "@/types/api";
+import { ORG_NAME_MAX_LENGTH } from "@/types/org";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 import { type OrgData } from "@/utils/orgs";
@@ -45,7 +46,7 @@ export class Admin extends BtrixElement {
     return this.appState.orgSlug;
   }
 
-  private readonly validateOrgNameMax = maxLengthValidator(40);
+  private readonly validateOrgNameMax = maxLengthValidator(ORG_NAME_MAX_LENGTH);
 
   protected firstUpdated(): void {
     this.initSuperAdmin();

--- a/frontend/src/pages/invite/ui/org-form.ts
+++ b/frontend/src/pages/invite/ui/org-form.ts
@@ -7,6 +7,7 @@ import { customElement, property, query } from "lit/decorators.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { type APIUser } from "@/index";
+import { ORG_NAME_MAX_LENGTH } from "@/types/org";
 import { isApiError } from "@/utils/api";
 import { maxLengthValidator } from "@/utils/form";
 import slugifyStrict from "@/utils/slugify";
@@ -40,7 +41,7 @@ export class OrgForm extends BtrixElement {
   @query("#orgForm")
   private readonly form?: HTMLFormElement | null;
 
-  private readonly validateOrgNameMax = maxLengthValidator(40);
+  private readonly validateOrgNameMax = maxLengthValidator(ORG_NAME_MAX_LENGTH);
 
   readonly _renameOrgTask = new Task(this, {
     autoRun: false,

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -588,7 +588,7 @@ export class ArchivedItemDetail extends BtrixElement {
       </main>
 
       <btrix-item-metadata-editor
-        .crawl=${this.item}
+        .item=${this.item}
         ?open=${this.openDialogName === "metadata"}
         @request-close=${() => (this.openDialogName = undefined)}
         @updated=${() => void this.fetchCrawl()}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1113,7 +1113,7 @@ export class ArchivedItemDetail extends BtrixElement {
       label=${msg("Crawler Channel (Exact Crawler Version)")}
     >
       <div class="flex items-center gap-2">
-        <code class="grow" title=${text}>${text}</code>
+        <code class="grow [word-break:break-word]" title=${text}>${text}</code>
       </div>
     </btrix-desc-list-item>`;
   }

--- a/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
+++ b/frontend/src/pages/org/archived-item-qa/archived-item-qa.ts
@@ -39,8 +39,13 @@ import type {
   APIPaginationQuery,
   APISortQuery,
 } from "@/types/api";
+import { DESCRIPTION_MAX_LENGTH } from "@/types/archivedItems";
 import type { ArchivedItem, ArchivedItemPageComment } from "@/types/crawler";
-import type { ArchivedItemQAPage, QARun } from "@/types/qa";
+import {
+  PAGE_COMMENT_MAX_LENGTH,
+  type ArchivedItemQAPage,
+  type QARun,
+} from "@/types/qa";
 import { SortDirection as APISortDirection } from "@/types/utils";
 import {
   isActive,
@@ -169,8 +174,12 @@ export class ArchivedItemQA extends BtrixElement {
 
   private readonly replaySwReg =
     navigator.serviceWorker.getRegistration("/replay/");
-  private readonly validateItemDescriptionMax = maxLengthValidator(500);
-  private readonly validatePageCommentMax = maxLengthValidator(500);
+  private readonly validateItemDescriptionMax = maxLengthValidator(
+    DESCRIPTION_MAX_LENGTH,
+  );
+  private readonly validatePageCommentMax = maxLengthValidator(
+    PAGE_COMMENT_MAX_LENGTH,
+  );
 
   @query("#hiddenReplayFrame")
   private readonly hiddenReplayFrame?: HTMLIFrameElement | null;

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -582,7 +582,7 @@ export class CrawlsList extends BtrixElement {
     ${this.itemToEdit
       ? html`
           <btrix-item-metadata-editor
-            .crawl=${this.itemToEdit}
+            .item=${this.itemToEdit}
             ?open=${this.isEditingItem}
             @request-close=${() => (this.isEditingItem = false)}
             @updated=${() => {

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -125,11 +125,11 @@ export class BrowserProfilesProfilePage extends BtrixElement {
         content: msg("Browser Profiles"),
       },
       {
-        content: this.profile?.name,
+        content: html`<div class="truncate">${this.profile?.name}</div>`,
       },
     ];
     const header = {
-      title: this.profile?.name,
+      title: html`<div class="truncate">${this.profile?.name}</div>`,
       suffix: when(
         this.profile && this.appState.isCrawler,
         () =>

--- a/frontend/src/pages/org/crawls.ts
+++ b/frontend/src/pages/org/crawls.ts
@@ -441,7 +441,7 @@ export class OrgCrawls extends BtrixElement {
     ${this.crawlToEdit
       ? html`
           <btrix-item-metadata-editor
-            .crawl=${this.crawlToEdit}
+            .item=${this.crawlToEdit}
             ?open=${this.isEditingItem}
             @request-close=${() => (this.isEditingItem = false)}
             @updated=${() => {

--- a/frontend/src/pages/org/settings/components/general.ts
+++ b/frontend/src/pages/org/settings/components/general.ts
@@ -14,6 +14,7 @@ import type { APIUser } from "@/index";
 import { columns } from "@/layouts/columns";
 import { RouteNamespace } from "@/routes";
 import { alerts } from "@/strings/orgs/alerts";
+import { ORG_DESCRIPTION_MAX_LENGTH, ORG_NAME_MAX_LENGTH } from "@/types/org";
 import { isApiError } from "@/utils/api";
 import { formValidator, maxLengthValidator } from "@/utils/form";
 import slugifyStrict from "@/utils/slugify";
@@ -41,8 +42,10 @@ export class OrgSettingsGeneral extends BtrixElement {
   private slugValue = "";
 
   private readonly checkFormValidity = formValidator(this);
-  private readonly validateOrgNameMax = maxLengthValidator(40);
-  private readonly validateDescriptionMax = maxLengthValidator(150);
+  private readonly validateOrgNameMax = maxLengthValidator(ORG_NAME_MAX_LENGTH);
+  private readonly validateDescriptionMax = maxLengthValidator(
+    ORG_DESCRIPTION_MAX_LENGTH,
+  );
 
   private get baseUrl() {
     return `${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;

--- a/frontend/src/types/archivedItems.ts
+++ b/frontend/src/types/archivedItems.ts
@@ -4,3 +4,6 @@ export type ArchivedItemSearchValues = {
   descriptions: string[];
   firstSeeds: string[];
 };
+
+export const NAME_MAX_LENGTH = 1000;
+export const DESCRIPTION_MAX_LENGTH = 5000;

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { DEDUPE_INDEX_STATES, dedupeIndexStatsSchema } from "./dedupe";
 import { storageFileSchema } from "./storage";
 
-export const COLLECTION_NAME_MAX_LENGTH = 80;
-export const COLLECTION_CAPTION_MAX_LENGTH = 150;
+export const COLLECTION_NAME_MAX_LENGTH = 1000;
+export const COLLECTION_CAPTION_MAX_LENGTH = 1000;
 
 export enum CollectionAccess {
   Private = "private",

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { DEDUPE_INDEX_STATES, dedupeIndexStatsSchema } from "./dedupe";
 import { storageFileSchema } from "./storage";
 
-export const COLLECTION_NAME_MAX_LENGTH = 1000;
+export const COLLECTION_NAME_MAX_LENGTH = 80;
 export const COLLECTION_CAPTION_MAX_LENGTH = 1000;
 
 export enum CollectionAccess {

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -6,7 +6,7 @@ import { publicCollectionSchema } from "./collection";
 import { featureFlagSchema } from "./featureFlags";
 
 export const ORG_NAME_MAX_LENGTH = 50;
-export const ORG_DESCRIPTION_MAX_LENGTH = 150;
+export const ORG_DESCRIPTION_MAX_LENGTH = 400;
 
 export enum OrgReadOnlyReason {
   SubscriptionPaused = "subscriptionPaused",

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -5,6 +5,9 @@ import { subscriptionSchema } from "./billing";
 import { publicCollectionSchema } from "./collection";
 import { featureFlagSchema } from "./featureFlags";
 
+export const ORG_NAME_MAX_LENGTH = 50;
+export const ORG_DESCRIPTION_MAX_LENGTH = 150;
+
 export enum OrgReadOnlyReason {
   SubscriptionPaused = "subscriptionPaused",
   SubscriptionCancelled = "subscriptionCancelled",

--- a/frontend/src/types/qa.ts
+++ b/frontend/src/types/qa.ts
@@ -29,3 +29,5 @@ export type ArchivedItemQAPage = ArchivedItemPage & {
     } | null;
   };
 };
+
+export const PAGE_COMMENT_MAX_LENGTH = 500;

--- a/frontend/src/types/qa.ts
+++ b/frontend/src/types/qa.ts
@@ -30,4 +30,4 @@ export type ArchivedItemQAPage = ArchivedItemPage & {
   };
 };
 
-export const PAGE_COMMENT_MAX_LENGTH = 500;
+export const PAGE_COMMENT_MAX_LENGTH = 5000;

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -3,6 +3,8 @@ import type { StorageFile } from "./storage";
 import type { TagCount, TagCounts } from "@/components/ui/tag-filter/types";
 import { ScopeType } from "@/types/crawler";
 
+export { NAME_MAX_LENGTH, DESCRIPTION_MAX_LENGTH } from "./archivedItems";
+
 export enum NewWorkflowOnlyScopeType {
   PageList = "page-list",
   Regex = "custom-regex",

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -87,7 +87,7 @@ export function renderName(
     return html`<sl-skeleton class="inline-block h-8 w-60"></sl-skeleton>`;
 
   if (item.name)
-    return html`<span class=${clsx("truncate", className)}>${item.name}</span>`;
+    return html`<div class=${clsx("truncate", className)}>${item.name}</div>`;
   if (item.firstSeed && item.seedCount) {
     const remainder = item.seedCount - 1;
     let nameSuffix: string | TemplateResult<1> = "";
@@ -99,9 +99,9 @@ export function renderName(
     }
     return html`
       <span class="inline-flex overflow-hidden whitespace-nowrap">
-        <span class=${clsx("min-w-0 truncate", className)}>
+        <div class=${clsx("min-w-0 truncate", className)}>
           ${item.firstSeed}
-        </span>
+        </div>
         ${nameSuffix}
       </span>
     `;

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -9,23 +9,61 @@ import isEqual from "lodash/fp/isEqual";
 import type { EmptyObject } from "type-fest";
 
 import localize from "./localize";
+import { pluralize } from "./pluralize";
 
 export type MaxLengthValidator = {
   helpText: string;
   validate: (e: CustomEvent) => boolean;
 };
 
-export function getHelpText(maxLength: number, currentLength: number) {
-  const helpText = msg(str`Maximum ${localize.number(maxLength)} characters`);
+const helpTextNormal = (maxLength: number) => {
+  const max = localize.number(maxLength);
+  return pluralize(maxLength, {
+    zero: msg(str`Maximum ${max} characters`, {
+      id: "maxLengthValidator.helpText.zero",
+    }),
+    one: msg(str`Maximum ${max} character`, {
+      id: "maxLengthValidator.helpText.one",
+    }),
+    two: msg(str`Maximum ${max} characters`, {
+      id: "maxLengthValidator.helpText.two",
+    }),
+    few: msg(str`Maximum ${max} characters`, {
+      id: "maxLengthValidator.helpText.few",
+    }),
+    many: msg(str`Maximum ${max} characters`, {
+      id: "maxLengthValidator.helpText.many",
+    }),
+    other: msg(str`Maximum ${max} characters`, {
+      id: "maxLengthValidator.helpText.other",
+    }),
+  });
+};
 
+export function getHelpText(maxLength: number, currentLength: number) {
   if (currentLength > maxLength) {
-    const overMax = currentLength - maxLength;
-    return overMax === 1
-      ? msg(str`${localize.number(overMax)} character over limit`)
-      : msg(str`${localize.number(overMax)} characters over limit`);
+    const overMax = localize.number(currentLength - maxLength);
+    return pluralize(currentLength - maxLength, {
+      zero: "",
+      one: msg(str`${overMax} character over limit`, {
+        id: "maxLengthValidator.helpTextError.one",
+      }),
+      two: msg(str`${overMax} characters over limit`, {
+        id: "maxLengthValidator.helpTextError.two",
+      }),
+      few: msg(str`${overMax} characters over limit`, {
+        id: "maxLengthValidator.helpTextError.few",
+      }),
+      many: msg(str`${overMax} characters over limit`, {
+        id: "maxLengthValidator.helpTextError.many",
+      }),
+      other: msg(str`${overMax} characters over limit`, {
+        id: "maxLengthValidator.helpTextError.other",
+      }),
+    });
   }
 
-  return helpText;
+  return helpTextNormal(maxLength);
 }
 
 /**
@@ -41,7 +79,8 @@ export function getHelpText(maxLength: number, currentLength: number) {
  * ```
  */
 export function maxLengthValidator(maxLength: number): MaxLengthValidator {
-  const validityHelpText = msg(str`Maximum ${maxLength} characters`);
+  const max = localize.number(maxLength);
+  const validityHelpText = helpTextNormal(maxLength);
   let origHelpText: null | string = null;
 
   const validate = (e: CustomEvent) => {
@@ -56,9 +95,7 @@ export function maxLengthValidator(maxLength: number): MaxLengthValidator {
 
     el.setCustomValidity(
       isInvalid
-        ? msg(
-            str`Please shorten this text to ${maxLength} or fewer characters.`,
-          )
+        ? msg(str`Please shorten this text to ${max} or fewer characters.`)
         : "",
     );
 


### PR DESCRIPTION
Closes #3290

## Changes

### From #3297

> This introduces a reusable validator that logs but allows values that fail validation when creating a Pydantic class that extends `BaseMongoModel` for fields that use it. This has the effect of preventing new validations added from breaking for existing values in the DB that fail the validation, while still enforcing these validations on creates and updates.
>
> - adds `LENIENT_ON_READ` `WrapValidator` that allows strings exceeding Pydantic field constraints when deserializing from the database
> - adds tests for this validator
> - tags length-validated strings (e.g. names, descriptions, etc) with this validator to allow long values in existing installations to not break when upgrading browsertrix versions
> 
> The changes in #3293 increase field length limits to above what we've observed users using from our Prod instance, but we don't have a way of knowing if users have much longer strings in their own self-hosted instances. This change ensures that users who do have longer strings won't have breakages due to these existing values. They may need to update their use of our API if they're writing very long strings to Browsertrix, but they will still be able to view and use Browsertrix as normal otherwise.

### From this PR

- Standardizes string field length limits across the codebase by
  introducing centralized constants and annotated types, ensuring
  consistent validation between frontend and backend
- Updates front-end validation logic to reflect back-end changes in a few
  places
- Fixes overflow/truncation issues in several places
	- **Note - there are still some issues with the collection list & collection detail pages, those are resolved separately in #2943**

### New max lengths

#### Workflows, Archived Items, Profiles
- `name`: 1,000
- `description`: 5,000
- `tags`: 80

#### Collections
- `name`/`slug`: 80
- `caption`: 1,000
- `description`: 5,000
- `tags`: 80

#### Orgs
- `name`: 50
- `publicDescription`: 400

#### Page Comments
- `text`: 5,000