### PR TITLE
docs: Update collection user guides

### DIFF
--- a/frontend/docs/docs/overrides/.icons/bootstrap/box-arrow-up.svg
+++ b/frontend/docs/docs/overrides/.icons/bootstrap/box-arrow-up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M3.5 6a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5h-2a.5.5 0 0 1 0-1h2A1.5 1.5 0 0 1 14 6.5v8a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 14.5v-8A1.5 1.5 0 0 1 3.5 5h2a.5.5 0 0 1 0 1z"/>
+  <path fill-rule="evenodd" d="M7.646.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 1.707V10.5a.5.5 0 0 1-1 0V1.707L5.354 3.854a.5.5 0 1 1-.708-.708z"/>
+</svg>

--- a/frontend/docs/docs/user-guide/collection.md
+++ b/frontend/docs/docs/user-guide/collection.md
@@ -16,11 +16,9 @@ The summary is a short description that summarizes this collection. If the colle
 
 In most cases, you will want to keep the default _Private_ visibility setting until items are added to your collection. If you do change this setting, the empty collection will be [shareable](#collection-access) upon creation.
 
-## Customize the Collection
+## Configure the Collection
 
 ### Add Archived Items
-
-Collections are the primary way of organizing and combining archived items into groups for presentation.
 
 Choose _Configure Items_ from the collection's actions menu to select crawled and uploaded items to add to a collection.
 
@@ -64,10 +62,14 @@ Collections can be set to one of the one following access modes:
 - **Unlisted** — Collection can be shared with others, given the link to the collection.
 - **Public** — Collection can be shared with others and is listed in the [public collections gallery](org-settings.md#public-collections-gallery).
 
-The [Presentation and Sharing](./presentation-sharing.md) guide provides further details for options on how to present and share collections.
+The [Presentation & Sharing](./presentation-sharing.md) guide provides further details for options on how to present and share collections.
 
 ## Deduplicate Content
 
 Deduplication (or “dedupe”) is the process of preventing duplicate content from being stored. When deduplication is enabled, the crawler will reference a collection’s existing items when checking for new content and URLs. Content that is identical, even when found at a different URL, will be deduplicated by writing "revisit" records rather than the full resource in the resulting crawl WACZ files. This results in a smaller, space-saving collection and smaller archived items.
 
 The [Deduplication](./deduplication.md) page goes into further detail on how deduplication works in Browsertrix, some of the tradeoffs and considerations for replay and download to keep in mind, and how to create and manage the deduplication index for a collection.
+
+## Remove a Collection
+
+To permanently remove a collection from your org, choose _Delete Collection_ from the collection _Actions_ menu. Deleting a collection will not delete any archived items.

--- a/frontend/docs/docs/user-guide/collection.md
+++ b/frontend/docs/docs/user-guide/collection.md
@@ -4,36 +4,53 @@ A collection is a specific, user-directed grouping of either crawls or uploaded 
 
 ## Create a Collection
 
-You can create a collection from the Collections page directly, or the  _Create New..._ shortcut from the org dashboard.
+You can create a collection from the **Collections** page directly, or the  _Create New..._ shortcut from the org dashboard.
 
 ### Name and Summary
 
-Choose a collection name that identifies your collection within the org. The name can contain letters, numbers, and special characters (like emojis.) The collection name should include at least one letter.
+Choose a collection name that identifies your collection within the org. The name can contain letters, numbers, and special characters (like emojis). The collection name should include at least one letter.
 
-The summary is a short description that summarizes this collection. If the collection is shareable, this will appear next to the collection name. You can add a longer description in the “About” section after creating the collection.
+The summary is a short description that summarizes this collection. If the collection is shareable, this will appear next to the collection name. You can add a longer description in the **About** section after creating the collection.
 
-### Add Collection Content
+### Visibility
 
-Collections are the primary way of organizing and combining archived items into groups for presentation. Collections also allow you to view a combined replay of any archived items they contain; if a link is present when viewing a collection but the actual page is missing, and another item with that captured page is added to the collection, the link will now work as expected.
+In most cases, you will want to keep the default _Private_ visibility setting until items are added to your collection. If you do change this setting, the empty collection will be [shareable](#collection-access) upon creation.
+
+## Customize the Collection
+
+### Add Archived Items
+
+Collections are the primary way of organizing and combining archived items into groups for presentation.
+
+Choose _Configure Items_ from the collection's actions menu to select crawled and uploaded items to add to a collection.
+
+A crawl workflow can also be set to [automatically add crawled items to a collection](workflow-setup.md#auto-add-to-collection).
+
+### Add a Description
+
+Whereas the collection summary can help describe the collection at a glance, the long-form description lets you add details that can help contextualize the collection and its contents.
+
+To write a description, select _Add Description_ from the **About** tab or choose _Edit Description_ from the _Actions_ menu. Description scan be written in plain text or [GitHub-style Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+
+If the collection is shareable, the description will be made public in **About This Collection**.
+
+### Add a Thumbnail
+
+The collection thumbnail represents the content of the collection by using a page screenshot. To choose a page screenshot, select the :bootstrap-pencil: button attached to the collection thumbnail to view compatible page screenshots.
+
+## Browse Collection
+
+The **Browse Collection** section of a collection allows you to view a combined replay of all archived items in the collection. The combined replay highlights another key feature of collections: the ability to “patch”, or fix, an archived item that contains links to missing pages. Add a crawled item with just the missing pages to the same collection and the link will now work as expected.
 
 !!! tip "Tip: Patching a crawl with interactive archiving"
     If the crawler has not captured every resource or interaction on a webpage, our [ArchiveWeb.page browser extension](https://webrecorder.net/archivewebpage) can be used to interactively capture missing content using your web browser and upload it directly to your org.
 
-    After adding crawls and uploads to a collection, content from both will become available in the replay viewer.
+To update the initial view of the **Browse Collection** tab, select _Set Homepage_ and choose an option:
 
-Crawls and uploads can be added to a collection after creation by selecting _Select Archived Items_ from the collection's actions menu.
+- **Current Page** — The page that is open in the replay view.
+- **Page List** — A list of all primary pages.
 
-A crawl workflow can also be set to [automatically add any completed crawls to a collection](workflow-setup.md#auto-add-to-collection) in the workflow's settings.
-
-### Customize a Collection
-
-The [Presentation and Sharing](./presentation-sharing.md) page provides further details for options on how to present and share Collections. You can customize how your Collection appears to the public by clicking the edit button :bootstrap-pencil: in each collection to:
-
-- **Name** it and add a **description** — include emojis if that’s your style 😉
-
-- Select a **thumbnail** to represent it: Choose between a page screenshot and a placeholder
-
-- Choose the **initial view** for your Collection
+If the _Current Page_ option is chosen, the collection thumbnail will automatically be updated to a screenshot of that page.
 
 ## Download a Collection
 
@@ -41,14 +58,13 @@ Downloading a collection will export every archived item in it as a single WACZ 
 
 ## Collection Access
 
-Collections can be set to one of the one following access modes.
+Collections can be set to one of the one following access modes:
 
-- Private — Collections only accessible to logged in users
-- Unlisted — Collections can be shared with others, given the link to the collection.
-- Public — Collections can be shared with others, and when enabled, collections can also be listed in the [public collections gallery](org-settings.md#public-collections-gallery).
+- **Private** — Collection is only accessible to logged-in users in the same organization.
+- **Unlisted** — Collection can be shared with others, given the link to the collection.
+- **Public** — Collection can be shared with others and is listed in the [public collections gallery](org-settings.md#public-collections-gallery).
 
-!!! tip "Note: About Public Collections Gallery"
-    If the public collections gallery page is not enabled, any existing public collections are treated the same as unlisted collections. Check out [enabling public collection gallery](./public-collections-gallery.md) for a guide on how to enable this page.
+The [Presentation and Sharing](./presentation-sharing.md) guide provides further details for options on how to present and share collections.
 
 ## Deduplicate Content
 

--- a/frontend/docs/docs/user-guide/collection.md
+++ b/frontend/docs/docs/user-guide/collection.md
@@ -1,6 +1,6 @@
 # Intro to Collections
 
-A collection is a specific, user-directed grouping of either crawls or uploaded WACZ files, both [archived items](./archived-items.md). You can create a collection, add content to your collection, include a description to your collection, download your collection, and share your collection whichever way you need to others in your community.
+Collections provide a way to dynamically combine and group multiple individual crawls and uploads into a contextual, unified archive replay experience.
 
 ## Create a Collection
 
@@ -30,7 +30,7 @@ A crawl workflow can also be set to [automatically add crawled items to a collec
 
 Whereas the collection summary can help describe the collection at a glance, the long-form description lets you add details that can help contextualize the collection and its contents.
 
-To write a description, select _Add Description_ from the **About** tab or choose _Edit Description_ from the _Actions_ menu. Description scan be written in plain text or [GitHub-style Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+To write a description, select _Add Description_ from the **About** tab or choose _Edit Description_ from the _Actions_ menu. The description supports basic text formatting like headings, bold and italicized text, lists, and links.
 
 If the collection is shareable, the description will be made public in **About This Collection**.
 
@@ -60,7 +60,7 @@ Downloading a collection will export every archived item in it as a single WACZ 
 
 Collections can be set to one of the one following access modes:
 
-- **Private** — Collection is only accessible to logged-in users in the same organization.
+- **Private** — Collection is only accessible to logged-in members in the same organization.
 - **Unlisted** — Collection can be shared with others, given the link to the collection.
 - **Public** — Collection can be shared with others and is listed in the [public collections gallery](org-settings.md#public-collections-gallery).
 

--- a/frontend/docs/docs/user-guide/collection.md
+++ b/frontend/docs/docs/user-guide/collection.md
@@ -36,7 +36,7 @@ If the collection is shareable, the description will be made public in **About T
 
 ### Add a Thumbnail
 
-The collection thumbnail represents the content of the collection by using a page screenshot. To choose a page screenshot, select the :bootstrap-pencil: button attached to the collection thumbnail to view compatible page screenshots.
+The collection thumbnail represents the content of the collection by using a page screenshot. To choose a page screenshot, select the :bootstrap-pencil: button on top of the collection thumbnail to view compatible page screenshots.
 
 ## Browse Collection
 
@@ -45,10 +45,10 @@ The **Browse Collection** section of a collection allows you to view a combined 
 !!! tip "Tip: Patching a crawl with interactive archiving"
     If the crawler has not captured every resource or interaction on a webpage, our [ArchiveWeb.page browser extension](https://webrecorder.net/archivewebpage) can be used to interactively capture missing content using your web browser and upload it directly to your org.
 
-To update the initial view of the **Browse Collection** tab, select _Set Homepage_ and choose an option:
+To update the initial view of **Browse Collection**, select _Set Homepage_ and choose an option:
 
-- **Current Page** — The page that is open in the replay view.
-- **Page List** — A list of all primary pages.
+- **Current Page** — The page that is currently open in your replay view.
+- **Page List** — A list of all crawl URLs.
 
 If the _Current Page_ option is chosen, the collection thumbnail will automatically be updated to a screenshot of that page.
 

--- a/frontend/docs/docs/user-guide/org-settings.md
+++ b/frontend/docs/docs/user-guide/org-settings.md
@@ -19,6 +19,8 @@ Org name and URLs are unique to each Browsertrix instance (for example, on `app.
 
 Enable a homepage for your public collections to easily share all public collections in your org. Once enabled, anyone on the internet with a link to your org's public collections gallery will be able to browse public collections and view general information like the org name, description, and website.
 
+Refer to the full [Public Collections Gallery](public-collections-gallery.md) guide for details.
+
 ## Billing
 
 `Paid Feature`{ .badge-green }

--- a/frontend/docs/docs/user-guide/presentation-sharing.md
+++ b/frontend/docs/docs/user-guide/presentation-sharing.md
@@ -1,5 +1,7 @@
 # Presentation & Sharing
 
+To present a collection to viewers outside of your organization, you can enable a shareable link.
+
 ## Share a Collection
 
 A collection is private by default, but can be made sharable either with an unlisted link, or displayed in your org's public gallery for everyone to discover.
@@ -27,7 +29,9 @@ Once you've opened the share settings dialog from one of these three locations, 
 2. Optional: Viewers can download the collection by default. To disable downloads, toggle _Show download button_ off.
 3. Save.
 
-## Customize a Collection
+The collection will now have a _Link to Share_ that can be given to anyone, even those without a Browsertrix account.
+
+## Edit a Collection
 
 You can customize how your collection appears to the public by making edits from the collection management page. This is same page from which you configure archived items and deduplication settings.
 

--- a/frontend/docs/docs/user-guide/presentation-sharing.md
+++ b/frontend/docs/docs/user-guide/presentation-sharing.md
@@ -21,7 +21,7 @@ To access share settings from the collection management page, open the _Actions_
 
 ### Share Settings Dialog
 
-Once you've opened the share settings dialog from one of the three locations:
+Once you've opened the share settings dialog from one of these three locations, you can make the collection shareable with the following steps:
 
 1. Change the visibility to _Unlisted_ or _Public_.
 2. Optional: Viewers can download the collection by default. To disable downloads, toggle _Show download button_ off.
@@ -29,7 +29,7 @@ Once you've opened the share settings dialog from one of the three locations:
 
 ## Customize a Collection
 
-You can customize how your collection appears to the public by making edits from the collection management page, the same page from which you configure archived items and deduplication settings.
+You can customize how your collection appears to the public by making edits from the collection management page. This is same page from which you configure archived items and deduplication settings.
 
 Every aspect of the collection with a :bootstrap-pencil: icon next to it, like collection name, is editable in-place.
 
@@ -67,3 +67,7 @@ To update the initial view, select _Set Homepage_ and choose an option:
 - **Page List** — A list of all crawl URLs.
 
 If the _Current Page_ option is chosen, the collection thumbnail will automatically be updated to a screenshot of that page.
+
+## Un-share a Collection
+
+To disable the shareable link to a collection, follow the steps in [Share a Collection](#share-a-collection) but choose _Private_ for _Visibility_. Visitors to the link will no longer be able to browse, download, or view the collection.

--- a/frontend/docs/docs/user-guide/presentation-sharing.md
+++ b/frontend/docs/docs/user-guide/presentation-sharing.md
@@ -1,55 +1,47 @@
 # Presentation & Sharing
 
-<video autoplay muted playsinline loop disablepictureinpicture disableremoteplayback>
-  <source src="https://webrecorder.net/assets/video/collection-editing-av1.mp4"/>
-  <source src="https://webrecorder.net/assets/video/collection-editing-h264.mp4"/>
-</video>
-
 ## Share a Collection
 
-A Collection is private by default, but can be made sharable either with an unlisted link, or displayed in your org's public gallery for everyone to discover. Sharing settings can be found within the **Sharing** tab of the Collection.
+A collection is private by default, but can be made sharable either with an unlisted link, or displayed in your org's public gallery for everyone to discover.
 
-1. Click the edit button :bootstrap-pencil: on the specific Collection you want to share
+### From Org Dashboard
 
-2. In that Collection's **Sharing** tab, change its visibility from the default **Private** to **Public** and save
+To access share settings for a collection from **Dashboard**:
 
-3. Click on the edit button :bootstrap-pencil: again, and now in the Collection's **Sharing** tab, there will be a new section, **Link to Share**, with a URL for this specific Collection that you can share and circulate to your community
+1. Select the asterisk icon :bootstrap-asterisk: in order to see all your collections.
+2. Select the share icon :bootstrap-box-arrow-up: on the specific collection you want to share.
 
-4. Optional: If you want to allow other viewers to download the Collection, confirm that the **Show download button** is enabled. If not, toggle it so that others would not be able to download it and only view.
+### From Collections List
+
+To access share settings for a collection from **Collections**, open the action menu :bootstrap-three-dots-vertical: for the collection and choose :bootstrap-box-arrow-up: **Share Collection**.
+
+### From Collection Management Page
+
+To access share settings from the collection management page, open the _Actions_ menu and choose :bootstrap-box-arrow-up: **Share Collection**.
+
+### Share Settings Dialog
+
+Once you've opened the share settings dialog from one of the three locations:
+
+1. Change the visibility to _Unlisted_ or _Public_.
+2. Optional: Viewers can download the collection by default. To disable downloads, toggle _Show download button_ off.
+3. Save.
 
 ## Customize a Collection
 
-You can customize how your Collection appears to the public by making edits within the **Presentation** tab of Collection.
+You can customize how your collection appears to the public by making edits from the collection management page, the same page from which you configure archived items and deduplication settings.
 
-You can access this tab via the edit button :bootstrap-pencil: of a Collection from the Public Collection Gallery or via the kebab icon of a Collection from your account's Collections tab.
-
-From the Collections tab:
-
-1. Click the Collections tab from your account
-
-2. Click the kebab icon :bootstrap-three-dots-vertical: for options
-
-3. Click Edit Collection Settings
-
-4. Edit any of the following information from the **Presentation** tab: Name, Summary, Thumbnail, and set Initial View
-
-From the Public Collection Gallery. When Public Collection Gallery is enabled, you can view Collections from your dashboard. To customize the Collection:
-
-1. Click on the edit button :bootstrap-pencil: of the Collection you want to edit
-
-2. Edit any of the following information from the **Presentation** tab: Name, Summary, Thumbnail, and set Initial View
+Every aspect of the collection with a :bootstrap-pencil: icon next to it, like collection name, is editable in-place.
 
 ### Name
 
-A **Name** is always required, so by default, your Collection's name is determined by the name of your crawl workflow.
-
-You can edit the **Name** as long as its within 50 characters, which is roughly between 7 words and 13 words with spaces included in the character count.
+You can change the **Name** as long as it is within 50 characters, which is roughly between 7 words and 13 words with spaces included in the character count.
 
 ### Summary
 
-A **Summary** describing your Collection is not required, but it is useful information to others to summarize the Collection and caption collection thumbnails.
+A summary describing your collection is not required, but it is useful information to others to summarize the collection and caption collection thumbnails in the gallery.
 
-You can edit the **Summary** as long as its within 150 characters, which is roughly between 90 words and 150 words with spaces included in the character count.
+URLs in the summary will be displayed as clickable links.
 
 ### Thumbnail
 
@@ -57,15 +49,21 @@ Choose a thumbnail image to represent this collection in your org's dashboard an
 
 To choose a screenshot:
 
-1. Click the _Enter a Page URL to preview it_ for a Page URL dropdown to appear
+1. Click on the thumbnail.
+2. Select one of the page screenshots or search for a specific URL from the collection.
 
-2. Select one of the URLs or search for a specific URL from the Collection
-
-3. Optional: You can choose a specific captured URL based on its Page Timestamp.
+The collection thumbnail will be updated upon selecting a screenshot.
 
 ??? question "Why isn't there a thumbnail preview for my page?"
     If you have uploaded archived items captured with tools other than Browsertrix, some of the pages in your collection may not have screenshots available to use as thumbnails. To fix this, either re-crawl a page you wish to use as a thumbnail with Browsertrix and add it to the collection, or choose a placeholder thumbnail.
 
 ### Initial View
 
-The **Initial View** is the first view visitors see first when viewing a Collection. The initial view can either be a list of pages, which is the default when replaying using ReplayWeb.page, or a single page from your collection such as a crawl start URL or index page.
+The homepage is the first view visitors see first when browsing a collection. This initial view can either be a list of pages, which is the default when replaying using ReplayWeb.page, or a single page from your collection such as a crawl start URL or index page.
+
+To update the initial view, select _Set Homepage_ and choose an option:
+
+- **Current Page** — The page that is currently open in your replay view.
+- **Page List** — A list of all crawl URLs.
+
+If the _Current Page_ option is chosen, the collection thumbnail will automatically be updated to a screenshot of that page.

--- a/frontend/docs/docs/user-guide/public-collections-gallery.md
+++ b/frontend/docs/docs/user-guide/public-collections-gallery.md
@@ -1,27 +1,20 @@
 # Public Collections Gallery
 
-Collections provide a way to dynamically combine and group multiple individual crawls and uploads into a contextual, unified archive replay experience.
-
-With Public Collections Gallery, you can create a dedicated page that showcases all public Collections in one place, allowing you to personalize, curate, and share your web archives with the world!
-
-<video autoplay muted playsinline loop disablepictureinpicture disableremoteplayback>
-  <source src="https://webrecorder.net/assets/video/collections-full-walkthrough-av1.mp4"/>
-  <source src="https://webrecorder.net/assets/video/collections-full-walkthrough-h264.mp4"/>
-</video>
+With a public collections gallery, you can create a dedicated page that showcases all public collections in one place, allowing you to personalize, curate, and share your web archives with the world.
 
 ## Enable Public Collections Gallery
 
-The _enable public collections gallery_ toggle is located in the org's **Settings** tab within your account. Follow these steps to activate the Public Collections Gallery.
+To active the public collections gallery:
 
-1. Log in to your Browsertrix account
+1. Navigate to org **Settings**
+2. Toggle **Enable public collections gallery** on
+3. Save
 
-2. In your org's **settings**, click **enable public collections gallery** and save
+You can share the link to your public collections gallery by copying the lin in org **Settings**, or by clicking on the copy button next to "**Visit public collections gallery**" from your dashboard.
 
-3. You can share the link to your Public Collections Page from either copying from the org's **settings**, or by clicking on the copy button next to "**Visit public collections gallery**" from your dashboard.
-
-Note: If you choose to hide the gallery later, you can go back to the setting and set the toggle to off at any time.
-The gallery will still be available for logged in users to preview, but the public page will be hidden.
-Public Collections will be treated the same as *Unlisted* when the public gallery is turned off.
+If you choose to hide the gallery later, you can go back to the setting and set the toggle to off at any time.
+The gallery will still be available for logged-in org members to preview, but the public page will be hidden.
+Public collections will be treated the same as _Unlisted_ when the public gallery is turned off.
 
 ### Customizing the Gallery
 
@@ -29,13 +22,17 @@ The Public Collection Gallery page will automatically have the title of your Org
 
 For example, if your org URL ends with `/my-org`, than the Public Collections Gallery will be made available at `/explore/my-org`.
 
+## Public Collections Dashboard
+
+You can quickly manage collections in the gallery from the **Public Collections** section of the org dashboard.
+
 ### Add Collections
 
 If you don’t have any public Collections yet, on the right side of the section you'll see three different icons.
 
 1. Click the asterisk icon :bootstrap-asterisk: in order to see all your Collections.
 
-2. Click the edit button :bootstrap-pencil: on the specific Collection you want to share
+2. Click the share icon :bootstrap-box-arrow-up: on the specific Collection you want to share
 
 3. In that Collection's **Sharing** tab, change its visibility from the default **Private** to **Public** and save
 
@@ -53,7 +50,6 @@ You'll take similar steps from [Add Collections](./public-collections-gallery.md
 
 2. In that Collection's **Sharing** tab, change its visibility from the default **Public** to **Private**, save, and that Collection should be removed from the Public Collections Gallery!
 
-
 ### Customize Collections
 
 The [Presentation and Sharing](./presentation-sharing.md) page provides further details for options on how to present and share Collections in your Public Collections Gallery. Your Public Collection Gallery page will automatically have the title of your org. You can customize this page by including a **Description** and your org's **Website** by adding them from your org's **Settings** of your account.
@@ -62,7 +58,7 @@ The [Presentation and Sharing](./presentation-sharing.md) page provides further 
 
 A **Description** about your Collection is not required, but it is useful information to share additional context and details of your collection with your org team members or the public by writing a description.
 
-You can edit the **Description** as long as its within 150 characters, which is roughly between 90 words and 150 words with spaces included in the character count. The **Description** supports basic text formatting like headings, bold and italicized text, lists, and links.
+The **Description** supports basic text formatting like headings, bold and italicized text, lists, and links.
 
 ### Website
 

--- a/frontend/docs/docs/user-guide/public-collections-gallery.md
+++ b/frontend/docs/docs/user-guide/public-collections-gallery.md
@@ -4,13 +4,13 @@ With a public collections gallery, you can create a dedicated page that showcase
 
 ## Enable Public Collections Gallery
 
-To active the public collections gallery:
+To activate the public collections gallery:
 
-1. Navigate to org **Settings**.
+1. Navigate to org **Settings** (only available to org admins).
 2. Toggle _Enable public collections gallery_ on.
 3. Save.
 
-You can share the link to your public collections gallery by copying the lin in org **Settings**, or by clicking on the copy button next to the _Visit public collections gallery_ link in the org dashboard.
+You can share the link to your public collections gallery by copying the link in org **Settings**, or by clicking on the copy button next to the _Visit public collections gallery_ link in the org dashboard.
 
 ### Customizing the Gallery
 
@@ -62,6 +62,6 @@ Link to your org's (or your personal) website so viewers can visit from your Pub
 
 ## Disable Public Collections Gallery
 
-To disable the shareable link to the public collections gallery, toggle _Enable public collections gallery_ off from org **Settings**.
+To disable the shareable link to the public collections gallery, toggle _Enable public collections gallery_ off from [org settings](org-settings.md).
 
 The gallery will still be available for logged-in org members to preview, but the page will no longer be visible to the public. Public collections will be treated the same as _Unlisted_ when the public gallery is turned off.

--- a/frontend/docs/docs/user-guide/public-collections-gallery.md
+++ b/frontend/docs/docs/user-guide/public-collections-gallery.md
@@ -7,14 +7,10 @@ With a public collections gallery, you can create a dedicated page that showcase
 To active the public collections gallery:
 
 1. Navigate to org **Settings**.
-2. Toggle **Enable public collections gallery** on.
+2. Toggle _Enable public collections gallery_ on.
 3. Save.
 
-You can share the link to your public collections gallery by copying the lin in org **Settings**, or by clicking on the copy button next to "**Visit public collections gallery**" from your dashboard.
-
-If you choose to hide the gallery later, you can go back to the setting and set the toggle to off at any time.
-The gallery will still be available for logged-in org members to preview, but the public page will be hidden.
-Public collections will be treated the same as _Unlisted_ when the public gallery is turned off.
+You can share the link to your public collections gallery by copying the lin in org **Settings**, or by clicking on the copy button next to the _Visit public collections gallery_ link in the org dashboard.
 
 ### Customizing the Gallery
 
@@ -52,7 +48,7 @@ You'll take similar steps from [Add Collections](./public-collections-gallery.md
 
 ### Customize Collections
 
-The [Presentation and Sharing](./presentation-sharing.md) page provides further details for options on how to present and share Collections in your Public Collections Gallery. Your Public Collection Gallery page will automatically have the title of your org. You can customize this page by including a **Description** and your org's **Website** by adding them from your org's **Settings** of your account.
+The [Presentation & Sharing](./presentation-sharing.md) guide provides further details for options on how to present and share Collections in your Public Collections Gallery. Your Public Collection Gallery page will automatically have the title of your org. You can customize this page by including a **Description** and your org's **Website** by adding them from your org's **Settings** of your account.
 
 ### Description
 
@@ -64,10 +60,8 @@ The **Description** supports basic text formatting like headings, bold and itali
 
 Link to your org's (or your personal) website so viewers can visit from your Public Collections Gallery page.
 
-how your Collection appears to the public by clicking the edit button :bootstrap-pencil: in each collection to:
+## Disable Public Collections Gallery
 
-- **Name** it and add a **description** — include emojis if that’s your style 😉
+To disable the shareable link to the public collections gallery, toggle _Enable public collections gallery_ off from org **Settings**.
 
-- Select a **thumbnail** to represent it: Choose between a page screenshot and a placeholder
-
-- Choose the **initial view** for your collection.
+The gallery will still be available for logged-in org members to preview, but the page will no longer be visible to the public. Public collections will be treated the same as _Unlisted_ when the public gallery is turned off.

--- a/frontend/docs/docs/user-guide/public-collections-gallery.md
+++ b/frontend/docs/docs/user-guide/public-collections-gallery.md
@@ -6,9 +6,9 @@ With a public collections gallery, you can create a dedicated page that showcase
 
 To active the public collections gallery:
 
-1. Navigate to org **Settings**
-2. Toggle **Enable public collections gallery** on
-3. Save
+1. Navigate to org **Settings**.
+2. Toggle **Enable public collections gallery** on.
+3. Save.
 
 You can share the link to your public collections gallery by copying the lin in org **Settings**, or by clicking on the copy button next to "**Visit public collections gallery**" from your dashboard.
 

--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -65,8 +65,8 @@ nav:
           - user-guide/review.md
       - Collections:
           - user-guide/collection.md
-          - user-guide/public-collections-gallery.md
           - user-guide/presentation-sharing.md
+          - user-guide/public-collections-gallery.md
       - Deduplication:
           - user-guide/deduplication.md
       - Quality Assurance:


### PR DESCRIPTION
Docs for https://github.com/webrecorder/browsertrix/issues/3337

## Changes

Fixes most immediate issues with collection user guides, like missing and incorrect documentation.

## Follow-ups

There's still some voice and capitalization consistency issues to address, but I think this can be done in a later general pass.