### PR TITLE
Fix minimum crawler version check to allow testing beta releases and remove check for alwaysAddBehaviorLinks

### DIFF
--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -561,20 +561,6 @@ class CrawlOperator(BaseOperator):
             raw_config["behaviors"], crawler_image
         )
 
-        if raw_config.get("alwaysAddBehaviorLinks") is True:
-            min_behavior_links_image = os.environ.get(
-                "MIN_BEHAVIOR_LINKS_CRAWLER_IMAGE"
-            )
-            if min_behavior_links_image and crawler_image_below_minimum(
-                crawler_image, min_behavior_links_image
-            ):
-                raw_config.pop("alwaysAddBehaviorLinks", None)
-                configmap_logger.warning(
-                    "crawl_configmap_always_add_behavior_links_ignored",
-                    crawler_image=crawler_image,
-                    min_behavior_links_image=min_behavior_links_image,
-                )
-
         if crawl.seed_file_url:
             raw_config["seedFile"] = crawl.seed_file_url
         raw_config.pop("seedFileId", None)

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -253,7 +253,7 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
 
     # Compare base_versions with pre- and post- information stripped out
     # so that beta releases (which otherwise would be considered less than
-    # their corresponding releases) are considered can be tested
+    # their corresponding releases) can be tested
     if parse_version(crawler_image_version.base_version) < parse_version(
         min_image_version.base_version
     ):

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -240,8 +240,8 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
     Return False by default or if versions can't be parsed as semver (e.g. "latest")
     """
     try:
-        crawler_image_version = crawler_image.split(":")[1]
-        min_image_version = min_image.split(":")[1]
+        crawler_image_version = parse_version(crawler_image.split(":")[1])
+        min_image_version = parse_version(min_image.split(":")[1])
     # pylint: disable=broad-exception-caught
     except Exception:
         logger.warning(
@@ -252,12 +252,10 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
         )
         return False
 
-    try:
-        parse_version(crawler_image_version)
-    except InvalidVersion:
-        return False
-
-    if crawler_image_version < min_image_version:
+    # Check base_version so that beta releases (which otherwise would be
+    # considered less than the corresponding release) are considered
+    # equivalent and can be tested
+    if crawler_image_version.base_version < min_image_version.base_version:
         return True
 
     return False

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -18,6 +18,7 @@ import structlog
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from iso639 import is_language
+from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 from pymongo.collation import Collation
 from pymongo.errors import DuplicateKeyError
@@ -239,8 +240,8 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
     Return False by default or if versions can't be parsed as semver (e.g. "latest")
     """
     try:
-        crawler_image_version = parse_version(crawler_image.split(":")[1])
-        min_image_version = parse_version(min_image.split(":")[1])
+        crawler_image_version = crawler_image.split(":")[1]
+        min_image_version = min_image.split(":")[1]
     # pylint: disable=broad-exception-caught
     except Exception:
         logger.warning(
@@ -249,6 +250,11 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
             min_image=min_image,
             unstructured_message="Unable to compare crawler versions, allowing",
         )
+        return False
+
+    try:
+        parse_version(crawler_image_version)
+    except InvalidVersion:
         return False
 
     if crawler_image_version < min_image_version:

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -18,7 +18,6 @@ import structlog
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from iso639 import is_language
-from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 from pymongo.collation import Collation
 from pymongo.errors import DuplicateKeyError

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -253,7 +253,7 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
 
     # Compare base_versions with pre- and post- information stripped out
     # so that beta releases (which otherwise would be considered less than
-    # their  corresponding releases) are considered can be tested
+    # their corresponding releases) are considered can be tested
     if parse_version(crawler_image_version.base_version) < parse_version(
         min_image_version.base_version
     ):

--- a/backend/btrixcloud/utils.py
+++ b/backend/btrixcloud/utils.py
@@ -251,10 +251,12 @@ def crawler_image_below_minimum(crawler_image: str, min_image: str):
         )
         return False
 
-    # Check base_version so that beta releases (which otherwise would be
-    # considered less than the corresponding release) are considered
-    # equivalent and can be tested
-    if crawler_image_version.base_version < min_image_version.base_version:
+    # Compare base_versions with pre- and post- information stripped out
+    # so that beta releases (which otherwise would be considered less than
+    # their  corresponding releases) are considered can be tested
+    if parse_version(crawler_image_version.base_version) < parse_version(
+        min_image_version.base_version
+    ):
         return True
 
     return False

--- a/backend/test/test_utils.py
+++ b/backend/test/test_utils.py
@@ -50,6 +50,13 @@ def test_slug_from_name(name: str, expected_slug: str):
             "docker.io/webrecorder/browsertrix-crawler:1.5.0",
             True,
         ),
+        # Beta versions should be considered not below the corresponding
+        # release, since we want to be able to test beta features
+        (
+            "docker.io/webrecorder/browsertrix-crawler:1.14.0-beta.1",
+            "docker.io/webrecorder/browsertrix-crawler:1.14.0",
+            True,
+        ),
         # "latest" and similar tags for either always return False
         (
             "docker.io/webreocrder/browsertrix-crawler:latest",

--- a/backend/test/test_utils.py
+++ b/backend/test/test_utils.py
@@ -55,7 +55,7 @@ def test_slug_from_name(name: str, expected_slug: str):
         (
             "docker.io/webrecorder/browsertrix-crawler:1.14.0-beta.1",
             "docker.io/webrecorder/browsertrix-crawler:1.14.0",
-            True,
+            False,
         ),
         # "latest" and similar tags for either always return False
         (

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -84,8 +84,6 @@ data:
 
   MIN_SEED_FILE_CRAWLER_IMAGE: "{{ .Values.min_seed_file_crawler_image }}"
 
-  MIN_BEHAVIOR_LINKS_CRAWLER_IMAGE: "{{ .Values.min_behavior_links_crawler_image }}"
-
   NUM_BROWSERS: "{{ .Values.crawler_browser_instances }}"
 
   MAX_CRAWLER_MEMORY: "{{ .Values.max_crawler_memory }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -333,9 +333,6 @@ min_autoclick_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.5.0"
 # if set, will restrict seed files to image names that are >= this value
 min_seed_file_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.7.0"
 
-# if set, will restrict always adding behavior links to image names that are >= this value
-min_behavior_links_crawler_image: "docker.io/webrecorder/browsertrix-crawler:1.14.0"
-
 # optional: enable to use a persist volume claim for all crawls
 # can be enabled to use a multi-write shared filesystem
 # crawler_pv_claim: "nfs-shared-crawls"


### PR DESCRIPTION
Fixes #3505 

Also removes the minimum crawler version image check for `--alwaysAddBehaviorLinks`, since this will be ignored if passed to an earlier version of the crawler.