### PR TITLE
Speed up `emails` builds - partially reverts #3403

### DIFF
--- a/.github/workflows/emails-build.yaml
+++ b/.github/workflows/emails-build.yaml
@@ -38,9 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: paths-filter
     if: needs.paths-filter.outputs.matches == 'true'
-    strategy:
-      matrix:
-        node: [20, 22]
     steps:
       # Setup:
       - name: Checkout
@@ -53,19 +50,6 @@ jobs:
           echo VERSION=`cat version.txt` >> $GITHUB_ENV
           echo GIT_COMMIT_HASH=`git rev-parse --short HEAD` >> $GITHUB_ENV
           echo GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD` >> $GITHUB_ENV
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node }}
-          cache: "yarn"
-          cache-dependency-path: emails/yarn.lock
-
-      - name: Install dependencies
-        working-directory: emails
-        env:
-          HUSKY: 0
-        run: yarn install --frozen-lockfile
 
       # Check build:
       - name: Set up Docker Buildx

--- a/emails/Dockerfile
+++ b/emails/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --production
 
 COPY . .
 

--- a/emails/Dockerfile
+++ b/emails/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN yarn install --frozen-lockfile --production
+RUN yarn install --frozen-lockfile --ignore-optional
 
 COPY . .
 
@@ -26,7 +26,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN yarn install --frozen-lockfile --production && yarn cache clean
+RUN yarn install --frozen-lockfile --production --ignore-optional && yarn cache clean
 
 COPY --from=builder /app/dist ./dist
 

--- a/emails/api-server.ts
+++ b/emails/api-server.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from "express";
 import { pinoHttp } from "pino-http";
 import { pino } from "pino";
-import { render, pretty as makePretty } from "react-email";
+import { render, pretty as makePretty } from "@react-email/components";
 
 import * as templates from "./emails/index.js";
 import z from "zod";

--- a/emails/components/button.tsx
+++ b/emails/components/button.tsx
@@ -1,4 +1,4 @@
-import { Button as EmailButton } from "react-email";
+import { Button as EmailButton } from "@react-email/components";
 
 export const Button = ({
   children,

--- a/emails/components/card.tsx
+++ b/emails/components/card.tsx
@@ -1,4 +1,4 @@
-import { Container, Heading, Link, Text } from "react-email";
+import { Container, Heading, Link, Text } from "@react-email/components";
 
 export const Card = ({
   title,

--- a/emails/components/warning.tsx
+++ b/emails/components/warning.tsx
@@ -1,4 +1,4 @@
-import { Text } from "react-email";
+import { Text } from "@react-email/components";
 
 export const Warning = ({ children }: { children: React.ReactNode }) => (
   <Text className="text-base font-semibold text-red-600 bg-red-50 rounded-lg p-4 border border-red-500 border-solid">

--- a/emails/emails/crawl-auto-paused.tsx
+++ b/emails/emails/crawl-auto-paused.tsx
@@ -1,4 +1,4 @@
-import { Link, Text } from "react-email";
+import { Link, Text } from "@react-email/components";
 
 import { Template } from "../templates/btrix.js";
 import {

--- a/emails/emails/failed-bg-job.tsx
+++ b/emails/emails/failed-bg-job.tsx
@@ -1,7 +1,7 @@
 import z from "zod";
 import { Template } from "../templates/btrix.js";
 import { formatDateTime } from "../lib/date.js";
-import { CodeInline } from "react-email";
+import { CodeInline } from "@react-email/components";
 
 export const schema = z.object({
   org: z.string().optional(),

--- a/emails/emails/invite.tsx
+++ b/emails/emails/invite.tsx
@@ -1,4 +1,4 @@
-import { Heading, Hr, Link, Section, Text } from "react-email";
+import { Heading, Hr, Link, Section, Text } from "@react-email/components";
 
 import { Template } from "../templates/btrix.js";
 import {

--- a/emails/emails/password-reset.tsx
+++ b/emails/emails/password-reset.tsx
@@ -1,4 +1,4 @@
-import { Link, Section, Text } from "react-email";
+import { Link, Section, Text } from "@react-email/components";
 
 import { Template } from "../templates/btrix.js";
 import { Button } from "../components/button.js";

--- a/emails/emails/subscription-cancel.tsx
+++ b/emails/emails/subscription-cancel.tsx
@@ -1,4 +1,4 @@
-import { Link, Text } from "react-email";
+import { Link, Text } from "@react-email/components";
 
 import { Template } from "../templates/btrix.js";
 import {

--- a/emails/emails/trial-ending-soon.tsx
+++ b/emails/emails/trial-ending-soon.tsx
@@ -1,4 +1,4 @@
-import { Link, Text } from "react-email";
+import { Link, Text } from "@react-email/components";
 
 import { Template } from "../templates/btrix.js";
 import {

--- a/emails/emails/verify-email.tsx
+++ b/emails/emails/verify-email.tsx
@@ -1,4 +1,4 @@
-import { Link, Section, Text } from "react-email";
+import { Link, Section, Text } from "@react-email/components";
 
 import { Template } from "../templates/btrix.js";
 import { Button } from "../components/button.js";

--- a/emails/package.json
+++ b/emails/package.json
@@ -14,9 +14,6 @@
   "dependencies": {
     "@react-email/components": "^1.0.12",
     "@sendgrid/mail": "^8.1.6",
-    "@types/express": "^5.0.6",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
     "@webrecorder/hickory": "^0.4.0",
     "express": "^5.2.1",
     "node-fetch": "^3.3.2",
@@ -24,10 +21,15 @@
     "pino-http": "^11.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "typescript": "^6.0.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3"
+  },
+  "optionalDependencies": {
     "@react-email/ui": "6.6.3",
     "pino-pretty": "^13.1.3",
     "react-email": "^6.6.3",

--- a/emails/package.json
+++ b/emails/package.json
@@ -12,7 +12,11 @@
     "start": "node dist/api-server.js"
   },
   "dependencies": {
+    "@react-email/components": "^1.0.12",
     "@sendgrid/mail": "^8.1.6",
+    "@types/express": "^5.0.6",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@webrecorder/hickory": "^0.4.0",
     "express": "^5.2.1",
     "node-fetch": "^3.3.2",
@@ -20,16 +24,13 @@
     "pino-http": "^11.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-email": "^6.6.3",
+    "typescript": "^6.0.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@react-email/ui": "6.6.3",
-    "@types/express": "^5.0.6",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
     "pino-pretty": "^13.1.3",
-    "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "react-email": "^6.6.3",
+    "tsx": "^4.22.4"
   }
 }

--- a/emails/readme.md
+++ b/emails/readme.md
@@ -25,7 +25,13 @@ This project includes an Express API server that can render the email templates 
 To start the API server:
 
 ```sh
-yarn start:api
+yarn start
 ```
 
 The API server will be available at [localhost:3000](http://localhost:3000).
+
+## Development notes
+
+We've decided to hold back on React Email's recommended move from `@react-email/components` to `react-email` for components and render functions because it's currently not possible to only import the relevant components from `react-email`, meaning that Docker build times & image sizes are _significantly_ longer. This seems to be a known issue (https://github.com/resend/react-email/issues/3556), so fingers crossed they'll resolve this in the future and we'll be able to switch off of the now-deprecated `@react-email/components` package.
+
+The `react-email` and `@react-email/ui` packages are kept in `optionalDependencies` so that local development (`yarn dev`) still works, but they're skipped in Docker builds with `--ignore-optional`.

--- a/emails/tailwind.config.ts
+++ b/emails/tailwind.config.ts
@@ -1,4 +1,4 @@
-import type { TailwindConfig } from "react-email";
+import type { TailwindConfig } from "@react-email/components";
 import { colors } from "@webrecorder/hickory/tokens/tailwind";
 
 export default {

--- a/emails/templates/btrix.tsx
+++ b/emails/templates/btrix.tsx
@@ -12,7 +12,7 @@ import {
   Section,
   Tailwind,
   Text,
-} from "react-email";
+} from "@react-email/components";
 
 import twConfig from "../tailwind.config.js";
 

--- a/emails/yarn.lock
+++ b/emails/yarn.lock
@@ -571,6 +571,119 @@
   resolved "https://registry.yarnpkg.com/@pinojs/redact/-/redact-0.4.0.tgz#c3de060dd12640dcc838516aa2a6803cc7b2e9d6"
   integrity sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==
 
+"@react-email/body@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@react-email/body/-/body-0.3.0.tgz#fdad70ce54d7a68029ad89bc4a001805fa260264"
+  integrity sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==
+
+"@react-email/button@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@react-email/button/-/button-0.2.1.tgz#e41581e73b54a3fda0ca3b14fcf41d181aa3052c"
+  integrity sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==
+
+"@react-email/code-block@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@react-email/code-block/-/code-block-0.2.1.tgz#11c0fb4ed87b97808f4e22f49d9106249554693c"
+  integrity sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==
+  dependencies:
+    prismjs "^1.30.0"
+
+"@react-email/code-inline@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@react-email/code-inline/-/code-inline-0.0.6.tgz#3cad348d06a0f048683088dfd6138b3b0ce33e6d"
+  integrity sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==
+
+"@react-email/column@0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@react-email/column/-/column-0.0.14.tgz#4568445e933be5c23142cb4a67b803fc69c5cdc2"
+  integrity sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==
+
+"@react-email/components@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/components/-/components-1.0.12.tgz#cfd5539b89e5a56ee53740a8665a7568a2941eec"
+  integrity sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==
+  dependencies:
+    "@react-email/body" "0.3.0"
+    "@react-email/button" "0.2.1"
+    "@react-email/code-block" "0.2.1"
+    "@react-email/code-inline" "0.0.6"
+    "@react-email/column" "0.0.14"
+    "@react-email/container" "0.0.16"
+    "@react-email/font" "0.0.10"
+    "@react-email/head" "0.0.13"
+    "@react-email/heading" "0.0.16"
+    "@react-email/hr" "0.0.12"
+    "@react-email/html" "0.0.12"
+    "@react-email/img" "0.0.12"
+    "@react-email/link" "0.0.13"
+    "@react-email/markdown" "0.0.18"
+    "@react-email/preview" "0.0.14"
+    "@react-email/render" "2.0.6"
+    "@react-email/row" "0.0.13"
+    "@react-email/section" "0.0.17"
+    "@react-email/tailwind" "2.0.7"
+    "@react-email/text" "0.1.6"
+
+"@react-email/container@0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@react-email/container/-/container-0.0.16.tgz#a2426e9d26b9cfc4f77f531091a6b68125cf01f1"
+  integrity sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==
+
+"@react-email/font@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@react-email/font/-/font-0.0.10.tgz#1c9e355a3a2678ac04bb8d8c68dfbc521ef3f08b"
+  integrity sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==
+
+"@react-email/head@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@react-email/head/-/head-0.0.13.tgz#bccbde95629901a8b9fabb0714c5de0225d77a52"
+  integrity sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==
+
+"@react-email/heading@0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@react-email/heading/-/heading-0.0.16.tgz#4d1e4136a1826fa64ead589685c4ba6291dcfb88"
+  integrity sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==
+
+"@react-email/hr@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/hr/-/hr-0.0.12.tgz#a3b43a83f038a71dbca0111e076c2f29de434bf2"
+  integrity sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==
+
+"@react-email/html@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/html/-/html-0.0.12.tgz#a0cbc790ad0c46edd47c7ceebaf6568cda6f568d"
+  integrity sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==
+
+"@react-email/img@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/img/-/img-0.0.12.tgz#8fa5c3ad8e330b8d1b23fd9d7f45ed1e8aa97fa6"
+  integrity sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==
+
+"@react-email/link@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@react-email/link/-/link-0.0.13.tgz#a0c5b053b3a608d5bf82c34374e08cebb64812d7"
+  integrity sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==
+
+"@react-email/markdown@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@react-email/markdown/-/markdown-0.0.18.tgz#d96fe36f56813552d9fc715faefee086cc47b078"
+  integrity sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==
+  dependencies:
+    marked "^15.0.12"
+
+"@react-email/preview@0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@react-email/preview/-/preview-0.0.14.tgz#da8ead3822c2cd27b349790419a86cfdf7d06070"
+  integrity sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==
+
+"@react-email/render@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@react-email/render/-/render-2.0.6.tgz#e663653c31ddcf8b8c8c4f24f96944c3607875cc"
+  integrity sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==
+  dependencies:
+    html-to-text "^9.0.5"
+    prettier "^3.5.3"
+
 "@react-email/render@>=2.0.9":
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/@react-email/render/-/render-2.0.9.tgz#f3780a4d637ac6dc8ae2ed45b3edc2cceaac6882"
@@ -578,6 +691,28 @@
   dependencies:
     html-to-text "^9.0.5"
     prettier "^3.5.3"
+
+"@react-email/row@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@react-email/row/-/row-0.0.13.tgz#c5d5c386fb1565f714d518e792a07a82ca6808ff"
+  integrity sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==
+
+"@react-email/section@0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@react-email/section/-/section-0.0.17.tgz#0ac9c65b24a7b17c042d75a9ff03b36a4296a8e7"
+  integrity sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==
+
+"@react-email/tailwind@2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@react-email/tailwind/-/tailwind-2.0.7.tgz#e0fe0a0103f00add89400c3226c4d97a18ce41a7"
+  integrity sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==
+  dependencies:
+    tailwindcss "^4.1.18"
+
+"@react-email/text@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@react-email/text/-/text-0.1.6.tgz#29fc7b130900cd192211e198066616aa210dd78d"
+  integrity sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==
 
 "@react-email/ui@6.6.3":
   version "6.6.3"


### PR DESCRIPTION
Switches back to using `@react-email/components`, even though it's deprecated, because the `react-email` package requires a bunch of big dependencies that can't be excluded when installing for production/building that are only used for the dev ui.

This also moves a few not-strictly-prod dependencies into the prod dependency group so that the rest of the dev dependencies can be excluded in the builder.

This also cleans up the `emails` build workflow, removing the node setup entirely, since it's not used at all - the build happens from the Dockerfile.