### PR TITLE
fix: Crawl queue editor UX fixes

### DIFF
--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -16,6 +16,8 @@ type URLs = string[];
  *   .matchedURLs=${this.matchedURLs}
  * ></btrix-crawl-pending-exclusions>
  * ```
+ *
+ * @cssPart heading
  */
 @customElement("btrix-crawl-pending-exclusions")
 @localized()
@@ -45,7 +47,10 @@ export class CrawlPendingExclusions extends BtrixElement {
 
   render() {
     return html`
-      <btrix-section-heading style="--margin: var(--sl-spacing-small)">
+      <btrix-section-heading
+        part="heading"
+        class="[--margin:--sl-spacing-small]"
+      >
         <div class="flex w-full items-center justify-between">
           <div>${msg("Pending Exclusions")} ${this.renderBadge()}</div>
           ${this.total && this.total > this.pageSize

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -87,7 +87,7 @@ export class CrawlPendingExclusions extends BtrixElement {
 
   private renderContent() {
     if (!this.total) {
-      return html`<p class="px-5 text-sm text-neutral-400">
+      return html`<p class="pb-5 text-neutral-400">
         ${this.matchedURLs
           ? msg("No matching URLs found in queue.")
           : msg(

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -3,7 +3,7 @@ import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import { BtrixElement } from "@/classes/BtrixElement";
-import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
+import { type PageChangeEvent } from "@/components/ui/pagination";
 
 type URLs = string[];
 
@@ -26,7 +26,7 @@ export class CrawlPendingExclusions extends BtrixElement {
   matchedURLs: URLs | null = null;
 
   @state()
-  private page = parsePage(new URLSearchParams(location.search).get("page"));
+  private page = 1;
 
   private get pageSize() {
     return 10;
@@ -62,6 +62,7 @@ export class CrawlPendingExclusions extends BtrixElement {
               size=${this.pageSize}
               totalCount=${this.total}
               compact
+              disablePersist
               @page-change=${(e: PageChangeEvent) => {
                 this.page = e.detail.page;
               }}

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -47,27 +47,29 @@ export class CrawlPendingExclusions extends BtrixElement {
 
   render() {
     return html`
-      <btrix-section-heading
-        part="heading"
-        class="[--margin:--sl-spacing-small]"
+      <btrix-details
+        class="[--margin-bottom:--sl-spacing-small]"
+        exportparts="summary:heading"
+        open
       >
-        <div class="flex w-full items-center justify-between">
-          <div>${msg("Pending Exclusions")} ${this.renderBadge()}</div>
-          ${this.total && this.total > this.pageSize
-            ? html`<btrix-pagination
-                page=${this.page}
-                size=${this.pageSize}
-                totalCount=${this.total}
-                compact
-                @page-change=${(e: PageChangeEvent) => {
-                  this.page = e.detail.page;
-                }}
-              >
-              </btrix-pagination>`
-            : ""}
+        <div slot="title">
+          ${msg("Pending Exclusions")} ${this.renderBadge()}
         </div>
-      </btrix-section-heading>
-      ${this.renderContent()}
+        ${this.total && this.total > this.pageSize
+          ? html`<btrix-pagination
+              slot="summary-description"
+              page=${this.page}
+              size=${this.pageSize}
+              totalCount=${this.total}
+              compact
+              @page-change=${(e: PageChangeEvent) => {
+                this.page = e.detail.page;
+              }}
+            >
+            </btrix-pagination>`
+          : ""}
+        ${this.renderContent()}
+      </btrix-details>
     `;
   }
 

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -31,6 +31,8 @@ const POLL_INTERVAL_SECONDS = 5;
  *   regex="skip-me"
  * ></btrix-crawl-queue>
  * ```
+ *
+ * @cssPart heading
  */
 @customElement("btrix-crawl-queue")
 @localized()
@@ -91,7 +93,10 @@ export class CrawlQueue extends BtrixElement {
 
   render() {
     return html`
-      <btrix-section-heading style="--margin: var(--sl-spacing-small)">
+      <btrix-section-heading
+        part="heading"
+        class="[--margin:--sl-spacing-small]"
+      >
         ${this.renderOffsetControl()} ${this.renderBadge()}
       </btrix-section-heading>
       ${this.renderContent()}

--- a/frontend/src/features/crawl-workflows/exclusion-editor.stylesheet.css
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.stylesheet.css
@@ -1,0 +1,13 @@
+/* Only supported in Chrome */
+@container sticky-form not scroll-state(stuck: none) {
+  .form-wrapper {
+    border-top: 1px solid var(--sl-panel-border-color);
+    margin-top: var(--sl-spacing-x-small);
+  }
+}
+
+@container sticky-form scroll-state(stuck: none) {
+  .form-wrapper {
+    border-top: 1px solid transparent;
+  }
+}

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -1,5 +1,5 @@
 import { localized, msg } from "@lit/localize";
-import { type PropertyValues } from "lit";
+import { html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type {
@@ -8,9 +8,9 @@ import type {
 } from "./queue-exclusion-form";
 import type { ExclusionRemoveEvent } from "./queue-exclusion-table";
 
+import { BtrixElement } from "@/classes/BtrixElement";
 import type { SeedConfig } from "@/pages/org/types";
 import { isApiError } from "@/utils/api";
-import LiteElement, { html } from "@/utils/LiteElement";
 
 type URLs = string[];
 type ResponseData = {
@@ -35,7 +35,7 @@ type ResponseData = {
  */
 @customElement("btrix-exclusion-editor")
 @localized()
-export class ExclusionEditor extends LiteElement {
+export class ExclusionEditor extends BtrixElement {
   @property({ type: String })
   crawlId?: string;
 
@@ -160,7 +160,7 @@ export class ExclusionEditor extends LiteElement {
   private async deleteExclusion({ regex }: { regex: string }) {
     try {
       const params = new URLSearchParams({ regex });
-      const data = await this.apiFetch<{ success: boolean }>(
+      const data = await this.api.fetch<{ success: boolean }>(
         `/orgs/${this.orgId}/crawls/${
           this.crawlId
         }/exclusions?${params.toString()}`,
@@ -170,7 +170,7 @@ export class ExclusionEditor extends LiteElement {
       );
 
       if (data.success) {
-        this.notify({
+        this.notify.toast({
           message: msg(html`Removed exclusion: <code>${regex}</code>`),
           variant: "success",
           icon: "check2-circle",
@@ -182,7 +182,7 @@ export class ExclusionEditor extends LiteElement {
         throw data;
       }
     } catch (e) {
-      this.notify({
+      this.notify.toast({
         message:
           isApiError(e) && e.message === "crawl_running_cant_deactivate"
             ? msg("Cannot remove exclusion when crawl is no longer running.")
@@ -209,7 +209,7 @@ export class ExclusionEditor extends LiteElement {
       if (isApiError(e) && e.message === "invalid_regex") {
         this.exclusionFieldErrorMessage = msg("Invalid Regex");
       } else {
-        this.notify({
+        this.notify.toast({
           message: msg(
             "Sorry, couldn't fetch pending exclusions at this time.",
           ),
@@ -226,7 +226,7 @@ export class ExclusionEditor extends LiteElement {
   private async getQueueMatches() {
     const regex = this.regex;
     const params = new URLSearchParams({ regex });
-    const data = await this.apiFetch<ResponseData>(
+    const data = await this.api.fetch<ResponseData>(
       `/orgs/${this.orgId}/crawls/${
         this.crawlId
       }/queueMatchAll?${params.toString()}`,
@@ -253,7 +253,7 @@ export class ExclusionEditor extends LiteElement {
 
     try {
       const params = new URLSearchParams({ regex });
-      const data = await this.apiFetch<{ success: boolean }>(
+      const data = await this.api.fetch<{ success: boolean }>(
         `/orgs/${this.orgId}/crawls/${
           this.crawlId
         }/exclusions?${params.toString()}`,
@@ -263,7 +263,7 @@ export class ExclusionEditor extends LiteElement {
       );
 
       if (data.success) {
-        this.notify({
+        this.notify.toast({
           message: msg("Exclusion added."),
           variant: "success",
           icon: "check2-circle",
@@ -289,7 +289,7 @@ export class ExclusionEditor extends LiteElement {
           this.exclusionFieldErrorMessage = msg("Invalid Regex");
         }
       } else {
-        this.notify({
+        this.notify.toast({
           message: msg("Sorry, couldn't add exclusion at this time."),
           variant: "danger",
           icon: "exclamation-octagon",

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -1,7 +1,8 @@
 import { localized, msg } from "@lit/localize";
-import { html, type PropertyValues } from "lit";
+import { html, unsafeCSS, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
+import stylesheet from "./exclusion-editor.stylesheet.css";
 import type {
   ExclusionAddEvent,
   ExclusionChangeEvent,
@@ -11,6 +12,8 @@ import type { ExclusionRemoveEvent } from "./queue-exclusion-table";
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { SeedConfig } from "@/pages/org/types";
 import { isApiError } from "@/utils/api";
+
+const styles = unsafeCSS(stylesheet);
 
 type URLs = string[];
 type ResponseData = {
@@ -36,6 +39,8 @@ type ResponseData = {
 @customElement("btrix-exclusion-editor")
 @localized()
 export class ExclusionEditor extends BtrixElement {
+  static styles = styles;
+
   @property({ type: String })
   crawlId?: string;
 
@@ -77,12 +82,18 @@ export class ExclusionEditor extends BtrixElement {
         >
           ${this.renderTable()}
         </div>
-        <div class="col-span-1 px-4 lg:overflow-y-auto lg:overflow-x-hidden">
+        <div class="col-span-1 flex flex-col lg:overflow-hidden">
           ${this.isActiveCrawl && this.regex
-            ? html`<section>${this.renderPending()}</section>`
+            ? html`<section
+                class="lg:flex-0 px-4 lg:max-h-[calc(100vh-12rem)] lg:overflow-auto"
+              >
+                ${this.renderPending()}
+              </section>`
             : ""}
           ${this.isActiveCrawl
-            ? html`<section>${this.renderQueue()}</section>`
+            ? html`<section class="px-4 lg:flex-1 lg:overflow-auto">
+                ${this.renderQueue()}
+              </section>`
             : ""}
         </div>
       </div>
@@ -115,14 +126,18 @@ export class ExclusionEditor extends BtrixElement {
             </div>
           `}
       ${this.isActiveCrawl
-        ? html`<div class="sticky bottom-0 bg-white py-2">
-            <btrix-queue-exclusion-form
-              ?isSubmitting=${this.isSubmitting}
-              fieldErrorMessage=${this.exclusionFieldErrorMessage}
-              @btrix-change=${this.handleRegexChange}
-              @btrix-add=${this.handleAddRegex}
-            >
-            </btrix-queue-exclusion-form>
+        ? html`<div
+            class="sticky bottom-0 [container-name:sticky-form] [container-type:scroll-state]"
+          >
+            <div class="form-wrapper bg-white py-2">
+              <btrix-queue-exclusion-form
+                ?isSubmitting=${this.isSubmitting}
+                fieldErrorMessage=${this.exclusionFieldErrorMessage}
+                @btrix-change=${this.handleRegexChange}
+                @btrix-add=${this.handleAddRegex}
+              >
+              </btrix-queue-exclusion-form>
+            </div>
           </div>`
         : ""}
     `;
@@ -131,7 +146,7 @@ export class ExclusionEditor extends BtrixElement {
   private renderPending() {
     return html`
       <btrix-crawl-pending-exclusions
-        class="part-[heading]:block part-[heading]:pt-2.5"
+        class="part-[heading]:sticky part-[heading]:top-0 part-[heading]:z-20 part-[heading]:bg-white part-[heading]:pt-1.5"
         .matchedURLs=${this.matchedURLs}
       ></btrix-crawl-pending-exclusions>
     `;
@@ -139,7 +154,7 @@ export class ExclusionEditor extends BtrixElement {
 
   private renderQueue() {
     return html`<btrix-crawl-queue
-      class="part-[heading]:sticky part-[heading]:top-0 part-[heading]:z-10 part-[heading]:block part-[heading]:bg-white part-[heading]:pt-2.5"
+      class="part-[heading]:sticky part-[heading]:top-0 part-[heading]:z-10 part-[heading]:block part-[heading]:bg-white part-[heading]:pt-1.5"
       crawlId=${this.crawlId!}
       regex=${this.regex}
       .exclusions=${this.config?.exclude || []}

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -69,14 +69,20 @@ export class ExclusionEditor extends LiteElement {
 
   render() {
     return html`
-      <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <div class="col-span-1">${this.renderTable()}</div>
-        <div class="col-span-1">
+      <div
+        class="grid size-full grid-cols-1 overflow-auto lg:grid-cols-2 lg:divide-x lg:overflow-hidden"
+      >
+        <div
+          class="col-span-1 px-4 pt-4 lg:overflow-y-auto lg:overflow-x-hidden"
+        >
+          ${this.renderTable()}
+        </div>
+        <div class="col-span-1 px-4 lg:overflow-y-auto lg:overflow-x-hidden">
           ${this.isActiveCrawl && this.regex
-            ? html` <section class="mt-5">${this.renderPending()}</section> `
+            ? html`<section>${this.renderPending()}</section>`
             : ""}
           ${this.isActiveCrawl
-            ? html` <section class="mt-5">${this.renderQueue()}</section> `
+            ? html`<section>${this.renderQueue()}</section>`
             : ""}
         </div>
       </div>
@@ -87,6 +93,7 @@ export class ExclusionEditor extends LiteElement {
     return html`
       ${this.config
         ? html`<btrix-queue-exclusion-table
+            pageSize="10"
             ?removable=${this.isActiveCrawl}
             .exclusions=${this.config.exclude || []}
             @btrix-change=${async (e: ExclusionRemoveEvent) => {
@@ -108,7 +115,7 @@ export class ExclusionEditor extends LiteElement {
             </div>
           `}
       ${this.isActiveCrawl
-        ? html`<div class="mt-2">
+        ? html`<div class="sticky bottom-0 bg-white py-2">
             <btrix-queue-exclusion-form
               ?isSubmitting=${this.isSubmitting}
               fieldErrorMessage=${this.exclusionFieldErrorMessage}
@@ -124,6 +131,7 @@ export class ExclusionEditor extends LiteElement {
   private renderPending() {
     return html`
       <btrix-crawl-pending-exclusions
+        class="part-[heading]:block part-[heading]:pt-2.5"
         .matchedURLs=${this.matchedURLs}
       ></btrix-crawl-pending-exclusions>
     `;
@@ -131,6 +139,7 @@ export class ExclusionEditor extends LiteElement {
 
   private renderQueue() {
     return html`<btrix-crawl-queue
+      class="part-[heading]:sticky part-[heading]:top-0 part-[heading]:z-10 part-[heading]:block part-[heading]:bg-white part-[heading]:pt-2.5"
       crawlId=${this.crawlId!}
       regex=${this.regex}
       .exclusions=${this.config?.exclude || []}

--- a/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
@@ -145,6 +145,7 @@ export class QueueExclusionForm extends LiteElement {
               <btrix-button
                 variant="neutral"
                 raised
+                filled
                 ?disabled=${!this.regex ||
                 this.isRegexInvalid ||
                 this.isSubmitting}

--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -69,7 +69,7 @@ export class QueueExclusionTable extends TailwindElement {
 
   // TODO switch to LitElement & slotted label
   @property({ type: String })
-  label = msg("Exclusions");
+  label = msg("Exclusion Rules");
   @property({ type: String })
   labelClassName?: string;
 

--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -15,7 +15,7 @@ import { when } from "lit/directives/when.js";
 import type { Exclusion } from "./queue-exclusion-form";
 
 import { TailwindElement } from "@/classes/TailwindElement";
-import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
+import { type PageChangeEvent } from "@/components/ui/pagination";
 import type { SeedConfig } from "@/pages/org/types";
 import { regexEscape, regexUnescape } from "@/utils/string";
 import { tw } from "@/utils/tailwind";
@@ -86,7 +86,7 @@ export class QueueExclusionTable extends TailwindElement {
   private results: Exclusion[] = [];
 
   @state()
-  private page = parsePage(new URLSearchParams(location.search).get("page"));
+  private page = 1;
 
   @state()
   private exclusionToRemove?: string;
@@ -171,6 +171,7 @@ export class QueueExclusionTable extends TailwindElement {
                     size=${this.pageSize}
                     totalCount=${this.total}
                     compact
+                    disablePersist
                     @page-change=${(e: PageChangeEvent) => {
                       this.page = e.detail.page;
                     }}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -234,6 +234,7 @@ export class WorkflowDetail extends BtrixElement {
           // Handle edge case where workflow may have finished and started
           // within the same poll interval:
           workflow.lastCrawlId !== currWorkflow.lastCrawlId;
+        const wasActive = isActive(workflow);
 
         // Retrieve additional data based on current tab
         if (this.isRunning) {
@@ -255,6 +256,15 @@ export class WorkflowDetail extends BtrixElement {
           void this.latestCrawlTask.run();
           void this.logTotalsTask.run();
           void this.crawlsTask.run();
+
+          // Reset dialog if previously running
+          if (
+            wasActive &&
+            (this.openDialogName === "scale" ||
+              this.openDialogName === "exclusions")
+          ) {
+            this.openDialogName = undefined;
+          }
         }
       }, POLL_INTERVAL_SECONDS * 1000);
     },

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1942,6 +1942,7 @@ export class WorkflowDetail extends BtrixElement {
       )}
 
       <btrix-dialog
+        class="[--body-spacing:0] part-[body]:flex part-[body]:content-stretch part-[body]:justify-stretch part-[body]:overflow-hidden"
         .label=${msg("Crawl Queue Editor")}
         .open=${this.openDialogName === "exclusions"}
         style=${`--width: var(--btrix-screen-desktop)`}
@@ -1951,6 +1952,7 @@ export class WorkflowDetail extends BtrixElement {
       >
         ${this.workflow && this.isDialogVisible
           ? html`<btrix-exclusion-editor
+              class="block w-full overflow-hidden"
               .crawlId=${this.lastCrawlId ?? undefined}
               .config=${this.workflow.config}
               ?isActiveCrawl=${this.workflow.lastCrawlState

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1942,7 +1942,7 @@ export class WorkflowDetail extends BtrixElement {
       )}
 
       <btrix-dialog
-        class="[--body-spacing:0] part-[body]:flex part-[body]:content-stretch part-[body]:justify-stretch part-[body]:overflow-hidden"
+        class="[--body-spacing:0] part-[body]:flex part-[panel]:h-screen part-[body]:content-stretch part-[body]:justify-stretch part-[body]:overflow-hidden"
         .label=${msg("Crawl Queue Editor")}
         .open=${this.openDialogName === "exclusions"}
         style=${`--width: var(--btrix-screen-desktop)`}


### PR DESCRIPTION
WIP for https://github.com/webrecorder/browsertrix/issues/3525

## Changes

- Previously, when scrolling down the queued URL list, the exclusion table and pending exclusions scrolls out of view and the list must be scrolled back to the top to view either
- Prevents exclusion table and pending exclusions pagination from persisting in the URL, which was resulting in unexpected pagination persistence when closing and opening the dialog
- Displays more exclusion rules at the same time
- Makes "add" button more apparent
- Updates "Exclusions" -> "Exclusion Rules" to match workflow editor

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow / Latest Crawl / Crawl Queue Editor | <img width="1023" height="392" alt="Screenshot 2026-07-22 at 8 58 53 PM" src="https://github.com/user-attachments/assets/58737a86-4720-4d6c-b163-1a41901c46e0" /> |
| Workflow / Latest Crawl / Crawl Queue Editor | <img width="979" height="691" alt="Screenshot 2026-07-22 at 9 35 23 PM" src="https://github.com/user-attachments/assets/e8672adc-5776-4c02-a67a-e8f627ba424d" /> |
| Workflow / Latest Crawl / Crawl Queue Editor | <img width="983" height="691" alt="Screenshot 2026-07-22 at 9 35 31 PM" src="https://github.com/user-attachments/assets/058b4303-9cd5-401e-94b8-ce84937af988" /> |


<!-- ## Follow-ups -->
