### PR TITLE
Security: Unsafe JSON Parsing via String Replacement in Echo Server

### DIFF
--- a/backend/test_nightly/echo_server.py
+++ b/backend/test_nightly/echo_server.py
@@ -33,7 +33,7 @@ class EchoServerHTTPRequestHandler(BaseHTTPRequestHandler):
         else:
             self.end_headers()
 
-        post_bodies.append(json.loads(body.decode("utf-8").replace("'", '"')))
+        post_bodies.append(json.loads(body.decode("utf-8")))
 
 
 httpd = HTTPServer((BIND_HOST, PORT), EchoServerHTTPRequestHandler)


### PR DESCRIPTION
## Summary

Security: Unsafe JSON Parsing via String Replacement in Echo Server

## Problem

**Severity**: `Medium` | **File**: `backend/test_nightly/echo_server.py:L39`

The echo server attempts to parse POST bodies using `json.loads(body.decode('utf-8').replace("'", '"'))`. Replacing single quotes with double quotes is a naive approach to handle single-quoted strings, but it will corrupt valid JSON payloads that contain apostrophes (e.g., `{"message": "it's a test"}` becomes `{"message": "it"s a test"}`). This can lead to JSONDecodeError exceptions or data corruption. If this server is used to validate webhook callbacks, this flaw could cause valid callbacks to fail or be misinterpreted.

## Solution

Remove the `.replace("'", '"')` logic and rely on standard `json.loads()` which strictly expects double quotes. If the client sending the data cannot be changed to produce valid JSON, use `ast.literal_eval()` to safely parse Python dictionary literals instead of performing fragile string replacements.

## Changes

- `backend/test_nightly/echo_server.py` (modified)