### PR TITLE
fix: Deselect collection items when workflow is deselected

### DIFF
--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -794,7 +794,9 @@ export class CollectionItemsDialog extends BtrixElement {
     // - Otherwise: selected if in selectedItems or was originally in collection
     const isSelected = workflowSelection?.allSelected
       ? !this.deselectedItems.has(item.id)
-      : this.selectedItems.has(item.id) || isInCollection;
+      : workflowSelection?.checked === false
+        ? false
+        : this.selectedItems.has(item.id) || isInCollection;
 
     return html`
       <btrix-archived-item-list-item


### PR DESCRIPTION
Related https://github.com/webrecorder/browsertrix/issues/3301

## Changes

Unchecks crawls in "Only items in collection" view when workflow is unchecked.

## Manual testing

1. Log in as crawler
2. Go to collection that has all items of a workflow added to it
3. Select "Configure Items"
4. Uncheck a workflow
5. Toggle "Only items in collection". Verify all items that were in workflow are deselected