### PR TITLE
fix: Add back and fix `failOnFailedSeed` form field

### DIFF
--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -57,11 +57,15 @@ The crawl scope is your starting point for scoping. The scope can be expanded to
     _Upload URL List_
     :    A longer list of URLs can be provided as a text file, containing one URL per line. The text file may not exceed 25MB, but there is no limit to the number of URLs in the file. Once a file is added, a link will be provided to view the file (but not edit it). To change the file, a new file can be uploaded in its place.
 
-    For both options, each line should contain a valid URL (starting with https:// or http://). Invalid or duplicate URLs will be skipped. The crawl will fail if the list contains no valid URLs or if the file is not a list of URLs.
+    For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl on Invalid URL](#fail-crawl-on-invalid-url)_ is enabled. The crawl will always fail if the list contains no valid URLs or if the file is not a list of URLs.
 
     While the uploaded text file can contain an unlimited number of URLs, the crawl will still be limited by the [page limit](#max-pages) for the workflow or organization - URLs beyond the limit will not be crawled.
 
     If both a list of entered list and an uploaded file are provided, the currently selected option will be used.
+
+    ##### Fail Crawl on Invalid URL
+
+    If enabled, the crawler will exit upon encountering any URL that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
 
 #### In-Page Links
 
@@ -200,7 +204,11 @@ This can be useful for capturing links that lead outside the crawled website but
 
 #### Custom List of Pages
 
-A list of URLs of pages to crawl.
+A list of URLs of pages to crawl. For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl on Invalid URL](#fail-crawl-on-invalid-url-for-custom-list-of-pages)_ is enabled.
+
+#### Fail Crawl on Invalid URL (For _Custom List of Pages_)
+
+If enabled, the crawler will exit upon encountering any URL in _Custom List of Pages_ that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
 
 ### Exclude Pages
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -57,13 +57,13 @@ The crawl scope is your starting point for scoping. The scope can be expanded to
     _Upload URL List_
     :    A longer list of URLs can be provided as a text file, containing one URL per line. The text file may not exceed 25MB, but there is no limit to the number of URLs in the file. Once a file is added, a link will be provided to view the file (but not edit it). To change the file, a new file can be uploaded in its place.
 
-    For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl on Invalid URL](#fail-crawl-on-invalid-url)_ is enabled. The crawl will always fail if the list contains no valid URLs or if the file is not a list of URLs.
+    For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl if Any URL Fails](#fail-crawl-on-invalid-url)_ is enabled. The crawl will always fail if the list contains no valid URLs or if the file is not a list of URLs.
 
     While the uploaded text file can contain an unlimited number of URLs, the crawl will still be limited by the [page limit](#max-pages) for the workflow or organization - URLs beyond the limit will not be crawled.
 
     If both a list of entered list and an uploaded file are provided, the currently selected option will be used.
 
-    ##### Fail Crawl on Invalid URL
+    ##### Fail Crawl if Any URL Fails
 
     If enabled, the crawler will exit upon encountering any URL that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
 
@@ -202,13 +202,13 @@ When enabled, the crawler will follow any hyperlink that is on a page selected b
 
 This can be useful for capturing links that lead outside the crawled website but should still be included in the archive.
 
-#### Custom List of Pages
+#### Additional List of Pages
 
-A list of URLs of pages to crawl. For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl on Invalid URL](#fail-crawl-on-invalid-url-for-custom-list-of-pages)_ is enabled.
+A list of URLs of pages to crawl. For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl if Any URL Fails](#fail-crawl-on-invalid-url-for-additional-list-of-pages)_ is enabled.
 
-#### Fail Crawl on Invalid URL (For _Custom List of Pages_)
+#### Fail Crawl if Any URL Fails (For _Additional List of Pages_)
 
-If enabled, the crawler will exit upon encountering any URL in _Custom List of Pages_ that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
+If enabled, the crawler will exit upon encountering any URL in _Additional List of Pages_ that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
 
 ### Exclude Pages
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -57,15 +57,13 @@ The crawl scope is your starting point for scoping. The scope can be expanded to
     _Upload URL List_
     :    A longer list of URLs can be provided as a text file, containing one URL per line. The text file may not exceed 25MB, but there is no limit to the number of URLs in the file. Once a file is added, a link will be provided to view the file (but not edit it). To change the file, a new file can be uploaded in its place.
 
-    For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl if Any URL Fails](#fail-crawl-on-invalid-url)_ is enabled. The crawl will always fail if the list contains no valid URLs or if the file is not a list of URLs.
+        While the text file can contain an unlimited number of URLs, the crawl will still be limited by the [page limit](#max-pages) for the workflow or organization. URLs beyond the limit will not be crawled.
 
-    While the uploaded text file can contain an unlimited number of URLs, the crawl will still be limited by the [page limit](#max-pages) for the workflow or organization - URLs beyond the limit will not be crawled.
-
-    If both a list of entered list and an uploaded file are provided, the currently selected option will be used.
+    For both options, each line should contain a valid URL (starting with `https://` or `http://`). Duplicate URLs will be skipped. Invalid URLs will be ignored unless _[Fail Crawl if Any URL Fails](#fail-crawl-if-any-url-fails)_ is enabled, in which case the crawl will fail. The crawl will always fail if the entered URL list contains no valid URLs or if the file is not a list of URLs.
 
     ##### Fail Crawl if Any URL Fails
 
-    If enabled, the crawler will exit upon encountering any URL that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
+    If enabled, the crawler will exit upon encountering any URL that fails to load. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
 
 #### In-Page Links
 
@@ -202,13 +200,13 @@ When enabled, the crawler will follow any hyperlink that is on a page selected b
 
 This can be useful for capturing links that lead outside the crawled website but should still be included in the archive.
 
-#### Additional List of Pages
+#### Additional URLs to Crawl
 
-A list of URLs of pages to crawl. For both options, each line should contain a valid URL (starting with `https://` or `http://`). Invalid or duplicate URLs will be skipped unless _[Fail Crawl if Any URL Fails](#fail-crawl-on-invalid-url-for-additional-list-of-pages)_ is enabled.
+A list of URLs of pages to crawl. Each line should contain a valid URL (starting with `https://` or `http://`). Invalid URLs will be ignored unless _[Fail Crawl if Any URL Fails](#fail-crawl-if-any-url-fails-for-additional-urls-to-crawl)_ is enabled.
 
-#### Fail Crawl if Any URL Fails (For _Additional List of Pages_)
+#### Fail Crawl if Any URL Fails (For _Additional URLs to Crawl_)
 
-If enabled, the crawler will exit upon encountering any URL in _Additional List of Pages_ that fails to open. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
+If enabled, the crawler will exit upon encountering any URL in _Additional URLs to Crawl_ that fails to load. No crawled content will be saved and the workflow status will be <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span>.
 
 ### Exclude Pages
 

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -475,7 +475,7 @@ export class ConfigDetails extends BtrixElement {
       )}
       ${when(isUrlList, () =>
         this.renderSetting(
-          msg("Fail Crawl on Invalid URL"),
+          msg("Fail Crawl if Any URL Fails"),
           config.failOnFailedSeed,
         ),
       )}
@@ -581,7 +581,7 @@ export class ConfigDetails extends BtrixElement {
       )}
       ${when(additionalUrlList.length, () =>
         this.renderSetting(
-          msg("Fail Crawl on Invalid URL"),
+          msg("Fail Crawl if Any URL Fails"),
           config.failOnFailedSeed,
         ),
       )}

--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -462,54 +462,22 @@ export class ConfigDetails extends BtrixElement {
           </btrix-file-list>`,
       );
 
-    const seeds = () =>
-      when(
-        this.seeds,
-        (seeds) => html`
-          <btrix-table class="grid-cols-[1fr_auto]">
-            ${seeds.map(
-              (seed: Seed) => html`
-                <btrix-table-row>
-                  <btrix-table-cell>
-                    <btrix-overflow-scroll
-                      class="-ml-5 w-[calc(100%+theme(spacing.5))] contain-inline-size part-[content]:px-5 part-[content]:[scrollbar-width:thin]"
-                    >
-                      <btrix-code
-                        language="url"
-                        class="block w-max whitespace-nowrap"
-                        .value=${seed.url}
-                      ></btrix-code>
-                    </btrix-overflow-scroll>
-                  </btrix-table-cell>
-                  <btrix-table-cell>
-                    <btrix-copy-button .value=${seed.url} placement="left">
-                    </btrix-copy-button>
-                    <sl-tooltip
-                      placement="right"
-                      content=${msg("Open in New Tab")}
-                    >
-                      <sl-icon-button
-                        name="arrow-up-right"
-                        href="${seed.url}"
-                        target="_blank"
-                      >
-                      </sl-icon-button>
-                    </sl-tooltip>
-                  </btrix-table-cell>
-                </btrix-table-row>
-              `,
-            )}
-          </btrix-table>
-        `,
-      );
+    const seeds = () => when(this.seeds, this.renderSeeds);
+    const isUrlList = this.seeds && this.seeds.length > 1;
 
     return html`
       ${this.renderSetting(
-        config.seedFileId || (this.seeds && this.seeds.length > 1)
+        config.seedFileId || isUrlList
           ? msg("URLs to Crawl")
           : msg("URL to Crawl"),
         config.seedFileId ? seedFile() : seeds(),
         true,
+      )}
+      ${when(isUrlList, () =>
+        this.renderSetting(
+          msg("Fail Crawl on Invalid URL"),
+          config.failOnFailedSeed,
+        ),
       )}
       ${this.renderSetting(
         msg("Visit Any Linked Page"),
@@ -608,25 +576,14 @@ export class ConfigDetails extends BtrixElement {
       )}
       ${this.renderSetting(
         labelFor.urlList,
-        additionalUrlList.length
-          ? html`
-              <ul>
-                ${additionalUrlList.map((seed) => {
-                  const seedUrl = typeof seed === "string" ? seed : seed.url;
-                  return html`<li>
-                    <a
-                      class="text-primary hover:text-primary-400"
-                      href="${seedUrl}"
-                      target="_blank"
-                      rel="noreferrer"
-                      >${seedUrl}</a
-                    >
-                  </li>`;
-                })}
-              </ul>
-            `
-          : none,
+        additionalUrlList.length ? this.renderSeeds(additionalUrlList) : none,
         true,
+      )}
+      ${when(additionalUrlList.length, () =>
+        this.renderSetting(
+          msg("Fail Crawl on Invalid URL"),
+          config.failOnFailedSeed,
+        ),
       )}
       ${this.renderSetting(
         msg("Use Robots.txt Disallow List"),
@@ -672,6 +629,44 @@ export class ConfigDetails extends BtrixElement {
       () => this.renderSetting(labelFor.exclusions, none),
     );
   }
+
+  private readonly renderSeeds = (seeds: Seed[]) => {
+    return html`<btrix-table class="grid-cols-[1fr_auto]">
+      ${seeds.map((seed: Seed) => {
+        const url = typeof seed === "string" ? seed : seed.url;
+
+        return html`
+          <btrix-table-row
+            class="-ml-1.5 rounded transition-colors duration-x-fast has-[btrix-copy-button:hover]:bg-neutral-50 has-[sl-icon-button:hover]:bg-neutral-50"
+          >
+            <btrix-table-cell class="pl-1.5">
+              <btrix-overflow-scroll
+                class="-ml-5 w-[calc(100%+theme(spacing.5))] contain-inline-size part-[content]:px-5 part-[content]:[scrollbar-width:thin]"
+              >
+                <btrix-code
+                  language="url"
+                  class="block w-max whitespace-nowrap"
+                  .value=${url}
+                ></btrix-code>
+              </btrix-overflow-scroll>
+            </btrix-table-cell>
+            <btrix-table-cell>
+              <btrix-copy-button .value=${url} placement="left">
+              </btrix-copy-button>
+              <sl-tooltip placement="right" content=${msg("Open in New Tab")}>
+                <sl-icon-button
+                  name="arrow-up-right"
+                  href="${url}"
+                  target="_blank"
+                >
+                </sl-icon-button>
+              </sl-tooltip>
+            </btrix-table-cell>
+          </btrix-table-row>
+        `;
+      })}
+    </btrix-table>`;
+  };
 
   private renderSetting(
     label: string | TemplateResult,

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1655,6 +1655,15 @@ https://archiveweb.page/es/`}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor.useSitemap, false)}
+      ${inputCol(html`
+        <sl-checkbox
+          name="failOnFailedSeed"
+          ?checked=${this.formState.failOnFailedSeed}
+        >
+          ${labelFor.failOnFailedSeed}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor.failOnFailedSeed, false)}
       ${this.renderLinkSelectors()}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1122,6 +1122,15 @@ export class WorkflowEditor extends BtrixElement {
                 content: msg("upload a URL list file"),
               })}.`,
       )}
+      ${inputCol(html`
+        <sl-checkbox
+          name="failOnFailedSeed"
+          ?checked=${this.formState.failOnFailedSeed}
+        >
+          ${labelFor.failOnFailedSeed}
+        </sl-checkbox>
+      `)}
+      ${this.renderHelpTextCol(infoTextFor.failOnFailedSeed, false)}
     `;
   };
 
@@ -1655,6 +1664,7 @@ https://archiveweb.page/es/`}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor.useSitemap, false)}
+      ${this.renderLinkSelectors()}
       ${inputCol(html`
         <sl-checkbox
           name="failOnFailedSeed"
@@ -1664,7 +1674,6 @@ https://archiveweb.page/es/`}
         </sl-checkbox>
       `)}
       ${this.renderHelpTextCol(infoTextFor.failOnFailedSeed, false)}
-      ${this.renderLinkSelectors()}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1665,15 +1665,6 @@ https://archiveweb.page/es/`}
       `)}
       ${this.renderHelpTextCol(infoTextFor.useSitemap, false)}
       ${this.renderLinkSelectors()}
-      ${inputCol(html`
-        <sl-checkbox
-          name="failOnFailedSeed"
-          ?checked=${this.formState.failOnFailedSeed}
-        >
-          ${labelFor.failOnFailedSeed}
-        </sl-checkbox>
-      `)}
-      ${this.renderHelpTextCol(infoTextFor.failOnFailedSeed, false)}
 
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
@@ -1718,6 +1709,17 @@ https://archiveweb.page/images/${"logo.svg"}`}
         ${msg(str`You can enter up to ${maxUrls} URLs.`, {
           desc: "`maxUrls` example: '1,000'",
         })}`,
+        showWhenOpen: html`
+          ${inputCol(html`
+            <sl-checkbox
+              name="failOnFailedSeed"
+              ?checked=${this.formState.failOnFailedSeed}
+            >
+              ${labelFor.failOnFailedSeed}
+            </sl-checkbox>
+          `)}
+          ${this.renderHelpTextCol(infoTextFor.failOnFailedSeed, false)}
+        `,
       })}
 
       <!-- Settings that modify the expanded scope by exclude links that would normally would be in scope -->

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -3823,8 +3823,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
       seeds: [primarySeed, ...additionalSeedUrlList],
       scopeType,
       useSitemap: this.formState.useSitemap,
-      failOnFailedSeed:
-        includeUrlList.length > 0 && this.formState.failOnFailedSeed,
+      failOnFailedSeed: this.formState.failOnFailedSeed,
     };
     return config;
   }

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -3775,7 +3775,9 @@ https://archiveweb.page/images/${"logo.svg"}`}
       scopeType: ScopeType.Page,
       extraHops: this.formState.includeLinkedPages ? 1 : 0,
       useSitemap: false,
-      failOnFailedSeed: this.formState.failOnFailedSeed,
+      failOnFailedSeed:
+        this.formState.scopeType === NewWorkflowOnlyScopeType.PageList &&
+        this.formState.failOnFailedSeed,
     };
 
     return config;
@@ -3821,7 +3823,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
       seeds: [primarySeed, ...additionalSeedUrlList],
       scopeType,
       useSitemap: this.formState.useSitemap,
-      failOnFailedSeed: false,
+      failOnFailedSeed:
+        includeUrlList.length > 0 && this.formState.failOnFailedSeed,
     };
     return config;
   }

--- a/frontend/src/layouts/columns.ts
+++ b/frontend/src/layouts/columns.ts
@@ -11,7 +11,7 @@ export type Cols = [TemplateResult<1>, TemplateResult | string | undefined][];
 // TODO Revisit, maybe configure with Cols?
 const singleLineFromControls = ["sl-checkbox", "sl-switch"];
 
-export const gridColsClasses = tw`grid grid-cols-5 gap-5`;
+export const gridColsClasses = tw`grid-cols-5 gap-5`;
 export const colSpanClasses = tw`col-span-5 min-h-6`;
 
 export function inputCol(content: TemplateResult<1>) {
@@ -40,7 +40,7 @@ export function infoCol(content: TemplateResult | string, classes?: string) {
 
 export function columns(cols: Cols) {
   return html`
-    <div class="${gridColsClasses}">
+    <div class=${clsx(gridColsClasses, tw`grid`)}>
       ${cols.map(([main, info]) => {
         const singleLineFormControl = new RegExp(
           `<(${singleLineFromControls.join("|")})`,

--- a/frontend/src/layouts/detailsInColumns.ts
+++ b/frontend/src/layouts/detailsInColumns.ts
@@ -16,15 +16,17 @@ export function detailsInColumns({
   description,
   info,
   open,
+  showWhenOpen,
 }: {
   title: TemplateResult | string;
   main: TemplateResult<1>;
   description?: TemplateResult | string;
   info?: TemplateResult | string;
   open?: boolean;
+  showWhenOpen?: TemplateResult;
 }) {
   return html`<div
-    class=${clsx(containerClass, colSpanClasses, gridColsClasses)}
+    class=${clsx(containerClass, colSpanClasses, gridColsClasses, tw`grid`)}
   >
     <btrix-details
       class=${clsx(colSpanClasses, tw`peer md:col-span-3`)}
@@ -42,6 +44,17 @@ export function detailsInColumns({
             : info,
           tw`peer-open:md:pt-[2rem] [&>div>p]:hidden peer-open:[&>div>p]:block peer-open:[&>div>span]:hidden`,
         )
+      : nothing}
+    ${showWhenOpen
+      ? html`<div
+          class=${clsx(
+            colSpanClasses,
+            gridColsClasses,
+            tw`hidden peer-open:grid`,
+          )}
+        >
+          ${showWhenOpen}
+        </div>`
       : nothing}
   </div>`;
 }

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -55,7 +55,7 @@ export const infoTextFor = {
     `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
   ),
   failOnFailedSeed: msg(
-    "If any URL in the list of pages fails to load, the crawler will cease crawling and mark the workflow run as failed.",
+    "If any page in the list of URLs fails to load, the crawler will cease crawling and mark the workflow run as failed.",
   ),
   failOnContentCheck: html`${msg(
     "Fail the crawl if a page behavior detects the browser is not logged in on supported pages.",

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -55,7 +55,7 @@ export const infoTextFor = {
     `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
   ),
   failOnFailedSeed: msg(
-    "If any page that matches the crawl scope fails to load, the crawler will cease crawling and mark the workflow run as failed.",
+    "If any URL fails to load, the crawler will cease crawling and mark the workflow run as failed.",
   ),
   failOnContentCheck: html`${msg(
     "Fail the crawl if a page behavior detects the browser is not logged in on supported pages.",

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -55,7 +55,7 @@ export const infoTextFor = {
     `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
   ),
   failOnFailedSeed: msg(
-    "If any URL fails to load, the crawler will cease crawling and mark the workflow run as failed.",
+    "If any URL in the list of pages fails to load, the crawler will cease crawling and mark the workflow run as failed.",
   ),
   failOnContentCheck: html`${msg(
     "Fail the crawl if a page behavior detects the browser is not logged in on supported pages.",

--- a/frontend/src/strings/crawl-workflows/infoText.ts
+++ b/frontend/src/strings/crawl-workflows/infoText.ts
@@ -54,6 +54,9 @@ export const infoTextFor = {
   customBehavior: msg(
     `Enable custom page actions with behavior scripts. You can specify any publicly accessible URL or public Git repository.`,
   ),
+  failOnFailedSeed: msg(
+    "If any page that matches the crawl scope fails to load, the crawler will cease crawling and mark the workflow run as failed.",
+  ),
   failOnContentCheck: html`${msg(
     "Fail the crawl if a page behavior detects the browser is not logged in on supported pages.",
   )}

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -21,5 +21,6 @@ export const labelFor = {
   customIncludeList: msg("Page Prefix URLs"),
   urlList: msg("Custom List of Pages"),
   failOnContentCheck: msg("Fail crawl if not logged in"),
+  failOnFailedSeed: msg("Fail crawl if page fails"),
   exclusions: msg("Custom Exclusion Rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -19,8 +19,8 @@ export const labelFor = {
   useSitemap: msg("Use sitemap"),
   useRobots: msg("Use robots.txt disallow list"),
   customIncludeList: msg("Page Prefix URLs"),
-  urlList: msg("Custom List of Pages"),
+  urlList: msg("Additional List of Pages"),
   failOnContentCheck: msg("Fail crawl if not logged in"),
-  failOnFailedSeed: msg("Fail crawl on invalid URL"),
+  failOnFailedSeed: msg("Fail crawl if any URL fails"),
   exclusions: msg("Custom Exclusion Rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -19,7 +19,7 @@ export const labelFor = {
   useSitemap: msg("Use sitemap"),
   useRobots: msg("Use robots.txt disallow list"),
   customIncludeList: msg("Page Prefix URLs"),
-  urlList: msg("Additional List of Pages"),
+  urlList: msg("Additional URLs to Crawl"),
   failOnContentCheck: msg("Fail crawl if not logged in"),
   failOnFailedSeed: msg("Fail crawl if any URL fails"),
   exclusions: msg("Custom Exclusion Rules"),

--- a/frontend/src/strings/crawl-workflows/labels.ts
+++ b/frontend/src/strings/crawl-workflows/labels.ts
@@ -21,6 +21,6 @@ export const labelFor = {
   customIncludeList: msg("Page Prefix URLs"),
   urlList: msg("Custom List of Pages"),
   failOnContentCheck: msg("Fail crawl if not logged in"),
-  failOnFailedSeed: msg("Fail crawl if page fails"),
+  failOnFailedSeed: msg("Fail crawl on invalid URL"),
   exclusions: msg("Custom Exclusion Rules"),
 } as const satisfies Partial<Record<FormStateField, string>>;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3437

## Changes

- Shows "Fail crawl on invalid URL" checkbox when "List of Pages" or "Custom List of Pages" seed list is enabled
- Consistently renders seed lists in workflow settings

## Manual testing

1. Log in as crawler
2. Go to workflow
3. Choose "List of Pages" crawl scope. Verify "Fail crawl on invalid URL" is shown
4. Enable option and save. Verify setting is shown in workflow settings
5. Edit workflow
6. Change scope to site crawl
7. Open "Custom List of Pages". Verify "Fail crawl on invalid URL" is shown

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow / Edit ("List of Pages" crawl scope) | <img width="907" height="260" alt="Screenshot 2026-07-07 at 5 19 35 PM" src="https://github.com/user-attachments/assets/1d81fe43-2456-4de9-b086-d3331166966b" /> |
| Workflow / Settings ("List of Pages" crawl scope) | <img width="393" height="170" alt="Screenshot 2026-07-07 at 5 26 22 PM" src="https://github.com/user-attachments/assets/11087c86-18c9-44a7-b289-bf4d67d04c6e" /> |
| Workflow / Edit (Site crawl scope) | <img width="914" height="176" alt="Screenshot 2026-07-07 at 5 26 53 PM" src="https://github.com/user-attachments/assets/a06b18c0-1114-4a6f-bae4-44618c0173d0" /> |
| Workflow / Settings (Site crawl scope) | <img width="469" height="125" alt="Screenshot 2026-07-07 at 5 39 57 PM" src="https://github.com/user-attachments/assets/f2e65ad3-7f34-4205-9f57-508cecffee70" /> |
| User Guide / Crawl Workflow Settings | <img width="696" height="240" alt="Screenshot 2026-07-07 at 5 57 53 PM" src="https://github.com/user-attachments/assets/76607ad2-af55-4b54-9b8d-d4730f932d57" /> |


<!-- ## Follow-ups -->
