### PR TITLE
ci: actions/checkout@v7

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       matches: ${{ steps.filter.outputs.matches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2  # important, to fetch previous commit
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # needed for progressive mode to work
 

--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       matches: ${{ steps.filter.outputs.matches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2 # important, to fetch previous commit
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -29,7 +29,7 @@ jobs:
           echo GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD` >> $GITHUB_ENV
 
       - name: Checkout values file from ops repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: "webrecorder/browsertrix-cloud-ops"
           path: "browsertrix-cloud-ops"

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -17,7 +17,7 @@ jobs:
   deploy_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/.github/workflows/emails-build.yaml
+++ b/.github/workflows/emails-build.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matches: ${{ steps.filter.outputs.matches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2 # important, to fetch previous commit
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       # Setup:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/frontend-lint-test-build.yaml
+++ b/.github/workflows/frontend-lint-test-build.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       matches: ${{ steps.filter.outputs.matches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2  # important, to fetch previous commit
 
@@ -49,7 +49,7 @@ jobs:
     steps:
       # Setup:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
 
@@ -68,7 +68,7 @@ jobs:
           echo "PLAYWRIGHT_VERSION=$(node scripts/get-resolved-playwright-version.js)" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: playwright-cache
         with:
           path: |
@@ -133,7 +133,7 @@ jobs:
           echo "PLAYWRIGHT_VERSION=$(node scripts/get-resolved-playwright-version.js)" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: playwright-cache
         with:
           path: |
@@ -275,7 +275,7 @@ jobs:
           cache-dependency-path: frontend/yarn.lock
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: frontend/dist
           key: ${{ runner.os }}-btrix-frontend-build-${{ hashFiles('frontend/dist') }}

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       matches: ${{ steps.filter.outputs.matches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2 # important, to fetch previous commit
 
@@ -64,7 +64,7 @@ jobs:
             --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set Env Vars
         run: |

--- a/.github/workflows/k3d-log-ci.yaml
+++ b/.github/workflows/k3d-log-ci.yaml
@@ -24,7 +24,7 @@ jobs:
             --k3s-arg "--no-deploy=traefik,metrics-server@server:*"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
         uses: azure/setup-kubectl@v3

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: set-matrix
         run: |
           echo matrix="$(ls ./backend/test_nightly/ | grep -o "^test_.*" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -49,7 +49,7 @@ jobs:
             --k3s-arg "--disable=traefik,servicelb@server:*"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set Env Vars
         run: |

--- a/.github/workflows/microk8s-ci.yaml
+++ b/.github/workflows/microk8s-ci.yaml
@@ -28,7 +28,7 @@ jobs:
           channel: "1.25/stable"
           addons: '["dns", "helm3", "hostpath-storage", "registry", "host-access"]'
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set Env Vars
         run: |

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/weblate-reformat.yaml
+++ b/.github/workflows/weblate-reformat.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       matches: ${{ steps.filter.outputs.matches }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2  # important, to fetch previous commit
 
@@ -47,7 +47,7 @@ jobs:
     steps:
       # Setup:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
Since I submitted the previous PR, looks like actions/checkout@v7 was released. Bumps us up one more version. Changelog: https://github.com/actions/checkout/releases/tag/v7.0.0

This is *mostly* internal changes but there's a handful of other changes that don't appear to affect us.