### PR TITLE
deps: Upgrade to Node 24

### DIFF
--- a/.github/workflows/frontend-lint-test-build.yaml
+++ b/.github/workflows/frontend-lint-test-build.yaml
@@ -45,7 +45,7 @@ jobs:
     if: needs.paths-filter.outputs.matches == 'true'
     strategy:
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     steps:
       # Setup:
       - name: Checkout
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     env:
       E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
       E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
@@ -189,7 +189,7 @@ jobs:
     if: needs.paths-filter.outputs.matches == 'true'
     strategy:
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     steps:
       # Setup:
       - name: Checkout
@@ -222,7 +222,7 @@ jobs:
     if: needs.paths-filter.outputs.matches == 'true'
     strategy:
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     steps:
       # Setup:
       - name: Checkout
@@ -259,7 +259,7 @@ jobs:
     if: needs.paths-filter.outputs.matches == 'true'
     strategy:
       matrix:
-        node: [20, 22]
+        node: [22, 24]
     steps:
       # Setup:
       - name: Checkout

--- a/.github/workflows/weblate-reformat.yaml
+++ b/.github/workflows/weblate-reformat.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'yarn'
           cache-dependency-path: frontend/yarn.lock
       - name: Install dependencies

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM docker.io/library/node:22-alpine as build_deps
+FROM --platform=$BUILDPLATFORM docker.io/library/node:24-alpine as build_deps
 
 WORKDIR /app
 COPY .yarnrc yarn.lock package.json ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,7 +18,6 @@ COPY --link lit-localize.json \
     index.d.ts \
     ./
 
-COPY --link lib ./lib/
 COPY --link src ./src/
 
 # Build variables used to show current app version

--- a/frontend/docs/docs/develop/frontend-dev.md
+++ b/frontend/docs/docs/develop/frontend-dev.md
@@ -12,7 +12,7 @@ The frontend development server requires an existing backend that has been deplo
 
 Once deployed, make note of the URL to the backend API. If you've deployed the backend locally using default values, the URL will be `http://localhost:30870`.
 
-### 2. Node.js ≥20
+### 2. Node.js ≥22
 
 To check if you already have Node.js installed, run the following command in your command line terminal:
 
@@ -20,13 +20,14 @@ To check if you already have Node.js installed, run the following command in you
 node --version
 ```
 
-You should see a version number like `v20.17.0`. If you see a command line error instead of a version number, [install Node.js](https://nodejs.org/en/download/package-manager) before continuing.
+You should see a version number like `v24.17.0`. If you see a command line error instead of a version number, [install Node.js](https://nodejs.org/en/download/package-manager) before continuing.
 
 ??? question "What if my other project requires a different version of Node.js?"
 
     You can use [Node Version Manager](https://nodejs.org/en/download/package-manager#nvm) to install multiple Node.js versions and switch versions between projects.
 
 ### 3. Yarn 1 (Classic)
+
 To verify your Yarn installation:
 
 ```sh
@@ -39,7 +40,6 @@ If Yarn isn't installed, install [Yarn 1 (Classic)](https://classic.yarnpkg.com/
 
 If your Yarn version is `2.0` or greater, run the following from your Browsertrix project directory to enable Yarn 1:
 
-
 ```sh
 cd frontend
 corepack enable
@@ -47,7 +47,6 @@ corepack install
 ```
 
 Check out the full [Yarn + Corepack installation guide](https://yarnpkg.com/corepack) for more details.
-
 
 ## Quickstart
 

--- a/frontend/lib/intl-durationformat.js
+++ b/frontend/lib/intl-durationformat.js
@@ -1,4 +1,0 @@
-// Polyfill doesn't have an export--provide our own
-require("@formatjs/intl-durationformat/lib/polyfill");
-
-module.exports = window.Intl.DurationFormat;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -171,7 +171,7 @@
     }
   },
   "engines": {
-    "node": ">=20 <23"
+    "node": ">=22 <25"
   },
   "resolutions": {
     "**/playwright": "1.49.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -156,7 +156,7 @@
   "optionalDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@open-wc/testing": "^3.2.0",
-    "@playwright/test": "1.57.0",
+    "@playwright/test": "1.60.0",
     "@types/react": "^19.1.3",
     "@web/test-runner": "^0.13.22",
     "@web/test-runner-playwright": "^0.11.1",
@@ -174,7 +174,7 @@
     "node": ">=22 <25"
   },
   "resolutions": {
-    "**/playwright": "1.57.0",
+    "**/playwright": "1.60.0",
     "**/lit": "~3.2.0",
     "**/@web/dev-server-core": "^0.7.5",
     "**/koa": "^2.16.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@awesome.me/webawesome": "^3.1.0",
     "@cheap-glitch/mi-cron": "^1.0.1",
-    "@formatjs/intl-durationformat": "^0.6.4",
-    "@formatjs/intl-localematcher": "^0.5.9",
+    "@formatjs/intl-durationformat": "^0.10.15",
+    "@formatjs/intl-localematcher": "^0.8.10",
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
     "@lit/context": "^1.1.3",
     "@lit/localize": "^0.12.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -156,7 +156,7 @@
   "optionalDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@open-wc/testing": "^3.2.0",
-    "@playwright/test": "1.49.0",
+    "@playwright/test": "1.57.0",
     "@types/react": "^19.1.3",
     "@web/test-runner": "^0.13.22",
     "@web/test-runner-playwright": "^0.11.1",
@@ -174,7 +174,7 @@
     "node": ">=22 <25"
   },
   "resolutions": {
-    "**/playwright": "1.49.0",
+    "**/playwright": "1.57.0",
     "**/lit": "~3.2.0",
     "**/@web/dev-server-core": "^0.7.5",
     "**/koa": "^2.16.1"

--- a/frontend/src/utils/executionTimeFormatter.test.ts
+++ b/frontend/src/utils/executionTimeFormatter.test.ts
@@ -37,7 +37,7 @@ describe("formatHours", () => {
       "12.345.000 h",
     );
     expect(humanizeSeconds(44_442_000_000, { locale: "de-DE" })).to.equal(
-      "12.345.000 Std.",
+      "12.345.000h",
     );
     expect(humanizeSeconds(44_442_000_000, { locale: "ar-EG" })).to.equal(
       "١٢٬٣٤٥٬٠٠٠ س",

--- a/frontend/src/utils/localize.test.ts
+++ b/frontend/src/utils/localize.test.ts
@@ -138,7 +138,7 @@ describe("Localize", () => {
           seconds: 4,
           milliseconds: 5,
         }),
-      ).to.equal("1 ቀ፣ 2 ሰ፣ 3 ደ፣ 4 ሰ 5 ሚሴ");
+      ).to.equal("1 ቀ፣ 2 ሰ፣ 3 ደ፣ 4 ሰ እና 5 ሚሴ");
     });
 
     it("formats an empty duration", () => {

--- a/frontend/src/utils/localize.ts
+++ b/frontend/src/utils/localize.ts
@@ -1,10 +1,5 @@
-/**
- * Manage translations and language-specific formatting throughout app
- *
- * @FIXME The Intl.DurationFormat polyfill is currently shimmed with webpack.ProvidePlugin
- * to avoid encoding issues when importing the polyfill asynchronously in the test server.
- * See https://github.com/web-dev-server/web-dev-server/issues/1
- */
+import "@formatjs/intl-durationformat/polyfill.js";
+
 import { match } from "@formatjs/intl-localematcher";
 import { configureLocalization } from "@lit/localize";
 import uniq from "lodash/uniq";

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -71,7 +71,6 @@ export default {
         "node_modules/slugify/**/*",
         "node_modules/parse-ms/**/*",
         "node_modules/regex-colorize/**/*",
-        "node_modules/@formatjs/intl-durationformat/**/*",
         "node_modules/@floating-ui/**/*",
       ],
     }),

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -189,14 +189,6 @@ const main = {
   },
 
   plugins: [
-    // Shim polyfill
-    new webpack.ProvidePlugin({
-      "Intl.DurationFormat": path.resolve(
-        __dirname,
-        "lib/intl-durationformat.js",
-      ),
-    }),
-
     new webpack.DefinePlugin(defineConfig),
 
     new webpack.optimize.LimitChunkCountPlugin({

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1779,12 +1779,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@1.49.0":
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.49.0.tgz#74227385b58317ee076b86b56d0e1e1b25cff01e"
-  integrity sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==
+"@playwright/test@1.57.0":
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.57.0.tgz#a14720ffa9ed7ef7edbc1f60784fc6134acbb003"
+  integrity sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==
   dependencies:
-    playwright "1.49.0"
+    playwright "1.57.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.24"
@@ -9155,17 +9155,17 @@ pkg-dir@4.2.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.49.0:
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.0.tgz#8e69ffed3f41855b854982f3632f2922c890afcb"
-  integrity sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==
+playwright-core@1.57.0:
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.57.0.tgz#3dcc9a865af256fa9f0af0d67fc8dd54eecaebf5"
+  integrity sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==
 
-playwright@1.49.0, playwright@^1.53.0:
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.49.0.tgz#df6b9e05423377a99658202844a294a8afb95d0a"
-  integrity sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==
+playwright@1.57.0, playwright@^1.53.0:
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.57.0.tgz#74d1dacff5048dc40bf4676940b1901e18ad0f46"
+  integrity sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==
   dependencies:
-    playwright-core "1.49.0"
+    playwright-core "1.57.0"
   optionalDependencies:
     fsevents "2.3.2"
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1026,44 +1026,30 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
-"@formatjs/ecma402-abstract@2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz#355e42d375678229d46dc8ad7a7139520dd03e7b"
-  integrity sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==
-  dependencies:
-    "@formatjs/fast-memoize" "2.2.3"
-    "@formatjs/intl-localematcher" "0.5.8"
-    tslib "2"
+"@formatjs/bigdecimal@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/bigdecimal/-/bigdecimal-0.2.6.tgz#2718cb8d4a37b3b426fd0bfdb097ea946375c0b3"
+  integrity sha512-aPzKsGQOkQRHUEbyO/ZtYfr4EqaBQnSs6U4tzTla1xBnIdEHgY2GqEqso28UMwWRkzKqqTj5+/6BmuOsRkfn2A==
 
-"@formatjs/fast-memoize@2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz#74e64109279d5244f9fc281f3ae90c407cece823"
-  integrity sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==
-  dependencies:
-    tslib "2"
+"@formatjs/fast-memoize@3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz#fca16a7d60f89df48f506f130f58223d7d81c2a2"
+  integrity sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==
 
-"@formatjs/intl-durationformat@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-durationformat/-/intl-durationformat-0.6.4.tgz#ac6b5ab006cf2b57500cce05dd1d201352500471"
-  integrity sha512-kpYLechF9ZvECzzMsvikBl48GkbCEAbZJN4kG/4x0FTVZkBuOWrBlj6DghCn7YsW3Bgsr0n9E0RYO373Kg3m+Q==
+"@formatjs/intl-durationformat@^0.10.15":
+  version "0.10.15"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-durationformat/-/intl-durationformat-0.10.15.tgz#ecb6c41e7fce8e639136bbad6a4d26dacec34d62"
+  integrity sha512-3W636wOl2pOVKR2+aFC+2BMOHA/FYsHZfKTr/cT1OG0YIXI2hhGrBH2+EFmqEzzClRi5BlPvwE6LlLN2dikdDQ==
   dependencies:
-    "@formatjs/ecma402-abstract" "2.2.4"
-    "@formatjs/intl-localematcher" "0.5.8"
-    tslib "2"
+    "@formatjs/bigdecimal" "0.2.6"
+    "@formatjs/intl-localematcher" "0.8.10"
 
-"@formatjs/intl-localematcher@0.5.8":
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz#b11bbd04bd3551f7cadcb1ef1e231822d0e3c97e"
-  integrity sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==
+"@formatjs/intl-localematcher@0.8.10", "@formatjs/intl-localematcher@^0.8.10":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz#e9bd512178122dd7c7a92d2f145daed7ce598147"
+  integrity sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==
   dependencies:
-    tslib "2"
-
-"@formatjs/intl-localematcher@^0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.5.9.tgz#43c6ee22be85b83340bcb09bdfed53657a2720db"
-  integrity sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==
-  dependencies:
-    tslib "2"
+    "@formatjs/fast-memoize" "3.1.6"
 
 "@fortawesome/fontawesome-free@^5.15.4":
   version "5.15.4"
@@ -11010,15 +10996,15 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.4.0, tslib@^2.6.3, tslib@^2.7.0, tslib@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 tslib@^1.10.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.4.0, tslib@^2.6.3, tslib@^2.7.0, tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.0.3, tslib@^2.1.0:
   version "2.5.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1765,12 +1765,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@1.57.0":
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.57.0.tgz#a14720ffa9ed7ef7edbc1f60784fc6134acbb003"
-  integrity sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==
+"@playwright/test@1.60.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
   dependencies:
-    playwright "1.57.0"
+    playwright "1.60.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.24"
@@ -9141,17 +9141,17 @@ pkg-dir@4.2.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.57.0:
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.57.0.tgz#3dcc9a865af256fa9f0af0d67fc8dd54eecaebf5"
-  integrity sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@1.57.0, playwright@^1.53.0:
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.57.0.tgz#74d1dacff5048dc40bf4676940b1901e18ad0f46"
-  integrity sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==
+playwright@1.60.0, playwright@^1.53.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.57.0"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4483,9 +4483,9 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001688:
-  version "1.0.30001712"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz"
-  integrity sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==
+  version "1.0.30001799"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz"
+  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3410

## Changes

- Upgrades Node 22 -> 24
- Drops support for Node 20
- Upgrades Playwright to 1.60.0 for [Node 24 support](https://github.com/microsoft/playwright/issues/38043) and [browser install fix](https://github.com/microsoft/playwright/issues/40998)
- Upgrades `Intl.DurationFormat` polyfill to latest to leverage ESM support in [0.8.0](https://github.com/formatjs/formatjs/blob/main/packages/intl-durationformat/CHANGELOG.md#080-2025-12-15) and removes wepack shim
- Updates localized values in unit tests