### PR TITLE
feat: Show collection slug when shareable

### DIFF
--- a/frontend/src/components/ui/button.ts
+++ b/frontend/src/components/ui/button.ts
@@ -36,7 +36,10 @@ export class Button extends TailwindElement {
   label?: string;
 
   @property({ type: String })
-  href?: string;
+  href?: HTMLAnchorElement["href"];
+
+  @property({ type: String })
+  target?: HTMLAnchorElement["target"];
 
   @property({ type: String })
   download?: string;
@@ -108,6 +111,7 @@ export class Button extends TailwindElement {
       )}
       ?disabled=${this.disabled}
       href=${ifDefined(this.href)}
+      target=${ifDefined(this.target)}
       download=${ifDefined(this.download)}
       aria-label=${ifDefined(this.label)}
       @click=${this.handleClick}

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -7,10 +7,14 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import { type BtrixChangeEventDetail } from "@/events/btrix-change";
+import type { BtrixChangeEvent } from "@/events/btrix-change";
+import type { BtrixInputEvent } from "@/events/btrix-input";
 import localize from "@/utils/localize";
 import { measureTextWithElement } from "@/utils/measure-text";
 import { tw } from "@/utils/tailwind";
+
+export type EditableTextFieldInputEvent = BtrixInputEvent<string>;
+export type EditableTextFieldChangeEvent = BtrixChangeEvent<string>;
 
 @customElement("btrix-editable-text-field")
 @localized()
@@ -119,11 +123,14 @@ export class EditableTextField extends TailwindElement {
     if (this.checkValidity()) {
       if (this.editing) {
         this.dispatchEvent(
-          new CustomEvent<BtrixChangeEventDetail<string>>("btrix-change", {
-            detail: { value: this.inputValue },
-            bubbles: true,
-            composed: true,
-          }),
+          new CustomEvent<EditableTextFieldChangeEvent["detail"]>(
+            "btrix-change",
+            {
+              detail: { value: this.inputValue },
+              bubbles: true,
+              composed: true,
+            },
+          ),
         );
       }
       this.endEditing();
@@ -189,9 +196,21 @@ export class EditableTextField extends TailwindElement {
         type="text"
         .value=${this.inputValue}
         placeholder=${ifDefined(this.placeholder)}
-        @input=${(e: Event) => {
+        @input=${async (e: Event) => {
           this.inputValue = (e.target as HTMLInputElement).value;
           this.checkValidity();
+
+          await this.updateComplete;
+          this.dispatchEvent(
+            new CustomEvent<EditableTextFieldInputEvent["detail"]>(
+              "btrix-input",
+              {
+                detail: { value: this.inputValue },
+                bubbles: true,
+                composed: true,
+              },
+            ),
+          );
         }}
         @focus=${() => {
           this.startEditing();

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -244,7 +244,7 @@ export class EditableTextField extends TailwindElement {
       ></span>
       ${this.maxLength && !this.valid
         ? html`<span
-            class="absolute bottom-0 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"
+            class="absolute bottom-0 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger tabular-nums"
           >
             ${this.showUnsavedWarning ? html`${msg("Unsaved")} - ` : null}
             ${localize.number(this.inputValue.length)} /

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -244,7 +244,7 @@ export class EditableTextField extends TailwindElement {
       ></span>
       ${this.maxLength && !this.valid
         ? html`<span
-            class="absolute bottom-1 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"
+            class="absolute bottom-0 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"
           >
             ${this.showUnsavedWarning ? html`${msg("Unsaved")} - ` : null}
             ${localize.number(this.inputValue.length)} /

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -225,18 +225,22 @@ export class EditableTextField extends TailwindElement {
       />
       <span
         class=${clsx(
-          tw`pointer-events-none block cursor-text select-none truncate whitespace-pre rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] peer-hover:outline peer-active:outline-none host-focus-within:outline-none`,
+          tw`pointer-events-none flex cursor-text select-none items-center gap-1.5 whitespace-pre rounded outline-1 outline-offset-[--sl-focus-ring-offset] outline-[--sl-input-border-color] peer-hover:outline peer-active:outline-none host-focus-within:outline-none`,
           !this.inputValue && tw`text-neutral-500`,
         )}
         style=${styleMap({
           visibility: this.editing ? "hidden" : "visible",
           width: this.editing ? `${minWidth}px` : "auto",
         })}
-        >${this.inputValue
-          ? this.renderContent
-            ? this.renderContent(this.inputValue)
-            : this.inputValue
-          : this.placeholder}<slot name="suffix"></slot
+      >
+        <span class="truncate"
+          >${this.inputValue
+            ? this.renderContent
+              ? this.renderContent(this.inputValue)
+              : this.inputValue
+            : this.placeholder}</span
+        >
+        <slot name="suffix"></slot
       ></span>
       ${this.maxLength && !this.valid
         ? html`<span

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -191,7 +191,7 @@ export class EditableTextField extends TailwindElement {
     return html`<input
         class=${clsx(
           tw`peer absolute inset-4 rounded bg-transparent`,
-          !this.valid && tw`z-[11] outline outline-danger`,
+          !this.valid && tw`z-[21] outline outline-danger`,
         )}
         type="text"
         .value=${this.inputValue}
@@ -244,7 +244,7 @@ export class EditableTextField extends TailwindElement {
       ></span>
       ${this.maxLength && !this.valid
         ? html`<span
-            class="absolute bottom-0 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger tabular-nums"
+            class="absolute bottom-0 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold tabular-nums leading-none text-danger"
           >
             ${this.showUnsavedWarning ? html`${msg("Unsaved")} - ` : null}
             ${localize.number(this.inputValue.length)} /

--- a/frontend/src/components/ui/editable-text-field.ts
+++ b/frontend/src/components/ui/editable-text-field.ts
@@ -150,7 +150,7 @@ export class EditableTextField extends TailwindElement {
   updatePlaceholderWidth() {
     if (!this.placeholder) return;
     const width = measureTextWithElement(this.placeholder, this).width;
-    if (width) this.placeholderWidth = width;
+    if (width) this.placeholderWidth = width + this.extraWidth;
   }
 
   willUpdate(changedProperties: PropertyValues<this>) {
@@ -244,7 +244,7 @@ export class EditableTextField extends TailwindElement {
       ></span>
       ${this.maxLength && !this.valid
         ? html`<span
-            class="absolute bottom-0 right-4 z-10 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"
+            class="absolute bottom-1 right-4 z-20 rounded-b-sm bg-white pt-1 text-xs font-semibold leading-none text-danger"
           >
             ${this.showUnsavedWarning ? html`${msg("Unsaved")} - ` : null}
             ${localize.number(this.inputValue.length)} /

--- a/frontend/src/features/collections/share-collection.ts
+++ b/frontend/src/features/collections/share-collection.ts
@@ -68,26 +68,31 @@ export class ShareCollection extends BtrixElement {
 
     return html`
       <div class="flex items-center gap-2">
-        <btrix-copy-button
-          name="link"
-          size="medium"
-          .getValue=${() => this.shareLink}
-          content=${msg("Copy Public Link")}
-          @click=${() => {
-            void this.clipboardController.copy(this.shareLink);
+        ${when(
+          this.context === "public",
+          () => html`
+            <btrix-copy-button
+              name="link"
+              size="medium"
+              .getValue=${() => this.shareLink}
+              content=${msg("Copy Public Link")}
+              @click=${() => {
+                void this.clipboardController.copy(this.shareLink);
 
-            if (
-              this.collection &&
-              this.collection.access === CollectionAccess.Public
-            ) {
-              track(AnalyticsTrackEvent.CopyShareCollectionLink, {
-                org_slug: this.orgSlug,
-                collection_slug: this.collection.slug,
-                logged_in: !!this.authState,
-              });
-            }
-          }}
-        ></btrix-copy-button>
+                if (
+                  this.collection &&
+                  this.collection.access === CollectionAccess.Public
+                ) {
+                  track(AnalyticsTrackEvent.CopyShareCollectionLink, {
+                    org_slug: this.orgSlug,
+                    collection_slug: this.collection.slug,
+                    logged_in: !!this.authState,
+                  });
+                }
+              }}
+            ></btrix-copy-button>
+          `,
+        )}
         <sl-tooltip content=${msg("View Embed Code")}>
           <sl-icon-button
             class="text-base"

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -46,7 +46,7 @@ import { emptyMessage } from "@/layouts/emptyMessage";
 import { pageNav, pageTitle, type Breadcrumb } from "@/layouts/pageHeader";
 import { panelBody, panelHeader } from "@/layouts/panel";
 import { updatingOverlay } from "@/layouts/updatingOverlay";
-import { RouteNamespace } from "@/routes";
+import { OrgTab, RouteNamespace } from "@/routes";
 import { getIndexErrorMessage } from "@/strings/collections/index-error";
 import {
   type APIPaginatedList,
@@ -273,17 +273,22 @@ export class CollectionDetail extends BtrixElement {
       </div>
       <header
         class=${clsx(
-          tw`mt-5 grid items-start gap-3 lg:grid-cols-[1fr_auto]`,
+          tw`mt-3 grid items-end gap-3 lg:grid-cols-[1fr_auto]`,
           this.isCrawler && tw`min-h-16`,
         )}
       >
         <div
           class=${clsx(
-            tw`overflow-hidden p-1`,
-            this.isCrawler && tw`-m-1 -mt-1.5`,
+            tw`overflow-hidden`,
+            this.isCrawler && tw`-m-1 -mt-1.5 p-1`,
           )}
         >
-          <div class="flex items-center gap-2.5">
+          <div
+            class=${clsx(
+              tw`flex items-center gap-2.5`,
+              this.isCrawler ? tw`mb-1` : tw`mb-2`,
+            )}
+          >
             ${pageTitle(
               this.isCrawler
                 ? html`<btrix-editable-text-field
@@ -318,10 +323,10 @@ export class CollectionDetail extends BtrixElement {
               tw`grid`,
             )}
           </div>
-          ${this.renderPublicLink()}
+          <div class="relative z-10">${this.renderAccessDetails()}</div>
         </div>
         <div
-          class="-mx-3 -mb-3 -mt-3 grid overflow-clip px-3 pb-3 lg:col-span-2"
+          class="-mx-3 -mb-3 -mt-2 grid overflow-clip px-3 pb-3 lg:col-span-2"
         >
           ${this.isCrawler
             ? when(
@@ -654,6 +659,41 @@ export class CollectionDetail extends BtrixElement {
       })}
     `;
   }
+
+  private readonly renderAccessDetails = () => {
+    if (!this.collection) {
+      return html`<sl-skeleton class="h-4 w-12"></sl-skeleton>`;
+    }
+
+    const badge = html`<btrix-badge>
+      <sl-icon
+        name=${SelectCollectionAccess.Options[this.collection.access].icon}
+        class="mr-1.5"
+      ></sl-icon>
+      ${SelectCollectionAccess.Options[this.collection.access].label}
+    </btrix-badge>`;
+
+    const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${RouteNamespace.PublicOrgs}/${this.viewState?.params.slug}/${OrgTab.Collections}`;
+    const slugPreview = this.slugPreview || this.collection.slug || "";
+    const publicGalleryUrl = `${baseUrl}/${slugPreview}`;
+
+    return html`<div class="flex items-start gap-1.5">
+      ${badge}
+      <span
+        class=${clsx(
+          tw`break-all text-xs`,
+          this.slugPreview ? tw` text-neutral-700` : tw`text-neutral-500`,
+        )}
+        >${slugPreview}</span
+      >
+      <btrix-copy-button
+        name="link"
+        content=${msg("Copy Shareable Link")}
+        size="x-small"
+        value=${new URL(publicGalleryUrl).href}
+      ></btrix-copy-button>
+    </div>`;
+  };
 
   private readonly renderPublicLink = () => {
     const baseUrl = `${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;
@@ -1612,7 +1652,11 @@ export class CollectionDetail extends BtrixElement {
   }
 
   private async updateName(name: string) {
-    if (name === this.collection?.name) return;
+    if (name === this.collection?.name) {
+      this.slugPreview = "";
+      return;
+    }
+
     try {
       await this.api.fetch<Collection>(
         `/orgs/${this.orgId}/collections/${this.collectionId}`,

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -309,7 +309,7 @@ export class CollectionDetail extends BtrixElement {
                     <sl-icon
                       slot="suffix"
                       name="pencil"
-                      class="ml-2 size-4"
+                      class="ml-2 size-3.5 shrink-0"
                       aria-label=${msg("Edit Collection Name")}
                     ></sl-icon>
                   </btrix-editable-text-field>`
@@ -341,8 +341,8 @@ export class CollectionDetail extends BtrixElement {
                     <sl-icon
                       slot="suffix"
                       name="pencil"
-                      class="ml-2 size-3"
-                      aria-label=${msg("Edit Collection Name")}
+                      class="ml-2 size-3 shrink-0"
+                      aria-label=${msg("Edit Collection Caption")}
                     ></sl-icon>
                   </btrix-editable-text-field>`,
               )

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -42,6 +42,7 @@ import { emptyMessage } from "@/layouts/emptyMessage";
 import { pageNav, pageTitle, type Breadcrumb } from "@/layouts/pageHeader";
 import { panelBody, panelHeader } from "@/layouts/panel";
 import { updatingOverlay } from "@/layouts/updatingOverlay";
+import { RouteNamespace } from "@/routes";
 import { getIndexErrorMessage } from "@/strings/collections/index-error";
 import {
   type APIPaginatedList,
@@ -66,6 +67,7 @@ import { pluralOf } from "@/utils/pluralize";
 import { formatRwpTimestamp } from "@/utils/replay";
 import { richText } from "@/utils/rich-text";
 import { tw } from "@/utils/tailwind";
+import { toShortUrl } from "@/utils/url-helpers";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_ITEMS_PAGE_SIZE = 20;
@@ -260,35 +262,43 @@ export class CollectionDetail extends BtrixElement {
       </div>
       <header
         class=${clsx(
-          tw`mt-5 grid gap-3 lg:grid-cols-[1fr_auto]`,
+          tw`mt-5 grid items-start gap-3 lg:grid-cols-[1fr_auto]`,
           this.isCrawler && tw`min-h-16`,
         )}
       >
-        <div class="flex items-center gap-2.5">
-          ${this.renderAccessIcon()}${pageTitle(
-            this.isCrawler
-              ? html`<btrix-editable-text-field
-                  class="-m-4 overflow-hidden p-4"
-                  minLength=${1}
-                  maxLength=${COLLECTION_NAME_MAX_LENGTH}
-                  .value=${this.collection?.name}
-                  placeholder=${msg("Collection name")}
-                  @btrix-change=${(e: BtrixChangeEvent<string>) => {
-                    void this.updateName(e.detail.value);
-                  }}
-                  extraWidth=${24}
-                >
-                  <sl-icon
-                    slot="suffix"
-                    name="pencil"
-                    class="ml-2 size-4"
-                    aria-label=${msg("Edit Collection Name")}
-                  ></sl-icon>
-                </btrix-editable-text-field>`
-              : this.collection?.name,
-            tw`mb-2 h-6 w-60`,
-            tw`grid`,
+        <div
+          class=${clsx(
+            tw`overflow-hidden p-0.5`,
+            this.isCrawler && tw`-m-0.5 -mt-1`,
           )}
+        >
+          <div class="flex items-center gap-2.5">
+            ${pageTitle(
+              this.isCrawler
+                ? html`<btrix-editable-text-field
+                    class="-m-4 overflow-hidden p-4"
+                    minLength=${1}
+                    maxLength=${COLLECTION_NAME_MAX_LENGTH}
+                    .value=${this.collection?.name}
+                    placeholder=${msg("Collection name")}
+                    @btrix-change=${(e: BtrixChangeEvent<string>) => {
+                      void this.updateName(e.detail.value);
+                    }}
+                    extraWidth=${24}
+                  >
+                    <sl-icon
+                      slot="suffix"
+                      name="pencil"
+                      class="ml-2 size-4"
+                      aria-label=${msg("Edit Collection Name")}
+                    ></sl-icon>
+                  </btrix-editable-text-field>`
+                : this.collection?.name,
+              tw`mb-2 h-6 w-60`,
+              tw`grid`,
+            )}
+          </div>
+          ${this.renderPublicLink()}
         </div>
         <div
           class="-mx-3 -mb-3 -mt-3 grid overflow-clip px-3 pb-3 lg:col-span-2"
@@ -320,7 +330,7 @@ export class CollectionDetail extends BtrixElement {
         </div>
 
         <div
-          class="mb-0.5 ml-auto flex flex-shrink-0 flex-wrap items-center justify-end gap-2 lg:col-start-2 lg:row-start-1"
+          class="ml-auto flex flex-shrink-0 flex-wrap items-center justify-end gap-2 lg:col-start-2 lg:row-start-1"
         >
           <btrix-share-collection
             orgSlug=${this.orgSlugState || ""}
@@ -624,6 +634,27 @@ export class CollectionDetail extends BtrixElement {
       })}
     `;
   }
+
+  private readonly renderPublicLink = () => {
+    const baseUrl = `${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;
+    const slugPreview = this.collection?.slug || "";
+    const publicGalleryUrl = `${window.location.protocol}//${baseUrl}/${RouteNamespace.PublicOrgs}/${slugPreview}`;
+    const url = new URL(publicGalleryUrl);
+
+    return html`<div
+      class="flex items-center gap-1.5 overflow-hidden text-neutral-700"
+    >
+      <span class="shrink-0">${this.renderAccessIcon()}</span>
+      <a
+        class="truncate font-medium leading-none text-stone-500 transition-colors hover:text-stone-600"
+        href="${url.href}"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+      >
+        ${toShortUrl(url.href, null)}
+      </a>
+    </div>`;
+  };
 
   private readonly renderCaption = (text: string) =>
     richText(text, {

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -72,7 +72,6 @@ import { formatRwpTimestamp } from "@/utils/replay";
 import { richText } from "@/utils/rich-text";
 import slugifyStrict from "@/utils/slugify";
 import { tw } from "@/utils/tailwind";
-import { toShortUrl } from "@/utils/url-helpers";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_ITEMS_PAGE_SIZE = 20;
@@ -246,34 +245,10 @@ export class CollectionDetail extends BtrixElement {
     };
 
     return html`
-      <div class="mb-7 flex flex-wrap justify-between gap-y-3 align-baseline">
-        ${this.renderBreadcrumbs()}
-        ${this.collection &&
-        (this.collection.access === CollectionAccess.Unlisted ||
-          this.collection.access === CollectionAccess.Public)
-          ? html`
-              <sl-button
-                href=${this.shareLink}
-                size="small"
-                variant="text"
-                class="-mx-3 -mb-3.5 -mt-1.5"
-              >
-                <sl-icon
-                  slot="prefix"
-                  name=${this.collection.access === CollectionAccess.Unlisted
-                    ? SelectCollectionAccess.Options.unlisted.icon
-                    : SelectCollectionAccess.Options.public.icon}
-                ></sl-icon>
-                ${this.collection.access === CollectionAccess.Unlisted
-                  ? msg("Go to Unlisted Page")
-                  : msg("Go to Public Page")}
-              </sl-button>
-            `
-          : nothing}
-      </div>
+      <div class="mb-7">${this.renderBreadcrumbs()}</div>
       <header
         class=${clsx(
-          tw`mt-3 grid items-end gap-3 lg:grid-cols-[1fr_auto]`,
+          tw`grid items-end gap-3 lg:grid-cols-[1fr_auto]`,
           this.isCrawler && tw`min-h-16`,
         )}
       >
@@ -296,7 +271,7 @@ export class CollectionDetail extends BtrixElement {
                     minLength=${1}
                     maxLength=${COLLECTION_NAME_MAX_LENGTH}
                     .value=${this.collection?.name}
-                    placeholder=${msg("Collection name")}
+                    placeholder=${msg("Enter collection name")}
                     @btrix-input=${(e: EditableTextFieldInputEvent) => {
                       e.stopPropagation();
 
@@ -326,7 +301,7 @@ export class CollectionDetail extends BtrixElement {
           <div class="relative z-10">${this.renderAccessDetails()}</div>
         </div>
         <div
-          class="-mx-3 -mb-3 -mt-2 grid overflow-clip px-3 pb-3 lg:col-span-2"
+          class="-mx-3 -mb-5 -mt-2 grid overflow-clip px-3 pb-3 lg:col-span-2"
         >
           ${this.isCrawler
             ? when(
@@ -673,46 +648,34 @@ export class CollectionDetail extends BtrixElement {
       ${SelectCollectionAccess.Options[this.collection.access].label}
     </btrix-badge>`;
 
-    const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${RouteNamespace.PublicOrgs}/${this.viewState?.params.slug}/${OrgTab.Collections}`;
-    const slugPreview = this.slugPreview || this.collection.slug || "";
-    const publicGalleryUrl = `${baseUrl}/${slugPreview}`;
+    const publicLink = () => {
+      const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${RouteNamespace.PublicOrgs}/${this.viewState?.params.slug}/${OrgTab.Collections}`;
+      const slugPreview = this.slugPreview || this.collection?.slug || "";
+      const link = new URL(`${baseUrl}/${slugPreview}`).href;
+
+      return html`<span
+          class=${clsx(
+            tw`break-all text-xs`,
+            this.slugPreview ? tw` text-blue-500` : tw`text-neutral-500`,
+          )}
+          >${slugPreview}</span
+        >
+        <btrix-copy-button
+          name="link"
+          content=${msg("Copy Shareable Link")}
+          size="x-small"
+          value=${link}
+        ></btrix-copy-button>
+        <sl-tooltip content=${msg("Open in New Tab")}>
+          <btrix-button size="x-small" href=${link} target="_blank">
+            <sl-icon name="arrow-up-right" class="size-3.5"></sl-icon>
+          </btrix-button>
+        </sl-tooltip>`;
+    };
 
     return html`<div class="flex items-start gap-1.5">
       ${badge}
-      <span
-        class=${clsx(
-          tw`break-all text-xs`,
-          this.slugPreview ? tw` text-neutral-700` : tw`text-neutral-500`,
-        )}
-        >${slugPreview}</span
-      >
-      <btrix-copy-button
-        name="link"
-        content=${msg("Copy Shareable Link")}
-        size="x-small"
-        value=${new URL(publicGalleryUrl).href}
-      ></btrix-copy-button>
-    </div>`;
-  };
-
-  private readonly renderPublicLink = () => {
-    const baseUrl = `${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;
-    const slugPreview = this.slugPreview || this.collection?.slug || "";
-    const publicGalleryUrl = `${window.location.protocol}//${baseUrl}/${RouteNamespace.PublicOrgs}/${slugPreview}`;
-    const url = new URL(publicGalleryUrl);
-
-    return html`<div
-      class="flex items-center gap-1.5 overflow-hidden text-neutral-700"
-    >
-      <span class="shrink-0">${this.renderAccessIcon()}</span>
-      <a
-        class="truncate font-medium leading-none text-stone-500 transition-colors hover:text-stone-600"
-        href="${url.href}"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-      >
-        ${toShortUrl(url.href, null)}
-      </a>
+      ${when(this.collection.access !== CollectionAccess.Private, publicLink)}
     </div>`;
   };
 
@@ -720,102 +683,6 @@ export class CollectionDetail extends BtrixElement {
     richText(text, {
       linkClass: tw`text-cyan-500 transition-colors hover:text-cyan-600`,
     });
-
-  private renderAccessIcon() {
-    return choose(this.collection?.access, [
-      [
-        CollectionAccess.Private,
-        () => html`
-          <sl-tooltip
-            content=${SelectCollectionAccess.Options[CollectionAccess.Private]
-              .label}
-          >
-            ${this.isCrawler
-              ? html` <sl-icon-button
-                  class="z-10 -mx-2 -mb-0.5 text-lg text-neutral-600"
-                  name=${SelectCollectionAccess.Options[
-                    CollectionAccess.Private
-                  ].icon}
-                  @click=${() => {
-                    this.openDialogName = "edit";
-                    this.editTab = "sharing";
-                  }}
-                ></sl-icon-button>`
-              : html`
-                  <sl-icon
-                    class="text-lg text-neutral-600"
-                    name=${SelectCollectionAccess.Options[
-                      CollectionAccess.Private
-                    ].icon}
-                  ></sl-icon>
-                `}
-          </sl-tooltip>
-        `,
-      ],
-      [
-        CollectionAccess.Unlisted,
-        () => html`
-          <sl-tooltip
-            content=${SelectCollectionAccess.Options[CollectionAccess.Unlisted]
-              .label}
-          >
-            ${this.isCrawler
-              ? html`
-                  <sl-icon-button
-                    class="z-10 -mx-2 -mb-0.5 text-lg text-neutral-600"
-                    name=${SelectCollectionAccess.Options[
-                      CollectionAccess.Unlisted
-                    ].icon}
-                    @click=${() => {
-                      this.openDialogName = "edit";
-                      this.editTab = "sharing";
-                    }}
-                  ></sl-icon-button>
-                `
-              : html`
-                  <sl-icon
-                    class="text-lg text-neutral-600"
-                    name=${SelectCollectionAccess.Options[
-                      CollectionAccess.Unlisted
-                    ].icon}
-                  ></sl-icon>
-                `}
-          </sl-tooltip>
-        `,
-      ],
-      [
-        CollectionAccess.Public,
-        () => html`
-          <sl-tooltip
-            content=${SelectCollectionAccess.Options[CollectionAccess.Public]
-              .label}
-          >
-            ${this.isCrawler
-              ? html`
-                  <sl-icon-button
-                    class="z-10 -mx-2 -mb-0.5 text-lg text-success-600"
-                    name=${SelectCollectionAccess.Options[
-                      CollectionAccess.Public
-                    ].icon}
-                    @click=${() => {
-                      this.openDialogName = "edit";
-                      this.editTab = "sharing";
-                    }}
-                  ></sl-icon-button>
-                `
-              : html`
-                  <sl-icon
-                    class="text-lg text-success-600"
-                    name=${SelectCollectionAccess.Options[
-                      CollectionAccess.Public
-                    ].icon}
-                  ></sl-icon>
-                `}
-          </sl-tooltip>
-        `,
-      ],
-    ]);
-  }
 
   private refreshReplay() {
     if (this.replayEmbed) {

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -20,6 +20,10 @@ import {
 } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import type {
+  EditableTextFieldChangeEvent,
+  EditableTextFieldInputEvent,
+} from "@/components/ui/editable-text-field";
 import type { MarkdownEditor } from "@/components/ui/markdown-editor";
 import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { viewStateContext, type ViewStateContext } from "@/context/view-state";
@@ -66,6 +70,7 @@ import { isNotEqual } from "@/utils/is-not-equal";
 import { pluralOf } from "@/utils/pluralize";
 import { formatRwpTimestamp } from "@/utils/replay";
 import { richText } from "@/utils/rich-text";
+import slugifyStrict from "@/utils/slugify";
 import { tw } from "@/utils/tailwind";
 import { toShortUrl } from "@/utils/url-helpers";
 
@@ -106,6 +111,9 @@ export class CollectionDetail extends BtrixElement {
 
   @state()
   private rwpDoFullReload = false;
+
+  @state()
+  private slugPreview = "";
 
   @consume({ context: viewStateContext })
   viewState?: ViewStateContext;
@@ -218,6 +226,9 @@ export class CollectionDetail extends BtrixElement {
         }, 200);
       }
     }
+    if (changedProperties.has("collection")) {
+      this.slugPreview = "";
+    }
   }
 
   render() {
@@ -281,7 +292,16 @@ export class CollectionDetail extends BtrixElement {
                     maxLength=${COLLECTION_NAME_MAX_LENGTH}
                     .value=${this.collection?.name}
                     placeholder=${msg("Collection name")}
-                    @btrix-change=${(e: BtrixChangeEvent<string>) => {
+                    @btrix-input=${(e: EditableTextFieldInputEvent) => {
+                      e.stopPropagation();
+
+                      const { value } = e.detail;
+
+                      this.slugPreview = value ? slugifyStrict(value) : "";
+                    }}
+                    @btrix-change=${(e: EditableTextFieldChangeEvent) => {
+                      e.stopPropagation();
+
                       void this.updateName(e.detail.value);
                     }}
                     extraWidth=${24}
@@ -637,7 +657,7 @@ export class CollectionDetail extends BtrixElement {
 
   private readonly renderPublicLink = () => {
     const baseUrl = `${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;
-    const slugPreview = this.collection?.slug || "";
+    const slugPreview = this.slugPreview || this.collection?.slug || "";
     const publicGalleryUrl = `${window.location.protocol}//${baseUrl}/${RouteNamespace.PublicOrgs}/${slugPreview}`;
     const url = new URL(publicGalleryUrl);
 
@@ -1615,6 +1635,7 @@ export class CollectionDetail extends BtrixElement {
         this.collection = {
           ...this.collection,
           name,
+          slug: this.slugPreview || this.collection.slug || "",
         };
       }
 

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -279,8 +279,8 @@ export class CollectionDetail extends BtrixElement {
       >
         <div
           class=${clsx(
-            tw`overflow-hidden p-0.5`,
-            this.isCrawler && tw`-m-0.5 -mt-1`,
+            tw`overflow-hidden p-1`,
+            this.isCrawler && tw`-m-1 -mt-1.5`,
           )}
         >
           <div class="flex items-center gap-2.5">

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -226,9 +226,6 @@ export class CollectionDetail extends BtrixElement {
         }, 200);
       }
     }
-    if (changedProperties.has("collection")) {
-      this.slugPreview = "";
-    }
   }
 
   render() {
@@ -283,7 +280,13 @@ export class CollectionDetail extends BtrixElement {
                     @btrix-change=${(e: EditableTextFieldChangeEvent) => {
                       e.stopPropagation();
 
-                      void this.updateName(e.detail.value);
+                      const { value } = e.detail;
+
+                      if (value === this.collection?.name) {
+                        this.slugPreview = "";
+                      }
+
+                      void this.updateName(value);
                     }}
                     extraWidth=${24}
                   >
@@ -1528,7 +1531,6 @@ export class CollectionDetail extends BtrixElement {
 
   private async updateName(name: string) {
     if (name === this.collection?.name) {
-      this.slugPreview = "";
       return;
     }
 
@@ -1558,7 +1560,9 @@ export class CollectionDetail extends BtrixElement {
         };
       }
 
-      void this.fetchCollection();
+      await this.fetchCollection();
+
+      this.slugPreview = "";
     } catch (err) {
       console.debug(err);
 

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -679,7 +679,7 @@ export class CollectionDetail extends BtrixElement {
               ></btrix-copy-button>
               <sl-tooltip content=${msg("Open in New Tab")}>
                 <btrix-button size="x-small" href=${link} target="_blank">
-                  <sl-icon name="arrow-up-right" class="size-3.5"></sl-icon>
+                  <sl-icon name="arrow-up-right" class="size-2.5"></sl-icon>
                 </btrix-button>
               </sl-tooltip>`}`;
     };

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -262,7 +262,7 @@ export class CollectionDetail extends BtrixElement {
           <div
             class=${clsx(
               tw`flex items-center gap-2.5`,
-              this.isCrawler ? tw`mb-1` : tw`mb-2`,
+              this.isCrawler ? tw`mb-1.5` : tw`mb-2`,
             )}
           >
             ${pageTitle(

--- a/frontend/src/pages/org/collection-detail/collection-detail.ts
+++ b/frontend/src/pages/org/collection-detail/collection-detail.ts
@@ -72,6 +72,7 @@ import { formatRwpTimestamp } from "@/utils/replay";
 import { richText } from "@/utils/rich-text";
 import slugifyStrict from "@/utils/slugify";
 import { tw } from "@/utils/tailwind";
+import { toShortUrl } from "@/utils/url-helpers";
 
 const ABORT_REASON_THROTTLE = "throttled";
 const INITIAL_ITEMS_PAGE_SIZE = 20;
@@ -649,28 +650,35 @@ export class CollectionDetail extends BtrixElement {
     </btrix-badge>`;
 
     const publicLink = () => {
-      const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/${RouteNamespace.PublicOrgs}/${this.viewState?.params.slug}/${OrgTab.Collections}`;
+      const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}`;
+      const namespacedPath = `${RouteNamespace.PublicOrgs}/${this.viewState?.params.slug}/${OrgTab.Collections}`;
       const slugPreview = this.slugPreview || this.collection?.slug || "";
-      const link = new URL(`${baseUrl}/${slugPreview}`).href;
+      const link = new URL(`${baseUrl}/${namespacedPath}/${slugPreview}`).href;
 
-      return html`<span
-          class=${clsx(
-            tw`break-all text-xs`,
-            this.slugPreview ? tw` text-blue-500` : tw`text-neutral-500`,
-          )}
-          >${slugPreview}</span
-        >
-        <btrix-copy-button
-          name="link"
-          content=${msg("Copy Shareable Link")}
-          size="x-small"
-          value=${link}
-        ></btrix-copy-button>
-        <sl-tooltip content=${msg("Open in New Tab")}>
-          <btrix-button size="x-small" href=${link} target="_blank">
-            <sl-icon name="arrow-up-right" class="size-3.5"></sl-icon>
-          </btrix-button>
-        </sl-tooltip>`;
+      return html`<span class="break-all text-xs text-neutral-500">
+          <span>${toShortUrl(baseUrl, null)}</span
+          ><span title="/${namespacedPath}/">/.../</span
+          ><span
+            class=${clsx(
+              tw`break-all text-xs`,
+              this.slugPreview ? tw` text-blue-500` : tw`text-neutral-500`,
+            )}
+            >${slugPreview}</span
+          >
+        </span>
+        ${this.slugPreview
+          ? nothing
+          : html`<btrix-copy-button
+                name="link"
+                content=${msg("Copy Shareable Link")}
+                size="x-small"
+                value=${link}
+              ></btrix-copy-button>
+              <sl-tooltip content=${msg("Open in New Tab")}>
+                <btrix-button size="x-small" href=${link} target="_blank">
+                  <sl-icon name="arrow-up-right" class="size-3.5"></sl-icon>
+                </btrix-button>
+              </sl-tooltip>`}`;
     };
 
     return html`<div class="flex items-start gap-1.5">


### PR DESCRIPTION
Partially addresses https://github.com/webrecorder/browsertrix/issues/3312

## Changes

- Displays updated collection slug near name
- Updates collection header layout to match header spacing on other pages
- Fixes editable text field pencil icon hidden when name is too long
- Fixes editable text field placeholder width

## Manual testing

1. Log in as crawler
2. Go to unlisted collection detail page. Verify slug is displayed under name
3. Edit name. Verify slug updates as name is updated

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Collection (private) | <img width="1247" height="218" alt="Screenshot 2026-05-27 at 1 39 05 PM" src="https://github.com/user-attachments/assets/662bc208-9fa6-446b-87ae-cfc6f60ad794" /> |
| Collection (unlisted) | <img width="447" height="70" alt="Screenshot 2026-05-27 at 1 40 09 PM" src="https://github.com/user-attachments/assets/ec7d25f9-0879-459e-b265-1c510004eb54" /> | 
| Collection (editing name) | <img width="938" height="67" alt="Screenshot 2026-05-27 at 1 40 25 PM" src="https://github.com/user-attachments/assets/25a4e222-0c51-4e95-ae78-1ea27115eedf" /> |
| Collection (small screen) | <img width="485" height="209" alt="Screenshot 2026-05-27 at 1 40 39 PM" src="https://github.com/user-attachments/assets/7407645f-a032-4abd-bfdf-d2099fed4aa6" /> |

<!-- ## Follow-ups -->
