### PR TITLE
fix: Workflow user guide improvements

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -462,6 +462,7 @@ export class WorkflowEditor extends BtrixElement {
 
   disconnectedCallback(): void {
     this.onPanelIntersect.cancel();
+    AppStateService.updateUserGuideOpen(false);
     super.disconnectedCallback();
   }
 

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -375,20 +375,6 @@ export class App extends BtrixElement {
         ?open=${this.appState.userGuideOpen}
         contained
         @sl-hide=${() => AppStateService.updateUserGuideOpen(false)}
-        @sl-after-hide=${() => {
-          // FIXME There might be a way to handle this in Mkdocs, but updating
-          // only the hash doesn't seem to update the docs view
-          const iframe = this.userGuideDrawer.querySelector("iframe");
-
-          if (!iframe) return;
-
-          const src = iframe.src;
-          const hashIdx = src.indexOf("#");
-
-          if (hashIdx > -1) {
-            iframe.src = src.slice(0, src.indexOf("#"));
-          }
-        }}
       >
         <span slot="label" class="flex items-center gap-3">
           <sl-icon name="book"></sl-icon>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3292

## Changes

- Closes workflow user guide when navigating away from editor.
- Fixes incorrect section when selecting same link multiple times.

## Manual testing

1. Log in as crawler
2. Go to Crawling > New Workflow
3. Open user guide
4. Go to a top-level page like Crawling. Verify that user guide closes