### PR TITLE
Better validate various backend parameters

### DIFF
--- a/backend/btrixcloud/crawl_validator.py
+++ b/backend/btrixcloud/crawl_validator.py
@@ -1,0 +1,41 @@
+"""Validation for crawl storage filename templates.
+
+Crawl workflows may customize the filename template used for archived
+files. This module validates that a template can be safely used as an S3
+object key before it is stored.
+"""
+
+import re
+
+from .db import is_lenient_read
+
+# Filename templates are used to generate S3 object keys, so any characters
+# that are valid in an S3 key are allowed, except control characters
+# (including line breaks). The crawler's @-placeholders (@ts, @hostname,
+# @hostsuffix, @id) are plain characters and need no special handling.
+CRAWL_FILENAME_TEMPLATE_RE = re.compile(r"^[^\x00-\x1f\x7f-\x9f]+$")
+
+
+def validate_crawl_filename_template(value: str | None) -> str | None:
+    """Validate that a crawl filename template is a usable S3 object key.
+
+    Any characters that can be stored in an S3-compatible bucket are
+    allowed; only control characters (newlines, tabs, etc.) are rejected.
+    Relative path components are allowed, but not path traversal ('.'/'..'
+    components or a leading '/').
+
+    Non-string values are not validated here - they are rejected by the
+    field's own type validation.
+    """
+    if not isinstance(value, str) or is_lenient_read() or value == "":
+        # non-string values are rejected by the field's own type validation;
+        # empty templates and lenient DB reads are left unchanged
+        return value
+    # keep filenames below 768 characters (s3 key limit is 1024 bytes, but
+    # we only allow 768 to account for other parts of the path)
+    if len(value) > 768 or not CRAWL_FILENAME_TEMPLATE_RE.match(value):
+        raise ValueError("invalid crawl filename template")
+    # reject path traversal: no absolute paths, no '.'/'..' path components
+    if value.startswith("/") or any(part in (".", "..") for part in value.split("/")):
+        raise ValueError("invalid crawl filename template")
+    return value

--- a/backend/btrixcloud/cron_validator.py
+++ b/backend/btrixcloud/cron_validator.py
@@ -1,0 +1,157 @@
+"""Validation for cron schedule expressions.
+
+Crawl workflows may define a schedule for scheduled crawls. This module
+validates that a schedule is a well-formed cron expression before it is
+stored.
+"""
+
+import re
+
+from .db import is_lenient_read
+
+# value ranges per position: seconds, minutes, hours, day-of-month, month,
+# day-of-week (0 and 7 both mean Sunday)
+CRON_FIELD_RANGES = (
+    (0, 59),
+    (0, 59),
+    (0, 23),
+    (1, 31),
+    (1, 12),
+    (0, 7),
+)
+
+CRON_MONTH_NAMES = {
+    "JAN": 1,
+    "FEB": 2,
+    "MAR": 3,
+    "APR": 4,
+    "MAY": 5,
+    "JUN": 6,
+    "JUL": 7,
+    "AUG": 8,
+    "SEP": 9,
+    "OCT": 10,
+    "NOV": 11,
+    "DEC": 12,
+}
+
+CRON_DOW_NAMES = {
+    "SUN": 0,
+    "MON": 1,
+    "TUE": 2,
+    "WED": 3,
+    "THU": 4,
+    "FRI": 5,
+    "SAT": 6,
+}
+
+# @ descriptors supported by Kubernetes CronJobs (robfig/cron v3)
+CRON_DESCRIPTORS = frozenset(
+    {
+        "@yearly",
+        "@annually",
+        "@monthly",
+        "@weekly",
+        "@daily",
+        "@midnight",
+        "@hourly",
+    }
+)
+
+# duration grammar for the '@every <duration>' descriptor (Go time.ParseDuration)
+CRON_EVERY_DURATION_RE = re.compile(r"^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$")
+
+
+def _cron_value_in_range(value: str, lo: int, hi: int, names: dict[str, int]) -> bool:
+    """Return True if value is a number or 3-letter name within [lo, hi]"""
+    if value in names:
+        return lo <= names[value] <= hi
+    return value.isdigit() and lo <= int(value) <= hi
+
+
+def _validate_cron_base(base: str, lo: int, hi: int, names: dict[str, int]) -> bool:
+    """Validate a cron field item: '*', a single value, or a range a-b"""
+    if base == "*":
+        return True
+    if "-" in base:
+        start, _, end = base.partition("-")
+        return _cron_value_in_range(start, lo, hi, names) and _cron_value_in_range(
+            end, lo, hi, names
+        )
+    return _cron_value_in_range(base, lo, hi, names)
+
+
+def _validate_cron_item(item: str, lo: int, hi: int, names: dict[str, int]) -> bool:
+    """Validate a comma-separated cron field item, incl. '/step' suffixes"""
+    if "/" in item:
+        base, _, step = item.partition("/")
+        if not step.isdigit() or int(step) < 1:
+            return False
+        return _validate_cron_base(base, lo, hi, names)
+    return _validate_cron_base(item, lo, hi, names)
+
+
+def _validate_cron_field(
+    field: str, lo: int, hi: int, names: dict[str, int], allow_question: bool
+) -> bool:
+    """Validate a single cron field (a comma-separated list of items)"""
+    if allow_question and field == "?":
+        return True
+    if field == "*":
+        return True
+    return all(_validate_cron_item(item, lo, hi, names) for item in field.split(","))
+
+
+def _validate_cron_descriptor(schedule: str) -> bool:
+    """Return True if schedule is a valid '@' descriptor (e.g. @daily, @every 5m)"""
+    if schedule in CRON_DESCRIPTORS:
+        return True
+    if schedule.startswith("@every "):
+        duration = schedule[len("@every ") :]
+        return bool(duration and CRON_EVERY_DURATION_RE.match(duration))
+    return False
+
+
+def validate_cron_schedule(value: str | None) -> str | None:
+    """Validate that a crawl schedule is a well-formed cron expression.
+
+    Supports the vixie-cron grammar (5 or 6 fields, ranges, lists, step
+    values and 3-letter month/day names) and the '@' descriptors (@daily,
+    @hourly, @every ..., ...) supported by Kubernetes CronJobs.
+
+    Non-string values are not validated here - they are rejected by the
+    field's own type validation.
+    """
+    if not isinstance(value, str) or is_lenient_read() or value == "":
+        # non-string values are rejected by the field's own type validation;
+        # empty schedules and lenient DB reads are left unchanged
+        return value
+    if len(value) > 100:
+        raise ValueError("invalid cron schedule")
+    if "\n" in value or "\r" in value:
+        raise ValueError("invalid cron schedule")
+    schedule = value.strip()
+    if schedule.startswith("@"):
+        if not _validate_cron_descriptor(schedule):
+            raise ValueError("invalid cron schedule")
+        return value
+    fields = schedule.split()
+    if len(fields) not in (5, 6):
+        raise ValueError("invalid cron schedule: expected 5 or 6 fields")
+    ranges = CRON_FIELD_RANGES[-len(fields) :]
+    dom_idx = len(fields) - 3
+    month_idx = len(fields) - 2
+    dow_idx = len(fields) - 1
+    for i, field in enumerate(fields):
+        lo, hi = ranges[i]
+        if i == month_idx:
+            names = CRON_MONTH_NAMES
+        elif i == dow_idx:
+            names = CRON_DOW_NAMES
+        else:
+            names = {}
+        # '?' is only valid in the day-of-month / day-of-week fields
+        allow_question = i in (dom_idx, dow_idx)
+        if not _validate_cron_field(field, lo, hi, names, allow_question):
+            raise ValueError("invalid cron schedule")
+    return value

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -347,6 +347,15 @@ _LENIENT_CTX = contextvars.ContextVar[Literal[False] | dict[str, Any]](
 )
 
 
+def is_lenient_read() -> bool:
+    """Return True if currently validating data read from the database.
+
+    Validators that may reject legacy data should skip validation when this
+    returns True, so that old documents remain readable.
+    """
+    return bool(_LENIENT_CTX.get())
+
+
 def _lenient_str(v, handler, info):
     """WrapValidator: skip string validation when reading from DB."""
     ctx = _LENIENT_CTX.get()

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -39,6 +39,8 @@ from slugify import slugify
 from typing_extensions import deprecated
 
 # from fastapi_users import models as fastapi_users_models
+from .crawl_validator import validate_crawl_filename_template
+from .cron_validator import validate_cron_schedule
 from .db import LENIENT_ON_READ, BaseMongoModel
 from .utils import is_bool
 
@@ -111,6 +113,23 @@ CollectionCaption = Annotated[str | None, Field(max_length=1000), LENIENT_ON_REA
 
 OrgName = Annotated[str, Field(min_length=1, max_length=50), LENIENT_ON_READ]
 OrgPublicDescription = Annotated[str | None, Field(max_length=400), LENIENT_ON_READ]
+
+# ============================================================================
+# Input validation for crawl configuration values (schedules, filename
+# templates) that are persisted and used when creating scheduled crawls
+# and crawl storage files.
+# ============================================================================
+
+Schedule = Annotated[
+    str | None,
+    BeforeValidator(validate_cron_schedule),
+    LENIENT_ON_READ,
+]
+CrawlFilenameTemplate = Annotated[
+    str | None,
+    BeforeValidator(validate_crawl_filename_template),
+    LENIENT_ON_READ,
+]
 
 
 # pylint: disable=too-few-public-methods
@@ -445,7 +464,7 @@ class RawCrawlConfig(BaseModel):
 class CrawlConfigIn(BaseModel):
     """CrawlConfig input model, submitted via API"""
 
-    schedule: str | None = ""
+    schedule: Schedule = ""
     runNow: bool = False
 
     config: RawCrawlConfig
@@ -473,7 +492,7 @@ class CrawlConfigIn(BaseModel):
     # Overrides scale if set
     browserWindows: BrowserWindowCount | None = None
 
-    crawlFilenameTemplate: str | None = None
+    crawlFilenameTemplate: CrawlFilenameTemplate = None
 
     shareable: bool = False
 
@@ -621,7 +640,7 @@ class UpdateCrawlConfig(BaseModel):
     updateRunning: bool = False
 
     # crawl data: revision tracked
-    schedule: str | None = None
+    schedule: Schedule = None
     profileid: UUID | EmptyStr | None = None
     crawlerChannel: str | None = None
     proxyId: str | None = None
@@ -629,7 +648,7 @@ class UpdateCrawlConfig(BaseModel):
     maxCrawlSize: int | None = None
     scale: Annotated[Scale | None, Field(deprecated=True)] = None
     browserWindows: BrowserWindowCount | None = None
-    crawlFilenameTemplate: str | None = None
+    crawlFilenameTemplate: CrawlFilenameTemplate = None
     config: RawCrawlConfig | None = None
     shareable: bool | None = None
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 import structlog
 import pymongo
 from fastapi import Depends, HTTPException, Request, Response
+from motor.motor_asyncio import AsyncIOMotorDatabase
 
 from .models import (
     DeletedResponse,
@@ -66,7 +67,13 @@ class PageOps:
     coll_ops: CollectionOps
 
     def __init__(
-        self, mdb, crawl_ops, org_ops, storage_ops, background_job_ops, coll_ops
+        self,
+        mdb: AsyncIOMotorDatabase,
+        crawl_ops,
+        org_ops,
+        storage_ops,
+        background_job_ops,
+        coll_ops,
     ):
         self.pages = mdb["pages"]
         self.crawls = mdb["crawls"]
@@ -955,7 +962,7 @@ class PageOps:
         if boundaries[-1] <= 1:
             boundaries.append(1.1)
 
-        aggregate = [
+        aggregate: list[dict[str, dict[str, Any]]] = [
             {
                 "$match": {
                     "crawl_id": crawl_id,
@@ -1254,6 +1261,12 @@ def init_pages_api(
         org: Organization = Depends(org_crawl_dep),
     ):
         """Re-add pages for crawl (may delete page QA data!)"""
+        crawl = await ops.crawls.find_one(
+            {"_id": crawl_id, "oid": org.id}, projection={"_id": 1}
+        )
+        if not crawl:
+            raise HTTPException(status_code=404, detail="crawl_not_found")
+
         job_id = await ops.background_job_ops.create_re_add_org_pages_job(
             org.id, crawl_id=crawl_id
         )

--- a/backend/test/test_run_crawl.py
+++ b/backend/test/test_run_crawl.py
@@ -7,6 +7,7 @@ import re
 import time
 import zipfile
 from tempfile import TemporaryFile
+from uuid import uuid4
 from zipfile import ZIP_STORED, ZipFile
 
 import structlog
@@ -1050,7 +1051,13 @@ def test_crawl_pages_qa_filters(crawler_auth_headers, default_org_id, crawler_cr
     assert r.json()["total"] == 2
 
 
-def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_id):
+def test_re_add_crawl_pages(
+    crawler_auth_headers,
+    default_org_id,
+    crawler_crawl_id,
+    admin_auth_headers,
+    non_default_org_id,
+):
     # Store page counts to compare against after re-adding
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{crawler_crawl_id}",
@@ -1108,6 +1115,23 @@ def test_re_add_crawl_pages(crawler_auth_headers, default_org_id, crawler_crawl_
         headers=crawler_auth_headers,
     )
     assert r.status_code == 403
+
+    # Crawl ids that do not exist are rejected
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/crawls/{uuid4()}/pages/reAdd",
+        headers=crawler_auth_headers,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "crawl_not_found"
+
+    # Crawl ids belonging to another org are rejected
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/all-crawls/"
+        f"{crawler_crawl_id}/pages/reAdd",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "crawl_not_found"
 
     # Check that crawl page counts were recalculated properly
     r = requests.get(

--- a/backend/test/test_yaml_manifest_validation.py
+++ b/backend/test/test_yaml_manifest_validation.py
@@ -1,0 +1,555 @@
+"""Tests for crawl configuration validation.
+
+Covers cron schedule validation, crawl filename template validation, and
+rendering of values into Kubernetes app templates.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import jinja2
+import pytest
+import yaml
+from pydantic import TypeAdapter, ValidationError
+
+from btrixcloud.crawl_validator import validate_crawl_filename_template
+from btrixcloud.cron_validator import validate_cron_schedule
+from btrixcloud.db import BaseMongoModel
+from btrixcloud.models import (
+    CrawlConfigIn,
+    CrawlFilenameTemplate,
+    RawCrawlConfig,
+    Schedule,
+    UpdateCrawlConfig,
+)
+from btrixcloud.operator.baseoperator import BaseOperator
+
+# ===========================================================================
+# cron schedule validation
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        # basic 5-field and 6-field expressions
+        "0 0 * * *",
+        "0 0 * * * *",
+        "* * * * *",
+        # step values
+        "*/15 * * * *",
+        "0 */5 * * *",
+        "1-10/2 * * * *",
+        "5/15 * * * *",
+        # ranges and lists
+        "0 8-17 * * *",
+        "0,30 * * * *",
+        "5,10,15 9-17 * * *",
+        # names (3-letter month / day-of-week)
+        "30 2 * JAN,MAR,MAY SUN",
+        "0 8-17/2 * * MON-FRI",
+        "0 0 1 JAN *",
+        # '?' in day-of-month / day-of-week only
+        "0 0 ? * MON",
+        "0 0 * * ?",
+        "0 0 ? * ?",
+        # edge values
+        "0 0 * * 7",
+        "0 0 31 12 *",
+        # whitespace tolerance (trailing space, tabs between fields)
+        "0 0 * * * ",
+        "0\t0 * * *",
+        # @ descriptors supported by Kubernetes CronJobs
+        "@yearly",
+        "@annually",
+        "@monthly",
+        "@weekly",
+        "@daily",
+        "@midnight",
+        "@hourly",
+        "@every 5m",
+        "@every 1h30m",
+        "@every 1h30m10s",
+        "@every 0.5s",
+        "@every 500ms",
+        # long but valid expression (fits within the length limit)
+        "0-59/1,0-59/2,0-59/3,0-59/4,0-59/5,0-59/6,0-59/7,0-59/8,0-59/9,"
+        "0-59/10,0-59/11 * * * MON-FRI",
+    ],
+)
+def test_valid_cron_schedules(schedule):
+    assert validate_cron_schedule(schedule) == schedule
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        # characters outside the cron grammar
+        '* * * * "',
+        "* * * * ---",
+        "*:* * * *",
+        "* * * * #",
+        '0 0 * * *"\n---\napiVersion: batch/v1\nkind: Job\nmetadata:\n  name: test',
+        # field count violations
+        "* * * *",
+        "* * * * * * *",
+        "0 0 * * * 0 0",
+        # out-of-range values
+        "99 * * * *",
+        "* 24 * * *",
+        "* * 32 * *",
+        "0 0 * 13 *",
+        "0 0 * * 8",
+        # misplaced names / '?'
+        "JAN * * * *",
+        "? * * * *",
+        "0 0 * * * * ?",
+        # malformed ranges
+        "1- * * * *",
+        "-5 * * * *",
+        "* * * * 5-",
+        # invalid descriptors
+        "@DAILY",
+        "@daily 5m",
+        "@EVERY 5m",
+        "@every",
+        "@every 5",
+        "@every 5x",
+        "@every -5m",
+        # invalid step value
+        "*/0 * * * *",
+        # newlines and carriage returns are not valid separators
+        "0 0 * * *\n*",
+        "0\n0\n*\n*\n*",
+        "0 0 * * *\r",
+    ],
+)
+def test_invalid_cron_schedules(schedule):
+    with pytest.raises(ValueError):
+        validate_cron_schedule(schedule)
+
+
+def test_cron_schedule_none_and_empty_passthrough():
+    assert validate_cron_schedule(None) is None
+    assert validate_cron_schedule("") == ""
+
+
+# ===========================================================================
+# crawl filename template validation
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "@ts-@hostsuffix.wacz",
+        "crawl-@id.wacz",
+        "@hostname-@ts.wacz",
+        "plain-name.wacz",
+        "archive_2024.wacz",
+        "with space.wacz",
+        "colon:name.wacz",
+        "slash/name.wacz",
+        'quote"name.wacz',
+        "(parens) [brackets] {braces} $%&+.wacz",
+        "crawls-名-2024.wacz",
+        # dots inside a path component are fine; only '.'/'..'
+        # components and leading '/' are rejected
+        "a..b.wacz",
+        # longest allowed template (768 characters)
+        "x" * 768,
+    ],
+)
+def test_valid_crawl_filename_templates(template):
+    assert validate_crawl_filename_template(template) == template
+
+
+def test_crawl_filename_template_none_and_empty_passthrough():
+    assert validate_crawl_filename_template(None) is None
+    assert validate_crawl_filename_template("") == ""
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        # control characters (newlines, tabs, etc.) are not valid in S3 keys
+        'x"\n---\napiVersion: batch/v1\nkind: Job',
+        "@ts\n---\nkind: Job",
+        "line\nbreak.wacz",
+        "tab\t.wacz",
+        "nul\x00.wacz",
+        "del\x7f.wacz",
+        # path traversal/absolute paths
+        "../evil.wacz",
+        "..",
+        "a/../b.wacz",
+        "a/./b.wacz",
+        "/abs/path.wacz",
+        "/etc/passwd",
+        # one character over the 768-character limit
+        "x" * 769,
+    ],
+)
+def test_invalid_crawl_filename_templates(template):
+    with pytest.raises(ValueError):
+        validate_crawl_filename_template(template)
+
+
+# ===========================================================================
+# model-level validation (the API input models)
+# ===========================================================================
+
+
+def test_crawl_config_in_rejects_invalid_schedule():
+    with pytest.raises(ValidationError):
+        CrawlConfigIn(
+            schedule='0 0 * * *"\n---\napiVersion: batch/v1',
+            name="test",
+            config=RawCrawlConfig(),
+        )
+
+
+def test_crawl_config_in_accepts_valid_schedule():
+    config = CrawlConfigIn(
+        schedule="@daily",
+        name="test",
+        config=RawCrawlConfig(),
+    )
+    assert config.schedule == "@daily"
+
+
+def test_update_crawl_config_rejects_invalid_filename_template():
+    with pytest.raises(ValidationError):
+        UpdateCrawlConfig(crawlFilenameTemplate='x"\n---\ntest/123')
+
+
+def test_update_crawl_config_rejects_invalid_schedule():
+    with pytest.raises(ValidationError):
+        UpdateCrawlConfig(schedule='0 0 * * *"\n---\ntest 123')
+
+
+def test_crawl_filename_template_type_rejects_invalid():
+    with pytest.raises(ValidationError):
+        TypeAdapter(CrawlFilenameTemplate).validate_python(
+            'x"\n---\napiVersion: batch/v1'
+        )
+
+
+def test_schedule_type_accepts_valid():
+    assert TypeAdapter(Schedule).validate_python("*/10 * * * *") == "*/10 * * * *"
+
+
+def test_schedule_type_accepts_unset_values():
+    # None and "" mean "no schedule" and must pass on the write path
+    assert TypeAdapter(Schedule).validate_python(None) is None
+    assert TypeAdapter(Schedule).validate_python("") == ""
+
+
+def test_schedule_type_rejects_non_strings():
+    with pytest.raises(ValidationError):
+        TypeAdapter(Schedule).validate_python(123)
+    with pytest.raises(ValidationError):
+        TypeAdapter(Schedule).validate_python(True)
+
+
+def test_schedule_type_rejects_overlong_schedule():
+    # 101 characters exceeds the 100-character limit
+    with pytest.raises(ValidationError):
+        TypeAdapter(Schedule).validate_python("* " * 50 + "*")
+
+
+def test_crawl_filename_template_type_accepts_unset_values():
+    assert TypeAdapter(CrawlFilenameTemplate).validate_python(None) is None
+    assert TypeAdapter(CrawlFilenameTemplate).validate_python("") == ""
+
+
+def test_crawl_filename_template_type_accepts_valid_value():
+    assert (
+        TypeAdapter(CrawlFilenameTemplate).validate_python("crawl-@id.wacz")
+        == "crawl-@id.wacz"
+    )
+
+
+def test_crawl_config_in_accepts_valid_filename_template():
+    config = CrawlConfigIn(
+        crawlFilenameTemplate="crawl-@id.wacz",
+        name="test",
+        config=RawCrawlConfig(),
+    )
+    assert config.crawlFilenameTemplate == "crawl-@id.wacz"
+
+
+def test_crawl_filename_template_type_rejects_non_strings():
+    with pytest.raises(ValidationError):
+        TypeAdapter(CrawlFilenameTemplate).validate_python(123)
+
+
+def test_models_accept_explicit_null_schedule_and_template():
+    # clearing a schedule / template via PATCH sends explicit null
+    config = CrawlConfigIn(schedule=None, name="test", config=RawCrawlConfig())
+    assert config.schedule is None
+    update = UpdateCrawlConfig(schedule=None, crawlFilenameTemplate=None)
+    assert update.schedule is None
+    assert update.crawlFilenameTemplate is None
+
+
+# ===========================================================================
+# lenient DB reads: legacy values must still load (validation only on writes)
+# ===========================================================================
+
+
+class _LenientScheduleModel(BaseMongoModel):
+    """Model with the Schedule type, for lenient-read testing"""
+
+    schedule: Schedule = ""
+
+
+class _LenientTemplateModel(BaseMongoModel):
+    """Model with the CrawlFilenameTemplate type, for lenient-read testing"""
+
+    template: CrawlFilenameTemplate = None
+
+
+def test_schedule_validates_on_write_but_is_lenient_on_db_read():
+    # direct construction (API write path) rejects invalid schedules
+    with pytest.raises(ValidationError):
+        _LenientScheduleModel(schedule='0 0 * * *"\n---\napiVersion: batch/v1')
+
+    # from_dict (DB read path) is lenient - legacy data still loads
+    model = _LenientScheduleModel.from_dict(
+        {"_id": uuid4(), "schedule": '0 0 * * *"\n---\napiVersion: batch/v1'}
+    )
+    assert model.schedule == '0 0 * * *"\n---\napiVersion: batch/v1'
+
+
+def test_filename_template_validates_on_write_but_is_lenient_on_db_read():
+    # direct construction (API write path) rejects invalid templates
+    with pytest.raises(ValidationError):
+        _LenientTemplateModel(template="bad\n---\nkind: Job")
+
+    # from_dict (DB read path) is lenient - legacy data still loads
+    model = _LenientTemplateModel.from_dict(
+        {"_id": uuid4(), "template": "bad\n---\nkind: Job"}
+    )
+    assert model.template == "bad\n---\nkind: Job"
+
+
+# --- operator template loading ---------------------------------------------
+
+APP_TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "chart" / "app-templates"
+
+
+class _TemplateHolder:
+    """Minimal stand-in for BaseOperator, exposing only the template loader"""
+
+    def __init__(self):
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(str(APP_TEMPLATES_DIR)),
+            autoescape=False,
+        )
+        self.k8s = SimpleNamespace(templates=SimpleNamespace(env=env))
+
+
+BACKGROUND_JOB_PARAMS = {
+    "id": "job1",
+    "job_type": "readd-pages",
+    "backend_image": "docker.io/webrecorder/browsertrix-backend:test",
+    "pull_policy": "IfNotPresent",
+    "larger_resources": True,
+}
+
+
+def test_cron_job_schedule_renders_as_single_document():
+    holder = _TemplateHolder()
+
+    docs = BaseOperator.load_from_yaml(
+        holder,
+        "crawl_cron_job.yaml",
+        {
+            "id": "cron1",
+            "cid": str(uuid4()),
+            "oid": str(uuid4()),
+            "userid": str(uuid4()),
+            "schedule": "0 0 * * *",
+        },
+    )
+
+    assert len(docs) == 1
+    assert docs[0]["kind"] == "CronJob"
+    assert docs[0]["spec"]["schedule"] == "0 0 * * *"
+
+
+# --- yaml-safe rendering of template values ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # cases where plain interpolation would change the parsed value or
+        # structure: YAML flow indicators, bool coercion, line breaks, and
+        # multi-document separators
+        "a: b",
+        "true",
+        "x\ny",
+        'x"\n---\napiVersion: batch/v1\nkind: Pod',
+        "https://example.com/path?q=1&r=2",
+    ],
+)
+def test_tojson_renders_single_line_roundtrippable_yaml_scalar(value):
+    env = jinja2.Environment()
+    rendered = env.from_string("{{ value | tojson }}").render(value=value)
+
+    # the filter output must never span multiple lines or create structure
+    assert "\n" not in rendered
+    assert yaml.safe_load(rendered) == value
+
+
+def _profile_browser_params(url):
+    return {
+        "id": "browser-abc",
+        "namespace": "crawlers",
+        "url": url,
+        "crawler_uid": "1000",
+        "crawler_gid": "1000",
+        "crawler_fsgroup": "1000",
+        "profile_browser_workdir_size": "1Gi",
+        "crawler_image": "docker.io/webrecorder/browsertrix-crawler:test",
+        "crawler_image_pull_policy": "IfNotPresent",
+        "memory_limit": "1Gi",
+        "profile_cpu": "100m",
+        "profile_memory": "256Mi",
+        "storage_secret": "storage-default",
+        "storage_path": "/tmp",
+        "vnc_password": "secret",
+    }
+
+
+def test_profile_browser_url_stays_single_scalar_when_it_contains_newlines():
+    holder = _TemplateHolder()
+    hostile_url = (
+        "https://example.com/x\n---\napiVersion: batch/v1\nkind: Pod\n"
+        "metadata:\n  name: garbage\n"
+    )
+
+    docs = BaseOperator.load_from_yaml(
+        holder,
+        "profilebrowser.yaml",
+        _profile_browser_params(hostile_url),
+    )
+
+    # the url remains a single command argument (data, not structure)
+    assert len(docs) == 1
+    command = docs[0]["spec"]["containers"][0]["command"]
+    assert command[command.index("--url") + 1] == hostile_url
+
+
+def test_background_job_crawl_id_stays_single_scalar_when_it_contains_newlines():
+    holder = _TemplateHolder()
+    hostile_crawl_id = (
+        "manual-abc\n---\napiVersion: batch/v1\nkind: Job\nmetadata:\n  name: garbage\n"
+    )
+
+    docs = BaseOperator.load_from_yaml(
+        holder,
+        "background_job.yaml",
+        {**BACKGROUND_JOB_PARAMS, "crawl_id": hostile_crawl_id},
+    )
+
+    assert len(docs) == 1
+    env = docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
+    crawl_id_env = [entry for entry in env if entry["name"] == "CRAWL_ID"][0]
+    assert crawl_id_env["value"] == hostile_crawl_id
+
+
+SIGNED_URL = (
+    "https://storage.example.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/"
+    "coll.wacz?X-Amz-Signature=abc%2Fdef%3D&part=1#frag"
+)
+
+
+@pytest.mark.parametrize(
+    "job_type,expected_args",
+    [
+        ("import", {"--sourceUrl": SIGNED_URL}),
+        ("purge", {"--sourceUrl": SIGNED_URL, "--removing": True}),
+        ("commit", {"--commitCrawlId": "manual-20260714225812-dc73dcee-99f"}),
+        ("cancel", {"--cancelCrawlId": "manual-20260714225812-dc73dcee-99f"}),
+    ],
+)
+def test_index_import_job_command_args_roundtrip_through_tojson(
+    job_type, expected_args
+):
+    holder = _TemplateHolder()
+
+    docs = BaseOperator.load_from_yaml(
+        holder,
+        "index-import-job.yaml",
+        {
+            "name": "import-index-abc12",
+            "job_type": job_type,
+            "id": str(uuid4()),
+            "oid": str(uuid4()),
+            "crawler_image": "docker.io/webrecorder/browsertrix-crawler:test",
+            "crawler_image_pull_policy": "IfNotPresent",
+            "redis_url": "redis://redis-x/0",
+            "import_source_url": SIGNED_URL,
+            "crawl_id": "manual-20260714225812-dc73dcee-99f",
+        },
+    )
+
+    command = docs[0]["spec"]["template"]["spec"]["containers"][0]["command"]
+    # walk flag/value pairs, tolerating valueless flags (e.g. --removing)
+    args: dict[str, str | bool] = {}
+    i = 1
+    while i < len(command):
+        flag = command[i]
+        value = command[i + 1] if i + 1 < len(command) else None
+        if value is not None and not value.startswith("--"):
+            args[flag] = value
+            i += 2
+        else:
+            args[flag] = True
+            i += 1
+    for flag, expected in expected_args.items():
+        assert args[flag] == expected
+
+
+def test_crawl_job_cr_user_values_stay_single_scalar_when_they_contain_newlines():
+    holder = _TemplateHolder()
+    hostile = "x\n---\napiVersion: btrix.cloud/v1\nkind: CrawlJob\n"
+
+    docs = BaseOperator.load_from_yaml(
+        holder,
+        "crawl_job.yaml",
+        {
+            "id": "manual-20260714225812-dc73dcee-99f",
+            "cid": str(uuid4()),
+            "userid": str(uuid4()),
+            "oid": str(uuid4()),
+            "storage_name": "default",
+            "crawler_channel": hostile,
+            "scale": 1,
+            "browser_windows": 1,
+            "timeout": 0,
+            "max_crawl_size": 0,
+            "manual": "1",
+            "warc_prefix": "colls/11111111-2222-3333-4444-555555555555",
+            "storage_filename": hostile,
+            "profile_filename": "profile-abc.tar.gz",
+            "profileid": "",
+            "qa_source": "",
+            "proxy_id": hostile,
+            "dedupe_coll_id": "",
+            "is_single_page": "0",
+            "seed_file_url": "",
+            "pausedAt": "",
+        },
+    )
+
+    # the values remain single spec fields (data, not structure)
+    assert len(docs) == 1
+    spec = docs[0]["spec"]
+    assert spec["storage_filename"] == hostile
+    assert spec["proxyId"] == hostile
+    assert spec["crawlerChannel"] == hostile

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -56,7 +56,7 @@ spec:
 
 {% if crawl_id %}
           - name: CRAWL_ID
-            value: {{ crawl_id }}
+            value: {{ crawl_id | tojson }}
 {% endif %}
 
 {% if collection_id %}

--- a/chart/app-templates/crawl_cron_job.yaml
+++ b/chart/app-templates/crawl_cron_job.yaml
@@ -15,7 +15,7 @@ spec:
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 2
 
-  schedule: "{{ schedule }}"
+  schedule: {{ schedule | tojson }}
 
   jobTemplate:
     metadata:

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -23,23 +23,23 @@ spec:
   browserWindows: {{ browser_windows }}
 
   profile_filename: "{{ profile_filename }}"
-  profileId: "{{ profileid }}"
-  storage_filename: "{{ storage_filename }}"
+  profileId: {{ profileid | tojson }}
+  storage_filename: {{ storage_filename | tojson }}
 
   maxCrawlSize: {{ max_crawl_size if not qa_source else 0 }}
   timeout: {{ timeout if not qa_source else 0 }}
   qaSourceCrawlId: "{{ qa_source }}"
 
   manual: {{ manual }}
-  crawlerChannel: "{{ crawler_channel }}"
+  crawlerChannel: {{ crawler_channel | tojson }}
   ttlSecondsAfterFinished: {{ 30 if not qa_source else 0 }}
   warcPrefix: "{{ warc_prefix }}"
 
   storageName: "{{ storage_name }}"
 
-  proxyId: "{{ proxy_id }}"
+  proxyId: {{ proxy_id | tojson }}
 
-  dedupeCollId: "{{ dedupe_coll_id }}"
+  dedupeCollId: {{ dedupe_coll_id | tojson }}
 
   pausedAt: "{{ pausedAt }}"
 

--- a/chart/app-templates/index-import-job.yaml
+++ b/chart/app-templates/index-import-job.yaml
@@ -58,20 +58,20 @@ spec:
 
           {% if job_type == "import" %}
             - --sourceUrl
-            - {{ import_source_url }}
+            - {{ import_source_url | tojson }}
 
           {% elif job_type == "purge" %}
             - --sourceUrl
-            - {{ import_source_url }}
+            - {{ import_source_url | tojson }}
             - --removing
 
           {% elif job_type == "commit" %}
             - --commitCrawlId
-            - {{ crawl_id }}
+            - {{ crawl_id | tojson }}
 
           {% elif job_type == "cancel" %}
             - --cancelCrawlId
-            - {{ crawl_id }}
+            - {{ crawl_id | tojson }}
 
           {% endif %}
 

--- a/chart/app-templates/profilebrowser.yaml
+++ b/chart/app-templates/profilebrowser.yaml
@@ -77,7 +77,7 @@ spec:
         - --filename
         - /tmp/profile.tar.gz
         - --url
-        - {{ url }}
+        - {{ url | tojson }}
       {%- if profile_filename %}
         - --profile
         - "@{{ profile_filename }}"


### PR DESCRIPTION
## Changes

Implements some validations on the backend (some of which are present on the frontend) so that errors happen earlier. Primarily, crawl schedules are now properly validated! I ended up writing a little validator myself based on https://github.com/robfig/cron, the library that k8s uses.

This also better validates crawl IDs for the `/pages/reAdd` endpoints, and adds some constraints to the `crawlFilenameTemplate` parameter as well.

## Testing

These changes should all be pretty well tested by the unit & integration tests added.

You can test the validation with API calls from your browser's dev tools (or curl, or whatever) with an invalid schedule to the create or update workflow endpoints.