### PR TITLE
Better user reporting for temporarily interrupted (or rate limited crawls) from k8s status

### DIFF
--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -259,7 +259,12 @@ class UserOrgInfoOut(BaseModel):
 
 # ============================================================================
 TYPE_RUNNING_STATES = Literal[
-    "running", "pending-wait", "generate-wacz", "uploading-wacz", "rate-limited"
+    "running",
+    "pending-wait",
+    "generate-wacz",
+    "uploading-wacz",
+    "rate-limited",
+    "running-interrupted",
 ]
 RUNNING_STATES = get_args(TYPE_RUNNING_STATES)
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1158,6 +1158,26 @@ class CrawlOperator(BaseOperator):
                 status.resync_after = self.fast_retry_secs
                 return status
 
+            # if all crashed and last exit was rate limited, set to rate limited state now
+            if status.allCrashed:
+                if not status.rateLimitedAtTime:
+                    status.rateLimitedAtTime = date_to_str(dt_now())
+
+                new_state: TYPE_ALL_CRAWL_STATES = (
+                    "rate-limited"
+                    if status.lastCrawlPodExitCode == 18
+                    else "running-interrupted"
+                )
+
+                await self.set_state(
+                    new_state,
+                    status,
+                    crawl,
+                    allowed_from=RUNNING_STATES,
+                )
+                status.resync_after = self.fast_retry_secs
+                return status
+
             # update lastActiveTime if crawler is running
             if crawler_running:
                 status.lastActiveTime = date_to_str(dt_now())
@@ -1236,6 +1256,8 @@ class CrawlOperator(BaseOperator):
         redis_running = False
         pod_done_count = 0
 
+        all_crashed = True
+
         try:
             for name, pod in pods.items():
                 running = False
@@ -1250,14 +1272,29 @@ class CrawlOperator(BaseOperator):
                 elif phase == "Failed" and pstatus.get("reason") == "Evicted":
                     evicted = True
 
-                status.podStatus[name].evicted = evicted
+                pod_status = status.podStatus[name]
+                pod_status.evicted = evicted
 
                 if "containerStatuses" in pstatus:
                     cstatus = pstatus["containerStatuses"][0]
 
-                    self.handle_terminated_pod(
-                        name, role, status, cstatus["state"].get("terminated")
+                    terminated = cstatus["state"].get("terminated")
+
+                    self.handle_terminated_pod(name, role, status, terminated)
+
+                    waiting = cstatus["state"].get("waiting")
+                    pod_status.backoffWait = (
+                        waiting and waiting.get("reason") == "CrashLoopBackOff"
                     )
+
+                    if role == "crawler":
+                        # consider crashed if:
+                        # - in 'waiting' state with CrashLoopBackOff reason
+                        # - in 'terminated' state with non-zero exit code (will be brief)
+                        all_crashed = all_crashed and bool(
+                            pod_status.backoffWait
+                            or (terminated and pod_status.exitCode != 0)
+                        )
 
                 if role == "crawler":
                     crawler_running = crawler_running or running
@@ -1265,6 +1302,8 @@ class CrawlOperator(BaseOperator):
                         pod_done_count += 1
                 elif role == "redis":
                     redis_running = redis_running or running
+
+            status.allCrashed = all_crashed
 
         # pylint: disable=broad-except
         except Exception:
@@ -1294,13 +1333,14 @@ class CrawlOperator(BaseOperator):
 
         pod_status = status.podStatus[name]
 
+        # detect reason
+        exit_code = terminated.get("exitCode")
+
         pod_status.isNewExit = pod_status.exitTime != exit_time
         if pod_status.isNewExit and role == "crawler":
             pod_status.exitTime = exit_time
             status.anyCrawlPodNewExit = True
-
-        # detect reason
-        exit_code = terminated.get("exitCode")
+            status.lastCrawlPodExitCode = exit_code
 
         if exit_code == 0:
             pod_status.reason = "done"

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1882,9 +1882,10 @@ class CrawlOperator(BaseOperator):
                 allowed_from=RUNNING_STATES,
             )
             status.resync_after = self.fast_retry_secs
+            return status
 
         # mark crawl as pausing or stopping
-        elif status.stopping:
+        if status.stopping:
             if status.stopReason in PAUSED_STATES:
                 if await redis.set(f"{crawl.id}:paused", "1", nx=True):
                     logger.info(

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1160,14 +1160,16 @@ class CrawlOperator(BaseOperator):
 
             # if all crashed and last exit was rate limited, set to rate limited state now
             if status.allCrashed:
-                if not status.rateLimitedAtTime:
-                    status.rateLimitedAtTime = date_to_str(dt_now())
+                new_state: TYPE_ALL_CRAWL_STATES
 
-                new_state: TYPE_ALL_CRAWL_STATES = (
-                    "rate-limited"
-                    if status.lastCrawlPodExitCode == 18
-                    else "running-interrupted"
-                )
+                # rate limit interrupt
+                if status.lastCrawlPodExitCode == 18:
+                    if not status.rateLimitedAtTime:
+                        status.rateLimitedAtTime = date_to_str(dt_now())
+                    new_state = "rate-limited"
+                # all other interrupts
+                else:
+                    new_state = "running-interrupted"
 
                 await self.set_state(
                     new_state,

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -1158,28 +1158,6 @@ class CrawlOperator(BaseOperator):
                 status.resync_after = self.fast_retry_secs
                 return status
 
-            # if all crashed and last exit was rate limited, set to rate limited state now
-            if status.allCrashed:
-                new_state: TYPE_ALL_CRAWL_STATES
-
-                # rate limit interrupt
-                if status.lastCrawlPodExitCode == 18:
-                    if not status.rateLimitedAtTime:
-                        status.rateLimitedAtTime = date_to_str(dt_now())
-                    new_state = "rate-limited"
-                # all other interrupts
-                else:
-                    new_state = "running-interrupted"
-
-                await self.set_state(
-                    new_state,
-                    status,
-                    crawl,
-                    allowed_from=RUNNING_STATES,
-                )
-                status.resync_after = self.fast_retry_secs
-                return status
-
             # update lastActiveTime if crawler is running
             if crawler_running:
                 status.lastActiveTime = date_to_str(dt_now())
@@ -1883,8 +1861,30 @@ class CrawlOperator(BaseOperator):
             status.stopReason = await self.is_crawl_stopping(crawl, status, stats)
             status.stopping = status.stopReason is not None
 
+        # if all crashed and last exit was rate limited, set to rate limited state now
+        # this should be after the storage check above to allow for adjusting storage
+        if status.allCrashed:
+            new_state: TYPE_ALL_CRAWL_STATES
+
+            # rate limit interrupt
+            if status.lastCrawlPodExitCode == 18:
+                if not status.rateLimitedAtTime:
+                    status.rateLimitedAtTime = date_to_str(dt_now())
+                new_state = "rate-limited"
+            # all other interrupts
+            else:
+                new_state = "running-interrupted"
+
+            await self.set_state(
+                new_state,
+                status,
+                crawl,
+                allowed_from=RUNNING_STATES,
+            )
+            status.resync_after = self.fast_retry_secs
+
         # mark crawl as pausing or stopping
-        if status.stopping:
+        elif status.stopping:
             if status.stopReason in PAUSED_STATES:
                 if await redis.set(f"{crawl.id}:paused", "1", nx=True):
                     logger.info(

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -159,6 +159,7 @@ class PodInfo(BaseModel):
     signalAtMem: int | None = None
 
     evicted: bool | None = False
+    backoffWait: bool | None = False
 
     lastWorkers: int | None = 0
 
@@ -274,6 +275,12 @@ class CrawlStatus(BaseModel):
 
     # any pods exited
     anyCrawlPodNewExit: bool | None = Field(default=False, exclude=True)
+
+    # exit code of last pod to exit
+    lastCrawlPodExitCode: int | None = 0
+
+    # all running pods have crashed
+    allCrashed: bool = False
 
     # if status is 'rate-limited', when first became rate-limited
     rateLimitedAtTime: str | None = None

--- a/frontend/docs/docs/user-guide/crawl-workflows.md
+++ b/frontend/docs/docs/user-guide/crawl-workflows.md
@@ -48,6 +48,7 @@ Statuses may be displayed with a reason that details how the current status came
 | <span class="status-violet-600">:bootstrap-hourglass-split: Waiting: _Reason_</span> | The workflow run is queued for one of the following reasons:<br/>**At Crawl Limit**: Org has reached maximum number of concurrent crawls<br/>**Dedupe Index**: An update to the deduplication index is in progress |
 | <span class="status-violet-600">:btrix-status-dot: Starting</span> | The crawler is being initialized. Crawling will begin shortly. |
 | <span class="status-green-600">:btrix-status-dot: Running</span> | The crawler is visiting and archiving pages. |
+| <span class="status-amber-600">:btrix-status-dot: Running (Temporarily Interrupted)</span> | The crawler is still running, but has been temporarily interrupted due to some issue but will keep retrying. |
 | <span class="status-amber-600">:btrix-status-dot: Running (Rate Limited)</span> | The crawler is running more slowly to capture [rate limited](running-crawl.md#rate-limit-detection) webpages. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing</span> | The crawler has been instructed to pause and is finishing crawl of the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Finishing Downloads)</span> | The crawler is finalizing downloads on the current page. |

--- a/frontend/docs/docs/user-guide/crawl-workflows.md
+++ b/frontend/docs/docs/user-guide/crawl-workflows.md
@@ -48,7 +48,7 @@ Statuses may be displayed with a reason that details how the current status came
 | <span class="status-violet-600">:bootstrap-hourglass-split: Waiting: _Reason_</span> | The workflow run is queued for one of the following reasons:<br/>**At Crawl Limit**: Org has reached maximum number of concurrent crawls<br/>**Dedupe Index**: An update to the deduplication index is in progress |
 | <span class="status-violet-600">:btrix-status-dot: Starting</span> | The crawler is being initialized. Crawling will begin shortly. |
 | <span class="status-green-600">:btrix-status-dot: Running</span> | The crawler is visiting and archiving pages. |
-| <span class="status-amber-600">:btrix-status-dot: Running (Temporarily Interrupted)</span> | The crawler is still running, but has been temporarily interrupted due to some issue but will keep retrying. |
+| <span class="status-amber-600">:btrix-status-dot: Running (Temporarily Interrupted)</span> | The crawler is running but has been temporarily interrupted due to some issue. |
 | <span class="status-amber-600">:btrix-status-dot: Running (Rate Limited)</span> | The crawler is running more slowly to capture [rate limited](running-crawl.md#rate-limit-detection) webpages. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing</span> | The crawler has been instructed to pause and is finishing crawl of the current page. |
 | <span class="status-violet-600">:bootstrap-pause-circle: Pausing (Finishing Downloads)</span> | The crawler is finalizing downloads on the current page. |

--- a/frontend/src/features/archived-items/crawl-status.ts
+++ b/frontend/src/features/archived-items/crawl-status.ts
@@ -149,6 +149,19 @@ export class CrawlStatus extends TailwindElement {
         label = msg("Running");
         break;
 
+      case "running-interrupted":
+        color = "var(--warning)";
+        icon = html`<sl-icon
+          name="dot"
+          library="app"
+          class="animatePulse"
+          slot="prefix"
+          style="color: ${color}"
+        ></sl-icon>`;
+        label = msg("Running");
+        substate = msg("Temporarily Interrupted");
+        break;
+
       case "rate-limited":
         color = "var(--warning)";
         icon = html`<sl-icon

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -375,7 +375,9 @@ export class WorkflowDetail extends BtrixElement {
       this.workflow?.isCrawlRunning &&
       !this.workflow.lastCrawlStopping &&
       this.workflow.lastCrawlState &&
-      ["running", "rate-limited"].includes(this.workflow.lastCrawlState)
+      ["running", "rate-limited", "running-interrupted"].includes(
+        this.workflow.lastCrawlState,
+      )
     );
   }
 
@@ -1722,7 +1724,7 @@ export class WorkflowDetail extends BtrixElement {
 
     return html`
       ${when(
-        this.isCrawling && this.workflow,
+        this.isRunning && this.workflow,
         (workflow) => html`
           <div id="screencast-crawl">
             <btrix-screencast

--- a/frontend/src/types/crawlState.ts
+++ b/frontend/src/types/crawlState.ts
@@ -1,6 +1,7 @@
 // Match backend TYPE_RUNNING_STATES in models.py
 export const RUNNING_STATES = [
   "running",
+  "running-interrupted",
   "rate-limited",
   "pending-wait",
   "generate-wacz",


### PR DESCRIPTION
detect crawls that have been interrupted or rate limited by k8s status:
- detect when all crawl pods are in a CrashBackLoop or Terminated status
- add new 'running_interrupted' state, display as 'Running (Temporarily Interrupted)' if in backoff loop or non-zero exit code
- set state to 'Running (Rate Limited)' if exit code was 18 even if redis doesn't have rate limited key set
- frontend: consider temporarily interrupted as running
- frontend: show watch pages when in any running state
- fixes issue #3513