### PR TITLE
feat: Line clamp long descriptions

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -388,11 +388,9 @@ export class ConfigDetails extends BtrixElement {
             ${this.renderSetting(
               msg("Description"),
               crawlConfig?.description
-                ? html`
-                    <p class="max-w-prose font-sans">
-                      ${richText(crawlConfig.description)}
-                    </p>
-                  `
+                ? html`<btrix-prose
+                    >${richText(crawlConfig.description)}</btrix-prose
+                  >`
                 : undefined,
             )}
             ${this.renderSetting(

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -388,7 +388,7 @@ export class ConfigDetails extends BtrixElement {
             ${this.renderSetting(
               msg("Description"),
               crawlConfig?.description
-                ? html`<btrix-prose
+                ? html`<btrix-prose class="[--btrix-line-clamp:12]"
                     >${richText(crawlConfig.description)}</btrix-prose
                   >`
                 : undefined,

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -37,6 +37,7 @@ import("./overflow-scroll");
 import("./pagination");
 import("./popover");
 import("./pw-strength-alert");
+import("./prose");
 import("./regex");
 import("./relative-duration");
 import("./search-combobox");

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -56,8 +56,9 @@ export class Prose extends TailwindElement {
       return;
     }
 
-    this.clamped = pre.scrollHeight > pre.clientHeight;
-
-    console.log(pre.clientHeight, pre.scrollHeight);
+    this.clamped =
+      pre.scrollHeight === pre.clientHeight
+        ? undefined
+        : pre.scrollHeight > pre.clientHeight;
   }
 }

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -33,9 +33,9 @@ export class Prose extends TailwindElement {
   render() {
     return html`<pre
         class=${clsx(
-          this.clamped !== false &&
-            tw`line-clamp-[var(--btrix-line-clamp)] max-h-[15.75rem]`,
-          tw`max-w-[var(--btrix-prose-width)] hyphens-auto whitespace-pre-line text-pretty font-sans leading-normal`,
+          this.clamped &&
+            tw`line-clamp-[--btrix-line-clamp] max-h-[15.75rem]`,
+          tw`max-w-[--btrix-prose-width] hyphens-auto whitespace-pre-line text-pretty font-sans leading-normal`,
         )}
       ><slot @slotchange=${this.onSlotChange}></slot></pre>
       ${this.clamped || this.clamped === false

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -11,6 +11,7 @@ import { tw } from "@/utils/tailwind";
  * Uses `overflow-hidden` as fallback
  *
  * @cssproperty --btrix-line-clamp
+ * @cssproperty --btrix-prose-width
  */
 @customElement("btrix-prose")
 @localized()
@@ -18,6 +19,8 @@ export class Prose extends TailwindElement {
   static styles = css`
     :host {
       --btrix-line-clamp: 6;
+      --btrix-prose-width: 65ch;
+      display: contents;
     }
   `;
 
@@ -32,12 +35,12 @@ export class Prose extends TailwindElement {
         class=${clsx(
           this.clamped !== false &&
             tw`line-clamp-[var(--btrix-line-clamp)] max-h-[15.75rem]`,
-          tw`max-w-prose whitespace-pre-line font-sans leading-normal`,
+          tw`max-w-[var(--btrix-prose-width)] hyphens-auto whitespace-pre-line text-pretty font-sans leading-normal`,
         )}
       ><slot @slotchange=${this.onSlotChange}></slot></pre>
       ${this.clamped || this.clamped === false
         ? html`<button
-            class="mt-1.5 leading-normal text-primary-500 transition-colors duration-fast hover:text-primary-600"
+            class="whitespace-nowrap leading-normal text-primary-500 transition-colors duration-fast hover:text-primary-600"
             @click=${() => (this.clamped = !this.clamped)}
           >
             ${this.clamped ? msg("Show more") : msg("Show less")}

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -17,7 +17,7 @@ import { tw } from "@/utils/tailwind";
 export class Prose extends TailwindElement {
   static styles = css`
     :host {
-      --btrix-line-clamp: 12;
+      --btrix-line-clamp: 6;
     }
   `;
 

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import clsx from "clsx";
-import { html, nothing } from "lit";
+import { css, html, nothing } from "lit";
 import { customElement, queryAsync, state } from "lit/decorators.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
@@ -9,10 +9,18 @@ import { tw } from "@/utils/tailwind";
 /**
  * Display prose, like workflow and item descriptions, with line clamping.
  * Uses `overflow-hidden` as fallback
+ *
+ * @cssproperty --btrix-line-clamp
  */
 @customElement("btrix-prose")
 @localized()
 export class Prose extends TailwindElement {
+  static styles = css`
+    :host {
+      --btrix-line-clamp: 12;
+    }
+  `;
+
   @state()
   private clamped?: boolean;
 
@@ -22,7 +30,8 @@ export class Prose extends TailwindElement {
   render() {
     return html`<pre
         class=${clsx(
-          this.clamped !== false && tw`line-clamp-6 max-h-32 overflow-hidden`,
+          this.clamped !== false &&
+            tw`line-clamp-[var(--btrix-line-clamp)] max-h-[15.75rem]`,
           tw`max-w-prose whitespace-pre-line font-sans leading-normal`,
         )}
       ><slot @slotchange=${this.onSlotChange}></slot></pre>

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -1,0 +1,51 @@
+import { localized, msg } from "@lit/localize";
+import clsx from "clsx";
+import { html, nothing } from "lit";
+import { customElement, queryAsync, state } from "lit/decorators.js";
+
+import { TailwindElement } from "@/classes/TailwindElement";
+import { tw } from "@/utils/tailwind";
+
+/**
+ * Display prose, like workflow and item descriptions, with line clamping.
+ * Uses `overflow-hidden` as fallback
+ */
+@customElement("btrix-prose")
+@localized()
+export class Prose extends TailwindElement {
+  @state()
+  private clamped?: boolean;
+
+  @queryAsync("pre")
+  private readonly pre?: Promise<HTMLPreElement>;
+
+  render() {
+    return html`<pre
+        class=${clsx(
+          this.clamped !== false && tw`line-clamp-6 max-h-32 overflow-hidden`,
+          tw`max-w-prose whitespace-pre-line font-sans leading-normal`,
+        )}
+      ><slot @slotchange=${this.onSlotChange}></slot></pre>
+      ${this.clamped || this.clamped === false
+        ? html`<button
+            class="mt-1.5 leading-normal text-primary-500 transition-colors duration-fast hover:text-primary-600"
+            @click=${() => (this.clamped = !this.clamped)}
+          >
+            ${this.clamped ? msg("Show more") : msg("Show less")}
+          </button>`
+        : nothing}`;
+  }
+
+  private async onSlotChange() {
+    const pre = await this.pre;
+
+    if (!pre) {
+      console.debug("no pre");
+      return;
+    }
+
+    this.clamped = pre.scrollHeight > pre.clientHeight;
+
+    console.log(pre.clientHeight, pre.scrollHeight);
+  }
+}

--- a/frontend/src/components/ui/prose.ts
+++ b/frontend/src/components/ui/prose.ts
@@ -22,6 +22,10 @@ export class Prose extends TailwindElement {
       --btrix-prose-width: 65ch;
       display: contents;
     }
+
+    .clamp {
+      max-height: calc(var(--btrix-line-clamp) * 1.3125rem);
+    }
   `;
 
   @state()
@@ -33,8 +37,10 @@ export class Prose extends TailwindElement {
   render() {
     return html`<pre
         class=${clsx(
-          this.clamped &&
-            tw`line-clamp-[--btrix-line-clamp] max-h-[15.75rem]`,
+          this.clamped !== false && [
+            tw`line-clamp-[--btrix-line-clamp]`,
+            "clamp",
+          ],
           tw`max-w-[--btrix-prose-width] hyphens-auto whitespace-pre-line text-pretty font-sans leading-normal`,
         )}
       ><slot @slotchange=${this.onSlotChange}></slot></pre>

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -124,7 +124,7 @@ export class CrawlMetadataEditor extends BtrixElement {
           name="crawlDescription"
           label=${msg("Description")}
           value=${item.description || ""}
-          rows="4"
+          rows="6"
           autocomplete="off"
           resize="auto"
           help-text=${this.validateItemDescriptionMax.helpText}

--- a/frontend/src/features/archived-items/item-metadata-editor.ts
+++ b/frontend/src/features/archived-items/item-metadata-editor.ts
@@ -124,7 +124,7 @@ export class CrawlMetadataEditor extends BtrixElement {
           name="crawlDescription"
           label=${msg("Description")}
           value=${item.description || ""}
-          rows="3"
+          rows="4"
           autocomplete="off"
           resize="auto"
           help-text=${this.validateItemDescriptionMax.helpText}

--- a/frontend/src/features/browser-profiles/profile-metadata-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-metadata-dialog.ts
@@ -174,7 +174,7 @@ export class ProfileMetadataDialog extends BtrixElement {
           class="with-max-help-text"
           label=${msg("Description")}
           value=${this.profile.description || ""}
-          rows="3"
+          rows="6"
           autocomplete="off"
           resize="auto"
           help-text=${this.validateDescriptionMax.helpText}

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1131,7 +1131,7 @@ export class ArchivedItemDetail extends BtrixElement {
               when(
                 item.description?.length,
                 () =>
-                  html`<btrix-prose
+                  html`<btrix-prose class="[--btrix-line-clamp:4]"
                     >${richText(item.description ?? "")}</btrix-prose
                   >`,
                 () => noneText,

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1131,7 +1131,7 @@ export class ArchivedItemDetail extends BtrixElement {
               when(
                 item.description?.length,
                 () =>
-                  html`<btrix-prose class="[--btrix-line-clamp:4]"
+                  html`<btrix-prose
                     >${richText(item.description ?? "")}</btrix-prose
                   >`,
                 () => noneText,

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -1127,13 +1127,12 @@ export class ArchivedItemDetail extends BtrixElement {
         <btrix-desc-list-item label=${msg("Description")}>
           ${when(
             this.item,
-            () =>
+            (item) =>
               when(
-                this.item!.description?.length,
+                item.description?.length,
                 () =>
-                  html`<pre class="whitespace-pre-line font-sans">
-                      ${richText(this.item?.description ?? "")}
-                </pre
+                  html`<btrix-prose
+                    >${richText(item.description ?? "")}</btrix-prose
                   >`,
                 () => noneText,
               ),
@@ -1143,11 +1142,11 @@ export class ArchivedItemDetail extends BtrixElement {
         <btrix-desc-list-item label=${msg("Tags")}>
           ${when(
             this.item,
-            () =>
+            (item) =>
               when(
-                this.item!.tags.length,
+                item.tags.length,
                 () =>
-                  this.item!.tags.map(
+                  item.tags.map(
                     (tag) =>
                       html`<btrix-tag class="mr-2 mt-1">${tag}</btrix-tag>`,
                   ),

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -453,13 +453,7 @@ export class BrowserProfilesProfilePage extends BtrixElement {
           <btrix-desc-list-item label=${msg("Description")}>
             ${this.renderDetail((profile) =>
               profile.description
-                ? html`
-                    <!-- display: inline -->
-                    <div
-                      class="text-balanced whitespace-pre-line font-sans leading-relaxed text-neutral-600"
-                      >${profile.description}</div
-                    >
-                  `
+                ? html`<btrix-prose>${profile.description}</btrix-prose>`
                 : none,
             )}
           </btrix-desc-list-item>

--- a/frontend/src/stories/components/Prose.stories.ts
+++ b/frontend/src/stories/components/Prose.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+
+import { renderComponent, type RenderProps } from "./Prose";
+
+const meta = {
+  title: "Components/Prose",
+  component: "btrix-prose",
+  tags: ["autodocs"],
+  decorators: [],
+  render: renderComponent,
+  argTypes: {},
+  args: {},
+} satisfies Meta<RenderProps>;
+
+export default meta;
+type Story = StoryObj<RenderProps>;
+
+export const Short: Story = {
+  args: {
+    content: "Lorem ipsum dolor sit amet consectetur adipiscing elit.",
+  },
+};
+
+export const Long: Story = {
+  args: {
+    content: `Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.`,
+  },
+};

--- a/frontend/src/stories/components/Prose.stories.ts
+++ b/frontend/src/stories/components/Prose.stories.ts
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/web-components";
 
 import { renderComponent, type RenderProps } from "./Prose";
 
+import { tw } from "@/utils/tailwind";
+
 const meta = {
   title: "Components/Prose",
   component: "btrix-prose",
@@ -23,6 +25,15 @@ export const Short: Story = {
 
 export const Long: Story = {
   args: {
+    content: `Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.`,
+  },
+};
+
+export const CustomLineClamp: Story = {
+  args: {
+    class: tw`[--btrix-line-clamp:2]`,
     content: `Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
 
 Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.`,

--- a/frontend/src/stories/components/Prose.ts
+++ b/frontend/src/stories/components/Prose.ts
@@ -1,11 +1,17 @@
 import { html, type TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import type { Prose } from "@/components/ui/prose";
 
 import "@/components/ui/prose";
 
-export type RenderProps = Prose & { content: string | TemplateResult };
+export type RenderProps = Prose & {
+  content: string | TemplateResult;
+  class?: string;
+};
 
 export const renderComponent = (props: Partial<RenderProps>) => {
-  return html`<btrix-prose>${props.content}</btrix-prose>`;
+  return html`<btrix-prose class=${ifDefined(props.class)}
+    >${props.content}</btrix-prose
+  >`;
 };

--- a/frontend/src/stories/components/Prose.ts
+++ b/frontend/src/stories/components/Prose.ts
@@ -1,0 +1,11 @@
+import { html, type TemplateResult } from "lit";
+
+import type { Prose } from "@/components/ui/prose";
+
+import "@/components/ui/prose";
+
+export type RenderProps = Prose & { content: string | TemplateResult };
+
+export const renderComponent = (props: Partial<RenderProps>) => {
+  return html`<btrix-prose>${props.content}</btrix-prose>`;
+};


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3317

## Changes

Prevents long descriptions from taking up too much vertical space.

## Manual testing

1. Log in as crawler
2. Go to Crawling > select "Edit Workflow Settings" for a workflow
3. Enter long description and save
4. Go to Settings tab. Verify description is clamped with "Show More" button
5. Choose "Show More". Verify description is expanded with "Show Less" button
6. Choose "Show Less". Verify description is truncated
7. Repeat test for archived item and browser profile

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow / Settings | <img width="930" height="493" alt="Screenshot 2026-05-18 at 2 09 25 PM" src="https://github.com/user-attachments/assets/0df17dc2-ea80-4c6c-bca8-87c5044f9dfa" /> |
| Archived Item | <img width="506" height="445" alt="Screenshot 2026-05-18 at 1 58 16 PM" src="https://github.com/user-attachments/assets/77475a8d-2f83-49a9-aea9-59306eb33829" /> |
| Browser Profile | <img width="370" height="683" alt="Screenshot 2026-05-18 at 1 57 42 PM" src="https://github.com/user-attachments/assets/559d5493-2829-4c19-a842-8194ed518fe3" /> |




<!-- ## Follow-ups -->
