### PR TITLE
backend: migration for recreating invite index

### DIFF
--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -47,7 +47,7 @@ else:
     ) = object
 
 
-CURR_DB_VERSION = "0057"
+CURR_DB_VERSION = "0058"
 
 MIN_DB_VERSION = 7.0
 

--- a/backend/btrixcloud/migrations/migration_0058_invite_index.py
+++ b/backend/btrixcloud/migrations/migration_0058_invite_index.py
@@ -1,0 +1,32 @@
+"""
+Migration 0058 - Recreate index for invites
+"""
+
+from typing import cast
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from btrixcloud.emailsender import EmailSender
+from btrixcloud.invites import InviteOps
+from btrixcloud.migrations import BaseMigration
+
+MIGRATION_VERSION = "0058"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb: AsyncIOMotorDatabase, **kwargs):
+        self.mdb = mdb
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Delete and recreate invite index
+        """
+        invites = self.mdb["invites"]
+        await invites.drop_indexes()
+        invite_ops = InviteOps(self.mdb, cast(EmailSender, None))
+        await invite_ops.init_index()


### PR DESCRIPTION
I neglected to recreate the index when changing the expiration in #3284. We always create the indices on startup, not as a part of the migrations, but this will fail with a runtime error if the database already has this index with a different value in it.

Fixes #3327.