### PR TITLE
Add lenient string validation for database reads

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -374,11 +374,11 @@ class BaseMongoModel(BaseModel):
         if not data:
             return cls()
         data["id"] = data.pop("_id")
-        _LENIENT_CTX.set({"id": data.get("id"), "model": cls.__name__})
+        token = _LENIENT_CTX.set({"id": data.get("id"), "model": cls.__name__})
         try:
             return cls(**data)
         finally:
-            _LENIENT_CTX.set(False)
+            _LENIENT_CTX.reset(token)
 
     def serialize(self, **opts):
         """convert class to dict"""

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -10,6 +10,8 @@ import contextvars
 from uuid import UUID, uuid4
 
 from typing import (
+    Any,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -317,7 +319,9 @@ async def create_indexes(
     await profile_ops.init_index()
 
 
-_LENIENT_CTX = contextvars.ContextVar("_lenient_ctx", default=False)
+_LENIENT_CTX = contextvars.ContextVar[Literal[False] | dict[str, Any]](
+    "_lenient_ctx", default=False
+)
 
 
 def _lenient_str(v, handler, info):

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -331,11 +331,11 @@ def _lenient_str(v, handler, info):
         try:
             return handler(v)
         except ValidationError as e:
-            # pylint: disable=fixme
-            # TODO: replace with logger.warning once we have structured logging in place
             doc_id = ctx.get("id", "?")
             model = ctx.get("model", "?")
             field = getattr(info, "field_name", "?")
+            # pylint: disable=fixme
+            # TODO: replace with logger.warning once we have structured logging in place
             print(
                 f"WARNING: lenient read - "
                 f"{model}.{field!r} value exceeds constraints in "

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -6,6 +6,7 @@ import importlib.util
 import os
 import urllib.parse
 import asyncio
+import contextvars
 from uuid import UUID, uuid4
 
 from typing import (
@@ -17,7 +18,7 @@ from typing import (
 )
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-from pydantic import BaseModel
+from pydantic import BaseModel, WrapValidator, ValidationError
 from pymongo.errors import InvalidName
 
 from .migrations import BaseMigration
@@ -316,6 +317,38 @@ async def create_indexes(
     await profile_ops.init_index()
 
 
+_LENIENT_CTX = contextvars.ContextVar("_lenient_ctx", default=False)
+
+
+def _lenient_str(v, handler, info):
+    """WrapValidator: skip string validation when reading from DB."""
+    ctx = _LENIENT_CTX.get()
+    if ctx and isinstance(v, str):
+        try:
+            return handler(v)
+        except ValidationError as e:
+            # pylint: disable=fixme
+            # TODO: replace with logger.warning once we have structured logging in place
+            doc_id = ctx.get("id", "?")
+            model = ctx.get("model", "?")
+            field = getattr(info, "field_name", "?")
+            print(
+                f"WARNING: lenient read - "
+                f"{model}.{field!r} value exceeds constraints in "
+                f"document id={doc_id!r}",
+                e,
+            )
+            return v
+    return handler(v)
+
+
+LENIENT_ON_READ = WrapValidator(_lenient_str)
+"""
+Marker for fields that allow validations to fail when read from the database.
+Useful for adding new validations without breaking existing data, e.g. max
+length constraints on text fields.
+"""
+
 # ============================================================================
 T = TypeVar("T")
 
@@ -337,7 +370,11 @@ class BaseMongoModel(BaseModel):
         if not data:
             return cls()
         data["id"] = data.pop("_id")
-        return cls(**data)
+        _LENIENT_CTX.set({"id": data.get("id"), "model": cls.__name__})
+        try:
+            return cls(**data)
+        finally:
+            _LENIENT_CTX.set(False)
 
     def serialize(self, **opts):
         """convert class to dict"""

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -34,7 +34,7 @@ from slugify import slugify
 
 # from fastapi_users import models as fastapi_users_models
 
-from .db import BaseMongoModel
+from .db import LENIENT_ON_READ, BaseMongoModel
 
 from .utils import is_bool
 
@@ -92,17 +92,17 @@ HttpUrl = Annotated[
     str, BeforeValidator(lambda value: str(http_url_adapter.validate_python(value)))
 ]
 
-Name = Annotated[str, Field(min_length=1, max_length=1000)]
-NameOrEmptyStr = Annotated[str, Field(min_length=0, max_length=1000)]
-Description = Annotated[str | None, Field(max_length=5000)]
-Tag = Annotated[str, Field(min_length=1, max_length=80)]
+Name = Annotated[str, Field(min_length=1, max_length=1000), LENIENT_ON_READ]
+NameOrEmptyStr = Annotated[str, Field(min_length=0, max_length=1000), LENIENT_ON_READ]
+Description = Annotated[str | None, Field(max_length=5000), LENIENT_ON_READ]
+Tag = Annotated[str, Field(min_length=1, max_length=80), LENIENT_ON_READ]
 
-CollectionName = Annotated[str, Field(min_length=1, max_length=80)]
-CollectionSlug = Annotated[str, Field(min_length=1, max_length=80)]
-CollectionCaption = Annotated[str | None, Field(max_length=1000)]
+CollectionName = Annotated[str, Field(min_length=1, max_length=80), LENIENT_ON_READ]
+CollectionSlug = Annotated[str, Field(min_length=1, max_length=80), LENIENT_ON_READ]
+CollectionCaption = Annotated[str | None, Field(max_length=1000), LENIENT_ON_READ]
 
-OrgName = Annotated[str, Field(min_length=1, max_length=50)]
-OrgPublicDescription = Annotated[str | None, Field(max_length=400)]
+OrgName = Annotated[str, Field(min_length=1, max_length=50), LENIENT_ON_READ]
+OrgPublicDescription = Annotated[str | None, Field(max_length=400), LENIENT_ON_READ]
 
 
 # pylint: disable=too-few-public-methods
@@ -501,7 +501,7 @@ class CrawlConfigCore(BaseMongoModel):
     jobType: Optional[JobType] = JobType.CUSTOM
     config: Optional[RawCrawlConfig] = None
 
-    tags: Optional[List[str]] = []
+    tags: list[Tag] | None = []
 
     crawlTimeout: Optional[int] = 0
     maxCrawlSize: Optional[int] = 0
@@ -525,8 +525,8 @@ class CrawlConfigCore(BaseMongoModel):
 class CrawlConfigAdditional(BaseModel):
     """Additional fields shared by CrawlConfig and CrawlConfigOut."""
 
-    name: Optional[str] = None
-    description: Optional[str] = None
+    name: NameOrEmptyStr | None = None
+    description: Description | None = None
 
     created: datetime
     createdBy: Optional[UUID] = None
@@ -2450,7 +2450,7 @@ class OrgOut(BaseMongoModel):
     """Organization API output model"""
 
     id: UUID
-    name: str
+    name: OrgName
     slug: str
     users: Dict[str, Any] = {}
 
@@ -2513,7 +2513,7 @@ class Organization(BaseMongoModel):
     """Organization Base Model"""
 
     id: UUID
-    name: str
+    name: OrgName
     slug: str
     users: Dict[str, UserRole] = {}
 

--- a/backend/test/test_base_models.py
+++ b/backend/test/test_base_models.py
@@ -1,0 +1,120 @@
+"""Tests for BaseMongoModel.from_dict lenient read via WrapValidator"""
+
+from typing import Annotated
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError, WrapValidator
+
+from btrixcloud.db import BaseMongoModel, _LENIENT_CTX
+
+
+def _lenient_str(v, handler, info):
+    """WrapValidator: skip string-length validation when reading from DB."""
+    if _LENIENT_CTX.get() and isinstance(v, str):
+        return v
+    return handler(v)
+
+
+# ---------------------------------------------------------------------------
+# Minimal test models
+# ---------------------------------------------------------------------------
+
+LenientStr = Annotated[str, Field(max_length=10), WrapValidator(_lenient_str)]
+StrictStr = Annotated[str, Field(max_length=10)]
+LenientOptionalStr = Annotated[str | None, Field(max_length=10), WrapValidator(_lenient_str)]
+
+
+class _LenientModel(BaseMongoModel):
+    name: LenientStr
+    strict_field: StrictStr
+
+
+class _LenientOptionalModel(BaseMongoModel):
+    name: LenientOptionalStr = None
+
+
+class _NonLenientModel(BaseMongoModel):
+    strict_field: StrictStr
+
+
+class _AllOptionalModel(BaseMongoModel):
+    id: str | None = None
+    name: LenientStr = "default"
+    strict_field: StrictStr = "default"
+
+
+# ---------------------------------------------------------------------------
+# from_dict -- normal path
+# ---------------------------------------------------------------------------
+
+def test_from_dict_valid():
+    obj = _LenientModel.from_dict({"_id": str(uuid4()), "name": "hello", "strict_field": "world"})
+    assert obj.name == "hello"
+    assert obj.strict_field == "world"
+
+
+def test_from_dict_empty():
+    obj = _AllOptionalModel.from_dict({})
+    assert obj.name == "default"
+    assert obj.strict_field == "default"
+
+
+# ---------------------------------------------------------------------------
+# from_dict -- lenient path (over-limit data is allowed)
+# ---------------------------------------------------------------------------
+
+def test_from_dict_lenient_field_over_limit():
+    obj = _LenientModel.from_dict(
+        {"_id": str(uuid4()), "name": "x" * 50, "strict_field": "ok"}
+    )
+    assert len(obj.name) == 50
+    assert obj.strict_field == "ok"
+
+
+def test_from_dict_lenient_optional_over_limit():
+    obj = _LenientOptionalModel.from_dict(
+        {"_id": str(uuid4()), "name": "x" * 50}
+    )
+    assert len(obj.name) == 50
+
+
+# ---------------------------------------------------------------------------
+# from_dict -- non-lenient field errors still propagate
+# ---------------------------------------------------------------------------
+
+def test_from_dict_non_lenient_field_raises():
+    with pytest.raises(ValidationError):
+        _LenientModel.from_dict(
+            {"_id": str(uuid4()), "name": "ok", "strict_field": "x" * 50}
+        )
+
+
+def test_from_dict_mixed_errors_raises():
+    with pytest.raises(ValidationError):
+        _LenientModel.from_dict(
+            {"_id": str(uuid4()), "name": "x" * 50, "strict_field": "x" * 50}
+        )
+
+
+def test_from_dict_non_lenient_model_raises():
+    with pytest.raises(ValidationError):
+        _NonLenientModel.from_dict(
+            {"_id": str(uuid4()), "strict_field": "x" * 50}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Strict constructor -- validation always enforced
+# ---------------------------------------------------------------------------
+
+def test_strict_constructor_lenient_field_over_limit_raises():
+    with pytest.raises(ValidationError):
+        _LenientModel(
+            id=uuid4(), name="x" * 50, strict_field="ok"
+        )
+
+
+def test_strict_constructor_optional_lenient_over_limit_raises():
+    with pytest.raises(ValidationError):
+        _LenientOptionalModel(id=uuid4(), name="x" * 50)

--- a/backend/test/test_lenient_validation.py
+++ b/backend/test/test_lenient_validation.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from uuid import uuid4
 
 import pytest
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import Field, ValidationError
 
 from btrixcloud.db import LENIENT_ON_READ, BaseMongoModel
 

--- a/backend/test/test_lenient_validation.py
+++ b/backend/test/test_lenient_validation.py
@@ -1,28 +1,21 @@
-"""Tests for BaseMongoModel.from_dict lenient read via WrapValidator"""
+"""Tests for BaseMongoModel.from_dict lenient read via LENIENT_ON_READ"""
 
 from typing import Annotated
 from uuid import uuid4
 
 import pytest
-from pydantic import BaseModel, Field, ValidationError, WrapValidator
+from pydantic import BaseModel, Field, ValidationError
 
-from btrixcloud.db import BaseMongoModel, _LENIENT_CTX
-
-
-def _lenient_str(v, handler, info):
-    """WrapValidator: skip string-length validation when reading from DB."""
-    if _LENIENT_CTX.get() and isinstance(v, str):
-        return v
-    return handler(v)
+from btrixcloud.db import LENIENT_ON_READ, BaseMongoModel
 
 
 # ---------------------------------------------------------------------------
 # Minimal test models
 # ---------------------------------------------------------------------------
 
-LenientStr = Annotated[str, Field(max_length=10), WrapValidator(_lenient_str)]
+LenientStr = Annotated[str, Field(max_length=10), LENIENT_ON_READ]
 StrictStr = Annotated[str, Field(max_length=10)]
-LenientOptionalStr = Annotated[str | None, Field(max_length=10), WrapValidator(_lenient_str)]
+LenientOptionalStr = Annotated[str | None, Field(max_length=10), LENIENT_ON_READ]
 
 
 class _LenientModel(BaseMongoModel):
@@ -40,16 +33,19 @@ class _NonLenientModel(BaseMongoModel):
 
 class _AllOptionalModel(BaseMongoModel):
     id: str | None = None
-    name: LenientStr = "default"
-    strict_field: StrictStr = "default"
+    name: LenientStr | None = "default"
+    strict_field: StrictStr | None = "default"
 
 
 # ---------------------------------------------------------------------------
 # from_dict -- normal path
 # ---------------------------------------------------------------------------
 
+
 def test_from_dict_valid():
-    obj = _LenientModel.from_dict({"_id": str(uuid4()), "name": "hello", "strict_field": "world"})
+    obj = _LenientModel.from_dict(
+        {"_id": str(uuid4()), "name": "hello", "strict_field": "world"}
+    )
     assert obj.name == "hello"
     assert obj.strict_field == "world"
 
@@ -64,6 +60,7 @@ def test_from_dict_empty():
 # from_dict -- lenient path (over-limit data is allowed)
 # ---------------------------------------------------------------------------
 
+
 def test_from_dict_lenient_field_over_limit():
     obj = _LenientModel.from_dict(
         {"_id": str(uuid4()), "name": "x" * 50, "strict_field": "ok"}
@@ -73,15 +70,14 @@ def test_from_dict_lenient_field_over_limit():
 
 
 def test_from_dict_lenient_optional_over_limit():
-    obj = _LenientOptionalModel.from_dict(
-        {"_id": str(uuid4()), "name": "x" * 50}
-    )
+    obj = _LenientOptionalModel.from_dict({"_id": str(uuid4()), "name": "x" * 50})
     assert len(obj.name) == 50
 
 
 # ---------------------------------------------------------------------------
 # from_dict -- non-lenient field errors still propagate
 # ---------------------------------------------------------------------------
+
 
 def test_from_dict_non_lenient_field_raises():
     with pytest.raises(ValidationError):
@@ -99,20 +95,17 @@ def test_from_dict_mixed_errors_raises():
 
 def test_from_dict_non_lenient_model_raises():
     with pytest.raises(ValidationError):
-        _NonLenientModel.from_dict(
-            {"_id": str(uuid4()), "strict_field": "x" * 50}
-        )
+        _NonLenientModel.from_dict({"_id": str(uuid4()), "strict_field": "x" * 50})
 
 
 # ---------------------------------------------------------------------------
 # Strict constructor -- validation always enforced
 # ---------------------------------------------------------------------------
 
+
 def test_strict_constructor_lenient_field_over_limit_raises():
     with pytest.raises(ValidationError):
-        _LenientModel(
-            id=uuid4(), name="x" * 50, strict_field="ok"
-        )
+        _LenientModel(id=uuid4(), name="x" * 50, strict_field="ok")
 
 
 def test_strict_constructor_optional_lenient_over_limit_raises():

--- a/backend/test/test_quota_updates.py
+++ b/backend/test/test_quota_updates.py
@@ -70,7 +70,7 @@ def get_org(quotas: OrgQuotas, monthly=None, **kwargs):
         storage=StorageRef(name="test-storage"),
         quotas=quotas,
         monthlyExecSeconds=monthlyExecSeconds,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/backend/test/test_quotas.py
+++ b/backend/test/test_quotas.py
@@ -19,7 +19,7 @@ def get_org(quotas: OrgQuotas, monthly=None, **kwargs):
         storage=StorageRef(name="test-storage"),
         quotas=quotas,
         monthlyExecSeconds=monthlyExecSeconds,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/backend/test_nightly/echo_server.py
+++ b/backend/test_nightly/echo_server.py
@@ -2,6 +2,7 @@
 """
 A web server to record POST requests and return them on a GET request
 """
+
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import json
 


### PR DESCRIPTION
To be merged into https://github.com/webrecorder/browsertrix/pull/3293.

## Changes

This introduces a reusable validator that logs but allows values that fail validation when creating a Pydantic class that extends `BaseMongoModel` for fields that use it. This has the effect of preventing new validations added from breaking for existing values in the DB that fail the validation, while still enforcing these validations on creates and updates.

- adds `LENIENT_ON_READ` `WrapValidator` that allows strings exceeding Pydantic field constraints when deserializing from the database
- adds tests for this validator
- tags length-validated strings (e.g. names, descriptions, etc) with this validator to allow long values in existing installations to not break when upgrading browsertrix versions

The changes in #3293 increase field length limits to above what we've observed users using from our Prod instance, but we don't have a way of knowing if users have much longer strings in their own self-hosted instances. This change ensures that users who do have longer strings won't have breakages due to these existing values. They may need to update their use of our API if they're writing very long strings to Browsertrix, but they will still be able to view and use Browsertrix as normal otherwise.