### PR TITLE
fix: Alllow excluding pages from smart scoping

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -464,6 +464,12 @@ export class ConfigDetails extends BtrixElement {
 
     const seeds = () => when(this.seeds, this.renderSeeds);
     const isUrlList = this.seeds && this.seeds.length > 1;
+    const showLinkSelectors =
+      config.extraHops || config.scopeType === ScopeType.SPA;
+    const showExclusions =
+      showLinkSelectors ||
+      config.alwaysAddBehaviorLinks ||
+      config.exclude?.length;
 
     return html`
       ${this.renderSetting(
@@ -487,10 +493,8 @@ export class ConfigDetails extends BtrixElement {
         titlecaseLabelFor.includeLinkedPages,
         Boolean(config.extraHops),
       )}
-      ${when(
-        config.extraHops || config.scopeType === ScopeType.SPA,
-        () => html`${this.renderLinkSelectors()}${this.renderExclusions()}`,
-      )}
+      ${when(showLinkSelectors, this.renderLinkSelectors)}
+      ${when(showExclusions, this.renderExclusions)}
     `;
   };
 
@@ -604,7 +608,7 @@ export class ConfigDetails extends BtrixElement {
     `;
   };
 
-  private renderLinkSelectors() {
+  private readonly renderLinkSelectors = () => {
     const selectors = this.crawlConfig?.config.selectLinks || [];
 
     return this.renderSetting(
@@ -621,9 +625,9 @@ export class ConfigDetails extends BtrixElement {
           `
         : msg("None"),
     );
-  }
+  };
 
-  private renderExclusions() {
+  private readonly renderExclusions = () => {
     const exclusions = this.crawlConfig?.config.exclude || [];
 
     return when(
@@ -639,7 +643,7 @@ export class ConfigDetails extends BtrixElement {
       `,
       () => this.renderSetting(labelFor.exclusions, none),
     );
-  }
+  };
 
   private readonly renderSeeds = (seeds: Seed[]) => {
     return html`<btrix-table class="grid-cols-[1fr_auto]">

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -500,7 +500,8 @@ export class WorkflowEditor extends BtrixElement {
       this.isCrawlRunning = this.configId ? null : false;
     }
     const prevFormState = changedProperties.get("formState") as
-      FormState | undefined;
+      | FormState
+      | undefined;
     if (prevFormState) {
       if (prevFormState.seedFile !== this.formState.seedFile) {
         if (this.formState.seedFile) {
@@ -535,7 +536,8 @@ export class WorkflowEditor extends BtrixElement {
       }
     }
     const prevFormState = changedProperties.get("formState") as
-      FormState | undefined;
+      | FormState
+      | undefined;
     if (prevFormState) {
       if (prevFormState.seedListFormat !== this.formState.seedListFormat) {
         void this.focusOnSeedListFormatChange();
@@ -611,17 +613,15 @@ export class WorkflowEditor extends BtrixElement {
           .options=${{
             threshold: 1,
           }}
-          @btrix-intersect=${
-            this.stickyFooter
-              ? null
-              : (e: IntersectEvent) => {
-                  const [entry] = e.detail.entries;
+          @btrix-intersect=${this.stickyFooter
+            ? null
+            : (e: IntersectEvent) => {
+                const [entry] = e.detail.entries;
 
-                  if (entry.isIntersecting) {
-                    this.stickyFooter = true;
-                  }
+                if (entry.isIntersecting) {
+                  this.stickyFooter = true;
                 }
-          }
+              }}
         >
           ${this.renderFooter()}
         </btrix-observable>
@@ -867,11 +867,9 @@ export class WorkflowEditor extends BtrixElement {
           </sl-button>
         </sl-tooltip>
         <sl-tooltip
-          content=${
-            this.isCrawlRunning
-              ? msg("Save and apply settings to current crawl")
-              : msg("Save and run with new settings")
-          }
+          content=${this.isCrawlRunning
+            ? msg("Save and apply settings to current crawl")
+            : msg("Save and run with new settings")}
           ?disabled=${this.isCrawlRunning === null}
         >
           <sl-button
@@ -879,15 +877,12 @@ export class WorkflowEditor extends BtrixElement {
             variant="primary"
             type="submit"
             value=${SubmitType.SaveAndRun}
-            ?disabled=${
-              (!this.isCrawlRunning && isArchivingDisabled(this.org, true)) ||
-              this.isSubmitting ||
-              this.isCrawlRunning === null
-            }
-            ?loading=${
-              (this.isSubmitting && this.saveAndRun) ||
-              this.isCrawlRunning === null
-            }
+            ?disabled=${(!this.isCrawlRunning &&
+              isArchivingDisabled(this.org, true)) ||
+            this.isSubmitting ||
+            this.isCrawlRunning === null}
+            ?loading=${(this.isSubmitting && this.saveAndRun) ||
+            this.isCrawlRunning === null}
           >
             ${this.isCrawlRunning ? msg("Update Crawl") : msg("Run Crawl")}
             ${when(this.showKeyboardShortcuts, () => keyboardShortcut("Enter"))}
@@ -961,11 +956,9 @@ export class WorkflowEditor extends BtrixElement {
             )}
         >
           <btrix-badge class="mr-2.5" slot="prefix" outline
-            >${
-              isPageScopeType(this.formState.scopeType)
-                ? stringForScopeGroup.page
-                : stringForScopeGroup.site
-            }</btrix-badge
+            >${isPageScopeType(this.formState.scopeType)
+              ? stringForScopeGroup.page
+              : stringForScopeGroup.site}</btrix-badge
           >
           <sl-menu-label>${stringForScopeGroup.page}</sl-menu-label>
           ${WORKFLOW_PAGE_SCOPES.map(
@@ -991,11 +984,9 @@ export class WorkflowEditor extends BtrixElement {
           )}
         </p>
       `)}
-      ${
-        isPageScopeType(this.formState.scopeType)
-          ? this.renderPageScope()
-          : this.renderSiteScope()
-      }
+      ${isPageScopeType(this.formState.scopeType)
+        ? this.renderPageScope()
+        : this.renderSiteScope()}
     `;
   };
 
@@ -1010,13 +1001,11 @@ export class WorkflowEditor extends BtrixElement {
     return detailsInColumns({
       open: exclusions.length > 0,
       title: html`${labelFor.exclusions}
-      ${
-        exclusions.length
-          ? html`<btrix-badge
-              >${this.localize.number(exclusions.length)}</btrix-badge
-            >`
-          : nothing
-      }`,
+      ${exclusions.length
+        ? html`<btrix-badge
+            >${this.localize.number(exclusions.length)}</btrix-badge
+          >`
+        : nothing}`,
       main: html`
         <btrix-queue-exclusion-table
           label=""
@@ -1507,16 +1496,14 @@ https://replayweb.page/docs`}
           class="mr-0.5 align-[-.175em]"
           name="info-circle"
         ></sl-icon>
-        ${
-          numberOfURLs
-            ? msg(
-                str`Automatically converted list of ${numberOfURLs} to a file.`,
-                {
-                  desc: "`numberOfURLs` example: '1,000 URLs'",
-                },
-              )
-            : msg("Automatically converted large URL list to a file.")
-        }`;
+        ${numberOfURLs
+          ? msg(
+              str`Automatically converted list of ${numberOfURLs} to a file.`,
+              {
+                desc: "`numberOfURLs` example: '1,000 URLs'",
+              },
+            )
+          : msg("Automatically converted large URL list to a file.")}`;
     } else if (this.seedFileUrlCount) {
       helpText = html`${msg(str`${numberOfURLs} entered.`, {
         desc: "`numberOfURLs` example: '1,000 URLs'",
@@ -1745,13 +1732,11 @@ https://archiveweb.page/es/`}
       ${detailsInColumns({
         open: additionalUrlList.length > 0,
         title: html`${labelFor.urlList}
-        ${
-          additionalUrlList.length
-            ? html`<btrix-badge
-                >${this.localize.number(additionalUrlList.length)}</btrix-badge
-              >`
-            : nothing
-        }`,
+        ${additionalUrlList.length
+          ? html`<btrix-badge
+              >${this.localize.number(additionalUrlList.length)}</btrix-badge
+            >`
+          : nothing}`,
         main: html`
           <sl-textarea
             class="part-[form-control-label]:sr-only"
@@ -1884,13 +1869,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
     return detailsInColumns({
       open: isCustom,
       title: html`${labelFor.selectLinks}
-      ${
-        isCustom
-          ? html`<btrix-badge
-              >${this.localize.number(selectors.length)}</btrix-badge
-            >`
-          : nothing
-      }`,
+      ${isCustom
+        ? html`<btrix-badge
+            >${this.localize.number(selectors.length)}</btrix-badge
+          >`
+        : nothing}`,
       main: html`<btrix-link-selector-table
         name="selectLinks"
         .selectors=${selectors}
@@ -2174,9 +2157,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
             () => html`
               <div class="mt-3">
                 <btrix-custom-behaviors-table
-                  .customBehaviors=${
-                    this.initialWorkflow?.config.customBehaviors || []
-                  }
+                  .customBehaviors=${this.initialWorkflow?.config
+                    .customBehaviors || []}
                   editable
                 ></btrix-custom-behaviors-table>
               </div>
@@ -2262,10 +2244,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
           ${inputCol(html`
             <sl-checkbox
               name="failOnContentCheck"
-              ?checked=${
-                this.formState.failOnContentCheck &&
-                this.formState.browserProfile !== null
-              }
+              ?checked=${this.formState.failOnContentCheck &&
+              this.formState.browserProfile !== null}
             >
               ${labelFor.failOnContentCheck}
             </sl-checkbox>
@@ -2293,38 +2273,36 @@ https://archiveweb.page/images/${"logo.svg"}`}
         })}`,
         false,
       )}
-      ${
-        proxies?.servers.length
-          ? [
-              inputCol(html`
-                <btrix-select-crawler-proxy
-                  defaultProxyId=${ifDefined(
-                    getDefaultProxyId(this.org, proxies),
-                  )}
-                  .proxyServers=${proxies.servers}
-                  .proxyId=${profileProxyId || this.formState.proxyId || ""}
-                  .profileProxyId=${profileProxyId}
-                  @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
-                    this.updateFormState({
-                      proxyId: e.detail.value,
-                    })}
-                >
-                  ${when(
-                    profileProxyId,
-                    () => html`
-                      <span
-                        slot="suffix"
-                        class="whitespace-nowrap text-neutral-1000"
-                        >${msg("Set by profile")}</span
-                      >
-                    `,
-                  )}
-                </btrix-select-crawler-proxy>
-              `),
-              this.renderHelpTextCol(infoTextFor["proxyId"]),
-            ]
-          : nothing
-      }
+      ${proxies?.servers.length
+        ? [
+            inputCol(html`
+              <btrix-select-crawler-proxy
+                defaultProxyId=${ifDefined(
+                  getDefaultProxyId(this.org, proxies),
+                )}
+                .proxyServers=${proxies.servers}
+                .proxyId=${profileProxyId || this.formState.proxyId || ""}
+                .profileProxyId=${profileProxyId}
+                @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
+                  this.updateFormState({
+                    proxyId: e.detail.value,
+                  })}
+              >
+                ${when(
+                  profileProxyId,
+                  () => html`
+                    <span
+                      slot="suffix"
+                      class="whitespace-nowrap text-neutral-1000"
+                      >${msg("Set by profile")}</span
+                    >
+                  `,
+                )}
+              </btrix-select-crawler-proxy>
+            `),
+            this.renderHelpTextCol(infoTextFor["proxyId"]),
+          ]
+        : nothing}
       ${inputCol(html`
         <sl-radio-group
           name="scale"
@@ -2864,22 +2842,20 @@ https://archiveweb.page/images/${"logo.svg"}`}
       `)}
       ${this.renderHelpTextCol(
         html`${msg(`Customize the name of this workflow.`)}
-        ${
-          urlList
-            ? this.formState.scopeType === ScopeType.Page
-              ? msg(
-                  html`If omitted, the workflow will be named after the URL
-                  specified in ${link_to_scope}.`,
-                )
-              : msg(
-                  html`If omitted, the workflow will be named after the first
-                  URL specified in ${link_to_scope}.`,
-                )
-            : msg(
-                html`If omitted, the workflow will be named after the
-                ${link_to_crawl_start_url}.`,
+        ${urlList
+          ? this.formState.scopeType === ScopeType.Page
+            ? msg(
+                html`If omitted, the workflow will be named after the URL
+                specified in ${link_to_scope}.`,
               )
-        } `,
+            : msg(
+                html`If omitted, the workflow will be named after the first URL
+                specified in ${link_to_scope}.`,
+              )
+          : msg(
+              html`If omitted, the workflow will be named after the
+              ${link_to_crawl_start_url}.`,
+            )} `,
       )}
       ${inputCol(html`
         <sl-textarea

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1036,6 +1036,14 @@ export class WorkflowEditor extends BtrixElement {
   }
 
   private readonly renderPageScope = () => {
+    const showLinkSelectors =
+      this.formState.includeLinkedPages ||
+      this.formState.scopeType === ScopeType.SPA;
+    const showExclusions =
+      showLinkSelectors ||
+      this.formState.alwaysAddBehaviorLinks ||
+      trimArray(this.formState.exclusions).length;
+
     return html`
       ${choose(this.formState.scopeType, [
         [ScopeType.Page, this.renderSingleUrlInput],
@@ -1046,11 +1054,10 @@ export class WorkflowEditor extends BtrixElement {
       <!-- Settings that expand the crawl scope by including links that would normally be out of scope -->
       ${this.renderSectionHeading(msg("Additional Scope"))}
       ${this.renderIncludeLinkedPages()} ${this.renderUseSmartScope()}
+      ${when(showLinkSelectors, this.renderLinkSelectors)}
       ${when(
-        this.formState.includeLinkedPages ||
-          this.formState.scopeType === ScopeType.SPA,
+        showExclusions,
         () => html`
-          ${this.renderLinkSelectors()}
           ${this.renderSectionHeading(msg("Exclude Pages"))}
           ${this.renderExcludePages()}
         `,
@@ -1849,7 +1856,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
     ${this.renderHelpTextCol(infoTextFor["includeLinkedPages"], false)}`;
   }
 
-  private renderLinkSelectors() {
+  private readonly renderLinkSelectors = () => {
     const selectors = this.formState.selectLinks;
     const isCustom = !isEqual(defaultFormState.selectLinks, selectors);
     const [defaultSel, defaultAttr] =
@@ -1896,7 +1903,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         )}
       `,
     });
-  }
+  };
 
   private renderCrawlLimits() {
     // Max Pages minimum value cannot be lower than seed count

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1042,7 +1042,8 @@ export class WorkflowEditor extends BtrixElement {
     const showExclusions =
       showLinkSelectors ||
       this.formState.alwaysAddBehaviorLinks ||
-      trimArray(this.formState.exclusions).length;
+      (this.formState.scopeType !== ScopeType.Page &&
+        trimArray(this.formState.exclusions).length);
 
     return html`
       ${choose(this.formState.scopeType, [
@@ -3776,6 +3777,11 @@ https://archiveweb.page/images/${"logo.svg"}`}
   }
 
   private parseConfig(uploadParams?: { seedFileId?: string }): WorkflowParams {
+    const canExclude =
+      this.formState.scopeType !== ScopeType.Page ||
+      this.formState.includeLinkedPages ||
+      this.formState.alwaysAddBehaviorLinks;
+
     const config: WorkflowParams = {
       // Job types are now merged into a single type
       jobType: "custom",
@@ -3809,7 +3815,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
         limit: this.formState.pageLimit,
         lang: this.formState.lang || "",
         blockAds: this.formState.blockAds,
-        exclude: trimArray(this.formState.exclusions),
+        exclude: canExclude ? trimArray(this.formState.exclusions) : [],
         behaviors: this.setBehaviors(),
         selectLinks: this.linkSelectorTable?.value.length
           ? this.linkSelectorTable.value


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3516

## Changes

- Always shows exclusion table if smart scoping is enabled.
- Removes exclusions from "Page" scope workflows if additional scope is not enabled.

## Manual testing

1. Log in as crawler
2. Go to new workflow
3. Change scope type to "Page List". Verify exclusion table is shown
4. Change scope type to "Page". Verify exclusion table is shown
5. Uncheck "Use smart scoping rules". Verify exclusion table is hidden
6. Go Settings > Crawling Defaults
7. Add default exclusion and save
8. Go back to new workflow
9. Uncheck "Use smart scoping rules". Verify exclusion table is still visible
10. Repeat 3-5 for editing existing workflow