### PR TITLE
feat: Improve workflow and crawl settings

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -16,9 +16,10 @@ import { none, notSpecified } from "@/layouts/empty";
 import {
   Behavior,
   CrawlerChannelImage,
-  type CrawlConfig,
+  type CrawlReplay,
   type Seed,
   type SeedConfig,
+  type Workflow,
 } from "@/pages/org/types";
 import { labelFor } from "@/strings/crawl-workflows/labels";
 import scopeTypeLabel from "@/strings/crawl-workflows/scopeType";
@@ -35,6 +36,9 @@ import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import { getServerDefaults, regexScopeConfig } from "@/utils/workflow";
 
+const isWorkflow = (data?: CrawlReplay | Workflow): data is Workflow =>
+  !!data && "crawlCount" in data;
+
 /**
  * Usage:
  * ```ts
@@ -50,7 +54,7 @@ export class ConfigDetails extends BtrixElement {
   private readonly orgProxies?: OrgProxiesContext;
 
   @property({ type: Object })
-  crawlConfig?: CrawlConfig;
+  crawlConfig?: CrawlReplay | Workflow;
 
   @property({ type: Array })
   seeds?: Seed[];
@@ -173,14 +177,16 @@ export class ConfigDetails extends BtrixElement {
               }
             }),
           )}
-          ${this.renderSetting(
-            msg("Crawl Time Limit"),
-            renderTimeLimit(this.crawlConfig?.crawlTimeout, Infinity),
-          )}
-          ${this.renderSetting(
-            msg("Crawl Size Limit"),
-            renderSize(this.crawlConfig?.maxCrawlSize),
-          )}
+          ${isWorkflow(this.crawlConfig)
+            ? html`${this.renderSetting(
+                msg("Crawl Time Limit"),
+                renderTimeLimit(this.crawlConfig.crawlTimeout, Infinity),
+              )}
+              ${this.renderSetting(
+                msg("Crawl Size Limit"),
+                renderSize(this.crawlConfig.maxCrawlSize),
+              )}`
+            : nothing}
         `,
       })}
       ${this.renderSection({
@@ -311,26 +317,28 @@ export class ConfigDetails extends BtrixElement {
             : nothing}
         `,
       })}
-      ${this.renderSection({
-        id: "crawl-scheduling",
-        heading: sectionStrings.scheduling,
-        renderDescItems: () => html`
-          ${this.renderSetting(
-            msg("Crawl Schedule Type"),
-            crawlConfig?.schedule
-              ? msg("Run on a Recurring Basis")
-              : msg("No Schedule"),
-          )}
-          ${when(crawlConfig?.schedule, () =>
-            this.renderSetting(
-              msg("Schedule"),
-              crawlConfig?.schedule
-                ? humanizeSchedule(crawlConfig.schedule)
-                : undefined,
-            ),
-          )}
-        `,
-      })}
+      ${isWorkflow(crawlConfig)
+        ? this.renderSection({
+            id: "crawl-scheduling",
+            heading: sectionStrings.scheduling,
+            renderDescItems: () => html`
+              ${this.renderSetting(
+                msg("Crawl Schedule Type"),
+                crawlConfig.schedule
+                  ? msg("Run on a Recurring Basis")
+                  : msg("No Schedule"),
+              )}
+              ${when(crawlConfig.schedule, () =>
+                this.renderSetting(
+                  msg("Schedule"),
+                  crawlConfig.schedule
+                    ? humanizeSchedule(crawlConfig.schedule)
+                    : undefined,
+                ),
+              )}
+            `,
+          })
+        : nothing}
       ${when(this.featureFlags.has("dedupeEnabled"), () =>
         this.renderSection({
           id: "deduplication",
@@ -346,27 +354,29 @@ export class ConfigDetails extends BtrixElement {
         }),
       )}
       ${when(!this.hideMetadata, () =>
-        this.renderSection({
-          id: "collection",
-          heading: sectionStrings.collections,
-          renderDescItems: () => html`
-            ${this.renderSetting(
-              html`<span class="mb-1 inline-block"
-                >${msg("Auto-Add to Collection")}</span
-              >`,
-              crawlConfig?.autoAddCollections.length
-                ? html`<btrix-linked-collections
-                    .collections=${crawlConfig.autoAddCollections}
-                    dedupeId=${ifDefined(
-                      (this.featureFlags.has("dedupeEnabled") &&
-                        crawlConfig.dedupeCollId) ||
-                        undefined,
-                    )}
-                  ></btrix-linked-collections>`
-                : undefined,
-            )}
-          `,
-        }),
+        isWorkflow(crawlConfig)
+          ? this.renderSection({
+              id: "collection",
+              heading: sectionStrings.collections,
+              renderDescItems: () => html`
+                ${this.renderSetting(
+                  html`<span class="mb-1 inline-block"
+                    >${msg("Auto-Add to Collection")}</span
+                  >`,
+                  crawlConfig.autoAddCollections.length
+                    ? html`<btrix-linked-collections
+                        .collections=${crawlConfig.autoAddCollections}
+                        dedupeId=${ifDefined(
+                          (this.featureFlags.has("dedupeEnabled") &&
+                            crawlConfig.dedupeCollId) ||
+                            undefined,
+                        )}
+                      ></btrix-linked-collections>`
+                    : undefined,
+                )}
+              `,
+            })
+          : nothing,
       )}
       ${when(!this.hideMetadata, () =>
         this.renderSection({
@@ -406,9 +416,7 @@ export class ConfigDetails extends BtrixElement {
   }: {
     id: string;
     heading: string;
-    renderDescItems: (
-      seedsConfig?: CrawlConfig["config"],
-    ) => TemplateResult | undefined;
+    renderDescItems: (seedsConfig?: SeedConfig) => TemplateResult | undefined;
   }) {
     return html`
       <section id=${id} class="mb-8">
@@ -422,9 +430,7 @@ export class ConfigDetails extends BtrixElement {
     `;
   }
 
-  private readonly renderConfirmUrlListSettings = (
-    config: CrawlConfig["config"],
-  ) => {
+  private readonly renderConfirmUrlListSettings = (config: SeedConfig) => {
     const seedFile = () =>
       when(
         this.seedFile,
@@ -518,9 +524,7 @@ export class ConfigDetails extends BtrixElement {
     `;
   };
 
-  private readonly renderConfirmSeededSettings = (
-    config: CrawlConfig["config"],
-  ) => {
+  private readonly renderConfirmSeededSettings = (config: SeedConfig) => {
     if (!this.seeds) return;
     const additionalUrlList = this.seeds.slice(1);
     const primarySeedConfig = this.seeds[0] as SeedConfig | Seed | undefined;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -112,6 +112,7 @@ import type { UnderlyingFunction } from "@/types/utils";
 import {
   NewWorkflowOnlyScopeType,
   type StorageSeedFile,
+  type WorkflowParams,
 } from "@/types/workflow";
 import { track } from "@/utils/analytics";
 import { isApiError, isApiErrorDetail } from "@/utils/api";
@@ -156,12 +157,6 @@ import {
   type WorkflowDefaults,
 } from "@/utils/workflow";
 
-type CrawlConfigParams = WorkflowSettings & {
-  config: WorkflowSettings["config"] & {
-    seeds: Seed[] | null;
-    seedFileId?: string | null;
-  };
-};
 type WorkflowRunParams = { runNow: boolean; updateRunning?: boolean };
 
 const STEPS = SECTIONS;
@@ -3355,7 +3350,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       }
     }
 
-    const config: CrawlConfigParams & WorkflowRunParams = {
+    const config: WorkflowParams & WorkflowRunParams = {
       ...this.parseConfig(uploadParams),
       runNow: this.saveAndRun && !this.isCrawlRunning,
     };
@@ -3595,10 +3590,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
     return { isValid, helpText };
   }
 
-  private parseConfig(uploadParams?: {
-    seedFileId?: string;
-  }): CrawlConfigParams {
-    const config: CrawlConfigParams = {
+  private parseConfig(uploadParams?: { seedFileId?: string }): WorkflowParams {
+    const config: WorkflowParams = {
       // Job types are now merged into a single type
       jobType: "custom",
       name: this.formState.jobName || "",
@@ -3667,7 +3660,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   private parseUrlListConfig(uploadParams?: {
     seedFileId?: string;
   }): Pick<
-    CrawlConfigParams["config"],
+    WorkflowParams["config"],
     | "seeds"
     | "seedFileId"
     | "scopeType"
@@ -3703,7 +3696,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private parseSeededConfig(): Pick<
-    CrawlConfigParams["config"],
+    WorkflowParams["config"],
     | "seeds"
     | "scopeType"
     | "useSitemap"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -106,7 +106,7 @@ import {
   ScopeType,
   type Profile,
   type Seed,
-  type WorkflowParams,
+  type WorkflowSettings,
 } from "@/types/crawler";
 import type { UnderlyingFunction } from "@/types/utils";
 import {
@@ -156,8 +156,8 @@ import {
   type WorkflowDefaults,
 } from "@/utils/workflow";
 
-type CrawlConfigParams = WorkflowParams & {
-  config: WorkflowParams["config"] & {
+type CrawlConfigParams = WorkflowSettings & {
+  config: WorkflowSettings["config"] & {
     seeds: Seed[] | null;
     seedFileId?: string | null;
   };
@@ -304,7 +304,7 @@ export class WorkflowEditor extends BtrixElement {
     // such as when the user guide is open
     hasChanged: isNotEqual,
   })
-  initialWorkflow?: WorkflowParams;
+  initialWorkflow?: WorkflowSettings;
 
   private updatingScopeType = false;
 

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -36,7 +36,6 @@ import type {
 import type {
   ArchivedItem,
   Crawl,
-  CrawlConfig,
   CrawlReplay,
   Seed,
   Workflow,
@@ -208,9 +207,11 @@ export class ArchivedItemDetail extends BtrixElement {
     task: async ([item], { signal }) => {
       if (!item) return;
       if (!isCrawlReplay(item)) return;
-      if (!item.config.seedFileId) return null;
 
-      return await this.getSeedFile(item.config.seedFileId, signal);
+      const { seedFileId } = item.config;
+      if (!seedFileId) return null;
+
+      return await this.getSeedFile(seedFileId, signal);
     },
     args: () => [this.item] as const,
   });
@@ -1107,7 +1108,8 @@ export class ArchivedItemDetail extends BtrixElement {
     const text =
       (this.item.crawlerChannel
         ? capitalize(this.item.crawlerChannel)
-        : msg("Default")) + (this.item.image ? ` (${this.item.image})` : "");
+        : msg("Default")) +
+      (isCrawlReplay(this.item) ? ` (${this.item.image})` : "");
 
     return html` <btrix-desc-list-item
       label=${msg("Crawler Channel (Exact Crawler Version)")}
@@ -1386,7 +1388,7 @@ export class ArchivedItemDetail extends BtrixElement {
             <btrix-config-details
               .crawlConfig=${{
                 ...this.item,
-              } as CrawlConfig}
+              }}
               .seeds=${this.seeds!.items}
               .seedFile=${this.seedFileTask.value || undefined}
               hideMetadata

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -2165,7 +2165,8 @@ export class WorkflowDetail extends BtrixElement {
   private settingsToJson() {
     if (!this.workflow || !this.seeds) return;
 
-    const params = {
+    const params: WorkflowParams = {
+      jobType: this.workflow.jobType,
       name: this.workflow.name,
       schedule: this.workflow.schedule,
       browserWindows: this.workflow.browserWindows,
@@ -2181,7 +2182,11 @@ export class WorkflowDetail extends BtrixElement {
         ...this.workflow.config,
         seeds: this.workflow.config.seedFileId ? null : this.seeds.items,
       },
-    } satisfies WorkflowParams;
+    };
+
+    if (this.featureFlags.has("dedupeEnabled")) {
+      params.dedupeCollId = this.workflow.dedupeCollId;
+    }
 
     const { error } = workflowParamsSchema.safeParse(params);
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -15,7 +15,7 @@ import queryString from "query-string";
 
 import type { ArchivedItemSectionName } from "./archived-item-detail/archived-item-detail";
 import {
-  workflowParamsSchema,
+  workflowSettingsSchema,
   type Crawl,
   type CrawlLog,
   type Seed,
@@ -2183,7 +2183,7 @@ export class WorkflowDetail extends BtrixElement {
       seeds: this.seeds.items.map(omitNil),
     };
 
-    const { error } = workflowParamsSchema.safeParse(params);
+    const { error } = workflowSettingsSchema.safeParse(params);
 
     if (error) {
       console.debug(error);

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -14,7 +14,13 @@ import isNil from "lodash/isNil";
 import queryString from "query-string";
 
 import type { ArchivedItemSectionName } from "./archived-item-detail/archived-item-detail";
-import type { Crawl, CrawlLog, Seed, Workflow } from "./types";
+import {
+  workflowParamsSchema,
+  type Crawl,
+  type CrawlLog,
+  type Seed,
+  type Workflow,
+} from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Alert } from "@/components/ui/alert";
@@ -800,14 +806,7 @@ export class WorkflowDetail extends BtrixElement {
               value=${ifDefined(
                 this.workflow &&
                   this.seeds &&
-                  JSON.stringify(
-                    {
-                      ...omitNil(this.workflow.config),
-                      seeds: this.seeds.items.map(omitNil),
-                    },
-                    null,
-                    2,
-                  ),
+                  JSON.stringify(this.settingsToJson(), null, 2),
               )}
               content=${msg("Copy as JSON")}
               size="medium"
@@ -2159,6 +2158,42 @@ export class WorkflowDetail extends BtrixElement {
       errors: errors.total,
       behaviors: behaviors.total,
     };
+  }
+
+  /**
+   * Copy workflow settings to clipboard in JSON format
+   * compatible with POST/PATCH API
+   */
+  private settingsToJson() {
+    if (!this.workflow || !this.seeds) return;
+
+    const params = {
+      name: this.workflow.name,
+      schedule: this.workflow.schedule,
+      browserWindows: this.workflow.browserWindows,
+      profileid: this.workflow.profileid,
+      tags: this.workflow.tags,
+      crawlTimeout: this.workflow.crawlTimeout,
+      maxCrawlSize: this.workflow.maxCrawlSize,
+      description: this.workflow.description,
+      autoAddCollections: this.workflow.autoAddCollections,
+      crawlerChannel: this.workflow.crawlerChannel,
+      proxyId: this.workflow.proxyId,
+      config: this.workflow.config,
+      seeds: this.seeds.items.map(omitNil),
+    };
+
+    const { error } = workflowParamsSchema.safeParse(params);
+
+    if (error) {
+      console.debug(error);
+    }
+
+    // Omit null and undefined values
+    return omitNil({
+      ...params,
+      config: omitNil(params.config),
+    });
   }
 
   /**

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -14,13 +14,7 @@ import isNil from "lodash/isNil";
 import queryString from "query-string";
 
 import type { ArchivedItemSectionName } from "./archived-item-detail/archived-item-detail";
-import {
-  workflowSettingsSchema,
-  type Crawl,
-  type CrawlLog,
-  type Seed,
-  type Workflow,
-} from "./types";
+import { type Crawl, type CrawlLog, type Seed, type Workflow } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Alert } from "@/components/ui/alert";
@@ -41,7 +35,11 @@ import { OrgTab, WorkflowTab } from "@/routes";
 import { deleteConfirmation, noData, notApplicable } from "@/strings/ui";
 import type { APIPaginatedList, APIPaginationQuery } from "@/types/api";
 import { type CrawlState } from "@/types/crawlState";
-import { type StorageSeedFile } from "@/types/workflow";
+import {
+  workflowParamsSchema,
+  type StorageSeedFile,
+  type WorkflowParams,
+} from "@/types/workflow";
 import { isApiError } from "@/utils/api";
 import { settingsForDuplicate } from "@/utils/crawl-workflows/settingsForDuplicate";
 import {
@@ -2179,11 +2177,13 @@ export class WorkflowDetail extends BtrixElement {
       autoAddCollections: this.workflow.autoAddCollections,
       crawlerChannel: this.workflow.crawlerChannel,
       proxyId: this.workflow.proxyId,
-      config: this.workflow.config,
-      seeds: this.seeds.items.map(omitNil),
-    };
+      config: {
+        ...this.workflow.config,
+        seeds: this.workflow.config.seedFileId ? null : this.seeds.items,
+      },
+    } satisfies WorkflowParams;
 
-    const { error } = workflowSettingsSchema.safeParse(params);
+    const { error } = workflowParamsSchema.safeParse(params);
 
     if (error) {
       console.debug(error);

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -794,7 +794,7 @@ export class WorkflowDetail extends BtrixElement {
 
     if (this.workflowTab === WorkflowTab.Settings) {
       return html`
-        ${this.appState.isAdmin
+        ${this.appState.isCrawler
           ? html`<btrix-copy-button
               name="filetype-json"
               value=${ifDefined(

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -13,7 +13,7 @@ import {
   CrawlerChannelImage,
   ScopeType,
   type Seed,
-  type WorkflowParams,
+  type WorkflowSettings,
 } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
@@ -59,9 +59,9 @@ export class WorkflowsNew extends BtrixElement {
   scopeType?: WorkflowFormState["scopeType"];
 
   @property({ type: Object })
-  initialWorkflow?: WorkflowParams;
+  initialWorkflow?: WorkflowSettings;
 
-  private get defaultNewWorkflow(): WorkflowParams {
+  private get defaultNewWorkflow(): WorkflowSettings {
     return {
       name: "",
       description: null,
@@ -161,14 +161,14 @@ export class WorkflowsNew extends BtrixElement {
             autoAddCollections: org.crawlingDefaults?.dedupeCollId
               ? [org.crawlingDefaults.dedupeCollId]
               : [],
-          } satisfies PartialDeep<WorkflowParams>,
+          } satisfies PartialDeep<WorkflowSettings>,
           this.initialWorkflow || {},
         );
 
         const initialWorkflow = makeArrUniq({
           ...mergedWorkflow,
           config: makeArrUniq(mergedWorkflow.config),
-        }) as WorkflowParams;
+        }) as WorkflowSettings;
 
         const scopeType = this.scopeType || initialWorkflow.config.scopeType;
 

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -18,7 +18,11 @@ import {
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
-import { WorkflowScopeType, type StorageSeedFile } from "@/types/workflow";
+import {
+  WorkflowScopeType,
+  type StorageSeedFile,
+  type WorkflowParams,
+} from "@/types/workflow";
 import { tw } from "@/utils/tailwind";
 import {
   DEFAULT_AUTOCLICK_SELECTOR,
@@ -59,9 +63,9 @@ export class WorkflowsNew extends BtrixElement {
   scopeType?: WorkflowFormState["scopeType"];
 
   @property({ type: Object })
-  initialWorkflow?: WorkflowSettings;
+  initialWorkflow?: Partial<WorkflowSettings>;
 
-  private get defaultNewWorkflow(): WorkflowSettings {
+  private get defaultNewWorkflow(): WorkflowParams {
     return {
       name: "",
       description: null,

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { CrawlState } from "./crawlState";
 import type { StorageFile } from "./storage";
 
@@ -23,61 +25,70 @@ export enum CrawlerChannelImage {
   Default = "default",
 }
 
-export type Seed = {
-  url: string;
-  scopeType: ScopeType | undefined;
-  include?: string[] | null;
-  exclude?: string[] | null;
-  limit?: number | null;
-  extraHops?: number | null;
-  depth?: number | null;
-};
+export const seedSchema = z.object({
+  url: z.string(),
+  scopeType: z.nativeEnum(ScopeType).optional(),
+  include: z.array(z.string()).nullable().optional(),
+  exclude: z.array(z.string()).nullable().optional(),
+  limit: z.number().nullable().optional(),
+  extraHops: z.number().nullable().optional(),
+  depth: z.number().nullable().optional(),
+});
+export type Seed = z.infer<typeof seedSchema>;
 
 type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 
-export type SeedConfig = Expand<
-  Pick<Seed, "scopeType" | "include" | "exclude" | "limit" | "extraHops"> & {
-    seedFileId?: string | null;
-    lang?: string | null;
-    blockAds?: boolean;
-    behaviorTimeout: number | null;
-    pageLoadTimeout: number | null;
-    pageExtraDelay: number | null;
-    postLoadDelay: number | null;
-    behaviors?: string | null;
-    extraHops?: number | null;
-    useSitemap?: boolean;
-    failOnFailedSeed?: boolean;
-    failOnContentCheck?: boolean;
-    depth?: number | null;
-    userAgent?: string | null;
-    selectLinks: string[];
-    customBehaviors: string[];
-    clickSelector: string;
-    saveStorage?: boolean;
-    useRobots?: boolean;
-  }
->;
+export const seedConfigSchema = seedSchema
+  .pick({
+    scopeType: true,
+    include: true,
+    exclude: true,
+    limit: true,
+    extraHops: true,
+  })
+  .merge(
+    z.object({
+      seedFileId: z.string().nullable().optional(),
+      lang: z.string().nullable().optional(),
+      blockAds: z.boolean().optional(),
+      behaviorTimeout: z.number().nullable(),
+      pageLoadTimeout: z.number().nullable(),
+      pageExtraDelay: z.number().nullable(),
+      postLoadDelay: z.number().nullable(),
+      behaviors: z.string().nullable().optional(),
+      extraHops: z.number().nullable().optional(),
+      useSitemap: z.boolean().optional(),
+      failOnFailedSeed: z.boolean().optional(),
+      failOnContentCheck: z.boolean().optional(),
+      depth: z.number().nullable().optional(),
+      userAgent: z.string().nullable().optional(),
+      selectLinks: z.array(z.string()),
+      customBehaviors: z.array(z.string()),
+      clickSelector: z.string(),
+      saveStorage: z.boolean().optional(),
+      useRobots: z.boolean().optional(),
+    }),
+  );
+export type SeedConfig = Expand<z.infer<typeof seedConfigSchema>>;
 
-export type JobType = "url-list" | "seed-crawl" | "custom";
-
-export type WorkflowParams = {
-  jobType?: JobType;
-  name: string;
-  schedule: string;
-  browserWindows: number;
-  profileid: string | null;
-  profileName?: string | null;
-  config: SeedConfig;
-  tags: string[];
-  crawlTimeout: number | null;
-  maxCrawlSize: number | null;
-  description: string | null;
-  autoAddCollections: string[];
-  crawlerChannel: string;
-  proxyId: string | null;
-  dedupeCollId?: string | null;
-};
+export const workflowParamsSchema = z.object({
+  jobType: z.enum(["url-list", "seed-crawl", "custom"]).optional(),
+  name: z.string(),
+  schedule: z.string(),
+  browserWindows: z.number().int(),
+  profileid: z.string().nullable(),
+  profileName: z.string().nullable().optional(),
+  config: seedConfigSchema,
+  tags: z.array(z.string()),
+  crawlTimeout: z.number().nullable(),
+  maxCrawlSize: z.number().nullable(),
+  description: z.string().nullable(),
+  autoAddCollections: z.array(z.string()),
+  crawlerChannel: z.string(),
+  proxyId: z.string().nullable(),
+  dedupeCollId: z.string().nullable().optional(),
+});
+export type WorkflowParams = z.infer<typeof workflowParamsSchema>;
 
 export type CrawlConfig = WorkflowParams & {
   oid: string;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -90,13 +90,8 @@ export const workflowParamsSchema = z.object({
 });
 export type WorkflowParams = z.infer<typeof workflowParamsSchema>;
 
-export type CrawlConfig = WorkflowParams & {
+export type Workflow = WorkflowParams & {
   oid: string;
-  profileName: string | null;
-  image: string | null;
-};
-
-export type Workflow = CrawlConfig & {
   id: string;
   createdBy: string; // User ID
   createdByName: string | null; // User full name
@@ -126,6 +121,8 @@ export type Workflow = CrawlConfig & {
   isCrawlRunning: boolean | null;
   autoAddCollections: string[];
   seedCount: number;
+  profileName: string | null;
+  image: string | null;
   shareable?: boolean;
 };
 
@@ -215,7 +212,7 @@ type ArchivedItemBase = {
 
 export type Crawl = ArchivedItemBase &
   Omit<
-    CrawlConfig,
+    WorkflowParams,
     | "config"
     | "autoAddCollections"
     | "schedule"
@@ -234,7 +231,7 @@ export type Crawl = ArchivedItemBase &
     })[];
   };
 
-export type CrawlReplay = Crawl & Pick<CrawlConfig, "config">;
+export type CrawlReplay = Crawl & Pick<Workflow, "config" | "image">;
 
 export type Upload = ArchivedItemBase & {
   type: "upload";

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -71,7 +71,7 @@ export const seedConfigSchema = seedSchema
   );
 export type SeedConfig = Expand<z.infer<typeof seedConfigSchema>>;
 
-export const workflowParamsSchema = z.object({
+export const workflowSettingsSchema = z.object({
   jobType: z.enum(["url-list", "seed-crawl", "custom"]).optional(),
   name: z.string(),
   schedule: z.string(),
@@ -88,9 +88,9 @@ export const workflowParamsSchema = z.object({
   proxyId: z.string().nullable(),
   dedupeCollId: z.string().nullable().optional(),
 });
-export type WorkflowParams = z.infer<typeof workflowParamsSchema>;
+export type WorkflowSettings = z.infer<typeof workflowSettingsSchema>;
 
-export type Workflow = WorkflowParams & {
+export type Workflow = WorkflowSettings & {
   oid: string;
   id: string;
   createdBy: string; // User ID
@@ -212,7 +212,7 @@ type ArchivedItemBase = {
 
 export type Crawl = ArchivedItemBase &
   Omit<
-    WorkflowParams,
+    WorkflowSettings,
     | "config"
     | "autoAddCollections"
     | "schedule"

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -78,7 +78,6 @@ export const workflowSettingsSchema = z.object({
   browserWindows: z.number().int(),
   profileid: z.string().nullable(),
   profileName: z.string().nullable().optional(),
-  config: seedConfigSchema,
   tags: z.array(z.string()),
   crawlTimeout: z.number().nullable(),
   maxCrawlSize: z.number().nullable(),
@@ -87,6 +86,7 @@ export const workflowSettingsSchema = z.object({
   crawlerChannel: z.string(),
   proxyId: z.string().nullable(),
   dedupeCollId: z.string().nullable().optional(),
+  config: seedConfigSchema,
 });
 export type WorkflowSettings = z.infer<typeof workflowSettingsSchema>;
 

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,7 +1,14 @@
+import { z } from "zod";
+
 import type { StorageFile } from "./storage";
 
 import type { TagCount, TagCounts } from "@/components/ui/tag-filter/types";
-import { ScopeType } from "@/types/crawler";
+import {
+  ScopeType,
+  seedConfigSchema,
+  seedSchema,
+  workflowSettingsSchema,
+} from "@/types/crawler";
 
 export enum NewWorkflowOnlyScopeType {
   PageList = "page-list",
@@ -9,6 +16,18 @@ export enum NewWorkflowOnlyScopeType {
 }
 
 export const WorkflowScopeType = { ...ScopeType, ...NewWorkflowOnlyScopeType };
+
+export const workflowParamsSchema = workflowSettingsSchema.merge(
+  z.object({
+    config: seedConfigSchema.merge(
+      z.object({
+        seeds: z.array(seedSchema).nullable().optional(),
+        seedFileId: z.string().nullable().optional(),
+      }),
+    ),
+  }),
+);
+export type WorkflowParams = z.infer<typeof workflowParamsSchema>;
 
 export type WorkflowTag = TagCount;
 export type WorkflowTags = TagCounts;

--- a/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
+++ b/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
@@ -8,7 +8,7 @@ import type {
   ScopeType,
   Seed,
   Workflow,
-  WorkflowParams,
+  WorkflowSettings,
 } from "@/types/crawler";
 import {
   NewWorkflowOnlyScopeType,
@@ -16,7 +16,7 @@ import {
 } from "@/types/workflow";
 
 export type DuplicateWorkflowSettings = {
-  workflow: Partial<WorkflowParams>;
+  workflow: Partial<WorkflowSettings>;
   scopeType?: ScopeType | NewWorkflowOnlyScopeType;
   seeds?: Seed[];
   seedFile?: StorageSeedFile;
@@ -31,7 +31,7 @@ export function settingsForDuplicate({
   seeds?: APIPaginatedList<Seed>;
   seedFile?: StorageSeedFile;
 }): DuplicateWorkflowSettings {
-  const workflowParams: Partial<WorkflowParams> = {
+  const workflowParams: Partial<WorkflowSettings> = {
     ...workflow,
     name: workflow.name ? msg(str`${workflow.name} Copy`) : "",
   };

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -15,7 +15,7 @@ import {
   type Profile,
   type Seed,
   type SeedConfig,
-  type WorkflowParams,
+  type WorkflowSettings,
 } from "@/types/crawler";
 import type { OrgData } from "@/types/org";
 import { NewWorkflowOnlyScopeType, WorkflowScopeType } from "@/types/workflow";
@@ -161,11 +161,11 @@ export type FormState = {
   scopeType:
     | Exclude<ScopeType, ScopeType.Any>
     | (typeof NewWorkflowOnlyScopeType)[keyof typeof NewWorkflowOnlyScopeType];
-  exclusions: WorkflowParams["config"]["exclude"];
-  pageLimit: WorkflowParams["config"]["limit"];
-  browserWindows: WorkflowParams["browserWindows"];
-  blockAds: WorkflowParams["config"]["blockAds"];
-  lang: WorkflowParams["config"]["lang"];
+  exclusions: WorkflowSettings["config"]["exclude"];
+  pageLimit: WorkflowSettings["config"]["limit"];
+  browserWindows: WorkflowSettings["browserWindows"];
+  blockAds: WorkflowSettings["config"]["blockAds"];
+  lang: WorkflowSettings["config"]["lang"];
   /**
    * NOTE The UI currently only supports "cron" and "none".
    */
@@ -202,11 +202,11 @@ export type FormState = {
   scheduleCustom?: string;
   dedupeType: DedupeType;
   dedupeCollection: { id: string } | { name: string } | null;
-  jobName: WorkflowParams["name"];
+  jobName: WorkflowSettings["name"];
   browserProfile: Profile | null;
   tags: Tags;
   autoAddCollections: string[];
-  description: WorkflowParams["description"];
+  description: WorkflowSettings["description"];
   autoscrollBehavior: boolean;
   autoclickBehavior: boolean;
   customBehavior: boolean;
@@ -215,8 +215,8 @@ export type FormState = {
   proxyId: string | null;
   selectLinks: string[];
   clickSelector: string;
-  saveStorage: WorkflowParams["config"]["saveStorage"];
-  useRobots: WorkflowParams["config"]["useRobots"];
+  saveStorage: WorkflowSettings["config"]["saveStorage"];
+  useRobots: WorkflowSettings["config"]["useRobots"];
 };
 
 export type FormStateField = keyof FormState;
@@ -290,7 +290,7 @@ export const mapSeedToUrl = (arr: Seed[]) =>
 export function getInitialFormState(params: {
   configId?: string;
   initialSeeds?: Seed[];
-  initialWorkflow?: WorkflowParams;
+  initialWorkflow?: WorkflowSettings;
   org?: OrgData | null;
 }): FormState {
   const defaultFormState = getDefaultFormState();


### PR DESCRIPTION
Related https://github.com/webrecorder/browsertrix/issues/3304

## Changes

- Fixes workflow and crawl setting typing
- Fixes workflow-only settings being displayed in crawl settings
- Includes seed file ID, dedupe collection ID, and other workflow settings that should be used in API POST body.
- Enables copying workflow settings as JSON to crawler permission role.

## Manual testing

1. Log in as crawler
2. Go to Crawling
3. Choose workflow and go to "Settings". Verify JSON icon button is displayed next to settings configuration icon
4. Select "Copy as JSON" button. Verify settings are copied to clipboard
5. POST JSON to `/crawlconfigs` API using curl or similar. Verify new workflow is created with the same settings.