### PR TITLE
build: Fix hickory import

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^7.0.3",
     "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.9.1",
     "eslint-plugin-import-x": "4.16.2",
     "eslint-plugin-lit": "^1.11.0",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,4 @@
-import theme from "@webrecorder/hickory/tokens/tailwind";
+import { colors } from "@webrecorder/hickory/tokens/tailwind";
 import { tailwindTransform } from "postcss-lit";
 
 import attributes from "./config/tailwind/plugins/attributes";
@@ -38,12 +38,12 @@ function makeTheme() {
     // https://github.com/tailwindlabs/tailwindcss/blob/52ab3154392ba3d7a05cae643694384e72dc24b2/stubs/defaultConfig.stub.js
     colors: {
       current: "currentColor",
-      ...theme.colors,
+      ...colors,
       primary: {
-        ...theme.colors.cyan,
-        DEFAULT: theme.colors.cyan[500],
+        ...colors.cyan,
+        DEFAULT: colors.cyan[500],
       },
-      brand: theme.colors.brand,
+      brand: colors.brand,
       success: {
         ...shoelaceColorPalette("success"),
         DEFAULT: `var(--success)`,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6104,10 +6104,10 @@ escape-string-regexp@^5.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
-eslint-config-prettier@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
-  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+eslint-config-prettier@^10.1.8:
+  version "10.1.8"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
+  integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
 
 eslint-import-context@^0.1.9:
   version "0.1.9"


### PR DESCRIPTION
- Fixes hickory import that was silently failing. Found inadvertently while addressing prettier not working after upgrade introduced here https://github.com/webrecorder/browsertrix/pull/3422
- Upgrades `eslint-config-prettier` dependency to latest to match other prettier dependency upgrades