### PR TITLE
Prevent tag container in browser profile list from expanding too large

### DIFF
--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -592,7 +592,10 @@ export class BrowserProfilesList extends BtrixElement {
           >
         </btrix-table-cell>
         <btrix-table-cell>
-          <btrix-tag-container class="relative hover:z-[2]" .tags=${data.tags}>
+          <btrix-tag-container
+            class="relative max-w-full hover:z-[2]"
+            .tags=${data.tags}
+          >
           </btrix-tag-container>
         </btrix-table-cell>
         <btrix-table-cell>


### PR DESCRIPTION
Quick fix for #3306.

Adds a max-width of 100% to browser profile list's tag container.