### PR TITLE
fix: Stricter custom link selector attribute validation

### DIFF
--- a/frontend/src/features/crawl-workflows/link-selector-table.ts
+++ b/frontend/src/features/crawl-workflows/link-selector-table.ts
@@ -231,7 +231,7 @@ export class LinkSelectorTable extends FormControl(BtrixElement) {
                       ),
                     },
                     () => {
-                      this.cssParser(`div[${value}="x-test"]`);
+                      this.cssParser(`a[${value}="x-test"]`);
                     },
                   );
 

--- a/frontend/src/features/crawl-workflows/link-selector-table.ts
+++ b/frontend/src/features/crawl-workflows/link-selector-table.ts
@@ -231,7 +231,7 @@ export class LinkSelectorTable extends FormControl(BtrixElement) {
                       ),
                     },
                     () => {
-                      document.createElement("a").setAttribute(value, "x-test");
+                      this.cssParser(`div[${value}="x-test"]`);
                     },
                   );
 


### PR DESCRIPTION
Partially addresses https://github.com/webrecorder/browsertrix/issues/3543

## Changes

Validates attribute as a CSS identifier to better check against potential typos. For example, these characters are currently acceptable as HTML attributes but are likely typos or unintended for use as attributes: `!`, `123`, `"href"`.

Note that users can still escape special characters (e.g. `\!`) as escaped characters are considered [considered valid CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/ident#syntax); this option remains undocumented.