### PR TITLE
dependabot: group together by dev/prod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,31 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"
   - package-ecosystem: "npm"
     directory: "/emails"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"
   - package-ecosystem: "uv"
     directory: "/backend"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"
 ...


### PR DESCRIPTION
The previous config ended up being a bit overwhelming. This regroups the deps into large dev/prod groups.