### PR TITLE
Fix browser windows workflow docs

### DIFF
--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -35,7 +35,7 @@ Exclusions added while crawling are applied to the same exclusion table saved in
 
 Like exclusions, the number of [browser windows](workflow-setup.md#browser-windows) can also be adjusted while crawling. On the **Watch** tab, press the **+/-** button next to the _Running in_ N _browser windows_ text and set the desired value.
 
-Unlike exclusions, this change will not be applied to future workflow runs.
+This change takes effect immediately on the running crawl and updates the crawl workflow settings for future runs.
 
 ## Pausing and Resuming Crawls
 


### PR DESCRIPTION
Fixes #3320.

This corrects the user guide's browser-window text so it matches the current product behavior: changing the number of browser windows during a crawl takes effect immediately and updates the workflow settings for later runs.

Validation:
- `uvx --with mkdocs-material --with mkdocs-redirects --with requests --with pyyaml mkdocs build --strict` from `frontend/docs` passes.

This is a small direct microfix. If it saves maintainer time and you accept it, a $10 tip through the Webrecorder GitHub Sponsors page would be appreciated: https://github.com/sponsors/webrecorder
