### PR TITLE
rate limit follow-ups and fixes (follow-up to #3257):

### DIFF
--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -909,6 +909,13 @@ class CrawlOps(BaseCrawlOps):
 
         raise HTTPException(status_code=404, detail="crawl_not_found")
 
+    async def mark_rate_limited(self, crawl_id: str, oid: UUID, dt: datetime | None):
+        """mark crawl as rate limited"""
+        await self.crawls.find_one_and_update(
+            {"_id": crawl_id, "type": "crawl", "oid": oid},
+            {"$set": {"rateLimitedAt": dt}},
+        )
+
     async def shutdown_crawl(
         self, crawl_id: str, org: Organization, graceful: bool
     ) -> dict[str, bool]:

--- a/backend/btrixcloud/crawls.py
+++ b/backend/btrixcloud/crawls.py
@@ -909,8 +909,8 @@ class CrawlOps(BaseCrawlOps):
 
         raise HTTPException(status_code=404, detail="crawl_not_found")
 
-    async def mark_rate_limited(self, crawl_id: str, oid: UUID, dt: datetime | None):
-        """mark crawl as rate limited"""
+    async def set_rate_limited_at(self, crawl_id: str, oid: UUID, dt: datetime | None):
+        """mark crawl as rate limited or not rate limited by setting/unsetting rateLimitedAt"""
         await self.crawls.find_one_and_update(
             {"_id": crawl_id, "type": "crawl", "oid": oid},
             {"$set": {"rateLimitedAt": dt}},

--- a/backend/btrixcloud/main.py
+++ b/backend/btrixcloud/main.py
@@ -131,6 +131,7 @@ class SettingsResponse(BaseModel):
     localesEnabled: list[str] | None
 
     pausedExpiryMinutes: int
+    rateLimitDurationMinutes: int
 
 
 # ============================================================================
@@ -171,6 +172,9 @@ def main() -> None:
             else None
         ),
         pausedExpiryMinutes=int(os.environ.get("PAUSED_CRAWL_LIMIT_MINUTES", 10080)),
+        rateLimitDurationMinutes=int(
+            os.environ.get("RATE_LIMIT_DURATION_MINUTES", 720)
+        ),
     )
 
     invites = init_invites(mdb, email)

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1185,6 +1185,9 @@ class Crawl(BaseCrawl, CrawlConfigCore):
 
     stopping: bool | None = False
     shouldPause: bool | None = False
+    pausedAt: datetime | None = None
+
+    rateLimitedAt: datetime | None = None
 
     qaCrawlExecSeconds: int = 0
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1013,6 +1013,7 @@ class CrawlOut(BaseMongoModel):
     stopping: bool | None = False
     shouldPause: bool | None = False
     pausedAt: datetime | None = None
+    rateLimitedAt: datetime | None = None
     manual: bool = False
     cid_rev: int | None = None
     scale: Annotated[Scale | None, Field(deprecated=True)] = None

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -327,9 +327,10 @@ class CrawlOperator(BaseOperator):
         if (
             status.rateLimitedAtTime
             and status.state != "rate-limited"
-            and (is_paused or (status.state in RUNNING_STATES))
+            and (is_paused or status.state == "running")
         ):
             status.rateLimitedAtTime = ""
+            await self.crawl_ops.mark_rate_limited(crawl.id, crawl.oid, None)
 
         # setup scale
         status.scale = len(pods)
@@ -1009,6 +1010,22 @@ class CrawlOperator(BaseOperator):
             status.canceled = True
 
         return status.canceled
+
+    async def rate_limit_crawl(self, crawl: CrawlSpec, status: CrawlStatus):
+        """mark crawl as rate limited"""
+        if not status.rateLimitedAtTime:
+            now = dt_now()
+            await self.crawl_ops.mark_rate_limited(crawl.id, crawl.oid, now)
+            status.rateLimitedAtTime = date_to_str(now)
+
+        await self.set_state(
+            "rate-limited",
+            status,
+            crawl,
+            allowed_from=RUNNING_AND_WAITING_STATES,
+        )
+        status.resync_after = self.fast_retry_secs
+        return status
 
     async def fail_crawl(
         self,
@@ -1944,17 +1961,7 @@ class CrawlOperator(BaseOperator):
         # if all crashed and last exit was rate-limit exit code (18),
         # set to rate limited state now and return
         if status.allCrashed and status.lastCrawlPodExitCode == ExitCodes.RATE_LIMITED:
-            if not status.rateLimitedAtTime:
-                status.rateLimitedAtTime = date_to_str(dt_now())
-
-            await self.set_state(
-                "rate-limited",
-                status,
-                crawl,
-                allowed_from=RUNNING_STATES,
-            )
-            status.resync_after = self.fast_retry_secs
-            return status
+            return await self.rate_limit_crawl(crawl, status)
 
         # mark crawl as pausing or stopping
         if status.stopping:
@@ -2066,18 +2073,19 @@ class CrawlOperator(BaseOperator):
 
         # check for other statuses, default to "running"
         else:
-            new_status: TYPE_RUNNING_STATES = "running"
+            new_status: TYPE_RUNNING_STATES = (
+                "running" if not stats.rate_limited else "rate-limited"
+            )
 
-            if stats.rate_limited:
-                new_status = "rate-limited"
-                if not status.rateLimitedAtTime:
-                    status.rateLimitedAtTime = date_to_str(dt_now())
             if status_count.get("generate-wacz"):
                 new_status = "generate-wacz"
             elif status_count.get("uploading-wacz"):
                 new_status = "uploading-wacz"
             elif status_count.get("pending-wait"):
                 new_status = "pending-wait"
+
+            if new_status == "rate-limited":
+                return await self.rate_limit_crawl(crawl, status)
 
             await self.set_state(
                 new_status, status, crawl, allowed_from=RUNNING_AND_WAITING_STATES

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -330,7 +330,7 @@ class CrawlOperator(BaseOperator):
             and (is_paused or status.state == "running")
         ):
             status.rateLimitedAtTime = ""
-            await self.crawl_ops.mark_rate_limited(crawl.id, crawl.oid, None)
+            await self.crawl_ops.set_rate_limited_at(crawl.id, crawl.oid, None)
 
         # setup scale
         status.scale = len(pods)
@@ -1013,17 +1013,20 @@ class CrawlOperator(BaseOperator):
 
     async def rate_limit_crawl(self, crawl: CrawlSpec, status: CrawlStatus):
         """mark crawl as rate limited"""
-        if not status.rateLimitedAtTime:
-            now = dt_now()
-            await self.crawl_ops.mark_rate_limited(crawl.id, crawl.oid, now)
-            status.rateLimitedAtTime = date_to_str(now)
-
-        await self.set_state(
+        # ensure rate-limited state is actually set, return otherwise, just in case
+        if not await self.set_state(
             "rate-limited",
             status,
             crawl,
             allowed_from=RUNNING_AND_WAITING_STATES,
-        )
+        ):
+            return status
+
+        if not status.rateLimitedAtTime:
+            now = dt_now()
+            status.rateLimitedAtTime = date_to_str(now)
+            await self.crawl_ops.set_rate_limited_at(crawl.id, crawl.oid, now)
+
         status.resync_after = self.fast_retry_secs
         return status
 

--- a/backend/test/test_api.py
+++ b/backend/test/test_api.py
@@ -52,4 +52,5 @@ def test_api_settings():
         "supportEmail": "",
         "localesEnabled": None,
         "pausedExpiryMinutes": 10080,
+        "rateLimitDurationMinutes": 720
     }


### PR DESCRIPTION
- db: add rateLimitedAt for crawl object and rateLimitDurationMinutes for global settings to allow showing when a crawl was rate-limited and when it will be paused to support #3483
- ensure rate-limited state only cleared if crawl is 'running' or paused, not one of other running states, such as generating/uploading/pending since those can occur while still rate-limited
- add rate_limit_crawl() function to consistently set to rate-limited and updated rateLimitedAt time in db, allow setting to rate-limited from any running or waiting states