### PR TITLE
Revert password hash algorithm change from #3239

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -43,8 +43,8 @@ RESET_VERIFY_TOKEN_LIFETIME_MINUTES = 60
 
 PWD_CONTEXT = PasswordHash(
     (
-        Argon2Hasher(),
         BcryptHasher(),
+        Argon2Hasher(),
     )
 )
 

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -40,7 +40,7 @@ ALGORITHM = "HS256"
 
 RESET_VERIFY_TOKEN_LIFETIME_MINUTES = 60
 
-PWD_CONTEXT = PasswordHash((BcryptHasher()))
+PWD_CONTEXT = PasswordHash((BcryptHasher(),))
 
 # Audiences
 CUSTOM_AUTH_AUD = "btrix:custom-auth"

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -7,7 +7,6 @@ from typing import Optional, Tuple, List
 import string
 import secrets
 from pwdlib import PasswordHash
-from pwdlib.hashers.argon2 import Argon2Hasher
 from pwdlib.hashers.bcrypt import BcryptHasher
 
 from pydantic import BaseModel

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -41,12 +41,7 @@ ALGORITHM = "HS256"
 
 RESET_VERIFY_TOKEN_LIFETIME_MINUTES = 60
 
-PWD_CONTEXT = PasswordHash(
-    (
-        BcryptHasher(),
-        Argon2Hasher(),
-    )
-)
+PWD_CONTEXT = PasswordHash((BcryptHasher()))
 
 # Audiences
 CUSTOM_AUTH_AUD = "btrix:custom-auth"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ gunicorn
 uvicorn[standard]
 fastapi==0.128.0
 motor
-pwdlib[argon2,bcrypt]
+pwdlib[bcrypt]
 PyJWT==2.8.0
 pydantic==2.12.5
 email-validator


### PR DESCRIPTION
Reverts the addition of `argon2` hasher introduced in #3239, making the PR just a swap from `passlib` to `pwdlib` without the hash change.