### PR TITLE
feat: Organize workflow scope settings

### DIFF
--- a/frontend/docs/docs/user-guide/crawl-workflows.md
+++ b/frontend/docs/docs/user-guide/crawl-workflows.md
@@ -16,7 +16,7 @@ The first step in creating a new crawl workflow is to choose what you'd like to 
 
 #### Page Crawl
 
-Choose one of these crawl scopes if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one hop out.
+Choose one of these crawl scopes if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one link out.
 
 A Page Crawl workflow is simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
 
@@ -34,7 +34,7 @@ Run a crawl workflow by clicking _Run Crawl_ in the actions menu of the workflow
 
 While crawling, the **Latest Crawl** section streams the current state of the browser windows as they visit pages. You can [modify the crawl live](./running-crawl.md) by adding URL exclusions or changing the number of crawling instances.
 
-Re-running a crawl workflow can be useful to capture a website as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#crawl-scope-options).
+Re-running a crawl workflow can be useful to capture a website as it changes over time, or to run with an updated [crawl scope](workflow-setup.md#crawl-scope).
 
 ## Workflow Status
 

--- a/frontend/docs/docs/user-guide/getting-started.md
+++ b/frontend/docs/docs/user-guide/getting-started.md
@@ -30,7 +30,8 @@ When you log in, the first page you see is the [org dashboard](overview.md). If 
 After running your first crawl, check out the following to learn more about Browsertrix's features:
 
 - A detailed list of [crawl workflow setup](workflow-setup.md) options.
-- Adding [exclusions](workflow-setup.md#exclude-pages) to limit your crawl's scope and evading crawler traps by [editing exclusion rules while crawling](running-crawl.md#live-exclusion-editing).
+- Adding [exclusions](workflow-setup.md#custom-exclusion-rules) to limit your crawl's scope
+- Evading crawler traps by [editing exclusion rules while crawling](running-crawl.md#live-exclusion-editing).
 - Best practices for crawling with [browser profiles](browser-profiles/browser-profiles-overview.md) to capture content only available when logged in to a website.
 - Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
 - Organizing and combining archived items with [collections](collection.md) for sharing and export.

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -12,7 +12,7 @@ You can watch the current state of the browser windows as the crawler visits pag
 
 ## Live Exclusion Editing
 
-While [exclusions](workflow-setup.md#exclude-pages) can be set before running a crawl workflow, sometimes while crawling the crawler may find new parts of the site that weren't previously known about and shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
+While [exclusions](workflow-setup.md#custom-exclusion-rules) can be set before running a crawl workflow, sometimes while crawling the crawler may find new parts of the site that weren't previously known about and shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
 
 If the crawl queue is filled with URLs that should not be crawled, use the _Edit Exclusions_ button in the **Watch** tab to instruct the crawler what pages should be excluded from the queue.
 
@@ -28,14 +28,14 @@ This change takes effect immediately on the running crawl and updates the crawl 
 
 If you need to reassess or rescope your crawl at any point after it has started, you can pause the running crawl.
 
-To pause a running crawl, click the *Pause* button. The crawl status will change from *Running* to *Pausing* as in-progress pages are completed, and then to *Paused* once the crawler is successful paused. Paused crawls do not continue to accrue execution time.
+To pause a running crawl, click the _Pause_ button. The crawl status will change from _Running_ to _Pausing_ as in-progress pages are completed, and then to _Paused_ once the crawler is successful paused. Paused crawls do not continue to accrue execution time.
 
-While a crawl is paused, it is possible to replay the pages crawled up to that point and to download the WACZ files from the *Latest Crawl* tab.
+While a crawl is paused, it is possible to replay the pages crawled up to that point and to download the WACZ files from the _Latest Crawl_ tab.
 
-To resume a paused crawl, simply click the *Resume* button. The crawl status will update from *Resuming* to *Running* to indicate that the crawler has started crawling again. Any changes to the workflow settings will be applied in the the resumed crawl.
+To resume a paused crawl, simply click the _Resume_ button. The crawl status will update from _Resuming_ to _Running_ to indicate that the crawler has started crawling again. Any changes to the workflow settings will be applied in the the resumed crawl.
 
 ???+ Note
-    Paused crawls that are not resumed within 7 days of being paused are automatically updated to *Stopped*. Once stopped, the crawl is finished and can no longer be resumed.
+    Paused crawls that are not resumed within 7 days of being paused are automatically updated to _Stopped_. Once stopped, the crawl is finished and can no longer be resumed.
 
 ## End a Crawl
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -13,6 +13,7 @@ Specify the range and depth of your crawl.
 Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 
 #### Page Crawl
+
 :   Choose one of these crawl scopes if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one hop out.
 
     A Page Crawl workflow can be simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
@@ -23,6 +24,7 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
         - You want to include URLs with different domain names in the same crawl (`List of Pages`)
 
 #### Site Crawl
+
 :   Choose one of these crawl scopes to have the the crawler automatically find pages based on a domain name, start page URL, or directory on a website.
 
     Site Crawl workflows are great for advanced use cases where you don't need (or want) to know every single URL of the website that you're archiving.
@@ -36,9 +38,11 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 #### Page Crawl
 
 ##### Single Page
+
 :   Crawls a single URL and does not include any linked pages.
 
 ##### List of Pages
+
 :   Crawls a list of specified URLs.
 
     Select one of two options to provide a list of URLs:
@@ -56,6 +60,7 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
     If both a list of entered list and an uploaded file are provided, the currently selected option will be used.
 
 ##### In-Page Links
+
 :   Crawls only the specified URL and treats linked sections of the page as distinct pages.
 
     Any link that begins with the _Crawl Start URL_ followed by a hashtag symbol (`#`) and then a string is considered an in-page link. This is commonly used to link to a section of a page. For example, because the "Scope" section of this guide is linked by its heading as `/user-guide/workflow-setup/#scope` it would be treated as a separate page under the _In-Page Links_ scope.
@@ -65,18 +70,23 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 #### Site Crawl
 
 ##### Pages in Same Directory
+
 :   This scope will only crawl pages in the same directory as the _Crawl Start URL_. If `example.com/path` is set as the _Crawl Start URL_, `example.com/path/path2` will be crawled but `example.com/path3` will not.
 
 ##### Pages on Same Domain
+
 :   This scope will crawl all pages on the domain entered as the _Crawl Start URL_ however it will ignore subdomains such as `subdomain.example.com`.
 
 ##### Pages on Same Domain + Subdomains
+
 :   This scope will crawl all pages on the domain and any subdomains found. If `example.com` is set as the _Crawl Start URL_, both pages on `example.com` and `subdomain.example.com` will be crawled.
 
 ##### Custom Page Prefix
+
 :   This scope will crawl the _Crawl Start URL_ and then include only those pages that begin with the URLs listed in [_Page Prefix URLs_](#page-prefix-urls).
 
 ##### Custom Page Match
+
 :   This scope will crawl the _Crawl Start URL_ and then include only those pages with URLs that match the regular expression patterns listed in [_Page Regex Patterns_](#page-regex-patterns).
 
 ### Crawl Start URL / URL(s) to Crawl
@@ -89,7 +99,6 @@ This is the URL used by the crawler to initiate the crawling process. The URL in
 | _List of Pages_ | URLs&nbsp;to&nbsp;Crawl | The crawler will visit each URL specified in the text list or file. |
 | _In-Page Links_<br/>_Pages in Same Directory_<br/>_Pages on Same Domain_<br/>_Pages on Same Domain + Subdomains_<br/>_Custom Page Prefix_ | Crawl&nbsp;Start&nbsp;URL | The crawler will visit this URL as its starting point and use this URL to collect information on which linked pages it should also visit. |
 
-
 URLs must follow [valid URL syntax](https://www.w3.org/Addressing/URL/url-spec.html). For example, if you're crawling a page that can be accessed on the public internet, your URL should start with `http://` or `https://`.
 
 Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on how each crawl scope interacts with this URL.
@@ -100,7 +109,7 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 
     **These credentials WILL BE WRITTEN into the archive.** We recommend exercising caution and only archiving with dedicated archival accounts, changing your password or deleting the account when finished.
 
-### Skip Pages Disallowed By Robots.txt
+### Use Robots.txt Disallow List
 
 When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at /robots.txt for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
 
@@ -115,7 +124,7 @@ When enabled, the crawler will visit all the links it finds within each URL defi
 
 When enabled, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Failed".
 
-### Max Depth in Scope
+### Max Discovery Depth
 
 Instructs the crawler to stop visiting new links past a specified depth.
 
@@ -178,7 +187,7 @@ The _CSS Selector_ for a custom link selector could be `button.link` and its _Li
 
 See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors) for examples of valid CSS selectors.
 
-### Additional Pages
+### Custom Page List
 
 A list of page URLs outside of the _Crawl Scope_ to include in the crawl.
 
@@ -189,11 +198,13 @@ The exclusions table will instruct the crawler to ignore links it finds on pages
 This can be useful for avoiding crawler traps — sites that may automatically generate pages such as calendars or filter options — or other pages that should not be crawled according to their URL.
 
 #### Matches text
+
 :   Will perform simple matching of entered text and exclude all URLs where matching text is found.
 
     e.g: If `about` is entered, `example.com/aboutme/` will not be crawled.
 
 #### Regex
+
 :   Regular expressions (Regex) can also be used to perform more complex matching.
 
     e.g: If `#!regex \babout\/?\b` is entered, `example.com/about/` will not be crawled however `example.com/aboutme/` will be crawled.
@@ -302,7 +313,7 @@ When enabled, instructs the crawler to save the browser's `localStorage` and `se
 
 !!! Warning "Privacy & security implications when used with browser profiles"
     Websites can use browser storage to store arbitrary data. During the browser profile creation process, some websites may save sensitive data such as login information and user-identifying preferences in browser storage. Since every website can implement browser storage differently, Browsertrix does not attempt to detect whether the information stored is potentially sensitive.
-    
+
     Use caution when sharing WACZ files created with this option enabled, especially if you’re crawling pages that require login. We always recommend creating dedicated website logins to be used only for crawling to mitigate the risk of compromised login information.
 
 ### Crawler Proxy Server
@@ -360,6 +371,7 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
 ### Crawl Schedule Type
 
 #### Run on a Recurring Basis
+
 :   When selected, additional configuration options for instructing the system when to run the crawl will be shown. If a crawl is already running when the schedule is set to activate it, the scheduled crawl will not run.
 
     !!! tip "Tip: Scheduling crawl workflows with logged-in browser profiles"
@@ -368,6 +380,7 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
         For some websites, a short schedule frequency can help keep the browser profile logged in by regularly and [automatically refreshing the login session](./browser-profiles/usage-in-crawls.md#effects-of-crawling). A separate crawl workflow could be created for this purpose. We recommend manually [checking the profile](./browser-profiles/configure-sites.md#saved-sites) periodically to ensure that it is still logged in.
 
 #### No Schedule
+
 :   When selected, the configuration options that have been set will be saved but the system will not do anything with them unless manually instructed.
 
 ### Frequency
@@ -424,7 +437,7 @@ Additionally, the following macros are supported:
 | Value | Description |
 | - | - |
 | `@yearly` | Run once a year at midnight of 1 January |
-| `@monthly` | 	Run once a month at midnight of the first day of the month |
+| `@monthly` |  Run once a month at midnight of the first day of the month |
 | `@weekly` | Run once a week at midnight on Sunday |
 | `@daily` | Run once a day at midnight |
 | `@hourly` | Run once an hour at the beginning of the hour |
@@ -445,9 +458,11 @@ Prevent duplicate content from being crawled and stored.
 ### Crawl Deduplication
 
 #### No Deduplication
+
 :   When selected, deduplication will not be enabled in crawls of this workflow.
 
 #### Deduplicate using a collection
+
 :   When selected, crawls of this workflow will reference items in the specified Collection to Use when checking for new content and URLs.
 
 ### Collection to Use

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -13,7 +13,6 @@ Specify the range and depth of your crawl.
 Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 
 #### Page Crawl
-
 :   Choose one of these crawl scopes if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one hop out.
 
     A Page Crawl workflow can be simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
@@ -24,7 +23,6 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
         - You want to include URLs with different domain names in the same crawl (`List of Pages`)
 
 #### Site Crawl
-
 :   Choose one of these crawl scopes to have the the crawler automatically find pages based on a domain name, start page URL, or directory on a website.
 
     Site Crawl workflows are great for advanced use cases where you don't need (or want) to know every single URL of the website that you're archiving.
@@ -38,11 +36,9 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 #### Page Crawl
 
 ##### Single Page
-
 :   Crawls a single URL and does not include any linked pages.
 
 ##### List of Pages
-
 :   Crawls a list of specified URLs.
 
     Select one of two options to provide a list of URLs:
@@ -60,7 +56,6 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
     If both a list of entered list and an uploaded file are provided, the currently selected option will be used.
 
 ##### In-Page Links
-
 :   Crawls only the specified URL and treats linked sections of the page as distinct pages.
 
     Any link that begins with the _Crawl Start URL_ followed by a hashtag symbol (`#`) and then a string is considered an in-page link. This is commonly used to link to a section of a page. For example, because the "Scope" section of this guide is linked by its heading as `/user-guide/workflow-setup/#scope` it would be treated as a separate page under the _In-Page Links_ scope.
@@ -70,23 +65,18 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 #### Site Crawl
 
 ##### Pages in Same Directory
-
 :   This scope will only crawl pages in the same directory as the _Crawl Start URL_. If `example.com/path` is set as the _Crawl Start URL_, `example.com/path/path2` will be crawled but `example.com/path3` will not.
 
 ##### Pages on Same Domain
-
 :   This scope will crawl all pages on the domain entered as the _Crawl Start URL_ however it will ignore subdomains such as `subdomain.example.com`.
 
 ##### Pages on Same Domain + Subdomains
-
 :   This scope will crawl all pages on the domain and any subdomains found. If `example.com` is set as the _Crawl Start URL_, both pages on `example.com` and `subdomain.example.com` will be crawled.
 
 ##### Custom Page Prefix
-
 :   This scope will crawl the _Crawl Start URL_ and then include only those pages that begin with the URLs listed in [_Page Prefix URLs_](#page-prefix-urls).
 
 ##### Custom Page Match
-
 :   This scope will crawl the _Crawl Start URL_ and then include only those pages with URLs that match the regular expression patterns listed in [_Page Regex Patterns_](#page-regex-patterns).
 
 ### Crawl Start URL / URL(s) to Crawl
@@ -99,6 +89,7 @@ This is the URL used by the crawler to initiate the crawling process. The URL in
 | _List of Pages_ | URLs&nbsp;to&nbsp;Crawl | The crawler will visit each URL specified in the text list or file. |
 | _In-Page Links_<br/>_Pages in Same Directory_<br/>_Pages on Same Domain_<br/>_Pages on Same Domain + Subdomains_<br/>_Custom Page Prefix_ | Crawl&nbsp;Start&nbsp;URL | The crawler will visit this URL as its starting point and use this URL to collect information on which linked pages it should also visit. |
 
+
 URLs must follow [valid URL syntax](https://www.w3.org/Addressing/URL/url-spec.html). For example, if you're crawling a page that can be accessed on the public internet, your URL should start with `http://` or `https://`.
 
 Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on how each crawl scope interacts with this URL.
@@ -109,7 +100,7 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 
     **These credentials WILL BE WRITTEN into the archive.** We recommend exercising caution and only archiving with dedicated archival accounts, changing your password or deleting the account when finished.
 
-### Use Robots.txt Disallow List
+### Skip Pages Disallowed By Robots.txt
 
 When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at /robots.txt for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
 
@@ -124,7 +115,7 @@ When enabled, the crawler will visit all the links it finds within each URL defi
 
 When enabled, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Failed".
 
-### Max Discovery Depth
+### Max Depth in Scope
 
 Instructs the crawler to stop visiting new links past a specified depth.
 
@@ -170,7 +161,7 @@ When enabled, the crawler will check for a sitemap at /sitemap.xml and use it to
 
 This can be useful for discovering and capturing pages on a website that aren't linked to from the seed and which might not otherwise be captured.
 
-### Custom Link Selectors
+### Link Selectors
 
 Instructs the crawler which HTML elements should be used to extract URLs, i.e. considered a “link.” By default, the crawler checks the `href` value of all anchor (`<a>`) elements on a page.
 
@@ -187,24 +178,22 @@ The _CSS Selector_ for a custom link selector could be `button.link` and its _Li
 
 See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors) for examples of valid CSS selectors.
 
-### Custom Page List
+### Additional Pages
 
 A list of page URLs outside of the _Crawl Scope_ to include in the crawl.
 
-### Custom Exclusion Rules
+### Exclude Pages
 
 The exclusions table will instruct the crawler to ignore links it finds on pages where all or part of the link matches an exclusion found in the table. The table is only available in Page List crawls when _Include Any Linked Page_ is enabled.
 
 This can be useful for avoiding crawler traps — sites that may automatically generate pages such as calendars or filter options — or other pages that should not be crawled according to their URL.
 
 #### Matches text
-
 :   Will perform simple matching of entered text and exclude all URLs where matching text is found.
 
     e.g: If `about` is entered, `example.com/aboutme/` will not be crawled.
 
 #### Regex
-
 :   Regular expressions (Regex) can also be used to perform more complex matching.
 
     e.g: If `#!regex \babout\/?\b` is entered, `example.com/about/` will not be crawled however `example.com/aboutme/` will be crawled.
@@ -313,7 +302,7 @@ When enabled, instructs the crawler to save the browser's `localStorage` and `se
 
 !!! Warning "Privacy & security implications when used with browser profiles"
     Websites can use browser storage to store arbitrary data. During the browser profile creation process, some websites may save sensitive data such as login information and user-identifying preferences in browser storage. Since every website can implement browser storage differently, Browsertrix does not attempt to detect whether the information stored is potentially sensitive.
-
+    
     Use caution when sharing WACZ files created with this option enabled, especially if you’re crawling pages that require login. We always recommend creating dedicated website logins to be used only for crawling to mitigate the risk of compromised login information.
 
 ### Crawler Proxy Server
@@ -371,7 +360,6 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
 ### Crawl Schedule Type
 
 #### Run on a Recurring Basis
-
 :   When selected, additional configuration options for instructing the system when to run the crawl will be shown. If a crawl is already running when the schedule is set to activate it, the scheduled crawl will not run.
 
     !!! tip "Tip: Scheduling crawl workflows with logged-in browser profiles"
@@ -380,7 +368,6 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
         For some websites, a short schedule frequency can help keep the browser profile logged in by regularly and [automatically refreshing the login session](./browser-profiles/usage-in-crawls.md#effects-of-crawling). A separate crawl workflow could be created for this purpose. We recommend manually [checking the profile](./browser-profiles/configure-sites.md#saved-sites) periodically to ensure that it is still logged in.
 
 #### No Schedule
-
 :   When selected, the configuration options that have been set will be saved but the system will not do anything with them unless manually instructed.
 
 ### Frequency
@@ -437,7 +424,7 @@ Additionally, the following macros are supported:
 | Value | Description |
 | - | - |
 | `@yearly` | Run once a year at midnight of 1 January |
-| `@monthly` |  Run once a month at midnight of the first day of the month |
+| `@monthly` | 	Run once a month at midnight of the first day of the month |
 | `@weekly` | Run once a week at midnight on Sunday |
 | `@daily` | Run once a day at midnight |
 | `@hourly` | Run once an hour at the beginning of the hour |
@@ -458,11 +445,9 @@ Prevent duplicate content from being crawled and stored.
 ### Crawl Deduplication
 
 #### No Deduplication
-
 :   When selected, deduplication will not be enabled in crawls of this workflow.
 
 #### Deduplicate using a collection
-
 :   When selected, crawls of this workflow will reference items in the specified Collection to Use when checking for new content and URLs.
 
 ### Collection to Use

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -10,12 +10,17 @@ Crawl settings are shown in the crawl workflow detail **Settings** tab and in th
 
 Specify the range and depth of your crawl.
 
+### Crawl Scope
+
+The crawl scope selects pages to be crawled based on the provided URL.
+
 Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 
 #### Page Crawl
-:   Choose one of these crawl scopes if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one hop out.
 
-    A Page Crawl workflow can be simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
+:   Choose one of these crawl scopes if you know the URL of every page you'd like to crawl and don't need to include any additional pages beyond one link out.
+
+    A page-based scope can be simpler to configure, since you don't need to worry about configuring the workflow to exclude parts of the website that you may not want to archive.
 
     ??? info "Page Crawl Use Cases"
         - You want to archive a social media post (`Single Page`)
@@ -23,30 +28,33 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
         - You want to include URLs with different domain names in the same crawl (`List of Pages`)
 
 #### Site Crawl
-:   Choose one of these crawl scopes to have the the crawler automatically find pages based on a domain name, start page URL, or directory on a website.
 
-    Site Crawl workflows are great for advanced use cases where you don't need (or want) to know every single URL of the website that you're archiving.
+:   Choose one of these crawl scopes to have the the crawler automatically discover pages based on a domain name, start page URL, or directory on a website.
+
+    Site-based scopes are great for advanced use cases where you don't need (or want) to know every single URL of the website that you're archiving.
 
     ??? info "Site Crawl Use Cases"
         - You're archiving a subset of a website, like everything under _website.com/your-username_ (`Pages in Same Directory`)
         - You're archiving an entire website _and_ external pages linked to from the website (`Pages on Same Domain` + _Include Any Linked Page_ checked)
 
-### Crawl Scope Options
+The crawl scope is your starting point for scoping. The scope can be expanded to include more pages or limited to less pages by combining the crawl scope with [Additional Scope](#additional-scope) and [Exclude Pages](#exclude-pages) settings.
 
-#### Page Crawl
+### Page Crawl Scopes
 
-##### Single Page
-:   Crawls a single URL and does not include any linked pages.
+#### Single Page
 
-##### List of Pages
+:   Crawls a single URL.
+
+#### List of Pages
+
 :   Crawls a list of specified URLs.
 
     Select one of two options to provide a list of URLs:
 
-    ###### Enter URLs
+    _Enter URLs_
     :    If the list is small enough, 100 URLs or less, the URLs can be entered directly into the text area. If a large list is pasted into the textbox, it will be converted into an uploaded URL list and attached to the workflow.
 
-    ###### Upload URL List
+    _Upload URL List_
     :    A longer list of URLs can be provided as a text file, containing one URL per line. The text file may not exceed 25MB, but there is no limit to the number of URLs in the file. Once a file is added, a link will be provided to view the file (but not edit it). To change the file, a new file can be uploaded in its place.
 
     For both options, each line should contain a valid URL (starting with https:// or http://). Invalid or duplicate URLs will be skipped. The crawl will fail if the list contains no valid URLs or if the file is not a list of URLs.
@@ -55,44 +63,63 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 
     If both a list of entered list and an uploaded file are provided, the currently selected option will be used.
 
-##### In-Page Links
+#### In-Page Links
+
 :   Crawls only the specified URL and treats linked sections of the page as distinct pages.
 
     Any link that begins with the _Crawl Start URL_ followed by a hashtag symbol (`#`) and then a string is considered an in-page link. This is commonly used to link to a section of a page. For example, because the "Scope" section of this guide is linked by its heading as `/user-guide/workflow-setup/#scope` it would be treated as a separate page under the _In-Page Links_ scope.
 
     This scope can also be useful for crawling websites that are single-page applications where each page has its own hash, such as `example.com/#/blog` and `example.com/#/about`.
 
-#### Site Crawl
+### Site Crawl Scopes
 
-##### Pages in Same Directory
-:   This scope will only crawl pages in the same directory as the _Crawl Start URL_. If `example.com/path` is set as the _Crawl Start URL_, `example.com/path/path2` will be crawled but `example.com/path3` will not.
+#### Pages in Same Directory
 
-##### Pages on Same Domain
-:   This scope will crawl all pages on the domain entered as the _Crawl Start URL_ however it will ignore subdomains such as `subdomain.example.com`.
+:   Crawls pages in the same directory as the _Crawl Start URL_ and subdirectories.
 
-##### Pages on Same Domain + Subdomains
-:   This scope will crawl all pages on the domain and any subdomains found. If `example.com` is set as the _Crawl Start URL_, both pages on `example.com` and `subdomain.example.com` will be crawled.
+    For example, if <https://webrecorder.net/blog/product> is provided, the following pages would also be crawled:
 
-##### Custom Page Prefix
-:   This scope will crawl the _Crawl Start URL_ and then include only those pages that begin with the URLs listed in [_Page Prefix URLs_](#page-prefix-urls).
+    - <https://webrecorder.net/blog/product/2>
+    - <https://webrecorder.net/blog/2026-04-09-deduplication/>
+    - <https://webrecorder.net/blog/resources>
+    
+    The following page would not be crawled: <https://webrecorder.net/resources> (because it's outside of the **`/blog/`** directory).
 
-##### Custom Page Match
-:   This scope will crawl the _Crawl Start URL_ and then include only those pages with URLs that match the regular expression patterns listed in [_Page Regex Patterns_](#page-regex-patterns).
+#### Pages on Same Domain
+
+:   Crawls all pages on the same domain as the _Crawl Start URL_ and ignores subdomains (ex: `subdomain.example.com`).
+
+    The `www` subdomain is an exemption; pages on `www.example.com` will be treated as the same domain as `example.com`. See [Special Treatment of Redirects](#special-treatment-of-redirects)
+
+#### Pages on Same Domain + Subdomains
+
+:   Crawls all pages on the domain and any linked subdomains. If `example.com` is set as the _Crawl Start URL_, both pages on `example.com` and `subdomain.example.com` will be crawled.
+
+#### Custom Page Prefix
+
+:   Crawls the _Crawl Start URL_ and only those pages that begin with the URLs listed in [_Page Prefix URLs_](#page-prefix-urls).
+
+#### Custom Page Match
+
+:   Crawls the _Crawl Start URL_ only those pages with URLs that match the regular expression patterns listed in [_Page Regex Patterns_](#page-regex-patterns).
 
 ### Crawl Start URL / URL(s) to Crawl
 
-This is the URL used by the crawler to initiate the crawling process. The URL input may be labeled _Crawl Start URL_ or _URL(s) to Crawl_ depending on which crawl scope is used:
+This is the URL used by the crawler to select pages to crawl and initiate the crawling process. The URL input may be labeled _Crawl Start URL_ or _URL(s) to Crawl_ depending on which crawl scope is used:
 
 | Crawl Scope | Label | Description |
 | ----------- | ----- | ----------- |
-| _Single Page_ | URL&nbsp;to&nbsp;Crawl | The crawler will visit only this URL. |
-| _List of Pages_ | URLs&nbsp;to&nbsp;Crawl | The crawler will visit each URL specified in the text list or file. |
-| _In-Page Links_<br/>_Pages in Same Directory_<br/>_Pages on Same Domain_<br/>_Pages on Same Domain + Subdomains_<br/>_Custom Page Prefix_ | Crawl&nbsp;Start&nbsp;URL | The crawler will visit this URL as its starting point and use this URL to collect information on which linked pages it should also visit. |
-
+| Single Page | URL&nbsp;to&nbsp;Crawl | The crawler will visit only this URL. |
+| List of Pages | URLs&nbsp;to&nbsp;Crawl | The crawler will visit each URL specified in the text list or file. |
+| - In-Page Links<br/>- Pages in Same Directory<br/>- Pages on Same Domain<br/>- Pages on Same Domain + Subdomains<br/>- Custom Page Prefix | Crawl&nbsp;Start&nbsp;URL | The crawler will visit this URL as its starting point and use this URL to collect information on which linked pages it should also visit. |
 
 URLs must follow [valid URL syntax](https://www.w3.org/Addressing/URL/url-spec.html). For example, if you're crawling a page that can be accessed on the public internet, your URL should start with `http://` or `https://`.
 
-Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on how each crawl scope interacts with this URL.
+Refer to a specific [_Crawl Scope_ option](#crawl-scope) for details on how each crawl scope interacts with this URL.
+
+#### Special Treatment of Redirects
+
+Browsertrix will handle redirects from `http` to `https` and a bare domain to the `www` subdomain gracefully. This means that if `webrecorder.net` redirects to `www.webrecorder.net`, `www.webrecorder.net` will be treated as being the same domain in the context of crawl scope.
 
 ??? example "Crawling with HTTP basic auth"
 
@@ -100,26 +127,15 @@ Refer to a specific [_Crawl Scope_ option](#crawl-scope-options) for details on 
 
     **These credentials WILL BE WRITTEN into the archive.** We recommend exercising caution and only archiving with dedicated archival accounts, changing your password or deleting the account when finished.
 
-### Skip Pages Disallowed By Robots.txt
+### Configure Site Crawl
 
-When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at /robots.txt for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
+Choosing a crawl scope that belongs to the _Site Crawl_ category will enable additional options that modify the crawl scope.
 
-### Include Any Linked Page
+#### Max Discovery Depth
 
-When enabled, the crawler will visit all the links it finds within each URL defined in the [URL input field](#crawl-start-url-urls-to-crawl) under _Crawl Scope_.
+When using a domain-based crawl scope, adds a limit to how far the crawler should recursively visit same-domain hyperlinks away from the starting page.
 
-??? example "Crawling tags & search queries with Page List crawls"
-    This setting can be useful for crawling a list of specific pages and pages they link to, such as a list of search queries. For example, you can add a list of multiple URLs such as: `https://example.com/search?q=search_this`, `https://example.com/search?q=also_search_this`, etc... to the _URLs to Crawl_ text box and enable _Include Any Linked Page_ to crawl all the content present on these search query pages.
-
-### Fail Crawl on Failed URL
-
-When enabled, the crawler will fail the entire crawl if any of the provided URLs are invalid or unsuccessfully crawled. The resulting archived item will have a status of "Failed".
-
-### Max Depth in Scope
-
-Instructs the crawler to stop visiting new links past a specified depth.
-
-### Page Prefix URLs
+#### Page Prefix URLs
 
 When using a scope of `Custom Page Prefix`, this field accepts a list of URLs that a page URL should begin with if it is to be crawled.
 
@@ -133,7 +149,7 @@ By default, _Page Prefix URLs_ will be prefilled with the _Crawl Start URL_ up t
 !!! tip "Use Case: Crawl website that uses multiple TLDs"
     This field can be useful for crawling websites that span multiple top-level domains (e.g. `example.org` and `example.net`) by specifying each domain in the list.
 
-### Page Regex Patterns
+#### Page Regex Patterns
 
 When using a scope of `Custom Page Match`, this field accepts a list of regular expressions (regexes) that will be matched against page URLs to be crawled.
 
@@ -149,19 +165,13 @@ Patterns should be written in the JavaScript regular expression syntax without t
 !!! tip "Use Case: Crawl website that uses multiple protocols"
     This field can be useful for crawling websites that link to both `http` and `https` pages by using a regex pattern like `^https?://example.com`. The `?` quantifier indicates that that the preceding character `s` is to be matched 0 times (in the case of `http`) or 1 time (in the case of `https`.)
 
-### Include Any Linked Page ("one hop out")
+#### Use Sitemap
 
-When enabled, the crawler bypasses the _Crawl Scope_ setting to visit links it finds in each page within scope. The crawler will not visit links it finds in the pages found outside of scope (hence only "one hop out".)
+When enabled, the crawler will check for a sitemap at `/sitemap.xml` and `/robots.txt` and use it to discover pages that match the crawl scope.
 
-This can be useful for capturing links on a page that lead outside the website that is being crawled but should still be included in the archive for context.
+This can be useful for selecting pages on a website that are not hyperlinked and may not otherwise be captured.
 
-### Check For Sitemap
-
-When enabled, the crawler will check for a sitemap at /sitemap.xml and use it to discover pages to crawl if found. It will not crawl pages found in the sitemap that do not meet the crawl's scope settings or limits.
-
-This can be useful for discovering and capturing pages on a website that aren't linked to from the seed and which might not otherwise be captured.
-
-### Link Selectors
+#### Custom Link Selectors
 
 Instructs the crawler which HTML elements should be used to extract URLs, i.e. considered a “link.” By default, the crawler checks the `href` value of all anchor (`<a>`) elements on a page.
 
@@ -178,25 +188,43 @@ The _CSS Selector_ for a custom link selector could be `button.link` and its _Li
 
 See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors) for examples of valid CSS selectors.
 
-### Additional Pages
+### Additional Scope
 
-A list of page URLs outside of the _Crawl Scope_ to include in the crawl.
+To include more pages than what is selected by the crawl scope, you can specify scoping rules that will add those pages to the scope.
+
+#### Visit Any Linked Page
+
+When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. Links will only be followed one level deep (aka “one hop out”).
+
+This can be useful for capturing links that lead outside the crawled website but should still be included in the archive.
+
+#### Custom List of Pages
+
+A list of URLs of pages to crawl.
 
 ### Exclude Pages
 
-The exclusions table will instruct the crawler to ignore links it finds on pages where all or part of the link matches an exclusion found in the table. The table is only available in Page List crawls when _Include Any Linked Page_ is enabled.
+You can prevent the crawler from visiting parts of a website that you do not want to be archived by setting exclusion rules. Exclusion rules will be applied last, after crawl scope and additional scoping rules are applied.
 
-This can be useful for avoiding crawler traps — sites that may automatically generate pages such as calendars or filter options — or other pages that should not be crawled according to their URL.
+#### Use Robots.txt Disallow List
 
-#### Matches text
-:   Will perform simple matching of entered text and exclude all URLs where matching text is found.
+When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at `/robots.txt` for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
 
-    e.g: If `about` is entered, `example.com/aboutme/` will not be crawled.
+#### Custom Exclusion Rules
 
-#### Regex
-:   Regular expressions (Regex) can also be used to perform more complex matching.
+Exclusion rules instruct the crawler to ignores pages with URLs that match a specified pattern. Patterns can be written as plain text or a regular expression per selected _Exclusion Type_:
 
-    e.g: If `#!regex \babout\/?\b` is entered, `example.com/about/` will not be crawled however `example.com/aboutme/` will be crawled.
+##### Matches Text
+
+:   Text patterns will be matched against any part of the URL. For example, a text pattern of `chi` will apply to `https://en.wikipedia.org/wiki/Web_archiving` (<code>ar**chi**ving</code>) and `https://www.chicago.gov` (<code>**chi**cago</code>).
+
+    Text patterns are case-sensitive. For example, `web` will apply to `https://webrecorder.net` but not `https://en.wikipedia.org/wiki/Web_archiving` since `Web` is capitalized.
+
+##### Regex
+
+:   Regular expressions (Regex) can be used to perform more complex matching. Regex patterns should be written in the JavaScript regular expression syntax without the enclosed slashes, as it would be passed to a [RegExp constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#writing_a_regular_expression_pattern).
+
+    Example: If `#!regex \babout\/?\b` is entered, `example.com/about/` will not be crawled however `example.com/aboutme/` will be crawled.
 
 ## Crawl Limits
 
@@ -302,7 +330,7 @@ When enabled, instructs the crawler to save the browser's `localStorage` and `se
 
 !!! Warning "Privacy & security implications when used with browser profiles"
     Websites can use browser storage to store arbitrary data. During the browser profile creation process, some websites may save sensitive data such as login information and user-identifying preferences in browser storage. Since every website can implement browser storage differently, Browsertrix does not attempt to detect whether the information stored is potentially sensitive.
-    
+
     Use caution when sharing WACZ files created with this option enabled, especially if you’re crawling pages that require login. We always recommend creating dedicated website logins to be used only for crawling to mitigate the risk of compromised login information.
 
 ### Crawler Proxy Server
@@ -360,6 +388,7 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
 ### Crawl Schedule Type
 
 #### Run on a Recurring Basis
+
 :   When selected, additional configuration options for instructing the system when to run the crawl will be shown. If a crawl is already running when the schedule is set to activate it, the scheduled crawl will not run.
 
     !!! tip "Tip: Scheduling crawl workflows with logged-in browser profiles"
@@ -368,6 +397,7 @@ Automatically start crawls periodically on a daily, weekly, or monthly schedule.
         For some websites, a short schedule frequency can help keep the browser profile logged in by regularly and [automatically refreshing the login session](./browser-profiles/usage-in-crawls.md#effects-of-crawling). A separate crawl workflow could be created for this purpose. We recommend manually [checking the profile](./browser-profiles/configure-sites.md#saved-sites) periodically to ensure that it is still logged in.
 
 #### No Schedule
+
 :   When selected, the configuration options that have been set will be saved but the system will not do anything with them unless manually instructed.
 
 ### Frequency
@@ -424,7 +454,7 @@ Additionally, the following macros are supported:
 | Value | Description |
 | - | - |
 | `@yearly` | Run once a year at midnight of 1 January |
-| `@monthly` | 	Run once a month at midnight of the first day of the month |
+| `@monthly` |  Run once a month at midnight of the first day of the month |
 | `@weekly` | Run once a week at midnight on Sunday |
 | `@daily` | Run once a day at midnight |
 | `@hourly` | Run once an hour at the beginning of the hour |
@@ -445,9 +475,11 @@ Prevent duplicate content from being crawled and stored.
 ### Crawl Deduplication
 
 #### No Deduplication
+
 :   When selected, deduplication will not be enabled in crawls of this workflow.
 
 #### Deduplicate using a collection
+
 :   When selected, crawls of this workflow will reference items in the specified Collection to Use when checking for new content and URLs.
 
 ### Collection to Use

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -170,7 +170,7 @@ When enabled, the crawler will check for a sitemap at /sitemap.xml and use it to
 
 This can be useful for discovering and capturing pages on a website that aren't linked to from the seed and which might not otherwise be captured.
 
-### Link Selectors
+### Custom Link Selectors
 
 Instructs the crawler which HTML elements should be used to extract URLs, i.e. considered a “link.” By default, the crawler checks the `href` value of all anchor (`<a>`) elements on a page.
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -191,7 +191,7 @@ See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_w
 
 A list of page URLs outside of the _Crawl Scope_ to include in the crawl.
 
-### Exclude Pages
+### Custom Exclusion Rules
 
 The exclusions table will instruct the crawler to ignore links it finds on pages where all or part of the link matches an exclusion found in the table. The table is only available in Page List crawls when _Include Any Linked Page_ is enabled.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "highlight.js": "^11.8.0",
     "html-loader": "^3.0.1",
     "html-webpack-plugin": "^5.6.7",
-    "immutable": "^4.1.0",
+    "immutable": "^4.3.8",
     "ink-mde": "~0.33.0",
     "iso-639-1": "^2.1.15",
     "lit": "~3.2.0",

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -593,12 +593,12 @@ export class ConfigDetails extends BtrixElement {
             : defaultLabel(Infinity),
         ),
       )}
+      ${this.renderLinkSelectors()}
       ${this.renderSetting(labelFor.useSitemap, Boolean(config.useSitemap))}
       ${this.renderSetting(
         labelFor.includeLinkedPages,
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
       )}
-      ${this.renderLinkSelectors()}
       ${this.renderSetting(
         labelFor.urlList,
         additionalUrlList.length
@@ -659,7 +659,7 @@ export class ConfigDetails extends BtrixElement {
           </btrix-queue-exclusion-table>
         </div>
       `,
-      () => this.renderSetting(msg("Exclusions"), none),
+      () => this.renderSetting(labelFor.exclusions, none),
     );
   }
 

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -16,6 +16,7 @@ import { none, notSpecified } from "@/layouts/empty";
 import {
   Behavior,
   CrawlerChannelImage,
+  ScopeType,
   type CrawlReplay,
   type Seed,
   type SeedConfig,
@@ -35,6 +36,7 @@ import { humanizeSchedule } from "@/utils/cron";
 import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import {
+  defaultLabel,
   getServerDefaults,
   isPageScope,
   regexScopeConfig,
@@ -273,6 +275,14 @@ export class ConfigDetails extends BtrixElement {
                 >`,
             ),
           )}
+          ${this.renderSetting(
+            labelFor.failOnContentCheck,
+            Boolean(seedsConfig?.failOnContentCheck),
+          )}
+          ${this.renderSetting(
+            labelFor["saveStorage"],
+            seedsConfig?.saveStorage,
+          )}
           ${crawlConfig?.proxyId
             ? this.renderSetting(
                 msg("Crawler Proxy Server"),
@@ -294,10 +304,6 @@ export class ConfigDetails extends BtrixElement {
           ${this.renderSetting(
             msg("Block Ads by Domain"),
             seedsConfig?.blockAds,
-          )}
-          ${this.renderSetting(
-            labelFor["saveStorage"],
-            seedsConfig?.saveStorage,
           )}
           ${this.renderSetting(
             msg("User Agent"),
@@ -502,19 +508,11 @@ export class ConfigDetails extends BtrixElement {
         true,
       )}
       ${this.renderSetting(
-        msg(labelFor.includeLinkedPages),
+        labelFor.includeLinkedPages,
         Boolean(config.extraHops),
       )}
-      ${this.renderSetting(
-        msg("Skip Pages Disallowed by robots.txt"),
-        Boolean(config.useRobots),
-      )}
-      ${this.renderSetting(
-        msg("Fail Crawl If Not Logged In"),
-        Boolean(config.failOnContentCheck),
-      )}
       ${when(
-        config.extraHops,
+        config.extraHops || config.scopeType === ScopeType.SPA,
         () => html`${this.renderLinkSelectors()}${this.renderExclusions()}`,
       )}
     `;
@@ -572,7 +570,7 @@ export class ConfigDetails extends BtrixElement {
                 true,
               )
             : this.renderSetting(
-                msg("Page Prefix URLs"),
+                labelFor.customIncludeList,
                 includeRegexList.length
                   ? html`
                       <btrix-data-table
@@ -591,29 +589,18 @@ export class ConfigDetails extends BtrixElement {
         this.renderSetting(
           labelFor.maxScopeDepth,
           primarySeedConfig && primarySeedConfig.depth !== null
-            ? msg(str`${primarySeedConfig.depth} hop(s)`)
-            : msg("Unlimited (default)"),
+            ? msg(str`${primarySeedConfig.depth} level(s)`)
+            : defaultLabel(Infinity),
         ),
       )}
+      ${this.renderSetting(labelFor.useSitemap, Boolean(config.useSitemap))}
       ${this.renderSetting(
-        msg(labelFor.includeLinkedPages),
+        labelFor.includeLinkedPages,
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
-      )}
-      ${this.renderSetting(
-        msg("Skip Pages Disallowed by robots.txt"),
-        Boolean(config.useRobots),
-      )}
-      ${this.renderSetting(
-        msg("Check For Sitemap"),
-        Boolean(config.useSitemap),
-      )}
-      ${this.renderSetting(
-        msg("Fail Crawl if Not Logged In"),
-        Boolean(config.failOnContentCheck),
       )}
       ${this.renderLinkSelectors()}
       ${this.renderSetting(
-        msg("Additional Page URLs"),
+        labelFor.urlList,
         additionalUrlList.length
           ? html`
               <ul>
@@ -634,6 +621,7 @@ export class ConfigDetails extends BtrixElement {
           : none,
         true,
       )}
+      ${this.renderSetting(labelFor.useRobots, Boolean(config.useRobots))}
       ${this.renderExclusions()}
     `;
   };

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -38,7 +38,7 @@ import { richText } from "@/utils/rich-text";
 import {
   defaultLabel,
   getServerDefaults,
-  isPageScope,
+  isUrlListScope,
   regexScopeConfig,
 } from "@/utils/workflow";
 
@@ -135,7 +135,10 @@ export class ConfigDetails extends BtrixElement {
                   ? scopeTypeLabel[WorkflowScopeType.PageList]
                   : when(this.seeds, (seeds) => {
                       if (!config.scopeType) return;
-                      if (isPageScope(config.scopeType) && seeds.length > 1) {
+                      if (
+                        isUrlListScope(config.scopeType) &&
+                        seeds.length > 1
+                      ) {
                         return scopeTypeLabel[WorkflowScopeType.PageList];
                       }
                       const primarySeedConfig = seeds[0];
@@ -145,7 +148,7 @@ export class ConfigDetails extends BtrixElement {
                       return scopeTypeLabel[config.scopeType];
                     }),
               )}
-              ${isPageScope(config.scopeType)
+              ${isUrlListScope(config.scopeType)
                 ? this.renderConfirmUrlListSettings(config)
                 : this.renderConfirmSeededSettings(config)}
             `,

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -30,7 +30,7 @@ import {
   type StorageSeedFile,
 } from "@/types/workflow";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
-import { DEPTH_SUPPORTED_SCOPES, isPageScopeType } from "@/utils/crawler";
+import { isDepthSupportedScopeType, isPageScopeType } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
@@ -586,7 +586,7 @@ export class ConfigDetails extends BtrixElement {
                 true,
               ),
       )}
-      ${when(DEPTH_SUPPORTED_SCOPES.includes(scopeType), () =>
+      ${when(isDepthSupportedScopeType(scopeType), () =>
         this.renderSetting(
           msg("Max Depth in Scope"),
           primarySeedConfig && primarySeedConfig.depth !== null

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -589,7 +589,7 @@ export class ConfigDetails extends BtrixElement {
       )}
       ${when(isDepthSupportedScopeType(scopeType), () =>
         this.renderSetting(
-          msg("Max Depth in Scope"),
+          labelFor.maxScopeDepth,
           primarySeedConfig && primarySeedConfig.depth !== null
             ? msg(str`${primarySeedConfig.depth} hop(s)`)
             : msg("Unlimited (default)"),

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { localized, msg, str } from "@lit/localize";
+import { localized, msg } from "@lit/localize";
 import ISO6391 from "iso-639-1";
 import { html, nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -33,12 +33,12 @@ import {
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
 import { isDepthSupportedScopeType } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
-import { pluralOf } from "@/utils/pluralize";
+import { pluralize, pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import {
   defaultLabel,
   getServerDefaults,
-  isUrlListScope,
+  isUrlListScopeType,
   regexScopeConfig,
 } from "@/utils/workflow";
 
@@ -136,7 +136,7 @@ export class ConfigDetails extends BtrixElement {
                   : when(this.seeds, (seeds) => {
                       if (!config.scopeType) return;
                       if (
-                        isUrlListScope(config.scopeType) &&
+                        isUrlListScopeType(config.scopeType) &&
                         seeds.length > 1
                       ) {
                         return scopeTypeLabel[WorkflowScopeType.PageList];
@@ -148,7 +148,7 @@ export class ConfigDetails extends BtrixElement {
                       return scopeTypeLabel[config.scopeType];
                     }),
               )}
-              ${isUrlListScope(config.scopeType)
+              ${isUrlListScopeType(config.scopeType)
                 ? this.renderConfirmUrlListSettings(config)
                 : this.renderConfirmSeededSettings(config)}
             `,
@@ -511,7 +511,7 @@ export class ConfigDetails extends BtrixElement {
         true,
       )}
       ${this.renderSetting(
-        labelFor.includeLinkedPages,
+        msg("Visit Any Linked Page"),
         Boolean(config.extraHops),
       )}
       ${when(
@@ -591,13 +591,23 @@ export class ConfigDetails extends BtrixElement {
       ${when(isDepthSupportedScopeType(scopeType), () =>
         this.renderSetting(
           labelFor.maxScopeDepth,
-          primarySeedConfig && primarySeedConfig.depth !== null
-            ? msg(str`${primarySeedConfig.depth} level(s)`)
+          primarySeedConfig &&
+            primarySeedConfig.depth !== null &&
+            primarySeedConfig.depth !== undefined
+            ? html`${this.localize.number(primarySeedConfig.depth)}
+              ${pluralize(primarySeedConfig.depth, {
+                zero: msg("levels"),
+                one: msg("level"),
+                two: msg("levels"),
+                few: msg("levels"),
+                many: msg("levels"),
+                other: msg("levels"),
+              })}`
             : defaultLabel(Infinity),
         ),
       )}
       ${this.renderLinkSelectors()}
-      ${this.renderSetting(labelFor.useSitemap, Boolean(config.useSitemap))}
+      ${this.renderSetting(msg("Use Sitemap"), Boolean(config.useSitemap))}
       ${this.renderSetting(
         labelFor.includeLinkedPages,
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
@@ -624,7 +634,10 @@ export class ConfigDetails extends BtrixElement {
           : none,
         true,
       )}
-      ${this.renderSetting(labelFor.useRobots, Boolean(config.useRobots))}
+      ${this.renderSetting(
+        msg("Use Robots.txt Disallow List"),
+        Boolean(config.useRobots),
+      )}
       ${this.renderExclusions()}
     `;
   };

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -502,7 +502,7 @@ export class ConfigDetails extends BtrixElement {
         true,
       )}
       ${this.renderSetting(
-        msg("Include Any Linked Page (“one hop out”)"),
+        msg(labelFor.includeLinkedPages),
         Boolean(config.extraHops),
       )}
       ${this.renderSetting(
@@ -596,7 +596,7 @@ export class ConfigDetails extends BtrixElement {
         ),
       )}
       ${this.renderSetting(
-        msg("Include Any Linked Page (“one hop out”)"),
+        msg(labelFor.includeLinkedPages),
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
       )}
       ${this.renderSetting(

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -33,10 +33,9 @@ import {
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
 import { isDepthSupportedScopeType } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
-import { pluralize, pluralOf } from "@/utils/pluralize";
+import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
 import {
-  defaultLabel,
   getServerDefaults,
   isUrlListScopeType,
   regexScopeConfig,
@@ -44,6 +43,11 @@ import {
 
 const isWorkflow = (data?: CrawlReplay | Workflow): data is Workflow =>
   !!data && "crawlCount" in data;
+
+const defaultLabel = (value: number | string) =>
+  html`<span class="text-neutral-400"
+    >${value === Infinity ? msg("Unlimited") : value} ${msg("(default)")}</span
+  >`;
 
 /**
  * Usage:
@@ -105,9 +109,8 @@ export class ConfigDetails extends BtrixElement {
             verbose: true,
           });
         }
-        return html`<span class="text-neutral-400"
-          >${value} ${msg("(default)")}</span
-        >`;
+
+        return defaultLabel(value);
       }
     };
     const renderSize = (valueBytes?: number | null) => {
@@ -116,9 +119,7 @@ export class ConfigDetails extends BtrixElement {
         return this.localize.bytes(valueBytes, { unitDisplay: "narrow" });
       }
 
-      return html`<span class="text-neutral-400"
-        >${msg("Unlimited")} ${msg("(default)")}</span
-      >`;
+      return defaultLabel(Infinity);
     };
 
     return html`
@@ -595,14 +596,7 @@ export class ConfigDetails extends BtrixElement {
             primarySeedConfig.depth !== null &&
             primarySeedConfig.depth !== undefined
             ? html`${this.localize.number(primarySeedConfig.depth)}
-              ${pluralize(primarySeedConfig.depth, {
-                zero: msg("levels"),
-                one: msg("level"),
-                two: msg("levels"),
-                few: msg("levels"),
-                many: msg("levels"),
-                other: msg("levels"),
-              })}`
+              ${pluralOf("levels", primarySeedConfig.depth)}`
             : defaultLabel(Infinity),
         ),
       )}

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -30,11 +30,15 @@ import {
   type StorageSeedFile,
 } from "@/types/workflow";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
-import { isDepthSupportedScopeType, isPageScopeType } from "@/utils/crawler";
+import { isDepthSupportedScopeType } from "@/utils/crawler";
 import { humanizeSchedule } from "@/utils/cron";
 import { pluralOf } from "@/utils/pluralize";
 import { richText } from "@/utils/rich-text";
-import { getServerDefaults, regexScopeConfig } from "@/utils/workflow";
+import {
+  getServerDefaults,
+  isPageScope,
+  regexScopeConfig,
+} from "@/utils/workflow";
 
 const isWorkflow = (data?: CrawlReplay | Workflow): data is Workflow =>
   !!data && "crawlCount" in data;
@@ -129,10 +133,7 @@ export class ConfigDetails extends BtrixElement {
                   ? scopeTypeLabel[WorkflowScopeType.PageList]
                   : when(this.seeds, (seeds) => {
                       if (!config.scopeType) return;
-                      if (
-                        isPageScopeType(config.scopeType) &&
-                        seeds.length > 1
-                      ) {
+                      if (isPageScope(config.scopeType) && seeds.length > 1) {
                         return scopeTypeLabel[WorkflowScopeType.PageList];
                       }
                       const primarySeedConfig = seeds[0];
@@ -142,7 +143,7 @@ export class ConfigDetails extends BtrixElement {
                       return scopeTypeLabel[config.scopeType];
                     }),
               )}
-              ${isPageScopeType(config.scopeType)
+              ${isPageScope(config.scopeType)
                 ? this.renderConfirmUrlListSettings(config)
                 : this.renderConfirmSeededSettings(config)}
             `,

--- a/frontend/src/components/ui/details.ts
+++ b/frontend/src/components/ui/details.ts
@@ -16,11 +16,17 @@ import caretRightFillSvg from "~assets/images/caret-right-fill.svg";
  * </btrix-details>
  * ```
  *
- * @event on-toggle { open: boolean; }
+ * @cssPart base
+ * @cssPart base--closed
+ * @cssPart base--open
+ * @cssPart summary
+ * @cssPart summary-content
+ * @cssPart summary-title
+ * @fires on-toggle { open: boolean; }
  */
 @customElement("btrix-details")
 export class Details extends LitElement {
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   open? = false;
 
   @property({ type: Boolean })
@@ -40,7 +46,7 @@ export class Details extends LitElement {
 
     summary {
       color: var(--sl-color-neutral-500);
-      margin-bottom: var(--sl-spacing-2x-small);
+      margin-bottom: 0;
       line-height: 1;
       display: flex;
       align-items: center;
@@ -49,16 +55,20 @@ export class Details extends LitElement {
 
     details[aria-disabled="false"] summary {
       border-bottom: var(--border-bottom);
-      margin-bottom: var(--margin-bottom);
       cursor: pointer;
       user-select: none;
+    }
+
+    details[open] summary {
+      margin-bottom: var(--margin-bottom);
     }
 
     details[aria-disabled="false"] summary::before {
       display: block;
       width: 1rem;
       height: 1rem;
-      margin-right: var(--sl-spacing-2x-small);
+      margin-right: 0.25rem;
+      margin-left: -0.25rem;
       flex: 0;
     }
 
@@ -96,6 +106,10 @@ export class Details extends LitElement {
     super.connectedCallback();
   }
 
+  public show() {
+    this.open = true;
+  }
+
   render() {
     return html`
       <details
@@ -103,10 +117,11 @@ export class Details extends LitElement {
         @click=${this.onClick}
         @toggle=${this.onToggle}
         aria-disabled=${this.disabled ? "true" : "false"}
+        part="base ${this.open ? "base--open" : "base--closed"}"
       >
-        <summary tabindex=${this.disabled ? "-1" : "0"}>
-          <div class="summary-content">
-            <div class="title">
+        <summary tabindex=${this.disabled ? "-1" : "0"} part="summary">
+          <div class="summary-content" part="summary-content">
+            <div class="title" part="summary-title">
               <slot name="title"></slot>
             </div>
             <slot name="summary-description"></slot>
@@ -128,6 +143,7 @@ export class Details extends LitElement {
     const isOpen = (e.target as HTMLDetailsElement).open;
 
     if (isOpen !== this.open) {
+      this.open = isOpen;
       this.dispatchEvent(
         new CustomEvent("on-toggle", {
           detail: { open: isOpen },

--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -1,7 +1,13 @@
 import { localized, msg, str } from "@lit/localize";
 import type { SlInput, SlSelect } from "@shoelace-style/shoelace";
 import clsx from "clsx";
-import { css, html, type PropertyValues, type TemplateResult } from "lit";
+import {
+  css,
+  html,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from "lit";
 import { customElement, property, queryAll, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
@@ -63,7 +69,7 @@ export class QueueExclusionTable extends TailwindElement {
 
   // TODO switch to LitElement & slotted label
   @property({ type: String })
-  label?: string;
+  label = msg("Exclusions");
   @property({ type: String })
   labelClassName?: string;
 
@@ -155,23 +161,25 @@ export class QueueExclusionTable extends TailwindElement {
       this.getColumnClassNames(0, this.results.length, true);
 
     return html`
-      <div class="mb-2 flex items-center justify-between leading-tight">
-        <div class=${ifDefined(this.labelClassName)}>
-          ${this.label ?? msg("Exclusions")}
-        </div>
-        ${this.total && this.total > this.pageSize
-          ? html`<btrix-pagination
-              page=${this.page}
-              size=${this.pageSize}
-              totalCount=${this.total}
-              compact
-              @page-change=${(e: PageChangeEvent) => {
-                this.page = e.detail.page;
-              }}
-            >
-            </btrix-pagination>`
-          : ""}
-      </div>
+      ${this.label
+        ? html`
+            <div class="mb-2 flex items-center justify-between leading-tight">
+              <div class=${ifDefined(this.labelClassName)}>${this.label}</div>
+              ${this.total && this.total > this.pageSize
+                ? html`<btrix-pagination
+                    page=${this.page}
+                    size=${this.pageSize}
+                    totalCount=${this.total}
+                    compact
+                    @page-change=${(e: PageChangeEvent) => {
+                      this.page = e.detail.page;
+                    }}
+                  >
+                  </btrix-pagination>`
+                : ""}
+            </div>
+          `
+        : nothing}
       <table
         class="w-full border-separate leading-none"
         style="border-spacing: 0;"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -293,7 +293,6 @@ export class WorkflowEditor extends BtrixElement {
     }
 
     btrix-details::part(summary) {
-      /* display: inline-flex; */
       color: inherit;
     }
   `;
@@ -1650,13 +1649,13 @@ https://archiveweb.page/es/`}
           )}
         `,
       )}
-      ${this.renderLinkSelectors()}
       ${inputCol(html`
         <sl-checkbox name="useSitemap" ?checked=${this.formState.useSitemap}>
           ${labelFor.useSitemap}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor.useSitemap, false)}
+      ${this.renderLinkSelectors()}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1051,7 +1051,9 @@ export class WorkflowEditor extends BtrixElement {
         this.formState.includeLinkedPages ||
           this.formState.scopeType === ScopeType.SPA,
         () => html`
-          ${this.renderLinkSelectors()} ${this.renderExcludePages()}
+          ${this.renderLinkSelectors()}
+          ${this.renderSectionHeading(msg("Exclude Pages"))}
+          ${this.renderExcludePages()}
         `,
       )}
     `;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1528,7 +1528,7 @@ https://replayweb.page/docs`}
           ${inputCol(html`
             <sl-textarea
               name="customIncludeList"
-              label=${msg("Page Prefix URLs")}
+              label=${labelFor.customIncludeList}
               rows="3"
               autocomplete="off"
               inputmode="url"
@@ -1658,7 +1658,7 @@ https://archiveweb.page/es/`}
       ${this.renderSectionHeading(msg("Additional Scope"))}
       ${this.renderIncludeLinkedPages()}
       ${detailsInColumns({
-        title: html`${msg("Custom List of Pages")}
+        title: html`${labelFor.urlList}
         ${additionalUrlList.length
           ? html`<btrix-badge>${additionalUrlList.length}</btrix-badge>`
           : ""}`,
@@ -2132,7 +2132,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
               ?checked=${this.formState.failOnContentCheck &&
               this.formState.browserProfile !== null}
             >
-              ${msg("Fail crawl if not logged in")}
+              ${labelFor.failOnContentCheck}
             </sl-checkbox>
           `)}
           ${this.renderHelpTextCol(

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -151,6 +151,7 @@ import {
   getInitialFormState,
   getServerDefaults,
   isPageScope,
+  isUrlListScope,
   makeUserGuideEvent,
   MAX_SEED_LIST_FILE_BYTES,
   MAX_SEED_LIST_STRING_BYTES,
@@ -1804,7 +1805,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     const minPages = Math.max(
       1,
       urlListToArray(this.formState.urlList).length +
-        (isPageScope(this.formState.scopeType) ? 0 : 1),
+        (isUrlListScope(this.formState.scopeType) ? 0 : 1),
     );
 
     return html`
@@ -2704,7 +2705,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private renderJobMetadata() {
-    const pageScope = isPageScope(this.formState.scopeType);
+    const urlList = isUrlListScope(this.formState.scopeType);
 
     const linkToScope = (label: string) =>
       html`<button
@@ -2738,7 +2739,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       `)}
       ${this.renderHelpTextCol(
         html`${msg(`Customize the name of this workflow.`)}
-        ${pageScope
+        ${urlList
           ? this.formState.scopeType === ScopeType.Page
             ? msg(
                 html`If omitted, the workflow will be named after the URL
@@ -2909,18 +2910,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
     };
     const urls = urlListToArray(this.formState.urlList);
 
-    const pageScope = isPageScope(value);
-    const isPrevPageScope = isPageScope(prevScopeType);
+    const urlList = isUrlListScope(value);
+    const prevUrlList = isUrlListScope(prevScopeType);
 
-    if (pageScope === isPrevPageScope) {
-      if (pageScope) {
+    if (urlList === prevUrlList) {
+      if (urlList) {
         formState.urlList = urls[0];
       }
     } else {
-      if (isPrevPageScope) {
+      if (prevUrlList) {
         formState.primarySeedUrl = urls[0];
         formState.urlList = urls.slice(1).join("\n");
-      } else if (pageScope) {
+      } else if (urlList) {
         formState.urlList = [this.formState.primarySeedUrl, ...urls].join("\n");
       }
     }
@@ -3039,7 +3040,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   });
 
   private hasRequiredFields(): boolean {
-    if (isPageScope(this.formState.scopeType)) {
+    if (isUrlListScope(this.formState.scopeType)) {
       return Boolean(
         this.formState.seedListFormat === SeedListFormat.File
           ? this.formState.seedFile || this.formState.seedFileId
@@ -3687,7 +3688,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           this.formState.dedupeCollection.id) ||
         "",
       config: {
-        ...(isPageScope(this.formState.scopeType)
+        ...(isUrlListScope(this.formState.scopeType)
           ? this.parseUrlListConfig(uploadParams)
           : this.parseSeededConfig()),
         behaviorTimeout: this.formState.behaviorTimeoutSeconds,
@@ -3708,6 +3709,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
           [],
         clickSelector:
           this.formState.clickSelector || DEFAULT_AUTOCLICK_SELECTOR,
+        failOnContentCheck: this.formState.failOnContentCheck,
+        saveStorage: this.formState.saveStorage,
+        useRobots: this.formState.useRobots,
       },
       crawlerChannel:
         this.formState.crawlerChannel || CrawlerChannelImage.Default,
@@ -3735,15 +3739,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     seedFileId?: string;
   }): Pick<
     WorkflowParams["config"],
-    | "seeds"
-    | "seedFileId"
-    | "scopeType"
-    | "extraHops"
-    | "useSitemap"
-    | "failOnFailedSeed"
-    | "failOnContentCheck"
-    | "saveStorage"
-    | "useRobots"
+    "seeds" | "seedFileId" | "scopeType" | "extraHops" | "failOnFailedSeed"
   > {
     const jsonSeeds = this.formState.seedListFormat === SeedListFormat.JSON;
 
@@ -3761,9 +3757,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
       useSitemap: false,
       failOnFailedSeed: this.formState.failOnFailedSeed,
-      failOnContentCheck: this.formState.failOnContentCheck,
-      saveStorage: this.formState.saveStorage,
-      useRobots: this.formState.useRobots,
     };
 
     return config;
@@ -3771,24 +3764,21 @@ https://archiveweb.page/images/${"logo.svg"}`}
 
   private parseSeededConfig(): Pick<
     WorkflowParams["config"],
-    | "seeds"
-    | "scopeType"
-    | "useSitemap"
-    | "failOnFailedSeed"
-    | "failOnContentCheck"
-    | "saveStorage"
-    | "useRobots"
+    "seeds" | "scopeType" | "useSitemap" | "failOnFailedSeed"
   > {
     const primarySeedUrl = this.formState.primarySeedUrl;
     const includeUrlList = this.formState.customIncludeList
       ? urlListToArray(this.formState.customIncludeList)
       : [];
-    const additionalSeedUrlList = this.formState.urlList
-      ? urlListToArray(this.formState.urlList).map((seedUrl) => {
-          const newSeed: Seed = { url: seedUrl, scopeType: ScopeType.Page };
-          return newSeed;
-        })
-      : [];
+    const additionalSeedUrlList =
+      !isPageScope(this.formState.scopeType) &&
+      // Page scopes do not support additional seed URLs
+      this.formState.urlList
+        ? urlListToArray(this.formState.urlList).map((seedUrl) => {
+            const newSeed: Seed = { url: seedUrl, scopeType: ScopeType.Page };
+            return newSeed;
+          })
+        : [];
     const scopeType = apiScopeType(this.formState.scopeType)
       ? this.formState.scopeType
       : ScopeType.Custom;
@@ -3813,9 +3803,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
       scopeType,
       useSitemap: this.formState.useSitemap,
       failOnFailedSeed: false,
-      failOnContentCheck: this.formState.failOnContentCheck,
-      saveStorage: this.formState.saveStorage,
-      useRobots: this.formState.useRobots,
     };
     return config;
   }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -90,6 +90,7 @@ import type {
   QueueExclusionTable,
 } from "@/features/crawl-workflows/queue-exclusion-table";
 import { infoCol, inputCol } from "@/layouts/columns";
+import { detailsInColumns } from "@/layouts/detailsInColumns";
 import { pageSectionsWithNav } from "@/layouts/pageSectionsWithNav";
 import { panel } from "@/layouts/panel";
 import { OrgTab, WorkflowTab } from "@/routes";
@@ -282,6 +283,17 @@ export class WorkflowEditor extends BtrixElement {
           opacity: 1;
         }
       }
+    }
+
+    btrix-details {
+      --margin-bottom: 0;
+      --border-bottom: 0;
+      margin-top: -0.5rem;
+    }
+
+    btrix-details::part(summary) {
+      /* display: inline-flex; */
+      color: inherit;
     }
   `;
 
@@ -960,34 +972,26 @@ export class WorkflowEditor extends BtrixElement {
   private renderExcludePages() {
     const exclusions = trimArray(this.formState.exclusions || []);
 
-    return html`
-      <div class="col-span-5">
-        <btrix-details ?open=${exclusions.length > 0}>
-          <span slot="title"
-            >${msg("Exclude Pages")}
-            ${exclusions.length
-              ? html`<btrix-badge>${exclusions.length}</btrix-badge>`
-              : ""}</span
-          >
-          <div class="grid grid-cols-5 gap-5 py-2">
-            ${inputCol(html`
-              <btrix-queue-exclusion-table
-                label=""
-                labelClassName=${tw`hidden`}
-                .exclusions=${this.formState.exclusions}
-                pageSize="10"
-                editable
-                removable
-                uncontrolled
-                @btrix-remove=${this.handleRemoveRegex}
-                @btrix-change=${this.handleChangeRegex}
-              ></btrix-queue-exclusion-table>
-            `)}
-            ${this.renderHelpTextCol(infoTextFor["exclusions"], false)}
-          </div>
-        </btrix-details>
-      </div>
-    `;
+    return detailsInColumns({
+      title: html`${msg("Custom Exclusion Rules")}
+      ${exclusions.length
+        ? html`<btrix-badge>${exclusions.length}</btrix-badge>`
+        : ""}`,
+      main: html`
+        <btrix-queue-exclusion-table
+          label=""
+          labelClassName=${tw`hidden`}
+          .exclusions=${this.formState.exclusions}
+          pageSize="10"
+          editable
+          removable
+          uncontrolled
+          @btrix-remove=${this.handleRemoveRegex}
+          @btrix-change=${this.handleChangeRegex}
+        ></btrix-queue-exclusion-table>
+      `,
+      info: infoTextFor["exclusions"],
+    });
   }
 
   private readonly renderPageScope = () => {
@@ -1633,51 +1637,43 @@ https://archiveweb.page/es/`}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
-
-      <div class="col-span-5">
-        <btrix-details>
-          <span slot="title">
-            ${msg("Custom Page List")}
-            ${additionalUrlList.length
-              ? html`<btrix-badge>${additionalUrlList.length}</btrix-badge>`
-              : ""}
-          </span>
-          <div class="grid grid-cols-5 gap-5 py-2">
-            ${inputCol(html`
-              <sl-textarea
-                name="urlList"
-                label=${msg("Page URLs")}
-                rows="3"
-                autocomplete="off"
-                inputmode="url"
-                value=${this.formState.urlList}
-                placeholder=${`https://webrecorder.net/blog
+      ${detailsInColumns({
+        title: html`${msg("Custom List of Pages")}
+        ${additionalUrlList.length
+          ? html`<btrix-badge>${additionalUrlList.length}</btrix-badge>`
+          : ""}`,
+        main: html`
+          <sl-textarea
+            class="part-[form-control-label]:sr-only"
+            name="urlList"
+            label=${msg("Page URLs")}
+            rows="3"
+            autocomplete="off"
+            inputmode="url"
+            value=${this.formState.urlList}
+            placeholder=${`https://webrecorder.net/blog
 https://archiveweb.page/images/${"logo.svg"}`}
-                @keyup=${async (e: KeyboardEvent) => {
-                  if (e.key === "Enter") {
-                    await (e.target as SlInput).updateComplete;
-                    this.doValidateUrlList(e);
-                  }
-                }}
-                @sl-input=${(e: CustomEvent) => {
-                  const inputEl = e.target as SlInput;
-                  if (!inputEl.value) {
-                    inputEl.helpText = msg("At least 1 URL is required.");
-                  }
-                }}
-                @sl-change=${this.doValidateUrlList}
-                @sl-blur=${this.doValidateUrlList}
-              ></sl-textarea>
-            `)}
-            ${this.renderHelpTextCol(
-              html`${infoTextFor["urlList"]}
-              ${msg(str`You can enter up to ${maxUrls} URLs.`, {
-                desc: "`maxUrls` example: '1,000'",
-              })}`,
-            )}
-          </div>
-        </btrix-details>
-      </div>
+            @keyup=${async (e: KeyboardEvent) => {
+              if (e.key === "Enter") {
+                await (e.target as SlInput).updateComplete;
+                this.doValidateUrlList(e);
+              }
+            }}
+            @sl-input=${(e: CustomEvent) => {
+              const inputEl = e.target as SlInput;
+              if (!inputEl.value) {
+                inputEl.helpText = msg("At least 1 URL is required.");
+              }
+            }}
+            @sl-change=${this.doValidateUrlList}
+            @sl-blur=${this.doValidateUrlList}
+          ></sl-textarea>
+        `,
+        info: html`${infoTextFor["urlList"]}
+        ${msg(str`You can enter up to ${maxUrls} URLs.`, {
+          desc: "`maxUrls` example: '1,000'",
+        })}`,
+      })}
 
       <!-- Settings that modify the expanded scope by exclude links that would normally would be in scope -->
       ${this.renderSectionHeading(msg("Exclude Pages"))}
@@ -1728,38 +1724,23 @@ https://archiveweb.page/images/${"logo.svg"}`}
       ><btrix-code language="xml" value=${defaultAttr}></btrix-code>
     </span>`;
 
-    return html`
-      <div class="col-span-5">
-        <btrix-details ?open=${isCustom}>
-          <span slot="title">
-            ${labelFor.selectLinks}
-            ${isCustom
-              ? html`<btrix-badge>${selectors.length}</btrix-badge>`
-              : ""}
-          </span>
-          <div class="grid grid-cols-5 gap-5 py-2">
-            ${inputCol(
-              html`<btrix-link-selector-table
-                name="selectLinks"
-                .selectors=${selectors}
-                editable
-              ></btrix-link-selector-table>`,
-            )}
-            ${this.renderHelpTextCol(
-              html`
-                ${infoTextFor["selectLinks"]}
-                <br /><br />
-                ${msg(
-                  html`If none are specified, the crawler will default to
-                  ${defaultValue}.`,
-                )}
-              `,
-              false,
-            )}
-          </div>
-        </btrix-details>
-      </div>
-    `;
+    return detailsInColumns({
+      title: html`${labelFor.selectLinks}
+      ${isCustom ? html`<btrix-badge>${selectors.length}</btrix-badge>` : ""}`,
+      main: html`<btrix-link-selector-table
+        name="selectLinks"
+        .selectors=${selectors}
+        editable
+      ></btrix-link-selector-table>`,
+      info: html`
+        ${infoTextFor["selectLinks"]}
+        <br /><br />
+        ${msg(
+          html`If none are specified, the crawler will default to
+          ${defaultValue}.`,
+        )}
+      `,
+    });
   }
 
   private renderCrawlLimits() {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -995,10 +995,13 @@ export class WorkflowEditor extends BtrixElement {
     });
 
     return detailsInColumns({
-      title: html`${msg("Custom Exclusion Rules")}
+      open: exclusions.length > 0,
+      title: html`${labelFor.exclusions}
       ${exclusions.length
-        ? html`<btrix-badge>${exclusions.length}</btrix-badge>`
-        : ""}`,
+        ? html`<btrix-badge
+            >${this.localize.number(exclusions.length)}</btrix-badge
+          >`
+        : nothing}`,
       main: html`
         <btrix-queue-exclusion-table
           label=""
@@ -1646,22 +1649,25 @@ https://archiveweb.page/es/`}
           )}
         `,
       )}
+      ${this.renderLinkSelectors()}
       ${inputCol(html`
         <sl-checkbox name="useSitemap" ?checked=${this.formState.useSitemap}>
           ${labelFor.useSitemap}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor.useSitemap, false)}
-      ${this.renderLinkSelectors()}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
       ${this.renderIncludeLinkedPages()}
       ${detailsInColumns({
+        open: additionalUrlList.length > 0,
         title: html`${labelFor.urlList}
         ${additionalUrlList.length
-          ? html`<btrix-badge>${additionalUrlList.length}</btrix-badge>`
-          : ""}`,
+          ? html`<btrix-badge
+              >${this.localize.number(additionalUrlList.length)}</btrix-badge
+            >`
+          : nothing}`,
         main: html`
           <sl-textarea
             class="part-[form-control-label]:sr-only"
@@ -1762,8 +1768,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
     });
 
     return detailsInColumns({
+      open: isCustom,
       title: html`${labelFor.selectLinks}
-      ${isCustom ? html`<btrix-badge>${selectors.length}</btrix-badge>` : ""}`,
+      ${isCustom
+        ? html`<btrix-badge
+            >${this.localize.number(selectors.length)}</btrix-badge
+          >`
+        : nothing}`,
       main: html`<btrix-link-selector-table
         name="selectLinks"
         .selectors=${selectors}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -921,10 +921,27 @@ export class WorkflowEditor extends BtrixElement {
     return infoCol(content, padTop ? tw`md:pt-[2.35rem]` : tw`md:pt-1`);
   }
 
+  private renderExternalLink({
+    href,
+    text,
+  }: {
+    href: string;
+    text: TemplateResult | string;
+  }) {
+    return html`<a
+      href=${href}
+      class="text-blue-600 hover:text-blue-500"
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      >${text} <sl-icon name="box-arrow-up-right"></sl-icon
+    ></a>`;
+  }
+
   private readonly renderScope = () => {
     return html`
       ${inputCol(html`
         <sl-select
+          class="part-[combobox]:pl-2.5"
           name="scopeType"
           label=${msg("Crawl Scope")}
           value=${this.formState.scopeType}
@@ -934,7 +951,7 @@ export class WorkflowEditor extends BtrixElement {
               (e.target as HTMLSelectElement).value as FormState["scopeType"],
             )}
         >
-          <btrix-badge slot="prefix"
+          <btrix-badge class="mr-2.5" slot="prefix" outline
             >${isPageScope(this.formState.scopeType)
               ? stringForScopeGroup.page
               : stringForScopeGroup.site}</btrix-badge
@@ -971,6 +988,11 @@ export class WorkflowEditor extends BtrixElement {
 
   private renderExcludePages() {
     const exclusions = trimArray(this.formState.exclusions || []);
+    const RegExp = html`<code>RegExp</code>`;
+    const RegExp_constructor = this.renderExternalLink({
+      href: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#writing_a_regular_expression_pattern",
+      text: msg(html`${RegExp} constructor`),
+    });
 
     return detailsInColumns({
       title: html`${msg("Custom Exclusion Rules")}
@@ -990,7 +1012,19 @@ export class WorkflowEditor extends BtrixElement {
           @btrix-change=${this.handleChangeRegex}
         ></btrix-queue-exclusion-table>
       `,
-      info: infoTextFor["exclusions"],
+      description: infoTextFor["exclusions"],
+      info: html`${infoTextFor["exclusions"]}
+      ${msg(
+        "Rules can be written as plain text or a regular expression pattern.",
+      )}
+      ${msg(
+        html`Regex patterns should be written in the JavaScript regular
+        expression syntax without the enclosed slashes, as it would be passed to
+        a ${RegExp_constructor}.`,
+        {
+          desc: "'RegExp_constructor' is a link to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#writing_a_regular_expression_pattern",
+        },
+      )}`,
     });
   }
 
@@ -1669,6 +1703,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             @sl-blur=${this.doValidateUrlList}
           ></sl-textarea>
         `,
+        description: infoTextFor["urlList"],
         info: html`${infoTextFor["urlList"]}
         ${msg(str`You can enter up to ${maxUrls} URLs.`, {
           desc: "`maxUrls` example: '1,000'",
@@ -1723,6 +1758,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
       ><code class="text-neutral-400">${SELECTOR_DELIMITER}</code
       ><btrix-code language="xml" value=${defaultAttr}></btrix-code>
     </span>`;
+    const CSS_selectors = this.renderExternalLink({
+      href: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors",
+      text: msg("CSS selectors"),
+    });
 
     return detailsInColumns({
       title: html`${labelFor.selectLinks}
@@ -1732,8 +1771,16 @@ https://archiveweb.page/images/${"logo.svg"}`}
         .selectors=${selectors}
         editable
       ></btrix-link-selector-table>`,
+      description: infoTextFor["selectLinks"],
       info: html`
         ${infoTextFor["selectLinks"]}
+        ${msg(
+          html`The crawler will use the specified ${CSS_selectors} to find URLs
+          that are defined in custom HTML attributes.`,
+          {
+            desc: "'CSS_selectors' is a link to https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors",
+          },
+        )}
         <br /><br />
         ${msg(
           html`If none are specified, the crawler will default to
@@ -2039,6 +2086,15 @@ https://archiveweb.page/images/${"logo.svg"}`}
         .filter((url) => url);
     };
 
+    const Steven_Blacks_Hosts_file = this.renderExternalLink({
+      href: "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts",
+      text: msg("Steven Black’s Hosts file"),
+    });
+    const Useragents_me = this.renderExternalLink({
+      href: "https://www.useragents.me/",
+      text: "Useragents.me",
+    });
+
     return html`
       ${inputCol(html`
         <btrix-select-browser-profile
@@ -2179,7 +2235,13 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ${msg("Block ads by domain")}
         </sl-checkbox>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["blockAds"], false)}
+      ${this.renderHelpTextCol(
+        html`${infoTextFor["blockAds"]}
+        ${msg(html`Uses ${Steven_Blacks_Hosts_file}.`, {
+          desc: "'Steven_Blacks_Hosts_file' is a link to https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts",
+        })} `,
+        false,
+      )}
       ${inputCol(html`
         <sl-input
           name="userAgent"
@@ -2190,7 +2252,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
         >
         </sl-input>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["userAgent"])}
+      ${this.renderHelpTextCol(
+        html`${infoTextFor["userAgent"]}
+        ${msg(html`For common user agents see ${Useragents_me}.`, {
+          desc: "'Useragents_me' is a link to https://www.useragents.me/",
+        })}`,
+      )}
       ${inputCol(html`
         <btrix-language-select
           .value=${this.formState.lang as LanguageCode}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -150,8 +150,8 @@ import {
   getDefaultFormState,
   getInitialFormState,
   getServerDefaults,
-  isPageScope,
-  isUrlListScope,
+  isPageScopeType,
+  isUrlListScopeType,
   makeUserGuideEvent,
   MAX_SEED_LIST_FILE_BYTES,
   MAX_SEED_LIST_STRING_BYTES,
@@ -953,7 +953,7 @@ export class WorkflowEditor extends BtrixElement {
             )}
         >
           <btrix-badge class="mr-2.5" slot="prefix" outline
-            >${isPageScope(this.formState.scopeType)
+            >${isPageScopeType(this.formState.scopeType)
               ? stringForScopeGroup.page
               : stringForScopeGroup.site}</btrix-badge
           >
@@ -981,7 +981,7 @@ export class WorkflowEditor extends BtrixElement {
           )}
         </p>
       `)}
-      ${isPageScope(this.formState.scopeType)
+      ${isPageScopeType(this.formState.scopeType)
         ? this.renderPageScope()
         : this.renderSiteScope()}
     `;
@@ -1805,7 +1805,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     const minPages = Math.max(
       1,
       urlListToArray(this.formState.urlList).length +
-        (isUrlListScope(this.formState.scopeType) ? 0 : 1),
+        (isUrlListScopeType(this.formState.scopeType) ? 0 : 1),
     );
 
     return html`
@@ -2705,7 +2705,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private renderJobMetadata() {
-    const urlList = isUrlListScope(this.formState.scopeType);
+    const urlList = isUrlListScopeType(this.formState.scopeType);
 
     const linkToScope = (label: string) =>
       html`<button
@@ -2910,18 +2910,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
     };
     const urls = urlListToArray(this.formState.urlList);
 
-    const urlList = isUrlListScope(value);
-    const prevUrlList = isUrlListScope(prevScopeType);
+    const isUrlList = isUrlListScopeType(value);
+    const prevIsUrlList = isUrlListScopeType(prevScopeType);
 
-    if (urlList === prevUrlList) {
-      if (urlList) {
+    if (isUrlList === prevIsUrlList) {
+      if (isUrlList) {
         formState.urlList = urls[0];
       }
     } else {
-      if (prevUrlList) {
+      if (prevIsUrlList) {
         formState.primarySeedUrl = urls[0];
         formState.urlList = urls.slice(1).join("\n");
-      } else if (urlList) {
+      } else if (isUrlList) {
         formState.urlList = [this.formState.primarySeedUrl, ...urls].join("\n");
       }
     }
@@ -3040,7 +3040,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   });
 
   private hasRequiredFields(): boolean {
-    if (isUrlListScope(this.formState.scopeType)) {
+    if (isUrlListScopeType(this.formState.scopeType)) {
       return Boolean(
         this.formState.seedListFormat === SeedListFormat.File
           ? this.formState.seedFile || this.formState.seedFileId
@@ -3688,7 +3688,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           this.formState.dedupeCollection.id) ||
         "",
       config: {
-        ...(isUrlListScope(this.formState.scopeType)
+        ...(isUrlListScopeType(this.formState.scopeType)
           ? this.parseUrlListConfig(uploadParams)
           : this.parseSeededConfig()),
         behaviorTimeout: this.formState.behaviorTimeoutSeconds,
@@ -3771,7 +3771,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       ? urlListToArray(this.formState.customIncludeList)
       : [];
     const additionalSeedUrlList =
-      !isPageScope(this.formState.scopeType) &&
+      !isPageScopeType(this.formState.scopeType) &&
       // Page scopes do not support additional seed URLs
       this.formState.urlList
         ? urlListToArray(this.formState.urlList).map((seedUrl) => {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1038,15 +1038,7 @@ export class WorkflowEditor extends BtrixElement {
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
-      ${inputCol(html`
-        <sl-checkbox
-          name="includeLinkedPages"
-          ?checked=${this.formState.includeLinkedPages}
-        >
-          ${msg("Include any linked page (“one hop out”)")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
+      ${this.renderIncludeLinkedPages()}
       ${when(
         this.formState.includeLinkedPages ||
           this.formState.scopeType === ScopeType.SPA,
@@ -1664,15 +1656,7 @@ https://archiveweb.page/es/`}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
-      ${inputCol(html`
-        <sl-checkbox
-          name="includeLinkedPages"
-          ?checked=${this.formState.includeLinkedPages}
-        >
-          ${msg("Include any linked page (“one hop out”)")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
+      ${this.renderIncludeLinkedPages()}
       ${detailsInColumns({
         title: html`${msg("Custom List of Pages")}
         ${additionalUrlList.length
@@ -1747,6 +1731,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
       inputEl.setCustomValidity(helpText);
     }
   };
+
+  private renderIncludeLinkedPages() {
+    return html`${inputCol(html`
+      <sl-checkbox
+        name="includeLinkedPages"
+        ?checked=${this.formState.includeLinkedPages}
+      >
+        ${labelFor.includeLinkedPages}
+      </sl-checkbox>
+    `)}
+    ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}`;
+  }
 
   private renderLinkSelectors() {
     const selectors = this.formState.selectLinks;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -95,6 +95,7 @@ import { panel } from "@/layouts/panel";
 import { OrgTab, WorkflowTab } from "@/routes";
 import { infoTextFor } from "@/strings/crawl-workflows/infoText";
 import { labelFor } from "@/strings/crawl-workflows/labels";
+import { stringForScopeGroup } from "@/strings/crawl-workflows/scopeGroup";
 import scopeTypeLabels from "@/strings/crawl-workflows/scopeType";
 import sectionStrings from "@/strings/crawl-workflows/section";
 import { dedupeTypeLabelFor } from "@/strings/dedupe";
@@ -921,7 +922,12 @@ export class WorkflowEditor extends BtrixElement {
               (e.target as HTMLSelectElement).value as FormState["scopeType"],
             )}
         >
-          <sl-menu-label>${msg("Page Crawl")}</sl-menu-label>
+          <btrix-badge slot="prefix"
+            >${isPageScope(this.formState.scopeType)
+              ? stringForScopeGroup.page
+              : stringForScopeGroup.site}</btrix-badge
+          >
+          <sl-menu-label>${stringForScopeGroup.page}</sl-menu-label>
           ${WORKFLOW_PAGE_SCOPES.map(
             (scope) =>
               html`<sl-option value=${scope}
@@ -929,7 +935,7 @@ export class WorkflowEditor extends BtrixElement {
               >`,
           )}
           <sl-divider></sl-divider>
-          <sl-menu-label>${msg("Site Crawl")}</sl-menu-label>
+          <sl-menu-label>${stringForScopeGroup.site}</sl-menu-label>
           ${WORKFLOW_SITE_SCOPES.map(
             (scope) =>
               html`<sl-option value=${scope}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1777,8 +1777,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
       info: html`
         ${infoTextFor["selectLinks"]}
         ${msg(
-          html`The crawler will use the specified ${CSS_selectors} to find URLs
-          that are defined in custom HTML attributes.`,
+          html`The crawler will use the specified ${CSS_selectors} and HTML
+          attributes to find links.`,
           {
             desc: "'CSS_selectors' is a link to https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors",
           },

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -945,7 +945,11 @@ export class WorkflowEditor extends BtrixElement {
         </sl-select>
       `)}
       ${this.renderHelpTextCol(html`
-        <p>${msg(`Tells the crawler which pages it can visit.`)}</p>
+        <p>
+          ${msg(
+            `Tells the crawler how to use the URL you provide to discover and visit pages.`,
+          )}
+        </p>
       `)}
       ${isPageScope(this.formState.scopeType)
         ? this.renderPageScope()
@@ -969,6 +973,7 @@ export class WorkflowEditor extends BtrixElement {
             ${inputCol(html`
               <btrix-queue-exclusion-table
                 label=""
+                labelClassName=${tw`hidden`}
                 .exclusions=${this.formState.exclusions}
                 pageSize="10"
                 editable
@@ -992,6 +997,9 @@ export class WorkflowEditor extends BtrixElement {
         [ScopeType.SPA, this.renderPrimarySeedInput],
         [NewWorkflowOnlyScopeType.PageList, this.renderUrlList],
       ])}
+
+      <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
+      ${this.renderSectionHeading(msg("Additional Scope"))}
       ${inputCol(html`
         <sl-checkbox
           name="includeLinkedPages"
@@ -1481,6 +1489,7 @@ https://replayweb.page/docs`}
 
     return html`
       ${this.renderPrimarySeedInput()}
+      ${this.renderSectionHeading(msg("Configure Site Crawl"))}
       ${when(
         this.formState.scopeType === ScopeType.Custom,
         () => html`
@@ -1584,7 +1593,7 @@ https://archiveweb.page/es/`}
           ${inputCol(html`
             <sl-input
               name="maxScopeDepth"
-              label=${msg("Max Depth in Scope")}
+              label=${labelFor.maxScopeDepth}
               value=${ifDefined(
                 this.formState.maxScopeDepth === null
                   ? undefined
@@ -1595,16 +1604,26 @@ https://archiveweb.page/es/`}
               type="number"
               inputmode="numeric"
             >
-              <span slot="suffix">${msg("hops")}</span>
+              <span slot="suffix">${msg("levels")}</span>
             </sl-input>
           `)}
           ${this.renderHelpTextCol(
             msg(
-              `Limits how many hops away the crawler can visit while staying within the Crawl Scope.`,
+              "The crawler will follow links this many levels deep to discover pages that match the crawl scope.",
             ),
           )}
         `,
       )}
+      ${inputCol(html`
+        <sl-checkbox name="useSitemap" ?checked=${this.formState.useSitemap}>
+          ${labelFor.useSitemap}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor.useSitemap, false)}
+      ${this.renderLinkSelectors()}
+
+      <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
+      ${this.renderSectionHeading(msg("Additional Scope"))}
       ${inputCol(html`
         <sl-checkbox
           name="includeLinkedPages"
@@ -1614,34 +1633,16 @@ https://archiveweb.page/es/`}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
-      ${inputCol(html`
-        <sl-checkbox name="useRobots" ?checked=${this.formState.useRobots}>
-          ${msg("Skip pages disallowed by robots.txt")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(infoTextFor["useRobots"], false)}
-      ${inputCol(html`
-        <sl-checkbox name="useSitemap" ?checked=${this.formState.useSitemap}>
-          ${msg("Check for sitemap")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(
-        msg(
-          `If checked, the crawler will check for a sitemap at /sitemap.xml and use it to discover pages to crawl if present.`,
-        ),
-        false,
-      )}
-      ${this.renderLinkSelectors()}
 
       <div class="col-span-5">
         <btrix-details>
           <span slot="title">
-            ${msg("Additional Pages")}
+            ${msg("Custom Page List")}
             ${additionalUrlList.length
               ? html`<btrix-badge>${additionalUrlList.length}</btrix-badge>`
               : ""}
           </span>
-          <div class="grid grid-cols-5 gap-4 py-2">
+          <div class="grid grid-cols-5 gap-5 py-2">
             ${inputCol(html`
               <sl-textarea
                 name="urlList"
@@ -1676,9 +1677,17 @@ https://archiveweb.page/images/${"logo.svg"}`}
             )}
           </div>
         </btrix-details>
-
-        ${this.renderExcludePages()}
       </div>
+
+      <!-- Settings that modify the expanded scope by exclude links that would normally would be in scope -->
+      ${this.renderSectionHeading(msg("Exclude Pages"))}
+      ${inputCol(html`
+        <sl-checkbox name="useRobots" ?checked=${this.formState.useRobots}>
+          ${labelFor.useRobots}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor["useRobots"], false)}
+      ${this.renderExcludePages()}
     `;
   };
 

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -119,11 +119,7 @@ import {
 import { track } from "@/utils/analytics";
 import { isApiError, isApiErrorDetail } from "@/utils/api";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
-import {
-  getDefaultProxyId,
-  isDepthSupportedScopeType,
-  isPageScopeType,
-} from "@/utils/crawler";
+import { getDefaultProxyId, isDepthSupportedScopeType } from "@/utils/crawler";
 import {
   getUTCSchedule,
   humanizeNextDate,
@@ -152,6 +148,7 @@ import {
   getDefaultFormState,
   getInitialFormState,
   getServerDefaults,
+  isPageScope,
   makeUserGuideEvent,
   MAX_SEED_LIST_FILE_BYTES,
   MAX_SEED_LIST_STRING_BYTES,
@@ -159,6 +156,8 @@ import {
   SECTIONS,
   SEED_LIST_FILE_EXT,
   SeedListFormat,
+  WORKFLOW_PAGE_SCOPES,
+  WORKFLOW_SITE_SCOPES,
   workflowTabToGuideHash,
   type FormState,
   type WorkflowDefaults,
@@ -910,8 +909,6 @@ export class WorkflowEditor extends BtrixElement {
   }
 
   private readonly renderScope = () => {
-    const exclusions = trimArray(this.formState.exclusions || []);
-
     return html`
       ${inputCol(html`
         <sl-select
@@ -925,135 +922,70 @@ export class WorkflowEditor extends BtrixElement {
             )}
         >
           <sl-menu-label>${msg("Page Crawl")}</sl-menu-label>
-          <sl-option value=${ScopeType.Page}
-            >${scopeTypeLabels[ScopeType.Page]}</sl-option
-          >
-          <sl-option value=${NewWorkflowOnlyScopeType.PageList}>
-            ${scopeTypeLabels[NewWorkflowOnlyScopeType.PageList]}
-          </sl-option>
-          <sl-option value=${ScopeType.SPA}>
-            ${scopeTypeLabels[ScopeType.SPA]}
-          </sl-option>
+          ${WORKFLOW_PAGE_SCOPES.map(
+            (scope) =>
+              html`<sl-option value=${scope}
+                >${scopeTypeLabels[scope]}</sl-option
+              >`,
+          )}
           <sl-divider></sl-divider>
           <sl-menu-label>${msg("Site Crawl")}</sl-menu-label>
-          <sl-option value=${ScopeType.Prefix}>
-            ${scopeTypeLabels[ScopeType.Prefix]}
-          </sl-option>
-          <sl-option value=${ScopeType.Host}>
-            ${scopeTypeLabels[ScopeType.Host]}
-          </sl-option>
-          <sl-option value=${ScopeType.Domain}>
-            ${scopeTypeLabels[ScopeType.Domain]}
-          </sl-option>
-          <sl-option value=${ScopeType.Custom}>
-            ${scopeTypeLabels[ScopeType.Custom]}
-          </sl-option>
-          <sl-option value=${NewWorkflowOnlyScopeType.Regex}>
-            ${scopeTypeLabels[NewWorkflowOnlyScopeType.Regex]}
-          </sl-option>
+          ${WORKFLOW_SITE_SCOPES.map(
+            (scope) =>
+              html`<sl-option value=${scope}
+                >${scopeTypeLabels[scope]}</sl-option
+              >`,
+          )}
         </sl-select>
       `)}
       ${this.renderHelpTextCol(html`
         <p>${msg(`Tells the crawler which pages it can visit.`)}</p>
       `)}
-      ${isPageScopeType(this.formState.scopeType)
+      ${isPageScope(this.formState.scopeType)
         ? this.renderPageScope()
         : this.renderSiteScope()}
-      ${!isPageScopeType(this.formState.scopeType) ||
-      this.formState.includeLinkedPages
-        ? html`
-            <div class="col-span-5">
-              <btrix-details ?open=${exclusions.length > 0}>
-                <span slot="title"
-                  >${msg("Exclude Pages")}
-                  ${exclusions.length
-                    ? html`<btrix-badge>${exclusions.length}</btrix-badge>`
-                    : ""}</span
-                >
-                <div class="grid grid-cols-5 gap-5 py-2">
-                  ${inputCol(html`
-                    <btrix-queue-exclusion-table
-                      label=""
-                      .exclusions=${this.formState.exclusions}
-                      pageSize="10"
-                      editable
-                      removable
-                      uncontrolled
-                      @btrix-remove=${this.handleRemoveRegex}
-                      @btrix-change=${this.handleChangeRegex}
-                    ></btrix-queue-exclusion-table>
-                  `)}
-                  ${this.renderHelpTextCol(infoTextFor["exclusions"], false)}
-                </div>
-              </btrix-details>
-            </div>
-          `
-        : nothing}
     `;
   };
 
+  private renderExcludePages() {
+    const exclusions = trimArray(this.formState.exclusions || []);
+
+    return html`
+      <div class="col-span-5">
+        <btrix-details ?open=${exclusions.length > 0}>
+          <span slot="title"
+            >${msg("Exclude Pages")}
+            ${exclusions.length
+              ? html`<btrix-badge>${exclusions.length}</btrix-badge>`
+              : ""}</span
+          >
+          <div class="grid grid-cols-5 gap-5 py-2">
+            ${inputCol(html`
+              <btrix-queue-exclusion-table
+                label=""
+                .exclusions=${this.formState.exclusions}
+                pageSize="10"
+                editable
+                removable
+                uncontrolled
+                @btrix-remove=${this.handleRemoveRegex}
+                @btrix-change=${this.handleChangeRegex}
+              ></btrix-queue-exclusion-table>
+            `)}
+            ${this.renderHelpTextCol(infoTextFor["exclusions"], false)}
+          </div>
+        </btrix-details>
+      </div>
+    `;
+  }
+
   private readonly renderPageScope = () => {
     return html`
-      ${this.formState.scopeType === ScopeType.Page
-        ? html`
-            ${inputCol(html`
-              <!-- TODO Use btrix-url-input -->
-              <sl-input
-                name="urlList"
-                label=${msg("URL to Crawl")}
-                placeholder="https://webrecorder.net/blog"
-                autocomplete="off"
-                inputmode="url"
-                value=${this.formState.urlList}
-                autofocus
-                required
-                @sl-input=${async (e: Event) => {
-                  const inputEl = e.target as SlInput;
-                  await inputEl.updateComplete;
-                  this.updateFormState(
-                    {
-                      urlList: inputEl.value,
-                    },
-                    true,
-                  );
-                  const valid = validURL(inputEl.value);
-                  if (!inputEl.checkValidity() && valid) {
-                    inputEl.setCustomValidity("");
-                    inputEl.helpText = "";
-                  }
-
-                  if (valid) {
-                    this.animateStickyFooter();
-                  }
-                }}
-                @sl-blur=${async (e: Event) => {
-                  const inputEl = e.target as SlInput;
-                  await inputEl.updateComplete;
-                  if (inputEl.value && !validURL(inputEl.value)) {
-                    const text = msg("Please enter a valid URL.");
-                    inputEl.helpText = text;
-                    inputEl.setCustomValidity(text);
-                  } else if (
-                    inputEl.value &&
-                    !inputEl.value.startsWith("https://") &&
-                    !inputEl.value.startsWith("http://")
-                  ) {
-                    this.updateFormState(
-                      {
-                        urlList: "https://" + inputEl.value,
-                      },
-                      true,
-                    );
-                  }
-                }}
-              >
-              </sl-input>
-            `)}
-            ${this.renderHelpTextCol(
-              msg(str`The crawler will visit this URL.`),
-            )}
-          `
-        : this.renderUrlList()}
+      ${choose(this.formState.scopeType, [
+        [ScopeType.Page, this.renderSingleUrlInput],
+        [ScopeType.SPA, this.renderPrimarySeedInput],
+        [NewWorkflowOnlyScopeType.PageList, this.renderUrlList],
+      ])}
       ${inputCol(html`
         <sl-checkbox
           name="includeLinkedPages"
@@ -1063,19 +995,17 @@ export class WorkflowEditor extends BtrixElement {
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}
-      ${inputCol(html`
-        <sl-checkbox name="useRobots" ?checked=${this.formState.useRobots}>
-          ${msg("Skip pages disallowed by robots.txt")}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(infoTextFor["useRobots"], false)}
-      ${when(this.formState.includeLinkedPages, () =>
-        this.renderLinkSelectors(),
+      ${when(
+        this.formState.includeLinkedPages ||
+          this.formState.scopeType === ScopeType.SPA,
+        () => html`
+          ${this.renderLinkSelectors()} ${this.renderExcludePages()}
+        `,
       )}
     `;
   };
 
-  private renderUrlList() {
+  private readonly renderUrlList = () => {
     let numberOfURLs: string | null = null;
 
     if (this.formState.seedListFormat === SeedListFormat.File) {
@@ -1144,7 +1074,208 @@ export class WorkflowEditor extends BtrixElement {
               })}.`,
       )}
     `;
-  }
+  };
+
+  private readonly renderSingleUrlInput = () => {
+    return html`${inputCol(html`
+      <!-- TODO Use btrix-url-input -->
+      <sl-input
+        name="urlList"
+        label=${msg("URL to Crawl")}
+        placeholder="https://webrecorder.net/blog"
+        autocomplete="off"
+        inputmode="url"
+        value=${this.formState.urlList}
+        autofocus
+        required
+        @sl-input=${async (e: Event) => {
+          const inputEl = e.target as SlInput;
+          await inputEl.updateComplete;
+          this.updateFormState(
+            {
+              urlList: inputEl.value,
+            },
+            true,
+          );
+          const valid = validURL(inputEl.value);
+          if (!inputEl.checkValidity() && valid) {
+            inputEl.setCustomValidity("");
+            inputEl.helpText = "";
+          }
+
+          if (valid) {
+            this.animateStickyFooter();
+          }
+        }}
+        @sl-blur=${async (e: Event) => {
+          const inputEl = e.target as SlInput;
+          await inputEl.updateComplete;
+          if (inputEl.value && !validURL(inputEl.value)) {
+            const text = msg("Please enter a valid URL.");
+            inputEl.helpText = text;
+            inputEl.setCustomValidity(text);
+          } else if (
+            inputEl.value &&
+            !inputEl.value.startsWith("https://") &&
+            !inputEl.value.startsWith("http://")
+          ) {
+            this.updateFormState(
+              {
+                urlList: "https://" + inputEl.value,
+              },
+              true,
+            );
+          }
+        }}
+      >
+      </sl-input>
+    `)}
+    ${this.renderHelpTextCol(msg(str`The crawler will visit this URL.`))}`;
+  };
+
+  private readonly renderPrimarySeedInput = () => {
+    const urlPlaceholder = "https://example.com/path/page.html";
+    let exampleUrl = new URL(urlPlaceholder);
+    if (this.formState.primarySeedUrl) {
+      try {
+        exampleUrl = new URL(this.formState.primarySeedUrl);
+      } catch {
+        /* empty */
+      }
+    }
+    const exampleHost = exampleUrl.host;
+    const exampleProtocol = exampleUrl.protocol;
+    const examplePathname = exampleUrl.pathname;
+    const exampleDomain = `${exampleProtocol}//${exampleHost}`;
+
+    let helpText: TemplateResult | string;
+
+    const custom = (customRegexFieldLabel: string) => {
+      const example_url = html`<span class="break-word text-blue-500"
+        >${exampleDomain}${examplePathname}</span
+      >`;
+      const custom_regexes = html`<em>${customRegexFieldLabel}</em>`;
+
+      return msg(
+        html`Will start crawl with ${example_url} and only follow links that
+        match the ${custom_regexes} listed below.`,
+      );
+    };
+
+    switch (this.formState.scopeType) {
+      case ScopeType.Prefix:
+        helpText = msg(
+          html`Will crawl all pages and paths in the same directory, e.g.
+            <span class="break-word break-word text-blue-500"
+              >${exampleDomain}</span
+            ><span class="break-word font-medium text-blue-500"
+              >${examplePathname.slice(
+                0,
+                examplePathname.lastIndexOf("/"),
+              )}/</span
+            >`,
+        );
+        break;
+      case ScopeType.Host:
+        helpText = msg(
+          html`Will crawl all pages on
+            <span class="text-blue-500">${exampleHost}</span> and ignore pages
+            on any subdomains.`,
+        );
+        break;
+      case ScopeType.Domain:
+        helpText = msg(
+          html`Will crawl all pages on
+            <span class="text-blue-500">${exampleHost}</span> and
+            <span class="text-blue-500">subdomain.${exampleHost}</span>.`,
+        );
+        break;
+      case ScopeType.SPA:
+        helpText = msg(
+          html`Will crawl hash anchor links as pages. For example,
+            <span class="break-word text-blue-500"
+              >${exampleDomain}${examplePathname}</span
+            ><span class="break-word font-medium text-blue-500"
+              >#example-page</span
+            >
+            will be treated as a separate page.`,
+        );
+        break;
+      case ScopeType.Custom:
+        helpText = custom(msg("Page Prefix URLs"));
+        break;
+      case NewWorkflowOnlyScopeType.Regex:
+        helpText = custom(msg("Page Regex Patterns"));
+        break;
+      default:
+        helpText = "";
+        break;
+    }
+
+    return html`${inputCol(html`
+      <sl-input
+        name="primarySeedUrl"
+        label=${msg("Crawl Start URL")}
+        autocomplete="off"
+        inputmode="url"
+        placeholder=${urlPlaceholder}
+        value=${this.formState.primarySeedUrl}
+        required
+        @sl-input=${async (e: Event) => {
+          const inputEl = e.target as SlInput;
+          await inputEl.updateComplete;
+          this.updateFormState(
+            {
+              primarySeedUrl: inputEl.value,
+            },
+            true,
+          );
+          if (!inputEl.checkValidity() && validURL(inputEl.value)) {
+            inputEl.setCustomValidity("");
+            inputEl.helpText = "";
+          }
+        }}
+        @sl-blur=${async (e: Event) => {
+          const inputEl = e.target as SlInput;
+          await inputEl.updateComplete;
+          if (inputEl.value && !validURL(inputEl.value)) {
+            const text = msg("Please enter a valid URL.");
+            inputEl.helpText = text;
+            inputEl.setCustomValidity(text);
+          } else if (
+            inputEl.value &&
+            !inputEl.value.startsWith("https://") &&
+            !inputEl.value.startsWith("http://")
+          ) {
+            this.updateFormState(
+              {
+                primarySeedUrl: "https://" + inputEl.value,
+              },
+              true,
+            );
+          }
+          const { primarySeedUrl } = this.formState;
+          if (
+            primarySeedUrl &&
+            (this.formState.scopeType === NewWorkflowOnlyScopeType.Regex ||
+              this.formState.scopeType === ScopeType.Custom) &&
+            !this.formState.customIncludeList
+          ) {
+            this.updateFormState(
+              {
+                customIncludeList:
+                  this.customIncludeListFromSeed(primarySeedUrl),
+              },
+              true,
+            );
+          }
+        }}
+      >
+        <div slot="help-text">${helpText}</div>
+      </sl-input>
+    `)}
+    ${this.renderHelpTextCol(msg(`The starting point of your crawl.`))}`;
+  };
 
   private readonly renderSeedListTextbox = () => {
     return html`<sl-textarea
@@ -1339,151 +1470,11 @@ https://replayweb.page/docs`}
   };
 
   private readonly renderSiteScope = () => {
-    const urlPlaceholder = "https://example.com/path/page.html";
-    let exampleUrl = new URL(urlPlaceholder);
-    if (this.formState.primarySeedUrl) {
-      try {
-        exampleUrl = new URL(this.formState.primarySeedUrl);
-      } catch {
-        /* empty */
-      }
-    }
-    const exampleHost = exampleUrl.host;
-    const exampleProtocol = exampleUrl.protocol;
-    const examplePathname = exampleUrl.pathname;
-    const exampleDomain = `${exampleProtocol}//${exampleHost}`;
-
-    let helpText: TemplateResult | string;
-
-    const custom = (customRegexFieldLabel: string) => {
-      const example_url = html`<span class="break-word text-blue-500"
-        >${exampleDomain}${examplePathname}</span
-      >`;
-      const custom_regexes = html`<em>${customRegexFieldLabel}</em>`;
-
-      return msg(
-        html`Will start crawl with ${example_url} and only follow links that
-        match the ${custom_regexes} listed below.`,
-      );
-    };
-
-    switch (this.formState.scopeType) {
-      case ScopeType.Prefix:
-        helpText = msg(
-          html`Will crawl all pages and paths in the same directory, e.g.
-            <span class="break-word break-word text-blue-500"
-              >${exampleDomain}</span
-            ><span class="break-word font-medium text-blue-500"
-              >${examplePathname.slice(
-                0,
-                examplePathname.lastIndexOf("/"),
-              )}/</span
-            >`,
-        );
-        break;
-      case ScopeType.Host:
-        helpText = msg(
-          html`Will crawl all pages on
-            <span class="text-blue-500">${exampleHost}</span> and ignore pages
-            on any subdomains.`,
-        );
-        break;
-      case ScopeType.Domain:
-        helpText = msg(
-          html`Will crawl all pages on
-            <span class="text-blue-500">${exampleHost}</span> and
-            <span class="text-blue-500">subdomain.${exampleHost}</span>.`,
-        );
-        break;
-      case ScopeType.SPA:
-        helpText = msg(
-          html`Will crawl hash anchor links as pages. For example,
-            <span class="break-word text-blue-500"
-              >${exampleDomain}${examplePathname}</span
-            ><span class="break-word font-medium text-blue-500"
-              >#example-page</span
-            >
-            will be treated as a separate page.`,
-        );
-        break;
-      case ScopeType.Custom:
-        helpText = custom(msg("Page Prefix URLs"));
-        break;
-      case NewWorkflowOnlyScopeType.Regex:
-        helpText = custom(msg("Page Regex Patterns"));
-        break;
-      default:
-        helpText = "";
-        break;
-    }
-
     const additionalUrlList = urlListToArray(this.formState.urlList);
     const maxUrls = this.localize.number(URL_LIST_MAX_URLS);
 
     return html`
-      ${inputCol(html`
-        <sl-input
-          name="primarySeedUrl"
-          label=${msg("Crawl Start URL")}
-          autocomplete="off"
-          inputmode="url"
-          placeholder=${urlPlaceholder}
-          value=${this.formState.primarySeedUrl}
-          required
-          @sl-input=${async (e: Event) => {
-            const inputEl = e.target as SlInput;
-            await inputEl.updateComplete;
-            this.updateFormState(
-              {
-                primarySeedUrl: inputEl.value,
-              },
-              true,
-            );
-            if (!inputEl.checkValidity() && validURL(inputEl.value)) {
-              inputEl.setCustomValidity("");
-              inputEl.helpText = "";
-            }
-          }}
-          @sl-blur=${async (e: Event) => {
-            const inputEl = e.target as SlInput;
-            await inputEl.updateComplete;
-            if (inputEl.value && !validURL(inputEl.value)) {
-              const text = msg("Please enter a valid URL.");
-              inputEl.helpText = text;
-              inputEl.setCustomValidity(text);
-            } else if (
-              inputEl.value &&
-              !inputEl.value.startsWith("https://") &&
-              !inputEl.value.startsWith("http://")
-            ) {
-              this.updateFormState(
-                {
-                  primarySeedUrl: "https://" + inputEl.value,
-                },
-                true,
-              );
-            }
-            const { primarySeedUrl } = this.formState;
-            if (
-              primarySeedUrl &&
-              (this.formState.scopeType === NewWorkflowOnlyScopeType.Regex ||
-                this.formState.scopeType === ScopeType.Custom) &&
-              !this.formState.customIncludeList
-            ) {
-              this.updateFormState(
-                {
-                  customIncludeList:
-                    this.customIncludeListFromSeed(primarySeedUrl),
-                },
-                true,
-              );
-            }
-          }}
-        >
-          <div slot="help-text">${helpText}</div>
-        </sl-input>
-      `)}
-      ${this.renderHelpTextCol(msg(`The starting point of your crawl.`))}
+      ${this.renderPrimarySeedInput()}
       ${when(
         this.formState.scopeType === ScopeType.Custom,
         () => html`
@@ -1679,6 +1670,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
             )}
           </div>
         </btrix-details>
+
+        ${this.renderExcludePages()}
       </div>
     `;
   };
@@ -1759,7 +1752,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     const minPages = Math.max(
       1,
       urlListToArray(this.formState.urlList).length +
-        (isPageScopeType(this.formState.scopeType) ? 0 : 1),
+        (isPageScope(this.formState.scopeType) ? 0 : 1),
     );
 
     return html`
@@ -2639,7 +2632,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private renderJobMetadata() {
-    const isPageScope = isPageScopeType(this.formState.scopeType);
+    const pageScope = isPageScope(this.formState.scopeType);
 
     const linkToScope = (label: string) =>
       html`<button
@@ -2673,7 +2666,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       `)}
       ${this.renderHelpTextCol(
         html`${msg(`Customize the name of this workflow.`)}
-        ${isPageScope
+        ${pageScope
           ? this.formState.scopeType === ScopeType.Page
             ? msg(
                 html`If omitted, the workflow will be named after the URL
@@ -2844,18 +2837,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
     };
     const urls = urlListToArray(this.formState.urlList);
 
-    const isPageScope = isPageScopeType(value);
-    const isPrevPageScope = isPageScopeType(prevScopeType);
+    const pageScope = isPageScope(value);
+    const isPrevPageScope = isPageScope(prevScopeType);
 
-    if (isPageScope === isPrevPageScope) {
-      if (isPageScope) {
+    if (pageScope === isPrevPageScope) {
+      if (pageScope) {
         formState.urlList = urls[0];
       }
     } else {
       if (isPrevPageScope) {
         formState.primarySeedUrl = urls[0];
         formState.urlList = urls.slice(1).join("\n");
-      } else if (isPageScope) {
+      } else if (pageScope) {
         formState.urlList = [this.formState.primarySeedUrl, ...urls].join("\n");
       }
     }
@@ -2974,7 +2967,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
   });
 
   private hasRequiredFields(): boolean {
-    if (isPageScopeType(this.formState.scopeType)) {
+    if (isPageScope(this.formState.scopeType)) {
       return Boolean(
         this.formState.seedListFormat === SeedListFormat.File
           ? this.formState.seedFile || this.formState.seedFileId
@@ -3622,7 +3615,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
           this.formState.dedupeCollection.id) ||
         "",
       config: {
-        ...(isPageScopeType(this.formState.scopeType)
+        ...(isPageScope(this.formState.scopeType)
           ? this.parseUrlListConfig(uploadParams)
           : this.parseSeededConfig()),
         behaviorTimeout: this.formState.behaviorTimeoutSeconds,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -120,8 +120,8 @@ import { track } from "@/utils/analytics";
 import { isApiError, isApiErrorDetail } from "@/utils/api";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
 import {
-  DEPTH_SUPPORTED_SCOPES,
   getDefaultProxyId,
+  isDepthSupportedScopeType,
   isPageScopeType,
 } from "@/utils/crawler";
 import {
@@ -1582,7 +1582,7 @@ https://archiveweb.page/es/`}
         `,
       )}
       ${when(
-        DEPTH_SUPPORTED_SCOPES.includes(this.formState.scopeType),
+        isDepthSupportedScopeType(this.formState.scopeType),
         () => html`
           ${inputCol(html`
             <sl-input
@@ -3691,7 +3691,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         : null,
       seedFileId: jsonSeeds
         ? null
-        : uploadParams?.seedFileId ?? this.formState.seedFileId,
+        : (uploadParams?.seedFileId ?? this.formState.seedFileId),
       scopeType: ScopeType.Page,
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
       useSitemap: false,
@@ -3739,7 +3739,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
     };
 
-    if (DEPTH_SUPPORTED_SCOPES.includes(this.formState.scopeType)) {
+    if (isDepthSupportedScopeType(this.formState.scopeType)) {
       primarySeed.depth = this.formState.maxScopeDepth;
     }
 

--- a/frontend/src/layouts/columns.ts
+++ b/frontend/src/layouts/columns.ts
@@ -11,18 +11,22 @@ export type Cols = [TemplateResult<1>, TemplateResult | string | undefined][];
 // TODO Revisit, maybe configure with Cols?
 const singleLineFromControls = ["sl-checkbox", "sl-switch"];
 
+export const gridColsClasses = tw`grid grid-cols-5 gap-5`;
+export const colSpanClasses = tw`col-span-5 min-h-6`;
+
 export function inputCol(content: TemplateResult<1>) {
   return html`
-    <div class="col-span-5 self-baseline md:col-span-3">${content}</div>
+    <div class="${colSpanClasses} self-baseline md:col-span-3">${content}</div>
   `;
 }
 
-export function infoCol(content: TemplateResult | string, topPadding: string) {
+export function infoCol(content: TemplateResult | string, classes?: string) {
   return html`
     <div
       class=${clsx(
-        tw`col-span-5 flex items-start gap-2 text-neutral-500 md:col-span-2`,
-        topPadding,
+        tw`flex items-start gap-2 text-neutral-500 md:col-span-2`,
+        colSpanClasses,
+        classes,
       )}
     >
       <sl-icon
@@ -36,14 +40,16 @@ export function infoCol(content: TemplateResult | string, topPadding: string) {
 
 export function columns(cols: Cols) {
   return html`
-    <div class="grid grid-cols-5 gap-5">
+    <div class="${gridColsClasses}">
       ${cols.map(([main, info]) => {
         const singleLineFormControl = new RegExp(
           `<(${singleLineFromControls.join("|")})`,
         ).test(main.strings[0].trim());
 
         return html`
-          <div class=${tw`col-span-5 self-baseline md:col-span-3`}>${main}</div>
+          <div class=${tw`${colSpanClasses} self-baseline md:col-span-3`}>
+            ${main}
+          </div>
           ${info
             ? infoCol(info, singleLineFormControl ? tw`md:pt-1` : tw`md:pt-8`)
             : nothing}

--- a/frontend/src/layouts/detailsInColumns.ts
+++ b/frontend/src/layouts/detailsInColumns.ts
@@ -1,14 +1,11 @@
 /**
  * For details used in columns layout
  */
-
-import { msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, nothing, type TemplateResult } from "lit";
 
 import { colSpanClasses, gridColsClasses, infoCol, inputCol } from "./columns";
 
-import type { Details } from "@/components/ui/details";
 import { tw } from "@/utils/tailwind";
 
 const containerClass = "details-container";
@@ -16,11 +13,13 @@ const containerClass = "details-container";
 export function detailsInColumns({
   title,
   main,
+  description,
   info,
   open,
 }: {
   title: TemplateResult | string;
   main: TemplateResult<1>;
+  description?: TemplateResult | string;
   info?: TemplateResult | string;
   open?: boolean;
 }) {
@@ -37,25 +36,11 @@ export function detailsInColumns({
 
     ${info
       ? infoCol(
-          html`
-            <div class="flex gap-1.5">
-              <p class="line-clamp-1">${info}</p>
-              <button
-                type="button"
-                class="whitespace-nowrap underline hover:no-underline"
-                @click=${(e: MouseEvent) => {
-                  const el = e.target as HTMLButtonElement;
-
-                  el.closest(`.${containerClass}`)
-                    ?.querySelector<Details>("btrix-details")
-                    ?.show();
-                }}
-              >
-                ${msg("More")}
-              </button>
-            </div>
-          `,
-          tw`peer-open:md:pt-[2rem] peer-open:[&_button]:hidden [&_p]:line-clamp-1 peer-open:[&_p]:line-clamp-none`,
+          description
+            ? html`<span>${description}</span>
+                <p>${info}</p>`
+            : info,
+          tw`peer-open:md:pt-[2rem] [&>div>p]:hidden peer-open:[&>div>p]:block peer-open:[&>div>span]:hidden`,
         )
       : nothing}
   </div>`;

--- a/frontend/src/layouts/detailsInColumns.ts
+++ b/frontend/src/layouts/detailsInColumns.ts
@@ -1,0 +1,62 @@
+/**
+ * For details used in columns layout
+ */
+
+import { msg } from "@lit/localize";
+import clsx from "clsx";
+import { html, nothing, type TemplateResult } from "lit";
+
+import { colSpanClasses, gridColsClasses, infoCol, inputCol } from "./columns";
+
+import type { Details } from "@/components/ui/details";
+import { tw } from "@/utils/tailwind";
+
+const containerClass = "details-container";
+
+export function detailsInColumns({
+  title,
+  main,
+  info,
+  open,
+}: {
+  title: TemplateResult | string;
+  main: TemplateResult<1>;
+  info?: TemplateResult | string;
+  open?: boolean;
+}) {
+  return html`<div
+    class=${clsx(containerClass, colSpanClasses, gridColsClasses)}
+  >
+    <btrix-details
+      class=${clsx(colSpanClasses, tw`peer md:col-span-3`)}
+      ?open=${open}
+    >
+      <span slot="title">${title}</span>
+      ${inputCol(main)}
+    </btrix-details>
+
+    ${info
+      ? infoCol(
+          html`
+            <div class="flex gap-1.5">
+              <p class="line-clamp-1">${info}</p>
+              <button
+                type="button"
+                class="whitespace-nowrap underline hover:no-underline"
+                @click=${(e: MouseEvent) => {
+                  const el = e.target as HTMLButtonElement;
+
+                  el.closest(`.${containerClass}`)
+                    ?.querySelector<Details>("btrix-details")
+                    ?.show();
+                }}
+              >
+                ${msg("More")}
+              </button>
+            </div>
+          `,
+          tw`peer-open:md:pt-[2rem] peer-open:[&_button]:hidden [&_p]:line-clamp-1 peer-open:[&_p]:line-clamp-none`,
+        )
+      : nothing}
+  </div>`;
+}

--- a/frontend/src/pages/org/crawling.ts
+++ b/frontend/src/pages/org/crawling.ts
@@ -4,15 +4,14 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 
-import { ScopeType } from "./types";
-
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { SelectJobTypeEvent } from "@/features/crawl-workflows/new-workflow-dialog";
 import { pageHeader } from "@/layouts/pageHeader";
 import { OrgTab, WorkflowTab } from "@/routes";
+import { stringForScopeGroup } from "@/strings/crawl-workflows/scopeGroup";
 import scopeTypeLabels from "@/strings/crawl-workflows/scopeType";
-import { NewWorkflowOnlyScopeType } from "@/types/workflow";
 import { tw } from "@/utils/tailwind";
+import { WORKFLOW_PAGE_SCOPES, WORKFLOW_SITE_SCOPES } from "@/utils/workflow";
 
 @customElement("btrix-org-crawling")
 @localized()
@@ -88,33 +87,21 @@ export class OrgCrawling extends BtrixElement {
                     >
                   </sl-button>
                   <sl-menu>
-                    <sl-menu-label> ${msg("Page Crawl")} </sl-menu-label>
-                    <sl-menu-item value=${ScopeType.Page}
-                      >${scopeTypeLabels[ScopeType.Page]}</sl-menu-item
-                    >
-                    <sl-menu-item value=${NewWorkflowOnlyScopeType.PageList}>
-                      ${scopeTypeLabels[NewWorkflowOnlyScopeType.PageList]}
-                    </sl-menu-item>
-                    <sl-menu-item value=${ScopeType.SPA}>
-                      ${scopeTypeLabels[ScopeType.SPA]}
-                    </sl-menu-item>
+                    <sl-menu-label>${stringForScopeGroup.page}</sl-menu-label>
+                    ${WORKFLOW_PAGE_SCOPES.map(
+                      (scope) =>
+                        html`<sl-menu-item value=${scope}
+                          >${scopeTypeLabels[scope]}</sl-menu-item
+                        >`,
+                    )}
                     <sl-divider></sl-divider>
-                    <sl-menu-label>${msg("Site Crawl")}</sl-menu-label>
-                    <sl-menu-item value=${ScopeType.Prefix}>
-                      ${scopeTypeLabels[ScopeType.Prefix]}
-                    </sl-menu-item>
-                    <sl-menu-item value=${ScopeType.Host}>
-                      ${scopeTypeLabels[ScopeType.Host]}
-                    </sl-menu-item>
-                    <sl-menu-item value=${ScopeType.Domain}>
-                      ${scopeTypeLabels[ScopeType.Domain]}
-                    </sl-menu-item>
-                    <sl-menu-item value=${ScopeType.Custom}>
-                      ${scopeTypeLabels[ScopeType.Custom]}
-                    </sl-menu-item>
-                    <sl-menu-item value=${NewWorkflowOnlyScopeType.Regex}>
-                      ${scopeTypeLabels[NewWorkflowOnlyScopeType.Regex]}
-                    </sl-menu-item>
+                    <sl-menu-label>${stringForScopeGroup.site}</sl-menu-label>
+                    ${WORKFLOW_SITE_SCOPES.map(
+                      (scope) =>
+                        html`<sl-menu-item value=${scope}
+                          >${scopeTypeLabels[scope]}</sl-menu-item
+                        >`,
+                    )}
                   </sl-menu>
                 </sl-dropdown>
               </sl-button-group>

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -50,7 +50,7 @@ export const infoTextFor = {
   lang: msg(`Websites that observe the browser’s language setting may serve
   content in that language if available.`),
   proxyId: msg(`Choose a proxy to crawl through.`),
-  selectLinks: msg("Customize how URLs are extracted from a page."),
+  selectLinks: msg("Customize how page links are extracted."),
   customBehavior: msg(
     `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
   ),

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -11,7 +11,7 @@ const robots_txt = html`<code>robots.txt</code>`;
 export const infoTextFor = {
   urlList: msg("The crawler will visit and record each URL listed here."),
   includeLinkedPages: msg(
-    "If checked, the crawler will visit pages one link away.",
+    "Expands crawl scope to include pages that are one link away.",
   ),
   exclusions: msg("Specify rules for which pages should not be visited."),
   pageLimit: msg(

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -5,6 +5,9 @@ import { type FormState } from "@/utils/workflow";
 
 type Field = keyof FormState;
 
+const sitemap_xml = html`<code>sitemap.xml</code>`;
+const robots_txt = html`<code>robots.txt</code>`;
+
 export const infoTextFor = {
   urlList: msg("The crawler will visit and record each URL listed here."),
   includeLinkedPages: msg(
@@ -94,8 +97,13 @@ export const infoTextFor = {
   ${msg(
     "This can improve replay quality, but may come with security implications.",
   )}`,
+  useSitemap: msg(
+    html`For each page host with a ${sitemap_xml} file, the crawler will use the
+    sitemap to discover pages.`,
+  ),
   useRobots: msg(
-    `Check for a robots.txt file for each host and skip any disallowed pages.`,
+    html`Tells the crawler to check for a ${robots_txt} file for each page host
+    and skip any disallowed pages.`,
   ),
   customIncludeList: msg(
     "Only crawl the page if the URL matches a regular expression pattern listed here.",

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -13,9 +13,7 @@ export const infoTextFor = {
   includeLinkedPages: msg(
     "If checked, the crawler will visit pages one link away.",
   ),
-  exclusions: msg(
-    "Specify exclusion rules for what pages should not be visited.",
-  ),
+  exclusions: msg("Specify rules for which pages should not be visited."),
   pageLimit: msg(
     "Adds a hard limit on the number of pages that will be crawled.",
   ),
@@ -45,42 +43,14 @@ export const infoTextFor = {
   crawlerChannel: msg(
     `Choose a Browsertrix Crawler release channel. If available, other versions may provide new or experimental crawling features.`,
   ),
-  blockAds: msg(
-    html`Blocks advertising content from being loaded. Uses
-      <a
-        href="https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
-        class="text-blue-600 hover:text-blue-500"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        >Steven Black’s Hosts file</a
-      >.`,
-  ),
+  blockAds: msg("Blocks advertising content from being loaded."),
   userAgent: msg(
-    html`Set custom user agent for crawler browsers to use in requests. For
-      common user agents see
-      <a
-        href="https://www.useragents.me/"
-        class="text-blue-600 hover:text-blue-500"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        >Useragents.me</a
-      >.`,
+    "Set custom user agent for crawler browsers to use in requests.",
   ),
   lang: msg(`Websites that observe the browser’s language setting may serve
   content in that language if available.`),
   proxyId: msg(`Choose a proxy to crawl through.`),
-  selectLinks: msg(
-    html`Customize how URLs are extracted from a page. The crawler will use the
-      specified
-      <a
-        href="https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors"
-        class="text-blue-600 hover:text-blue-500"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        >CSS selectors</a
-      >
-      to find URLs that are defined in custom HTML attributes.`,
-  ),
+  selectLinks: msg("Customize how URLs are extracted from a page."),
   customBehavior: msg(
     `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
   ),

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -18,4 +18,7 @@ export const labelFor = {
   includeLinkedPages: msg("Visit any linked page"),
   useSitemap: msg("Use sitemap"),
   useRobots: msg("Use robots.txt disallow list"),
+  customIncludeList: msg("Page Prefix URLs"),
+  urlList: msg("Custom List of Pages"),
+  failOnContentCheck: msg("Fail crawl if not logged in"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -10,7 +10,7 @@ export const labelFor = {
   postLoadDelaySeconds: msg("Delay After Page Load"),
   behaviorTimeoutSeconds: "Behavior Limit",
   pageExtraDelaySeconds: msg("Delay Before Next Page"),
-  selectLinks: msg("Link Selectors"),
+  selectLinks: msg("Custom Link Selectors"),
   clickSelector: msg("Click Selector"),
   dedupeType: msg("Crawl Deduplication"),
   saveStorage: msg("Include browser storage data"),

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -21,4 +21,5 @@ export const labelFor = {
   customIncludeList: msg("Page Prefix URLs"),
   urlList: msg("Custom List of Pages"),
   failOnContentCheck: msg("Fail crawl if not logged in"),
+  exclusions: msg("Custom Exclusion Rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -15,6 +15,7 @@ export const labelFor = {
   dedupeType: msg("Crawl Deduplication"),
   saveStorage: msg("Include browser storage data"),
   maxScopeDepth: msg("Max Discovery Depth"),
+  includeLinkedPages: msg("Visit any linked page"),
   useSitemap: msg("Use sitemap"),
   useRobots: msg("Use robots.txt disallow list"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -14,4 +14,7 @@ export const labelFor = {
   clickSelector: msg("Click Selector"),
   dedupeType: msg("Crawl Deduplication"),
   saveStorage: msg("Include browser storage data"),
+  maxScopeDepth: msg("Max Discovery Depth"),
+  useSitemap: msg("Use sitemap"),
+  useRobots: msg("Use robots.txt disallow list"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/scopeGroup.ts
+++ b/frontend/src/strings/crawl-workflows/scopeGroup.ts
@@ -1,0 +1,6 @@
+import { msg } from "@lit/localize";
+
+export const stringForScopeGroup = {
+  page: msg("Page Crawl"),
+  site: msg("Site Crawl"),
+} as const;

--- a/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
+++ b/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
@@ -3,6 +3,8 @@
  */
 import { msg, str } from "@lit/localize";
 
+import { isPageScope } from "../workflow";
+
 import type { APIPaginatedList } from "@/types/api";
 import type {
   ScopeType,
@@ -40,7 +42,10 @@ export function settingsForDuplicate({
 
   return {
     scopeType:
-      seedFile || (seedItems?.length && seedItems.length > 1)
+      seedFile ||
+      (isPageScope(workflowParams.config?.scopeType) &&
+        seedItems?.length &&
+        seedItems.length > 1)
         ? NewWorkflowOnlyScopeType.PageList
         : workflowParams.config?.scopeType,
     workflow: workflowParams,

--- a/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
+++ b/frontend/src/utils/crawl-workflows/settingsForDuplicate.ts
@@ -3,7 +3,7 @@
  */
 import { msg, str } from "@lit/localize";
 
-import { isPageScope } from "../workflow";
+import { isPageScopeType } from "../workflow";
 
 import type { APIPaginatedList } from "@/types/api";
 import type {
@@ -43,7 +43,7 @@ export function settingsForDuplicate({
   return {
     scopeType:
       seedFile ||
-      (isPageScope(workflowParams.config?.scopeType) &&
+      (isPageScopeType(workflowParams.config?.scopeType) &&
         seedItems?.length &&
         seedItems.length > 1)
         ? NewWorkflowOnlyScopeType.PageList

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -2,13 +2,14 @@ import { msg } from "@lit/localize";
 import clsx from "clsx";
 import { html, type TemplateResult } from "lit";
 
-import type {
-  ArchivedItem,
-  Crawl,
-  CrawlReplay,
-  ProxiesAPIResponse,
-  Upload,
-  Workflow,
+import {
+  ScopeType,
+  type ArchivedItem,
+  type Crawl,
+  type CrawlReplay,
+  type ProxiesAPIResponse,
+  type Upload,
+  type Workflow,
 } from "@/types/crawler";
 import {
   FAILED_STATES,
@@ -30,12 +31,12 @@ export const inactiveCrawlStates = SUCCESSFUL_AND_FAILED_STATES;
 
 export const DEFAULT_MAX_SCALE = 8;
 
-export const DEPTH_SUPPORTED_SCOPES = [
-  "prefix",
-  "host",
-  "domain",
-  "custom",
-  "any",
+const DEPTH_SUPPORTED_SCOPES = [
+  ScopeType.Prefix,
+  ScopeType.Host,
+  ScopeType.Domain,
+  ScopeType.Custom,
+  ScopeType.Any,
 ];
 
 export function isCrawl(item: Crawl | Upload): item is Crawl {
@@ -68,6 +69,17 @@ export function isNotFailed({ state }: { state: string | null }) {
 
 export function isPaused(state: string | null) {
   return state && (PAUSED_STATES as readonly string[]).includes(state);
+}
+
+export function isDepthSupportedScopeType(
+  scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
+): scope is ScopeType {
+  return (
+    scope !== undefined &&
+    (
+      DEPTH_SUPPORTED_SCOPES as readonly (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType][]
+    ).includes(scope)
+  );
 }
 
 export function isPageScopeType(

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -20,7 +20,7 @@ import {
 } from "@/types/crawlState";
 import type { OrgData } from "@/types/org";
 import type { QARun } from "@/types/qa";
-import { WorkflowScopeType } from "@/types/workflow";
+import { type WorkflowScopeType } from "@/types/workflow";
 import localize from "@/utils/localize";
 import { pluralOf } from "@/utils/pluralize";
 
@@ -79,14 +79,6 @@ export function isDepthSupportedScopeType(
     (
       DEPTH_SUPPORTED_SCOPES as readonly (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType][]
     ).includes(scope)
-  );
-}
-
-export function isPageScopeType(
-  scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
-) {
-  return (
-    scope === WorkflowScopeType.Page || scope === WorkflowScopeType.PageList
   );
 }
 

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -507,6 +507,32 @@ const plurals = {
       id: "files.plural.other",
     }),
   },
+  levels: {
+    zero: msg("levels", {
+      desc: 'plural form of "level" for zero levels',
+      id: "levels.plural.zero",
+    }),
+    one: msg("level", {
+      desc: 'singular form for "level"',
+      id: "levels.plural.one",
+    }),
+    two: msg("levels", {
+      desc: 'plural form of "level" for two levels',
+      id: "levels.plural.two",
+    }),
+    few: msg("levels", {
+      desc: 'plural form of "level" for few levels',
+      id: "levels.plural.few",
+    }),
+    many: msg("levels", {
+      desc: 'plural form of "level" for many levels',
+      id: "levels.plural.many",
+    }),
+    other: msg("levels", {
+      desc: 'plural form of "level" for multiple/other levels',
+      id: "levels.plural.other",
+    }),
+  },
 };
 
 /**

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -1,7 +1,6 @@
-/**
- * TODO Move to utils/crawl-configs/
- */
 import { msg, str } from "@lit/localize";
+import { Set as ImmutableSet } from "immutable";
+import sortBy from "lodash/fp/sortBy";
 import { z } from "zod";
 
 import { getAppSettings, type AppSettings } from "./app";
@@ -21,7 +20,7 @@ import type { OrgData } from "@/types/org";
 import { NewWorkflowOnlyScopeType, WorkflowScopeType } from "@/types/workflow";
 import { BYTES_PER_GB } from "@/utils/bytes";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
-import { DEFAULT_MAX_SCALE, isPageScopeType } from "@/utils/crawler";
+import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
 import { getNextDate, getScheduleInterval } from "@/utils/cron";
 import localize, { getDefaultLang } from "@/utils/localize";
 
@@ -71,6 +70,44 @@ export const workflowTabToGuideHash: Record<SectionsEnum, GuideHash> = {
   collections: GuideHash.Collections,
   metadata: GuideHash.Metadata,
 };
+
+const WorkflowScopeSet = ImmutableSet(
+  Object.values(WorkflowScopeType),
+).subtract([ScopeType.Any]);
+const WorkflowPageScopeSet = ImmutableSet([
+  ScopeType.Page,
+  NewWorkflowOnlyScopeType.PageList,
+  ScopeType.SPA,
+]);
+const WorkflowSiteScopeSet = WorkflowScopeSet.subtract(WorkflowPageScopeSet);
+
+const SCOPE_PRIORITY = {
+  [ScopeType.Page]: 1,
+  [NewWorkflowOnlyScopeType.PageList]: 2,
+  [ScopeType.SPA]: 3,
+  [ScopeType.Prefix]: 4,
+  [ScopeType.Host]: 5,
+  [ScopeType.Domain]: 6,
+  [ScopeType.Custom]: 7,
+  [NewWorkflowOnlyScopeType.Regex]: 8,
+  [ScopeType.Any]: 9,
+} satisfies Record<ScopeType | NewWorkflowOnlyScopeType, number>;
+const sortByPriority = sortBy<ScopeType | NewWorkflowOnlyScopeType>(
+  (scope) => SCOPE_PRIORITY[scope],
+);
+
+export const WORKFLOW_PAGE_SCOPES = sortByPriority(
+  Array.from(WorkflowPageScopeSet.values()),
+);
+export const WORKFLOW_SITE_SCOPES = sortByPriority(
+  Array.from(WorkflowSiteScopeSet.values()),
+);
+
+export function isPageScope(
+  scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
+) {
+  return scope !== undefined && WorkflowPageScopeSet.has(scope);
+}
 
 export function makeUserGuideEvent(
   section: SectionsEnum,
@@ -299,7 +336,7 @@ export function getInitialFormState(params: {
   const formState: Partial<FormState> = {};
   const seedsConfig = params.initialWorkflow.config;
   let primarySeedConfig: SeedConfig | Seed = seedsConfig;
-  if (!isPageScopeType(params.initialWorkflow.config.scopeType)) {
+  if (!isPageScope(params.initialWorkflow.config.scopeType)) {
     if (params.initialSeeds) {
       const firstSeed = params.initialSeeds[0];
       if (typeof firstSeed === "string") {

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -107,13 +107,13 @@ export const WORKFLOW_SITE_SCOPES = sortByPriority(
   Array.from(WorkflowSiteScopeSet.values()),
 );
 
-export function isPageScope(
+export function isPageScopeType(
   scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
 ) {
   return scope !== undefined && WorkflowPageScopeSet.has(scope);
 }
 
-export function isUrlListScope(
+export function isUrlListScopeType(
   scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
 ) {
   return scope !== undefined && WorkflowUrlListScopeSet.has(scope);
@@ -352,7 +352,7 @@ export function getInitialFormState(params: {
   const formState: Partial<FormState> = {};
   const seedsConfig = params.initialWorkflow.config;
   let primarySeedConfig: SeedConfig | Seed = seedsConfig;
-  if (!isUrlListScope(params.initialWorkflow.config.scopeType)) {
+  if (!isUrlListScopeType(params.initialWorkflow.config.scopeType)) {
     if (params.initialSeeds) {
       const firstSeed = params.initialSeeds[0];
       if (typeof firstSeed === "string") {

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -352,7 +352,7 @@ export function getInitialFormState(params: {
   const formState: Partial<FormState> = {};
   const seedsConfig = params.initialWorkflow.config;
   let primarySeedConfig: SeedConfig | Seed = seedsConfig;
-  if (!isUrlListScopeType(params.initialWorkflow.config.scopeType)) {
+  if (isPrimarySeedScope(params.initialWorkflow.config.scopeType)) {
     if (params.initialSeeds) {
       const firstSeed = params.initialSeeds[0];
       if (typeof firstSeed === "string") {
@@ -381,6 +381,11 @@ export function getInitialFormState(params: {
     if (additionalSeeds?.length) {
       formState.urlList = mapSeedToUrl(additionalSeeds).join("\n");
     }
+
+    formState.maxScopeDepth =
+      !primarySeedConfig.depth || primarySeedConfig.depth === -1
+        ? defaultFormState.maxScopeDepth
+        : primarySeedConfig.depth;
     formState.useSitemap = seedsConfig.useSitemap;
   } else {
     if (params.initialWorkflow.config.seedFileId) {
@@ -395,10 +400,8 @@ export function getInitialFormState(params: {
       }
 
       formState.urlList = mapSeedToUrl(params.initialSeeds).join("\n");
+      formState.maxScopeDepth = null;
     }
-
-    formState.failOnFailedSeed = seedsConfig.failOnFailedSeed;
-    formState.failOnContentCheck = seedsConfig.failOnContentCheck;
   }
 
   if (params.initialWorkflow.schedule) {
@@ -473,7 +476,6 @@ export function getInitialFormState(params: {
       seedsConfig.pageExtraDelay ?? defaultFormState.pageExtraDelaySeconds,
     postLoadDelaySeconds:
       seedsConfig.postLoadDelay ?? defaultFormState.postLoadDelaySeconds,
-    maxScopeDepth: primarySeedConfig.depth ?? defaultFormState.maxScopeDepth,
     browserWindows: params.initialWorkflow.browserWindows,
     blockAds: params.initialWorkflow.config.blockAds,
     lang: params.initialWorkflow.config.lang ?? defaultFormState.lang,

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -80,6 +80,10 @@ const WorkflowPageScopeSet = ImmutableSet([
   ScopeType.SPA,
 ]);
 const WorkflowSiteScopeSet = WorkflowScopeSet.subtract(WorkflowPageScopeSet);
+const WorkflowUrlListScopeSet = WorkflowPageScopeSet.subtract([ScopeType.SPA]);
+const WorkflowPrimarySeedScopeSet = WorkflowScopeSet.subtract(
+  WorkflowUrlListScopeSet,
+);
 
 const SCOPE_PRIORITY = {
   [ScopeType.Page]: 1,
@@ -107,6 +111,18 @@ export function isPageScope(
   scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
 ) {
   return scope !== undefined && WorkflowPageScopeSet.has(scope);
+}
+
+export function isUrlListScope(
+  scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
+) {
+  return scope !== undefined && WorkflowUrlListScopeSet.has(scope);
+}
+
+export function isPrimarySeedScope(
+  scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
+) {
+  return scope !== undefined && WorkflowPrimarySeedScopeSet.has(scope);
 }
 
 export function makeUserGuideEvent(
@@ -336,7 +352,7 @@ export function getInitialFormState(params: {
   const formState: Partial<FormState> = {};
   const seedsConfig = params.initialWorkflow.config;
   let primarySeedConfig: SeedConfig | Seed = seedsConfig;
-  if (!isPageScope(params.initialWorkflow.config.scopeType)) {
+  if (!isUrlListScope(params.initialWorkflow.config.scopeType)) {
     if (params.initialSeeds) {
       const firstSeed = params.initialSeeds[0];
       if (typeof firstSeed === "string") {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7278,10 +7278,10 @@ ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
   integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
 
-immutable@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.0.tgz#eb1738f14ffb39fd068b1dbe1296117484dd34be"
-  integrity sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==
+immutable@^4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
+  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
 
 import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3420

## Changes

- Fixes page scope types showing unused settings
- Fixes inconsistencies between workflow form labels and workflow setting labels
- Groups workflow scope settings by inclusion and exclusion settings
- Updates user guide (https://github.com/webrecorder/browsertrix/pull/3442)

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow (Single Page) | <img width="933" height="386" alt="Screenshot 2026-06-29 at 1 03 16 PM" src="https://github.com/user-attachments/assets/845f6779-c595-4e6b-ba5e-66f9361000df" /> |
| Workflow (List of Pages) | <img width="933" height="507" alt="Screenshot 2026-06-29 at 1 03 31 PM" src="https://github.com/user-attachments/assets/28f4f79d-5f35-470a-800f-299d5696a637" /> |
| Workflow (In-Page Links) | <img width="934" height="573" alt="Screenshot 2026-06-29 at 1 03 41 PM" src="https://github.com/user-attachments/assets/7c393021-5487-45bf-aa97-035726e70378" /> |
| Workflow (Pages in Same Directory) | <img width="933" height="872" alt="Screenshot 2026-06-29 at 1 04 17 PM" src="https://github.com/user-attachments/assets/76767223-ec7a-4da6-b02a-98dc7e130d2b" /> |
| Workflow (details expanded) | <img width="905" height="878" alt="Screenshot 2026-06-29 at 1 04 48 PM" src="https://github.com/user-attachments/assets/27bb7753-5a29-4eaa-a52b-eaf3c31071b2" /> |


## Follow-ups

Docs to be updated with https://github.com/webrecorder/browsertrix/issues/3441