### PR TITLE
Add ruff ignore for banned subprocess shell method

### DIFF
--- a/backend/test/test_unit_crawlconfigs.py
+++ b/backend/test/test_unit_crawlconfigs.py
@@ -179,7 +179,7 @@ async def test_shell_injection_positive_control():
 
     try:
         # Simulate the old vulnerable code path
-        proc = await asyncio.create_subprocess_shell(
+        proc = await asyncio.create_subprocess_shell(  # noqa: TID251
             f"git ls-remote {malicious_url} HEAD"
         )
         await asyncio.wait_for(proc.wait(), timeout=5)


### PR DESCRIPTION
Follows #3371 and #3373 - the latter added a check that flags the call that is made in one of the tests added in the former to ensure it doesn't get used.