### PR TITLE
feat: Allows users to add site-specific behavior links to workflow

### DIFF
--- a/frontend/docs/docs/stylesheets/extra.css
+++ b/frontend/docs/docs/stylesheets/extra.css
@@ -191,34 +191,29 @@ h5 {
 
 /* Callouts show more information than badges but less than admonitions. */
 
-.callout-blue {
+[class^="callout-"],
+[class*=" callout-"] {
   background-color: white !important;
-  border-color: var(--color-cyan-300) !important;
   border-radius: 0.2rem !important;
-  color: var(--color-cyan-600) !important;
   font-family: var(--md-text-font);
-  font-size: 0.64rem;
-  padding: 0.2rem 0.4rem !important;
+  font-size: 0.64rem !important;
+  line-height: 1;
+  padding: 0.2rem 0.2rem 0.15rem !important;
+}
+
+.callout-blue {
+  border-color: var(--color-cyan-200) !important;
+  color: var(--color-cyan-700) !important;
 }
 
 .callout-green {
-  background-color: white !important;
-  border-color: var(--color-lime-300) !important;
-  border-radius: 0.2rem !important;
-  color: var(--color-lime-600) !important;
-  font-family: var(--md-text-font);
-  font-size: 0.64rem;
-  padding: 0.2rem 0.4rem !important;
+  border-color: var(--color-lime-200) !important;
+  color: var(--color-lime-700) !important;
 }
 
 .callout-orange {
-  background-color: white !important;
-  border-color: var(--color-orange-300) !important;
-  border-radius: 0.2rem !important;
-  color: var(--color-orange-600) !important;
-  font-family: var(--md-text-font);
-  font-size: 0.64rem;
-  padding: 0.2rem 0.4rem !important;
+  border-color: var(--color-orange-200) !important;
+  color: var(--color-orange-700) !important;
 }
 
 /* Status Styling */

--- a/frontend/docs/docs/stylesheets/extra.css
+++ b/frontend/docs/docs/stylesheets/extra.css
@@ -51,6 +51,7 @@
   --md-code-font: "Recursive", monospace;
   --md-text-font: "Inter Variable", "Helvetica", "Arial", sans-serif;
   --wr-blue-primary: var(--color-brand-blue);
+  --wr-green-primary: var(--color-brand-green);
   --wr-orange-primary: var(--color-orange-500);
 }
 
@@ -186,6 +187,38 @@ h5 {
   color: white !important;
   font-family: var(--md-text-font);
   font-weight: 600;
+}
+
+/* Callouts show more information than badges but less than admonitions. */
+
+.callout-blue {
+  background-color: white !important;
+  border-color: var(--color-cyan-300) !important;
+  border-radius: 0.2rem !important;
+  color: var(--color-cyan-600) !important;
+  font-family: var(--md-text-font);
+  font-size: 0.64rem;
+  padding: 0.2rem 0.4rem !important;
+}
+
+.callout-green {
+  background-color: white !important;
+  border-color: var(--color-lime-300) !important;
+  border-radius: 0.2rem !important;
+  color: var(--color-lime-600) !important;
+  font-family: var(--md-text-font);
+  font-size: 0.64rem;
+  padding: 0.2rem 0.4rem !important;
+}
+
+.callout-orange {
+  background-color: white !important;
+  border-color: var(--color-orange-300) !important;
+  border-radius: 0.2rem !important;
+  color: var(--color-orange-600) !important;
+  font-family: var(--md-text-font);
+  font-size: 0.64rem;
+  padding: 0.2rem 0.4rem !important;
 }
 
 /* Status Styling */

--- a/frontend/docs/docs/stylesheets/extra.css
+++ b/frontend/docs/docs/stylesheets/extra.css
@@ -8,9 +8,10 @@
   font-display: swap;
   src: url("https://cdn.webrecorder.net/fonts/recursive/recursive-latin.woff2")
     format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
-    U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
@@ -145,8 +146,12 @@ h5 {
   font-size: 1.125em;
 }
 
-.md-typeset h4,
+.md-typeset h4 {
+  font-size: 1em;
+}
+
 .md-typeset h5 {
+  text-transform: none;
   font-size: 0.875em;
 }
 

--- a/frontend/docs/docs/user-guide/behaviors.md
+++ b/frontend/docs/docs/user-guide/behaviors.md
@@ -1,0 +1,1 @@
+# Behaviors

--- a/frontend/docs/docs/user-guide/behaviors.md
+++ b/frontend/docs/docs/user-guide/behaviors.md
@@ -22,6 +22,8 @@ Browsertrix automatically enables behaviors for popular social media platforms i
 | TikTok            | tiktok.com         | Video                          | No                                               |
 | YouTube           | youtube.com        | Video                          | No                                               |
 
+A detailed description of each behavior can be found in [Browser Behavior docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#site-specific-behaviors).
+
 ### Custom
 
 Custom behaviors allow you to add and modify page interactions for pages that are not supported by Browsertrix’s built-in behaviors. Custom behaviors can be written using the Browsertrix **JavaScript Behavior** format or created in the Chrome DevTools  **JSON User Flow** format. See [Browser Behaviors docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#creating-custom-behaviors) for a detailed overview of creating custom behaviors in either format.

--- a/frontend/docs/docs/user-guide/behaviors.md
+++ b/frontend/docs/docs/user-guide/behaviors.md
@@ -17,9 +17,9 @@ Browsertrix automatically enables behaviors for popular social media platforms i
 | Bluesky           | bsky.app           | All                            | No                                               |
 | Facebook          | facebook.com       | Timeline, Posts, Photos, Reels | [Yes](workflow-setup.md#use-smart-scoping-rules) |
 | Instagram         | instagram.com      | Posts, Profiles, Stories       | [Yes](workflow-setup.md#use-smart-scoping-rules) |
-| Twitter           | x.com, twitter.com | Timeline, Posts                | No                                               |
 | Telegram          | t.me               | Public Channels                | No                                               |
 | TikTok            | tiktok.com         | Video                          | No                                               |
+| Twitter/X         | x.com, twitter.com | Timeline, Posts                | No                                               |
 | YouTube           | youtube.com        | Video                          | No                                               |
 
 A detailed description of each behavior can be found in [Browser Behavior docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#site-specific-behaviors).

--- a/frontend/docs/docs/user-guide/behaviors.md
+++ b/frontend/docs/docs/user-guide/behaviors.md
@@ -1,1 +1,32 @@
 # Behaviors
+
+Behaviors are browser operations that can be enabled to customize how the crawler interacts with a page. Browsertrix provides several built-in behaviors, some of which are automatically applied to ensure the highest crawl fidelity, and some of which can be configured. It is also possible to add fully custom behaviors to trigger specific actions on certain pages that are not supported by built-in behaviors.
+
+## Built-In Behaviors
+
+### Site-Specific
+
+If an applicable page is detected, the required site-specific behavior will automatically be enabled.
+Browsertrix enables site-specific behaviors for the following platforms:
+
+| **Platform Name** | **Page Host**      | **Applicable Pages** | **Smart Scoping Available**                      |
+|-------------------|--------------------|----------------------|--------------------------------------------------|
+| Bluesky           | bsky.app           | All                  | No                                               |
+| Facebook          | facebook.com       | Timeline             | [Yes](workflow-setup.md#use-smart-scoping-rules) |
+| Instagram         | instagram.com      | Posts, Stories       | [Yes](workflow-setup.md#use-smart-scoping-rules) |
+| Twitter           | x.com, twitter.com | Timeline             | No                                               |
+| Telegram          | t.me               | Posts                | No                                               |
+| TikTok            | tiktok.com         | Profile, Video       | No                                               |
+| YouTube           | youtube.com        | Video                | No                                               |
+
+Site-specific behaviors will take precedence over other built-in behaviors and custom behaviors.
+
+### Opt-In
+
+The following behaviors can be enabled or disabled in the workflow: [**autoscroll**](workflow-setup.md#autoscroll) and [**autoclick**](workflow-setup.md#autoclick). These behaviors may be overridden by site-specific and custom behaviors.
+
+## Custom Behaviors
+
+Custom behaviors allow you to add and modify page interactions for sites that are not supported by Browsertrix’s built-in behaviors. Like built-in behaviors, custom behaviors should be written using the Browsertrix JavaScript behavior format. See [Browser Behaviors docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#javascript-behaviors) for a detailed overview of the format.
+
+Once created and hosted on a public site or Git repository, the custom behavior script can be [added to a workflow](workflow-setup.md#use-custom-behaviors).

--- a/frontend/docs/docs/user-guide/behaviors.md
+++ b/frontend/docs/docs/user-guide/behaviors.md
@@ -2,31 +2,40 @@
 
 Behaviors are browser operations that can be enabled to customize how the crawler interacts with a page. Browsertrix provides several built-in behaviors, some of which are automatically applied to ensure the highest crawl fidelity, and some of which can be configured. It is also possible to add fully custom behaviors to trigger specific actions on certain pages that are not supported by built-in behaviors.
 
-## Built-In Behaviors
+## Behavior Types
 
-### Site-Specific
+### Default
 
-If an applicable page is detected, the required site-specific behavior will automatically be enabled.
-Browsertrix enables site-specific behaviors for the following platforms:
+Default behaviors apply to all pages. Some default behaviors, such as auto-playing videos, are always enabled. The following default behaviors can be enabled or disabled per workflow: [**autoscroll**](workflow-setup.md#autoscroll) and [**autoclick**](workflow-setup.md#autoclick).
 
-| **Platform Name** | **Page Host**      | **Applicable Pages** | **Smart Scoping Available**                      |
-|-------------------|--------------------|----------------------|--------------------------------------------------|
-| Bluesky           | bsky.app           | All                  | No                                               |
+### Platform-Specific
+
+Browsertrix automatically enables behaviors for popular social media platforms in order to provide the highest quality capture of the platform’s features. Built-in behaviors are available for the following platforms:
+
+| **Platform Name** | **Page Host**      | **Applicable Pages**           | **Smart Scoping Available**                      |
+|-------------------|--------------------|--------------------------------|--------------------------------------------------|
+| Bluesky           | bsky.app           | All                            | No                                               |
 | Facebook          | facebook.com       | Timeline, Posts, Photos, Reels | [Yes](workflow-setup.md#use-smart-scoping-rules) |
 | Instagram         | instagram.com      | Posts, Profiles, Stories       | [Yes](workflow-setup.md#use-smart-scoping-rules) |
-| Twitter           | x.com, twitter.com | Timeline, Posts             | No                                               |
+| Twitter           | x.com, twitter.com | Timeline, Posts                | No                                               |
 | Telegram          | t.me               | Public Channels                | No                                               |
-| TikTok            | tiktok.com         | Video       | No                                               |
-| YouTube           | youtube.com        | Video                | No                                               |
+| TikTok            | tiktok.com         | Video                          | No                                               |
+| YouTube           | youtube.com        | Video                          | No                                               |
 
-Site-specific behaviors will take precedence over other built-in behaviors and custom behaviors.
+### Custom
 
-### Opt-In
-
-The following behaviors can be enabled or disabled in the workflow: [**autoscroll**](workflow-setup.md#autoscroll) and [**autoclick**](workflow-setup.md#autoclick). These behaviors may be overridden by site-specific and custom behaviors.
-
-## Custom Behaviors
-
-Custom behaviors allow you to add and modify page interactions for sites that are not supported by Browsertrix’s built-in behaviors. Custom behaviors can written using the Browsertrix JavaScript behavior format or created in the Chrome Dev Tools Recorder tab and provided to Browsertrix in the JSON User Flow format. See [Browser Behaviors docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#creating-custom-behaviors) for a detailed overview of creating custom behaviors.
+Custom behaviors allow you to add and modify page interactions for pages that are not supported by Browsertrix’s built-in behaviors. Custom behaviors can be written using the Browsertrix **JavaScript Behavior** format or created in the Chrome DevTools  **JSON User Flow** format. See [Browser Behaviors docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#creating-custom-behaviors) for a detailed overview of creating custom behaviors in either format.
 
 Once created and hosted on a public site or Git repository, the custom behavior script can be [added to a workflow](workflow-setup.md#use-custom-behaviors).
+
+## Behavior Precedence
+
+Only one behavior type is enabled per page. During a crawl, each page is checked against the page match rules given a set of behaviors enabled for a workflow.
+
+Page-matching is prioritized in the following order:
+
+1. Platform-Specific
+2. Custom
+3. Default
+
+For example, given a crawl URL of <https://bsky.app/profile/webrecorder.net>, only the platform-specific Bluesky behavior will be applied, even if a custom behavior matching the page URL or the default _Autoscroll_ behavior is enabled.

--- a/frontend/docs/docs/user-guide/behaviors.md
+++ b/frontend/docs/docs/user-guide/behaviors.md
@@ -12,11 +12,11 @@ Browsertrix enables site-specific behaviors for the following platforms:
 | **Platform Name** | **Page Host**      | **Applicable Pages** | **Smart Scoping Available**                      |
 |-------------------|--------------------|----------------------|--------------------------------------------------|
 | Bluesky           | bsky.app           | All                  | No                                               |
-| Facebook          | facebook.com       | Timeline             | [Yes](workflow-setup.md#use-smart-scoping-rules) |
-| Instagram         | instagram.com      | Posts, Stories       | [Yes](workflow-setup.md#use-smart-scoping-rules) |
-| Twitter           | x.com, twitter.com | Timeline             | No                                               |
-| Telegram          | t.me               | Posts                | No                                               |
-| TikTok            | tiktok.com         | Profile, Video       | No                                               |
+| Facebook          | facebook.com       | Timeline, Posts, Photos, Reels | [Yes](workflow-setup.md#use-smart-scoping-rules) |
+| Instagram         | instagram.com      | Posts, Profiles, Stories       | [Yes](workflow-setup.md#use-smart-scoping-rules) |
+| Twitter           | x.com, twitter.com | Timeline, Posts             | No                                               |
+| Telegram          | t.me               | Public Channels                | No                                               |
+| TikTok            | tiktok.com         | Video       | No                                               |
 | YouTube           | youtube.com        | Video                | No                                               |
 
 Site-specific behaviors will take precedence over other built-in behaviors and custom behaviors.
@@ -27,6 +27,6 @@ The following behaviors can be enabled or disabled in the workflow: [**autoscrol
 
 ## Custom Behaviors
 
-Custom behaviors allow you to add and modify page interactions for sites that are not supported by Browsertrix’s built-in behaviors. Like built-in behaviors, custom behaviors should be written using the Browsertrix JavaScript behavior format. See [Browser Behaviors docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#javascript-behaviors) for a detailed overview of the format.
+Custom behaviors allow you to add and modify page interactions for sites that are not supported by Browsertrix’s built-in behaviors. Custom behaviors can written using the Browsertrix JavaScript behavior format or created in the Chrome Dev Tools Recorder tab and provided to Browsertrix in the JSON User Flow format. See [Browser Behaviors docs](https://crawler.docs.browsertrix.com/user-guide/behaviors/#creating-custom-behaviors) for a detailed overview of creating custom behaviors.
 
 Once created and hosted on a public site or Git repository, the custom behavior script can be [added to a workflow](workflow-setup.md#use-custom-behaviors).

--- a/frontend/docs/docs/user-guide/collection.md
+++ b/frontend/docs/docs/user-guide/collection.md
@@ -23,7 +23,7 @@ Collections are the primary way of organizing and combining archived items into 
 
 Crawls and uploads can be added to a collection after creation by selecting _Select Archived Items_ from the collection's actions menu.
 
-A crawl workflow can also be set to [automatically add any completed crawls to a collection](workflow-setup.md#collection-auto-add) in the workflow's settings.
+A crawl workflow can also be set to [automatically add any completed crawls to a collection](workflow-setup.md#auto-add-to-collection) in the workflow's settings.
 
 ### Customize a Collection
 

--- a/frontend/docs/docs/user-guide/overview.md
+++ b/frontend/docs/docs/user-guide/overview.md
@@ -9,7 +9,7 @@ The storage panel displays the total size and count of archived items and browse
 For organizations with a set storage quota, the storage panel displays a visual breakdown of how much space the organization has left and how much has been taken up by all types of archived items and browser profiles. To view additional information about each item, hover over its section in the graph.
 
 ??? Info "Miscellaneous storage"
-    You may see an additional _Miscellaneous_ size depending on your crawl workflow and collection configuration. _Miscellaneous_ is the total size of all supplementary files in use by your organization, such as [workflow URL list files](./workflow-setup.md#upload-url-list) and [custom collection thumbnails](./presentation-sharing.md#thumbnail).
+    You may see an additional _Miscellaneous_ size depending on your crawl workflow and collection configuration. _Miscellaneous_ is the total size of all supplementary files in use by your organization, such as [workflow URL list files](./workflow-setup.md#list-of-pages) and [custom collection thumbnails](./presentation-sharing.md#thumbnail).
 
 ## Crawling
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -205,7 +205,7 @@ Browsertrix provides smart scoping rules for the following sites:
 | **Platform Name** | **Page Host** | **Applicable Pages** |
 |-------------------|---------------|----------------------|
 | Facebook          | facebook.com  | Timeline             |
-| Instagram         | instagram.com | Posts, Stories       |
+| Instagram         | instagram.com | Profile              |
 
 #### Custom Scoping Rules
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -221,7 +221,7 @@ Browsertrix provides smart scoping rules for the following sites:
 
 ##### Custom Scoping Rules
 
-Scoping rules for other platforms can be added through [custom behavior scripts](#use-custom-behaviors). When _Use Smart Scoping Rules_ is enabled, any URLs added to the crawl through the `addLink()` method in a custom behavior will be queued regardless of whether they would otherwise be in scope.
+Scoping rules for other platforms can be added through [custom behavior scripts](#use-custom-behaviors). When _Use Smart Scoping Rules_ is enabled, any URLs added to the crawl through the [`addLink()`](https://crawler.docs.browsertrix.com/user-guide/behaviors/#additional-links-from-behaviors) method in a custom behavior will be queued regardless of whether they would otherwise be in scope.
 
 Customizing scope through custom behaviors should only be done to achieve advanced use cases for sites that are not listed above, as Browsertrix’s built-in behaviors and scoping rules will take precedence over custom behavior scripts.
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -169,7 +169,7 @@ Patterns should be written in the JavaScript regular expression syntax without t
 
 #### Use Sitemap
 
-`Named “Check for sitemap” prior to Browsertrix version 1.24`{ .callout-blue }
+`Named “Check for sitemap” prior to v1.24`{ .callout-blue }
 
 When enabled, the crawler will check for a sitemap at `/sitemap.xml` and `/robots.txt` and use it to discover pages that match the crawl scope.
 
@@ -198,7 +198,7 @@ To include more pages than what is selected by the [crawl scope](#crawl-scope), 
 
 #### Include Directly Linked Pages
 
-`Named “Include any linked page (“one hop out”)” prior to Browsertrix version 1.24`{ .callout-blue }
+`Named “Include any linked page (“one hop out”)” prior to v1.24`{ .callout-blue }
 
 When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. This can be useful for capturing supplementary pages without having to manually add their URLs.
 
@@ -206,7 +206,7 @@ Links will only be followed one level deep (aka “one hop out”). For example,
 
 #### Use Smart Scoping Rules
 
-`New in Browsertrix version 1.24`{ .callout-green }
+`New in v1.24`{ .callout-green }
 
 Smart scoping rules reduce the complexity associated with scoping social media sites. When enabled, scoping rules for major social media platforms and other page-specific scoping rules will be automatically applied to the workflow. This setting is only applicable if a page selected by the crawl scope is hosted by a social media platform that Browsertrix supports, or if the page is selected by a custom behavior.
 
@@ -227,7 +227,7 @@ Customizing scope through custom behaviors should only be done to achieve advanc
 
 #### Additional URLs to Crawl
 
-`Named “Additional Pages” prior to Browsertrix version 1.24`{ .callout-blue }
+`Named “Additional Pages” prior to v1.24`{ .callout-blue }
 
 A list of URLs of pages to crawl. Each line should contain a valid URL (starting with `https://` or `http://`). Invalid URLs will be ignored unless _[Fail Crawl if Any URL Fails](#fail-crawl-if-any-url-fails-for-additional-urls-to-crawl)_ is enabled.
 
@@ -241,7 +241,7 @@ You can prevent the crawler from visiting parts of a website that you do not wan
 
 #### Use Robots.txt Disallow List
 
-`Named “Skip pages disallowed by robots.txt” prior to Browsertrix version 1.24`{ .callout-blue }
+`Named “Skip pages disallowed by robots.txt” prior to v1.24`{ .callout-blue }
 
 When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at `/robots.txt` for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -213,7 +213,7 @@ Scoping rules for other platforms can be added through [custom behavior scripts]
 
 Customizing scope through custom behaviors should only be done to achieve advanced use cases for sites that are not listed above, as Browsertrix’s built-in behaviors and scoping rules will take precedence over custom behavior scripts.
 
-#### Visit Any Linked Page
+#### Include Directly Linked Pages
 
 When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. Links will only be followed one level deep (aka “one hop out”).
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -169,7 +169,7 @@ Patterns should be written in the JavaScript regular expression syntax without t
 
 #### Use Sitemap
 
-`Named “Check for sitemap” prior to Browsertrix version 1.23`{ .callout-blue }
+`Named “Check for sitemap” prior to Browsertrix version 1.24`{ .callout-blue }
 
 When enabled, the crawler will check for a sitemap at `/sitemap.xml` and `/robots.txt` and use it to discover pages that match the crawl scope.
 
@@ -198,7 +198,7 @@ To include more pages than what is selected by the [crawl scope](#crawl-scope), 
 
 #### Include Directly Linked Pages
 
-`Named “Include any linked page (“one hop out”)” prior to Browsertrix version 1.23`{ .callout-blue }
+`Named “Include any linked page (“one hop out”)” prior to Browsertrix version 1.24`{ .callout-blue }
 
 When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. This can be useful for capturing supplementary pages without having to manually add their URLs.
 
@@ -206,7 +206,7 @@ Links will only be followed one level deep (aka “one hop out”). For example,
 
 #### Use Smart Scoping Rules
 
-`New in Browsertrix version 1.23`{ .callout-green }
+`New in Browsertrix version 1.24`{ .callout-green }
 
 Smart scoping rules reduce the complexity associated with scoping social media sites. When enabled, scoping rules for major social media platforms and other page-specific scoping rules will be automatically applied to the workflow. This setting is only applicable if a page selected by the crawl scope is hosted by a social media platform that Browsertrix supports, or if the page is selected by a custom behavior.
 
@@ -227,7 +227,7 @@ Customizing scope through custom behaviors should only be done to achieve advanc
 
 #### Additional URLs to Crawl
 
-`Named “Additional Pages” prior to Browsertrix version 1.23`{ .callout-blue }
+`Named “Additional Pages” prior to Browsertrix version 1.24`{ .callout-blue }
 
 A list of URLs of pages to crawl. Each line should contain a valid URL (starting with `https://` or `http://`). Invalid URLs will be ignored unless _[Fail Crawl if Any URL Fails](#fail-crawl-if-any-url-fails-for-additional-urls-to-crawl)_ is enabled.
 
@@ -241,7 +241,7 @@ You can prevent the crawler from visiting parts of a website that you do not wan
 
 #### Use Robots.txt Disallow List
 
-`Named “Skip pages disallowed by robots.txt” prior to Browsertrix version 1.23`{ .callout-blue }
+`Named “Skip pages disallowed by robots.txt” prior to Browsertrix version 1.24`{ .callout-blue }
 
 When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at `/robots.txt` for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -271,10 +271,6 @@ The crawl will be gracefully stopped after reaching this set size in GB.
 
 Customize how and when the browser performs specific operations on a page.
 
-_**Behaviors**_
-
-Behaviors are browser operations that can be enabled for additional page interactivity.
-
 ### Autoscroll
 
 When enabled, the browser will automatically scroll to the end of the page.
@@ -300,17 +296,17 @@ See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_w
 
 ### Use Custom Behaviors
 
-Enable custom behaviors to add your own behavior scripts. See [Browser Behaviors crawler documentation](https://crawler.docs.browsertrix.com/user-guide/behaviors/#built-in-behaviors) on creating custom behaviors.
-
-Custom behaviors can be specified as:
+[Custom behaviors](behaviors.md/#custom-behaviors) can be enabled by specifying the location of the behavior script. Scripts can be provided through one of two source options:
 
 #### URL
 
-A URL for a single JavaScript or JSON behavior file to download. This should be a URL that the crawler has access to. The workflow editor will validate that the supplied URL can be reached.
+:   A URL for a single JavaScript or JSON behavior file to download. This should be a URL that the crawler has access to. The workflow editor will validate that the supplied URL can be reached.
 
 #### Git repository
 
-A URL for a public Git repository containing one or more behavior files. Optionally, you can specify a branch and/or a relative path within the repository to specify exactly which behavior files within the repository should be used. The workflow editor will validate that the URL can be reached and is a Git repository. If a branch name is specified, the workflow editor will also validate that the branch exists in the Git repository.
+:   A URL for a public Git repository containing one or more behavior files. Optionally, you can specify a branch and/or a relative path within the repository to specify exactly which behavior files within the repository should be used. The workflow editor will validate that the URL can be reached and is a Git repository. If a branch name is specified, the workflow editor will also validate that the branch exists in the Git repository.
+
+Custom behaviors will take precedence over the built-in [_Autoscroll_](#autoscroll) and [_Autoclick_](#autoclick) behaviors. [Site-specific behaviors](behaviors.md#site-specific) will take precedence over custom behaviors.
 
 _**Page Timing**_
 
@@ -326,7 +322,7 @@ Waits on the page after initial HTML page load for a set number of seconds prior
 
 ### Behavior Limit
 
-Limits amount of elapsed time behaviors have to complete.
+Limits the amount of elapsed time that behaviors have to complete.
 
 ### Delay Before Next Page
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -194,6 +194,25 @@ See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_w
 
 To include more pages than what is selected by the crawl scope, you can specify scoping rules that will add those pages to the scope.
 
+#### Use Smart Scoping Rules
+
+Smart scoping rules reduce the complexity associated with scoping social media sites. When enabled, scoping rules for major social media platforms and other site-specific scoping rules will be automatically applied to the workflow. This setting is only applicable if a page selected by the crawl scope is hosted by a social media platform that Browsertrix supports, or if the page is selected by a custom behavior.
+
+We recommend keeping this setting enabled to ensure that pages from social media sites are archived to completion and are replayable. Disabling this setting may result in replay issues for popular social media platforms.
+
+Browsertrix provides smart scoping rules for the following sites:
+
+| **Platform Name** | **Page Host** | **Applicable Pages** |
+|-------------------|---------------|----------------------|
+| Facebook          | facebook.com  | Timeline             |
+| Instagram         | instagram.com | Posts, Stories       |
+
+#### Custom Scoping Rules
+
+Scoping rules for other platforms can be added through [custom behavior scripts](#use-custom-behaviors). When _Use Smart Scoping Rules_ is enabled, any URLs added to the crawl through the `addLink()` method in a custom behavior will be queued regardless of whether they would otherwise be in scope.
+
+Customizing scope through custom behaviors should only be done to achieve advanced use cases for sites that are not listed above, as Browsertrix’s built-in behaviors and scoping rules will take precedence over custom behavior scripts.
+
 #### Visit Any Linked Page
 
 When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. Links will only be followed one level deep (aka “one hop out”).

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -196,7 +196,7 @@ To include more pages than what is selected by the crawl scope, you can specify 
 
 #### Use Smart Scoping Rules
 
-Smart scoping rules reduce the complexity associated with scoping social media sites. When enabled, scoping rules for major social media platforms and other site-specific scoping rules will be automatically applied to the workflow. This setting is only applicable if a page selected by the crawl scope is hosted by a social media platform that Browsertrix supports, or if the page is selected by a custom behavior.
+Smart scoping rules reduce the complexity associated with scoping social media sites. When enabled, scoping rules for major social media platforms and other page-specific scoping rules will be automatically applied to the workflow. This setting is only applicable if a page selected by the crawl scope is hosted by a social media platform that Browsertrix supports, or if the page is selected by a custom behavior.
 
 We recommend keeping this setting enabled to ensure that pages from social media sites are archived to completion and are replayable. Disabling this setting may result in replay issues for popular social media platforms.
 
@@ -296,7 +296,7 @@ See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_w
 
 ### Use Custom Behaviors
 
-[Custom behaviors](behaviors.md/#custom-behaviors) can be enabled by specifying the location of the behavior script. Scripts can be provided through one of two source options:
+[Custom behaviors](behaviors.md#custom) can be enabled by specifying the location of the behavior script. Scripts can be provided through one of two source options:
 
 #### URL
 
@@ -306,7 +306,7 @@ See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_w
 
 :   A URL for a public Git repository containing one or more behavior files. Optionally, you can specify a branch and/or a relative path within the repository to specify exactly which behavior files within the repository should be used. The workflow editor will validate that the URL can be reached and is a Git repository. If a branch name is specified, the workflow editor will also validate that the branch exists in the Git repository.
 
-Custom behaviors will take precedence over the built-in [_Autoscroll_](#autoscroll) and [_Autoclick_](#autoclick) behaviors. [Site-specific behaviors](behaviors.md#site-specific) will take precedence over custom behaviors.
+Custom behaviors will take precedence over the default [_Autoscroll_](#autoscroll) and [_Autoclick_](#autoclick) behaviors and may be overridden by platform-specific behaviors (see [Behavior Precedence](behaviors.md#behavior-precedence)).
 
 _**Page Timing**_
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -12,7 +12,7 @@ Specify the range and depth of your crawl.
 
 ### Crawl Scope
 
-The crawl scope selects pages to be crawled based on the provided URL.
+The crawl scope selects pages to be crawled based on the [provided URL](#crawl-start-url-urls-to-crawl).
 
 Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 
@@ -35,7 +35,7 @@ Crawl scopes are categorized as a **Page Crawl** or **Site Crawl**:
 
     ??? info "Site Crawl Use Cases"
         - You're archiving a subset of a website, like everything under _website.com/your-username_ (`Pages in Same Directory`)
-        - You're archiving an entire website _and_ external pages linked to from the website (`Pages on Same Domain` + _Include Any Linked Page_ checked)
+        - You're archiving an entire website _and_ external pages linked to from the website (`Pages on Same Domain` + _Include Directly Linked Pages_ checked)
 
 The crawl scope is your starting point for scoping. The scope can be expanded to include more pages or limited to less pages by combining the crawl scope with [Additional Scope](#additional-scope) and [Exclude Pages](#exclude-pages) settings.
 
@@ -192,7 +192,13 @@ See [Basic CSS selectors (MDN)](https://developer.mozilla.org/en-US/docs/Learn_w
 
 ### Additional Scope
 
-To include more pages than what is selected by the crawl scope, you can specify scoping rules that will add those pages to the scope.
+To include more pages than what is selected by the [crawl scope](#crawl-scope), you can specify scoping rules that will add those pages to the scope.
+
+#### Include Directly Linked Pages
+
+When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. This can be useful for capturing supplementary pages without having to manually add their URLs.
+
+Links will only be followed one level deep (aka “one hop out”). For example, given a site crawl of [webrecorder.net](https://webrecorder.net/), the crawler will visit [github.com/webrecorder](https://github.com/webrecorder/) because it is hyperlinked in the footer of the website. The crawler will _not_ visit any of the links on the GitHub page (like [github.com/webrecorder/browsertrix](https://github.com/webrecorder/browsertrix/)) because those links are two visits (or “hops”) away from the crawl URL that is in scope.
 
 #### Use Smart Scoping Rules
 
@@ -207,17 +213,11 @@ Browsertrix provides smart scoping rules for the following sites:
 | Facebook          | facebook.com  | Timeline             |
 | Instagram         | instagram.com | Profile              |
 
-#### Custom Scoping Rules
+##### Custom Scoping Rules
 
 Scoping rules for other platforms can be added through [custom behavior scripts](#use-custom-behaviors). When _Use Smart Scoping Rules_ is enabled, any URLs added to the crawl through the `addLink()` method in a custom behavior will be queued regardless of whether they would otherwise be in scope.
 
 Customizing scope through custom behaviors should only be done to achieve advanced use cases for sites that are not listed above, as Browsertrix’s built-in behaviors and scoping rules will take precedence over custom behavior scripts.
-
-#### Include Directly Linked Pages
-
-When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. Links will only be followed one level deep (aka “one hop out”).
-
-This can be useful for capturing links that lead outside the crawled website but should still be included in the archive.
 
 #### Additional URLs to Crawl
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -169,6 +169,8 @@ Patterns should be written in the JavaScript regular expression syntax without t
 
 #### Use Sitemap
 
+`Named “Check for sitemap” prior to Browsertrix version 1.23`{ .callout-blue }
+
 When enabled, the crawler will check for a sitemap at `/sitemap.xml` and `/robots.txt` and use it to discover pages that match the crawl scope.
 
 This can be useful for selecting pages on a website that are not hyperlinked and may not otherwise be captured.
@@ -196,11 +198,15 @@ To include more pages than what is selected by the [crawl scope](#crawl-scope), 
 
 #### Include Directly Linked Pages
 
+`Named “Include any linked page (“one hop out”)” prior to Browsertrix version 1.23`{ .callout-blue }
+
 When enabled, the crawler will follow any hyperlink that is on a page selected by the crawl scope. This can be useful for capturing supplementary pages without having to manually add their URLs.
 
 Links will only be followed one level deep (aka “one hop out”). For example, given a site crawl of [webrecorder.net](https://webrecorder.net/), the crawler will visit [github.com/webrecorder](https://github.com/webrecorder/) because it is hyperlinked in the footer of the website. The crawler will _not_ visit any of the links on the GitHub page (like [github.com/webrecorder/browsertrix](https://github.com/webrecorder/browsertrix/)) because those links are two visits (or “hops”) away from the crawl URL that is in scope.
 
 #### Use Smart Scoping Rules
+
+`New in Browsertrix version 1.23`{ .callout-green }
 
 Smart scoping rules reduce the complexity associated with scoping social media sites. When enabled, scoping rules for major social media platforms and other page-specific scoping rules will be automatically applied to the workflow. This setting is only applicable if a page selected by the crawl scope is hosted by a social media platform that Browsertrix supports, or if the page is selected by a custom behavior.
 
@@ -221,6 +227,8 @@ Customizing scope through custom behaviors should only be done to achieve advanc
 
 #### Additional URLs to Crawl
 
+`Named “Additional Pages” prior to Browsertrix version 1.23`{ .callout-blue }
+
 A list of URLs of pages to crawl. Each line should contain a valid URL (starting with `https://` or `http://`). Invalid URLs will be ignored unless _[Fail Crawl if Any URL Fails](#fail-crawl-if-any-url-fails-for-additional-urls-to-crawl)_ is enabled.
 
 #### Fail Crawl if Any URL Fails (For _Additional URLs to Crawl_)
@@ -232,6 +240,8 @@ If enabled, the crawler will exit upon encountering any URL in _Additional URLs 
 You can prevent the crawler from visiting parts of a website that you do not want to be archived by setting exclusion rules. Exclusion rules will be applied last, after crawl scope and additional scoping rules are applied.
 
 #### Use Robots.txt Disallow List
+
+`Named “Skip pages disallowed by robots.txt” prior to Browsertrix version 1.23`{ .callout-blue }
 
 When enabled, the crawler will check for a [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file at `/robots.txt` for each host encountered during crawling and skip any pages that are disallowed by the rules found therein.
 

--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
           - user-guide/crawl-workflows.md
           - user-guide/workflow-setup.md
           - user-guide/running-crawl.md
+          - user-guide/behaviors.md
       - Archived Items:
           - user-guide/archived-items.md
           - user-guide/review.md

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -22,7 +22,7 @@ import {
   type SeedConfig,
   type Workflow,
 } from "@/pages/org/types";
-import { labelFor } from "@/strings/crawl-workflows/labels";
+import { labelFor, titlecaseLabelFor } from "@/strings/crawl-workflows/labels";
 import scopeTypeLabel from "@/strings/crawl-workflows/scopeType";
 import sectionStrings from "@/strings/crawl-workflows/section";
 import {
@@ -280,11 +280,11 @@ export class ConfigDetails extends BtrixElement {
             ),
           )}
           ${this.renderSetting(
-            labelFor.failOnContentCheck,
+            titlecaseLabelFor.failOnContentCheck,
             Boolean(seedsConfig?.failOnContentCheck),
           )}
           ${this.renderSetting(
-            labelFor["saveStorage"],
+            titlecaseLabelFor.saveStorage,
             seedsConfig?.saveStorage,
           )}
           ${crawlConfig?.proxyId
@@ -480,7 +480,7 @@ export class ConfigDetails extends BtrixElement {
         ),
       )}
       ${this.renderSetting(
-        msg("Visit Any Linked Page"),
+        titlecaseLabelFor.includeLinkedPages,
         Boolean(config.extraHops),
       )}
       ${when(
@@ -569,9 +569,12 @@ export class ConfigDetails extends BtrixElement {
         ),
       )}
       ${this.renderLinkSelectors()}
-      ${this.renderSetting(msg("Use Sitemap"), Boolean(config.useSitemap))}
       ${this.renderSetting(
-        labelFor.includeLinkedPages,
+        titlecaseLabelFor.useSitemap,
+        Boolean(config.useSitemap),
+      )}
+      ${this.renderSetting(
+        titlecaseLabelFor.includeLinkedPages,
         Boolean(primarySeedConfig?.extraHops ?? config.extraHops),
       )}
       ${this.renderSetting(
@@ -586,7 +589,7 @@ export class ConfigDetails extends BtrixElement {
         ),
       )}
       ${this.renderSetting(
-        msg("Use Robots.txt Disallow List"),
+        titlecaseLabelFor.useRobots,
         Boolean(config.useRobots),
       )}
       ${this.renderExclusions()}

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -480,6 +480,10 @@ export class ConfigDetails extends BtrixElement {
         ),
       )}
       ${this.renderSetting(
+        titlecaseLabelFor.alwaysAddBehaviorLinks,
+        Boolean(config.alwaysAddBehaviorLinks),
+      )}
+      ${this.renderSetting(
         titlecaseLabelFor.includeLinkedPages,
         Boolean(config.extraHops),
       )}
@@ -572,6 +576,10 @@ export class ConfigDetails extends BtrixElement {
       ${this.renderSetting(
         titlecaseLabelFor.useSitemap,
         Boolean(config.useSitemap),
+      )}
+      ${this.renderSetting(
+        titlecaseLabelFor.alwaysAddBehaviorLinks,
+        Boolean(config.alwaysAddBehaviorLinks),
       )}
       ${this.renderSetting(
         titlecaseLabelFor.includeLinkedPages,

--- a/frontend/src/constants/smart-scope-sites.ts
+++ b/frontend/src/constants/smart-scope-sites.ts
@@ -1,0 +1,8 @@
+import type { ArrayElement } from "type-fest/source/internal";
+
+/**
+ * List of sites supported by smart scoping, based on https://github.com/webrecorder/browsertrix-behaviors.
+ */
+export const SmartScopeSites = ["instagram.com", "facebook.com"] as const;
+
+export type SmartScopeSite = ArrayElement<typeof SmartScopeSites>;

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1041,7 +1041,7 @@ export class WorkflowEditor extends BtrixElement {
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
-      ${this.renderIncludeLinkedPages()}
+      ${this.renderUseSmartScope()} ${this.renderIncludeLinkedPages()}
       ${when(
         this.formState.includeLinkedPages ||
           this.formState.scopeType === ScopeType.SPA,
@@ -1668,7 +1668,7 @@ https://archiveweb.page/es/`}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
-      ${this.renderIncludeLinkedPages()}
+      ${this.renderUseSmartScope()} ${this.renderIncludeLinkedPages()}
       ${detailsInColumns({
         open: additionalUrlList.length > 0,
         title: html`${labelFor.urlList}
@@ -1757,6 +1757,18 @@ https://archiveweb.page/images/${"logo.svg"}`}
       inputEl.setCustomValidity(helpText);
     }
   };
+
+  private renderUseSmartScope() {
+    return html`${inputCol(html`
+      <sl-checkbox
+        name="alwaysAddBehaviorLinks"
+        ?checked=${this.formState.alwaysAddBehaviorLinks}
+      >
+        ${labelFor.alwaysAddBehaviorLinks}
+      </sl-checkbox>
+    `)}
+    ${this.renderHelpTextCol(infoTextFor["alwaysAddBehaviorLinks"], false)}`;
+  }
 
   private renderIncludeLinkedPages() {
     return html`${inputCol(html`
@@ -3731,6 +3743,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         failOnContentCheck: this.formState.failOnContentCheck,
         saveStorage: this.formState.saveStorage,
         useRobots: this.formState.useRobots,
+        alwaysAddBehaviorLinks: this.formState.alwaysAddBehaviorLinks,
       },
       crawlerChannel:
         this.formState.crawlerChannel || CrawlerChannelImage.Default,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -65,6 +65,10 @@ import type { SyntaxInput } from "@/components/ui/syntax-input";
 import type { TabListTab } from "@/components/ui/tab-list";
 import type { TimeInputChangeEvent } from "@/components/ui/time-input";
 import { validURL } from "@/components/ui/url-input";
+import {
+  SmartScopeSites,
+  type SmartScopeSite,
+} from "@/constants/smart-scope-sites";
 import { docsUrlContext, type DocsUrlContext } from "@/context/docs-url";
 import {
   orgCrawlerChannelsContext,
@@ -1186,6 +1190,9 @@ export class WorkflowEditor extends BtrixElement {
           }
         }}
       >
+        ${guard(this.formState.urlList, () =>
+          when(this.formState.urlList, this.renderSmartScopeNotice),
+        )}
       </sl-input>
     `)}
     ${this.renderHelpTextCol(msg(str`The crawler will visit this URL.`))}`;
@@ -1330,6 +1337,10 @@ export class WorkflowEditor extends BtrixElement {
         }}
       >
         <div slot="help-text">${helpText}</div>
+
+        ${guard(this.formState.primarySeedUrl, () =>
+          when(this.formState.primarySeedUrl, this.renderSmartScopeNotice),
+        )}
       </sl-input>
     `)}
     ${this.renderHelpTextCol(msg(`The starting point of your crawl.`))}`;
@@ -1337,74 +1348,83 @@ export class WorkflowEditor extends BtrixElement {
 
   private readonly renderSeedListTextbox = () => {
     return html`<sl-textarea
-      id="seedUrlList"
-      name="urlList"
-      placeholder=${`https://webrecorder.net/resources
+        id="seedUrlList"
+        name="urlList"
+        placeholder=${`https://webrecorder.net/resources
 https://archiveweb.page/guide
 https://replayweb.page/docs`}
-      rows="4"
-      autocomplete="off"
-      inputmode="url"
-      value=${this.formState.urlList}
-      required
-      help-text=${msg("Enter one URL per line.")}
-      @paste=${(e: ClipboardEvent) => {
-        const text = `${(e.currentTarget as SlTextarea).value}
+        rows="4"
+        autocomplete="off"
+        inputmode="url"
+        value=${this.formState.urlList}
+        required
+        help-text=${msg("Enter one URL per line.")}
+        @paste=${(e: ClipboardEvent) => {
+          const text = `${(e.currentTarget as SlTextarea).value}
           ${e.clipboardData?.getData("text")}`
-          // Remove zero-width characters
-          .replace(/[\u200B-\u200D\uFEFF]/g, "")
-          // Remove multiple whitespaces
-          .replace(/\s+/g, "\n")
-          .trim();
+            // Remove zero-width characters
+            .replace(/[\u200B-\u200D\uFEFF]/g, "")
+            // Remove multiple whitespaces
+            .replace(/\s+/g, "\n")
+            .trim();
 
-        if (text) {
-          const textBlob = new Blob([text]);
-          if (
-            (textBlob.size > MAX_SEED_LIST_STRING_BYTES &&
-              textBlob.size <= MAX_SEED_LIST_FILE_BYTES) ||
-            urlListToArray(text).length > URL_LIST_MAX_URLS
-          ) {
-            const file = new File([textBlob], pastedUrlListFileName, {
-              type: "text/plain",
-            });
+          if (text) {
+            const textBlob = new Blob([text]);
+            if (
+              (textBlob.size > MAX_SEED_LIST_STRING_BYTES &&
+                textBlob.size <= MAX_SEED_LIST_FILE_BYTES) ||
+              urlListToArray(text).length > URL_LIST_MAX_URLS
+            ) {
+              const file = new File([textBlob], pastedUrlListFileName, {
+                type: "text/plain",
+              });
 
-            this.updateFormState(
-              {
-                urlList: undefined,
-                seedFileId: null,
-                seedListFormat: SeedListFormat.File,
-                seedFile: file,
-              },
-              true,
-            );
-          }
-        }
-      }}
-      @keyup=${async (e: KeyboardEvent) => {
-        if (e.key === "Enter") {
-          await (e.target as SlInput).updateComplete;
-          this.doValidateUrlList(e);
-        }
-      }}
-      @sl-input=${(e: CustomEvent) => {
-        const inputEl = e.target as SlInput;
-        const value = inputEl.value;
-
-        if (value) {
-          if (!this.stickyFooter) {
-            const { isValid } = this.validateUrlList(inputEl.value);
-
-            if (isValid) {
-              this.animateStickyFooter();
+              this.updateFormState(
+                {
+                  urlList: undefined,
+                  seedFileId: null,
+                  seedListFormat: SeedListFormat.File,
+                  seedFile: file,
+                },
+                true,
+              );
             }
           }
-        } else {
-          inputEl.helpText = msg("At least 1 URL is required.");
-        }
-      }}
-      @sl-change=${this.doValidateUrlList}
-      @sl-blur=${this.doValidateUrlList}
-    ></sl-textarea>`;
+        }}
+        @keyup=${async (e: KeyboardEvent) => {
+          if (e.key === "Enter") {
+            await (e.target as SlInput).updateComplete;
+            this.doValidateUrlList(e);
+          }
+        }}
+        @sl-input=${(e: CustomEvent) => {
+          const inputEl = e.target as SlInput;
+          const value = inputEl.value;
+
+          if (value) {
+            if (!this.stickyFooter) {
+              const { isValid } = this.validateUrlList(inputEl.value);
+
+              if (isValid) {
+                this.animateStickyFooter();
+              }
+            }
+          } else {
+            inputEl.helpText = msg("At least 1 URL is required.");
+          }
+        }}
+        @sl-change=${this.doValidateUrlList}
+        @sl-blur=${this.doValidateUrlList}
+      ></sl-textarea>
+      ${guard(this.formState.urlList, () =>
+        when(
+          this.formState.urlList,
+          (urlList) =>
+            html`<div class="form-help-text mt-0">
+              ${this.renderSmartScopeNotice(urlList)}
+            </div>`,
+        ),
+      )}`;
   };
 
   private readonly renderSeedListFileUpload = () => {
@@ -1525,6 +1545,46 @@ https://replayweb.page/docs`}
 
       ${helpText ? html`<div slot="help-text">${helpText}</div>` : nothing}
     </btrix-file-input>`;
+  };
+
+  private readonly renderSmartScopeNotice = (urlStr: string) => {
+    const urls = urlListToArray(urlStr);
+    const sites: SmartScopeSite[] = [];
+
+    urls.forEach((url) => {
+      if (!url.startsWith("http") || !validURL(url)) return;
+
+      try {
+        const hostname = new URL(url).hostname.replace(/^www\./, "");
+
+        if ((SmartScopeSites as readonly string[]).includes(hostname)) {
+          sites.push(hostname as SmartScopeSite);
+        }
+      } catch {
+        console.debug("invalid URL not caught by `validURL`:", url);
+      }
+    });
+
+    if (!sites.length) return;
+
+    const list_of_sites = this.localize
+      .list(sites)
+      .map(
+        (part) =>
+          html`<span class=${clsx(part.type === "element" && tw`text-blue-500`)}
+            >${part.value}</span
+          >`,
+      );
+
+    return html`<span slot="help-text">
+      <sl-icon
+        name="check2-circle"
+        class="align-[-.175em] text-sm text-success"
+      ></sl-icon>
+      ${msg(html`Smart scoping rules available for ${list_of_sites}.`, {
+        desc: '`list_of_sites` is replaced with an actual list of sites, e.g. "instagram.com and facebook.com".',
+      })}
+    </span>`;
   };
 
   private readonly renderSiteScope = () => {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1767,7 +1767,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ${labelFor.alwaysAddBehaviorLinks}
       </sl-checkbox>
     `)}
-    ${this.renderHelpTextCol(infoTextFor["alwaysAddBehaviorLinks"], false)}`;
+    ${this.renderHelpTextCol(
+      html`${infoTextFor["alwaysAddBehaviorLinks"]}
+      ${this.renderUserGuideLink({
+        hash: "use-smart-scoping-rules",
+        content: msg("More details"),
+      })}`,
+      false,
+    )}`;
   }
 
   private renderIncludeLinkedPages() {
@@ -2049,7 +2056,12 @@ https://archiveweb.page/images/${"logo.svg"}`}
           <span slot="suffix">${msg("seconds")}</span>
         </sl-input>
       `)}
-      ${this.renderHelpTextCol(infoTextFor["behaviorTimeoutSeconds"])}
+      ${this.renderHelpTextCol(
+        html`${infoTextFor["behaviorTimeoutSeconds"]}
+        ${msg(
+          "Also applies to site-specific behaviors that are automatically added by scoping rules.",
+        )}`,
+      )}
       ${inputCol(html`
         <sl-input
           name="pageExtraDelaySeconds"
@@ -2183,7 +2195,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
             ${this.renderUserGuideLink({
               hash: "fail-crawl-if-not-logged-in",
               content: msg("More details"),
-            })}.`,
+            })}`,
             false,
           )}
         `,
@@ -2198,7 +2210,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ${this.renderUserGuideLink({
           hash: "include-browser-storage-data",
           content: msg("More details"),
-        })}.`,
+        })}`,
         false,
       )}
       ${proxies?.servers.length

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1045,7 +1045,7 @@ export class WorkflowEditor extends BtrixElement {
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
-      ${this.renderUseSmartScope()} ${this.renderIncludeLinkedPages()}
+      ${this.renderIncludeLinkedPages()} ${this.renderUseSmartScope()}
       ${when(
         this.formState.includeLinkedPages ||
           this.formState.scopeType === ScopeType.SPA,
@@ -1728,7 +1728,7 @@ https://archiveweb.page/es/`}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
-      ${this.renderUseSmartScope()} ${this.renderIncludeLinkedPages()}
+      ${this.renderIncludeLinkedPages()} ${this.renderUseSmartScope()}
       ${detailsInColumns({
         open: additionalUrlList.length > 0,
         title: html`${labelFor.urlList}

--- a/frontend/src/pages/org/workflows-new.ts
+++ b/frontend/src/pages/org/workflows-new.ts
@@ -85,6 +85,7 @@ export class WorkflowsNew extends BtrixElement {
         selectLinks: DEFAULT_SELECT_LINKS,
         customBehaviors: [],
         clickSelector: DEFAULT_AUTOCLICK_SELECTOR,
+        alwaysAddBehaviorLinks: true,
       },
       tags: [],
       crawlTimeout: null,

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -7,12 +7,10 @@ type Field = keyof FormState;
 
 const sitemap_xml = html`<code>sitemap.xml</code>`;
 const robots_txt = html`<code>robots.txt</code>`;
-
 export const infoTextFor = {
   urlList: msg("The crawler will visit and record each URL listed here."),
   alwaysAddBehaviorLinks: msg(
-    html`For supported social media platforms, expands crawl scope to include
-    URLs that ensure content completeness.`,
+    "Expands crawl scope to more accurately crawl social media pages, if detected.",
   ),
   includeLinkedPages: msg(
     "Expands crawl scope to include pages that are one link away.",

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -10,7 +10,7 @@ const robots_txt = html`<code>robots.txt</code>`;
 export const infoTextFor = {
   urlList: msg("The crawler will visit and record each URL listed here."),
   alwaysAddBehaviorLinks: msg(
-    "Expands crawl scope to more accurately crawl social media pages, if detected.",
+    "Expands crawl scope to more accurately crawl social media pages, if applicable.",
   ),
   includeLinkedPages: msg(
     "Expands crawl scope to include pages that are one link away.",

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -13,7 +13,7 @@ export const infoTextFor = {
     "Expands crawl scope to more accurately crawl social media pages, if applicable.",
   ),
   includeLinkedPages: msg(
-    "Expands crawl scope to include pages that are one link away.",
+    "The crawler will follow links one level deep (aka “one hop out”) from pages selected by the crawl scope.",
   ),
   exclusions: msg("Specify rules for which pages should not be visited."),
   pageLimit: msg(

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -10,6 +10,10 @@ const robots_txt = html`<code>robots.txt</code>`;
 
 export const infoTextFor = {
   urlList: msg("The crawler will visit and record each URL listed here."),
+  alwaysAddBehaviorLinks: msg(
+    html`For supported social media platforms, expands crawl scope to include
+    URLs that ensure content completeness.`,
+  ),
   includeLinkedPages: msg(
     "Expands crawl scope to include pages that are one link away.",
   ),

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -15,7 +15,7 @@ export const labelFor = {
   dedupeType: msg("Crawl Deduplication"),
   saveStorage: msg("Include browser storage data"),
   maxScopeDepth: msg("Max Discovery Depth"),
-  includeLinkedPages: msg("Visit any linked page"),
+  includeLinkedPages: msg("Include directly linked pages"),
   useSitemap: msg("Use sitemap"),
   useRobots: msg("Use robots.txt disallow list"),
   customIncludeList: msg("Page Prefix URLs"),
@@ -28,7 +28,7 @@ export const labelFor = {
 
 export const titlecaseLabelFor = {
   saveStorage: msg("Include Browser Storage Data"),
-  includeLinkedPages: msg("Visit Any Linked Page"),
+  includeLinkedPages: msg("Include Directly Linked Pages"),
   useSitemap: msg("Use Sitemap"),
   useRobots: msg("Use Robots.txt Disallow List"),
   failOnContentCheck: msg("Fail Crawl if Not Logged In"),

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -23,6 +23,7 @@ export const labelFor = {
   failOnContentCheck: msg("Fail crawl if not logged in"),
   failOnFailedSeed: msg("Fail crawl if any URL fails"),
   exclusions: msg("Custom Exclusion Rules"),
+  alwaysAddBehaviorLinks: msg("Use smart scoping rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;
 
 export const titlecaseLabelFor = {
@@ -31,4 +32,5 @@ export const titlecaseLabelFor = {
   useSitemap: msg("Use Sitemap"),
   useRobots: msg("Use Robots.txt Disallow List"),
   failOnContentCheck: msg("Fail Crawl if Not Logged In"),
+  alwaysAddBehaviorLinks: msg("Use Smart Scoping Rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -24,3 +24,11 @@ export const labelFor = {
   failOnFailedSeed: msg("Fail crawl if any URL fails"),
   exclusions: msg("Custom Exclusion Rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;
+
+export const titlecaseLabelFor = {
+  saveStorage: msg("Include Browser Storage Data"),
+  includeLinkedPages: msg("Visit Any Linked Page"),
+  useSitemap: msg("Use Sitemap"),
+  useRobots: msg("Use Robots.txt Disallow List"),
+  failOnContentCheck: msg("Fail Crawl if Not Logged In"),
+} as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -67,6 +67,7 @@ export const seedConfigSchema = seedSchema
       clickSelector: z.string(),
       saveStorage: z.boolean().optional(),
       useRobots: z.boolean().optional(),
+      alwaysAddBehaviorLinks: z.boolean(),
     }),
   );
 export type SeedConfig = Expand<z.infer<typeof seedConfigSchema>>;

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -271,6 +271,7 @@ export type FormState = {
   clickSelector: string;
   saveStorage: WorkflowSettings["config"]["saveStorage"];
   useRobots: WorkflowSettings["config"]["useRobots"];
+  alwaysAddBehaviorLinks: WorkflowSettings["config"]["alwaysAddBehaviorLinks"];
 };
 
 export type FormStateField = keyof FormState;
@@ -336,6 +337,7 @@ export const getDefaultFormState = (): FormState => ({
   customBehavior: false,
   saveStorage: false,
   useRobots: false,
+  alwaysAddBehaviorLinks: false,
 });
 
 export const mapSeedToUrl = (arr: Seed[]) =>
@@ -352,7 +354,7 @@ export function getInitialFormState(params: {
   const formState: Partial<FormState> = {};
   const seedsConfig = params.initialWorkflow.config;
   let primarySeedConfig: SeedConfig | Seed = seedsConfig;
-  if (isPrimarySeedScope(params.initialWorkflow.config.scopeType)) {
+  if (isPrimarySeedScope(seedsConfig.scopeType)) {
     if (params.initialSeeds) {
       const firstSeed = params.initialSeeds[0];
       if (typeof firstSeed === "string") {
@@ -388,8 +390,8 @@ export function getInitialFormState(params: {
         : primarySeedConfig.depth;
     formState.useSitemap = seedsConfig.useSitemap;
   } else {
-    if (params.initialWorkflow.config.seedFileId) {
-      formState.seedFileId = params.initialWorkflow.config.seedFileId;
+    if (seedsConfig.seedFileId) {
+      formState.seedFileId = seedsConfig.seedFileId;
       formState.scopeType = WorkflowScopeType.PageList;
       formState.seedListFormat = SeedListFormat.File;
     } else if (params.initialSeeds?.length) {
@@ -451,9 +453,7 @@ export function getInitialFormState(params: {
     return fallback;
   };
 
-  const enableCustomBehaviors = Boolean(
-    params.initialWorkflow.config.customBehaviors.length,
-  );
+  const enableCustomBehaviors = Boolean(seedsConfig.customBehaviors.length);
 
   return {
     ...defaultFormState,
@@ -477,8 +477,8 @@ export function getInitialFormState(params: {
     postLoadDelaySeconds:
       seedsConfig.postLoadDelay ?? defaultFormState.postLoadDelaySeconds,
     browserWindows: params.initialWorkflow.browserWindows,
-    blockAds: params.initialWorkflow.config.blockAds,
-    lang: params.initialWorkflow.config.lang ?? defaultFormState.lang,
+    blockAds: seedsConfig.blockAds,
+    lang: seedsConfig.lang ?? defaultFormState.lang,
     scheduleType: defaultFormState.scheduleType,
     scheduleFrequency: defaultFormState.scheduleFrequency,
     tags: params.initialWorkflow.tags,
@@ -501,28 +501,27 @@ export function getInitialFormState(params: {
       seedsConfig.failOnFailedSeed ?? defaultFormState.failOnFailedSeed,
     failOnContentCheck:
       seedsConfig.failOnContentCheck ?? defaultFormState.failOnContentCheck,
-    pageLimit:
-      params.initialWorkflow.config.limit ?? defaultFormState.pageLimit,
-    autoscrollBehavior: params.initialWorkflow.config.behaviors
-      ? params.initialWorkflow.config.behaviors.includes(Behavior.AutoScroll)
+    pageLimit: seedsConfig.limit ?? defaultFormState.pageLimit,
+    autoscrollBehavior: seedsConfig.behaviors
+      ? seedsConfig.behaviors.includes(Behavior.AutoScroll)
       : enableCustomBehaviors
         ? false
         : defaultFormState.autoscrollBehavior,
-    autoclickBehavior: params.initialWorkflow.config.behaviors
-      ? params.initialWorkflow.config.behaviors.includes(Behavior.AutoClick)
+    autoclickBehavior: seedsConfig.behaviors
+      ? seedsConfig.behaviors.includes(Behavior.AutoClick)
       : enableCustomBehaviors
         ? false
         : defaultFormState.autoclickBehavior,
     customBehavior: enableCustomBehaviors,
-    selectLinks: params.initialWorkflow.config.selectLinks,
-    clickSelector: params.initialWorkflow.config.clickSelector,
-    userAgent:
-      params.initialWorkflow.config.userAgent ?? defaultFormState.userAgent,
+    selectLinks: seedsConfig.selectLinks,
+    clickSelector: seedsConfig.clickSelector,
+    userAgent: seedsConfig.userAgent ?? defaultFormState.userAgent,
     crawlerChannel:
       params.initialWorkflow.crawlerChannel || defaultFormState.crawlerChannel,
     proxyId: params.initialWorkflow.proxyId || defaultFormState.proxyId,
-    saveStorage: params.initialWorkflow.config.saveStorage,
-    useRobots: params.initialWorkflow.config.useRobots,
+    saveStorage: seedsConfig.saveStorage,
+    useRobots: seedsConfig.useRobots,
+    alwaysAddBehaviorLinks: Boolean(seedsConfig.alwaysAddBehaviorLinks),
     ...formState,
   };
 }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3370, resolves https://github.com/webrecorder/browsertrix/issues/3445
Depends on https://github.com/webrecorder/browsertrix/pull/3430

## Changes

- Adds "smart scoping" checkbox to workflow form that allows users to add site-specific behavior links to the workflow
- Adds new user guide page for behaviors

## Manual testing

1. Log in as crawler
2. Go to New Workflow. Verify that "Use Smart Scoping Rules" is enabled by default
3. Go to existing workflow
4. Go to Edit workflow. Verify that "Use Smart Scoping Rules" is disabled by default
5. Enable "Use Smart Scoping Rules"
6. Save. Verify setting is saved as expected

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| New Workflow | <img width="904" height="340" alt="Screenshot 2026-06-30 at 6 44 06 PM" src="https://github.com/user-attachments/assets/0a91eb87-3adf-48df-b0cb-dfbbb32a0cd2" /> |
| Edit Workflow | <img width="542" height="108" alt="Screenshot 2026-06-30 at 6 46 19 PM" src="https://github.com/user-attachments/assets/3fbb2119-0c79-46fb-9e58-febe7099c1d5" /><br/><br/><img width="543" height="305" alt="Screenshot 2026-06-30 at 6 49 52 PM" src="https://github.com/user-attachments/assets/d3ecfa4b-097a-4501-8a2d-5564ce4f5be3" /> |
| Workflow Settings | <img width="442" height="282" alt="Screenshot 2026-06-29 at 6 09 36 PM" src="https://github.com/user-attachments/assets/8254fab8-3245-47eb-97a8-b376d70794e5" /> |
| User Guide / Crawl Workflow Settings | <img width="457" height="762" alt="Screenshot 2026-06-30 at 6 46 11 PM" src="https://github.com/user-attachments/assets/3b8a1394-4ebb-4c64-b056-4ffac2d20ca0" /> |
| User Guide / Behaviors | <img width="463" height="1256" alt="Screenshot 2026-06-30 at 7 32 55 PM" src="https://github.com/user-attachments/assets/9f178c6a-162b-4dd9-ad9b-1ad367544b0f" /> |


<!-- ## Follow-ups -->
