### PR TITLE
Add endpoint to get counts of running crawls (per-org, or across all orgs)

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1696,7 +1696,7 @@ class CrawlConfigOps:
         """Return counts of running workflows, total and status, optionally by org"""
 
         try:
-            base_query: dict[str, UUID | dict[str, list[str]]] = {}
+            base_query: dict[str, UUID | str] = {}
             if org:
                 base_query["oid"] = org.id
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -27,7 +27,6 @@ from motor.motor_asyncio import (
 )
 
 from .models import (
-    RUNNING_STATES,
     SUCCESSFUL_STATES,
     TYPE_ALL_CRAWL_STATES,
     ConfigRevision,
@@ -1701,9 +1700,7 @@ class CrawlConfigOps:
             if org:
                 base_query["oid"] = org.id
 
-            total = await self.crawls.count_documents(
-                {**base_query, "state": {"$in": RUNNING_STATES}}
-            )
+            # Running states
             running = await self.crawls.count_documents(
                 {**base_query, "state": "running"}
             )
@@ -1719,6 +1716,11 @@ class CrawlConfigOps:
             rate_limited = await self.crawls.count_documents(
                 {**base_query, "state": "rate-limited"}
             )
+            total_running = (
+                running + pending_wait + generate_wacz + uploading_wacz + rate_limited
+            )
+
+            # Paused states
             paused = await self.crawls.count_documents(
                 {**base_query, "state": "paused"}
             )
@@ -1734,6 +1736,15 @@ class CrawlConfigOps:
             paused_rate_limit = await self.crawls.count_documents(
                 {**base_query, "state": "paused_rate_limit_time_reached"}
             )
+            total_paused = (
+                paused
+                + paused_storage
+                + paused_time
+                + paused_read_only
+                + paused_rate_limit
+            )
+
+            # Waiting states
             starting = await self.crawls.count_documents(
                 {**base_query, "state": "starting"}
             )
@@ -1746,9 +1757,17 @@ class CrawlConfigOps:
             waiting_dedupe = await self.crawls.count_documents(
                 {**base_query, "state": "waiting_dedupe_index"}
             )
+            total_waiting = (
+                starting + waiting_capacity + waiting_org_limit + waiting_dedupe
+            )
+
+            total = total_running + total_paused + total_waiting
 
             return CrawlConfigRunningCountsResponse(
                 totalRunningPausedWaiting=total,
+                totalRunning=total_running,
+                totalPaused=total_paused,
+                totalWaiting=total_waiting,
                 # Running states
                 running=running,
                 pendingWait=pending_wait,

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1706,7 +1706,7 @@ class CrawlConfigOps:
             res = await self.crawls.aggregate(
                 [
                     {"$match": match_query},
-                    {"$group": {"_id": "$state", "count": {"$sum": 1}}},
+                    {"$group": {"_id": "$state", "count": {"$count": {}}}},
                 ]
             ).to_list()
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -27,6 +27,7 @@ from motor.motor_asyncio import (
 )
 
 from .models import (
+    ALL_CRAWL_STATES,
     SUCCESSFUL_STATES,
     TYPE_ALL_CRAWL_STATES,
     ConfigRevision,
@@ -1695,47 +1696,51 @@ class CrawlConfigOps:
     ) -> CrawlConfigRunningCountsResponse:
         """Return counts of running workflows, total and status, optionally by org"""
 
+        state_count_logger = logger.bind(oid=org.id if org else None)
+
         try:
-            base_query: dict[str, UUID | str] = {}
+            match_query: dict[str, UUID | str] = {}
             if org:
-                base_query["oid"] = org.id
+                match_query["oid"] = org.id
+
+            res = await self.crawls.aggregate(
+                [
+                    {"$match": match_query},
+                    {"$group": {"_id": "$state", "count": {"$sum": 1}}},
+                    {"$project": {"state": "$_id", "count": "$count", "_id": 0}},
+                    {"$sort": {"count": -1, "state": 1}},
+                ]
+            ).to_list()
+
+            state_counts: dict[str, int] = {}
+
+            for state_dict in res:
+                state = state_dict["state"]
+                count = state_dict.get("count", 0)
+                if state not in ALL_CRAWL_STATES:
+                    state_count_logger.error(
+                        "unexpected_crawl_state_found", state=state, count=count
+                    )
+                else:
+                    state_counts[state] = count
 
             # Running states
-            running = await self.crawls.count_documents(
-                {**base_query, "state": "running"}
-            )
-            pending_wait = await self.crawls.count_documents(
-                {**base_query, "state": "pending-wait"}
-            )
-            generate_wacz = await self.crawls.count_documents(
-                {**base_query, "state": "generate-wacz"}
-            )
-            uploading_wacz = await self.crawls.count_documents(
-                {**base_query, "state": "uploading-wacz"}
-            )
-            rate_limited = await self.crawls.count_documents(
-                {**base_query, "state": "rate-limited"}
-            )
+            running = state_counts.get("running", 0)
+            pending_wait = state_counts.get("pending-wait", 0)
+            generate_wacz = state_counts.get("generate-wacz", 0)
+            uploading_wacz = state_counts.get("uploading-wacz", 0)
+            rate_limited = state_counts.get("rate-limited", 0)
             total_running = (
                 running + pending_wait + generate_wacz + uploading_wacz + rate_limited
             )
 
             # Paused states
-            paused = await self.crawls.count_documents(
-                {**base_query, "state": "paused"}
-            )
-            paused_storage = await self.crawls.count_documents(
-                {**base_query, "state": "paused_storage_quota_reached"}
-            )
-            paused_time = await self.crawls.count_documents(
-                {**base_query, "state": "paused_time_quota_reached"}
-            )
-            paused_read_only = await self.crawls.count_documents(
-                {**base_query, "state": "paused_org_readonly"}
-            )
-            paused_rate_limit = await self.crawls.count_documents(
-                {**base_query, "state": "paused_rate_limit_time_reached"}
-            )
+            paused = state_counts.get("paused", 0)
+            paused_storage = state_counts.get("paused_storage_quota_reached", 0)
+            paused_time = state_counts.get("paused_time_quota_reached", 0)
+            paused_read_only = state_counts.get("paused_org_readonly", 0)
+            paused_rate_limit = state_counts.get("paused_rate_limit_time_reached", 0)
+
             total_paused = (
                 paused
                 + paused_storage
@@ -1745,18 +1750,10 @@ class CrawlConfigOps:
             )
 
             # Waiting states
-            starting = await self.crawls.count_documents(
-                {**base_query, "state": "starting"}
-            )
-            waiting_capacity = await self.crawls.count_documents(
-                {**base_query, "state": "waiting_capacity"}
-            )
-            waiting_org_limit = await self.crawls.count_documents(
-                {**base_query, "state": "waiting_org_limit"}
-            )
-            waiting_dedupe = await self.crawls.count_documents(
-                {**base_query, "state": "waiting_dedupe_index"}
-            )
+            starting = state_counts.get("starting", 0)
+            waiting_capacity = state_counts.get("waiting_capacity", 0)
+            waiting_org_limit = state_counts.get("waiting_org_limit", 0)
+            waiting_dedupe = state_counts.get("waiting_dedupe", 0)
             total_waiting = (
                 starting + waiting_capacity + waiting_org_limit + waiting_dedupe
             )
@@ -1787,9 +1784,8 @@ class CrawlConfigOps:
                 waitingDedupeIndex=waiting_dedupe,
             )
         except Exception:
-            logger.exception(
+            state_count_logger.exception(
                 "running_workflow_counts_calculation_failed",
-                oid=org.id if org else None,
             )
             # pylint: disable=raise-missing-from
             raise HTTPException(status_code=400, detail="calculation_failure")

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1707,15 +1707,14 @@ class CrawlConfigOps:
                 [
                     {"$match": match_query},
                     {"$group": {"_id": "$state", "count": {"$sum": 1}}},
-                    {"$project": {"state": "$_id", "count": "$count", "_id": 0}},
-                    {"$sort": {"count": -1, "state": 1}},
+                    {"$project": {"_id": 1, "count": "$count"}},
                 ]
             ).to_list()
 
             state_counts: dict[str, int] = {}
 
             for state_dict in res:
-                state = state_dict["state"]
+                state = state_dict["_id"]
                 count = state_dict.get("count", 0)
                 if state not in ALL_CRAWL_STATES:
                     state_count_logger.error(

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -27,6 +27,7 @@ from motor.motor_asyncio import (
 )
 
 from .models import (
+    RUNNING_STATES,
     SUCCESSFUL_STATES,
     TYPE_ALL_CRAWL_STATES,
     ConfigRevision,
@@ -35,6 +36,7 @@ from .models import (
     CrawlConfigDeletedResponse,
     CrawlConfigIn,
     CrawlConfigOut,
+    CrawlConfigRunningCountsResponse,
     CrawlConfigSearchValues,
     CrawlConfigUpdateResponse,
     CrawlerChannel,
@@ -1689,6 +1691,90 @@ class CrawlConfigOps:
 
         return {"success": True}
 
+    async def get_running_counts(
+        self, org: Organization | None = None
+    ) -> CrawlConfigRunningCountsResponse:
+        """Return counts of running workflows, total and status, optionally by org"""
+
+        try:
+            base_query: dict[str, UUID | dict[str, list[str]]] = {}
+            if org:
+                base_query["oid"] = org.id
+
+            total = await self.crawls.count_documents(
+                {**base_query, "state": {"$in": RUNNING_STATES}}
+            )
+            running = await self.crawls.count_documents(
+                {**base_query, "state": "running"}
+            )
+            pending_wait = await self.crawls.count_documents(
+                {**base_query, "state": "pending-wait"}
+            )
+            generate_wacz = await self.crawls.count_documents(
+                {**base_query, "state": "generate-wacz"}
+            )
+            uploading_wacz = await self.crawls.count_documents(
+                {**base_query, "state": "uploading-wacz"}
+            )
+            rate_limited = await self.crawls.count_documents(
+                {**base_query, "state": "rate-limited"}
+            )
+            paused = await self.crawls.count_documents(
+                {**base_query, "state": "paused"}
+            )
+            paused_storage = await self.crawls.count_documents(
+                {**base_query, "state": "paused_storage_quota_reached"}
+            )
+            paused_time = await self.crawls.count_documents(
+                {**base_query, "state": "paused_time_quota_reached"}
+            )
+            paused_read_only = await self.crawls.count_documents(
+                {**base_query, "state": "paused_org_readonly"}
+            )
+            paused_rate_limit = await self.crawls.count_documents(
+                {**base_query, "state": "paused_rate_limit_time_reached"}
+            )
+            starting = await self.crawls.count_documents(
+                {**base_query, "state": "starting"}
+            )
+            waiting_capacity = await self.crawls.count_documents(
+                {**base_query, "state": "waiting_capacity"}
+            )
+            waiting_org_limit = await self.crawls.count_documents(
+                {**base_query, "state": "waiting_org_limit"}
+            )
+            waiting_dedupe = await self.crawls.count_documents(
+                {**base_query, "state": "waiting_dedupe_index"}
+            )
+
+            return CrawlConfigRunningCountsResponse(
+                totalRunningPausedWaiting=total,
+                # Running states
+                running=running,
+                pendingWait=pending_wait,
+                generateWACZ=generate_wacz,
+                uploadingWACZ=uploading_wacz,
+                rateLimited=rate_limited,
+                # Paused states
+                paused=paused,
+                pausedStorageQuotaReached=paused_storage,
+                pausedTimeQuotaReached=paused_time,
+                pausedOrgReadOnly=paused_read_only,
+                pausedRateLimitTimeReached=paused_rate_limit,
+                # Waiting states
+                starting=starting,
+                waitingCapacity=waiting_capacity,
+                waitingOrgLimit=waiting_org_limit,
+                waitingDedupeIndex=waiting_dedupe,
+            )
+        except Exception:
+            logger.exception(
+                "running_workflow_counts_calculation_failed",
+                oid=org.id if org else None,
+            )
+            # pylint: disable=raise-missing-from
+            raise HTTPException(status_code=400, detail="calculation_failure")
+
 
 # ============================================================================
 # pylint: disable=too-many-locals
@@ -1944,6 +2030,24 @@ def init_crawl_config_api(
             raise HTTPException(status_code=403, detail="Not Allowed")
 
         return ops.get_crawler_proxies()
+
+    @router.get("/running", response_model=CrawlConfigRunningCountsResponse)
+    async def get_org_crawl_config_running_counts(
+        org: Organization = Depends(org_viewer_dep),
+    ):
+        return await ops.get_running_counts(org)
+
+    @app.get(
+        "/orgs/all/crawlconfigs/running",
+        response_model=CrawlConfigRunningCountsResponse,
+    )
+    async def get_all_crawl_config_running_counts(
+        user: User = Depends(user_dep),
+    ):
+        if not user.is_superuser:
+            raise HTTPException(status_code=403, detail="Not Allowed")
+
+        return await ops.get_running_counts()
 
     @app.get(
         "/orgs/{oid}/crawlconfigs/{cid}/public/replay.json",

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1707,7 +1707,6 @@ class CrawlConfigOps:
                 [
                     {"$match": match_query},
                     {"$group": {"_id": "$state", "count": {"$sum": 1}}},
-                    {"$project": {"_id": 1, "count": "$count"}},
                 ]
             ).to_list()
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -129,6 +129,9 @@ class CrawlOps(BaseCrawlOps):
                 ("started", pymongo.ASCENDING),
             ]
         )
+        await self.crawls.create_index(
+            [("oid", pymongo.HASHED), ("state", pymongo.DESCENDING)]
+        )
         await self.crawls.create_index([("finished", pymongo.DESCENDING)])
         await self.crawls.create_index([("oid", pymongo.HASHED)])
         await self.crawls.create_index([("cid", pymongo.HASHED)])

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -710,6 +710,33 @@ class TagsResponse(BaseModel):
 
 
 # ============================================================================
+class CrawlConfigRunningCountsResponse(BaseModel):
+    """Response model for counts of running workflows (total and by status)"""
+
+    totalRunningPausedWaiting: int = 0
+
+    # Running states
+    running: int = 0
+    pendingWait: int = 0
+    generateWACZ: int = 0
+    uploadingWACZ: int = 0
+    rateLimited: int = 0
+
+    # Paused states
+    paused: int = 0
+    pausedStorageQuotaReached: int = 0
+    pausedTimeQuotaReached: int = 0
+    pausedOrgReadOnly: int = 0
+    pausedRateLimitTimeReached: int = 0
+
+    # Waiting states
+    starting: int = 0
+    waitingCapacity: int = 0
+    waitingOrgLimit: int = 0
+    waitingDedupeIndex: int = 0
+
+
+# ============================================================================
 class CrawlConfigSearchValues(BaseModel):
     """Response model for adding crawlconfigs"""
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -714,6 +714,9 @@ class CrawlConfigRunningCountsResponse(BaseModel):
     """Response model for counts of running workflows (total and by status)"""
 
     totalRunningPausedWaiting: int = 0
+    totalRunning: int = 0
+    totalPaused: int = 0
+    totalWaiting: int = 0
 
     # Running states
     running: int = 0

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -176,6 +176,41 @@ def test_remove_exclusion(admin_auth_headers, default_org_id):
     assert r.json()["success"] == True
 
 
+def test_running_workflow_counts(
+    admin_auth_headers, crawler_auth_headers, default_org_id
+):
+    # Verify running workflow counts are updated
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/running",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["totalRunningPausedWaiting"] >= 1
+    assert (
+        data["running"] >= 1 or data["generateWACZ"] >= 1 or data["uploadingWACZ"] >= 1
+    )
+
+    # Verify again but from non-org-specific endpoint
+    r = requests.get(
+        f"{API_PREFIX}/orgs/all/crawlconfigs/running",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["totalRunningPausedWaiting"] >= 1
+    assert (
+        data["running"] >= 1 or data["generateWACZ"] >= 1 or data["uploadingWACZ"] >= 1
+    )
+
+    # Check that non-org-specific endpoint is only available to superadmins
+    r = requests.get(
+        f"{API_PREFIX}/orgs/all/crawlconfigs/running",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 403
+
+
 def test_wait_for_complete(admin_auth_headers, default_org_id):
     state = None
     data = None

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -187,6 +187,7 @@ def test_running_workflow_counts(
     assert r.status_code == 200
     data = r.json()
     assert data["totalRunningPausedWaiting"] >= 1
+    assert data["totalRunning"] >= 1
     assert (
         data["running"] >= 1 or data["generateWACZ"] >= 1 or data["uploadingWACZ"] >= 1
     )
@@ -199,6 +200,7 @@ def test_running_workflow_counts(
     assert r.status_code == 200
     data = r.json()
     assert data["totalRunningPausedWaiting"] >= 1
+    assert data["totalRunning"] >= 1
     assert (
         data["running"] >= 1 or data["generateWACZ"] >= 1 or data["uploadingWACZ"] >= 1
     )


### PR DESCRIPTION
Part of #3541 

This PR adds:

- New `/orgs/all/crawlconfigs/running` (superadmin) and `/orgs/{oid}/crawlconfigs/running` endpoints that provide counts of the number of workflows in all running, paused, and waiting states, as well as totals.
- A new index to the crawls mongo collection to help facilitate the query
- Some basic tests
