### PR TITLE
support 'max_redis_memory' with custom memory limit for redis pods:

### DIFF
--- a/backend/btrixcloud/operator/baseoperator.py
+++ b/backend/btrixcloud/operator/baseoperator.py
@@ -42,6 +42,7 @@ class K8sOpAPI(K8sAPI):
     has_pod_metrics: bool
     enable_auto_resize: bool
     max_crawler_memory_size: int
+    max_redis_memory_size: int
 
     def __init__(self):
         super().__init__()
@@ -52,6 +53,7 @@ class K8sOpAPI(K8sAPI):
         self.has_pod_metrics = False
         self.enable_auto_resize = False
         self.max_crawler_memory_size = 0
+        self.max_redis_memory_size = 0
 
         self.compute_crawler_resources()
         self.compute_profile_resources()
@@ -79,6 +81,11 @@ class K8sOpAPI(K8sAPI):
             max_crawler_memory_size = int(parse_quantity(max_crawler_memory))
 
         self.max_crawler_memory_size = max_crawler_memory_size or crawler_memory
+
+        # optional: if set to 0, will use fixed memory
+        max_redis_memory = os.environ.get("MAX_REDIS_MEMORY")
+        if max_redis_memory:
+            self.max_redis_memory_size = int(parse_quantity(max_redis_memory))
 
         logger.debug(
             "crawler_resources_computed",

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -467,6 +467,11 @@ class CrawlOperator(BaseOperator):
         params["memory"] = pod_info.newMemory or params.get("redis_memory")
         params["no_pvc"] = crawl.is_single_page
 
+        if self.k8s.enable_auto_resize:
+            params["memory_limit"] = float(params["memory"]) * MEM_LIMIT_PADDING
+        else:
+            params["memory_limit"] = self.k8s.max_redis_memory_size or params["memory"]
+
         restart_reason = None
         if has_pod:
             restart_reason = pod_info.should_restart_pod()

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -466,11 +466,7 @@ class CrawlOperator(BaseOperator):
         params["cpu"] = pod_info.newCpu or params.get("redis_cpu")
         params["memory"] = pod_info.newMemory or params.get("redis_memory")
         params["no_pvc"] = crawl.is_single_page
-
-        if self.k8s.enable_auto_resize:
-            params["memory_limit"] = float(params["memory"]) * MEM_LIMIT_PADDING
-        else:
-            params["memory_limit"] = self.k8s.max_redis_memory_size or params["memory"]
+        params["memory_limit"] = self.k8s.max_redis_memory_size or params["memory"]
 
         restart_reason = None
         if has_pod:

--- a/chart/app-templates/redis.yaml
+++ b/chart/app-templates/redis.yaml
@@ -122,7 +122,7 @@ spec:
 
       resources:
         limits:
-          memory: {{ memory }}
+          memory: {{ memory_limit }}
 
         requests:
           cpu: {{ cpu }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -89,6 +89,7 @@ data:
   NUM_BROWSERS: "{{ .Values.crawler_browser_instances }}"
 
   MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"
+  MAX_REDIS_MEMORY: "{{ .Values.max_redis_memory }}"
 
   CRAWLER_MIN_AVAIL_STORAGE_RATIO: "{{ .Values.crawler_min_avail_storage_ratio }}"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -262,6 +262,10 @@ redis_memory: "200Mi"
 
 redis_storage: "3Gi"
 
+# max redis memory, if set, will allow redis to use upto max_redis_memory as the upper limit
+# if not set or 0, redis memory is fixed to 'redis_memory' above
+# max_redis_memory: 0
+
 # Dedupe Index
 # =========================================
 dedupe:


### PR DESCRIPTION
- if optional 'max_redis_memory' is set, the limit on Redis pods is set to this value
- if unset or set to 0, redis memory limit is fixed to request value, which is 'redis_memory'
- fixes #3472

Testing:
- set `max_redis_memory` in local chart override to some value different than `redis_memory`
- start crawl
- confirm the `limit` on the redis pod is set to the `max_redis_memory`