### PR TITLE
ruff: flag asyncio.create_subprocess_shell

### DIFF
--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -9,7 +9,9 @@ extend-select = [
 	# flake8-builtins
 	"A",
 	# flake8-quotes
-	"Q"
+	"Q",
+	# banned-api
+	"TID251",
 ]
 ignore = [
 	# Comparison to true should be 'if cond is true:' or 'if cond:'
@@ -25,3 +27,5 @@ ignore = [
 	# unused variable
 	"F841"
 ]
+[lint.flake8-tidy-imports.banned-api]
+"asyncio.create_subprocess_shell".msg = "Use the non-shell asyncio.create_subprocess_exec function instead."


### PR DESCRIPTION
refs #3371 - makes sure we flag this automatically so we get nudged towards the API we'd rather use.

This won't catch `subprocess` functions with `shell=True`, since those aren't separate functions, but we do seem to prefer the asyncio versions anyway.

See https://docs.astral.sh/ruff/settings/#lint_flake8-tidy-imports_ban-relative-imports for the config docs.