### PR TITLE
fix: Prevent page reload on clicking workflow

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-list.ts
+++ b/frontend/src/features/crawl-workflows/workflow-list.ts
@@ -310,7 +310,11 @@ export class WorkflowListItem extends BtrixElement {
       const href = `/orgs/${this.orgSlugState}/${OrgTab.Workflows}/${this.workflow?.id}/${this.workflow?.lastCrawlState?.startsWith("failed") ? WorkflowTab.Logs : WorkflowTab.LatestCrawl}`;
 
       return html`<div class="col rowClickTarget--cell">
-        <a class="detail url rowClickTarget items-center truncate" href=${href}>
+        <a
+          class="detail url rowClickTarget items-center truncate"
+          href=${href}
+          @click=${this.navigate.link}
+        >
           ${when(this.workflow?.shareable, ShareableNotice)}
           ${this.safeRender(this.renderName)}
         </a>


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3201

## Changes

Prevents page from reloading new URL when clicking workflow

## Manual testing

1. Log in
2. Go to Crawling
3. Click a workflow. Verify top navigation does not flash during page reload

## Context

More relevant with persisted dialogs for https://github.com/webrecorder/browsertrix/issues/3253