### PR TITLE
fix: Fix execution time display inconsistencies

### DIFF
--- a/frontend/src/features/crawls/crawl-list/crawl-list-item.ts
+++ b/frontend/src/features/crawls/crawl-list/crawl-list-item.ts
@@ -71,9 +71,11 @@ export class CrawlListItem extends BtrixElement {
 
     return html`
       <btrix-table-row
-        class=${this.href
-          ? "cursor-pointer select-none transition-colors hover:bg-neutral-50 focus-within:bg-neutral-50 duration-fast"
-          : ""}
+        class=${
+          this.href
+            ? "cursor-pointer select-none transition-colors hover:bg-neutral-50 focus-within:bg-neutral-50 duration-fast"
+            : ""
+        }
         @click=${async (e: MouseEvent) => {
           if (e.target === this.dropdownMenu) {
             return;
@@ -95,30 +97,34 @@ export class CrawlListItem extends BtrixElement {
           )}
         </btrix-table-cell>
         <btrix-table-cell rowClickTarget=${this.href ? "a" : nothing}>
-          ${this.href
-            ? html`<a href=${this.href} @click=${this.navigate.link}>
-                ${label}
-              </a>`
-            : label}
+          ${
+            this.href
+              ? html`<a href=${this.href} @click=${this.navigate.link}>
+                  ${label}
+                </a>`
+              : label
+          }
         </btrix-table-cell>
-        ${this.workflowId
-          ? nothing
-          : html`
-              <btrix-table-cell>
-                ${this.safeRender(
-                  (crawl) => html`
-                    <btrix-format-date
-                      date=${crawl.started}
-                      month="2-digit"
-                      day="2-digit"
-                      year="numeric"
-                      hour="2-digit"
-                      minute="2-digit"
-                    ></btrix-format-date>
-                  `,
-                )}
-              </btrix-table-cell>
-            `}
+        ${
+          this.workflowId
+            ? nothing
+            : html`
+                <btrix-table-cell>
+                  ${this.safeRender(
+                    (crawl) => html`
+                      <btrix-format-date
+                        date=${crawl.started}
+                        month="2-digit"
+                        day="2-digit"
+                        year="numeric"
+                        hour="2-digit"
+                        minute="2-digit"
+                      ></btrix-format-date>
+                    `,
+                  )}
+                </btrix-table-cell>
+              `
+        }
         <btrix-table-cell>
           ${this.safeRender((crawl) =>
             crawl.finished
@@ -138,11 +144,9 @@ export class CrawlListItem extends BtrixElement {
         <btrix-table-cell>
           ${this.safeRender((crawl) =>
             !skipped
-              ? html`<span
-                  >${humanizeExecutionSeconds(crawl.crawlExecSeconds, {
-                    style: "short",
-                  })}</span
-                >`
+              ? humanizeExecutionSeconds(crawl.crawlExecSeconds, {
+                  style: "short",
+                })
               : notApplicable,
           )}
         </btrix-table-cell>

--- a/frontend/src/features/crawls/crawl-list/crawl-list-item.ts
+++ b/frontend/src/features/crawls/crawl-list/crawl-list-item.ts
@@ -138,16 +138,11 @@ export class CrawlListItem extends BtrixElement {
         <btrix-table-cell>
           ${this.safeRender((crawl) =>
             !skipped
-              ? html`<sl-tooltip>
-                  ${humanizeExecutionSeconds(crawl.crawlExecSeconds, {
+              ? html`<span
+                  >${humanizeExecutionSeconds(crawl.crawlExecSeconds, {
                     style: "short",
-                  })}
-                  <span slot="content">
-                    ${humanizeExecutionSeconds(crawl.crawlExecSeconds, {
-                      style: "long",
-                    })}
-                  </span>
-                </sl-tooltip>`
+                  })}</span
+                >`
               : notApplicable,
           )}
         </btrix-table-cell>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1587,26 +1587,6 @@ export class WorkflowDetail extends BtrixElement {
     const execTime = () => {
       if (!latestCrawl) return skeleton;
 
-      if (this.isRunning) {
-        return html`<span class="text-neutral-400">
-          ${noData}
-          <btrix-popover
-            content=${msg(
-              "Execution time will be calculated once this crawl is finished or paused.",
-            )}
-            distance="12"
-          >
-            <sl-icon name="question-circle"></sl-icon>
-          </btrix-popover>
-        </span>`;
-      }
-
-      if (latestCrawl.crawlExecSeconds < 60) {
-        return this.localize.humanizeDuration(
-          latestCrawl.crawlExecSeconds * 1000,
-        );
-      }
-
       return humanizeExecutionSeconds(latestCrawl.crawlExecSeconds, {
         style: "short",
       });

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -1,7 +1,9 @@
+import clsx from "clsx";
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 import localize from "./localize";
+import { tw } from "./tailwind";
 
 /**
  * Returns either `nothing`, or hours-minutes-seconds wrapped in parens.
@@ -161,19 +163,24 @@ export const humanizeExecutionSeconds = (
       : "";
 
   switch (style) {
-    case "long":
+    case "long": {
+      const tooltip = fullMinutes !== compactMinutes ? fullMinutes : undefined;
       return html`<span
-        title="${ifDefined(
-          fullMinutes !== compactMinutes ? fullMinutes : undefined,
-        )}"
+        class=${clsx(
+          // Place above 'rowClickTarget' in tables if tooltip is available
+          tooltip && tw`z-[1]`,
+        )}
+        title=${ifDefined(tooltip)}
         >${prefix}${detailsRelevant ? formattedDetails : compactMinutes}</span
       >`;
+    }
     case "short":
       return html`<span
+        class="z-[1]"
         title="${displaySeconds && seconds < 60 ? fullSeconds : fullMinutes}"
-        >${prefix}${displaySeconds && seconds < 60
-          ? compactSeconds
-          : compactMinutes}</span
+        >${prefix}${
+          displaySeconds && seconds < 60 ? compactSeconds : compactMinutes
+        }</span
       >`;
   }
 };

--- a/frontend/src/utils/executionTimeFormatter.ts
+++ b/frontend/src/utils/executionTimeFormatter.ts
@@ -135,6 +135,7 @@ export const humanizeExecutionSeconds = (
   });
 
   if (seconds === 0) {
+    if (style === "short") return compactMinuteFormatter.format(0);
     return longMinuteFormatter.format(0);
   }
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3063

## Changes

- Fixes display of execution minutes in workflow crawls list
- Displays execution minutes in workflow's latest crawl tab

## Manual testing

1. Log in as crawler
2. Go to "Crawling"
3. Start a crawl
4. Go to "Crawls" tab. Verify that "0 min" is displayed (instead of "0 minutes")
5. Hover over "X min". Verify native browser tooltip with "X minutes" is shown (instead of double tooltips)
6. Go to "Latest Crawl"
7. Wait for crawl to begin running. Verify "Execution Time" updates as crawl runs