### PR TITLE
Use environ.get for version env vars to be more permissive

### DIFF
--- a/backend/btrixcloud/version.py
+++ b/backend/btrixcloud/version.py
@@ -3,5 +3,5 @@
 import os
 
 __version__ = "1.24.0-beta.2"
-__commit_hash__ = os.environ["GIT_COMMIT_HASH"]
-__branch__ = os.environ["GIT_BRANCH_NAME"]
+__commit_hash__ = os.environ.get("GIT_COMMIT_HASH")
+__branch__ = os.environ.get("GIT_BRANCH_NAME")


### PR DESCRIPTION
Very small change that allows for easier local testing, where env vars might not be set.