### PR TITLE
refactor: Rewrite browser window range function as array

### DIFF
--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -553,18 +553,17 @@ export async function getServerDefaults(): Promise<WorkflowDefaults> {
   return defaults;
 }
 
-export function* rangeBrowserWindows(
-  settings: AppSettings | null,
-): Iterable<number> {
+export function rangeBrowserWindows(settings: AppSettings | null): number[] {
+  const steps: number[] = [];
+
   if (!settings) {
-    yield 1;
-    return;
+    return steps;
   }
 
   const { numBrowsersPerInstance, maxBrowserWindows } = settings;
 
   for (let i = 1; i < numBrowsersPerInstance; i++) {
-    yield i;
+    steps.push(i);
   }
 
   for (
@@ -572,6 +571,8 @@ export function* rangeBrowserWindows(
     i <= maxBrowserWindows;
     i += numBrowsersPerInstance
   ) {
-    yield i;
+    steps.push(i);
   }
+
+  return steps;
 }


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/2696

## Changes

Refactors `rangeBrowserWindows` from a generator to plain array methods as a potential fix for https://github.com/webrecorder/browsertrix/issues/2696. This is still a theory since I can't reproduce the issue, but the generator may be introducing unexpected side effects for what could be a simple array operation and this change eliminates that prospect.