### PR TITLE
Replace unmaintained k3d-action with direct installation of k3d and cluster creation

### DIFF
--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -51,20 +51,27 @@ jobs:
           remove-browsers: true
           verbose: true
 
-      - name: Create k3d Cluster
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          k3d-version: v5.8.3
-          cluster-name: btrix-1
-          args: >-
-            -p "30870:30870@agent:0:direct"
-            -p "30872:30872@agent:0:direct"
-            --agents 1
-            --no-lb
-            --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*"
-
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Install k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/install-k3d.sh
+          k3d version
+
+      - name: Create K3d Cluster
+        run: |
+          k3d cluster create btrix-1 \
+            --servers 1 \
+            --agents 1 \
+            -p "30870:30870@agent:0:direct" \
+            -p "30872:30872@agent:0:direct" \
+            --no-lb \
+            --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*" \
+            --wait \
+            --timeout 60s
 
       - name: Set Env Vars
         run: |
@@ -172,3 +179,7 @@ jobs:
       - name: Print K8S Events
         if: ${{ always() }}
         run: kubectl events --all-namespaces
+
+      - name: Cleanup Cluster
+        if: ${{ always() }}
+        run: k3d cluster delete btrix-1

--- a/.github/workflows/k3d-ci.yaml
+++ b/.github/workflows/k3d-ci.yaml
@@ -1,6 +1,6 @@
 name: Cluster Run (K3d)
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/k3d-log-ci.yaml
+++ b/.github/workflows/k3d-log-ci.yaml
@@ -13,18 +13,25 @@ jobs:
   btrix-k3d-admin-logging-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Create k3d Cluster
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          k3d-version: v5.8.3
-          cluster-name: btrix-1
-          args: >-
-            --agents 1
-            -p "443:443@loadbalancer"
-            --k3s-arg "--no-deploy=traefik,metrics-server@server:*"
-
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Install k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/install-k3d.sh
+          k3d version
+
+      - name: Create K3d Cluster
+        run: |
+          k3d cluster create btrix-1 \
+            --servers 1 \
+            --agents 1 \
+            -p "443:443@loadbalancer" \
+            --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*" \
+            --wait \
+            --timeout 60s
 
       - name: Install Kubectl
         uses: azure/setup-kubectl@v3
@@ -89,3 +96,8 @@ jobs:
         run: |
           helm uninstall btrix-admin-log
           ./chart/admin/logging/scripts/eck_uninstall.sh
+
+      - name: Cleanup Cluster
+        if: ${{ always() }}
+        run: k3d cluster delete btrix-1
+

--- a/.github/workflows/k3d-nightly-ci.yaml
+++ b/.github/workflows/k3d-nightly-ci.yaml
@@ -36,20 +36,27 @@ jobs:
           remove-browsers: true
           verbose: true
 
-      - name: Create k3d Cluster
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          k3d-version: v5.8.3
-          cluster-name: btrix-nightly
-          args: >-
-            -p "30870:30870@agent:0:direct"
-            -p "30090:30090@agent:0:direct"
-            --agents 1
-            --no-lb
-            --k3s-arg "--disable=traefik,servicelb@server:*"
-
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Install k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/install-k3d.sh
+          k3d version
+
+      - name: Create K3d Cluster
+        run: |
+          k3d cluster create btrix-nightly \
+            --servers 1 \
+            --agents 1 \
+            -p "30870:30870@agent:0:direct" \
+            -p "30090:30090@agent:0:direct" \
+            --no-lb \
+            --k3s-arg "--disable=traefik,servicelb@server:*" \
+            --wait \
+            --timeout 60s
 
       - name: Set Env Vars
         run: |
@@ -160,3 +167,7 @@ jobs:
       - name: Print K8S Events
         if: ${{ always() }}
         run: kubectl events --all-namespaces
+
+      - name: Cleanup Cluster
+        if: ${{ always() }}
+        run: k3d cluster delete btrix-nightly

--- a/scripts/install-k3d.sh
+++ b/scripts/install-k3d.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+
+# Script copied from k3d repository, modified to use GitHub token to avoid rate limiting
+
+APP_NAME="k3d"
+REPO_URL="https://github.com/k3d-io/k3d"
+
+GITHUB_TOKEN=$GITHUB_TOKEN
+
+: ${USE_SUDO:="true"}
+: ${K3D_INSTALL_DIR:="/usr/local/bin"}
+
+# initArch discovers the architecture for this system.
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    armv5*) ARCH="armv5";;
+    armv6*) ARCH="armv6";;
+    armv7*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+  esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+  OS=$(uname|tr '[:upper:]' '[:lower:]')
+
+  case "$OS" in
+    # Minimalist GNU for Windows
+    mingw*) 
+      OS="windows"
+      USE_SUDO="false"
+      if [[ ! -d "$K3D_INSTALL_DIR" ]]; then
+        # mingw bash that ships with Git for Windows doesn't have /usr/local/bin but ~/bin is first entry in the path
+        mkdir -p ~/bin
+        K3D_INSTALL_DIR=~/bin
+      fi
+      ;;
+  esac
+}
+
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+  local CMD="$*"
+
+  if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+    CMD="sudo $CMD"
+  fi
+
+  $CMD
+}
+
+# scurl invokes `curl` with secure defaults
+scurl() {
+  # - `--proto =https` requires that all URLs use HTTPS. Attempts to call http://
+  #   URLs will fail.
+  # - `--tlsv1.2` ensures that at least TLS v1.2 is used, disabling less secure
+  #   prior TLS versions.
+  # - `--fail` ensures that the command fails if HTTP response is not 2xx.
+  # - `--show-error` causes curl to output error messages when it fails (when
+  #   also invoked with -s|--silent).
+  if [[ "$DEBUG" == "true" ]]; then
+    echo "Executing: curl --proto \"=https\" --tlsv1.2 --fail --show-error $*" >&2
+  fi
+  # Use GITHUB TOKEN auth if env variable is set
+  curl --proto "=https" --tlsv1.2 --fail --show-error ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} "$@"
+}
+
+wgetWithAuth() {
+  HEADER=""
+
+  if [ -n "$GITHUB_TOKEN" ]; then
+      HEADER="--header=Authorization: Bearer $GITHUB_TOKEN"
+  fi
+
+  wget $HEADER "$@"
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds.
+verifySupported() {
+  local supported="darwin-386\ndarwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nwindows-386\nwindows-amd64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuilt binary for ${OS}-${ARCH}."
+    echo "To build from source, go to $REPO_URL"
+    exit 1
+  fi
+
+  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+}
+
+# checkK3dInstalledVersion checks which version of k3d is installed and
+# if it needs to be changed.
+checkK3dInstalledVersion() {
+  if [[ -f "${K3D_INSTALL_DIR}/${APP_NAME}" ]]; then
+    local version=$(k3d version | grep 'k3d version' | cut -d " " -f3)
+    if [[ "$version" == "$TAG" ]]; then
+      echo "k3d ${version} is already ${DESIRED_VERSION:-latest}"
+      return 0
+    else
+      echo "k3d ${TAG} is available. Changing from version ${version}."
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+# checkTagProvided checks whether TAG has provided as an environment variable so we can skip checkLatestVersion.
+checkTagProvided() {
+  [[ ! -z "$TAG" ]]
+}
+
+# checkLatestVersion grabs the latest version string from the releases
+checkLatestVersion() {
+  local latest_release_url="$REPO_URL/releases/latest"
+  if type "curl" > /dev/null; then
+    TAG=$(scurl -Ls -o /dev/null -w %{url_effective} $latest_release_url | grep -oE "[^/]+$" )
+  elif type "wget" > /dev/null; then
+    TAG=$(wgetWithAuth $latest_release_url --server-response -O /dev/null 2>&1 | awk '/^\s*Location: /{DEST=$2} END{ print DEST}' | grep -oE "[^/]+$")
+  fi
+  if [[ "$DEBUG" == "true" ]]; then
+    echo "Resolved latest tag: <$TAG>" >&2
+  fi
+  if [[ "$TAG" == "latest" ]]; then
+    echo "Failed to get the latest version for $REPO_URL"
+    exit 1
+  fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+  K3D_DIST="k3d-$OS-$ARCH"
+  DOWNLOAD_URL="$REPO_URL/releases/download/$TAG/$K3D_DIST"
+  CHECKSUM_URL="$REPO_URL/releases/download/$TAG/checksums.txt"
+  if [[ "$OS" == "windows" ]]; then
+    DOWNLOAD_URL=${DOWNLOAD_URL}.exe
+  fi
+  K3D_TMP_ROOT="$(mktemp -dt k3d-binary-XXXXXX)"
+  K3D_TMP_FILE="$K3D_TMP_ROOT/$K3D_DIST"
+  K3D_SUM_FILE="$K3D_TMP_ROOT/checksums.txt"
+  if type "curl" > /dev/null; then
+    scurl -sL "$DOWNLOAD_URL" -o "$K3D_TMP_FILE"
+    scurl -sL "$CHECKSUM_URL" -o "$K3D_SUM_FILE"
+  elif type "wget" > /dev/null; then
+    wgetWithAuth -q -O "$K3D_TMP_FILE" "$DOWNLOAD_URL"
+    wgetWithAuth -q -O "$K3D_SUM_FILE" "$CHECKSUM_URL"
+  fi
+}
+
+# verifyChecksum verifies the SHA256 checksum of the downloaded binary.
+verifyChecksum() {
+  echo "Verifying SHA256 checksum of $K3D_TMP_FILE..."
+
+  local expected_sum
+  expected_sum=$(grep "_dist/${K3D_DIST}" "$K3D_SUM_FILE" | awk '{print $1}')
+
+  if [[ -z "$expected_sum" ]]; then
+    echo "Error: Could not find checksum for ${K3D_DIST} in checksums.txt"
+    exit 1
+  fi
+
+  local actual_sum
+  if type "sha256sum" > /dev/null 2>&1; then
+    actual_sum=$(sha256sum "$K3D_TMP_FILE" | awk '{print $1}')
+  elif type "shasum" > /dev/null 2>&1; then
+    actual_sum=$(shasum -a 256 "$K3D_TMP_FILE" | awk '{print $1}')
+  else
+    echo "Error: Neither sha256sum nor shasum is available — cannot verify checksum"
+    exit 1
+  fi
+
+  if [[ "$actual_sum" != "$expected_sum" ]]; then
+    echo "Error: SHA256 checksum verification FAILED for $K3D_TMP_FILE"
+    echo "  Expected: $expected_sum"
+    echo "  Actual:   $actual_sum"
+    exit 1
+  fi
+
+  echo "Checksum verified OK ($actual_sum)"
+}
+
+# installFile verifies the SHA256 for the file, then unpacks and
+# installs it.
+installFile() {
+  verifyChecksum
+  echo "Preparing to install $APP_NAME into ${K3D_INSTALL_DIR}"
+  runAsRoot chmod +x "$K3D_TMP_FILE"
+  runAsRoot cp "$K3D_TMP_FILE" "$K3D_INSTALL_DIR/$APP_NAME"
+  echo "$APP_NAME installed into $K3D_INSTALL_DIR/$APP_NAME"
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+  result=$?
+  if [ "$result" != "0" ]; then
+    if [[ -n "$INPUT_ARGUMENTS" ]]; then
+      echo "Failed to install $APP_NAME with the arguments provided: $INPUT_ARGUMENTS"
+      help
+    else
+      echo "Failed to install $APP_NAME"
+    fi
+    echo -e "\tFor support, go to $REPO_URL."
+  fi
+  cleanup
+  exit $result
+}
+
+# testVersion tests the installed client to make sure it is working.
+testVersion() {
+  if ! command -v $APP_NAME &> /dev/null; then
+    echo "$APP_NAME not found. Is $K3D_INSTALL_DIR on your "'$PATH?'
+    exit 1
+  fi
+  echo "Run '$APP_NAME --help' to see what you can do with it."
+}
+
+# help provides possible cli installation arguments
+help () {
+  echo "Accepted cli arguments are:"
+  echo -e "\t[--help|-h ] ->> prints this help"
+  echo -e "\t[--no-sudo]  ->> install without sudo"
+}
+
+# cleanup temporary files
+cleanup() {
+  if [[ -d "${K3D_TMP_ROOT:-}" ]]; then
+    rm -rf "$K3D_TMP_ROOT"
+  fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+set -e
+
+# Parsing input arguments (if any)
+export INPUT_ARGUMENTS="${@}"
+set -u
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    '--no-sudo')
+       USE_SUDO="false"
+       ;;
+    '--help'|-h)
+       help
+       exit 0
+       ;;
+    *) exit 1
+       ;;
+  esac
+  shift
+done
+set +u
+
+initArch
+initOS
+verifySupported
+checkTagProvided || checkLatestVersion
+if ! checkK3dInstalledVersion; then
+  downloadFile
+  installFile
+fi
+testVersion
+cleanup


### PR DESCRIPTION
Fixes #3173

Replaces the unmaintained `AbsaOSS/k3d-action` with direct installation of k3d and direct invocation of `k3d cluster create`.

Installation is handled through a local, slightly modified version of the official k3d installation bash script https://github.com/k3d-io/k3d/blob/main/install.sh, which adds GitHub authentication to all API calls and file downloads to avoid getting rate limited in our CI.

Also includes two temporary commits that should be dropped before merging, added just to trigger the CI for testing purposes.