### PR TITLE
docs: Improve onboarding documentation

### DIFF
--- a/frontend/docs/docs/stylesheets/browsertrix.css
+++ b/frontend/docs/docs/stylesheets/browsertrix.css
@@ -20,7 +20,7 @@
 
 /* Reveal elements */
 .btrix-app-embed .btrix-embed-visible:not(.grid) {
-  display: block !important;
+  display: revert !important;
 }
 .btrix-app-embed .btrix-embed-visible.grid {
   display: grid !important;
@@ -76,6 +76,7 @@
   padding: 0;
 }
 .btrix-app-embed .md-header__title {
+  font-size: 0.8rem;
   height: calc(2.25rem + 1px);
   padding-left: 0.5rem;
 }

--- a/frontend/docs/docs/user-guide/change-password.md
+++ b/frontend/docs/docs/user-guide/change-password.md
@@ -1,0 +1,12 @@
+# Change or Reset Your Password
+
+## Change Password
+
+Tap the **Account** button at the top every page to access your account settings, then go to **Security**.
+
+!!! Tip "Browsertrix Subscribers"
+    You can access your account settings using this link: [app.browsertrix.com/account/settings/security](https://app.browsertrix.com/account/settings/security).
+
+## Reset Password
+
+To reset your password on hosted Browsertrix, go to [app.browsertrix.com/log-in/forgot-password](https://app.browsertrix.com/log-in/forgot-password).

--- a/frontend/docs/docs/user-guide/getting-started.md
+++ b/frontend/docs/docs/user-guide/getting-started.md
@@ -1,38 +1,119 @@
+---
+hide:
+  - tags
+tags:
+  - Social Media
+---
+
 # Your First Crawl
 
-Let’s crawl your first webpage! Start by opening up a webpage that you'd like to crawl, and note the URL for later.
+<!-- markdownlint-disable MD033 -->
+
+Set up your first website or social media page crawl in just a few minutes
+{ .hero-paragraph }
+
+---
+
+This guide will walk you through the basic steps for starting a website crawl.
 
 ## Accessing your dashboard
 
-To start a crawl, you'll need to log in using a Browsertrix account that has [**crawler** permissions](./org-members.md#permission-levels).
+To start a crawl, you’ll need to log in using a Browsertrix account with access to crawls.
 
-You likely have crawler permissions already if:
+You likely have access already if:
 
-- You [registered for an org on hosted Browsertrix](./signup.md)
-- You [joined an existing org](./join.md) and were given crawler permissions
-- You are the admin of a self-hosted instance
+- [x] You signed up for a Browsertrix subscription.
+- [x] You joined an existing org and were given “crawler” permissions.
+- [x] You are the admin of a self-hosted instance.
 
-Check if you have crawler permissions by logging in. If you see a _+ Create New..._ button near the org name, you're able to start a crawl. If you don't see this button and think that you should, contact your org admin to update your permissions.
+Check if you have access by logging in. If you see a [+ Create New...](#accessing-your-dashboard){ .md-button .md-button--primary .btrix-button } button in the dashboard, you’re able to start a site crawl. If you don’t see this button and think that you should, contact your org administrator to update your permissions.
+
+## Choose what to archive
+
+Open the webpage that you would like to archive in a new browser tab. Copy the URL; we will use this URL to start the crawl.
+
+Choose one of the following options to tailor this guide to what you’d like to archive:
+
+=== "One page<div data-tab-description="Archive a single page on a site"></div>"
+
+    <!--  -->
+
+=== "Social media page<div data-tab-description="Archive a social media post or profile"></div>"
+
+    #### Before You Start
+
+    Many popular social media platforms require logging in to view the full page. To check if the social media page requires login, open the page in private browsing or incognito mode (instructions for [Chrome](https://support.google.com/chrome/answer/95464), [Safari](https://support.apple.com/guide/safari/browse-privately-ibrw1069/mac), [Edge](https://support.microsoft.com/en-us/edge/browse-inprivate-in-microsoft-edge), [Firefox](https://www.firefox.com/en-US/features/private-browsing/)). If you see a prompt to sign up or login, the site will need to be provided login credentials during the crawl.
+
+    If this is the case, sign up for a new account using login credentials dedicated to archiving. Make note of these credentials in a secure place before continuing.
+    
+    ??? Question "Can I use my existing social media account?"
+        Although there is nothing preventing you from doing so, using your personal account to archive social media pages may [put your personal login information at risk](browser-profiles/browser-profiles-overview.md#use-logins-dedicated-to-web-archiving){ data-preview }. We always recommend creating a new account dedicated to archiving to reduce the risk of accidentally archiving your private data.
+
+=== "Entire website<div data-tab-description="Archive every page on a webs"></div>"
 
 ## Starting the crawl
 
-When you log in, the first page you see is the [org dashboard](overview.md). If you've navigated away to another page, navigate back to **Dashboard**.
+When you log in, the first page you see is the [org dashboard](overview.md){ data-preview }. If you’ve navigated away to another page, navigate back to **Dashboard**.
 
-1. Tap the _Create New..._ shortcut and select **Crawl Workflow**.
-2. Enter the URL of the webpage that you noted earlier as the **URL to Crawl**.
-3. Tap _Run Crawl_.
-4. You should now see your new crawl workflow running. Give the crawler a few moments to warm up, and then watch as it archives the webpage!
+You will create a [crawl workflow](crawl-workflows.md){ data-preview } to set up the crawl.
+
+1. Tap the [+ Create New...](#accessing-your-dashboard){ .md-button .md-button--primary .btrix-button } button and select **Crawl Workflow**.
+
+1. Select the [Crawl Scope](workflow-setup.md#crawl-scope){ data-preview } that best fits what you intend to archive:
+
+    === "One page"
+
+        Leave the setting at **Single Page**.
+
+    === "Social media page"
+
+        Leave the setting at **Single Page**. Browsertrix [automatically adjust the scope](workflow-setup.md#use-smart-scoping-rules){ data-preview } for popular social media platforms.
+
+    === "Entire website"
+
+        Choose **Pages on Same Domain**. This will find and archive every page that shares the same domain (e.g. _your-site_.com).
+
+1. Enter the URL of the webpage that you copied earlier.
+1. Configure optional settings:
+
+    === "One page"
+
+        Check **Include directly linked pages** to crawl pages linked from your target page. Including directly linked pages can improve the replay experience by preventing broken links.
+
+    === "Social media page"
+
+        If the social media page requires logging in, you can use a [browser profile](browser-profiles/browser-profiles-overview.md){ data-preview } to provide the login credentials.
+
+        To add a browser profile:
+
+        1. Scroll down and open the **Browser Settings** section.
+        1. Open the **Browser Profile** menu and select **New Browser Profile**.
+        1. Tap the **Start Browser**{ .md-button .md-button--success .btrix-button } button.
+        1. Log in using the account [that you created earlier](#before-you-start).
+        1. Tap **Create Profile**{ .md-button .md-button--primary .btrix-button } to save the profile.
+
+    === "Entire website"
+
+        It can be difficult to estimate how many pages are on a website, especially if it is your first time crawling the site. Setting [crawl limits](workflow-setup.md#crawl-limits){ data-preview } is recommended as you familiarize yourself with the site crawl.
+
+        To add a crawl limit:
+
+        1. Scroll down and open the **Crawl Limits** section.
+        1. Set a **Crawl Time Limit** and/or **Crawl Size Limit** according to what is reasonable within your org quotas.
+
+1. When you’re finished entering workflow settings, tap **Run Crawl**{ .md-button .md-button--primary .btrix-button }.
+
+You should now see your new crawl workflow running. Give the crawler a few moments to warm up, and then watch as it crawls the webpage!
 
 ---
 
 ## Next steps
 
-After running your first crawl, check out the following to learn more about Browsertrix's features:
+After running your first crawl, you may want to:
 
-- A detailed list of [crawl workflow setup](workflow-setup.md) options.
-- Adding [exclusions](workflow-setup.md#custom-exclusion-rules) to limit your crawl's scope
-- Evading crawler traps by [editing exclusion rules while crawling](running-crawl.md#live-exclusion-editing).
-- Best practices for crawling with [browser profiles](browser-profiles/browser-profiles-overview.md) to capture content only available when logged in to a website.
-- Managing archived items, including [uploading previously archived content](archived-items.md#uploading-web-archives).
-- Organizing and combining archived items with [collections](collection.md) for sharing and export.
-- [Invite collaborators](org-members.md) to your org.
+- [Include pages](workflow-setup.md#additional-scope){ data-preview } that the crawler didn’t visit.
+- [Exclude pages](workflow-setup.md#exclude-pages){ data-preview } that shouldn’t be crawled.
+- Explore all available [crawl workflow setup](workflow-setup.md){ data-preview } options.
+- Review the crawled content for [quality assurance](quality-assurance.md){ data-preview }.
+- Import [previously archived content](archived-items.md#uploading-web-archives){ data-preview }.
+- Start a [collection](collection.md){ data-preview } of crawled content.

--- a/frontend/docs/docs/user-guide/getting-started.md
+++ b/frontend/docs/docs/user-guide/getting-started.md
@@ -49,7 +49,7 @@ Choose one of the following options to tailor this guide to what you’d like to
     ??? Question "Can I use my existing social media account?"
         Although there is nothing preventing you from doing so, using your personal account to archive social media pages may [put your personal login information at risk](browser-profiles/browser-profiles-overview.md#use-logins-dedicated-to-web-archiving){ data-preview }. We always recommend creating a new account dedicated to archiving to reduce the risk of accidentally archiving your private data.
 
-=== "Entire website<div data-tab-description="Archive every page on a webs"></div>"
+=== "Entire website<div data-tab-description="Archive every page on a website"></div>"
 
 ## Starting the crawl
 

--- a/frontend/docs/docs/user-guide/index.md
+++ b/frontend/docs/docs/user-guide/index.md
@@ -34,6 +34,8 @@ The user guide documents features, terminology, and settings in the Browsertrix 
       { .btrix-embed-hidden }
       - [Set up your account](signup.md)
       { .btrix-embed-hidden }
+      - [Set up your org](signup.md)
+      { .btrix-embed-visible }
       - [Crawl your first webpage](getting-started.md#__tabbed_1_1)
       - [Crawl your first social media page](getting-started.md#__tabbed_1_2)
       - [Crawl an entire website](getting-started.md#__tabbed_1_3)

--- a/frontend/docs/docs/user-guide/index.md
+++ b/frontend/docs/docs/user-guide/index.md
@@ -34,7 +34,7 @@ The user guide documents features, terminology, and settings in the Browsertrix 
       { .btrix-embed-hidden }
       - [Set up your account](signup.md)
       { .btrix-embed-hidden }
-      - [Set up your org](signup.md)
+      - [Set up your account](signup.md#set-up-your-personal-account)
       { .btrix-embed-visible }
       - [Crawl your first webpage](getting-started.md#__tabbed_1_1)
       - [Crawl your first social media page](getting-started.md#__tabbed_1_2)

--- a/frontend/docs/docs/user-guide/index.md
+++ b/frontend/docs/docs/user-guide/index.md
@@ -1,15 +1,97 @@
+
 # Introduction
 
-Browsertrix is an intuitive, automated web archiving platform designed to allow you to archive, replay, and share websites exactly as they were at a certain point in time.
+<!-- markdownlint-disable MD033 -->
 
-Browsertrix is built and hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building.
+[Browsertrix](https://webrecorder.net/browsertrix/) is an intuitive, automated web archiving platform designed to allow you to archive, replay, and share interactive websites.
+{ .btrix-embed-hidden .hero-paragraph }
 
-This user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide navigation is organized similarly to the Browsertrix web interface for ease of browsing. You can also use the search box up top to search by topic.
+<hr class="btrix-embed-hidden" />
 
-If you have any feedback on our documentation [we'd love to hear it](mailto:docs-feedback@webrecorder.net). We've written the user guide with both seasoned web archivists and new archivists in mind and we value feedback from all levels of archiving experience.
+## How to use this guide
 
-For help with a specific topic, try our [community help forum](https://forum.webrecorder.net/c/help/5).
+The user guide documents features, terminology, and settings in the Browsertrix web interface. The user guide navigation is organized similarly to the Browsertrix web interface for ease of browsing. You can also use the search box up top to search by topic.
 
-For bug reports or feature requests, please open a [GitHub issue](https://github.com/webrecorder/browsertrix/issues/new/choose).
+## Quick links
 
-Thanks for choosing Browsertrix! Ready for [your first crawl](./getting-started.md)?
+<div class="btrix-embed-hidden card card-primary card--button-right grid" markdown>
+
+**New to Browsertrix?**<br/>Sign up for a free trial to follow along.
+
+[Start Free Trial](https://buy.stripe.com/fZe01jcHR8vkg00cN3){ .md-button .md-button--primary .md-button--right target="_blank" }
+  
+</div>
+
+<div class="grid cards" markdown>
+
+- **Getting Started**
+
+    Start here if you’re new to Browsertrix.
+
+    ---
+
+      - [Create an account :octicons-link-external-16:](https://buy.stripe.com/fZe01jcHR8vkg00cN3){ target="_blank" }
+      { .btrix-embed-hidden }
+      - [Set up your account](signup.md)
+      { .btrix-embed-hidden }
+      - [Crawl your first webpage](getting-started.md#__tabbed_1_1)
+      - [Crawl your first social media page](getting-started.md#__tabbed_1_2)
+      - [Crawl an entire website](getting-started.md#__tabbed_1_3)
+      - [Review glossary of terms :octicons-link-external-16:](https://webrecorder.net/resources/glossary){ target="_blank" }
+      - [Watch video tutorials :octicons-link-external-16:](https://www.youtube.com/@webrecorder){ target="_blank" }
+      
+
+- **Crawl Settings**
+
+    Customize crawls to achieve your archiving goals.
+
+    ---
+
+      - [Exclude pages from the archive](workflow-setup.md#exclude-pages)
+      - [Exclude popups and prompts](browser-profiles/browser-profiles-overview.md)
+      - [Watch pages in real-time](running-crawl.md#watch-crawl)
+      - [Avoid crawler traps in real-time](running-crawl.md#live-exclusion-editing)
+      - [Organize crawls into collections](collection.md)
+      - [Review, rate, and comment on crawled content](quality-assurance.md)
+
+- **Org Settings**
+
+    Manage your workspace and archived items.
+
+    ---
+
+      - [View essential stats & quotas](overview.md)
+      - [Manage billing](org-settings.md#billing)
+      - [Invite team members](org-members.md)
+      - [Import a collection](archived-items.md#uploading-web-archives)
+      - [Create a public archive](public-collections-gallery.md)
+      - [Enable org deduplication](deduplication.md#enable-deduplication-across-your-entire-organization)
+
+- **Account Settings**
+
+    Manage your personal profile and preferences.
+
+    ---
+
+      - [Change your email](user-settings.md)
+      - [Change your password](change-password.md#change-password)
+      - [Reset your password](change-password.md#reset-password)
+      - [Choose your preferred language](user-settings.md)
+      - [Change how your name appears to team members](user-settings.md)
+
+</div>
+
+## Feedback
+
+If you have any feedback on our documentation [we'd love to hear it :material-email-outline:](mailto:docs-feedback@webrecorder.net). We've written the user guide with both seasoned web archivists and new archivists in mind and we value feedback from all levels of archiving experience.
+
+For help with a specific topic, try our [community help forum :octicons-link-external-16:](https://forum.webrecorder.net/c/help/5){ target="_blank" }.
+
+For bug reports or feature requests, please open a [GitHub issue :octicons-link-external-16:](https://github.com/webrecorder/browsertrix/issues/new/choose){ target="_blank" }.
+
+<hr class="btrix-embed-hidden" />
+
+## About Webrecorder { .btrix-embed-hidden }
+
+Browsertrix is built and hosted by [Webrecorder](https://webrecorder.net/), a leading expert in web archiving. Our goal is to make web archiving easier and more accessible to everyone through open source tools, easy-to-use interfaces, and community building. [Learn more about us](https://webrecorder.net/about/)
+{ .btrix-embed-hidden }

--- a/frontend/docs/docs/user-guide/join.md
+++ b/frontend/docs/docs/user-guide/join.md
@@ -2,4 +2,6 @@
 
 If you've received an email inviting you to an org, you can join the org by accepting the invitation.
 
-If you don't have a Browsertrix account, you'll be prompted to [create a password and display name](./signup.md#configure-your-user-account).
+If you don't have a Browsertrix account, you'll be prompted to create a password and display name.
+
+Your display name is the name that is visible to other org members. For example, your display name will be visible next to crawl workflows that you create or run.

--- a/frontend/docs/docs/user-guide/org-settings.md
+++ b/frontend/docs/docs/user-guide/org-settings.md
@@ -23,9 +23,27 @@ Refer to the full [Public Collections Gallery](public-collections-gallery.md) gu
 
 ## Billing
 
-`Paid Feature`{ .badge-green }
+`Subscription Feature`{ .badge-green .btrix-embed-hidden }
 
-View and manage your org's current payment plan and associated quotas. Usage history statistics for previous months are shown here to better inform your plan and quota requirements.
+View and manage your org's current subscription plan and payment information from the **Billing & Usage** section of your org settings.
+
+### Upgrade, Downgrade, or Cancel Plan
+
+To update your subscription, visit the **Manage Subscription** link.
+
+### Change Payment Method
+
+To update payment information for an active subscription, visit the **Manage Subscription** link.
+
+To replace a failed payment method, visit the **Update Billing** link.
+
+### Re-Subscribe to Plan
+
+To subscribe again after canceling your plan, visit the **Choose Plan** link, or **Subscribe Now** for canceled trials.
+
+### Usage History
+
+Usage history statistics for previous months are shown here to better inform your plan and quota requirements.
 
 ## Crawling Defaults
 

--- a/frontend/docs/docs/user-guide/overview.md
+++ b/frontend/docs/docs/user-guide/overview.md
@@ -1,8 +1,17 @@
-# View Usage Stats and Quotas
+# Org Dashboard
 
-Your **Dashboard** delivers key statistics about the org's resource usage. You can also create crawl workflows, upload archived items, create collections, and create browser profiles through the _Create New ..._ shortcut.
+Get an overall picture of how your org archives
+{ .hero-paragraph }
 
-## Storage
+## Introduction { .invisible }
+
+---
+
+The dashboard is the first page that you see when you log in. It gives you access to essential stats and a _Create New ..._ shortcut to quickly add a crawl workflow, collection, browser profile, or uploaded item.
+
+## Usage Stats and Quotas
+
+### Storage
 
 The storage panel displays the total size and count of archived items and browser profiles.
 
@@ -11,19 +20,23 @@ For organizations with a set storage quota, the storage panel displays a visual 
 ??? Info "Miscellaneous storage"
     You may see an additional _Miscellaneous_ size depending on your crawl workflow and collection configuration. _Miscellaneous_ is the total size of all supplementary files in use by your organization, such as [workflow URL list files](./workflow-setup.md#list-of-pages) and [custom collection thumbnails](./presentation-sharing.md#thumbnail).
 
-## Crawling
+### Crawling
 
 The crawling panel lists the number of currently running and waiting crawls, as well as the total number of pages captured.
 
-### Execution Time
+#### Execution Time
 
-`Paid Feature`{.badge-green}
+`Subscription Feature`{ .badge-green .btrix-embed-hidden }
 
 For organizations with a set execution minute limit, the crawling panel displays a graph of how much execution time has been used and how much is currently remaining. Monthly execution time limits reset on the first of each month at 12:00 AM GMT.
 
 ??? Question "How is execution time calculated?"
     Execution time is the total runtime of a crawl scaled by the [_Browser Windows_](workflow-setup.md/#browser-windows) value during a crawl. Like elapsed time, this is tracked while the crawl runs. Changing the amount of _Browser Windows_ while a crawl is running may change the amount of execution time used in a given time period.
 
-## Collections
+### Collections
 
 The collections panel displays the number of total collections and collections marked as sharable.
+
+## Public Collections
+
+If any of org collections are [public](public-collections-gallery.md), their thumbnails will be displayed in the **Public Collections** section of the dashboard.

--- a/frontend/docs/docs/user-guide/resources.md
+++ b/frontend/docs/docs/user-guide/resources.md
@@ -1,0 +1,36 @@
+# Resources
+
+Links to additional resources to help you get the most out of Browsertrix
+{ .hero-paragraph }
+
+---
+
+## General Resources
+
+Visit the Webrecorder resources portal for general information, terminology, and presentations regarding web archiving.
+
+[Explore Resources :octicons-arrow-up-right-16:](https://webrecorder.net/resources/){ .md-button .md-button--primary target="_blank" }
+
+---
+
+## Product Announcements
+
+For the latest on new and upgraded Browsertrix features, check out our product blog.
+
+[Explore Articles :octicons-arrow-up-right-16:](https://webrecorder.net/blog/product/){ .md-button target="_blank" }
+
+---
+
+## Community Forum
+
+Tap into community knowledge and support from other Browsertrix users and archivists.
+
+[Explore Forum :octicons-arrow-up-right-16:](https://forum.webrecorder.net/){ .md-button target="_blank" }
+
+---
+
+## Topics
+
+Browse the user guide as tagged by topic.
+
+<!-- material/tags -->

--- a/frontend/docs/docs/user-guide/signup.md
+++ b/frontend/docs/docs/user-guide/signup.md
@@ -21,7 +21,7 @@
       
     </div>
 
-    ## Sign Up
+    ## Sign Up { .btrix-embed-hidden }
 
     Each Browsertrix subscription includes one org (organization), which is created for you when you [sign up](https://webrecorder.net/browsertrix/#get-started).
     { .btrix-embed-hidden }

--- a/frontend/docs/docs/user-guide/signup.md
+++ b/frontend/docs/docs/user-guide/signup.md
@@ -23,29 +23,34 @@
 
     ## Sign Up { .btrix-embed-hidden }
 
-    Each Browsertrix subscription includes one org (organization), which is created for you when you [sign up](https://webrecorder.net/browsertrix/#get-started).
+    Once you finish setting up your subscription, you’ll receive an email from Webrecorder with a link to confirm your email address and set up your org.
     { .btrix-embed-hidden }
-
-    Once you finish setting up your subscription, you’ll receive an email from Webrecorder with a link to set up your org.
-    { .btrix-embed-hidden }
-
-    ## Set Up Your Org
-
-    Choose an org name that's unique and memorable, like the name of your company or organization. Your org URL identifier will determine the unique URL of the org's home page.
 
     ## Set Up Your Personal Account
 
-    When prompted, set up the account that you will use to log in to Browsertrix.
-
-    ### Password
-
-    Your email and password will be used to log in to [app.browsertrix.com](https://app.browsertrix.com/log-in){ target="_blank" }.
+    Set up the account that you will use to log in to Browsertrix.
 
     ### Display Name
 
     Your display name is the name that is visible to other org members. For example, your display name will be visible next to crawl workflows that you create or run.
 
-    Once you’ve completed this step, you’re in!
+    ### Password
+
+    Your email and password will be used to log in to [app.browsertrix.com](https://app.browsertrix.com/log-in){ target="_blank" }.
+
+    ## Set Up Your Org
+
+    A Browsertrix org (organization) is your primary workspace for creating and publishing web archives. If you’re archiving collaboratively, an org workspace can be shared between team members.
+
+    Each Browsertrix subscription includes one org, which is created for you when you sign up.
+
+    ### Org Name
+
+    Your org name appears throughout the web application and in email notifications. Choose a display name for your org that's unique and memorable, like the name of your company, organization, or personal project.
+
+    ### Custom URL Identifier
+    
+    The org URL is where you and other org members will go to view the dashboard, configure org settings, and manage all other org-related activities.
 
     ---
 

--- a/frontend/docs/docs/user-guide/signup.md
+++ b/frontend/docs/docs/user-guide/signup.md
@@ -1,27 +1,114 @@
-# Register For an Account
 
-!!! tip "Already have an account?"
+# Set up Your Account
 
-    Skip ahead to [running your first crawl](./getting-started.md).
+<!-- markdownlint-disable MD033 -->
 
-!!! note "Self-hosting?"
+=== "Hosted Browsertrix"
 
-    This guide only applies to hosted Browsertrix accounts. If you're self-hosting Browsertrix, [enable open registration](../deploy/customization.md#enable-open-registration) to allow others to sign up for an account on your instance.
+    <div class="btrix-embed-hidden card card-primary card--button-right grid" markdown>
 
-To sign up for Browsertrix, [choose a plan](https://webrecorder.net/browsertrix/pricing/). We offer a variety of plans for individuals, teams, and organizations of all sizes.
+    **Need an account?**<br/>Start your free trial, then follow this guide.
 
-## Register Your Org
+    [Start Free Trial](https://buy.stripe.com/fZe01jcHR8vkg00cN3){ .md-button .md-button--primary .md-button--right target="_blank" }
+      
+    </div>
 
-After you finish setting up your subscription, you'll receive an email from Webrecorder with a link to set up your org (organization.)
+    <div class="btrix-embed-visible card card-info card--button-right grid" markdown>
 
-Choose an org name that's unique and memorable, like the name of your company or organization. Your org URL identifier will determine the unique URL of the org's home page.
+    If you’re already logged in to your dashboard, skip ahead to running your first crawl.
 
-## Configure Your User Account
+    [Your First Crawl](getting-started.md){ .md-button .md-button--primary .md-button--right }
+      
+    </div>
 
-Create a password and display name. Your display name is the name that is visible to other org members. For example, your display name will be visible in crawl workflows that you create or run.
+    ## Sign Up
 
-Once you've completed this step, you're in! Next, familiarize yourself with the [org overview](./overview.md), head over to [crawl workflows](./crawl-workflows.md), or [invite team members](./org-settings.md).
+    Each Browsertrix subscription includes one org (organization), which is created for you when you [sign up](https://webrecorder.net/browsertrix/#get-started).
+    { .btrix-embed-hidden }
 
-## Can't complete sign-up or have a question?
+    Once you finish setting up your subscription, you’ll receive an email from Webrecorder with a link to set up your org.
+    { .btrix-embed-hidden }
 
-Don't hesitate to [reach out to us](mailto:support@webrecorder.org) if you encounter any issues while signing up.
+    ## Set Up Your Org
+
+    Choose an org name that's unique and memorable, like the name of your company or organization. Your org URL identifier will determine the unique URL of the org's home page.
+
+    ## Set Up Your Personal Account
+
+    When prompted, set up the account that you will use to log in to Browsertrix.
+
+    ### Password
+
+    Your email and password will be used to log in to [app.browsertrix.com](https://app.browsertrix.com/log-in){ target="_blank" }.
+
+    ### Display Name
+
+    Your display name is the name that is visible to other org members. For example, your display name will be visible next to crawl workflows that you create or run.
+
+    Once you’ve completed this step, you’re in!
+
+    ---
+
+    ## Your Free Trial
+
+    Browsertrix offers a free trial period to help you determine which plan is right for you. The full Browsertrix suite of features is available during your trial; use this period to run test crawls and hone in on the crawl workflows that work with your archiving goals.
+
+    ### Make the Most of Your Free Trial
+
+    The trial period is a good time to assess how much storage space and how many crawl minutes are used to create your web archives. Use the [dashboard usage statistics](overview.md){ data-preview } to track disk space and execution time.
+
+    If you find yourself close to your quotas, try optimizing storage space with [deduplication](deduplication.md){ data-preview } or set [crawl limits](workflow-setup.md#crawl-limits){ data-preview }. You can [upgrade at any time](org-settings.md#upgrade-downgrade-or-cancel-plan){ data-preview } to a subscription plan with more disk space and minutes.
+
+    All Browsertrix subscriptions include unlimited seats. You can invite collaborators during the trial period to work on archiving goals together.
+
+    ### What Happens When the Trial Ends
+
+    You’ll be charged automatically to the payment method you signed up with at the end of the trial. You can [update the payment method](org-settings.md#change-payment-method) or [cancel your subscription](org-settings.md#upgrade-downgrade-or-cancel-plan) at any time during the trial.
+
+    Usage during your trial period will count towards your monthly quota. Your quota will reset at the start of the next calendar month.
+
+=== "Self-Hosting"
+
+    Log in using the admin account created [during installation](../deploy/local.md#installing-from-github-release-directly).
+
+    To allow others to create accounts on your instance, enable [open registration](../deploy/customization.md#enable-open-registration).
+
+---
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+- :material-clock-fast: **Your First Crawl**
+
+    ---
+
+    Get started with your first webpage crawl in just a few minutes.
+
+    [Read Guide :octicons-arrow-right-24:](getting-started.md)
+
+- :fontawesome-solid-dashboard: **Explore Your Dashboard**
+
+    ---
+
+    Your dashboard delivers key statistics about your org and usage.
+
+    [Learn More :octicons-arrow-right-24:](overview.md)
+
+- :fontawesome-solid-users: **Invite Team Members**
+
+    ---
+
+    Invite collaborators to view or manage archives in your org.
+
+    [Learn More :octicons-arrow-right-24:](org-members.md)
+
+- :material-message-question-outline: **Questions or Issues?**
+
+    ---
+
+    Don't hesitate to reach out if you encounter any issues while setting up your account.
+
+    [:material-email-outline: Email Support](mailto:support@webrecorder.net)
+
+</div>

--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -99,6 +99,8 @@ nav:
           - user-guide/org-members.md
       - Account Settings:
           - user-guide/user-settings.md
+          - user-guide/change-password.md
+      - user-guide/resources.md
       - user-guide/contribute.md
   - Self-Hosting:
       - Overview: deploy/index.md
@@ -132,6 +134,7 @@ nav:
 
 markdown_extensions:
   - toc:
+      title: On This Page
       toc_depth: 3
       permalink: true
   - pymdownx.highlight:
@@ -173,6 +176,9 @@ copyright: "Creative Commons Attribution 4.0 International (CC BY 4.0)"
 
 plugins:
   - search
+  - tags:
+      tags_allowed:
+        - Social Media
   - redirects:
       redirect_maps:
         "user-guide/collections.md": "user-guide/collection.md"


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/2304
Blocked by https://github.com/webrecorder/browsertrix/pull/3569

## Changes

- Updates user guide landing page
- Adds option to customize "your first crawl" guide by concern, like social media archiving
- Improves overall flow of user guides relevant to new users (e.g. sign up, subscription, trial)

## Screenshots

### User guide landing page

<img width="903" height="1155" alt="Screenshot 2026-08-17 at 9 59 23 AM" src="https://github.com/user-attachments/assets/7664784b-6972-4f89-a02c-32aafb827761" />

### "Set up Your Account" page

<img width="844" height="1194" alt="Screenshot 2026-08-17 at 9 59 58 AM" src="https://github.com/user-attachments/assets/bdbda70a-8eed-483c-a288-0e1e96f8eb2b" />

### "Your First Crawl" page

<img width="840" height="1164" alt="Screenshot 2026-08-17 at 10 00 22 AM" src="https://github.com/user-attachments/assets/dc6a585f-2042-4753-9808-78a18c666ff5" />


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>