### PR TITLE
Only run one update stats job per collection, have it continue to recalculate stats as new changes are detected

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -834,6 +834,7 @@ class BackgroundJobOps:
                 job.collection_id,
                 existing_job_id=job.id,
             )
+            return {"success": True}
 
         if job.type == BgJobType.CLEANUP_SEED_FILES:
             raise HTTPException(status_code=400, detail="cron_job_retry_not_supported")

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -970,13 +970,13 @@ class CollectionOps:
         """determine if collection stats need update"""
         coll = await self.get_collection(coll_id, oid)
 
-        if coll.statsLastUpdated is None:
+        if coll.lastStatsUpdateStarted is None:
             return True
 
         if (
             coll.modified
-            and coll.statsLastUpdated
-            and coll.modified >= coll.statsLastUpdated
+            and coll.lastStatsUpdateStarted
+            and coll.modified >= coll.lastStatsUpdateStarted
         ):
             return True
 
@@ -1044,10 +1044,10 @@ class CollectionOps:
             {"_id": collection_id},
             {
                 "$set": {
-                    # Set statsLastUpdated to when update started so that if
-                    # collection is modified any time after calculations begin
-                    # we will recalculate again after
-                    "statsLastUpdated": update_start_time,
+                    # store time update started so that if collection is modified
+                    # again while an update job is running the job will know to
+                    # recalculate again before quitting
+                    "lastStatsUpdateStarted": update_start_time,
                     "crawlCount": crawl_count,
                     "pageCount": page_count,
                     "uniquePageCount": unique_page_count,

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -966,6 +966,22 @@ class CollectionOps:
         async for coll in self.collections.find({"oid": org.id}, projection={"_id": 1}):
             await self.update_collection_stats(coll.get("_id"), org.id)
 
+    async def should_update_stats(self, coll_id: UUID, oid: UUID) -> bool:
+        """determine if collection stats need update"""
+        coll = await self.get_collection(coll_id, oid)
+
+        if coll.statsLastUpdated is None:
+            return True
+
+        if (
+            coll.modified
+            and coll.statsLastUpdated
+            and coll.modified >= coll.statsLastUpdated
+        ):
+            return True
+
+        return False
+
     async def update_collection_stats(self, collection_id: UUID, oid: UUID):
         """recalculate counts, tags, and dates for collection"""
         # pylint: disable=too-many-locals
@@ -1026,6 +1042,7 @@ class CollectionOps:
             {"_id": collection_id},
             {
                 "$set": {
+                    "statsLastUpdated": dt_now(),
                     "crawlCount": crawl_count,
                     "pageCount": page_count,
                     "uniquePageCount": unique_page_count,
@@ -1082,6 +1099,8 @@ class CollectionOps:
                 oid, coll_id
             )
 
+            # TODO: Should we be setting modified here at all? or are we just
+            # updating stats? look into where this is called from
             result = await self.collections.find_one_and_update(
                 {"_id": coll_id},
                 {"$set": {"modified": modified}},

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -1095,16 +1095,14 @@ class CollectionOps:
         modified = dt_now()
 
         for coll_id in crawl_coll_ids:
-            await self.background_job_ops.create_update_collection_stats_job(
-                oid, coll_id
-            )
-
-            # TODO: Should we be setting modified here at all? or are we just
-            # updating stats? look into where this is called from
             result = await self.collections.find_one_and_update(
                 {"_id": coll_id},
                 {"$set": {"modified": modified}},
                 return_document=pymongo.ReturnDocument.AFTER,
+            )
+
+            await self.background_job_ops.create_update_collection_stats_job(
+                oid, coll_id
             )
 
             # if this is a collection that has an index and its *not* the collection that the crawl

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -976,7 +976,7 @@ class CollectionOps:
         if (
             coll.modified
             and coll.lastStatsUpdateStarted
-            and coll.modified >= coll.lastStatsUpdateStarted
+            and coll.modified > coll.lastStatsUpdateStarted
         ):
             return True
 

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -985,6 +985,8 @@ class CollectionOps:
     async def update_collection_stats(self, collection_id: UUID, oid: UUID):
         """recalculate counts, tags, and dates for collection"""
         # pylint: disable=too-many-locals
+        update_start_time = dt_now()
+
         crawl_count = 0
         page_count = 0
         total_size = 0
@@ -1042,7 +1044,10 @@ class CollectionOps:
             {"_id": collection_id},
             {
                 "$set": {
-                    "statsLastUpdated": dt_now(),
+                    # Set statsLastUpdated to when update started so that if
+                    # collection is modified any time after calculations begin
+                    # we will recalculate again after
+                    "statsLastUpdated": update_start_time,
                     "crawlCount": crawl_count,
                     "pageCount": page_count,
                     "uniquePageCount": unique_page_count,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -210,7 +210,7 @@ class CrawlManager(K8sAPI):
         if existing_job_id:
             job_id = existing_job_id
         else:
-            job_id = f"update-coll-{secrets.token_hex(5)}"
+            job_id = f"update-coll-{collection_id}"
 
         return await self._run_bg_job_with_ops_classes(
             job_id,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -210,6 +210,7 @@ class CrawlManager(K8sAPI):
         if existing_job_id:
             job_id = existing_job_id
         else:
+            # Ensures we only get one concurrent update job per collection
             job_id = f"update-coll-{collection_id}"
 
         return await self._run_bg_job_with_ops_classes(

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -115,6 +115,7 @@ async def main():
 
     if job_type == BgJobType.UPDATE_COLL_STATS:
         print(f"Updating collection {coll_id}", flush=True)
+        count = 0
         try:
             # Loop check so that if a collection is updated again since this job
             # started, the job will re-calculate the stats again before quitting
@@ -122,6 +123,9 @@ async def main():
                 if not await coll_ops.should_update_stats(UUID(coll_id), org.id):
                     break
                 await coll_ops.update_collection_stats(UUID(coll_id), org.id)
+                count += 1
+
+            print(f"Ran update {count} times", flush=True)
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -122,10 +122,16 @@ async def main():
             while True:
                 if not await coll_ops.should_update_stats(UUID(coll_id), org.id):
                     break
+
+                count += 1
+                print(f"Starting update number {count}", flush=True)
                 await coll_ops.update_collection_stats(UUID(coll_id), org.id)
                 count += 1
 
-            print(f"Ran update {count} times", flush=True)
+            print(
+                f"No changes to collection since start of last update, job complete",
+                flush=True,
+            )
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -116,7 +116,12 @@ async def main():
     if job_type == BgJobType.UPDATE_COLL_STATS:
         print(f"Updating collection {coll_id}", flush=True)
         try:
-            await coll_ops.update_collection_stats(UUID(coll_id), org.id)
+            # Loop check so that if a collection is updated again since this job
+            # started, the job will re-calculate the stats again before quitting
+            while True:
+                if not await coll_ops.should_update_stats(UUID(coll_id), org.id):
+                    break
+                await coll_ops.update_collection_stats(UUID(coll_id), org.id)
             return 0
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -19,7 +19,7 @@ coll_id = os.environ.get("COLLECTION_ID")
 
 # ============================================================================
 # pylint: disable=too-many-function-args, duplicate-code, too-many-locals, too-many-return-statements
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches, too-many-statements
 async def main():
     """run background job with access to ops classes"""
 
@@ -117,8 +117,9 @@ async def main():
         print(f"Updating collection {coll_id}", flush=True)
         count = 0
         try:
-            # Loop check so that if a collection is updated again since this job
-            # started, the job will re-calculate the stats again before quitting
+            # Loop check so that if a collection is modified again since update
+            # calculation started, the job will re-calculate the stats again
+            # before quitting
             while True:
                 if not await coll_ops.should_update_stats(UUID(coll_id), org.id):
                     break
@@ -126,10 +127,9 @@ async def main():
                 count += 1
                 print(f"Starting update number {count}", flush=True)
                 await coll_ops.update_collection_stats(UUID(coll_id), org.id)
-                count += 1
 
             print(
-                f"No changes to collection since start of last update, job complete",
+                "No changes to collection since start of last update, job complete",
                 flush=True,
             )
             return 0

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1696,6 +1696,8 @@ class Collection(BaseMongoModel):
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
+    statsLastUpdated: Optional[datetime] = None
+
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0
     uniquePageCount: Optional[int] = 0
@@ -1762,6 +1764,8 @@ class CollOut(BaseMongoModel):
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
+    statsLastUpdated: Optional[datetime] = None
+
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0
     uniquePageCount: Optional[int] = 0
@@ -1815,6 +1819,8 @@ class PublicCollOut(BaseMongoModel):
     caption: Optional[str] = None
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
+
+    statsLastUpdated: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1696,7 +1696,7 @@ class Collection(BaseMongoModel):
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
-    statsLastUpdated: Optional[datetime] = None
+    lastStatsUpdateStarted: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0
@@ -1764,7 +1764,7 @@ class CollOut(BaseMongoModel):
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
-    statsLastUpdated: Optional[datetime] = None
+    lastStatsUpdateStarted: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0
@@ -1820,7 +1820,7 @@ class PublicCollOut(BaseMongoModel):
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
 
-    statsLastUpdated: Optional[datetime] = None
+    lastStatsUpdateStarted: Optional[datetime] = None
 
     crawlCount: Optional[int] = 0
     pageCount: Optional[int] = 0


### PR DESCRIPTION
Fixes #3298 

## Changes

- Modify naming for update jobs to a fixed name based on the collection id, which prevents multiple jobs from running at the same time
- Save `lastStatsUpdateStarted` on collection model when re-calculation of stats starts
- If collection is modified after `lastStatsUpdateStarted` while job is running, background job will now recalculate stats again rather than spawning a new job
- Missing return added to `retry_org_background_job`

## Testing

On a large collection like https://dev.browsertrix.com/orgs/default-org/collections/view/2edfc4dd-b408-4acd-8ea6-a9eac871ea18/items where updates will take a minute or so:

1. Remove some items from the collection to trigger an update
2. Start following logs of job container: `kubectl logs -f <job container id>`
3. After logs show that calculation has started, make other changes in the collection
4. Verify that no new jobs are started, and that after first calculation concludes in the running background job, the job will pick up the changes and start recalculating
5. Repeat as desired
6. Verify that after all is said and done, the collection stats are accurate