### PR TITLE
enhancement: Wrap URLs in crawl queue

### DIFF
--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -196,6 +196,7 @@ export class CrawlQueue extends BtrixElement {
           this.queue?.matched.some((v) => v === url) || false}
         .excludeUrl=${this.isExcluded}
         aria-live="polite"
+        size="small"
         ordered
         border
         highlight

--- a/frontend/src/features/crawls/url-list.ts
+++ b/frontend/src/features/crawls/url-list.ts
@@ -51,6 +51,10 @@ export class UrlList extends TailwindElement {
       overflow: hidden;
     }
 
+    btrix-table-cell {
+      align-items: flex-start;
+    }
+
     .bordered btrix-table-body {
       padding-top: 1px;
     }
@@ -59,7 +63,7 @@ export class UrlList extends TailwindElement {
       margin-top: -1px;
     }
 
-    .bordered btrix-table-cell:not(.url-order) {
+    .bordered btrix-table-cell {
       border-top: 1px solid transparent;
       border-bottom: 1px solid transparent;
     }
@@ -152,6 +156,15 @@ export class UrlList extends TailwindElement {
       font-family: var(--sl-font-mono);
       justify-content: end;
       padding-inline-end: var(--sl-spacing-2x-small);
+      padding-top: 1px;
+    }
+
+    .url-base {
+      margin-top: 1px;
+    }
+
+    .url-link::part(base) {
+      padding: var(--sl-spacing-2x-small);
     }
   `;
 
@@ -277,7 +290,7 @@ export class UrlList extends TailwindElement {
                           ${msg("Copy URL")}`}
                   </div>
                   <btrix-overflow-scroll
-                    class="url-control cursor-pointer"
+                    class="url-control url-base cursor-pointer"
                     hideScrollbar
                     @mousedown=${this.onUrlMouseDown}
                     @mouseup=${this.onUrlMouseUp}
@@ -314,8 +327,8 @@ export class UrlList extends TailwindElement {
                         exclude && "url-exclude",
                       )}
                       class=${clsx(
-                        tw`block part-[base]:text-sky-800`,
-                        this.noWrap ? tw`w-max` : tw`break-all`,
+                        tw`part-[base]:text-sky-800`,
+                        this.noWrap ? tw`block w-max` : tw`break-all`,
                       )}
                       language=${ifDefined(this.highlight ? "url" : undefined)}
                       .value=${url}
@@ -331,7 +344,7 @@ export class UrlList extends TailwindElement {
                 <div>
                   <sl-tooltip content=${msg("Open in New Tab")} hoist>
                     <sl-icon-button
-                      class="url-control part-[base]:p-1.5"
+                      class="url-control url-link"
                       name="arrow-up-right"
                       href="${url}"
                       target="_blank"

--- a/frontend/src/features/crawls/url-list.ts
+++ b/frontend/src/features/crawls/url-list.ts
@@ -183,6 +183,12 @@ export class UrlList extends TailwindElement {
   animateChange = false;
 
   /**
+   * Scroll URLs instead of wrapping with `break-all`
+   */
+  @property({ type: Boolean, noAccessor: true })
+  noWrap = false;
+
+  /**
    * Offset ordered list
    */
   @property({ type: Number })
@@ -299,10 +305,13 @@ export class UrlList extends TailwindElement {
                         match && "url-match",
                         exclude && "url-exclude",
                       )}
-                      class="block w-max part-[base]:text-sky-800"
+                      class=${clsx(
+                        tw`block part-[base]:text-sky-800`,
+                        this.noWrap ? tw`w-max` : tw`break-all`,
+                      )}
                       language=${ifDefined(this.highlight ? "url" : undefined)}
                       .value=${url}
-                      noWrap
+                      ?noWrap=${this.noWrap}
                       tabindex="0"
                       @keydown=${(e: KeyboardEvent) =>
                         e.key === "Enter" &&

--- a/frontend/src/features/crawls/url-list.ts
+++ b/frontend/src/features/crawls/url-list.ts
@@ -189,6 +189,12 @@ export class UrlList extends TailwindElement {
   noWrap = false;
 
   /**
+   * Size of rows and text
+   */
+  @property({ type: String, noAccessor: true })
+  size: "small" | "medium" | "large" = "medium";
+
+  /**
    * Offset ordered list
    */
   @property({ type: Number })
@@ -218,7 +224,9 @@ export class UrlList extends TailwindElement {
 
     return html`<btrix-table
       class=${clsx(
-        tw`text-[0.8125rem]`,
+        this.size === "small"
+          ? tw`text-xs`
+          : this.size === "medium" && tw`text-[0.8125rem]`, // 13px
         this.ordered
           ? tw`grid-cols-[min-content_1fr_auto]`
           : tw`grid-cols-[1fr_auto]`,

--- a/frontend/src/stories/features/crawls/UrlList.stories.ts
+++ b/frontend/src/stories/features/crawls/UrlList.stories.ts
@@ -60,6 +60,20 @@ export const NoWrap: Story = {
   },
 };
 
+export const Small: Story = {
+  args: {
+    ...WithManyUrls.args,
+    size: "small",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    ...WithManyUrls.args,
+    size: "large",
+  },
+};
+
 export const Highlighted: Story = {
   args: {
     ...WithManyUrls.args,

--- a/frontend/src/stories/features/crawls/UrlList.stories.ts
+++ b/frontend/src/stories/features/crawls/UrlList.stories.ts
@@ -53,6 +53,13 @@ export const WithManyUrls: Story = {
   },
 };
 
+export const NoWrap: Story = {
+  args: {
+    ...WithManyUrls.args,
+    noWrap: true,
+  },
+};
+
 export const Highlighted: Story = {
   args: {
     ...WithManyUrls.args,

--- a/frontend/src/stories/features/crawls/UrlList.ts
+++ b/frontend/src/stories/features/crawls/UrlList.ts
@@ -15,6 +15,7 @@ export const renderComponent = (props: Partial<RenderProps>) => {
     ?highlight=${props.highlight}
     ?border=${props.border}
     ?ordered=${props.ordered}
+    ?noWrap=${props.noWrap}
     .includeUrl=${props.includeUrl}
     .excludeUrl=${props.excludeUrl}
   ></btrix-url-list>`;

--- a/frontend/src/stories/features/crawls/UrlList.ts
+++ b/frontend/src/stories/features/crawls/UrlList.ts
@@ -12,6 +12,7 @@ export const renderComponent = (props: Partial<RenderProps>) => {
     class=${ifDefined(props.classes)}
     .urls=${props.urls || []}
     offset=${ifDefined(props.offset)}
+    size=${ifDefined(props.size)}
     ?highlight=${props.highlight}
     ?border=${props.border}
     ?ordered=${props.ordered}


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/issues/3525

## Changes

- Wraps URLs in crawl queue
- Makes crawl queue text smaller


## Screenshots

<img width="610" height="401" alt="Screenshot 2026-08-03 at 10 56 59 AM" src="https://github.com/user-attachments/assets/132fd6cb-7800-48e8-8750-82cbe0b62140" />

