### PR TITLE
Replace per-file replication with periodic cron job to copy entire bucket at once

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -600,7 +600,11 @@ class BackgroundJobOps:
         """Ensure periodic background cron jobs exist"""
         await self.crawl_manager.ensure_cleanup_seed_file_cron_job_exists()
         await self.crawl_manager.ensure_retry_stuck_uploads_cron_job_exists()
-        await self.crawl_manager.ensure_file_replication_cron_job_exists()
+
+        replicas_configured = True if self.storage_ops.get_default_replicas() else False
+        await self.crawl_manager.ensure_file_replication_cron_job_exists(
+            replicas_configured
+        )
 
     async def job_finished(
         self,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -599,7 +599,9 @@ class BackgroundJobOps:
     async def ensure_cron_jobs_exist(self):
         """Ensure periodic background cron jobs exist"""
         await self.crawl_manager.ensure_cleanup_seed_file_cron_job_exists()
-        await self.crawl_manager.ensure_retry_stuck_uploads_cron_job_exists()
+        await self.crawl_manager.ensure_retry_stuck_uploads_cron_job_exists(
+            bool(os.environ.get("DISABLE_STUCK_UPLOADS_CRON", False))
+        )
         await self.crawl_manager.ensure_file_replication_cron_job_exists(
             bool(self.storage_ops.get_default_replicas())
         )

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -99,139 +99,10 @@ class BackgroundJobOps:
             parts.path[1:], ""
         )
 
-    # TODO: Remove
-    # async def handle_replica_job_succeeded(self, job: CreateReplicaJob) -> None:
-    #     """Update replicas in corresponding file objects, based on type"""
-    #     res = None
-    #     if job.object_type in CRAWL_TYPES:
-    #         res = await self.base_crawl_ops.add_crawl_file_replica(
-    #             job.object_id, job.file_path, job.replica_storage
-    #         )
-    #     elif job.object_type == "profile":
-    #         res = await self.profile_ops.add_profile_file_replica(
-    #             UUID(job.object_id), job.file_path, job.replica_storage
-    #         )
-    #     if not res:
-    #         logger.debug(
-    #             "file_deleted_before_replication",
-    #             object_id=job.object_id,
-    #             file_path=job.file_path,
-    #             replica_storage=job.replica_storage,
-    #             oid=job.oid,
-    #             unstructured_message="File deleted before replication job started, ignoring",
-    #         )
-
     async def handle_delete_replica_job_finished(self, job: DeleteReplicaJob) -> None:
         """After successful replica deletion, delete cronjob if scheduled"""
         if job.schedule:
             await self.crawl_manager.delete_replica_deletion_scheduled_job(job.id)
-
-    # TODO: Remove
-    # async def create_replica_jobs(
-    #     self, oid: UUID, file: BaseFile, object_id: str, object_type: str
-    # ) -> dict[str, bool | list[str]]:
-    #     """Create k8s background job to replicate a file to all replica storage locations."""
-    #     org = await self.org_ops.get_org_by_id(oid)
-
-    #     primary_storage = self.storage_ops.get_org_storage_by_ref(org, file.storage)
-    #     primary_endpoint, bucket_suffix = self.strip_bucket(
-    #         primary_storage.endpoint_url
-    #     )
-
-    #     primary_file_path = bucket_suffix + file.filename
-
-    #     ids = []
-
-    #     for replica_ref in self.storage_ops.get_org_replicas_storage_refs(org):
-    #         job_id = await self.create_replica_job(
-    #             org,
-    #             file,
-    #             object_id,
-    #             object_type,
-    #             replica_ref,
-    #             primary_file_path,
-    #             primary_endpoint,
-    #         )
-    #         ids.append(job_id)
-
-    #     return {"added": True, "ids": ids}
-
-    # TODO: Remove
-    # async def create_replica_job(
-    #     self,
-    #     org: Organization,
-    #     file: BaseFile,
-    #     object_id: str,
-    #     object_type: str,
-    #     replica_ref: StorageRef,
-    #     primary_file_path: str,
-    #     primary_endpoint: str,
-    #     existing_job_id: str | None = None,
-    # ) -> str:
-    #     """Create k8s background job to replicate a file to a specific replica storage location."""
-    #     replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
-    #     replica_endpoint, bucket_suffix = self.strip_bucket(
-    #         replica_storage.endpoint_url
-    #     )
-    #     replica_file_path = bucket_suffix + file.filename
-
-    #     job_type = BgJobType.CREATE_REPLICA.value
-
-    #     try:
-    #         job_id, _ = await self.crawl_manager.run_replica_job(
-    #             oid=str(org.id),
-    #             job_type=job_type,
-    #             primary_storage=file.storage,
-    #             primary_file_path=primary_file_path,
-    #             primary_endpoint=primary_endpoint,
-    #             replica_storage=replica_ref,
-    #             replica_file_path=replica_file_path,
-    #             replica_endpoint=replica_endpoint,
-    #             delay_days=0,
-    #             existing_job_id=existing_job_id,
-    #         )
-    #         if existing_job_id:
-    #             replication_job = await self.get_background_job(existing_job_id, org.id)
-    #             previous_attempt = {
-    #                 "started": replication_job.started,
-    #                 "finished": replication_job.finished,
-    #             }
-    #             if replication_job.previousAttempts:
-    #                 replication_job.previousAttempts.append(previous_attempt)
-    #             else:
-    #                 replication_job.previousAttempts = [previous_attempt]
-    #             replication_job.started = dt_now()
-    #             replication_job.finished = None
-    #             replication_job.success = None
-    #         else:
-    #             replication_job = CreateReplicaJob(
-    #                 id=job_id,
-    #                 oid=org.id,
-    #                 started=dt_now(),
-    #                 file_path=file.filename,
-    #                 object_type=object_type,
-    #                 object_id=object_id,
-    #                 primary=file.storage,
-    #                 replica_storage=replica_ref,
-    #             )
-
-    #         await self.jobs.find_one_and_update(
-    #             {"_id": job_id}, {"$set": replication_job.to_dict()}, upsert=True
-    #         )
-
-    #         return job_id
-    #     # pylint: disable=broad-exception-caught
-    #     except Exception as exc:
-    #         logger.warning(
-    #             "replica_job_start_failed",
-    #             object_type=object_type,
-    #             oid=org.id,
-    #             file=file,
-    #             exc_info=True,
-    #             unstructured_message=f"warning: replica job could not be started "
-    #             f"for {object_type} {file}: {exc}",
-    #         )
-    #         return ""
 
     async def create_delete_replica_jobs(
         self, org: Organization, file: BaseFile, object_id: str, object_type: str
@@ -690,10 +561,6 @@ class BackgroundJobOps:
 
         if job.type != job_type:
             raise HTTPException(status_code=400, detail="invalid_job_type")
-
-        # TODO: Remove
-        # if success and job_type == BgJobType.CREATE_REPLICA:
-        #     await self.handle_replica_job_succeeded(cast(CreateReplicaJob, job))
 
         if job_type == BgJobType.DELETE_REPLICA:
             await self.handle_delete_replica_job_finished(cast(DeleteReplicaJob, job))

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -111,7 +111,7 @@ class BackgroundJobOps:
         """Create a job to delete each replica for the given file"""
         ids = []
 
-        for replica_ref in file.replicas or []:
+        for replica_ref in self.storage_ops.get_org_replicas_storage_refs(org):
             job_id = await self.create_delete_replica_job(
                 org, file, object_id, object_type, replica_ref
             )
@@ -278,7 +278,7 @@ class BackgroundJobOps:
 
             return job_id
         # pylint: disable=broad-exception-caught
-        except Exception as exc:
+        except Exception:
             replica_logger.warning(
                 "copy_bucket_job_start_failed",
                 exc_info=True,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -29,6 +29,7 @@ from .models import (
     ReAddOrgPagesJob,
     RecalculateOrgStatsJob,
     RetryStuckUploadsJob,
+    ReplicateFilesCronJob,
     StorageRef,
     SuccessResponse,
     SuccessResponseId,
@@ -509,6 +510,7 @@ class BackgroundJobOps:
         """Ensure periodic background cron jobs exist"""
         await self.crawl_manager.ensure_cleanup_seed_file_cron_job_exists()
         await self.crawl_manager.ensure_retry_stuck_uploads_cron_job_exists()
+        await self.crawl_manager.ensure_file_replication_cron_job_exists()
 
     async def job_finished(
         self,
@@ -524,12 +526,23 @@ class BackgroundJobOps:
 
         # For periodic cron jobs, no database record will exist for each
         # run before this point, so create it here
-        if job_type in (BgJobType.CLEANUP_SEED_FILES, BgJobType.RETRY_STUCK_UPLOADS):
+        if job_type in (
+            BgJobType.CLEANUP_SEED_FILES,
+            BgJobType.RETRY_STUCK_UPLOADS,
+            BgJobType.REPLICATE_FILES_CRON
+        ):
             if not started:
                 started = finished
             if job_type == BgJobType.CLEANUP_SEED_FILES:
                 cron_job: BackgroundJob = CleanupSeedFilesJob(
                     id=f"seed-files-{secrets.token_hex(5)}",
+                    started=started,
+                    finished=finished,
+                    success=success,
+                )
+            if job_type == BgJobType.REPLICATE_FILES_CRON:
+                cron_job = ReplicateFilesCronJob(
+                    id=f"replicate-cron-{secrets.token_hex(5)}",
                     started=started,
                     finished=finished,
                     success=success,
@@ -607,6 +620,7 @@ class BackgroundJobOps:
         | UpdateCollStatsJob
         | PostProcessUploadJob
         | RetryStuckUploadsJob
+        | ReplicateFilesCronJob
     ):
         """Get background job"""
         query: dict[str, object] = {"_id": job_id}
@@ -648,6 +662,9 @@ class BackgroundJobOps:
 
         if data["type"] == BgJobType.RETRY_STUCK_UPLOADS:
             return RetryStuckUploadsJob.from_dict(data)
+
+        if data["type"] == BgJobType.REPLICATE_FILES_CRON:
+            return ReplicateFilesCronJob.from_dict(data)
 
         if data["type"] == BgJobType.DELETE_ORG:
             return DeleteOrgJob.from_dict(data)
@@ -831,7 +848,7 @@ class BackgroundJobOps:
             )
             return {"success": True}
 
-        if job.type == BgJobType.CLEANUP_SEED_FILES:
+        if job.type in (BgJobType.CLEANUP_SEED_FILES, BgJobType.REPLICATE_FILES_CRON):
             raise HTTPException(status_code=400, detail="cron_job_retry_not_supported")
 
         return {"success": False}

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -99,136 +99,139 @@ class BackgroundJobOps:
             parts.path[1:], ""
         )
 
-    async def handle_replica_job_succeeded(self, job: CreateReplicaJob) -> None:
-        """Update replicas in corresponding file objects, based on type"""
-        res = None
-        if job.object_type in CRAWL_TYPES:
-            res = await self.base_crawl_ops.add_crawl_file_replica(
-                job.object_id, job.file_path, job.replica_storage
-            )
-        elif job.object_type == "profile":
-            res = await self.profile_ops.add_profile_file_replica(
-                UUID(job.object_id), job.file_path, job.replica_storage
-            )
-        if not res:
-            logger.debug(
-                "file_deleted_before_replication",
-                object_id=job.object_id,
-                file_path=job.file_path,
-                replica_storage=job.replica_storage,
-                oid=job.oid,
-                unstructured_message="File deleted before replication job started, ignoring",
-            )
+    # TODO: Remove
+    # async def handle_replica_job_succeeded(self, job: CreateReplicaJob) -> None:
+    #     """Update replicas in corresponding file objects, based on type"""
+    #     res = None
+    #     if job.object_type in CRAWL_TYPES:
+    #         res = await self.base_crawl_ops.add_crawl_file_replica(
+    #             job.object_id, job.file_path, job.replica_storage
+    #         )
+    #     elif job.object_type == "profile":
+    #         res = await self.profile_ops.add_profile_file_replica(
+    #             UUID(job.object_id), job.file_path, job.replica_storage
+    #         )
+    #     if not res:
+    #         logger.debug(
+    #             "file_deleted_before_replication",
+    #             object_id=job.object_id,
+    #             file_path=job.file_path,
+    #             replica_storage=job.replica_storage,
+    #             oid=job.oid,
+    #             unstructured_message="File deleted before replication job started, ignoring",
+    #         )
 
     async def handle_delete_replica_job_finished(self, job: DeleteReplicaJob) -> None:
         """After successful replica deletion, delete cronjob if scheduled"""
         if job.schedule:
             await self.crawl_manager.delete_replica_deletion_scheduled_job(job.id)
 
-    async def create_replica_jobs(
-        self, oid: UUID, file: BaseFile, object_id: str, object_type: str
-    ) -> dict[str, bool | list[str]]:
-        """Create k8s background job to replicate a file to all replica storage locations."""
-        org = await self.org_ops.get_org_by_id(oid)
+    # TODO: Remove
+    # async def create_replica_jobs(
+    #     self, oid: UUID, file: BaseFile, object_id: str, object_type: str
+    # ) -> dict[str, bool | list[str]]:
+    #     """Create k8s background job to replicate a file to all replica storage locations."""
+    #     org = await self.org_ops.get_org_by_id(oid)
 
-        primary_storage = self.storage_ops.get_org_storage_by_ref(org, file.storage)
-        primary_endpoint, bucket_suffix = self.strip_bucket(
-            primary_storage.endpoint_url
-        )
+    #     primary_storage = self.storage_ops.get_org_storage_by_ref(org, file.storage)
+    #     primary_endpoint, bucket_suffix = self.strip_bucket(
+    #         primary_storage.endpoint_url
+    #     )
 
-        primary_file_path = bucket_suffix + file.filename
+    #     primary_file_path = bucket_suffix + file.filename
 
-        ids = []
+    #     ids = []
 
-        for replica_ref in self.storage_ops.get_org_replicas_storage_refs(org):
-            job_id = await self.create_replica_job(
-                org,
-                file,
-                object_id,
-                object_type,
-                replica_ref,
-                primary_file_path,
-                primary_endpoint,
-            )
-            ids.append(job_id)
+    #     for replica_ref in self.storage_ops.get_org_replicas_storage_refs(org):
+    #         job_id = await self.create_replica_job(
+    #             org,
+    #             file,
+    #             object_id,
+    #             object_type,
+    #             replica_ref,
+    #             primary_file_path,
+    #             primary_endpoint,
+    #         )
+    #         ids.append(job_id)
 
-        return {"added": True, "ids": ids}
+    #     return {"added": True, "ids": ids}
 
-    async def create_replica_job(
-        self,
-        org: Organization,
-        file: BaseFile,
-        object_id: str,
-        object_type: str,
-        replica_ref: StorageRef,
-        primary_file_path: str,
-        primary_endpoint: str,
-        existing_job_id: str | None = None,
-    ) -> str:
-        """Create k8s background job to replicate a file to a specific replica storage location."""
-        replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
-        replica_endpoint, bucket_suffix = self.strip_bucket(
-            replica_storage.endpoint_url
-        )
-        replica_file_path = bucket_suffix + file.filename
+    # TODO: Remove
+    # async def create_replica_job(
+    #     self,
+    #     org: Organization,
+    #     file: BaseFile,
+    #     object_id: str,
+    #     object_type: str,
+    #     replica_ref: StorageRef,
+    #     primary_file_path: str,
+    #     primary_endpoint: str,
+    #     existing_job_id: str | None = None,
+    # ) -> str:
+    #     """Create k8s background job to replicate a file to a specific replica storage location."""
+    #     replica_storage = self.storage_ops.get_org_storage_by_ref(org, replica_ref)
+    #     replica_endpoint, bucket_suffix = self.strip_bucket(
+    #         replica_storage.endpoint_url
+    #     )
+    #     replica_file_path = bucket_suffix + file.filename
 
-        job_type = BgJobType.CREATE_REPLICA.value
+    #     job_type = BgJobType.CREATE_REPLICA.value
 
-        try:
-            job_id, _ = await self.crawl_manager.run_replica_job(
-                oid=str(org.id),
-                job_type=job_type,
-                primary_storage=file.storage,
-                primary_file_path=primary_file_path,
-                primary_endpoint=primary_endpoint,
-                replica_storage=replica_ref,
-                replica_file_path=replica_file_path,
-                replica_endpoint=replica_endpoint,
-                delay_days=0,
-                existing_job_id=existing_job_id,
-            )
-            if existing_job_id:
-                replication_job = await self.get_background_job(existing_job_id, org.id)
-                previous_attempt = {
-                    "started": replication_job.started,
-                    "finished": replication_job.finished,
-                }
-                if replication_job.previousAttempts:
-                    replication_job.previousAttempts.append(previous_attempt)
-                else:
-                    replication_job.previousAttempts = [previous_attempt]
-                replication_job.started = dt_now()
-                replication_job.finished = None
-                replication_job.success = None
-            else:
-                replication_job = CreateReplicaJob(
-                    id=job_id,
-                    oid=org.id,
-                    started=dt_now(),
-                    file_path=file.filename,
-                    object_type=object_type,
-                    object_id=object_id,
-                    primary=file.storage,
-                    replica_storage=replica_ref,
-                )
+    #     try:
+    #         job_id, _ = await self.crawl_manager.run_replica_job(
+    #             oid=str(org.id),
+    #             job_type=job_type,
+    #             primary_storage=file.storage,
+    #             primary_file_path=primary_file_path,
+    #             primary_endpoint=primary_endpoint,
+    #             replica_storage=replica_ref,
+    #             replica_file_path=replica_file_path,
+    #             replica_endpoint=replica_endpoint,
+    #             delay_days=0,
+    #             existing_job_id=existing_job_id,
+    #         )
+    #         if existing_job_id:
+    #             replication_job = await self.get_background_job(existing_job_id, org.id)
+    #             previous_attempt = {
+    #                 "started": replication_job.started,
+    #                 "finished": replication_job.finished,
+    #             }
+    #             if replication_job.previousAttempts:
+    #                 replication_job.previousAttempts.append(previous_attempt)
+    #             else:
+    #                 replication_job.previousAttempts = [previous_attempt]
+    #             replication_job.started = dt_now()
+    #             replication_job.finished = None
+    #             replication_job.success = None
+    #         else:
+    #             replication_job = CreateReplicaJob(
+    #                 id=job_id,
+    #                 oid=org.id,
+    #                 started=dt_now(),
+    #                 file_path=file.filename,
+    #                 object_type=object_type,
+    #                 object_id=object_id,
+    #                 primary=file.storage,
+    #                 replica_storage=replica_ref,
+    #             )
 
-            await self.jobs.find_one_and_update(
-                {"_id": job_id}, {"$set": replication_job.to_dict()}, upsert=True
-            )
+    #         await self.jobs.find_one_and_update(
+    #             {"_id": job_id}, {"$set": replication_job.to_dict()}, upsert=True
+    #         )
 
-            return job_id
-        # pylint: disable=broad-exception-caught
-        except Exception as exc:
-            logger.warning(
-                "replica_job_start_failed",
-                object_type=object_type,
-                oid=org.id,
-                file=file,
-                exc_info=True,
-                unstructured_message=f"warning: replica job could not be started "
-                f"for {object_type} {file}: {exc}",
-            )
-            return ""
+    #         return job_id
+    #     # pylint: disable=broad-exception-caught
+    #     except Exception as exc:
+    #         logger.warning(
+    #             "replica_job_start_failed",
+    #             object_type=object_type,
+    #             oid=org.id,
+    #             file=file,
+    #             exc_info=True,
+    #             unstructured_message=f"warning: replica job could not be started "
+    #             f"for {object_type} {file}: {exc}",
+    #         )
+    #         return ""
 
     async def create_delete_replica_jobs(
         self, org: Organization, file: BaseFile, object_id: str, object_type: str
@@ -688,8 +691,9 @@ class BackgroundJobOps:
         if job.type != job_type:
             raise HTTPException(status_code=400, detail="invalid_job_type")
 
-        if success and job_type == BgJobType.CREATE_REPLICA:
-            await self.handle_replica_job_succeeded(cast(CreateReplicaJob, job))
+        # TODO: Remove
+        # if success and job_type == BgJobType.CREATE_REPLICA:
+        #     await self.handle_replica_job_succeeded(cast(CreateReplicaJob, job))
 
         if job_type == BgJobType.DELETE_REPLICA:
             await self.handle_delete_replica_job_finished(cast(DeleteReplicaJob, job))
@@ -902,24 +906,9 @@ class BackgroundJobOps:
     ) -> dict[str, bool | str | None]:
         """Retry background job specific to one org"""
         if job.type == BgJobType.CREATE_REPLICA:
-            job = cast(CreateReplicaJob, job)
-            file = await self.get_replica_job_file(job, org)
-            primary_storage = self.storage_ops.get_org_storage_by_ref(org, file.storage)
-            primary_endpoint, bucket_suffix = self.strip_bucket(
-                primary_storage.endpoint_url
+            raise HTTPException(
+                status_code=400, detail="create_replica_job_retry_not_supported"
             )
-            primary_file_path = bucket_suffix + file.filename
-            await self.create_replica_job(
-                org,
-                file,
-                job.object_id,
-                job.object_type,
-                job.replica_storage,
-                primary_file_path,
-                primary_endpoint,
-                existing_job_id=job.id,
-            )
-            return {"success": True}
 
         if job.type == BgJobType.DELETE_REPLICA:
             job = cast(DeleteReplicaJob, job)

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -14,7 +14,6 @@ from kubernetes_asyncio.utils.create_from_yaml import FailToCreateError
 
 from .crawlmanager import CrawlManager
 from .models import (
-    CRAWL_TYPES,
     AnyJob,
     BackgroundJob,
     BaseFile,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -29,8 +29,8 @@ from .models import (
     PostProcessUploadJob,
     ReAddOrgPagesJob,
     RecalculateOrgStatsJob,
-    RetryStuckUploadsJob,
     ReplicateFilesCronJob,
+    RetryStuckUploadsJob,
     StorageRef,
     SuccessResponse,
     SuccessResponseId,
@@ -619,7 +619,7 @@ class BackgroundJobOps:
         if job_type in (
             BgJobType.CLEANUP_SEED_FILES,
             BgJobType.RETRY_STUCK_UPLOADS,
-            BgJobType.REPLICATE_FILES_CRON
+            BgJobType.REPLICATE_FILES_CRON,
         ):
             if not started:
                 started = finished

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -137,15 +137,12 @@ class BackgroundJobOps:
             )
             replica_file_path = bucket_suffix + file.filename
 
-            job_type = BgJobType.DELETE_REPLICA.value
-
             delay_days = int(os.environ.get("REPLICA_DELETION_DELAY_DAYS", 0))
             if force_start_immediately:
                 delay_days = 0
 
-            job_id, schedule = await self.crawl_manager.run_replica_job(
+            job_id, schedule = await self.crawl_manager.run_delete_replica_job(
                 oid=str(org.id),
-                job_type=job_type,
                 replica_storage=replica_ref,
                 replica_file_path=replica_file_path,
                 replica_endpoint=replica_endpoint,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -634,7 +634,7 @@ class BackgroundJobOps:
                     finished=finished,
                     success=success,
                 )
-            if job_type == BgJobType.REPLICATE_FILES_CRON:
+            elif job_type == BgJobType.REPLICATE_FILES_CRON:
                 cron_job = ReplicateFilesCronJob(
                     id=f"replicate-cron-{secrets.token_hex(5)}",
                     started=started,

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -19,6 +19,7 @@ from .models import (
     BaseFile,
     BgJobType,
     CleanupSeedFilesJob,
+    CopyBucketJob,
     CreateReplicaJob,
     DeleteOrgJob,
     DeleteReplicaJob,
@@ -193,6 +194,95 @@ class BackgroundJobOps:
                 oid=org.id,
                 unstructured_message="warning: replica deletion job could not be "
                 f"started for {object_type} {file}: {exc}",
+            )
+            return ""
+
+    async def create_copy_bucket_jobs(self):
+        """Create background jobs to copy primary storage to each default replica location
+
+        Note that this replicates default storages only, and not any org-specific
+        custom storage, which is not yet fully supported by Browsertrix. When custom
+        storage support is added, we will need to spin up additional copy jobs.
+
+        Because rclone copy is only additive, these copy bucket jobs will ensure
+        that all files in primary storage also exist in the configured replica
+        locations without being able to delete any files from the replica location.
+        """
+        primary_storage_ref = self.storage_ops.get_default_primary()
+        primary_storage = self.storage_ops.get_default_s3_storage(primary_storage_ref)
+        primary_endpoint, primary_bucket_suffix = self.strip_bucket(
+            primary_storage.endpoint_url
+        )
+
+        for default_replica_ref in self.storage_ops.get_default_replicas():
+            await self.create_copy_bucket_job(
+                primary_storage_ref,
+                primary_endpoint,
+                primary_bucket_suffix,
+                default_replica_ref,
+            )
+
+    async def create_copy_bucket_job(
+        self,
+        primary_storage_ref: StorageRef,
+        primary_endpoint: str,
+        primary_bucket_suffix: str,
+        replica_ref: StorageRef,
+        existing_job_id: str | None = None,
+    ) -> str:
+        """Create background job to copy contents of bucket to replica location"""
+        replica_logger = logger.bind(
+            primary_storage=primary_storage_ref, replica_storage=replica_ref
+        )
+
+        try:
+            replica_storage = self.storage_ops.get_default_s3_storage(replica_ref)
+            replica_endpoint, replica_bucket_suffix = self.strip_bucket(
+                replica_storage.endpoint_url
+            )
+
+            job_id = await self.crawl_manager.run_copy_bucket_job(
+                primary_storage=primary_storage_ref,
+                replica_storage=replica_ref,
+                primary_endpoint=primary_endpoint,
+                primary_bucket_suffix=primary_bucket_suffix,
+                replica_endpoint=replica_endpoint,
+                replica_bucket_suffix=replica_bucket_suffix,
+                existing_job_id=existing_job_id,
+            )
+            if existing_job_id:
+                copy_bucket_job = await self.get_background_job(existing_job_id)
+                previous_attempt = {
+                    "started": copy_bucket_job.started,
+                    "finished": copy_bucket_job.finished,
+                }
+                if copy_bucket_job.previousAttempts:
+                    copy_bucket_job.previousAttempts.append(previous_attempt)
+                else:
+                    copy_bucket_job.previousAttempts = [previous_attempt]
+                copy_bucket_job.started = dt_now()
+                copy_bucket_job.finished = None
+                copy_bucket_job.success = None
+            else:
+                copy_bucket_job = CopyBucketJob(
+                    id=job_id,
+                    started=dt_now(),
+                    replica_storage=replica_ref,
+                )
+
+            await self.jobs.find_one_and_update(
+                {"_id": job_id}, {"$set": copy_bucket_job.to_dict()}, upsert=True
+            )
+
+            replica_logger.info("copy_bucket_job_started", job_id=job_id)
+
+            return job_id
+        # pylint: disable=broad-exception-caught
+        except Exception as exc:
+            replica_logger.warning(
+                "copy_bucket_job_start_failed",
+                exc_info=True,
+                existing_job_id=existing_job_id,
             )
             return ""
 
@@ -621,6 +711,7 @@ class BackgroundJobOps:
         | PostProcessUploadJob
         | RetryStuckUploadsJob
         | ReplicateFilesCronJob
+        | CopyBucketJob
     ):
         """Get background job"""
         query: dict[str, object] = {"_id": job_id}
@@ -665,6 +756,9 @@ class BackgroundJobOps:
 
         if data["type"] == BgJobType.REPLICATE_FILES_CRON:
             return ReplicateFilesCronJob.from_dict(data)
+
+        if data["type"] == BgJobType.COPY_BUCKET:
+            return CopyBucketJob.from_dict(data)
 
         if data["type"] == BgJobType.DELETE_ORG:
             return DeleteOrgJob.from_dict(data)
@@ -779,6 +873,26 @@ class BackgroundJobOps:
             )
             return {"success": True}
 
+        if job.type == BgJobType.COPY_BUCKET:
+            job = cast(CopyBucketJob, job)
+
+            primary_storage_ref = self.storage_ops.get_default_primary()
+            primary_storage = self.storage_ops.get_default_s3_storage(
+                primary_storage_ref
+            )
+            primary_endpoint, primary_bucket_suffix = self.strip_bucket(
+                primary_storage.endpoint_url
+            )
+
+            await self.create_copy_bucket_job(
+                primary_storage_ref,
+                primary_endpoint,
+                primary_bucket_suffix,
+                job.replica_storage,
+                existing_job_id=job_id,
+            )
+            return {"success": True}
+
         return {"success": False}
 
     async def retry_org_background_job(
@@ -787,7 +901,15 @@ class BackgroundJobOps:
         """Retry background job specific to one org"""
         if job.type == BgJobType.CREATE_REPLICA:
             raise HTTPException(
-                status_code=400, detail="create_replica_job_retry_not_supported"
+                status_code=400, detail="create_replica_job_retry_no_longer_supported"
+            )
+
+        if job.type in (BgJobType.CLEANUP_SEED_FILES, BgJobType.REPLICATE_FILES_CRON):
+            raise HTTPException(status_code=400, detail="cron_job_retry_not_supported")
+
+        if job.type in (BgJobType.COPY_BUCKET, BgJobType.OPTIMIZE_PAGES):
+            raise HTTPException(
+                status_code=400, detail="non_org_specific_job_retry_not_supported"
             )
 
         if job.type == BgJobType.DELETE_REPLICA:

--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -600,10 +600,8 @@ class BackgroundJobOps:
         """Ensure periodic background cron jobs exist"""
         await self.crawl_manager.ensure_cleanup_seed_file_cron_job_exists()
         await self.crawl_manager.ensure_retry_stuck_uploads_cron_job_exists()
-
-        replicas_configured = True if self.storage_ops.get_default_replicas() else False
         await self.crawl_manager.ensure_file_replication_cron_job_exists(
-            replicas_configured
+            bool(self.storage_ops.get_default_replicas())
         )
 
     async def job_finished(

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -344,46 +344,48 @@ class BaseCrawlOps:
             {"userid": userid}, {"$set": {"userName": updated_name}}
         )
 
-    async def replicate_crawl_files(
-        self, crawl_id: str, org: Organization, type_: TYPE_CRAWL_TYPES
-    ):
-        """Replicate crawl files to configured replica locations"""
-        repl_logger = logger.bind(crawl_id=crawl_id, oid=org.id, type=type_)
+    # TODO: Remove
+    # async def replicate_crawl_files(
+    #     self, crawl_id: str, org: Organization, type_: TYPE_CRAWL_TYPES
+    # ):
+    #     """Replicate crawl files to configured replica locations"""
+    #     repl_logger = logger.bind(crawl_id=crawl_id, oid=org.id, type=type_)
 
-        try:
-            crawl = await self.get_base_crawl(crawl_id, org, type_)
-        # pylint: disable=broad-exception-caught
-        except Exception:
-            repl_logger.warning(
-                "crawl_replicate_skipped_not_found",
-                unstructured_message=f"Not replicating files for crawl {crawl_id}: crawl not found",
-            )
-            return
+    #     try:
+    #         crawl = await self.get_base_crawl(crawl_id, org, type_)
+    #     # pylint: disable=broad-exception-caught
+    #     except Exception:
+    #         repl_logger.warning(
+    #             "crawl_replicate_skipped_not_found",
+    #             unstructured_message=f"Not replicating files for crawl {crawl_id}: crawl not found",
+    #         )
+    #         return
 
-        for crawl_file in crawl.files:
-            try:
-                await self.background_job_ops.create_replica_jobs(
-                    crawl.oid, crawl_file, crawl.id, type_
-                )
-            # pylint: disable=broad-exception-caught
-            except Exception as exc:
-                repl_logger.exception(
-                    "crawl_replicate_failed",
-                    unstructured_message=f"Replicate Exception {exc}",
-                )
+    #     for crawl_file in crawl.files:
+    #         try:
+    #             await self.background_job_ops.create_replica_jobs(
+    #                 crawl.oid, crawl_file, crawl.id, type_
+    #             )
+    #         # pylint: disable=broad-exception-caught
+    #         except Exception as exc:
+    #             repl_logger.exception(
+    #                 "crawl_replicate_failed",
+    #                 unstructured_message=f"Replicate Exception {exc}",
+    #             )
 
-    async def add_crawl_file_replica(
-        self, crawl_id: str, filename: str, ref: StorageRef
-    ) -> dict[str, object]:
-        """Add replica StorageRef to existing CrawlFile"""
-        return await self.crawls.find_one_and_update(
-            {"_id": crawl_id, "files.filename": filename},
-            {
-                "$addToSet": {
-                    "files.$.replicas": {"name": ref.name, "custom": ref.custom}
-                }
-            },
-        )
+    # TODO: Remove
+    # async def add_crawl_file_replica(
+    #     self, crawl_id: str, filename: str, ref: StorageRef
+    # ) -> dict[str, object]:
+    #     """Add replica StorageRef to existing CrawlFile"""
+    #     return await self.crawls.find_one_and_update(
+    #         {"_id": crawl_id, "files.filename": filename},
+    #         {
+    #             "$addToSet": {
+    #                 "files.$.replicas": {"name": ref.name, "custom": ref.custom}
+    #             }
+    #         },
+    #     )
 
     async def shutdown_crawl(self, crawl_id: str, org: Organization, graceful: bool):
         """placeholder, implemented in crawls, base version does nothing"""

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -634,7 +634,6 @@ class BaseCrawlOps:
                                 hash=file["hash"],
                                 size=file["size"],
                                 crawlId=file["crawl_id"],
-                                numReplicas=len(file.get("replicas") or []),
                                 expireAt=date_to_str(
                                     presigned["signedAt"]
                                     + self.storage_ops.signed_duration_delta
@@ -676,7 +675,6 @@ class BaseCrawlOps:
                         hash=file["hash"],
                         size=file["size"],
                         crawlId=file["crawl_id"],
-                        numReplicas=len(file.get("replicas") or []),
                         expireAt=date_to_str(expire_at),
                     )
                 )

--- a/backend/btrixcloud/basecrawls.py
+++ b/backend/btrixcloud/basecrawls.py
@@ -344,49 +344,6 @@ class BaseCrawlOps:
             {"userid": userid}, {"$set": {"userName": updated_name}}
         )
 
-    # TODO: Remove
-    # async def replicate_crawl_files(
-    #     self, crawl_id: str, org: Organization, type_: TYPE_CRAWL_TYPES
-    # ):
-    #     """Replicate crawl files to configured replica locations"""
-    #     repl_logger = logger.bind(crawl_id=crawl_id, oid=org.id, type=type_)
-
-    #     try:
-    #         crawl = await self.get_base_crawl(crawl_id, org, type_)
-    #     # pylint: disable=broad-exception-caught
-    #     except Exception:
-    #         repl_logger.warning(
-    #             "crawl_replicate_skipped_not_found",
-    #             unstructured_message=f"Not replicating files for crawl {crawl_id}: crawl not found",
-    #         )
-    #         return
-
-    #     for crawl_file in crawl.files:
-    #         try:
-    #             await self.background_job_ops.create_replica_jobs(
-    #                 crawl.oid, crawl_file, crawl.id, type_
-    #             )
-    #         # pylint: disable=broad-exception-caught
-    #         except Exception as exc:
-    #             repl_logger.exception(
-    #                 "crawl_replicate_failed",
-    #                 unstructured_message=f"Replicate Exception {exc}",
-    #             )
-
-    # TODO: Remove
-    # async def add_crawl_file_replica(
-    #     self, crawl_id: str, filename: str, ref: StorageRef
-    # ) -> dict[str, object]:
-    #     """Add replica StorageRef to existing CrawlFile"""
-    #     return await self.crawls.find_one_and_update(
-    #         {"_id": crawl_id, "files.filename": filename},
-    #         {
-    #             "$addToSet": {
-    #                 "files.$.replicas": {"name": ref.name, "custom": ref.custom}
-    #             }
-    #         },
-    #     )
-
     async def shutdown_crawl(self, crawl_id: str, org: Organization, graceful: bool):
         """placeholder, implemented in crawls, base version does nothing"""
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -414,6 +414,69 @@ class CrawlManager(K8sAPI):
         cron_logger.info("bg_cron_job_creating")
         await self.create_from_yaml(data, namespace=DEFAULT_NAMESPACE)
 
+    async def ensure_file_replication_cron_job_exists(self):
+        """ensure cron background job to periodically replicate all files exists
+
+        Each time the background job runs, it will spawn one additional background
+        job for each configured replica storage location, and run `rclone copy` from
+        primary storage to each replica location to keep them in sync without the
+        possibility of deleting anything from the destination.
+
+        Deletions are handled separately with individual jobs and are subject to
+        the replica deletion delay.
+        """
+
+        job_id = "replicate-files-cron"
+
+        # Default schedule is every 2 hours
+        default_schedule = "0 */2 * * *"
+        job_schedule = os.environ.get("REPLICATION_JOB_CRON_SCHEDULE", default_schedule)
+
+        # Don't create a duplicate cron job if already exists
+        replication_logger = logger.bind(schedule=job_schedule)
+
+        try:
+            cron_job = await self.batch_api.read_namespaced_cron_job(
+                name=job_id,
+                namespace=self.namespace,
+            )
+            if cron_job:
+                replication_logger.info("replication_cron_job_exists")
+
+                if cron_job.spec.schedule != job_schedule:
+                    cron_job.spec.schedule = job_schedule
+
+                    await self.batch_api.patch_namespaced_cron_job(
+                        name=cron_job.metadata.name,
+                        namespace=self.namespace,
+                        body=cron_job,
+                    )
+                    replication_logger.info(
+                        "replication_cron_job_updated",
+                        prev_schedule=cron_job.spec.schedule,
+                    )
+                return
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            pass
+
+        replication_logger.info("replication_cron_job_creating")
+
+        params = {
+            "id": job_id,
+            "job_type": BgJobType.REPLICATE_FILES_CRON.value,
+            "backend_image": os.environ.get("BACKEND_IMAGE", ""),
+            "pull_policy": os.environ.get("BACKEND_IMAGE_PULL_POLICY", ""),
+            "schedule": job_schedule,
+            "larger_resources": False,
+        }
+
+        data = self.templates.env.get_template("background_cron_job.yaml").render(
+            params
+        )
+
+        await self.create_from_yaml(data)
+
     async def create_crawl_job(
         self,
         crawlconfig: CrawlConfig,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -81,6 +81,41 @@ class CrawlManager(K8sAPI):
 
         return browserid
 
+    async def run_copy_bucket_job(
+        self,
+        primary_storage: StorageRef,
+        replica_storage: StorageRef,
+        primary_endpoint: str,
+        primary_bucket_suffix: str,
+        replica_endpoint: str,
+        replica_bucket_suffix: str,
+        existing_job_id: str | None = None,
+    ) -> str:
+        """run job to replicate primary storage bucket to replica location"""
+        job_type = BgJobType.COPY_BUCKET.value
+
+        if existing_job_id:
+            job_id = existing_job_id
+        else:
+            job_id = f"{job_type}-{secrets.token_hex(5)}"
+
+        params: dict[str, object] = {
+            "id": job_id,
+            "primary_secret_name": primary_storage.get_storage_secret_name(),
+            "primary_file_path": primary_bucket_suffix,
+            "primary_endpoint": primary_endpoint,
+            "replica_secret_name": replica_storage.get_storage_secret_name(),
+            "replica_file_path": replica_bucket_suffix,
+            "replica_endpoint": replica_endpoint,
+            "BgJobType": BgJobType,
+        }
+
+        data = self.templates.env.get_template("copy_bucket_job.yaml").render(params)
+
+        await self.create_from_yaml(data)
+
+        return job_id
+
     async def run_delete_replica_job(
         self,
         oid: str,
@@ -88,9 +123,6 @@ class CrawlManager(K8sAPI):
         replica_file_path: str,
         replica_endpoint: str,
         delay_days: int = 0,
-        primary_storage: StorageRef | None = None,
-        primary_file_path: str | None = None,
-        primary_endpoint: str | None = None,
         existing_job_id: str | None = None,
     ) -> tuple[str, str | None]:
         """run job to replicate file from primary storage to replica storage"""
@@ -110,13 +142,6 @@ class CrawlManager(K8sAPI):
             "replica_secret_name": replica_storage.get_storage_secret_name(oid),
             "replica_file_path": replica_file_path,
             "replica_endpoint": replica_endpoint,
-            "primary_secret_name": (
-                primary_storage.get_storage_secret_name(oid)
-                if primary_storage
-                else None
-            ),
-            "primary_file_path": primary_file_path if primary_file_path else None,
-            "primary_endpoint": primary_endpoint if primary_endpoint else None,
             "BgJobType": BgJobType,
         }
 
@@ -438,22 +463,23 @@ class CrawlManager(K8sAPI):
         try:
             cron_job = await self.batch_api.read_namespaced_cron_job(
                 name=job_id,
-                namespace=self.namespace,
+                namespace=DEFAULT_NAMESPACE,
             )
             if cron_job:
                 replication_logger.info("replication_cron_job_exists")
 
                 if cron_job.spec.schedule != job_schedule:
+                    prev_schedule = cron_job.spec.schedule
                     cron_job.spec.schedule = job_schedule
 
                     await self.batch_api.patch_namespaced_cron_job(
                         name=cron_job.metadata.name,
-                        namespace=self.namespace,
+                        namespace=DEFAULT_NAMESPACE,
                         body=cron_job,
                     )
                     replication_logger.info(
                         "replication_cron_job_updated",
-                        prev_schedule=cron_job.spec.schedule,
+                        prev_schedule=prev_schedule,
                     )
                 return
         # pylint: disable=broad-exception-caught
@@ -475,7 +501,7 @@ class CrawlManager(K8sAPI):
             params
         )
 
-        await self.create_from_yaml(data)
+        await self.create_from_yaml(data, namespace=DEFAULT_NAMESPACE)
 
     async def create_crawl_job(
         self,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -81,10 +81,9 @@ class CrawlManager(K8sAPI):
 
         return browserid
 
-    async def run_replica_job(
+    async def run_delete_replica_job(
         self,
         oid: str,
-        job_type: str,
         replica_storage: StorageRef,
         replica_file_path: str,
         replica_endpoint: str,
@@ -95,6 +94,8 @@ class CrawlManager(K8sAPI):
         existing_job_id: str | None = None,
     ) -> tuple[str, str | None]:
         """run job to replicate file from primary storage to replica storage"""
+
+        job_type = BgJobType.DELETE_REPLICA.value
 
         if existing_job_id:
             job_id = existing_job_id
@@ -119,13 +120,13 @@ class CrawlManager(K8sAPI):
             "BgJobType": BgJobType,
         }
 
-        if job_type == BgJobType.DELETE_REPLICA.value and delay_days > 0:
+        if delay_days > 0:
             # If replica deletion delay is configured, schedule as cronjob
             return await self.create_replica_deletion_scheduled_job(
                 job_id, params, delay_days
             )
 
-        data = self.templates.env.get_template("replica_job.yaml").render(params)
+        data = self.templates.env.get_template("delete_replica_job.yaml").render(params)
 
         await self.create_from_yaml(data)
 

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -378,7 +378,9 @@ class CrawlManager(K8sAPI):
             larger_resources=True,
         )
 
-    async def ensure_retry_stuck_uploads_cron_job_exists(self):
+    async def ensure_retry_stuck_uploads_cron_job_exists(
+        self, disable_job: bool = False
+    ):
         """ensure cron background job to retry stuck uploads exists"""
 
         default_schedule = "0 * * * *"
@@ -386,11 +388,19 @@ class CrawlManager(K8sAPI):
             "RETRY_STUCK_UPLOADS_CRON_SCHEDULE", default_schedule
         )
 
-        await self._ensure_bg_cron_job_exists(
-            "retry-stuck-uploads-cron",
-            BgJobType.RETRY_STUCK_UPLOADS.value,
-            job_schedule,
-        )
+        job_id = "retry-stuck-uploads-cron"
+
+        if not disable_job:
+            return await self._ensure_bg_cron_job_exists(
+                job_id,
+                BgJobType.RETRY_STUCK_UPLOADS.value,
+                job_schedule,
+            )
+
+        # If no replica locations are configured, make sure no replication cron
+        # job exists, as one could have been previously configured.
+        logger.info("bg_cron_job_deleting", job_id=job_id, disable_job=True)
+        await self._delete_cron_job_if_exists(job_id)
 
     async def ensure_file_replication_cron_job_exists(
         self, replicas_configured: bool = False
@@ -412,17 +422,8 @@ class CrawlManager(K8sAPI):
 
         # If no replica locations are configured, make sure no replication cron
         # job exists, as one could have been previously configured.
-        try:
-            await self.batch_api.delete_namespaced_cron_job(
-                name=job_id,
-                namespace=DEFAULT_NAMESPACE,
-            )
-            logger.info(
-                "bg_cron_job_deleting", job_id=job_id, replicas_configured=False
-            )
-        except ApiException as exc:
-            if exc.status != 404:
-                raise
+        logger.info("bg_cron_job_deleting", job_id=job_id, replicas_configured=False)
+        await self._delete_cron_job_if_exists(job_id)
 
     async def _ensure_bg_cron_job_exists(
         self,
@@ -470,6 +471,17 @@ class CrawlManager(K8sAPI):
 
         cron_logger.info("bg_cron_job_creating")
         await self.create_from_yaml(data, namespace=DEFAULT_NAMESPACE)
+
+    async def _delete_cron_job_if_exists(self, job_id: str):
+        """Delete cron job by id if it exists"""
+        try:
+            await self.batch_api.delete_namespaced_cron_job(
+                name=job_id,
+                namespace=DEFAULT_NAMESPACE,
+            )
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
 
     async def create_crawl_job(
         self,

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -392,6 +392,24 @@ class CrawlManager(K8sAPI):
             job_schedule,
         )
 
+    async def ensure_file_replication_cron_job_exists(self):
+        """ensure cron background job to replica default storages exists"""
+
+        # Default schedule is every 2 hours
+        default_schedule = "0 */2 * * *"
+        job_schedule = os.environ.get("REPLICATION_JOB_CRON_SCHEDULE", default_schedule)
+
+        # TODO: Only create background job if default replica storage locations
+        # are configured.
+        # If replica locations were configured and then removed, do we want to
+        # do any cleanup around that as well?
+
+        await self._ensure_bg_cron_job_exists(
+            "replicate-files-cron",
+            BgJobType.REPLICATE_FILES_CRON.value,
+            job_schedule,
+        )
+
     async def _ensure_bg_cron_job_exists(
         self,
         job_id: str,
@@ -437,70 +455,6 @@ class CrawlManager(K8sAPI):
             return
 
         cron_logger.info("bg_cron_job_creating")
-        await self.create_from_yaml(data, namespace=DEFAULT_NAMESPACE)
-
-    async def ensure_file_replication_cron_job_exists(self):
-        """ensure cron background job to periodically replicate all files exists
-
-        Each time the background job runs, it will spawn one additional background
-        job for each configured replica storage location, and run `rclone copy` from
-        primary storage to each replica location to keep them in sync without the
-        possibility of deleting anything from the destination.
-
-        Deletions are handled separately with individual jobs and are subject to
-        the replica deletion delay.
-        """
-
-        job_id = "replicate-files-cron"
-
-        # Default schedule is every 2 hours
-        default_schedule = "0 */2 * * *"
-        job_schedule = os.environ.get("REPLICATION_JOB_CRON_SCHEDULE", default_schedule)
-
-        # Don't create a duplicate cron job if already exists
-        replication_logger = logger.bind(schedule=job_schedule)
-
-        try:
-            cron_job = await self.batch_api.read_namespaced_cron_job(
-                name=job_id,
-                namespace=DEFAULT_NAMESPACE,
-            )
-            if cron_job:
-                replication_logger.info("replication_cron_job_exists")
-
-                if cron_job.spec.schedule != job_schedule:
-                    prev_schedule = cron_job.spec.schedule
-                    cron_job.spec.schedule = job_schedule
-
-                    await self.batch_api.patch_namespaced_cron_job(
-                        name=cron_job.metadata.name,
-                        namespace=DEFAULT_NAMESPACE,
-                        body=cron_job,
-                    )
-                    replication_logger.info(
-                        "replication_cron_job_updated",
-                        prev_schedule=prev_schedule,
-                    )
-                return
-        # pylint: disable=broad-exception-caught
-        except Exception:
-            pass
-
-        replication_logger.info("replication_cron_job_creating")
-
-        params = {
-            "id": job_id,
-            "job_type": BgJobType.REPLICATE_FILES_CRON.value,
-            "backend_image": os.environ.get("BACKEND_IMAGE", ""),
-            "pull_policy": os.environ.get("BACKEND_IMAGE_PULL_POLICY", ""),
-            "schedule": job_schedule,
-            "larger_resources": False,
-        }
-
-        data = self.templates.env.get_template("background_cron_job.yaml").render(
-            params
-        )
-
         await self.create_from_yaml(data, namespace=DEFAULT_NAMESPACE)
 
     async def create_crawl_job(

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -392,23 +392,37 @@ class CrawlManager(K8sAPI):
             job_schedule,
         )
 
-    async def ensure_file_replication_cron_job_exists(self):
+    async def ensure_file_replication_cron_job_exists(
+        self, replicas_configured: bool = False
+    ):
         """ensure cron background job to replica default storages exists"""
 
         # Default schedule is every 2 hours
         default_schedule = "0 */2 * * *"
         job_schedule = os.environ.get("REPLICATION_JOB_CRON_SCHEDULE", default_schedule)
 
-        # TODO: Only create background job if default replica storage locations
-        # are configured.
-        # If replica locations were configured and then removed, do we want to
-        # do any cleanup around that as well?
+        job_id = "replicate-files-cron"
 
-        await self._ensure_bg_cron_job_exists(
-            "replicate-files-cron",
-            BgJobType.REPLICATE_FILES_CRON.value,
-            job_schedule,
-        )
+        if replicas_configured:
+            return await self._ensure_bg_cron_job_exists(
+                job_id,
+                BgJobType.REPLICATE_FILES_CRON.value,
+                job_schedule,
+            )
+
+        # If no replica locations are configured, make sure no replication cron
+        # job exists, as one could have been previously configured.
+        try:
+            await self.batch_api.delete_namespaced_cron_job(
+                name=job_id,
+                namespace=DEFAULT_NAMESPACE,
+            )
+            logger.info(
+                "bg_cron_job_deleting", job_id=job_id, replicas_configured=False
+            )
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
 
     async def _ensure_bg_cron_job_exists(
         self,

--- a/backend/btrixcloud/db.py
+++ b/backend/btrixcloud/db.py
@@ -39,7 +39,7 @@ else:
     ) = object
 
 
-CURR_DB_VERSION = "0058"
+CURR_DB_VERSION = "0059"
 
 MIN_DB_VERSION = 7.0
 

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -107,6 +107,16 @@ async def main():
             )
             return ExitCode.ERROR
 
+    if job_type == BgJobType.REPLICATE_FILES_CRON:
+        try:
+            # Call method to launch actual rclone copy jobs - from storage_ops?
+            crawl_logger.info("replicate_files_cron_reached")
+            return ExitCode.SUCCESS
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            crawl_logger.exception("bg_job_failed")
+            return ExitCode.ERROR
+
     # Run job (org-specific)
     if not oid:
         crawl_logger.error(

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -60,7 +60,7 @@ async def main():
         coll_ops,
         _,
         _,
-        _,
+        bg_job_ops,
         _,
         user_manager,
         _,
@@ -109,8 +109,7 @@ async def main():
 
     if job_type == BgJobType.REPLICATE_FILES_CRON:
         try:
-            # Call method to launch actual rclone copy jobs - from storage_ops?
-            crawl_logger.info("replicate_files_cron_reached")
+            await bg_job_ops.create_copy_bucket_jobs()
             return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:

--- a/backend/btrixcloud/migrations/migration_0052_profile_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0052_profile_filenames.py
@@ -26,8 +26,6 @@ class Migration(BaseMigration):
         """Perform migration up.
 
         Add oid prefix to profile resource filenames that don't already have it.
-        For any profiles that match, also delete the database record for any
-        existing replicas and then spawn new replication jobs.
         """
         profiles_mdb = self.mdb["profiles"]
 
@@ -59,25 +57,9 @@ class Migration(BaseMigration):
                         {
                             "$set": {
                                 "resource.filename": new_filename,
-                                "resource.replicas": [],
                             }
                         },
                     )
-
-                    profile.resource.filename = new_filename
-                    profile.resource.replicas = []
-
-                    # TODO: Remove
-                    # logger.info(
-                    #     "profile_replication_job_started",
-                    #     profile_id=profile.id,
-                    #     unstructured_message=(
-                    #         f"Starting background jobs to replicate profile {profile.id}"
-                    #     ),
-                    # )
-                    # await self.background_job_ops.create_replica_jobs(
-                    #     profile.oid, profile.resource, str(profile.id), "profile"
-                    # )
                 # pylint: disable=broad-exception-caught
                 except Exception:
                     logger.exception(

--- a/backend/btrixcloud/migrations/migration_0052_profile_filenames.py
+++ b/backend/btrixcloud/migrations/migration_0052_profile_filenames.py
@@ -67,16 +67,17 @@ class Migration(BaseMigration):
                     profile.resource.filename = new_filename
                     profile.resource.replicas = []
 
-                    logger.info(
-                        "profile_replication_job_started",
-                        profile_id=profile.id,
-                        unstructured_message=(
-                            f"Starting background jobs to replicate profile {profile.id}"
-                        ),
-                    )
-                    await self.background_job_ops.create_replica_jobs(
-                        profile.oid, profile.resource, str(profile.id), "profile"
-                    )
+                    # TODO: Remove
+                    # logger.info(
+                    #     "profile_replication_job_started",
+                    #     profile_id=profile.id,
+                    #     unstructured_message=(
+                    #         f"Starting background jobs to replicate profile {profile.id}"
+                    #     ),
+                    # )
+                    # await self.background_job_ops.create_replica_jobs(
+                    #     profile.oid, profile.resource, str(profile.id), "profile"
+                    # )
                 # pylint: disable=broad-exception-caught
                 except Exception:
                     logger.exception(

--- a/backend/btrixcloud/migrations/migration_0059_remove_file_replicas_from_db.py
+++ b/backend/btrixcloud/migrations/migration_0059_remove_file_replicas_from_db.py
@@ -1,0 +1,49 @@
+"""
+Migration 0059 - Remove per-file tracking of file replicas in database
+"""
+
+import structlog
+
+from btrixcloud.migrations import BaseMigration
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+MIGRATION_VERSION = "0059"
+
+
+class Migration(BaseMigration):
+    """Migration class."""
+
+    # pylint: disable=unused-argument
+    def __init__(self, mdb, **kwargs):
+        super().__init__(mdb, migration_version=MIGRATION_VERSION)
+
+    async def migrate_up(self):
+        """Perform migration up.
+
+        Remove replicas array from all crawl and profile files.
+        """
+        crawls_mdb = self.mdb["crawls"]
+        profiles_mdb = self.mdb["profiles"]
+
+        try:
+            res = await crawls_mdb.update_many(
+                {"files": {"$nin": [None, []]}},
+                {"$unset": {"files.$[].replicas": 1}},
+            )
+            updated = res.modified_count
+            logger.info("updated_crawl_files", count=updated)
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            logger.exception("failed_to_update_crawl_files")
+
+        try:
+            res = await profiles_mdb.update_many(
+                {"resource": {"$ne": None}},
+                {"$unset": {"resource.replicas": 1}},
+            )
+            updated = res.modified_count
+            logger.info("updated_profile_files", count=updated)
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            logger.exception("failed_to_update_profile_files")

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -863,7 +863,7 @@ class StorageRef(BaseModel):
             return self.name
         return "cs-" + self.name
 
-    def get_storage_secret_name(self, oid: str) -> str:
+    def get_storage_secret_name(self, oid: str = "") -> str:
         """get k8s secret name for this storage and oid"""
         if not self.custom:
             return "storage-" + self.name
@@ -3252,6 +3252,8 @@ class BgJobType(StrEnum):
     CREATE_REPLICA = "create-replica"
     # New replication job that spins up rclone copy jobs as needed
     REPLICATE_FILES_CRON = "replicate-files-cron"
+    # Per-bucket replication job
+    COPY_BUCKET = "copy-bucket"
 
 
 # ============================================================================
@@ -3345,6 +3347,14 @@ class ReplicateFilesCronJob(BackgroundJob):
 
 
 # ============================================================================
+class CopyBucketJob(BackgroundJob):
+    """Model for tracking job to copy primary storage bucket to replica storage"""
+
+    type: Literal[BgJobType.COPY_BUCKET] = BgJobType.COPY_BUCKET
+    replica_storage: StorageRef
+
+
+# ============================================================================
 class UpdateCollStatsJob(BackgroundJob):
     """Model for tracking jobs to readd pages for an org or single crawl"""
 
@@ -3385,6 +3395,7 @@ AnyJob = RootModel[
     | PostProcessUploadJob
     | RetryStuckUploadsJob
     | ReplicateFilesCronJob
+    | CopyBucketJob
 ]
 
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -896,8 +896,6 @@ class BaseFile(BaseModel):
     size: int
     storage: StorageRef
 
-    replicas: list[StorageRef] | None = []
-
 
 # ============================================================================
 class CrawlFile(BaseFile):
@@ -914,7 +912,6 @@ class CrawlFileOut(BaseModel):
     size: int
 
     crawlId: str | None = None
-    numReplicas: int = 0
     expireAt: str | None = None
     fromDependency: bool = False
 

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -3239,7 +3239,6 @@ class WebhookNotification(BaseMongoModel):
 class BgJobType(StrEnum):
     """Background Job Types"""
 
-    CREATE_REPLICA = "create-replica"
     DELETE_REPLICA = "delete-replica"
     DELETE_ORG = "delete-org"
     RECALCULATE_ORG_STATS = "recalculate-org-stats"
@@ -3249,6 +3248,10 @@ class BgJobType(StrEnum):
     UPDATE_COLL_STATS = "update-coll-stats"
     POSTPROCESS_UPLOAD = "postprocess-upload"
     RETRY_STUCK_UPLOADS = "retry-stuck-uploads"
+    # Deprecated per-file replication jobs
+    CREATE_REPLICA = "create-replica"
+    # New replication job that spins up rclone copy jobs as needed
+    REPLICATE_FILES_CRON = "replicate-files-cron"
 
 
 # ============================================================================
@@ -3335,6 +3338,13 @@ class CleanupSeedFilesJob(BackgroundJob):
 
 
 # ============================================================================
+class ReplicateFilesCronJob(BackgroundJob):
+    """Model for tracking cron jobs to replicate files"""
+
+    type: Literal[BgJobType.REPLICATE_FILES_CRON] = BgJobType.REPLICATE_FILES_CRON
+
+
+# ============================================================================
 class UpdateCollStatsJob(BackgroundJob):
     """Model for tracking jobs to readd pages for an org or single crawl"""
 
@@ -3374,6 +3384,7 @@ AnyJob = RootModel[
     | UpdateCollStatsJob
     | PostProcessUploadJob
     | RetryStuckUploadsJob
+    | ReplicateFilesCronJob
 ]
 
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -2202,8 +2202,6 @@ class CrawlOperator(BaseOperator):
             await self.coll_ops.add_successful_crawl_to_collections(
                 crawl.id, crawl.cid, crawl.oid
             )
-            # TODO: Remove
-            # await self.crawl_ops.replicate_crawl_files(crawl.id, crawl.org, "crawl")
 
             if stats and stats.profile_update and crawl.profileid:
                 await self.crawl_config_ops.profiles.update_profile_from_crawl_upload(

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -2202,7 +2202,8 @@ class CrawlOperator(BaseOperator):
             await self.coll_ops.add_successful_crawl_to_collections(
                 crawl.id, crawl.cid, crawl.oid
             )
-            await self.crawl_ops.replicate_crawl_files(crawl.id, crawl.org, "crawl")
+            # TODO: Remove
+            # await self.crawl_ops.replicate_crawl_files(crawl.id, crawl.org, "crawl")
 
             if stats and stats.profile_update and crawl.profileid:
                 await self.crawl_config_ops.profiles.update_profile_from_crawl_upload(

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -30,7 +30,6 @@ from .models import (
     ProfilePingResponse,
     ProfileSearchValuesResponse,
     ProfileUpdate,
-    StorageRef,
     SuccessResponse,
     SuccessResponseStorageQuota,
     TagsResponse,
@@ -647,15 +646,6 @@ class ProfileOps:
             raise HTTPException(status_code=200, detail="waiting_for_browser")
 
         return data or {}
-
-    async def add_profile_file_replica(
-        self, profileid: UUID, filename: str, ref: StorageRef
-    ) -> dict[str, object]:
-        """Add replica StorageRef to existing ProfileFile"""
-        return await self.profiles.find_one_and_update(
-            {"_id": profileid, "resource.filename": filename},
-            {"$push": {"resource.replicas": {"name": ref.name, "custom": ref.custom}}},
-        )
 
     async def calculate_org_profile_file_storage(self, oid: UUID) -> int:
         """Calculate and return total size of profile files in org"""

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -351,11 +351,6 @@ class ProfileOps:
                 {"_id": profile.id}, {"$set": profile.to_dict()}, upsert=True
             )
 
-            # TODO: Remove
-            # await self.background_job_ops.create_replica_jobs(
-            #     org.id, profile_file, str(profileid), "profile"
-            # )
-
             await self.orgs.inc_org_bytes_stored(
                 org.id, file_size - prev_file_size, "profile"
             )
@@ -450,15 +445,6 @@ class ProfileOps:
         # same hash, profile unchanged, no updates needed
         if profile_file.hash == hash_:
             return True
-
-        profile_file.size = size
-        profile_file.hash = hash_
-
-        # update replica
-        # TODO: Remove
-        # await self.background_job_ops.create_replica_jobs(
-        #     org_id, profile_file, str(profileid), "profile"
-        # )
 
         # update size stats, if changed
         if size != prev_file_size:

--- a/backend/btrixcloud/profiles.py
+++ b/backend/btrixcloud/profiles.py
@@ -351,9 +351,10 @@ class ProfileOps:
                 {"_id": profile.id}, {"$set": profile.to_dict()}, upsert=True
             )
 
-            await self.background_job_ops.create_replica_jobs(
-                org.id, profile_file, str(profileid), "profile"
-            )
+            # TODO: Remove
+            # await self.background_job_ops.create_replica_jobs(
+            #     org.id, profile_file, str(profileid), "profile"
+            # )
 
             await self.orgs.inc_org_bytes_stored(
                 org.id, file_size - prev_file_size, "profile"
@@ -454,9 +455,10 @@ class ProfileOps:
         profile_file.hash = hash_
 
         # update replica
-        await self.background_job_ops.create_replica_jobs(
-            org_id, profile_file, str(profileid), "profile"
-        )
+        # TODO: Remove
+        # await self.background_job_ops.create_replica_jobs(
+        #     org_id, profile_file, str(profileid), "profile"
+        # )
 
         # update size stats, if changed
         if size != prev_file_size:

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -287,6 +287,23 @@ class StorageOps:
             refs.append(StorageRef(name=name, custom=True))
         return refs
 
+    def get_default_primary(self) -> StorageRef:
+        """return default primary storageref"""
+        if not self.default_primary:
+            raise HTTPException(status_code=400, detail="no_primary_storage")
+        return self.default_primary
+
+    def get_default_replicas(self) -> list[StorageRef]:
+        """return default replica storage locations"""
+        return self.default_replicas
+
+    def get_default_s3_storage(self, ref: StorageRef) -> S3Storage:
+        """return s3storage object for default storage ref (not org specific)"""
+        storage = self.default_storages.get(ref.name)
+        if not storage:
+            raise KeyError(f"Storage ref {ref.name} not found")
+        return storage
+
     @asynccontextmanager
     async def get_s3_client(
         self, storage: S3Storage, for_presign=False

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -280,6 +280,7 @@ class UploadOps(BaseCrawlOps):
         upload_logger.debug(
             "upload_create", state="completed", quota_reached=quota_reached
         )
+
         return {"id": crawl_id, "added": True, "storageQuotaReached": quota_reached}
 
     async def post_process_upload(
@@ -393,8 +394,8 @@ class UploadOps(BaseCrawlOps):
                 {"_id": crawl_id}, {"$set": {"state": "complete"}}
             )
 
-            pp_logger.debug("post_process_upload", state="replicate_crawl_files")
-            await self.replicate_crawl_files(crawl_id, org, "upload")
+            # pp_logger.debug("post_process_upload", state="replicate_crawl_files")
+            # await self.replicate_crawl_files(crawl_id, org, "upload")
 
             pp_logger.debug(
                 "post_process_upload", state="finished_processing_dispatching_webhook"

--- a/backend/btrixcloud/uploads.py
+++ b/backend/btrixcloud/uploads.py
@@ -394,9 +394,6 @@ class UploadOps(BaseCrawlOps):
                 {"_id": crawl_id}, {"$set": {"state": "complete"}}
             )
 
-            # pp_logger.debug("post_process_upload", state="replicate_crawl_files")
-            # await self.replicate_crawl_files(crawl_id, org, "upload")
-
             pp_logger.debug(
                 "post_process_upload", state="finished_processing_dispatching_webhook"
             )

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -871,7 +871,6 @@ def profile_config_id(admin_auth_headers, default_org_id, profile_id):
     assert resource["size"]
     assert resource["storage"]
     assert resource["storage"]["name"]
-    assert resource.get("replicas") or resource.get("replicas") == []
 
     # Use profile in a workflow
     r = requests.post(

--- a/backend/test/test_profiles.py
+++ b/backend/test/test_profiles.py
@@ -62,7 +62,6 @@ def test_get_profile(admin_auth_headers, default_org_id, profile_id, profile_con
             assert resource["size"]
             assert resource["storage"]
             assert resource["storage"]["name"]
-            assert "replicas" in resource and isinstance(resource["replicas"], list)
 
             assert "crawlconfigs" not in data
             assert data["inUse"] == True
@@ -118,7 +117,6 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert resource["size"]
             assert resource["storage"]
             assert resource["storage"]["name"]
-            assert "replicas" in resource and isinstance(resource["replicas"], list)
 
             # First profile should be listed second by default because it was
             # modified less recently
@@ -145,7 +143,6 @@ def test_list_profiles(admin_auth_headers, default_org_id, profile_id, profile_2
             assert resource["size"]
             assert resource["storage"]
             assert resource["storage"]["name"]
-            assert "replicas" in resource and isinstance(resource["replicas"], list)
 
             break
         except:

--- a/backend/test/test_unit_background_jobs.py
+++ b/backend/test/test_unit_background_jobs.py
@@ -12,6 +12,7 @@ from btrixcloud.background_jobs import BackgroundJobOps
 from btrixcloud.models import (
     BgJobType,
     CleanupSeedFilesJob,
+    CopyBucketJob,
     CreateReplicaJob,
     DeleteOrgJob,
     DeleteReplicaJob,
@@ -19,6 +20,7 @@ from btrixcloud.models import (
     PostProcessUploadJob,
     ReAddOrgPagesJob,
     RecalculateOrgStatsJob,
+    ReplicateFilesCronJob,
     RetryStuckUploadsJob,
     UpdateCollStatsJob,
 )
@@ -34,6 +36,8 @@ JOB_TYPE_TO_CLASS = {
     BgJobType.UPDATE_COLL_STATS: UpdateCollStatsJob,
     BgJobType.POSTPROCESS_UPLOAD: PostProcessUploadJob,
     BgJobType.RETRY_STUCK_UPLOADS: RetryStuckUploadsJob,
+    BgJobType.REPLICATE_FILES_CRON: ReplicateFilesCronJob,
+    BgJobType.COPY_BUCKET: CopyBucketJob,
 }
 
 _TYPE_EXTRAS = {
@@ -47,6 +51,9 @@ _TYPE_EXTRAS = {
         "file_path": "/test/path",
         "object_type": "crawl",
         "object_id": "test-object",
+        "replica_storage": {"name": "test-storage"},
+    },
+    BgJobType.COPY_BUCKET: {
         "replica_storage": {"name": "test-storage"},
     },
 }

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -376,17 +376,6 @@ def deleted_crawl_id(admin_auth_headers, default_org_id):
             break
         time.sleep(5)
 
-    # Wait until replica background job completes
-    while True:
-        r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/jobs/?jobType=create-replica&success=True",
-            headers=admin_auth_headers,
-        )
-        assert r.status_code == 200
-        if r.json()["total"] == 1:
-            break
-        time.sleep(5)
-
     # Delete crawl
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/delete",
@@ -394,16 +383,5 @@ def deleted_crawl_id(admin_auth_headers, default_org_id):
         json={"crawl_ids": [crawl_id]},
     )
     assert r.status_code == 200
-
-    # Wait until delete replica background job completes
-    while True:
-        r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/jobs/?jobType=delete-replica&success=True",
-            headers=admin_auth_headers,
-        )
-        assert r.status_code == 200
-        if r.json()["total"] == 1:
-            break
-        time.sleep(5)
 
     return crawl_id

--- a/backend/test_nightly/conftest.py
+++ b/backend/test_nightly/conftest.py
@@ -376,6 +376,9 @@ def deleted_crawl_id(admin_auth_headers, default_org_id):
             break
         time.sleep(5)
 
+    # Wait for it to replicate
+    time.sleep(300)
+
     # Delete crawl
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/delete",

--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -2,6 +2,8 @@ import time
 
 import requests
 
+from btrixcloud.utils import dt_now
+
 from .conftest import API_PREFIX
 from .utils import verify_file_replicated
 
@@ -33,16 +35,20 @@ def test_crawl_timeout(admin_auth_headers, default_org_id, timeout_crawl):
 
 
 def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_crawl):
-    time.sleep(20)
+    crawl_complete = dt_now()
 
-    # Verify replication job was successful
+    # Wait a few minutes so that replication jobs have time to run
+    time.sleep(300)
+
+    # Verify copy bucket job has run and succeeded since crawl completed
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=create-replica",
+        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
     latest_job = r.json()["items"][0]
-    assert latest_job["type"] == "create-replica"
+    assert latest_job["type"] == "copy-bucket"
+    assert latest_job["started"] >= crawl_complete
     job_id = latest_job["id"]
 
     attempts = 0
@@ -62,22 +68,20 @@ def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_craw
         assert job["success"]
         break
 
-    # Assert file was updated
+    # Verify crawlfiles are stored in replica location
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/crawls/{timeout_crawl}/replay.json",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
+
+    oid = data["oid"]
+    assert oid
+
     files = data.get("resources")
     assert files
     for file_ in files:
-        assert file_["numReplicas"] == 1
-
-    # Verify replica is stored
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}", headers=admin_auth_headers
-    )
-    assert r.status_code == 200
-    data = r.json()
-    verify_file_replicated(data["file_path"])
+        filename = file_["name"]
+        file_path = f"{oid}/{filename}"
+        verify_file_replicated(file_path)

--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -42,42 +42,26 @@ def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_craw
     # Verify copy bucket job has run and succeeded since crawl completed
     job_id = None
 
-    # Give job up to 15 minutes to complete
+    # Give copy bucket job (which is kicked off by cron replication job)
+    # up to 20 minutes to start and then complete
     attempts = 0
-    while attempts < 15:
+    while attempts < 20:
         r = requests.get(
             f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=copy-bucket",
             headers=admin_auth_headers,
         )
         assert r.status_code == 200
         jobs = r.json().get("items", [])
-        if jobs:
-            latest_job = jobs[0]
-            assert latest_job["type"] == "copy-bucket"
-            if latest_job["started"] >= crawl_complete:
-                job_id = latest_job["id"]
+        for job in jobs:
+            assert job["type"] == "copy-bucket"
+            if job.get("started") >= crawl_complete and job.get("finished"):
+                job_id = job["id"]
                 break
 
         attempts += 1
         time.sleep(60)
 
-    # Give job up to 5 minutes to finish
-    attempts = 0
-    while attempts < 10:
-        r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}",
-            headers=admin_auth_headers,
-        )
-        assert r.status_code == 200
-        job = r.json()
-        finished = latest_job.get("finished")
-        if not finished:
-            attempts += 1
-            time.sleep(30)
-            continue
-
-        assert job["success"]
-        break
+    assert job_id
 
     # Verify crawlfiles are stored in replica location
     r = requests.get(

--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -39,22 +39,31 @@ def test_crawl_timeout(admin_auth_headers, default_org_id, timeout_crawl):
 def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_crawl):
     crawl_complete = dt_now()
 
-    # Wait a few minutes so that replication jobs have time to run
-    time.sleep(300)
-
     # Verify copy bucket job has run and succeeded since crawl completed
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
-        headers=admin_auth_headers,
-    )
-    assert r.status_code == 200
-    latest_job = r.json()["items"][0]
-    assert latest_job["type"] == "copy-bucket"
-    assert latest_job["started"] >= crawl_complete
-    job_id = latest_job["id"]
+    job_id = None
 
+    # Give job up to 15 minutes to complete
     attempts = 0
-    while attempts < 5:
+    while attempts < 15:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
+            headers=admin_auth_headers,
+        )
+        assert r.status_code == 200
+        jobs = r.json().get("items", [])
+        if jobs:
+            latest_job = jobs[0]
+            assert latest_job["type"] == "copy-bucket"
+            if latest_job["started"] >= crawl_complete:
+                job_id = latest_job["id"]
+                break
+
+        attempts += 1
+        time.sleep(60)
+
+    # Give job up to 5 minutes to finish
+    attempts = 0
+    while attempts < 10:
         r = requests.get(
             f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}",
             headers=admin_auth_headers,
@@ -64,7 +73,7 @@ def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_craw
         finished = latest_job.get("finished")
         if not finished:
             attempts += 1
-            time.sleep(10)
+            time.sleep(30)
             continue
 
         assert job["success"]

--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -46,7 +46,7 @@ def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_craw
     attempts = 0
     while attempts < 15:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
+            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=copy-bucket",
             headers=admin_auth_headers,
         )
         assert r.status_code == 200

--- a/backend/test_nightly/test_crawl_timeout.py
+++ b/backend/test_nightly/test_crawl_timeout.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 import requests
 
 from btrixcloud.utils import dt_now
@@ -34,6 +35,7 @@ def test_crawl_timeout(admin_auth_headers, default_org_id, timeout_crawl):
         attempts += 1
 
 
+@pytest.mark.timeout(1800)
 def test_crawl_files_replicated(admin_auth_headers, default_org_id, timeout_crawl):
     crawl_complete = dt_now()
 

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -43,42 +43,26 @@ def test_upload_file_replicated(admin_auth_headers, default_org_id):
     # Verify copy bucket job has run and succeeded since crawl completed
     job_id = None
 
-    # Give job up to 15 minutes to complete
+    # Give copy bucket job (which is kicked off by cron replication job)
+    # up to 20 minutes to start and then complete
     attempts = 0
-    while attempts < 15:
+    while attempts < 20:
         r = requests.get(
             f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=copy-bucket",
             headers=admin_auth_headers,
         )
         assert r.status_code == 200
         jobs = r.json().get("items", [])
-        if jobs:
-            latest_job = jobs[0]
-            assert latest_job["type"] == "copy-bucket"
-            if latest_job["started"] >= upload_complete:
-                job_id = latest_job["id"]
+        for job in jobs:
+            assert job["type"] == "copy-bucket"
+            if job.get("started") >= upload_complete and job.get("finished"):
+                job_id = job["id"]
                 break
 
         attempts += 1
         time.sleep(60)
 
-    # Give job up to 5 minutes to finish
-    attempts = 0
-    while attempts < 10:
-        r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}",
-            headers=admin_auth_headers,
-        )
-        assert r.status_code == 200
-        job = r.json()
-        finished = latest_job.get("finished")
-        if not finished:
-            attempts += 1
-            time.sleep(30)
-            continue
-
-        assert job["success"]
-        break
+    assert job_id
 
     # Verify upload file is stored
     r = requests.get(

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -40,22 +40,31 @@ def test_upload_stream(admin_auth_headers, default_org_id):
 def test_upload_file_replicated(admin_auth_headers, default_org_id):
     upload_complete = dt_now()
 
-    # Wait a few minutes so that replication jobs have time to run
-    time.sleep(300)
+    # Verify copy bucket job has run and succeeded since crawl completed
+    job_id = None
 
-    # Verify copy bucket job has run and succeeded since upload
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
-        headers=admin_auth_headers,
-    )
-    assert r.status_code == 200
-    latest_job = r.json()["items"][0]
-    assert latest_job["type"] == "copy-bucket"
-    assert latest_job["started"] >= upload_complete
-    job_id = latest_job["id"]
-
+    # Give job up to 15 minutes to complete
     attempts = 0
-    while attempts < 5:
+    while attempts < 15:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
+            headers=admin_auth_headers,
+        )
+        assert r.status_code == 200
+        jobs = r.json().get("items", [])
+        if jobs:
+            latest_job = jobs[0]
+            assert latest_job["type"] == "copy-bucket"
+            if latest_job["started"] >= upload_complete:
+                job_id = latest_job["id"]
+                break
+
+        attempts += 1
+        time.sleep(60)
+
+    # Give job up to 5 minutes to finish
+    attempts = 0
+    while attempts < 10:
         r = requests.get(
             f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}",
             headers=admin_auth_headers,
@@ -65,7 +74,7 @@ def test_upload_file_replicated(admin_auth_headers, default_org_id):
         finished = latest_job.get("finished")
         if not finished:
             attempts += 1
-            time.sleep(10)
+            time.sleep(30)
             continue
 
         assert job["success"]

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -47,7 +47,7 @@ def test_upload_file_replicated(admin_auth_headers, default_org_id):
     attempts = 0
     while attempts < 15:
         r = requests.get(
-            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
+            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=copy-bucket",
             headers=admin_auth_headers,
         )
         assert r.status_code == 200

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -4,6 +4,7 @@ import time
 import structlog
 import requests
 
+from btrixcloud.utils import dt_now
 from test.utils import read_in_chunks
 
 from .conftest import API_PREFIX
@@ -33,16 +34,20 @@ def test_upload_stream(admin_auth_headers, default_org_id):
 
 
 def test_upload_file_replicated(admin_auth_headers, default_org_id):
-    time.sleep(20)
+    upload_complete = dt_now()
 
-    # Verify replication job was successful
+    # Wait a few minutes so that replication jobs have time to run
+    time.sleep(300)
+
+    # Verify copy bucket job has run and succeeded since upload
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=create-replica",
+        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=1&jobType=copy-bucket",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
     latest_job = r.json()["items"][0]
-    assert latest_job["type"] == "create-replica"
+    assert latest_job["type"] == "copy-bucket"
+    assert latest_job["started"] >= upload_complete
     job_id = latest_job["id"]
 
     attempts = 0
@@ -62,30 +67,24 @@ def test_upload_file_replicated(admin_auth_headers, default_org_id):
         assert job["success"]
         break
 
-    # Verify file updated
+    # Verify upload file is stored
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/{upload_id}/replay.json",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
     data = r.json()
+
     files = data.get("resources")
     assert files
-    for file_ in files:
-        assert file_["numReplicas"] == 1
 
-    # Verify replica is stored
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs/{job_id}", headers=admin_auth_headers
-    )
-    assert r.status_code == 200
-    job = r.json()
-    logger.info(
-        "upload_file_path",
-        file_path=job["file_path"],
-        unstructured_message=f"{job['file_path']}",
-    )
-    verify_file_replicated(job["file_path"])
+    file_ = files[0]
+    filename = file_["name"]
+
+    global upload_file_path
+    upload_file_path = f"{default_org_id}/{filename}"
+
+    verify_file_replicated(upload_file_path)
 
 
 def test_delete_upload_and_replicas(admin_auth_headers, default_org_id):
@@ -145,4 +144,8 @@ def test_delete_upload_and_replicas(admin_auth_headers, default_org_id):
     )
     assert r.status_code == 200
     job = r.json()
-    verify_file_and_replica_deleted(job["file_path"])
+
+    job_file_path = job["file_path"]
+    assert job_file_path == upload_file_path
+
+    verify_file_and_replica_deleted(job_file_path)

--- a/backend/test_nightly/test_upload_replicas.py
+++ b/backend/test_nightly/test_upload_replicas.py
@@ -2,6 +2,7 @@ import os
 import time
 
 import structlog
+import pytest
 import requests
 
 from btrixcloud.utils import dt_now
@@ -16,6 +17,8 @@ from .utils import (
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
+
+upload_file_path = None
 
 
 def test_upload_stream(admin_auth_headers, default_org_id):
@@ -33,6 +36,7 @@ def test_upload_stream(admin_auth_headers, default_org_id):
     upload_id = r.json()["id"]
 
 
+@pytest.mark.timeout(1800)
 def test_upload_file_replicated(admin_auth_headers, default_org_id):
     upload_complete = dt_now()
 
@@ -87,6 +91,7 @@ def test_upload_file_replicated(admin_auth_headers, default_org_id):
     verify_file_replicated(upload_file_path)
 
 
+@pytest.mark.timeout(1800)
 def test_delete_upload_and_replicas(admin_auth_headers, default_org_id):
     r = requests.post(
         f"{API_PREFIX}/orgs/{default_org_id}/uploads/delete",

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -33,12 +33,11 @@ def test_background_jobs_list(admin_auth_headers, default_org_id, deleted_crawl_
     assert job_id
 
 
-@pytest.mark.parametrize("job_type", [("create-replica"), ("delete-replica")])
 def test_background_jobs_list_filter_by_type(
     admin_auth_headers, default_org_id, deleted_crawl_id, job_type
 ):
     r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs/?jobType={job_type}",
+        f"{API_PREFIX}/orgs/{default_org_id}/jobs/?jobType=delete-replica",
         headers=admin_auth_headers,
     )
     assert r.status_code == 200
@@ -49,7 +48,7 @@ def test_background_jobs_list_filter_by_type(
     assert len(items) == data["total"]
 
     for item in items:
-        assert item["type"] == job_type
+        assert item["type"] == "delete-replica"
 
 
 def test_background_jobs_list_filter_by_success(
@@ -91,7 +90,12 @@ def test_get_background_job(admin_auth_headers, default_org_id, deleted_crawl_id
     data = r.json()
 
     assert data["id"]
-    assert data["type"] in ("create-replica", "delete-replica")
+    assert data["type"] in (
+        "replicate-files-cron",
+        "copy-bucket",
+        "delete-replica",
+        "cleanup-seed-files",
+    )
     assert data["oid"] == default_org_id
     assert data["success"]
     assert data["started"]
@@ -99,7 +103,8 @@ def test_get_background_job(admin_auth_headers, default_org_id, deleted_crawl_id
     assert data["file_path"]
     assert data["object_type"]
     assert data["object_id"]
-    assert data["replica_storage"]
+    if data["type"] in ("delete-replica", "copy-bucket"):
+        assert data["replica_storage"]
 
 
 def test_retry_all_failed_bg_jobs_not_superuser(crawler_auth_headers, deleted_crawl_id):

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -8,6 +8,7 @@ from .conftest import API_PREFIX
 job_id = None
 
 
+@pytest.mark.timeout(1800)
 def test_background_jobs_list(admin_auth_headers, default_org_id, deleted_crawl_id):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/", headers=admin_auth_headers

--- a/backend/test_nightly/test_z_background_jobs.py
+++ b/backend/test_nightly/test_z_background_jobs.py
@@ -35,7 +35,7 @@ def test_background_jobs_list(admin_auth_headers, default_org_id, deleted_crawl_
 
 
 def test_background_jobs_list_filter_by_type(
-    admin_auth_headers, default_org_id, deleted_crawl_id, job_type
+    admin_auth_headers, default_org_id, deleted_crawl_id
 ):
     r = requests.get(
         f"{API_PREFIX}/orgs/{default_org_id}/jobs/?jobType=delete-replica",

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 2
 
   schedule: "{{ schedule }}"

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -88,8 +88,8 @@ spec:
 
         resources:
           limits:
-            memory: "200Mi"
+            memory: "1200Mi"
 
           requests:
-            memory: "200Mi"
-            cpu: "50m"
+            memory: "500Mi"
+            cpu: "200m"

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -84,7 +84,7 @@ spec:
         - name: RCLONE_CONFIG_REPLICA_ENDPOINT
           value: "{{ replica_endpoint }}"
 
-        command: ["rclone", "-vv", "copy", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replica:{{ replica_file_path }}"]
+        command: ["rclone", "-vv", "copy", "--checksum", "primary:{{ primary_file_path }}", "replica:{{ replica_file_path }}"]
 
         resources:
           limits:

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -2,15 +2,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ id }}"
-  finalizers:
-    - metacontroller.io/decoratorcontroller-background-job-operator
   labels:
     role: "background-job"
     job_type: {{ job_type }}
-    btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 300
   backoffLimit: 5
   template:
     spec:
@@ -27,6 +24,36 @@ spec:
       - name: rclone
         image: rclone/rclone:latest
         env:
+        - name: RCLONE_CONFIG_PRIMARY_TYPE
+          value: "s3"
+
+        - name: RCLONE_CONFIG_PRIMARY_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ primary_secret_name }}"
+              key: STORE_ACCESS_KEY
+
+        - name: RCLONE_CONFIG_PRIMARY_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ primary_secret_name }}"
+              key: STORE_SECRET_KEY
+
+        - name: RCLONE_CONFIG_PRIMARY_REGION
+          valueFrom:
+            secretKeyRef:
+              name: "{{ primary_secret_name }}"
+              key: STORE_REGION
+
+        - name: RCLONE_CONFIG_PRIMARY_PROVIDER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ primary_secret_name }}"
+              key: STORE_S3_PROVIDER
+
+        - name: RCLONE_CONFIG_PRIMARY_ENDPOINT
+          value: "{{ primary_endpoint }}"
+
         - name: RCLONE_CONFIG_REPLICA_TYPE
           value: "s3"
 
@@ -57,7 +84,7 @@ spec:
         - name: RCLONE_CONFIG_REPLICA_ENDPOINT
           value: "{{ replica_endpoint }}"
 
-        command: ["rclone", "-vv", "delete", "replica:{{ replica_file_path }}"]
+        command: ["rclone", "-vv", "copy", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replica:{{ replica_file_path }}"]
 
         resources:
           limits:

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ id }}"
   labels:
     role: "background-job"
-    job_type: {{ job_type }}
+    job_type: "{{ job_type }}"
 
 spec:
   ttlSecondsAfterFinished: 300

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   ttlSecondsAfterFinished: 300
-  backoffLimit: 5
+  backoffLimit: 6
   template:
     spec:
       restartPolicy: Never

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ id }}"
+  finalizers:
+    - metacontroller.io/decoratorcontroller-background-job-operator
   labels:
     role: "background-job"
     job_type: "{{ job_type }}"

--- a/chart/app-templates/copy_bucket_job.yaml
+++ b/chart/app-templates/copy_bucket_job.yaml
@@ -13,13 +13,6 @@ spec:
     spec:
       restartPolicy: Never
       priorityClassName: bg-job
-      podFailurePolicy:
-        rules:
-        - action: FailJob
-          onExitCodes:
-            containerName: rclone
-            operator: NotIn
-            values: [0]
       containers:
       - name: rclone
         image: rclone/rclone:latest

--- a/chart/app-templates/delete_replica_job.yaml
+++ b/chart/app-templates/delete_replica_job.yaml
@@ -16,13 +16,6 @@ spec:
     spec:
       restartPolicy: Never
       priorityClassName: bg-job
-      podFailurePolicy:
-        rules:
-        - action: FailJob
-          onExitCodes:
-            containerName: rclone
-            operator: NotIn
-            values: [0]
       containers:
       - name: rclone
         image: rclone/rclone:latest

--- a/chart/app-templates/delete_replica_job.yaml
+++ b/chart/app-templates/delete_replica_job.yaml
@@ -6,8 +6,8 @@ metadata:
     - metacontroller.io/decoratorcontroller-background-job-operator
   labels:
     role: "background-job"
-    job_type: {{ job_type }}
-    btrix.org: {{ oid }}
+    job_type: "{{ job_type }}"
+    btrix.org: "{{ oid }}"
 
 spec:
   ttlSecondsAfterFinished: 0

--- a/chart/app-templates/delete_replica_job.yaml
+++ b/chart/app-templates/delete_replica_job.yaml
@@ -27,40 +27,6 @@ spec:
       - name: rclone
         image: rclone/rclone:latest
         env:
-
-{% if job_type == BgJobType.CREATE_REPLICA %}
-        - name: RCLONE_CONFIG_PRIMARY_TYPE
-          value: "s3"
-
-        - name: RCLONE_CONFIG_PRIMARY_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: "{{ primary_secret_name }}"
-              key: STORE_ACCESS_KEY
-
-        - name: RCLONE_CONFIG_PRIMARY_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "{{ primary_secret_name }}"
-              key: STORE_SECRET_KEY
-
-        - name: RCLONE_CONFIG_PRIMARY_REGION
-          valueFrom:
-            secretKeyRef:
-              name: "{{ primary_secret_name }}"
-              key: STORE_REGION
-
-        - name: RCLONE_CONFIG_PRIMARY_PROVIDER
-          valueFrom:
-            secretKeyRef:
-              name: "{{ primary_secret_name }}"
-              key: STORE_S3_PROVIDER
-
-        - name: RCLONE_CONFIG_PRIMARY_ENDPOINT
-          value: "{{ primary_endpoint }}"
-
-{% endif %}
-
         - name: RCLONE_CONFIG_REPLICA_TYPE
           value: "s3"
 
@@ -91,11 +57,8 @@ spec:
         - name: RCLONE_CONFIG_REPLICA_ENDPOINT
           value: "{{ replica_endpoint }}"
 
-{% if job_type == BgJobType.CREATE_REPLICA %}
-        command: ["rclone", "-vv", "copyto", "--checksum", "--error-on-no-transfer", "primary:{{ primary_file_path }}", "replica:{{ replica_file_path }}"]
-{% elif job_type == BgJobType.DELETE_REPLICA %}
         command: ["rclone", "-vv", "delete", "replica:{{ replica_file_path }}"]
-{% endif %}
+
         resources:
           limits:
             memory: "200Mi"

--- a/chart/app-templates/delete_replica_job.yaml
+++ b/chart/app-templates/delete_replica_job.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   ttlSecondsAfterFinished: 0
-  backoffLimit: 5
+  backoffLimit: 6
   template:
     spec:
       restartPolicy: Never

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -127,6 +127,8 @@ data:
 
   RETRY_STUCK_UPLOADS_CRON_SCHEDULE: "{{ .Values.stuck_uploads_cron_schedule }}"
 
+  DISABLE_STUCK_UPLOADS_CRON: "{{ .Values.disable_stuck_uploads_cron }}"
+
   DEDUPE_IMPORTER_CHANNEL: "{{ .Values.dedupe.importer_channel }}"
 
   ENABLE_AUTO_RESIZE_INDEX_STORAGE: "{{ .Values.dedupe.enable_auto_resize }}"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -121,6 +121,8 @@ data:
 
   CLEANUP_JOB_CRON_SCHEDULE: "{{ .Values.cleanup_job_cron_schedule }}"
 
+  REPLICATION_JOB_CRON_SCHEDULE: "{{ .Values.replication_job_cron_schedule }}"
+
   CLEANUP_FILES_AFTER_MINUTES: "{{ .Values.cleanup_files_after_minutes | default 1440 }}"
 
   RETRY_STUCK_UPLOADS_CRON_SCHEDULE: "{{ .Values.stuck_uploads_cron_schedule }}"

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -10,6 +10,9 @@ cleanup_job_cron_schedule: "* * * * *"
 # Clean up files > 1 minute old in testing
 cleanup_files_after_minutes: 1
 
+# Every 2 minutes, for use in testing file replication
+replication_job_cron_schedule: "*/2 * * * *"
+
 # max crawl queue size x concurrent crawls
 crawl_queue_limit_scale: 1
 

--- a/chart/test/test-nightly-addons.yaml
+++ b/chart/test/test-nightly-addons.yaml
@@ -13,6 +13,9 @@ cleanup_files_after_minutes: 1
 # Every 2 minutes, for use in testing file replication
 replication_job_cron_schedule: "*/2 * * * *"
 
+# Disable retry uploads cron job to ease resource usage on CI workers
+disable_stuck_uploads_cron: true
+
 # max crawl queue size x concurrent crawls
 crawl_queue_limit_scale: 1
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -192,6 +192,10 @@ cleanup_files_after_minutes: 1440
 # without a running background job and retrying them
 stuck_uploads_cron_schedule: "0 * * * *"
 
+# Cron schedule for periodically syncing replica storage
+# locations from primary storage
+replication_job_cron_schedule: ""
+
 # Emails Image
 # =========================================
 emails_image: "docker.io/webrecorder/browsertrix-emails:1.25.1"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -192,8 +192,8 @@ cleanup_files_after_minutes: 1440
 # without a running background job and retrying them
 stuck_uploads_cron_schedule: "0 * * * *"
 
-# Cron schedule for periodically syncing replica storage
-# locations from primary storage
+# Cron schedule for periodically syncing replica storage from primary
+# Defaults to every two hours
 replication_job_cron_schedule: "0 */2 * * *"
 
 # Emails Image

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -192,6 +192,10 @@ cleanup_files_after_minutes: 1440
 # without a running background job and retrying them
 stuck_uploads_cron_schedule: "0 * * * *"
 
+# Option to disable stuck uploads cron job
+# Generally should only be set true for testing in CI
+disable_stuck_uploads_cron: false
+
 # Cron schedule for periodically syncing replica storage from primary
 # Defaults to every two hours
 replication_job_cron_schedule: "0 */2 * * *"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -194,7 +194,7 @@ stuck_uploads_cron_schedule: "0 * * * *"
 
 # Cron schedule for periodically syncing replica storage
 # locations from primary storage
-replication_job_cron_schedule: ""
+replication_job_cron_schedule: "0 */2 * * *"
 
 # Emails Image
 # =========================================

--- a/frontend/src/pages/org/browser-profiles/profile.ts
+++ b/frontend/src/pages/org/browser-profiles/profile.ts
@@ -24,7 +24,6 @@ import {
 import type { ProfileUpdatedEvent } from "@/features/browser-profiles/types";
 import type { WorkflowColumnName } from "@/features/crawl-workflows/workflow-list";
 import { emptyMessage } from "@/layouts/emptyMessage";
-import { labelWithIcon } from "@/layouts/labelWithIcon";
 import { pageHeader, pageNav } from "@/layouts/pageHeader";
 import { panel, panelBody } from "@/layouts/panel";
 import { OrgTab, WorkflowTab } from "@/routes";
@@ -547,19 +546,6 @@ export class BrowserProfilesProfilePage extends BtrixElement {
                   })
                 : noData,
             )}
-          </btrix-desc-list-item>
-          <btrix-desc-list-item label=${msg("Backup Status")}>
-            ${this.renderDetail((profile) => {
-              const isBackedUp =
-                profile.resource?.replicas &&
-                profile.resource.replicas.length > 0;
-              return labelWithIcon({
-                label: isBackedUp ? msg("Backed Up") : msg("Not Backed Up"),
-                icon: html`<sl-icon
-                  name=${isBackedUp ? "clouds-fill" : "cloud-slash-fill"}
-                ></sl-icon>`,
-              });
-            })}
           </btrix-desc-list-item>
         </btrix-desc-list>
       `,

--- a/frontend/src/types/collection.ts
+++ b/frontend/src/types/collection.ts
@@ -40,7 +40,6 @@ export const publicCollectionSchema = z.object({
       hash: z.string(),
       size: z.number(),
       crawlId: z.string().nullable(),
-      numReplicas: z.number(),
       expireAt: z.string().datetime().nullable(),
       fromDependency: z.boolean(),
     }),

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -131,11 +131,6 @@ export type ListWorkflow = Omit<Workflow, "config" | "image"> & {
   config: Workflow["config"] | null;
 };
 
-export type ProfileReplica = {
-  name: string;
-  custom?: boolean;
-};
-
 export type Profile = {
   id: string;
   name: string;
@@ -160,7 +155,6 @@ export type Profile = {
     path: string;
     hash: string;
     size: number;
-    replicas: ProfileReplica[] | null;
   };
   crawlerChannel?: CrawlerChannelImage | AnyString;
   proxyId?: string;


### PR DESCRIPTION
Fixes #3342 

## Changes

- Remove per-file replication jobs (keeps model and some code paths required to get out and serialize the old jobs from the database, but they can no longer be run or retried)
- Add a `replicate-files-cron` cron job that runs on a configurable schedule (current default: every 2 hours) if any replica storage locations are configured on the instance, and launches a new `copy-bucket` background job for each configured replica location
- Add a `copy-bucket` background job that runs `rclone copy` on the entire primary storage bucket to a replica storage location. This will sync the replica storage with all files currently in primary without the possibility of deleting anything from the replica destination as `rclone sync` would, as replica deletions will still be per-file and subject to the replica deletion delay
- Stop tracking replicas on each file in the database
- Add a migration to remove per-file replica information from the database
- Remove "backed up" icons from the frontend

## To note

A few nightly tests are failing (see [most recent run](https://github.com/webrecorder/browsertrix/actions/runs/32884046361/job/97920241144)), I believe possibly because the copy bucket job possibly doesn't have sufficient resources to start in our CI runners. We'll want to fix or change the tests before merging, but I could use another pair of eyes on the problem.

## Testing

### New instance

1. Set up a local Browsertrix instance with one or more default replica storage locations configured
2. Run some crawls and browser profiles
3. Verify that the cron job runs on the configured schedule and kicks off one copy bucket job per replica location
4. Verify those jobs are successful
5. Verify all files are replicated to each default replica storage location

### Existing instance

1. Bootstrap an existing Browsertrix instance that already has at least one replica location configured and has previously had per-file replication jobs run
2. Verify that the new cron replication and copy bucket jobs run and are successful
3. Verify that the switch in replication jobs have not modified any filepaths unexpected in replica locations