### PR TITLE
Add uv configuration to exclude packages newer than 7 days

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
     "uvicorn[standard]>=0.46.0",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 stream-zip = { url = "https://github.com/ikreymer/stream-zip/archive/refs/heads/crc32-optional.zip" }
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"


### PR DESCRIPTION
Now that we're using uv instead of pip, we can set up a rule to help protect against supply chain attacks.

This sets the minimum pypi package age to 7 days.