### PR TITLE
docs: removed deprecated `--no-deploy` with `--disable`; add traefik post-deletion steps (refs k3s-io/k3s#1160)

### DIFF
--- a/.github/workflows/k3d-log-ci.yaml
+++ b/.github/workflows/k3d-log-ci.yaml
@@ -21,7 +21,7 @@ jobs:
           args: >-
             --agents 1
             -p "443:443@loadbalancer"
-            --k3s-arg "--no-deploy=traefik,metrics-server@server:*"
+            --k3s-arg "--disable=traefik,metrics-server@server:*"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/chart/examples/k3s-hosted.yaml
+++ b/chart/examples/k3s-hosted.yaml
@@ -12,7 +12,7 @@
 #
 # One way to deploy this is with k3s (https://k3s.io/), which will require the following changes:
 #
-# Make sure to disable traefik on your k3s cluster by adding `--no-deploy traefik` to the systemd unit that starts k3s _before_ starting your server.
+# Make sure to disable traefik on your k3s cluster by adding `--disable traefik` to the systemd unit that starts k3s _before_ starting your server. Note: this flag was renamed from `--no-deploy` to `--disable` (see https://github.com/k3s-io/k3s/issues/1160).
 # One way to check that traefik is not running your cluster is with `kubectl get deployments -n kube-system` and see if traefik shows up in the output.
 #
 # Once traefik has been disabled, you must install `nginx-ingress`, which can be installed by:

--- a/chart/examples/k3s-hosted.yaml
+++ b/chart/examples/k3s-hosted.yaml
@@ -12,7 +12,7 @@
 #
 # One way to deploy this is with k3s (https://k3s.io/), which will require the following changes:
 #
-# Make sure to disable traefik on your k3s cluster by adding `--disable traefik` to the systemd unit that starts k3s _before_ starting your server. Note: this flag was renamed from `--no-deploy` to `--disable` (see https://github.com/k3s-io/k3s/issues/1160).
+# Make sure to disable traefik on your k3s cluster by adding `--disable traefik` to the systemd unit that starts k3s _before_ starting your server.
 # One way to check that traefik is not running your cluster is with `kubectl get deployments -n kube-system` and see if traefik shows up in the output.
 #
 # Once traefik has been disabled, you must install `nginx-ingress`, which can be installed by:

--- a/frontend/docs/docs/deploy/remote.md
+++ b/frontend/docs/docs/deploy/remote.md
@@ -30,7 +30,14 @@ For a single-machine remote deployment, we recommend using [MicroK8s](https://mi
 
 Another option for a single-machine remote deployment is [k3s](https://k3s.io)
 
-1. Install K3s, as suggested in the [local deployment guide](../deploy/local.md). Make sure to **disable traefik** which can be done by adding `--no-deploy traefik` to the `systemd` unit when installing k3s
+1. Install K3s, as suggested in the [local deployment guide](../deploy/local.md). Make sure to **disable traefik** which can be done by adding `--disable traefik` to the `systemd` unit when installing k3s. Note: the flag was renamed from `--no-deploy` to `--disable` (see https://github.com/k3s-io/k3s/issues/1160). If traefik has already been deployed, remove it after installation with the following (from https://github.com/k3s-io/k3s/issues/1160#issuecomment-1133559423):
+
+    ```sh
+    helm -n kube-system delete traefik traefik-crd
+    kubectl -n kube-system delete helmchart traefik traefik-crd
+    touch /var/lib/rancher/k3s/server/manifests/traefik.yaml.skip
+    systemctl restart k3s
+    ```
 
 2. Install `nginx-ingress` with:
 

--- a/frontend/docs/docs/deploy/remote.md
+++ b/frontend/docs/docs/deploy/remote.md
@@ -30,14 +30,7 @@ For a single-machine remote deployment, we recommend using [MicroK8s](https://mi
 
 Another option for a single-machine remote deployment is [k3s](https://k3s.io)
 
-1. Install K3s, as suggested in the [local deployment guide](../deploy/local.md). Make sure to **disable traefik** which can be done by adding `--disable traefik` to the `systemd` unit when installing k3s. Note: the flag was renamed from `--no-deploy` to `--disable` (see https://github.com/k3s-io/k3s/issues/1160). If traefik has already been deployed, remove it after installation with the following (from https://github.com/k3s-io/k3s/issues/1160#issuecomment-1133559423):
-
-    ```sh
-    helm -n kube-system delete traefik traefik-crd
-    kubectl -n kube-system delete helmchart traefik traefik-crd
-    touch /var/lib/rancher/k3s/server/manifests/traefik.yaml.skip
-    systemctl restart k3s
-    ```
+1. Install K3s, as suggested in the [local deployment guide](../deploy/local.md). Make sure to **disable traefik** which can be done by adding `--disable traefik` to the `systemd` unit when installing k3s. (Note: in previous versions of k3s, the `--disable` flag was named `--no-deploy`. If upgrading an existing installation, ensure you've updated the `systemd` unit with the new flag.)
 
 2. Install `nginx-ingress` with:
 


### PR DESCRIPTION
Rename occurrences of the removed --no-deploy flag to the new --disable form and add traefik post-deletion steps. See upstream discussion: https://github.com/k3s-io/k3s/issues/1160 (comment: https://github.com/k3s-io/k3s/issues/1160#issuecomment-1133559423).