### PR TITLE
docs: Adds mkdocs features

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -40,7 +40,9 @@ FROM --platform=$BUILDPLATFORM docker.io/library/python:3.12-slim as build_docs
 
 WORKDIR /docs
 
-RUN pip install mkdocs-material mkdocs-redirects
+COPY --link ./docs/requirements.txt .
+
+RUN pip install -r requirements.txt
 
 COPY --link ./docs/mkdocs.yml .
 COPY --link ./docs/docs ./docs

--- a/frontend/docs/mkdocs.yml
+++ b/frontend/docs/mkdocs.yml
@@ -14,11 +14,15 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
     - navigation.tracking
     - navigation.footer
+    - navigation.prune
     - content.code.copy
     - content.action.edit
     - content.tooltips
+    - content.tabs.link
     - search.suggest
   palette:
     scheme: webrecorder
@@ -126,6 +130,8 @@ markdown_extensions:
       options:
         custom_icons:
           - docs/overrides/.icons
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - admonition
   - pymdownx.inlinehilite
   - pymdownx.details
@@ -135,6 +141,7 @@ markdown_extensions:
   - pymdownx.keys
   - def_list
   - attr_list
+  - md_in_html
 
 extra:
   generator: false

--- a/frontend/docs/requirements.txt
+++ b/frontend/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs~=1.6.1
+mkdocs-material~=9.7.7
+mkdocs-redirects~=1.2.2


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/2304

- Specifies mkdocs and mkdocs material versions to address https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/
- Enables features available in newest version of mkdocs material

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

