### PR TITLE
feat: Show rate limit expiry date

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "cronstrue": "^3.24.0",
     "css-loader": "^6.3.0",
     "css-selector-parser": "^3.3.0",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.0.0",
     "del-cli": "^4.0.1",
     "diff": "^5.2.0",
     "dotenv": "^10.0.0",

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -53,6 +53,7 @@ import {
   DEFAULT_MAX_SCALE,
   isActive,
   isPaused,
+  isRateLimited,
   isSkipped,
   isSuccessfullyFinished,
   renderName,
@@ -1530,17 +1531,15 @@ export class WorkflowDetail extends BtrixElement {
   private renderRateLimitedNotice() {
     const latestCrawl = this.latestCrawlTask.value;
 
-    if (latestCrawl?.state !== "rate-limited") {
+    if (!latestCrawl || !isRateLimited(latestCrawl)) {
       return;
     }
 
-    const expiryDate =
-      this.appState.settings?.rateLimitDurationMinutes &&
-      latestCrawl.rateLimitedAt
-        ? addMinutes(this.appState.settings.rateLimitDurationMinutes)(
-            latestCrawl.rateLimitedAt,
-          )
-        : null;
+    const expiryDate = this.appState.settings?.rateLimitDurationMinutes
+      ? addMinutes(this.appState.settings.rateLimitDurationMinutes)(
+          latestCrawl.rateLimitedAt,
+        )
+      : null;
 
     return html`
       <btrix-alert class="sticky top-2 z-50 part-[base]:mb-5" variant="warning">
@@ -1625,6 +1624,7 @@ export class WorkflowDetail extends BtrixElement {
 
   private readonly renderCrawlDetails = () => {
     const latestCrawl = this.latestCrawlTask.value;
+    const rateLimited = latestCrawl && isRateLimited(latestCrawl);
     const skeleton = html`<sl-skeleton class="w-full"></sl-skeleton>`;
 
     const duration = (workflow: Workflow) => {
@@ -1636,6 +1636,16 @@ export class WorkflowDetail extends BtrixElement {
           : new Date()
         ).valueOf() - new Date(workflow.lastCrawlStartTime).valueOf(),
       );
+    };
+
+    const rateLimitedTime = () => {
+      if (!rateLimited) return skeleton;
+
+      return html`<span class="text-warning">
+        ${this.localize.humanizeDuration(
+          new Date().valueOf() - new Date(latestCrawl.rateLimitedAt).valueOf(),
+        )}
+      </span>`;
     };
 
     const execTime = () => {
@@ -1702,6 +1712,9 @@ export class WorkflowDetail extends BtrixElement {
               )}`
             : duration(workflow),
         )}
+        ${rateLimited
+          ? this.renderDetailItem(msg("Rate Limited Time"), rateLimitedTime)
+          : nothing}
         ${this.renderDetailItem(msg("Execution Time"), () =>
           isLoading(this.runNowTask)
             ? html`${until(

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1564,7 +1564,7 @@ export class WorkflowDetail extends BtrixElement {
                 >${this.localize.date(date)}</strong
               >`;
               return msg(
-                html`The crawl run will automatically pause on ${date_to_pause}
+                html`The crawl will automatically pause after ${date_to_pause}
                 if rate limiting continues.`,
                 {
                   desc: "`date_to_pause` example: '01/01/2036, 01:00 PM'",

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import { Task, TaskStatus } from "@lit/task";
 import type { SlDropdown } from "@shoelace-style/shoelace";
+import { addMinutes } from "date-fns/fp";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { choose } from "lit/directives/choose.js";
@@ -1527,9 +1528,19 @@ export class WorkflowDetail extends BtrixElement {
   };
 
   private renderRateLimitedNotice() {
-    if (this.workflow?.lastCrawlState !== "rate-limited") {
-      return html``;
+    const latestCrawl = this.latestCrawlTask.value;
+
+    if (latestCrawl?.state !== "rate-limited") {
+      return;
     }
+
+    const expiryDate =
+      this.appState.settings?.rateLimitDurationMinutes &&
+      latestCrawl.rateLimitedAt
+        ? addMinutes(this.appState.settings.rateLimitDurationMinutes)(
+            latestCrawl.rateLimitedAt,
+          )
+        : null;
 
     return html`
       <btrix-alert class="sticky top-2 z-50 part-[base]:mb-5" variant="warning">
@@ -1549,6 +1560,12 @@ export class WorkflowDetail extends BtrixElement {
             ${msg(
               "This crawl is running slower due to being rate limited by a website being crawled.",
             )}
+            ${when(expiryDate, (date) => {
+              const date_to_pause = this.localize.date(date);
+              return msg(
+                str`The crawl run will automatically pause on ${date_to_pause} if rate limiting continues.`,
+              );
+            })}
             <a
               target="_blank"
               href="${this

--- a/frontend/src/pages/org/workflow-detail.ts
+++ b/frontend/src/pages/org/workflow-detail.ts
@@ -1561,9 +1561,15 @@ export class WorkflowDetail extends BtrixElement {
               "This crawl is running slower due to being rate limited by a website being crawled.",
             )}
             ${when(expiryDate, (date) => {
-              const date_to_pause = this.localize.date(date);
+              const date_to_pause = html`<strong class="font-medium"
+                >${this.localize.date(date)}</strong
+              >`;
               return msg(
-                str`The crawl run will automatically pause on ${date_to_pause} if rate limiting continues.`,
+                html`The crawl run will automatically pause on ${date_to_pause}
+                if rate limiting continues.`,
+                {
+                  desc: "`date_to_pause` example: '01/01/2036, 01:00 PM'",
+                },
               );
             })}
             <a

--- a/frontend/src/types/crawler.ts
+++ b/frontend/src/types/crawler.ts
@@ -226,6 +226,7 @@ export type Crawl = ArchivedItemBase &
     scale: number;
     browserWindows: number;
     shouldPause: boolean | null;
+    rateLimitedAt: string | null;
     resources?: (StorageFile & {
       numReplicas: number;
       fromDependency: boolean;

--- a/frontend/src/utils/app.ts
+++ b/frontend/src/utils/app.ts
@@ -15,6 +15,8 @@ export type AppSettings = {
   salesEmail: string;
   supportEmail: string;
   localesEnabled?: readonly string[];
+  pausedExpiryMinutes?: number;
+  rateLimitDurationMinutes?: number;
 };
 
 export async function getAppSettings(): Promise<AppSettings> {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -54,6 +54,12 @@ export function isRunning({ state }: Partial<Crawl>) {
   return (RUNNING_STATES as readonly (typeof state)[]).includes(state);
 }
 
+export function isRateLimited(
+  crawl: Crawl,
+): crawl is Crawl & { rateLimitedAt: string } {
+  return crawl.state === "rate-limited";
+}
+
 export function isActive({ state }: Partial<Crawl | QARun>) {
   return (activeCrawlStates as readonly (typeof state)[]).includes(state);
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6398,7 +6398,7 @@ __metadata:
     cronstrue: "npm:^3.24.0"
     css-loader: "npm:^6.3.0"
     css-selector-parser: "npm:^3.3.0"
-    date-fns: "npm:^3.6.0"
+    date-fns: "npm:^4.0.0"
     del-cli: "npm:^4.0.1"
     diff: "npm:^5.2.0"
     dotenv: "npm:^10.0.0"
@@ -7515,10 +7515,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "date-fns@npm:3.6.0"
-  checksum: 10c0/0b5fb981590ef2f8e5a3ba6cd6d77faece0ea7f7158948f2eaae7bbb7c80a8f63ae30b01236c2923cf89bb3719c33aeb150c715ea4fe4e86e37dcf06bed42fb6
+"date-fns@npm:^4.0.0":
+  version: 4.4.0
+  resolution: "date-fns@npm:4.4.0"
+  checksum: 10c0/988f0a13db183f5dfc85c36bbb6847a9c135a9225888bbea4005876ec15539a8613c21a07370a4e7ea543918d5a1cafb423c528b42cdbbde5fdfddb178126b21
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3483

## Changes

Displays how long a crawl has been rate limited for and the date that rate limited crawl will pause.

## Screenshots

<img width="965" height="198" alt="Screenshot 2026-08-18 at 9 58 16 AM" src="https://github.com/user-attachments/assets/f58b01f0-d5b5-4049-922a-8882b270cd99" />

