### PR TITLE
feat: Allow editing crawl name

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -65,10 +65,6 @@ export class ConfigDetails extends BtrixElement {
   @property({ type: Boolean })
   anchorLinks = false;
 
-  // Hide metadata section, e.g. if embedded in crawl detail view
-  @property({ type: Boolean })
-  hideMetadata = false;
-
   @state()
   private orgDefaults?: {
     pageLoadTimeoutSeconds?: number;
@@ -354,9 +350,9 @@ export class ConfigDetails extends BtrixElement {
           `,
         }),
       )}
-      ${when(!this.hideMetadata, () =>
-        isWorkflow(crawlConfig)
-          ? this.renderSection({
+      ${isWorkflow(crawlConfig)
+        ? html`
+            ${this.renderSection({
               id: "collection",
               heading: sectionStrings.collections,
               renderDescItems: () => html`
@@ -376,35 +372,35 @@ export class ConfigDetails extends BtrixElement {
                     : undefined,
                 )}
               `,
-            })
-          : nothing,
-      )}
-      ${when(!this.hideMetadata, () =>
-        this.renderSection({
-          id: "crawl-metadata",
-          heading: sectionStrings.metadata,
-          renderDescItems: () => html`
-            ${this.renderSetting(msg("Name"), crawlConfig?.name)}
-            ${this.renderSetting(
-              msg("Description"),
-              crawlConfig?.description
-                ? html`<btrix-prose class="[--btrix-line-clamp:12]"
-                    >${richText(crawlConfig.description)}</btrix-prose
-                  >`
-                : undefined,
-            )}
-            ${this.renderSetting(
-              msg("Tags"),
-              crawlConfig?.tags.length
-                ? crawlConfig.tags.map(
-                    (tag) =>
-                      html`<btrix-tag class="mr-2 mt-1">${tag}</btrix-tag>`,
-                  )
-                : [],
-            )}
-          `,
-        }),
-      )}
+            })}
+            ${this.renderSection({
+              id: "crawl-metadata",
+              heading: sectionStrings.metadata,
+              renderDescItems: () => html`
+                ${this.renderSetting(msg("Name"), crawlConfig.name)}
+                ${this.renderSetting(
+                  msg("Description"),
+                  crawlConfig.description
+                    ? html`
+                        <btrix-prose class="[--btrix-line-clamp:12]"
+                          >${richText(crawlConfig.description)}</btrix-prose
+                        >
+                      `
+                    : undefined,
+                )}
+                ${this.renderSetting(
+                  msg("Tags"),
+                  crawlConfig.tags.length
+                    ? crawlConfig.tags.map(
+                        (tag) =>
+                          html`<btrix-tag class="mr-2 mt-1">${tag}</btrix-tag>`,
+                      )
+                    : [],
+                )}
+              `,
+            })}
+          `
+        : nothing}
     `;
   }
 

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -1,7 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import type { SlInput, SlTextarea } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
-import { html, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 
@@ -14,7 +14,7 @@ import type {
 } from "@/features/collections/collections-add";
 import { DESCRIPTION_MAX_LENGTH, NAME_MAX_LENGTH } from "@/types/archivedItems";
 import type { ArchivedItem } from "@/types/crawler";
-import { isSuccessfullyFinished } from "@/utils/crawler";
+import { isCrawl, isSuccessfullyFinished } from "@/utils/crawler";
 import { maxLengthValidator } from "@/utils/form";
 
 /**
@@ -95,6 +95,7 @@ export class CrawlMetadataEditor extends BtrixElement {
 
     const item = this.item;
     const isSuccess = isSuccessfullyFinished(item);
+    const crawl = isCrawl(this.item);
 
     return html`
       <form
@@ -105,14 +106,23 @@ export class CrawlMetadataEditor extends BtrixElement {
         <div class="mb-3">
           <sl-input
             id="name-input"
+            class=${crawl ? "help-text-same-line" : "with-max-help-text"}
             label="Name"
             name="name"
             value="${item.name}"
             help-text=${this.validateItemNameMax.helpText}
+            placeholder=${(crawl ? item.firstSeed : item.name) || ""}
+            ?required=${!crawl}
             @sl-input=${this.validateItemNameMax.validate}
-            placeholder="${item.name}"
           >
           </sl-input>
+          ${crawl
+            ? html`<p class="form-help-text">
+                ${msg(
+                  "If omitted, the item will be named after the first URL crawled.",
+                )}
+              </p>`
+            : nothing}
         </div>
         <sl-textarea
           id="description-input"
@@ -183,7 +193,7 @@ export class CrawlMetadataEditor extends BtrixElement {
       description?: string;
       name?: string;
     } = {};
-    if (name && name !== this.item.name) {
+    if (name !== this.item.name) {
       params.name = name as string;
     }
     if (

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -1,5 +1,5 @@
 import { localized, msg } from "@lit/localize";
-import type { SlTextarea } from "@shoelace-style/shoelace";
+import type { SlInput, SlTextarea } from "@shoelace-style/shoelace";
 import { serialize } from "@shoelace-style/shoelace/dist/utilities/form.js";
 import { html, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -52,6 +52,9 @@ export class CrawlMetadataEditor extends BtrixElement {
   @state()
   private collectionsToSave: string[] = [];
 
+  @query("#name-input")
+  public readonly nameInput?: SlInput | null;
+
   @query("#description-input")
   public readonly descriptionInput?: SlTextarea | null;
 
@@ -101,6 +104,7 @@ export class CrawlMetadataEditor extends BtrixElement {
       >
         <div class="mb-3">
           <sl-input
+            id="name-input"
             label="Name"
             name="name"
             value="${item.name}"

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -47,9 +47,6 @@ export class CrawlMetadataEditor extends BtrixElement {
   private isDialogVisible = false;
 
   @state()
-  private includeName = false;
-
-  @state()
   private tagsToSave: Tags = [];
 
   @state()
@@ -69,7 +66,6 @@ export class CrawlMetadataEditor extends BtrixElement {
 
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("item") && this.item) {
-      this.includeName = this.item.type === "upload";
       this.tagsToSave = this.item.tags;
       this.collectionsToSave = this.item.collectionIds;
     }
@@ -103,21 +99,17 @@ export class CrawlMetadataEditor extends BtrixElement {
         @submit=${this.onSubmitMetadata}
         @reset=${this.requestClose}
       >
-        ${this.includeName
-          ? html`
-              <div class="mb-3">
-                <sl-input
-                  label="Name"
-                  name="name"
-                  value="${item.name}"
-                  help-text=${this.validateItemNameMax.helpText}
-                  @sl-input=${this.validateItemNameMax.validate}
-                  placeholder="${item.name}"
-                >
-                </sl-input>
-              </div>
-            `
-          : ``}
+        <div class="mb-3">
+          <sl-input
+            label="Name"
+            name="name"
+            value="${item.name}"
+            help-text=${this.validateItemNameMax.helpText}
+            @sl-input=${this.validateItemNameMax.validate}
+            placeholder="${item.name}"
+          >
+          </sl-input>
+        </div>
         <sl-textarea
           id="description-input"
           class="with-max-help-text mb-3"
@@ -187,7 +179,7 @@ export class CrawlMetadataEditor extends BtrixElement {
       description?: string;
       name?: string;
     } = {};
-    if (this.includeName && name && name !== this.item.name) {
+    if (name && name !== this.item.name) {
       params.name = name as string;
     }
     if (

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -453,29 +453,7 @@ export class ArchivedItemDetail extends BtrixElement {
         break;
       case "config":
         sectionContent = this.renderPanel(
-          html`
-            ${this.renderTitle(html`
-              ${this.tabLabels.config}
-              <sl-tooltip
-                content=${msg("Workflow settings used to run this crawl")}
-              >
-                <sl-icon
-                  class="align-[-.175em] text-base text-neutral-500"
-                  name="info-circle"
-                ></sl-icon>
-              </sl-tooltip>
-            `)}
-            <sl-button
-              size="small"
-              href="${this.navigate.orgBasePath}/workflows/${this.item
-                ?.cid}?edit"
-              ?disabled=${!this.item}
-              @click=${this.navigate.link}
-            >
-              <sl-icon slot="prefix" name="gear"></sl-icon>
-              ${msg("Edit Workflow")}
-            </sl-button>
-          `,
+          this.renderTitle(this.tabLabels.config),
           this.renderConfig(),
           [tw`rounded-lg border p-4`],
         );
@@ -507,9 +485,9 @@ export class ArchivedItemDetail extends BtrixElement {
       default:
         sectionContent = html`
           <div
-            class="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:grid-rows-[auto_1fr]"
+            class="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:grid-rows-[auto_auto_1fr]"
           >
-            <div class="col-span-1 row-span-1 flex flex-col lg:row-span-2">
+            <div class="col-span-1 row-span-1 flex flex-col lg:row-span-3">
               ${this.renderPanel(msg("Overview"), this.renderOverview(), [
                 tw`rounded-lg border p-4`,
               ])}
@@ -563,6 +541,25 @@ export class ArchivedItemDetail extends BtrixElement {
                   )}
                 </div>
               `,
+            )}
+            ${when(
+              this.item && isCrawl(this.item),
+              () =>
+                html`<div class="col-span-1 row-span-1 flex flex-col">
+                  ${this.renderPanel(
+                    html`
+                      ${this.renderTitle(msg("Workflow"))}
+                      <btrix-copy-button
+                        value=${this.item?.cid || ""}
+                        content=${msg("Copy Workflow ID")}
+                        size="medium"
+                        placement="left"
+                        hoist
+                      ></btrix-copy-button>
+                    `,
+                    this.renderWorkflow(),
+                  )}
+                </div>`,
             )}
           </div>
         `;
@@ -1191,6 +1188,28 @@ export class ArchivedItemDetail extends BtrixElement {
     `;
   }
 
+  private renderWorkflow() {
+    return html`
+      <div
+        class="flex min-h-8 items-center rounded border"
+        aria-busy="${!this.workflow}"
+      >
+        <div class="flex-1 overflow-hidden p-1.5 leading-none">
+          ${renderName(this.workflow)}
+        </div>
+        <div class="flex-none">
+          <sl-icon-button
+            name="link"
+            href="${this.navigate.orgBasePath}/workflows/${this.item?.cid}"
+            label=${msg("Visit Link")}
+            @click=${this.navigate.link}
+          >
+          </sl-icon-button>
+        </div>
+      </div>
+    `;
+  }
+
   private renderDependencies() {
     if (!this.item) return;
 
@@ -1390,7 +1409,6 @@ export class ArchivedItemDetail extends BtrixElement {
               }}
               .seeds=${this.seeds!.items}
               .seedFile=${this.seedFileTask.value || undefined}
-              hideMetadata
             ></btrix-config-details>
           `,
           this.renderLoading,

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1194,9 +1194,7 @@ export class ArchivedItemDetail extends BtrixElement {
         class="flex min-h-8 items-center rounded border"
         aria-busy="${!this.workflow}"
       >
-        <div class="flex-1 overflow-hidden p-1.5 leading-none">
-          ${renderName(this.workflow)}
-        </div>
+        <div class="flex-1 truncate p-1.5">${renderName(this.workflow)}</div>
         <div class="flex-none">
           <sl-icon-button
             name="link"

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -485,9 +485,9 @@ export class ArchivedItemDetail extends BtrixElement {
       default:
         sectionContent = html`
           <div
-            class="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:grid-rows-[auto_auto_1fr]"
+            class="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:grid-rows-[auto_1fr]"
           >
-            <div class="col-span-1 row-span-1 flex flex-col lg:row-span-3">
+            <div class="col-span-1 row-span-1 flex flex-col lg:row-span-2">
               ${this.renderPanel(msg("Overview"), this.renderOverview(), [
                 tw`rounded-lg border p-4`,
               ])}
@@ -541,25 +541,6 @@ export class ArchivedItemDetail extends BtrixElement {
                   )}
                 </div>
               `,
-            )}
-            ${when(
-              this.item && isCrawl(this.item),
-              () =>
-                html`<div class="col-span-1 row-span-1 flex flex-col">
-                  ${this.renderPanel(
-                    html`
-                      ${this.renderTitle(msg("Workflow"))}
-                      <btrix-copy-button
-                        value=${this.item?.cid || ""}
-                        content=${msg("Copy Workflow ID")}
-                        size="medium"
-                        placement="left"
-                        hoist
-                      ></btrix-copy-button>
-                    `,
-                    this.renderWorkflow(),
-                  )}
-                </div>`,
             )}
           </div>
         `;
@@ -1185,26 +1166,6 @@ export class ArchivedItemDetail extends BtrixElement {
           ),
         () => html`<sl-skeleton class="h-[16px] w-24"></sl-skeleton>`,
       )}
-    `;
-  }
-
-  private renderWorkflow() {
-    return html`
-      <div
-        class="flex min-h-8 items-center rounded border"
-        aria-busy="${!this.workflow}"
-      >
-        <div class="flex-1 truncate p-1.5">${renderName(this.workflow)}</div>
-        <div class="flex-none">
-          <sl-icon-button
-            name="link"
-            href="${this.navigate.orgBasePath}/workflows/${this.item?.cid}"
-            label=${msg("Visit Link")}
-            @click=${this.navigate.link}
-          >
-          </sl-icon-button>
-        </div>
-      </div>
     `;
   }
 

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1664,6 +1664,7 @@ export class ArchivedItemDetail extends BtrixElement {
               this.editDialog?.collectionInput?.focus();
               break;
             default:
+              this.editDialog?.nameInput?.focus();
               break;
           }
         },

--- a/frontend/src/theme.stylesheet.css
+++ b/frontend/src/theme.stylesheet.css
@@ -459,6 +459,32 @@
     grid-column-start: 2;
   }
 
+  /** Render help text to the side of the label **/
+  .help-text-same-line::part(form-control) {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    align-items: enter;
+    gap: var(--sl-spacing-3x-small);
+  }
+
+  .help-text-same-line::part(form-control-label) {
+    grid-column: 1 / 2;
+    grid-row-start: 1;
+    margin: 0;
+  }
+
+  .help-text-same-line::part(form-control-input) {
+    grid-column: 1 / 3;
+    grid-row-start: 2;
+  }
+
+  .help-text-same-line::part(form-control-help-text) {
+    grid-column-start: 2;
+    grid-row-start: 1;
+    margin: 0;
+  }
+
   /* Button group tweaks */
   [data-sl-button-group__button--first][variant="primary"]:has(
       + [data-sl-button-group__button][variant="default"]


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3277

## Changes

- Allows users to edit crawled archived item name
- Requires name for uploads
- Refactors `<btrix-config-details>` to remove unused property

## Manual testing

1. Log in as crawler
2. Go to Archived Items > Crawled Items > choose item
3. Select Actions > Edit Archived Item. Verify "Name" input is displayed
4. Change name and save. Verify name is updated
5. Repeat 4-5 with no name. Verify name is updated to first seed
6. Go to Archived Items > Uploaded Items > choose item
7. Select Actions > Edit Archived Item. Verify "Name" input is required and help text about omission is not visible

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit Archived Item (crawl) | <img width="494" height="583" alt="Screenshot 2026-05-18 at 12 47 59 PM" src="https://github.com/user-attachments/assets/2d8a5d37-fca9-42e0-9280-63d757a51dc5" /> |
| Edit Archived Item (crawl) | <img width="494" height="113" alt="Screenshot 2026-05-18 at 12 48 05 PM" src="https://github.com/user-attachments/assets/b0ae4e8f-756a-4953-a6b9-f09a36bd00f2" /> |


<!-- ## Follow-ups -->
