### PR TITLE
build: Limit Dependabot frontend updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,14 @@ updates:
     groups:
       production:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       development:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/emails"
     schedule:


### PR DESCRIPTION
Only allows patch and minor updates by Dependabot for frontend dependencies.