### PR TITLE
fix: Prevent initial view resetting on poll

### DIFF
--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -61,6 +61,7 @@ import type { CrawlState } from "@/types/crawlState";
 import type { DedupeIndexState } from "@/types/dedupe";
 import { isCrawlReplay, renderName } from "@/utils/crawler";
 import { indexAvailable, indexInUse, indexUpdating } from "@/utils/dedupe";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { pluralOf } from "@/utils/pluralize";
 import { formatRwpTimestamp } from "@/utils/replay";
 import { richText } from "@/utils/rich-text";
@@ -80,7 +81,7 @@ export class CollectionDetail extends BtrixElement {
   @property({ type: String })
   collectionTab: Tab | null = Tab.Replay;
 
-  @state()
+  @state({ hasChanged: isNotEqual })
   private collection?: Collection;
 
   @state()


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3288

## Changes

Fixes collection "Set Initial View" dialog from resetting on collection poll.

## Manual testing

1. Log in as crawler
2. Go to Collections > choose collection > choose "Set Initial View"
3. Change view option
4. Wait 10 seconds. Verify that option isn't reset to previous value