### PR TITLE
ci: test fix + use latest edge crawler for all tests

### DIFF
--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -358,7 +358,6 @@ def sample_crawl_data():
         "name": "Test Crawl",
         "config": {
             "seeds": [{"url": "https://example-com.webrecorder.net/"}],
-            "extraHops": 1,
             # Add some extra config fields so we can ensure they're
             # not modified when we do a PATCH for other fields in the
             # config object

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -210,10 +210,12 @@ def large_crawl_id(admin_auth_headers, default_org_id):
         "name": "Large Test Crawl",
         "tags": ["wacz-logs"],
         "config": {
-            "seeds": [{"url": "https://old.webrecorder.net/"}],
-            "scopeType": "domain",
+            "seeds": [
+                {"url": "https://old.webrecorder.net/", "scopeType": "domain"},
+                {"url": "https://specs.webrecorder.net", "scopeType": "domain"},
+                {"url": "https://example-com.webrecorder.net", "scopeType": "page"},
+            ],
             "limit": 100,
-            "extraHops": 1,
         },
     }
     r = requests.post(

--- a/backend/test_nightly/test_execution_minutes_quota.py
+++ b/backend/test_nightly/test_execution_minutes_quota.py
@@ -9,12 +9,10 @@ from .utils import get_crawl_status
 
 EXEC_MINS_QUOTA = 1
 EXEC_SECS_QUOTA = EXEC_MINS_QUOTA * 60
-GIFTED_MINS_QUOTA = 3
+GIFTED_MINS_QUOTA = 1
 GIFTED_SECS_QUOTA = GIFTED_MINS_QUOTA * 60
-EXTRA_MINS_QUOTA = 5
+EXTRA_MINS_QUOTA = 2
 EXTRA_SECS_QUOTA = EXTRA_MINS_QUOTA * 60
-EXTRA_MINS_ADDED_QUOTA = 7
-EXTRA_SECS_ADDED_QUOTA = EXTRA_MINS_ADDED_QUOTA * 60
 
 
 def test_set_execution_mins_quota(org_with_quotas, admin_auth_headers):
@@ -163,7 +161,7 @@ def run_crawl(org_id, headers):
         "name": "Execution Mins Quota",
         "config": {
             "seeds": [{"url": "https://old.webrecorder.net/"}],
-            "extraHops": 1,
+            "pageExtraDelay": 45,
         },
     }
     r = requests.post(

--- a/backend/test_nightly/test_storage_quota.py
+++ b/backend/test_nightly/test_storage_quota.py
@@ -20,8 +20,9 @@ def run_crawl(org_id, headers):
         "runNow": True,
         "name": "Storage Quota",
         "config": {
-            "seeds": [{"url": "https://specs.webrecorder.net/"}],
-            "extraHops": 1,
+            "seeds": [
+                {"url": "https://old.webrecorder.net/", "scopeType": "domain"},
+            ],
         },
     }
     r = requests.post(

--- a/chart/test/test.yaml
+++ b/chart/test/test.yaml
@@ -37,11 +37,12 @@ crawler_extra_memory_per_browser: 256Mi
 
 crawler_channels:
   - id: default
-    image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    image: "docker.io/webrecorder/browsertrix-crawler:edge"
     imagePullPolicy: Always
 
   - id: test
-    image: "docker.io/webrecorder/browsertrix-crawler:latest"
+    image: "docker.io/webrecorder/browsertrix-crawler:edge"
+    imagePullPolicy: Always
 
 mongo_image: "docker.io/library/mongo:8.0"
 


### PR DESCRIPTION
nightly time quota test: use pageExtraDelay instead of extraHops to simulate long-running crawl hitting quotas without external sites

ci: use webrecorder/browsertrix-crawler:edge image for all tests

nightly test run: https://github.com/webrecorder/browsertrix/actions/runs/29938802544/job/88987183324