### PR TITLE
feat: Confirm deselecting dependencies

### DIFF
--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -35,6 +35,7 @@ import type { ArchivedItem, Crawl, Upload, Workflow } from "@/types/crawler";
 import { SortDirection } from "@/types/utils";
 import { isApiError } from "@/utils/api";
 import { finishedCrawlStates, isCrawl } from "@/utils/crawler";
+import { stopProp } from "@/utils/events";
 import { computeSelectionDelta } from "@/utils/nested-selection-difference";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
@@ -100,6 +101,9 @@ export class CollectionItemsDialog extends BtrixElement {
 
   @property({ type: Boolean })
   open = false;
+
+  @state()
+  private showConfirmation = false;
 
   @state()
   private isSubmitting = false;
@@ -227,7 +231,8 @@ export class CollectionItemsDialog extends BtrixElement {
   private readonly dependenciesTask = new Task(this, {
     task: async (_args, { signal }) => {
       const { removeItems, removeWorkflows } = this.difference;
-      console.log("remove:", removeItems, removeWorkflows);
+
+      this.showConfirmation = false;
 
       if (!removeItems.size && !removeWorkflows.size) return;
 
@@ -965,21 +970,71 @@ export class CollectionItemsDialog extends BtrixElement {
       selectionMessage = messages.join(" / ");
     }
 
+    const confirmationContent = () => {
+      const count = this.dependenciesTask.value?.size;
+
+      if (!count) return;
+
+      const number_of_dependencies = this.localize.number(count);
+      const plural_of_dependencies = pluralOf("dependencies", count);
+
+      return html`<p class="font-semibold">
+          ${msg(
+            str`Are you sure you want to remove ${number_of_dependencies} ${plural_of_dependencies}?`,
+          )}
+        </p>
+        <p class="mt-2">
+          ${msg(
+            "Removing this item may result in incomplete replay and downloads until dependent URLs are crawled again.",
+          )}
+        </p> `;
+    };
+
     return html`
       <div class="inline-flex items-center gap-1.5 text-warning">
         <span>${selectionMessage}</span>
         ${this.renderDependencyWarning()}
       </div>
 
-      <sl-button
-        variant="primary"
-        size="small"
-        ?disabled=${this.isSubmitting}
-        ?loading=${this.isSubmitting}
-        @click=${hasChange ? () => void this.save() : () => this.close()}
+      ${this.showConfirmation
+        ? html`<sl-button
+            size="small"
+            @click=${() => (this.showConfirmation = false)}
+          >
+            ${msg("Edit Selection")}
+          </sl-button>`
+        : nothing}
+
+      <btrix-popover
+        ?open=${this.showConfirmation}
+        trigger="manual"
+        placement="top-end"
+        hoist
+        @sl-show=${stopProp}
+        @sl-after-show=${stopProp}
+        @sl-hide=${stopProp}
+        @sl-after-hide=${stopProp}
       >
-        ${hasChange ? msg("Save Selection") : msg("Done")}
-      </sl-button>
+        <div slot="content" @click=${() => (this.showConfirmation = false)}>
+          ${confirmationContent()}
+        </div>
+
+        <sl-button
+          variant="primary"
+          size="small"
+          ?disabled=${this.isSubmitting}
+          ?loading=${this.isSubmitting}
+          @click=${hasChange
+            ? () =>
+                this.showConfirmation ? void this.save() : void this.trySave()
+            : () => this.close()}
+        >
+          ${this.showConfirmation
+            ? html`<sl-icon slot="prefix" name="check2-all"></sl-icon>`
+            : nothing}
+          ${hasChange ? msg("Save Selection") : msg("Done")}
+        </sl-button>
+      </btrix-popover>
     `;
   };
 
@@ -998,7 +1053,7 @@ export class CollectionItemsDialog extends BtrixElement {
     };
 
     return this.dependenciesTask.render({
-      complete: (deps) => (deps ? warning(deps) : nothing),
+      complete: (deps) => (deps?.size ? warning(deps) : nothing),
     });
   }
 
@@ -1015,6 +1070,7 @@ export class CollectionItemsDialog extends BtrixElement {
   private reset() {
     this.isReady = false;
     // Reset selection and filters
+    this.showConfirmation = false;
     this.activeTab = TABS[0];
     this.crawls = undefined;
     this.workflows = undefined;
@@ -1038,6 +1094,8 @@ export class CollectionItemsDialog extends BtrixElement {
     this.workflowSelection = new Map();
     this.savedWorkflowSelection = new Map();
     this.batchWorkflows = new Map();
+
+    this.dependenciesTask.abort();
   }
 
   private get difference() {
@@ -1100,6 +1158,17 @@ export class CollectionItemsDialog extends BtrixElement {
       addWorkflows: delta.includedContainers,
       removeWorkflows: delta.excludedContainers,
     };
+  }
+
+  private async trySave() {
+    const deps = await this.dependenciesTask.taskComplete;
+
+    if (deps?.size) {
+      this.showConfirmation = true;
+      return;
+    }
+
+    await this.save();
   }
 
   private async save() {

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -1,7 +1,8 @@
 import { localized, msg, str } from "@lit/localize";
+import { Task } from "@lit/task";
 import clsx from "clsx";
 import { merge } from "immutable";
-import { css, html, type PropertyValues } from "lit";
+import { css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { cache } from "lit/directives/cache.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -222,6 +223,63 @@ export class CollectionItemsDialog extends BtrixElement {
       label: msg("Uploaded Items"),
     },
   };
+
+  private readonly dependenciesTask = new Task(this, {
+    task: async (_args, { signal }) => {
+      const { removeItems, removeWorkflows } = this.difference;
+      console.log("remove:", removeItems, removeWorkflows);
+
+      if (!removeItems.size && !removeWorkflows.size) return;
+
+      const requests: Promise<APIPaginatedList<ArchivedItem>>[] = [];
+
+      if (removeItems.size) {
+        const query = queryString.stringify({
+          ids: [...removeItems],
+          collectionId: this.collectionId,
+          hasRequiredByCrawls: true,
+        });
+
+        requests.push(
+          this.api.fetch<APIPaginatedList<ArchivedItem>>(
+            `/orgs/${this.orgId}/all-crawls?${query}`,
+            { signal },
+          ),
+        );
+      }
+
+      if (removeWorkflows.size) {
+        removeWorkflows.forEach((id) => {
+          const query = queryString.stringify({
+            cid: id,
+            collectionId: this.collectionId,
+            hasRequiredByCrawls: true,
+          });
+
+          requests.push(
+            this.api.fetch<APIPaginatedList<ArchivedItem>>(
+              `/orgs/${this.orgId}/all-crawls?${query}`,
+              { signal },
+            ),
+          );
+        });
+      }
+
+      const results = await Promise.all(requests);
+      const deps = new Set<string>();
+
+      results.forEach(({ items, total }) => {
+        if (items.length > total) {
+          console.warn("some dependencies hidden");
+        }
+
+        items.forEach(({ id }) => deps.add(id));
+      });
+
+      return deps;
+    },
+    args: () => [this.deselectedItems, this.workflowSelection] as const,
+  });
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (!this.open) {
@@ -892,25 +950,27 @@ export class CollectionItemsDialog extends BtrixElement {
     if (hasChange) {
       const messages: string[] = [];
       if (addCount) {
-        messages.push(
-          msg(
-            str`Adding ${this.localize.number(addCount)} ${pluralOf("items", addCount)}`,
-          ),
-        );
+        const number_of_items = this.localize.number(addCount);
+        const plural_of_items = pluralOf("items", addCount);
+
+        messages.push(msg(str`Adding ${number_of_items} ${plural_of_items}`));
       }
       if (removeCount) {
-        messages.push(
-          msg(
-            str`Removing ${this.localize.number(removeCount)} ${pluralOf("items", removeCount)}`,
-          ),
-        );
+        const number_of_items = this.localize.number(removeCount);
+        const plural_of_items = pluralOf("items", removeCount);
+
+        messages.push(msg(str`Removing ${number_of_items} ${plural_of_items}`));
       }
 
       selectionMessage = messages.join(" / ");
     }
 
     return html`
-      <span class="text-warning">${selectionMessage}</span>
+      <div class="inline-flex items-center gap-1.5 text-warning">
+        <span>${selectionMessage}</span>
+        ${this.renderDependencyWarning()}
+      </div>
+
       <sl-button
         variant="primary"
         size="small"
@@ -922,6 +982,25 @@ export class CollectionItemsDialog extends BtrixElement {
       </sl-button>
     `;
   };
+
+  private renderDependencyWarning() {
+    const warning = (deps: Set<string>) => {
+      const count = deps.size;
+      const number_of_dependencies = this.localize.number(count);
+      const plural_of_dependencies = pluralOf("dependencies", count);
+
+      return html`<btrix-popover placement="top-end" hoist>
+      <div slot="content">
+        ${msg(str`${number_of_dependencies} ${plural_of_dependencies} will be removed`)}
+      </div>
+      <sl-icon class="text-base" name="exclamation-diamond" label=${msg("Warning")}></sl-icon></sl-icon>
+    </btrix-popover>`;
+    };
+
+    return this.dependenciesTask.render({
+      complete: (deps) => (deps ? warning(deps) : nothing),
+    });
+  }
 
   private readonly renderLoading = () => html`
     <div class="my-24 flex w-full items-center justify-center text-3xl">


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3202

## Changes

Displays warning and confirmation to users when dependencies may be removed.

## Manual testing

1. Log in as crawler to org with dedupe enabled
2. Go to Collections and choose collection with dependencies
3. Go to Archived Items
4. Select "Configure Items"
5. Deselect entire workflow. Verify warning icon is displayed next to "Removing X items" message
6. Reset selection
7. Deselect individual dependencies. Verify warning icon is displayed
8. Choose "Save Selection". Verify confirmation is displayed
9. Choose "Edit Selection". Verify confirmation is dismissed
10. Repeat 7-8
11. Confirm "Save Selection". Verify selection is saved

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Configure Items | <img width="363" height="96" alt="Screenshot 2026-05-13 at 12 13 28 PM" src="https://github.com/user-attachments/assets/8d3f5657-2a77-4886-b792-f3fb39139639" /> |
| Configure Items | <img width="452" height="143" alt="Screenshot 2026-05-13 at 12 13 36 PM" src="https://github.com/user-attachments/assets/463a6ed1-4fd2-4bda-b00a-92af9f039ad4" /> |


<!-- ## Follow-ups -->
