### PR TITLE
Update rate limited detection user guide

### DIFF
--- a/frontend/docs/docs/user-guide/crawl-workflows.md
+++ b/frontend/docs/docs/user-guide/crawl-workflows.md
@@ -48,11 +48,12 @@ Statuses may be displayed with a reason that details how the current status came
 | <span class="status-violet-600">:bootstrap-hourglass-split: Waiting: _Reason_</span> | The workflow run is queued for one of the following reasons:<br/>**At Crawl Limit**: Org has reached maximum number of concurrent crawls<br/>**Dedupe Index**: An update to the deduplication index is in progress |
 | <span class="status-violet-600">:btrix-status-dot: Starting</span> | The crawler is being initialized. Crawling will begin shortly. |
 | <span class="status-green-600">:btrix-status-dot: Running</span> | The crawler is visiting and archiving pages. |
-| <span class="status-amber-600">:bootstrap-exclamation-triangle-fill: Rate Limited</span> | The crawler has detected [rate limiting](running-crawl.md#rate-limit-detection) from the sites that are being crawled and is running more slowly. |
+| <span class="status-amber-600">:btrix-status-dot: Running (Rate Limited)</span> | The crawler is running more slowly to capture [rate limited](running-crawl.md#rate-limit-detection) webpages. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing</span> | The crawler has been instructed to pause and is finishing crawl of the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Finishing Downloads)</span> | The crawler is finalizing downloads on the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Creating WACZ)</span> | Pages crawled so far are being packaged into WACZ files and transferred to storage. |
 | <span class="status-neutral-500">:bootstrap-pause-circle: Paused</span> | The workflow run has been paused by a user. It can be resumed for up to 7 days; afterwards, the run stops. |
+| <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout</span> | The workflow run has been paused automatically due to being [rate limited](running-crawl.md#rate-limit-detection) for too long. |
 | <span class="status-neutral-500">:bootstrap-pause-circle: Paused: _Reason_</span> | The workflow run has been paused automatically due to an enforced limit, as specified in the reason. |
 | <span class="status-violet-600">:bootstrap-play-circle: Resuming</span> | The workflow run is starting back up after being paused. |
 | <span class="status-violet-600">:btrix-status-dot: Stopping</span> | The crawler has been instructed to stop and is finishing crawl of the current page.|

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -53,9 +53,9 @@ Unfortunately, there is not much Browsertrix can do to prevent being rate limite
 
 ### Rate Limited Workflow Status
 
-If the crawler can no longer continue by skipping error pages while being rate limited, it will switch to a time-delay-based strategy to continue running. The workflow status during this state will be **Running (Rate limited)**. In this state, the crawler will slow down and retry the page URL at longer intervals, up to once every 5 minutes. Pages that were not captured before will be queued to be retried. Crawls in this state will only use a few seconds of crawl time to check that it is still rate limited, thus avoiding wasting execution minutes on error pages.
+If the crawler can no longer continue by skipping error pages while being rate limited, it will switch to a time-delay-based strategy to continue running. The workflow status during this state will be <span class="status-amber-600">:btrix-status-dot: Running (Rate Limited)</span>. In this state, the crawler will slow down and retry the page URL at longer intervals, up to once every 5 minutes. Pages that were not captured before will be queued to be retried. Crawls in this state will only use a few seconds of crawl time to check that it is still rate limited, thus avoiding wasting execution minutes on error pages.
 
-If the crawl remains rate limited for an extended period of time (12 hours by default), the crawl may be automatically paused to avoid retrying indefinitely. The workflow status will then be **Paused: Rate Limit Timeout**.
+If the crawl remains rate limited for an extended period of time (12 hours by default), the crawl may be automatically paused to avoid retrying indefinitely. The workflow status will then be <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout</span>.
 
 ## End a Crawl
 

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -39,25 +39,23 @@ To resume a paused crawl, simply click the _Resume_ button. The crawl status wil
 
 ## Rate Limit Detection
 
-A site may 'rate limit' a crawl by returning error codes or showing CAPTCHA pages. Browsertrix will automatically
-attempt to detect such error pages, and skip archiving them. If enough consecutive error pages are show, the
-crawl will enter into a <span class="status-amber-600">:bootstrap-exclamation-triangle-fill: Rate Limited</span> state, indicating that the crawl is being rate limited by the current site.
+A website may limit the number of requests it receives in a given amount of time. This practice is called [rate limiting](https://en.wikipedia.org/wiki/Rate_limiting) and it can improve server performance, mitigate network attacks, and reduce spam traffic.
 
-In this state, the crawler will slow down and retry at slower interval, up to once every 5 minutes. Pages that were
-not captured before will be queued to be retried.
+Rate limiting can also make pages harder to archive: when a visitor (human, bot, or crawler) is rate limited by a website, they may see an error or [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) page instead of the actual page content for the given URL. Browsertrix attempts to capture only actual page content (i.e. prevent including error pages in an archive) by automatically detecting and temporarily skipping such error pages.
 
-While rate limited, the crawler will use only a few seconds of crawling time to check if it is still rate limited,
-thus avoiding wasting crawling minutes on rate limited pages.
+If too many error pages are encountered, the crawler adapts by slowing down and retrying the page URL after a longer delay. This behavior is distinct from the [page delay](workflow-setup.md#delay-before-next-page) workflow setting, which can reduce the chance of being rate limited by increasing the time spent on each page, at the cost of increasing the overall crawl time.
 
-If the crawl remains rate limited for an extended period of time (12 hours by default), it may revert to a <span class="status-neutral-500">:bootstrap-pause-circle: Paused: Rate Limit Timeout Reached</span>
-state to avoid running indefinitely.
+Unfortunately, there is not much Browsertrix can do to prevent being rate limited altogether. Adding a [browser profile](browser-profiles/browser-profiles-overview.md) or configuring a [proxy server](workflow-setup.md#crawler-proxy-server) may help reduce rate limits for certain sites, while other sites may need to provide explicit permission to be crawled, thus requiring the list of IP ranges used by Browsertrix.
 
-While a crawl is rate limited, there is not much Browsertrix can do, unfortunately. Occasionally, adding a [browser profile](browser-profiles/browser-profiles-overview.md) or configuring a [proxy server](../workflow-setup/#crawler-proxy-server) (if available) may help reduce rate limit for certain sites, while other sites may require permission to be crawled, such as allow-listing the IP address range(s) used by Browsertrix. If Browsertrix detects that the crawler is no longer being rate limited, the crawl status will switch back to *Running*.
+???+ "Allow-listing Browsertrix on your website"
+    `Paid Feature`{ .badge-green }
+    If you subscribe to hosted Browsertrix and need help with being rate limited by your own website, please reach out to [support](support@webrecorder.org) for assistance.
 
-???+ Note
-    If you are a customer of our service and need help with rate limits on your own site, please reach out to [Support](support@webrecorder.org) and we may be able to assist.
-    
+### Rate Limited Workflow Status
 
+If the crawler can no longer continue by skipping error pages while being rate limited, it will switch to a time-delay-based strategy to continue running. The workflow status during this state will be **Running (Rate limited)**. In this state, the crawler will slow down and retry the page URL at longer intervals, up to once every 5 minutes. Pages that were not captured before will be queued to be retried. Crawls in this state will only use a few seconds of crawl time to check that it is still rate limited, thus avoiding wasting execution minutes on error pages.
+
+If the crawl remains rate limited for an extended period of time (12 hours by default), the crawl may be automatically paused to avoid retrying indefinitely. The workflow status will then be **Paused: Rate Limit Timeout**.
 
 ## End a Crawl
 

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -90,7 +90,7 @@ export class CrawlStatus extends TailwindElement {
           : originalState.endsWith("_org_readonly")
             ? msg("Crawling Disabled")
             : originalState.endsWith("_rate_limit_time_reached")
-              ? msg("Rate Limit Timeout Reached")
+              ? msg("Rate Limit Timeout")
               : ""
       : "";
     let substate = "";
@@ -152,11 +152,14 @@ export class CrawlStatus extends TailwindElement {
       case "rate-limited":
         color = "var(--warning)";
         icon = html`<sl-icon
-          name="exclamation-triangle-fill"
+          name="dot"
+          library="app"
+          class="animatePulse"
           slot="prefix"
           style="color: ${color}"
         ></sl-icon>`;
-        label = msg("Rate Limited");
+        label = msg("Running");
+        substate = msg("Rate Limited");
         break;
 
       case "stopping":

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1503,7 +1503,7 @@ export class WorkflowDetail extends BtrixElement {
     }
 
     return html`
-      <btrix-alert class="sticky top-2 z-50 part-[base]:mb-5" variant="info">
+      <btrix-alert class="sticky top-2 z-50 part-[base]:mb-5" variant="warning">
         <div class="mb-2 flex justify-between">
           <span class="inline-flex items-center gap-1.5">
             <sl-icon
@@ -1511,14 +1511,14 @@ export class WorkflowDetail extends BtrixElement {
               name="exclamation-diamond-fill"
             ></sl-icon>
             <strong class="font-medium">
-              ${msg("Rate limiting detected")}
+              ${msg("Rate Limiting Detected")}
             </strong>
           </span>
         </div>
-        <div class="text-pretty text-neutral-600">
-          <p class="mb-2">
+        <div class="text-pretty">
+          <p>
             ${msg(
-              "This crawl is being rate limited by a website being crawled.",
+              "This crawl is running slower due to being rate limited by a website being crawled.",
             )}
             <a
               target="_blank"
@@ -1526,7 +1526,7 @@ export class WorkflowDetail extends BtrixElement {
                 .docsUrl}user-guide/running-crawl/#rate-limit-detection"
             >
               <strong class="font-semibold"
-                >${msg("More Info on Rate Limit Detection")}</strong
+                >${msg("More Information")}</strong
               ></a
             >
           </p>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1503,23 +1503,22 @@ export class WorkflowDetail extends BtrixElement {
     }
 
     return html`
-      <btrix-alert
-        id="pausedNotice"
-        class="sticky top-2 z-50 part-[base]:mb-5"
-        variant="info"
-      >
+      <btrix-alert class="sticky top-2 z-50 part-[base]:mb-5" variant="info">
         <div class="mb-2 flex justify-between">
           <span class="inline-flex items-center gap-1.5">
-            <sl-icon class="text-base" name="exclamation-triangle"></sl-icon>
+            <sl-icon
+              class="text-base"
+              name="exclamation-diamond-fill"
+            ></sl-icon>
             <strong class="font-medium">
-              ${msg("Crawling is being rate limited or blocked")}
+              ${msg("Rate limiting detected")}
             </strong>
           </span>
         </div>
         <div class="text-pretty text-neutral-600">
           <p class="mb-2">
             ${msg(
-              `Browsertrix has detected that pages being crawled are error or CAPTCHA pages and is skipping them.`,
+              "This crawl is being rate limited by a website being crawled.",
             )}
             <a
               target="_blank"

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -1,10 +1,10 @@
 // Match backend TYPE_RUNNING_STATES in models.py
 export const RUNNING_STATES = [
   "running",
+  "rate-limited",
   "pending-wait",
   "generate-wacz",
   "uploading-wacz",
-  "rate-limited",
 ] as const;
 
 // Match backend TYPE_WAITING_NOT_PAUSED_STATES in models.py


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3260, resolves https://github.com/webrecorder/browsertrix/issues/3268

## Changes

- Updates rate limited status names
- Updates rate limited notice
- Documents paused due to rate limited status in user guide
- Updates rate limited detection user guide to explain general concept of rate limiting

## Screenshots

<img width="658" height="36" alt="Screenshot 2026-07-07 at 3 00 36 PM" src="https://github.com/user-attachments/assets/b1c5ab28-427c-4e72-87f1-718248412e67" />

<img width="673" height="60" alt="Screenshot 2026-07-07 at 3 00 44 PM" src="https://github.com/user-attachments/assets/90072a27-a15f-47bb-a074-8415f8e81e65" />

<img width="483" height="672" alt="Screenshot 2026-07-07 at 2 59 27 PM" src="https://github.com/user-attachments/assets/9c0e6e0b-3031-4257-ae1d-1bb14eb180d5" />

<img width="483" height="394" alt="Screenshot 2026-07-07 at 2 59 33 PM" src="https://github.com/user-attachments/assets/2c6fbce6-8c0b-4914-af0a-61e2d88ae153" />

<img width="950" height="79" alt="Screenshot 2026-07-07 at 3 10 35 PM" src="https://github.com/user-attachments/assets/14200289-5173-40e0-8a36-6710969b6378" />
