### PR TITLE
docs: Add security notice & dedicated security page

### DIFF
--- a/frontend/docs/docs/deploy/index.md
+++ b/frontend/docs/docs/deploy/index.md
@@ -6,7 +6,7 @@
 
 !!! danger "Security vulnerability in versions of Browsertrix prior to v1.22.8"
 
-    Versions of Browsertrix prior to v1.22.8 are vulnerable to a security issue that allows users with crawler permissions to access all data on the Browsertrix instance. If you are running an older version, upgrade to v1.22.8 or later to mitigate this issue, or [contact us for assistance](mailto:support@webrecorder.net) if you are unable to upgrade.
+    Versions of Browsertrix >=v1.15.0 and <v1.22.8 are vulnerable to a security issue that allows users with crawler permissions to access all data on the Browsertrix instance. If you are running an older version, upgrade to v1.22.8 or later to mitigate this issue, or [contact us for assistance](mailto:support@webrecorder.net) if you are unable to upgrade.
 
     Learn more about this security vulnerability and how to upgrade in the [security advisory](https://github.com/webrecorder/browsertrix/security/advisories/GHSA-47vv-v544-r985).
 

--- a/frontend/docs/docs/deploy/index.md
+++ b/frontend/docs/docs/deploy/index.md
@@ -8,7 +8,9 @@
 
     Versions of Browsertrix >=v1.15.0 and <v1.22.8 are vulnerable to a security issue that allows users with crawler permissions to access all data on the Browsertrix instance. If you are running an older version, upgrade to v1.22.8 or later to mitigate this issue, or [contact us for assistance](mailto:support@webrecorder.net) if you are unable to upgrade.
 
-    Learn more about this security vulnerability and how to upgrade in the [security advisory](https://github.com/webrecorder/browsertrix/security/advisories/GHSA-47vv-v544-r985).
+    We also recommend upgrading Browsertrix Crawler to v1.13.0 or later if your instance is pinned to an older version.
+
+    Learn more about this security vulnerability and how to upgrade in the [security advisory](https://github.com/webrecorder/browsertrix/security/advisories/GHSA-47vv-v544-r985).    
 
 Browsertrix is designed to be a cloud-native application running in Kubernetes.
 

--- a/frontend/docs/docs/deploy/index.md
+++ b/frontend/docs/docs/deploy/index.md
@@ -4,6 +4,12 @@
 
     This guide is for developers and users who are self-hosting Browsertrix. If you've registered through [webrecorder.net](https://webrecorder.net/browsertrix), you may be looking for the [user guide](../user-guide/index.md).
 
+!!! danger "Security vulnerability in versions of Browsertrix prior to v1.22.8"
+
+    Versions of Browsertrix prior to v1.22.8 are vulnerable to a security issue that allows users with crawler permissions to access all data on the Browsertrix instance. If you are running an older version, upgrade to v1.22.8 or later to mitigate this issue, or [contact us for assistance](mailto:support@webrecorder.net) if you are unable to upgrade.
+
+    Learn more about this security vulnerability and how to upgrade in the [security advisory](https://github.com/webrecorder/browsertrix/security/advisories/GHSA-47vv-v544-r985).
+
 Browsertrix is designed to be a cloud-native application running in Kubernetes.
 
 However, it is perfectly reasonable to deploy Browsertrix locally using one of the many available local Kubernetes options.

--- a/frontend/docs/docs/deploy/security.md
+++ b/frontend/docs/docs/deploy/security.md
@@ -1,0 +1,6 @@
+# Security
+
+We publish security advisories for Browsertrix on [GitHub](https://github.com/webrecorder/browsertrix/security/advisories). We also recommend signing up for our [security mailing list](https://mailchi.mp/webrecorder/webrecorder-security-announcements) to receive notifications about security updates for Browsertrix and our other open-source tools.
+
+## Reporting Security Vulnerabilities
+We welcome security vulnerability reports from the community. If you believe you have found a security vulnerability in Browsertrix, please let us know via [email](mailto:security@webrecorder.org) or [GitHub](https://github.com/webrecorder/browsertrix/security/advisories).

--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Administration:
           - deploy/admin/upgrade-notes.md
           - deploy/admin/org-import-export.md
+      - deploy/security.md
   - Development:
       - develop/index.md
       - develop/local-dev-setup.md


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/security/advisories/GHSA-47vv-v544-r985 publish.