### PR TITLE
Update `emails` container name to "emails" from "api"

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Print Emails Logs
         if: ${{ always() }}
-        run: kubectl logs svc/browsertrix-cloud-emails -c api
+        run: kubectl logs svc/browsertrix-cloud-emails -c emails
 
       - name: Print K8S Events
         if: ${{ always() }}

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Print Emails Logs
         if: ${{ always() }}
-        run: kubectl logs svc/browsertrix-cloud-emails -c api
+        run: kubectl logs svc/browsertrix-cloud-emails -c emails
 
       - name: Print K8S Events
         if: ${{ always() }}

--- a/chart/templates/emails.yaml
+++ b/chart/templates/emails.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
 
       containers:
-        - name: api
+        - name: emails
           image: {{ .Values.emails_image }}
           imagePullPolicy: {{ .Values.emails_pull_policy }}
           command:
@@ -99,7 +99,7 @@ spec:
   ports:
     - protocol: TCP
       port: 3000
-      name: api
+      name: emails
 
   {{- if and .Values.local_emails_port (not .Values.ingress.host) }}
       nodePort: {{ .Values.local_emails_port }}


### PR DESCRIPTION
Quick change to address an issue making it a little harder to search through logs: both the primary backend container and the email templating container were named "api". It's possible to filter by pod name with a regex, but that's complicated and unintuitive – this simplifies that.