### PR TITLE
Update collection editing and sharing UI - Rendering performance

### DIFF
--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -150,7 +150,6 @@ export class EditableTextField extends TailwindElement {
     }
 
     if (
-      changedProperties.has("editing") ||
       changedProperties.has("inputValue") ||
       changedProperties.has("placeholder")
     ) {

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -2,6 +2,7 @@ import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
 import { css, html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import type { DirectiveResult } from "lit/directive.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
@@ -35,8 +36,8 @@ export class EditableTextField extends TailwindElement {
   @property({ type: Number })
   maxLength?: number;
 
-  @property({ type: Object })
-  renderContent?: (text: string) => TemplateResult;
+  @property({ attribute: false })
+  renderContent?: (text: string) => TemplateResult | DirectiveResult;
 
   /**
    * Extra width to add to the computed width to accommodate the suffix slot.

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -55,9 +55,6 @@ export class EditableTextField extends TailwindElement {
   @query("input")
   input?: HTMLInputElement;
 
-  @query("span")
-  label?: HTMLSpanElement;
-
   @property({ type: String })
   placeholder?: string;
 
@@ -115,6 +112,7 @@ export class EditableTextField extends TailwindElement {
     this.valid = true;
     this.input?.blur();
     this.updateWidth();
+    this.updatePlaceholderWidth();
   }
 
   save() {
@@ -133,24 +131,31 @@ export class EditableTextField extends TailwindElement {
   }
 
   updateWidth() {
-    if (!this.label) return;
     const width = measureTextWithElement(
       this.inputValue || this.placeholder || "",
-      this.label,
+      this,
     ).width;
     if (width) this.width = width + this.extraWidth;
   }
 
   updatePlaceholderWidth() {
     if (!this.placeholder) return;
-    if (!this.label) return;
-    const width = measureTextWithElement(this.placeholder, this.label).width;
+    const width = measureTextWithElement(this.placeholder, this).width;
     if (width) this.placeholderWidth = width;
   }
 
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("value")) {
       this.inputValue = this.value;
+    }
+
+    if (
+      changedProperties.has("editing") ||
+      changedProperties.has("inputValue") ||
+      changedProperties.has("placeholder")
+    ) {
+      this.updateWidth();
+      this.updatePlaceholderWidth();
     }
   }
 
@@ -173,17 +178,11 @@ export class EditableTextField extends TailwindElement {
   }
 
   render() {
-    // Normally we wouldn't want to run code like this on every render, but it's
-    // a) cached by args already, and b) very quick to run - these use canvas
-    // text measurements, rather than element measurements which cause reflows
-    this.updateWidth();
-    this.updatePlaceholderWidth();
-
     const minWidth = Math.max(this.placeholderWidth, this.width, 1);
 
     return html`<input
         class=${clsx(
-          tw`peer absolute inset-4 rounded bg-yellow-500/50`,
+          tw`peer absolute inset-4 rounded bg-transparent`,
           !this.valid && tw`z-[11] outline outline-danger`,
         )}
         type="text"

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -183,7 +183,7 @@ export class EditableTextField extends TailwindElement {
 
     return html`<input
         class=${clsx(
-          tw`peer absolute inset-4 rounded bg-transparent`,
+          tw`peer absolute inset-4 rounded bg-yellow-500/50`,
           !this.valid && tw`z-[11] outline outline-danger`,
         )}
         type="text"

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -301,10 +301,7 @@ export class CollectionDetail extends BtrixElement {
                     maxLength=${COLLECTION_CAPTION_MAX_LENGTH}
                     .value=${col.caption}
                     placeholder=${msg("Add a summary...")}
-                    .renderContent=${(text: string) =>
-                      richText(text, {
-                        linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
-                      })}
+                    .renderContent=${this.renderCaption}
                     @btrix-change=${(e: BtrixChangeEvent<string>) => {
                       void this.updateSummary(e.detail.value);
                     }}
@@ -626,6 +623,11 @@ export class CollectionDetail extends BtrixElement {
       })}
     `;
   }
+
+  private readonly renderCaption = (text: string) =>
+    richText(text, {
+      linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
+    });
 
   private renderAccessIcon() {
     return choose(this.collection?.access, [


### PR DESCRIPTION
- Prevents `renderContent` from causing unnecessary re-renders
- Gets font from `<btrix-editable-text-field>` to remove dependency on render call to get width of text

Moving from `renderContent` to slotted content should help prevent similar issues, though this requires holding state in the parent.