### PR TITLE
Enable & apply ruff pyupgrade lints & fixes

### DIFF
--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -3,8 +3,9 @@
 import os
 import secrets
 import string
+from collections.abc import AsyncGenerator
 from datetime import timedelta
-from typing import AsyncGenerator, List, Optional, Tuple
+from typing import List, Optional, Tuple
 from uuid import UUID, uuid4
 
 import structlog
@@ -112,7 +113,7 @@ def generate_jwt(data: dict, minutes: int) -> str:
 
 
 # ============================================================================
-def decode_jwt(token: str, audience: Optional[List[str]] = None) -> dict:
+def decode_jwt(token: str, audience: list[str] | None = None) -> dict:
     """decode JWT token"""
     return jwt.decode(token, PASSWORD_SECRET, algorithms=[ALGORITHM], audience=audience)
 
@@ -152,7 +153,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 # ============================================================================
 def verify_and_update_password(
     plain_password: str, hashed_password: str
-) -> Tuple[bool, Optional[str]]:
+) -> tuple[bool, str | None]:
     """verify password and return updated hash, if any"""
     return PWD_CONTEXT.verify_and_update(plain_password, hashed_password)
 
@@ -179,7 +180,7 @@ def init_jwt_auth(user_manager):
     async def _get_current_user_core(token: str) -> User:
         try:
             payload = decode_jwt(token, AUTH_ALLOW_AUD)
-            uid: Optional[str] = payload.get("sub") or payload.get("user_id")
+            uid: str | None = payload.get("sub") or payload.get("user_id")
             user = await user_manager.get_by_id(UUID(uid))
             assert user
             return user

--- a/backend/btrixcloud/auth.py
+++ b/backend/btrixcloud/auth.py
@@ -5,7 +5,6 @@ import secrets
 import string
 from collections.abc import AsyncGenerator
 from datetime import timedelta
-from typing import List, Optional, Tuple
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -4,15 +4,7 @@ import os
 import secrets
 from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit
 from uuid import UUID
 
@@ -662,7 +654,16 @@ class BackgroundJobOps:
 
     async def get_background_job(
         self, job_id: str, oid: UUID | None = None
-    ) -> CreateReplicaJob | DeleteReplicaJob | DeleteOrgJob | RecalculateOrgStatsJob | ReAddOrgPagesJob | OptimizePagesJob | CleanupSeedFilesJob | UpdateCollStatsJob:
+    ) -> (
+        CreateReplicaJob
+        | DeleteReplicaJob
+        | DeleteOrgJob
+        | RecalculateOrgStatsJob
+        | ReAddOrgPagesJob
+        | OptimizePagesJob
+        | CleanupSeedFilesJob
+        | UpdateCollStatsJob
+    ):
         """Get background job"""
         query: dict[str, object] = {"_id": job_id}
         if oid:
@@ -786,9 +787,7 @@ class BackgroundJobOps:
         except Exception:
             raise HTTPException(status_code=404, detail="file_not_found")
 
-    async def retry_background_job(
-        self, job_id: str, org: Organization | None = None
-    ):
+    async def retry_background_job(self, job_id: str, org: Organization | None = None):
         """Retry background job"""
         job = await self.get_background_job(job_id)
         if not job:

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -2,11 +2,10 @@
 
 import os
 import secrets
+from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
-    AsyncGenerator,
-    Callable,
     Dict,
     List,
     Optional,
@@ -131,7 +130,7 @@ class BackgroundJobOps:
 
     async def create_replica_jobs(
         self, oid: UUID, file: BaseFile, object_id: str, object_type: str
-    ) -> Dict[str, Union[bool, List[str]]]:
+    ) -> dict[str, bool | list[str]]:
         """Create k8s background job to replicate a file to all replica storage locations."""
         org = await self.org_ops.get_org_by_id(oid)
 
@@ -167,7 +166,7 @@ class BackgroundJobOps:
         replica_ref: StorageRef,
         primary_file_path: str,
         primary_endpoint: str,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ) -> str:
         """Create k8s background job to replicate a file to a specific replica storage location."""
         replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
@@ -236,7 +235,7 @@ class BackgroundJobOps:
 
     async def create_delete_replica_jobs(
         self, org: Organization, file: BaseFile, object_id: str, object_type: str
-    ) -> Dict[str, Union[bool, List[str]]]:
+    ) -> dict[str, bool | list[str]]:
         """Create a job to delete each replica for the given file"""
         ids = []
 
@@ -257,7 +256,7 @@ class BackgroundJobOps:
         object_type: str,
         replica_ref: StorageRef,
         force_start_immediately: bool = False,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ) -> str:
         """Create a job to delete one replica of a given file"""
         try:
@@ -332,8 +331,8 @@ class BackgroundJobOps:
     async def create_delete_org_job(
         self,
         org: Organization,
-        existing_job_id: Optional[str] = None,
-    ) -> Optional[str]:
+        existing_job_id: str | None = None,
+    ) -> str | None:
         """Create background job to delete org and its data"""
 
         try:
@@ -381,8 +380,8 @@ class BackgroundJobOps:
     async def create_recalculate_org_stats_job(
         self,
         org: Organization,
-        existing_job_id: Optional[str] = None,
-    ) -> Optional[str]:
+        existing_job_id: str | None = None,
+    ) -> str | None:
         """Create background job to recalculate org stats"""
 
         try:
@@ -431,9 +430,9 @@ class BackgroundJobOps:
     async def create_re_add_org_pages_job(
         self,
         oid: UUID,
-        crawl_type: Optional[str] = None,
-        crawl_id: Optional[str] = None,
-        existing_job_id: Optional[str] = None,
+        crawl_type: str | None = None,
+        crawl_id: str | None = None,
+        existing_job_id: str | None = None,
     ):
         """Create job to (re)add all pages in an org, optionally filtered by crawl type"""
 
@@ -484,7 +483,7 @@ class BackgroundJobOps:
 
     async def create_optimize_crawl_pages_job(
         self,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ):
         """Create job to optimize crawl pages"""
 
@@ -530,7 +529,7 @@ class BackgroundJobOps:
         self,
         oid: UUID,
         collection_id: UUID,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ):
         """Create job to update collection stats"""
         try:
@@ -587,8 +586,8 @@ class BackgroundJobOps:
         job_type: str,
         success: bool,
         finished: datetime,
-        started: Optional[datetime] = None,
-        oid: Optional[UUID] = None,
+        started: datetime | None = None,
+        oid: UUID | None = None,
     ) -> None:
         """Update job as finished, including
         job-specific task handling"""
@@ -662,17 +661,8 @@ class BackgroundJobOps:
             )
 
     async def get_background_job(
-        self, job_id: str, oid: Optional[UUID] = None
-    ) -> Union[
-        CreateReplicaJob,
-        DeleteReplicaJob,
-        DeleteOrgJob,
-        RecalculateOrgStatsJob,
-        ReAddOrgPagesJob,
-        OptimizePagesJob,
-        CleanupSeedFilesJob,
-        UpdateCollStatsJob,
-    ]:
+        self, job_id: str, oid: UUID | None = None
+    ) -> CreateReplicaJob | DeleteReplicaJob | DeleteOrgJob | RecalculateOrgStatsJob | ReAddOrgPagesJob | OptimizePagesJob | CleanupSeedFilesJob | UpdateCollStatsJob:
         """Get background job"""
         query: dict[str, object] = {"_id": job_id}
         if oid:
@@ -712,14 +702,14 @@ class BackgroundJobOps:
 
     async def list_background_jobs(
         self,
-        org: Optional[Organization] = None,
+        org: Organization | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        success: Optional[bool] = None,
-        job_type: Optional[str] = None,
-        sort_by: Optional[str] = None,
-        sort_direction: Optional[int] = -1,
-    ) -> Tuple[List[BackgroundJob], int]:
+        success: bool | None = None,
+        job_type: str | None = None,
+        sort_by: str | None = None,
+        sort_direction: int | None = -1,
+    ) -> tuple[list[BackgroundJob], int]:
         """List all background jobs"""
         # pylint: disable=duplicate-code
         # Zero-index page for query
@@ -778,7 +768,7 @@ class BackgroundJobOps:
         return jobs, total
 
     async def get_replica_job_file(
-        self, job: Union[CreateReplicaJob, DeleteReplicaJob], org: Organization
+        self, job: CreateReplicaJob | DeleteReplicaJob, org: Organization
     ) -> BaseFile:
         """Return file from replica job"""
         try:
@@ -797,7 +787,7 @@ class BackgroundJobOps:
             raise HTTPException(status_code=404, detail="file_not_found")
 
     async def retry_background_job(
-        self, job_id: str, org: Optional[Organization] = None
+        self, job_id: str, org: Organization | None = None
     ):
         """Retry background job"""
         job = await self.get_background_job(job_id)
@@ -823,7 +813,7 @@ class BackgroundJobOps:
 
     async def retry_org_background_job(
         self, job: BackgroundJob, org: Organization
-    ) -> Dict[str, Union[bool, Optional[str]]]:
+    ) -> dict[str, bool | str | None]:
         """Retry background job specific to one org"""
         if job.type == BgJobType.CREATE_REPLICA:
             job = cast(CreateReplicaJob, job)
@@ -901,7 +891,7 @@ class BackgroundJobOps:
 
     async def retry_failed_org_background_jobs(
         self, org: Organization
-    ) -> Dict[str, Union[bool, Optional[str]]]:
+    ) -> dict[str, bool | str | None]:
         """Retry all failed background jobs in an org"""
         async for job in self.jobs.find({"oid": org.id, "success": False}):
             run_async_task(self.retry_background_job(job["_id"], org))
@@ -909,7 +899,7 @@ class BackgroundJobOps:
 
     async def retry_all_failed_background_jobs(
         self,
-    ) -> Dict[str, Union[bool, Optional[str]]]:
+    ) -> dict[str, bool | str | None]:
         """Retry all failed background jobs from all orgs"""
         async for job in self.jobs.find({"success": False}):
             org = None
@@ -1021,10 +1011,10 @@ def init_background_jobs_api(
     async def list_all_background_jobs(
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        success: Optional[bool] = None,
-        jobType: Optional[str] = None,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        success: bool | None = None,
+        jobType: str | None = None,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
         user: User = Depends(user_dep),
     ):
         """Retrieve paginated list of background jobs"""
@@ -1047,10 +1037,10 @@ def init_background_jobs_api(
         org: Organization = Depends(org_crawl_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        success: Optional[bool] = None,
-        jobType: Optional[str] = None,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        success: bool | None = None,
+        jobType: str | None = None,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
     ):
         """Retrieve paginated list of background jobs"""
         jobs, total = await ops.list_background_jobs(

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -3,14 +3,12 @@
 import asyncio
 import os
 import urllib.parse
+from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    AsyncGenerator,
-    AsyncIterable,
-    Callable,
     Dict,
     List,
     Optional,
@@ -120,10 +118,10 @@ class BaseCrawlOps:
     async def get_crawl_raw(
         self,
         crawlid: str,
-        org: Optional[Organization] = None,
-        type_: Optional[TYPE_CRAWL_TYPES] = None,
-        project: Optional[dict[str, bool]] = None,
-    ) -> Dict[str, Any]:
+        org: Organization | None = None,
+        type_: TYPE_CRAWL_TYPES | None = None,
+        project: dict[str, bool] | None = None,
+    ) -> dict[str, Any]:
         """Get data for single crawl"""
 
         query: dict[str, object] = {"_id": crawlid}
@@ -142,10 +140,10 @@ class BaseCrawlOps:
 
     async def _files_to_resources(
         self,
-        files: List[Dict],
+        files: list[dict],
         org: Organization,
         crawlid: str,
-    ) -> List[CrawlFileOut]:
+    ) -> list[CrawlFileOut]:
         if not files:
             return []
 
@@ -164,8 +162,8 @@ class BaseCrawlOps:
     async def get_base_crawl(
         self,
         crawlid: str,
-        org: Optional[Organization] = None,
-        type_: Optional[TYPE_CRAWL_TYPES] = None,
+        org: Organization | None = None,
+        type_: TYPE_CRAWL_TYPES | None = None,
     ) -> BaseCrawl:
         """Get crawl data for internal use"""
         res = await self.get_crawl_raw(crawlid, org, type_)
@@ -174,11 +172,11 @@ class BaseCrawlOps:
     async def get_crawl_out(
         self,
         crawlid: str,
-        org: Optional[Organization] = None,
-        type_: Optional[TYPE_CRAWL_TYPES] = None,
+        org: Organization | None = None,
+        type_: TYPE_CRAWL_TYPES | None = None,
         skip_resources=False,
-        headers: Optional[dict] = None,
-        cid: Optional[UUID] = None,
+        headers: dict | None = None,
+        cid: UUID | None = None,
         with_dependencies: bool = False,
     ) -> CrawlOutWithResources:
         """Get crawl data for api output"""
@@ -275,7 +273,7 @@ class BaseCrawlOps:
         return missing
 
     async def _update_crawl_collections(
-        self, crawl_id: str, org: Organization, collection_ids: List[UUID]
+        self, crawl_id: str, org: Organization, collection_ids: list[UUID]
     ):
         """Update crawl collections to match updated list."""
         crawl = await self.get_crawl_out(crawl_id, org, skip_resources=True)
@@ -407,7 +405,7 @@ class BaseCrawlOps:
         org: Organization,
         delete_list: DeleteCrawlList,
         type_: TYPE_CRAWL_TYPES,
-        user: Optional[User] = None,
+        user: User | None = None,
     ) -> tuple[int, dict[UUID, dict[str, int]], bool]:
         """Delete a list of crawls by id for given org"""
         cids_to_update: dict[UUID, dict[str, int]] = {}
@@ -496,7 +494,7 @@ class BaseCrawlOps:
         return res.deleted_count, cids_to_update, quota_reached
 
     async def _delete_crawl_files(
-        self, crawl: Union[BaseCrawl, QARun], org: Organization
+        self, crawl: BaseCrawl | QARun, org: Organization
     ):
         """Delete files associated with crawl from storage."""
         size = 0
@@ -539,9 +537,9 @@ class BaseCrawlOps:
 
     async def _resolve_crawl_refs(
         self,
-        crawl: Union[CrawlOut, CrawlOutWithResources],
-        org: Optional[Organization],
-        files: Optional[list[dict]],
+        crawl: CrawlOut | CrawlOutWithResources,
+        org: Organization | None,
+        files: list[dict] | None,
         session: AsyncIOMotorClientSession | None = None,
     ):
         """Resolve running crawl data"""
@@ -572,12 +570,12 @@ class BaseCrawlOps:
 
     async def resolve_signed_urls(
         self,
-        files: List[CrawlFile],
+        files: list[CrawlFile],
         org: Organization,
-        crawl_id: Optional[str] = None,
+        crawl_id: str | None = None,
         force_update=False,
         session: AsyncIOMotorClientSession | None = None,
-    ) -> List[CrawlFileOut]:
+    ) -> list[CrawlFileOut]:
         """Regenerate presigned URLs for files as necessary"""
         if not files:
             return []
@@ -706,7 +704,7 @@ class BaseCrawlOps:
         return resources, pages_optimized
 
     async def validate_all_crawls_successful(
-        self, crawl_ids: List[str], org: Organization
+        self, crawl_ids: list[str], org: Organization
     ):
         """Validate that crawls in list exist and have a succesful state, or throw"""
         # convert to set to remove any duplicates
@@ -725,7 +723,7 @@ class BaseCrawlOps:
             )
 
     async def add_to_collection(
-        self, crawl_ids: List[str], collection_id: UUID, org: Organization
+        self, crawl_ids: list[str], collection_id: UUID, org: Organization
     ):
         """Add crawls to collection."""
         await self.crawls.update_many(
@@ -733,7 +731,7 @@ class BaseCrawlOps:
             {"$addToSet": {"collectionIds": collection_id}},
         )
 
-    async def remove_from_collection(self, crawl_ids: List[str], collection_id: UUID):
+    async def remove_from_collection(self, crawl_ids: list[str], collection_id: UUID):
         """Remove crawls from collection."""
         await self.crawls.update_many(
             {"_id": {"$in": crawl_ids}},
@@ -755,27 +753,27 @@ class BaseCrawlOps:
     # pylint: disable=too-many-branches, invalid-name, too-many-statements
     async def list_all_base_crawls(
         self,
-        org: Optional[Organization] = None,
-        userid: Optional[UUID] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        org: Organization | None = None,
+        userid: UUID | None = None,
+        name: str | None = None,
+        description: str | None = None,
         tags: list[str] | None = None,
         tag_match: ListFilterType | None = None,
-        collection_id: Optional[UUID] = None,
-        dedupe_coll_id: Optional[UUID] = None,
+        collection_id: UUID | None = None,
+        dedupe_coll_id: UUID | None = None,
         requires_crawls: list[str] | None = None,
         required_by_crawls: list[str] | None = None,
-        has_requires_crawls: Optional[bool] = None,
-        has_required_by_crawls: Optional[bool] = None,
-        crawl_ids: Optional[List[str]] = None,
-        states: Optional[List[str]] = None,
-        first_seed: Optional[str] = None,
-        type_: Optional[TYPE_CRAWL_TYPES] = None,
-        cid: Optional[UUID] = None,
-        cls_type: Type[Union[CrawlOut, CrawlOutWithResources]] = CrawlOut,
+        has_requires_crawls: bool | None = None,
+        has_required_by_crawls: bool | None = None,
+        crawl_ids: list[str] | None = None,
+        states: list[str] | None = None,
+        first_seed: str | None = None,
+        type_: TYPE_CRAWL_TYPES | None = None,
+        cid: UUID | None = None,
+        cls_type: type[CrawlOut | CrawlOutWithResources] = CrawlOut,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: Optional[str] = None,
+        sort_by: str | None = None,
         sort_direction: int = -1,
         review_status_range: tuple[int, int] | None = None,
     ):
@@ -980,7 +978,7 @@ class BaseCrawlOps:
         self,
         delete_list: DeleteCrawlList,
         org: Organization,
-        user: Optional[User] = None,
+        user: User | None = None,
     ) -> dict[str, bool]:
         """Delete uploaded crawls"""
         crawls: list[str] = []
@@ -1033,8 +1031,8 @@ class BaseCrawlOps:
     async def get_all_crawl_search_values(
         self,
         org: Organization,
-        type_: Optional[TYPE_CRAWL_TYPES] = None,
-        collection_id: Optional[UUID] = None,
+        type_: TYPE_CRAWL_TYPES | None = None,
+        collection_id: UUID | None = None,
     ):
         """List unique names, first seeds, and descriptions from all captures in org"""
         match_query: dict[str, object] = {"oid": org.id}
@@ -1128,8 +1126,8 @@ class BaseCrawlOps:
         )
 
     async def calculate_org_crawl_file_storage(
-        self, oid: UUID, type_: Optional[TYPE_CRAWL_TYPES] = None
-    ) -> Tuple[int, int, int]:
+        self, oid: UUID, type_: TYPE_CRAWL_TYPES | None = None
+    ) -> tuple[int, int, int]:
         """Calculate and return total size of crawl files in org.
 
         Returns tuple of (total, crawls only, uploads only)
@@ -1155,9 +1153,9 @@ class BaseCrawlOps:
 
         return total_size, crawls_size, uploads_size
 
-    async def get_org_last_crawl_finished(self, oid: UUID) -> Optional[datetime]:
+    async def get_org_last_crawl_finished(self, oid: UUID) -> datetime | None:
         """Get last crawl finished time for org"""
-        last_crawl_finished: Optional[datetime] = None
+        last_crawl_finished: datetime | None = None
 
         cursor = (
             self.crawls.find({"oid": oid, "finished": {"$ne": None}})
@@ -1174,10 +1172,10 @@ class BaseCrawlOps:
         self,
         org: Organization,
         only_successful: bool = True,
-        type_: Optional[TYPE_CRAWL_TYPES] = None,
+        type_: TYPE_CRAWL_TYPES | None = None,
     ):
         """get distinct tags from archived items for this org"""
-        match_query: Dict[str, Any] = {"oid": org.id}
+        match_query: dict[str, Any] = {"oid": org.id}
         if only_successful:
             match_query["state"] = {"$in": SUCCESSFUL_STATES}
         if type_ in CRAWL_TYPES:
@@ -1216,11 +1214,11 @@ def init_base_crawls_api(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        userid: Optional[UUID] = None,
-        name: Optional[str] = None,
+        userid: UUID | None = None,
+        name: str | None = None,
         state: Annotated[list[str] | None, Query()] = None,
-        firstSeed: Optional[str] = None,
-        description: Optional[str] = None,
+        firstSeed: str | None = None,
+        description: str | None = None,
         tags: Annotated[list[str] | None, Query()] = None,
         tag_match: Annotated[
             ListFilterType | None,
@@ -1230,17 +1228,17 @@ def init_base_crawls_api(
                 description='Defaults to `"and"` if omitted',
             ),
         ] = ListFilterType.AND,
-        collectionId: Optional[UUID] = None,
-        dedupeCollId: Optional[UUID] = None,
+        collectionId: UUID | None = None,
+        dedupeCollId: UUID | None = None,
         requiresCrawls: Annotated[list[str] | None, Query()] = None,
         requiredByCrawls: Annotated[list[str] | None, Query()] = None,
-        hasRequiresCrawls: Optional[bool] = None,
-        hasRequiredByCrawls: Optional[bool] = None,
+        hasRequiresCrawls: bool | None = None,
+        hasRequiredByCrawls: bool | None = None,
         ids: Annotated[list[str] | None, Query()] = None,
-        crawlType: Optional[TYPE_CRAWL_TYPES] = None,
-        cid: Optional[UUID] = None,
+        crawlType: TYPE_CRAWL_TYPES | None = None,
+        cid: UUID | None = None,
         reviewStatus: Annotated[list[int] | None, Query()] = None,
-        sortBy: Optional[str] = "finished",
+        sortBy: str | None = "finished",
         sortDirection: int = -1,
     ):
         # Support both comma-separated values and multiple search parameters
@@ -1302,8 +1300,8 @@ def init_base_crawls_api(
     )
     async def get_all_crawls_search_values(
         org: Organization = Depends(org_viewer_dep),
-        crawlType: Optional[TYPE_CRAWL_TYPES] = None,
-        collectionId: Optional[UUID] = None,
+        crawlType: TYPE_CRAWL_TYPES | None = None,
+        collectionId: UUID | None = None,
     ):
         return await ops.get_all_crawl_search_values(
             org, type_=crawlType, collection_id=collectionId
@@ -1317,7 +1315,7 @@ def init_base_crawls_api(
     async def get_all_crawls_tag_counts(
         org: Organization = Depends(org_viewer_dep),
         onlySuccessful: bool = True,
-        crawlType: Optional[TYPE_CRAWL_TYPES] = None,
+        crawlType: TYPE_CRAWL_TYPES | None = None,
     ):
         tags = await ops.get_all_crawls_tag_counts(
             org, only_successful=onlySuccessful, type_=crawlType

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -5,18 +5,7 @@ import os
 import urllib.parse
 from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import UUID
 
 import structlog
@@ -493,9 +482,7 @@ class BaseCrawlOps:
 
         return res.deleted_count, cids_to_update, quota_reached
 
-    async def _delete_crawl_files(
-        self, crawl: BaseCrawl | QARun, org: Organization
-    ):
+    async def _delete_crawl_files(self, crawl: BaseCrawl | QARun, org: Organization):
         """Delete files associated with crawl from storage."""
         size = 0
         for file_ in crawl.files:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -5,12 +5,11 @@ Collections API
 # pylint: disable=too-many-lines
 import os
 from collections import Counter
+from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    Callable,
     Dict,
     List,
     Optional,
@@ -265,7 +264,7 @@ class CollectionOps:
     async def add_crawls_to_collection(
         self,
         coll_id: UUID,
-        crawl_ids: List[str],
+        crawl_ids: list[str],
         org: Organization,
     ) -> UpdatedResponse:
         """Add crawls to collection"""
@@ -301,7 +300,7 @@ class CollectionOps:
     async def update_collection_post_remove(
         self,
         coll_id: UUID,
-        crawl_ids: List[str],
+        crawl_ids: list[str],
         org: Organization,
     ):
         """Update collection after crawls are removed or deleted outright"""
@@ -330,7 +329,7 @@ class CollectionOps:
     async def remove_crawls_from_collection(
         self,
         coll_id: UUID,
-        crawl_ids: List[str],
+        crawl_ids: list[str],
         org: Organization,
     ) -> UpdatedResponse:
         """Remove crawls from collection"""
@@ -340,7 +339,7 @@ class CollectionOps:
 
     async def get_collection_raw(
         self, coll_id: UUID, oid: UUID, public_or_unlisted_only: bool = False
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get collection by id as dict from database"""
         query: dict[str, object] = {"_id": coll_id, "oid": oid}
         if public_or_unlisted_only:
@@ -358,7 +357,7 @@ class CollectionOps:
         oid: UUID,
         previous_slugs: bool = False,
         public_or_unlisted_only: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get collection by slug (current or previous) as dict from database"""
         query: dict[str, object] = {"oid": oid}
         if previous_slugs:
@@ -409,7 +408,7 @@ class CollectionOps:
         resources=False,
         public_or_unlisted_only=False,
         updates_count=True,
-        headers: Optional[dict] = None,
+        headers: dict | None = None,
     ) -> CollOut:
         """Get CollOut by id"""
         # pylint: disable=too-many-locals
@@ -545,13 +544,13 @@ class CollectionOps:
         public_colls_out: bool = False,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: Optional[str] = None,
+        sort_by: str | None = None,
         sort_direction: int = 1,
-        name: Optional[str] = None,
-        name_prefix: Optional[str] = None,
-        has_dedupe_index: Optional[bool] = None,
-        access: Optional[str] = None,
-        headers: Optional[dict] = None,
+        name: str | None = None,
+        name_prefix: str | None = None,
+        has_dedupe_index: bool | None = None,
+        access: str | None = None,
+        headers: dict | None = None,
     ):
         """List all collections for org"""
         # pylint: disable=too-many-locals, duplicate-code, too-many-branches
@@ -559,7 +558,7 @@ class CollectionOps:
         page = page - 1
         skip = page * page_size
 
-        match_query: Dict[str, Union[str, UUID, int, object]] = {"oid": org.id}
+        match_query: dict[str, str | UUID | int | object] = {"oid": org.id}
 
         if name:
             match_query["name"] = name
@@ -575,7 +574,7 @@ class CollectionOps:
         elif access:
             match_query["access"] = access
 
-        aggregate: List[Dict[str, Union[str, UUID, int, object]]] = [
+        aggregate: list[dict[str, str | UUID | int | object]] = [
             {"$match": match_query}
         ]
 
@@ -629,7 +628,7 @@ class CollectionOps:
         except (IndexError, ValueError):
             total = 0
 
-        collections: List[Union[CollOut, PublicCollOut]] = []
+        collections: list[CollOut | PublicCollOut] = []
 
         for res in items:
             thumbnail = res.get("thumbnail")
@@ -657,8 +656,8 @@ class CollectionOps:
 
     # pylint: disable=too-many-locals
     async def get_collection_crawl_resources(
-        self, coll_id: Optional[UUID], org: Organization
-    ) -> tuple[List[CrawlFileOut], List[str], bool]:
+        self, coll_id: UUID | None, org: Organization
+    ) -> tuple[list[CrawlFileOut], list[str], bool]:
         """Return pre-signed resources for all collection crawl files."""
         match: dict[str, Any]
 
@@ -675,7 +674,7 @@ class CollectionOps:
 
         return resources, crawl_ids, pages_optimized
 
-    async def get_collection_names(self, uuids: List[UUID]):
+    async def get_collection_names(self, uuids: list[UUID]):
         """return object of {_id, names} given list of collection ids"""
         cursor = self.collections.find(
             {"_id": {"$in": uuids}}, projection=["_id", "name"]
@@ -698,7 +697,7 @@ class CollectionOps:
         coll_id: UUID,
         oid: UUID,
         public_or_unlisted_only=False,
-    ) -> List[str]:
+    ) -> list[str]:
         """Return list of crawl ids in collection, including only public collections"""
         crawl_ids = []
         # ensure collection is public or unlisted, else throw here
@@ -809,7 +808,7 @@ class CollectionOps:
         coll_id: UUID,
         oid: UUID,
         job_type: TYPE_INDEX_JOB_TYPES = "import",
-        crawl_id: Optional[str] = None,
+        crawl_id: str | None = None,
     ):
         """update index with import / purge / post-crawl job"""
 
@@ -913,8 +912,8 @@ class CollectionOps:
         coll_id: UUID,
         oid: UUID,
         state: TYPE_DEDUPE_INDEX_STATES,
-        index_file: Optional[DedupeIndexFile] = None,
-        dt: Optional[datetime] = None,
+        index_file: DedupeIndexFile | None = None,
+        dt: datetime | None = None,
         if_exists=False,
     ) -> bool:
         """update the state, and optionally, dedupe index file info"""
@@ -947,7 +946,7 @@ class CollectionOps:
 
         return res is not None
 
-    async def get_dedupe_index_saved(self, coll_id: UUID) -> Optional[datetime]:
+    async def get_dedupe_index_saved(self, coll_id: UUID) -> datetime | None:
         """return datetime for when index was last saved, if any"""
         coll = await self.collections.find_one(
             {"_id": coll_id, "indexLastSavedAt": {"$ne": None}},
@@ -1149,9 +1148,9 @@ class CollectionOps:
         org_slug: str,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: Optional[str] = None,
+        sort_by: str | None = None,
         sort_direction: int = 1,
-        headers: Optional[dict] = None,
+        headers: dict | None = None,
     ):
         """List public collections for org"""
         try:
@@ -1184,7 +1183,7 @@ class CollectionOps:
 
     async def set_home_url(
         self, coll_id: UUID, update: UpdateCollHomeUrl, org: Organization
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """Set home URL for collection and save thumbnail to database"""
         if update.pageId:
             page = await self.page_ops.get_page(update.pageId, org.id)
@@ -1215,10 +1214,10 @@ class CollectionOps:
         coll_id: UUID,
         org: Organization,
         user: User,
-        source_url: Optional[AnyHttpUrl] = None,
-        source_ts: Optional[datetime] = None,
-        source_page_id: Optional[UUID] = None,
-    ) -> Dict[str, bool]:
+        source_url: AnyHttpUrl | None = None,
+        source_ts: datetime | None = None,
+        source_page_id: UUID | None = None,
+    ) -> dict[str, bool]:
         """Upload file as stream to use as collection thumbnail"""
         coll = await self.get_collection(coll_id, org.id)
 
@@ -1424,12 +1423,12 @@ def init_collections_api(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = None,
+        sortBy: str | None = None,
         sortDirection: int = 1,
-        name: Optional[str] = None,
-        namePrefix: Optional[str] = None,
-        hasDedupeIndex: Optional[bool] = None,
-        access: Optional[str] = None,
+        name: str | None = None,
+        namePrefix: str | None = None,
+        hasDedupeIndex: bool | None = None,
+        access: str | None = None,
     ):
         # pylint: disable=duplicate-code
         collections, total = await colls.list_collections(
@@ -1607,7 +1606,7 @@ def init_collections_api(
         request: Request,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = None,
+        sortBy: str | None = None,
         sortDirection: int = 1,
     ):
         return await colls.get_org_public_collections(
@@ -1704,9 +1703,9 @@ def init_collections_api(
         request: Request,
         filename: str,
         coll_id: UUID,
-        sourceUrl: Optional[AnyHttpUrl],
-        sourceTs: Optional[datetime],
-        sourcePageId: Optional[UUID],
+        sourceUrl: AnyHttpUrl | None,
+        sourceTs: datetime | None,
+        sourcePageId: UUID | None,
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ):

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -7,15 +7,7 @@ import os
 from collections import Counter
 from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/btrixcloud/crawl_logs.py
+++ b/backend/btrixcloud/crawl_logs.py
@@ -1,7 +1,7 @@
 """crawl logs"""
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/btrixcloud/crawl_logs.py
+++ b/backend/btrixcloud/crawl_logs.py
@@ -71,7 +71,7 @@ class CrawlLogOps:
         crawl_id: str,
         oid: UUID,
         log_line: str,
-        qa_run_id: Optional[str] = None,
+        qa_run_id: str | None = None,
     ) -> bool:
         """add crawl log line to database"""
         try:
@@ -122,10 +122,10 @@ class CrawlLogOps:
         page: int = 1,
         sort_by: str = "timestamp",
         sort_direction: int = -1,
-        contexts: Optional[List[str]] = None,
-        log_levels: Optional[List[str]] = None,
-        qa_run_id: Optional[str] = None,
-    ) -> Tuple[list[CrawlLogLine], int]:
+        contexts: list[str] | None = None,
+        log_levels: list[str] | None = None,
+        qa_run_id: str | None = None,
+    ) -> tuple[list[CrawlLogLine], int]:
         """list all logs for particular crawl"""
         # pylint: disable=too-many-locals, duplicate-code
 
@@ -133,7 +133,7 @@ class CrawlLogOps:
         page = page - 1
         skip = page_size * page
 
-        match_query: Dict[str, Any] = {
+        match_query: dict[str, Any] = {
             "oid": org.id,
             "crawlId": crawl_id,
             "qaRunId": qa_run_id,
@@ -145,7 +145,7 @@ class CrawlLogOps:
         if log_levels:
             match_query["logLevel"] = {"$in": log_levels}
 
-        aggregate: List[Dict[str, Any]] = [{"$match": match_query}]
+        aggregate: list[dict[str, Any]] = [{"$match": match_query}]
 
         if sort_by:
             if sort_by not in (
@@ -189,7 +189,7 @@ class CrawlLogOps:
         return log_lines, total
 
     async def delete_crawl_logs(
-        self, crawl_id: str, oid: UUID, qa_run_id: Optional[str] = None
+        self, crawl_id: str, oid: UUID, qa_run_id: str | None = None
     ):
         """Delete all logs from a specific crawl"""
         query: dict[str, str | UUID] = {"crawlId": crawl_id, "oid": oid}

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -9,13 +9,12 @@ import json
 import os
 import re
 import urllib.parse
+from collections.abc import AsyncGenerator, Callable
 from datetime import datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    AsyncGenerator,
-    Callable,
     Dict,
     List,
     Optional,
@@ -339,7 +338,7 @@ class CrawlConfigOps:
                     status_code=400, detail="use_one_of_seeds_or_seedfile"
                 )
 
-            seeds = cast(List[Seed], config_in.config.seeds)
+            seeds = cast(list[Seed], config_in.config.seeds)
             seed_count = len(seeds)
 
             first_seed = seeds[0].url
@@ -443,7 +442,7 @@ class CrawlConfigOps:
 
         return extra_hops == 0 and scope_type == "page"
 
-    def _validate_link_selectors(self, link_selectors: List[str]):
+    def _validate_link_selectors(self, link_selectors: list[str]):
         """Validate link selectors
 
         Ensure at least one link selector is set and that all the link slectors passed
@@ -461,7 +460,7 @@ class CrawlConfigOps:
             if not parts[0] or not parts[1]:
                 raise HTTPException(status_code=400, detail="invalid_link_selector")
 
-    def _validate_custom_behavior_url_syntax(self, url: str) -> Tuple[bool, List[str]]:
+    def _validate_custom_behavior_url_syntax(self, url: str) -> tuple[bool, list[str]]:
         """Validate custom behaviors are valid URLs after removing custom git syntax"""
         git_prefix = "git+"
         is_git_repo = False
@@ -837,18 +836,18 @@ class CrawlConfigOps:
         org: Organization,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        created_by: Optional[UUID] = None,
-        modified_by: Optional[UUID] = None,
-        profile_ids: Optional[List[UUID]] = None,
-        first_seed: Optional[str] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        tag_match: Optional[ListFilterType] = ListFilterType.AND,
-        dedupe_coll_id: Optional[UUID] = None,
+        created_by: UUID | None = None,
+        modified_by: UUID | None = None,
+        profile_ids: list[UUID] | None = None,
+        first_seed: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        tag_match: ListFilterType | None = ListFilterType.AND,
+        dedupe_coll_id: UUID | None = None,
         last_crawl_state: list[TYPE_ALL_CRAWL_STATES] | None = None,
-        schedule: Optional[bool] = None,
-        is_crawl_running: Optional[bool] = None,
+        schedule: bool | None = None,
+        is_crawl_running: bool | None = None,
         sort_by: str = "lastRun",
         sort_direction: int = -1,
     ) -> tuple[list[CrawlConfigOut], int]:
@@ -892,7 +891,7 @@ class CrawlConfigOps:
             match_query["lastCrawlState"] = {"$in": last_crawl_state}
 
         # pylint: disable=duplicate-code
-        aggregate: List[Dict[str, Union[object, str, int]]] = [
+        aggregate: list[dict[str, object | str | int]] = [
             {"$match": match_query},
             {"$unset": ["config"]},
         ]
@@ -975,7 +974,7 @@ class CrawlConfigOps:
         )
         return res is not None
 
-    async def mark_profiles_in_use(self, profiles: List[Profile], org: Organization):
+    async def mark_profiles_in_use(self, profiles: list[Profile], org: Organization):
         """mark which profiles are in use by querying and grouping crawlconfigs"""
         profile_ids = [profile.id for profile in profiles]
         cursor = self.crawl_configs.aggregate(
@@ -1004,7 +1003,7 @@ class CrawlConfigOps:
 
     async def get_running_crawl(
         self, cid: UUID, session: AsyncIOMotorClientSession | None = None
-    ) -> Optional[CrawlOut]:
+    ) -> CrawlOut | None:
         """Return the id of currently running crawl for this config, if any"""
         # crawls = await self.crawl_manager.list_running_crawls(cid=crawlconfig.id)
         crawls, _ = await self.crawl_ops.list_crawls(
@@ -1020,8 +1019,8 @@ class CrawlConfigOps:
         self,
         cid: UUID,
         org: Organization,
-        request: Optional[Request] = None,
-    ) -> Optional[CrawlOutWithResources]:
+        request: Request | None = None,
+    ) -> CrawlOutWithResources | None:
         """Return the last successful crawl out with resources for this config, if any"""
         headers = dict(request.headers) if request else None
         match_query = {
@@ -1148,7 +1147,7 @@ class CrawlConfigOps:
     async def get_crawl_config(
         self,
         cid: UUID,
-        oid: Optional[UUID] = None,
+        oid: UUID | None = None,
         active_only: bool = True,
         config_cls=CrawlConfig,
     ):
@@ -1307,10 +1306,10 @@ class CrawlConfigOps:
         return tags
 
     async def get_crawl_config_search_values(
-        self, org, profile_ids: Optional[List[UUID]] = None
+        self, org, profile_ids: list[UUID] | None = None
     ):
         """List unique names, first seeds, and descriptions from all workflows in org"""
-        query: Dict[str, Any] = {"oid": org.id, "inactive": {"$ne": True}}
+        query: dict[str, Any] = {"oid": org.id, "inactive": {"$ne": True}}
         if profile_ids:
             query["profileid"] = {"$in": profile_ids}
 
@@ -1471,13 +1470,13 @@ class CrawlConfigOps:
             return [], 0
 
     def get_channel_crawler_image(
-        self, crawler_channel: Optional[str]
-    ) -> Optional[str]:
+        self, crawler_channel: str | None
+    ) -> str | None:
         """Get crawler image name by id"""
         return self.crawler_images_map.get(crawler_channel or "")
 
     def get_channel_crawler_image_pull_policy(
-        self, crawler_channel: Optional[str]
+        self, crawler_channel: str | None
     ) -> str:
         """Get crawler image name by id"""
         return (
@@ -1528,7 +1527,7 @@ class CrawlConfigOps:
             servers=list(self.get_crawler_proxies_map().values()),
         )
 
-    def get_crawler_proxy(self, proxy_id: str) -> Optional[CrawlerProxy]:
+    def get_crawler_proxy(self, proxy_id: str) -> CrawlerProxy | None:
         """Get crawlerProxy by id"""
         return self.get_crawler_proxies_map().get(proxy_id)
 
@@ -1547,7 +1546,7 @@ class CrawlConfigOps:
             _proxy.shared and org.allowSharedProxies
         ) or _proxy.id in org.allowedProxies
 
-    def assert_can_org_use_proxy(self, org: Organization, proxy: Optional[str]):
+    def assert_can_org_use_proxy(self, org: Organization, proxy: str | None):
         """assert that proxy can be used or throw error"""
         if proxy and not self.can_org_use_proxy(org, proxy):
             raise HTTPException(status_code=400, detail="proxy_not_found")
@@ -1606,7 +1605,7 @@ class CrawlConfigOps:
                     status_code=404,
                     detail="custom_behavior_not_found",
                 )
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             proc.kill()
             raise HTTPException(
                 status_code=504, detail="custom_behavior_timeout"
@@ -1634,7 +1633,7 @@ class CrawlConfigOps:
                         status_code=404,
                         detail="custom_behavior_branch_not_found",
                     )
-            except asyncio.TimeoutError as e:
+            except TimeoutError as e:
                 proc.kill()
                 raise HTTPException(
                     status_code=504, detail="custom_behavior_timeout"
@@ -1658,7 +1657,7 @@ class CrawlConfigOps:
                 detail="custom_behavior_not_found",
             )
 
-    async def validate_custom_behavior(self, url: str) -> Dict[str, bool]:
+    async def validate_custom_behavior(self, url: str) -> dict[str, bool]:
         """Validate custom behavior URL
 
         Implemented:
@@ -1711,7 +1710,7 @@ async def stats_recompute_all(
     total_size = 0
     successful_count = 0
 
-    last_crawl: Optional[dict[str, object]] = None
+    last_crawl: dict[str, object] | None = None
     last_crawl_size = 0
 
     if count:
@@ -1821,25 +1820,25 @@ def init_crawl_config_api(
         page: int = 1,
         # createdBy, kept as userid for API compatibility
         user_id: Annotated[
-            Optional[UUID], Query(alias="userid", title="User ID")
+            UUID | None, Query(alias="userid", title="User ID")
         ] = None,
         modified_by: Annotated[
-            Optional[UUID], Query(alias="modifiedBy", title="Modified By User ID")
+            UUID | None, Query(alias="modifiedBy", title="Modified By User ID")
         ] = None,
         profile_ids: Annotated[
-            Optional[List[UUID]], Query(alias="profileIds", title="Profile IDs")
+            list[UUID] | None, Query(alias="profileIds", title="Profile IDs")
         ] = None,
         first_seed: Annotated[
-            Optional[str], Query(alias="firstSeed", title="First Seed")
+            str | None, Query(alias="firstSeed", title="First Seed")
         ] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
         tag: Annotated[
-            Optional[List[str]], Query(title="Tags", deprecated=True)
+            list[str] | None, Query(title="Tags", deprecated=True)
         ] = None,
-        tags: Annotated[Optional[List[str]], Query(title="Tags")] = None,
+        tags: Annotated[list[str] | None, Query(title="Tags")] = None,
         tag_match: Annotated[
-            Optional[ListFilterType],
+            ListFilterType | None,
             Query(
                 alias="tagMatch",
                 title="Tag Match Type",
@@ -1847,16 +1846,16 @@ def init_crawl_config_api(
             ),
         ] = ListFilterType.AND,
         dedupe_coll_id: Annotated[
-            Optional[UUID],
+            UUID | None,
             Query(alias="dedupeCollId", title="Deduplication Source Collection"),
         ] = None,
         last_crawl_state: Annotated[
             list[TYPE_ALL_CRAWL_STATES] | None,
             Query(alias="lastCrawlState", title="Last Crawl State"),
         ] = None,
-        schedule: Optional[bool] = None,
+        schedule: bool | None = None,
         is_crawl_running: Annotated[
-            Optional[bool], Query(alias="isCrawlRunning", title="Is Crawl Running")
+            bool | None, Query(alias="isCrawlRunning", title="Is Crawl Running")
         ] = None,
         sort_by: Annotated[str, Query(alias="sortBy", title="Sort Field")] = "",
         sort_direction: Annotated[
@@ -1898,7 +1897,7 @@ def init_crawl_config_api(
         )
         return paginated_format(crawl_configs, total, page, page_size)
 
-    @router.get("/tags", response_model=List[str], deprecated=True)
+    @router.get("/tags", response_model=list[str], deprecated=True)
     async def get_crawl_config_tags(org: Organization = Depends(org_viewer_dep)):
         """
         Deprecated - prefer /api/orgs/{oid}/crawlconfigs/tagCounts instead.
@@ -1913,7 +1912,7 @@ def init_crawl_config_api(
     async def get_crawl_config_search_values(
         org: Organization = Depends(org_viewer_dep),
         profile_ids: Annotated[
-            Optional[List[UUID]], Query(alias="profileIds", title="Profile IDs")
+            list[UUID] | None, Query(alias="profileIds", title="Profile IDs")
         ] = None,
     ):
         return await ops.get_crawl_config_search_values(org, profile_ids)

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -11,17 +11,7 @@ import re
 import urllib.parse
 from collections.abc import AsyncGenerator, Callable
 from datetime import datetime, timedelta
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import UUID, uuid4
 
 import structlog
@@ -1469,15 +1459,11 @@ class CrawlConfigOps:
         except Exception:
             return [], 0
 
-    def get_channel_crawler_image(
-        self, crawler_channel: str | None
-    ) -> str | None:
+    def get_channel_crawler_image(self, crawler_channel: str | None) -> str | None:
         """Get crawler image name by id"""
         return self.crawler_images_map.get(crawler_channel or "")
 
-    def get_channel_crawler_image_pull_policy(
-        self, crawler_channel: str | None
-    ) -> str:
+    def get_channel_crawler_image_pull_policy(self, crawler_channel: str | None) -> str:
         """Get crawler image name by id"""
         return (
             self.crawler_image_pull_policy_map.get(crawler_channel or "")
@@ -1819,9 +1805,7 @@ def init_crawl_config_api(
         ] = DEFAULT_PAGE_SIZE,
         page: int = 1,
         # createdBy, kept as userid for API compatibility
-        user_id: Annotated[
-            UUID | None, Query(alias="userid", title="User ID")
-        ] = None,
+        user_id: Annotated[UUID | None, Query(alias="userid", title="User ID")] = None,
         modified_by: Annotated[
             UUID | None, Query(alias="modifiedBy", title="Modified By User ID")
         ] = None,
@@ -1833,9 +1817,7 @@ def init_crawl_config_api(
         ] = None,
         name: str | None = None,
         description: str | None = None,
-        tag: Annotated[
-            list[str] | None, Query(title="Tags", deprecated=True)
-        ] = None,
+        tag: Annotated[list[str] | None, Query(title="Tags", deprecated=True)] = None,
         tags: Annotated[list[str] | None, Query(title="Tags")] = None,
         tag_match: Annotated[
             ListFilterType | None,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -3,7 +3,6 @@
 import os
 import secrets
 from datetime import datetime, timedelta
-from typing import Dict, Optional, Tuple
 
 import structlog
 from fastapi import HTTPException

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -89,11 +89,11 @@ class CrawlManager(K8sAPI):
         replica_file_path: str,
         replica_endpoint: str,
         delay_days: int = 0,
-        primary_storage: Optional[StorageRef] = None,
-        primary_file_path: Optional[str] = None,
-        primary_endpoint: Optional[str] = None,
-        existing_job_id: Optional[str] = None,
-    ) -> Tuple[str, Optional[str]]:
+        primary_storage: StorageRef | None = None,
+        primary_file_path: str | None = None,
+        primary_endpoint: str | None = None,
+        existing_job_id: str | None = None,
+    ) -> tuple[str, str | None]:
         """run job to replicate file from primary storage to replica storage"""
 
         if existing_job_id:
@@ -102,7 +102,7 @@ class CrawlManager(K8sAPI):
             # Keep name shorter than in past to avoid k8s issues with length
             job_id = f"{job_type}-{secrets.token_hex(5)}"
 
-        params: Dict[str, object] = {
+        params: dict[str, object] = {
             "id": job_id,
             "oid": oid,
             "job_type": job_type,
@@ -134,7 +134,7 @@ class CrawlManager(K8sAPI):
     async def run_delete_org_job(
         self,
         oid: str,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ) -> str:
         """run job to delete org and all of its data"""
 
@@ -150,7 +150,7 @@ class CrawlManager(K8sAPI):
     async def run_recalculate_org_stats_job(
         self,
         oid: str,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ) -> str:
         """run job to recalculate storage stats for the org"""
 
@@ -166,9 +166,9 @@ class CrawlManager(K8sAPI):
     async def run_re_add_org_pages_job(
         self,
         oid: str,
-        crawl_type: Optional[str] = None,
-        crawl_id: Optional[str] = None,
-        existing_job_id: Optional[str] = None,
+        crawl_type: str | None = None,
+        crawl_id: str | None = None,
+        existing_job_id: str | None = None,
     ) -> str:
         """run job to recalculate storage stats for the org"""
 
@@ -186,7 +186,7 @@ class CrawlManager(K8sAPI):
         )
 
     async def run_optimize_pages_job(
-        self, existing_job_id: Optional[str] = None, scale=1
+        self, existing_job_id: str | None = None, scale=1
     ) -> str:
         """run job to optimize crawl pages"""
 
@@ -203,7 +203,7 @@ class CrawlManager(K8sAPI):
         self,
         oid: str,
         collection_id: str,
-        existing_job_id: Optional[str] = None,
+        existing_job_id: str | None = None,
     ) -> str:
         """run job to update collection stats"""
 
@@ -224,7 +224,7 @@ class CrawlManager(K8sAPI):
         self,
         job_id: str,
         job_type: str,
-        oid: Optional[str] = None,
+        oid: str | None = None,
         **kwargs,
     ) -> str:
         """run background job with access to ops classes"""
@@ -253,7 +253,7 @@ class CrawlManager(K8sAPI):
         image: str,
         image_pull_policy: str,
         job_type: TYPE_INDEX_JOB_TYPES,
-        crawl_id: Optional[str] = None,
+        crawl_id: str | None = None,
     ):
         """create dedupe index import/purge/post-crawl job"""
 
@@ -508,7 +508,7 @@ class CrawlManager(K8sAPI):
             return False
 
     async def add_org_storage(
-        self, storage: StorageRef, string_data: Dict[str, str], oid: str
+        self, storage: StorageRef, string_data: dict[str, str], oid: str
     ) -> None:
         """Add custom org storage secret"""
         labels = {"btrix.org": oid}
@@ -580,7 +580,7 @@ class CrawlManager(K8sAPI):
         return await self.delete_crawl_job(crawl_id)
 
     async def pause_resume_crawl(
-        self, crawl_id: str, paused_at: Optional[datetime] = None
+        self, crawl_id: str, paused_at: datetime | None = None
     ) -> dict:
         """pause or resume a crawl"""
         return await self._patch_job(
@@ -626,8 +626,8 @@ class CrawlManager(K8sAPI):
         await self._delete_custom_objects(f"btrix.org={oid_str}", plural="profilejobs")
 
     async def update_scheduled_job(
-        self, crawlconfig: CrawlConfig, userid: Optional[str] = None
-    ) -> Optional[str]:
+        self, crawlconfig: CrawlConfig, userid: str | None = None
+    ) -> str | None:
         """create or remove cron job based on crawlconfig schedule"""
         cid = str(crawlconfig.id)
 
@@ -679,9 +679,9 @@ class CrawlManager(K8sAPI):
     async def create_replica_deletion_scheduled_job(
         self,
         job_id: str,
-        params: Dict[str, object],
+        params: dict[str, object],
         delay_days: int,
-    ) -> Tuple[str, Optional[str]]:
+    ) -> tuple[str, str | None]:
         """create scheduled job to delay replica file in x days"""
         now = dt_now()
         run_at = now + timedelta(days=delay_days)

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -10,15 +10,7 @@ import re
 import urllib.parse
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from datetime import datetime
-from typing import (
-    Annotated,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Annotated, Any
 from uuid import UUID
 
 import structlog

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -8,17 +8,14 @@ import json
 import os
 import re
 import urllib.parse
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from datetime import datetime
 from typing import (
     Annotated,
     Any,
-    AsyncGenerator,
-    AsyncIterator,
-    Callable,
     Dict,
     List,
     Optional,
-    Sequence,
     Tuple,
     Union,
 )
@@ -149,7 +146,7 @@ class CrawlOps(BaseCrawlOps):
     async def get_crawl(
         self,
         crawlid: str,
-        org: Optional[Organization] = None,
+        org: Organization | None = None,
     ) -> Crawl:
         """Get crawl data for internal use"""
         res = await self.get_crawl_raw(crawlid, org, "crawl")
@@ -169,27 +166,27 @@ class CrawlOps(BaseCrawlOps):
 
     async def list_crawls(
         self,
-        org: Optional[Organization] = None,
-        cid: Optional[UUID] = None,
-        userid: Optional[UUID] = None,
+        org: Organization | None = None,
+        cid: UUID | None = None,
+        userid: UUID | None = None,
         crawl_id: str = "",
         running_only=False,
-        state: Optional[List[str]] = None,
-        first_seed: Optional[str] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        state: list[str] | None = None,
+        first_seed: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
         tags: list[str] | None = None,
         tag_match: ListFilterType | None = ListFilterType.AND,
-        collection_id: Optional[UUID] = None,
-        dedupe_coll_id: Optional[UUID] = None,
+        collection_id: UUID | None = None,
+        dedupe_coll_id: UUID | None = None,
         requires_crawls: list[str] | None = None,
         required_by_crawls: list[str] | None = None,
-        has_requires_crawls: Optional[bool] = None,
-        has_required_by_crawls: Optional[bool] = None,
-        crawl_ids: Optional[List[str]] = None,
+        has_requires_crawls: bool | None = None,
+        has_required_by_crawls: bool | None = None,
+        crawl_ids: list[str] | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: Optional[str] = None,
+        sort_by: str | None = None,
         sort_direction: int = -1,
         resources: bool = False,
         session: AsyncIOMotorClientSession | None = None,
@@ -439,7 +436,7 @@ class CrawlOps(BaseCrawlOps):
         org: Organization,
         delete_list: DeleteCrawlList,
         type_="crawl",
-        user: Optional[User] = None,
+        user: User | None = None,
     ) -> tuple[int, dict[UUID, dict[str, int]], bool]:
         """Delete a list of crawls by id for given org"""
 
@@ -694,19 +691,19 @@ class CrawlOps(BaseCrawlOps):
         is_qa: bool,
         state: TYPE_ALL_CRAWL_STATES,
         allowed_from: Sequence[TYPE_ALL_CRAWL_STATES],
-        finished: Optional[datetime] = None,
-        stats: Optional[CrawlStats] = None,
+        finished: datetime | None = None,
+        stats: CrawlStats | None = None,
     ) -> bool:
         """update crawl state and other properties in db if state has changed"""
         prefix = "" if not is_qa else "qa."
 
-        update: Dict[str, Any] = {f"{prefix}state": state}
+        update: dict[str, Any] = {f"{prefix}state": state}
         if finished:
             update[f"{prefix}finished"] = finished
         if stats:
             update[f"{prefix}stats"] = stats.dict()
 
-        query: Dict[str, Any] = {"_id": crawl_id, "type": "crawl"}
+        query: dict[str, Any] = {"_id": crawl_id, "type": "crawl"}
         if allowed_from:
             query[f"{prefix}state"] = {"$in": allowed_from}
 
@@ -760,7 +757,7 @@ class CrawlOps(BaseCrawlOps):
 
     async def get_crawl_exec_last_update_time(
         self, crawl_id: str, is_qa: bool
-    ) -> Optional[datetime]:
+    ) -> datetime | None:
         """get crawl last updated time"""
         field = "_lut" if not is_qa else "qa._lut"
         res = await self.crawls.find_one(
@@ -773,7 +770,7 @@ class CrawlOps(BaseCrawlOps):
 
     async def get_crawl_state(
         self, crawl_id: str, is_qa: bool
-    ) -> tuple[Optional[TYPE_ALL_CRAWL_STATES], Optional[datetime]]:
+    ) -> tuple[TYPE_ALL_CRAWL_STATES | None, datetime | None]:
         """return current crawl state of a crawl"""
         prefix = "" if not is_qa else "qa."
 
@@ -828,22 +825,22 @@ class CrawlOps(BaseCrawlOps):
             return [], 0
 
     async def get_crawl_stats(
-        self, org: Optional[Organization] = None
-    ) -> List[Dict[str, Union[str, int]]]:
+        self, org: Organization | None = None
+    ) -> list[dict[str, str | int]]:
         """Return crawl statistics"""
         # pylint: disable=too-many-locals
         org_slugs = await self.orgs.get_org_slugs_by_ids()
         user_emails = await self.user_manager.get_user_emails_by_ids()
 
-        crawls_data: List[Dict[str, Union[str, int]]] = []
+        crawls_data: list[dict[str, str | int]] = []
 
-        query: Dict[str, Union[str, UUID]] = {"type": "crawl"}
+        query: dict[str, str | UUID] = {"type": "crawl"}
         if org:
             query["oid"] = org.id
 
         async for crawl_raw in self.crawls.find(query):
             crawl = Crawl.from_dict(crawl_raw)
-            data: Dict[str, Union[str, int]] = {}
+            data: dict[str, str | int] = {}
             data["id"] = crawl.id
 
             data["oid"] = str(crawl.oid)
@@ -885,8 +882,8 @@ class CrawlOps(BaseCrawlOps):
         crawl_id: str,
         org: Organization,
         pause: bool,
-        paused_at: Optional[datetime] = None,
-    ) -> Dict[str, bool]:
+        paused_at: datetime | None = None,
+    ) -> dict[str, bool]:
         """pause or resume a crawl temporarily"""
         crawl = await self.get_base_crawl(crawl_id, org)
         if crawl and crawl.type != "crawl":
@@ -922,7 +919,7 @@ class CrawlOps(BaseCrawlOps):
 
     async def shutdown_crawl(
         self, crawl_id: str, org: Organization, graceful: bool
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """stop or cancel specified crawl"""
         crawl = await self.get_base_crawl(crawl_id, org)
         if crawl and crawl.type != "crawl":
@@ -1115,7 +1112,7 @@ class CrawlOps(BaseCrawlOps):
         if not crawl.qa:
             return False
 
-        query: Dict[str, Any] = {"qa": None}
+        query: dict[str, Any] = {"qa": None}
 
         if crawl.qa.finished and crawl.qa.state in NON_RUNNING_STATES:
             query[f"qaFinished.{crawl.qa.id}"] = crawl.qa.dict()
@@ -1134,8 +1131,8 @@ class CrawlOps(BaseCrawlOps):
         self,
         crawl_id: str,
         skip_failed: bool = False,
-        org: Optional[Organization] = None,
-    ) -> List[QARunOut]:
+        org: Organization | None = None,
+    ) -> list[QARunOut]:
         """Return list of QA runs"""
         crawl_data = await self.get_crawl_raw(
             crawl_id, org, "crawl", project={"qaFinished": True, "qa": True}
@@ -1157,8 +1154,8 @@ class CrawlOps(BaseCrawlOps):
         return all_qa
 
     async def get_active_qa(
-        self, crawl_id: str, org: Optional[Organization] = None
-    ) -> Optional[QARunOut]:
+        self, crawl_id: str, org: Organization | None = None
+    ) -> QARunOut | None:
         """return just the active QA, if any"""
         crawl_data = await self.get_crawl_raw(
             crawl_id, org, "crawl", project={"qa": True}
@@ -1167,7 +1164,7 @@ class CrawlOps(BaseCrawlOps):
         return QARunOut(**qa) if qa else None
 
     async def get_qa_run(
-        self, crawl_id: str, qa_run_id: str, org: Optional[Organization] = None
+        self, crawl_id: str, qa_run_id: str, org: Organization | None = None
     ):
         """Get QARun by id"""
         crawl = await self.get_crawl(crawl_id, org)
@@ -1180,7 +1177,7 @@ class CrawlOps(BaseCrawlOps):
         return qa_run
 
     async def get_qa_run_for_replay(
-        self, crawl_id: str, qa_run_id: str, org: Optional[Organization] = None
+        self, crawl_id: str, qa_run_id: str, org: Organization | None = None
     ) -> QARunWithResources:
         """Fetch QA runs with resources for replay.json"""
         crawl = await self.get_crawl(crawl_id, org)
@@ -1241,7 +1238,7 @@ class CrawlOps(BaseCrawlOps):
         self,
         crawl_id: str,
         qa_run_id: str,
-        thresholds: Dict[str, List[float]],
+        thresholds: dict[str, list[float]],
     ) -> QARunAggregateStatsOut:
         """Get aggregate stats for QA run"""
         screenshot_results = await self.page_ops.get_qa_run_aggregate_counts(
@@ -1263,10 +1260,10 @@ class CrawlOps(BaseCrawlOps):
         page: int = 1,
         sort_by: str = "timestamp",
         sort_direction: int = 1,
-        contexts: Optional[List[str]] = None,
-        log_levels: Optional[List[str]] = None,
-        qa_run_id: Optional[str] = None,
-    ) -> Tuple[list[CrawlLogLine], int]:
+        contexts: list[str] | None = None,
+        log_levels: list[str] | None = None,
+        qa_run_id: str | None = None,
+    ) -> tuple[list[CrawlLogLine], int]:
         """get crawl logs"""
         return await self.crawl_log_ops.get_crawl_logs(
             org,
@@ -1393,17 +1390,17 @@ def init_crawls_api(
         user: User = Depends(user_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        userid: Optional[UUID] = None,
-        cid: Optional[UUID] = None,
-        state: Optional[str] = None,
-        firstSeed: Optional[str] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        collectionId: Optional[UUID] = None,
+        userid: UUID | None = None,
+        cid: UUID | None = None,
+        state: str | None = None,
+        firstSeed: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        collectionId: UUID | None = None,
         ids: Annotated[list[str] | None, Query()] = None,
-        sortBy: Optional[str] = None,
+        sortBy: str | None = None,
         sortDirection: int = -1,
-        runningOnly: Optional[bool] = True,
+        runningOnly: bool | None = True,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")
@@ -1446,12 +1443,12 @@ def init_crawls_api(
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        userid: Optional[UUID] = None,
-        cid: Optional[UUID] = None,
+        userid: UUID | None = None,
+        cid: UUID | None = None,
         state: Annotated[list[str] | None, Query()] = None,
-        firstSeed: Optional[str] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        firstSeed: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
         tags: Annotated[list[str] | None, Query()] = None,
         tag_match: Annotated[
             ListFilterType | None,
@@ -1461,14 +1458,14 @@ def init_crawls_api(
                 description='Defaults to `"and"` if omitted',
             ),
         ] = ListFilterType.AND,
-        collectionId: Optional[UUID] = None,
-        dedupeCollId: Optional[UUID] = None,
+        collectionId: UUID | None = None,
+        dedupeCollId: UUID | None = None,
         requiresCrawls: Annotated[list[str] | None, Query()] = None,
         requiredByCrawls: Annotated[list[str] | None, Query()] = None,
-        hasRequiresCrawls: Optional[bool] = None,
-        hasRequiredByCrawls: Optional[bool] = None,
+        hasRequiresCrawls: bool | None = None,
+        hasRequiredByCrawls: bool | None = None,
         ids: Annotated[list[str] | None, Query()] = None,
-        sortBy: Optional[str] = None,
+        sortBy: str | None = None,
         sortDirection: int = -1,
     ):
         # Support both comma-separated values and multiple search parameters
@@ -1697,7 +1694,7 @@ def init_crawls_api(
         # pylint: disable=unused-argument
         org: Organization = Depends(org_viewer_dep),
     ):
-        thresholds: Dict[str, List[float]] = {}
+        thresholds: dict[str, list[float]] = {}
         try:
             thresholds["screenshotMatch"] = [
                 float(threshold) for threshold in screenshotThresholds.split(",")
@@ -1765,7 +1762,7 @@ def init_crawls_api(
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/qa",
         tags=["qa"],
-        response_model=List[QARunOut],
+        response_model=list[QARunOut],
     )
     async def get_qa_runs(
         crawl_id, org: Organization = Depends(org_viewer_dep), skipFailed: bool = False
@@ -1775,7 +1772,7 @@ def init_crawls_api(
     @app.get(
         "/orgs/{oid}/crawls/{crawl_id}/qa/activeQA",
         tags=["qa"],
-        response_model=Dict[str, Optional[QARunOut]],
+        response_model=dict[str, QARunOut | None],
     )
     async def get_active_qa(crawl_id, org: Organization = Depends(org_viewer_dep)):
         return {"qa": await ops.get_active_qa(crawl_id, org)}
@@ -1935,8 +1932,8 @@ def init_crawls_api(
     async def stream_crawl_logs(
         crawl_id,
         org: Organization = Depends(org_viewer_dep),
-        logLevel: Optional[str] = None,
-        context: Optional[str] = None,
+        logLevel: str | None = None,
+        context: str | None = None,
     ):
         crawl = await ops.get_crawl_out(crawl_id, org)
 

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -7,15 +7,7 @@ import contextvars
 import importlib.util
 import os
 import urllib.parse
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -395,7 +395,7 @@ T = TypeVar("T")
 class BaseMongoModel(BaseModel):
     """Base pydantic model that is also a mongo doc"""
 
-    id: Optional[Union[UUID, str]]
+    id: UUID | str | None
 
     @property
     def id_str(self):
@@ -403,7 +403,7 @@ class BaseMongoModel(BaseModel):
         return str(self.id)
 
     @classmethod
-    def from_dict(cls: Type[T], data: dict) -> T:
+    def from_dict(cls: type[T], data: dict) -> T:
         """convert dict from mongo to a class"""
         if not data:
             return cls()

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -58,7 +58,7 @@ class EmailSender:
     sender: str
     password: str
     reply_to: str
-    smtp_server: Optional[str]
+    smtp_server: str | None
     smtp_port: int
     smtp_use_tls: bool
     support_email: str
@@ -159,7 +159,7 @@ class EmailSender:
                         )
                         return
 
-                    msg: Union[EmailMessage, MIMEMultipart]
+                    msg: EmailMessage | MIMEMultipart
 
                     if html:
                         msg = MIMEMultipart("alternative")
@@ -193,7 +193,7 @@ class EmailSender:
             raise exc
 
     async def send_user_validation(
-        self, receiver_email: str, token: str, headers: Optional[dict] = None
+        self, receiver_email: str, token: str, headers: dict | None = None
     ):
         """Send email to validate registration email address"""
 
@@ -214,8 +214,8 @@ class EmailSender:
         token: UUID,
         org_name: str,
         is_new: bool,
-        subscription: Optional[Subscription] = None,
-        headers: Optional[dict] = None,
+        subscription: Subscription | None = None,
+        headers: dict | None = None,
     ):
         """Send email to invite new user"""
 
@@ -258,10 +258,10 @@ class EmailSender:
 
     async def send_background_job_failed(
         self,
-        job: Union[CreateReplicaJob, DeleteReplicaJob],
+        job: CreateReplicaJob | DeleteReplicaJob,
         finished: datetime,
         receiver_email: str,
-        org: Optional[Organization] = None,
+        org: Organization | None = None,
     ):
         """Send background job failed email to superuser"""
         await self._send_encrypted(

--- a/backend/btrixcloud/emailsender.py
+++ b/backend/btrixcloud/emailsender.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from email.message import EmailMessage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Literal, Optional, Union
+from typing import Literal
 from uuid import UUID
 
 import structlog

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -2,12 +2,11 @@
 
 import os
 import tempfile
+from collections.abc import AsyncGenerator, Callable
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    Callable,
     Dict,
     List,
     Optional,
@@ -83,10 +82,10 @@ class FileUploadOps:
     async def get_file_raw(
         self,
         file_id: UUID,
-        org: Optional[Organization] = None,
-        type_: Optional[str] = None,
+        org: Organization | None = None,
+        type_: str | None = None,
         session: AsyncIOMotorClientSession | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get raw file from db"""
         query: dict[str, object] = {"_id": file_id}
         if org:
@@ -105,8 +104,8 @@ class FileUploadOps:
     async def get_seed_file(
         self,
         file_id: UUID,
-        org: Optional[Organization] = None,
-        type_: Optional[str] = None,
+        org: Organization | None = None,
+        type_: str | None = None,
         session: AsyncIOMotorClientSession | None = None,
     ) -> SeedFile:
         """Get file by UUID"""
@@ -116,9 +115,9 @@ class FileUploadOps:
     async def get_seed_file_out(
         self,
         file_id: UUID,
-        org: Optional[Organization] = None,
-        type_: Optional[str] = None,
-        headers: Optional[dict] = None,
+        org: Organization | None = None,
+        type_: str | None = None,
+        headers: dict | None = None,
     ) -> SeedFileOut:
         """Get file output model by UUID"""
         user_file = await self.get_seed_file(file_id, org, type_)
@@ -131,8 +130,8 @@ class FileUploadOps:
         page: int = 1,
         sort_by: str = "created",
         sort_direction: int = -1,
-        headers: Optional[dict] = None,
-    ) -> Tuple[list[SeedFileOut], int]:
+        headers: dict | None = None,
+    ) -> tuple[list[SeedFileOut], int]:
         """list all user-uploaded files"""
         # pylint: disable=too-many-locals
 
@@ -142,7 +141,7 @@ class FileUploadOps:
 
         match_query = {"oid": org.id}
 
-        aggregate: List[Dict[str, Any]] = [{"$match": match_query}]
+        aggregate: list[dict[str, Any]] = [{"$match": match_query}]
 
         if sort_by:
             if sort_by not in (
@@ -200,7 +199,7 @@ class FileUploadOps:
         org: Organization,
         user: User,
         upload_type: str = "seedFile",
-    ) -> Dict[str, Union[bool, UUID]]:
+    ) -> dict[str, bool | UUID]:
         """Upload file stream and return its id"""
         self.org_ops.can_write_data(org, include_time=False)
 
@@ -316,7 +315,7 @@ class FileUploadOps:
 
     async def _parse_seed_info_from_file(
         self, file_obj: UserFile, org: Organization
-    ) -> Tuple[str, int]:
+    ) -> tuple[str, int]:
         first_seed = ""
         seed_count = 0
 
@@ -352,7 +351,7 @@ class FileUploadOps:
         file_id: UUID,
         org: Organization,
         session: AsyncIOMotorClientSession | None = None,
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """Delete user-uploaded file from storage and db"""
         file = await self.get_seed_file(file_id, org, session=session)
 

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -4,15 +4,7 @@ import os
 import tempfile
 from collections.abc import AsyncGenerator, Callable
 from datetime import timedelta
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -4,7 +4,7 @@ import hashlib
 import os
 import time
 import urllib.parse
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/btrixcloud/invites.py
+++ b/backend/btrixcloud/invites.py
@@ -82,8 +82,8 @@ class InviteOps:
         new_user_invite: InvitePending,
         invite_token: UUID,
         org_name: str,
-        subscription: Optional[Subscription],
-        headers: Optional[dict],
+        subscription: Subscription | None,
+        headers: dict | None,
     ) -> None:
         """Add invite for new user"""
 
@@ -123,7 +123,7 @@ class InviteOps:
         user: User,
         org: Organization,
         org_name: str,
-        headers: Optional[dict],
+        headers: dict | None,
     ) -> None:
         """Add existing user invite"""
 
@@ -158,8 +158,8 @@ class InviteOps:
     async def get_valid_invite(
         self,
         invite_token: UUID,
-        email: Optional[EmailStr],
-        userid: Optional[UUID] = None,
+        email: EmailStr | None,
+        userid: UUID | None = None,
     ) -> InvitePending:
         """Retrieve a valid invite data from db, or throw if invalid"""
         token_hash = get_hash(invite_token)
@@ -182,7 +182,7 @@ class InviteOps:
         await self.invites.delete_one({"_id": invite_token})
 
     async def remove_invite_by_email(
-        self, email: EmailStr, oid: Optional[UUID] = None
+        self, email: EmailStr, oid: UUID | None = None
     ) -> Any:
         """remove invite from invite list by email"""
         query: dict[str, object] = {"email": email}
@@ -199,7 +199,7 @@ class InviteOps:
         user: User,
         user_manager: UserManager,
         org: Organization,
-        headers: Optional[dict] = None,
+        headers: dict | None = None,
     ) -> tuple[bool, UUID]:
         """Invite user to org (if not specified, to default org).
 
@@ -256,7 +256,7 @@ class InviteOps:
     async def get_pending_invites(
         self,
         users: UserManager,
-        org: Optional[Organization] = None,
+        org: Organization | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
     ) -> tuple[list[InviteOut], int]:

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -80,7 +80,7 @@ class K8sAPI:
             socket_timeout=20,
         )
 
-    async def get_redis_connected(self, obj_id: str) -> Optional[Redis]:
+    async def get_redis_connected(self, obj_id: str) -> Redis | None:
         """init redis, ensure connectivity"""
         redis_url = self.get_redis_url(obj_id)
         redis = None
@@ -104,14 +104,14 @@ class K8sAPI:
         userid: str,
         oid: str,
         storage: str,
-        crawler_channel: Optional[str] = "",
-        scale: Optional[int] = 1,
-        browser_windows: Optional[int] = 1,
-        crawl_timeout: Optional[int] = 0,
-        max_crawl_size: Optional[int] = 0,
+        crawler_channel: str | None = "",
+        scale: int | None = 1,
+        browser_windows: int | None = 1,
+        crawl_timeout: int | None = 0,
+        max_crawl_size: int | None = 0,
         manual: bool = True,
-        crawl_id: Optional[str] = None,
-        warc_prefix: Optional[str] = "",
+        crawl_id: str | None = None,
+        warc_prefix: str | None = "",
         storage_filename: str = "",
         profile_filename: str = "",
         profileid: str = "",
@@ -159,14 +159,14 @@ class K8sAPI:
         userid: str,
         oid: str,
         storage: str,
-        crawler_channel: Optional[str] = "",
-        scale: Optional[int] = 1,
-        browser_windows: Optional[int] = 1,
-        crawl_timeout: Optional[int] = 0,
-        max_crawl_size: Optional[int] = 0,
+        crawler_channel: str | None = "",
+        scale: int | None = 1,
+        browser_windows: int | None = 1,
+        crawl_timeout: int | None = 0,
+        max_crawl_size: int | None = 0,
         manual: bool = True,
-        crawl_id: Optional[str] = None,
-        warc_prefix: Optional[str] = "",
+        crawl_id: str | None = None,
+        warc_prefix: str | None = "",
         storage_filename: str = "",
         profile_filename: str = "",
         profileid: str = "",
@@ -487,7 +487,7 @@ class K8sAPI:
             namespace=self.namespace,
         )
 
-    async def list_cron_jobs(self, label: str = "") -> List[V1CronJob]:
+    async def list_cron_jobs(self, label: str = "") -> list[V1CronJob]:
         """Return list of all cron jobs, optionally filtered by label"""
         resp = await self.batch_api.list_namespaced_cron_job(
             namespace=self.namespace,
@@ -495,7 +495,7 @@ class K8sAPI:
         )
         return resp.items
 
-    async def list_crawl_jobs(self, label: str = "") -> List[dict[str, Any]]:
+    async def list_crawl_jobs(self, label: str = "") -> list[dict[str, Any]]:
         """Return list of all crawl jobs, optionally filtered by label"""
         resp = await self.custom_api.list_namespaced_custom_object(
             group="btrix.cloud",

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -1,7 +1,7 @@
 """K8S API Access"""
 
 import os
-from typing import Any, List, Optional
+from typing import Any
 
 import structlog
 import yaml

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -5,7 +5,6 @@ supports docker and kubernetes based deployments of multiple browsertrix-crawler
 
 import os
 import sys
-from typing import List, Optional
 
 import structlog
 from fastapi import FastAPI, HTTPException

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -129,7 +129,7 @@ class SettingsResponse(BaseModel):
     salesEmail: str = ""
     supportEmail: str = ""
 
-    localesEnabled: Optional[List[str]]
+    localesEnabled: list[str] | None
 
     pausedExpiryMinutes: int
 

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -48,7 +48,7 @@ class Migration(BaseMigration):
                     )
                     continue
 
-                seeds = cast(List[Seed], config.config.seeds)
+                seeds = cast(list[Seed], config.config.seeds)
                 seed_count = len(seeds)
                 first_seed = seeds[0].url
 
@@ -70,7 +70,7 @@ class Migration(BaseMigration):
                 )
 
         # Crawls
-        crawl_query: Dict[str, Any] = {
+        crawl_query: dict[str, Any] = {
             "type": "crawl",
             "$or": [
                 {"firstSeed": {"$in": [None, ""]}},

--- a/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
+++ b/backend/btrixcloud/migrations/migration_0048_first_seed_seed_count.py
@@ -2,7 +2,7 @@
 Migration 0048 - Calculate firstSeed/seedCount and store directly in database
 """
 
-from typing import Any, Dict, List, cast
+from typing import Any, cast
 
 import structlog
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -151,12 +151,12 @@ class InvitePending(BaseMongoModel):
     created: datetime
     tokenHash: str
     inviterEmail: EmailStr
-    fromSuperuser: Optional[bool] = False
-    oid: Optional[UUID] = None
+    fromSuperuser: bool | None = False
+    oid: UUID | None = None
     role: UserRole = UserRole.VIEWER
-    email: Optional[EmailStr] = None
+    email: EmailStr | None = None
     # set if existing user
-    userid: Optional[UUID] = None
+    userid: UUID | None = None
 
 
 # ============================================================================
@@ -164,14 +164,14 @@ class InviteOut(BaseModel):
     """Single invite output model"""
 
     created: datetime
-    inviterEmail: Optional[EmailStr] = None
-    inviterName: Optional[str] = None
+    inviterEmail: EmailStr | None = None
+    inviterName: str | None = None
     fromSuperuser: bool
-    oid: Optional[UUID] = None
-    orgName: Optional[str] = None
-    orgSlug: Optional[str] = None
+    oid: UUID | None = None
+    orgName: str | None = None
+    orgSlug: str | None = None
     role: UserRole = UserRole.VIEWER
-    email: Optional[EmailStr] = None
+    email: EmailStr | None = None
     firstOrgAdmin: bool = False
 
 
@@ -384,71 +384,71 @@ class Seed(BaseModel):
     """Crawl seed"""
 
     url: HttpUrl
-    scopeType: Optional[ScopeType] = None
+    scopeType: ScopeType | None = None
 
-    include: Union[str, List[str], None] = None
-    exclude: Union[str, List[str], None] = None
-    sitemap: Union[bool, HttpUrl, None] = None
-    allowHash: Optional[bool] = None
-    depth: Optional[int] = None
-    extraHops: Optional[int] = None
+    include: str | list[str] | None = None
+    exclude: str | list[str] | None = None
+    sitemap: bool | HttpUrl | None = None
+    allowHash: bool | None = None
+    depth: int | None = None
+    extraHops: int | None = None
 
 
 # ============================================================================
 class RawCrawlConfig(BaseModel):
     """Base Crawl Config"""
 
-    seeds: Optional[List[Seed]] = []
+    seeds: list[Seed] | None = []
 
-    seedFileId: Optional[UUID] = None
+    seedFileId: UUID | None = None
 
-    scopeType: Optional[ScopeType] = ScopeType.PREFIX
+    scopeType: ScopeType | None = ScopeType.PREFIX
 
-    include: Union[str, List[str], None] = None
-    exclude: Union[str, List[str], None] = None
+    include: str | list[str] | None = None
+    exclude: str | list[str] | None = None
 
-    depth: Optional[int] = -1
-    limit: Optional[int] = 0
-    extraHops: Optional[int] = 0
+    depth: int | None = -1
+    limit: int | None = 0
+    extraHops: int | None = 0
 
-    lang: Optional[str] = None
-    blockAds: Optional[bool] = False
+    lang: str | None = None
+    blockAds: bool | None = False
 
-    behaviorTimeout: Optional[int] = None
-    pageLoadTimeout: Optional[int] = None
-    pageExtraDelay: Optional[int] = 0
-    postLoadDelay: Optional[int] = 0
+    behaviorTimeout: int | None = None
+    pageLoadTimeout: int | None = None
+    pageExtraDelay: int | None = 0
+    postLoadDelay: int | None = 0
 
-    workers: Optional[int] = None
+    workers: int | None = None
 
-    headless: Optional[bool] = None
+    headless: bool | None = None
 
-    generateWACZ: Optional[bool] = None
-    combineWARC: Optional[bool] = None
+    generateWACZ: bool | None = None
+    combineWARC: bool | None = None
 
-    useSitemap: Optional[bool] = False
-    useRobots: Optional[bool] = False
+    useSitemap: bool | None = False
+    useRobots: bool | None = False
 
-    failOnFailedSeed: Optional[bool] = False
-    failOnContentCheck: Optional[bool] = False
+    failOnFailedSeed: bool | None = False
+    failOnContentCheck: bool | None = False
 
-    logging: Optional[str] = None
-    behaviors: Optional[str] = "autoscroll,autoplay,autofetch,siteSpecific"
-    customBehaviors: List[str] = []
+    logging: str | None = None
+    behaviors: str | None = "autoscroll,autoplay,autofetch,siteSpecific"
+    customBehaviors: list[str] = []
 
-    userAgent: Optional[str] = None
+    userAgent: str | None = None
 
-    selectLinks: List[str] = ["a[href]->href"]
+    selectLinks: list[str] = ["a[href]->href"]
     clickSelector: str = "a"
 
-    saveStorage: Optional[bool] = False
+    saveStorage: bool | None = False
 
 
 # ============================================================================
 class CrawlConfigIn(BaseModel):
     """CrawlConfig input model, submitted via API"""
 
-    schedule: Optional[str] = ""
+    schedule: str | None = ""
     runNow: bool = False
 
     config: RawCrawlConfig
@@ -457,14 +457,14 @@ class CrawlConfigIn(BaseModel):
 
     description: Description = ""
 
-    jobType: Optional[JobType] = JobType.CUSTOM
+    jobType: JobType | None = JobType.CUSTOM
 
-    profileid: Union[UUID, EmptyStr, None] = None
+    profileid: UUID | EmptyStr | None = None
     crawlerChannel: str = "default"
-    proxyId: Optional[str] = None
+    proxyId: str | None = None
 
-    autoAddCollections: Optional[List[UUID]] = []
-    dedupeCollId: Union[UUID, EmptyStr, None] = None
+    autoAddCollections: list[UUID] | None = []
+    dedupeCollId: UUID | EmptyStr | None = None
 
     tags: list[Tag] | None = []
 
@@ -474,9 +474,9 @@ class CrawlConfigIn(BaseModel):
     scale: Scale = 1
 
     # Overrides scale if set
-    browserWindows: Optional[BrowserWindowCount] = None
+    browserWindows: BrowserWindowCount | None = None
 
-    crawlFilenameTemplate: Optional[str] = None
+    crawlFilenameTemplate: str | None = None
 
     shareable: bool = False
 
@@ -487,21 +487,21 @@ class ConfigRevision(BaseMongoModel):
 
     cid: UUID
 
-    schedule: Optional[str] = ""
+    schedule: str | None = ""
 
     config: RawCrawlConfig
 
-    profileid: Optional[UUID] = None
-    crawlerChannel: Optional[str] = None
-    proxyId: Optional[str] = None
+    profileid: UUID | None = None
+    crawlerChannel: str | None = None
+    proxyId: str | None = None
 
-    crawlTimeout: Optional[int] = 0
-    maxCrawlSize: Optional[int] = 0
-    scale: Optional[Scale] = 1
-    browserWindows: Optional[BrowserWindowCount] = 2
+    crawlTimeout: int | None = 0
+    maxCrawlSize: int | None = 0
+    scale: Scale | None = 1
+    browserWindows: BrowserWindowCount | None = 2
 
     modified: datetime
-    modifiedBy: Optional[UUID] = None
+    modifiedBy: UUID | None = None
 
     rev: int = 0
 
@@ -510,29 +510,29 @@ class ConfigRevision(BaseMongoModel):
 class CrawlConfigCore(BaseMongoModel):
     """Core data shared between crawls and crawlconfigs"""
 
-    schedule: Optional[str] = ""
+    schedule: str | None = ""
 
-    jobType: Optional[JobType] = JobType.CUSTOM
-    config: Optional[RawCrawlConfig] = None
+    jobType: JobType | None = JobType.CUSTOM
+    config: RawCrawlConfig | None = None
 
     tags: list[Tag] | None = []
 
-    crawlTimeout: Optional[int] = 0
-    maxCrawlSize: Optional[int] = 0
+    crawlTimeout: int | None = 0
+    maxCrawlSize: int | None = 0
 
-    scale: Optional[Scale] = None
+    scale: Scale | None = None
     browserWindows: BrowserWindowCount = 2
 
     oid: UUID
 
-    profileid: Optional[UUID] = None
-    crawlerChannel: Optional[str] = None
-    proxyId: Optional[str] = None
+    profileid: UUID | None = None
+    crawlerChannel: str | None = None
+    proxyId: str | None = None
 
     firstSeed: str = ""
     seedCount: int = 0
 
-    dedupeCollId: Optional[UUID] = None
+    dedupeCollId: UUID | None = None
 
 
 # ============================================================================
@@ -543,37 +543,37 @@ class CrawlConfigAdditional(BaseModel):
     description: Description | None = None
 
     created: datetime
-    createdBy: Optional[UUID] = None
+    createdBy: UUID | None = None
 
-    modified: Optional[datetime] = None
-    modifiedBy: Optional[UUID] = None
+    modified: datetime | None = None
+    modifiedBy: UUID | None = None
 
-    autoAddCollections: Optional[List[UUID]] = []
+    autoAddCollections: list[UUID] | None = []
 
-    inactive: Optional[bool] = False
+    inactive: bool | None = False
 
     rev: int = 0
 
-    crawlAttemptCount: Optional[int] = 0
-    crawlCount: Optional[int] = 0
-    crawlSuccessfulCount: Optional[int] = 0
+    crawlAttemptCount: int | None = 0
+    crawlCount: int | None = 0
+    crawlSuccessfulCount: int | None = 0
 
-    totalSize: Optional[int] = 0
+    totalSize: int | None = 0
 
-    lastCrawlId: Optional[str] = None
-    lastCrawlStartTime: Optional[datetime] = None
-    lastStartedBy: Optional[UUID] = None
-    lastCrawlTime: Optional[datetime] = None
-    lastCrawlState: Optional[str] = None
-    lastCrawlSize: Optional[int] = None
+    lastCrawlId: str | None = None
+    lastCrawlStartTime: datetime | None = None
+    lastStartedBy: UUID | None = None
+    lastCrawlTime: datetime | None = None
+    lastCrawlState: str | None = None
+    lastCrawlSize: int | None = None
 
-    lastRun: Optional[datetime] = None
+    lastRun: datetime | None = None
 
-    isCrawlRunning: Optional[bool] = False
+    isCrawlRunning: bool | None = False
 
-    crawlFilenameTemplate: Optional[str] = None
+    crawlFilenameTemplate: str | None = None
 
-    shareable: Optional[bool] = False
+    shareable: bool | None = False
 
 
 # ============================================================================
@@ -583,9 +583,9 @@ class CrawlConfig(CrawlConfigCore, CrawlConfigAdditional):
     id: UUID
 
     config: RawCrawlConfig
-    createdByName: Optional[str] = None
-    modifiedByName: Optional[str] = None
-    lastStartedByName: Optional[str] = None
+    createdByName: str | None = None
+    modifiedByName: str | None = None
+    lastStartedByName: str | None = None
 
     def get_raw_config(self):
         """serialize config for browsertrix-crawler"""
@@ -598,16 +598,16 @@ class CrawlConfigOut(CrawlConfigCore, CrawlConfigAdditional):
 
     id: UUID
 
-    lastCrawlStopping: Optional[bool] = False
-    lastCrawlShouldPause: Optional[bool] = False
-    lastCrawlPausedAt: Optional[datetime] = None
-    lastCrawlPausedExpiry: Optional[datetime] = None
-    lastCrawlStats: Optional[CrawlStats] = None
-    profileName: Optional[str] = None
+    lastCrawlStopping: bool | None = False
+    lastCrawlShouldPause: bool | None = False
+    lastCrawlPausedAt: datetime | None = None
+    lastCrawlPausedExpiry: datetime | None = None
+    lastCrawlStats: CrawlStats | None = None
+    profileName: str | None = None
 
-    createdByName: Optional[str] = None
-    modifiedByName: Optional[str] = None
-    lastStartedByName: Optional[str] = None
+    createdByName: str | None = None
+    modifiedByName: str | None = None
+    lastStartedByName: str | None = None
 
 
 # ============================================================================
@@ -618,52 +618,52 @@ class UpdateCrawlConfig(BaseModel):
     name: NameOrEmptyStr | None = None
     tags: list[Tag] | None = None
     description: Description = None
-    autoAddCollections: Optional[List[UUID]] = None
-    dedupeCollId: Union[UUID, EmptyStr, None] = None
+    autoAddCollections: list[UUID] | None = None
+    dedupeCollId: UUID | EmptyStr | None = None
     runNow: bool = False
     updateRunning: bool = False
 
     # crawl data: revision tracked
-    schedule: Optional[str] = None
-    profileid: Union[UUID, EmptyStr, None] = None
-    crawlerChannel: Optional[str] = None
-    proxyId: Optional[str] = None
-    crawlTimeout: Optional[int] = None
-    maxCrawlSize: Optional[int] = None
-    scale: Optional[Scale] = None
-    browserWindows: Optional[BrowserWindowCount] = None
-    crawlFilenameTemplate: Optional[str] = None
-    config: Optional[RawCrawlConfig] = None
-    shareable: Optional[bool] = None
+    schedule: str | None = None
+    profileid: UUID | EmptyStr | None = None
+    crawlerChannel: str | None = None
+    proxyId: str | None = None
+    crawlTimeout: int | None = None
+    maxCrawlSize: int | None = None
+    scale: Scale | None = None
+    browserWindows: BrowserWindowCount | None = None
+    crawlFilenameTemplate: str | None = None
+    config: RawCrawlConfig | None = None
+    shareable: bool | None = None
 
 
 # ============================================================================
 class CrawlConfigDefaults(BaseModel):
     """Crawl Config Org Defaults"""
 
-    crawlTimeout: Optional[int] = None
-    maxCrawlSize: Optional[int] = None
+    crawlTimeout: int | None = None
+    maxCrawlSize: int | None = None
 
-    pageLoadTimeout: Optional[int] = None
-    postLoadDelay: Optional[int] = None
-    behaviorTimeout: Optional[int] = None
-    pageExtraDelay: Optional[int] = None
+    pageLoadTimeout: int | None = None
+    postLoadDelay: int | None = None
+    behaviorTimeout: int | None = None
+    pageExtraDelay: int | None = None
 
-    blockAds: Optional[bool] = None
+    blockAds: bool | None = None
 
-    profileid: Optional[UUID] = None
-    crawlerChannel: Optional[str] = None
-    proxyId: Optional[str] = None
+    profileid: UUID | None = None
+    crawlerChannel: str | None = None
+    proxyId: str | None = None
 
-    lang: Optional[str] = None
+    lang: str | None = None
 
-    userAgent: Optional[str] = None
+    userAgent: str | None = None
 
-    exclude: Optional[List[str]] = None
+    exclude: list[str] | None = None
 
-    customBehaviors: List[str] = []
+    customBehaviors: list[str] = []
 
-    dedupeCollId: Optional[UUID] = None
+    dedupeCollId: UUID | None = None
 
 
 # ============================================================================
@@ -672,10 +672,10 @@ class CrawlConfigAddedResponse(BaseModel):
 
     added: bool
     id: str
-    run_now_job: Optional[str] = None
+    run_now_job: str | None = None
     storageQuotaReached: bool
     execMinutesQuotaReached: bool
-    errorDetail: Optional[str] = None
+    errorDetail: str | None = None
 
 
 # ============================================================================
@@ -690,17 +690,17 @@ class TagCount(BaseModel):
 class TagsResponse(BaseModel):
     """Response model for crawlconfig/crawl tags"""
 
-    tags: List[TagCount]
+    tags: list[TagCount]
 
 
 # ============================================================================
 class CrawlConfigSearchValues(BaseModel):
     """Response model for adding crawlconfigs"""
 
-    names: List[str]
-    descriptions: List[str]
-    firstSeeds: List[str]
-    workflowIds: List[UUID]
+    names: list[str]
+    descriptions: list[str]
+    firstSeeds: list[str]
+    workflowIds: list[UUID]
 
 
 # ============================================================================
@@ -712,10 +712,10 @@ class CrawlConfigUpdateResponse(BaseModel):
     metadata_changed: bool
     updatedRunning: bool = False
 
-    storageQuotaReached: Optional[bool] = False
-    execMinutesQuotaReached: Optional[bool] = False
+    storageQuotaReached: bool | None = False
+    execMinutesQuotaReached: bool | None = False
 
-    started: Optional[str] = None
+    started: str | None = None
 
 
 # ============================================================================
@@ -744,14 +744,14 @@ class CrawlerChannel(BaseModel):
 
     id: str
     image: str
-    imagePullPolicy: Optional[str] = None
+    imagePullPolicy: str | None = None
 
 
 # ============================================================================
 class CrawlerChannels(BaseModel):
     """List of CrawlerChannel instances for API"""
 
-    channels: List[CrawlerChannel] = []
+    channels: list[CrawlerChannel] = []
 
 
 # ============================================================================
@@ -776,8 +776,8 @@ class CrawlerProxy(BaseModel):
 class CrawlerProxies(BaseModel):
     """List of CrawlerProxy instances for API"""
 
-    default_proxy_id: Optional[str] = None
-    servers: List[CrawlerProxy] = []
+    default_proxy_id: str | None = None
+    servers: list[CrawlerProxy] = []
 
 
 # ============================================================================
@@ -798,7 +798,7 @@ class StorageRef(BaseModel):
     """Reference to actual storage"""
 
     name: str
-    custom: Optional[bool] = False
+    custom: bool | None = False
 
     def __init__(self, *args, **kwargs):
         if args:
@@ -847,7 +847,7 @@ class BaseFile(BaseModel):
     size: int
     storage: StorageRef
 
-    replicas: Optional[List[StorageRef]] = []
+    replicas: list[StorageRef] | None = []
 
 
 # ============================================================================
@@ -864,9 +864,9 @@ class CrawlFileOut(BaseModel):
     hash: str
     size: int
 
-    crawlId: Optional[str] = None
+    crawlId: str | None = None
     numReplicas: int = 0
-    expireAt: Optional[str] = None
+    expireAt: str | None = None
     fromDependency: bool = False
 
 
@@ -888,20 +888,20 @@ class CoreCrawlable(BaseModel):
     id: str
 
     userid: UUID
-    userName: Optional[str] = None
+    userName: str | None = None
 
     started: datetime
-    finished: Optional[datetime] = None
+    finished: datetime | None = None
 
     state: str
 
     crawlExecSeconds: int = 0
 
-    image: Optional[str] = None
+    image: str | None = None
 
-    stats: Optional[CrawlStats] = CrawlStats()
+    stats: CrawlStats | None = CrawlStats()
 
-    files: List[CrawlFile] = []
+    files: list[CrawlFile] = []
 
     fileSize: int = 0
     fileCount: int = 0
@@ -914,29 +914,29 @@ class BaseCrawl(CoreCrawlable, BaseMongoModel):
     type: TYPE_CRAWL_TYPES
 
     oid: UUID
-    cid: Optional[UUID] = None
+    cid: UUID | None = None
 
-    name: Optional[str] = ""
+    name: str | None = ""
 
-    description: Optional[str] = ""
+    description: str | None = ""
 
-    tags: Optional[List[str]] = []
+    tags: list[str] | None = []
 
-    collectionIds: Optional[List[UUID]] = []
+    collectionIds: list[UUID] | None = []
 
     reviewStatus: ReviewStatus = None
 
-    pageCount: Optional[int] = 0
-    uniquePageCount: Optional[int] = 0
+    pageCount: int | None = 0
+    uniquePageCount: int | None = 0
 
-    filePageCount: Optional[int] = 0
-    errorPageCount: Optional[int] = 0
+    filePageCount: int | None = 0
+    errorPageCount: int | None = 0
 
-    isMigrating: Optional[bool] = None
-    version: Optional[int] = None
+    isMigrating: bool | None = None
+    version: int | None = None
 
-    requiresCrawls: Optional[list[str]] = []
-    requiredByCrawls: Optional[list[str]] = []
+    requiresCrawls: list[str] | None = []
+    requiredByCrawls: list[str] | None = []
 
 
 # ============================================================================
@@ -958,85 +958,85 @@ class CrawlOut(BaseMongoModel):
     id: str
 
     userid: UUID
-    userName: Optional[str] = None
+    userName: str | None = None
     oid: UUID
 
-    profileid: Optional[UUID] = None
+    profileid: UUID | None = None
 
-    name: Optional[str] = None
-    description: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
 
     started: datetime
-    finished: Optional[datetime] = None
+    finished: datetime | None = None
 
     state: str
 
-    stats: Optional[CrawlStats] = None
+    stats: CrawlStats | None = None
 
     fileSize: int = 0
     fileCount: int = 0
     pendingSize: int = 0
 
     # computed only if dependencies are looked up
-    fileSizeWithDeps: Optional[int] = None
+    fileSizeWithDeps: int | None = None
 
-    tags: Optional[List[str]] = []
+    tags: list[str] | None = []
 
-    dedupeCollId: Optional[UUID] = None
-    collectionIds: Optional[List[UUID]] = []
+    dedupeCollId: UUID | None = None
+    collectionIds: list[UUID] | None = []
 
     crawlExecSeconds: int = 0
     qaCrawlExecSeconds: int = 0
 
     # automated crawl fields
-    config: Optional[RawCrawlConfig] = None
-    cid: Optional[UUID] = None
-    firstSeed: Optional[str] = None
-    seedCount: Optional[int] = None
-    profileName: Optional[str] = None
-    stopping: Optional[bool] = False
-    shouldPause: Optional[bool] = False
-    pausedAt: Optional[datetime] = None
+    config: RawCrawlConfig | None = None
+    cid: UUID | None = None
+    firstSeed: str | None = None
+    seedCount: int | None = None
+    profileName: str | None = None
+    stopping: bool | None = False
+    shouldPause: bool | None = False
+    pausedAt: datetime | None = None
     manual: bool = False
-    cid_rev: Optional[int] = None
-    scale: Optional[Scale] = None
+    cid_rev: int | None = None
+    scale: Scale | None = None
     browserWindows: BrowserWindowCount = 2
 
-    storageQuotaReached: Optional[bool] = False
-    execMinutesQuotaReached: Optional[bool] = False
+    storageQuotaReached: bool | None = False
+    execMinutesQuotaReached: bool | None = False
 
     crawlerChannel: str = "default"
-    proxyId: Optional[str] = None
-    image: Optional[str] = None
+    proxyId: str | None = None
+    image: str | None = None
 
     reviewStatus: ReviewStatus = None
 
     qaRunCount: int = 0
-    activeQAStats: Optional[CrawlStats] = None
-    lastQAState: Optional[str] = None
-    lastQAStarted: Optional[datetime] = None
+    activeQAStats: CrawlStats | None = None
+    lastQAState: str | None = None
+    lastQAStarted: datetime | None = None
 
-    pageCount: Optional[int] = 0
-    uniquePageCount: Optional[int] = 0
-    filePageCount: Optional[int] = 0
-    errorPageCount: Optional[int] = 0
+    pageCount: int | None = 0
+    uniquePageCount: int | None = 0
+    filePageCount: int | None = 0
+    errorPageCount: int | None = 0
 
     # Set to older version by default, crawls with optimized
     # pages will have this explicitly set to 2
-    version: Optional[int] = 1
+    version: int | None = 1
 
     # Retained for backward compatibility
-    errors: Optional[List[str]] = Field(default=[], deprecated=True)
-    behaviorLogs: Optional[List[str]] = Field(default=[], deprecated=True)
+    errors: list[str] | None = Field(default=[], deprecated=True)
+    behaviorLogs: list[str] | None = Field(default=[], deprecated=True)
 
     # Linked Crawls for dedupe
-    requiresCrawls: Optional[list[str]] = []
-    requiredByCrawls: Optional[list[str]] = []
+    requiresCrawls: list[str] | None = []
+    requiredByCrawls: list[str] | None = []
 
     # computed only if dependencies are looked up
-    missingRequiresCrawls: Optional[list[str]] = None
+    missingRequiresCrawls: list[str] | None = None
 
-    dedupeStats: Optional[CrawlDedupeStats] = None
+    dedupeStats: CrawlDedupeStats | None = None
 
 
 # ============================================================================
@@ -1046,7 +1046,7 @@ class UpdateCrawl(BaseModel):
     name: NameOrEmptyStr | None = None
     description: Description = None
     tags: list[Tag] | None = None
-    collectionIds: Optional[List[UUID]] = []
+    collectionIds: list[UUID] | None = []
     reviewStatus: ReviewStatus = None
 
 
@@ -1054,24 +1054,24 @@ class UpdateCrawl(BaseModel):
 class DeleteCrawlList(BaseModel):
     """delete crawl list POST body"""
 
-    crawl_ids: List[str]
+    crawl_ids: list[str]
 
 
 # ============================================================================
 class DeleteQARunList(BaseModel):
     """delete qa run list POST body"""
 
-    qa_run_ids: List[str]
+    qa_run_ids: list[str]
 
 
 # ============================================================================
 class CrawlSearchValuesResponse(BaseModel):
     """Response model for crawl search values"""
 
-    ids: List[str]
-    names: List[str]
-    descriptions: List[str]
-    firstSeeds: List[str]
+    ids: list[str]
+    names: list[str]
+    descriptions: list[str]
+    firstSeeds: list[str]
 
 
 # ============================================================================
@@ -1079,8 +1079,8 @@ class CrawlQueueResponse(BaseModel):
     """Response model for GET crawl queue"""
 
     total: int
-    results: List[AnyHttpUrl]
-    matched: List[AnyHttpUrl]
+    results: list[AnyHttpUrl]
+    matched: list[AnyHttpUrl]
 
 
 # ============================================================================
@@ -1088,7 +1088,7 @@ class MatchCrawlQueueResponse(BaseModel):
     """Response model for match crawl queue"""
 
     total: int
-    matched: List[AnyHttpUrl]
+    matched: list[AnyHttpUrl]
     nextOffset: int
 
 
@@ -1101,8 +1101,8 @@ class MatchCrawlQueueResponse(BaseModel):
 class CrawlScale(BaseModel):
     """scale the crawl to N parallel containers or windows"""
 
-    scale: Optional[Scale] = None
-    browserWindows: Optional[BrowserWindowCount] = None
+    scale: Scale | None = None
+    browserWindows: BrowserWindowCount | None = None
 
 
 # ============================================================================
@@ -1114,7 +1114,7 @@ class QARun(CoreCrawlable, BaseModel):
 class QARunWithResources(QARun):
     """QA crawl output model including resources"""
 
-    resources: Optional[List[CrawlFileOut]] = []
+    resources: list[CrawlFileOut] | None = []
 
 
 # ============================================================================
@@ -1123,10 +1123,10 @@ class QARunOut(BaseModel):
 
     id: str
 
-    userName: Optional[str] = None
+    userName: str | None = None
 
     started: datetime
-    finished: Optional[datetime] = None
+    finished: datetime | None = None
 
     state: str
 
@@ -1147,8 +1147,8 @@ class QARunBucketStats(BaseModel):
 class QARunAggregateStatsOut(BaseModel):
     """QA Run aggregate stats out"""
 
-    screenshotMatch: List[QARunBucketStats]
-    textMatch: List[QARunBucketStats]
+    screenshotMatch: list[QARunBucketStats]
+    textMatch: list[QARunBucketStats]
 
 
 # ============================================================================
@@ -1166,19 +1166,19 @@ class Crawl(BaseCrawl, CrawlConfigCore):
     # schedule: Optional[str]
     manual: bool = False
 
-    stopping: Optional[bool] = False
-    shouldPause: Optional[bool] = False
+    stopping: bool | None = False
+    shouldPause: bool | None = False
 
     qaCrawlExecSeconds: int = 0
 
-    qa: Optional[QARun] = None
-    qaFinished: Optional[Dict[str, QARun]] = {}
+    qa: QARun | None = None
+    qaFinished: dict[str, QARun] | None = {}
 
     pendingSize: int = 0
 
     autoPausedEmailsSent: bool = False
 
-    dedupeStats: Optional[CrawlDedupeStats] = None
+    dedupeStats: CrawlDedupeStats | None = None
 
 
 # ============================================================================
@@ -1193,7 +1193,7 @@ class CrawlCompleteIn(BaseModel):
     size: int
     hash: str
 
-    completed: Optional[bool] = True
+    completed: bool | None = True
 
 
 # ============================================================================
@@ -1272,13 +1272,13 @@ class CrawlLogLine(BaseMongoModel):
     crawlId: str
     oid: UUID
 
-    qaRunId: Optional[str] = None
+    qaRunId: str | None = None
 
     timestamp: datetime
     logLevel: str
     context: str
     message: str
-    details: Optional[Dict[str, Any]] = None
+    details: dict[str, Any] | None = None
 
     @property
     def is_qa(self) -> bool:
@@ -1336,14 +1336,14 @@ class UserFile(BaseFile):
     created: datetime
 
     async def get_absolute_presigned_url(
-        self, org, storage_ops, headers: Optional[dict]
+        self, org, storage_ops, headers: dict | None
     ) -> str:
         """Get presigned URL as absolute URL"""
         presigned_url, _ = await storage_ops.get_presigned_url(org, self)
         return storage_ops.resolve_relative_access_path(presigned_url, headers) or ""
 
     async def get_file_out(
-        self, org, storage_ops, headers: Optional[dict] = None
+        self, org, storage_ops, headers: dict | None = None
     ) -> UserFileOut:
         """Get UserFileOut with new presigned url"""
         return UserFileOut(
@@ -1359,7 +1359,7 @@ class UserFile(BaseFile):
         )
 
     async def get_public_file_out(
-        self, org, storage_ops, headers: Optional[dict] = None
+        self, org, storage_ops, headers: dict | None = None
     ) -> PublicUserFileOut:
         """Get PublicUserFileOut with new presigned url"""
         return PublicUserFileOut(
@@ -1419,8 +1419,8 @@ class SeedFileOut(UserFileOut):
     oid: UUID
     type: str
 
-    firstSeed: Optional[str] = None
-    seedCount: Optional[int] = None
+    firstSeed: str | None = None
+    seedCount: int | None = None
 
 
 # ============================================================================
@@ -1434,11 +1434,11 @@ class SeedFile(UserFile, BaseMongoModel):
     id: UUID
     oid: UUID
 
-    firstSeed: Optional[str] = None
-    seedCount: Optional[int] = None
+    firstSeed: str | None = None
+    seedCount: int | None = None
 
     async def get_file_out(
-        self, org, storage_ops, headers: Optional[dict] = None
+        self, org, storage_ops, headers: dict | None = None
     ) -> SeedFileOut:
         """Get SeedFileOut with new presigned url"""
         return SeedFileOut(
@@ -1468,7 +1468,7 @@ class SeedFile(UserFile, BaseMongoModel):
 class PageReviewUpdate(BaseModel):
     """Update model for page manual review/approval"""
 
-    approved: Optional[bool] = None
+    approved: bool | None = None
 
 
 # ============================================================================
@@ -1490,7 +1490,7 @@ class PageNoteEdit(BaseModel):
 class PageNoteDelete(BaseModel):
     """Delete model for page notes"""
 
-    delete_list: List[UUID] = []
+    delete_list: list[UUID] = []
 
 
 # ============================================================================
@@ -1508,9 +1508,9 @@ class PageNote(BaseModel):
 class PageQACompare(BaseModel):
     """Model for updating pages from QA run"""
 
-    screenshotMatch: Optional[float] = None
-    textMatch: Optional[float] = None
-    resourceCounts: Optional[Dict[str, int]] = None
+    screenshotMatch: float | None = None
+    textMatch: float | None = None
+    resourceCounts: dict[str, int] | None = None
 
 
 # ============================================================================
@@ -1524,24 +1524,24 @@ class Page(BaseMongoModel):
 
     # core page data
     url: AnyHttpUrl
-    title: Optional[str] = None
-    ts: Optional[datetime] = None
-    loadState: Optional[int] = None
-    status: Optional[int] = None
-    mime: Optional[str] = None
-    filename: Optional[str] = None
-    depth: Optional[int] = None
-    favIconUrl: Optional[str] = None
-    isSeed: Optional[bool] = False
+    title: str | None = None
+    ts: datetime | None = None
+    loadState: int | None = None
+    status: int | None = None
+    mime: str | None = None
+    filename: str | None = None
+    depth: int | None = None
+    favIconUrl: str | None = None
+    isSeed: bool | None = False
 
     # manual review
-    userid: Optional[UUID] = None
-    modified: Optional[datetime] = None
-    approved: Optional[bool] = None
-    notes: List[PageNote] = []
+    userid: UUID | None = None
+    modified: datetime | None = None
+    approved: bool | None = None
+    notes: list[PageNote] = []
 
-    isFile: Optional[bool] = False
-    isError: Optional[bool] = False
+    isFile: bool | None = False
+    isError: bool | None = False
 
     def compute_page_type(self):
         """sets self.isFile or self.isError flags"""
@@ -1563,7 +1563,7 @@ class PageWithAllQA(Page):
     """Model for core page data + qa"""
 
     # automated heuristics, keyed by QA run id
-    qa: Optional[Dict[str, PageQACompare]] = {}
+    qa: dict[str, PageQACompare] | None = {}
 
 
 # ============================================================================
@@ -1577,7 +1577,7 @@ class PageOut(Page):
 class PageOutWithSingleQA(Page):
     """Page out with single QA entry"""
 
-    qa: Optional[PageQACompare] = None
+    qa: PageQACompare | None = None
 
 
 # ============================================================================
@@ -1601,7 +1601,7 @@ class PageIdTimestamp(BaseModel):
     """Simplified model for page info to include in PageUrlCount"""
 
     pageId: UUID
-    ts: Optional[datetime] = None
+    ts: datetime | None = None
     status: int = 200
 
 
@@ -1611,26 +1611,26 @@ class PageUrlCount(BaseModel):
 
     url: AnyHttpUrl
     count: int = 0
-    snapshots: List[PageIdTimestamp] = []
+    snapshots: list[PageIdTimestamp] = []
 
 
 # ============================================================================
 class ResourcesOnly(BaseModel):
     """Resources-only response"""
 
-    resources: Optional[List[CrawlFileOut]] = []
+    resources: list[CrawlFileOut] | None = []
 
 
 # ============================================================================
 class CrawlOutWithResources(CrawlOut):
     """Crawl output model including resources"""
 
-    resources: Optional[List[CrawlFileOut]] = []
-    collections: Optional[List[CollIdName]] = []
+    resources: list[CrawlFileOut] | None = []
+    collections: list[CollIdName] | None = []
 
-    initialPages: List[PageOut] = []
+    initialPages: list[PageOut] = []
     pagesQueryUrl: str = ""
-    downloadUrl: Optional[str] = None
+    downloadUrl: str | None = None
 
 
 # ============================================================================
@@ -1723,44 +1723,44 @@ class Collection(BaseMongoModel):
     description: Description = None
     caption: CollectionCaption = None
 
-    created: Optional[datetime] = None
-    modified: Optional[datetime] = None
+    created: datetime | None = None
+    modified: datetime | None = None
 
-    lastStatsUpdateStarted: Optional[datetime] = None
+    lastStatsUpdateStarted: datetime | None = None
 
-    crawlCount: Optional[int] = 0
-    pageCount: Optional[int] = 0
-    uniquePageCount: Optional[int] = 0
-    totalSize: Optional[int] = 0
+    crawlCount: int | None = 0
+    pageCount: int | None = 0
+    uniquePageCount: int | None = 0
+    totalSize: int | None = 0
 
-    dateEarliest: Optional[datetime] = None
-    dateLatest: Optional[datetime] = None
+    dateEarliest: datetime | None = None
+    dateLatest: datetime | None = None
 
     # Sorted by count, descending
-    tags: Optional[List[str]] = []
+    tags: list[str] | None = []
 
     access: CollAccessType = CollAccessType.PRIVATE
 
-    homeUrl: Optional[AnyHttpUrl] = None
-    homeUrlTs: Optional[datetime] = None
-    homeUrlPageId: Optional[UUID] = None
+    homeUrl: AnyHttpUrl | None = None
+    homeUrlTs: datetime | None = None
+    homeUrlPageId: UUID | None = None
 
-    thumbnail: Optional[UserFile] = None
-    thumbnailSource: Optional[CollectionThumbnailSource] = None
-    defaultThumbnailName: Optional[str] = None
+    thumbnail: UserFile | None = None
+    thumbnailSource: CollectionThumbnailSource | None = None
+    defaultThumbnailName: str | None = None
 
-    allowPublicDownload: Optional[bool] = True
+    allowPublicDownload: bool | None = True
 
-    previousSlugs: List[str] = []
+    previousSlugs: list[str] = []
 
-    indexLastSavedAt: Optional[datetime] = None
-    indexFile: Optional[DedupeIndexFile] = None
-    indexState: Optional[TYPE_DEDUPE_INDEX_STATES] = None
+    indexLastSavedAt: datetime | None = None
+    indexFile: DedupeIndexFile | None = None
+    indexState: TYPE_DEDUPE_INDEX_STATES | None = None
 
-    indexStats: Optional[DedupeIndexStats] = None
+    indexStats: DedupeIndexStats | None = None
 
     # size of db on disk when in use
-    indexDiskSpaceUsed: Optional[int] = None
+    indexDiskSpaceUsed: int | None = None
 
 
 # ============================================================================
@@ -1771,11 +1771,11 @@ class CollIn(BaseModel):
     slug: CollectionSlug | None = None
     description: Description = None
     caption: CollectionCaption = None
-    crawlIds: Optional[List[str]] = []
+    crawlIds: list[str] | None = []
 
     access: CollAccessType = CollAccessType.PRIVATE
 
-    defaultThumbnailName: Optional[str] = None
+    defaultThumbnailName: str | None = None
     allowPublicDownload: bool = True
 
     hasDedupeIndex: bool = False
@@ -1789,48 +1789,48 @@ class CollOut(BaseMongoModel):
     name: str
     slug: str
     oid: UUID
-    description: Optional[str] = None
-    caption: Optional[str] = None
-    created: Optional[datetime] = None
-    modified: Optional[datetime] = None
+    description: str | None = None
+    caption: str | None = None
+    created: datetime | None = None
+    modified: datetime | None = None
 
-    lastStatsUpdateStarted: Optional[datetime] = None
+    lastStatsUpdateStarted: datetime | None = None
 
-    crawlCount: Optional[int] = 0
-    pageCount: Optional[int] = 0
-    uniquePageCount: Optional[int] = 0
-    totalSize: Optional[int] = 0
+    crawlCount: int | None = 0
+    pageCount: int | None = 0
+    uniquePageCount: int | None = 0
+    totalSize: int | None = 0
 
-    dateEarliest: Optional[datetime] = None
-    dateLatest: Optional[datetime] = None
+    dateEarliest: datetime | None = None
+    dateLatest: datetime | None = None
 
     # Sorted by count, descending
-    tags: Optional[List[str]] = []
+    tags: list[str] | None = []
 
     access: CollAccessType = CollAccessType.PRIVATE
 
-    homeUrl: Optional[AnyHttpUrl] = None
-    homeUrlTs: Optional[datetime] = None
-    homeUrlPageId: Optional[UUID] = None
+    homeUrl: AnyHttpUrl | None = None
+    homeUrlTs: datetime | None = None
+    homeUrlPageId: UUID | None = None
 
-    resources: List[CrawlFileOut] = []
-    thumbnail: Optional[UserFileOut] = None
-    thumbnailSource: Optional[CollectionThumbnailSource] = None
-    defaultThumbnailName: Optional[str] = None
+    resources: list[CrawlFileOut] = []
+    thumbnail: UserFileOut | None = None
+    thumbnailSource: CollectionThumbnailSource | None = None
+    defaultThumbnailName: str | None = None
 
     allowPublicDownload: bool = True
 
-    initialPages: List[PageOut] = []
-    preloadResources: List[PreloadResource] = []
+    initialPages: list[PageOut] = []
+    preloadResources: list[PreloadResource] = []
     pagesQueryUrl: str = ""
-    downloadUrl: Optional[str] = None
+    downloadUrl: str | None = None
 
-    topPageHosts: List[HostCount] = []
+    topPageHosts: list[HostCount] = []
 
-    indexLastSavedAt: Optional[datetime] = None
-    indexState: Optional[TYPE_DEDUPE_INDEX_STATES] = None
+    indexLastSavedAt: datetime | None = None
+    indexState: TYPE_DEDUPE_INDEX_STATES | None = None
 
-    indexStats: Optional[DedupeIndexStats] = None
+    indexStats: DedupeIndexStats | None = None
 
     runningUpdatesCount: int = 0
 
@@ -1845,34 +1845,34 @@ class PublicCollOut(BaseMongoModel):
     oid: UUID
     orgName: str
     orgPublicProfile: bool
-    description: Optional[str] = None
-    caption: Optional[str] = None
-    created: Optional[datetime] = None
-    modified: Optional[datetime] = None
+    description: str | None = None
+    caption: str | None = None
+    created: datetime | None = None
+    modified: datetime | None = None
 
-    lastStatsUpdateStarted: Optional[datetime] = None
+    lastStatsUpdateStarted: datetime | None = None
 
-    crawlCount: Optional[int] = 0
-    pageCount: Optional[int] = 0
-    uniquePageCount: Optional[int] = 0
-    totalSize: Optional[int] = 0
+    crawlCount: int | None = 0
+    pageCount: int | None = 0
+    uniquePageCount: int | None = 0
+    totalSize: int | None = 0
 
-    dateEarliest: Optional[datetime] = None
-    dateLatest: Optional[datetime] = None
+    dateEarliest: datetime | None = None
+    dateLatest: datetime | None = None
 
     access: CollAccessType = CollAccessType.PUBLIC
 
-    homeUrl: Optional[AnyHttpUrl] = None
-    homeUrlTs: Optional[datetime] = None
+    homeUrl: AnyHttpUrl | None = None
+    homeUrlTs: datetime | None = None
 
-    resources: List[CrawlFileOut] = []
-    thumbnail: Optional[PublicUserFileOut] = None
-    thumbnailSource: Optional[CollectionThumbnailSource] = None
-    defaultThumbnailName: Optional[str] = None
+    resources: list[CrawlFileOut] = []
+    thumbnail: PublicUserFileOut | None = None
+    thumbnailSource: CollectionThumbnailSource | None = None
+    defaultThumbnailName: str | None = None
 
     allowPublicDownload: bool = True
 
-    topPageHosts: List[HostCount] = []
+    topPageHosts: list[HostCount] = []
 
     runningUpdatesCount: int = 0
 
@@ -1885,40 +1885,40 @@ class UpdateColl(BaseModel):
     slug: CollectionSlug | None = None
     description: Description = None
     caption: CollectionCaption = None
-    access: Optional[CollAccessType] = None
-    defaultThumbnailName: Optional[str] = None
-    allowPublicDownload: Optional[bool] = None
-    thumbnailSource: Optional[CollectionThumbnailSource] = None
-    hasDedupeIndex: Optional[bool] = None
+    access: CollAccessType | None = None
+    defaultThumbnailName: str | None = None
+    allowPublicDownload: bool | None = None
+    thumbnailSource: CollectionThumbnailSource | None = None
+    hasDedupeIndex: bool | None = None
 
 
 # ============================================================================
 class UpdateCollHomeUrl(BaseModel):
     """Update home url for collection"""
 
-    pageId: Optional[UUID] = None
+    pageId: UUID | None = None
 
 
 # ============================================================================
 class CollectionAddRemove(BaseModel):
     """Items to add or remove from collection"""
 
-    crawlIds: List[str] = []
-    crawlconfigIds: List[UUID] = []
+    crawlIds: list[str] = []
+    crawlconfigIds: list[UUID] = []
 
 
 # ============================================================================
 class CollectionSearchValuesResponse(BaseModel):
     """Response model for collections search values"""
 
-    names: List[str]
+    names: list[str]
 
 
 # ============================================================================
 class CollectionAllResponse(BaseModel):
     """Response model for '$all' collection endpoint"""
 
-    resources: List[CrawlFileOut] = []
+    resources: list[CrawlFileOut] = []
 
 
 # ============================================================================
@@ -1953,7 +1953,7 @@ class RenameOrg(BaseModel):
     """Rename an existing org"""
 
     name: OrgName
-    slug: Optional[str] = None
+    slug: str | None = None
 
 
 # ============================================================================
@@ -1971,7 +1971,7 @@ class OrgPublicCollections(BaseModel):
 
     org: PublicOrgDetails
 
-    collections: List[PublicCollOut] = []
+    collections: list[PublicCollOut] = []
 
 
 # ============================================================================
@@ -1980,7 +1980,7 @@ class OrgStorageRefs(BaseModel):
 
     storage: StorageRef
 
-    storageReplicas: List[StorageRef] = []
+    storageReplicas: list[StorageRef] = []
 
 
 # ============================================================================
@@ -1995,7 +1995,7 @@ class S3StorageIn(BaseModel):
     secret_key: str
     endpoint_url: str
     bucket: str
-    access_endpoint_url: Optional[str] = None
+    access_endpoint_url: str | None = None
     access_addressing_style: Literal["virtual", "path"] = "virtual"
     region: str = ""
 
@@ -2046,14 +2046,14 @@ class OrgQuotas(BaseModel):
 class OrgQuotasIn(BaseModel):
     """Update for existing OrgQuotas"""
 
-    storageQuota: Optional[int] = None
-    maxExecMinutesPerMonth: Optional[int] = None
+    storageQuota: int | None = None
+    maxExecMinutesPerMonth: int | None = None
 
-    maxConcurrentCrawls: Optional[int] = None
-    maxPagesPerCrawl: Optional[int] = None
+    maxConcurrentCrawls: int | None = None
+    maxPagesPerCrawl: int | None = None
 
-    extraExecMinutes: Optional[int] = None
-    giftedExecMinutes: Optional[int] = None
+    extraExecMinutes: int | None = None
+    giftedExecMinutes: int | None = None
 
 
 # ============================================================================
@@ -2091,7 +2091,7 @@ class SubscriptionCreate(BaseModel):
     planId: str
 
     firstAdminInviteEmail: EmailStr
-    quotas: Optional[OrgQuotas] = None
+    quotas: OrgQuotas | None = None
 
 
 # ============================================================================
@@ -2126,8 +2126,8 @@ class SubscriptionUpdate(BaseModel):
     status: str
     planId: str
 
-    futureCancelDate: Optional[datetime] = None
-    quotas: Optional[OrgQuotasIn] = None
+    futureCancelDate: datetime | None = None
+    quotas: OrgQuotasIn | None = None
 
 
 # ============================================================================
@@ -2249,7 +2249,7 @@ class Subscription(BaseModel):
     status: str
     planId: str
 
-    futureCancelDate: Optional[datetime] = None
+    futureCancelDate: datetime | None = None
     # pylint: disable=C0301
     """When in a trial, future cancel date is the trial end date; when not in a trial, future cancel date is the date the subscription will be canceled, if set."""
 
@@ -2271,9 +2271,9 @@ class UserOrgInfoOutWithSubs(UserOrgInfoOut):
     """org per user with sub info"""
 
     readOnly: bool
-    readOnlyReason: Optional[str] = None
+    readOnlyReason: str | None = None
 
-    subscription: Optional[Subscription] = None
+    subscription: Subscription | None = None
 
 
 # ============================================================================
@@ -2282,7 +2282,7 @@ class UserOutNoId(BaseModel):
 
     name: str = ""
     email: EmailStr
-    orgs: List[UserOrgInfoOut | UserOrgInfoOutWithSubs]
+    orgs: list[UserOrgInfoOut | UserOrgInfoOutWithSubs]
     is_verified: bool = False
 
 
@@ -2412,7 +2412,7 @@ class OrgCreate(BaseModel):
     """Create a new org"""
 
     name: OrgName
-    slug: Optional[str] = None
+    slug: str | None = None
 
 
 # ============================================================================
@@ -2437,33 +2437,33 @@ class OrgReadOnlyUpdate(BaseModel):
     """Organization readonly update"""
 
     readOnly: bool
-    readOnlyReason: Optional[str] = None
+    readOnlyReason: str | None = None
 
 
 # ============================================================================
 class OrgPublicProfileUpdate(BaseModel):
     """Organization enablePublicProfile update"""
 
-    enablePublicProfile: Optional[bool] = None
+    enablePublicProfile: bool | None = None
     publicDescription: OrgPublicDescription = None
-    publicUrl: Optional[str] = None
+    publicUrl: str | None = None
 
 
 # ============================================================================
 class OrgWebhookUrls(BaseModel):
     """Organization webhook URLs"""
 
-    crawlStarted: Optional[AnyHttpUrl] = None
-    crawlFinished: Optional[AnyHttpUrl] = None
-    crawlDeleted: Optional[AnyHttpUrl] = None
-    qaAnalysisStarted: Optional[AnyHttpUrl] = None
-    qaAnalysisFinished: Optional[AnyHttpUrl] = None
-    crawlReviewed: Optional[AnyHttpUrl] = None
-    uploadFinished: Optional[AnyHttpUrl] = None
-    uploadDeleted: Optional[AnyHttpUrl] = None
-    addedToCollection: Optional[AnyHttpUrl] = None
-    removedFromCollection: Optional[AnyHttpUrl] = None
-    collectionDeleted: Optional[AnyHttpUrl] = None
+    crawlStarted: AnyHttpUrl | None = None
+    crawlFinished: AnyHttpUrl | None = None
+    crawlDeleted: AnyHttpUrl | None = None
+    qaAnalysisStarted: AnyHttpUrl | None = None
+    qaAnalysisFinished: AnyHttpUrl | None = None
+    crawlReviewed: AnyHttpUrl | None = None
+    uploadFinished: AnyHttpUrl | None = None
+    uploadDeleted: AnyHttpUrl | None = None
+    addedToCollection: AnyHttpUrl | None = None
+    removedFromCollection: AnyHttpUrl | None = None
+    collectionDeleted: AnyHttpUrl | None = None
 
 
 # ============================================================================
@@ -2473,9 +2473,9 @@ class OrgOut(BaseMongoModel):
     id: UUID
     name: OrgName
     slug: str
-    users: Dict[str, Any] = {}
+    users: dict[str, Any] = {}
 
-    created: Optional[datetime] = None
+    created: datetime | None = None
 
     default: bool = False
     bytesStored: int
@@ -2485,42 +2485,42 @@ class OrgOut(BaseMongoModel):
     bytesStoredSeedFiles: int = 0
     bytesStoredThumbnails: int = 0
     bytesStoredDedupeIndexes: int = 0
-    origin: Optional[AnyHttpUrl] = None
+    origin: AnyHttpUrl | None = None
 
-    storageQuotaReached: Optional[bool] = False
-    execMinutesQuotaReached: Optional[bool] = False
+    storageQuotaReached: bool | None = False
+    execMinutesQuotaReached: bool | None = False
 
     # total usage and exec time
-    usage: Optional[Dict[str, int]] = {}
-    crawlExecSeconds: Dict[str, int] = {}
+    usage: dict[str, int] | None = {}
+    crawlExecSeconds: dict[str, int] = {}
 
     # qa only usage + exec time
-    qaUsage: Optional[Dict[str, int]] = {}
-    qaCrawlExecSeconds: Dict[str, int] = {}
+    qaUsage: dict[str, int] | None = {}
+    qaCrawlExecSeconds: dict[str, int] = {}
 
     # exec time limits
-    monthlyExecSeconds: Dict[str, int] = {}
-    extraExecSeconds: Dict[str, int] = {}
-    giftedExecSeconds: Dict[str, int] = {}
+    monthlyExecSeconds: dict[str, int] = {}
+    extraExecSeconds: dict[str, int] = {}
+    giftedExecSeconds: dict[str, int] = {}
 
     extraExecSecondsAvailable: int = 0
     giftedExecSecondsAvailable: int = 0
 
     quotas: OrgQuotas = OrgQuotas()
-    quotaUpdates: Optional[List[OrgQuotaUpdateOut]] = []
+    quotaUpdates: list[OrgQuotaUpdateOut] | None = []
 
-    webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
+    webhookUrls: OrgWebhookUrls | None = OrgWebhookUrls()
 
-    readOnly: Optional[bool] = False
-    readOnlyReason: Optional[str] = None
+    readOnly: bool | None = False
+    readOnlyReason: str | None = None
 
-    subscription: Optional[Subscription] = None
+    subscription: Subscription | None = None
 
     allowSharedProxies: bool = False
     allowedProxies: list[str] = []
-    crawlingDefaults: Optional[CrawlConfigDefaults] = None
+    crawlingDefaults: CrawlConfigDefaults | None = None
 
-    lastCrawlFinished: Optional[datetime] = None
+    lastCrawlFinished: datetime | None = None
 
     enablePublicProfile: bool = False
     publicDescription: OrgPublicDescription = ""
@@ -2536,15 +2536,15 @@ class Organization(BaseMongoModel):
     id: UUID
     name: OrgName
     slug: str
-    users: Dict[str, UserRole] = {}
+    users: dict[str, UserRole] = {}
 
-    created: Optional[datetime] = None
+    created: datetime | None = None
 
     default: bool = False
 
     storage: StorageRef
-    storageReplicas: List[StorageRef] = []
-    customStorages: Dict[str, S3Storage] = {}
+    storageReplicas: list[StorageRef] = []
+    customStorages: dict[str, S3Storage] = {}
 
     bytesStored: int = 0
     bytesStoredCrawls: int = 0
@@ -2555,42 +2555,42 @@ class Organization(BaseMongoModel):
     bytesStoredDedupeIndexes: int = 0
 
     # total usage + exec time
-    usage: Dict[str, int] = {}
-    crawlExecSeconds: Dict[str, int] = {}
+    usage: dict[str, int] = {}
+    crawlExecSeconds: dict[str, int] = {}
 
     # qa only usage + exec time
-    qaUsage: Dict[str, int] = {}
-    qaCrawlExecSeconds: Dict[str, int] = {}
+    qaUsage: dict[str, int] = {}
+    qaCrawlExecSeconds: dict[str, int] = {}
 
     # exec time limits
-    monthlyExecSeconds: Dict[str, int] = {}
-    extraExecSeconds: Dict[str, int] = {}
-    giftedExecSeconds: Dict[str, int] = {}
+    monthlyExecSeconds: dict[str, int] = {}
+    extraExecSeconds: dict[str, int] = {}
+    giftedExecSeconds: dict[str, int] = {}
 
     extraExecSecondsAvailable: int = 0
     giftedExecSecondsAvailable: int = 0
 
     quotas: OrgQuotas = OrgQuotas()
-    quotaUpdates: Optional[List[OrgQuotaUpdate]] = []
+    quotaUpdates: list[OrgQuotaUpdate] | None = []
 
-    webhookUrls: Optional[OrgWebhookUrls] = OrgWebhookUrls()
+    webhookUrls: OrgWebhookUrls | None = OrgWebhookUrls()
 
-    origin: Optional[AnyHttpUrl] = None
+    origin: AnyHttpUrl | None = None
 
-    readOnly: Optional[bool] = False
-    readOnlyReason: Optional[str] = None
+    readOnly: bool | None = False
+    readOnlyReason: str | None = None
 
-    subscription: Optional[Subscription] = None
+    subscription: Subscription | None = None
 
     allowSharedProxies: bool = False
     allowedProxies: list[str] = []
-    crawlingDefaults: Optional[CrawlConfigDefaults] = None
+    crawlingDefaults: CrawlConfigDefaults | None = None
 
-    lastCrawlFinished: Optional[datetime] = None
+    lastCrawlFinished: datetime | None = None
 
     enablePublicProfile: bool = False
     publicDescription: OrgPublicDescription = None
-    publicUrl: Optional[str] = None
+    publicUrl: str | None = None
 
     featureFlags: FeatureFlags = FeatureFlags()
 
@@ -2665,7 +2665,7 @@ class OrgOutExport(Organization):
     """Org out for export"""
 
     # Additional field so export contains user names and emails
-    userDetails: Optional[List[Dict[str, Union[str, int, UUID]]]] = None
+    userDetails: list[dict[str, str | int | UUID]] | None = None
 
     async def serialize_for_export(self, user_manager):
         """Serialize result with users for org export"""
@@ -2725,13 +2725,13 @@ class OrgImportExportData(BaseModel):
     """Model for org import/export data"""
 
     dbVersion: str
-    org: Dict[str, Any]
-    profiles: List[Dict[str, Any]]
-    workflows: List[Dict[str, Any]]
-    workflowRevisions: List[Dict[str, Any]]
-    items: List[Dict[str, Any]]
-    pages: List[Dict[str, Any]]
-    collections: List[Dict[str, Any]]
+    org: dict[str, Any]
+    profiles: list[dict[str, Any]]
+    workflows: list[dict[str, Any]]
+    workflowRevisions: list[dict[str, Any]]
+    items: list[dict[str, Any]]
+    pages: list[dict[str, Any]]
+    collections: list[dict[str, Any]]
 
 
 # ============================================================================
@@ -2769,7 +2769,7 @@ class OrgDeleteInviteResponse(BaseModel):
 class OrgSlugsResponse(BaseModel):
     """Model for org slugs response"""
 
-    slugs: List[str]
+    slugs: list[str]
 
 
 # ============================================================================
@@ -2810,32 +2810,32 @@ class Profile(BaseMongoModel):
     id: UUID
 
     name: str
-    description: Optional[str] = ""
+    description: str | None = ""
 
     userid: UUID
     oid: UUID
 
-    origins: List[str]
-    resource: Optional[ProfileFile] = None
+    origins: list[str]
+    resource: ProfileFile | None = None
 
-    created: Optional[datetime] = None
-    createdBy: Optional[UUID] = None
-    createdByName: Optional[str] = None
-    modified: Optional[datetime] = None
-    modifiedBy: Optional[UUID] = None
-    modifiedByName: Optional[str] = None
+    created: datetime | None = None
+    createdBy: UUID | None = None
+    createdByName: str | None = None
+    modified: datetime | None = None
+    modifiedBy: UUID | None = None
+    modifiedByName: str | None = None
 
-    modifiedCrawlDate: Optional[datetime] = None
-    modifiedCrawlId: Optional[str] = None
-    modifiedCrawlCid: Optional[UUID] = None
+    modifiedCrawlDate: datetime | None = None
+    modifiedCrawlId: str | None = None
+    modifiedCrawlCid: UUID | None = None
 
-    baseid: Optional[UUID] = None
-    crawlerChannel: Optional[str] = None
-    proxyId: Optional[str] = None
+    baseid: UUID | None = None
+    crawlerChannel: str | None = None
+    proxyId: str | None = None
 
     inUse: bool = False
 
-    tags: Optional[List[str]] = []
+    tags: list[str] | None = []
 
 
 # ============================================================================
@@ -2846,7 +2846,7 @@ class ProfileBrowserMetadata(BaseModel):
 
     oid: str = Field(alias="btrix.org")
     userid: UUID = Field(alias="btrix.user")
-    baseprofile: Optional[UUID] = Field(alias="btrix.baseprofile", default=None)
+    baseprofile: UUID | None = Field(alias="btrix.baseprofile", default=None)
     storage: str = Field(alias="btrix.storage")
 
     profileid: UUID
@@ -2854,7 +2854,7 @@ class ProfileBrowserMetadata(BaseModel):
     proxyid: str = ""
     crawlerChannel: str
 
-    committing: Optional[str] = None
+    committing: str | None = None
 
 
 # ============================================================================
@@ -2868,9 +2868,9 @@ class UrlIn(BaseModel):
 class ProfileLaunchBrowserIn(UrlIn):
     """Request to launch new browser for creating profile"""
 
-    profileId: Optional[UUID] = None
+    profileId: UUID | None = None
     crawlerChannel: str = "default"
-    proxyId: Optional[str] = None
+    proxyId: str | None = None
 
 
 # ============================================================================
@@ -2903,7 +2903,7 @@ class ProfilePingResponse(BaseModel):
     """Response model for pinging profile"""
 
     success: bool
-    origins: List[AnyHttpUrl]
+    origins: list[AnyHttpUrl]
 
 
 # ============================================================================
@@ -2922,7 +2922,7 @@ class ProfileBrowserGetUrlResponse(BaseModel):
 class ProfileSearchValuesResponse(BaseModel):
     """Response model for profiles search values"""
 
-    names: List[str]
+    names: list[str]
 
 
 # ============================================================================
@@ -2939,9 +2939,9 @@ class UserCreate(BaseModel):
     email: EmailStr
     password: str
 
-    name: Optional[str] = ""
+    name: str | None = ""
 
-    inviteToken: Optional[UUID] = None
+    inviteToken: UUID | None = None
 
 
 # ============================================================================
@@ -2950,8 +2950,8 @@ class UserUpdateEmailName(BaseModel):
     Update email and/or name
     """
 
-    email: Optional[EmailStr] = None
-    name: Optional[str] = None
+    email: EmailStr | None = None
+    name: str | None = None
 
 
 # ============================================================================
@@ -3004,7 +3004,7 @@ class BaseCollectionItemBody(WebhookNotificationBody):
     """Webhook notification base POST body for collection changes"""
 
     collectionId: str
-    itemIds: List[str]
+    itemIds: list[str]
     downloadUrl: str
 
 
@@ -3047,7 +3047,7 @@ class BaseArchivedItemBody(WebhookNotificationBody):
 class BaseArchivedItemFinishedBody(BaseArchivedItemBody):
     """Webhook notification POST body for when archived item is finished"""
 
-    resources: List[CrawlFileOut]
+    resources: list[CrawlFileOut]
     state: str
 
 
@@ -3117,7 +3117,7 @@ class CrawlReviewedBody(BaseArchivedItemBody):
 
     reviewStatus: ReviewStatus
     reviewStatusLabel: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 # ============================================================================
@@ -3126,23 +3126,11 @@ class WebhookNotification(BaseMongoModel):
 
     event: WebhookEventType
     oid: UUID
-    body: Union[
-        CrawlStartedBody,
-        CrawlFinishedBody,
-        CrawlDeletedBody,
-        QaAnalysisStartedBody,
-        QaAnalysisFinishedBody,
-        CrawlReviewedBody,
-        UploadFinishedBody,
-        UploadDeletedBody,
-        CollectionItemAddedBody,
-        CollectionItemRemovedBody,
-        CollectionDeletedBody,
-    ]
+    body: CrawlStartedBody | CrawlFinishedBody | CrawlDeletedBody | QaAnalysisStartedBody | QaAnalysisFinishedBody | CrawlReviewedBody | UploadFinishedBody | UploadDeletedBody | CollectionItemAddedBody | CollectionItemRemovedBody | CollectionDeletedBody
     success: bool = False
     attempts: int = 0
     created: datetime
-    lastAttempted: Optional[datetime] = None
+    lastAttempted: datetime | None = None
 
 
 # ============================================================================
@@ -3170,12 +3158,12 @@ class BackgroundJob(BaseMongoModel):
 
     id: str
     type: BgJobType
-    oid: Optional[UUID] = None
-    success: Optional[bool] = None
+    oid: UUID | None = None
+    success: bool | None = None
     started: datetime
-    finished: Optional[datetime] = None
+    finished: datetime | None = None
 
-    previousAttempts: Optional[List[Dict[str, Optional[datetime]]]] = None
+    previousAttempts: list[dict[str, datetime | None]] | None = None
 
 
 # ============================================================================
@@ -3198,7 +3186,7 @@ class DeleteReplicaJob(BackgroundJob):
     object_type: str
     object_id: str
     replica_storage: StorageRef
-    schedule: Optional[str] = None
+    schedule: str | None = None
 
 
 # ============================================================================
@@ -3220,8 +3208,8 @@ class ReAddOrgPagesJob(BackgroundJob):
     """Model for tracking jobs to readd pages for an org or single crawl"""
 
     type: Literal[BgJobType.READD_ORG_PAGES] = BgJobType.READD_ORG_PAGES
-    crawl_type: Optional[str] = None
-    crawl_id: Optional[str] = None
+    crawl_type: str | None = None
+    crawl_id: str | None = None
 
 
 # ============================================================================
@@ -3288,7 +3276,7 @@ class SuccessResponse(BaseModel):
 class SuccessResponseId(SuccessResponse):
     """Response for API endpoints that return success and a background job id"""
 
-    id: Optional[str] = None
+    id: str | None = None
 
 
 # ============================================================================
@@ -3405,126 +3393,126 @@ class EmptyResponse(BaseModel):
 class PaginatedBackgroundJobResponse(PaginatedResponse):
     """Response model for paginated background jobs"""
 
-    items: List[AnyJob]
+    items: list[AnyJob]
 
 
 # ============================================================================
 class PaginatedCrawlOutResponse(PaginatedResponse):
     """Response model for paginated crawls"""
 
-    items: List[Union[CrawlOut, CrawlOutWithResources]]
+    items: list[CrawlOut | CrawlOutWithResources]
 
 
 # ============================================================================
 class PaginatedCollOutResponse(PaginatedResponse):
     """Response model for paginated collections"""
 
-    items: List[CollOut]
+    items: list[CollOut]
 
 
 # ============================================================================
 class PaginatedCrawlConfigOutResponse(PaginatedResponse):
     """Response model for paginated crawlconfigs"""
 
-    items: List[CrawlConfigOut]
+    items: list[CrawlConfigOut]
 
 
 # ============================================================================
 class PaginatedSeedResponse(PaginatedResponse):
     """Response model for paginated seeds"""
 
-    items: List[Seed]
+    items: list[Seed]
 
 
 # ============================================================================
 class PaginatedConfigRevisionResponse(PaginatedResponse):
     """Response model for paginated crawlconfig revisions"""
 
-    items: List[ConfigRevision]
+    items: list[ConfigRevision]
 
 
 # ============================================================================
 class PaginatedOrgOutResponse(PaginatedResponse):
     """Response model for paginated orgs"""
 
-    items: List[OrgOut]
+    items: list[OrgOut]
 
 
 # ============================================================================
 class PaginatedInvitePendingResponse(PaginatedResponse):
     """Response model for paginated orgs"""
 
-    items: List[InviteOut]
+    items: list[InviteOut]
 
 
 # ============================================================================
 class PaginatedPageOutResponse(PaginatedResponse):
     """Response model for paginated pages"""
 
-    items: List[PageOut]
+    items: list[PageOut]
 
 
 # ============================================================================
 class PageOutItemsResponse(BaseModel):
     """Response model for pages without total"""
 
-    items: List[PageOut]
+    items: list[PageOut]
 
 
 # ============================================================================
 class PaginatedPageOutWithQAResponse(PaginatedResponse):
     """Response model for paginated pages with single QA info"""
 
-    items: List[PageOutWithSingleQA]
+    items: list[PageOutWithSingleQA]
 
 
 # ============================================================================
 class PaginatedProfileResponse(PaginatedResponse):
     """Response model for paginated profiles"""
 
-    items: List[Profile]
+    items: list[Profile]
 
 
 # ============================================================================
 class PaginatedSubscriptionEventResponse(PaginatedResponse):
     """Response model for paginated subscription events"""
 
-    items: List[SubscriptionEventAnyOut]
+    items: list[SubscriptionEventAnyOut]
 
 
 # ============================================================================
 class PaginatedWebhookNotificationResponse(PaginatedResponse):
     """Response model for paginated webhook notifications"""
 
-    items: List[WebhookNotification]
+    items: list[WebhookNotification]
 
 
 # ============================================================================
 class PaginatedCrawlLogResponse(PaginatedResponse):
     """Response model for crawl logs"""
 
-    items: List[CrawlLogLine]
+    items: list[CrawlLogLine]
 
 
 # ============================================================================
 class PaginatedUserOutResponse(PaginatedResponse):
     """Response model for user emails with org info"""
 
-    items: List[UserOutNoId]
+    items: list[UserOutNoId]
 
 
 # ============================================================================
 class PaginatedUserFileResponse(PaginatedResponse):
     """Response model for user-uploaded files (e.g. seed files)"""
 
-    items: List[SeedFileOut]
+    items: list[SeedFileOut]
 
 
 # ============================================================================
 class PageUrlCountResponse(BaseModel):
     """Response model for page count by url"""
 
-    items: List[PageUrlCount]
+    items: list[PageUrlCount]
 
 
 # FILTER UTILITIES

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -11,19 +11,8 @@ import math
 import mimetypes
 import os
 from datetime import datetime
-from enum import Enum, IntEnum
-from typing import (
-    Annotated,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Self,
-    Union,
-    get_args,
-    get_origin,
-)
+from enum import IntEnum, StrEnum
+from typing import Annotated, Any, Literal, Self, get_args, get_origin
 from uuid import UUID
 
 from pydantic import (
@@ -94,7 +83,7 @@ EmptyStr = Annotated[str, Field(min_length=0, max_length=0)]
 
 Scale = Annotated[int, Field(strict=True, ge=1, le=MAX_CRAWL_SCALE, deprecated=True)]
 BrowserWindowCount = Annotated[int, Field(strict=True, ge=1, le=MAX_BROWSER_WINDOWS)]
-ReviewStatus = Optional[Annotated[int, Field(strict=True, ge=1, le=5)]]
+ReviewStatus = Annotated[int, Field(strict=True, ge=1, le=5)] | None
 
 any_http_url_adapter = TypeAdapter(AnyHttpUrlNonStr)
 AnyHttpUrl = Annotated[
@@ -358,7 +347,7 @@ class CrawlStats(BaseModel):
 
 
 # ============================================================================
-class JobType(str, Enum):
+class JobType(StrEnum):
     """Job Types"""
 
     URL_LIST = "url-list"
@@ -367,7 +356,7 @@ class JobType(str, Enum):
 
 
 # ============================================================================
-class ScopeType(str, Enum):
+class ScopeType(StrEnum):
     """Crawl scope type"""
 
     PAGE = "page"
@@ -1649,7 +1638,7 @@ INDEX_JOB_TYPES = get_args(TYPE_INDEX_JOB_TYPES)
 
 
 # ============================================================================
-class CollAccessType(str, Enum):
+class CollAccessType(StrEnum):
     """Collection access types"""
 
     PRIVATE = "private"
@@ -2170,21 +2159,21 @@ class SubscriptionAddMinutesOut(SubscriptionAddMinutes, SubscriptionEventOut):
 
 
 # ============================================================================
-SubscriptionEventAny = Union[
-    SubscriptionCreate,
-    SubscriptionUpdate,
-    SubscriptionCancel,
-    SubscriptionImport,
-    SubscriptionAddMinutes,
-]
+SubscriptionEventAny = (
+    SubscriptionCreate
+    | SubscriptionUpdate
+    | SubscriptionCancel
+    | SubscriptionImport
+    | SubscriptionAddMinutes
+)
 
-SubscriptionEventAnyOut = Union[
-    SubscriptionCreateOut,
-    SubscriptionUpdateOut,
-    SubscriptionCancelOut,
-    SubscriptionImportOut,
-    SubscriptionAddMinutesOut,
-]
+SubscriptionEventAnyOut = (
+    SubscriptionCreateOut
+    | SubscriptionUpdateOut
+    | SubscriptionCancelOut
+    | SubscriptionImportOut
+    | SubscriptionAddMinutesOut
+)
 
 
 # ============================================================================
@@ -2979,7 +2968,7 @@ class WebhookNotificationBody(BaseModel):
 
 
 # ============================================================================
-class WebhookEventType(str, Enum):
+class WebhookEventType(StrEnum):
     """Webhook Event Types"""
 
     CRAWL_STARTED = "crawlStarted"
@@ -3126,7 +3115,19 @@ class WebhookNotification(BaseMongoModel):
 
     event: WebhookEventType
     oid: UUID
-    body: CrawlStartedBody | CrawlFinishedBody | CrawlDeletedBody | QaAnalysisStartedBody | QaAnalysisFinishedBody | CrawlReviewedBody | UploadFinishedBody | UploadDeletedBody | CollectionItemAddedBody | CollectionItemRemovedBody | CollectionDeletedBody
+    body: (
+        CrawlStartedBody
+        | CrawlFinishedBody
+        | CrawlDeletedBody
+        | QaAnalysisStartedBody
+        | QaAnalysisFinishedBody
+        | CrawlReviewedBody
+        | UploadFinishedBody
+        | UploadDeletedBody
+        | CollectionItemAddedBody
+        | CollectionItemRemovedBody
+        | CollectionDeletedBody
+    )
     success: bool = False
     attempts: int = 0
     created: datetime
@@ -3139,7 +3140,7 @@ class WebhookNotification(BaseMongoModel):
 
 
 # ============================================================================
-class BgJobType(str, Enum):
+class BgJobType(StrEnum):
     """Background Job Types"""
 
     CREATE_REPLICA = "create-replica"
@@ -3239,17 +3240,15 @@ class UpdateCollStatsJob(BackgroundJob):
 # Union of all job types, for response model
 
 AnyJob = RootModel[
-    Union[
-        CreateReplicaJob,
-        DeleteReplicaJob,
-        BackgroundJob,
-        DeleteOrgJob,
-        RecalculateOrgStatsJob,
-        ReAddOrgPagesJob,
-        OptimizePagesJob,
-        CleanupSeedFilesJob,
-        UpdateCollStatsJob,
-    ]
+    CreateReplicaJob
+    | DeleteReplicaJob
+    | BackgroundJob
+    | DeleteOrgJob
+    | RecalculateOrgStatsJob
+    | ReAddOrgPagesJob
+    | OptimizePagesJob
+    | CleanupSeedFilesJob
+    | UpdateCollStatsJob
 ]
 
 
@@ -3519,7 +3518,7 @@ class PageUrlCountResponse(BaseModel):
 
 
 # ============================================================================
-class ListFilterType(str, Enum):
+class ListFilterType(StrEnum):
     """Combination type for query filters that accept lists"""
 
     OR = "or"

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -3,8 +3,9 @@
 import json
 import math
 import os
+from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import Any, Literal, Optional, Sequence
+from typing import Any, Literal, Optional
 from uuid import UUID
 
 import structlog
@@ -313,8 +314,8 @@ class CrawlOperator(BaseOperator):
 
         # stopping paused crawls
         if crawl.paused_at:
-            stop_reason: Optional[StopReason] = None
-            state: Optional[TYPE_NON_RUNNING_STATES] = None
+            stop_reason: StopReason | None = None
+            state: TYPE_NON_RUNNING_STATES | None = None
             # Check if pause expiry limit is reached and if so, stop crawl
             if dt_now() >= (crawl.paused_at + self.paused_expires_delta):
                 logger.info(
@@ -482,8 +483,8 @@ class CrawlOperator(BaseOperator):
         return self.load_from_yaml("redis.yaml", params)
 
     def _filter_autoclick_behavior(
-        self, behaviors: Optional[str], crawler_image: str
-    ) -> Optional[str]:
+        self, behaviors: str | None, crawler_image: str
+    ) -> str | None:
         """Remove autoclick behavior if crawler version doesn't support it"""
         min_autoclick_crawler_image = os.environ.get("MIN_AUTOCLICK_CRAWLER_IMAGE")
 
@@ -765,8 +766,8 @@ class CrawlOperator(BaseOperator):
         status: CrawlStatus,
         crawl: CrawlSpec,
         allowed_from: Sequence[TYPE_ALL_CRAWL_STATES],
-        finished: Optional[datetime] = None,
-        stats: Optional[OpCrawlStats] = None,
+        finished: datetime | None = None,
+        stats: OpCrawlStats | None = None,
     ):
         """set status state and update db, if changed
         if allowed_from passed in, can only transition from allowed_from state,
@@ -1250,7 +1251,7 @@ class CrawlOperator(BaseOperator):
         return crawler_running, redis_running, pod_done_count
 
     def handle_terminated_pod(
-        self, name, role, status: CrawlStatus, terminated: Optional[dict[str, Any]]
+        self, name, role, status: CrawlStatus, terminated: dict[str, Any] | None
     ) -> None:
         """handle terminated pod state"""
         if not terminated:
@@ -1613,7 +1614,7 @@ class CrawlOperator(BaseOperator):
 
     async def is_crawl_stopping(
         self, crawl: CrawlSpec, status: CrawlStatus
-    ) -> Optional[StopReason]:
+    ) -> StopReason | None:
         """check if crawl is stopping and set reason"""
         # if user requested stop, then enter stopping phase
         if crawl.stopping:
@@ -1660,7 +1661,7 @@ class CrawlOperator(BaseOperator):
 
     def request_pause_crawl(
         self, reason: StopReason, crawl: CrawlSpec
-    ) -> Optional[StopReason]:
+    ) -> StopReason | None:
         """Request crawl to be paused asynchronously, equivalent of user clicking 'pause' button
         if crawl is paused, then use the specified reason instead of default paused state
         """
@@ -1952,7 +1953,7 @@ class CrawlOperator(BaseOperator):
         crawl: CrawlSpec,
         status: CrawlStatus,
         state: TYPE_NON_RUNNING_STATES,
-        stats: Optional[OpCrawlStats] = None,
+        stats: OpCrawlStats | None = None,
     ) -> bool:
         """mark crawl as finished, set finished timestamp and final state"""
 
@@ -2000,7 +2001,7 @@ class CrawlOperator(BaseOperator):
         crawl: CrawlSpec,
         status: CrawlStatus,
         state: TYPE_NON_RUNNING_STATES,
-        stats: Optional[OpCrawlStats],
+        stats: OpCrawlStats | None,
     ) -> None:
         """Run tasks after crawl completes in asyncio.task coroutine."""
         if state in SUCCESSFUL_STATES:

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -5,7 +5,7 @@ import math
 import os
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from uuid import UUID
 
 import structlog

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -1,6 +1,5 @@
 """Operator handler for crawl CronJobs"""
 
-from typing import Optional
 from uuid import UUID
 
 import structlog

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -31,7 +31,7 @@ class CronJobOperator(BaseOperator):
             return await self.sync_cronjob_crawl(data)
 
     def get_finished_response(
-        self, metadata: dict[str, str], set_status=True, finished: Optional[str] = None
+        self, metadata: dict[str, str], set_status=True, finished: str | None = None
     ) -> MCDecoratorSyncResponse:
         """get final response to indicate cronjob created job is finished"""
 
@@ -60,11 +60,11 @@ class CronJobOperator(BaseOperator):
     async def make_new_crawljob(
         self,
         cid: UUID,
-        oid: Optional[UUID],
-        userid: Optional[UUID],
+        oid: UUID | None,
+        userid: UUID | None,
         crawl_id: str,
         metadata: dict[str, str],
-        state: Optional[str],
+        state: str | None,
     ) -> MCDecoratorSyncResponse:
         """declare new CrawlJob from cid, based on db data"""
         # cronjob doesn't exist yet

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -73,8 +73,8 @@ class MCDecoratorSyncResponse(BaseModel):
     """Response model for decoratorcontroller sync api"""
 
     attachments: list[dict[str, Any]]
-    status: Optional[dict[str, Any]] = None
-    annotations: Optional[dict[str, str]] = None
+    status: dict[str, Any] | None = None
+    annotations: dict[str, str] | None = None
 
 
 # ============================================================================
@@ -91,16 +91,16 @@ class CrawlSpec(BaseModel):
     started: str
     crawler_channel: str
     stopping: bool = False
-    paused_at: Optional[datetime] = None
+    paused_at: datetime | None = None
     scheduled: bool = False
     timeout: int = 0
     max_crawl_size: int = 0
-    qa_source_crawl_id: Optional[str] = ""
-    proxy_id: Optional[str] = None
-    profileid: Optional[str] = None
-    dedupe_coll_id: Optional[str] = None
+    qa_source_crawl_id: str | None = ""
+    proxy_id: str | None = None
+    profileid: str | None = None
+    dedupe_coll_id: str | None = None
     is_single_page: bool = False
-    seed_file_url: Optional[str] = ""
+    seed_file_url: str | None = ""
 
     @property
     def db_crawl_id(self) -> str:
@@ -144,24 +144,24 @@ class PodResources(BaseModel):
 class PodInfo(BaseModel):
     """Aggregate pod status info held in CrawlJob"""
 
-    exitTime: Optional[str] = None
-    exitCode: Optional[int] = None
-    isNewExit: Optional[bool] = Field(default=None, exclude=True)
-    reason: Optional[str] = None
+    exitTime: str | None = None
+    exitCode: int | None = None
+    isNewExit: bool | None = Field(default=None, exclude=True)
+    reason: str | None = None
 
     allocated: PodResources = PodResources()
     used: PodResources = PodResources()
 
-    newCpu: Optional[int] = None
-    newMemory: Optional[int] = None
-    newStorage: Optional[str] = None
-    signalAtMem: Optional[int] = None
+    newCpu: int | None = None
+    newMemory: int | None = None
+    newStorage: str | None = None
+    signalAtMem: int | None = None
 
-    evicted: Optional[bool] = False
+    evicted: bool | None = False
 
-    lastWorkers: Optional[int] = 0
+    lastWorkers: int | None = 0
 
-    sizePending: Optional[int] = 0
+    sizePending: int | None = 0
 
     def dict(self, *a, **kw):
         res = super().dict(*a, **kw)
@@ -197,7 +197,7 @@ class PodInfo(BaseModel):
             else 0
         )
 
-    def should_restart_pod(self, forced: bool = False) -> Optional[str]:
+    def should_restart_pod(self, forced: bool = False) -> str | None:
         """return true if pod should be restarted"""
         if self.newMemory and self.newMemory != self.allocated.memory:
             return "newMemory"
@@ -218,7 +218,7 @@ class PodInfo(BaseModel):
 class OpCrawlStats(CrawlStats):
     """crawl stats + internal profile update"""
 
-    profile_update: Optional[str] = ""
+    profile_update: str | None = ""
 
 
 # ============================================================================
@@ -243,19 +243,19 @@ class CrawlStatus(BaseModel):
 
     filesAdded: int = 0
     filesAddedSize: int = 0
-    finished: Optional[str] = None
+    finished: str | None = None
     stopping: bool = False
-    stopReason: Optional[StopReason] = None
+    stopReason: StopReason | None = None
     initRedis: bool = False
-    crawlerImage: Optional[str] = None
+    crawlerImage: str | None = None
     lastConfigUpdate: str = ""
 
     lastActiveTime: str = ""
-    podStatus: DefaultDict[str, Annotated[PodInfo, Field(default_factory=PodInfo)]] = (
+    podStatus: defaultdict[str, Annotated[PodInfo, Field(default_factory=PodInfo)]] = (
         defaultdict(lambda: PodInfo())  # pylint: disable=unnecessary-lambda
     )
 
-    restartTime: Optional[str] = None
+    restartTime: str | None = None
     canceled: bool = False
 
     # updated on pod exits and at regular interval
@@ -271,10 +271,10 @@ class CrawlStatus(BaseModel):
     lastUpdatedTime: str = ""
 
     # any pods exited
-    anyCrawlPodNewExit: Optional[bool] = Field(default=False, exclude=True)
+    anyCrawlPodNewExit: bool | None = Field(default=False, exclude=True)
 
     # don't include in status, use by metacontroller
-    resync_after: Optional[int] = Field(default=None, exclude=True)
+    resync_after: int | None = Field(default=None, exclude=True)
 
     # last state
     last_state: TYPE_ALL_CRAWL_STATES = Field(default="starting", exclude=True)

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from datetime import datetime
-from typing import Annotated, Any, DefaultDict, Literal, Optional
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from kubernetes.utils import parse_quantity

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -1,7 +1,5 @@
 """shared helper to initialize ops classes"""
 
-from typing import Tuple
-
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 
 from .background_jobs import BackgroundJobOps

--- a/backend/btrixcloud/ops.py
+++ b/backend/btrixcloud/ops.py
@@ -25,7 +25,7 @@ from .webhooks import EventWebhookOps
 
 
 # pylint: disable=too-many-locals
-def init_ops() -> Tuple[
+def init_ops() -> tuple[
     OrgOps,
     CrawlConfigOps,
     BaseCrawlOps,

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -8,13 +8,11 @@ import json
 import math
 import os
 import time
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from tempfile import NamedTemporaryFile
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
     Dict,
     List,
     Literal,
@@ -201,15 +199,15 @@ class OrgOps(BaseOrgs):
     invites: InviteOps
     user_manager: UserManager
     crawl_manager: CrawlManager
-    register_to_org_id: Optional[str]
+    register_to_org_id: str | None
     base_crawl_ops: BaseCrawlOps
-    default_primary: Optional[StorageRef]
+    default_primary: StorageRef | None
 
-    router: Optional[APIRouter]
-    org_viewer_dep: Optional[Callable[..., AsyncGenerator[Organization, None]]]
-    org_crawl_dep: Optional[Callable[..., Awaitable[Organization]]]
-    org_owner_dep: Optional[Callable[..., Awaitable[Organization]]]
-    org_public: Optional[Callable[..., AsyncGenerator[Organization, None]]]
+    router: APIRouter | None
+    org_viewer_dep: Callable[..., AsyncGenerator[Organization, None]] | None
+    org_crawl_dep: Callable[..., Awaitable[Organization]] | None
+    org_owner_dep: Callable[..., Awaitable[Organization]] | None
+    org_public: Callable[..., AsyncGenerator[Organization, None]] | None
 
     def __init__(
         self,
@@ -307,7 +305,7 @@ class OrgOps(BaseOrgs):
         page: int = 1,
         sort_by: str = "name",
         sort_direction: int = 1,
-    ) -> tuple[List[Organization], int]:
+    ) -> tuple[list[Organization], int]:
         """Get all orgs a user is a member of"""
         # pylint: disable=duplicate-code,too-many-locals
 
@@ -315,11 +313,11 @@ class OrgOps(BaseOrgs):
         page = page - 1
         skip = page_size * page
 
-        query: Dict[str, Any] = {}
+        query: dict[str, Any] = {}
         if not user.is_superuser:
             query[f"users.{user.id}"] = {"$gte": role.value}
 
-        aggregate: List[Dict[str, Any]] = [
+        aggregate: list[dict[str, Any]] = [
             {"$match": query},
             {"$set": {"nameLower": {"$toLower": "$name"}}},
         ]
@@ -383,8 +381,8 @@ class OrgOps(BaseOrgs):
         return [Organization.from_dict(data) for data in items], total
 
     async def get_org_for_user_by_id(
-        self, oid: UUID, user: Optional[User], role: UserRole = UserRole.VIEWER
-    ) -> Optional[Organization]:
+        self, oid: UUID, user: User | None, role: UserRole = UserRole.VIEWER
+    ) -> Organization | None:
         """Get an org for user by unique id"""
         query: dict[str, object]
         if not user or user.is_superuser:
@@ -399,10 +397,10 @@ class OrgOps(BaseOrgs):
 
     async def get_users_for_org(
         self, org: Organization, min_role=UserRole.VIEWER
-    ) -> List[User]:
+    ) -> list[User]:
         """get users for org"""
         uuid_ids = [UUID(id_) for id_, role in org.users.items() if role >= min_role]
-        users: List[User] = []
+        users: list[User] = []
         async for user_dict in self.users_db.find({"id": {"$in": uuid_ids}}):
             users.append(User(**user_dict))
         return users
@@ -510,10 +508,10 @@ class OrgOps(BaseOrgs):
 
     async def create_org(
         self,
-        name: Optional[str] = None,
-        slug: Optional[str] = None,
-        quotas: Optional[OrgQuotas] = None,
-        subscription: Optional[Subscription] = None,
+        name: str | None = None,
+        slug: str | None = None,
+        quotas: OrgQuotas | None = None,
+        subscription: Subscription | None = None,
     ) -> Organization:
         """create new org"""
         id_ = uuid4()
@@ -642,7 +640,7 @@ class OrgOps(BaseOrgs):
 
     async def update_subscription_data(
         self, update: SubscriptionUpdate
-    ) -> Optional[Organization]:
+    ) -> Organization | None:
         """Update subscription by id"""
 
         query: dict[str, Any] = {
@@ -670,7 +668,7 @@ class OrgOps(BaseOrgs):
 
     async def cancel_subscription_data(
         self, cancel: SubscriptionCancel
-    ) -> Optional[Organization]:
+    ) -> Organization | None:
         """Find org by subscription by id and delete subscription data, return org"""
         org_data = await self.orgs.find_one_and_update(
             {"subscription.subId": cancel.subId},
@@ -679,7 +677,7 @@ class OrgOps(BaseOrgs):
         )
         return Organization.from_dict(org_data) if org_data else None
 
-    async def find_org_by_subscription_id(self, sub_id: str) -> Optional[Organization]:
+    async def find_org_by_subscription_id(self, sub_id: str) -> Organization | None:
         """Find org by subscription id"""
         org_data = await self.orgs.find_one({"subscription.subId": sub_id})
         return Organization.from_dict(org_data) if org_data else None
@@ -909,7 +907,7 @@ class OrgOps(BaseOrgs):
         self,
         invite: InvitePending,
         user: User,
-        default_org: Optional[Organization] = None,
+        default_org: Organization | None = None,
     ) -> Organization:
         """Lookup an invite by user email (if new) or userid (if existing)
 
@@ -998,7 +996,7 @@ class OrgOps(BaseOrgs):
         org.users[str(userid)] = role
         await self.update_users(org)
 
-    async def get_org_owners(self, org: Organization) -> List[str]:
+    async def get_org_owners(self, org: Organization) -> list[str]:
         """Return list of org's Owner users."""
         org_owners = []
         for key, value in org.users.items():
@@ -1275,7 +1273,7 @@ class OrgOps(BaseOrgs):
         Append async generators to list in order that we want them to be
         exhausted in order to stream a semantically correct JSON document.
         """
-        export_stream_generators: List[AsyncGenerator] = []
+        export_stream_generators: list[AsyncGenerator] = []
 
         oid_query = {"oid": org.id}
 
@@ -1302,7 +1300,7 @@ class OrgOps(BaseOrgs):
             skip_closing_comma=False,
         ) -> AsyncGenerator:
             """Async generator to add json items in list, keyed by supplied str"""
-            yield f'"{key}": [\n'.encode("utf-8")
+            yield f'"{key}": [\n'.encode()
 
             doc_index = 1
 
@@ -1314,7 +1312,7 @@ class OrgOps(BaseOrgs):
                     yield b"\n"
                 doc_index += 1
 
-            yield f"]{'' if skip_closing_comma else ','}\n".encode("utf-8")
+            yield f"]{'' if skip_closing_comma else ','}\n".encode()
 
         async def json_closing_gen() -> AsyncGenerator:
             """Async generator to close JSON document"""
@@ -1371,7 +1369,7 @@ class OrgOps(BaseOrgs):
         self,
         stream_file_object,
         ignore_version: bool = False,
-        storage_name: Optional[str] = None,
+        storage_name: str | None = None,
     ) -> None:
         """Import org from exported org JSON
 
@@ -1408,7 +1406,7 @@ class OrgOps(BaseOrgs):
         stream_org = json_stream.to_standard_types(stream_org)
         oid = UUID(stream_org["_id"])
 
-        existing_org: Optional[Organization] = None
+        existing_org: Organization | None = None
         try:
             existing_org = await self.get_org_by_id(oid)
         except HTTPException:
@@ -2170,7 +2168,7 @@ def init_orgs_api(
         return await ops.get_all_org_slugs()
 
     @app.get(
-        "/orgs/slug-lookup", tags=["organizations"], response_model=Dict[UUID, str]
+        "/orgs/slug-lookup", tags=["organizations"], response_model=dict[UUID, str]
     )
     async def get_all_org_slugs_with_ids(user: User = Depends(user_dep)):
         if not user.is_superuser:
@@ -2194,7 +2192,7 @@ def init_orgs_api(
         request: Request,
         user: User = Depends(user_dep),
         ignoreVersion: bool = False,
-        storageName: Optional[str] = None,
+        storageName: str | None = None,
     ):
         if not user.is_superuser:
             raise HTTPException(status_code=403, detail="Not Allowed")

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -10,15 +10,7 @@ import os
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from tempfile import NamedTemporaryFile
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import UUID, uuid4
 
 import structlog
@@ -1287,7 +1279,7 @@ class OrgOps(BaseOrgs):
         async def json_opening_gen() -> AsyncGenerator:
             """Async generator that opens JSON document, writes dbVersion and org"""
             # pylint: disable=consider-using-f-string
-            opening_section = '{{"data": {{\n"dbVersion": "{0}",\n"org": {1},\n'.format(
+            opening_section = '{{"data": {{\n"dbVersion": "{}",\n"org": {},\n'.format(
                 version.get("version"),
                 json.dumps(org_serialized.to_dict(), cls=JSONSerializer),
             )

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -6,15 +6,7 @@ import asyncio
 import urllib.parse
 from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 import structlog
@@ -450,9 +442,7 @@ class PageOps:
         user: User | None = None,
     ) -> dict[str, bool]:
         """Update page manual review"""
-        query: dict[str, bool | None | str | datetime | UUID] = {
-            "approved": approved
-        }
+        query: dict[str, bool | None | str | datetime | UUID] = {"approved": approved}
         query["modified"] = dt_now()
         if user:
             query["userid"] = user.id

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -4,12 +4,11 @@
 
 import asyncio
 import urllib.parse
+from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    Callable,
     Dict,
     List,
     Optional,
@@ -112,7 +111,7 @@ class PageOps:
         self, crawl_id: str, batch_size=100, num_retries=5
     ):
         """Add pages to database from WACZ files"""
-        pages_buffer: List[Page] = []
+        pages_buffer: list[Page] = []
         crawl = await self.crawl_ops.get_crawl_out(crawl_id)
 
         wacz_logger = logger.bind(crawl_id=crawl_id, oid=crawl.oid)
@@ -185,7 +184,7 @@ class PageOps:
             )
 
     def _get_page_from_dict(
-        self, page_dict: Dict[str, Any], crawl_id: str, oid: UUID, new_uuid: bool
+        self, page_dict: dict[str, Any], crawl_id: str, oid: UUID, new_uuid: bool
     ) -> Page:
         """Return Page object from dict"""
         page_id = page_dict.get("id", "") if not new_uuid else None
@@ -218,7 +217,7 @@ class PageOps:
         p.compute_page_type()
         return p
 
-    async def _add_pages_to_db(self, crawl_id: str, pages: List[Page], ordered=True):
+    async def _add_pages_to_db(self, crawl_id: str, pages: list[Page], ordered=True):
         """Add batch of pages to db in one insert"""
         try:
             result = await self.pages.insert_many(
@@ -244,9 +243,9 @@ class PageOps:
 
     async def add_page_to_db(
         self,
-        page_dict: Dict[str, Any],
+        page_dict: dict[str, Any],
         crawl_id: str,
-        qa_run_id: Optional[str],
+        qa_run_id: str | None,
         oid: UUID,
     ):
         """Add page to database"""
@@ -288,7 +287,7 @@ class PageOps:
             await self.add_qa_run_for_page(page.id, oid, qa_run_id, crawl_id, compare)
 
     async def update_crawl_file_and_error_counts(
-        self, crawl_id: str, pages: Optional[List[Page]] = None
+        self, crawl_id: str, pages: list[Page] | None = None
     ):
         """Update crawl filePageCount and errorPageCount for pages."""
         file_count = 0
@@ -324,11 +323,11 @@ class PageOps:
             {"$inc": inc_query},
         )
 
-    async def delete_crawl_pages(self, crawl_id: str, oid: Optional[UUID] = None):
+    async def delete_crawl_pages(self, crawl_id: str, oid: UUID | None = None):
         """Delete crawl pages from db and clear crawl page counts"""
         delete_logger = logger.bind(crawl_id=crawl_id, oid=oid)
 
-        query: Dict[str, Union[str, UUID]] = {"crawl_id": crawl_id}
+        query: dict[str, str | UUID] = {"crawl_id": crawl_id}
         if oid:
             query["oid"] = oid
         try:
@@ -363,10 +362,10 @@ class PageOps:
         self,
         page_id: UUID,
         oid: UUID,
-        crawl_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        crawl_id: str | None = None,
+    ) -> dict[str, Any]:
         """Return page dict by id"""
-        query: Dict[str, Union[str, UUID]] = {"_id": page_id, "oid": oid}
+        query: dict[str, str | UUID] = {"_id": page_id, "oid": oid}
         if crawl_id:
             query["crawl_id"] = crawl_id
 
@@ -379,7 +378,7 @@ class PageOps:
         self,
         page_id: UUID,
         oid: UUID,
-        crawl_id: Optional[str] = None,
+        crawl_id: str | None = None,
     ) -> Page:
         """Return Page object by id"""
         page_raw = await self.get_page_raw(page_id, oid, crawl_id)
@@ -389,9 +388,9 @@ class PageOps:
         self,
         page_id: UUID,
         oid: UUID,
-        crawl_id: Optional[str] = None,
-        qa_run_id: Optional[str] = None,
-    ) -> Union[PageOut, PageOutWithSingleQA]:
+        crawl_id: str | None = None,
+        qa_run_id: str | None = None,
+    ) -> PageOut | PageOutWithSingleQA:
         """Return PageOut or PageOutWithSingleQA for page"""
         page_raw = await self.get_page_raw(page_id, oid, crawl_id)
         if qa_run_id:
@@ -446,12 +445,12 @@ class PageOps:
         self,
         page_id: UUID,
         oid: UUID,
-        approved: Optional[bool] = None,
-        crawl_id: Optional[str] = None,
-        user: Optional[User] = None,
-    ) -> Dict[str, bool]:
+        approved: bool | None = None,
+        crawl_id: str | None = None,
+        user: User | None = None,
+    ) -> dict[str, bool]:
         """Update page manual review"""
-        query: Dict[str, Union[Optional[bool], str, datetime, UUID]] = {
+        query: dict[str, bool | None | str | datetime | UUID] = {
             "approved": approved
         }
         query["modified"] = dt_now()
@@ -476,7 +475,7 @@ class PageOps:
         text: str,
         user: User,
         crawl_id: str,
-    ) -> Dict[str, Union[bool, PageNote]]:
+    ) -> dict[str, bool | PageNote]:
         """Add note to page"""
         note = PageNote(
             id=uuid4(), text=text, userid=user.id, userName=user.name, created=dt_now()
@@ -505,7 +504,7 @@ class PageOps:
         note_in: PageNoteEdit,
         user: User,
         crawl_id: str,
-    ) -> Dict[str, Union[bool, PageNote]]:
+    ) -> dict[str, bool | PageNote]:
         """Update specific page note"""
         page = await self.get_page_raw(page_id, oid)
         page_notes = page.get("notes", [])
@@ -549,7 +548,7 @@ class PageOps:
         oid: UUID,
         delete: PageNoteDelete,
         crawl_id: str,
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """Delete specific page notes"""
         page = await self.get_page_raw(page_id, oid)
         page_notes = page.get("notes", [])
@@ -574,31 +573,31 @@ class PageOps:
 
     async def list_pages(
         self,
-        coll_id: Optional[UUID] = None,
-        crawl_ids: Optional[List[str]] = None,
+        coll_id: UUID | None = None,
+        crawl_ids: list[str] | None = None,
         public_or_unlisted_only=False,
-        org: Optional[Organization] = None,
-        search: Optional[str] = None,
-        url: Optional[str] = None,
-        url_prefix: Optional[str] = None,
-        ts: Optional[datetime] = None,
-        is_seed: Optional[bool] = None,
-        depth: Optional[int] = None,
-        qa_run_id: Optional[str] = None,
-        qa_filter_by: Optional[str] = None,
-        qa_gte: Optional[float] = None,
-        qa_gt: Optional[float] = None,
-        qa_lte: Optional[float] = None,
-        qa_lt: Optional[float] = None,
-        reviewed: Optional[bool] = None,
-        approved: Optional[List[Union[bool, None]]] = None,
-        has_notes: Optional[bool] = None,
+        org: Organization | None = None,
+        search: str | None = None,
+        url: str | None = None,
+        url_prefix: str | None = None,
+        ts: datetime | None = None,
+        is_seed: bool | None = None,
+        depth: int | None = None,
+        qa_run_id: str | None = None,
+        qa_filter_by: str | None = None,
+        qa_gte: float | None = None,
+        qa_gt: float | None = None,
+        qa_lte: float | None = None,
+        qa_lt: float | None = None,
+        reviewed: bool | None = None,
+        approved: list[bool | None] | None = None,
+        has_notes: bool | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: Optional[str] = None,
-        sort_direction: Optional[int] = -1,
+        sort_by: str | None = None,
+        sort_direction: int | None = -1,
         include_total=False,
-    ) -> Tuple[Union[List[PageOut], List[PageOutWithSingleQA]], int]:
+    ) -> tuple[list[PageOut] | list[PageOutWithSingleQA], int]:
         """List all pages in crawl"""
         # pylint: disable=duplicate-code, too-many-locals, too-many-branches, too-many-statements
         # Zero-index page for query
@@ -698,7 +697,7 @@ class PageOps:
 
                 query[f"qa.{qa_run_id}.{qa_filter_by}"] = range_filter
 
-        aggregate: List[Dict[str, Union[int, object]]] = [{"$match": query}]
+        aggregate: list[dict[str, int | object]] = [{"$match": query}]
 
         # Extra QA Set
         if qa_run_id:
@@ -795,9 +794,9 @@ class PageOps:
         self,
         coll_id: UUID,
         oid: UUID,
-        url_prefix: Optional[str] = None,
+        url_prefix: str | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
-    ) -> List[PageUrlCount]:
+    ) -> list[PageUrlCount]:
         """List all page URLs in collection sorted desc by snapshot count
         unless prefix is specified"""
         crawl_ids = await self.coll_ops.get_collection_crawl_ids(coll_id, oid)
@@ -830,7 +829,7 @@ class PageOps:
 
         return list(url_counts.values())
 
-    async def re_add_crawl_pages(self, crawl_id: str, oid: Optional[UUID] = None):
+    async def re_add_crawl_pages(self, crawl_id: str, oid: UUID | None = None):
         """Delete existing pages for crawl and re-add from WACZs."""
 
         try:
@@ -920,10 +919,10 @@ class PageOps:
             readd_logger.exception("page_re_add_error")
 
     async def re_add_all_crawl_pages(
-        self, org: Organization, crawl_type: Optional[str] = None
+        self, org: Organization, crawl_type: str | None = None
     ):
         """Re-add pages for all crawls and uploads in org"""
-        match_query: Dict[str, Union[object, UUID]] = {
+        match_query: dict[str, object | UUID] = {
             "oid": org.id,
             "finished": {"$ne": None},
         }
@@ -948,7 +947,7 @@ class PageOps:
         self,
         crawl_id: str,
         qa_run_id: str,
-        thresholds: Dict[str, List[float]],
+        thresholds: dict[str, list[float]],
         key: str = "screenshotMatch",
     ):
         """Get counts for pages in QA run in buckets by score key based on thresholds"""
@@ -1029,7 +1028,7 @@ class PageOps:
 
         return crawl_type
 
-    async def get_unique_page_count(self, crawl_ids: List[str]) -> int:
+    async def get_unique_page_count(self, crawl_ids: list[str]) -> int:
         """Get count of unique page URLs across list of archived items"""
         cursor = self.pages.aggregate(
             [
@@ -1042,8 +1041,8 @@ class PageOps:
         return res[0].get("urls") if res else 0
 
     async def get_top_page_hosts(
-        self, crawl_ids: List[str]
-    ) -> List[dict[str, str | int]]:
+        self, crawl_ids: list[str]
+    ) -> list[dict[str, str | int]]:
         """Get count of top page hosts across all archived items"""
         cursor = self.pages.aggregate(
             [
@@ -1386,22 +1385,22 @@ def init_pages_api(
     async def get_crawl_pages_list(
         crawl_id: str,
         org: Organization = Depends(org_crawl_dep),
-        search: Optional[str] = None,
-        url: Optional[str] = None,
-        urlPrefix: Optional[str] = None,
-        ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
-        depth: Optional[int] = None,
-        reviewed: Optional[bool] = None,
-        approved: Optional[str] = None,
-        hasNotes: Optional[bool] = None,
+        search: str | None = None,
+        url: str | None = None,
+        urlPrefix: str | None = None,
+        ts: datetime | None = None,
+        isSeed: bool | None = None,
+        depth: int | None = None,
+        reviewed: bool | None = None,
+        approved: str | None = None,
+        hasNotes: bool | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
     ):
         """Retrieve paginated list of pages"""
-        formatted_approved: Optional[List[Union[bool, None]]] = None
+        formatted_approved: list[bool | None] | None = None
         if approved:
             formatted_approved = str_list_to_bools(approved.split(","))
 
@@ -1433,11 +1432,11 @@ def init_pages_api(
     async def get_search_pages_list(
         crawl_id: str,
         org: Organization = Depends(org_crawl_dep),
-        search: Optional[str] = None,
-        url: Optional[str] = None,
-        ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
-        depth: Optional[int] = None,
+        search: str | None = None,
+        url: str | None = None,
+        ts: datetime | None = None,
+        isSeed: bool | None = None,
+        depth: int | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
     ):
@@ -1464,11 +1463,11 @@ def init_pages_api(
     async def get_search_pages_list_shareable_crawl_config(
         cid: UUID,
         org: Organization = Depends(org_public),
-        search: Optional[str] = None,
-        url: Optional[str] = None,
-        ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
-        depth: Optional[int] = None,
+        search: str | None = None,
+        url: str | None = None,
+        ts: datetime | None = None,
+        isSeed: bool | None = None,
+        depth: int | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
     ):
@@ -1506,15 +1505,15 @@ def init_pages_api(
         coll_id: UUID,
         response: Response,
         org: Organization = Depends(org_public),
-        search: Optional[str] = None,
-        url: Optional[str] = None,
-        ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
-        depth: Optional[int] = None,
+        search: str | None = None,
+        url: str | None = None,
+        ts: datetime | None = None,
+        isSeed: bool | None = None,
+        depth: int | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
     ):
         """Retrieve paginated list of pages in collection"""
         pages, _ = await ops.list_pages(
@@ -1566,15 +1565,15 @@ def init_pages_api(
         coll_id: UUID,
         response: Response,
         org: Organization = Depends(org_viewer_dep),
-        search: Optional[str] = None,
-        url: Optional[str] = None,
-        ts: Optional[datetime] = None,
-        isSeed: Optional[bool] = None,
-        depth: Optional[int] = None,
+        search: str | None = None,
+        url: str | None = None,
+        ts: datetime | None = None,
+        isSeed: bool | None = None,
+        depth: int | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
     ):
         """Retrieve paginated list of pages in collection"""
         pages, _ = await ops.list_pages(
@@ -1602,22 +1601,22 @@ def init_pages_api(
     async def get_pages_list_with_qa(
         crawl_id: str,
         qa_run_id: str,
-        filterQABy: Optional[str] = None,
-        gte: Optional[float] = None,
-        gt: Optional[float] = None,
-        lte: Optional[float] = None,
-        lt: Optional[float] = None,
-        reviewed: Optional[bool] = None,
-        approved: Optional[str] = None,
-        hasNotes: Optional[bool] = None,
+        filterQABy: str | None = None,
+        gte: float | None = None,
+        gt: float | None = None,
+        lte: float | None = None,
+        lt: float | None = None,
+        reviewed: bool | None = None,
+        approved: str | None = None,
+        hasNotes: bool | None = None,
         org: Organization = Depends(org_crawl_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
     ):
         """Retrieve paginated list of pages"""
-        formatted_approved: Optional[List[Union[bool, None]]] = None
+        formatted_approved: list[bool | None] | None = None
         if approved:
             formatted_approved = str_list_to_bools(approved.split(","))
 
@@ -1648,7 +1647,7 @@ def init_pages_api(
     )
     async def get_collection_url_list(
         coll_id: UUID,
-        urlPrefix: Optional[str] = None,
+        urlPrefix: str | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         org: Organization = Depends(org_viewer_dep),
         # page: int = 1,

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -7,7 +7,7 @@ DEFAULT_PAGE_SIZE = 1_000
 
 # ============================================================================
 def paginated_format(
-    items: Optional[List[Any]],
+    items: list[Any] | None,
     total: int,
     page: int = 1,
     page_size: int = DEFAULT_PAGE_SIZE,

--- a/backend/btrixcloud/pagination.py
+++ b/backend/btrixcloud/pagination.py
@@ -1,16 +1,25 @@
 """API pagination"""
 
-from typing import Any, List, Optional
+from typing import TypedDict
 
 DEFAULT_PAGE_SIZE = 1_000
 
 
+class PaginatedResponse[T](TypedDict):
+    """Paginated response type."""
+
+    items: list[T] | None
+    total: int
+    page: int
+    pageSize: int
+
+
 # ============================================================================
-def paginated_format(
-    items: list[Any] | None,
+def paginated_format[T](
+    items: list[T] | None,
     total: int,
     page: int = 1,
     page_size: int = DEFAULT_PAGE_SIZE,
-):
+) -> PaginatedResponse[T]:
     """Return items in paged format."""
     return {"items": items, "total": total, "page": page, "pageSize": page_size}

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -2,12 +2,11 @@
 
 import json
 import os
+from collections.abc import AsyncGenerator, Callable
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    AsyncGenerator,
-    Callable,
     Dict,
     List,
     Optional,
@@ -241,7 +240,7 @@ class ProfileOps:
         browser_commit: ProfileCreate,
         org: Organization,
         user: User,
-        existing_profile: Optional[Profile] = None,
+        existing_profile: Profile | None = None,
     ) -> dict[str, Any]:
         """commit to profile async, returning if committed, or waiting"""
         if not metadata.profileid:
@@ -276,7 +275,7 @@ class ProfileOps:
         browser_commit: ProfileCreate,
         org: Organization,
         user: User,
-        existing_profile: Optional[Profile] = None,
+        existing_profile: Profile | None = None,
     ) -> bool:
         """commit profile and shutdown profile browser"""
         # pylint: disable=too-many-locals
@@ -480,15 +479,15 @@ class ProfileOps:
     async def list_profiles(
         self,
         org: Organization,
-        userid: Optional[UUID] = None,
-        tags: Optional[List[str]] = None,
-        tag_match: Optional[ListFilterType] = ListFilterType.AND,
-        name: Optional[str] = None,
+        userid: UUID | None = None,
+        tags: list[str] | None = None,
+        tag_match: ListFilterType | None = ListFilterType.AND,
+        name: str | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sort_by: str = "modified",
         sort_direction: int = -1,
-    ) -> Tuple[list[Profile], int]:
+    ) -> tuple[list[Profile], int]:
         """list all profiles"""
         # pylint: disable=too-many-locals,duplicate-code
 
@@ -496,7 +495,7 @@ class ProfileOps:
         page = page - 1
         skip = page_size * page
 
-        match_query: Dict[str, Any] = {"oid": org.id}
+        match_query: dict[str, Any] = {"oid": org.id}
         if userid:
             match_query["userid"] = userid
         if tags:
@@ -505,7 +504,7 @@ class ProfileOps:
         if name:
             match_query["name"] = name
 
-        aggregate: List[Dict[str, Any]] = [{"$match": match_query}]
+        aggregate: list[dict[str, Any]] = [{"$match": match_query}]
 
         if sort_by:
             if sort_by not in ("modified", "created", "name", "url"):
@@ -570,7 +569,7 @@ class ProfileOps:
         return profile
 
     async def get_profile_filename_proxy_channel(
-        self, profileid: Optional[UUID], org: Organization
+        self, profileid: UUID | None, org: Organization
     ) -> tuple[str, str, str]:
         """return profile path filename (relative path) for given profile id and org"""
         if not profileid:
@@ -641,7 +640,7 @@ class ProfileOps:
         browserid: str,
         path: str,
         method: str = "GET",
-        post_data: Optional[dict[str, Any]] = None,
+        post_data: dict[str, Any] | None = None,
         committing="",
     ) -> dict[str, Any]:
         """make request to browser api to get state"""
@@ -694,7 +693,7 @@ class ProfileOps:
 
     async def get_profile_tag_counts(
         self, org: Organization
-    ) -> list[dict[str, Union[str, int]]]:
+    ) -> list[dict[str, str | int]]:
         """get distinct tags from all profiles for this org, sorted by count"""
         # pylint: disable=duplicate-code
         tags = await self.profiles.aggregate(
@@ -767,17 +766,17 @@ def init_profiles_api(
     @router.get("", response_model=PaginatedProfileResponse)
     async def list_profiles(
         org: Organization = Depends(org_crawl_dep),
-        userid: Optional[UUID] = None,
-        tags: Annotated[Optional[List[str]], Query(title="Tags")] = None,
+        userid: UUID | None = None,
+        tags: Annotated[list[str] | None, Query(title="Tags")] = None,
         tag_match: Annotated[
-            Optional[ListFilterType],
+            ListFilterType | None,
             Query(
                 alias="tagMatch",
                 title="Tag Match Type",
                 description='Defaults to `"and"` if omitted',
             ),
         ] = ListFilterType.AND,
-        name: Optional[str] = None,
+        name: str | None = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
         sortBy: str = "modified",

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -3,17 +3,7 @@
 import json
 import os
 from collections.abc import AsyncGenerator, Callable
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from urllib.parse import urlencode
 from uuid import UUID, uuid4
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -12,15 +12,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable, I
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from itertools import chain
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
 from zipfile import ZipInfo
 
@@ -634,9 +626,7 @@ class StorageOps:
 
         return urls, now + self.signed_duration_delta
 
-    async def delete_file_object(
-        self, org: Organization, crawlfile: BaseFile
-    ) -> bool:
+    async def delete_file_object(self, org: Organization, crawlfile: BaseFile) -> bool:
         """delete crawl file from storage."""
         return await self._delete_file(org, crawlfile.filename, crawlfile.storage)
 

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -8,18 +8,14 @@ import json
 import os
 import time
 import zlib
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterable, Iterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    AsyncIterator,
-    Callable,
     Dict,
-    Iterable,
-    Iterator,
     List,
     Optional,
     Union,
@@ -76,11 +72,11 @@ CHUNK_SIZE = 1024 * 256
 class StorageOps:
     """All storage handling, download/upload operations"""
 
-    default_storages: Dict[str, S3Storage] = {}
+    default_storages: dict[str, S3Storage] = {}
 
-    default_primary: Optional[StorageRef] = None
+    default_primary: StorageRef | None = None
 
-    default_replicas: List[StorageRef] = []
+    default_replicas: list[StorageRef] = []
 
     org_ops: OrgOps
     crawl_manager: CrawlManager
@@ -290,9 +286,9 @@ class StorageOps:
 
         return {"updated": True}
 
-    def get_available_storages(self, org: Organization) -> List[StorageRef]:
+    def get_available_storages(self, org: Organization) -> list[StorageRef]:
         """return a list of available default + custom storages"""
-        refs: List[StorageRef] = []
+        refs: list[StorageRef] = []
         for name in self.default_storages:
             refs.append(StorageRef(name=name, custom=False))
         for name in org.customStorages:
@@ -353,7 +349,7 @@ class StorageOps:
             return self.frontend_origin + path
         return path
 
-    def resolve_relative_access_path(self, path: str, headers: Optional[dict] = None):
+    def resolve_relative_access_path(self, path: str, headers: dict | None = None):
         """Resolve relative path for internal access or external if headers provided"""
         if path.startswith("/"):
             if headers is None:
@@ -376,7 +372,7 @@ class StorageOps:
 
         return self.get_org_storage_by_ref(org, org.storage)
 
-    def get_org_replicas_storage_refs(self, org: Organization) -> List[StorageRef]:
+    def get_org_replicas_storage_refs(self, org: Organization) -> list[StorageRef]:
         """get org replicas storages, defaulting to default replicas if none found"""
 
         if org.storageReplicas:
@@ -422,7 +418,7 @@ class StorageOps:
         filename: str,
         file_: AsyncIterator,
         min_size: int,
-        mime: Optional[str] = None,
+        mime: str | None = None,
     ) -> bool:
         """do upload to specified key using multipart chunking"""
         s3storage = self.get_org_primary_storage(org)
@@ -564,7 +560,7 @@ class StorageOps:
 
     def get_host_endpoint_url(
         self, s3storage: S3Storage, bucket: str, key: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """compute host endpoint for given storage for replacement for access"""
         if not s3storage.access_endpoint_url:
             return None
@@ -639,7 +635,7 @@ class StorageOps:
         return urls, now + self.signed_duration_delta
 
     async def delete_file_object(
-        self, org: Organization, crawlfile: Union[BaseFile]
+        self, org: Organization, crawlfile: BaseFile
     ) -> bool:
         """delete crawl file from storage."""
         return await self._delete_file(org, crawlfile.filename, crawlfile.storage)
@@ -675,8 +671,8 @@ class StorageOps:
         return await self._delete_file_from_storage(s3storage, filename)
 
     async def sync_stream_wacz_pages(
-        self, wacz_files: List[CrawlFileOut], num_retries=5
-    ) -> Iterator[Dict[Any, Any]]:
+        self, wacz_files: list[CrawlFileOut], num_retries=5
+    ) -> Iterator[dict[Any, Any]]:
         """Return stream of pages specified WACZ"""
         loop = asyncio.get_event_loop()
 
@@ -688,9 +684,9 @@ class StorageOps:
 
     async def sync_stream_wacz_logs(
         self,
-        wacz_files: List[CrawlFileOut],
-        log_levels: List[str],
-        contexts: List[str],
+        wacz_files: list[CrawlFileOut],
+        log_levels: list[str],
+        contexts: list[str],
     ) -> Iterator[bytes]:
         """Return filtered stream of logs from specified WACZs sorted by timestamp"""
         loop = asyncio.get_event_loop()
@@ -707,9 +703,9 @@ class StorageOps:
 
     def _sync_get_logs(
         self,
-        wacz_files: List[CrawlFileOut],
-        log_levels: List[str],
-        contexts: List[str],
+        wacz_files: list[CrawlFileOut],
+        log_levels: list[str],
+        contexts: list[str],
     ) -> Iterator[bytes]:
         """Generate filtered stream of logs from specified WACZs sorted by timestamp"""
 
@@ -734,7 +730,7 @@ class StorageOps:
                 yield _parse_json(line.decode("utf-8", errors="ignore"))
 
         def stream_json_lines(
-            iterator: Iterable[dict], log_levels: List[str], contexts: List[str]
+            iterator: Iterable[dict], log_levels: list[str], contexts: list[str]
         ) -> Iterator[bytes]:
             """Yield parsed JSON dicts as JSON-lines bytes after filtering as necessary"""
             for line_dict in iterator:
@@ -746,11 +742,11 @@ class StorageOps:
                 yield json_str.encode("utf-8")
 
         def organize_based_on_instance_number(
-            wacz_files: List[CrawlFileOut],
-        ) -> List[List[CrawlFileOut]]:
+            wacz_files: list[CrawlFileOut],
+        ) -> list[list[CrawlFileOut]]:
             """Place wacz_files into their own list based on instance number"""
             wacz_files.sort(key=lambda file: file.name)
-            waczs_groups: Dict[str, List[CrawlFileOut]] = {}
+            waczs_groups: dict[str, list[CrawlFileOut]] = {}
             for file in wacz_files:
                 instance_number = file.name[
                     file.name.rfind("-") + 1 : file.name.rfind(".")
@@ -761,16 +757,16 @@ class StorageOps:
                     waczs_groups[instance_number] = [file]
             return list(waczs_groups.values())
 
-        log_generators: List[Iterator[dict]] = []
+        log_generators: list[Iterator[dict]] = []
 
         waczs_groups = organize_based_on_instance_number(wacz_files)
         for instance_list in waczs_groups:
-            wacz_log_streams: List[Iterator[dict]] = []
+            wacz_log_streams: list[Iterator[dict]] = []
 
             for wacz_file in instance_list:
                 wacz_url = self.resolve_internal_access_path(wacz_file.path)
                 with RemoteZip(wacz_url) as remote_zip:
-                    log_files: List[ZipInfo] = [
+                    log_files: list[ZipInfo] = [
                         f
                         for f in remote_zip.infolist()
                         if f.filename.startswith("logs/") and not f.is_dir()
@@ -789,8 +785,8 @@ class StorageOps:
         return stream_json_lines(heap_iter, log_levels, contexts)
 
     def _sync_get_pages(
-        self, wacz_files: List[CrawlFileOut], num_retries=5
-    ) -> Iterator[Dict[Any, Any]]:
+        self, wacz_files: list[CrawlFileOut], num_retries=5
+    ) -> Iterator[dict[Any, Any]]:
         """Generate stream of page dicts from specified WACZs"""
 
         # pylint: disable=too-many-function-args
@@ -798,7 +794,7 @@ class StorageOps:
             pagefile_zipinfo: ZipInfo,
             wacz_url: str,
             wacz_filename: str,
-        ) -> Iterator[Dict[Any, Any]]:
+        ) -> Iterator[dict[Any, Any]]:
             """Pass lines as json objects"""
             filename = pagefile_zipinfo.filename
 
@@ -838,7 +834,7 @@ class StorageOps:
             while True:
                 try:
                     with RemoteZip(wacz_url) as remote_zip:
-                        page_files: List[ZipInfo] = [
+                        page_files: list[ZipInfo] = [
                             f
                             for f in remote_zip.infolist()
                             if f.filename.startswith("pages/")
@@ -885,7 +881,7 @@ class StorageOps:
     def _sync_dl(
         self,
         metadata: dict[str, str],
-        all_files: List[CrawlFileOut],
+        all_files: list[CrawlFileOut],
         prefer_single_wacz: bool = False,
         max_retries=5,
     ) -> Iterator[bytes]:
@@ -985,7 +981,7 @@ class StorageOps:
     async def download_streaming_wacz(
         self,
         metadata: dict[str, str],
-        files: List[CrawlFileOut],
+        files: list[CrawlFileOut],
         prefer_single_wacz: bool = False,
     ) -> Iterator[bytes]:
         """return an iter for downloading a stream nested wacz file
@@ -1002,7 +998,7 @@ class StorageOps:
 # ============================================================================
 def _parse_json(line) -> dict:
     """Parse JSON str into dict."""
-    parsed_json: Optional[dict] = None
+    parsed_json: dict | None = None
     try:
         parsed_json = json.loads(line)
     except json.JSONDecodeError as err:
@@ -1039,7 +1035,7 @@ def init_storages_api(
         """get storage refs for an org"""
         return OrgStorageRefs(storage=org.storage, storageReplicas=org.storageReplicas)
 
-    @router.get("/allStorages", tags=["organizations"], response_model=List[StorageRef])
+    @router.get("/allStorages", tags=["organizations"], response_model=list[StorageRef])
     def get_available_storages(org: Organization = Depends(org_owner_dep)):
         return storage_ops.get_available_storages(org)
 

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -4,8 +4,9 @@ Subscription API handling
 
 import asyncio
 import os
+from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
-from typing import Annotated, Any, AsyncGenerator, Callable, List, Optional, Tuple
+from typing import Annotated, Any, List, Optional, Tuple
 from uuid import UUID
 
 import structlog
@@ -303,17 +304,17 @@ class SubOps:
     # pylint: disable=too-many-arguments
     async def list_sub_events(
         self,
-        status: Optional[str] = None,
-        sub_id: Optional[str] = None,
-        oid: Optional[UUID] = None,
-        plan_id: Optional[str] = None,
-        type_: Optional[SubscriptionEventType] = None,
+        status: str | None = None,
+        sub_id: str | None = None,
+        oid: UUID | None = None,
+        plan_id: str | None = None,
+        type_: SubscriptionEventType | None = None,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sort_by: Optional[str] = None,
-        sort_direction: Optional[int] = -1,
-    ) -> Tuple[
-        List[SubscriptionEventAnyOut],
+        sort_by: str | None = None,
+        sort_direction: int | None = -1,
+    ) -> tuple[
+        list[SubscriptionEventAnyOut],
         int,
     ]:
         """list subscription events"""
@@ -508,7 +509,7 @@ def init_subs_api(
     org_ops: OrgOps,
     user_manager: UserManager,
     superuser_or_shared_secret_dep: Callable[[str], AsyncGenerator[User, None]],
-) -> Optional[SubOps]:
+) -> SubOps | None:
     """init subs API"""
 
     if not subscriptions_enabled:
@@ -600,15 +601,15 @@ def init_subs_api(
         response_model=PaginatedSubscriptionEventResponse,
     )
     async def get_sub_events(
-        status: Optional[str] = None,
-        subId: Optional[str] = None,
-        oid: Optional[UUID] = None,
-        planId: Optional[str] = None,
-        type_: Annotated[Optional[SubscriptionEventType], Query(alias="type")] = None,
+        status: str | None = None,
+        subId: str | None = None,
+        oid: UUID | None = None,
+        planId: str | None = None,
+        type_: Annotated[SubscriptionEventType | None, Query(alias="type")] = None,
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        sortBy: Optional[str] = "timestamp",
-        sortDirection: Optional[int] = 1,
+        sortBy: str | None = "timestamp",
+        sortDirection: int | None = 1,
     ):
         events, total = await ops.list_sub_events(
             status=status,

--- a/backend/btrixcloud/subs.py
+++ b/backend/btrixcloud/subs.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 from collections.abc import AsyncGenerator, Callable
 from datetime import datetime
-from typing import Annotated, Any, List, Optional, Tuple
+from typing import Annotated, Any
 from uuid import UUID
 
 import structlog

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -3,7 +3,7 @@
 import uuid
 from collections.abc import AsyncGenerator, Callable
 from io import BufferedReader
-from typing import Any, List, Optional
+from typing import Any
 from urllib.parse import unquote
 from uuid import UUID
 

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -1,8 +1,9 @@
 """handle user uploads into browsertrix"""
 
 import uuid
+from collections.abc import AsyncGenerator, Callable
 from io import BufferedReader
-from typing import Any, AsyncGenerator, Callable, List, Optional
+from typing import Any, List, Optional
 from urllib.parse import unquote
 from uuid import UUID
 
@@ -42,7 +43,7 @@ class UploadOps(BaseCrawlOps):
     async def get_upload(
         self,
         crawlid: str,
-        org: Optional[Organization] = None,
+        org: Organization | None = None,
     ) -> UploadedCrawl:
         """Get crawl data for internal use"""
         res = await self.get_crawl_raw(crawlid, org, "upload")
@@ -54,13 +55,13 @@ class UploadOps(BaseCrawlOps):
         self,
         stream,
         filename: str,
-        name: Optional[str],
-        description: Optional[str],
-        collections: Optional[List[str]],
-        tags: Optional[List[str]],
+        name: str | None,
+        description: str | None,
+        collections: list[str] | None,
+        tags: list[str] | None,
         org: Organization,
         user: User,
-        replaceId: Optional[str],
+        replaceId: str | None,
     ) -> dict[str, Any]:
         """Upload streaming file, length unknown"""
         self.orgs.can_write_data(org, include_time=False)
@@ -124,11 +125,11 @@ class UploadOps(BaseCrawlOps):
     # pylint: disable=too-many-arguments, too-many-locals
     async def upload_formdata(
         self,
-        uploads: List[UploadFile],
-        name: Optional[str],
-        description: Optional[str],
-        collections: Optional[List[str]],
-        tags: Optional[List[str]],
+        uploads: list[UploadFile],
+        name: str | None,
+        description: str | None,
+        collections: list[str] | None,
+        tags: list[str] | None,
         org: Organization,
         user: User,
     ) -> dict[str, Any]:
@@ -136,7 +137,7 @@ class UploadOps(BaseCrawlOps):
         self.orgs.can_write_data(org, include_time=False)
 
         id_ = uuid.uuid4()
-        files: List[CrawlFile] = []
+        files: list[CrawlFile] = []
 
         prefix = org.storage.get_storage_extra_path(str(org.id)) + f"uploads/{id_}"
 
@@ -155,11 +156,11 @@ class UploadOps(BaseCrawlOps):
 
     async def _create_upload(
         self,
-        files: List[CrawlFile],
-        name: Optional[str],
-        description: Optional[str],
-        collections: Optional[List[str]],
-        tags: Optional[List[str]],
+        files: list[CrawlFile],
+        name: str | None,
+        description: str | None,
+        collections: list[str] | None,
+        tags: list[str] | None,
         crawl_id: str,
         org: Organization,
         user: User,
@@ -167,7 +168,7 @@ class UploadOps(BaseCrawlOps):
         now = dt_now()
         file_size = sum(file_.size or 0 for file_ in files)
 
-        collection_uuids: List[UUID] = []
+        collection_uuids: list[UUID] = []
         if collections:
             try:
                 for coll in collections:
@@ -217,7 +218,7 @@ class UploadOps(BaseCrawlOps):
         return {"id": crawl_id, "added": True, "storageQuotaReached": quota_reached}
 
     async def _add_pages_and_update_collections(
-        self, crawl_id: str, oid: UUID, collections: Optional[List[str]] = None
+        self, crawl_id: str, oid: UUID, collections: list[str] | None = None
     ):
         await self.page_ops.add_crawl_pages_to_db_from_wacz(crawl_id)
         if collections:
@@ -227,7 +228,7 @@ class UploadOps(BaseCrawlOps):
         self,
         delete_list: DeleteCrawlList,
         org: Organization,
-        user: Optional[User] = None,
+        user: User | None = None,
     ):
         """Delete uploaded crawls"""
         deleted_count, _, quota_reached = await self.delete_crawls(
@@ -248,7 +249,7 @@ class UploadFileReader(BufferedReader):
         super().__init__(upload.file._file)
         self.file_prep = file_prep
 
-    def read(self, size: Optional[int] = CHUNK_SIZE) -> bytes:
+    def read(self, size: int | None = CHUNK_SIZE) -> bytes:
         """read and digest file chunk"""
         chunk = super().read(size)
         self.file_prep.add_chunk(chunk)
@@ -271,11 +272,11 @@ def init_uploads_api(app, user_dep: Callable[[str], AsyncGenerator[User, None]],
         response_model=AddedResponseIdQuota,
     )
     async def upload_formdata(
-        uploads: List[UploadFile] = File(...),
+        uploads: list[UploadFile] = File(...),
         name: str = "",
         description: str = "",
-        collections: Optional[str] = "",
-        tags: Optional[str] = "",
+        collections: str | None = "",
+        tags: str | None = "",
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ) -> dict[str, Any]:
@@ -303,9 +304,9 @@ def init_uploads_api(app, user_dep: Callable[[str], AsyncGenerator[User, None]],
         filename: str,
         name: str = "",
         description: str = "",
-        collections: Optional[str] = "",
-        tags: Optional[str] = "",
-        replaceId: Optional[str] = "",
+        collections: str | None = "",
+        tags: str | None = "",
+        replaceId: str | None = "",
         org: Organization = Depends(org_crawl_dep),
         user: User = Depends(user_dep),
     ) -> dict[str, Any]:
@@ -340,11 +341,11 @@ def init_uploads_api(app, user_dep: Callable[[str], AsyncGenerator[User, None]],
         org: Organization = Depends(org_viewer_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        state: Optional[str] = None,
-        userid: Optional[UUID] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        collectionId: Optional[UUID] = None,
+        state: str | None = None,
+        userid: UUID | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        collectionId: UUID | None = None,
         sortBy: str = "finished",
         sortDirection: int = -1,
     ):

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -3,10 +3,9 @@ FastAPI user handling (via fastapi-users)
 """
 
 import os
+from collections.abc import AsyncGenerator, Callable
 from typing import (
     TYPE_CHECKING,
-    AsyncGenerator,
-    Callable,
     List,
     Optional,
     Tuple,
@@ -121,7 +120,7 @@ class UserManager:
         await self.failed_logins.create_index("attempted", expireAfterSeconds=3600)
 
     async def register(
-        self, create: UserCreate, request: Optional[Request] = None
+        self, create: UserCreate, request: Request | None = None
     ) -> User:
         """override user creation to check if invite token is present"""
         create.name = create.name or create.email
@@ -130,7 +129,7 @@ class UserManager:
         if not self.registration_enabled and not create.inviteToken:
             raise HTTPException(status_code=400, detail="invite_token_required")
 
-        invite: Optional[InvitePending] = None
+        invite: InvitePending | None = None
         if create.inviteToken:
             # raises if invite is invalid
             invite = await self.invites.get_valid_invite(
@@ -176,8 +175,8 @@ class UserManager:
     async def get_user_info_with_orgs(
         self,
         user: User,
-        info_out_cls: Type[UserOrgInfoOut | UserOrgInfoOutWithSubs] = UserOrgInfoOut,
-        user_out_cls: Type[UserOut | UserOutNoId] = UserOut,
+        info_out_cls: type[UserOrgInfoOut | UserOrgInfoOutWithSubs] = UserOrgInfoOut,
+        user_out_cls: type[UserOut | UserOutNoId] = UserOut,
     ) -> UserOut | UserOutNoId:
         """return User info"""
         user_orgs, _ = await self.org_ops.get_orgs_for_user(
@@ -243,7 +242,7 @@ class UserManager:
 
         return True
 
-    async def authenticate(self, email: EmailStr, password: str) -> Optional[User]:
+    async def authenticate(self, email: EmailStr, password: str) -> User | None:
         """authenticate user via login form"""
         user = await self.get_by_email(email)
         if not user:
@@ -257,7 +256,7 @@ class UserManager:
 
         return None
 
-    async def get_user_names_by_ids(self, user_ids: List[str]) -> dict[str, str]:
+    async def get_user_names_by_ids(self, user_ids: list[str]) -> dict[str, str]:
         """return list of user names for given ids"""
         user_uuid_ids = [UUID(id_) for id_ in user_ids]
         cursor = self.users.find(
@@ -272,7 +271,7 @@ class UserManager:
             email_id_map[user["id"]] = user["email"]
         return email_id_map
 
-    async def get_superuser(self) -> Optional[User]:
+    async def get_superuser(self) -> User | None:
         """return current superuser, if any"""
         user_data = await self.users.find_one({"is_superuser": True})
         if not user_data:
@@ -333,7 +332,7 @@ class UserManager:
             )
 
     async def request_verify(
-        self, user: User, request: Optional[Request] = None
+        self, user: User, request: Request | None = None
     ) -> None:
         """start verifying user, if not already verified"""
         if user.is_verified:
@@ -358,7 +357,7 @@ class UserManager:
         self,
         name: str,
         email: str,
-        password: Optional[str] = None,
+        password: str | None = None,
         is_superuser=False,
         is_verified=False,
     ) -> User:
@@ -389,7 +388,7 @@ class UserManager:
 
         return user
 
-    async def get_by_id(self, _id: UUID) -> Optional[User]:
+    async def get_by_id(self, _id: UUID) -> User | None:
         """get user by unique id"""
         user = await self.users.find_one({"id": _id})
 
@@ -398,7 +397,7 @@ class UserManager:
 
         return User(**user)
 
-    async def get_by_email(self, email: str) -> Optional[User]:
+    async def get_by_email(self, email: str) -> User | None:
         """get user by email"""
         user = await self.users.find_one(
             {"email": email}, collation=self.email_collation
@@ -448,7 +447,7 @@ class UserManager:
         await self.update_verified(user)
 
     async def forgot_password(
-        self, user: User, request: Optional[Request] = None
+        self, user: User, request: Request | None = None
     ) -> None:
         """start forgot password reset request"""
         token_data = {
@@ -544,7 +543,7 @@ class UserManager:
         )
 
     async def update_email_name(
-        self, user: User, email: Optional[EmailStr], name: Optional[str]
+        self, user: User, email: EmailStr | None, name: str | None
     ) -> None:
         """Update email for user"""
         query: dict[str, str] = {}
@@ -613,13 +612,13 @@ class UserManager:
         self,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-    ) -> Tuple[List[UserOutNoId], int]:
+    ) -> tuple[list[UserOutNoId], int]:
         """Get user emails with org info for each for paginated endpoint"""
         # Zero-index page for query
         page = page - 1
         skip = page_size * page
 
-        emails: List[UserOutNoId] = []
+        emails: list[UserOutNoId] = []
 
         total = await self.users.count_documents({"is_superuser": False})
         async for res in self.users.find(

--- a/backend/btrixcloud/users.py
+++ b/backend/btrixcloud/users.py
@@ -4,14 +4,7 @@ FastAPI user handling (via fastapi-users)
 
 import os
 from collections.abc import AsyncGenerator, Callable
-from typing import (
-    TYPE_CHECKING,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    cast,
-)
+from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
 import structlog
@@ -331,9 +324,7 @@ class UserManager:
                 unstructured_message=f"User {email} already exists",
             )
 
-    async def request_verify(
-        self, user: User, request: Request | None = None
-    ) -> None:
+    async def request_verify(self, user: User, request: Request | None = None) -> None:
         """start verifying user, if not already verified"""
         if user.is_verified:
             raise HTTPException(status_code=400, detail="verify_user_already_verified")
@@ -446,9 +437,7 @@ class UserManager:
         user.is_verified = True
         await self.update_verified(user)
 
-    async def forgot_password(
-        self, user: User, request: Request | None = None
-    ) -> None:
+    async def forgot_password(self, user: User, request: Request | None = None) -> None:
         """start forgot password reset request"""
         token_data = {
             "user_id": str(user.id),

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -9,7 +9,7 @@ import os
 import re
 import signal
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 from uuid import UUID
@@ -60,7 +60,7 @@ def get_templates_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "templates")
 
 
-def str_to_date(string: str) -> Optional[datetime]:
+def str_to_date(string: str) -> datetime | None:
     """convert k8s date string to datetime"""
     return datetime.fromisoformat(string) if string else None
 
@@ -72,7 +72,7 @@ def date_to_str(dt_val: datetime) -> str:
 
 def dt_now() -> datetime:
     """get current ts"""
-    return datetime.now(timezone.utc).replace(microsecond=0)
+    return datetime.now(UTC).replace(microsecond=0)
 
 
 def register_exit_handler() -> None:
@@ -107,14 +107,14 @@ def parse_jsonl_log_messages(log_lines: list[str]) -> list[dict]:
     return parsed_log_lines
 
 
-def is_bool(stri: Optional[str]) -> bool:
+def is_bool(stri: str | None) -> bool:
     """Check if the string parameter is stringly true"""
     if stri:
         return stri.lower() in ("true", "1", "yes", "on")
     return False
 
 
-def is_falsy_bool(stri: Optional[str]) -> bool:
+def is_falsy_bool(stri: str | None) -> bool:
     """Check if the string parameter is stringly false"""
     if stri:
         return stri.lower() in ("false", "0", "no", "off")
@@ -130,9 +130,9 @@ def is_url(url: str) -> bool:
         return False
 
 
-def str_list_to_bools(str_list: List[str], allow_none=True) -> List[Union[bool, None]]:
+def str_list_to_bools(str_list: list[str], allow_none=True) -> list[bool | None]:
     """Return version of input string list cast to bool or None, ignoring other values"""
-    output: List[Union[bool, None]] = []
+    output: list[bool | None] = []
     for val in str_list:
         if is_bool(val):
             output.append(True)
@@ -158,7 +158,7 @@ def validate_slug(slug: str) -> None:
 
 
 def stream_dict_list_as_csv(
-    data: List[Dict[str, Union[str, int]]], filename: str
+    data: list[dict[str, str | int]], filename: str
 ) -> StreamingResponse:
     """Stream list of dictionaries as CSV with attachment filename header"""
     if not data:
@@ -205,7 +205,7 @@ def get_origin(headers) -> str:
     return scheme + "://" + host
 
 
-def validate_regexes(regexes: List[str]):
+def validate_regexes(regexes: list[str]):
     """Validate regular expressions, raise HTTPException if invalid"""
     for regex in regexes:
         try:

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -9,8 +9,8 @@ import os
 import re
 import signal
 import sys
-from datetime import UTC, datetime, timezone
-from typing import Any, Dict, List, Optional, Union
+from datetime import UTC, datetime
+from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
 

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -72,10 +72,10 @@ class EventWebhookOps:
         org: Organization,
         page_size: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        success: Optional[bool] = None,
-        event: Optional[str] = None,
-        sort_by: Optional[str] = None,
-        sort_direction: Optional[int] = -1,
+        success: bool | None = None,
+        event: str | None = None,
+        sort_by: str | None = None,
+        sort_direction: int | None = -1,
     ):
         """List all webhook notifications"""
         # pylint: disable=duplicate-code
@@ -210,7 +210,7 @@ class EventWebhookOps:
         crawl_id: str,
         org: Organization,
         event: str,
-        body: Union[CrawlFinishedBody, QaAnalysisFinishedBody, UploadFinishedBody],
+        body: CrawlFinishedBody | QaAnalysisFinishedBody | UploadFinishedBody,
     ):
         """Create webhook notification for finished crawl/upload."""
         crawl = await self.crawl_ops.get_crawl_out(crawl_id, org)
@@ -249,7 +249,7 @@ class EventWebhookOps:
         self,
         org: Organization,
         event: str,
-        body: Union[CrawlDeletedBody, UploadDeletedBody, CollectionDeletedBody],
+        body: CrawlDeletedBody | UploadDeletedBody | CollectionDeletedBody,
     ):
         """Create webhook notification for deleted crawl/upload/collection."""
         notification = WebhookNotification(
@@ -452,8 +452,8 @@ class EventWebhookOps:
         self,
         crawl_id: str,
         oid: UUID,
-        review_status: Optional[int],
-        description: Optional[str],
+        review_status: int | None,
+        description: str | None,
     ) -> None:
         """Create webhook notification for crawl being reviewed in qa"""
         org = await self.org_ops.get_org_by_id(oid)
@@ -494,7 +494,7 @@ class EventWebhookOps:
         coll_id: UUID,
         org: Organization,
         event: str,
-        body: Union[CollectionItemAddedBody, CollectionItemRemovedBody],
+        body: CollectionItemAddedBody | CollectionItemRemovedBody,
     ):
         """Create webhook notification for item added/removed to collection."""
         coll_download_url = f"/api/orgs/{org.id}/collections/{coll_id}/download"
@@ -519,7 +519,7 @@ class EventWebhookOps:
 
     async def create_added_to_collection_notification(
         self,
-        crawl_ids: List[str],
+        crawl_ids: list[str],
         coll_id: UUID,
         org: Organization,
     ) -> None:
@@ -541,7 +541,7 @@ class EventWebhookOps:
 
     async def create_removed_from_collection_notification(
         self,
-        crawl_ids: List[str],
+        crawl_ids: list[str],
         coll_id: UUID,
         org: Organization,
     ) -> None:
@@ -596,10 +596,10 @@ def init_event_webhooks_api(mdb, org_ops, app):
         org: Organization = Depends(org_owner_dep),
         pageSize: int = DEFAULT_PAGE_SIZE,
         page: int = 1,
-        success: Optional[bool] = None,
-        event: Optional[str] = None,
-        sortBy: Optional[str] = None,
-        sortDirection: Optional[int] = -1,
+        success: bool | None = None,
+        event: str | None = None,
+        sortBy: str | None = None,
+        sortDirection: int | None = -1,
     ):
         notifications, total = await ops.list_notifications(
             org,

--- a/backend/btrixcloud/webhooks.py
+++ b/backend/btrixcloud/webhooks.py
@@ -1,6 +1,6 @@
 """Webhook management"""
 
-from typing import TYPE_CHECKING, List, Optional, Union, cast
+from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
 import structlog

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -16,6 +16,7 @@ extend-select = [
 	"LOG",
 	"G",
 	"T20",
+	"UP"
 ]
 ignore = [
 	# Comparison to true should be 'if cond is true:' or 'if cond:'

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import time
-from typing import Dict
 from uuid import UUID
 
 import structlog

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -685,7 +685,7 @@ def profile_browser_2_id(admin_auth_headers, default_org_id):
 
 
 def create_profile_browser(
-    headers: Dict[str, str],
+    headers: dict[str, str],
     oid: UUID,
     url="https://old.webrecorder.net",
     baseprofile="",
@@ -745,7 +745,7 @@ PROFILE_2_TAGS = ["profile", "specs-webrecorder"]
 
 
 def prepare_browser_for_profile_commit(
-    browser_id: str, headers: Dict[str, str], oid: UUID, url=None
+    browser_id: str, headers: dict[str, str], oid: UUID, url=None
 ) -> None:
     # Ping to make sure it doesn't expire
     r = requests.post(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -1,5 +1,4 @@
 import time
-from typing import Dict
 from uuid import UUID
 
 import pytest

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 import structlog
 import pytest
@@ -334,7 +334,7 @@ def error_crawl_id(admin_auth_headers, default_org_id):
 
 @pytest.fixture(scope="session")
 def org_with_quotas(admin_auth_headers):
-    name = "Quota Org " + datetime.now(timezone.utc).isoformat()
+    name = "Quota Org " + datetime.now(UTC).isoformat()
     r = requests.post(
         f"{API_PREFIX}/orgs/create", headers=admin_auth_headers, json={"name": name}
     )

--- a/backend/test_nightly/test_crawl_not_logged_in.py
+++ b/backend/test_nightly/test_crawl_not_logged_in.py
@@ -1,5 +1,4 @@
 import time
-from typing import Dict
 from uuid import UUID
 
 import pytest

--- a/backend/test_nightly/test_crawl_not_logged_in.py
+++ b/backend/test_nightly/test_crawl_not_logged_in.py
@@ -11,7 +11,7 @@ config_id = None
 
 
 def _create_profile_browser(
-    headers: Dict[str, str], oid: UUID, url: str = "https://old.webrecorder.net"
+    headers: dict[str, str], oid: UUID, url: str = "https://old.webrecorder.net"
 ):
     r = requests.post(
         f"{API_PREFIX}/orgs/{oid}/profiles/browser",
@@ -41,7 +41,7 @@ def profile_browser_id(admin_auth_headers, default_org_id):
 
 
 def prepare_browser_for_profile_commit(
-    browser_id: str, headers: Dict[str, str], oid: UUID
+    browser_id: str, headers: dict[str, str], oid: UUID
 ) -> None:
     # Ping to make sure it doesn't expire
     r = requests.post(

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -177,7 +177,7 @@ def run_crawl(org_id, headers):
     return data["run_now_job"], data["id"]
 
 
-def get_total_exec_seconds(execSeconds: Dict[str, int]) -> int:
+def get_total_exec_seconds(execSeconds: dict[str, int]) -> int:
     return sum(list(execSeconds.values()))
 
 

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -1,6 +1,5 @@
 import math
 import time
-from typing import Dict
 
 import pytest
 import requests

--- a/backend/test_nightly/test_storage_quota.py
+++ b/backend/test_nightly/test_storage_quota.py
@@ -1,7 +1,6 @@
 import math
 import time
 from datetime import datetime
-from typing import Dict
 
 import requests
 


### PR DESCRIPTION
Enables [ruff's `UP` rules](https://docs.astral.sh/ruff/rules/#pyupgrade-up), which converts a bunch of now-deprecated language features to newer syntax. Primarily this is useful to keep syntax consistent (e.g. we had a bunch of both `Option[str]` and `str | None` in various places). Nothing here should affect any runtime behaviour, since we're using python >3.10.