### PR TITLE
feat: Create browser profile from workflow

### DIFF
--- a/frontend/src/components/ui/config-details.ts
+++ b/frontend/src/components/ui/config-details.ts
@@ -26,6 +26,7 @@ import {
 import { labelFor, titlecaseLabelFor } from "@/strings/crawl-workflows/labels";
 import scopeTypeLabel from "@/strings/crawl-workflows/scopeType";
 import sectionStrings from "@/strings/crawl-workflows/section";
+import { stringFor } from "@/strings/ui";
 import {
   NewWorkflowOnlyScopeType,
   WorkflowScopeType,
@@ -276,9 +277,7 @@ export class ConfigDetails extends BtrixElement {
               `,
               () =>
                 crawlConfig?.profileName ||
-                html`<span class="text-neutral-400"
-                  >${msg("No custom profile")}</span
-                >`,
+                html`<span class="text-neutral-400">${stringFor.none}</span>`,
             ),
           )}
           ${this.renderSetting(

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -21,6 +21,9 @@ import {
   type Proxy,
 } from "@/types/crawler";
 
+/**
+ * @fires btrix-updated
+ */
 @customElement("btrix-new-browser-profile-dialog")
 @localized()
 export class NewBrowserProfileDialog extends BtrixElement {
@@ -77,6 +80,14 @@ export class NewBrowserProfileDialog extends BtrixElement {
           this.crawlerChannel) ||
         this.defaultCrawlerChannel;
     }
+  }
+
+  show() {
+    void this.dialog?.show();
+  }
+
+  hide() {
+    void this.dialog?.hide();
   }
 
   render() {
@@ -197,8 +208,7 @@ export class NewBrowserProfileDialog extends BtrixElement {
               proxyId: this.proxyId ?? undefined,
             }}
             ?open=${this.browserOpen}
-            @btrix-updated=${() => {}}
-            @sl-after-hide=${() => {}}
+            @sl-hide=${() => void this.dialog?.hide()}
           >
           </btrix-profile-browser-dialog>`,
       )}

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -219,7 +219,12 @@ export class NewBrowserProfileDialog extends BtrixElement {
             }}
             ?open=${this.browserOpen}
             ?navigateOnSave=${this.navigateOnSave}
-            @sl-hide=${() => void this.dialog?.hide()}
+            @sl-hide=${(e: Event) => {
+              e.stopPropagation();
+              this.browserOpen = false;
+              this.open = false;
+              void this.dialog?.hide();
+            }}
           >
           </btrix-profile-browser-dialog>`,
       )}

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -31,6 +31,9 @@ export class NewBrowserProfileDialog extends BtrixElement {
   defaultUrl?: string;
 
   @property({ type: String })
+  defaultName?: string;
+
+  @property({ type: String })
   defaultProxyId?: string;
 
   @property({ type: String })
@@ -155,7 +158,11 @@ export class NewBrowserProfileDialog extends BtrixElement {
             label=${msg("Profile Name")}
             name="profile-name"
             placeholder=${msg("example.com")}
-            value=${ifDefined(this.defaultUrl)}
+            value=${ifDefined(
+              this.defaultName ??
+                (this.defaultUrl &&
+                  new URL(this.defaultUrl).hostname.slice(0, 50)),
+            )}
             help-text=${msg(
               "Defaults to the primary site's domain name if omitted.",
             )}

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -48,6 +48,9 @@ export class NewBrowserProfileDialog extends BtrixElement {
   @property({ type: Boolean })
   open = false;
 
+  @property({ type: Boolean })
+  navigateOnSave = false;
+
   @state()
   browserOpen = false;
 
@@ -215,6 +218,7 @@ export class NewBrowserProfileDialog extends BtrixElement {
               proxyId: this.proxyId ?? undefined,
             }}
             ?open=${this.browserOpen}
+            ?navigateOnSave=${this.navigateOnSave}
             @sl-hide=${() => void this.dialog?.hide()}
           >
           </btrix-profile-browser-dialog>`,

--- a/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
+++ b/frontend/src/features/browser-profiles/new-browser-profile-dialog.ts
@@ -1,5 +1,4 @@
 import { localized, msg } from "@lit/localize";
-import { type SlInput } from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues } from "lit";
 import {
   customElement,
@@ -15,6 +14,7 @@ import { BtrixElement } from "@/classes/BtrixElement";
 import type { Dialog } from "@/components/ui/dialog";
 import { type SelectCrawlerChangeEvent } from "@/components/ui/select-crawler";
 import { type SelectCrawlerProxyChangeEvent } from "@/components/ui/select-crawler-proxy";
+import type { UrlInput } from "@/components/ui/url-input";
 import {
   CrawlerChannelImage,
   type CrawlerChannel,
@@ -66,6 +66,9 @@ export class NewBrowserProfileDialog extends BtrixElement {
   @state()
   private proxyId: string | null = null;
 
+  @query("btrix-url-input")
+  private readonly urlInput?: UrlInput;
+
   @query("btrix-dialog")
   private readonly dialog?: Dialog;
 
@@ -107,14 +110,13 @@ export class NewBrowserProfileDialog extends BtrixElement {
         .label=${msg("New Browser Profile")}
         .open=${this.open}
         @sl-initial-focus=${async (e: CustomEvent) => {
-          const nameInput = (await this.form).querySelector<SlInput>(
-            "btrix-url-input",
-          );
-          if (nameInput) {
+          if (this.urlInput) {
             e.preventDefault();
-            nameInput.focus();
+            this.urlInput.focus();
           }
         }}
+        @sl-hide=${() => (this.open = false)}
+        @sl-after-hide=${async () => (await this.form).reset()}
       >
         <form
           id="browserProfileForm"
@@ -219,11 +221,11 @@ export class NewBrowserProfileDialog extends BtrixElement {
             }}
             ?open=${this.browserOpen}
             ?navigateOnSave=${this.navigateOnSave}
-            @sl-hide=${(e: Event) => {
+            @sl-hide=${async (e: Event) => {
               e.stopPropagation();
               this.browserOpen = false;
               this.open = false;
-              void this.dialog?.hide();
+              this.hide();
             }}
           >
           </btrix-profile-browser-dialog>`,
@@ -231,12 +233,13 @@ export class NewBrowserProfileDialog extends BtrixElement {
     `;
   }
 
-  private async hideDialog() {
-    void (await this.form).closest<Dialog>("btrix-dialog")?.hide();
-  }
-
   private onReset() {
-    void this.hideDialog();
+    this.urlInput?.setAttribute("value", this.defaultUrl ?? "");
+    this.urlInput?.setCustomValidity("");
+
+    if (this.dialog?.open) {
+      this.hide();
+    }
   }
 
   private async onSubmit(event: SubmitEvent) {

--- a/frontend/src/features/browser-profiles/profile-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-browser-dialog.ts
@@ -50,6 +50,9 @@ export class ProfileBrowserDialog extends BtrixElement {
   @property({ type: Boolean })
   open = false;
 
+  @property({ type: Boolean })
+  navigateOnSave = false;
+
   @state()
   private browserStatus = BrowserStatus.Initial;
 
@@ -379,14 +382,7 @@ export class ProfileBrowserDialog extends BtrixElement {
       if (this.saveProfileTask.value?.id) {
         void dialog?.hide();
 
-        const url = new URL(window.location.href);
-
-        // Don't navigate away if creating a browser profile from a workflow
-        if (
-          !url.pathname.startsWith(
-            `${this.navigate.orgBasePath}/${OrgTab.Workflows}/`,
-          )
-        ) {
+        if (this.navigateOnSave) {
           this.navigate.to(
             `${this.navigate.orgBasePath}/${OrgTab.BrowserProfiles}/profile/${this.saveProfileTask.value.id}`,
           );

--- a/frontend/src/features/browser-profiles/profile-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-browser-dialog.ts
@@ -142,7 +142,11 @@ export class ProfileBrowserDialog extends BtrixElement {
 
         this.dispatchEvent(
           new CustomEvent<ProfileUpdatedEvent["detail"]>("btrix-updated", {
-            detail: { id: data.id, name },
+            detail: {
+              id: data.id,
+              name,
+              proxyId: this.profile?.proxyId ?? this.config?.proxyId,
+            },
             composed: true,
             bubbles: true,
           }),

--- a/frontend/src/features/browser-profiles/profile-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-browser-dialog.ts
@@ -110,14 +110,16 @@ export class ProfileBrowserDialog extends BtrixElement {
     task: async ([browserId, config], { signal }) => {
       if (!browserId || !config) return;
 
+      const name =
+        config.name ||
+        this.profile?.name ||
+        new URL(config.url).origin.slice(0, 50);
+
       try {
         const data = await this.saveProfile(
           {
             browserId,
-            name:
-              config.name ||
-              this.profile?.name ||
-              new URL(config.url).origin.slice(0, 50),
+            name,
           },
           signal,
         );
@@ -125,7 +127,11 @@ export class ProfileBrowserDialog extends BtrixElement {
         this.#savedBrowserId = browserId;
 
         this.dispatchEvent(
-          new CustomEvent<ProfileUpdatedEvent["detail"]>("btrix-updated"),
+          new CustomEvent<ProfileUpdatedEvent["detail"]>("btrix-updated", {
+            detail: { id: data.id, name },
+            composed: true,
+            bubbles: true,
+          }),
         );
 
         return data;
@@ -372,9 +378,19 @@ export class ProfileBrowserDialog extends BtrixElement {
 
       if (this.saveProfileTask.value?.id) {
         void dialog?.hide();
-        this.navigate.to(
-          `${this.navigate.orgBasePath}/${OrgTab.BrowserProfiles}/profile/${this.saveProfileTask.value.id}`,
-        );
+
+        const url = new URL(window.location.href);
+
+        // Don't navigate away if creating a browser profile from a workflow
+        if (
+          !url.pathname.startsWith(
+            `${this.navigate.orgBasePath}/${OrgTab.Workflows}/`,
+          )
+        ) {
+          this.navigate.to(
+            `${this.navigate.orgBasePath}/${OrgTab.BrowserProfiles}/profile/${this.saveProfileTask.value.id}`,
+          );
+        }
       } else {
         await dialog?.hide();
       }

--- a/frontend/src/features/browser-profiles/profile-browser-dialog.ts
+++ b/frontend/src/features/browser-profiles/profile-browser-dialog.ts
@@ -94,6 +94,17 @@ export class ProfileBrowserDialog extends BtrixElement {
         this.browserStatus = BrowserStatus.Initial;
         this.#savedBrowserId = undefined;
         this.browserIdTask.abort();
+
+        if (this.saveProfileTask.status === TaskStatus.PENDING) {
+          this.saveProfileTask.abort();
+
+          this.notify.toast({
+            message: msg("Profile was not saved."),
+            variant: "warning",
+            icon: "exclamation-circle",
+            id: "browser-profile-save-status",
+          });
+        }
       }
     }
   }
@@ -386,17 +397,17 @@ export class ProfileBrowserDialog extends BtrixElement {
           this.navigate.to(
             `${this.navigate.orgBasePath}/${OrgTab.BrowserProfiles}/profile/${this.saveProfileTask.value.id}`,
           );
+        } else {
+          await dialog?.hide();
         }
-      } else {
-        await dialog?.hide();
-      }
 
-      this.notify.toast({
-        message: msg("Successfully saved browser profile."),
-        variant: "success",
-        icon: "check2-circle",
-        id: "browser-profile-save-status",
-      });
+        this.notify.toast({
+          message: msg("Successfully saved browser profile."),
+          variant: "success",
+          icon: "check2-circle",
+          id: "browser-profile-save-status",
+        });
+      }
     } catch (err) {
       if (typeof err === "string") {
         this.notify.toast({

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit/context";
 import { localized, msg } from "@lit/localize";
 import { Task } from "@lit/task";
 import type {
@@ -12,9 +13,19 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { when } from "lit/directives/when.js";
 import queryString from "query-string";
 
+import type { NewBrowserProfileDialog } from "./new-browser-profile-dialog";
 import { originsWithRemainder } from "./templates/origins-with-remainder";
+import { type ProfileUpdatedEvent } from "./types";
 
 import { BtrixElement } from "@/classes/BtrixElement";
+import {
+  orgCrawlerChannelsContext,
+  type OrgCrawlerChannelsContext,
+} from "@/context/org-crawler-channels";
+import {
+  orgProxiesContext,
+  type OrgProxiesContext,
+} from "@/context/org-proxies";
 import { none } from "@/layouts/empty";
 import { pageHeading } from "@/layouts/page";
 import { CrawlerChannelImage, type Profile } from "@/pages/org/types";
@@ -25,6 +36,7 @@ import type {
   APISortQuery,
 } from "@/types/api";
 import { SortDirection } from "@/types/utils";
+import { getDefaultProxyId } from "@/utils/crawler";
 import { isNotEqual } from "@/utils/is-not-equal";
 import { AppStateService } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
@@ -35,6 +47,7 @@ type SelectBrowserProfileChangeDetail = {
 
 // TODO Paginate results
 const INITIAL_PAGE_SIZE = 1000;
+const NEW_PROFILE_KEY = "_new";
 
 export type SelectBrowserProfileChangeEvent =
   CustomEvent<SelectBrowserProfileChangeDetail>;
@@ -54,6 +67,12 @@ export type SelectBrowserProfileChangeEvent =
 @customElement("btrix-select-browser-profile")
 @localized()
 export class SelectBrowserProfile extends BtrixElement {
+  @consume({ context: orgProxiesContext, subscribe: true })
+  private readonly proxies?: OrgProxiesContext;
+
+  @consume({ context: orgCrawlerChannelsContext, subscribe: true })
+  private readonly crawlerChannels?: OrgCrawlerChannelsContext;
+
   @property({ type: String })
   size?: SlSelect["size"];
 
@@ -78,6 +97,9 @@ export class SelectBrowserProfile extends BtrixElement {
   @query("sl-drawer")
   private readonly drawer?: SlDrawer | null;
 
+  @query("btrix-new-browser-profile-dialog")
+  private readonly newBrowserProfileDialog?: NewBrowserProfileDialog | null;
+
   public get value() {
     return this.select?.value as string;
   }
@@ -97,8 +119,8 @@ export class SelectBrowserProfile extends BtrixElement {
   });
 
   private readonly selectedProfileTask = new Task(this, {
-    task: async ([profileId, profiles], { signal }) => {
-      if (!profileId || !profiles || signal.aborted) return;
+    task: async ([profileId, profiles]) => {
+      if (!profileId || !profiles) return;
 
       this.selectedProfile = this.findProfileById(profileId);
     },
@@ -131,9 +153,6 @@ export class SelectBrowserProfile extends BtrixElement {
       >
         ${loading ? html`<sl-spinner slot="prefix"></sl-spinner>` : nothing}
         ${this.renderProfileOptions()}
-        ${browserProfiles && !browserProfiles.total
-          ? this.renderNoProfiles()
-          : ""}
         <div slot="help-text" class="flex justify-between">
           ${selectedProfile
             ? html`
@@ -169,6 +188,31 @@ export class SelectBrowserProfile extends BtrixElement {
       ${browserProfiles || selectedProfile
         ? this.renderSelectedProfileInfo()
         : ""}
+      ${this.org && this.proxies && this.crawlerChannels
+        ? html`<btrix-new-browser-profile-dialog
+            .proxyServers=${this.proxies.servers}
+            .crawlerChannels=${this.crawlerChannels}
+            defaultProxyId=${ifDefined(
+              getDefaultProxyId(this.org, this.proxies),
+            )}
+            defaultCrawlerChannel=${ifDefined(
+              this.org.crawlingDefaults?.crawlerChannel || undefined,
+            )}
+            @btrix-updated=${async (e: ProfileUpdatedEvent) => {
+              e.stopPropagation();
+              const { id } = e.detail;
+
+              if (id) {
+                void this.profilesTask.run();
+                await this.profilesTask.taskComplete;
+                this.profileId = id;
+              } else {
+                console.debug("no id for updated profile", e.detail);
+              }
+            }}
+          >
+          </btrix-new-browser-profile-dialog>`
+        : nothing}
     `;
   }
 
@@ -238,7 +282,9 @@ export class SelectBrowserProfile extends BtrixElement {
     }
 
     return html`
-      <sl-option value="">${msg("No custom profile")}</sl-option>
+      ${profiles.length
+        ? html`<sl-option value="">${msg("No custom profile")}</sl-option>`
+        : nothing}
       ${suggestions.length
         ? html`
             <sl-divider></sl-divider>
@@ -257,6 +303,11 @@ export class SelectBrowserProfile extends BtrixElement {
             ${rest.map(option)}
           `
         : nothing}
+      ${profiles.length ? html`<sl-divider></sl-divider>` : nothing}
+      <sl-option value=${NEW_PROFILE_KEY}>
+        <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+        ${msg("New Browser Profile")}
+      </sl-option>
     `;
   }
 
@@ -300,7 +351,7 @@ export class SelectBrowserProfile extends BtrixElement {
     };
 
     return html` <sl-drawer
-      class="[--body-spacing:var(--sl-spacing-medium)] [--footer-spacing:var(--sl-spacing-x-small)_var(--sl-spacing-medium)] [--header-spacing:var(--sl-spacing-medium)]  part-[header]:[border-bottom:1px_solid_var(--sl-panel-border-color)]"
+      class="[--body-spacing:var(--sl-spacing-medium)] [--footer-spacing:var(--sl-spacing-x-small)_var(--sl-spacing-medium)] [--header-spacing:var(--sl-spacing-medium)] part-[header]:[border-bottom:1px_solid_var(--sl-panel-border-color)]"
       @sl-show=${() => {
         // Hide any other open panels
         AppStateService.updateUserGuideOpen(false);
@@ -365,41 +416,24 @@ export class SelectBrowserProfile extends BtrixElement {
     </btrix-desc-list>`;
   };
 
-  private renderNoProfiles() {
-    return html`
-      <div class="mx-2 text-sm text-neutral-500">
-        <span class="inline-block align-middle"
-          >${msg("This org doesn't have any custom profiles yet.")}</span
-        >
-        <a
-          href=${`${this.navigate.orgBasePath}/browser-profiles?new=browser-profile`}
-          class="font-medium text-primary hover:text-primary-500"
-          target="_blank"
-          @click=${(e: Event) => {
-            const select = (e.target as HTMLElement).closest<SlSelect>(
-              "sl-select",
-            );
-            if (select) {
-              select.blur();
-              // TODO what is this? why isn't it documented in Shoelace?
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (select as any).dropdown?.hide();
-            }
-          }}
-          ><span class="inline-block align-middle"
-            >${msg("Create profile")}</span
-          >
-          <sl-icon
-            class="inline-block align-middle"
-            name="box-arrow-up-right"
-          ></sl-icon
-        ></a>
-      </div>
-    `;
-  }
-
   private async onChange(e: SlChangeEvent) {
-    const profileId = (e.target as SlSelect | null)?.value as string;
+    const el = e.currentTarget as SlSelect;
+    const profileId = el.value as string;
+
+    if (profileId === NEW_PROFILE_KEY) {
+      e.preventDefault();
+
+      // Revert value
+      el.value = this.profileId || "";
+
+      if (this.newBrowserProfileDialog) {
+        this.newBrowserProfileDialog.show();
+      } else {
+        console.debug("no <btrix-new-browser-profile-dialog>");
+      }
+      return;
+    }
+
     this.selectedProfile = this.findProfileById(profileId);
 
     await this.updateComplete;

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -88,6 +88,12 @@ export class SelectBrowserProfile extends BtrixElement {
   @property({ type: String })
   profileName?: string;
 
+  @property({ type: String })
+  defaultProxyId?: string;
+
+  @property({ type: String })
+  defaultCrawlerChannel?: string;
+
   /**
    * List of origins to match to prioritize profile options
    */
@@ -210,10 +216,12 @@ export class SelectBrowserProfile extends BtrixElement {
             .proxyServers=${this.proxies.servers}
             .crawlerChannels=${this.crawlerChannels}
             defaultProxyId=${ifDefined(
-              getDefaultProxyId(this.org, this.proxies),
+              this.defaultProxyId ?? getDefaultProxyId(this.org, this.proxies),
             )}
             defaultCrawlerChannel=${ifDefined(
-              this.org.crawlingDefaults?.crawlerChannel || undefined,
+              this.defaultCrawlerChannel ||
+                this.org.crawlingDefaults?.crawlerChannel ||
+                undefined,
             )}
             @btrix-updated=${async (e: ProfileUpdatedEvent) => {
               e.stopPropagation();

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -320,6 +320,15 @@ export class SelectBrowserProfile extends BtrixElement {
       ${profiles.length
         ? html`<sl-option value="">${stringFor.none}</sl-option>`
         : nothing}
+      ${when(
+        this.allowNew,
+        () =>
+          html`${profiles.length ? html`<sl-divider></sl-divider>` : nothing}
+            <sl-option value=${NEW_PROFILE_KEY}>
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              ${msg("New Browser Profile")}
+            </sl-option>`,
+      )}
       ${suggestions.length
         ? html`
             <sl-divider></sl-divider>
@@ -353,15 +362,6 @@ export class SelectBrowserProfile extends BtrixElement {
               ${msg("Manage Profiles")}
             </btrix-link>
           </sl-menu-label>`,
-      )}
-      ${when(
-        this.allowNew,
-        () =>
-          html`${profiles.length ? html`<sl-divider></sl-divider>` : nothing}
-            <sl-option value=${NEW_PROFILE_KEY}>
-              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              ${msg("New Browser Profile")}
-            </sl-option>`,
       )}
     `;
   }

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -190,6 +190,8 @@ export class SelectBrowserProfile extends BtrixElement {
         : ""}
       ${this.org && this.proxies && this.crawlerChannels
         ? html`<btrix-new-browser-profile-dialog
+            .defaultUrl=${this.suggestOrigins?.[0] &&
+            `https://${this.suggestOrigins[0]}`}
             .proxyServers=${this.proxies.servers}
             .crawlerChannels=${this.crawlerChannels}
             defaultProxyId=${ifDefined(

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -190,8 +190,10 @@ export class SelectBrowserProfile extends BtrixElement {
         : ""}
       ${this.org && this.proxies && this.crawlerChannels
         ? html`<btrix-new-browser-profile-dialog
-            .defaultUrl=${this.suggestOrigins?.[0] &&
-            `https://${this.suggestOrigins[0]}`}
+            defaultUrl=${ifDefined(
+              this.suggestOrigins?.[0] && `https://${this.suggestOrigins[0]}`,
+            )}
+            defaultName=""
             .proxyServers=${this.proxies.servers}
             .crawlerChannels=${this.crawlerChannels}
             defaultProxyId=${ifDefined(

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -30,6 +30,7 @@ import { none } from "@/layouts/empty";
 import { pageHeading } from "@/layouts/page";
 import { CrawlerChannelImage, type Profile } from "@/pages/org/types";
 import { OrgTab } from "@/routes";
+import { stringFor } from "@/strings/ui";
 import type {
   APIPaginatedList,
   APIPaginationQuery,
@@ -91,6 +92,9 @@ export class SelectBrowserProfile extends BtrixElement {
   @state()
   selectedProfile?: Profile;
 
+  @property({ type: Boolean })
+  allowNew = false;
+
   @query("sl-select")
   private readonly select?: SlSelect | null;
 
@@ -141,9 +145,7 @@ export class SelectBrowserProfile extends BtrixElement {
       <sl-select
         label=${msg("Browser Profile")}
         value=${this.profileId || selectedProfile?.id || ""}
-        placeholder=${browserProfiles
-          ? msg("No custom profile")
-          : msg("Loading")}
+        placeholder=${browserProfiles ? stringFor.none : msg("Loading")}
         size=${ifDefined(this.size)}
         hoist
         clearable
@@ -170,18 +172,7 @@ export class SelectBrowserProfile extends BtrixElement {
                   )}
                 </span>
               `
-            : browserProfiles
-              ? html`
-                  <btrix-link
-                    class="ml-auto"
-                    href="${this.navigate
-                      .orgBasePath}/${OrgTab.BrowserProfiles}"
-                    target="_blank"
-                  >
-                    ${msg("View Browser Profiles")}
-                  </btrix-link>
-                `
-              : nothing}
+            : nothing}
         </div>
       </sl-select>
 
@@ -287,7 +278,7 @@ export class SelectBrowserProfile extends BtrixElement {
 
     return html`
       ${profiles.length
-        ? html`<sl-option value="">${msg("No custom profile")}</sl-option>`
+        ? html`<sl-option value="">${stringFor.none}</sl-option>`
         : nothing}
       ${suggestions.length
         ? html`
@@ -307,11 +298,31 @@ export class SelectBrowserProfile extends BtrixElement {
             ${rest.map(option)}
           `
         : nothing}
-      ${profiles.length ? html`<sl-divider></sl-divider>` : nothing}
-      <sl-option value=${NEW_PROFILE_KEY}>
-        <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-        ${msg("New Browser Profile")}
-      </sl-option>
+      ${when(
+        !this.allowNew && !profiles.length,
+        () =>
+          html`<sl-menu-label
+            class="part-[base]:flex part-[base]:items-center part-[base]:justify-between"
+          >
+            <span>${msg("No browser profiles found.")}</span>
+            <btrix-link
+              class="ml-auto"
+              href="${this.navigate.orgBasePath}/${OrgTab.BrowserProfiles}"
+              target="_blank"
+            >
+              ${msg("Manage Profiles")}
+            </btrix-link>
+          </sl-menu-label>`,
+      )}
+      ${when(
+        this.allowNew,
+        () =>
+          html`${profiles.length ? html`<sl-divider></sl-divider>` : nothing}
+            <sl-option value=${NEW_PROFILE_KEY}>
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              ${msg("New Browser Profile")}
+            </sl-option>`,
+      )}
     `;
   }
 

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -42,7 +42,8 @@ import { isNotEqual } from "@/utils/is-not-equal";
 import { AppStateService } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
-type SelectedProfile = Partial<Profile> & Pick<Profile, "id" | "name">;
+type SelectedProfile = Partial<Profile> &
+  Pick<Profile, "id" | "name" | "proxyId">;
 type SelectBrowserProfileChangeDetail = {
   value: SelectedProfile | undefined;
 };
@@ -225,7 +226,7 @@ export class SelectBrowserProfile extends BtrixElement {
             )}
             @btrix-updated=${async (e: ProfileUpdatedEvent) => {
               e.stopPropagation();
-              const { id, name } = e.detail;
+              const { id, name, proxyId } = e.detail;
 
               if (id) {
                 void this.profilesTask.run();
@@ -236,7 +237,7 @@ export class SelectBrowserProfile extends BtrixElement {
                     "on-change",
                     {
                       detail: {
-                        value: { id, name: name ?? id },
+                        value: { id, name: name ?? id, proxyId },
                       },
                     },
                   ),

--- a/frontend/src/features/browser-profiles/select-browser-profile.ts
+++ b/frontend/src/features/browser-profiles/select-browser-profile.ts
@@ -42,9 +42,14 @@ import { isNotEqual } from "@/utils/is-not-equal";
 import { AppStateService } from "@/utils/state";
 import { tw } from "@/utils/tailwind";
 
+type SelectedProfile = Partial<Profile> & Pick<Profile, "id" | "name">;
 type SelectBrowserProfileChangeDetail = {
-  value: Profile | undefined;
+  value: SelectedProfile | undefined;
 };
+
+const isFullProfile = (
+  profile: SelectedProfile | Profile,
+): profile is Profile => "modified" in profile || "created" in profile;
 
 // TODO Paginate results
 const INITIAL_PAGE_SIZE = 1000;
@@ -90,7 +95,7 @@ export class SelectBrowserProfile extends BtrixElement {
   suggestOrigins?: string[];
 
   @state()
-  selectedProfile?: Profile;
+  selectedProfile?: SelectedProfile;
 
   @property({ type: Boolean })
   allowNew = false;
@@ -123,17 +128,34 @@ export class SelectBrowserProfile extends BtrixElement {
   });
 
   private readonly selectedProfileTask = new Task(this, {
-    task: async ([profileId, profiles]) => {
+    task: async ([profileId, profiles], { signal }) => {
       if (!profileId || !profiles) return;
 
-      this.selectedProfile = this.findProfileById(profileId);
+      let profile = this.findProfileById(profileId);
+
+      if (!profile) {
+        try {
+          profile = await this.getProfile(profileId, signal);
+        } catch (err) {
+          console.debug(err);
+        }
+      }
+
+      this.selectedProfile = profile;
+
+      return profile;
     },
     args: () => [this.profileId, this.profilesTask.value] as const,
   });
 
   private findProfileById(profileId?: string) {
     if (!profileId) return;
-    return this.profilesTask.value?.items.find(({ id }) => id === profileId);
+    return (
+      this.profilesTask.value?.items.find(({ id }) => id === profileId) || {
+        id: profileId,
+        name: profileId,
+      }
+    );
   }
 
   render() {
@@ -156,7 +178,7 @@ export class SelectBrowserProfile extends BtrixElement {
         ${loading ? html`<sl-spinner slot="prefix"></sl-spinner>` : nothing}
         ${this.renderProfileOptions()}
         <div slot="help-text" class="flex justify-between">
-          ${selectedProfile
+          ${selectedProfile && isFullProfile(selectedProfile)
             ? html`
                 <button
                   class="text-blue-500 transition-colors duration-fast hover:text-blue-600"
@@ -195,12 +217,22 @@ export class SelectBrowserProfile extends BtrixElement {
             )}
             @btrix-updated=${async (e: ProfileUpdatedEvent) => {
               e.stopPropagation();
-              const { id } = e.detail;
+              const { id, name } = e.detail;
 
               if (id) {
                 void this.profilesTask.run();
                 await this.profilesTask.taskComplete;
-                this.profileId = id;
+
+                this.dispatchEvent(
+                  new CustomEvent<SelectBrowserProfileChangeDetail>(
+                    "on-change",
+                    {
+                      detail: {
+                        value: { id, name: name ?? id },
+                      },
+                    },
+                  ),
+                );
               } else {
                 console.debug("no id for updated profile", e.detail);
               }
@@ -380,7 +412,9 @@ export class SelectBrowserProfile extends BtrixElement {
         <span class="leading-4">${this.selectedProfile?.name}</span>
       </span>
 
-      ${when(this.selectedProfile, profileContent)}
+      ${this.selectedProfile && isFullProfile(this.selectedProfile)
+        ? profileContent(this.selectedProfile)
+        : nothing}
     </sl-drawer>`;
   }
 
@@ -482,6 +516,15 @@ export class SelectBrowserProfile extends BtrixElement {
 
     const data = await this.api.fetch<APIPaginatedList<Profile>>(
       `/orgs/${this.orgId}/profiles?${query}`,
+      { signal },
+    );
+
+    return data;
+  }
+
+  private async getProfile(id: string, signal: AbortSignal) {
+    const data = await this.api.fetch<Profile>(
+      `/orgs/${this.orgId}/profiles/${id}`,
       { signal },
     );
 

--- a/frontend/src/features/browser-profiles/types.ts
+++ b/frontend/src/features/browser-profiles/types.ts
@@ -1,7 +1,7 @@
 import type { Profile } from "@/types/crawler";
 
 export type ProfileUpdatedEvent = CustomEvent<
-  Partial<Pick<Profile, "name" | "description">>
+  Partial<Pick<Profile, "id" | "name" | "description">>
 >;
 
 export type CreateBrowserOptions = {

--- a/frontend/src/features/browser-profiles/types.ts
+++ b/frontend/src/features/browser-profiles/types.ts
@@ -1,7 +1,7 @@
 import type { Profile } from "@/types/crawler";
 
 export type ProfileUpdatedEvent = CustomEvent<
-  Partial<Pick<Profile, "id" | "name" | "description">>
+  Partial<Pick<Profile, "id" | "name" | "description" | "proxyId">>
 >;
 
 export type CreateBrowserOptions = {

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2242,6 +2242,7 @@ https://archiveweb.page/images/${"logo.svg"}`}
                   : this.formState.saveStorage,
             });
           }}
+          allowNew
         ></btrix-select-browser-profile>
       `)}
       ${this.renderHelpTextCol(html`

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2226,6 +2226,8 @@ https://archiveweb.page/images/${"logo.svg"}`}
         <btrix-select-browser-profile
           .profileId=${this.formState.browserProfile?.id}
           .profileName=${this.formState.browserProfile?.name}
+          defaultProxyId=${ifDefined(this.formState.proxyId ?? undefined)}
+          defaultCrawlerChannel=${ifDefined(this.formState.crawlerChannel)}
           .suggestOrigins=${guard(
             [this.formState.primarySeedUrl, this.formState.urlList],
             priorityOrigins,
@@ -2296,14 +2298,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
                 )}
                 .proxyServers=${proxies.servers}
                 .proxyId=${profileProxyId || this.formState.proxyId || ""}
-                .profileProxyId=${profileProxyId}
+                .profileProxyId=${this.formState.browserProfile?.proxyId}
                 @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                   this.updateFormState({
                     proxyId: e.detail.value,
                   })}
               >
                 ${when(
-                  profileProxyId,
+                  this.formState.browserProfile?.proxyId,
                   () => html`
                     <span
                       slot="suffix"

--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1,6 +1,5 @@
 import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
-import { Task } from "@lit/task";
 import type {
   SlBlurEvent,
   SlChangeEvent,
@@ -110,7 +109,6 @@ import {
   Behavior,
   CrawlerChannelImage,
   ScopeType,
-  type Profile,
   type Seed,
   type WorkflowSettings,
 } from "@/types/crawler";
@@ -445,15 +443,6 @@ export class WorkflowEditor extends BtrixElement {
   // CSS parser should ideally match the parser used in browsertrix-crawler.
   // https://github.com/webrecorder/browsertrix-crawler/blob/v1.5.8/package.json#L23
   private readonly cssParser = createParser();
-
-  private readonly profileTask = new Task(this, {
-    task: async ([formState], { signal }) => {
-      if (!formState.browserProfile) return;
-
-      return this.getProfile(formState.browserProfile.id, signal);
-    },
-    args: () => [this.formState] as const,
-  });
 
   connectedCallback(): void {
     this.initializeEditor();
@@ -3989,15 +3978,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
     } catch (e) {
       console.debug(e);
     }
-  }
-
-  private async getProfile(profileId: string, signal: AbortSignal) {
-    const data = await this.api.fetch<Profile>(
-      `/orgs/${this.orgId}/profiles/${profileId}`,
-      { signal },
-    );
-
-    return data;
   }
 
   private async createCollection(

--- a/frontend/src/pages/org/browser-profiles-list.ts
+++ b/frontend/src/pages/org/browser-profiles-list.ts
@@ -332,6 +332,7 @@ export class BrowserProfilesList extends BtrixElement {
       }}
       ?open=${this.openDialog === "duplicate"}
       duplicating
+      navigateOnSave
       @sl-after-hide=${() => {
         this.selectedProfile = undefined;
         this.openDialog = undefined;

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -775,6 +775,7 @@ export class BrowserProfilesProfilePage extends BtrixElement {
   }
 
   private readonly onUpdated = async (e: ProfileUpdatedEvent) => {
+    e.stopPropagation();
     this.updatedProfileParams = e.detail;
     void this.profileTask.run();
   };

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -187,6 +187,7 @@ export class BrowserProfilesProfilePage extends BtrixElement {
         .config=${config}
         ?open=${this.openDialog === "browser" || duplicating}
         ?duplicating=${duplicating}
+        ?navigateOnSave=${duplicating}
         @btrix-updated=${duplicating ? undefined : this.onUpdated}
         @sl-after-hide=${this.closeBrowser}
       >

--- a/frontend/src/pages/org/index.ts
+++ b/frontend/src/pages/org/index.ts
@@ -526,6 +526,7 @@ export class Org extends BtrixElement {
                 org.crawlingDefaults?.crawlerChannel || undefined,
               )}
               ?open=${this.openDialogName === "browser-profile"}
+              navigateOnSave
               @sl-hide=${() => (this.openDialogName = undefined)}
             >
             </btrix-new-browser-profile-dialog>`

--- a/frontend/src/utils/workflow.ts
+++ b/frontend/src/utils/workflow.ts
@@ -292,7 +292,7 @@ export type FormState = {
   dedupeType: DedupeType;
   dedupeCollection: { id: string } | { name: string } | null;
   jobName: WorkflowSettings["name"];
-  browserProfile: Profile | null;
+  browserProfile: (Partial<Profile> & Pick<Profile, "id" | "name">) | null;
   tags: Tags;
   autoAddCollections: string[];
   description: WorkflowSettings["description"];


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3568

## Changes

- Allows users to create a new browser profile directly from a workflow
- Fixes proxy selector being disabled if any browser profile is selected, even one without a proxy
- Fixes incorrect toast when aborting save profile task

## Manual testing

1. Log in as crawler
2. Go to new workflow
3. Open browser profile dropdown. Verify "New Browser Profile" is shown
4. Select "New Browser Profile". Verify dialog opens
5. Finish creating browser profile. Verify new browser profile is selected in the workflow
6. Repeat 3-5 for existing workflow

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Workflow (org without profiles) | <img width="546" height="140" alt="Screenshot 2026-08-11 at 11 06 26 AM" src="https://github.com/user-attachments/assets/da146508-14e9-4b65-a529-41f1cc7d7c23" /> |
| Workflow (org with profiles) | <img width="554" height="296" alt="Screenshot 2026-08-11 at 11 44 48 AM" src="https://github.com/user-attachments/assets/1ad272a3-2ee5-4854-b1bb-71022edd45c3" /> |


## Context

This change allows us to write better guides as related to https://github.com/webrecorder/browsertrix/issues/2304
