### PR TITLE
fix: Sync archived item tags

### DIFF
--- a/frontend/src/components/ui/tag-filter/tag-filter.ts
+++ b/frontend/src/components/ui/tag-filter/tag-filter.ts
@@ -73,7 +73,13 @@ export class TagFilter extends BtrixElement {
   @state()
   type: "and" | "or" = "or";
 
-  protected willUpdate(changedProperties: PropertyValues<this>): void {
+  public refreshOrgTags() {
+    void this.orgTagsTask.run();
+  }
+
+  protected async willUpdate(
+    changedProperties: PropertyValues<this>,
+  ): Promise<void> {
     if (changedProperties.has("tags")) {
       if (this.tags) {
         this.selected = new Map(this.tags.map((tag) => [tag, true]));

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -21,6 +21,7 @@ import {
   type Pagination,
 } from "@/components/ui/pagination";
 import type { BtrixSearchComboboxSelectEvent } from "@/components/ui/search-combobox";
+import type { TagFilter } from "@/components/ui/tag-filter/tag-filter";
 import type { BtrixChangeTagFilterEvent } from "@/components/ui/tag-filter/types";
 import { ClipboardController } from "@/controllers/clipboard";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
@@ -286,6 +287,9 @@ export class CrawlsList extends BtrixElement {
 
   @query("#stateSelect")
   stateSelect?: SlSelect;
+
+  @query("btrix-tag-filter")
+  private readonly tagFilter?: TagFilter | null;
 
   private get hasFiltersSet() {
     return [
@@ -583,6 +587,7 @@ export class CrawlsList extends BtrixElement {
             @updated=${() => {
               /* TODO fetch current page or single crawl */
               void this.archivedItemsTask.run();
+              this.tagFilter?.refreshOrgTags();
             }}
           ></btrix-item-metadata-editor>
         `
@@ -1052,6 +1057,8 @@ export class CrawlsList extends BtrixElement {
         variant: "success",
         icon: "check2-circle",
       });
+
+      this.tagFilter?.refreshOrgTags();
     } catch (e) {
       if (this.itemToDelete) {
         this.confirmDeleteItem(this.itemToDelete);


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3035

## Changes

Fixes archived item tag filter not being synced when tags or item is updated.

## Manual testing

1. Log in as crawler
2. Go to "Archived Items"
3. Choose overflow menu > "Edit Archived Item"
4. Add new tag and save
5. Open "Tags" filter and enter new tag. Verify tag appears
6. Delete same archived item
7. Open "Tags" filter and enter new tag. Verify tag no longer appears