### PR TITLE
docs: Add hosted Browsertrix CTAs

### DIFF
--- a/frontend/docs/docs/deploy/index.md
+++ b/frontend/docs/docs/deploy/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+    - footer
+---
+
 # Self-Hosting
 
 !!! info "Already signed up for Browsertrix?"

--- a/frontend/docs/docs/deploy/proxies.md
+++ b/frontend/docs/docs/deploy/proxies.md
@@ -1,10 +1,20 @@
 # Configuring Proxies
 
+<!-- markdownlint-disable MD033 -->
+
 Browsertrix can be configured to direct crawling traffic through dedicated proxy servers, allowing websites to be crawled from a specific geographic location regardless of where Browsertrix itself is deployed.
 
 The Browsertrix superadmin can configure which proxy servers are available to which organizations or if they are shared across all organizations, and users can [choose from one of the available proxies in each crawl workflow](../user-guide/workflow-setup.md#crawler-proxy-server). Users can also configure the default crawling proxy that will be used for the organization in organization-wide [Crawling Defaults](../user-guide/org-settings.md#crawling-defaults).
 
 This guide covers how to set up proxy servers for use with Browsertrix, as well as how to configure Browsertrix to make those proxies available to organizations.
+
+<div class="btrix-embed-hidden card card-info card--button-right grid" markdown>
+
+**Need professional support?**<br/>Dedicated professional support is available with a custom plan or add-on.
+
+[View Plans](https://webrecorder.net/browsertrix/#get-started){ .md-button .md-button--primary .md-button--right target="_blank" }
+  
+</div>
 
 ## Proxy Configuration
 

--- a/frontend/docs/docs/deploy/remote.md
+++ b/frontend/docs/docs/deploy/remote.md
@@ -1,11 +1,20 @@
 # Remote: Self-Hosted and Cloud
 
-For remote and hosted deployments (both on a single machine or in the cloud), the only requirement is to have a designed domain and (strongly recommended, but not required) second domain for signing web archives. 
+<!-- markdownlint-disable MD033 -->
+
+For remote and hosted deployments (both on a single machine or in the cloud), the only requirement is to have a designed domain and (strongly recommended, but not required) second domain for signing web archives.
 
 We are also experimenting with [Ansible playbooks](ansible/digitalocean.md) for cloud deployment setups.
 
 The production deployments also allow using an external mongodb server, and/or external S3-compatible storage instead of the bundled minio.
 
+<div class="btrix-embed-hidden card card-info card--button-right grid" markdown>
+
+**Need professional support?**<br/>Dedicated professional support is available with a custom plan or add-on.
+
+[View Plans](https://webrecorder.net/browsertrix/#get-started){ .md-button .md-button--primary .md-button--right target="_blank" }
+  
+</div>
 
 ## Single Machine Deployment with MicroK8S
 
@@ -15,11 +24,11 @@ For a single-machine remote deployment, we recommend using [MicroK8s](https://mi
 
 2. Copy `cp ./chart/examples/microk8s-hosted.yaml ./chart/my-config.yaml` to make local changes.
 
-2. Set the `ingress.host`, `ingress.cert_email` and `signing.host` fields in `./chart/my-config.yaml` to your host and domain
+3. Set the `ingress.host`, `ingress.cert_email` and `signing.host` fields in `./chart/my-config.yaml` to your host and domain
 
-3. Set the super-admin username and password, and mongodb username and password in `./chart/my-config.yaml`
+4. Set the super-admin username and password, and mongodb username and password in `./chart/my-config.yaml`
 
-4. Run with:
+5. Run with:
 
     ```shell
     helm upgrade --install -f ./chart/values.yaml -f ./chart/my-config.yaml \
@@ -40,7 +49,7 @@ Another option for a single-machine remote deployment is [k3s](https://k3s.io)
       --namespace ingress-nginx --create-namespace
     ```
 
-3. Install `cert-manager`. We recommend installing `cert-manager` through Jetpack, like so: 
+3. Install `cert-manager`. We recommend installing `cert-manager` through Jetpack, like so:
 
     ```zsh
     helm repo add jetstack https://charts.jetstack.io
@@ -85,13 +94,11 @@ storages:
 
 Note that this setup is not limited to Amazon S3, but should work with any S3-compatible storage service.
 
-
 ### Using Custom MongoDB
 
 If you would like to use an externally hosted MongoDB, you can add the following config to point to a custom MongoDB instance.
 
 The `db_url` should follow the [MongoDB Connection String Format](https://www.mongodb.com/docs/manual/reference/connection-string/) which should include the username and password of the remote instance.
-
 
 ```yaml
 mongo_local: false
@@ -109,7 +116,7 @@ To simplify this process, we are working on Ansible playbooks for setting up Bro
 
 ### Ansible Deployment
 
-[Ansible](https://ansible.com) makes the initial setup and configuration of your Browsertrix instance automated and repeatable. 
+[Ansible](https://ansible.com) makes the initial setup and configuration of your Browsertrix instance automated and repeatable.
 
 To use, you will need to [install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#control-node-requirements) on your control computer and then you can use these to deploy to Browsertrix on remote and cloud environments.
 

--- a/frontend/docs/docs/develop/docs.md
+++ b/frontend/docs/docs/develop/docs.md
@@ -164,14 +164,14 @@ For in-line code blocks, syntax highlighting should be added for all code-relate
 
 Renders to: `#!python range()`
 
-### Paid features
+### Subscription Feature
 
-`Paid Feature`{ .badge-green }
+`Subscription Feature`{ .badge-green .btrix-embed-hidden }
 
 Some features of Browsertrix only pertain to those paying for the software on a hosted plan. Denote these with the following:
 
 ```markdown
-`Paid Feature`{ .badge-green }
+`Subscription Feature`{ .badge-green .btrix-embed-hidden }
 ```
 
 ### Admonitions
@@ -200,3 +200,39 @@ There are a lot of different options provided by Material for MkDocs — So many
 
 !!! Danger "Danger: Must have a title stating the warning"
     Used to deliver information about serious unrecoverable actions such as deleting large amounts of data or resetting things — should always be expanded.
+
+### Hide in Browsertrix Embed
+
+The user guide is embedded in the Browsertrix web application. You may want to hide certain elements in the embed. To do so, add the `btrix-embed-hidden` class.
+
+```markdown
+<!-- Hide heading -->
+## Special Heading { .btrix-embed-hidden }
+
+<!-- Hide paragraph -->
+This paragraph will be hidden in Browsertrix.
+{ .btrix-embed-hidden }
+
+<!-- Hide list item -->
+- I'm visible
+- I'm visible
+- I'm hidden!
+{ .btrix-embed-hidden }
+- I'm visible
+
+<!-- Hide inline HTML -->
+<hr class="btrix-embed-hidden" />
+```
+
+### Show in Browsertrix Embed
+
+The `btrix-embed-visible` class will show elements only in the Browsertrix embed:
+
+```markdown
+<!-- Show heading -->
+## Special Heading { .btrix-embed-visible }
+
+<!-- Show paragraph -->
+This paragraph will be visible only in Browsertrix.
+{ .btrix-embed-visible }
+```

--- a/frontend/docs/docs/develop/index.md
+++ b/frontend/docs/docs/develop/index.md
@@ -1,6 +1,7 @@
 ---
 hide:
   - toc
+  - footer
 ---
 
 # Developing Browsertrix

--- a/frontend/docs/docs/index.md
+++ b/frontend/docs/docs/index.md
@@ -4,27 +4,83 @@ hide:
     - toc
 ---
 
-# Browsertrix Docs
+# Browsertrix Documentation
 
-Browsertrix is an open source web archiving system created by [Webrecorder](https://webrecorder.net/). [Sign up for Browsertrix](https://webrecorder.net/browsertrix) to start archiving with zero setup, or follow our self-hosting guide to deploy Browsertrix on your own infrastructure.
+<!-- markdownlint-disable MD033 -->
 
-## Documentation
+Documentation for all—for Browsertrix users, archivists, and developers
+{ .hero-paragraph }
 
-Docs are organized into the following sections:
+[Get started with Browsertrix](user-guide/index.md){ .md-button .md-button--primary }
 
-- [User Guide](./user-guide/index.md) — Instructions on how to use Browsertrix to create and share web archives.
-- [Self-Hosting](./deploy/index.md) — Instructions on how to install, set up, and deploy self-hosted Browsertrix.
-- [Development](./develop/index.md) — Contribute to the open source development of Browsertrix software.
-- [API Reference](/api) — Full API reference for interacting with the Browsertrix backend.
+---
 
-If you have feedback on the docs, please feel free to [reach out to us](mailto:docs-feedback@webrecorder.net).
+## User Guides
+
+Power your archives with Browsertrix. Signing up for hosted Browsertrix gives you access to all web archiving features like automated crawling, built on top of resilient Webrecorder infrastructure.
+
+<div class="btrix-embed-hidden card card-primary card--button-right grid" markdown>
+
+**Need an account?**<br/>Start your free trial to follow along.
+
+[Create an Account](https://buy.stripe.com/fZe01jcHR8vkg00cN3){ .md-button .md-button--right target="_blank" }
+  
+</div>
+
+<div class="grid cards" markdown>
+
+- :material-arrow-right: **[Set up your account](user-guide/signup.md)**
+
+- :material-arrow-right: **[Crawl your first webpage](user-guide/getting-started.md)**
+
+- :material-arrow-right: **[Import & export your web archive](user-guide/archived-items.md)**
+
+- :material-arrow-right: **[Publish your web archive](user-guide/collection.md)**
+
+</div>
+
+---
+
+## Developer Guides
+
+Use your own infrastructure to host Browsertrix.
+
+<div class="grid cards" markdown>
+
+- **Self-Hosting**
+
+    [Requirements for self-hosting](deploy/index.md)<br/>
+    [Configure deployment](deploy/customization.md)<br/>
+    [Configure proxies](deploy/proxies.md)
+
+- **Development**
+
+    [Run Browsertrix locally](develop/local-dev-setup.md)<br/>
+    [API reference :octicons-link-external-16:](/api/){ target="_blank" }<br/>
+    [Source code :octicons-link-external-16:](https://github.com/webrecorder/browsertrix){ target="_blank" }<br/>
+
+</div>
+
+---
 
 ## Support
 
 For help with a specific topic, try our [community help forum](https://forum.webrecorder.net/c/help/5).
 
-Dedicated professional support is available with a custom subscription or support contract. Check out [our plans](https://webrecorder.net/browsertrix/pricing/) for details.
+<div class="btrix-embed-hidden card card-info card--button-right grid" markdown>
 
-## Bugs
+**Need professional support?**<br/>Dedicated professional support is available with a custom plan or add-on.
 
-For bug reports or feature requests, please open a [GitHub issue](https://github.com/webrecorder/browsertrix/issues/new/choose).
+[View Plans](https://webrecorder.net/browsertrix/#get-started){ .md-button .md-button--primary .md-button--right target="_blank" }
+  
+</div>
+
+---
+
+<div class="icon-list" markdown>
+
+- :material-message-text-outline: Feedback on docs? [Email us](mailto:docs-feedback@webrecorder.net).
+- :octicons-bug-24: Found a bug? Please open a [GitHub issue](https://github.com/webrecorder/browsertrix/issues/new/choose){ target="_blank" }.
+- :material-lightbulb-on-30: Feature idea? Start a [discussion](https://forum.webrecorder.net/){ target="_blank" }.
+
+</div>


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/2304

## Changes

- Updates docs landing page
- Adds support CTAs in self-hosting pages

## Screenshots

### Docs landing page

<img width="832" height="1197" alt="Screenshot 2026-08-17 at 9 57 56 AM" src="https://github.com/user-attachments/assets/50ec2f10-a34e-4de3-affe-e9cf6756c8a8" />

### Remote deploy page

<img width="860" height="351" alt="Screenshot 2026-08-17 at 10 04 18 AM" src="https://github.com/user-attachments/assets/a26b55a8-834c-48a0-974c-4ae1779a0d5b" />



<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>