### PR TITLE
Fix broken nightly test: Wait for upload post-processing to complete

### DIFF
--- a/backend/test_nightly/test_cleanup_seed_files.py
+++ b/backend/test_nightly/test_cleanup_seed_files.py
@@ -5,8 +5,9 @@ import structlog
 import pytest
 import requests
 
+from test.utils import read_in_chunks
+
 from .conftest import API_PREFIX
-from .utils import read_in_chunks
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -4,9 +4,10 @@ import time
 import structlog
 import requests
 
+from test.utils import read_in_chunks
+
 from .conftest import API_PREFIX
 from .utils import (
-    read_in_chunks,
     verify_file_and_replica_deleted,
     verify_file_replicated,
 )

--- a/backend/test_nightly/test_webhooks.py
+++ b/backend/test_nightly/test_webhooks.py
@@ -7,8 +7,9 @@ import structlog
 import pytest
 import requests
 
+from test.utils import read_in_chunks, wait_for_upload_processed_sync
+
 from .conftest import API_PREFIX
-from .utils import read_in_chunks
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
@@ -399,6 +400,10 @@ def test_webhooks_sent(
     data = r.json()
     assert data["added"]
     webhooks_upload_id = data["id"]
+
+    wait_for_upload_processed_sync(
+        admin_auth_headers, default_org_id, webhooks_upload_id
+    )
 
     # Remove upload from collection
     r = requests.post(

--- a/backend/test_nightly/utils.py
+++ b/backend/test_nightly/utils.py
@@ -20,16 +20,6 @@ def get_crawl_status(org_id, crawl_id, headers):
     return data["state"]
 
 
-def read_in_chunks(fh, blocksize=1024):
-    """Lazy function (generator) to read a file piece by piece.
-    Default chunk size: 1k."""
-    while True:
-        data = fh.read(blocksize)
-        if not data:
-            break
-        yield data
-
-
 def download_file_and_return_hash(bucket_name: str, file_path: str) -> str:
     endpoint_url = "http://127.0.0.1:30090/"
     client = boto3.client(


### PR DESCRIPTION
Quick follow-up to https://github.com/webrecorder/browsertrix/pull/3323, which broke one of the nightly tests when we dropped sync processing of small multi-WACZ uploads.

Also removes duplication of the `read_in_chunks` utility between test and test_nightly packages, in favor of importing existing utils from the test package when appropriate.

Nightly test run from main with failing test: https://github.com/webrecorder/browsertrix/actions/runs/31682468779

Nightly test run from this branch: https://github.com/webrecorder/browsertrix/actions/runs/31715626918