### PR TITLE
Add alwaysAddBehaviorLinks to crawlconfig

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -441,6 +441,8 @@ class RawCrawlConfig(BaseModel):
     selectLinks: List[str] = ["a[href]->href"]
     clickSelector: str = "a"
 
+    ignoreScopeForBehaviorLinks: bool | None = False
+
     saveStorage: Optional[bool] = False
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -441,7 +441,7 @@ class RawCrawlConfig(BaseModel):
     selectLinks: List[str] = ["a[href]->href"]
     clickSelector: str = "a"
 
-    ignoreScopeForBehaviorLinks: bool | None = False
+    alwaysAddBehaviorLinks: bool | None = False
 
     saveStorage: Optional[bool] = False
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -533,6 +533,8 @@ class CrawlOperator(BaseOperator):
 
         crawler_image = params["crawler_image"]
 
+        configmap_logger = logger.bind(crawl_id=crawl.id)
+
         raw_config = crawlconfig.get_raw_config()
         raw_config["behaviors"] = self._filter_autoclick_behavior(
             raw_config["behaviors"], crawler_image
@@ -546,6 +548,11 @@ class CrawlOperator(BaseOperator):
                 crawler_image, min_behavior_links_image
             ):
                 raw_config.pop("ignoreScopeForBehaviorLinks", None)
+                configmap_logger.warning(
+                    "crawl_configmap_ignore_scope_behavior_links_ignored",
+                    crawler_image=crawler_image,
+                    min_behavior_links_image=min_behavior_links_image,
+                )
 
         if crawl.seed_file_url:
             raw_config["seedFile"] = crawl.seed_file_url
@@ -554,9 +561,8 @@ class CrawlOperator(BaseOperator):
         params["config"] = json.dumps(raw_config)
 
         if config_update_needed:
-            logger.debug(
+            configmap_logger.debug(
                 "crawl_configmap_updated",
-                crawl_id=crawl.id,
                 unstructured_message=f"Updating config for {crawl.id}",
             )
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -531,10 +531,21 @@ class CrawlOperator(BaseOperator):
 
         self.crawl_config_ops.ensure_quota_page_limit(crawlconfig, crawl.org)
 
+        crawler_image = params["crawler_image"]
+
         raw_config = crawlconfig.get_raw_config()
         raw_config["behaviors"] = self._filter_autoclick_behavior(
-            raw_config["behaviors"], params["crawler_image"]
+            raw_config["behaviors"], crawler_image
         )
+
+        if raw_config.get("ignoreScopeForBehaviorLinks") is True:
+            min_behavior_links_image = os.environ.get(
+                "MIN_BEHAVIOR_LINKS_CRAWLER_IMAGE"
+            )
+            if min_behavior_links_image and crawler_image_below_minimum(
+                crawler_image, min_behavior_links_image
+            ):
+                raw_config.pop("ignoreScopeForBehaviorLinks", None)
 
         if crawl.seed_file_url:
             raw_config["seedFile"] = crawl.seed_file_url

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -540,16 +540,16 @@ class CrawlOperator(BaseOperator):
             raw_config["behaviors"], crawler_image
         )
 
-        if raw_config.get("ignoreScopeForBehaviorLinks") is True:
+        if raw_config.get("alwaysAddBehaviorLinks") is True:
             min_behavior_links_image = os.environ.get(
                 "MIN_BEHAVIOR_LINKS_CRAWLER_IMAGE"
             )
             if min_behavior_links_image and crawler_image_below_minimum(
                 crawler_image, min_behavior_links_image
             ):
-                raw_config.pop("ignoreScopeForBehaviorLinks", None)
+                raw_config.pop("alwaysAddBehaviorLinks", None)
                 configmap_logger.warning(
-                    "crawl_configmap_ignore_scope_behavior_links_ignored",
+                    "crawl_configmap_always_add_behavior_links_ignored",
                     crawler_image=crawler_image,
                     min_behavior_links_image=min_behavior_links_image,
                 )

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -317,6 +317,17 @@ def test_verify_default_click_selector(
     assert r.json()["config"]["clickSelector"] == "a"
 
 
+def test_verify_default_ignore_scope_behavior_links(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["config"]["ignoreScopeForBehaviorLinks"] is False
+
+
 def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_data):
     r = requests.patch(
         f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
@@ -327,6 +338,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
                 "clickSelector": "button",
+                "ignoreScopeForBehaviorLinks": True,
             }
         },
     )
@@ -344,6 +356,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
     assert config["scopeType"] == "domain"
     assert config["selectLinks"] == ["a[href]->href", "script[src]->src"]
     assert config["clickSelector"] == "button"
+    assert config["ignoreScopeForBehaviorLinks"] is True
 
     # Verify fields set in config originally are unchanged
     assert config["lang"] == "en"
@@ -363,6 +376,7 @@ def test_update_config_no_changes(
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
                 "clickSelector": "button",
+                "ignoreScopeForBehaviorLinks": True,
             }
         },
     )

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -325,7 +325,7 @@ def test_verify_default_ignore_scope_behavior_links(
         headers=crawler_auth_headers,
     )
     assert r.status_code == 200
-    assert r.json()["config"]["ignoreScopeForBehaviorLinks"] is False
+    assert r.json()["config"]["alwaysAddBehaviorLinks"] is False
 
 
 def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_data):
@@ -338,7 +338,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
                 "clickSelector": "button",
-                "ignoreScopeForBehaviorLinks": True,
+                "alwaysAddBehaviorLinks": True,
             }
         },
     )
@@ -356,7 +356,7 @@ def test_update_config_data(crawler_auth_headers, default_org_id, sample_crawl_d
     assert config["scopeType"] == "domain"
     assert config["selectLinks"] == ["a[href]->href", "script[src]->src"]
     assert config["clickSelector"] == "button"
-    assert config["ignoreScopeForBehaviorLinks"] is True
+    assert config["alwaysAddBehaviorLinks"] is True
 
     # Verify fields set in config originally are unchanged
     assert config["lang"] == "en"
@@ -376,7 +376,7 @@ def test_update_config_no_changes(
                 "scopeType": "domain",
                 "selectLinks": ["a[href]->href", "script[src]->src"],
                 "clickSelector": "button",
-                "ignoreScopeForBehaviorLinks": True,
+                "alwaysAddBehaviorLinks": True,
             }
         },
     )

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -84,6 +84,8 @@ data:
 
   MIN_SEED_FILE_CRAWLER_IMAGE: "{{ .Values.min_seed_file_crawler_image }}"
 
+  MIN_BEHAVIOR_LINKS_CRAWLER_IMAGE: "{{ .Values.min_behavior_links_crawler_image }}"
+
   NUM_BROWSERS: "{{ .Values.crawler_browser_instances }}"
 
   MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -321,7 +321,7 @@ min_autoclick_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.5.0"
 # if set, will restrict seed files to image names that are >= this value
 min_seed_file_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.7.0"
 
-# if set, will restrict ignoring scope for behaviors to image names that are >= this value
+# if set, will restrict always adding behavior links to image names that are >= this value
 min_behavior_links_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.14.0"
 
 # optional: enable to use a persist volume claim for all crawls

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -321,6 +321,9 @@ min_autoclick_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.5.0"
 # if set, will restrict seed files to image names that are >= this value
 min_seed_file_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.7.0"
 
+# if set, will restrict ignoring scope for behaviors to image names that are >= this value
+min_behavior_links_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.14.0"
+
 # optional: enable to use a persist volume claim for all crawls
 # can be enabled to use a multi-write shared filesystem
 # crawler_pv_claim: "nfs-shared-crawls"


### PR DESCRIPTION
Fixes #3369 

Backend support for the new crawler `--alwaysAddBehaviorLinks` (renamed from `ignoreScopeForBehaviorLinks`) option, with test coverage for updates.

The second commit adds a minimum crawler version check for this flag and sets the default value to 1.14.0. Feel free to drop this commit if this seems excessive but since we may set this value to true in the frontend (at least for social media sites, if not more broadly) and it'll break crawls running <1.14.0, it seemed like a wise precaution.

## Testing

1. Checkout this branch locally and set default for new field to `True` in `RawCrawlConfig` model (since we don't have a way to set it from frontend yet)
2. Add a crawler channel that will fail the minimum version check to your local config, e.g. (assuming you also have latest crawler image built from main locally):
```yaml
crawler_channels:
  - id: default
    image: "docker.io/webrecorder/browsertrix-crawler:latest"
    imagePullPolicy: Never
  - id: previous
    image: "docker.io/webrecorder/browsertrix-crawler:1.13.2"
    imagePullPolicy: IfNotPresent
```
3. Run a crawl with default crawler channel and verify setting is applied to the crawl
4. Run a crawl with previous crawler channel and verify setting is not applied to the crawl and that the warn message is in operator logs