### PR TITLE
fix: Prevent using disabled proxy from crawling defaults

### DIFF
--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -284,7 +284,13 @@ def main() -> None:
     upload_ops.set_page_ops(page_ops)
 
     org_ops.set_ops(
-        base_crawl_ops, profiles, coll_ops, background_job_ops, page_ops, file_ops
+        base_crawl_ops,
+        profiles,
+        coll_ops,
+        background_job_ops,
+        page_ops,
+        file_ops,
+        crawl_config_ops,
     )
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -117,7 +117,13 @@ def init_ops() -> Tuple[
     upload_ops.set_page_ops(page_ops)
 
     org_ops.set_ops(
-        base_crawl_ops, profile_ops, coll_ops, background_job_ops, page_ops, file_ops
+        base_crawl_ops,
+        profile_ops,
+        coll_ops,
+        background_job_ops,
+        page_ops,
+        file_ops,
+        crawl_config_ops,
     )
 
     user_manager.set_ops(org_ops, crawl_config_ops, base_crawl_ops)

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -125,8 +125,9 @@ if TYPE_CHECKING:
     from .pages import PageOps
     from .file_uploads import FileUploadOps
     from .crawlmanager import CrawlManager
+    from .crawlconfigs import CrawlConfigOps
 else:
-    InviteOps = BaseCrawlOps = ProfileOps = CollectionOps = object
+    InviteOps = BaseCrawlOps = ProfileOps = CollectionOps = CrawlConfigOps = object
     BackgroundJobOps = UserManager = PageOps = FileUploadOps = CrawlManager = object
 
 
@@ -252,6 +253,7 @@ class OrgOps(BaseOrgs):
         background_job_ops: BackgroundJobOps,
         page_ops: PageOps,
         file_ops: FileUploadOps,
+        crawl_config_ops: CrawlConfigOps,
     ) -> None:
         """Set additional ops classes"""
         # pylint: disable=attribute-defined-outside-init
@@ -261,6 +263,7 @@ class OrgOps(BaseOrgs):
         self.background_job_ops = background_job_ops
         self.page_ops = page_ops
         self.file_ops = file_ops
+        self.crawl_config_ops = crawl_config_ops
 
     def set_default_primary_storage(self, storage: StorageRef):
         """set default primary storage"""
@@ -664,7 +667,7 @@ class OrgOps(BaseOrgs):
 
     async def update_proxies(self, org: Organization, proxies: OrgProxies) -> None:
         """Update org proxy settings"""
-        await self.orgs.find_one_and_update(
+        updated_org = await self.orgs.find_one_and_update(
             {"_id": org.id},
             {
                 "$set": {
@@ -672,7 +675,27 @@ class OrgOps(BaseOrgs):
                     "allowedProxies": proxies.allowedProxies,
                 }
             },
+            return_document=ReturnDocument.AFTER,
         )
+        org = Organization.from_dict(updated_org)
+
+        # If proxy currently set as crawling default was removed from org,
+        # remove it from crawling defaults as well
+        if (
+            org.crawlingDefaults
+            and org.crawlingDefaults.proxyId
+            and not self.crawl_config_ops.can_org_use_proxy(
+                org, org.crawlingDefaults.proxyId
+            )
+        ):
+            await self.orgs.find_one_and_update(
+                {"_id": org.id, "crawlingDefaults.proxyId": {"$ne": None}},
+                {
+                    "$set": {
+                        "crawlingDefaults.proxyId": None,
+                    }
+                },
+            )
 
     async def update_quotas(
         self,

--- a/frontend/src/features/browser-profiles/start-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/start-browser-dialog.ts
@@ -29,6 +29,7 @@ import {
 } from "@/context/org-proxies";
 import type { Profile } from "@/types/crawler";
 import type { WorkflowSearchValues } from "@/types/workflow";
+import { getDefaultProxyId } from "@/utils/crawler";
 
 type StartBrowserEventDetail = {
   url?: string;
@@ -235,9 +236,7 @@ export class StartBrowserDialog extends BtrixElement {
               <btrix-select-crawler-proxy
                 .label=${msg("Proxy Server")}
                 defaultProxyId=${ifDefined(
-                  this.org?.crawlingDefaults?.profileid ||
-                    proxies.default_proxy_id ||
-                    undefined,
+                  getDefaultProxyId(this.org, proxies),
                 )}
                 .proxyServers=${proxyServers}
                 .proxyId=${profile.proxyId || ""}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -119,7 +119,11 @@ import {
 import { track } from "@/utils/analytics";
 import { isApiError, isApiErrorDetail } from "@/utils/api";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
-import { DEPTH_SUPPORTED_SCOPES, isPageScopeType } from "@/utils/crawler";
+import {
+  DEPTH_SUPPORTED_SCOPES,
+  getDefaultProxyId,
+  isPageScopeType,
+} from "@/utils/crawler";
 import {
   getUTCSchedule,
   humanizeNextDate,
@@ -2115,7 +2119,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             inputCol(html`
               <btrix-select-crawler-proxy
                 defaultProxyId=${ifDefined(
-                  proxies.default_proxy_id ?? undefined,
+                  getDefaultProxyId(this.org, proxies),
                 )}
                 .proxyServers=${proxies.servers}
                 .proxyId=${profileProxyId || this.formState.proxyId || ""}

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -46,7 +46,7 @@ import type { UserOrg } from "@/types/user";
 import { isApiError } from "@/utils/api";
 import type { ViewState } from "@/utils/APIRouter";
 import type { DuplicateWorkflowSettings } from "@/utils/crawl-workflows/settingsForDuplicate";
-import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
+import { DEFAULT_MAX_SCALE, getDefaultProxyId } from "@/utils/crawler";
 import { type OrgData } from "@/utils/orgs";
 import { AppStateService } from "@/utils/state";
 import type { FormState as WorkflowFormState } from "@/utils/workflow";
@@ -519,13 +519,9 @@ export class Org extends BtrixElement {
           ? html`<btrix-new-browser-profile-dialog
               .proxyServers=${proxies.servers}
               .crawlerChannels=${crawlerChannels}
-              defaultProxyId=${ifDefined(
-                org.crawlingDefaults?.proxyId ||
-                  proxies.default_proxy_id ||
-                  undefined,
-              )}
+              defaultProxyId=${ifDefined(getDefaultProxyId(org, proxies))}
               defaultCrawlerChannel=${ifDefined(
-                org.crawlingDefaults?.crawlerChannel,
+                org.crawlingDefaults?.crawlerChannel || undefined,
               )}
               ?open=${this.openDialogName === "browser-profile"}
               @sl-hide=${() => (this.openDialogName = undefined)}

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -6,6 +6,7 @@ import type {
   ArchivedItem,
   Crawl,
   CrawlReplay,
+  ProxiesAPIResponse,
   Upload,
   Workflow,
 } from "@/types/crawler";
@@ -16,6 +17,7 @@ import {
   SUCCESSFUL_AND_FAILED_STATES,
   SUCCESSFUL_STATES,
 } from "@/types/crawlState";
+import type { OrgData } from "@/types/org";
 import type { QARun } from "@/types/qa";
 import { WorkflowScopeType } from "@/types/workflow";
 import localize from "@/utils/localize";
@@ -74,6 +76,23 @@ export function isPageScopeType(
   return (
     scope === WorkflowScopeType.Page || scope === WorkflowScopeType.PageList
   );
+}
+
+export function getDefaultProxyId(
+  org?: OrgData | null,
+  proxies?: ProxiesAPIResponse,
+): string | undefined {
+  if (!org || !proxies) return;
+
+  let defaultProxyId = proxies.default_proxy_id;
+  const orgProxyId = org.crawlingDefaults?.proxyId;
+
+  // Proxy in crawling default may not exist if it was removed from the proxy list
+  if (orgProxyId && proxies.servers.some(({ id }) => id === orgProxyId)) {
+    defaultProxyId = orgProxyId;
+  }
+
+  return defaultProxyId || undefined;
 }
 
 export function renderName(


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3278

## Changes

- Fixes edge case where a proxy that is no longer enabled from an org is used.
- Fixes incorrect value passed for default proxy ID.

## Manual testing

1. Log in as superadmin
2. Enable `us-proxy-2` on an org
3. Go to org settings
4. Set `us-proxy-2` as default from org settings
5. Go to superadmin dashboard
6. Remove `us-proxy-2` from org from superadmin dashboard
7. Go to org dashboard
8. Go to New Browser Profile > Start Browser. Verify that `us-proxy-2` is not selected

## Follow-ups

This change doesn't actually remove the disabled proxy from crawling defaults, just checks if the proxy ID specified as a crawling default exists in the org proxy server list. We may want to update the backend to remove the proxy from crawling defaults when it's disabled by a superadmin (cc @tw4l.)
