### PR TITLE
ensure paused state / avoid edge-case restarts while pausing:

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1796,18 +1796,18 @@ class CrawlOperator(BaseOperator):
             status.stopReason = await self.is_crawl_stopping(crawl, status)
             status.stopping = status.stopReason is not None
 
-            # mark crawl as stopping
-            if status.stopping:
-                if status.stopReason in PAUSED_STATES:
-                    await redis.set(f"{crawl.id}:paused", "1")
+        # mark crawl as pausing or stopping
+        if status.stopping:
+            if status.stopReason in PAUSED_STATES:
+                if await redis.set(f"{crawl.id}:paused", "1", nx=True):
                     logger.info(
                         "crawl_pausing",
                         stop_reason=status.stopReason,
                         crawl_id=crawl.id,
                         unstructured_message=f"Crawl pausing: {status.stopReason}, id: {crawl.id}",
                     )
-                else:
-                    await redis.set(f"{crawl.id}:stopping", "1")
+            else:
+                if await redis.set(f"{crawl.id}:stopping", "1", nx=True):
                     logger.info(
                         "crawl_gracefully_stopping",
                         stop_reason=status.stopReason,


### PR DESCRIPTION
- ensure redis key is set if status.stopping is already set (even if previously set)
- in rare cases, it's possible for key to be deleted when crawler is thought to be stopped, but if pod is recreated, and status.stopping already set the redis is not reset, resulting in a pod for paused crawl restarting
- log only when state is actually set
- Fixes #3457 3457