### PR TITLE
fix: Fix crawl queue exclusions syncing

### DIFF
--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -24,6 +24,7 @@ export type ResponseData = {
 };
 
 const POLL_INTERVAL_SECONDS = 5;
+const PAGE_SIZE = 50;
 
 /**
  * Show real-time crawl queue results
@@ -237,6 +238,8 @@ export class CrawlQueue extends BtrixElement {
       `;
     }
 
+    const number_of_pages = this.localize.number(PAGE_SIZE);
+
     return html`
       <btrix-url-list
         class=${clsx(
@@ -264,12 +267,8 @@ export class CrawlQueue extends BtrixElement {
             </div>`,
           () => html`
             <btrix-observable @btrix-intersect=${this.onLoadMoreIntersect}>
-              <div class="py-3">
-                <sl-icon-button
-                  name="three-dots"
-                  @click=${this.loadMore}
-                  label=${msg("Load more")}
-                ></sl-icon-button>
+              <div class="py-3 text-xs text-neutral-500">
+                ${msg(str`Loading ${number_of_pages} more...`)}
               </div>
             </btrix-observable>
           `,
@@ -300,7 +299,7 @@ export class CrawlQueue extends BtrixElement {
   }) as (e: CustomEvent) => void;
 
   private loadMore() {
-    this.pageSize = this.pageSize + 50;
+    this.pageSize = this.pageSize + PAGE_SIZE;
   }
 
   private readonly isIncluded = (url: string) => {

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -60,6 +60,12 @@ export class CrawlQueue extends BtrixElement {
   @property({ type: Boolean })
   starting?: Boolean;
 
+  /**
+   * Prevent polling
+   */
+  @property({ type: Boolean })
+  noPoll = false;
+
   @state()
   private exclusionsRx: RegExp[] = [];
 
@@ -81,7 +87,7 @@ export class CrawlQueue extends BtrixElement {
     task: async ([crawlId, regex, pageSize, pageOffset], { signal }) => {
       if (!crawlId) return;
 
-      window.clearTimeout(this.pollTask.value);
+      this.stopPoll();
 
       try {
         return this.getQueue({ crawlId, regex, pageSize, pageOffset }, signal);
@@ -108,20 +114,32 @@ export class CrawlQueue extends BtrixElement {
   });
 
   private readonly pollTask = new Task(this, {
-    task: async ([queue]) => {
+    task: async ([queue, noPoll]) => {
       if (!queue) return;
 
-      window.clearTimeout(this.pollTask.value);
+      this.stopPoll();
+
+      if (noPoll) {
+        console.debug("poll prevented");
+        return;
+      }
 
       return window.setTimeout(() => {
         void this.queueTask.run();
       }, POLL_INTERVAL_SECONDS * 1000);
     },
-    args: () => [this.queueTask.value] as const,
+    args: () => [this.queueTask.value, this.noPoll] as const,
   });
 
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.get("noPoll") && !this.noPoll) {
+      // Restart poll
+      void this.queueTask.run();
+    }
+  }
+
   disconnectedCallback() {
-    window.clearTimeout(this.pollTask.value);
+    this.stopPoll();
     super.disconnectedCallback();
   }
 
@@ -129,6 +147,10 @@ export class CrawlQueue extends BtrixElement {
     if (changedProperties.has("exclusions")) {
       this.exclusionsRx = this.exclusions.map((x) => new RegExp(x));
     }
+  }
+
+  private stopPoll() {
+    window.clearTimeout(this.pollTask.value);
   }
 
   render() {

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -192,8 +192,7 @@ export class CrawlQueue extends BtrixElement {
         )}
         .urls=${this.queue.results}
         offset=${this.pageOffset + 1}
-        .includeUrl=${(url: string) =>
-          this.queue?.matched.some((v) => v === url) || false}
+        .includeUrl=${this.isIncluded}
         .excludeUrl=${this.isExcluded}
         aria-live="polite"
         size="small"
@@ -284,6 +283,10 @@ export class CrawlQueue extends BtrixElement {
       });
     }
   }
+
+  private readonly isIncluded = (url: string) => {
+    return this.queue?.matched.some((v) => v === url) || false;
+  };
 
   private readonly isExcluded = (url: string) => {
     for (const rx of this.exclusionsRx) {

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -1,4 +1,5 @@
 import { localized, msg, str } from "@lit/localize";
+import { Task, TaskStatus } from "@lit/task";
 import type {
   SlChangeEvent,
   SlInput,
@@ -12,6 +13,7 @@ import throttle from "lodash/fp/throttle";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { IntersectEvent } from "@/controllers/observable";
+import { isApiError } from "@/utils/api";
 import { tw } from "@/utils/tailwind";
 
 type Pages = string[];
@@ -62,40 +64,70 @@ export class CrawlQueue extends BtrixElement {
   private exclusionsRx: RegExp[] = [];
 
   @state()
-  private queue?: ResponseData;
-
-  @state()
-  private isLoading = false;
-
-  @state()
   private pageOffset = 0;
 
   @state()
   private pageSize = 50;
 
-  private timerId?: number;
+  private get isLoading() {
+    return this.queueTask.status === TaskStatus.PENDING;
+  }
+
+  private get queue() {
+    return this.queueTask.value;
+  }
+
+  private readonly queueTask = new Task(this, {
+    task: async ([crawlId, regex, pageSize, pageOffset], { signal }) => {
+      if (!crawlId) return;
+
+      window.clearTimeout(this.pollTask.value);
+
+      try {
+        return this.getQueue({ crawlId, regex, pageSize, pageOffset }, signal);
+      } catch (err) {
+        if (
+          isApiError(err) &&
+          (err.message === "invalid_regex" ||
+            err.message === "crawl_not_running")
+        ) {
+          // TODO Handle error
+          console.error(err);
+        }
+
+        this.notify.toast({
+          message: msg("Sorry, couldn't fetch page queue at this time."),
+          variant: "danger",
+          icon: "exclamation-octagon",
+          id: "crawl-queue-status",
+        });
+      }
+    },
+    args: () =>
+      [this.crawlId, this.regex, this.pageSize, this.pageOffset] as const,
+  });
+
+  private readonly pollTask = new Task(this, {
+    task: async ([queue]) => {
+      if (!queue) return;
+
+      window.clearTimeout(this.pollTask.value);
+
+      return window.setTimeout(() => {
+        void this.queueTask.run();
+      }, POLL_INTERVAL_SECONDS * 1000);
+    },
+    args: () => [this.queueTask.value] as const,
+  });
 
   disconnectedCallback() {
-    window.clearInterval(this.timerId);
+    window.clearTimeout(this.pollTask.value);
     super.disconnectedCallback();
   }
 
   protected updated(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("exclusions")) {
       this.exclusionsRx = this.exclusions.map((x) => new RegExp(x));
-    }
-  }
-
-  willUpdate(changedProperties: PropertyValues<this> & Map<string, unknown>) {
-    if (
-      changedProperties.has("crawlId") ||
-      changedProperties.has("pageSize") ||
-      changedProperties.has("regex") ||
-      (changedProperties.has("pageOffset") &&
-        // Prevents double-fetch when offset is programmatically changed according to queue total
-        !changedProperties.has("queue"))
-    ) {
-      void this.fetchOnUpdate();
     }
   }
 
@@ -250,40 +282,6 @@ export class CrawlQueue extends BtrixElement {
     this.pageSize = this.pageSize + 50;
   }
 
-  private async fetchOnUpdate() {
-    window.clearInterval(this.timerId);
-    await this.performUpdate;
-    this.isLoading = true;
-    await this.fetchQueue();
-    this.isLoading = false;
-  }
-
-  private async fetchQueue() {
-    try {
-      this.queue = await this.getQueue();
-      this.timerId = window.setTimeout(() => {
-        void this.fetchQueue();
-      }, POLL_INTERVAL_SECONDS * 1000);
-    } catch (e) {
-      const errorMessage = (e as Error).message;
-
-      if (
-        errorMessage === "invalid_regex" ||
-        errorMessage === "crawl_not_running"
-      ) {
-        console.debug(errorMessage);
-        return;
-      }
-
-      this.notify.toast({
-        message: msg("Sorry, couldn't fetch page queue at this time."),
-        variant: "danger",
-        icon: "exclamation-octagon",
-        id: "crawl-queue-status",
-      });
-    }
-  }
-
   private readonly isIncluded = (url: string) => {
     return this.queue?.matched.some((v) => v === url) || false;
   };
@@ -298,16 +296,29 @@ export class CrawlQueue extends BtrixElement {
     return false;
   };
 
-  private async getQueue(): Promise<ResponseData> {
-    const count = this.pageSize.toString();
-    const regex = this.regex;
+  private async getQueue(
+    {
+      crawlId,
+      regex,
+      pageSize,
+      pageOffset,
+    }: {
+      crawlId: string;
+      regex: CrawlQueue["regex"];
+      pageSize: CrawlQueue["pageSize"];
+      pageOffset: CrawlQueue["pageOffset"];
+    },
+    signal: AbortSignal,
+  ): Promise<ResponseData> {
+    const count = pageSize.toString();
     const params = new URLSearchParams({
-      offset: this.pageOffset.toString(),
+      offset: pageOffset.toString(),
       count,
       regex,
     });
     const data: ResponseData = await this.api.fetch(
-      `/orgs/${this.orgId}/crawls/${this.crawlId}/queue?${params.toString()}`,
+      `/orgs/${this.orgId}/crawls/${crawlId}/queue?${params.toString()}`,
+      { signal },
     );
 
     return data;

--- a/frontend/src/features/archived-items/crawl-queue.ts
+++ b/frontend/src/features/archived-items/crawl-queue.ts
@@ -253,7 +253,6 @@ export class CrawlQueue extends BtrixElement {
         ordered
         border
         highlight
-        animateChange
       ></btrix-url-list>
 
       <footer class="text-center">

--- a/frontend/src/features/crawl-workflows/exclusion-editor.ts
+++ b/frontend/src/features/crawl-workflows/exclusion-editor.ts
@@ -213,8 +213,6 @@ export class ExclusionEditor extends BtrixElement {
 
     if (valid) {
       this.regex = value;
-    } else {
-      this.regex = "";
     }
   }
 

--- a/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
+++ b/frontend/src/features/crawl-workflows/queue-exclusion-form.ts
@@ -44,6 +44,9 @@ export class QueueExclusionForm extends LiteElement {
   @state()
   private selectValue: Exclusion["type"] = "text";
 
+  @state()
+  private inputValue = "";
+
   @property({ type: String })
   regex = "";
 
@@ -57,17 +60,11 @@ export class QueueExclusionForm extends LiteElement {
     changedProperties: PropertyValues<this> & Map<string, unknown>,
   ) {
     if (changedProperties.get("regex") && this.regex === "") {
-      if (this.input) {
-        this.input.value = "";
-      }
+      this.inputValue = "";
+      this.checkInputValidity();
     }
 
-    if (
-      changedProperties.get("selectValue") ||
-      (changedProperties.has("regex") &&
-        changedProperties.get("regex") !== undefined)
-    ) {
-      this.fieldErrorMessage = "";
+    if (changedProperties.get("selectValue")) {
       this.checkInputValidity();
     }
   }
@@ -79,7 +76,9 @@ export class QueueExclusionForm extends LiteElement {
 
   render() {
     const invalidRegex =
-      !this.regex || this.isRegexInvalid || this.regex.length > MAX_LENGTH;
+      !this.inputValue ||
+      this.isRegexInvalid ||
+      this.inputValue.length > MAX_LENGTH;
     const minimum_number_of_characters = this.localize.number(MIN_LENGTH);
     const maximum_number_of_characters = this.localize.number(MAX_LENGTH);
 
@@ -115,6 +114,7 @@ export class QueueExclusionForm extends LiteElement {
                   ? "/skip-this-page"
                   : "example.com/skip.*"}
                 ?disabled=${this.isSubmitting}
+                value=${this.inputValue}
                 @keydown=${this.onKeyDown}
                 @sl-input=${this.onInput as UnderlyingFunction<
                   typeof this.onInput
@@ -181,7 +181,8 @@ export class QueueExclusionForm extends LiteElement {
   }
 
   private readonly onInput = debounce(200)(() => {
-    this.regex = this.input?.value || "";
+    this.inputValue = this.input?.value.trim() || "";
+    this.checkInputValidity();
     void this.dispatchChangeEvent();
   });
 
@@ -197,14 +198,16 @@ export class QueueExclusionForm extends LiteElement {
   };
 
   private checkInputValidity(): void {
+    this.fieldErrorMessage = "";
+
     let isValid = true;
 
-    if (!this.regex || this.regex.length < MIN_LENGTH) {
+    if (!this.inputValue || this.inputValue.length < MIN_LENGTH) {
       isValid = false;
     } else if (this.selectValue === "regex") {
       try {
         // Check if valid regex
-        new RegExp(this.regex);
+        new RegExp(this.inputValue);
       } catch (err) {
         this.fieldErrorMessage = (err as Error).message;
         isValid = false;
@@ -217,29 +220,31 @@ export class QueueExclusionForm extends LiteElement {
   private async dispatchChangeEvent() {
     await this.updateComplete;
     this.dispatchEvent(
-      new CustomEvent("btrix-change", {
+      new CustomEvent<ExclusionChangeEvent["detail"]>("btrix-change", {
         detail: {
           value:
-            this.selectValue === "text" ? regexEscape(this.regex) : this.regex,
+            this.selectValue === "text"
+              ? regexEscape(this.inputValue)
+              : this.inputValue,
           valid: !this.isRegexInvalid,
         },
-      }) as ExclusionChangeEvent,
+      }),
     );
   }
 
   private async handleAdd() {
     this.onInput.flush();
     await this.updateComplete;
-    if (!this.regex || this.isRegexInvalid) return;
+    if (!this.inputValue || this.isRegexInvalid) return;
 
-    let regex = this.regex;
+    let value = this.inputValue;
     if (this.selectValue === "text") {
-      regex = regexEscape(this.regex);
+      value = regexEscape(this.inputValue);
     }
 
     this.dispatchEvent(
       new CustomEvent<ExclusionAddEvent["detail"]>("btrix-add", {
-        detail: { regex },
+        detail: { regex: value },
       }),
     );
   }

--- a/frontend/src/features/crawls/url-list.ts
+++ b/frontend/src/features/crawls/url-list.ts
@@ -11,7 +11,6 @@ import { TailwindElement } from "@/classes/TailwindElement";
 import type { FloatingPopover } from "@/components/ui/floating-popover";
 import { ClipboardController } from "@/controllers/clipboard";
 import type { Seed } from "@/types/crawler";
-import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 /**
@@ -168,7 +167,7 @@ export class UrlList extends TailwindElement {
     }
   `;
 
-  @property({ type: Array, hasChanged: isNotEqual })
+  @property({ type: Array })
   urls?: (string | Seed)[] = [];
 
   /**

--- a/frontend/src/features/crawls/url-list.ts
+++ b/frontend/src/features/crawls/url-list.ts
@@ -190,6 +190,8 @@ export class UrlList extends TailwindElement {
 
   /**
    * Animate changes to the list
+   *
+   * @NOTE May cause performance issues in Chrome, needs investigation
    */
   @property({ type: Boolean, noAccessor: true })
   animateChange = false;

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1927,6 +1927,8 @@ export class WorkflowDetail extends BtrixElement {
       this.workflow &&
       isActivelyCrawling(this.workflow) &&
       !this.isCancelingRun;
+    const openExclusionsDialog =
+      this.editDialog.value === EditDialogValues.Exclusions;
 
     return html`
       <header class="flex items-center justify-between">
@@ -1954,6 +1956,7 @@ export class WorkflowDetail extends BtrixElement {
           <btrix-crawl-queue
             .crawlId=${this.lastCrawlId ?? undefined}
             ?starting=${this.workflow?.lastCrawlState === "starting"}
+            ?noPoll=${openExclusionsDialog}
           ></btrix-crawl-queue>
         `,
       )}
@@ -1967,7 +1970,7 @@ export class WorkflowDetail extends BtrixElement {
               stopping: this.workflow.lastCrawlStopping,
             })
           : false}
-        ?open=${this.editDialog.value === EditDialogValues.Exclusions}
+        ?open=${openExclusionsDialog}
         @sl-hide=${(e: CustomEvent) => {
           e.stopPropagation();
           this.closeEditDialog();

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1929,6 +1929,7 @@ export class WorkflowDetail extends BtrixElement {
       !this.isCancelingRun;
     const openExclusionsDialog =
       this.editDialog.value === EditDialogValues.Exclusions;
+    const exclusionRules = this.workflow?.config.exclude;
 
     return html`
       <header class="flex items-center justify-between">
@@ -1955,6 +1956,7 @@ export class WorkflowDetail extends BtrixElement {
         () => html`
           <btrix-crawl-queue
             .crawlId=${this.lastCrawlId ?? undefined}
+            .exclusions=${exclusionRules || []}
             ?starting=${this.workflow?.lastCrawlState === "starting"}
             ?noPoll=${openExclusionsDialog}
           ></btrix-crawl-queue>
@@ -1963,7 +1965,7 @@ export class WorkflowDetail extends BtrixElement {
 
       <btrix-exclusion-editor-dialog
         crawlId=${ifDefined(this.lastCrawlId || undefined)}
-        .exclusions=${this.workflow?.config.exclude}
+        .exclusions=${exclusionRules}
         ?activeCrawl=${this.workflow?.lastCrawlState
           ? isActive({
               state: this.workflow.lastCrawlState,


### PR DESCRIPTION
## Changes

- Fixes exclusion values being double escaped
- Fixes exclusion highlighting not updating
- Improves performance of crawl queue polling
- Pauses crawl queue when exclusion editor is open