### PR TITLE
Ensure background job pods have template volume needed to start other background jobs

### DIFF
--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -35,6 +35,10 @@ spec:
           secret:
             secretName: ops-configs
 
+        - name: app-templates
+          configMap:
+            name: app-templates
+
       containers:
         - name: btrixbgjob
           image: {{ backend_image }}
@@ -69,6 +73,9 @@ spec:
           volumeMounts:
             - name: ops-configs
               mountPath: /ops-configs/
+
+            - name: app-templates
+              mountPath: /app/btrixcloud/templates/
 
           command: ["python3", "-m", "btrixcloud.main_bg"]
 


### PR DESCRIPTION
Fixes #3453 

Currently deployed on dev for testing

The background job pod still differs from main backend pods in that `/ops-proxy-configs/` or `/config` are not mounted as volumes in the former still, but it seems like a good idea to provide each pod the minimal amount of information needed.