### PR TITLE
Enable `isort` rules in ruff, and set up pre-commit/ci checks

### DIFF
--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2  # important, to fetch previous commit
+          fetch-depth: 2 # important, to fetch previous commit
 
       # workaround for https://github.com/dorny/paths-filter/issues/240
       - id: previous-sha
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           cd backend/
           pylint btrixcloud/
-          #ruff check --exit-non-zero-on-fix btrixcloud/
+          ruff check --exit-non-zero-on-fix btrixcloud/
 
       - name: Type Check
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,8 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.14.13
   hooks:
+    - id: ruff-check
+      args: ["--fix", "backend/btrixcloud/"]
     - id: ruff-format
       args: ["backend/btrixcloud/"]
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,33 @@
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.13
-  hooks:
-    - id: ruff-check
-      args: ["--fix", "backend/btrixcloud/"]
-    - id: ruff-format
-      args: ["backend/btrixcloud/"]
-- repo: local
-  hooks:
-    - id: pylint
-      name: pylint
-      entry: cd backend && pylint
-      language: system
-      types: [python]
-      args: ["btrixcloud/"]
-- repo: local
-  hooks:
-    - id: mypy
-      name: mypy
-      entry: cd backend && mypy
-      language: python
-      args: ["btrixcloud/"]
-- repo: local
-  hooks:
-    - id: husky-run-pre-commit
-      name: husky
-      language: system
-      entry: frontend/.husky/pre-commit
-      pass_filenames: false
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.13
+    hooks:
+      - id: ruff-check
+        args: ["--fix", "backend/btrixcloud/"]
+      - id: ruff-format
+        args: ["backend/btrixcloud/"]
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: cd backend && pylint
+        language: system
+        types: [python]
+        args: ["btrixcloud/"]
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: cd backend && mypy
+        language: python
+        args: ["btrixcloud/"]
+  - repo: local
+    hooks:
+      - id: husky-run-pre-commit
+        name: husky
+        language: system
+        entry: frontend/.husky/pre-commit
+        pass_filenames: false
 # - repo: local
 #   hooks:
 #     - id: password-check

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -1,30 +1,27 @@
 """auth functions for login"""
 
 import os
-from uuid import UUID, uuid4
-from datetime import timedelta
-from typing import Optional, Tuple, List
-import string
 import secrets
+import string
+from datetime import timedelta
+from typing import List, Optional, Tuple
+from uuid import UUID, uuid4
+
+import jwt
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Request,
+    WebSocket,
+)
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pwdlib import PasswordHash
 from pwdlib.hashers.bcrypt import BcryptHasher
-
 from pydantic import BaseModel
-import jwt
-
-from fastapi import (
-    Request,
-    HTTPException,
-    Depends,
-    WebSocket,
-    APIRouter,
-)
-
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
 from .models import User, UserOut
 from .utils import dt_now, run_async_task
-
 
 # ============================================================================
 PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", uuid4().hex)

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -3,43 +3,41 @@
 import os
 import secrets
 from datetime import datetime
-from typing import Optional, Tuple, Union, List, Dict, TYPE_CHECKING, cast
-from uuid import UUID
-
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urlsplit
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from .storages import StorageOps
 from .crawlmanager import CrawlManager
-
 from .models import (
-    BaseFile,
-    Organization,
-    BackgroundJob,
-    BgJobType,
-    CreateReplicaJob,
-    DeleteReplicaJob,
-    DeleteOrgJob,
-    RecalculateOrgStatsJob,
-    ReAddOrgPagesJob,
-    OptimizePagesJob,
-    CleanupSeedFilesJob,
-    UpdateCollStatsJob,
-    PaginatedBackgroundJobResponse,
+    CRAWL_TYPES,
     AnyJob,
+    BackgroundJob,
+    BaseFile,
+    BgJobType,
+    CleanupSeedFilesJob,
+    CreateReplicaJob,
+    DeleteOrgJob,
+    DeleteReplicaJob,
+    OptimizePagesJob,
+    Organization,
+    PaginatedBackgroundJobResponse,
+    ReAddOrgPagesJob,
+    RecalculateOrgStatsJob,
     StorageRef,
-    User,
     SuccessResponse,
     SuccessResponseId,
-    CRAWL_TYPES,
+    UpdateCollStatsJob,
+    User,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .storages import StorageOps
 from .utils import dt_now, run_async_task
 
 if TYPE_CHECKING:
-    from .orgs import OrgOps
     from .basecrawls import BaseCrawlOps
+    from .orgs import OrgOps
     from .profiles import ProfileOps
 else:
     OrgOps = CrawlManager = BaseCrawlOps = ProfileOps = object

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -1,66 +1,66 @@
 """base crawl type"""
 
-from datetime import datetime
-from typing import (
-    Annotated,
-    Optional,
-    List,
-    Union,
-    Dict,
-    Any,
-    Type,
-    TYPE_CHECKING,
-    cast,
-    Tuple,
-    AsyncIterable,
-)
-from uuid import UUID
+import asyncio
 import os
 import urllib.parse
+from datetime import datetime
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    AsyncIterable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+from uuid import UUID
 
-import asyncio
-from fastapi import HTTPException, Depends, Query, Request
+import pymongo
+from fastapi import Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from motor.motor_asyncio import AsyncIOMotorClientSession, AsyncIOMotorDatabase
-import pymongo
 
 from .models import (
-    SUCCESSFUL_STATES,
-    TagsResponse,
-    CrawlFile,
-    CrawlFileOut,
-    BaseCrawl,
-    CrawlOut,
-    CrawlOutWithResources,
-    ListFilterType,
-    UpdateCrawl,
-    DeleteCrawlList,
-    Organization,
-    PaginatedCrawlOutResponse,
-    User,
-    StorageRef,
+    CRAWL_TYPES,
     RUNNING_AND_WAITING_STATES,
     SUCCESSFUL_AND_PAUSED_STATES,
-    QARun,
-    UpdatedResponse,
-    DeletedResponseQuota,
-    CrawlSearchValuesResponse,
+    SUCCESSFUL_STATES,
     TYPE_CRAWL_TYPES,
-    CRAWL_TYPES,
+    BaseCrawl,
+    CrawlFile,
+    CrawlFileOut,
+    CrawlOut,
+    CrawlOutWithResources,
+    CrawlSearchValuesResponse,
+    DeleteCrawlList,
+    DeletedResponseQuota,
+    ListFilterType,
+    Organization,
+    PaginatedCrawlOutResponse,
+    QARun,
+    StorageRef,
+    TagsResponse,
+    UpdateCrawl,
+    UpdatedResponse,
+    User,
 )
-from .pagination import paginated_format, DEFAULT_PAGE_SIZE
-from .utils import dt_now, get_origin, date_to_str, run_async_task
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .utils import date_to_str, dt_now, get_origin, run_async_task
 
 if TYPE_CHECKING:
-    from .crawlconfigs import CrawlConfigOps
-    from .users import UserManager
-    from .orgs import OrgOps
-    from .colls import CollectionOps
-    from .storages import StorageOps
-    from .webhooks import EventWebhookOps
     from .background_jobs import BackgroundJobOps
-    from .pages import PageOps
+    from .colls import CollectionOps
     from .crawl_logs import CrawlLogOps
+    from .crawlconfigs import CrawlConfigOps
+    from .orgs import OrgOps
+    from .pages import PageOps
+    from .storages import StorageOps
+    from .users import UserManager
+    from .webhooks import EventWebhookOps
 
 else:
     CrawlConfigOps = UserManager = OrgOps = CollectionOps = PageOps = object

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -3,78 +3,76 @@ Collections API
 """
 
 # pylint: disable=too-many-lines
-from datetime import datetime
-from collections import Counter
-from uuid import UUID, uuid4
-from typing import Optional, List, TYPE_CHECKING, cast, Dict, Any, Union
 import os
+from collections import Counter
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from uuid import UUID, uuid4
 
-import pymongo
 import aiohttp
+import pymongo
 from fastapi import Depends, HTTPException, Response
 from fastapi.responses import StreamingResponse
 from starlette.requests import Request
 
-from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .auth import get_custom_jwt_token
+from .crawlmanager import CrawlManager
 from .models import (
+    MIN_UPLOAD_PART_SIZE,
+    SUCCESSFUL_STATES,
+    TYPE_DEDUPE_INDEX_STATES,
+    TYPE_INDEX_JOB_TYPES,
+    AddedResponse,
+    AddedResponseIdName,
     AnyHttpUrl,
+    BaseCrawl,
+    BgJobType,
+    CollAccessType,
     Collection,
+    CollectionAddRemove,
+    CollectionAllResponse,
+    CollectionSearchValuesResponse,
+    CollectionThumbnailSource,
+    CollIdName,
     CollIn,
     CollOut,
-    CollIdName,
-    CollectionThumbnailSource,
-    UpdateColl,
-    DedupeIndexStats,
-    DedupeIndexFile,
-    CollectionAddRemove,
-    BaseCrawl,
     CrawlFileOut,
-    Organization,
-    PaginatedCollOutResponse,
-    SUCCESSFUL_STATES,
-    AddedResponseIdName,
-    EmptyResponse,
-    UpdatedResponse,
-    SuccessResponse,
-    AddedResponse,
+    DedupeIndexFile,
+    DedupeIndexStats,
+    DeleteDedupeIndex,
     DeletedResponse,
-    CollectionSearchValuesResponse,
-    CollectionAllResponse,
+    EmptyResponse,
+    Organization,
     OrgPublicCollections,
+    PaginatedCollOutResponse,
+    PublicCollOut,
     PublicOrgDetails,
-    CollAccessType,
+    ResourcesOnly,
+    SuccessResponse,
+    UpdateColl,
     UpdateCollHomeUrl,
+    UpdatedResponse,
     User,
     UserFile,
     UserFilePreparer,
-    MIN_UPLOAD_PART_SIZE,
-    PublicCollOut,
-    ResourcesOnly,
-    DeleteDedupeIndex,
-    BgJobType,
-    TYPE_DEDUPE_INDEX_STATES,
-    TYPE_INDEX_JOB_TYPES,
 )
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import (
+    case_insensitive_collation,
     dt_now,
-    slug_from_name,
     get_duplicate_key_error_field,
     get_origin,
-    case_insensitive_collation,
     run_async_task,
+    slug_from_name,
 )
 
-from .auth import get_custom_jwt_token
-
-from .crawlmanager import CrawlManager
-
 if TYPE_CHECKING:
+    from .background_jobs import BackgroundJobOps
+    from .crawls import CrawlOps
     from .orgs import OrgOps
+    from .pages import PageOps
     from .storages import StorageOps
     from .webhooks import EventWebhookOps
-    from .crawls import CrawlOps
-    from .pages import PageOps
-    from .background_jobs import BackgroundJobOps
 else:
     OrgOps = StorageOps = EventWebhookOps = CrawlOps = PageOps = BackgroundJobOps = (
         object

--- a/backend/btrixcloud/crawl_logs.py
+++ b/backend/btrixcloud/crawl_logs.py
@@ -1,12 +1,11 @@
 """crawl logs"""
 
-from typing import TYPE_CHECKING, Any, Optional, Dict, Tuple, List
-
 import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
-from fastapi import HTTPException
 import pymongo
+from fastapi import HTTPException
 
 from .models import CrawlLogLine, Organization
 from .pagination import DEFAULT_PAGE_SIZE

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -4,30 +4,29 @@ Crawl Config API handling
 
 # pylint: disable=too-many-lines
 
-from typing import (
-    List,
-    Optional,
-    TYPE_CHECKING,
-    cast,
-    Dict,
-    Tuple,
-    Annotated,
-    Union,
-    Any,
-)
-
 import asyncio
 import json
-import re
 import os
+import re
 import traceback
-from datetime import datetime, timedelta
-from uuid import UUID, uuid4
 import urllib.parse
+from datetime import datetime, timedelta
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
+from uuid import UUID, uuid4
 
 import aiohttp
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 import pymongo
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from motor.motor_asyncio import (
     AsyncIOMotorClient,
     AsyncIOMotorClientSession,
@@ -35,63 +34,63 @@ from motor.motor_asyncio import (
     AsyncIOMotorDatabase,
 )
 
-from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
+    SUCCESSFUL_STATES,
     TYPE_ALL_CRAWL_STATES,
-    CrawlConfigIn,
     ConfigRevision,
     CrawlConfig,
-    CrawlConfigOut,
-    TagsResponse,
-    CrawlOut,
-    CrawlOutWithResources,
-    UpdateCrawlConfig,
-    Organization,
-    User,
-    PaginatedCrawlConfigOutResponse,
-    PaginatedSeedResponse,
-    PaginatedConfigRevisionResponse,
-    SUCCESSFUL_STATES,
-    CrawlerChannel,
-    CrawlerChannels,
-    StartedResponse,
-    SuccessResponse,
-    EmptyResponse,
     CrawlConfigAddedResponse,
+    CrawlConfigDeletedResponse,
+    CrawlConfigIn,
+    CrawlConfigOut,
     CrawlConfigSearchValues,
     CrawlConfigUpdateResponse,
-    CrawlConfigDeletedResponse,
-    CrawlerProxy,
+    CrawlerChannel,
+    CrawlerChannels,
     CrawlerProxies,
-    ValidateCustomBehavior,
-    RawCrawlConfig,
+    CrawlerProxy,
+    CrawlOut,
+    CrawlOutWithResources,
+    EmptyResponse,
     ListFilterType,
+    Organization,
+    PaginatedConfigRevisionResponse,
+    PaginatedCrawlConfigOutResponse,
+    PaginatedSeedResponse,
+    Profile,
+    RawCrawlConfig,
     ScopeType,
     Seed,
-    Profile,
+    StartedResponse,
+    SuccessResponse,
+    TagsResponse,
+    UpdateCrawlConfig,
+    User,
+    ValidateCustomBehavior,
 )
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import (
-    dt_now,
-    drop_privileges,
-    slug_from_name,
-    validate_regexes,
-    validate_language_code,
-    is_url,
     browser_windows_from_scale,
     case_insensitive_collation,
     crawler_image_below_minimum,
+    drop_privileges,
+    dt_now,
+    is_url,
     run_async_task,
+    slug_from_name,
+    validate_language_code,
+    validate_regexes,
 )
 
 if TYPE_CHECKING:
-    from .orgs import OrgOps
-    from .crawlmanager import CrawlManager
-    from .users import UserManager
-    from .profiles import ProfileOps
-    from .crawls import CrawlOps
     from .colls import CollectionOps
+    from .crawlmanager import CrawlManager
+    from .crawls import CrawlOps
     from .file_uploads import FileUploadOps
+    from .orgs import OrgOps
+    from .profiles import ProfileOps
     from .storages import StorageOps
+    from .users import UserManager
 else:
     OrgOps = CrawlManager = UserManager = ProfileOps = CrawlOps = CollectionOps = (
         FileUploadOps

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -2,24 +2,21 @@
 
 import os
 import secrets
-
-from typing import Optional, Dict, Tuple
 from datetime import datetime, timedelta
+from typing import Dict, Optional, Tuple
 
 from fastapi import HTTPException
 
-from .utils import dt_now, date_to_str, scale_from_browser_windows
-from .k8sapi import K8sAPI, ApiException
 from .auth import create_custom_jwt_token
-
+from .k8sapi import ApiException, K8sAPI
 from .models import (
-    StorageRef,
-    CrawlConfig,
-    BgJobType,
-    ProfileBrowserMetadata,
     TYPE_INDEX_JOB_TYPES,
+    BgJobType,
+    CrawlConfig,
+    ProfileBrowserMetadata,
+    StorageRef,
 )
-
+from .utils import date_to_str, dt_now, scale_from_browser_windows
 
 # ============================================================================
 DEFAULT_PROXY_ID: str = os.environ.get("DEFAULT_PROXY_ID", "")

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -2,90 +2,88 @@
 
 # pylint: disable=too-many-lines
 
+import asyncio
+import contextlib
 import json
 import os
 import re
-import contextlib
 import urllib.parse
 from datetime import datetime
-from uuid import UUID
-import asyncio
-
 from typing import (
     Annotated,
-    Optional,
-    List,
-    Dict,
-    Union,
     Any,
-    Sequence,
     AsyncIterator,
+    Dict,
+    List,
+    Optional,
+    Sequence,
     Tuple,
+    Union,
 )
+from uuid import UUID
 
+import pymongo
 from fastapi import Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from redis import asyncio as exceptions
 from redis.asyncio.client import Redis
-import pymongo
 
-from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import (
-    dt_now,
-    date_to_str,
-    stream_dict_list_as_csv,
-    validate_regexes,
-    scale_from_browser_windows,
-    browser_windows_from_scale,
-    crawler_image_below_minimum,
-)
 from .basecrawls import BaseCrawlOps
 from .crawlmanager import CrawlManager
 from .models import (
-    ListFilterType,
-    UpdateCrawl,
-    DeleteCrawlList,
-    CrawlConfig,
-    UpdateCrawlConfig,
-    CrawlScale,
-    CrawlStats,
-    CrawlFile,
-    Crawl,
-    CrawlOut,
-    CrawlOutWithResources,
-    QARun,
-    QARunOut,
-    QARunWithResources,
-    QARunAggregateStatsOut,
-    DeleteQARunList,
-    Organization,
-    User,
-    Seed,
-    PaginatedCrawlOutResponse,
-    PaginatedSeedResponse,
-    PaginatedCrawlLogResponse,
+    ALL_CRAWL_STATES,
+    NON_RUNNING_STATES,
     RUNNING_AND_WAITING_STATES,
     SUCCESSFUL_STATES,
-    NON_RUNNING_STATES,
-    ALL_CRAWL_STATES,
     TYPE_ALL_CRAWL_STATES,
-    UpdatedResponse,
-    SuccessResponse,
-    StartedResponse,
-    DeletedCountResponseQuota,
-    DeletedCountResponse,
-    EmptyResponse,
-    CrawlScaleResponse,
-    CrawlQueueResponse,
-    MatchCrawlQueueResponse,
-    CrawlLogLine,
-    TagsResponse,
     TYPE_AUTO_PAUSED_STATES,
-    UserRole,
+    Crawl,
+    CrawlConfig,
     CrawlDedupeStats,
+    CrawlFile,
+    CrawlLogLine,
+    CrawlOut,
+    CrawlOutWithResources,
+    CrawlQueueResponse,
+    CrawlScale,
+    CrawlScaleResponse,
+    CrawlStats,
+    DeleteCrawlList,
+    DeletedCountResponse,
+    DeletedCountResponseQuota,
+    DeleteQARunList,
+    EmptyResponse,
+    ListFilterType,
+    MatchCrawlQueueResponse,
+    Organization,
+    PaginatedCrawlLogResponse,
+    PaginatedCrawlOutResponse,
+    PaginatedSeedResponse,
+    QARun,
+    QARunAggregateStatsOut,
+    QARunOut,
+    QARunWithResources,
+    Seed,
+    StartedResponse,
+    SuccessResponse,
+    TagsResponse,
+    UpdateCrawl,
+    UpdateCrawlConfig,
+    UpdatedResponse,
+    User,
+    UserRole,
 )
-
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .utils import (
+    browser_windows_from_scale,
+    crawler_image_below_minimum,
+    date_to_str,
+    dt_now,
+    scale_from_browser_windows,
+    stream_dict_list_as_csv,
+    validate_regexes,
+)
 
 MAX_MATCH_SIZE = 500000
 DEFAULT_RANGE_LIMIT = 50

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -2,43 +2,42 @@
 Browsertrix API Mongo DB initialization
 """
 
+import asyncio
+import contextvars
 import importlib.util
 import os
 import urllib.parse
-import asyncio
-import contextvars
-from uuid import UUID, uuid4
-
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     Optional,
     Type,
     TypeVar,
     Union,
-    TYPE_CHECKING,
 )
+from uuid import UUID, uuid4
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-from pydantic import BaseModel, WrapValidator, ValidationError
+from pydantic import BaseModel, ValidationError, WrapValidator
 from pymongo.errors import InvalidName
 
 from .migrations import BaseMigration
 
 if TYPE_CHECKING:
-    from .users import UserManager
-    from .orgs import OrgOps
-    from .crawlconfigs import CrawlConfigOps
-    from .crawl_logs import CrawlLogOps
-    from .crawls import CrawlOps
-    from .colls import CollectionOps
-    from .invites import InviteOps
-    from .storages import StorageOps
-    from .pages import PageOps
     from .background_jobs import BackgroundJobOps
-    from .file_uploads import FileUploadOps
+    from .colls import CollectionOps
+    from .crawl_logs import CrawlLogOps
+    from .crawlconfigs import CrawlConfigOps
     from .crawlmanager import CrawlManager
+    from .crawls import CrawlOps
+    from .file_uploads import FileUploadOps
+    from .invites import InviteOps
+    from .orgs import OrgOps
+    from .pages import PageOps
     from .profiles import ProfileOps
+    from .storages import StorageOps
+    from .users import UserManager
 else:
     UserManager = OrgOps = CrawlConfigOps = CrawlOps = CollectionOps = InviteOps = (
         StorageOps

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -1,28 +1,27 @@
 """Basic Email Sending Support"""
 
-from datetime import datetime
 import os
 import smtplib
 import ssl
-from uuid import UUID
-from typing import Optional, Union, Literal
-
+from datetime import datetime
 from email.message import EmailMessage
-from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Literal, Optional, Union
+from uuid import UUID
 
 import aiohttp
 from fastapi import HTTPException
 
 from .models import (
+    TYPE_AUTO_PAUSED_STATES,
     CreateReplicaJob,
     DeleteReplicaJob,
-    Organization,
     InvitePending,
+    Organization,
     Subscription,
-    TYPE_AUTO_PAUSED_STATES,
 )
-from .utils import is_bool, get_origin
+from .utils import get_origin, is_bool
 
 
 # pylint: disable=too-few-public-methods, too-many-instance-attributes

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -1,32 +1,31 @@
 """user-uploaded files"""
 
-from typing import TYPE_CHECKING, Union, Any, Optional, Dict, Tuple, List
-
-from datetime import timedelta
 import os
 import tempfile
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID, uuid4
 
 import aiohttp
+import pymongo
 from fastapi import APIRouter, Depends, HTTPException, Request
 from motor.motor_asyncio import AsyncIOMotorClientSession
-import pymongo
 
 from .models import (
-    SeedFileOut,
+    MIN_UPLOAD_PART_SIZE,
+    AddedResponseId,
+    Organization,
+    PaginatedUserFileResponse,
     SeedFile,
+    SeedFileOut,
+    SuccessResponse,
+    User,
     UserFile,
     UserFilePreparer,
-    Organization,
-    User,
-    AddedResponseId,
-    SuccessResponse,
-    MIN_UPLOAD_PART_SIZE,
-    PaginatedUserFileResponse,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .storages import CHUNK_SIZE, StorageOps
 from .utils import dt_now, is_url
-from .storages import StorageOps, CHUNK_SIZE
 
 if TYPE_CHECKING:
     from .orgs import OrgOps

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -1,30 +1,30 @@
 """Invite system management"""
 
-from typing import Optional, Any
-import os
-import urllib.parse
-import time
 import hashlib
+import os
+import time
+import urllib.parse
+from typing import Any, Optional
 from uuid import UUID, uuid4
 
-from pymongo.errors import AutoReconnect
 import pymongo
 from fastapi import HTTPException
+from pymongo.errors import AutoReconnect
 
-from .pagination import DEFAULT_PAGE_SIZE
+from .emailsender import EmailSender
 from .models import (
     EmailStr,
-    UserRole,
+    InviteOut,
     InvitePending,
     InviteToOrgRequest,
-    InviteOut,
-    User,
     Organization,
     Subscription,
+    User,
+    UserRole,
 )
+from .pagination import DEFAULT_PAGE_SIZE
 from .users import UserManager
-from .emailsender import EmailSender
-from .utils import is_bool, dt_now
+from .utils import dt_now, is_bool
 
 
 # ============================================================================

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -2,25 +2,22 @@
 
 import os
 import traceback
-from typing import Optional, List, Any
+from typing import Any, List, Optional
 
 import yaml
-
+from fastapi import HTTPException
+from fastapi.templating import Jinja2Templates
 from kubernetes_asyncio import client, config
-from kubernetes_asyncio.stream import WsApiClient
-from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.client.api import custom_objects_api
-from kubernetes_asyncio.client.models import V1CronJob
-from kubernetes_asyncio.utils import create_from_dict
+from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.client.exceptions import ApiException
-
+from kubernetes_asyncio.client.models import V1CronJob
+from kubernetes_asyncio.stream import WsApiClient
+from kubernetes_asyncio.utils import create_from_dict
 from redis import asyncio as aioredis
 from redis.asyncio.client import Redis
 
-from fastapi import HTTPException
-from fastapi.templating import Jinja2Templates
-
-from .utils import get_templates_dir, dt_now
+from .utils import dt_now, get_templates_dir
 
 
 # ============================================================================

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -8,39 +8,34 @@ import sys
 from typing import List, Optional
 
 from fastapi import FastAPI, HTTPException
+from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
-
-from fastapi.openapi.utils import get_openapi
-from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
 from pydantic import BaseModel
 
-from .db import init_db, await_db_and_migrations
-
-from .emailsender import EmailSender
-from .invites import init_invites
 from .auth import JWT_TOKEN_LIFETIME
-from .users import init_users_api, init_user_manager
-from .orgs import init_orgs_api
-
-from .profiles import init_profiles_api
-
-from .storages import init_storages_api
-from .uploads import init_uploads_api
-from .crawlconfigs import init_crawl_config_api
-from .crawl_logs import CrawlLogOps
-from .colls import init_collections_api
-from .crawls import init_crawls_api
-from .basecrawls import init_base_crawls_api
-from .webhooks import init_event_webhooks_api
 from .background_jobs import init_background_jobs_api
-from .pages import init_pages_api
-from .subs import init_subs_api
-from .file_uploads import init_file_uploads_api
-
+from .basecrawls import init_base_crawls_api
+from .colls import init_collections_api
+from .crawl_logs import CrawlLogOps
+from .crawlconfigs import init_crawl_config_api
 from .crawlmanager import CrawlManager
-from .utils import register_exit_handler, is_bool, run_async_task
+from .crawls import init_crawls_api
+from .db import await_db_and_migrations, init_db
+from .emailsender import EmailSender
+from .file_uploads import init_file_uploads_api
+from .invites import init_invites
+from .orgs import init_orgs_api
+from .pages import init_pages_api
+from .profiles import init_profiles_api
+from .storages import init_storages_api
+from .subs import init_subs_api
+from .uploads import init_uploads_api
+from .users import init_user_manager, init_users_api
+from .utils import is_bool, register_exit_handler, run_async_task
 from .version import __version__
+from .webhooks import init_event_webhooks_api
 
 API_PREFIX = "/api"
 

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -9,7 +9,6 @@ from uuid import UUID
 from .models import BgJobType
 from .ops import init_ops
 
-
 job_type = os.environ.get("BG_JOB_TYPE")
 oid = os.environ.get("OID")
 crawl_type = os.environ.get("CRAWL_TYPE")

--- a/backend/btrixcloud/main_migrations.py
+++ b/backend/btrixcloud/main_migrations.py
@@ -1,11 +1,11 @@
 """entrypoint module for init_container, handles db migration"""
 
+import asyncio
 import os
 import sys
-import asyncio
 
+from .db import ensure_feature_version, update_and_prepare_db
 from .ops import init_ops
-from .db import update_and_prepare_db, ensure_feature_version
 
 
 # ============================================================================

--- a/backend/btrixcloud/main_op.py
+++ b/backend/btrixcloud/main_op.py
@@ -9,7 +9,6 @@ from .operator import init_operator_api
 from .ops import init_ops
 from .utils import register_exit_handler
 
-
 app_root = FastAPI()
 
 

--- a/backend/btrixcloud/migrations/__init__.py
+++ b/backend/btrixcloud/migrations/__init__.py
@@ -4,6 +4,7 @@ BaseMigration class to subclass in each migration module
 
 import os
 import traceback
+
 from pymongo.errors import OperationFailure
 
 

--- a/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
+++ b/backend/btrixcloud/migrations/migration_0001_archives_to_orgs.py
@@ -6,9 +6,8 @@ import os
 
 from pymongo.errors import OperationFailure
 
-from btrixcloud.migrations import BaseMigration
 from btrixcloud.k8sapi import K8sAPI
-
+from btrixcloud.migrations import BaseMigration
 
 MIGRATION_VERSION = "0001"
 

--- a/backend/btrixcloud/migrations/migration_0002_crawlconfig_crawlstats.py
+++ b/backend/btrixcloud/migrations/migration_0002_crawlconfig_crawlstats.py
@@ -4,7 +4,6 @@ Migration 0002 - Dropping CrawlConfig crawl stats
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0002"
 
 

--- a/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
+++ b/backend/btrixcloud/migrations/migration_0003_mutable_crawl_configs.py
@@ -2,10 +2,9 @@
 Migration 0003 - Mutable crawl configs and crawl revision history
 """
 
-from btrixcloud.models import Crawl, CrawlConfig
 from btrixcloud.migrations import BaseMigration, MigrationError
+from btrixcloud.models import Crawl, CrawlConfig
 from btrixcloud.utils import dt_now
-
 
 MIGRATION_VERSION = "0003"
 

--- a/backend/btrixcloud/migrations/migration_0004_config_seeds.py
+++ b/backend/btrixcloud/migrations/migration_0004_config_seeds.py
@@ -4,9 +4,8 @@ Migration 0004 - Ensuring all config.seeds are Seeds not HttpUrls
 
 from pydantic import HttpUrl
 
-from btrixcloud.models import Crawl, CrawlConfig, ScopeType, Seed
 from btrixcloud.migrations import BaseMigration
-
+from btrixcloud.models import Crawl, CrawlConfig, ScopeType, Seed
 
 MIGRATION_VERSION = "0004"
 

--- a/backend/btrixcloud/migrations/migration_0005_operator_scheduled_jobs.py
+++ b/backend/btrixcloud/migrations/migration_0005_operator_scheduled_jobs.py
@@ -2,10 +2,9 @@
 Migration 0005 - Updating scheduled cron jobs after Operator changes
 """
 
-from btrixcloud.models import CrawlConfig
 from btrixcloud.crawlmanager import CrawlManager
 from btrixcloud.migrations import BaseMigration
-
+from btrixcloud.models import CrawlConfig
 
 MIGRATION_VERSION = "0005"
 

--- a/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
+++ b/backend/btrixcloud/migrations/migration_0006_precompute_crawl_stats.py
@@ -5,7 +5,6 @@ Migration 0006 - Precomputing workflow crawl stats
 from btrixcloud.crawlconfigs import stats_recompute_all
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0006"
 
 

--- a/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
+++ b/backend/btrixcloud/migrations/migration_0007_colls_and_config_update.py
@@ -8,7 +8,6 @@ Migration 0007 - Workflows changes
 from btrixcloud.crawlconfigs import stats_recompute_all
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0007"
 
 

--- a/backend/btrixcloud/migrations/migration_0008_precompute_crawl_file_stats.py
+++ b/backend/btrixcloud/migrations/migration_0008_precompute_crawl_file_stats.py
@@ -5,7 +5,6 @@ Migration 0008 - Precomputing crawl file stats
 from btrixcloud.crawls import recompute_crawl_file_count_and_size
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0008"
 
 

--- a/backend/btrixcloud/migrations/migration_0009_crawl_types.py
+++ b/backend/btrixcloud/migrations/migration_0009_crawl_types.py
@@ -4,7 +4,6 @@ Migration 0009 - Crawl types
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0009"
 
 

--- a/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
+++ b/backend/btrixcloud/migrations/migration_0010_collection_total_size.py
@@ -4,15 +4,13 @@ Migration 0010 - Precomputing collection total size
 
 from typing import cast
 
-from btrixcloud.colls import CollectionOps
-from btrixcloud.migrations import BaseMigration
-
 from btrixcloud.background_jobs import BackgroundJobOps
+from btrixcloud.colls import CollectionOps
+from btrixcloud.crawlmanager import CrawlManager
+from btrixcloud.migrations import BaseMigration
 from btrixcloud.orgs import OrgOps
 from btrixcloud.storages import StorageOps
 from btrixcloud.webhooks import EventWebhookOps
-from btrixcloud.crawlmanager import CrawlManager
-
 
 MIGRATION_VERSION = "0010"
 

--- a/backend/btrixcloud/migrations/migration_0011_crawl_timeout_configmap.py
+++ b/backend/btrixcloud/migrations/migration_0011_crawl_timeout_configmap.py
@@ -5,9 +5,7 @@ Migration 0011 - Remove None CRAWL_TIMEOUT values from configmaps
 import os
 
 from btrixcloud.k8sapi import K8sAPI
-
 from btrixcloud.migrations import BaseMigration
-
 
 MIGRATION_VERSION = "0011"
 

--- a/backend/btrixcloud/migrations/migration_0012_notes_to_description.py
+++ b/backend/btrixcloud/migrations/migration_0012_notes_to_description.py
@@ -4,7 +4,6 @@ Migration 0012 - Notes to description
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0012"
 
 

--- a/backend/btrixcloud/migrations/migration_0013_crawl_name.py
+++ b/backend/btrixcloud/migrations/migration_0013_crawl_name.py
@@ -4,7 +4,6 @@ Migration 0013 - Copy config name to crawls
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0013"
 
 

--- a/backend/btrixcloud/migrations/migration_0014_to_collection_ids.py
+++ b/backend/btrixcloud/migrations/migration_0014_to_collection_ids.py
@@ -4,7 +4,6 @@ Migration 0014 - collections to collectionIDs
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0014"
 
 

--- a/backend/btrixcloud/migrations/migration_0015_org_storage_usage.py
+++ b/backend/btrixcloud/migrations/migration_0015_org_storage_usage.py
@@ -4,7 +4,6 @@ Migration 0015 - Calculate and store org storage usage
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0015"
 
 

--- a/backend/btrixcloud/migrations/migration_0016_operator_scheduled_jobs_v2.py
+++ b/backend/btrixcloud/migrations/migration_0016_operator_scheduled_jobs_v2.py
@@ -3,10 +3,10 @@ Migration 0016 - Updating scheduled cron jobs after Operator changes v2
 """
 
 import os
-from btrixcloud.models import CrawlConfig
+
 from btrixcloud.crawlmanager import CrawlManager
 from btrixcloud.migrations import BaseMigration
-
+from btrixcloud.models import CrawlConfig
 
 MIGRATION_VERSION = "0016"
 

--- a/backend/btrixcloud/migrations/migration_0017_storage_by_type.py
+++ b/backend/btrixcloud/migrations/migration_0017_storage_by_type.py
@@ -4,7 +4,6 @@ Migration 0017 - Calculate and store org storage usage by type
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0017"
 
 

--- a/backend/btrixcloud/migrations/migration_0018_usernames.py
+++ b/backend/btrixcloud/migrations/migration_0018_usernames.py
@@ -2,12 +2,10 @@
 Migration 0018 - Store crawl and workflow userName directly in db
 """
 
-from btrixcloud.migrations import BaseMigration
-
 from btrixcloud.emailsender import EmailSender
 from btrixcloud.invites import init_invites
+from btrixcloud.migrations import BaseMigration
 from btrixcloud.users import init_user_manager
-
 
 MIGRATION_VERSION = "0018"
 

--- a/backend/btrixcloud/migrations/migration_0019_org_slug.py
+++ b/backend/btrixcloud/migrations/migration_0019_org_slug.py
@@ -5,7 +5,6 @@ Migration 0019 - Organization slug
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.utils import slug_from_name
 
-
 MIGRATION_VERSION = "0019"
 
 

--- a/backend/btrixcloud/migrations/migration_0020_org_storage_refs.py
+++ b/backend/btrixcloud/migrations/migration_0020_org_storage_refs.py
@@ -4,7 +4,6 @@ Migration 0020 - New Storage Ref System
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0020"
 
 

--- a/backend/btrixcloud/migrations/migration_0021_profile_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0021_profile_filenames.py
@@ -5,7 +5,6 @@ Migration 0021 - Profile filenames
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.models import Profile
 
-
 MIGRATION_VERSION = "0021"
 
 

--- a/backend/btrixcloud/migrations/migration_0022_partial_complete.py
+++ b/backend/btrixcloud/migrations/migration_0022_partial_complete.py
@@ -4,7 +4,6 @@ Migration 0022 -- Partial Complete
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0022"
 
 

--- a/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
+++ b/backend/btrixcloud/migrations/migration_0023_available_extra_exec_mins.py
@@ -4,7 +4,6 @@ Migration 0023 -- Available extra/gifted minutes
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0023"
 
 

--- a/backend/btrixcloud/migrations/migration_0024_crawlerchannel.py
+++ b/backend/btrixcloud/migrations/migration_0024_crawlerchannel.py
@@ -4,7 +4,6 @@ Migration 0024 -- crawlerChannel
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0024"
 
 

--- a/backend/btrixcloud/migrations/migration_0025_workflow_db_configmap_fixes.py
+++ b/backend/btrixcloud/migrations/migration_0025_workflow_db_configmap_fixes.py
@@ -4,7 +4,6 @@ Migration 0025 -- fix workflow database and configmap issues.
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0025"
 
 

--- a/backend/btrixcloud/migrations/migration_0026_crawl_review_status.py
+++ b/backend/btrixcloud/migrations/migration_0026_crawl_review_status.py
@@ -4,7 +4,6 @@ Migration 0026 - Crawl reviewStatus type
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0026"
 
 

--- a/backend/btrixcloud/migrations/migration_0027_profile_modified.py
+++ b/backend/btrixcloud/migrations/migration_0027_profile_modified.py
@@ -4,7 +4,6 @@ Migration 0027 - Profile modified date fallback
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0027"
 
 

--- a/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
+++ b/backend/btrixcloud/migrations/migration_0028_page_files_errors.py
@@ -3,8 +3,7 @@ Migration 0028 - Page files and errors
 """
 
 from btrixcloud.migrations import BaseMigration
-from btrixcloud.models import Page, Crawl
-
+from btrixcloud.models import Crawl, Page
 
 MIGRATION_VERSION = "0028"
 

--- a/backend/btrixcloud/migrations/migration_0029_remove_workflow_configmaps.py
+++ b/backend/btrixcloud/migrations/migration_0029_remove_workflow_configmaps.py
@@ -2,9 +2,8 @@
 Migration 0028 - Page files and errors
 """
 
-from btrixcloud.migrations import BaseMigration
 from btrixcloud.crawlmanager import CrawlManager
-
+from btrixcloud.migrations import BaseMigration
 
 MIGRATION_VERSION = "0029"
 

--- a/backend/btrixcloud/migrations/migration_0030_user_invites_flatten.py
+++ b/backend/btrixcloud/migrations/migration_0030_user_invites_flatten.py
@@ -2,9 +2,9 @@
 Migration 0030 - Move user invites from user.invites to invites collection
 """
 
+from btrixcloud.invites import get_hash
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.models import InvitePending
-from btrixcloud.invites import get_hash
 
 MIGRATION_VERSION = "0030"
 

--- a/backend/btrixcloud/migrations/migration_0031_org_created.py
+++ b/backend/btrixcloud/migrations/migration_0031_org_created.py
@@ -4,7 +4,6 @@ Migration 0031 - Organization created field
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0031"
 
 

--- a/backend/btrixcloud/migrations/migration_0032_dupe_org_names.py
+++ b/backend/btrixcloud/migrations/migration_0032_dupe_org_names.py
@@ -9,7 +9,6 @@ from pymongo.errors import DuplicateKeyError
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.utils import slug_from_name
 
-
 MIGRATION_VERSION = "0032"
 
 

--- a/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
+++ b/backend/btrixcloud/migrations/migration_0033_crawl_quota_states.py
@@ -4,7 +4,6 @@ Migration 0033 - Standardizing quota-based crawl states
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0033"
 
 

--- a/backend/btrixcloud/migrations/migration_0034_drop_invalid_crc.py
+++ b/backend/btrixcloud/migrations/migration_0034_drop_invalid_crc.py
@@ -4,7 +4,6 @@ Migration 0034 -- remove crc32 from CrawlFile
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0034"
 
 

--- a/backend/btrixcloud/migrations/migration_0035_fix_failed_logins.py
+++ b/backend/btrixcloud/migrations/migration_0035_fix_failed_logins.py
@@ -4,7 +4,6 @@ Migration 0035 -- fix model for failed logins
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0035"
 
 

--- a/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
+++ b/backend/btrixcloud/migrations/migration_0036_coll_visibility.py
@@ -4,7 +4,6 @@ Migration 0036 -- collection access
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0036"
 
 

--- a/backend/btrixcloud/migrations/migration_0037_upload_pages.py
+++ b/backend/btrixcloud/migrations/migration_0037_upload_pages.py
@@ -5,7 +5,6 @@ Migration 0037 -- upload pages
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.models import Organization, UploadedCrawl
 
-
 MIGRATION_VERSION = "0037"
 
 

--- a/backend/btrixcloud/migrations/migration_0038_org_last_crawl_finished.py
+++ b/backend/btrixcloud/migrations/migration_0038_org_last_crawl_finished.py
@@ -4,7 +4,6 @@ Migration 0038 - Organization lastCrawlFinished field
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0038"
 
 

--- a/backend/btrixcloud/migrations/migration_0039_coll_slugs.py
+++ b/backend/btrixcloud/migrations/migration_0039_coll_slugs.py
@@ -4,11 +4,11 @@ Migration 0039 -- collection slugs
 
 from uuid import UUID
 
-from pymongo.errors import DuplicateKeyError
 import pymongo
+from pymongo.errors import DuplicateKeyError
 
 from btrixcloud.migrations import BaseMigration
-from btrixcloud.utils import slug_from_name, case_insensitive_collation
+from btrixcloud.utils import case_insensitive_collation, slug_from_name
 
 MIGRATION_VERSION = "0039"
 

--- a/backend/btrixcloud/migrations/migration_0040_archived_item_page_count.py
+++ b/backend/btrixcloud/migrations/migration_0040_archived_item_page_count.py
@@ -4,7 +4,6 @@ Migration 0040 -- archived item pageCount
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0040"
 
 

--- a/backend/btrixcloud/migrations/migration_0041_pages_snapshots.py
+++ b/backend/btrixcloud/migrations/migration_0041_pages_snapshots.py
@@ -4,7 +4,6 @@ Migration 0041 - Rationalize page counts
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0041"
 
 

--- a/backend/btrixcloud/migrations/migration_0042_page_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0042_page_filenames.py
@@ -4,7 +4,6 @@ Migration 0042 - Add filename to pages
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0042"
 
 

--- a/backend/btrixcloud/migrations/migration_0043_unset_file_expireat.py
+++ b/backend/btrixcloud/migrations/migration_0043_unset_file_expireat.py
@@ -4,7 +4,6 @@ Migration 0043 - Remove expireAt and presignedUrl from files, now stored in sepa
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0043"
 
 

--- a/backend/btrixcloud/migrations/migration_0044_coll_stats.py
+++ b/backend/btrixcloud/migrations/migration_0044_coll_stats.py
@@ -4,7 +4,6 @@ Migration 0044 - Recalculate collection stats
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0044"
 
 

--- a/backend/btrixcloud/migrations/migration_0045_crawl_counts.py
+++ b/backend/btrixcloud/migrations/migration_0045_crawl_counts.py
@@ -4,7 +4,6 @@ Migration 0045 - Recalculate crawl filePageCount and errorPageCount
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0045"
 
 

--- a/backend/btrixcloud/migrations/migration_0046_invalid_lang.py
+++ b/backend/btrixcloud/migrations/migration_0046_invalid_lang.py
@@ -4,7 +4,6 @@ Migration 0046 - Invalid language codes
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0046"
 
 ISO_639_1_CODES = [

--- a/backend/btrixcloud/migrations/migration_0047_scale_to_browser_windows.py
+++ b/backend/btrixcloud/migrations/migration_0047_scale_to_browser_windows.py
@@ -5,7 +5,6 @@ Migration 0047 - Convert scale to browserWindows
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.utils import browser_windows_from_scale
 
-
 MIGRATION_VERSION = "0047"
 
 

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -2,11 +2,10 @@
 Migration 0048 - Calculate firstSeed/seedCount and store directly in database
 """
 
-from typing import cast, List, Dict, Any
+from typing import Any, Dict, List, cast
 
 from btrixcloud.migrations import BaseMigration
-from btrixcloud.models import CrawlConfig, Crawl, Seed
-
+from btrixcloud.models import Crawl, CrawlConfig, Seed
 
 MIGRATION_VERSION = "0048"
 

--- a/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
+++ b/backend/btrixcloud/migrations/migration_0049_recalculate_org_storage.py
@@ -4,7 +4,6 @@ Migration 0049 - Recalculate org storage for seed file and thumbnail size
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0049"
 
 

--- a/backend/btrixcloud/migrations/migration_0050_crawl_logs.py
+++ b/backend/btrixcloud/migrations/migration_0050_crawl_logs.py
@@ -4,7 +4,6 @@ Migration 0050 - Move crawl logs to seperate mongo collection
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0050"
 
 

--- a/backend/btrixcloud/migrations/migration_0051_fail_on_content_check_profiles.py
+++ b/backend/btrixcloud/migrations/migration_0051_fail_on_content_check_profiles.py
@@ -4,7 +4,6 @@ Migration 0051 - Ensure failOnContentCheck is not set for workflows without prof
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0051"
 
 

--- a/backend/btrixcloud/migrations/migration_0052_profile_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0052_profile_filenames.py
@@ -5,7 +5,6 @@ Migration 0052 - Fix profile filenames in db to be full path from bucket
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.models import Profile
 
-
 MIGRATION_VERSION = "0052"
 
 

--- a/backend/btrixcloud/migrations/migration_0053_delete_leftover_cronjobs.py
+++ b/backend/btrixcloud/migrations/migration_0053_delete_leftover_cronjobs.py
@@ -8,7 +8,6 @@ from fastapi import HTTPException
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0053"
 
 

--- a/backend/btrixcloud/migrations/migration_0054_clear_proxyid_when_using_profiles.py
+++ b/backend/btrixcloud/migrations/migration_0054_clear_proxyid_when_using_profiles.py
@@ -5,7 +5,6 @@ using proxyId from profile always
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0054"
 
 

--- a/backend/btrixcloud/migrations/migration_0055_recompute_crawlconfig_stats.py
+++ b/backend/btrixcloud/migrations/migration_0055_recompute_crawlconfig_stats.py
@@ -7,7 +7,6 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 from btrixcloud.crawlconfigs import stats_recompute_all
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0055"
 
 

--- a/backend/btrixcloud/migrations/migration_0056_crawl_logs_deleted_cleanup.py
+++ b/backend/btrixcloud/migrations/migration_0056_crawl_logs_deleted_cleanup.py
@@ -6,7 +6,6 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 
 from btrixcloud.migrations import BaseMigration
 
-
 MIGRATION_VERSION = "0056"
 
 NOT_NULLISH = {"$nin": [None, ""]}

--- a/backend/btrixcloud/migrations/migration_0058_fix_failed_bg_jobs.py
+++ b/backend/btrixcloud/migrations/migration_0058_fix_failed_bg_jobs.py
@@ -2,12 +2,11 @@
 Migration 0058 - Fix failed background jobs with success and finished unset
 """
 
-from datetime import timedelta
 import os
+from datetime import timedelta
 
 from btrixcloud.migrations import BaseMigration
 from btrixcloud.utils import dt_now
-
 
 MIGRATION_VERSION = "0058"
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -4,48 +4,52 @@ Crawl-related models and types
 
 # pylint: disable=invalid-name, too-many-lines
 from __future__ import annotations
-from datetime import datetime
-from enum import Enum, IntEnum
-from uuid import UUID
+
 import base64
 import hashlib
-import mimetypes
 import math
+import mimetypes
 import os
-
+from datetime import datetime
+from enum import Enum, IntEnum
 from typing import (
-    Optional,
-    List,
+    Annotated,
+    Any,
     Dict,
+    List,
+    Literal,
+    Optional,
     Self,
     Union,
-    Literal,
-    Any,
     get_args,
     get_origin,
-    Annotated,
 )
+from uuid import UUID
 
 from pydantic import (
-    BaseModel,
-    Field,
-    HttpUrl as HttpUrlNonStr,
     AnyHttpUrl as AnyHttpUrlNonStr,
-    EmailStr as CasedEmailStr,
+)
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    RootModel,
+    TypeAdapter,
     create_model,
     model_validator,
     validate_email,
-    RootModel,
-    BeforeValidator,
-    TypeAdapter,
-    ConfigDict,
+)
+from pydantic import (
+    EmailStr as CasedEmailStr,
+)
+from pydantic import (
+    HttpUrl as HttpUrlNonStr,
 )
 from slugify import slugify
 
 # from fastapi_users import models as fastapi_users_models
-
 from .db import LENIENT_ON_READ, BaseMongoModel
-
 from .utils import is_bool
 
 # num browsers per crawler instance

--- a/backend/btrixcloud/operator/__init__.py
+++ b/backend/btrixcloud/operator/__init__.py
@@ -1,12 +1,12 @@
 """operators module"""
 
-from .profiles import ProfileOperator
+from .baseoperator import K8sOpAPI
 from .bgjobs import BgJobOperator
-from .cronjobs import CronJobOperator
-from .crawls import CrawlOperator
 from .collindexes import CollIndexOperator
 from .collindexjob import CollIndexImportJobOperator
-from .baseoperator import K8sOpAPI
+from .crawls import CrawlOperator
+from .cronjobs import CronJobOperator
+from .profiles import ProfileOperator
 
 operator_classes = [
     ProfileOperator,

--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -1,28 +1,31 @@
 """Base Operator class for all operators"""
 
-import os
 import json
+import os
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
-from kubernetes.utils import parse_quantity
 
 import yaml
+from kubernetes.utils import parse_quantity
+
 from btrixcloud.k8sapi import K8sAPI
-from btrixcloud.utils import is_bool, dt_now, str_to_date
+from btrixcloud.utils import dt_now, is_bool, str_to_date
+
 from .models import COLLINDEX
 
 if TYPE_CHECKING:
+    from redis.asyncio.client import Redis
+
+    from btrixcloud.background_jobs import BackgroundJobOps
+    from btrixcloud.colls import CollectionOps
+    from btrixcloud.crawl_logs import CrawlLogOps
     from btrixcloud.crawlconfigs import CrawlConfigOps
     from btrixcloud.crawls import CrawlOps
-    from btrixcloud.crawl_logs import CrawlLogOps
     from btrixcloud.orgs import OrgOps
-    from btrixcloud.colls import CollectionOps
-    from btrixcloud.storages import StorageOps
-    from btrixcloud.webhooks import EventWebhookOps
-    from btrixcloud.users import UserManager
-    from btrixcloud.background_jobs import BackgroundJobOps
     from btrixcloud.pages import PageOps
-    from redis.asyncio.client import Redis
+    from btrixcloud.storages import StorageOps
+    from btrixcloud.users import UserManager
+    from btrixcloud.webhooks import EventWebhookOps
 else:
     CrawlConfigOps = CrawlOps = OrgOps = CollectionOps = Redis = CrawlLogOps = object
     StorageOps = EventWebhookOps = UserManager = BackgroundJobOps = PageOps = object

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -1,15 +1,15 @@
 """Operator handler for BackgroundJobs"""
 
-from uuid import UUID
 import traceback
+from uuid import UUID
 
 from btrixcloud.utils import (
-    str_to_date,
     dt_now,
+    str_to_date,
 )
 
-from .models import MCDecoratorSyncData
 from .baseoperator import BaseOperator
+from .models import MCDecoratorSyncData
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/collindexes.py
+++ b/backend/btrixcloud/operator/collindexes.py
@@ -1,36 +1,35 @@
 """Operator handler for CollIndexes"""
 
-import re
 import datetime
-import traceback
 import os
-
+import re
+import traceback
 from typing import Literal
 from urllib.parse import urlsplit
-
 from uuid import UUID
+
+from kubernetes.utils import parse_quantity
 from pydantic import BaseModel
 from redis.asyncio.client import Redis
-from kubernetes.utils import parse_quantity
 
+from btrixcloud.models import (
+    TYPE_DEDUPE_INDEX_STATES,
+    DedupeIndexFile,
+    DedupeIndexStats,
+    Organization,
+)
 from btrixcloud.utils import (
-    str_to_date,
     date_to_str,
     dt_now,
     gb_storage_ceil,
     gb_storage_floor,
     is_bool,
     run_async_task,
-)
-from btrixcloud.models import (
-    TYPE_DEDUPE_INDEX_STATES,
-    DedupeIndexStats,
-    DedupeIndexFile,
-    Organization,
+    str_to_date,
 )
 
-from .models import MCSyncData, MCBaseRequest, POD, JOB, CJS, BTRIX_API
 from .baseoperator import BaseOperator
+from .models import BTRIX_API, CJS, JOB, POD, MCBaseRequest, MCSyncData
 
 # Threshold used / capacity at which a resize should happen
 USED_DISK_THRESHOLD = 0.70

--- a/backend/btrixcloud/operator/collindexjob.py
+++ b/backend/btrixcloud/operator/collindexjob.py
@@ -2,14 +2,14 @@
 
 from btrixcloud.utils import run_async_task
 
+from .baseoperator import BaseOperator
 from .models import (
+    BTRIX_API,
+    CMAP,
     MCBaseRequest,
     MCDecoratorSyncData,
     MCDecoratorSyncResponse,
-    BTRIX_API,
-    CMAP,
 )
-from .baseoperator import BaseOperator
 
 
 # ============================================================================

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1,63 +1,58 @@
 """CrawlOperator"""
 
-import traceback
-import os
+import json
 import math
-from pprint import pprint
-from typing import Optional, Any, Sequence, Literal
+import os
+import traceback
 from datetime import datetime, timedelta
+from pprint import pprint
+from typing import Any, Literal, Optional, Sequence
 from uuid import UUID
 
-import json
-
 import humanize
-
+from fastapi import HTTPException
 from kubernetes.utils import parse_quantity
 
-from fastapi import HTTPException
-
 from btrixcloud.models import (
-    TYPE_NON_RUNNING_STATES,
-    TYPE_RUNNING_STATES,
-    TYPE_ALL_CRAWL_STATES,
-    TYPE_PAUSED_STATES,
-    RUNNING_STATES,
-    WAITING_STATES,
-    RUNNING_AND_STARTING_ONLY,
-    RUNNING_AND_WAITING_STATES,
-    SUCCESSFUL_STATES,
     FAILED_STATES,
     PAUSED_STATES,
-    CrawlFile,
+    RUNNING_AND_STARTING_ONLY,
+    RUNNING_AND_WAITING_STATES,
+    RUNNING_STATES,
+    SUCCESSFUL_STATES,
+    TYPE_ALL_CRAWL_STATES,
+    TYPE_NON_RUNNING_STATES,
+    TYPE_PAUSED_STATES,
+    TYPE_RUNNING_STATES,
+    WAITING_STATES,
     CrawlCompleteIn,
-    StorageRef,
     CrawlDedupeStats,
+    CrawlFile,
+    StorageRef,
 )
-
 from btrixcloud.utils import (
-    str_to_date,
+    crawler_image_below_minimum,
     date_to_str,
     dt_now,
-    scale_from_browser_windows,
-    crawler_image_below_minimum,
     run_async_task,
+    scale_from_browser_windows,
+    str_to_date,
 )
 
 from .baseoperator import BaseOperator, Redis
 from .models import (
+    BTRIX_API,
+    CMAP,
+    POD,
+    PVC,
     CrawlSpec,
     CrawlStatus,
-    OpCrawlStats,
-    StopReason,
     MCBaseRequest,
     MCSyncData,
+    OpCrawlStats,
     PodInfo,
-    POD,
-    CMAP,
-    PVC,
-    BTRIX_API,
+    StopReason,
 )
-
 
 METRICS_API = "metrics.k8s.io/v1beta1"
 METRICS = f"PodMetrics.{METRICS_API}"

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -1,15 +1,16 @@
 """Operator handler for crawl CronJobs"""
 
-from uuid import UUID
 from typing import Optional
+from uuid import UUID
+
 import yaml
 
 from btrixcloud.utils import date_to_str, dt_now, run_async_task
-from .models import MCDecoratorSyncData, CJS, MCDecoratorSyncResponse
-from .baseoperator import BaseOperator
 
 from ..models import CrawlConfig
 from ..utils import scale_from_browser_windows
+from .baseoperator import BaseOperator
+from .models import CJS, MCDecoratorSyncData, MCDecoratorSyncResponse
 
 
 # pylint: disable=too-many-locals

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -2,17 +2,18 @@
 
 from collections import defaultdict
 from datetime import datetime
+from typing import Annotated, Any, DefaultDict, Literal, Optional
 from uuid import UUID
-from typing import Optional, DefaultDict, Literal, Annotated, Any
-from pydantic import BaseModel, Field
-from kubernetes.utils import parse_quantity
-from btrixcloud.models import (
-    StorageRef,
-    TYPE_ALL_CRAWL_STATES,
-    Organization,
-    CrawlStats,
-)
 
+from kubernetes.utils import parse_quantity
+from pydantic import BaseModel, Field
+
+from btrixcloud.models import (
+    TYPE_ALL_CRAWL_STATES,
+    CrawlStats,
+    Organization,
+    StorageRef,
+)
 
 BTRIX_API = "btrix.cloud/v1"
 

--- a/backend/btrixcloud/operator/profiles.py
+++ b/backend/btrixcloud/operator/profiles.py
@@ -1,11 +1,10 @@
 """Operator handler for ProfileJobs"""
 
-from btrixcloud.utils import str_to_date, dt_now, run_async_task
-
 from btrixcloud.models import StorageRef
+from btrixcloud.utils import dt_now, run_async_task, str_to_date
 
-from .models import MCSyncData
 from .baseoperator import BaseOperator
+from .models import MCSyncData
 
 
 # ============================================================================

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -1,18 +1,18 @@
 """shared helper to initialize ops classes"""
 
 from typing import Tuple
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 
-from .crawlmanager import CrawlManager
-from .db import init_db
-from .emailsender import EmailSender
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 
 from .background_jobs import BackgroundJobOps
 from .basecrawls import BaseCrawlOps
 from .colls import CollectionOps
-from .crawls import CrawlOps
-from .crawlconfigs import CrawlConfigOps
 from .crawl_logs import CrawlLogOps
+from .crawlconfigs import CrawlConfigOps
+from .crawlmanager import CrawlManager
+from .crawls import CrawlOps
+from .db import init_db
+from .emailsender import EmailSender
 from .file_uploads import FileUploadOps
 from .invites import InviteOps
 from .orgs import OrgOps

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -8,23 +8,25 @@ import json
 import math
 import os
 import time
-
-from uuid import UUID, uuid4
 from tempfile import NamedTemporaryFile
-
 from typing import (
-    Awaitable,
-    Optional,
     TYPE_CHECKING,
-    Dict,
+    Any,
+    AsyncGenerator,
+    Awaitable,
     Callable,
+    Dict,
     List,
     Literal,
-    AsyncGenerator,
-    Any,
+    Optional,
     cast,
 )
+from uuid import UUID, uuid4
 
+import json_stream
+from aiostream import stream
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from motor.motor_asyncio import (
     AsyncIOMotorClient,
     AsyncIOMotorClientSession,
@@ -34,98 +36,93 @@ from pydantic import ValidationError
 from pymongo import ReturnDocument
 from pymongo.errors import AutoReconnect, DuplicateKeyError
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import StreamingResponse
-import json_stream
-from aiostream import stream
-
 from .models import (
-    SUCCESSFUL_STATES,
+    ACTIVE,
+    MAX_BROWSER_WINDOWS,
+    MAX_CRAWL_SCALE,
+    PAUSED_PAYMENT_FAILED,
+    REASON_PAUSED,
     RUNNING_STATES,
+    SUCCESSFUL_STATES,
     WAITING_STATES,
+    AddedResponse,
+    AddedResponseId,
+    AddToOrgRequest,
     BaseCrawl,
-    FeatureFlagStats,
+    BgJobType,
+    Collection,
+    ConfigRevision,
+    Crawl,
+    CrawlConfig,
+    CrawlConfigDefaults,
+    DeleteCrawlList,
+    DeletedResponseId,
     FeatureFlags,
     FeatureFlagsPartial,
+    FeatureFlagStats,
+    InvitePending,
+    InviteToOrgRequest,
+    OrgAcceptInviteResponse,
     Organization,
-    PlansResponse,
-    StorageRef,
+    OrgCreate,
+    OrgDeleteInviteResponse,
+    OrgImportResponse,
+    OrgInviteResponse,
+    OrgMetrics,
+    OrgOut,
+    OrgOutExport,
+    OrgProxies,
+    OrgPublicProfileUpdate,
     OrgQuotas,
     OrgQuotasIn,
     OrgQuotaUpdate,
-    OrgReadOnlyUpdate,
     OrgReadOnlyOnCancel,
-    OrgMetrics,
+    OrgReadOnlyUpdate,
+    OrgSlugsResponse,
     OrgWebhookUrls,
-    OrgCreate,
-    OrgProxies,
-    Subscription,
-    SubscriptionUpdate,
-    SubscriptionCancel,
-    RenameOrg,
-    UpdateRole,
-    RemovePendingInvite,
-    RemoveFromOrg,
-    AddToOrgRequest,
-    InvitePending,
-    InviteToOrgRequest,
-    UserRole,
-    User,
+    PageWithAllQA,
     PaginatedInvitePendingResponse,
     PaginatedOrgOutResponse,
-    CrawlConfig,
-    Crawl,
-    CrawlConfigDefaults,
-    UploadedCrawl,
-    ConfigRevision,
+    PlansResponse,
     Profile,
-    Collection,
-    OrgOut,
-    OrgOutExport,
-    PageWithAllQA,
-    DeleteCrawlList,
-    PAUSED_PAYMENT_FAILED,
-    REASON_PAUSED,
-    ACTIVE,
-    DeletedResponseId,
-    UpdatedResponse,
-    AddedResponse,
-    AddedResponseId,
-    SuccessResponseId,
-    OrgInviteResponse,
-    OrgAcceptInviteResponse,
-    OrgDeleteInviteResponse,
     RemovedResponse,
-    OrgSlugsResponse,
-    OrgImportResponse,
-    OrgPublicProfileUpdate,
-    MAX_BROWSER_WINDOWS,
-    MAX_CRAWL_SCALE,
-    BgJobType,
+    RemoveFromOrg,
+    RemovePendingInvite,
+    RenameOrg,
+    StorageRef,
+    Subscription,
+    SubscriptionCancel,
+    SubscriptionUpdate,
+    SuccessResponseId,
+    UpdatedResponse,
+    UpdateRole,
+    UploadedCrawl,
+    User,
+    UserRole,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import (
-    dt_now,
-    slug_from_name,
-    validate_slug,
-    get_duplicate_key_error_field,
-    validate_language_code,
     JSONSerializer,
     browser_windows_from_scale,
     case_insensitive_collation,
+    dt_now,
+    get_duplicate_key_error_field,
+    slug_from_name,
+    validate_language_code,
+    validate_slug,
 )
 
 if TYPE_CHECKING:
-    from .invites import InviteOps
+    from .background_jobs import BackgroundJobOps
     from .basecrawls import BaseCrawlOps
     from .colls import CollectionOps
+    from .crawlconfigs import CrawlConfigOps
+    from .crawlmanager import CrawlManager
+    from .file_uploads import FileUploadOps
+    from .invites import InviteOps
+    from .pages import PageOps
     from .profiles import ProfileOps
     from .users import UserManager
-    from .background_jobs import BackgroundJobOps
-    from .pages import PageOps
-    from .file_uploads import FileUploadOps
-    from .crawlmanager import CrawlManager
-    from .crawlconfigs import CrawlConfigOps
 else:
     InviteOps = BaseCrawlOps = ProfileOps = CollectionOps = CrawlConfigOps = object
     BackgroundJobOps = UserManager = PageOps = FileUploadOps = CrawlManager = object

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -6,40 +6,40 @@ import asyncio
 import traceback
 import urllib.parse
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional, Tuple, List, Dict, Any, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID, uuid4
 
-from fastapi import Depends, HTTPException, Request, Response
 import pymongo
+from fastapi import Depends, HTTPException, Request, Response
 
 from .models import (
+    DeletedResponse,
+    EmptyResponse,
+    Organization,
     Page,
-    PageOut,
-    PageOutWithSingleQA,
-    PageReviewUpdate,
-    PageQACompare,
     PageIdTimestamp,
+    PageNote,
+    PageNoteAddedResponse,
+    PageNoteDelete,
+    PageNoteEdit,
+    PageNoteIn,
+    PageNoteUpdatedResponse,
+    PageOut,
+    PageOutItemsResponse,
+    PageOutWithSingleQA,
+    PageQACompare,
+    PageReviewUpdate,
     PageUrlCount,
     PageUrlCountResponse,
-    Organization,
     PaginatedPageOutResponse,
-    PageOutItemsResponse,
     PaginatedPageOutWithQAResponse,
-    User,
-    PageNote,
-    PageNoteIn,
-    PageNoteEdit,
-    PageNoteDelete,
     QARunBucketStats,
     StartedResponse,
     UpdatedResponse,
-    DeletedResponse,
-    PageNoteAddedResponse,
-    PageNoteUpdatedResponse,
-    EmptyResponse,
+    User,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import str_to_date, str_list_to_bools, dt_now
+from .utils import dt_now, str_list_to_bools, str_to_date
 
 if TYPE_CHECKING:
     from .background_jobs import BackgroundJobOps

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -2,7 +2,6 @@
 
 from typing import Any, List, Optional
 
-
 DEFAULT_PAGE_SIZE = 1_000
 
 

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -1,61 +1,60 @@
 """Profile Management"""
 
+import json
+import os
 from typing import (
-    Optional,
     TYPE_CHECKING,
+    Annotated,
     Any,
-    cast,
     Dict,
     List,
+    Optional,
     Tuple,
     Union,
-    Annotated,
+    cast,
 )
-from uuid import UUID, uuid4
-import os
-import json
-
 from urllib.parse import urlencode
+from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, Request, HTTPException, Query
+import aiohttp
+import pymongo
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from starlette.requests import Headers
-import pymongo
-import aiohttp
 
-from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
-    Profile,
-    ProfileFile,
-    UrlIn,
-    ProfileLaunchBrowserIn,
-    BrowserId,
-    ProfileCreate,
-    ProfileUpdate,
-    Organization,
-    User,
-    PaginatedProfileResponse,
-    StorageRef,
-    EmptyResponse,
-    SuccessResponse,
     AddedResponseIdQuota,
-    UpdatedResponse,
-    SuccessResponseStorageQuota,
-    ProfilePingResponse,
+    BrowserId,
+    EmptyResponse,
+    ListFilterType,
+    Organization,
+    PaginatedProfileResponse,
+    Profile,
     ProfileBrowserGetUrlResponse,
     ProfileBrowserMetadata,
-    TagsResponse,
-    ListFilterType,
+    ProfileCreate,
+    ProfileFile,
+    ProfileLaunchBrowserIn,
+    ProfilePingResponse,
     ProfileSearchValuesResponse,
+    ProfileUpdate,
+    StorageRef,
+    SuccessResponse,
+    SuccessResponseStorageQuota,
+    TagsResponse,
+    UpdatedResponse,
+    UrlIn,
+    User,
 )
-from .utils import dt_now, str_to_date, case_insensitive_collation, run_async_task
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .utils import case_insensitive_collation, dt_now, run_async_task, str_to_date
 
 if TYPE_CHECKING:
-    from .orgs import OrgOps
-    from .crawlmanager import CrawlManager
-    from .storages import StorageOps
-    from .crawlconfigs import CrawlConfigOps
     from .background_jobs import BackgroundJobOps
+    from .crawlconfigs import CrawlConfigOps
+    from .crawlmanager import CrawlManager
+    from .orgs import OrgOps
+    from .storages import StorageOps
 else:
     OrgOps = CrawlManager = StorageOps = CrawlConfigOps = BackgroundJobOps = object
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -2,69 +2,63 @@
 Storage API
 """
 
-from typing import (
-    Optional,
-    Iterator,
-    Iterable,
-    List,
-    Dict,
-    AsyncIterator,
-    TYPE_CHECKING,
-    Any,
-    cast,
-    Union,
-)
-from urllib.parse import urlsplit
-from contextlib import asynccontextmanager
-from itertools import chain
-
 import asyncio
-import time
 import heapq
-import zlib
 import json
 import os
-
+import time
+import zlib
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from itertools import chain
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+)
+from urllib.parse import urlsplit
 from zipfile import ZipInfo
 
-from fastapi import Depends, HTTPException, APIRouter
-from stream_zip import stream_zip, NO_COMPRESSION_64, Method
-from remotezip import RemoteZip
-from aiobotocore.config import AioConfig
-
 import aiobotocore.session
-import requests
 import pymongo
-
+import requests
+from aiobotocore.config import AioConfig
+from fastapi import APIRouter, Depends, HTTPException
+from remotezip import RemoteZip
+from stream_zip import NO_COMPRESSION_64, Method, stream_zip
 from types_aiobotocore_s3 import S3Client as AIOS3Client
 from types_aiobotocore_s3.type_defs import CompletedPartTypeDef
 
 from .models import (
+    PRESIGN_DURATION_SECONDS,
+    AddedResponseName,
     BaseFile,
     CrawlFile,
     CrawlFileOut,
+    DeletedResponse,
     Organization,
-    StorageRef,
+    OrgStorageRefs,
+    PresignedUrl,
     S3Storage,
     S3StorageIn,
-    OrgStorageRefs,
-    DeletedResponse,
-    UpdatedResponse,
-    AddedResponseName,
-    PRESIGN_DURATION_SECONDS,
-    PresignedUrl,
+    StorageRef,
     SuccessResponse,
+    UpdatedResponse,
     User,
 )
-
-from .utils import slug_from_name, dt_now, get_origin
+from .utils import dt_now, get_origin, slug_from_name
 from .version import __version__
 
-
 if TYPE_CHECKING:
-    from .orgs import OrgOps
     from .crawlmanager import CrawlManager
+    from .orgs import OrgOps
 else:
     OrgOps = CrawlManager = object
 

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -2,56 +2,54 @@
 Subscription API handling
 """
 
-from typing import Awaitable, Callable, Any, Optional, Tuple, List, Annotated
-import os
 import asyncio
-from uuid import UUID
+import os
 from datetime import datetime
+from typing import Annotated, Any, Awaitable, Callable, List, Optional, Tuple
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Query
 import aiohttp
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
-from .orgs import OrgOps
-from .users import UserManager
-from .utils import is_bool, get_origin
 from .models import (
+    REASON_CANCELED,
+    AddedResponseId,
     AddonMinutesPricing,
     CheckoutAddonMinutesRequest,
     CheckoutAddonMinutesResponse,
-    SubscriptionCreate,
-    SubscriptionImport,
-    SubscriptionUpdate,
-    SubscriptionCancel,
-    SubscriptionAddMinutes,
-    SubscriptionEventAny,
-    SubscriptionCreateOut,
-    SubscriptionImportOut,
-    SubscriptionUpdateOut,
-    SubscriptionCancelOut,
-    SubscriptionAddMinutesOut,
-    SubscriptionEventAnyOut,
-    SubscriptionEventType,
-    Subscription,
-    SubscriptionPortalUrlRequest,
-    SubscriptionPortalUrlResponse,
-    SubscriptionCanceledResponse,
-    SubscriptionTrialEndReminder,
+    InviteAddedResponse,
+    InviteToOrgRequest,
     Organization,
     OrgQuotasIn,
-    InviteToOrgRequest,
-    InviteAddedResponse,
+    PaginatedSubscriptionEventResponse,
+    Subscription,
+    SubscriptionAddMinutes,
+    SubscriptionAddMinutesOut,
+    SubscriptionCancel,
+    SubscriptionCanceledResponse,
+    SubscriptionCancelOut,
+    SubscriptionCreate,
+    SubscriptionCreateOut,
+    SubscriptionEventAny,
+    SubscriptionEventAnyOut,
+    SubscriptionEventType,
+    SubscriptionImport,
+    SubscriptionImportOut,
+    SubscriptionPortalUrlRequest,
+    SubscriptionPortalUrlResponse,
+    SubscriptionTrialEndReminder,
+    SubscriptionUpdate,
+    SubscriptionUpdateOut,
+    SuccessResponse,
+    UpdatedResponse,
     User,
     UserRole,
-    AddedResponseId,
-    UpdatedResponse,
-    SuccessResponse,
-    PaginatedSubscriptionEventResponse,
-    REASON_CANCELED,
 )
+from .orgs import OrgOps
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import dt_now, run_async_task
-
+from .users import UserManager
+from .utils import dt_now, get_origin, is_bool, run_async_task
 
 # if set, will enable this api
 subscriptions_enabled = is_bool(os.environ.get("BILLING_ENABLED"))

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -1,35 +1,34 @@
 """handle user uploads into browsertrix"""
 
 import uuid
+from io import BufferedReader
+from typing import Any, List, Optional
 from urllib.parse import unquote
 from uuid import UUID
 
-from io import BufferedReader
-from typing import Optional, List, Any
-from fastapi import Depends, UploadFile, File
-from fastapi import HTTPException
+from fastapi import Depends, File, HTTPException, UploadFile
 from starlette.requests import Request
 
 from .basecrawls import BaseCrawlOps
-from .storages import CHUNK_SIZE
 from .models import (
+    MIN_UPLOAD_PART_SIZE,
+    AddedResponseIdQuota,
+    CrawlFile,
     CrawlOut,
     CrawlOutWithResources,
-    CrawlFile,
     DeleteCrawlList,
-    UploadedCrawl,
-    UpdateUpload,
+    DeletedResponseQuota,
+    FilePreparer,
     Organization,
     PaginatedCrawlOutResponse,
-    User,
-    UpdatedResponse,
-    DeletedResponseQuota,
-    AddedResponseIdQuota,
-    FilePreparer,
-    MIN_UPLOAD_PART_SIZE,
     TagsResponse,
+    UpdatedResponse,
+    UpdateUpload,
+    UploadedCrawl,
+    User,
 )
-from .pagination import paginated_format, DEFAULT_PAGE_SIZE
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
+from .storages import CHUNK_SIZE
 from .utils import dt_now, run_async_task
 
 

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -3,63 +3,60 @@ FastAPI user handling (via fastapi-users)
 """
 
 import os
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type, cast
 from uuid import UUID, uuid4
 
-from typing import Optional, List, TYPE_CHECKING, cast, Callable, Tuple, Type
-
 from fastapi import (
-    Request,
-    HTTPException,
-    Depends,
     APIRouter,
     Body,
+    Depends,
+    HTTPException,
+    Request,
 )
-
-from pymongo.errors import DuplicateKeyError
 from pymongo.collation import Collation
+from pymongo.errors import DuplicateKeyError
 
+from .auth import (
+    RESET_ALLOW_AUD,
+    RESET_AUD,
+    RESET_VERIFY_TOKEN_LIFETIME_MINUTES,
+    VERIFY_ALLOW_AUD,
+    VERIFY_AUD,
+    decode_jwt,
+    generate_jwt,
+    generate_password,
+    get_password_hash,
+    init_jwt_auth,
+    verify_and_update_password,
+)
 from .models import (
     EmailStr,
-    UserCreate,
-    UserUpdateEmailName,
-    UserUpdatePassword,
+    FailedLogin,
+    InviteOut,
+    InvitePending,
+    PaginatedInvitePendingResponse,
+    PaginatedUserOutResponse,
+    SuccessResponse,
+    UpdatedResponse,
     User,
+    UserCreate,
     UserOrgInfoOut,
     UserOrgInfoOutWithSubs,
     UserOut,
     UserOutNoId,
     UserRole,
-    InvitePending,
-    InviteOut,
-    PaginatedInvitePendingResponse,
-    FailedLogin,
-    UpdatedResponse,
-    SuccessResponse,
-    PaginatedUserOutResponse,
+    UserUpdateEmailName,
+    UserUpdatePassword,
 )
 from .pagination import DEFAULT_PAGE_SIZE, paginated_format
-from .utils import is_bool, dt_now, run_async_task
-
-from .auth import (
-    init_jwt_auth,
-    RESET_AUD,
-    RESET_ALLOW_AUD,
-    VERIFY_AUD,
-    VERIFY_ALLOW_AUD,
-    RESET_VERIFY_TOKEN_LIFETIME_MINUTES,
-    verify_and_update_password,
-    get_password_hash,
-    generate_password,
-    generate_jwt,
-    decode_jwt,
-)
+from .utils import dt_now, is_bool, run_async_task
 
 if TYPE_CHECKING:
-    from .invites import InviteOps
-    from .emailsender import EmailSender
-    from .orgs import OrgOps
     from .basecrawls import BaseCrawlOps
     from .crawlconfigs import CrawlConfigOps
+    from .emailsender import EmailSender
+    from .invites import InviteOps
+    from .orgs import OrgOps
 else:
     InviteOps = EmailSender = OrgOps = BaseCrawlOps = CrawlConfigOps = object
 

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -4,14 +4,13 @@ import asyncio
 import csv
 import io
 import json
-import signal
-import os
-import sys
-import re
 import math
-
+import os
+import re
+import signal
+import sys
 from datetime import datetime, timezone
-from typing import Optional, Dict, Union, List, Any
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -22,7 +21,6 @@ from packaging.version import parse as parse_version
 from pymongo.collation import Collation
 from pymongo.errors import DuplicateKeyError
 from slugify import slugify
-
 
 default_origin = os.environ.get("APP_ORIGIN", "")
 

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -1,36 +1,36 @@
 """Webhook management"""
 
-from typing import List, Union, Optional, TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, List, Optional, Union, cast
 from uuid import UUID, uuid4
 
 import aiohttp
 import backoff
 from fastapi import APIRouter, Depends, HTTPException
 
-from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .models import (
-    WebhookEventType,
-    WebhookNotification,
-    CrawlStartedBody,
-    CrawlFinishedBody,
-    CrawlDeletedBody,
-    QaAnalysisStartedBody,
-    QaAnalysisFinishedBody,
-    CrawlReviewedBody,
-    UploadFinishedBody,
-    UploadDeletedBody,
+    CollectionDeletedBody,
     CollectionItemAddedBody,
     CollectionItemRemovedBody,
-    CollectionDeletedBody,
-    PaginatedWebhookNotificationResponse,
+    CrawlDeletedBody,
+    CrawlFinishedBody,
+    CrawlReviewedBody,
+    CrawlStartedBody,
     Organization,
+    PaginatedWebhookNotificationResponse,
+    QaAnalysisFinishedBody,
+    QaAnalysisStartedBody,
     QARun,
+    UploadDeletedBody,
+    UploadFinishedBody,
+    WebhookEventType,
+    WebhookNotification,
 )
+from .pagination import DEFAULT_PAGE_SIZE, paginated_format
 from .utils import dt_now, run_async_task
 
 if TYPE_CHECKING:
-    from .orgs import OrgOps
     from .crawls import CrawlOps
+    from .orgs import OrgOps
 else:
     OrgOps = CrawlOps = object
 

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+select = ["I"]

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,2 +1,2 @@
 [lint]
-select = ["I"]
+select = ["I", "PLE", "W", "A", "Q"]

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -1,13 +1,13 @@
 import os
-import pytest
-import requests
 import subprocess
 import time
 from typing import Dict
 from uuid import UUID
 
-from .utils import read_in_chunks
+import pytest
+import requests
 
+from .utils import read_in_chunks
 
 HOST_PREFIX = "http://127.0.0.1:30870"
 API_PREFIX = HOST_PREFIX + "/api"

--- a/backend/test/echo_server.py
+++ b/backend/test/echo_server.py
@@ -3,8 +3,8 @@
 A web server to record POST requests and return them on a GET request
 """
 
-from http.server import HTTPServer, BaseHTTPRequestHandler
 import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 BIND_HOST = "0.0.0.0"
 PORT = 18080

--- a/backend/test/test_all_crawls_review_status_filter.py
+++ b/backend/test/test_all_crawls_review_status_filter.py
@@ -1,7 +1,8 @@
-import requests
-import pytest
-import time
 import itertools
+import time
+
+import pytest
+import requests
 
 from .conftest import API_PREFIX, FINISHED_STATES
 

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -1,10 +1,10 @@
-import requests
 import os
 import time
-from uuid import uuid4
-
-from zipfile import ZipFile, ZIP_STORED
 from tempfile import TemporaryFile
+from uuid import uuid4
+from zipfile import ZIP_STORED, ZipFile
+
+import requests
 
 from .conftest import API_PREFIX, NON_DEFAULT_ORG_NAME, NON_DEFAULT_ORG_SLUG
 from .utils import read_in_chunks

--- a/backend/test/test_crawl_config_profile_filter.py
+++ b/backend/test/test_crawl_config_profile_filter.py
@@ -1,5 +1,5 @@
-import requests
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test/test_emails.py
+++ b/backend/test/test_emails.py
@@ -1,8 +1,8 @@
 """Tests for the email sending functionality in emailsender.py & email templating microservice"""
 
 import asyncio
-import uuid
 import os
+import uuid
 from datetime import datetime
 from typing import cast
 
@@ -11,11 +11,11 @@ import pytest
 
 from btrixcloud.emailsender import EmailSender
 from btrixcloud.models import (
-    Organization,
-    InvitePending,
-    EmailStr,
-    StorageRef,
     CreateReplicaJob,
+    EmailStr,
+    InvitePending,
+    Organization,
+    StorageRef,
 )
 from btrixcloud.utils import dt_now
 

--- a/backend/test/test_files.py
+++ b/backend/test/test_files.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 from .conftest import API_PREFIX

--- a/backend/test/test_filter_sort_results.py
+++ b/backend/test/test_filter_sort_results.py
@@ -1,5 +1,6 @@
-import requests
 import urllib.parse
+
+import requests
 
 from .conftest import API_PREFIX
 from .test_collections import UPDATED_NAME as COLLECTION_NAME

--- a/backend/test/test_lenient_validation.py
+++ b/backend/test/test_lenient_validation.py
@@ -8,7 +8,6 @@ from pydantic import Field, ValidationError
 
 from btrixcloud.db import LENIENT_ON_READ, BaseMongoModel
 
-
 # ---------------------------------------------------------------------------
 # Minimal test models
 # ---------------------------------------------------------------------------

--- a/backend/test/test_login.py
+++ b/backend/test/test_login.py
@@ -1,6 +1,6 @@
 import requests
 
-from .conftest import API_PREFIX, ADMIN_USERNAME, ADMIN_PW
+from .conftest import ADMIN_PW, ADMIN_USERNAME, API_PREFIX
 
 
 def test_login_invalid():

--- a/backend/test/test_org.py
+++ b/backend/test/test_org.py
@@ -1,8 +1,8 @@
 import os
-import requests
 import uuid
 
 import pytest
+import requests
 
 from .conftest import API_PREFIX, NON_DEFAULT_ORG_NAME, NON_DEFAULT_ORG_SLUG
 from .utils import read_in_chunks

--- a/backend/test/test_org_subs.py
+++ b/backend/test/test_org_subs.py
@@ -1,6 +1,7 @@
-import requests
 import time
 from uuid import uuid4
+
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -2,22 +2,22 @@ import time
 from typing import Dict
 from uuid import UUID
 
-import requests
 import pytest
+import requests
 
 from .conftest import (
     API_PREFIX,
-    PROFILE_NAME,
-    PROFILE_DESC,
-    PROFILE_TAGS,
-    PROFILE_NAME_UPDATED,
-    PROFILE_DESC_UPDATED,
-    PROFILE_2_NAME,
     PROFILE_2_DESC,
+    PROFILE_2_NAME,
     PROFILE_2_TAGS,
+    PROFILE_DESC,
+    PROFILE_DESC_UPDATED,
+    PROFILE_NAME,
+    PROFILE_NAME_UPDATED,
+    PROFILE_TAGS,
     PROFILE_TAGS_UPDATED,
-    prepare_browser_for_profile_commit,
     create_profile_browser,
+    prepare_browser_for_profile_commit,
 )
 
 

--- a/backend/test/test_qa.py
+++ b/backend/test/test_qa.py
@@ -1,11 +1,12 @@
-from .conftest import API_PREFIX, HOST_PREFIX
-import requests
 import time
 from datetime import datetime
 from tempfile import TemporaryFile
-from zipfile import ZipFile, ZIP_STORED
+from zipfile import ZIP_STORED, ZipFile
 
 import pytest
+import requests
+
+from .conftest import API_PREFIX, HOST_PREFIX
 
 MAX_ATTEMPTS = 24
 

--- a/backend/test/test_quota_updates.py
+++ b/backend/test/test_quota_updates.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-from btrixcloud.models import OrgQuotasIn, Organization, StorageRef, OrgQuotas
+
+from btrixcloud.models import Organization, OrgQuotas, OrgQuotasIn, StorageRef
 from btrixcloud.orgs import BaseOrgs, OrgOps
 from btrixcloud.utils import dt_now
 

--- a/backend/test/test_quotas.py
+++ b/backend/test/test_quotas.py
@@ -1,5 +1,6 @@
 import uuid
-from btrixcloud.models import Organization, StorageRef, OrgQuotas
+
+from btrixcloud.models import Organization, OrgQuotas, StorageRef
 from btrixcloud.orgs import BaseOrgs
 from btrixcloud.utils import dt_now
 

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -1,18 +1,18 @@
-import requests
-import hashlib
-import time
-import io
-import zipfile
-import re
-import csv
 import codecs
+import csv
+import hashlib
+import io
 import json
+import re
+import time
+import zipfile
 from tempfile import TemporaryFile
-from zipfile import ZipFile, ZIP_STORED
+from zipfile import ZIP_STORED, ZipFile
 
 import pytest
+import requests
 
-from .conftest import API_PREFIX, HOST_PREFIX, FINISHED_STATES
+from .conftest import API_PREFIX, FINISHED_STATES, HOST_PREFIX
 from .test_collections import UPDATED_NAME as COLLECTION_NAME
 
 wacz_path = None

--- a/backend/test/test_stop_cancel_crawl.py
+++ b/backend/test/test_stop_cancel_crawl.py
@@ -1,7 +1,8 @@
-import requests
-import time
 import os
+import time
+
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test/test_uploads.py
+++ b/backend/test/test_uploads.py
@@ -1,15 +1,14 @@
-import requests
 import os
 import time
 from tempfile import TemporaryFile
 from urllib.parse import urljoin
-from zipfile import ZipFile, ZIP_STORED
+from zipfile import ZIP_STORED, ZipFile
 
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 from .utils import read_in_chunks
-
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 

--- a/backend/test/test_users.py
+++ b/backend/test/test_users.py
@@ -1,13 +1,14 @@
-import requests
 import time
 from uuid import uuid4
 
+import requests
+
 from .conftest import (
+    ADMIN_USERNAME,
     API_PREFIX,
+    CRAWLER_PW,
     CRAWLER_USERNAME,
     CRAWLER_USERNAME_LOWERCASE,
-    CRAWLER_PW,
-    ADMIN_USERNAME,
     FINISHED_STATES,
 )
 

--- a/backend/test/test_utils.py
+++ b/backend/test/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from btrixcloud.utils import slug_from_name, crawler_image_below_minimum
+from btrixcloud.utils import crawler_image_below_minimum, slug_from_name
 
 
 @pytest.mark.parametrize(

--- a/backend/test/test_workflow_auto_add_to_collection.py
+++ b/backend/test/test_workflow_auto_add_to_collection.py
@@ -1,5 +1,6 @@
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test/test_y_org_import_export.py
+++ b/backend/test/test_y_org_import_export.py
@@ -1,20 +1,21 @@
 import json
 import os
-import requests
 import tempfile
 import time
 
-from .conftest import API_PREFIX
+import requests
+
 from btrixcloud.models import (
-    Organization,
-    Profile,
-    CrawlConfig,
-    ConfigRevision,
     BaseCrawl,
     Collection,
+    ConfigRevision,
+    CrawlConfig,
+    Organization,
     Page,
+    Profile,
 )
 
+from .conftest import API_PREFIX
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 

--- a/backend/test/test_z_delete_org.py
+++ b/backend/test/test_z_delete_org.py
@@ -1,6 +1,7 @@
-import requests
 import time
+
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -1,8 +1,8 @@
-import pytest
-import requests
 import time
 from datetime import datetime, timezone
 
+import pytest
+import requests
 
 HOST_PREFIX = "http://127.0.0.1:30870"
 API_PREFIX = HOST_PREFIX + "/api"

--- a/backend/test_nightly/echo_server.py
+++ b/backend/test_nightly/echo_server.py
@@ -3,8 +3,8 @@
 A web server to record POST requests and return them on a GET request
 """
 
-from http.server import HTTPServer, BaseHTTPRequestHandler
 import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 BIND_HOST = "0.0.0.0"
 PORT = 18080

--- a/backend/test_nightly/test_cleanup_seed_files.py
+++ b/backend/test_nightly/test_cleanup_seed_files.py
@@ -1,8 +1,8 @@
 import os
-import requests
 import time
 
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 from .utils import read_in_chunks

--- a/backend/test_nightly/test_concurrent_crawl_limit.py
+++ b/backend/test_nightly/test_concurrent_crawl_limit.py
@@ -1,5 +1,6 @@
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX
 from .utils import get_crawl_status

--- a/backend/test_nightly/test_crawl_behavior_logs.py
+++ b/backend/test_nightly/test_crawl_behavior_logs.py
@@ -1,7 +1,7 @@
 import time
 
-import requests
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_crawl_errors.py
+++ b/backend/test_nightly/test_crawl_errors.py
@@ -1,5 +1,5 @@
-import requests
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_crawl_logs.py
+++ b/backend/test_nightly/test_crawl_logs.py
@@ -1,11 +1,10 @@
 import json
-import requests
 import time
 
 import pytest
+import requests
 
 from .conftest import API_PREFIX
-
 
 LINES_TO_TEST = 10
 

--- a/backend/test_nightly/test_crawl_not_logged_in.py
+++ b/backend/test_nightly/test_crawl_not_logged_in.py
@@ -1,9 +1,9 @@
 import time
+from typing import Dict
+from uuid import UUID
 
 import pytest
 import requests
-from typing import Dict
-from uuid import UUID
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -1,5 +1,6 @@
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX
 from .utils import verify_file_replicated

--- a/backend/test_nightly/test_crawlconfig_crawl_stats.py
+++ b/backend/test_nightly/test_crawlconfig_crawl_stats.py
@@ -1,5 +1,6 @@
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_dedupe.py
+++ b/backend/test_nightly/test_dedupe.py
@@ -1,11 +1,11 @@
-import time
-import pytest
-import requests
 import random
 import string
+import time
+
+import pytest
+import requests
 
 from .conftest import API_PREFIX
-
 
 MAX_ATTEMPTS = 24
 

--- a/backend/test_nightly/test_delete_crawls.py
+++ b/backend/test_nightly/test_delete_crawls.py
@@ -1,6 +1,7 @@
 import os
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX, HOST_PREFIX
 from .utils import verify_file_and_replica_deleted

--- a/backend/test_nightly/test_invite_expiration.py
+++ b/backend/test_nightly/test_invite_expiration.py
@@ -1,5 +1,6 @@
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_max_crawl_size_limit.py
+++ b/backend/test_nightly/test_max_crawl_size_limit.py
@@ -1,5 +1,6 @@
-import requests
 import time
+
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_org_deletion.py
+++ b/backend/test_nightly/test_org_deletion.py
@@ -1,8 +1,8 @@
-import requests
 import time
 from uuid import uuid4
 
 import pytest
+import requests
 
 from .conftest import API_PREFIX
 

--- a/backend/test_nightly/test_storage_quota.py
+++ b/backend/test_nightly/test_storage_quota.py
@@ -1,12 +1,12 @@
 import math
-import requests
 import time
 from datetime import datetime
 from typing import Dict
 
+import requests
+
 from .conftest import API_PREFIX
 from .utils import get_crawl_status
-
 
 STORAGE_QUOTA_MB_TO_INCREASE = 5
 STORAGE_QUOTA_BYTES_INC = STORAGE_QUOTA_MB_TO_INCREASE * 1000 * 1000

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -1,13 +1,13 @@
-import time
 import os
+import time
+
 import requests
 
 from .conftest import API_PREFIX
-
 from .utils import (
     read_in_chunks,
-    verify_file_replicated,
     verify_file_and_replica_deleted,
+    verify_file_replicated,
 )
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -1,11 +1,9 @@
 """background jobs tests, named to run after everything else has finished"""
 
+import pytest
 import requests
 
-import pytest
-
 from .conftest import API_PREFIX
-
 
 job_id = None
 

--- a/backend/test_nightly/utils.py
+++ b/backend/test_nightly/utils.py
@@ -1,13 +1,12 @@
 """nightly test utils"""
 
-import requests
 import hashlib
 import os
 import tempfile
 
 import boto3
 import pytest
-
+import requests
 
 from .conftest import API_PREFIX
 


### PR DESCRIPTION
Small change with a large set of changes, we'd (briefly) talked about this in Discord.

Enables ruff's `isort` ruleset, which automatically sorts imports into groups. This PR enables the rule, adds sorting checks to the pre-commit hook & CI, and applies the auto-fixer to all of our backend code. 

This also enables a couple other rules that do not raise any issues with the current codebase (Pylint errors `PLE`, pycodestyle warnings `W`, flake8 builtins `A`, and flake8 quotes `Q` — all pretty straightforward rules that might catch hard-to-find bugs once in a while).

The changes worth looking at are in c314f2422a019d66e504e7bf8488fde34e554805 and 4b223d54e01bfbe78f4af8158f94279a8ac9cb93, those in 35dd27ee8053883b5454d14f2465f7abaa868f9d are just the result of applying the fix.