### PR TITLE
fix: Prevent losing collection navigation context when navigating item tabs

### DIFF
--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -679,7 +679,9 @@ export class ArchivedItemDetail extends BtrixElement {
       beta?: boolean;
     }) => {
       const isActive = section === this.activeTab;
-      const baseUrl = window.location.pathname.split("#")[0];
+      const url = new URL(window.location.href);
+      const baseUrl = `${url.pathname}${url.search}`;
+
       return html`
         <btrix-navigation-button
           class="whitespace-nowrap md:whitespace-normal"


### PR DESCRIPTION
Resolves #3357

## Changes

Fixes page reloading and losing "Back to collection" navigation context when navigating to an archived item tab.

## Manual testing

1. Log in
2. Go to Collections
3. Choose collection with archived items
4. Go to Archived Items
5. Choose an archived item
6. Click any tab, like "Quality Assurance". Verify only the tab content refreshes and "Back to collection" link remains