### PR TITLE
Pin `kubernetes` to < v36

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ email-validator
 loguru
 aiofiles
 kubernetes-asyncio==29.0.0
-kubernetes
+kubernetes==35.0.0
 aiobotocore>=2.22.0
 requests
 redis>=5.0.0


### PR DESCRIPTION
See related issue https://github.com/kubernetes-client/python/issues/2583

`kubernetes==36.0.0` adds a `kubernetes_asyncio` top-level folder than overwrites some of the files in the `kubernetes-asyncio` package. This causes issues on startup from incorrect/missing imports in `kubernetes_asyncio` code.