### PR TITLE
logging: Refactor callsite hander to point to correct location

### DIFF
--- a/backend/btrixcloud/logger.py
+++ b/backend/btrixcloud/logger.py
@@ -150,14 +150,18 @@ _callsite_adder = structlog.processors.CallsiteParameterAdder(
 )
 
 
-def _add_callsite(logger, method_name: str, event_dict: EventDict) -> EventDict:
-    """Add callsite info to all events except request-logging events,
+def _strip_callsite_for_excluded_events(
+    _logger: structlog.stdlib.BoundLogger, _method_name: str, event_dict: EventDict
+) -> EventDict:
+    """Strip callsite info from request-logging events and uvicorn.access,
     whose callsite is always the same middleware location."""
-    if event_dict.get("event") not in (
+    if event_dict.get("event") in (
         "http_request",
         "http_unhandled_exception",
-    ) and event_dict.get("logger") not in ("uvicorn.access",):
-        return _callsite_adder(logger, method_name, event_dict)
+    ) or event_dict.get("logger") == "uvicorn.access":
+        event_dict.pop("filename", None)
+        event_dict.pop("func_name", None)
+        event_dict.pop("lineno", None)
     return event_dict
 
 
@@ -172,7 +176,8 @@ SHARED_PROCESSORS: list[Processor] = [
     structlog.processors.TimeStamper(fmt="iso"),
     structlog.processors.StackInfoRenderer(),
     structlog.processors.UnicodeDecoder(),
-    _add_callsite,
+    _callsite_adder,
+    _strip_callsite_for_excluded_events,
 ]
 
 

--- a/backend/btrixcloud/logger.py
+++ b/backend/btrixcloud/logger.py
@@ -155,10 +155,14 @@ def _strip_callsite_for_excluded_events(
 ) -> EventDict:
     """Strip callsite info from request-logging events and uvicorn.access,
     whose callsite is always the same middleware location."""
-    if event_dict.get("event") in (
-        "http_request",
-        "http_unhandled_exception",
-    ) or event_dict.get("logger") == "uvicorn.access":
+    if (
+        event_dict.get("event")
+        in (
+            "http_request",
+            "http_unhandled_exception",
+        )
+        or event_dict.get("logger") == "uvicorn.access"
+    ):
         event_dict.pop("filename", None)
         event_dict.pop("func_name", None)
         event_dict.pop("lineno", None)


### PR DESCRIPTION
Previously the callsite adder was called from a helper function, which meant it was grabbing the wrong callsite location. this change adds it to the chain unconditionally, but then strips the callsite info for requests that shouldn't have it instead.

Raised [in Discord](https://discord.com/channels/895426029194207262/910966759165657161/1523806682889846866).

Example showing the fix from the CI logs:

```
2026-07-07T19:39:03.433916Z [warning  ] crawl_run_now_blocked          [btrixcloud.crawlconfigs] btrix_branch=HEAD btrix_commit_hash=ccb8b86 btrix_version=1.23.0 config_id=d6f50a17-6461-47b3-b2e9-7e46658e34ab config_name='Read Only Test Crawl' error_detail=org_set_to_read_only filename=crawlconfigs.py func_name=add_crawl_config lineno=401 oid=0fd3a2d6-0a24-45e6-b884-1d03b8bd57bb request_id=31a4b377 unstructured_message="Can't run crawl now: org_set_to_read_only" user_id=951274af-3f64-4731-ba59-b3a593545ced
```