### PR TITLE
Fix cross-org validations in collection and workflow endpoints

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -332,7 +332,9 @@ class CollectionOps:
     async def get_collection_raw(
         self, coll_id: UUID, oid: UUID, public_or_unlisted_only: bool = False
     ) -> dict[str, Any]:
-        """Get collection by id as dict from database"""
+        """Get collection by id as dict from database
+
+        If `public_or_unlisted_only`, only public or unlisted collections are returned"""
         query: dict[str, object] = {"_id": coll_id, "oid": oid}
         if public_or_unlisted_only:
             query["access"] = {"$in": ["public", "unlisted"]}
@@ -691,13 +693,11 @@ class CollectionOps:
         public_or_unlisted_only=False,
     ) -> list[str]:
         """Return list of crawl ids in collection, including only public collections"""
-        crawl_ids = []
-        # ensure collection is public or unlisted, else throw here
-        if public_or_unlisted_only:
-            await self.get_collection_raw(coll_id, oid, public_or_unlisted_only)
+        await self.get_collection_raw(coll_id, oid, public_or_unlisted_only)
 
+        crawl_ids = []
         async for crawl_raw in self.crawls.find(
-            {"collectionIds": coll_id}, projection=["_id"]
+            {"collectionIds": coll_id, "oid": oid}, projection=["_id"]
         ):
             crawl_id = crawl_raw.get("_id")
             if crawl_id:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -264,7 +264,7 @@ class CollectionOps:
 
         modified = dt_now()
         result = await self.collections.find_one_and_update(
-            {"_id": coll_id},
+            {"_id": coll_id, "oid": org.id},
             {"$set": {"modified": modified}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
@@ -298,7 +298,7 @@ class CollectionOps:
         """Update collection after crawls are removed or deleted outright"""
         modified = dt_now()
         result = await self.collections.find_one_and_update(
-            {"_id": coll_id},
+            {"_id": coll_id, "oid": org.id},
             {"$set": {"modified": modified}},
             return_document=pymongo.ReturnDocument.AFTER,
         )

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1165,9 +1165,16 @@ class CrawlConfigOps:
         return config_cls.from_dict(res)
 
     async def get_crawl_config_revs(
-        self, cid: UUID, page_size: int = DEFAULT_PAGE_SIZE, page: int = 1
+        self,
+        cid: UUID,
+        oid: UUID,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
     ):
         """return all config revisions for crawlconfig"""
+        # ensure config belongs to the requesting org, else 404
+        await self.get_crawl_config(cid, oid, active_only=False)
+
         # Zero-index page for query
         page = page - 1
         skip = page_size * page
@@ -1988,14 +1995,16 @@ def init_crawl_config_api(
 
     @router.get(
         "/{cid}/revs",
-        dependencies=[Depends(org_viewer_dep)],
         response_model=PaginatedConfigRevisionResponse,
     )
     async def get_crawl_config_revisions(
-        cid: UUID, pageSize: int = DEFAULT_PAGE_SIZE, page: int = 1
+        cid: UUID,
+        org: Organization = Depends(org_viewer_dep),
+        pageSize: int = DEFAULT_PAGE_SIZE,
+        page: int = 1,
     ):
         revisions, total = await ops.get_crawl_config_revs(
-            cid, page_size=pageSize, page=page
+            cid, org.id, page_size=pageSize, page=page
         )
         return paginated_format(revisions, total, page, pageSize)
 

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -1064,6 +1064,9 @@ class CrawlOps(BaseCrawlOps):
         self, crawl_id: str, delete_list: DeleteQARunList, org: Organization
     ) -> dict[str, int]:
         """delete specified finished QA run"""
+        # ensure crawl belongs to the requesting org before any changes
+        await self.get_crawl(crawl_id, org)
+
         count = 0
         for qa_run_id in delete_list.qa_run_ids:
             await self.page_ops.delete_qa_run_from_pages(crawl_id, qa_run_id)

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -620,8 +620,8 @@ class PageOps:
         query: dict[str, object] = {
             "crawl_id": {"$in": crawl_ids},
         }
-        # if org:
-        #    query["oid"] = org.id
+        if org:
+            query["oid"] = org.id
 
         # Text Search
         is_text_search = False

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -377,7 +377,7 @@ class ProfileOps:
         return True
 
     async def update_profile_metadata(
-        self, profileid: UUID, update: ProfileUpdate, user: User
+        self, profileid: UUID, update: ProfileUpdate, user: User, org: Organization
     ) -> dict[str, bool]:
         """Update name and description metadata only on existing profile"""
         query = {
@@ -394,7 +394,7 @@ class ProfileOps:
             query["tags"] = update.tags
 
         if not await self.profiles.find_one_and_update(
-            {"_id": profileid}, {"$set": query}
+            {"_id": profileid, "oid": org.id}, {"$set": query}
         ):
             raise HTTPException(status_code=404, detail="profile_not_found")
 
@@ -818,7 +818,7 @@ def init_profiles_api(
         user: User = Depends(user_dep),
     ):
         if not browser_commit.browserid:
-            await ops.update_profile_metadata(profileid, browser_commit, user)
+            await ops.update_profile_metadata(profileid, browser_commit, user, org)
 
         else:
             metadata = await browser_get_metadata(browser_commit.browserid, org)

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -716,6 +716,22 @@ def test_collection_wrong_org(admin_auth_headers, non_default_org_id):
     assert r.status_code == 404
 
 
+def test_collection_pages_wrong_org(admin_auth_headers, non_default_org_id):
+    # collection belongs to the default org; requesting its pages through
+    # another org's path must not return cross-org page data
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/collections/{_coll_id}/pages",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/collections/{_coll_id}/pageUrlCounts",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+
+
 def test_collection_public_make_private(crawler_auth_headers, default_org_id):
     # make private again
     r = requests.patch(

--- a/backend/test/test_collections.py
+++ b/backend/test/test_collections.py
@@ -732,6 +732,45 @@ def test_collection_pages_wrong_org(admin_auth_headers, non_default_org_id):
     assert r.status_code == 404
 
 
+def test_collection_add_remove_wrong_org(
+    admin_auth_headers,
+    crawler_auth_headers,
+    default_org_id,
+    non_default_org_id,
+    crawler_crawl_id,
+):
+    # create a collection in the non-default org, then attempt to add/remove
+    # crawls to it through the default org's path
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/collections",
+        headers=admin_auth_headers,
+        json={"name": "wrong-org-target"},
+    )
+    assert r.status_code == 200
+    foreign_coll_id = r.json()["id"]
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{foreign_coll_id}/add",
+        headers=crawler_auth_headers,
+        json={"crawlIds": [crawler_crawl_id]},
+    )
+    assert r.status_code == 404
+
+    r = requests.post(
+        f"{API_PREFIX}/orgs/{default_org_id}/collections/{foreign_coll_id}/remove",
+        headers=crawler_auth_headers,
+        json={"crawlIds": [crawler_crawl_id]},
+    )
+    assert r.status_code == 404
+
+    # cleanup
+    r = requests.delete(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/collections/{foreign_coll_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+
+
 def test_collection_public_make_private(crawler_auth_headers, default_org_id):
     # make private again
     r = requests.patch(

--- a/backend/test/test_crawlconfigs.py
+++ b/backend/test/test_crawlconfigs.py
@@ -541,6 +541,16 @@ def test_verify_revs_history(crawler_auth_headers, default_org_id):
     assert sorted_data[0]["config"]["scopeType"] == "prefix"
 
 
+def test_verify_revs_history_wrong_org(admin_auth_headers, non_default_org_id):
+    # config belongs to the default org; requesting its revisions through
+    # another org's path must not leak the raw config history
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/crawlconfigs/{cid}/revs",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 404
+
+
 def test_workflow_total_size_and_last_crawl_stats(
     crawler_auth_headers, default_org_id, admin_crawl_id, crawler_crawl_id
 ):

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -260,10 +260,30 @@ def test_update_profile_metadata(crawler_auth_headers, default_org_id, profile_i
     assert data["modified"] > original_modified
     assert data["modifiedBy"]
     assert data["modifiedByName"] == "new-crawler"
-
     assert data["created"] == original_created
     assert data["createdBy"]
     assert data["createdByName"] == "admin"
+
+
+def test_update_profile_metadata_wrong_org(
+    admin_auth_headers, default_org_id, non_default_org_id, profile_id
+):
+    # profile belongs to the default org; patching it through another org's
+    # path must not modify it
+    r = requests.patch(
+        f"{API_PREFIX}/orgs/{non_default_org_id}/profiles/{profile_id}",
+        headers=admin_auth_headers,
+        json={"name": "should-not-stick"},
+    )
+    assert r.status_code == 404
+
+    # profile unchanged in the default org
+    r = requests.get(
+        f"{API_PREFIX}/orgs/{default_org_id}/profiles/{profile_id}",
+        headers=admin_auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == PROFILE_NAME_UPDATED
 
 
 def test_commit_browser_to_existing_profile(

--- a/backend/test/test_unit_collection_pages.py
+++ b/backend/test/test_unit_collection_pages.py
@@ -1,0 +1,152 @@
+"""Unit tests for org-scoping of collection pages lookups.
+
+Regression tests for the cross-org disclosure of archived page metadata:
+get_collection_crawl_ids() must verify collection ownership against the
+requesting org before returning crawl ids (and pages/pageUrlCounts routes
+depend on this check).
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from btrixcloud.colls import CollectionOps
+
+
+def _matches(doc: dict, query: dict) -> bool:
+    """Match a doc against a simple equality query, supporting $in and
+    array-contains semantics (mongo: {"collectionIds": x} matches arrays)."""
+    for key, value in query.items():
+        doc_val = doc.get(key)
+        if isinstance(value, dict) and "$in" in value:
+            if doc_val not in value["$in"]:
+                return False
+        elif isinstance(doc_val, list):
+            if value not in doc_val:
+                return False
+        elif doc_val != value:
+            return False
+    return True
+
+
+class _Cursor:
+    """Minimal async-iterable cursor (motor find() returns a cursor, not a coroutine)."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def __aiter__(self):
+        async def gen():
+            for doc in self._docs:
+                yield doc
+
+        return gen()
+
+
+class FakeCollection:
+    """Minimal fake for a mongo collection supporting find_one / find"""
+
+    def __init__(self, docs):
+        self.docs = docs
+
+    async def find_one(self, query):
+        for doc in self.docs:
+            if _matches(doc, query):
+                return dict(doc)
+        return None
+
+    def find(self, query, projection=None):
+        docs = [dict(doc) for doc in self.docs if _matches(doc, query)]
+        if projection:
+            docs = [{k: v for k, v in doc.items() if k in projection} for doc in docs]
+        return _Cursor(docs)
+
+
+class FakeMDB:
+    """Minimal fake for the motor mdb object"""
+
+    def __init__(self, collections, crawls):
+        self._collections = collections
+        self._crawls = crawls
+
+    def __getitem__(self, name):
+        if name == "collections":
+            return self._collections
+        if name == "crawls":
+            return self._crawls
+        # crawl_configs / pages etc. are unused by these tests
+        return FakeCollection([])
+
+
+@pytest.fixture
+def coll_ops():
+    org_a = uuid.uuid4()
+    org_b = uuid.uuid4()
+    coll_a = {"_id": uuid.uuid4(), "oid": org_a, "access": "private"}
+    coll_b_public = {"_id": uuid.uuid4(), "oid": org_b, "access": "public"}
+    coll_b_private = {"_id": uuid.uuid4(), "oid": org_b, "access": "private"}
+    crawl_a_id = uuid.uuid4()
+    crawl_b_id = uuid.uuid4()
+    crawls = [
+        {"_id": crawl_a_id, "oid": org_a, "collectionIds": [coll_a["_id"]]},
+        {"_id": crawl_b_id, "oid": org_b, "collectionIds": [coll_b_public["_id"]]},
+    ]
+    mdb = FakeMDB(
+        FakeCollection([coll_a, coll_b_public, coll_b_private]),
+        FakeCollection(crawls),
+    )
+    ops = CollectionOps(mdb, None, None, None, None, None)
+    return (
+        ops,
+        org_a,
+        org_b,
+        coll_a,
+        coll_b_public,
+        coll_b_private,
+        crawl_a_id,
+        crawl_b_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_collection_crawl_ids_foreign_org_404(coll_ops):
+    """A collection owned by org B must not resolve via org A's id."""
+    ops, org_a, _, _, coll_b_public, coll_b_private, _, _ = coll_ops
+
+    with pytest.raises(HTTPException) as exc:
+        await ops.get_collection_crawl_ids(coll_b_public["_id"], org_a)
+    assert exc.value.status_code == 404
+
+    with pytest.raises(HTTPException) as exc:
+        await ops.get_collection_crawl_ids(coll_b_private["_id"], org_a)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_collection_crawl_ids_same_org(coll_ops):
+    """Own collections (any visibility) resolve to their crawl ids."""
+    ops, org_a, org_b, coll_a, coll_b_public, _, crawl_a_id, crawl_b_id = coll_ops
+
+    crawl_ids = await ops.get_collection_crawl_ids(coll_a["_id"], org_a)
+    assert crawl_ids == [crawl_a_id]
+
+    crawl_ids = await ops.get_collection_crawl_ids(coll_b_public["_id"], org_b)
+    assert crawl_ids == [crawl_b_id]
+
+
+@pytest.mark.asyncio
+async def test_get_collection_crawl_ids_public_access_requirement(coll_ops):
+    """public_or_unlisted_only must still reject private collections of the same org."""
+    ops, _, org_b, _, coll_b_public, coll_b_private, _, _ = coll_ops
+
+    with pytest.raises(HTTPException) as exc:
+        await ops.get_collection_crawl_ids(
+            coll_b_private["_id"], org_b, public_or_unlisted_only=True
+        )
+    assert exc.value.status_code == 404
+
+    crawl_ids = await ops.get_collection_crawl_ids(
+        coll_b_public["_id"], org_b, public_or_unlisted_only=True
+    )
+    assert len(crawl_ids) == 1

--- a/backend/test/test_unit_crawl_config_revs.py
+++ b/backend/test/test_unit_crawl_config_revs.py
@@ -1,0 +1,163 @@
+"""Unit tests for org-scoping of crawl config revision lookups.
+
+Regression tests for the cross-org raw config disclosure via
+GET /orgs/{oid}/crawlconfigs/{cid}/revs: revision history must only be
+returned when the crawl config belongs to the requesting org.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from fastapi import HTTPException
+
+from btrixcloud.crawlconfigs import CrawlConfigOps
+
+
+def _matches(doc: dict, query: dict) -> bool:
+    """Match a doc against a simple equality query, supporting $in."""
+    for key, value in query.items():
+        doc_val = doc.get(key)
+        if isinstance(value, dict) and "$in" in value:
+            if doc_val not in value["$in"]:
+                return False
+        elif doc_val != value:
+            return False
+    return True
+
+
+class _Cursor:
+    """Minimal async-iterable cursor with motor's to_list()."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def __aiter__(self):
+        async def gen():
+            for doc in self._docs:
+                yield doc
+
+        return gen()
+
+    async def to_list(self, length=None):
+        return list(self._docs)
+
+
+class FakeCollection:
+    """Minimal fake for a mongo collection supporting the queries used here."""
+
+    def __init__(self, docs):
+        self.docs = docs
+
+    async def find_one(self, query):
+        for doc in self.docs:
+            if _matches(doc, query):
+                return dict(doc)
+        return None
+
+    async def count_documents(self, query):
+        return sum(1 for doc in self.docs if _matches(doc, query))
+
+    def find(self, query, **kwargs):
+        return _Cursor([dict(doc) for doc in self.docs if _matches(doc, query)])
+
+
+class FakeMDB:
+    """Minimal fake for the motor mdb object."""
+
+    def __init__(self, crawl_configs, config_revs):
+        self._crawl_configs = crawl_configs
+        self._config_revs = config_revs
+
+    def __getitem__(self, name):
+        if name == "crawl_configs":
+            return self._crawl_configs
+        if name == "configs_revs":
+            return self._config_revs
+        return FakeCollection([])
+
+
+@pytest.fixture
+def crawl_config_ops(monkeypatch):
+    """CrawlConfigOps backed by fake collections, other deps mocked."""
+    monkeypatch.setenv("DEFAULT_CRAWL_FILENAME_TEMPLATE", "")
+    monkeypatch.setenv("CRAWLER_CHANNELS_JSON", "")
+
+    org_a = uuid.uuid4()
+    org_b = uuid.uuid4()
+    now = datetime.now(UTC)
+    config_a = {
+        "_id": uuid.uuid4(),
+        "oid": org_a,
+        "name": "config-a",
+        "created": now,
+        "config": {"scopeType": "prefix"},
+    }
+    config_b_inactive = {
+        "_id": uuid.uuid4(),
+        "oid": org_b,
+        "name": "config-b",
+        "inactive": True,
+        "created": now,
+        "config": {"scopeType": "prefix"},
+    }
+    rev_a = {
+        "_id": uuid.uuid4(),
+        "cid": config_a["_id"],
+        "rev": 1,
+        "config": {"scopeType": "prefix"},
+        "modified": datetime.now(UTC),
+    }
+    mdb = FakeMDB(
+        FakeCollection([config_a, config_b_inactive]),
+        FakeCollection([rev_a]),
+    )
+    with patch(
+        "builtins.open",
+        mock_open(read_data='[{"id": "default", "image": ""}]'),
+    ):
+        ops = CrawlConfigOps(
+            dbclient=MagicMock(),
+            mdb=mdb,
+            user_manager=MagicMock(),
+            org_ops=MagicMock(),
+            crawl_manager=MagicMock(),
+            profiles=MagicMock(),
+            file_ops=MagicMock(),
+            storage_ops=MagicMock(),
+        )
+    return ops, org_a, org_b, config_a, config_b_inactive
+
+
+@pytest.mark.asyncio
+async def test_get_crawl_config_revs_foreign_org_404(crawl_config_ops):
+    """A config owned by org B must not return revisions via org A."""
+    ops, org_a, _, _, config_b_inactive = crawl_config_ops
+
+    with pytest.raises(HTTPException) as exc:
+        await ops.get_crawl_config_revs(config_b_inactive["_id"], org_a)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_crawl_config_revs_same_org(crawl_config_ops):
+    """Own configs return their revision history."""
+    ops, org_a, _, config_a, _ = crawl_config_ops
+
+    revisions, total = await ops.get_crawl_config_revs(config_a["_id"], org_a)
+    assert total == 1
+    assert len(revisions) == 1
+    assert revisions[0].cid == config_a["_id"]
+
+
+@pytest.mark.asyncio
+async def test_get_crawl_config_revs_deactivated_config_still_accessible(
+    crawl_config_ops,
+):
+    """Deactivated configs of the same org must still expose their revisions."""
+    ops, _, org_b, _, config_b_inactive = crawl_config_ops
+
+    revisions, total = await ops.get_crawl_config_revs(config_b_inactive["_id"], org_b)
+    assert total == 0
+    assert revisions == []


### PR DESCRIPTION
## Changes

Closes a couple of gaps in org validation in a few endpoints. Tests cover regressions.