### PR TITLE
fix: More page queue editor UX files

### DIFF
--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -12,11 +12,11 @@ You can watch the current state of the browser windows as the crawler visits pag
 
 ## Live Exclusion Editing
 
-While [exclusions](workflow-setup.md#custom-exclusion-rules) can be set before running a crawl workflow, sometimes while crawling the crawler may find new parts of the site that weren't previously known about and shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
+While [exclusion rules](workflow-setup.md#custom-exclusion-rules) can be set before running a crawl workflow, you may want to update rules based on the real-time page queue: the crawler may find new parts of the site that shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
 
-If the crawl queue is filled with URLs that should not be crawled, use the _Edit Exclusions_ button in the **Watch** tab to instruct the crawler what pages should be excluded from the queue.
+If the page queue contains URLs that should not be crawled, use the _Edit Exclusion Rules_ button in the **Watch** tab or from the workflow’s action menu.
 
-Exclusions added while crawling are applied to the same exclusion table saved in the workflow's settings and will be used the next time the crawl workflow is run unless they are manually removed.
+Edited exclusion rules will take effect immediately on the running crawl. Additionally, the workflow’s settings will automatically update with the edited exclusion rules so that subsequent crawls use the same rules.
 
 ## Changing the Number of Browser Windows
 
@@ -63,7 +63,7 @@ If a crawl workflow is not crawling websites as intended it may be preferable to
 
 ### Stopping
 
-Stopping a crawl will throw away the crawl queue but otherwise gracefully end the process and save anything that has been collected. Stopped crawls show up in **Archived Items** and can be used like any other item in the app.
+Stopping a crawl will gracefully finish crawling the open page and save all content that has been captured so far. Stopped crawls are shown in **Archived Items** and can be used like any other archived item in the app, such as being added to collections.
 
 ### Canceling
 

--- a/frontend/docs/docs/user-guide/running-crawl.md
+++ b/frontend/docs/docs/user-guide/running-crawl.md
@@ -12,11 +12,11 @@ You can watch the current state of the browser windows as the crawler visits pag
 
 ## Live Exclusion Editing
 
-While [exclusion rules](workflow-setup.md#custom-exclusion-rules) can be set before running a crawl workflow, you may want to update rules based on the real-time page queue: the crawler may find new parts of the site that shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
+While [exclusion rules](workflow-setup.md#custom-exclusion-rules) can be set before running a crawl workflow, sometimes while crawling the crawler may find new parts of the site that weren't previously known about and shouldn't be crawled, or get stuck browsing parts of a website that automatically generate URLs known as ["crawler traps"](https://en.wikipedia.org/wiki/Spider_trap).
 
-If the page queue contains URLs that should not be crawled, use the _Edit Exclusion Rules_ button in the **Watch** tab or from the workflow’s action menu.
+If the crawl queue is filled with URLs that should not be crawled, use the _Edit Exclusion Rules_ button in the **Watch** tab to instruct the crawler what pages should be excluded from the queue.
 
-Edited exclusion rules will take effect immediately on the running crawl. Additionally, the workflow’s settings will automatically update with the edited exclusion rules so that subsequent crawls use the same rules.
+Exclusions added while crawling are applied to the same exclusion table saved in the workflow's settings and will be used the next time the crawl workflow is run unless they are manually removed.
 
 ## Changing the Number of Browser Windows
 
@@ -63,7 +63,7 @@ If a crawl workflow is not crawling websites as intended it may be preferable to
 
 ### Stopping
 
-Stopping a crawl will gracefully finish crawling the open page and save all content that has been captured so far. Stopped crawls are shown in **Archived Items** and can be used like any other archived item in the app, such as being added to collections.
+Stopping a crawl will throw away the crawl queue but otherwise gracefully end the process and save anything that has been collected. Stopped crawls show up in **Archived Items** and can be used like any other item in the app.
 
 ### Canceling
 

--- a/frontend/docs/docs/user-guide/workflow-setup.md
+++ b/frontend/docs/docs/user-guide/workflow-setup.md
@@ -247,7 +247,7 @@ When enabled, the crawler will check for a [Robots Exclusion Protocol](https://w
 
 #### Custom Exclusion Rules
 
-Exclusion rules instruct the crawler to ignores pages with URLs that match a specified pattern. Patterns can be written as plain text or a regular expression per selected _Exclusion Type_:
+Exclusion rules instruct the crawler to ignore pages with URLs that match a specified pattern. Patterns can be written as plain text or a regular expression per selected _Exclusion Type_:
 
 ##### Matches Text
 

--- a/frontend/src/events/btrix-add.ts
+++ b/frontend/src/events/btrix-add.ts
@@ -1,0 +1,7 @@
+export type BtrixAddEvent<T = unknown> = CustomEvent<{ item: T }>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    "btrix-add": BtrixAddEvent;
+  }
+}

--- a/frontend/src/features/archived-items/crawl-pending-exclusions.ts
+++ b/frontend/src/features/archived-items/crawl-pending-exclusions.ts
@@ -25,6 +25,12 @@ export class CrawlPendingExclusions extends BtrixElement {
   @property({ type: Array })
   matchedURLs: URLs | null = null;
 
+  @property({ type: Boolean })
+  loading?: boolean;
+
+  @property({ type: String })
+  errorMessage?: string;
+
   @state()
   private page = 1;
 
@@ -89,7 +95,11 @@ export class CrawlPendingExclusions extends BtrixElement {
   }
 
   private renderContent() {
-    if (!this.total) {
+    if (this.errorMessage) {
+      return html`<p class="pb-5 text-danger">${this.errorMessage}</p>`;
+    }
+
+    if (!this.loading && !this.total) {
       return html`<p class="pb-5 text-neutral-400">
         ${this.matchedURLs
           ? msg("No matching URLs found in queue.")

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -268,7 +268,7 @@ export class CrawlQueue extends BtrixElement {
       }
 
       this.notify.toast({
-        message: msg("Sorry, couldn't fetch crawl queue at this time."),
+        message: msg("Sorry, couldn't fetch page queue at this time."),
         variant: "danger",
         icon: "exclamation-octagon",
         id: "crawl-queue-status",

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -52,6 +52,12 @@ export class CrawlQueue extends BtrixElement {
   @property({ type: Array })
   exclusions: string[] = [];
 
+  /**
+   * Crawl is starting
+   */
+  @property({ type: Boolean })
+  starting?: Boolean;
+
   @state()
   private exclusionsRx: RegExp[] = [];
 
@@ -171,7 +177,9 @@ export class CrawlQueue extends BtrixElement {
       }
 
       return html`
-        <p class="text-sm text-neutral-400">${msg("No pages queued.")}</p>
+        <p class="text-sm text-neutral-400">
+          ${this.starting ? msg("Crawl starting...") : msg("No pages queued.")}
+        </p>
       `;
     }
 

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -345,9 +345,6 @@ export class CollectionItemsDialog extends BtrixElement {
         ${when(this.isReady, this.renderContent)}
       </div>
       <div slot="footer" class="flex items-center justify-end gap-3">
-        <sl-button class="mr-auto" size="small" @click=${() => this.close()}
-          >${msg("Cancel")}</sl-button
-        >
         ${this.renderSave()}
       </div>
     </btrix-dialog>`;
@@ -991,6 +988,15 @@ export class CollectionItemsDialog extends BtrixElement {
     };
 
     return html`
+      ${hasChange
+        ? html`<sl-button
+            class="mr-auto"
+            size="small"
+            @click=${() => this.close()}
+            >${msg("Cancel")}</sl-button
+          >`
+        : nothing}
+
       <div class="inline-flex items-center gap-1.5 text-warning">
         <span>${selectionMessage}</span>
         ${this.renderDependencyWarning()}
@@ -1020,7 +1026,7 @@ export class CollectionItemsDialog extends BtrixElement {
         </div>
 
         <sl-button
-          variant="primary"
+          variant=${hasChange ? "primary" : "default"}
           size="small"
           ?disabled=${this.isSubmitting}
           ?loading=${this.isSubmitting}

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -330,8 +330,7 @@ export class CollectionItemsDialog extends BtrixElement {
   render() {
     return html` <btrix-dialog
       ?open=${this.open}
-      class="part-[title]:overflow-hidden"
-      style="--width: calc(var(--btrix-screen-desktop) - 3.5rem); --body-spacing: 0;"
+      class="[--body-spacing:0] [--width:calc(var(--btrix-screen-desktop)-3.5rem)] part-[title]:overflow-hidden"
       @sl-show=${() => (this.isReady = true)}
       @sl-after-hide=${() => this.reset()}
     >

--- a/frontend/src/features/collections/collection-items-dialog.ts
+++ b/frontend/src/features/collections/collection-items-dialog.ts
@@ -26,6 +26,7 @@ import type {
   SortChangeEventDetail,
   SortOptions,
 } from "@/features/archived-items/item-list-controls";
+import { dialogClassesForHeader, dialogLabel } from "@/layouts/dialogHeader";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -330,16 +331,14 @@ export class CollectionItemsDialog extends BtrixElement {
   render() {
     return html` <btrix-dialog
       ?open=${this.open}
-      class="[--body-spacing:0] [--width:calc(var(--btrix-screen-desktop)-3.5rem)] part-[title]:overflow-hidden"
+      class="${dialogClassesForHeader} [--body-spacing:0] [--width:calc(var(--btrix-screen-desktop)-3.5rem)]"
       @sl-show=${() => (this.isReady = true)}
       @sl-after-hide=${() => this.reset()}
     >
-      <div slot="label" class="flex items-center gap-3 divide-x">
-        <div class="whitespace-nowrap">${msg("Configure Items")}</div>
-        <div class="truncate px-3 text-sm leading-none text-neutral-500">
-          ${this.collectionName}
-        </div>
-      </div>
+      ${dialogLabel({
+        title: msg("Configure Items"),
+        subtitle: this.collectionName,
+      })}
       <div class="dialogContent flex flex-col">
         ${when(this.isReady, this.renderContent)}
       </div>

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -1,12 +1,18 @@
 import { localized, msg } from "@lit/localize";
+import { Task, TaskStatus } from "@lit/task";
 import { html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
 
-import { type RemoveExclusionEvent } from "./exclusion-editor";
+import {
+  type AddExclusionEvent,
+  type RemoveExclusionEvent,
+} from "./exclusion-editor";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
+import { textSeparator } from "@/layouts/separator";
 import type { SeedConfig } from "@/types/crawler";
 import { isApiError } from "@/utils/api";
 import { isNotEqual } from "@/utils/is-not-equal";
@@ -25,8 +31,8 @@ export class ExclusionEditorDialog extends BtrixElement {
   @property({ type: Boolean })
   activeCrawl?: boolean;
 
-  @property({ type: Object, hasChanged: isNotEqual })
-  config?: SeedConfig;
+  @property({ attribute: false, hasChanged: isNotEqual })
+  exclusions?: SeedConfig["exclude"];
 
   @property({ type: Boolean })
   open = false;
@@ -35,9 +41,80 @@ export class ExclusionEditorDialog extends BtrixElement {
   private visible = false;
 
   @state()
+  private added = new Set<string>();
+
+  @state()
   private removed = new Set<string>();
 
+  private readonly addRuleTask = new Task(this, {
+    autoRun: false,
+    task: async ([regex], { signal }) => {
+      if (!regex) return;
+      try {
+        await this.addRule(regex, signal);
+
+        if (this.removed.has(regex)) {
+          this.removed = this.removed.difference(new Set([regex]));
+        } else {
+          this.added = this.added.add(regex);
+        }
+
+        this.dispatchEvent(new CustomEvent("btrix-saved"));
+      } catch (e) {
+        let error = msg("Sorry, couldn't add exclusion at this time.");
+
+        if (isApiError(e)) {
+          if (e.message === "exclusion_already_exists") {
+            error = msg("Exclusion already exists");
+          } else if (e.message === "invalid_regex") {
+            error = msg("Invalid Regex");
+          }
+        }
+
+        this.dispatchEvent(new CustomEvent("btrix-error"));
+
+        throw error;
+      }
+    },
+    args: () => [undefined] as readonly [string | undefined],
+  });
+
+  private readonly deleteRuleTask = new Task(this, {
+    autoRun: false,
+    task: async ([regex], { signal }) => {
+      if (!regex) return;
+      try {
+        await this.deleteRule(regex, signal);
+
+        if (this.added.has(regex)) {
+          this.added = this.added.difference(new Set([regex]));
+        } else {
+          this.removed = this.removed.add(regex);
+        }
+
+        this.dispatchEvent(new CustomEvent("btrix-saved"));
+      } catch (e) {
+        let error = msg("Sorry, couldn't remove exclusion at this time.");
+
+        if (isApiError(e) && e.message === "crawl_running_cant_deactivate") {
+          error = msg(
+            "Cannot remove exclusion when crawl is no longer running.",
+          );
+        }
+
+        this.dispatchEvent(new CustomEvent("btrix-error"));
+
+        throw error;
+      }
+    },
+    args: () => [undefined] as readonly [string | undefined],
+  });
+
   render() {
+    const errorMessage =
+      this.addRuleTask.render({ error: (errorMessage) => errorMessage }) ||
+      this.deleteRuleTask.render({ error: (errorMessage) => errorMessage });
+
     return html`<btrix-dialog
       class="[--body-spacing:0] [--width:--btrix-screen-desktop] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
       .label=${msg("Crawl Queue Editor")}
@@ -45,35 +122,22 @@ export class ExclusionEditorDialog extends BtrixElement {
       @sl-show=${() => (this.visible = true)}
       @sl-after-hide=${() => (this.visible = false)}
     >
-      ${this.config && this.visible
+      ${this.exclusions && this.visible
         ? html`<btrix-exclusion-editor
             .crawlId=${this.crawlId}
-            .config=${this.config}
+            .exclusions=${this.exclusions}
             ?isActiveCrawl=${this.activeCrawl}
+            errorMessage=${ifDefined(
+              typeof errorMessage === "string" ? errorMessage : undefined,
+            )}
+            ?submitting=${this.addRuleTask.status === TaskStatus.PENDING}
+            @btrix-add=${(e: AddExclusionEvent) =>
+              void this.addRuleTask.run([e.detail.item])}
             @btrix-remove=${async (e: RemoveExclusionEvent) =>
-              void this.deleteExclusion({ regex: e.detail.item })}
+              void this.deleteRuleTask.run([e.detail.item])}
           ></btrix-exclusion-editor>`
         : nothing}
-      ${this.removed.size
-        ? html`<btrix-popover slot="footer">
-            <ul slot="content" class="list-disc px-2">
-              ${map(
-                this.removed,
-                (value) => html`<li class="font-mono">${value}</li>`,
-              )}
-            </ul>
-            <div class="flex cursor-default items-center gap-1.5">
-              <sl-icon
-                name="check-lg"
-                class="text-base text-success-500"
-              ></sl-icon>
-              <span class="text-neutral-600"
-                >${msg("Removed")} ${this.localize.number(this.removed.size)}
-                ${pluralOf("exclusions", this.removed.size)}</span
-              >
-            </div>
-          </btrix-popover>`
-        : nothing}
+      ${this.renderConfirmation()}
       <sl-button
         slot="footer"
         size="small"
@@ -86,37 +150,73 @@ export class ExclusionEditorDialog extends BtrixElement {
     </btrix-dialog>`;
   }
 
-  private async deleteExclusion({ regex }: { regex: string }) {
-    try {
-      const params = new URLSearchParams({ regex });
-      const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.orgId}/crawls/${
-          this.crawlId
-        }/exclusions?${params.toString()}`,
-        {
-          method: "DELETE",
-        },
-      );
+  private renderConfirmation() {
+    if (!this.added.size && !this.removed.size) return;
 
-      if (data.success) {
-        this.removed = this.removed.add(regex);
+    const added = this.added;
+    const removed = this.removed;
 
-        this.dispatchEvent(new CustomEvent("btrix-saved"));
-      } else {
-        throw data;
-      }
-    } catch (e) {
-      this.notify.toast({
-        message:
-          isApiError(e) && e.message === "crawl_running_cant_deactivate"
-            ? msg("Cannot remove exclusion when crawl is no longer running.")
-            : msg("Sorry, couldn't remove exclusion at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-        id: "exclusion-edit-status",
-      });
+    const list = (set: Set<string>) => html`
+      <ul slot="content" class="list-disc px-2">
+        ${map(set, (value) => html`<li class="font-mono">${value}</li>`)}
+      </ul>
+    `;
 
-      this.dispatchEvent(new CustomEvent("btrix-error"));
-    }
+    return html`
+      <div
+        slot="footer"
+        class="flex cursor-default items-center gap-1.5 text-neutral-600"
+      >
+        <sl-icon name="check-lg" class="text-base text-success-500"></sl-icon>
+        ${added.size
+          ? html`<btrix-popover>
+              ${list(added)}
+              <span
+                >${msg("Added")} ${this.localize.number(added.size)}
+                ${added.size && removed.size
+                  ? nothing
+                  : pluralOf("exclusions", added.size)}</span
+              >
+            </btrix-popover>`
+          : nothing}
+        ${added.size && removed.size ? textSeparator() : nothing}
+        ${removed.size
+          ? html`<btrix-popover>
+              ${list(removed)}
+              <span
+                >${msg("Removed")} ${this.localize.number(removed.size)}
+                ${pluralOf("exclusions", removed.size)}</span
+              >
+            </btrix-popover>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private async deleteRule(regex: string, signal: AbortSignal) {
+    const params = new URLSearchParams({ regex });
+
+    return this.api.fetch<{ success: boolean }>(
+      `/orgs/${this.orgId}/crawls/${
+        this.crawlId
+      }/exclusions?${params.toString()}`,
+      {
+        method: "DELETE",
+        signal,
+      },
+    );
+  }
+
+  private async addRule(regex: string, signal: AbortSignal) {
+    const params = new URLSearchParams({ regex });
+    return this.api.fetch<{ success: boolean }>(
+      `/orgs/${this.orgId}/crawls/${
+        this.crawlId
+      }/exclusions?${params.toString()}`,
+      {
+        method: "POST",
+        signal,
+      },
+    );
   }
 }

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -122,12 +122,24 @@ export class ExclusionEditorDialog extends BtrixElement {
       this.deleteRuleTask.render({ error: (errorMessage) => errorMessage });
 
     return html`<btrix-dialog
-      class="[--body-spacing:0] [--width:--btrix-screen-desktop] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
-      .label=${msg("Edit Exclusions")}
+      class="[--body-spacing:0] [--width:--btrix-screen-desktop] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[header-actions]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
+      .label=${msg("Edit Exclusion Rules")}
       .open=${this.open}
       @sl-show=${() => (this.visible = true)}
       @sl-after-hide=${() => (this.visible = false)}
     >
+      <btrix-popover
+        slot="header-actions"
+        content="${msg(
+          "Add or remove exclusion rules to filter URLs out from the page queue.",
+        )} ${msg(
+          "Edited exclusion rules will apply to the current crawl run and to subsequent crawl runs.",
+        )}"
+        placement="bottom-end"
+        hoist
+      >
+        <sl-icon name="question-circle" class="text-neutral-600"></sl-icon>
+      </btrix-popover>
       ${this.exclusions && this.visible
         ? html`<btrix-exclusion-editor
             class="block size-full overflow-hidden"

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -60,13 +60,15 @@ export class ExclusionEditorDialog extends BtrixElement {
         }
 
         this.dispatchEvent(new CustomEvent("btrix-saved"));
-      } catch (e) {
+      } catch (err) {
+        if (signal.aborted) return;
+
         let error = msg("Sorry, couldn't add exclusion at this time.");
 
-        if (isApiError(e)) {
-          if (e.message === "exclusion_already_exists") {
+        if (isApiError(err)) {
+          if (err.message === "exclusion_already_exists") {
             error = msg("Exclusion already exists");
-          } else if (e.message === "invalid_regex") {
+          } else if (err.message === "invalid_regex") {
             error = msg("Invalid Regex");
           }
         }
@@ -93,10 +95,15 @@ export class ExclusionEditorDialog extends BtrixElement {
         }
 
         this.dispatchEvent(new CustomEvent("btrix-saved"));
-      } catch (e) {
+      } catch (err) {
+        if (signal.aborted) return;
+
         let error = msg("Sorry, couldn't remove exclusion at this time.");
 
-        if (isApiError(e) && e.message === "crawl_running_cant_deactivate") {
+        if (
+          isApiError(err) &&
+          err.message === "crawl_running_cant_deactivate"
+        ) {
           error = msg(
             "Cannot remove exclusion when crawl is no longer running.",
           );
@@ -146,7 +153,7 @@ export class ExclusionEditorDialog extends BtrixElement {
             .crawlId=${this.crawlId}
             .exclusions=${this.exclusions}
             ?isActiveCrawl=${this.activeCrawl}
-            errorMessage=${ifDefined(
+            formErrorMessage=${ifDefined(
               typeof errorMessage === "string" ? errorMessage : undefined,
             )}
             ?submitting=${this.addRuleTask.status === TaskStatus.PENDING}

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -1,7 +1,7 @@
 import { localized, msg } from "@lit/localize";
 import { html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { when } from "lit/directives/when.js";
+import { map } from "lit/directives/map.js";
 
 import { type RemoveExclusionEvent } from "./exclusion-editor";
 
@@ -35,7 +35,7 @@ export class ExclusionEditorDialog extends BtrixElement {
   private visible = false;
 
   @state()
-  private removed = 0;
+  private removed = new Set<string>();
 
   render() {
     return html`<btrix-dialog
@@ -54,20 +54,26 @@ export class ExclusionEditorDialog extends BtrixElement {
               void this.deleteExclusion({ regex: e.detail.item })}
           ></btrix-exclusion-editor>`
         : nothing}
-      ${when(
-        this.removed,
-        (removed) =>
-          html`<div slot="footer" class="flex items-center gap-1.5">
-            <sl-icon
-              name="check-lg"
-              class="text-base text-success-500"
-            ></sl-icon>
-            <span class="text-neutral-600"
-              >${msg("Removed")} ${this.localize.number(removed)}
-              ${pluralOf("exclusions", removed)}</span
-            >
-          </div>`,
-      )}
+      ${this.removed.size
+        ? html`<btrix-popover slot="footer">
+            <ul slot="content" class="list-disc px-2">
+              ${map(
+                this.removed,
+                (value) => html`<li class="font-mono">${value}</li>`,
+              )}
+            </ul>
+            <div class="flex cursor-default items-center gap-1.5">
+              <sl-icon
+                name="check-lg"
+                class="text-base text-success-500"
+              ></sl-icon>
+              <span class="text-neutral-600"
+                >${msg("Removed")} ${this.localize.number(this.removed.size)}
+                ${pluralOf("exclusions", this.removed.size)}</span
+              >
+            </div>
+          </btrix-popover>`
+        : nothing}
       <sl-button
         slot="footer"
         size="small"
@@ -93,7 +99,7 @@ export class ExclusionEditorDialog extends BtrixElement {
       );
 
       if (data.success) {
-        this.removed = this.removed + 1;
+        this.removed = this.removed.add(regex);
 
         this.dispatchEvent(new CustomEvent("btrix-saved"));
       } else {

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -13,10 +13,11 @@ import {
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import { textSeparator } from "@/layouts/separator";
+import { pluralOfAddedExclusionRules } from "@/plurals/added-exclusion-rules";
+import { pluralOfRemovedExclusionRules } from "@/plurals/removed-exclusion-rules";
 import type { SeedConfig } from "@/types/crawler";
 import { isApiError } from "@/utils/api";
 import { isNotEqual } from "@/utils/is-not-equal";
-import { pluralOf } from "@/utils/pluralize";
 
 /**
  * @fires btrix-saved
@@ -121,6 +122,13 @@ export class ExclusionEditorDialog extends BtrixElement {
     if (changedProperties.has("open")) {
       this.visible = this.open;
     }
+
+    if (changedProperties.get("visible")) {
+      if (!this.visible) {
+        this.added = new Set();
+        this.removed = new Set();
+      }
+    }
   }
 
   render() {
@@ -198,22 +206,14 @@ export class ExclusionEditorDialog extends BtrixElement {
         ${added.size
           ? html`<btrix-popover>
               ${list(added)}
-              <span
-                >${msg("Added")} ${this.localize.number(added.size)}
-                ${added.size && removed.size
-                  ? nothing
-                  : pluralOf("exclusions", added.size)}</span
-              >
+              <span>${pluralOfAddedExclusionRules(added.size)}</span>
             </btrix-popover>`
           : nothing}
         ${added.size && removed.size ? textSeparator() : nothing}
         ${removed.size
           ? html`<btrix-popover>
               ${list(removed)}
-              <span
-                >${msg("Removed")} ${this.localize.number(removed.size)}
-                ${pluralOf("exclusions", removed.size)}</span
-              >
+              <span>${pluralOfRemovedExclusionRules(removed.size)}</span>
             </btrix-popover>`
           : nothing}
       </div>

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -1,6 +1,6 @@
 import { localized, msg } from "@lit/localize";
 import { Task, TaskStatus } from "@lit/task";
-import { html, nothing } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
@@ -110,6 +110,12 @@ export class ExclusionEditorDialog extends BtrixElement {
     args: () => [undefined] as readonly [string | undefined],
   });
 
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("open")) {
+      this.visible = this.open;
+    }
+  }
+
   render() {
     const errorMessage =
       this.addRuleTask.render({ error: (errorMessage) => errorMessage }) ||
@@ -124,6 +130,7 @@ export class ExclusionEditorDialog extends BtrixElement {
     >
       ${this.exclusions && this.visible
         ? html`<btrix-exclusion-editor
+            class="block size-full overflow-hidden"
             .crawlId=${this.crawlId}
             .exclusions=${this.exclusions}
             ?isActiveCrawl=${this.activeCrawl}

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -123,7 +123,7 @@ export class ExclusionEditorDialog extends BtrixElement {
 
     return html`<btrix-dialog
       class="[--body-spacing:0] [--width:--btrix-screen-desktop] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
-      .label=${msg("Crawl Queue Editor")}
+      .label=${msg("Edit Exclusions")}
       .open=${this.open}
       @sl-show=${() => (this.visible = true)}
       @sl-after-hide=${() => (this.visible = false)}
@@ -152,7 +152,7 @@ export class ExclusionEditorDialog extends BtrixElement {
           void (e.target as HTMLElement)
             .closest<Dialog>("btrix-dialog")
             ?.hide()}
-        >${msg("Done Editing")}</sl-button
+        >${msg("Done")}</sl-button
       >
     </btrix-dialog>`;
   }

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -1,0 +1,116 @@
+import { localized, msg } from "@lit/localize";
+import { html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { when } from "lit/directives/when.js";
+
+import { type RemoveExclusionEvent } from "./exclusion-editor";
+
+import { BtrixElement } from "@/classes/BtrixElement";
+import type { Dialog } from "@/components/ui/dialog";
+import type { SeedConfig } from "@/types/crawler";
+import { isApiError } from "@/utils/api";
+import { isNotEqual } from "@/utils/is-not-equal";
+import { pluralOf } from "@/utils/pluralize";
+
+/**
+ * @fires btrix-saved
+ * @fires btrix-error
+ */
+@customElement("btrix-exclusion-editor-dialog")
+@localized()
+export class ExclusionEditorDialog extends BtrixElement {
+  @property({ type: String })
+  crawlId?: string;
+
+  @property({ type: Boolean })
+  activeCrawl?: boolean;
+
+  @property({ type: Object, hasChanged: isNotEqual })
+  config?: SeedConfig;
+
+  @property({ type: Boolean })
+  open = false;
+
+  @state()
+  private visible = false;
+
+  @state()
+  private removed = 0;
+
+  render() {
+    return html`<btrix-dialog
+      class="[--body-spacing:0] [--width:--btrix-screen-desktop] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
+      .label=${msg("Crawl Queue Editor")}
+      .open=${this.open}
+      @sl-show=${() => (this.visible = true)}
+      @sl-after-hide=${() => (this.visible = false)}
+    >
+      ${this.config && this.visible
+        ? html`<btrix-exclusion-editor
+            .crawlId=${this.crawlId}
+            .config=${this.config}
+            ?isActiveCrawl=${this.activeCrawl}
+            @btrix-remove=${async (e: RemoveExclusionEvent) =>
+              void this.deleteExclusion({ regex: e.detail.item })}
+          ></btrix-exclusion-editor>`
+        : nothing}
+      ${when(
+        this.removed,
+        (removed) =>
+          html`<div slot="footer" class="flex items-center gap-1.5">
+            <sl-icon
+              name="check-lg"
+              class="text-base text-success-500"
+            ></sl-icon>
+            <span class="text-neutral-600"
+              >${msg("Removed")} ${this.localize.number(removed)}
+              ${pluralOf("exclusions", removed)}</span
+            >
+          </div>`,
+      )}
+      <sl-button
+        slot="footer"
+        size="small"
+        @click=${(e: MouseEvent) =>
+          void (e.target as HTMLElement)
+            .closest<Dialog>("btrix-dialog")
+            ?.hide()}
+        >${msg("Done Editing")}</sl-button
+      >
+    </btrix-dialog>`;
+  }
+
+  private async deleteExclusion({ regex }: { regex: string }) {
+    try {
+      const params = new URLSearchParams({ regex });
+      const data = await this.api.fetch<{ success: boolean }>(
+        `/orgs/${this.orgId}/crawls/${
+          this.crawlId
+        }/exclusions?${params.toString()}`,
+        {
+          method: "DELETE",
+        },
+      );
+
+      if (data.success) {
+        this.removed = this.removed + 1;
+
+        this.dispatchEvent(new CustomEvent("btrix-saved"));
+      } else {
+        throw data;
+      }
+    } catch (e) {
+      this.notify.toast({
+        message:
+          isApiError(e) && e.message === "crawl_running_cant_deactivate"
+            ? msg("Cannot remove exclusion when crawl is no longer running.")
+            : msg("Sorry, couldn't remove exclusion at this time."),
+        variant: "danger",
+        icon: "exclamation-octagon",
+        id: "exclusion-edit-status",
+      });
+
+      this.dispatchEvent(new CustomEvent("btrix-error"));
+    }
+  }
+}

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -129,12 +129,13 @@ export class ExclusionEditorDialog extends BtrixElement {
       this.deleteRuleTask.render({ error: (errorMessage) => errorMessage });
 
     return html`<btrix-dialog
-      class="[--body-spacing:0] [--width:--btrix-screen-desktop] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[header-actions]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
+      class="[--body-spacing:0] [--width:calc(var(--btrix-screen-desktop)-3.5rem)] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[header-actions]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden part-[title]:overflow-hidden"
       .label=${msg("Edit Exclusion Rules")}
       .open=${this.open}
       @sl-show=${() => (this.visible = true)}
       @sl-after-hide=${() => (this.visible = false)}
     >
+      <slot name="dialog-label" slot="label"></slot>
       <btrix-popover
         slot="header-actions"
         content="${msg(

--- a/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor-dialog.ts
@@ -12,6 +12,10 @@ import {
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
+import {
+  dialogClassesForHeader,
+  dialogHelpPopover,
+} from "@/layouts/dialogHeader";
 import { textSeparator } from "@/layouts/separator";
 import { pluralOfAddedExclusionRules } from "@/plurals/added-exclusion-rules";
 import { pluralOfRemovedExclusionRules } from "@/plurals/removed-exclusion-rules";
@@ -137,25 +141,20 @@ export class ExclusionEditorDialog extends BtrixElement {
       this.deleteRuleTask.render({ error: (errorMessage) => errorMessage });
 
     return html`<btrix-dialog
-      class="[--body-spacing:0] [--width:calc(var(--btrix-screen-desktop)-3.5rem)] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[header-actions]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden part-[title]:overflow-hidden"
+      class="${dialogClassesForHeader} [--body-spacing:0] [--width:calc(var(--btrix-screen-desktop)-3.5rem)] part-[body]:flex part-[footer]:flex part-[panel]:h-screen part-[footer]:flex-wrap part-[body]:content-stretch part-[footer]:items-center part-[header-actions]:items-center part-[footer]:justify-end part-[body]:justify-stretch part-[footer]:gap-3 part-[body]:overflow-hidden"
       .label=${msg("Edit Exclusion Rules")}
       .open=${this.open}
       @sl-show=${() => (this.visible = true)}
       @sl-after-hide=${() => (this.visible = false)}
     >
-      <slot name="dialog-label" slot="label"></slot>
-      <btrix-popover
-        slot="header-actions"
-        content="${msg(
+      <slot name="label" slot="label"></slot>
+      ${dialogHelpPopover({
+        content: `${msg(
           "Add or remove exclusion rules to filter URLs out from the page queue.",
         )} ${msg(
           "Edited exclusion rules will apply to the current crawl run and to subsequent crawl runs.",
-        )}"
-        placement="bottom-end"
-        hoist
-      >
-        <sl-icon name="question-circle" class="text-neutral-600"></sl-icon>
-      </btrix-popover>
+        )}`,
+      })}
       ${this.exclusions && this.visible
         ? html`<btrix-exclusion-editor
             class="block size-full overflow-hidden"

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -10,13 +10,16 @@ import type {
 import type { ExclusionRemoveEvent } from "./queue-exclusion-table";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import { type BtrixAddEvent } from "@/events/btrix-add";
 import type { BtrixRemoveEvent } from "@/events/btrix-remove";
 import type { SeedConfig } from "@/pages/org/types";
 import { isApiError } from "@/utils/api";
+import { isNotEqual } from "@/utils/is-not-equal";
 
 const styles = unsafeCSS(stylesheet);
 
 export type RemoveExclusionEvent = BtrixRemoveEvent<string>;
+export type AddExclusionEvent = BtrixAddEvent<string>;
 
 type URLs = string[];
 type ResponseData = {
@@ -37,6 +40,7 @@ type ResponseData = {
  * </btrix-exclusion-editor>
  * ```
  *
+ * @fires btrix-add
  * @fires btrix-remove
  */
 @customElement("btrix-exclusion-editor")
@@ -47,17 +51,17 @@ export class ExclusionEditor extends BtrixElement {
   @property({ type: String })
   crawlId?: string;
 
-  @property({ attribute: false })
-  config?: SeedConfig;
+  @property({ attribute: false, hasChanged: isNotEqual })
+  exclusions?: SeedConfig["exclude"];
 
   @property({ type: Boolean })
   isActiveCrawl = false;
 
-  @state()
-  private isSubmitting = false;
+  @property({ type: Boolean })
+  submitting?: boolean;
 
-  @state()
-  private exclusionFieldErrorMessage = "";
+  @property({ type: String })
+  errorMessage = "";
 
   @state()
   /** `new RegExp` constructor string */
@@ -70,7 +74,16 @@ export class ExclusionEditor extends BtrixElement {
   private isLoading = false;
 
   willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
-    if (changedProperties.has("crawlId") || changedProperties.has("regex")) {
+    if (changedProperties.has("crawlId")) {
+      void this.fetchQueueMatches();
+    }
+
+    if (changedProperties.has("exclusions") && this.exclusions) {
+      if (this.regex && this.exclusions.includes(this.regex)) {
+        this.regex = "";
+        this.matchedURLs = null;
+      }
+    } else if (changedProperties.has("regex")) {
       void this.fetchQueueMatches();
     }
   }
@@ -105,20 +118,20 @@ export class ExclusionEditor extends BtrixElement {
 
   private renderTable() {
     return html`
-      ${this.config
+      ${this.exclusions
         ? html`<btrix-queue-exclusion-table
             pageSize="10"
             ?removable=${this.isActiveCrawl}
-            .exclusions=${this.config.exclude || []}
+            .exclusions=${this.exclusions}
             @btrix-change=${async (e: ExclusionRemoveEvent) => {
               await this.updateComplete;
               const { index, regex } = e.detail;
-              if (this.config?.exclude && index === 0 && !regex) {
+              if (this.exclusions && index === 0 && !regex) {
                 this.dispatchEvent(
                   new CustomEvent<RemoveExclusionEvent["detail"]>(
                     "btrix-remove",
                     {
-                      detail: { item: this.config.exclude[index] },
+                      detail: { item: this.exclusions[index] },
                     },
                   ),
                 );
@@ -146,8 +159,9 @@ export class ExclusionEditor extends BtrixElement {
           >
             <div class="form-wrapper bg-white py-2">
               <btrix-queue-exclusion-form
-                ?isSubmitting=${this.isSubmitting}
-                fieldErrorMessage=${this.exclusionFieldErrorMessage}
+                regex=${this.regex}
+                ?isSubmitting=${this.submitting}
+                fieldErrorMessage=${this.errorMessage}
                 @btrix-change=${this.handleRegexChange}
                 @btrix-add=${this.handleAddRegex}
               >
@@ -172,7 +186,7 @@ export class ExclusionEditor extends BtrixElement {
       class="part-[heading]:sticky part-[heading]:top-0 part-[heading]:z-10 part-[heading]:block part-[heading]:bg-white part-[heading]:pt-1.5"
       crawlId=${this.crawlId!}
       regex=${this.regex}
-      .exclusions=${this.config?.exclude || []}
+      .exclusions=${this.exclusions || []}
       matchedTotal=${this.matchedURLs?.length || 0}
     ></btrix-crawl-queue>`;
   }
@@ -200,7 +214,7 @@ export class ExclusionEditor extends BtrixElement {
       this.matchedURLs = matched;
     } catch (e) {
       if (isApiError(e) && e.message === "invalid_regex") {
-        this.exclusionFieldErrorMessage = msg("Invalid Regex");
+        this.errorMessage = msg("Invalid Regex");
       } else {
         this.notify.toast({
           message: msg(
@@ -229,71 +243,15 @@ export class ExclusionEditor extends BtrixElement {
   }
 
   async handleAddRegex(e?: ExclusionAddEvent) {
-    this.isSubmitting = true;
+    const regex = e?.detail.regex ?? this.regex;
 
-    let regex = null;
-    let onSuccess = null;
-
-    if (e) {
-      ({ regex, onSuccess } = e.detail);
-    } else {
-      // if not provided, use current regex, if set
-      if (!this.regex) {
-        return;
-      }
-      regex = this.regex;
-    }
-
-    try {
-      const params = new URLSearchParams({ regex });
-      const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.orgId}/crawls/${
-          this.crawlId
-        }/exclusions?${params.toString()}`,
-        {
-          method: "POST",
-        },
+    if (regex) {
+      this.dispatchEvent(
+        new CustomEvent<AddExclusionEvent["detail"]>("btrix-add", {
+          detail: { item: regex },
+        }),
       );
-
-      if (data.success) {
-        this.notify.toast({
-          message: msg("Exclusion added."),
-          variant: "success",
-          icon: "check2-circle",
-          id: "exclusion-edit-status",
-        });
-
-        this.regex = "";
-        this.matchedURLs = null;
-        await this.updateComplete;
-
-        if (onSuccess) {
-          onSuccess();
-        }
-        this.dispatchEvent(new CustomEvent("btrix-saved"));
-      } else {
-        throw data;
-      }
-    } catch (e) {
-      if (isApiError(e)) {
-        if (e.message === "exclusion_already_exists") {
-          this.exclusionFieldErrorMessage = msg("Exclusion already exists");
-        } else if (e.message === "invalid_regex") {
-          this.exclusionFieldErrorMessage = msg("Invalid Regex");
-        }
-      } else {
-        this.notify.toast({
-          message: msg("Sorry, couldn't add exclusion at this time."),
-          variant: "danger",
-          icon: "exclamation-octagon",
-          id: "exclusion-edit-status",
-        });
-      }
-
-      this.dispatchEvent(new CustomEvent("btrix-error"));
     }
-
-    this.isSubmitting = false;
   }
 
   async onClose() {

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -10,10 +10,13 @@ import type {
 import type { ExclusionRemoveEvent } from "./queue-exclusion-table";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import type { BtrixRemoveEvent } from "@/events/btrix-remove";
 import type { SeedConfig } from "@/pages/org/types";
 import { isApiError } from "@/utils/api";
 
 const styles = unsafeCSS(stylesheet);
+
+export type RemoveExclusionEvent = BtrixRemoveEvent<string>;
 
 type URLs = string[];
 type ResponseData = {
@@ -34,7 +37,7 @@ type ResponseData = {
  * </btrix-exclusion-editor>
  * ```
  *
- * @event on-success On successful edit
+ * @fires btrix-remove
  */
 @customElement("btrix-exclusion-editor")
 @localized()
@@ -111,13 +114,25 @@ export class ExclusionEditor extends BtrixElement {
               await this.updateComplete;
               const { index, regex } = e.detail;
               if (this.config?.exclude && index === 0 && !regex) {
-                void this.deleteExclusion({
-                  regex: this.config.exclude[index],
-                });
+                this.dispatchEvent(
+                  new CustomEvent<RemoveExclusionEvent["detail"]>(
+                    "btrix-remove",
+                    {
+                      detail: { item: this.config.exclude[index] },
+                    },
+                  ),
+                );
               }
             }}
             @btrix-remove=${(e: ExclusionRemoveEvent) =>
-              void this.deleteExclusion({ regex: e.detail.regex })}
+              this.dispatchEvent(
+                new CustomEvent<RemoveExclusionEvent["detail"]>(
+                  "btrix-remove",
+                  {
+                    detail: { item: e.detail.regex },
+                  },
+                ),
+              )}
           >
           </btrix-queue-exclusion-table>`
         : html`
@@ -169,43 +184,6 @@ export class ExclusionEditor extends BtrixElement {
       this.regex = value;
     } else {
       this.regex = "";
-    }
-  }
-
-  private async deleteExclusion({ regex }: { regex: string }) {
-    try {
-      const params = new URLSearchParams({ regex });
-      const data = await this.api.fetch<{ success: boolean }>(
-        `/orgs/${this.orgId}/crawls/${
-          this.crawlId
-        }/exclusions?${params.toString()}`,
-        {
-          method: "DELETE",
-        },
-      );
-
-      if (data.success) {
-        this.notify.toast({
-          message: msg(html`Removed exclusion: <code>${regex}</code>`),
-          variant: "success",
-          icon: "check2-circle",
-          id: "exclusion-edit-status",
-        });
-
-        this.dispatchEvent(new CustomEvent("on-success"));
-      } else {
-        throw data;
-      }
-    } catch (e) {
-      this.notify.toast({
-        message:
-          isApiError(e) && e.message === "crawl_running_cant_deactivate"
-            ? msg("Cannot remove exclusion when crawl is no longer running.")
-            : msg("Sorry, couldn't remove exclusion at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-        id: "exclusion-edit-status",
-      });
     }
   }
 
@@ -292,7 +270,7 @@ export class ExclusionEditor extends BtrixElement {
         if (onSuccess) {
           onSuccess();
         }
-        this.dispatchEvent(new CustomEvent("on-success"));
+        this.dispatchEvent(new CustomEvent("btrix-saved"));
       } else {
         throw data;
       }
@@ -311,6 +289,8 @@ export class ExclusionEditor extends BtrixElement {
           id: "exclusion-edit-status",
         });
       }
+
+      this.dispatchEvent(new CustomEvent("btrix-error"));
     }
 
     this.isSubmitting = false;

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -1,6 +1,8 @@
 import { localized, msg } from "@lit/localize";
-import { html, unsafeCSS, type PropertyValues } from "lit";
+import { Task, TaskStatus } from "@lit/task";
+import { html, unsafeCSS } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import stylesheet from "./exclusion-editor.stylesheet.css";
 import type {
@@ -61,32 +63,39 @@ export class ExclusionEditor extends BtrixElement {
   submitting?: boolean;
 
   @property({ type: String })
-  errorMessage = "";
+  formErrorMessage = "";
 
   @state()
   /** `new RegExp` constructor string */
   private regex = "";
 
-  @state()
-  matchedURLs: URLs | null = null;
+  private readonly getMatchesTask = new Task(this, {
+    task: async ([crawlId, exclusions, regex], { signal }) => {
+      if (!crawlId || !exclusions || !regex) return null;
 
-  @state()
-  private isLoading = false;
-
-  willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
-    if (changedProperties.has("crawlId")) {
-      void this.fetchQueueMatches();
-    }
-
-    if (changedProperties.has("exclusions") && this.exclusions) {
-      if (this.regex && this.exclusions.includes(this.regex)) {
+      if (regex && exclusions.includes(this.regex)) {
         this.regex = "";
-        this.matchedURLs = null;
+        return null;
       }
-    } else if (changedProperties.has("regex")) {
-      void this.fetchQueueMatches();
-    }
-  }
+
+      try {
+        const { matched } = await this.getQueueMatches(regex, signal);
+
+        return matched;
+      } catch (err) {
+        if (signal.aborted) return;
+
+        console.debug(err);
+
+        if (isApiError(err) && err.message === "invalid_regex") {
+          this.formErrorMessage = msg("Invalid Regex");
+        }
+
+        throw msg("Sorry, couldn't fetch pending exclusions at this time.");
+      }
+    },
+    args: () => [this.crawlId, this.exclusions, this.regex],
+  });
 
   render() {
     return html`
@@ -161,7 +170,7 @@ export class ExclusionEditor extends BtrixElement {
               <btrix-queue-exclusion-form
                 regex=${this.regex}
                 ?isSubmitting=${this.submitting}
-                fieldErrorMessage=${this.errorMessage}
+                fieldErrorMessage=${this.formErrorMessage}
                 @btrix-change=${this.handleRegexChange}
                 @btrix-add=${this.handleAddRegex}
               >
@@ -173,10 +182,18 @@ export class ExclusionEditor extends BtrixElement {
   }
 
   private renderPending() {
+    const errorMessage = this.getMatchesTask.render({
+      error: (errorMessage) => errorMessage,
+    });
+
     return html`
       <btrix-crawl-pending-exclusions
         class="part-[heading]:sticky part-[heading]:top-0 part-[heading]:z-20 part-[heading]:bg-white part-[heading]:pt-1.5"
-        .matchedURLs=${this.matchedURLs}
+        .matchedURLs=${this.getMatchesTask.value ?? null}
+        ?loading=${this.getMatchesTask.status === TaskStatus.PENDING}
+        errorMessage=${ifDefined(
+          typeof errorMessage === "string" ? errorMessage : undefined,
+        )}
       ></btrix-crawl-pending-exclusions>
     `;
   }
@@ -187,7 +204,7 @@ export class ExclusionEditor extends BtrixElement {
       crawlId=${this.crawlId!}
       regex=${this.regex}
       .exclusions=${this.exclusions || []}
-      matchedTotal=${this.matchedURLs?.length || 0}
+      matchedTotal=${this.getMatchesTask.value?.length || 0}
     ></btrix-crawl-queue>`;
   }
 
@@ -201,42 +218,13 @@ export class ExclusionEditor extends BtrixElement {
     }
   }
 
-  private async fetchQueueMatches() {
-    if (!this.regex) {
-      this.matchedURLs = null;
-      return;
-    }
-
-    this.isLoading = true;
-
-    try {
-      const { matched } = await this.getQueueMatches();
-      this.matchedURLs = matched;
-    } catch (e) {
-      if (isApiError(e) && e.message === "invalid_regex") {
-        this.errorMessage = msg("Invalid Regex");
-      } else {
-        this.notify.toast({
-          message: msg(
-            "Sorry, couldn't fetch pending exclusions at this time.",
-          ),
-          variant: "danger",
-          icon: "exclamation-octagon",
-          id: "exclusion-edit-status",
-        });
-      }
-    }
-
-    this.isLoading = false;
-  }
-
-  private async getQueueMatches() {
-    const regex = this.regex;
+  private async getQueueMatches(regex: string, signal: AbortSignal) {
     const params = new URLSearchParams({ regex });
     const data = await this.api.fetch<ResponseData>(
       `/orgs/${this.orgId}/crawls/${
         this.crawlId
       }/queueMatchAll?${params.toString()}`,
+      { signal },
     );
 
     return data;

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -164,7 +164,7 @@ export class ExclusionEditor extends BtrixElement {
           `}
       ${this.isActiveCrawl
         ? html`<div
-            class="sticky bottom-0 [container-name:sticky-form] [container-type:scroll-state]"
+            class="sticky bottom-0 z-20 [container-name:sticky-form] [container-type:scroll-state]"
           >
             <div class="form-wrapper bg-white py-2">
               <btrix-queue-exclusion-form

--- a/frontend/src/features/crawl-workflows/index.ts
+++ b/frontend/src/features/crawl-workflows/index.ts
@@ -1,5 +1,6 @@
 import("./custom-behaviors-table");
 import("./exclusion-editor");
+import("./exclusion-editor-dialog");
 import("./live-workflow-status");
 import("./link-selector-table");
 import("./new-workflow-dialog");

--- a/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
@@ -20,7 +20,6 @@ export type ExclusionChangeEvent = CustomEvent<{
 
 export type ExclusionAddEvent = CustomEvent<{
   regex: string;
-  onSuccess: () => void;
 }>;
 
 const MIN_LENGTH = 2;
@@ -43,8 +42,8 @@ export class QueueExclusionForm extends LiteElement {
   @state()
   private selectValue: Exclusion["type"] = "text";
 
-  @state()
-  private regex = "";
+  @property({ type: String })
+  regex = "";
 
   @state()
   private isRegexInvalid = false;
@@ -55,6 +54,12 @@ export class QueueExclusionForm extends LiteElement {
   async willUpdate(
     changedProperties: PropertyValues<this> & Map<string, unknown>,
   ) {
+    if (changedProperties.get("regex") && this.regex === "") {
+      if (this.input) {
+        this.input.value = "";
+      }
+    }
+
     if (
       changedProperties.get("selectValue") ||
       (changedProperties.has("regex") &&
@@ -212,24 +217,15 @@ export class QueueExclusionForm extends LiteElement {
     await this.updateComplete;
     if (!this.regex || this.isRegexInvalid) return;
 
-    if (this.input) {
-      this.input.value = "";
-    }
-
     let regex = this.regex;
     if (this.selectValue === "text") {
       regex = regexEscape(this.regex);
     }
 
     this.dispatchEvent(
-      new CustomEvent("btrix-add", {
-        detail: {
-          regex,
-          onSuccess: () => {
-            this.regex = "";
-          },
-        },
-      }) as ExclusionAddEvent,
+      new CustomEvent<ExclusionAddEvent["detail"]>("btrix-add", {
+        detail: { regex },
+      }),
     );
   }
 

--- a/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
@@ -1,8 +1,10 @@
-import { localized, msg } from "@lit/localize";
+import { localized, msg, str } from "@lit/localize";
 import { type SlInput, type SlSelect } from "@shoelace-style/shoelace";
 import { type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import debounce from "lodash/fp/debounce";
+
+import { MIN_LENGTH } from "./queue-exclusion-table";
 
 import type { UnderlyingFunction } from "@/types/utils";
 import LiteElement, { html } from "@/utils/LiteElement";
@@ -22,7 +24,7 @@ export type ExclusionAddEvent = CustomEvent<{
   regex: string;
 }>;
 
-const MIN_LENGTH = 2;
+const MAX_LENGTH = 1000;
 
 /**
  * Inline form for adding a new crawl exclusion while the crawl is running.
@@ -67,7 +69,6 @@ export class QueueExclusionForm extends LiteElement {
     ) {
       this.fieldErrorMessage = "";
       this.checkInputValidity();
-      void this.dispatchChangeEvent();
     }
   }
 
@@ -77,6 +78,11 @@ export class QueueExclusionForm extends LiteElement {
   }
 
   render() {
+    const invalidRegex =
+      !this.regex || this.isRegexInvalid || this.regex.length > MAX_LENGTH;
+    const minimum_number_of_characters = this.localize.number(MIN_LENGTH);
+    const maximum_number_of_characters = this.localize.number(MAX_LENGTH);
+
     return html`
       <fieldset>
         <div class="flex">
@@ -91,6 +97,7 @@ export class QueueExclusionForm extends LiteElement {
                 this.selectValue = (e.target as SlSelect).value as
                   | "text"
                   | "regex";
+                void this.dispatchChangeEvent();
               }}
             >
               <sl-option value="text">${msg("Matches Text")}</sl-option>
@@ -147,18 +154,25 @@ export class QueueExclusionForm extends LiteElement {
               </sl-input>
             </div>
             <div class="flex-0 w-10 text-center">
-              <btrix-button
-                variant="neutral"
-                raised
-                filled
-                ?disabled=${!this.regex ||
-                this.isRegexInvalid ||
-                this.isSubmitting}
-                ?loading=${this.isSubmitting}
-                @click=${this.onButtonClick}
+              <btrix-popover
+                ?disabled=${!invalidRegex}
+                content=${msg(
+                  str`Please enter a valid regular expression between ${minimum_number_of_characters} and ${maximum_number_of_characters} characters.`,
+                )}
+                hoist
+                placement="right"
               >
-                <sl-icon name="plus-lg"></sl-icon>
-              </btrix-button>
+                <btrix-button
+                  variant="neutral"
+                  raised
+                  filled
+                  ?disabled=${invalidRegex || this.isSubmitting}
+                  ?loading=${this.isSubmitting}
+                  @click=${this.onButtonClick}
+                >
+                  <sl-icon name="plus-lg"></sl-icon>
+                </btrix-button>
+              </btrix-popover>
             </div>
           </div>
         </div>
@@ -168,6 +182,7 @@ export class QueueExclusionForm extends LiteElement {
 
   private readonly onInput = debounce(200)(() => {
     this.regex = this.input?.value || "";
+    void this.dispatchChangeEvent();
   });
 
   private onButtonClick() {

--- a/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-table.ts
@@ -30,7 +30,7 @@ export type ExclusionChangeEvent = CustomEvent<ExclusionChangeEventDetail>;
 
 export type ExclusionRemoveEvent = CustomEvent<ExclusionChangeEventDetail>;
 
-const MIN_LENGTH = 2;
+export const MIN_LENGTH = 2;
 
 function formatValue(type: Exclusion["type"], value: Exclusion["value"]) {
   return type == "text" ? regexEscape(value) : value;
@@ -181,10 +181,7 @@ export class QueueExclusionTable extends TailwindElement {
             </div>
           `
         : nothing}
-      <table
-        class="w-full border-separate leading-none"
-        style="border-spacing: 0;"
-      >
+      <table class="w-full border-separate border-spacing-0 leading-none">
         <thead class="text-xs text-neutral-600">
           <tr class="h-10 text-left">
             <th class="${typeColClass} w-40 bg-slate-50 px-2 font-normal">
@@ -232,7 +229,7 @@ export class QueueExclusionTable extends TailwindElement {
         <td class="${typeColClass} whitespace-nowrap">
           ${this.renderType({ exclusion, index })}
         </td>
-        <td class="${valueColClass}">
+        <td class="${valueColClass} break-all">
           ${this.renderValue({ exclusion, index })}
         </td>
         <td class="${actionColClass} text-center text-[1rem]">

--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -12,6 +12,7 @@ import { WorkflowTab } from "@/routes";
 import type { Crawl, ListWorkflow, Workflow } from "@/types/crawler";
 import { isNotFailed, isPaused, isSuccessfullyFinished } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
+import { isActivelyCrawling, isRunningNotStopping } from "@/utils/workflow";
 
 @customElement("btrix-workflow-action-menu")
 @localized()
@@ -42,11 +43,8 @@ export class WorkflowActionMenu extends BtrixElement {
     const canCrawl = this.appState.isCrawler;
     const archivingDisabled = isArchivingDisabled(this.org, true);
     const paused = isPaused(workflow.lastCrawlState || "");
-    const crawling =
-      workflow.isCrawlRunning &&
-      !workflow.lastCrawlStopping &&
-      !workflow.lastCrawlShouldPause &&
-      workflow.lastCrawlState === "running";
+    const running = isRunningNotStopping(workflow) && !this.cancelingRun;
+    const crawling = isActivelyCrawling(workflow);
 
     return html`<sl-menu
       @sl-select=${(e: SlSelectEvent) => {
@@ -130,9 +128,7 @@ export class WorkflowActionMenu extends BtrixElement {
         canCrawl,
         () =>
           html`${when(
-              workflow.isCrawlRunning &&
-                !workflow.lastCrawlStopping &&
-                !this.cancelingRun,
+              running,
               () => html`
                 <sl-menu-item data-action=${Action.EditBrowserWindows}>
                   <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>
@@ -140,7 +136,7 @@ export class WorkflowActionMenu extends BtrixElement {
                 </sl-menu-item>
                 <sl-menu-item
                   data-action=${Action.EditExclusions}
-                  ?disabled=${!crawling && !paused}
+                  ?disabled=${!crawling}
                 >
                   <sl-icon name="table" slot="prefix"></sl-icon>
                   ${msg("Edit Exclusions")}

--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -138,8 +138,8 @@ export class WorkflowActionMenu extends BtrixElement {
                   data-action=${Action.EditExclusions}
                   ?disabled=${!crawling}
                 >
-                  <sl-icon name="table" slot="prefix"></sl-icon>
-                  ${msg("Edit Exclusions")}
+                  <sl-icon name="file-earmark-diff" slot="prefix"></sl-icon>
+                  ${msg("Edit Exclusion Rules")}
                 </sl-menu-item>
               `,
             )}

--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -12,7 +12,11 @@ import { WorkflowTab } from "@/routes";
 import type { Crawl, ListWorkflow, Workflow } from "@/types/crawler";
 import { isNotFailed, isPaused, isSuccessfullyFinished } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
-import { isActivelyCrawling, isRunningNotStopping } from "@/utils/workflow";
+import {
+  isActivelyCrawling,
+  isRunningNotPaused,
+  isRunningNotStopping,
+} from "@/utils/workflow";
 
 @customElement("btrix-workflow-action-menu")
 @localized()
@@ -43,7 +47,9 @@ export class WorkflowActionMenu extends BtrixElement {
     const canCrawl = this.appState.isCrawler;
     const archivingDisabled = isArchivingDisabled(this.org, true);
     const paused = isPaused(workflow.lastCrawlState || "");
-    const running = isRunningNotStopping(workflow) && !this.cancelingRun;
+    const watchable = isRunningNotPaused(workflow);
+    const canEditRunning =
+      watchable && isRunningNotStopping(workflow) && !this.cancelingRun;
     const crawling = isActivelyCrawling(workflow);
 
     return html`<sl-menu
@@ -128,7 +134,7 @@ export class WorkflowActionMenu extends BtrixElement {
         canCrawl,
         () =>
           html`${when(
-              running,
+              canEditRunning,
               () => html`
                 <sl-menu-item data-action=${Action.EditBrowserWindows}>
                   <sl-icon name="plus-slash-minus" slot="prefix"></sl-icon>

--- a/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
+++ b/frontend/src/features/crawl-workflows/workflow-action-menu/workflow-action-menu.ts
@@ -12,11 +12,7 @@ import { WorkflowTab } from "@/routes";
 import type { Crawl, ListWorkflow, Workflow } from "@/types/crawler";
 import { isNotFailed, isPaused, isSuccessfullyFinished } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
-import {
-  isActivelyCrawling,
-  isRunningNotPaused,
-  isRunningNotStopping,
-} from "@/utils/workflow";
+import { isActivelyCrawling } from "@/utils/workflow";
 
 @customElement("btrix-workflow-action-menu")
 @localized()
@@ -47,9 +43,7 @@ export class WorkflowActionMenu extends BtrixElement {
     const canCrawl = this.appState.isCrawler;
     const archivingDisabled = isArchivingDisabled(this.org, true);
     const paused = isPaused(workflow.lastCrawlState || "");
-    const watchable = isRunningNotPaused(workflow);
-    const canEditRunning =
-      watchable && isRunningNotStopping(workflow) && !this.cancelingRun;
+    const canEditRunning = isActivelyCrawling(workflow) && !this.cancelingRun;
     const crawling = isActivelyCrawling(workflow);
 
     return html`<sl-menu

--- a/frontend/src/layouts/dialogHeader.ts
+++ b/frontend/src/layouts/dialogHeader.ts
@@ -51,10 +51,7 @@ export function dialogHelpPopover({
   content: string | TemplateResult;
 }) {
   return html`<btrix-popover slot="header-actions" placement="bottom-end" hoist>
-      <div slot="content">${content}</div>
-      <sl-icon
-        name="question-circle"
-        class="text-neutral-600"
-      ></sl-icon></btrix-popover
-    >>`;
+    <div slot="content">${content}</div>
+    <sl-icon name="question-circle" class="text-neutral-600"></sl-icon
+  ></btrix-popover>`;
 }

--- a/frontend/src/layouts/dialogHeader.ts
+++ b/frontend/src/layouts/dialogHeader.ts
@@ -1,0 +1,60 @@
+import { html, nothing, type TemplateResult } from "lit";
+
+import { tw } from "@/utils/tailwind";
+
+/**
+ * Classnames needed for dialog header to render correctly
+ *
+ * @example Usage:
+ * ```ts
+ * <btrix-dialog class=${dialogHeaderClasses}></btrix-dialog>
+ * ```
+ */
+export const dialogClassesForHeader = tw`part-[title]:overflow-hidden`;
+
+/**
+ * Label for `<btrix-dialog>` with optional subtitle.
+ */
+export function dialogLabel({
+  title,
+  subtitle,
+  helpText,
+}: {
+  title: string | TemplateResult;
+  subtitle?: string | TemplateResult;
+  helpText?: string | TemplateResult;
+}) {
+  return html`<div slot="label" class="flex items-center gap-3 divide-x">
+    <div class="whitespace-nowrap">${title}</div>
+    ${subtitle
+      ? html`<div class="truncate px-3 text-sm leading-none text-neutral-500">
+          ${subtitle}
+        </div>`
+      : nothing}
+    ${helpText
+      ? html`
+          <btrix-popover slot="header-actions" placement="bottom-end" hoist>
+            <div slot="content">${helpText}</div>
+            <sl-icon name="question-circle" class="text-neutral-600"></sl-icon>
+          </btrix-popover>
+        `
+      : nothing}
+  </div>`;
+}
+
+/**
+ * "Help" icon with popover in `<btrix-dialog>` header.
+ */
+export function dialogHelpPopover({
+  content,
+}: {
+  content: string | TemplateResult;
+}) {
+  return html`<btrix-popover slot="header-actions" placement="bottom-end" hoist>
+      <div slot="content">${content}</div>
+      <sl-icon
+        name="question-circle"
+        class="text-neutral-600"
+      ></sl-icon></btrix-popover
+    >>`;
+}

--- a/frontend/src/layouts/pageHeader.ts
+++ b/frontend/src/layouts/pageHeader.ts
@@ -125,12 +125,12 @@ export function pageHeader({
   return html`
     <header
       class=${clsx(
-        tw`mt-5 flex flex-row flex-wrap gap-3 pb-3`,
+        tw`mt-5 flex max-w-full flex-row flex-wrap gap-3 overflow-hidden pb-3`,
         border && tw`border-b`,
         classNames,
       )}
     >
-      <div class="flex min-w-72 flex-1 flex-col gap-2">
+      <div class="flex flex-1 flex-col gap-2 overflow-hidden lg:min-w-72">
         <div class="flex flex-wrap items-center gap-2.5">
           ${prefix}${pageTitle(title)}${suffix}
         </div>

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -556,7 +556,7 @@ export class ArchivedItemDetail extends BtrixElement {
           <div
             class="col-span-14 grid min-w-0 border-b md:col-span-3 md:border-b-0"
           >
-            <div class="-mx-3 box-border flex overflow-x-auto px-3 md:block ">
+            <div class="-mx-3 box-border flex overflow-x-auto px-3 md:block">
               ${this.renderNav()}
             </div>
           </div>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -57,7 +57,12 @@ import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
-import { rangeBrowserWindows } from "@/utils/workflow";
+import { isActivelyCrawling, rangeBrowserWindows } from "@/utils/workflow";
+
+export const EDIT_DIALOG_PARAM_NAME = "editDialog";
+export enum EditDialogValues {
+  Exclusions = "exclusions",
+}
 
 const POLL_INTERVAL_SECONDS = 10;
 const CRAWLS_PAGINATION_NAME = "crawlsPage";
@@ -91,17 +96,17 @@ export class WorkflowDetail extends BtrixElement {
   @property({ type: String })
   openDialogName?: "scale" | "cancel" | "stop" | "delete" | "deleteCrawl";
 
-  private readonly editDialog = new SearchParamsValue<null | "exclusions">(
+  private readonly editDialog = new SearchParamsValue<null | EditDialogValues>(
     this,
     (value, params) => {
       if (value) {
-        params.set("editDialog", value);
+        params.set(EDIT_DIALOG_PARAM_NAME, value);
       } else {
-        params.delete("editDialog");
+        params.delete(EDIT_DIALOG_PARAM_NAME);
       }
       return params;
     },
-    (params) => params.get("editDialog") as "exclusions" | null,
+    (params) => params.get(EDIT_DIALOG_PARAM_NAME) as EditDialogValues | null,
   );
 
   @property({ type: Number })
@@ -268,7 +273,7 @@ export class WorkflowDetail extends BtrixElement {
           if (
             wasActive &&
             (this.openDialogName === "scale" ||
-              this.editDialog.value == "exclusions")
+              this.editDialog.value == EditDialogValues.Exclusions)
           ) {
             this.closeDialogs();
           }
@@ -388,12 +393,8 @@ export class WorkflowDetail extends BtrixElement {
 
   // Crawl is explicitly running
   private get isCrawling() {
-    return (
-      this.workflow?.isCrawlRunning &&
-      !this.workflow.lastCrawlStopping &&
-      this.workflow.lastCrawlState &&
-      ["running", "rate-limited"].includes(this.workflow.lastCrawlState)
-    );
+    if (!this.workflow) return;
+    return isActivelyCrawling(this.workflow);
   }
 
   private get isPaused() {
@@ -460,7 +461,7 @@ export class WorkflowDetail extends BtrixElement {
   firstUpdated() {
     if (this.openDialogName === "scale") {
       void this.showDialog();
-    } else if (this.editDialog.value === "exclusions") {
+    } else if (this.editDialog.value === EditDialogValues.Exclusions) {
       this.openEditDialog();
     }
   }
@@ -1969,7 +1970,7 @@ export class WorkflowDetail extends BtrixElement {
               stopping: this.workflow.lastCrawlStopping,
             })
           : false}
-        ?open=${this.editDialog.value === "exclusions"}
+        ?open=${this.editDialog.value === EditDialogValues.Exclusions}
         @sl-hide=${(e: CustomEvent) => {
           e.stopPropagation();
           this.closeEditDialog();
@@ -2052,9 +2053,12 @@ export class WorkflowDetail extends BtrixElement {
       <sl-spinner></sl-spinner>
     </div>`;
 
+  /**
+   * @note Only supports exclusions dialog at this time
+   */
   private openEditDialog() {
     this.openDialogName = undefined;
-    this.editDialog.setValue("exclusions");
+    this.editDialog.setValue(EditDialogValues.Exclusions);
   }
 
   private closeEditDialog() {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1942,13 +1942,9 @@ export class WorkflowDetail extends BtrixElement {
         <h3 class="mb-2 text-base font-semibold leading-none">
           ${msg("Upcoming Pages")}
         </h3>
-        <sl-button
-          size="small"
-          variant="primary"
-          @click=${() => this.openEditDialog()}
-        >
-          <sl-icon slot="prefix" name="table"></sl-icon>
-          ${msg("Edit Exclusions")}
+        <sl-button size="small" @click=${() => this.openEditDialog()}>
+          <sl-icon slot="prefix" name="file-earmark-diff"></sl-icon>
+          ${msg("Edit Exclusion Rules")}
         </sl-button>
       </header>
 

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -24,7 +24,6 @@ import { docsUrlContext, type DocsUrlContext } from "@/context/docs-url";
 import { ClipboardController } from "@/controllers/clipboard";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { missingDependenciesNotice } from "@/features/archived-items/templates/missing-dependencies-notice";
-import { ExclusionEditor } from "@/features/crawl-workflows/exclusion-editor";
 import { ShareableNotice } from "@/features/crawl-workflows/templates/shareable-notice";
 import {
   Action,
@@ -1951,34 +1950,23 @@ export class WorkflowDetail extends BtrixElement {
         `,
       )}
 
-      <btrix-dialog
-        class="[--body-spacing:0] part-[body]:flex part-[panel]:h-screen part-[body]:content-stretch part-[body]:justify-stretch part-[body]:overflow-hidden"
-        .label=${msg("Crawl Queue Editor")}
-        .open=${this.openDialogName === "exclusions"}
-        style=${`--width: var(--btrix-screen-desktop)`}
-        @sl-request-close=${() => (this.openDialogName = undefined)}
-        @sl-show=${this.showDialog}
-        @sl-after-hide=${() => (this.isDialogVisible = false)}
+      <btrix-exclusion-editor-dialog
+        crawlId=${ifDefined(this.lastCrawlId || undefined)}
+        .config=${this.workflow?.config}
+        ?activeCrawl=${this.workflow?.lastCrawlState
+          ? isActive({
+              state: this.workflow.lastCrawlState,
+              stopping: this.workflow.lastCrawlStopping,
+            })
+          : false}
+        ?open=${this.openDialogName === "exclusions"}
+        @sl-hide=${(e: CustomEvent) => {
+          e.stopPropagation();
+          this.openDialogName = undefined;
+        }}
+        @btrix-saved=${this.handleExclusionChange}
       >
-        ${this.workflow && this.isDialogVisible
-          ? html`<btrix-exclusion-editor
-              .crawlId=${this.lastCrawlId ?? undefined}
-              .config=${this.workflow.config}
-              ?isActiveCrawl=${this.workflow.lastCrawlState
-                ? isActive({
-                    state: this.workflow.lastCrawlState,
-                    stopping: this.workflow.lastCrawlStopping,
-                  })
-                : false}
-              @on-success=${this.handleExclusionChange}
-            ></btrix-exclusion-editor>`
-          : ""}
-        <div slot="footer">
-          <sl-button size="small" @click=${this.onCloseExclusions}
-            >${msg("Done Editing")}</sl-button
-          >
-        </div>
-      </btrix-dialog>
+      </btrix-exclusion-editor-dialog>
     `;
   }
 
@@ -2104,14 +2092,6 @@ export class WorkflowDetail extends BtrixElement {
       { signal },
     );
     return data;
-  }
-
-  private async onCloseExclusions() {
-    const editor = this.querySelector("btrix-exclusion-editor");
-    if (editor && editor instanceof ExclusionEditor) {
-      await editor.onClose();
-    }
-    this.openDialogName = undefined;
   }
 
   private async getSeeds(workflowId: string, signal: AbortSignal) {

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1952,7 +1952,7 @@ export class WorkflowDetail extends BtrixElement {
 
       <btrix-exclusion-editor-dialog
         crawlId=${ifDefined(this.lastCrawlId || undefined)}
-        .config=${this.workflow?.config}
+        .exclusions=${this.workflow?.config.exclude}
         ?activeCrawl=${this.workflow?.lastCrawlState
           ? isActive({
               state: this.workflow.lastCrawlState,

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1973,6 +1973,12 @@ export class WorkflowDetail extends BtrixElement {
         }}
         @btrix-saved=${this.handleExclusionChange}
       >
+        <div slot="dialog-label" class="flex items-center gap-3 divide-x">
+          <div class="whitespace-nowrap">${msg("Edit Exclusion Rules")}</div>
+          <div class="truncate px-3 text-sm leading-none text-neutral-500">
+            ${renderName(this.workflow)}
+          </div>
+        </div>
       </btrix-exclusion-editor-dialog>
     `;
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -22,6 +22,7 @@ import type { Alert } from "@/components/ui/alert";
 import { parsePage, type PageChangeEvent } from "@/components/ui/pagination";
 import { docsUrlContext, type DocsUrlContext } from "@/context/docs-url";
 import { ClipboardController } from "@/controllers/clipboard";
+import { SearchParamsValue } from "@/controllers/searchParamsValue";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
 import { missingDependenciesNotice } from "@/features/archived-items/templates/missing-dependencies-notice";
 import { ShareableNotice } from "@/features/crawl-workflows/templates/shareable-notice";
@@ -88,13 +89,20 @@ export class WorkflowDetail extends BtrixElement {
   isCrawler!: boolean;
 
   @property({ type: String })
-  openDialogName?:
-    | "scale"
-    | "exclusions"
-    | "cancel"
-    | "stop"
-    | "delete"
-    | "deleteCrawl";
+  openDialogName?: "scale" | "cancel" | "stop" | "delete" | "deleteCrawl";
+
+  private readonly editDialog = new SearchParamsValue<null | "exclusions">(
+    this,
+    (value, params) => {
+      if (value) {
+        params.set("editDialog", value);
+      } else {
+        params.delete("editDialog");
+      }
+      return params;
+    },
+    (params) => params.get("editDialog") as "exclusions" | null,
+  );
 
   @property({ type: Number })
   maxBrowserWindows = DEFAULT_MAX_SCALE;
@@ -260,9 +268,9 @@ export class WorkflowDetail extends BtrixElement {
           if (
             wasActive &&
             (this.openDialogName === "scale" ||
-              this.openDialogName === "exclusions")
+              this.editDialog.value == "exclusions")
           ) {
-            this.openDialogName = undefined;
+            this.closeDialogs();
           }
         }
       }, POLL_INTERVAL_SECONDS * 1000);
@@ -444,14 +452,16 @@ export class WorkflowDetail extends BtrixElement {
     ) {
       this.workflowTab = WorkflowTab.LatestCrawl;
     }
+    if (changedProperties.has("openDialogName") && this.openDialogName) {
+      this.closeEditDialog();
+    }
   }
 
   firstUpdated() {
-    if (
-      this.openDialogName &&
-      (this.openDialogName === "scale" || this.openDialogName === "exclusions")
-    ) {
+    if (this.openDialogName === "scale") {
       void this.showDialog();
+    } else if (this.editDialog.value === "exclusions") {
+      this.openEditDialog();
     }
   }
 
@@ -1051,7 +1061,7 @@ export class WorkflowDetail extends BtrixElement {
         this.openDialogName = "scale";
         break;
       case Action.EditExclusions:
-        this.openDialogName = "exclusions";
+        this.openEditDialog();
         break;
       case Action.Duplicate:
         void this.duplicateConfig();
@@ -1934,7 +1944,7 @@ export class WorkflowDetail extends BtrixElement {
         <sl-button
           size="small"
           variant="primary"
-          @click=${() => (this.openDialogName = "exclusions")}
+          @click=${() => this.openEditDialog()}
         >
           <sl-icon slot="prefix" name="table"></sl-icon>
           ${msg("Edit Exclusions")}
@@ -1959,10 +1969,10 @@ export class WorkflowDetail extends BtrixElement {
               stopping: this.workflow.lastCrawlStopping,
             })
           : false}
-        ?open=${this.openDialogName === "exclusions"}
+        ?open=${this.editDialog.value === "exclusions"}
         @sl-hide=${(e: CustomEvent) => {
           e.stopPropagation();
-          this.openDialogName = undefined;
+          this.closeEditDialog();
         }}
         @btrix-saved=${this.handleExclusionChange}
       >
@@ -2041,6 +2051,20 @@ export class WorkflowDetail extends BtrixElement {
     html`<div class="my-24 flex w-full items-center justify-center text-3xl">
       <sl-spinner></sl-spinner>
     </div>`;
+
+  private openEditDialog() {
+    this.openDialogName = undefined;
+    this.editDialog.setValue("exclusions");
+  }
+
+  private closeEditDialog() {
+    this.editDialog.setValue(null);
+  }
+
+  private closeDialogs() {
+    this.openDialogName = undefined;
+    this.closeEditDialog();
+  }
 
   private readonly showDialog = async () => {
     await this.workflowTask.taskComplete;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -57,7 +57,12 @@ import { humanizeExecutionSeconds } from "@/utils/executionTimeFormatter";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { pluralOf } from "@/utils/pluralize";
 import { tw } from "@/utils/tailwind";
-import { isActivelyCrawling, rangeBrowserWindows } from "@/utils/workflow";
+import {
+  isActivelyCrawling,
+  isRunningNotPaused,
+  isRunningNotStopping,
+  rangeBrowserWindows,
+} from "@/utils/workflow";
 
 export const EDIT_DIALOG_PARAM_NAME = "editDialog";
 export enum EditDialogValues {
@@ -379,7 +384,8 @@ export class WorkflowDetail extends BtrixElement {
 
   // Workflow is active and not paused
   private get isRunning() {
-    return this.workflow?.isCrawlRunning && !this.isPaused;
+    if (!this.workflow) return;
+    return isRunningNotPaused(this.workflow);
   }
 
   private get isSkippedOrCanceled() {
@@ -1320,7 +1326,8 @@ export class WorkflowDetail extends BtrixElement {
     }
 
     const logTotals = this.logTotalsTask.value;
-    const showReplay = !this.isRunning;
+    const watchable = this.isRunning;
+    const showReplay = !watchable;
 
     return html`
       <div class="mb-3 rounded-lg border px-4 py-2">
@@ -1558,10 +1565,12 @@ export class WorkflowDetail extends BtrixElement {
   private renderLatestCrawlAction() {
     if (!this.workflow || !this.lastCrawlId) return;
 
-    if (this.isRunning) {
+    const watchable = this.isRunning;
+
+    if (watchable) {
       if (!this.isCrawler) return;
 
-      const enableEditBrowserWindows = !this.workflow.lastCrawlStopping;
+      const canEditRunning = isRunningNotStopping(this.workflow);
       const windowCount = this.workflow.browserWindows || 1;
 
       return html`
@@ -1570,21 +1579,20 @@ export class WorkflowDetail extends BtrixElement {
           ${pluralOf("browserWindows", windowCount)}
         </div>
 
-        <sl-tooltip
-          content=${enableEditBrowserWindows
-            ? msg("Edit Browser Windows")
-            : msg(
-                "Browser windows can only be edited while a crawl is starting or running",
-              )}
+        <btrix-popover
+          content=${msg(
+            "Browser windows can only be edited while a crawl is starting or running",
+          )}
+          ?disabled=${canEditRunning}
         >
           <sl-icon-button
             name="plus-slash-minus"
             label=${msg("Increase or decrease")}
-            ?disabled=${!enableEditBrowserWindows}
+            ?disabled=${!canEditRunning}
             @click=${() => (this.openDialogName = "scale")}
           >
           </sl-icon-button>
-        </sl-tooltip>
+        </btrix-popover>
       `;
     }
   }
@@ -1724,25 +1732,23 @@ export class WorkflowDetail extends BtrixElement {
           waitingMsg = msg("Crawl waiting for deduplication index...");
           break;
 
-        case "pending-wait":
-        case "generate-wacz":
-        case "uploading-wacz":
-          waitingMsg = msg("Crawl finishing...");
-          break;
-
         default:
-          if (this.workflow.lastCrawlStopping) {
-            waitingMsg = msg("Crawl stopping...");
+          if (this.isCancelingRun) {
+            waitingMsg = msg("Canceling crawl run...");
+          } else {
+            // TODO Handle finishing by checking if there are any URLs left in the queue
+            console.debug("crawl may be finishing");
           }
           break;
       }
     }
 
+    const watchable = this.isRunning && !this.isCancelingRun;
     const authToken = this.authState.headers.Authorization.split(" ")[1];
 
     return html`
       ${when(
-        this.isCrawling && this.workflow,
+        watchable && this.workflow,
         (workflow) => html`
           <div id="screencast-crawl">
             <btrix-screencast
@@ -1937,15 +1943,24 @@ export class WorkflowDetail extends BtrixElement {
   }
 
   private renderExclusions() {
+    const canEditRunning = this.workflow && isRunningNotStopping(this.workflow);
+
     return html`
       <header class="flex items-center justify-between">
         <h3 class="mb-2 text-base font-semibold leading-none">
           ${msg("Upcoming Pages")}
         </h3>
-        <sl-button size="small" @click=${() => this.openEditDialog()}>
-          <sl-icon slot="prefix" name="file-earmark-diff"></sl-icon>
-          ${msg("Edit Exclusion Rules")}
-        </sl-button>
+        <btrix-popover
+          content=${msg(
+            "Exclusion rules can only be edited while a crawl is starting or running",
+          )}
+          ?disabled=${canEditRunning}
+        >
+          <sl-button size="small" @click=${() => this.openEditDialog()}>
+            <sl-icon slot="prefix" name="file-earmark-diff"></sl-icon>
+            ${msg("Edit Exclusion Rules")}
+          </sl-button>
+        </btrix-popover>
       </header>
 
       ${when(
@@ -1953,6 +1968,7 @@ export class WorkflowDetail extends BtrixElement {
         () => html`
           <btrix-crawl-queue
             .crawlId=${this.lastCrawlId ?? undefined}
+            ?starting=${this.workflow?.lastCrawlState === "starting"}
           ></btrix-crawl-queue>
         `,
       )}

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -31,6 +31,7 @@ import {
   type BtrixSelectActionEvent,
 } from "@/features/crawl-workflows/workflow-action-menu/types";
 import type { BtrixChangeCrawlStateFilterEvent } from "@/features/crawls/crawl-state-filter";
+import { dialogLabel } from "@/layouts/dialogHeader";
 import { pageError } from "@/layouts/pageError";
 import { pageNav, type Breadcrumb } from "@/layouts/pageHeader";
 import { OrgTab, WorkflowTab } from "@/routes";
@@ -1989,12 +1990,10 @@ export class WorkflowDetail extends BtrixElement {
         }}
         @btrix-saved=${this.handleExclusionChange}
       >
-        <div slot="dialog-label" class="flex items-center gap-3 divide-x">
-          <div class="whitespace-nowrap">${msg("Edit Exclusion Rules")}</div>
-          <div class="truncate px-3 text-sm leading-none text-neutral-500">
-            ${renderName(this.workflow)}
-          </div>
-        </div>
+        ${dialogLabel({
+          title: msg("Edit Exclusion Rules"),
+          subtitle: renderName(this.workflow),
+        })}
       </btrix-exclusion-editor-dialog>
     `;
   }

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1571,7 +1571,8 @@ export class WorkflowDetail extends BtrixElement {
     if (watchable) {
       if (!this.isCrawler) return;
 
-      const canEditRunning = isRunningNotStopping(this.workflow);
+      const canEditBrowserWindows =
+        isRunningNotStopping(this.workflow) && !this.isCancelingRun;
       const windowCount = this.workflow.browserWindows || 1;
 
       return html`
@@ -1584,12 +1585,12 @@ export class WorkflowDetail extends BtrixElement {
           content=${msg(
             "Browser windows can only be edited while a crawl is starting or running",
           )}
-          ?disabled=${canEditRunning}
+          ?disabled=${canEditBrowserWindows}
         >
           <sl-icon-button
             name="plus-slash-minus"
             label=${msg("Increase or decrease")}
-            ?disabled=${!canEditRunning}
+            ?disabled=${!canEditBrowserWindows}
             @click=${() => (this.openDialogName = "scale")}
           >
           </sl-icon-button>
@@ -1944,7 +1945,10 @@ export class WorkflowDetail extends BtrixElement {
   }
 
   private renderExclusions() {
-    const canEditRunning = this.workflow && isRunningNotStopping(this.workflow);
+    const canEditExclusions =
+      this.workflow &&
+      isActivelyCrawling(this.workflow) &&
+      !this.isCancelingRun;
 
     return html`
       <header class="flex items-center justify-between">
@@ -1952,10 +1956,8 @@ export class WorkflowDetail extends BtrixElement {
           ${msg("Upcoming Pages")}
         </h3>
         <btrix-popover
-          content=${msg(
-            "Exclusion rules can only be edited while a crawl is starting or running",
-          )}
-          ?disabled=${canEditRunning}
+          content=${msg("Enabled when crawl starts running.")}
+          ?disabled=${canEditExclusions}
         >
           <sl-button size="small" @click=${() => this.openEditDialog()}>
             <sl-icon slot="prefix" name="file-earmark-diff"></sl-icon>

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1959,7 +1959,11 @@ export class WorkflowDetail extends BtrixElement {
           content=${msg("Enabled when crawl starts running.")}
           ?disabled=${canEditExclusions}
         >
-          <sl-button size="small" @click=${() => this.openEditDialog()}>
+          <sl-button
+            size="small"
+            @click=${() => this.openEditDialog()}
+            ?disabled=${!canEditExclusions}
+          >
             <sl-icon slot="prefix" name="file-earmark-diff"></sl-icon>
             ${msg("Edit Exclusion Rules")}
           </sl-button>

--- a/frontend/src/pages/org/workflows-list.ts
+++ b/frontend/src/pages/org/workflows-list.ts
@@ -9,6 +9,7 @@ import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
 import { type ListWorkflow, type Seed, type Workflow } from "./types";
+import { EDIT_DIALOG_PARAM_NAME, EditDialogValues } from "./workflow-detail";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type {
@@ -718,10 +719,7 @@ export class WorkflowsList extends BtrixElement {
               break;
             case Action.EditExclusions:
               this.navigate.to(
-                `${this.navigate.orgBasePath}/workflows/${workflow.id}/${WorkflowTab.LatestCrawl}`,
-                {
-                  dialog: "exclusions",
-                },
+                `${this.navigate.orgBasePath}/workflows/${workflow.id}/${WorkflowTab.LatestCrawl}?${new URLSearchParams({ [EDIT_DIALOG_PARAM_NAME]: EditDialogValues.Exclusions }).toString()}`,
               );
               break;
             case Action.Duplicate:

--- a/frontend/src/plurals/added-exclusion-rules.ts
+++ b/frontend/src/plurals/added-exclusion-rules.ts
@@ -1,0 +1,34 @@
+import { msg, str } from "@lit/localize";
+
+import localize from "@/utils/localize";
+import { pluralize } from "@/utils/pluralize";
+
+export const pluralOfAddedExclusionRules = (number: number) => {
+  const count = localize.number(number);
+  return pluralize(number, {
+    zero: msg("Added 0 rules", {
+      desc: "plural form of 'Added X rules' for zero exclusion rules",
+      id: "added_exclusion_rules.plural.zero",
+    }),
+    one: msg("Added 1 rule", {
+      desc: "plural form of 'Added X rules' for one exclusion rule",
+      id: "added_exclusion_rules.plural.one",
+    }),
+    two: msg("Added 2 rules", {
+      desc: "plural form of 'Added X rules' for two exclusion rules",
+      id: "added_exclusion_rules.plural.two",
+    }),
+    few: msg(str`Added ${count} rules`, {
+      desc: "plural form of 'Added X rules' for few exclusion rules",
+      id: "added_exclusion_rules.plural.few",
+    }),
+    many: msg(str`Added ${count} rules`, {
+      desc: "plural form of 'Added X rules' for many exclusion rules",
+      id: "added_exclusion_rules.plural.many",
+    }),
+    other: msg(str`Added ${count} rules`, {
+      desc: "plural form of 'Added X rules' for other exclusion rules",
+      id: "added_exclusion_rules.plural.other",
+    }),
+  });
+};

--- a/frontend/src/plurals/removed-exclusion-rules.ts
+++ b/frontend/src/plurals/removed-exclusion-rules.ts
@@ -1,0 +1,34 @@
+import { msg, str } from "@lit/localize";
+
+import localize from "@/utils/localize";
+import { pluralize } from "@/utils/pluralize";
+
+export const pluralOfRemovedExclusionRules = (number: number) => {
+  const count = localize.number(number);
+  return pluralize(number, {
+    zero: msg("Removed 0 rules", {
+      desc: "plural form of 'Removed X rules' for zero exclusion rules",
+      id: "removed_exclusion_rules.plural.zero",
+    }),
+    one: msg("Removed 1 rule", {
+      desc: "plural form of 'Removed X rules' for one exclusion rule",
+      id: "removed_exclusion_rules.plural.one",
+    }),
+    two: msg("Removed 2 rules", {
+      desc: "plural form of 'Removed X rules' for two exclusion rules",
+      id: "removed_exclusion_rules.plural.two",
+    }),
+    few: msg(str`Removed ${count} rules`, {
+      desc: "plural form of 'Removed X rules' for few exclusion rules",
+      id: "removed_exclusion_rules.plural.few",
+    }),
+    many: msg(str`Removed ${count} rules`, {
+      desc: "plural form of 'Removed X rules' for many exclusion rules",
+      id: "removed_exclusion_rules.plural.many",
+    }),
+    other: msg(str`Removed ${count} rules`, {
+      desc: "plural form of 'Removed X rules' for other exclusion rules",
+      id: "removed_exclusion_rules.plural.other",
+    }),
+  });
+};

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -110,7 +110,7 @@ export function renderName(
     return html`<sl-skeleton class="inline-block h-8 w-60"></sl-skeleton>`;
 
   if (item.name)
-    return html`<div class=${clsx("truncate", className)}>${item.name}</div>`;
+    return html`<span class=${clsx("truncate", className)}>${item.name}</span>`;
   if (item.firstSeed && item.seedCount) {
     const remainder = item.seedCount - 1;
     let nameSuffix: string | TemplateResult<1> = "";

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -126,8 +126,8 @@ export function renderName(
       </span>`;
     }
     return html`
-      <span class="inline-flex overflow-hidden whitespace-nowrap">
-        <div class=${clsx("min-w-0 truncate", className)}>
+      <span class="inline-flex max-w-full overflow-hidden whitespace-nowrap">
+        <div class=${clsx("min-w-0 truncate max-w-[30ch]", className)}>
           ${item.firstSeed}
         </div>
         ${nameSuffix}

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -15,6 +15,7 @@ import {
   FAILED_STATES,
   PAUSED_STATES,
   RUNNING_AND_WAITING_STATES,
+  RUNNING_STATES,
   SUCCESSFUL_AND_FAILED_STATES,
   SUCCESSFUL_STATES,
 } from "@/types/crawlState";
@@ -47,6 +48,10 @@ export function isCrawlReplay(
   item: ArchivedItem | CrawlReplay,
 ): item is CrawlReplay {
   return isCrawl(item) && "config" in item;
+}
+
+export function isRunning({ state }: Partial<Crawl>) {
+  return (RUNNING_STATES as readonly (typeof state)[]).includes(state);
 }
 
 export function isActive({ state }: Partial<Crawl | QARun>) {

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -533,32 +533,6 @@ const plurals = {
       id: "levels.plural.other",
     }),
   },
-  exclusions: {
-    zero: msg("exclusions", {
-      desc: 'plural form of "exclusion" for zero exclusions',
-      id: "exclusions.plural.zero",
-    }),
-    one: msg("exclusion", {
-      desc: 'singular form for "exclusion"',
-      id: "exclusions.plural.one",
-    }),
-    two: msg("exclusions", {
-      desc: 'plural form of "exclusion" for two exclusions',
-      id: "exclusions.plural.two",
-    }),
-    few: msg("exclusions", {
-      desc: 'plural form of "exclusion" for few exclusions',
-      id: "exclusions.plural.few",
-    }),
-    many: msg("exclusions", {
-      desc: 'plural form of "exclusion" for many exclusions',
-      id: "exclusions.plural.many",
-    }),
-    other: msg("exclusions", {
-      desc: 'plural form of "exclusion" for multiple/other exclusions',
-      id: "exclusions.plural.other",
-    }),
-  },
 };
 
 /**

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -533,6 +533,32 @@ const plurals = {
       id: "levels.plural.other",
     }),
   },
+  exclusions: {
+    zero: msg("exclusions", {
+      desc: 'plural form of "exclusion" for zero exclusions',
+      id: "exclusions.plural.zero",
+    }),
+    one: msg("exclusion", {
+      desc: 'singular form for "exclusion"',
+      id: "exclusions.plural.one",
+    }),
+    two: msg("exclusions", {
+      desc: 'plural form of "exclusion" for two exclusions',
+      id: "exclusions.plural.two",
+    }),
+    few: msg("exclusions", {
+      desc: 'plural form of "exclusion" for few exclusions',
+      id: "exclusions.plural.few",
+    }),
+    many: msg("exclusions", {
+      desc: 'plural form of "exclusion" for many exclusions',
+      id: "exclusions.plural.many",
+    }),
+    other: msg("exclusions", {
+      desc: 'plural form of "exclusion" for multiple/other exclusions',
+      id: "exclusions.plural.other",
+    }),
+  },
 };
 
 /**

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -11,9 +11,11 @@ import {
   Behavior,
   CrawlerChannelImage,
   ScopeType,
+  type ListWorkflow,
   type Profile,
   type Seed,
   type SeedConfig,
+  type Workflow,
   type WorkflowSettings,
 } from "@/types/crawler";
 import type { OrgData } from "@/types/org";
@@ -123,6 +125,28 @@ export function isPrimarySeedScope(
   scope?: (typeof WorkflowScopeType)[keyof typeof WorkflowScopeType],
 ) {
   return scope !== undefined && WorkflowPrimarySeedScopeSet.has(scope);
+}
+
+/**
+ * Whether crawler has started running and is not expected to stop or pause.
+ */
+export function isRunningNotStopping(workflow: ListWorkflow | Workflow) {
+  return (
+    workflow.isCrawlRunning &&
+    !workflow.lastCrawlStopping &&
+    !workflow.lastCrawlShouldPause
+  );
+}
+
+/**
+ * Whether crawler is actively crawling pages and is not expected to stop or pause.
+ */
+export function isActivelyCrawling(workflow: ListWorkflow | Workflow) {
+  return (
+    isRunningNotStopping(workflow) &&
+    workflow.lastCrawlState &&
+    ["running", "rate-limited"].includes(workflow.lastCrawlState)
+  );
 }
 
 export function makeUserGuideEvent(

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -22,7 +22,7 @@ import type { OrgData } from "@/types/org";
 import { NewWorkflowOnlyScopeType, WorkflowScopeType } from "@/types/workflow";
 import { BYTES_PER_GB } from "@/utils/bytes";
 import { unescapeCustomPrefix } from "@/utils/crawl-workflows/unescapeCustomPrefix";
-import { DEFAULT_MAX_SCALE } from "@/utils/crawler";
+import { DEFAULT_MAX_SCALE, isPaused, isRunning } from "@/utils/crawler";
 import { getNextDate, getScheduleInterval } from "@/utils/cron";
 import localize, { getDefaultLang } from "@/utils/localize";
 
@@ -128,24 +128,35 @@ export function isPrimarySeedScope(
 }
 
 /**
- * Whether crawler has started running and is not expected to stop or pause.
+ * Whether crawler is starting or has started running and is not paused.
  */
-export function isRunningNotStopping(workflow: ListWorkflow | Workflow) {
-  return (
+export function isRunningNotPaused(workflow: ListWorkflow | Workflow) {
+  return Boolean(
     workflow.isCrawlRunning &&
-    !workflow.lastCrawlStopping &&
-    !workflow.lastCrawlShouldPause
+    workflow.lastCrawlState &&
+    !isPaused(workflow.lastCrawlState),
   );
 }
 
 /**
- * Whether crawler is actively crawling pages and is not expected to stop or pause.
+ * Whether crawler has started running, is not paused, and is not expected to stop or pause.
+ */
+export function isRunningNotStopping(workflow: ListWorkflow | Workflow) {
+  return Boolean(
+    isRunningNotPaused(workflow) &&
+    !workflow.lastCrawlStopping &&
+    !workflow.lastCrawlShouldPause,
+  );
+}
+
+/**
+ * Whether crawler is in an explicit running state (i.e. crawling pages) and is not expected to stop or pause.
  */
 export function isActivelyCrawling(workflow: ListWorkflow | Workflow) {
-  return (
+  return Boolean(
     isRunningNotStopping(workflow) &&
     workflow.lastCrawlState &&
-    ["running", "rate-limited"].includes(workflow.lastCrawlState)
+    isRunning({ state: workflow.lastCrawlState }),
   );
 }
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3525, partially addresses https://github.com/webrecorder/browsertrix/issues/3515

## Changes

- Fixes confirmation messages and server errors not being visible by displaying them in the dialog instead of in toast stack
- Deep link into dialog
- Standardizes display of full-overlay dialogs (like collection item editing) and shows name of workflow in dialog title
- Fixes long exclusion rules breaking layout
- Renames "Edit Exclusions" -> "Edit Exclusion Rules"
- Fixes inconsistent rendering of "Edit Exclusion Rules" menu item when crawl is running but not actively crawling
- Show queue if crawl is running and in "Creating WACZ/Uploading WACZ/Finishing Download"state (https://github.com/webrecorder/browsertrix/issues/3515)
- Displays additional feedback when "add" button is disabled
- Adds more information on updating exclusion rules and renames "crawl queue" -> "page queue"
- Migrates `btrix-exclusion-editor` to `BtrixElement` and to use `Task`-based API calls

## Manual testing

1. Log in as crawler
2. Start a crawl
3. Select "Edit Exclusion Rules"
4. Interact with dialog. Verify that exclusions update as expected and confirmation is displayed next to "Done" button

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Edit Exclusion Rules (confirmation) | <img width="1010" height="552" alt="Screenshot 2026-07-24 at 9 21 52 AM" src="https://github.com/user-attachments/assets/e1d6a98c-f0e9-4abe-9f5c-7f7005021477" /> |
| Edit Exclusion Rules (long rules) | <img width="481" height="273" alt="Screenshot 2026-07-23 at 1 28 31 PM" src="https://github.com/user-attachments/assets/29eb9011-f95d-486d-a48d-5b230f05cc31" /> |
| Edit Exclusion Rules (disabled submit feedback) |<img width="399" height="78" alt="Screenshot 2026-07-23 at 1 29 09 PM" src="https://github.com/user-attachments/assets/25fae502-be26-4f57-b0f2-40fbc2ea3212" /> |
| Edit Exclusion Rules (help text) | <img width="353" height="110" alt="Screenshot 2026-07-23 at 12 48 18 PM" src="https://github.com/user-attachments/assets/ff15f647-d958-4da9-a9cb-acef569cb2fd" /> |

### Small screens
| Edit Exclusion Rules (confirmation) | <img width="484" height="780" alt="Screenshot 2026-07-24 at 9 25 42 AM" src="https://github.com/user-attachments/assets/1d9a923f-dc9a-4e2a-b3aa-7aeff2449816" /> |
| Edit Exclusion Rules (small screens) | <img width="484" height="776" alt="Screenshot 2026-07-24 at 9 25 50 AM" src="https://github.com/user-attachments/assets/4293582a-8c1a-4a83-8ef7-c06b23797809" /> |

<!-- ## Follow-ups -->
