### PR TITLE
WIP: Add user-friendly sort order to initial pages in collection replay.json endpoint

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -431,7 +431,8 @@ class CollectionOps:
                 result["initialPages"] = initial_pages
                 result["pagesQueryUrl"] = (
                     origin
-                    + f"/api/orgs/{org.id}/collections/{coll_id}/{public}pages?sortBy=isSeed&sortDirection=1"
+                    + f"/api/orgs/{org.id}/collections/{coll_id}/{public}pages"
+                    + "?sortBy=isSeed&sortDirection=1"
                 )
 
         thumbnail = result.get("thumbnail")

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -411,8 +411,7 @@ class CollectionOps:
             ) = await self.get_collection_crawl_resources(coll_id, org)
 
             initial_pages, _ = await self.page_ops.list_pages(
-                crawl_ids=crawl_ids,
-                page_size=25,
+                crawl_ids=crawl_ids, page_size=25, sort_by="isSeed", sort_direction=1
             )
 
             public = "public/" if public_or_unlisted_only else ""
@@ -431,7 +430,8 @@ class CollectionOps:
             if pages_optimized:
                 result["initialPages"] = initial_pages
                 result["pagesQueryUrl"] = (
-                    origin + f"/api/orgs/{org.id}/collections/{coll_id}/{public}pages"
+                    origin
+                    + f"/api/orgs/{org.id}/collections/{coll_id}/{public}pages?sortBy=isSeed&sortDirection=1"
                 )
 
         thumbnail = result.get("thumbnail")

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -694,7 +694,18 @@ class PageOps:
                 # note: not using qa.{qa_run_id} because $set above means qa = qa.{qa_run_id}
                 sort_by = f"qa.{sort_by}"
 
-            aggregate.extend([{"$sort": {sort_by: sort_direction}}])
+            sort_query = {sort_by: sort_direction}
+
+            if sort_by == "isSeed":
+                # If sorting first by seed, add secondary and tertiary sorts of URL
+                # and timestamp so that page order comes out nicely in replay
+                sort_query = {
+                    "isSeed": sort_direction,
+                    "url": sort_direction,
+                    "ts": sort_direction,
+                }
+
+            aggregate.extend([{"$sort": sort_query}])
 
         # default sort with search
         elif search or url_prefix:


### PR DESCRIPTION
Fixes #3356 

This PR applies a new sort order to the `initialPages` returned by the collection replay.json endpoint, as part of the solution to provide a more sensible order of pages in collection replay.

Specifically, this applies `isSeed` as the primary sort order, followed by `url` and then `ts`.

Kept in draft for now for two reasons:
- It appears RWP/wabac.js is adding its own sort order for pages regardless of what the backend passes in, so this change alone doesn't resolve the problem
- I'm unsure at this point if adding the query parameters to the `pagesQueryUrl` to match the `initialPages` sort order will break any of the code in RWP/wabac.js that fetches subsequent pages