### PR TITLE
Fix safari hang by refactoring crawl list item name

### DIFF
--- a/frontend/src/features/crawls/crawl-list/crawl-list-item.ts
+++ b/frontend/src/features/crawls/crawl-list/crawl-list-item.ts
@@ -1,7 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import { css, html, nothing, type TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { OverflowDropdown } from "@/components/ui/overflow-dropdown";
@@ -48,52 +47,21 @@ export class CrawlListItem extends BtrixElement {
 
   render() {
     if (!this.crawl) return;
-    let idCell: TemplateResult;
 
-    if (this.workflowId) {
-      const label = html`
-        <div>
-          ${this.safeRender(
-            (crawl) => html`
-              <btrix-format-date
-                date=${crawl.started}
-                month="2-digit"
-                day="2-digit"
-                year="numeric"
-                hour="2-digit"
-                minute="2-digit"
-              ></btrix-format-date>
-            `,
-          )}
-        </div>
-      `;
-      idCell = html`
-        <btrix-table-cell
-          rowClickTarget=${ifDefined(this.href ? "a" : undefined)}
-        >
-          ${this.href
-            ? html`<a href=${this.href} @click=${this.navigate.link}>
-                ${label}
-              </a>`
-            : html`<div>${label}</div> `}
-        </btrix-table-cell>
-      `;
-    } else {
-      const label = html`
-        <btrix-table-cell class="clickLabel pl-0" role="generic">
-          ${this.safeRender((workflow) => renderName(workflow))}
-        </btrix-table-cell>
-      `;
-      idCell = html`
-        <btrix-table-cell rowClickTarget="a">
-          ${this.href
-            ? html`<a href=${this.href} @click=${this.navigate.link}>
-                ${label}
-              </a>`
-            : html`<div>${label}</div> `}
-        </btrix-table-cell>
-      `;
-    }
+    const label = this.workflowId
+      ? this.safeRender(
+          (crawl) => html`
+            <btrix-format-date
+              date=${crawl.started}
+              month="2-digit"
+              day="2-digit"
+              year="numeric"
+              hour="2-digit"
+              minute="2-digit"
+            ></btrix-format-date>
+          `,
+        )
+      : this.safeRender((workflow) => renderName(workflow));
 
     const skipped = isSkipped(this.crawl);
     const hasExec = Boolean(this.crawl.crawlExecSeconds);
@@ -126,7 +94,13 @@ export class CrawlListItem extends BtrixElement {
             `,
           )}
         </btrix-table-cell>
-        ${idCell}
+        <btrix-table-cell rowClickTarget=${this.href ? "a" : nothing}>
+          ${this.href
+            ? html`<a href=${this.href} @click=${this.navigate.link}>
+                ${label}
+              </a>`
+            : label}
+        </btrix-table-cell>
         ${this.workflowId
           ? nothing
           : html`


### PR DESCRIPTION
Fixes a hang in Safari on the **Crawling** → **Crawls** page.

I'm not totally sure what was causing the hang, but removing the nested `<btrix-table-cell>`s fixes it – I suspect it was an issue with how Safari handles shadow DOM and querying nested elements maybe? I wasn't easily able to find an exact root cause.

## Changes

- Simplifies conditional rendering of ID cell by extracting label creation and using single template structure
- Removes redundant wrapper divs and duplicated table cell markup (this is what caused the hang)

## Testing

The hang occurs on the `/orgs/<org>/workflows/crawls` page, before the crawl list render completes. I was able to reproduce it on both Safari Version 26.4 (20624.1.16.18.2) and Safari Technology Preview Release 242 (WebKit 20625.1.13.19.1) on macOS 15.7.5 (24G624). There's no action required to cause the hang besides being logged in and navigating to this page.