### PR TITLE
backend: validate link selector parses

### DIFF
--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 
 import structlog
 import aiohttp
+import cssselect
 import pymongo
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from motor.motor_asyncio import (
@@ -442,8 +443,6 @@ class CrawlConfigOps:
 
         Ensure at least one link selector is set and that all the link slectors passed
         follow expected syntax: selector->attribute/property.
-
-        We don't yet check the validity of the CSS selector itself.
         """
         if not link_selectors:
             raise HTTPException(status_code=400, detail="invalid_link_selector")
@@ -454,6 +453,12 @@ class CrawlConfigOps:
                 raise HTTPException(status_code=400, detail="invalid_link_selector")
             if not parts[0] or not parts[1]:
                 raise HTTPException(status_code=400, detail="invalid_link_selector")
+            try:
+                cssselect.parse(parts[0])
+            except cssselect.parser.SelectorSyntaxError as exc:
+                raise HTTPException(
+                    status_code=400, detail="invalid_link_selector"
+                ) from exc
 
     def _validate_custom_behavior_url_syntax(self, url: str) -> tuple[bool, list[str]]:
         """Validate custom behaviors are valid URLs after removing custom git syntax"""

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "aiofiles>=25.1.0",
     "aiostream>=0.7.1",
     "backoff>=2.2.1",
+    "cssselect>=1.4.0",
     "email-validator>=2.3.0",
     "fastapi==0.128.0",
     "gunicorn>=26.0.0",

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -282,6 +282,39 @@ def test_update_config_invalid_link_selector(
     assert r.json()["detail"] == "invalid_link_selector"
 
 
+def test_update_config_link_selector_invalid_syntax(
+    crawler_auth_headers, default_org_id, sample_crawl_data
+):
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={
+            "config": {
+                "selectLinks": [
+                    "a[href]->href",
+                    "aria[3]->href",
+                ]
+            }
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "invalid_link_selector"
+
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawlconfigs/{cid}/",
+        headers=crawler_auth_headers,
+        json={
+            "config": {
+                "selectLinks": [
+                    "div[2]->href",
+                ]
+            }
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "invalid_link_selector"
+
+
 def test_update_config_invalid_lang(
     crawler_auth_headers, default_org_id, sample_crawl_data
 ):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -262,6 +262,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "aiostream" },
     { name = "backoff" },
+    { name = "cssselect" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "gunicorn" },
@@ -312,6 +313,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiostream", specifier = ">=0.7.1" },
     { name = "backoff", specifier = ">=2.2.1" },
+    { name = "cssselect", specifier = ">=1.4.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = "==0.128.0" },
     { name = "gunicorn", specifier = ">=26.0.0" },
@@ -670,6 +672,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
     { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
     { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/2e/cdfd8b01c37cbf4f9482eefd455853a3cf9c995029a46acd31dfaa9c1dd6/cssselect-1.4.0.tar.gz", hash = "sha256:fdaf0a1425e17dfe8c5cf66191d211b357cf7872ae8afc4c6762ddd8ac47fc92", size = 40589, upload-time = "2026-01-29T07:00:26.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/0c/7bb51e3acfafd16c48875bf3db03607674df16f5b6ef8d056586af7e2b8b/cssselect-1.4.0-py3-none-any.whl", hash = "sha256:c0ec5c0191c8ee39fcc8afc1540331d8b55b0183478c50e9c8a79d44dbceb1d8", size = 18540, upload-time = "2026-01-29T07:00:24.994Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We were validating the basic structure but not the actual selector previously to this. This is the backend counterpart to #3545; this ensures that even if this slips through the frontend, or gets added without going through the frontend, we should still reject it.