### PR TITLE
Increase retries and observability for replication jobs

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -537,6 +537,11 @@ class BackgroundJobOps:
         """Update job as finished, including
         job-specific task handling"""
 
+        print(
+            f"Finishing job: {job_id=} {job_type=} {success=} {finished=} {started=} {oid=}",
+            flush=True,
+        )
+
         # For seed file cleanup jobs, no database record will exist for each
         # run before this point, so create it here
         if job_type == BgJobType.CLEANUP_SEED_FILES:
@@ -561,16 +566,24 @@ class BackgroundJobOps:
 
         job = await self.get_background_job(job_id)
         if not job or job.finished:
+            print(f"No job found for job {job_id}", flush=True)
             return
 
         if job.type != job_type:
+            print(
+                f"Job type mismatch for job {job_id}: {job.type} vs {job_type}",
+                flush=True,
+            )
             raise HTTPException(status_code=400, detail="invalid_job_type")
 
         if success and job_type == BgJobType.CREATE_REPLICA:
+            print(f"Handling replication success for job {job_id}", flush=True)
             await self.handle_replica_job_succeeded(cast(CreateReplicaJob, job))
 
         if job_type == BgJobType.DELETE_REPLICA:
             await self.handle_delete_replica_job_finished(cast(DeleteReplicaJob, job))
+
+        print(f"Updating job {job_id}, {success=} {finished=}")
 
         await self.jobs.find_one_and_update(
             {"_id": job_id, "oid": oid},

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -38,15 +38,20 @@ class BgJobOperator(BaseOperator):
         job_type: str = labels.get("job_type") or ""
         job_id: str = labels.get("job_id") or metadata.get("name")
 
+        print(f"Finalizing job {job_id} (type: {job_type})", flush=True)
+
         status = data.object["status"]
         spec = data.object["spec"]
-        success = status.get("succeeded") == spec.get("parallelism")
+        parallelism = spec.get("parallelism") or 1
+        success = status.get("succeeded") == parallelism
         if not success:
             print(
                 f"Succeeded: {status.get('succeeded')}, Num Pods: {spec.get('parallelism')}"
             )
         start_time = status.get("startTime")
         completion_time = status.get("completionTime")
+
+        print(f"{job_id=} {success=} {start_time=} {completion_time=}", flush=True)
 
         finalized = True
 
@@ -65,6 +70,8 @@ class BgJobOperator(BaseOperator):
         # pylint: disable=broad-except
         except Exception:
             org_id = None
+
+        print(f"{job_id=} {finished=} {org_id=}", flush=True)
 
         try:
             await self.background_job_ops.job_finished(

--- a/chart/app-templates/replica_job.yaml
+++ b/chart/app-templates/replica_job.yaml
@@ -8,8 +8,8 @@ metadata:
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 0
-  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
   template:
     spec:
       restartPolicy: Never


### PR DESCRIPTION
Partial fix for https://github.com/webrecorder/browsertrix/issues/3365
Related to https://github.com/webrecorder/browsertrix/issues/3342

We've been seeing many more odd `create-replica` jobs lately that never update the database after completion. These jobs by and large have `success` and `finished` values of null in the database, indicating something unexpected is happening in the operator. The `replica` array on the associated crawl files is also left empty.

The actual rclone job seems to be successful in at least many cases. In those cases the files are replicated, but the database is never updated after the fact as it should be to reflect that state.

This PR makes a few changes to help make this job more resilient (which will help in the case of actual failures due to network issues, etc.) and to hunt down the source of the issue in production.

## Permanent changes

- Increase replica job `backoffLimit` from 3 to 10 to allow many more retries over a longer period of time

## Temporary changes for debugging

- Set `ttlSecondsAfterFinished` for replica jobs to 600, or 10 minutes, so that we have more observability into the logs of the failed pods
- Add print logging at many steps in the background job finalizer to assist in determining the cause of the issue